### PR TITLE
Add CSRF protection to public ticket reservation form

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -10,11 +10,15 @@ import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { homePage, ticketFields, ticketPage } from "#templates";
 import {
   createIdRoute,
+  csrfCookie,
+  generateSecureToken,
   getBaseUrl,
   htmlResponse,
-  parseFormData,
+  parseCookies,
   type RouteHandler,
   redirect,
+  requireCsrfForm,
+  withCookie,
   withEvent,
 } from "./utils.ts";
 
@@ -25,11 +29,20 @@ export const handleHome = (): Response => {
   return htmlResponse(homePage());
 };
 
+/** Path for ticket CSRF cookies */
+const ticketCsrfPath = (eventId: number): string => `/ticket/${eventId}`;
+
 /**
  * Handle GET /ticket/:id
  */
 export const handleTicketGet = (eventId: number): Promise<Response> =>
-  withEvent(eventId, (event) => htmlResponse(ticketPage(event)));
+  withEvent(eventId, (event) => {
+    const token = generateSecureToken();
+    return withCookie(
+      htmlResponse(ticketPage(event, token)),
+      csrfCookie(token, ticketCsrfPath(eventId)),
+    );
+  });
 
 /**
  * Check if payment is required for an event
@@ -52,6 +65,7 @@ const handlePaymentFlow = async (
   event: EventWithCount,
   attendee: Attendee,
   quantity: number,
+  csrfToken: string,
 ): Promise<Response> => {
   const baseUrl = getBaseUrl(request);
   const session = await createCheckoutSession(
@@ -68,7 +82,11 @@ const handlePaymentFlow = async (
   // If Stripe session creation failed, clean up and show error
   await deleteAttendee(attendee.id);
   return htmlResponse(
-    ticketPage(event, "Failed to create payment session. Please try again."),
+    ticketPage(
+      event,
+      csrfToken,
+      "Failed to create payment session. Please try again.",
+    ),
     500,
   );
 };
@@ -88,24 +106,43 @@ const parseQuantity = (
 };
 
 /**
+ * Create CSRF error response for ticket page
+ */
+const ticketCsrfError = (event: EventWithCount) => (newToken: string) =>
+  withCookie(
+    htmlResponse(
+      ticketPage(event, newToken, "Invalid or expired form. Please try again."),
+      403,
+    ),
+    csrfCookie(newToken, ticketCsrfPath(event.id)),
+  );
+
+/**
  * Process ticket reservation for an event
  */
 const processTicketReservation = async (
   request: Request,
   event: EventWithCount,
 ): Promise<Response> => {
-  const form = await parseFormData(request);
+  // Get current CSRF token from cookie for re-rendering on validation errors
+  const cookies = parseCookies(request);
+  const currentToken = cookies.get("csrf_token") || generateSecureToken();
+
+  const csrfResult = await requireCsrfForm(request, ticketCsrfError(event));
+  if (!csrfResult.ok) return csrfResult.response;
+
+  const { form } = csrfResult;
   const validation = validateForm(form, ticketFields);
 
   if (!validation.valid) {
-    return htmlResponse(ticketPage(event, validation.error), 400);
+    return htmlResponse(ticketPage(event, currentToken, validation.error), 400);
   }
 
   const quantity = parseQuantity(form, event);
   const available = await hasAvailableSpots(event.id, quantity);
   if (!available) {
     return htmlResponse(
-      ticketPage(event, "Sorry, not enough spots available"),
+      ticketPage(event, currentToken, "Sorry, not enough spots available"),
       400,
     );
   }
@@ -120,7 +157,7 @@ const processTicketReservation = async (
   );
 
   if (await requiresPayment(event)) {
-    return handlePaymentFlow(request, event, attendee, quantity);
+    return handlePaymentFlow(request, event, attendee, quantity, currentToken);
   }
 
   return redirect(event.thank_you_url);

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -31,7 +31,11 @@ const quantityOptions = (max: number): string =>
 /**
  * Public ticket page
  */
-export const ticketPage = (event: EventWithCount, error?: string): string => {
+export const ticketPage = (
+  event: EventWithCount,
+  csrfToken: string,
+  error?: string,
+): string => {
   const spotsRemaining = event.max_attendees - event.attendee_count;
   const isFull = spotsRemaining <= 0;
   const maxPurchasable = Math.min(event.max_quantity, spotsRemaining);
@@ -49,6 +53,7 @@ export const ticketPage = (event: EventWithCount, error?: string): string => {
         <div class="error">Sorry, this event is full.</div>
       ) : (
         <form method="POST" action={`/ticket/${event.id}`}>
+          <input type="hidden" name="csrf_token" value={csrfToken} />
           <Raw html={renderFields(ticketFields)} />
           {showQuantity ? (
             <div class="field">

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -161,13 +161,22 @@ export const getCsrfTokenFromCookie = async (
 };
 
 /**
- * Extract setup CSRF token from set-cookie header
+ * Extract a named cookie value from set-cookie header
  */
-export const getSetupCsrfToken = (setCookie: string | null): string | null => {
+const getCookieValue = (
+  setCookie: string | null,
+  name: string,
+): string | null => {
   if (!setCookie) return null;
-  const match = setCookie.match(/setup_csrf=([^;]+)/);
+  const match = setCookie.match(new RegExp(`${name}=([^;]+)`));
   return match?.[1] ?? null;
 };
+
+/**
+ * Extract setup CSRF token from set-cookie header
+ */
+export const getSetupCsrfToken = (setCookie: string | null): string | null =>
+  getCookieValue(setCookie, "setup_csrf");
 
 /**
  * Create a mock setup POST request with CSRF token
@@ -180,6 +189,27 @@ export const mockSetupFormRequest = (
     "/setup/",
     { ...data, csrf_token: csrfToken },
     `setup_csrf=${csrfToken}`,
+  );
+};
+
+/**
+ * Extract ticket CSRF token from set-cookie header
+ */
+export const getTicketCsrfToken = (setCookie: string | null): string | null =>
+  getCookieValue(setCookie, "csrf_token");
+
+/**
+ * Create a mock ticket form POST request with CSRF token
+ */
+export const mockTicketFormRequest = (
+  eventId: number,
+  data: Record<string, string>,
+  csrfToken: string,
+): Request => {
+  return mockFormRequest(
+    `/ticket/${eventId}`,
+    { ...data, csrf_token: csrfToken },
+    `csrf_token=${csrfToken}`,
   );
 };
 

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -214,28 +214,35 @@ describe("html", () => {
       unit_price: null,
       max_quantity: 1,
     };
+    const csrfToken = "test-csrf-token";
 
     test("renders event info", () => {
-      const html = ticketPage(event);
+      const html = ticketPage(event, csrfToken);
       expect(html).toContain("Test Event");
       expect(html).toContain("Test Description");
     });
 
     test("shows spots remaining", () => {
-      const html = ticketPage(event);
+      const html = ticketPage(event, csrfToken);
       expect(html).toContain("50"); // 100 - 50
     });
 
     test("renders registration form when spots available", () => {
-      const html = ticketPage(event);
+      const html = ticketPage(event, csrfToken);
       expect(html).toContain('action="/ticket/1"');
       expect(html).toContain('name="name"');
       expect(html).toContain('name="email"');
       expect(html).toContain("Reserve Ticket");
     });
 
+    test("includes CSRF token in form", () => {
+      const html = ticketPage(event, csrfToken);
+      expect(html).toContain('name="csrf_token"');
+      expect(html).toContain(`value="${csrfToken}"`);
+    });
+
     test("shows error when provided", () => {
-      const html = ticketPage(event, "Name and email are required");
+      const html = ticketPage(event, csrfToken, "Name and email are required");
       expect(html).toContain("Name and email are required");
       expect(html).toContain('class="error"');
     });
@@ -245,7 +252,7 @@ describe("html", () => {
         ...event,
         attendee_count: 100,
       };
-      const html = ticketPage(fullEvent);
+      const html = ticketPage(fullEvent, csrfToken);
       expect(html).toContain("this event is full");
       expect(html).not.toContain(">Reserve Ticket</button>");
     });
@@ -255,7 +262,7 @@ describe("html", () => {
         ...event,
         name: "<script>evil()</script>",
       };
-      const html = ticketPage(evilEvent);
+      const html = ticketPage(evilEvent, csrfToken);
       expect(html).toContain("&lt;script&gt;");
     });
 
@@ -266,7 +273,7 @@ describe("html", () => {
         max_attendees: 100,
         attendee_count: 0,
       };
-      const html = ticketPage(multiTicketEvent);
+      const html = ticketPage(multiTicketEvent, csrfToken);
       expect(html).toContain("Number of Tickets");
       expect(html).toContain('name="quantity"');
       expect(html).toContain('<option value="1">1</option>');
@@ -281,14 +288,14 @@ describe("html", () => {
         max_attendees: 100,
         attendee_count: 97, // Only 3 spots remaining
       };
-      const html = ticketPage(limitedEvent);
+      const html = ticketPage(limitedEvent, csrfToken);
       expect(html).toContain("Number of Tickets");
       expect(html).toContain('<option value="3">3</option>');
       expect(html).not.toContain('<option value="4">4</option>');
     });
 
     test("hides quantity selector when max_quantity is 1", () => {
-      const html = ticketPage(event); // max_quantity is 1
+      const html = ticketPage(event, csrfToken); // max_quantity is 1
       expect(html).not.toContain("Number of Tickets");
       expect(html).toContain('type="hidden" name="quantity" value="1"');
       expect(html).toContain("Reserve Ticket"); // Singular


### PR DESCRIPTION
## Summary
Implements CSRF protection for the public ticket reservation form using the double-submit cookie pattern. This prevents cross-site request forgery attacks on ticket bookings.

## Key Changes
- **CSRF Token Generation & Validation**: Added `generateSecureToken()`, `csrfCookie()`, and `requireCsrfForm()` utilities to handle token generation and validation
- **Ticket Page Updates**: Modified `ticketPage()` template to accept and render a CSRF token as a hidden form field
- **GET /ticket/:id Handler**: Now generates a secure CSRF token and sets it as an HttpOnly, Secure, SameSite=Strict cookie when rendering the ticket page
- **POST /ticket/:id Handler**: Validates CSRF token from both cookie and form data before processing reservations; returns 403 with a new token on validation failure
- **Error Handling**: Created `ticketCsrfError()` helper to generate CSRF error responses with a fresh token for re-rendering
- **Test Utilities**: Added `getTicketCsrfToken()` and `mockTicketFormRequest()` helpers to support CSRF-aware testing
- **Test Updates**: Updated all ticket form submission tests to use the new `submitTicketForm()` helper that automatically handles CSRF token extraction and submission

## Implementation Details
- Uses double-submit cookie pattern: token is set in an HttpOnly cookie and must also be present in the form data
- CSRF tokens are path-specific (`/ticket/{eventId}`) and expire after 1 hour
- Invalid/expired CSRF tokens result in a 403 response with a new token, allowing users to retry
- The pattern ensures form data cannot be obtained without validating CSRF, making it integral to the form processing flow
- All existing ticket reservation functionality (validation, payment flow, availability checks) remains unchanged