### PR TITLE
Fix payment cancel authentication and add admin attendee deletion

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -96,7 +96,7 @@ export const createCheckoutSession = async (
 
   const currency = (await getCurrencyCode()).toLowerCase();
   const successUrl = `${baseUrl}/payment/success?attendee_id=${attendee.id}&session_id={CHECKOUT_SESSION_ID}`;
-  const cancelUrl = `${baseUrl}/payment/cancel?attendee_id=${attendee.id}`;
+  const cancelUrl = `${baseUrl}/payment/cancel?attendee_id=${attendee.id}&session_id={CHECKOUT_SESSION_ID}`;
   const ticketLabel = quantity > 1 ? `${quantity} Tickets` : "Ticket";
 
   return safeAsync(() =>

--- a/src/templates/admin.tsx
+++ b/src/templates/admin.tsx
@@ -83,13 +83,18 @@ export const adminDashboardPage = (
   );
 };
 
-const AttendeeRow = ({ a }: { a: Attendee }): string =>
+const AttendeeRow = ({ a, eventId }: { a: Attendee; eventId: number }): string =>
   String(
     <tr>
       <td>{a.name}</td>
       <td>{a.email}</td>
       <td>{a.quantity}</td>
       <td>{new Date(a.created).toLocaleString()}</td>
+      <td>
+        <a href={`/admin/event/${eventId}/attendee/${a.id}/delete`} style="color: #c00;">
+          Delete
+        </a>
+      </td>
     </tr>
   );
 
@@ -102,8 +107,11 @@ export const adminEventPage = (
 ): string => {
   const attendeeRows =
     attendees.length > 0
-      ? pipe(map((a: Attendee) => AttendeeRow({ a })), joinStrings)(attendees)
-      : '<tr><td colspan="4">No attendees yet</td></tr>';
+      ? pipe(
+          map((a: Attendee) => AttendeeRow({ a, eventId: event.id })),
+          joinStrings,
+        )(attendees)
+      : '<tr><td colspan="5">No attendees yet</td></tr>';
 
   return String(
     <Layout title={`Event: ${event.name}`}>
@@ -151,6 +159,7 @@ export const adminEventPage = (
             <th>Email</th>
             <th>Qty</th>
             <th>Registered</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -232,6 +241,55 @@ export const adminDeleteEventPage = (
           style="background: #c00; border-color: #900;"
         >
           Delete Event
+        </button>
+      </form>
+    </Layout>
+  );
+
+/**
+ * Admin delete attendee confirmation page
+ */
+export const adminDeleteAttendeePage = (
+  event: EventWithCount,
+  attendee: Attendee,
+  csrfToken: string,
+  error?: string,
+): string =>
+  String(
+    <Layout title={`Delete Attendee: ${attendee.name}`}>
+      <h1>Delete Attendee</h1>
+      <p><a href={`/admin/event/${event.id}`}>&larr; Back to Event</a></p>
+
+      {error && <div class="error">{error}</div>}
+
+      <p style="color: #c00; font-weight: bold;">
+        Warning: This will permanently remove this attendee from the event.
+      </p>
+
+      <h2>Attendee Details</h2>
+      <p><strong>Name:</strong> {attendee.name}</p>
+      <p><strong>Email:</strong> {attendee.email}</p>
+      <p><strong>Quantity:</strong> {attendee.quantity}</p>
+      <p><strong>Registered:</strong> {new Date(attendee.created).toLocaleString()}</p>
+
+      <p>To delete this attendee, you must type their name "{attendee.name}" into the box below:</p>
+
+      <form method="POST" action={`/admin/event/${event.id}/attendee/${attendee.id}/delete`}>
+        <input type="hidden" name="csrf_token" value={csrfToken} />
+        <div class="field">
+          <input
+            type="text"
+            name="confirm_name"
+            placeholder={attendee.name}
+            autocomplete="off"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          style="background: #c00; border-color: #900;"
+        >
+          Delete Attendee
         </button>
       </form>
     </Layout>

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -5,6 +5,7 @@
 // Admin pages
 export {
   adminDashboardPage,
+  adminDeleteAttendeePage,
   adminDeleteEventPage,
   adminEventEditPage,
   adminEventPage,

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -1432,6 +1432,33 @@ describe("server", () => {
       expect(response.status).toBe(404);
     });
 
+    test("returns 404 for non-existent attendee", async () => {
+      await createEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+
+      const loginResponse = await handleRequest(
+        mockFormRequest("/admin/login", { password: TEST_ADMIN_PASSWORD }),
+      );
+      const cookie = loginResponse.headers.get("set-cookie") || "";
+      const csrfToken = await getCsrfTokenFromCookie(cookie);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/event/1/attendee/999/delete",
+          {
+            confirm_name: "John Doe",
+            csrf_token: csrfToken || "",
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(404);
+    });
+
     test("rejects invalid CSRF token", async () => {
       await createEvent({
         name: "Test Event",
@@ -1552,6 +1579,27 @@ describe("server", () => {
       );
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("/admin/event/1");
+    });
+  });
+
+  describe("PATCH /admin/event/:eventId/attendee/:attendeeId/delete", () => {
+    test("route handler returns null for unsupported method", async () => {
+      await createEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      await createAttendee(1, "John Doe", "john@example.com");
+
+      // PATCH is not supported by this specific route handler, which returns null.
+      // The request then continues through middleware that returns 403.
+      const response = await handleRequest(
+        new Request("http://localhost/admin/event/1/attendee/1/delete", {
+          method: "PATCH",
+        }),
+      );
+      expect(response.status).toBe(403);
     });
   });
 


### PR DESCRIPTION
Security fixes:
- /payment/cancel now requires session_id parameter for Stripe verification
- Verify session metadata matches attendee_id (prevents IDOR attacks)
- Only allow cancellation of unpaid attendees (stripe_payment_id is null)

Admin features:
- Add /admin/event/:id/attendee/:id/delete endpoint with name verification
- Delete confirmation page similar to event deletion (type name to confirm)
- Attendee table now shows delete action link for each attendee

https://claude.ai/code/session_012SPPpXKSuFmjv2fFPsT2iC