### PR TITLE
Add support for bulk ticket purchases with quantity selection

### DIFF
--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -61,6 +61,16 @@ export const initDb = async (): Promise<void> => {
   // Migration: add stripe_payment_id column if it doesn't exist (for existing databases)
   await runMigration("ALTER TABLE attendees ADD COLUMN stripe_payment_id TEXT");
 
+  // Migration: add quantity column to attendees (default 1 for existing records)
+  await runMigration(
+    "ALTER TABLE attendees ADD COLUMN quantity INTEGER NOT NULL DEFAULT 1",
+  );
+
+  // Migration: add max_quantity column to events (default 1 for existing records)
+  await runMigration(
+    "ALTER TABLE events ADD COLUMN max_quantity INTEGER NOT NULL DEFAULT 1",
+  );
+
   // Create sessions table
   await client.execute(`
     CREATE TABLE IF NOT EXISTS sessions (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export interface Event {
   max_attendees: number;
   thank_you_url: string;
   unit_price: number | null;
+  max_quantity: number;
 }
 
 export interface Attendee {
@@ -19,6 +20,7 @@ export interface Attendee {
   email: string;
   created: string;
   stripe_payment_id: string | null;
+  quantity: number;
 }
 
 export interface Settings {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -95,6 +95,7 @@ const extractEventInput = (values: Record<string, unknown>): EventInput => ({
   maxAttendees: values.max_attendees as number,
   thankYouUrl: values.thank_you_url as string,
   unitPrice: values.unit_price as number | null,
+  maxQuantity: values.max_quantity as number,
 });
 
 /** Attendee type */

--- a/src/templates/admin.tsx
+++ b/src/templates/admin.tsx
@@ -88,6 +88,7 @@ const AttendeeRow = ({ a }: { a: Attendee }): string =>
     <tr>
       <td>{a.name}</td>
       <td>{a.email}</td>
+      <td>{a.quantity}</td>
       <td>{new Date(a.created).toLocaleString()}</td>
     </tr>
   );
@@ -102,7 +103,7 @@ export const adminEventPage = (
   const attendeeRows =
     attendees.length > 0
       ? pipe(map((a: Attendee) => AttendeeRow({ a })), joinStrings)(attendees)
-      : '<tr><td colspan="3">No attendees yet</td></tr>';
+      : '<tr><td colspan="4">No attendees yet</td></tr>';
 
   return String(
     <Layout title={`Event: ${event.name}`}>
@@ -115,7 +116,8 @@ export const adminEventPage = (
       <h2>Event Details</h2>
       <p><strong>Description:</strong> {event.description}</p>
       <p><strong>Max Attendees:</strong> {event.max_attendees}</p>
-      <p><strong>Current Attendees:</strong> {event.attendee_count}</p>
+      <p><strong>Max Tickets Per Purchase:</strong> {event.max_quantity}</p>
+      <p><strong>Tickets Sold:</strong> {event.attendee_count}</p>
       <p><strong>Spots Remaining:</strong> {event.max_attendees - event.attendee_count}</p>
       <p>
         <strong>Thank You URL:</strong>{" "}
@@ -140,6 +142,7 @@ export const adminEventPage = (
           <tr>
             <th>Name</th>
             <th>Email</th>
+            <th>Qty</th>
             <th>Registered</th>
           </tr>
         </thead>
@@ -158,6 +161,7 @@ const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   name: event.name,
   description: event.description,
   max_attendees: event.max_attendees,
+  max_quantity: event.max_quantity,
   unit_price: event.unit_price,
   thank_you_url: event.thank_you_url,
 });

--- a/src/templates/csv.ts
+++ b/src/templates/csv.ts
@@ -19,12 +19,13 @@ const escapeCsvValue = (value: string): string => {
  * Generate CSV content from attendees
  */
 export const generateAttendeesCsv = (attendees: Attendee[]): string => {
-  const header = "Name,Email,Registered";
+  const header = "Name,Email,Quantity,Registered";
   const rows = pipe(
     map((a: Attendee) =>
       [
         escapeCsvValue(a.name),
         escapeCsvValue(a.email),
+        String(a.quantity),
         escapeCsvValue(new Date(a.created).toISOString()),
       ].join(","),
     ),

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -71,6 +71,14 @@ export const eventFields: Field[] = [
     min: 1,
   },
   {
+    name: "max_quantity",
+    label: "Max Tickets Per Purchase",
+    type: "number",
+    required: true,
+    min: 1,
+    hint: "Maximum tickets a customer can buy in one transaction",
+  },
+  {
     name: "unit_price",
     label: "Ticket Price (in pence/cents, leave empty for free)",
     type: "number",

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -21,11 +21,21 @@ export const homePage = (): string =>
   );
 
 /**
+ * Build quantity select options
+ */
+const quantityOptions = (max: number): string =>
+  Array.from({ length: max }, (_, i) => i + 1)
+    .map((n) => `<option value="${n}">${n}</option>`)
+    .join("");
+
+/**
  * Public ticket page
  */
 export const ticketPage = (event: EventWithCount, error?: string): string => {
   const spotsRemaining = event.max_attendees - event.attendee_count;
   const isFull = spotsRemaining <= 0;
+  const maxPurchasable = Math.min(event.max_quantity, spotsRemaining);
+  const showQuantity = maxPurchasable > 1;
 
   return String(
     <Layout title={`Reserve Ticket: ${event.name}`}>
@@ -40,7 +50,17 @@ export const ticketPage = (event: EventWithCount, error?: string): string => {
       ) : (
         <form method="POST" action={`/ticket/${event.id}`}>
           <Raw html={renderFields(ticketFields)} />
-          <button type="submit">Reserve Ticket</button>
+          {showQuantity ? (
+            <div class="field">
+              <label for="quantity">Number of Tickets</label>
+              <select name="quantity" id="quantity">
+                <Raw html={quantityOptions(maxPurchasable)} />
+              </select>
+            </div>
+          ) : (
+            <input type="hidden" name="quantity" value="1" />
+          )}
+          <button type="submit">Reserve Ticket{showQuantity ? "s" : ""}</button>
         </form>
       )}
     </Layout>

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -297,6 +297,7 @@ describe("forms", () => {
         name: "Event",
         description: "Desc",
         max_attendees: "100",
+        max_quantity: "1",
         thank_you_url: "javascript:alert(1)",
       });
       const result = validateForm(form, eventFields);
@@ -311,6 +312,7 @@ describe("forms", () => {
         name: "Event",
         description: "Desc",
         max_attendees: "100",
+        max_quantity: "1",
         thank_you_url: "not-a-valid-url",
       });
       const result = validateForm(form, eventFields);
@@ -325,6 +327,7 @@ describe("forms", () => {
         name: "Event",
         description: "Desc",
         max_attendees: "100",
+        max_quantity: "1",
         thank_you_url: "/thank-you",
       });
       const result = validateForm(form, eventFields);
@@ -336,6 +339,7 @@ describe("forms", () => {
         name: "Event",
         description: "Desc",
         max_attendees: "100",
+        max_quantity: "1",
         thank_you_url: "https://example.com",
         unit_price: "-100",
       });

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -490,6 +490,7 @@ describe("server", () => {
           name: "Test",
           description: "Desc",
           max_attendees: "100",
+          max_quantity: "1",
           thank_you_url: "https://example.com",
         }),
       );
@@ -512,6 +513,7 @@ describe("server", () => {
             name: "New Event",
             description: "Description",
             max_attendees: "50",
+            max_quantity: "1",
             thank_you_url: "https://example.com/thanks",
             csrf_token: csrfToken || "",
           },
@@ -536,6 +538,7 @@ describe("server", () => {
             name: "New Event",
             description: "Description",
             max_attendees: "50",
+            max_quantity: "1",
             thank_you_url: "https://example.com/thanks",
             csrf_token: "invalid-csrf-token",
           },
@@ -724,7 +727,7 @@ describe("server", () => {
         }),
       );
       const csv = await response.text();
-      expect(csv).toContain("Name,Email,Registered");
+      expect(csv).toContain("Name,Email,Quantity,Registered");
       expect(csv).toContain("John Doe");
       expect(csv).toContain("john@example.com");
       expect(csv).toContain("Jane Smith");
@@ -829,6 +832,7 @@ describe("server", () => {
           name: "Updated",
           description: "Updated Desc",
           max_attendees: "50",
+          max_quantity: "1",
           thank_you_url: "https://example.com/updated",
         }),
       );
@@ -851,6 +855,7 @@ describe("server", () => {
             name: "Updated",
             description: "Updated Desc",
             max_attendees: "50",
+            max_quantity: "1",
             thank_you_url: "https://example.com/updated",
             csrf_token: csrfToken || "",
           },
@@ -881,6 +886,7 @@ describe("server", () => {
             name: "Updated",
             description: "Updated Desc",
             max_attendees: "50",
+            max_quantity: "1",
             thank_you_url: "https://example.com/updated",
             csrf_token: "invalid-token",
           },
@@ -914,6 +920,7 @@ describe("server", () => {
             name: "",
             description: "Desc",
             max_attendees: "50",
+            max_quantity: "1",
             thank_you_url: "https://example.com",
             csrf_token: csrfToken || "",
           },
@@ -947,6 +954,7 @@ describe("server", () => {
             name: "Updated Event",
             description: "Updated Description",
             max_attendees: "200",
+            max_quantity: "5",
             thank_you_url: "https://example.com/updated",
             unit_price: "2000",
             csrf_token: csrfToken || "",
@@ -1085,7 +1093,7 @@ describe("server", () => {
       );
       expect(response.status).toBe(400);
       const html = await response.text();
-      expect(html).toContain("event is now full");
+      expect(html).toContain("not enough spots available");
     });
 
     test("returns 404 for unsupported method on ticket route", async () => {
@@ -1184,6 +1192,7 @@ describe("server", () => {
             name: "Paid Event",
             description: "Description",
             max_attendees: "50",
+            max_quantity: "1",
             thank_you_url: "https://example.com/thanks",
             unit_price: "1000",
             csrf_token: csrfToken || "",

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -142,6 +142,7 @@ describe("stripe", () => {
         max_attendees: 50,
         thank_you_url: "https://example.com",
         unit_price: 1000,
+        max_quantity: 1,
       };
       const attendee = {
         id: 1,
@@ -150,6 +151,7 @@ describe("stripe", () => {
         email: "john@example.com",
         created: new Date().toISOString(),
         stripe_payment_id: null,
+        quantity: 1,
       };
       const result = await createCheckoutSession(
         event,
@@ -169,6 +171,7 @@ describe("stripe", () => {
         max_attendees: 50,
         thank_you_url: "https://example.com",
         unit_price: null,
+        max_quantity: 1,
       };
       const attendee = {
         id: 1,
@@ -177,6 +180,7 @@ describe("stripe", () => {
         email: "john@example.com",
         created: new Date().toISOString(),
         stripe_payment_id: null,
+        quantity: 1,
       };
       const result = await createCheckoutSession(
         event,
@@ -224,6 +228,7 @@ describe("stripe", () => {
         max_attendees: 50,
         thank_you_url: "https://example.com/thanks",
         unit_price: 1000,
+        max_quantity: 1,
       };
       const attendee = {
         id: 1,
@@ -232,6 +237,7 @@ describe("stripe", () => {
         email: "john@example.com",
         created: new Date().toISOString(),
         stripe_payment_id: null,
+        quantity: 1,
       };
 
       const session = await createCheckoutSession(
@@ -257,6 +263,7 @@ describe("stripe", () => {
         max_attendees: 50,
         thank_you_url: "https://example.com/thanks",
         unit_price: 1000,
+        max_quantity: 1,
       };
       const attendee = {
         id: 1,
@@ -265,6 +272,7 @@ describe("stripe", () => {
         email: "john@example.com",
         created: new Date().toISOString(),
         stripe_payment_id: null,
+        quantity: 1,
       };
 
       const createdSession = await createCheckoutSession(


### PR DESCRIPTION
## Summary
This PR adds support for purchasing multiple tickets in a single transaction. Events can now specify a maximum quantity of tickets that can be purchased at once, and attendees can select how many tickets they want to reserve.

## Key Changes

- **Database Schema**: Added `quantity` column to `attendees` table (defaults to 1) and `max_quantity` column to `events` table (defaults to 1)
- **Attendee Management**: Updated `createAttendee()` to accept and store ticket quantity; modified `hasAvailableSpots()` to validate availability based on requested quantity
- **Event Configuration**: Added `max_quantity` field to event creation/update forms, allowing admins to set the maximum tickets per purchase
- **Ticket Counting**: Changed attendee count calculations from `COUNT(a.id)` to `COALESCE(SUM(a.quantity), 0)` to properly track total tickets sold
- **Public UI**: Added quantity selector dropdown on ticket reservation page (only shown when `max_quantity > 1` and spots available); dynamically limits options to remaining capacity
- **Stripe Integration**: Updated checkout session creation to pass quantity to Stripe and include it in payment metadata; adjusted product description to show "Tickets" (plural) when quantity > 1
- **Admin Dashboard**: Added quantity column to attendee table; updated labels to distinguish between "Max Tickets Per Purchase" and "Tickets Sold"
- **CSV Export**: Added quantity column to exported attendee data

## Implementation Details

- Quantity is parsed and validated from form input, defaulting to 1 and capped at `max_quantity`
- Availability check now accounts for requested quantity: `attendee_count + quantity <= max_attendees`
- Quantity selector is conditionally rendered based on `max_quantity` and remaining spots
- All existing tests updated to include new `quantity` and `max_quantity` fields
- New tests added for quantity selector visibility and limiting logic