### PR TITLE
Remove unused test-only exports and add code quality check

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,27 +31,6 @@ export const getCurrencyCode = async (): Promise<string> => {
 };
 
 /**
- * Get database URL from environment
- */
-export const getDbUrl = (): string | undefined => {
-  return process.env.DB_URL;
-};
-
-/**
- * Get database auth token from environment
- */
-export const getDbToken = (): string | undefined => {
-  return process.env.DB_TOKEN;
-};
-
-/**
- * Get server port from environment
- */
-export const getPort = (): number => {
-  return Number.parseInt(process.env.PORT || "3000", 10);
-};
-
-/**
  * Check if initial setup has been completed
  */
 export { isSetupComplete } from "./db/index.ts";

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -95,13 +95,6 @@ const getEncryptionKeyBytes = (): Uint8Array => {
 };
 
 /**
- * Check if encryption key is configured
- */
-export const isEncryptionConfigured = (): boolean => {
-  return !!process.env.DB_ENCRYPTION_KEY;
-};
-
-/**
  * Validate encryption key is present and valid
  * Call this on startup to fail fast if key is missing
  */
@@ -168,13 +161,6 @@ export const decrypt = async (encrypted: string): Promise<string> => {
   // Decode to string
   const decoder = new TextDecoder();
   return decoder.decode(plaintextBytes);
-};
-
-/**
- * Check if a value is encrypted (has the encryption prefix)
- */
-export const isEncrypted = (value: string): boolean => {
-  return value.startsWith(ENCRYPTION_PREFIX);
 };
 
 /**

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -38,7 +38,6 @@ export { initDb } from "./migrations/index.ts";
 export {
   createSession,
   deleteAllSessions,
-  deleteExpiredSessions,
   deleteSession,
   getSession,
 } from "./sessions.ts";

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -35,16 +35,6 @@ export const deleteSession = async (token: string): Promise<void> =>
   executeByField("sessions", "token", token);
 
 /**
- * Delete all expired sessions
- */
-export const deleteExpiredSessions = async (): Promise<void> => {
-  await getDb().execute({
-    sql: "DELETE FROM sessions WHERE expires < ?",
-    args: [Date.now()],
-  });
-};
-
-/**
  * Delete all sessions (used when password is changed)
  */
 export const deleteAllSessions = async (): Promise<void> => {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -135,30 +135,3 @@ export const retrieveCheckoutSession = async (
   sessionId: string,
 ): Promise<Stripe.Checkout.Session | null> =>
   withStripe((stripe) => stripe.checkout.sessions.retrieve(sessionId));
-
-/**
- * Verify a Stripe webhook signature
- */
-export const verifyWebhookSignature = async (
-  payload: string,
-  signature: string,
-  webhookSecret: string,
-): Promise<Stripe.Event | null> => {
-  const stripe = await getStripeClient();
-  if (!stripe) return null;
-  return safeAsync(async () =>
-    stripe.webhooks.constructEvent(payload, signature, webhookSecret),
-  );
-};
-
-/**
- * Format price for display (converts from smallest currency unit)
- */
-export const formatPrice = async (amount: number): Promise<string> => {
-  const currency = await getCurrencyCode();
-  const formatter = new Intl.NumberFormat("en-GB", {
-    style: "currency",
-    currency,
-  });
-  return formatter.format(amount / 100);
-};

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   getCurrencyCode,
-  getDbToken,
-  getDbUrl,
-  getPort,
   getStripeSecretKey,
   isPaymentsEnabled,
   isSetupComplete,
@@ -13,21 +10,12 @@ import { completeSetup, setSetting } from "#lib/db";
 import { createTestDb, resetDb } from "#test-utils";
 
 describe("config", () => {
-  const originalEnv = { ...process.env };
-
   beforeEach(async () => {
-    // Clear relevant env vars before each test
-    delete process.env.DB_URL;
-    delete process.env.DB_TOKEN;
-    delete process.env.PORT;
-    // Create in-memory db for testing
     await createTestDb();
   });
 
   afterEach(() => {
     resetDb();
-    // Restore original environment
-    process.env = { ...originalEnv };
   });
 
   describe("getStripeSecretKey", () => {
@@ -84,39 +72,6 @@ describe("config", () => {
     test("returns true when setup is complete", async () => {
       await completeSetup("password123", null, "GBP");
       expect(await isSetupComplete()).toBe(true);
-    });
-  });
-
-  describe("getDbUrl", () => {
-    test("returns undefined when not set", () => {
-      expect(getDbUrl()).toBeUndefined();
-    });
-
-    test("returns set value", () => {
-      process.env.DB_URL = "libsql://test.turso.io";
-      expect(getDbUrl()).toBe("libsql://test.turso.io");
-    });
-  });
-
-  describe("getDbToken", () => {
-    test("returns undefined when not set", () => {
-      expect(getDbToken()).toBeUndefined();
-    });
-
-    test("returns set value", () => {
-      process.env.DB_TOKEN = "token123";
-      expect(getDbToken()).toBe("token123");
-    });
-  });
-
-  describe("getPort", () => {
-    test("returns 3000 by default", () => {
-      expect(getPort()).toBe(3000);
-    });
-
-    test("returns set value as number", () => {
-      process.env.PORT = "8080";
-      expect(getPort()).toBe(8080);
     });
   });
 });

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -6,8 +6,6 @@ import {
   encrypt,
   generateSecureToken,
   hashPassword,
-  isEncrypted,
-  isEncryptionConfigured,
   validateEncryptionKey,
   verifyPassword,
 } from "#lib/crypto.ts";
@@ -88,17 +86,6 @@ describe("encryption", () => {
 
   afterEach(() => {
     clearTestEncryptionKey();
-  });
-
-  describe("isEncryptionConfigured", () => {
-    it("returns true when encryption key is set", () => {
-      expect(isEncryptionConfigured()).toBe(true);
-    });
-
-    it("returns false when encryption key is not set", () => {
-      clearTestEncryptionKey();
-      expect(isEncryptionConfigured()).toBe(false);
-    });
   });
 
   describe("validateEncryptionKey", () => {
@@ -188,26 +175,6 @@ describe("encryption", () => {
       }
       const tampered = parts.join(":");
       await expect(decrypt(tampered)).rejects.toThrow();
-    });
-  });
-
-  describe("isEncrypted", () => {
-    it("returns true for encrypted values", async () => {
-      const encrypted = await encrypt("test");
-      expect(isEncrypted(encrypted)).toBe(true);
-    });
-
-    it("returns false for plain text", () => {
-      expect(isEncrypted("plain text")).toBe(false);
-    });
-
-    it("returns false for empty string", () => {
-      expect(isEncrypted("")).toBe(false);
-    });
-
-    it("returns false for similar-looking but invalid prefix", () => {
-      expect(isEncrypted("enc:2:something")).toBe(false);
-      expect(isEncrypted("encrypted:1:something")).toBe(false);
     });
   });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -10,7 +10,6 @@ import {
   deleteAllSessions,
   deleteAttendee,
   deleteEvent,
-  deleteExpiredSessions,
   deleteSession,
   getAdminPasswordFromDb,
   getAllEvents,
@@ -609,19 +608,6 @@ describe("db", () => {
 
       const session = await getSession("delete-me");
       expect(session).toBeNull();
-    });
-
-    test("deleteExpiredSessions removes expired sessions", async () => {
-      await createSession("expired", "csrf-expired", Date.now() - 1000);
-      await createSession("valid", "csrf-valid", Date.now() + 10000);
-
-      await deleteExpiredSessions();
-
-      const expiredSession = await getSession("expired");
-      const validSession = await getSession("valid");
-
-      expect(expiredSession).toBeNull();
-      expect(validSession).not.toBeNull();
     });
 
     test("deleteAllSessions removes all sessions", async () => {

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -3,11 +3,9 @@ import { encrypt } from "#lib/crypto.ts";
 import { setSetting } from "#lib/db";
 import {
   createCheckoutSession,
-  formatPrice,
   getStripeClient,
   resetStripeClient,
   retrieveCheckoutSession,
-  verifyWebhookSignature,
 } from "#lib/stripe.ts";
 import { createTestDb, resetDb } from "#test-utils";
 
@@ -59,46 +57,6 @@ describe("stripe", () => {
 
       const client2 = await getStripeClient();
       expect(client2).toBeNull();
-    });
-  });
-
-  describe("formatPrice", () => {
-    test("formats price in GBP by default", async () => {
-      const formatted = await formatPrice(1000);
-      expect(formatted).toContain("10");
-    });
-
-    test("formats price in specified currency", async () => {
-      await setSetting("currency_code", "USD");
-      const formatted = await formatPrice(2500);
-      expect(formatted).toContain("25");
-    });
-
-    test("formats zero price", async () => {
-      const formatted = await formatPrice(0);
-      expect(formatted).toContain("0");
-    });
-
-    test("formats small amounts correctly", async () => {
-      const formatted = await formatPrice(99);
-      expect(formatted).toContain("0.99");
-    });
-  });
-
-  describe("verifyWebhookSignature", () => {
-    test("returns null when stripe key not set", async () => {
-      const result = await verifyWebhookSignature("payload", "sig", "secret");
-      expect(result).toBeNull();
-    });
-
-    test("returns null for invalid signature", async () => {
-      await setSetting("stripe_key", await encrypt("sk_test_123"));
-      const result = await verifyWebhookSignature(
-        "invalid_payload",
-        "invalid_signature",
-        "whsec_test",
-      );
-      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
This PR removes several exported functions that were only being used in tests, not in production code. It also adds a new code quality check to prevent this pattern from recurring.

## Key Changes

### Removed Test-Only Exports
- **config.ts**: Removed `getDbUrl()`, `getDbToken()`, and `getPort()` - these were simple environment variable accessors only tested directly
- **crypto.ts**: Removed `isEncryptionConfigured()` and `isEncrypted()` - utility functions only used in tests
- **db/sessions.ts**: Removed `deleteExpiredSessions()` - only called in tests, not used in production
- **stripe.ts**: Removed `verifyWebhookSignature()` and `formatPrice()` - test-only utilities
- **db/index.ts**: Removed `deleteExpiredSessions` from exports

### Cleaned Up Tests
- Removed corresponding test cases for the deleted functions
- Simplified test setup in `config.test.ts` by removing environment variable mocking that's no longer needed

### Added Code Quality Check
- New test in `code-quality.test.ts`: "no test-only exports" that detects exports used only in tests
- Allows specific test hooks via allowlist (e.g., `setDb`, `clearEncryptionKeyCache`, `resetStripeClient`)
- Excludes test utilities, library modules, and aggregation modules from the check
- Helps maintain the principle of testing outcomes rather than implementation details

## Rationale
Exporting functions solely for testing purposes creates unnecessary API surface and couples tests to implementation details. These functions should either be:
1. Kept internal and tested indirectly through public APIs
2. Moved to test utilities if genuinely needed for test infrastructure

The new code quality check ensures this pattern doesn't regress in future changes.