### PR TITLE
Normalize trailing slashes on all request paths

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -115,15 +115,15 @@ const attendeeDeleteHandler: RouteHandlerFn = (request, params) => {
 
 /** Attendee routes */
 export const attendeesRoutes = defineRoutes({
-  "GET /admin/event/:eventId/attendee/:attendeeId/delete": (
+  "GET /admin/event/:eventId/attendee/:attendeeId/delete/": (
     request,
     params,
   ) => {
     const ids = parseAttendeeIds(params);
     return handleAdminAttendeeDeleteGet(request, ids.eventId, ids.attendeeId);
   },
-  "POST /admin/event/:eventId/attendee/:attendeeId/delete":
+  "POST /admin/event/:eventId/attendee/:attendeeId/delete/":
     attendeeDeleteHandler,
-  "DELETE /admin/event/:eventId/attendee/:attendeeId/delete":
+  "DELETE /admin/event/:eventId/attendee/:attendeeId/delete/":
     attendeeDeleteHandler,
 });

--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -82,7 +82,7 @@ const handleAdminLogout = (request: Request): Promise<Response> =>
 
 /** Authentication routes */
 export const authRoutes = defineRoutes({
-  "POST /admin/login": (request, _, server) =>
+  "POST /admin/login/": (request, _, server) =>
     handleAdminLogin(request, server),
-  "GET /admin/logout": (request) => handleAdminLogout(request),
+  "GET /admin/logout/": (request) => handleAdminLogout(request),
 });

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -161,19 +161,19 @@ const parseEventId = (params: RouteParams): number =>
 
 /** Event routes */
 export const eventsRoutes = defineRoutes({
-  "POST /admin/event": (request) => handleCreateEvent(request),
-  "GET /admin/event/:id": (request, params) =>
+  "POST /admin/event/": (request) => handleCreateEvent(request),
+  "GET /admin/event/:id/": (request, params) =>
     handleAdminEventGet(request, parseEventId(params)),
-  "GET /admin/event/:id/edit": (request, params) =>
+  "GET /admin/event/:id/edit/": (request, params) =>
     handleAdminEventEditGet(request, parseEventId(params)),
-  "POST /admin/event/:id/edit": (request, params) =>
+  "POST /admin/event/:id/edit/": (request, params) =>
     handleAdminEventEditPost(request, parseEventId(params)),
-  "GET /admin/event/:id/export": (request, params) =>
+  "GET /admin/event/:id/export/": (request, params) =>
     handleAdminEventExport(request, parseEventId(params)),
-  "GET /admin/event/:id/delete": (request, params) =>
+  "GET /admin/event/:id/delete/": (request, params) =>
     handleAdminEventDeleteGet(request, parseEventId(params)),
-  "POST /admin/event/:id/delete": (request, params) =>
+  "POST /admin/event/:id/delete/": (request, params) =>
     handleAdminEventDelete(request, parseEventId(params)),
-  "DELETE /admin/event/:id/delete": (request, params) =>
+  "DELETE /admin/event/:id/delete/": (request, params) =>
     handleAdminEventDelete(request, parseEventId(params)),
 });

--- a/src/routes/admin/sessions.ts
+++ b/src/routes/admin/sessions.ts
@@ -37,6 +37,6 @@ const handleAdminSessionsPost = (request: Request): Promise<Response> =>
 
 /** Session management routes */
 export const sessionsRoutes = defineRoutes({
-  "GET /admin/sessions": (request) => handleAdminSessionsGet(request),
-  "POST /admin/sessions": (request) => handleAdminSessionsPost(request),
+  "GET /admin/sessions/": (request) => handleAdminSessionsGet(request),
+  "POST /admin/sessions/": (request) => handleAdminSessionsPost(request),
 });

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -161,7 +161,7 @@ const handleAdminStripePost = async (request: Request): Promise<Response> => {
 
 /** Settings routes */
 export const settingsRoutes = defineRoutes({
-  "GET /admin/settings": (request) => handleAdminSettingsGet(request),
-  "POST /admin/settings": (request) => handleAdminSettingsPost(request),
-  "POST /admin/settings/stripe": (request) => handleAdminStripePost(request),
+  "GET /admin/settings/": (request) => handleAdminSettingsGet(request),
+  "POST /admin/settings/": (request) => handleAdminSettingsPost(request),
+  "POST /admin/settings/stripe/": (request) => handleAdminStripePost(request),
 });

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -50,9 +50,10 @@ export const getSecurityHeaders = (
 
 /**
  * Check if a path is embeddable (public ticket pages only)
+ * Paths are normalized to always have trailing slashes
  */
 export const isEmbeddablePath = (path: string): boolean =>
-  /^\/ticket\/\d+$/.test(path);
+  /^\/ticket\/\d+\/$/.test(path);
 
 /**
  * Extract hostname from Host header (removes port if present)

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -194,8 +194,8 @@ const parseTicketId = (params: RouteParams): number =>
 
 /** Ticket routes definition */
 const ticketRoutes = defineRoutes({
-  "GET /ticket/:id": (_, params) => handleTicketGet(parseTicketId(params)),
-  "POST /ticket/:id": (request, params) =>
+  "GET /ticket/:id/": (_, params) => handleTicketGet(parseTicketId(params)),
+  "POST /ticket/:id/": (request, params) =>
     handleTicketPost(request, parseTicketId(params)),
 });
 

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -24,10 +24,10 @@ type CompiledRoute = {
 /**
  * Compile a route pattern into a regex
  * Supports :param syntax for path parameters
+ * All paths are normalized to have trailing slashes before matching
  * Examples:
- *   "GET /admin/" -> matches exact path
- *   "GET /admin/event/:id" -> extracts id param
- *   "POST /admin/event/:eventId/attendee/:attendeeId/delete" -> extracts both params
+ *   "GET /admin/" -> matches /admin/
+ *   "GET /admin/event/:id/" -> extracts id param from /admin/event/123/
  */
 const compilePattern = (
   pattern: string,
@@ -35,17 +35,12 @@ const compilePattern = (
   const paramNames: string[] = [];
 
   // Escape special regex chars except : which we use for params
-  let regexStr = pattern
+  const regexStr = pattern
     .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
     .replace(/:(\w+)/g, (_, name) => {
       paramNames.push(name);
       return "(\\d+)"; // Capture digits for ID params
     });
-
-  // Handle trailing slash optionality for paths ending in /
-  if (regexStr.endsWith("/")) {
-    regexStr = `${regexStr.slice(0, -1)}/?`;
-  }
 
   const regex = new RegExp(`^${regexStr}$`) as RegExp & {
     paramNames: string[];

--- a/src/routes/static.ts
+++ b/src/routes/static.ts
@@ -8,9 +8,9 @@ import { createRouter, defineRoutes } from "#routes/router.ts";
 
 /** Static routes definition */
 const staticRoutes = defineRoutes({
-  "GET /health": () => handleHealthCheck(),
-  "GET /favicon.ico": () => handleFavicon(),
-  "GET /mvp.css": () => handleMvpCss(),
+  "GET /health/": () => handleHealthCheck(),
+  "GET /favicon.ico/": () => handleFavicon(),
+  "GET /mvp.css/": () => handleMvpCss(),
 });
 
 /** Route static asset requests */

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -148,13 +148,21 @@ export const getBaseUrl = (request: Request): string => {
 };
 
 /**
+ * Normalize path to always have a trailing slash
+ * This allows consistent path comparisons like "/admin/" instead of checking both "/admin" and "/admin/"
+ */
+export const normalizePath = (path: string): string =>
+  path.endsWith("/") ? path : `${path}/`;
+
+/**
  * Parse request URL and extract path/method
+ * Paths are normalized to always have a trailing slash
  */
 export const parseRequest = (
   request: Request,
 ): { url: URL; path: string; method: string } => {
   const url = new URL(request.url);
-  return { url, path: url.pathname, method: request.method };
+  return { url, path: normalizePath(url.pathname), method: request.method };
 };
 
 /**

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -232,8 +232,8 @@ const handlePaymentCancel = createPaymentHandler(null)(
 
 /** Payment routes definition */
 const paymentRoutes = defineRoutes({
-  "GET /payment/success": (request) => handlePaymentSuccess(request),
-  "GET /payment/cancel": (request) => handlePaymentCancel(request),
+  "GET /payment/success/": (request) => handlePaymentSuccess(request),
+  "GET /payment/cancel/": (request) => handlePaymentCancel(request),
 });
 
 /**


### PR DESCRIPTION
Add early path normalization in parseRequest() so all paths consistently
end with a trailing slash. This eliminates the need for dual path checks
like `path === "/admin/" || path === "/admin"` throughout the codebase.

Changes:
- Add normalizePath() function in utils.ts
- Update parseRequest() to normalize all incoming paths
- Update all route patterns to use trailing slashes
- Update isEmbeddablePath regex to expect trailing slash
- Remove optional trailing slash handling from router.ts