### PR TITLE
Allow environment variable as admin password

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ const result = reduce((acc, item) => {
 
 - `DB_URL` - Database URL (required, e.g. `libsql://your-db.turso.io`)
 - `DB_TOKEN` - Database auth token (required for remote databases)
-- `ADMIN_PASSWORD` - Admin password (optional, generates random if not set)
+- `ADMIN_PASSWORD` - Additional admin password (optional, works alongside the randomly generated database password)
 - `STRIPE_SECRET_KEY` - Stripe secret key (optional, enables payments when set)
 - `CURRENCY_CODE` - Currency code for payments (defaults to GBP)
 - `PORT` - Server port (defaults to 3000)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -122,16 +122,10 @@ export const setSetting = async (key: string, value: string): Promise<void> => {
 };
 
 /**
- * Get admin password
- * Priority: 1) ADMIN_PASSWORD env var, 2) stored in database, 3) generate new
+ * Get admin password from database (always randomly generated)
+ * The ADMIN_PASSWORD env var is an additional valid password, not a replacement
  */
 export const getOrCreateAdminPassword = async (): Promise<string> => {
-  // Check environment variable first
-  const envPassword = process.env.ADMIN_PASSWORD;
-  if (envPassword && envPassword.trim() !== "") {
-    return envPassword;
-  }
-
   // Check database
   const existing = await getSetting("admin_password");
   if (existing) return existing;
@@ -144,10 +138,18 @@ export const getOrCreateAdminPassword = async (): Promise<string> => {
 
 /**
  * Verify admin password
+ * Accepts either the ADMIN_PASSWORD env var or the database password
  */
 export const verifyAdminPassword = async (
   password: string,
 ): Promise<boolean> => {
+  // Check env var password first
+  const envPassword = process.env.ADMIN_PASSWORD;
+  if (envPassword && envPassword.trim() !== "" && password === envPassword) {
+    return true;
+  }
+
+  // Check database password
   const stored = await getSetting("admin_password");
   return stored === password;
 };

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -111,6 +111,47 @@ describe("db", () => {
       const result = await verifyAdminPassword("wrong");
       expect(result).toBe(false);
     });
+
+    test("verifyAdminPassword returns true for ADMIN_PASSWORD env var", async () => {
+      const originalEnv = process.env.ADMIN_PASSWORD;
+      process.env.ADMIN_PASSWORD = "env-password-123";
+
+      try {
+        await getOrCreateAdminPassword();
+        const result = await verifyAdminPassword("env-password-123");
+        expect(result).toBe(true);
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.ADMIN_PASSWORD = originalEnv;
+        } else {
+          delete process.env.ADMIN_PASSWORD;
+        }
+      }
+    });
+
+    test("verifyAdminPassword accepts both env var and database password", async () => {
+      const originalEnv = process.env.ADMIN_PASSWORD;
+      process.env.ADMIN_PASSWORD = "env-password-123";
+
+      try {
+        const dbPassword = await getOrCreateAdminPassword();
+
+        const envResult = await verifyAdminPassword("env-password-123");
+        expect(envResult).toBe(true);
+
+        const dbResult = await verifyAdminPassword(dbPassword);
+        expect(dbResult).toBe(true);
+
+        const wrongResult = await verifyAdminPassword("wrong");
+        expect(wrongResult).toBe(false);
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.ADMIN_PASSWORD = originalEnv;
+        } else {
+          delete process.env.ADMIN_PASSWORD;
+        }
+      }
+    });
   });
 
   describe("events", () => {


### PR DESCRIPTION
The ADMIN_PASSWORD env var now acts as an additional valid password rather than replacing the randomly generated database password. This allows both passwords to work for admin login.