### PR TITLE
Refactor testRequest helper to accept token as positional parameter

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -207,8 +207,6 @@ export const mockTicketFormRequest = (
  * Options for testRequest helper
  */
 interface TestRequestOptions {
-  /** Session token - will be formatted as "session={token}" */
-  session?: string;
   /** Full cookie string (use when you have raw set-cookie value) */
   cookie?: string;
   /** HTTP method (defaults to GET, or POST if data is provided) */
@@ -222,27 +220,28 @@ interface TestRequestOptions {
  * Simplifies the verbose new Request() pattern in tests
  *
  * @example
+ * // Simple GET
+ * testRequest("/admin/")
+ *
  * // GET with session token
- * testRequest("/admin/logout", { session: token })
+ * testRequest("/admin/logout", token)
  *
- * // GET with full cookie string
- * testRequest("/admin/", { cookie: setCookieHeader })
- *
- * // POST with form data
- * testRequest("/admin/login", { data: { password: "test" } })
+ * // POST with form data (no auth)
+ * testRequest("/admin/login", null, { data: { password: "test" } })
  *
  * // POST with session and form data
- * testRequest("/admin/event/new", { session: token, data: { name: "Event" } })
+ * testRequest("/admin/event/new", token, { data: { name: "Event" } })
  */
 export const testRequest = (
   path: string,
+  token?: string | null,
   options: TestRequestOptions = {},
 ): Request => {
-  const { session, cookie, method, data } = options;
+  const { cookie, method, data } = options;
   const headers: Record<string, string> = { host: "localhost" };
 
-  if (session) {
-    headers.cookie = `session=${session}`;
+  if (token) {
+    headers.cookie = `session=${token}`;
   } else if (cookie) {
     headers.cookie = cookie;
   }

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -22,6 +22,7 @@ import {
   mockTicketFormRequest,
   resetDb,
   TEST_ADMIN_PASSWORD,
+  testRequest,
 } from "#test-utils";
 
 /**
@@ -66,13 +67,7 @@ describe("server", () => {
 
     test("returns 404 for non-GET requests to /health", async () => {
       const response = await handleRequest(
-        new Request("http://localhost/health", {
-          method: "POST",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            host: "localhost",
-          },
-        }),
+        testRequest("/health", null, { method: "POST", data: {} }),
       );
       expect(response.status).toBe(404);
     });
@@ -90,13 +85,7 @@ describe("server", () => {
 
     test("returns 404 for non-GET requests to /favicon.ico", async () => {
       const response = await handleRequest(
-        new Request("http://localhost/favicon.ico", {
-          method: "POST",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            host: "localhost",
-          },
-        }),
+        testRequest("/favicon.ico", null, { method: "POST", data: {} }),
       );
       expect(response.status).toBe(404);
     });
@@ -111,7 +100,6 @@ describe("server", () => {
     });
 
     test("shows dashboard when authenticated", async () => {
-      TEST_ADMIN_PASSWORD;
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", {
           password: TEST_ADMIN_PASSWORD,
@@ -120,9 +108,7 @@ describe("server", () => {
       const cookie = loginResponse.headers.get("set-cookie");
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -259,9 +245,7 @@ describe("server", () => {
       const cookie = loginResponse.headers.get("set-cookie") || "";
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/settings", {
-          headers: { host: "localhost", cookie },
-        }),
+        testRequest("/admin/settings", null, { cookie }),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -429,9 +413,7 @@ describe("server", () => {
 
       // Verify old session is invalidated
       const dashboardResponse = await handleRequest(
-        new Request("http://localhost/admin/", {
-          headers: { host: "localhost", cookie },
-        }),
+        testRequest("/admin/", null, { cookie }),
       );
       const html = await dashboardResponse.text();
       expect(html).toContain("Admin Login"); // Should show login, not dashboard
@@ -630,9 +612,7 @@ describe("server", () => {
       const cookie = loginResponse.headers.get("set-cookie");
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/999", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/999", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(404);
     });
@@ -652,9 +632,7 @@ describe("server", () => {
       });
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -676,9 +654,7 @@ describe("server", () => {
       });
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1", null, { cookie: cookie || "" }),
       );
       const html = await response.text();
       expect(html).toContain("/admin/event/1/edit");
@@ -709,9 +685,7 @@ describe("server", () => {
       const cookie = loginResponse.headers.get("set-cookie");
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/999/export", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/999/export", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(404);
     });
@@ -731,9 +705,7 @@ describe("server", () => {
       });
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1/export", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1/export", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe(
@@ -762,9 +734,7 @@ describe("server", () => {
       await createAttendee(1, "Jane Smith", "jane@example.com");
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1/export", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1/export", null, { cookie: cookie || "" }),
       );
       const csv = await response.text();
       expect(csv).toContain("Name,Email,Quantity,Registered");
@@ -789,9 +759,7 @@ describe("server", () => {
       });
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1/export", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1/export", null, { cookie: cookie || "" }),
       );
       const disposition = response.headers.get("content-disposition");
       expect(disposition).toContain("Test_Event___Special_");
@@ -821,9 +789,7 @@ describe("server", () => {
       const cookie = loginResponse.headers.get("set-cookie");
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/999/edit", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/999/edit", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(404);
     });
@@ -844,9 +810,7 @@ describe("server", () => {
       });
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1/edit", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1/edit", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -1038,9 +1002,7 @@ describe("server", () => {
       const cookie = loginResponse.headers.get("set-cookie");
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/999/delete", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/999/delete", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(404);
     });
@@ -1059,9 +1021,7 @@ describe("server", () => {
       });
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/event/1/delete", {
-          headers: { host: "localhost", cookie: cookie || "" },
-        }),
+        testRequest("/admin/event/1/delete", null, { cookie: cookie || "" }),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -1402,10 +1362,7 @@ describe("server", () => {
         thankYouUrl: "https://example.com",
       });
       const response = await handleRequest(
-        new Request("http://localhost/ticket/1", {
-          method: "PUT",
-          headers: { host: "localhost" },
-        }),
+        testRequest("/ticket/1", null, { method: "PUT" }),
       );
       expect(response.status).toBe(404);
     });
@@ -1421,9 +1378,7 @@ describe("server", () => {
   describe("session expiration", () => {
     test("nonexistent session shows login page", async () => {
       const response = await handleRequest(
-        new Request("http://localhost/admin/", {
-          headers: { host: "localhost", cookie: "session=nonexistent" },
-        }),
+        testRequest("/admin/", "nonexistent"),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -1435,9 +1390,7 @@ describe("server", () => {
       await createSession("expired-token", "csrf-expired", Date.now() - 1000);
 
       const response = await handleRequest(
-        new Request("http://localhost/admin/", {
-          headers: { host: "localhost", cookie: "session=expired-token" },
-        }),
+        testRequest("/admin/", "expired-token"),
       );
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -1465,9 +1418,7 @@ describe("server", () => {
 
       // Now logout
       const logoutResponse = await handleRequest(
-        new Request("http://localhost/admin/logout", {
-          headers: { host: "localhost", cookie: `session=${token}` },
-        }),
+        testRequest("/admin/logout", token),
       );
       expect(logoutResponse.status).toBe(302);
 
@@ -1599,13 +1550,7 @@ describe("server", () => {
   describe("payment routes", () => {
     test("returns 404 for unsupported method on payment routes", async () => {
       const response = await handleRequest(
-        new Request("http://localhost/payment/success", {
-          method: "POST",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            host: "localhost",
-          },
-        }),
+        testRequest("/payment/success", null, { method: "POST", data: {} }),
       );
       expect(response.status).toBe(404);
     });
@@ -2211,10 +2156,7 @@ describe("server", () => {
 
       test("PUT /setup/ redirects to /setup/ (unsupported method)", async () => {
         const response = await handleRequest(
-          new Request("http://localhost/setup/", {
-            method: "PUT",
-            headers: { host: "localhost" },
-          }),
+          testRequest("/setup/", null, { method: "PUT" }),
         );
         // PUT method falls through routeSetup (returns null), then redirects to /setup/
         expect(response.status).toBe(302);

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -86,27 +86,26 @@ describe("test-utils", () => {
     });
 
     test("formats session token as cookie", () => {
-      const request = testRequest("/admin/logout", { session: "abc123" });
+      const request = testRequest("/admin/logout", "abc123");
       expect(request.headers.get("cookie")).toBe("session=abc123");
     });
 
     test("uses raw cookie string when provided", () => {
-      const request = testRequest("/admin/", {
+      const request = testRequest("/admin/", null, {
         cookie: "session=xyz; other=value",
       });
       expect(request.headers.get("cookie")).toBe("session=xyz; other=value");
     });
 
-    test("session takes precedence over cookie", () => {
-      const request = testRequest("/admin/", {
-        session: "token123",
+    test("token takes precedence over cookie", () => {
+      const request = testRequest("/admin/", "token123", {
         cookie: "session=other",
       });
       expect(request.headers.get("cookie")).toBe("session=token123");
     });
 
     test("creates POST request with form data", async () => {
-      const request = testRequest("/admin/login", {
+      const request = testRequest("/admin/login", null, {
         data: { username: "admin", password: "secret" },
       });
       expect(request.method).toBe("POST");
@@ -118,9 +117,8 @@ describe("test-utils", () => {
       expect(body).toContain("password=secret");
     });
 
-    test("combines session with form data", async () => {
-      const request = testRequest("/admin/event/new", {
-        session: "mytoken",
+    test("combines token with form data", async () => {
+      const request = testRequest("/admin/event/new", "mytoken", {
         data: { name: "Test Event" },
       });
       expect(request.method).toBe("POST");
@@ -130,15 +128,14 @@ describe("test-utils", () => {
     });
 
     test("allows custom method override", () => {
-      const request = testRequest("/admin/event/1", {
-        session: "token",
+      const request = testRequest("/admin/event/1", "token", {
         method: "DELETE",
       });
       expect(request.method).toBe("DELETE");
     });
 
     test("allows custom method with form data", async () => {
-      const request = testRequest("/admin/event/1", {
+      const request = testRequest("/admin/event/1", null, {
         method: "PUT",
         data: { name: "Updated" },
       });


### PR DESCRIPTION
## Summary
Refactored the `testRequest` helper function to accept session tokens as a positional parameter instead of within the options object. This simplifies the API and makes test code more readable.

## Key Changes
- **API Signature Change**: `testRequest(path, options)` → `testRequest(path, token?, options?)`
  - Session token is now the second positional parameter
  - Can pass `null` or `undefined` when no token is needed
  - Options object moved to third parameter

- **Removed `session` property** from `TestRequestOptions` interface
  - Token handling is now unified through the positional parameter
  - Token takes precedence over raw cookie string (when both provided)

- **Updated documentation**: JSDoc examples now reflect the new API usage:
  - `testRequest("/admin/logout", token)` - with token
  - `testRequest("/admin/login", null, { data: {...} })` - without token
  - `testRequest("/admin/event/new", token, { data: {...} })` - with token and data

- **Updated all test calls**: Refactored 20+ test cases in `server.test.ts` to use the new API
  - Replaced verbose `new Request()` patterns with `testRequest()` calls
  - Simplified test readability by using the cleaner positional parameter syntax

- **Updated test-utils tests**: All unit tests for `testRequest` updated to verify new behavior

## Implementation Details
- The token parameter is optional and defaults to `undefined`
- When a token is provided, it's formatted as `session={token}` in the cookie header
- The raw cookie string option still works and is used when no token is provided
- All existing functionality is preserved; this is purely an API improvement