### PR TITLE
Enhance session cookie security with __Host- prefix

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -169,13 +169,13 @@ const handleAdminLogin = async (
 
   return redirect(
     "/admin/",
-    `session=${token}; HttpOnly; Secure; SameSite=Strict; Path=/admin/; Max-Age=86400`,
+    `__Host-session=${token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=86400`,
   );
 };
 
 /** Cookie to clear admin session */
 const clearSessionCookie =
-  "session=; HttpOnly; Secure; SameSite=Strict; Path=/admin/; Max-Age=0";
+  "__Host-session=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0";
 
 /**
  * Handle GET /admin/logout

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -58,7 +58,7 @@ export const getAuthenticatedSession = async (
   request: Request,
 ): Promise<{ token: string; csrfToken: string } | null> => {
   const cookies = parseCookies(request);
-  const token = cookies.get("session");
+  const token = cookies.get("__Host-session");
   if (!token) return null;
 
   const session = await getSession(token);

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -142,7 +142,7 @@ export const randomString = (length: number): string => {
 export const getCsrfTokenFromCookie = async (
   cookie: string,
 ): Promise<string | null> => {
-  const sessionMatch = cookie.match(/session=([^;]+)/);
+  const sessionMatch = cookie.match(/__Host-session=([^;]+)/);
   if (!sessionMatch?.[1]) return null;
 
   const sessionToken = sessionMatch[1];
@@ -207,7 +207,7 @@ export const mockTicketFormRequest = (
  * Options for testRequest helper
  */
 interface TestRequestOptions {
-  /** Session token - will be formatted as "session={token}" */
+  /** Session token - will be formatted as "__Host-session={token}" */
   session?: string;
   /** Full cookie string (use when you have raw set-cookie value) */
   cookie?: string;
@@ -242,7 +242,7 @@ export const testRequest = (
   const headers: Record<string, string> = { host: "localhost" };
 
   if (session) {
-    headers.cookie = `session=${session}`;
+    headers.cookie = `__Host-session=${session}`;
   } else if (cookie) {
     headers.cookie = cookie;
   }

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -166,7 +166,7 @@ describe("server", () => {
       );
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("/admin/");
-      expect(response.headers.get("set-cookie")).toContain("session=");
+      expect(response.headers.get("set-cookie")).toContain("__Host-session=");
     });
 
     test("returns 429 when rate limited", async () => {
@@ -1422,7 +1422,7 @@ describe("server", () => {
     test("nonexistent session shows login page", async () => {
       const response = await handleRequest(
         new Request("http://localhost/admin/", {
-          headers: { host: "localhost", cookie: "session=nonexistent" },
+          headers: { host: "localhost", cookie: "__Host-session=nonexistent" },
         }),
       );
       expect(response.status).toBe(200);
@@ -1436,7 +1436,10 @@ describe("server", () => {
 
       const response = await handleRequest(
         new Request("http://localhost/admin/", {
-          headers: { host: "localhost", cookie: "session=expired-token" },
+          headers: {
+            host: "localhost",
+            cookie: "__Host-session=expired-token",
+          },
         }),
       );
       expect(response.status).toBe(200);
@@ -1466,7 +1469,7 @@ describe("server", () => {
       // Now logout
       const logoutResponse = await handleRequest(
         new Request("http://localhost/admin/logout", {
-          headers: { host: "localhost", cookie: `session=${token}` },
+          headers: { host: "localhost", cookie: `__Host-session=${token}` },
         }),
       );
       expect(logoutResponse.status).toBe(302);

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -71,9 +71,9 @@ describe("test-utils", () => {
       const request = mockFormRequest(
         "/test",
         { name: "John" },
-        "session=abc123",
+        "__Host-session=abc123",
       );
-      expect(request.headers.get("cookie")).toBe("session=abc123");
+      expect(request.headers.get("cookie")).toBe("__Host-session=abc123");
     });
   });
 
@@ -87,22 +87,24 @@ describe("test-utils", () => {
 
     test("formats session token as cookie", () => {
       const request = testRequest("/admin/logout", { session: "abc123" });
-      expect(request.headers.get("cookie")).toBe("session=abc123");
+      expect(request.headers.get("cookie")).toBe("__Host-session=abc123");
     });
 
     test("uses raw cookie string when provided", () => {
       const request = testRequest("/admin/", {
-        cookie: "session=xyz; other=value",
+        cookie: "__Host-session=xyz; other=value",
       });
-      expect(request.headers.get("cookie")).toBe("session=xyz; other=value");
+      expect(request.headers.get("cookie")).toBe(
+        "__Host-session=xyz; other=value",
+      );
     });
 
     test("session takes precedence over cookie", () => {
       const request = testRequest("/admin/", {
         session: "token123",
-        cookie: "session=other",
+        cookie: "__Host-session=other",
       });
-      expect(request.headers.get("cookie")).toBe("session=token123");
+      expect(request.headers.get("cookie")).toBe("__Host-session=token123");
     });
 
     test("creates POST request with form data", async () => {
@@ -124,7 +126,7 @@ describe("test-utils", () => {
         data: { name: "Test Event" },
       });
       expect(request.method).toBe("POST");
-      expect(request.headers.get("cookie")).toBe("session=mytoken");
+      expect(request.headers.get("cookie")).toBe("__Host-session=mytoken");
       const body = await request.text();
       expect(body).toContain("name=Test+Event");
     });


### PR DESCRIPTION
## Summary
This PR improves the security of admin session cookies by implementing the `__Host-` prefix standard and adjusting the cookie scope from `/admin/` to `/`.

## Key Changes
- **Cookie naming**: Renamed session cookie from `session` to `__Host-session` across all files
  - The `__Host-` prefix is a security best practice that restricts cookies to HTTPS-only, prevents subdomains from accessing the cookie, and requires an explicit Path attribute
- **Cookie path**: Changed cookie path from `/admin/` to `/` to align with the `__Host-` prefix requirements
  - This ensures the cookie is available across the entire application while maintaining security through the prefix restrictions
- **Updated all references**: Modified cookie handling in:
  - Admin login/logout route handlers (`src/routes/admin.ts`)
  - Session authentication utility (`src/routes/utils.ts`)
  - Test utilities and test cases to match the new cookie name

## Implementation Details
- The `__Host-` prefix automatically enforces `Secure` and `HttpOnly` flags, providing defense-in-depth against XSS and man-in-the-middle attacks
- All existing functionality remains unchanged; this is purely a security enhancement to the cookie mechanism
- Tests have been updated to verify the new cookie format is correctly used throughout the authentication flow