### PR TITLE
Fix: Specify repository and branch for checkout action

### DIFF
--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          repository: chobbledotcom/tickets
+          ref: main
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
Updated the GitHub Actions checkout step in the bunny-deploy workflow to explicitly specify the repository and branch to be checked out.

## Key Changes
- Added `repository: chobbledotcom/tickets` to the checkout action to ensure the correct repository is cloned
- Added `ref: main` to explicitly specify the `main` branch as the target ref

## Implementation Details
These changes ensure that the workflow explicitly checks out the correct repository and branch rather than relying on default behavior. This is particularly important in workflows that may be triggered from different contexts or when the workflow file itself might be in a different repository. The explicit configuration makes the workflow's intent clearer and more maintainable.