### PR TITLE
Add coverage requirements documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,16 @@ All tests must meet these mandatory criteria:
 - Each test has a single reason to fail
 - If you need "and" in the description, split the test
 
+### Coverage Requirements
+
+100% test coverage is required to merge into main. To find which specific lines are uncovered, run:
+
+```bash
+bun test --coverage --coverage-reporter=lcov
+```
+
+Then check `coverage/lcov.info` for detailed line-by-line coverage information.
+
 ### Test Utilities
 
 Use helpers from `#test-utils` instead of defining locally:


### PR DESCRIPTION
## Summary
Added documentation for test coverage requirements to the CLAUDE.md guidelines, specifying that 100% test coverage is required for merging into main and providing instructions on how to measure coverage.

## Changes
- Added new "Coverage Requirements" section to testing guidelines
- Documented the requirement for 100% test coverage before merging to main
- Provided command to generate coverage reports: `bun test --coverage --coverage-reporter=lcov`
- Included instructions for locating detailed line-by-line coverage information in `coverage/lcov.info`

## Details
This documentation clarifies the coverage expectations for contributors and provides clear, actionable steps to identify uncovered lines before submitting pull requests. The guidance uses the project's existing test runner (bun) and standard coverage reporting tools.