### PR TITLE
Move config from environment variables to setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,13 @@ const result = reduce((acc, item) => {
 
 ## Environment Variables
 
+Only database connection settings use environment variables:
+
 - `DB_URL` - Database URL (required, e.g. `libsql://your-db.turso.io`)
 - `DB_TOKEN` - Database auth token (required for remote databases)
-- `ADMIN_PASSWORD` - Additional admin password (optional, works alongside the randomly generated database password)
-- `STRIPE_SECRET_KEY` - Stripe secret key (optional, enables payments when set)
-- `CURRENCY_CODE` - Currency code for payments (defaults to GBP)
 - `PORT` - Server port (defaults to 3000)
+
+All other configuration (admin password, Stripe secret key, currency code) is set through the web-based setup page at `/setup/` and stored in the database.
 
 ## Lint Rules
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal ticket reservation system built with Bun and libsql, deployable to Bun
 - Optional Stripe payment integration
 - Admin dashboard with password protection
 - Edge-ready deployment to Bunny CDN
+- Web-based initial setup (no environment variables for config)
 
 ## Quick Start
 
@@ -24,16 +25,27 @@ stripe-mock &
 bun test
 ```
 
+## Initial Setup
+
+On first launch, the application will redirect to `/setup/` where you can configure:
+
+- **Admin Password** - Required for accessing the admin dashboard
+- **Stripe Secret Key** - Optional, enables paid tickets when set
+- **Currency Code** - Currency for payments (default: GBP)
+
+These settings are stored securely in the database, not in environment variables.
+
 ## Environment Variables
+
+Only database connection settings use environment variables:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DB_URL` | Yes | LibSQL database URL (e.g., `libsql://your-db.turso.io`) |
 | `DB_TOKEN` | Yes* | Database auth token (*required for remote databases) |
-| `ADMIN_PASSWORD` | No | Admin login password. If not set, a random password is generated and stored in the database |
-| `STRIPE_SECRET_KEY` | No | Stripe secret key. When set, enables paid tickets |
-| `CURRENCY_CODE` | No | Currency for payments (default: `GBP`) |
 | `PORT` | No | Server port for local development (default: `3000`) |
+
+All other configuration (admin password, Stripe keys, currency) is set through the web-based setup page and stored in the database.
 
 ## Deployment
 
@@ -45,9 +57,6 @@ Add these secrets to your GitHub repository for Bunny Edge deployment:
 |--------|-------------|
 | `DB_URL` | LibSQL database URL |
 | `DB_TOKEN` | Database auth token |
-| `ADMIN_PASSWORD` | Admin password (recommended for production) |
-| `STRIPE_SECRET_KEY` | Stripe secret key (optional) |
-| `CURRENCY_CODE` | Currency code (optional, defaults to GBP) |
 | `BUNNY_SCRIPT_ID` | Bunny Edge script ID |
 | `BUNNY_ACCESS_KEY` | Bunny API access key |
 
@@ -59,6 +68,10 @@ Environment variables are inlined at build time since Bunny Edge doesn't support
 # Build for edge deployment
 bun run build:edge
 ```
+
+### First Deployment
+
+After deploying to Bunny Edge, visit your site URL. You'll be automatically redirected to the setup page to configure your admin password and payment settings.
 
 ## Development
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,30 +1,33 @@
 /**
  * Configuration module for ticket reservation system
- * Reads environment variables with defaults
+ * Reads configuration from database (set during setup phase)
+ * Only DB_URL and DB_TOKEN come from environment variables
  */
 
+import { getCurrencyCodeFromDb, getStripeSecretKeyFromDb } from "./db.ts";
+
 /**
- * Get Stripe secret key from environment
+ * Get Stripe secret key from database
  * Returns null if not set (payments disabled)
  */
-export const getStripeSecretKey = (): string | null => {
-  const key = process.env.STRIPE_SECRET_KEY;
+export const getStripeSecretKey = async (): Promise<string | null> => {
+  const key = await getStripeSecretKeyFromDb();
   return key && key.trim() !== "" ? key : null;
 };
 
 /**
  * Check if Stripe payments are enabled
  */
-export const isPaymentsEnabled = (): boolean => {
-  return getStripeSecretKey() !== null;
+export const isPaymentsEnabled = async (): Promise<boolean> => {
+  return (await getStripeSecretKey()) !== null;
 };
 
 /**
- * Get currency code from environment
+ * Get currency code from database
  * Defaults to GBP if not set
  */
-export const getCurrencyCode = (): string => {
-  return process.env.CURRENCY_CODE || "GBP";
+export const getCurrencyCode = async (): Promise<string> => {
+  return getCurrencyCodeFromDb();
 };
 
 /**
@@ -32,15 +35,6 @@ export const getCurrencyCode = (): string => {
  */
 export const getDbUrl = (): string | undefined => {
   return process.env.DB_URL;
-};
-
-/**
- * Get admin password from environment
- * If not set, a random password will be generated and stored in the database
- */
-export const getAdminPassword = (): string | undefined => {
-  const password = process.env.ADMIN_PASSWORD;
-  return password && password.trim() !== "" ? password : undefined;
 };
 
 /**
@@ -56,3 +50,8 @@ export const getDbToken = (): string | undefined => {
 export const getPort = (): number => {
   return Number.parseInt(process.env.PORT || "3000", 10);
 };
+
+/**
+ * Check if initial setup has been completed
+ */
+export { isSetupComplete } from "./db.ts";

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -139,7 +139,7 @@ export const setSetting = async (key: string, value: string): Promise<void> => {
  */
 export const CONFIG_KEYS = {
   ADMIN_PASSWORD: "admin_password",
-  STRIPE_SECRET_KEY: "stripe_secret_key",
+  STRIPE_KEY: "stripe_key",
   CURRENCY_CODE: "currency_code",
   SETUP_COMPLETE: "setup_complete",
 } as const;
@@ -162,7 +162,7 @@ export const completeSetup = async (
 ): Promise<void> => {
   await setSetting(CONFIG_KEYS.ADMIN_PASSWORD, adminPassword);
   if (stripeSecretKey) {
-    await setSetting(CONFIG_KEYS.STRIPE_SECRET_KEY, stripeSecretKey);
+    await setSetting(CONFIG_KEYS.STRIPE_KEY, stripeSecretKey);
   }
   await setSetting(CONFIG_KEYS.CURRENCY_CODE, currencyCode);
   await setSetting(CONFIG_KEYS.SETUP_COMPLETE, "true");
@@ -172,7 +172,7 @@ export const completeSetup = async (
  * Get Stripe secret key from database
  */
 export const getStripeSecretKeyFromDb = async (): Promise<string | null> => {
-  return getSetting(CONFIG_KEYS.STRIPE_SECRET_KEY);
+  return getSetting(CONFIG_KEYS.STRIPE_KEY);
 };
 
 /**

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -324,3 +324,53 @@ export const paymentErrorPage = (message: string): string =>
     <p><a href="/">Return to home</a></p>
   `,
   );
+
+/**
+ * Initial setup page
+ */
+export const setupPage = (error?: string): string =>
+  layout(
+    "Setup",
+    `
+    <h1>Initial Setup</h1>
+    <p>Welcome! Please configure your ticket reservation system.</p>
+    ${error ? `<div class="error">${escapeHtml(error)}</div>` : ""}
+    <form method="POST" action="/setup/">
+      <div class="form-group">
+        <label for="admin_password">Admin Password *</label>
+        <input type="password" id="admin_password" name="admin_password" required minlength="8">
+        <small style="color: #666; display: block; margin-top: 0.25rem;">Minimum 8 characters</small>
+      </div>
+      <div class="form-group">
+        <label for="admin_password_confirm">Confirm Admin Password *</label>
+        <input type="password" id="admin_password_confirm" name="admin_password_confirm" required>
+      </div>
+      <div class="form-group">
+        <label for="stripe_secret_key">Stripe Secret Key (optional)</label>
+        <input type="password" id="stripe_secret_key" name="stripe_secret_key" placeholder="sk_live_... or sk_test_...">
+        <small style="color: #666; display: block; margin-top: 0.25rem;">Leave empty to disable payments</small>
+      </div>
+      <div class="form-group">
+        <label for="currency_code">Currency Code</label>
+        <input type="text" id="currency_code" name="currency_code" value="GBP" maxlength="3" pattern="[A-Z]{3}" style="width: 100px;">
+        <small style="color: #666; display: block; margin-top: 0.25rem;">3-letter ISO code (e.g., GBP, USD, EUR)</small>
+      </div>
+      <button type="submit">Complete Setup</button>
+    </form>
+  `,
+  );
+
+/**
+ * Setup complete page
+ */
+export const setupCompletePage = (): string =>
+  layout(
+    "Setup Complete",
+    `
+    <h1>Setup Complete!</h1>
+    <div class="success">
+      <p>Your ticket reservation system has been configured successfully.</p>
+    </div>
+    <p><a href="/admin/">Go to Admin Dashboard</a></p>
+  `,
+  );

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -3,7 +3,12 @@
  */
 
 import { createClient } from "@libsql/client";
-import { initDb, setDb } from "../lib/db.ts";
+import { completeSetup, initDb, setDb } from "../lib/db.ts";
+
+/**
+ * Default test admin password
+ */
+export const TEST_ADMIN_PASSWORD = "testpassword123";
 
 /**
  * Create an in-memory database for testing
@@ -12,6 +17,18 @@ export const createTestDb = async (): Promise<void> => {
   const client = createClient({ url: ":memory:" });
   setDb(client);
   await initDb();
+};
+
+/**
+ * Create an in-memory database with setup already completed
+ * This is the common case for most tests
+ */
+export const createTestDbWithSetup = async (
+  stripeKey: string | null = null,
+  currency = "GBP",
+): Promise<void> => {
+  await createTestDb();
+  await completeSetup(TEST_ADMIN_PASSWORD, stripeKey, currency);
 };
 
 /**

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -35,17 +35,17 @@ describe("config", () => {
     });
 
     test("returns null when empty string in database", async () => {
-      await setSetting("stripe_secret_key", "");
+      await setSetting("stripe_key", "");
       expect(await getStripeSecretKey()).toBeNull();
     });
 
     test("returns null when whitespace only in database", async () => {
-      await setSetting("stripe_secret_key", "   ");
+      await setSetting("stripe_key", "   ");
       expect(await getStripeSecretKey()).toBeNull();
     });
 
     test("returns key when set in database", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       expect(await getStripeSecretKey()).toBe("sk_test_123");
     });
   });
@@ -56,7 +56,7 @@ describe("config", () => {
     });
 
     test("returns true when stripe key is set", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       expect(await isPaymentsEnabled()).toBe(true);
     });
   });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -1,72 +1,85 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
-  getAdminPassword,
   getCurrencyCode,
   getDbToken,
   getDbUrl,
   getPort,
   getStripeSecretKey,
   isPaymentsEnabled,
+  isSetupComplete,
 } from "#lib/config.ts";
+import { completeSetup, setSetting } from "#lib/db.ts";
+import { createTestDb, resetDb } from "#test-utils";
 
 describe("config", () => {
   const originalEnv = { ...process.env };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Clear relevant env vars before each test
-    delete process.env.STRIPE_SECRET_KEY;
-    delete process.env.CURRENCY_CODE;
     delete process.env.DB_URL;
     delete process.env.DB_TOKEN;
     delete process.env.PORT;
-    delete process.env.ADMIN_PASSWORD;
+    // Create in-memory db for testing
+    await createTestDb();
   });
 
   afterEach(() => {
+    resetDb();
     // Restore original environment
     process.env = { ...originalEnv };
   });
 
   describe("getStripeSecretKey", () => {
-    test("returns null when not set", () => {
-      expect(getStripeSecretKey()).toBeNull();
+    test("returns null when not set in database", async () => {
+      expect(await getStripeSecretKey()).toBeNull();
     });
 
-    test("returns null when empty string", () => {
-      process.env.STRIPE_SECRET_KEY = "";
-      expect(getStripeSecretKey()).toBeNull();
+    test("returns null when empty string in database", async () => {
+      await setSetting("stripe_secret_key", "");
+      expect(await getStripeSecretKey()).toBeNull();
     });
 
-    test("returns null when whitespace only", () => {
-      process.env.STRIPE_SECRET_KEY = "   ";
-      expect(getStripeSecretKey()).toBeNull();
+    test("returns null when whitespace only in database", async () => {
+      await setSetting("stripe_secret_key", "   ");
+      expect(await getStripeSecretKey()).toBeNull();
     });
 
-    test("returns key when set", () => {
-      process.env.STRIPE_SECRET_KEY = "sk_test_123";
-      expect(getStripeSecretKey()).toBe("sk_test_123");
+    test("returns key when set in database", async () => {
+      await setSetting("stripe_secret_key", "sk_test_123");
+      expect(await getStripeSecretKey()).toBe("sk_test_123");
     });
   });
 
   describe("isPaymentsEnabled", () => {
-    test("returns false when STRIPE_SECRET_KEY not set", () => {
-      expect(isPaymentsEnabled()).toBe(false);
+    test("returns false when stripe key not set", async () => {
+      expect(await isPaymentsEnabled()).toBe(false);
     });
 
-    test("returns true when STRIPE_SECRET_KEY is set", () => {
-      process.env.STRIPE_SECRET_KEY = "sk_test_123";
-      expect(isPaymentsEnabled()).toBe(true);
+    test("returns true when stripe key is set", async () => {
+      await setSetting("stripe_secret_key", "sk_test_123");
+      expect(await isPaymentsEnabled()).toBe(true);
     });
   });
 
   describe("getCurrencyCode", () => {
-    test("returns GBP by default", () => {
-      expect(getCurrencyCode()).toBe("GBP");
+    test("returns GBP by default", async () => {
+      expect(await getCurrencyCode()).toBe("GBP");
     });
 
-    test("returns set value", () => {
-      process.env.CURRENCY_CODE = "USD";
-      expect(getCurrencyCode()).toBe("USD");
+    test("returns set value from database", async () => {
+      await setSetting("currency_code", "USD");
+      expect(await getCurrencyCode()).toBe("USD");
+    });
+  });
+
+  describe("isSetupComplete", () => {
+    test("returns false when setup not complete", async () => {
+      expect(await isSetupComplete()).toBe(false);
+    });
+
+    test("returns true when setup is complete", async () => {
+      await completeSetup("password123", null, "GBP");
+      expect(await isSetupComplete()).toBe(true);
     });
   });
 
@@ -78,27 +91,6 @@ describe("config", () => {
     test("returns set value", () => {
       process.env.DB_URL = "libsql://test.turso.io";
       expect(getDbUrl()).toBe("libsql://test.turso.io");
-    });
-  });
-
-  describe("getAdminPassword", () => {
-    test("returns undefined when not set", () => {
-      expect(getAdminPassword()).toBeUndefined();
-    });
-
-    test("returns undefined when empty string", () => {
-      process.env.ADMIN_PASSWORD = "";
-      expect(getAdminPassword()).toBeUndefined();
-    });
-
-    test("returns undefined when whitespace only", () => {
-      process.env.ADMIN_PASSWORD = "   ";
-      expect(getAdminPassword()).toBeUndefined();
-    });
-
-    test("returns password when set", () => {
-      process.env.ADMIN_PASSWORD = "mysecretpassword";
-      expect(getAdminPassword()).toBe("mysecretpassword");
     });
   });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -123,7 +123,7 @@ describe("db", () => {
 
     test("CONFIG_KEYS contains expected keys", () => {
       expect(CONFIG_KEYS.ADMIN_PASSWORD).toBe("admin_password");
-      expect(CONFIG_KEYS.STRIPE_SECRET_KEY).toBe("stripe_secret_key");
+      expect(CONFIG_KEYS.STRIPE_KEY).toBe("stripe_key");
       expect(CONFIG_KEYS.CURRENCY_CODE).toBe("currency_code");
       expect(CONFIG_KEYS.SETUP_COMPLETE).toBe("setup_complete");
     });

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -1,27 +1,29 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { createClient } from "@libsql/client";
 import {
   createAttendee,
   createEvent,
   createSession,
-  getOrCreateAdminPassword,
   getSession,
-  initDb,
-  setDb,
+  setSetting,
 } from "#lib/db.ts";
 import { resetStripeClient } from "#lib/stripe.ts";
 import { handleRequest } from "#src/server.ts";
-import { mockFormRequest, mockRequest } from "#test-utils";
+import {
+  createTestDb,
+  createTestDbWithSetup,
+  mockFormRequest,
+  mockRequest,
+  resetDb,
+  TEST_ADMIN_PASSWORD,
+} from "#test-utils";
 
 describe("server", () => {
   beforeEach(async () => {
-    const client = createClient({ url: ":memory:" });
-    setDb(client);
-    await initDb();
+    await createTestDbWithSetup();
   });
 
   afterEach(() => {
-    setDb(null);
+    resetDb();
   });
 
   describe("GET /", () => {
@@ -40,6 +42,13 @@ describe("server", () => {
       const json = await response.json();
       expect(json).toEqual({ status: "ok" });
     });
+
+    test("returns 404 for non-GET requests to /health", async () => {
+      const response = await handleRequest(
+        new Request("http://localhost/health", { method: "POST" }),
+      );
+      expect(response.status).toBe(404);
+    });
   });
 
   describe("GET /admin/", () => {
@@ -51,10 +60,10 @@ describe("server", () => {
     });
 
     test("shows dashboard when authenticated", async () => {
-      await getOrCreateAdminPassword();
+      TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", {
-          password: await getOrCreateAdminPassword(),
+          password: TEST_ADMIN_PASSWORD,
         }),
       );
       const cookie = loginResponse.headers.get("set-cookie");
@@ -81,7 +90,7 @@ describe("server", () => {
 
   describe("POST /admin/login", () => {
     test("rejects wrong password", async () => {
-      await getOrCreateAdminPassword();
+      TEST_ADMIN_PASSWORD;
       const response = await handleRequest(
         mockFormRequest("/admin/login", { password: "wrong" }),
       );
@@ -91,7 +100,7 @@ describe("server", () => {
     });
 
     test("accepts correct password and sets cookie", async () => {
-      const password = await getOrCreateAdminPassword();
+      const password = TEST_ADMIN_PASSWORD;
       const response = await handleRequest(
         mockFormRequest("/admin/login", { password }),
       );
@@ -125,7 +134,7 @@ describe("server", () => {
     });
 
     test("creates event when authenticated", async () => {
-      const password = await getOrCreateAdminPassword();
+      const password = TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", { password }),
       );
@@ -155,7 +164,7 @@ describe("server", () => {
     });
 
     test("returns 404 for non-existent event", async () => {
-      const password = await getOrCreateAdminPassword();
+      const password = TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", { password }),
       );
@@ -170,7 +179,7 @@ describe("server", () => {
     });
 
     test("shows event details when authenticated", async () => {
-      const password = await getOrCreateAdminPassword();
+      const password = TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", { password }),
       );
@@ -329,7 +338,7 @@ describe("server", () => {
   describe("logout with valid session", () => {
     test("deletes session from database", async () => {
       // Log in first
-      const password = await getOrCreateAdminPassword();
+      const password = TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", { password }),
       );
@@ -356,7 +365,7 @@ describe("server", () => {
 
   describe("POST /admin/event with unit_price", () => {
     test("creates event with unit_price when authenticated", async () => {
-      const password = await getOrCreateAdminPassword();
+      const password = TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", { password }),
       );
@@ -482,20 +491,15 @@ describe("server", () => {
   describe("ticket purchase with payments enabled", () => {
     // These tests require stripe-mock running on localhost:12111
     // STRIPE_MOCK_HOST/PORT are set in test/setup.ts
-    const originalStripeKey = process.env.STRIPE_SECRET_KEY;
+    // We use CONFIG_KEYS.STRIPE_SECRET_KEY in database instead of env var
 
     afterEach(() => {
       resetStripeClient();
-      if (originalStripeKey) {
-        process.env.STRIPE_SECRET_KEY = originalStripeKey;
-      } else {
-        delete process.env.STRIPE_SECRET_KEY;
-      }
     });
 
     test("handles payment flow error when Stripe fails", async () => {
-      // Set a fake Stripe key to enable payments
-      process.env.STRIPE_SECRET_KEY = "sk_test_fake_key";
+      // Set a fake Stripe key to enable payments (in database)
+      await setSetting("stripe_secret_key", "sk_test_fake_key");
 
       // Create a paid event
       const event = await createEvent(
@@ -521,7 +525,7 @@ describe("server", () => {
     });
 
     test("free ticket still works when payments enabled", async () => {
-      process.env.STRIPE_SECRET_KEY = "sk_test_fake_key";
+      await setSetting("stripe_secret_key", "sk_test_fake_key");
 
       // Create a free event (no price)
       const event = await createEvent(
@@ -547,7 +551,7 @@ describe("server", () => {
     });
 
     test("zero price ticket is treated as free", async () => {
-      process.env.STRIPE_SECRET_KEY = "sk_test_fake_key";
+      await setSetting("stripe_secret_key", "sk_test_fake_key");
 
       // Create event with 0 price
       const event = await createEvent(
@@ -573,7 +577,7 @@ describe("server", () => {
     });
 
     test("redirects to Stripe checkout with stripe-mock", async () => {
-      process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+      await setSetting("stripe_secret_key", "sk_test_mock");
 
       const event = await createEvent(
         "Paid Event",
@@ -637,7 +641,7 @@ describe("server", () => {
     });
 
     test("handles successful payment verification with stripe-mock", async () => {
-      process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+      await setSetting("stripe_secret_key", "sk_test_mock");
 
       const event = await createEvent(
         "Paid Event",
@@ -677,7 +681,7 @@ describe("server", () => {
       } as Awaited<ReturnType<typeof stripeModule.retrieveCheckoutSession>>);
 
       try {
-        process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+        await setSetting("stripe_secret_key", "sk_test_mock");
 
         const event = await createEvent(
           "Paid Event",
@@ -710,6 +714,160 @@ describe("server", () => {
       } finally {
         mockRetrieve.mockRestore();
       }
+    });
+  });
+
+  describe("setup routes", () => {
+    describe("when setup not complete", () => {
+      beforeEach(async () => {
+        // Use a fresh db without setup
+        resetDb();
+        await createTestDb();
+      });
+
+      test("redirects home to /setup/", async () => {
+        const response = await handleRequest(mockRequest("/"));
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe("/setup/");
+      });
+
+      test("redirects admin to /setup/", async () => {
+        const response = await handleRequest(mockRequest("/admin/"));
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe("/setup/");
+      });
+
+      test("health check still works", async () => {
+        const response = await handleRequest(mockRequest("/health"));
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json).toEqual({ status: "ok" });
+      });
+
+      test("GET /setup/ shows setup page", async () => {
+        const response = await handleRequest(mockRequest("/setup/"));
+        expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain("Initial Setup");
+        expect(html).toContain("Admin Password");
+        expect(html).toContain("Stripe Secret Key");
+      });
+
+      test("GET /setup (without trailing slash) shows setup page", async () => {
+        const response = await handleRequest(mockRequest("/setup"));
+        expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain("Initial Setup");
+      });
+
+      test("POST /setup/ with valid data completes setup", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "mypassword123",
+            admin_password_confirm: "mypassword123",
+            stripe_secret_key: "sk_test_123",
+            currency_code: "USD",
+          }),
+        );
+        expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain("Setup Complete");
+      });
+
+      test("POST /setup/ with mismatched passwords shows error", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "mypassword123",
+            admin_password_confirm: "different",
+            currency_code: "GBP",
+          }),
+        );
+        expect(response.status).toBe(400);
+        const html = await response.text();
+        expect(html).toContain("Passwords do not match");
+      });
+
+      test("POST /setup/ with short password shows error", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "short",
+            admin_password_confirm: "short",
+            currency_code: "GBP",
+          }),
+        );
+        expect(response.status).toBe(400);
+        const html = await response.text();
+        expect(html).toContain("at least 8 characters");
+      });
+
+      test("POST /setup/ with invalid currency shows error", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "mypassword123",
+            admin_password_confirm: "mypassword123",
+            currency_code: "INVALID",
+          }),
+        );
+        expect(response.status).toBe(400);
+        const html = await response.text();
+        expect(html).toContain("Currency code must be 3 uppercase letters");
+      });
+
+      test("POST /setup/ without stripe key still works", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "mypassword123",
+            admin_password_confirm: "mypassword123",
+            stripe_secret_key: "",
+            currency_code: "GBP",
+          }),
+        );
+        expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain("Setup Complete");
+      });
+
+      test("POST /setup/ normalizes lowercase currency to uppercase", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "mypassword123",
+            admin_password_confirm: "mypassword123",
+            currency_code: "usd",
+          }),
+        );
+        expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain("Setup Complete");
+      });
+
+      test("PUT /setup/ redirects to /setup/ (unsupported method)", async () => {
+        const response = await handleRequest(
+          new Request("http://localhost/setup/", { method: "PUT" }),
+        );
+        // PUT method falls through routeSetup (returns null), then redirects to /setup/
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe("/setup/");
+      });
+    });
+
+    describe("when setup already complete", () => {
+      test("GET /setup/ redirects to home", async () => {
+        const response = await handleRequest(mockRequest("/setup/"));
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe("/");
+      });
+
+      test("POST /setup/ redirects to home", async () => {
+        const response = await handleRequest(
+          mockFormRequest("/setup/", {
+            admin_password: "newpassword123",
+            admin_password_confirm: "newpassword123",
+            currency_code: "EUR",
+          }),
+        );
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe("/");
+      });
     });
   });
 });

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -499,7 +499,7 @@ describe("server", () => {
 
     test("handles payment flow error when Stripe fails", async () => {
       // Set a fake Stripe key to enable payments (in database)
-      await setSetting("stripe_secret_key", "sk_test_fake_key");
+      await setSetting("stripe_key", "sk_test_fake_key");
 
       // Create a paid event
       const event = await createEvent(
@@ -525,7 +525,7 @@ describe("server", () => {
     });
 
     test("free ticket still works when payments enabled", async () => {
-      await setSetting("stripe_secret_key", "sk_test_fake_key");
+      await setSetting("stripe_key", "sk_test_fake_key");
 
       // Create a free event (no price)
       const event = await createEvent(
@@ -551,7 +551,7 @@ describe("server", () => {
     });
 
     test("zero price ticket is treated as free", async () => {
-      await setSetting("stripe_secret_key", "sk_test_fake_key");
+      await setSetting("stripe_key", "sk_test_fake_key");
 
       // Create event with 0 price
       const event = await createEvent(
@@ -577,7 +577,7 @@ describe("server", () => {
     });
 
     test("redirects to Stripe checkout with stripe-mock", async () => {
-      await setSetting("stripe_secret_key", "sk_test_mock");
+      await setSetting("stripe_key", "sk_test_mock");
 
       const event = await createEvent(
         "Paid Event",
@@ -641,7 +641,7 @@ describe("server", () => {
     });
 
     test("handles successful payment verification with stripe-mock", async () => {
-      await setSetting("stripe_secret_key", "sk_test_mock");
+      await setSetting("stripe_key", "sk_test_mock");
 
       const event = await createEvent(
         "Paid Event",
@@ -681,7 +681,7 @@ describe("server", () => {
       } as Awaited<ReturnType<typeof stripeModule.retrieveCheckoutSession>>);
 
       try {
-        await setSetting("stripe_secret_key", "sk_test_mock");
+        await setSetting("stripe_key", "sk_test_mock");
 
         const event = await createEvent(
           "Paid Event",

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -32,13 +32,13 @@ describe("stripe", () => {
     });
 
     test("returns client when stripe key is set in database", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       const client = await getStripeClient();
       expect(client).not.toBeNull();
     });
 
     test("returns same client on subsequent calls", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       const client1 = await getStripeClient();
       const client2 = await getStripeClient();
       expect(client1).toBe(client2);
@@ -47,7 +47,7 @@ describe("stripe", () => {
 
   describe("resetStripeClient", () => {
     test("resets client to null", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       const client1 = await getStripeClient();
       expect(client1).not.toBeNull();
 
@@ -91,7 +91,7 @@ describe("stripe", () => {
     });
 
     test("returns null for invalid signature", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       const result = await verifyWebhookSignature(
         "invalid_payload",
         "invalid_signature",
@@ -111,7 +111,7 @@ describe("stripe", () => {
       const { spyOn } = await import("bun:test");
 
       // Enable Stripe with mock
-      await setSetting("stripe_secret_key", "sk_test_mock");
+      await setSetting("stripe_key", "sk_test_mock");
       const client = await getStripeClient();
       if (!client) throw new Error("Expected client to be defined");
 
@@ -159,7 +159,7 @@ describe("stripe", () => {
     });
 
     test("returns null when unit_price is null", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       const event = {
         id: 1,
         name: "Test",
@@ -189,7 +189,7 @@ describe("stripe", () => {
   describe("mock configuration", () => {
     test("creates client with mock config when STRIPE_MOCK_HOST is set", async () => {
       // This test exercises the getMockConfig code path
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       process.env.STRIPE_MOCK_HOST = "localhost";
       process.env.STRIPE_MOCK_PORT = "12111";
 
@@ -199,7 +199,7 @@ describe("stripe", () => {
     });
 
     test("uses default port 12111 when STRIPE_MOCK_PORT not set", async () => {
-      await setSetting("stripe_secret_key", "sk_test_123");
+      await setSetting("stripe_key", "sk_test_123");
       process.env.STRIPE_MOCK_HOST = "localhost";
       delete process.env.STRIPE_MOCK_PORT;
 
@@ -213,7 +213,7 @@ describe("stripe", () => {
     // STRIPE_MOCK_HOST/PORT are set in test/setup.ts
 
     test("creates checkout session with stripe-mock", async () => {
-      await setSetting("stripe_secret_key", "sk_test_mock");
+      await setSetting("stripe_key", "sk_test_mock");
 
       const event = {
         id: 1,
@@ -245,7 +245,7 @@ describe("stripe", () => {
     });
 
     test("retrieves checkout session with stripe-mock", async () => {
-      await setSetting("stripe_secret_key", "sk_test_mock");
+      await setSetting("stripe_key", "sk_test_mock");
 
       // First create a session
       const event = {


### PR DESCRIPTION
Move configuration from environment variables to database storage:
- Admin password, Stripe secret key, and currency code are now set through a web-based setup page at /setup/
- Only DB_URL and DB_TOKEN remain as environment variables
- All routes redirect to /setup/ until configuration is complete
- Health check endpoint remains accessible without setup

Changes:
- db.ts: Add setup detection and config storage functions
- config.ts: Read config from database instead of env vars
- stripe.ts: Update to use async config functions
- server.ts: Add setup routes and gate all routes behind setup check
- html.ts: Add setup page and setup complete page templates
- test-utils: Add createTestDbWithSetup helper for tests
- Update all tests to work with new async config and setup flow
- Update README and CLAUDE.md documentation