### PR TITLE
Add admin password change functionality with session invalidation

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -240,6 +240,18 @@ export const verifyAdminPassword = async (
 };
 
 /**
+ * Update admin password and invalidate all existing sessions
+ * Passwords are hashed using Argon2id before storage
+ */
+export const updateAdminPassword = async (
+  newPassword: string,
+): Promise<void> => {
+  const hashedPassword = await Bun.password.hash(newPassword);
+  await setSetting(CONFIG_KEYS.ADMIN_PASSWORD, hashedPassword);
+  await deleteAllSessions();
+};
+
+/**
  * Create a new event
  */
 export const createEvent = async (
@@ -453,6 +465,13 @@ export const deleteExpiredSessions = async (): Promise<void> => {
     sql: "DELETE FROM sessions WHERE expires < ?",
     args: [Date.now()],
   });
+};
+
+/**
+ * Delete all sessions (used when password is changed)
+ */
+export const deleteAllSessions = async (): Promise<void> => {
+  await getDb().execute("DELETE FROM sessions");
 };
 
 /**

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -132,7 +132,7 @@ export const adminDashboardPage = (
     "Admin Dashboard",
     `
     <h1>Admin Dashboard</h1>
-    <p><a href="/admin/logout">Logout</a></p>
+    <p><a href="/admin/settings">Settings</a> | <a href="/admin/logout">Logout</a></p>
 
     <h2>Events</h2>
     <table>
@@ -529,5 +529,57 @@ export const setupCompletePage = (): string =>
       <p>Your ticket reservation system has been configured successfully.</p>
     </div>
     <p><a href="/admin/">Go to Admin Dashboard</a></p>
+  `,
+  );
+
+/**
+ * Change password form field definitions
+ */
+export const changePasswordFields: Field[] = [
+  {
+    name: "current_password",
+    label: "Current Password",
+    type: "password",
+    required: true,
+  },
+  {
+    name: "new_password",
+    label: "New Password",
+    type: "password",
+    required: true,
+    hint: "Minimum 8 characters",
+  },
+  {
+    name: "new_password_confirm",
+    label: "Confirm New Password",
+    type: "password",
+    required: true,
+  },
+];
+
+/**
+ * Admin settings page
+ */
+export const adminSettingsPage = (
+  csrfToken: string,
+  error?: string,
+  success?: string,
+): string =>
+  layout(
+    "Admin Settings",
+    `
+    <h1>Admin Settings</h1>
+    <p><a href="/admin/">&larr; Back to Dashboard</a></p>
+
+    ${error ? `<div class="error">${escapeHtml(error)}</div>` : ""}
+    ${success ? `<div class="success">${escapeHtml(success)}</div>` : ""}
+
+    <h2>Change Password</h2>
+    <p>Changing your password will log you out of all sessions.</p>
+    <form method="POST" action="/admin/settings">
+      <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
+      ${renderFields(changePasswordFields)}
+      <button type="submit">Change Password</button>
+    </form>
   `,
   );


### PR DESCRIPTION
## Summary
This PR adds a new admin settings page that allows administrators to change their password. When a password is changed, all existing sessions are automatically invalidated, forcing the admin to log in again with their new credentials.

## Key Changes

- **Database Functions** (`src/lib/db.ts`):
  - Added `updateAdminPassword()` to hash and store new password, then invalidate all sessions
  - Added `deleteAllSessions()` to clear all active sessions (used when password changes)

- **UI Components** (`src/lib/html.ts`):
  - Added `changePasswordFields` form field definitions with validation hints
  - Added `adminSettingsPage()` to render the settings interface
  - Updated admin dashboard to include link to settings page

- **Server Routes** (`src/server.ts`):
  - Added `GET /admin/settings` handler to display the settings form
  - Added `POST /admin/settings` handler to process password changes
  - Implemented comprehensive validation: CSRF token, required fields, password length (8+ chars), password confirmation match, and current password verification
  - Session is cleared after successful password change, redirecting to login

- **Tests** (`test/lib/db.test.ts` and `test/lib/server.test.ts`):
  - Added tests for `deleteAllSessions()` functionality
  - Added tests for `updateAdminPassword()` including password update and session invalidation
  - Added comprehensive tests for both GET and POST `/admin/settings` endpoints covering authentication, validation, error cases, and successful password changes

## Implementation Details

- Password validation requires minimum 8 characters and confirmation match
- Current password must be verified before allowing the change
- All sessions are invalidated immediately after password update for security
- CSRF protection is enforced on the settings form
- Error messages are displayed on the settings page for failed attempts
- Successful password change redirects to login with session cookie cleared