### PR TITLE
Add database version check to optimize initDb startup

### DIFF
--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -227,6 +227,8 @@ describe("code quality", () => {
       // Event CRUD for test data setup (production uses REST library)
       "lib/db/events.ts:createEvent",
       "lib/db/events.ts:updateEvent",
+      // DB version constant used in production but test pattern doesn't detect constant comparison
+      "lib/db/migrations/index.ts:LATEST_UPDATE",
     ];
 
     /**


### PR DESCRIPTION
Skip running all migrations when database is already up to date by
checking a version marker in the settings table. This significantly
improves startup time for production deployments.