### PR TITLE
Add testRequest helper for simplified test request creation

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -203,6 +203,65 @@ export const mockTicketFormRequest = (
   );
 };
 
+/**
+ * Options for testRequest helper
+ */
+interface TestRequestOptions {
+  /** Session token - will be formatted as "session={token}" */
+  session?: string;
+  /** Full cookie string (use when you have raw set-cookie value) */
+  cookie?: string;
+  /** HTTP method (defaults to GET, or POST if data is provided) */
+  method?: string;
+  /** Form data for POST requests */
+  data?: Record<string, string>;
+}
+
+/**
+ * Create a test request with common options
+ * Simplifies the verbose new Request() pattern in tests
+ *
+ * @example
+ * // GET with session token
+ * testRequest("/admin/logout", { session: token })
+ *
+ * // GET with full cookie string
+ * testRequest("/admin/", { cookie: setCookieHeader })
+ *
+ * // POST with form data
+ * testRequest("/admin/login", { data: { password: "test" } })
+ *
+ * // POST with session and form data
+ * testRequest("/admin/event/new", { session: token, data: { name: "Event" } })
+ */
+export const testRequest = (
+  path: string,
+  options: TestRequestOptions = {},
+): Request => {
+  const { session, cookie, method, data } = options;
+  const headers: Record<string, string> = { host: "localhost" };
+
+  if (session) {
+    headers.cookie = `session=${session}`;
+  } else if (cookie) {
+    headers.cookie = cookie;
+  }
+
+  if (data) {
+    headers["content-type"] = "application/x-www-form-urlencoded";
+    return new Request(`http://localhost${path}`, {
+      method: method ?? "POST",
+      headers,
+      body: new URLSearchParams(data).toString(),
+    });
+  }
+
+  return new Request(`http://localhost${path}`, {
+    method: method ?? "GET",
+    headers,
+  });
+};
+
 /** Re-export createEvent and EventInput for test use */
 export { createEvent };
 export type { EventInput };

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -5,6 +5,7 @@ import {
   mockRequest,
   randomString,
   resetDb,
+  testRequest,
   wait,
 } from "#test-utils";
 
@@ -73,6 +74,77 @@ describe("test-utils", () => {
         "session=abc123",
       );
       expect(request.headers.get("cookie")).toBe("session=abc123");
+    });
+  });
+
+  describe("testRequest", () => {
+    test("creates a GET request by default", () => {
+      const request = testRequest("/test");
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe("http://localhost/test");
+      expect(request.headers.get("host")).toBe("localhost");
+    });
+
+    test("formats session token as cookie", () => {
+      const request = testRequest("/admin/logout", { session: "abc123" });
+      expect(request.headers.get("cookie")).toBe("session=abc123");
+    });
+
+    test("uses raw cookie string when provided", () => {
+      const request = testRequest("/admin/", {
+        cookie: "session=xyz; other=value",
+      });
+      expect(request.headers.get("cookie")).toBe("session=xyz; other=value");
+    });
+
+    test("session takes precedence over cookie", () => {
+      const request = testRequest("/admin/", {
+        session: "token123",
+        cookie: "session=other",
+      });
+      expect(request.headers.get("cookie")).toBe("session=token123");
+    });
+
+    test("creates POST request with form data", async () => {
+      const request = testRequest("/admin/login", {
+        data: { username: "admin", password: "secret" },
+      });
+      expect(request.method).toBe("POST");
+      expect(request.headers.get("content-type")).toBe(
+        "application/x-www-form-urlencoded",
+      );
+      const body = await request.text();
+      expect(body).toContain("username=admin");
+      expect(body).toContain("password=secret");
+    });
+
+    test("combines session with form data", async () => {
+      const request = testRequest("/admin/event/new", {
+        session: "mytoken",
+        data: { name: "Test Event" },
+      });
+      expect(request.method).toBe("POST");
+      expect(request.headers.get("cookie")).toBe("session=mytoken");
+      const body = await request.text();
+      expect(body).toContain("name=Test+Event");
+    });
+
+    test("allows custom method override", () => {
+      const request = testRequest("/admin/event/1", {
+        session: "token",
+        method: "DELETE",
+      });
+      expect(request.method).toBe("DELETE");
+    });
+
+    test("allows custom method with form data", async () => {
+      const request = testRequest("/admin/event/1", {
+        method: "PUT",
+        data: { name: "Updated" },
+      });
+      expect(request.method).toBe("PUT");
+      const body = await request.text();
+      expect(body).toContain("name=Updated");
     });
   });
 


### PR DESCRIPTION
## Summary
Introduces a new `testRequest` helper function to the test utilities that simplifies creating HTTP requests in tests by providing a convenient API for common scenarios like session tokens, cookies, and form data.

## Changes
- **New `testRequest` helper function** in `src/test-utils/index.ts`:
  - Accepts a path and optional configuration object
  - Supports session token formatting as cookies
  - Supports raw cookie strings
  - Automatically handles POST requests when form data is provided
  - Allows custom HTTP method override
  - Sets appropriate content-type headers for form data
  - Defaults to GET requests when no data is provided

- **Comprehensive test coverage** in `test/lib/test-utils.test.ts`:
  - Tests default GET request behavior
  - Tests session token formatting
  - Tests raw cookie string handling
  - Tests session precedence over cookie
  - Tests POST with form data
  - Tests combining session with form data
  - Tests custom method override
  - Tests custom method with form data

## Implementation Details
- The helper intelligently determines HTTP method: defaults to GET, switches to POST when data is provided, or uses explicit method override
- Session tokens are automatically formatted as `session={token}` cookie header
- Form data is URL-encoded using `URLSearchParams`
- All requests include a `host: localhost` header by default
- Follows existing test utility patterns and conventions