### PR TITLE
Simplify admin page headers and navigation

### DIFF
--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -4,6 +4,7 @@
 
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { Layout } from "#templates/layout.tsx";
+import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
 
 /**
  * Admin delete attendee confirmation page
@@ -16,12 +17,8 @@ export const adminDeleteAttendeePage = (
 ): string =>
   String(
     <Layout title={`Delete Attendee: ${attendee.name}`}>
-      <header>
-        <h1>Delete Attendee</h1>
-        <nav>
-          <a href={`/admin/event/${event.id}`}>&larr; Back to Event</a>
-        </nav>
-      </header>
+      <AdminNav />
+      <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
 
       <section>
         {error && <div class="error">{error}</div>}

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -8,6 +8,7 @@ import type { EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { eventFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
+import { AdminNav } from "#templates/admin/nav.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
@@ -39,16 +40,7 @@ export const adminDashboardPage = (
 
   return String(
     <Layout title="Admin Dashboard">
-      <header>
-        <h1>Admin Dashboard</h1>
-        <nav>
-          <ul>
-            <li><a href="/admin/settings">Settings</a></li>
-            <li><a href="/admin/sessions">Sessions</a></li>
-            <li><a href="/admin/logout">Logout</a></li>
-          </ul>
-        </nav>
-      </header>
+      <AdminNav />
 
       <section>
         <header>

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -8,6 +8,7 @@ import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { eventFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
+import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
@@ -43,19 +44,21 @@ export const adminEventPage = (
 
   return String(
     <Layout title={`Event: ${event.name}`}>
+      <AdminNav />
+
       <header>
+        <Breadcrumb href="/admin/" label="Dashboard" />
         <h1>{event.name}</h1>
         <nav>
-          <ul>
-            <li><a href="/admin/">&larr; Back to Dashboard</a></li>
-            <li><a href={`/admin/event/${event.id}/edit`}>Edit Event</a></li>
-            {event.active === 1 ? (
-              <li><a href={`/admin/event/${event.id}/deactivate`} class="danger">Deactivate</a></li>
-            ) : (
-              <li><a href={`/admin/event/${event.id}/reactivate`}>Reactivate</a></li>
-            )}
-            <li><a href={`/admin/event/${event.id}/delete`} class="danger">Delete Event</a></li>
-          </ul>
+          <a href={`/admin/event/${event.id}/edit`}>Edit</a>
+          {" | "}
+          {event.active === 1 ? (
+            <a href={`/admin/event/${event.id}/deactivate`} class="danger">Deactivate</a>
+          ) : (
+            <a href={`/admin/event/${event.id}/reactivate`}>Reactivate</a>
+          )}
+          {" | "}
+          <a href={`/admin/event/${event.id}/delete`} class="danger">Delete</a>
         </nav>
       </header>
 
@@ -142,12 +145,8 @@ export const adminEventEditPage = (
 ): string =>
   String(
     <Layout title={`Edit: ${event.name}`}>
-      <header>
-        <h1>Edit Event</h1>
-        <nav>
-          <a href={`/admin/event/${event.id}`}>&larr; Back to Event</a>
-        </nav>
-      </header>
+      <AdminNav />
+      <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
       <section>
         <Raw html={renderError(error)} />
         <form method="POST" action={`/admin/event/${event.id}/edit`}>
@@ -169,12 +168,8 @@ export const adminDeleteEventPage = (
 ): string =>
   String(
     <Layout title={`Delete: ${event.name}`}>
-      <header>
-        <h1>Delete Event</h1>
-        <nav>
-          <a href={`/admin/event/${event.id}`}>&larr; Back to Event</a>
-        </nav>
-      </header>
+      <AdminNav />
+      <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
 
       <section>
         {error && <div class="error">{error}</div>}
@@ -215,12 +210,8 @@ export const adminDeactivateEventPage = (
 ): string =>
   String(
     <Layout title={`Deactivate: ${event.name}`}>
-      <header>
-        <h1>Deactivate Event</h1>
-        <nav>
-          <a href={`/admin/event/${event.id}`}>&larr; Back to Event</a>
-        </nav>
-      </header>
+      <AdminNav />
+      <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
 
       <section>
         <article>
@@ -254,12 +245,8 @@ export const adminReactivateEventPage = (
 ): string =>
   String(
     <Layout title={`Reactivate: ${event.name}`}>
-      <header>
-        <h1>Reactivate Event</h1>
-        <nav>
-          <a href={`/admin/event/${event.id}`}>&larr; Back to Event</a>
-        </nav>
-      </header>
+      <AdminNav />
+      <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
 
       <section>
         <article>

--- a/src/templates/admin/login.tsx
+++ b/src/templates/admin/login.tsx
@@ -12,16 +12,11 @@ import { Layout } from "#templates/layout.tsx";
  */
 export const adminLoginPage = (error?: string): string =>
   String(
-    <Layout title="Admin Login">
-      <header>
-        <h1>Admin Login</h1>
-      </header>
-      <section>
-        <Raw html={renderError(error)} />
-        <form method="POST" action="/admin/login">
-          <Raw html={renderFields(loginFields)} />
-          <button type="submit">Login</button>
-        </form>
-      </section>
+    <Layout title="Login">
+      <Raw html={renderError(error)} />
+      <form method="POST" action="/admin/login">
+        <Raw html={renderFields(loginFields)} />
+        <button type="submit">Login</button>
+      </form>
     </Layout>
   );

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -1,0 +1,29 @@
+/**
+ * Shared admin navigation component
+ */
+
+/**
+ * Main admin navigation - shown at top of all admin pages
+ */
+export const AdminNav = (): JSX.Element => (
+  <nav>
+    <ul>
+      <li><a href="/admin/">Dashboard</a></li>
+      <li><a href="/admin/settings">Settings</a></li>
+      <li><a href="/admin/sessions">Sessions</a></li>
+      <li><a href="/admin/logout">Logout</a></li>
+    </ul>
+  </nav>
+);
+
+interface BreadcrumbProps {
+  href: string;
+  label: string;
+}
+
+/**
+ * Breadcrumb link for sub-pages
+ */
+export const Breadcrumb = ({ href, label }: BreadcrumbProps): JSX.Element => (
+  <p><a href={href}>&larr; {label}</a></p>
+);

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -6,6 +6,7 @@ import { map, pipe, reduce } from "#fp";
 import type { Session } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { Layout } from "#templates/layout.tsx";
+import { AdminNav } from "#templates/admin/nav.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
@@ -48,13 +49,8 @@ export const adminSessionsPage = (
   ).length;
 
   return String(
-    <Layout title="Admin Sessions">
-      <header>
-        <h1>Sessions</h1>
-        <nav>
-          <a href="/admin/">&larr; Back to Dashboard</a>
-        </nav>
-      </header>
+    <Layout title="Sessions">
+      <AdminNav />
 
       {success && <div class="success">{success}</div>}
 

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -6,6 +6,7 @@ import { renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { changePasswordFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
+import { AdminNav } from "#templates/admin/nav.tsx";
 
 /**
  * Admin settings page
@@ -13,13 +14,8 @@ import { Layout } from "#templates/layout.tsx";
  */
 export const adminSettingsPage = (csrfToken: string, error?: string): string =>
   String(
-    <Layout title="Admin Settings">
-      <header>
-        <h1>Admin Settings</h1>
-        <nav>
-          <a href="/admin/">&larr; Back to Dashboard</a>
-        </nav>
-      </header>
+    <Layout title="Settings">
+      <AdminNav />
 
       {error && <div class="error">{error}</div>}
 

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -47,7 +47,7 @@ describe("html", () => {
   describe("adminLoginPage", () => {
     test("renders login form", () => {
       const html = adminLoginPage();
-      expect(html).toContain("Admin Login");
+      expect(html).toContain("Login");
       expect(html).toContain('action="/admin/login"');
       expect(html).toContain('type="password"');
     });

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -284,7 +284,7 @@ describe("server", () => {
       const response = await awaitTestRequest("/admin/settings", { cookie });
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Admin Settings");
+      expect(html).toContain("Settings");
       expect(html).toContain("Change Password");
     });
   });
@@ -817,7 +817,7 @@ describe("server", () => {
       });
       const html = await response.text();
       expect(html).toContain("/admin/event/1/edit");
-      expect(html).toContain("Edit Event");
+      expect(html).toContain(">Edit<");
     });
   });
 
@@ -973,7 +973,7 @@ describe("server", () => {
       });
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Edit Event");
+      expect(html).toContain("Edit:");
       expect(html).toContain('value="Test Event"');
       expect(html).toContain("Test Description");
       expect(html).toContain('value="100"');

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -133,7 +133,7 @@ describe("server", () => {
       const response = await handleRequest(mockRequest("/admin/"));
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Admin Login");
+      expect(html).toContain("Login");
     });
 
     test("shows dashboard when authenticated", async () => {
@@ -158,7 +158,7 @@ describe("server", () => {
       const response = await handleRequest(mockRequest("/admin"));
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Admin Login");
+      expect(html).toContain("Login");
     });
   });
 
@@ -449,7 +449,7 @@ describe("server", () => {
       // Verify old session is invalidated
       const dashboardResponse = await awaitTestRequest("/admin/", { cookie });
       const html = await dashboardResponse.text();
-      expect(html).toContain("Admin Login"); // Should show login, not dashboard
+      expect(html).toContain("Login"); // Should show login, not dashboard
 
       // Verify new password works
       const newLoginResponse = await handleRequest(
@@ -2318,7 +2318,7 @@ describe("server", () => {
       const response = await awaitTestRequest("/admin/", "nonexistent");
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Admin Login");
+      expect(html).toContain("Login");
     });
 
     test("expired session is deleted and shows login page", async () => {
@@ -2328,7 +2328,7 @@ describe("server", () => {
       const response = await awaitTestRequest("/admin/", "expired-token");
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Admin Login");
+      expect(html).toContain("Login");
 
       // Verify the expired session was deleted
       const session = await getSession("expired-token");


### PR DESCRIPTION
- Create shared AdminNav component for consistent navigation across admin pages
- Remove redundant h1 page titles (Admin Dashboard, Admin Settings, etc.)
- Add navigation as first element on all logged-in admin pages
- Add Breadcrumb component for sub-page navigation back to parent
- Keep event name as h1 on event detail page (not redundant)
- Update page titles to be shorter (Settings, Sessions)