### PR TITLE
Refactor numeric comparison methods to reduce duplication

### DIFF
--- a/src/test-utils/test-compat.ts
+++ b/src/test-utils/test-compat.ts
@@ -206,40 +206,49 @@ class ExpectChain<T> {
     }
   }
 
-  toBeGreaterThan(expected: number): void {
-    const result = (this.actual as number) > expected;
+  private assertNumericComparison(
+    compareFn: (actual: number, expected: number) => boolean,
+    expected: number,
+    message: string,
+  ): void {
+    const result = compareFn(this.actual as number, expected);
     if (this.isNot) {
       assertFalse(result);
     } else {
-      assert(result, `Expected ${this.actual} to be greater than ${expected}`);
+      assert(result, message);
     }
+  }
+
+  toBeGreaterThan(expected: number): void {
+    this.assertNumericComparison(
+      (a, e) => a > e,
+      expected,
+      `Expected ${this.actual} to be greater than ${expected}`,
+    );
   }
 
   toBeGreaterThanOrEqual(expected: number): void {
-    const result = (this.actual as number) >= expected;
-    if (this.isNot) {
-      assertFalse(result);
-    } else {
-      assert(result, `Expected ${this.actual} to be >= ${expected}`);
-    }
+    this.assertNumericComparison(
+      (a, e) => a >= e,
+      expected,
+      `Expected ${this.actual} to be >= ${expected}`,
+    );
   }
 
   toBeLessThan(expected: number): void {
-    const result = (this.actual as number) < expected;
-    if (this.isNot) {
-      assertFalse(result);
-    } else {
-      assert(result, `Expected ${this.actual} to be less than ${expected}`);
-    }
+    this.assertNumericComparison(
+      (a, e) => a < e,
+      expected,
+      `Expected ${this.actual} to be less than ${expected}`,
+    );
   }
 
   toBeLessThanOrEqual(expected: number): void {
-    const result = (this.actual as number) <= expected;
-    if (this.isNot) {
-      assertFalse(result);
-    } else {
-      assert(result, `Expected ${this.actual} to be <= ${expected}`);
-    }
+    this.assertNumericComparison(
+      (a, e) => a <= e,
+      expected,
+      `Expected ${this.actual} to be <= ${expected}`,
+    );
   }
 
   toContain(expected: unknown): void {


### PR DESCRIPTION
## Summary
Refactored the numeric comparison assertion methods in `ExpectChain` to eliminate code duplication by extracting common logic into a shared `assertNumericComparison` helper method.

## Key Changes
- Created a new private `assertNumericComparison` method that handles the common pattern for all numeric comparison assertions
- Updated `toBeGreaterThan`, `toBeGreaterThanOrEqual`, `toBeLessThan`, and `toBeLessThanOrEqual` to use the new helper method
- Each comparison method now passes a comparison function, expected value, and error message to the helper

## Implementation Details
The refactoring consolidates the repeated logic of:
1. Performing the numeric comparison
2. Checking the `isNot` flag to determine assertion behavior
3. Calling either `assert` or `assertFalse` with an appropriate error message

This reduces code duplication from ~40 lines to ~15 lines while maintaining identical functionality and error messages for each comparison type.