### PR TITLE
Refactor response helpers to reduce duplication

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -137,6 +137,10 @@ const withEventAttendees = async (
   );
 };
 
+/** Login page response helper */
+const loginResponse = (error?: string, status = 200) =>
+  htmlResponse(adminLoginPage(error), status);
+
 /**
  * Handle GET /admin/
  */
@@ -145,7 +149,7 @@ const handleAdminGet = (request: Request): Promise<Response> =>
     request,
     async (session) =>
       htmlResponse(adminDashboardPage(await getAllEvents(), session.csrfToken)),
-    () => htmlResponse(adminLoginPage()),
+    () => loginResponse(),
   );
 
 /**
@@ -159,8 +163,8 @@ const handleAdminLogin = async (
 
   // Check rate limiting
   if (await isLoginRateLimited(clientIp)) {
-    return htmlResponse(
-      adminLoginPage("Too many login attempts. Please try again later."),
+    return loginResponse(
+      "Too many login attempts. Please try again later.",
       429,
     );
   }
@@ -169,13 +173,13 @@ const handleAdminLogin = async (
   const validation = validateForm(form, loginFields);
 
   if (!validation.valid) {
-    return htmlResponse(adminLoginPage(validation.error), 400);
+    return loginResponse(validation.error, 400);
   }
 
   const valid = await verifyAdminPassword(validation.values.password as string);
   if (!valid) {
     await recordFailedLogin(clientIp);
-    return htmlResponse(adminLoginPage("Invalid credentials"), 401);
+    return loginResponse("Invalid credentials", 401);
   }
 
   // Clear failed attempts on successful login

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -41,7 +41,6 @@ import {
   eventFields,
   generateAttendeesCsv,
   loginFields,
-  notFoundPage,
   stripeKeyFields,
 } from "#templates";
 import type { ServerContext } from "./types.ts";
@@ -54,6 +53,7 @@ import {
   htmlResponse,
   isAuthenticated,
   matchRoute,
+  notFoundResponse,
   parseFormData,
   type RouteHandler,
   type RouteHandlerWithServer,
@@ -353,7 +353,7 @@ const eventErrorPage = async (
   const event = await getEventWithCount(id);
   return event
     ? htmlResponse(renderPage(event, csrfToken, error), 400)
-    : htmlResponse(notFoundPage(), 404);
+    : notFoundResponse();
 };
 
 /** Handle GET /admin/event/:id/edit */
@@ -364,7 +364,7 @@ const handleAdminEventEditPost = updateHandler(eventsResource, {
   onSuccess: (row) => redirect(`/admin/event/${row.id}`),
   onError: (id, error, session) =>
     eventErrorPage(id as number, adminEventEditPage, session.csrfToken, error),
-  onNotFound: () => htmlResponse(notFoundPage(), 404),
+  onNotFound: notFoundResponse,
 });
 
 /**
@@ -395,7 +395,7 @@ const handleAdminEventDelete = deleteHandler(eventsResource, {
       session.csrfToken,
       "Event name does not match. Please type the exact name to confirm deletion.",
     ),
-  onNotFound: () => htmlResponse(notFoundPage(), 404),
+  onNotFound: notFoundResponse,
 });
 
 /** Verify name matches for deletion confirmation (case-insensitive, trimmed) */
@@ -426,7 +426,7 @@ const withAttendeeForEvent =
     handler: (data: AttendeeWithEvent) => Response | Promise<Response>,
   ): Promise<Response> => {
     const data = await loadAttendeeForEvent(eventId, attendeeId);
-    return data ? handler(data) : htmlResponse(notFoundPage(), 404);
+    return data ? handler(data) : notFoundResponse();
   };
 
 /** Handle GET /admin/event/:eventId/attendee/:attendeeId/delete */

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,6 @@
  */
 
 import { isSetupComplete } from "#lib/config.ts";
-import { notFoundPage } from "#templates";
 import { routeAdmin } from "./admin.ts";
 import { handleFavicon } from "./favicon.ts";
 import { handleHealthCheck } from "./health.ts";
@@ -18,7 +17,7 @@ import {
 import { handleHome, routeTicket } from "./public.ts";
 import { routeSetup } from "./setup.ts";
 import type { ServerContext } from "./types.ts";
-import { htmlResponse, parseRequest, redirect } from "./utils.ts";
+import { notFoundResponse, parseRequest, redirect } from "./utils.ts";
 import { routePayment } from "./webhooks.ts";
 
 // Re-export middleware functions for testing
@@ -54,7 +53,7 @@ const routeMainApp = async (
   const paymentResponse = await routePayment(request, path, method);
   if (paymentResponse) return paymentResponse;
 
-  return htmlResponse(notFoundPage(), 404);
+  return notFoundResponse();
 };
 
 /**

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -33,15 +33,29 @@ export const handleHome = (): Response => {
 /** Path for ticket CSRF cookies */
 const ticketCsrfPath = (eventId: number): string => `/ticket/${eventId}`;
 
+/** Ticket response with CSRF cookie - curried to thread event and token through */
+const ticketResponseWithCookie =
+  (event: EventWithCount) =>
+  (token: string) =>
+  (error?: string, status = 200) =>
+    htmlResponseWithCookie(csrfCookie(token, ticketCsrfPath(event.id)))(
+      ticketPage(event, token, error),
+      status,
+    );
+
+/** Ticket response without cookie - for validation errors after CSRF passed */
+const ticketResponse =
+  (event: EventWithCount, token: string) =>
+  (error: string, status = 400) =>
+    htmlResponse(ticketPage(event, token, error), status);
+
 /**
  * Handle GET /ticket/:id
  */
 export const handleTicketGet = (eventId: number): Promise<Response> =>
   withEvent(eventId, (event) => {
     const token = generateSecureToken();
-    return htmlResponseWithCookie(csrfCookie(token, ticketCsrfPath(eventId)))(
-      ticketPage(event, token),
-    );
+    return ticketResponseWithCookie(event)(token)();
   });
 
 /**
@@ -81,12 +95,8 @@ const handlePaymentFlow = async (
 
   // If Stripe session creation failed, clean up and show error
   await deleteAttendee(attendee.id);
-  return htmlResponse(
-    ticketPage(
-      event,
-      csrfToken,
-      "Failed to create payment session. Please try again.",
-    ),
+  return ticketResponse(event, csrfToken)(
+    "Failed to create payment session. Please try again.",
     500,
   );
 };
@@ -105,12 +115,10 @@ const parseQuantity = (
   return Math.min(quantity, event.max_quantity);
 };
 
-/**
- * Create CSRF error response for ticket page
- */
-const ticketCsrfError = (event: EventWithCount) => (newToken: string) =>
-  htmlResponseWithCookie(csrfCookie(newToken, ticketCsrfPath(event.id)))(
-    ticketPage(event, newToken, "Invalid or expired form. Please try again."),
+/** CSRF error response for ticket page */
+const ticketCsrfError = (event: EventWithCount) => (token: string) =>
+  ticketResponseWithCookie(event)(token)(
+    "Invalid or expired form. Please try again.",
     403,
   );
 
@@ -132,16 +140,16 @@ const processTicketReservation = async (
   const validation = validateForm(form, ticketFields);
 
   if (!validation.valid) {
-    return htmlResponse(ticketPage(event, currentToken, validation.error), 400);
+    return ticketResponse(event, currentToken)(validation.error);
   }
 
   const quantity = parseQuantity(form, event);
   const available = await hasAvailableSpots(event.id, quantity);
   if (!available) {
-    return htmlResponse(
-      ticketPage(event, currentToken, "Sorry, not enough spots available"),
-      400,
-    );
+    return ticketResponse(
+      event,
+      currentToken,
+    )("Sorry, not enough spots available");
   }
 
   const { values } = validation;

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -15,11 +15,11 @@ import {
   generateSecureToken,
   getBaseUrl,
   htmlResponse,
+  htmlResponseWithCookie,
   parseCookies,
   type RouteHandler,
   redirect,
   requireCsrfForm,
-  withCookie,
   withEvent,
 } from "./utils.ts";
 
@@ -39,9 +39,8 @@ const ticketCsrfPath = (eventId: number): string => `/ticket/${eventId}`;
 export const handleTicketGet = (eventId: number): Promise<Response> =>
   withEvent(eventId, (event) => {
     const token = generateSecureToken();
-    return withCookie(
-      htmlResponse(ticketPage(event, token)),
-      csrfCookie(token, ticketCsrfPath(eventId)),
+    return htmlResponseWithCookie(csrfCookie(token, ticketCsrfPath(eventId)))(
+      ticketPage(event, token),
     );
   });
 
@@ -110,12 +109,9 @@ const parseQuantity = (
  * Create CSRF error response for ticket page
  */
 const ticketCsrfError = (event: EventWithCount) => (newToken: string) =>
-  withCookie(
-    htmlResponse(
-      ticketPage(event, newToken, "Invalid or expired form. Please try again."),
-      403,
-    ),
-    csrfCookie(newToken, ticketCsrfPath(event.id)),
+  htmlResponseWithCookie(csrfCookie(newToken, ticketCsrfPath(event.id)))(
+    ticketPage(event, newToken, "Invalid or expired form. Please try again."),
+    403,
   );
 
 /**

--- a/src/routes/setup.ts
+++ b/src/routes/setup.ts
@@ -8,11 +8,11 @@ import { setupCompletePage, setupFields, setupPage } from "#templates";
 import {
   generateSecureToken,
   htmlResponse,
+  htmlResponseWithCookie,
   parseCookies,
   parseFormData,
   redirect,
   validateCsrfToken,
-  withCookie,
 } from "./utils.ts";
 
 /** Cookie for CSRF token with standard security options */
@@ -96,9 +96,8 @@ export const handleSetupGet = async (
     return redirect("/");
   }
   const csrfToken = generateSecureToken();
-  return withCookie(
-    htmlResponse(setupPage(undefined, csrfToken)),
-    setupCsrfCookie(csrfToken),
+  return htmlResponseWithCookie(setupCsrfCookie(csrfToken))(
+    setupPage(undefined, csrfToken),
   );
 };
 
@@ -152,12 +151,9 @@ export const handleSetupPost = async (
     // biome-ignore lint/suspicious/noConsole: Debug logging for edge script
     console.log("[Setup] CSRF validation FAILED");
     const newCsrfToken = generateSecureToken();
-    return withCookie(
-      htmlResponse(
-        setupPage("Invalid or expired form. Please try again.", newCsrfToken),
-        403,
-      ),
-      setupCsrfCookie(newCsrfToken),
+    return htmlResponseWithCookie(setupCsrfCookie(newCsrfToken))(
+      setupPage("Invalid or expired form. Please try again.", newCsrfToken),
+      403,
     );
   }
 


### PR DESCRIPTION
Add three new response helper functions to utils.ts:
- notFoundResponse(): replaces htmlResponse(notFoundPage(), 404)
- paymentErrorResponse(message, status?): replaces htmlResponse(paymentErrorPage(message), status)
- htmlResponseWithCookie(cookie)(html, status?): curried composition for withCookie + htmlResponse

Updated all usages across admin.ts, index.ts, public.ts, setup.ts, and webhooks.ts.

https://claude.ai/code/session_01MKMxJz9JZ17gbnfxEVfh46