### PR TITLE
Add spacing between tables and forms on admin pages

### DIFF
--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -65,6 +65,8 @@ export const adminDashboardPage = (
         </table>
       </section>
 
+      <br />
+
       <section>
         <form method="POST" action="/admin/event">
           <header>

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -74,14 +74,18 @@ export const adminSessionsPage = (
       </section>
 
       {otherSessionCount > 0 && (
-        <section>
-          <form method="POST" action="/admin/sessions">
-            <input type="hidden" name="csrf_token" value={csrfToken} />
-            <button type="submit" class="danger">
-              Log out of all other sessions ({otherSessionCount})
-            </button>
-          </form>
-        </section>
+        <>
+          <br />
+
+          <section>
+            <form method="POST" action="/admin/sessions">
+              <input type="hidden" name="csrf_token" value={csrfToken} />
+              <button type="submit" class="danger">
+                Log out of all other sessions ({otherSessionCount})
+              </button>
+            </form>
+          </section>
+        </>
       )}
     </Layout>
   );

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -44,6 +44,8 @@ export const adminSettingsPage = (
         </form>
       </section>
 
+      <br />
+
       <section>
         <form method="POST" action="/admin/settings">
           <header>


### PR DESCRIPTION
Add <br> tags between consecutive sections containing tables and forms
on the dashboard, sessions, and settings pages to improve visual spacing.