### PR TITLE
Optimize scrypt hashing performance in tests

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -20,9 +20,11 @@ export const TEST_ENCRYPTION_KEY =
 
 /**
  * Set up test encryption key in environment
+ * Also enables fast scrypt hashing for tests
  */
 export const setupTestEncryptionKey = (): void => {
   process.env.DB_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  process.env.TEST_SCRYPT_N = "1"; // Enable fast password hashing for tests
   clearEncryptionKeyCache();
 };
 
@@ -31,6 +33,7 @@ export const setupTestEncryptionKey = (): void => {
  */
 export const clearTestEncryptionKey = (): void => {
   delete process.env.DB_ENCRYPTION_KEY;
+  delete process.env.TEST_SCRYPT_N;
   clearEncryptionKeyCache();
 };
 


### PR DESCRIPTION
## Summary
Reduce test execution time by using a lower scrypt cost parameter during testing while maintaining production-grade security parameters in production.

## Changes
- **Scrypt parameter configuration**: Split `SCRYPT_N` into `SCRYPT_N_DEFAULT` (2^14 for production) and `SCRYPT_N_TEST` (2^1 for tests)
- **Dynamic cost selection**: Added `getScryptN()` function that returns the appropriate cost parameter based on the `TEST_SCRYPT_N` environment variable
- **Test setup integration**: Updated `setupTestEncryptionKey()` to enable fast scrypt hashing by setting `TEST_SCRYPT_N=1`
- **Test cleanup**: Updated `clearTestEncryptionKey()` to properly clean up the `TEST_SCRYPT_N` environment variable

## Implementation Details
- The scrypt N parameter directly impacts password hashing speed (exponential cost)
- Using 2^1 instead of 2^14 provides ~8000x faster hashing in tests while maintaining identical hash format and verification logic
- The hash format string now uses the dynamic `N` value, ensuring test hashes are properly formatted with their actual cost parameter
- No changes to production code paths—the optimization only applies when `TEST_SCRYPT_N` is explicitly set