### PR TITLE
Add CORS protection and iframe embedding controls

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -59,6 +59,7 @@ export const mockFormRequest = (
   const body = new URLSearchParams(data).toString();
   const headers: HeadersInit = {
     "content-type": "application/x-www-form-urlencoded",
+    origin: "http://localhost",
   };
   if (cookie) {
     headers.cookie = cookie;
@@ -66,6 +67,25 @@ export const mockFormRequest = (
   return new Request(`http://localhost${path}`, {
     method: "POST",
     headers,
+    body,
+  });
+};
+
+/**
+ * Create a mock cross-origin POST request with form data
+ */
+export const mockCrossOriginFormRequest = (
+  path: string,
+  data: Record<string, string>,
+  origin = "http://evil.com",
+): Request => {
+  const body = new URLSearchParams(data).toString();
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      origin,
+    },
     body,
   });
 };


### PR DESCRIPTION
- Add security headers to all responses (X-Content-Type-Options, Referrer-Policy)
- Add X-Frame-Options: DENY and frame-ancestors CSP to prevent clickjacking
- Make ticket pages (/ticket/:id) embeddable by excluding them from frame restrictions
- Add CORS protection for POST requests by validating Origin/Referer headers
- Reject cross-origin POST requests with 403 Forbidden