### PR TITLE
Replace Bun.password with scrypt for browser-compatible hashing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "test-searcher",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
         "stripe": "^17.0.0",
       },
       "devDependencies": {
@@ -71,6 +72,8 @@
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
+
+    "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, ""],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@noble/ciphers": "^2.1.1",
+    "@noble/hashes": "^2.0.1",
     "stripe": "^17.0.0"
   },
   "devDependencies": {

--- a/test/lib/jsx-runtime.test.ts
+++ b/test/lib/jsx-runtime.test.ts
@@ -76,7 +76,8 @@ describe("jsx-runtime", () => {
     });
 
     test("passes props to component", () => {
-      const Component = ({ name }: { name?: string }) => `Hello ${name}`;
+      const Component = (props: Record<string, unknown>) =>
+        `Hello ${props.name}`;
       const result = jsx(Component, { name: "World" });
       expect(result.toString()).toBe("Hello World");
     });


### PR DESCRIPTION
## Summary
Replace Bun-specific password hashing (`Bun.password.hash` and `Bun.password.verify`) with a browser-compatible scrypt implementation using `@noble/hashes`. This improves portability and allows the password hashing logic to work in non-Bun environments.

## Key Changes
- **Dependencies**: Added `@noble/hashes@^2.0.1` to support scrypt password hashing
- **Crypto module**: Implemented `hashPassword()` and `verifyPassword()` functions using scrypt with:
  - N=2^14 (CPU/memory cost)
  - r=8 (block size)
  - p=1 (parallelization)
  - 32-byte output length
  - Custom format: `scrypt:N:r:p:$base64salt:$base64hash`
  - Constant-time comparison to prevent timing attacks
- **Database module**: Updated `completeSetup()`, `verifyAdminPassword()`, and `updateAdminPassword()` to use the new scrypt functions instead of `Bun.password` APIs
- **Tests**: Added comprehensive test coverage for password hashing and verification, including edge cases (wrong password, invalid format, malformed hash, length mismatch)
- **Minor fix**: Updated JSX runtime test to use generic props typing for better compatibility

## Implementation Details
- Passwords are hashed with a random 16-byte salt generated using `randomBytes()`
- The hash format includes all scrypt parameters, allowing future algorithm parameter updates
- Verification uses constant-time comparison to prevent timing-based attacks
- All operations are async and browser-compatible (uses `TextEncoder` and `btoa`/`atob`)