### PR TITLE
Remove ADMIN_PASSWORD from deployment configuration

### DIFF
--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -29,7 +29,6 @@ jobs:
           DB_URL: ${{ secrets.DB_URL }}
           DB_TOKEN: ${{ secrets.DB_TOKEN }}
           DB_ENCRYPTION_KEY: ${{ secrets.DB_ENCRYPTION_KEY }}
-          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           CURRENCY_CODE: ${{ secrets.CURRENCY_CODE || 'GBP' }}
 

--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -20,7 +20,6 @@ const ENV_VARS = {
   DB_URL: process.env.DB_URL as string,
   DB_TOKEN: process.env.DB_TOKEN as string,
   DB_ENCRYPTION_KEY: process.env.DB_ENCRYPTION_KEY as string,
-  ADMIN_PASSWORD: process.env.ADMIN_PASSWORD || "",
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || "",
   CURRENCY_CODE: process.env.CURRENCY_CODE || "GBP",
 };
@@ -40,7 +39,6 @@ const result = await Bun.build({
     "process.env.DB_URL": JSON.stringify(ENV_VARS.DB_URL),
     "process.env.DB_TOKEN": JSON.stringify(ENV_VARS.DB_TOKEN),
     "process.env.DB_ENCRYPTION_KEY": JSON.stringify(ENV_VARS.DB_ENCRYPTION_KEY),
-    "process.env.ADMIN_PASSWORD": JSON.stringify(ENV_VARS.ADMIN_PASSWORD),
     "process.env.STRIPE_SECRET_KEY": JSON.stringify(ENV_VARS.STRIPE_SECRET_KEY),
     "process.env.CURRENCY_CODE": JSON.stringify(ENV_VARS.CURRENCY_CODE),
   },


### PR DESCRIPTION
## Summary
Removes the `ADMIN_PASSWORD` environment variable from the deployment pipeline and build configuration. This variable is no longer needed for the application's operation.

## Changes
- Removed `ADMIN_PASSWORD` secret from GitHub Actions workflow (bunny-deploy.yml)
- Removed `ADMIN_PASSWORD` from environment variables in build script (scripts/build-edge.ts)
- Removed `ADMIN_PASSWORD` from Bun build define configuration

## Notes
This change simplifies the deployment configuration by eliminating an unused environment variable. The application should no longer depend on this secret for authentication or initialization purposes.