### PR TITLE
Add SVG favicon endpoint at /favicon.ico

### DIFF
--- a/src/routes/favicon.ts
+++ b/src/routes/favicon.ts
@@ -1,0 +1,15 @@
+/**
+ * Favicon route - serves SVG favicon
+ */
+
+const FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5"><path d="M22 8.879c-.067-1.542-.254-2.546-.78-3.34a4.7 4.7 0 0 0-1.109-1.174C18.945 3.5 17.3 3.5 14.008 3.5H9.993c-3.291 0-4.937 0-6.103.865c-.432.32-.807.717-1.11 1.174c-.525.794-.712 1.798-.78 3.34c-.01.263.216.465.465.465c1.386 0 2.51 1.189 2.51 2.656s-1.124 2.656-2.51 2.656c-.249 0-.476.202-.464.466c.067 1.541.254 2.545.78 3.34a4.7 4.7 0 0 0 1.109 1.173c1.166.865 2.812.865 6.103.865h4.015c3.291 0 4.937 0 6.103-.865c.432-.32.807-.717 1.11-1.174c.525-.794.712-1.798.779-3.34z"/><path stroke-linecap="round" d="M13 12h4m-8 4h8"/></g></svg>`;
+
+/**
+ * Handle favicon request
+ */
+export const handleFavicon = (method: string): Response | null => {
+  if (method !== "GET") return null;
+  return new Response(FAVICON_SVG, {
+    headers: { "content-type": "image/svg+xml" },
+  });
+};

--- a/src/routes/favicon.ts
+++ b/src/routes/favicon.ts
@@ -2,14 +2,11 @@
  * Favicon route - serves SVG favicon
  */
 
+import { staticGetRoute } from "./utils.ts";
+
 const FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5"><path d="M22 8.879c-.067-1.542-.254-2.546-.78-3.34a4.7 4.7 0 0 0-1.109-1.174C18.945 3.5 17.3 3.5 14.008 3.5H9.993c-3.291 0-4.937 0-6.103.865c-.432.32-.807.717-1.11 1.174c-.525.794-.712 1.798-.78 3.34c-.01.263.216.465.465.465c1.386 0 2.51 1.189 2.51 2.656s-1.124 2.656-2.51 2.656c-.249 0-.476.202-.464.466c.067 1.541.254 2.545.78 3.34a4.7 4.7 0 0 0 1.109 1.173c1.166.865 2.812.865 6.103.865h4.015c3.291 0 4.937 0 6.103-.865c.432-.32.807-.717 1.11-1.174c.525-.794.712-1.798.779-3.34z"/><path stroke-linecap="round" d="M13 12h4m-8 4h8"/></g></svg>`;
 
 /**
  * Handle favicon request
  */
-export const handleFavicon = (method: string): Response | null => {
-  if (method !== "GET") return null;
-  return new Response(FAVICON_SVG, {
-    headers: { "content-type": "image/svg+xml" },
-  });
-};
+export const handleFavicon = staticGetRoute(FAVICON_SVG, "image/svg+xml");

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -2,12 +2,12 @@
  * Health check route
  */
 
+import { staticGetRoute } from "./utils.ts";
+
 /**
  * Handle health check request
  */
-export const handleHealthCheck = (method: string): Response | null => {
-  if (method !== "GET") return null;
-  return new Response(JSON.stringify({ status: "ok" }), {
-    headers: { "content-type": "application/json" },
-  });
-};
+export const handleHealthCheck = staticGetRoute(
+  JSON.stringify({ status: "ok" }),
+  "application/json",
+);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@
 import { isSetupComplete } from "#lib/config.ts";
 import { notFoundPage } from "#templates";
 import { routeAdmin } from "./admin.ts";
+import { handleFavicon } from "./favicon.ts";
 import { handleHealthCheck } from "./health.ts";
 import {
   applySecurityHeaders,
@@ -57,6 +58,15 @@ const routeMainApp = async (
 };
 
 /**
+ * Route static assets (health check, favicon) - always available
+ */
+const routeStatic = (path: string, method: string): Response | null => {
+  if (path === "/health") return handleHealthCheck(method);
+  if (path === "/favicon.ico") return handleFavicon(method);
+  return null;
+};
+
+/**
  * Handle incoming requests (internal, without security headers)
  */
 const handleRequestInternal = async (
@@ -65,11 +75,9 @@ const handleRequestInternal = async (
 ): Promise<Response> => {
   const { path, method } = parseRequest(request);
 
-  // Health check always available
-  if (path === "/health") {
-    const healthResponse = handleHealthCheck(method);
-    if (healthResponse) return healthResponse;
-  }
+  // Static routes always available
+  const staticResponse = routeStatic(path, method);
+  if (staticResponse) return staticResponse;
 
   // Setup routes
   const setupResponse = await routeSetup(

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -99,6 +99,16 @@ export const htmlResponse = (html: string, status = 200): Response =>
   });
 
 /**
+ * Create a GET-only route handler for static content
+ */
+export const staticGetRoute =
+  (body: string, contentType: string) =>
+  (method: string): Response | null =>
+    method === "GET"
+      ? new Response(body, { headers: { "content-type": contentType } })
+      : null;
+
+/**
  * Create redirect response
  */
 export const redirect = (url: string, cookie?: string): Response => {

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -62,6 +62,30 @@ describe("server", () => {
     });
   });
 
+  describe("GET /favicon.ico", () => {
+    test("returns SVG favicon", async () => {
+      const response = await handleRequest(mockRequest("/favicon.ico"));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("image/svg+xml");
+      const svg = await response.text();
+      expect(svg).toContain("<svg");
+      expect(svg).toContain("viewBox");
+    });
+
+    test("returns 404 for non-GET requests to /favicon.ico", async () => {
+      const response = await handleRequest(
+        new Request("http://localhost/favicon.ico", {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            origin: "http://localhost",
+          },
+        }),
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe("GET /admin/", () => {
     test("shows login page when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/"));


### PR DESCRIPTION
## Summary
This PR adds a dedicated favicon route that serves an SVG favicon at `/favicon.ico`. The favicon is always available regardless of authentication or setup status, and only responds to GET requests.

## Changes
- **New favicon route** (`src/routes/favicon.ts`): Created a new route handler that serves an inline SVG favicon with proper `image/svg+xml` content type
- **Route integration** (`src/routes/index.ts`): Integrated the favicon handler into the main request routing logic, positioned early in the request pipeline to ensure it's always accessible
- **Test coverage** (`test/lib/server.test.ts`): Added comprehensive tests verifying:
  - GET requests return 200 with correct SVG content and headers
  - Non-GET requests (e.g., POST) return 404

## Implementation Details
- The favicon is an inline SVG embedded directly in the route handler, eliminating the need for a separate file
- The route is checked early in the request pipeline, before setup and authentication checks, ensuring it's always available
- Only GET requests are handled; other HTTP methods fall through to the standard 404 handling
- The SVG uses `currentColor` for the stroke, allowing it to adapt to different color schemes