### PR TITLE
Refactor edge build script to use dynamic env var configuration

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -4,14 +4,21 @@
  * Inlines environment variables since they're not available at edge runtime
  */
 
-// Required environment variables - build fails if not set
-const REQUIRED_ENV_VARS = [
-  "DB_URL",
-  "DB_TOKEN",
-  "DB_ENCRYPTION_KEY",
-  "ALLOWED_DOMAIN",
-] as const;
-const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+// Environment variable configuration: undefined = required, string = default value
+const ENV_CONFIG: Record<string, string | undefined> = {
+  DB_URL: undefined,
+  DB_TOKEN: undefined,
+  DB_ENCRYPTION_KEY: undefined,
+  ALLOWED_DOMAIN: undefined,
+  ADMIN_PASSWORD: "",
+  STRIPE_SECRET_KEY: "",
+  CURRENCY_CODE: "GBP",
+};
+
+const missing = Object.entries(ENV_CONFIG)
+  .filter(([key, defaultVal]) => defaultVal === undefined && !process.env[key])
+  .map(([key]) => key);
+
 if (missing.length > 0) {
   // biome-ignore lint/suspicious/noConsole: Build script output
   console.error(
@@ -20,16 +27,13 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-// Environment variables to inline (read at build time)
-const ENV_VARS = {
-  DB_URL: process.env.DB_URL as string,
-  DB_TOKEN: process.env.DB_TOKEN as string,
-  DB_ENCRYPTION_KEY: process.env.DB_ENCRYPTION_KEY as string,
-  ALLOWED_DOMAIN: process.env.ALLOWED_DOMAIN as string,
-  ADMIN_PASSWORD: process.env.ADMIN_PASSWORD || "",
-  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || "",
-  CURRENCY_CODE: process.env.CURRENCY_CODE || "GBP",
-};
+// Read env vars with defaults
+const ENV_VARS = Object.fromEntries(
+  Object.entries(ENV_CONFIG).map(([key, defaultVal]) => [
+    key,
+    process.env[key] ?? defaultVal ?? "",
+  ]),
+);
 
 const result = await Bun.build({
   entrypoints: ["./src/edge/bunny-script.ts"],
@@ -42,15 +46,12 @@ const result = await Bun.build({
     "@libsql/client",
     "@libsql/client/web",
   ],
-  define: {
-    "process.env.DB_URL": JSON.stringify(ENV_VARS.DB_URL),
-    "process.env.DB_TOKEN": JSON.stringify(ENV_VARS.DB_TOKEN),
-    "process.env.DB_ENCRYPTION_KEY": JSON.stringify(ENV_VARS.DB_ENCRYPTION_KEY),
-    "process.env.ADMIN_PASSWORD": JSON.stringify(ENV_VARS.ADMIN_PASSWORD),
-    "process.env.STRIPE_SECRET_KEY": JSON.stringify(ENV_VARS.STRIPE_SECRET_KEY),
-    "process.env.CURRENCY_CODE": JSON.stringify(ENV_VARS.CURRENCY_CODE),
-    "process.env.ALLOWED_DOMAIN": JSON.stringify(ENV_VARS.ALLOWED_DOMAIN),
-  },
+  define: Object.fromEntries(
+    Object.entries(ENV_VARS).map(([key, value]) => [
+      `process.env.${key}`,
+      JSON.stringify(value),
+    ]),
+  ),
 });
 
 if (!result.success) {


### PR DESCRIPTION
## Summary
Refactored the edge build script to use a declarative configuration object for environment variables instead of hardcoded lists. This improves maintainability and makes it easier to add new environment variables in the future.

## Key Changes
- Replaced separate `REQUIRED_ENV_VARS` array and `ENV_VARS` object with a single `ENV_CONFIG` configuration object that declares both required variables (with `undefined` as default) and optional variables (with their default values)
- Updated validation logic to filter based on the configuration, only requiring variables where `defaultVal === undefined`
- Simplified environment variable reading using `Object.fromEntries()` and `Object.entries()` for a more declarative approach
- Dynamically generated the `define` object for Bun's build configuration instead of manually listing each variable

## Implementation Details
- The `ENV_CONFIG` object now serves as the single source of truth for all environment variables used in the edge runtime
- Variables like `ADMIN_PASSWORD`, `STRIPE_SECRET_KEY`, and `CURRENCY_CODE` now have sensible defaults defined in the configuration
- The validation and variable reading logic is now data-driven, reducing code duplication and making it easier to maintain
- All environment variables are still properly inlined at build time with `JSON.stringify()`