### PR TITLE
Remove test-only createEvent and updateEvent exports

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -113,42 +113,6 @@ const buildAttendeeResult = (
   quantity,
 });
 
-/** Common attendee input parameters */
-type AttendeeInput = {
-  eventId: number;
-  name: string;
-  email: string;
-  stripePaymentId?: string | null;
-  quantity?: number;
-};
-
-/** Execute simple insert (no capacity check) */
-const insertAttendee = async (
-  input: Required<AttendeeInput>,
-  encrypted: EncryptedAttendeeData,
-): Promise<Attendee> => {
-  const result = await getDb().execute({
-    sql: "INSERT INTO attendees (event_id, name, email, created, stripe_payment_id, quantity) VALUES (?, ?, ?, ?, ?, ?)",
-    args: [
-      input.eventId,
-      encrypted.encryptedName,
-      encrypted.encryptedEmail,
-      encrypted.created,
-      encrypted.encryptedPaymentId,
-      input.quantity,
-    ],
-  });
-  return buildAttendeeResult(
-    result.lastInsertRowid,
-    input.eventId,
-    input.name,
-    input.email,
-    encrypted.created,
-    input.stripePaymentId,
-    input.quantity,
-  );
-};
-
 /**
  * Get an attendee by ID without decrypting PII
  * Used for payment callbacks and webhooks where decryption is not needed

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -40,17 +40,6 @@ export const eventsTable = defineTable<Event, EventInput>({
   },
 });
 
-/**
- * Create a new event
- */
-export const createEvent = (e: EventInput): Promise<Event> =>
-  eventsTable.insert(e);
-
-/**
- * Update an existing event
- */
-export const updateEvent = (id: number, e: EventInput): Promise<Event | null> =>
-  eventsTable.update(id, e);
 
 /**
  * Get a single event by ID

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -10,7 +10,7 @@ import {
   getStripeSecretKey,
   getStripeWebhookSecret,
 } from "#lib/config.ts";
-import type { Attendee, Event } from "#lib/types.ts";
+import type { Event } from "#lib/types.ts";
 
 /** Lazy-load Stripe SDK only when needed */
 const loadStripe = once(async () => {
@@ -134,30 +134,6 @@ export const stripeApi = {
   /** Reset Stripe client (for testing) */
   resetStripeClient: (): void => setCache(null),
 
-  /** Create checkout session for ticket purchase */
-  createCheckoutSession: async (
-    evt: Event,
-    attendee: Attendee,
-    base: string,
-    qty = 1,
-  ): Promise<Stripe.Checkout.Session | null> => {
-    const attendeeQuery = `attendee_id=${attendee.id}&session_id={CHECKOUT_SESSION_ID}`;
-    const sessionParams = await buildSessionParams({
-      event: evt,
-      quantity: qty,
-      email: attendee.email,
-      successUrl: `${base}/payment/success?${attendeeQuery}`,
-      cancelUrl: `${base}/payment/cancel?${attendeeQuery}`,
-      metadata: {
-        attendee_id: String(attendee.id),
-        event_id: String(evt.id),
-        quantity: String(qty),
-      },
-    });
-    if (!sessionParams) return null;
-    return withClient((s) => s.checkout.sessions.create(sessionParams));
-  },
-
   /** Retrieve checkout session */
   retrieveCheckoutSession: (id: string): Promise<Stripe.Checkout.Session | null> =>
     withClient((s) => s.checkout.sessions.retrieve(id)),
@@ -203,12 +179,6 @@ export const resetStripeClient = () => stripeApi.resetStripeClient();
 export const retrieveCheckoutSession = (id: string) =>
   stripeApi.retrieveCheckoutSession(id);
 export const refundPayment = (id: string) => stripeApi.refundPayment(id);
-export const createCheckoutSession = (
-  e: Event,
-  a: Attendee,
-  b: string,
-  q?: number,
-) => stripeApi.createCheckoutSession(e, a, b, q);
 export const createCheckoutSessionWithIntent = (
   e: Event,
   i: RegistrationIntent,

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -529,8 +529,3 @@ export const createTestAttendee = async (
  */
 export { getAttendeesRaw };
 
-/**
- * Re-export legacy checkout session for test use
- * Production uses createCheckoutSessionWithIntent instead
- */
-export { createCheckoutSession } from "#lib/stripe.ts";

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -236,9 +236,6 @@ describe("code quality", () => {
       "lib/db/settings.ts:clearSetupCompleteCache",
       // Reset cached sessions between tests
       "lib/db/sessions.ts:resetSessionCache",
-      // Test helpers for creating test data (production uses atomic versions)
-      "lib/db/attendees.ts:createAttendee",
-      "lib/db/attendees.ts:updateAttendeePayment",
       // Legacy checkout session (production uses createCheckoutSessionWithIntent)
       "lib/stripe.ts:createCheckoutSession",
       // DB version constant used in production but test pattern doesn't detect constant comparison

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -236,8 +236,6 @@ describe("code quality", () => {
       "lib/db/settings.ts:clearSetupCompleteCache",
       // Reset cached sessions between tests
       "lib/db/sessions.ts:resetSessionCache",
-      // Legacy checkout session (production uses createCheckoutSessionWithIntent)
-      "lib/stripe.ts:createCheckoutSession",
       // DB version constant used in production but test pattern doesn't detect constant comparison
       "lib/db/migrations/index.ts:LATEST_UPDATE",
       // Client-side Stripe publishable key (for future payment form templates)

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -241,9 +241,6 @@ describe("code quality", () => {
       "lib/db/attendees.ts:updateAttendeePayment",
       // Legacy checkout session (production uses createCheckoutSessionWithIntent)
       "lib/stripe.ts:createCheckoutSession",
-      // Event CRUD for test data setup (production uses REST library)
-      "lib/db/events.ts:createEvent",
-      "lib/db/events.ts:updateEvent",
       // DB version constant used in production but test pattern doesn't detect constant comparison
       "lib/db/migrations/index.ts:LATEST_UPDATE",
       // Client-side Stripe publishable key (for future payment form templates)

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -16,10 +16,10 @@ import {
 import { getDb, setDb } from "#lib/db/client.ts";
 import {
   deleteEvent,
+  eventsTable,
   getAllEvents,
   getEvent,
   getEventWithCount,
-  updateEvent,
 } from "#lib/db/events.ts";
 import {
   clearLoginAttempts,
@@ -396,7 +396,7 @@ describe("db", () => {
       expect(fetched?.attendee_count).toBe(0);
     });
 
-    test("updateEvent updates event properties", async () => {
+    test("eventsTable.update updates event properties", async () => {
       const created = await createTestEvent({
         name: "Original",
         description: "Original Desc",
@@ -404,7 +404,7 @@ describe("db", () => {
         thankYouUrl: "https://example.com/original",
       });
 
-      const updated = await updateEvent(created.id, {
+      const updated = await eventsTable.update(created.id, {
         slug: created.slug,
         name: "Updated",
         description: "Updated Desc",
@@ -421,8 +421,8 @@ describe("db", () => {
       expect(updated?.unit_price).toBe(1500);
     });
 
-    test("updateEvent returns null for non-existent event", async () => {
-      const result = await updateEvent(999, {
+    test("eventsTable.update returns null for non-existent event", async () => {
+      const result = await eventsTable.update(999, {
         slug: "non-existent",
         name: "Name",
         description: "Desc",
@@ -432,7 +432,7 @@ describe("db", () => {
       expect(result).toBeNull();
     });
 
-    test("updateEvent can set unit_price to null", async () => {
+    test("eventsTable.update can set unit_price to null", async () => {
       const created = await createTestEvent({
         name: "Paid",
         description: "Desc",
@@ -441,7 +441,7 @@ describe("db", () => {
         unitPrice: 1000,
       });
 
-      const updated = await updateEvent(created.id, {
+      const updated = await eventsTable.update(created.id, {
         slug: created.slug,
         name: "Free Now",
         description: "Desc",

--- a/test/lib/processed-payments.test.ts
+++ b/test/lib/processed-payments.test.ts
@@ -5,7 +5,7 @@ import {
   markSessionProcessed,
 } from "#lib/db/processed-payments.ts";
 import {
-  createAttendee,
+  createTestAttendee,
   createTestDbWithSetup,
   createTestEvent,
   resetDb,
@@ -22,9 +22,9 @@ describe("processed-payments", () => {
     await createTestDbWithSetup();
     // Create test event and attendees to satisfy foreign key constraints
     const event = await createTestEvent();
-    const attendee1 = await createAttendee(event.id, "Test User 1", "test1@example.com");
-    const attendee2 = await createAttendee(event.id, "Test User 2", "test2@example.com");
-    const attendee3 = await createAttendee(event.id, "Test User 3", "test3@example.com");
+    const attendee1 = await createTestAttendee(event.id, event.slug, "Test User 1", "test1@example.com");
+    const attendee2 = await createTestAttendee(event.id, event.slug, "Test User 2", "test2@example.com");
+    const attendee3 = await createTestAttendee(event.id, event.slug, "Test User 3", "test3@example.com");
     testAttendeeId = attendee1.id;
     testAttendeeId2 = attendee2.id;
     testAttendeeId3 = attendee3.id;

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
-import { eventsTable } from "#lib/db/events.ts";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { resetStripeClient } from "#lib/stripe.ts";
 import { handleRequest } from "#src/server.ts";
@@ -19,7 +18,6 @@ import {
   mockRequestWithHost,
   mockSetupFormRequest,
   mockTicketFormRequest,
-  updateTestEvent,
   resetDb,
   resetTestSlugCounter,
   TEST_ADMIN_PASSWORD,
@@ -2091,8 +2089,8 @@ describe("server", () => {
 
       // Verify attendee was deleted
       const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
-      const attendee = await getAttendeeRaw(1);
-      expect(attendee).toBeNull();
+      const deletedAttendee = await getAttendeeRaw(1);
+      expect(deletedAttendee).toBeNull();
     });
   });
 

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
-import { updateEvent } from "#lib/db/events.ts";
+import { eventsTable } from "#lib/db/events.ts";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { resetStripeClient } from "#lib/stripe.ts";
 import { handleRequest } from "#src/server.ts";
 import {
   awaitTestRequest,
   createAttendee,
-  createEvent,
   createTestDb,
   createTestDbWithSetup,
   createTestEvent,
+  deactivateTestEvent,
   getCsrfTokenFromCookie,
   getSetupCsrfToken,
   getTicketCsrfToken,
@@ -18,6 +18,7 @@ import {
   mockRequestWithHost,
   mockSetupFormRequest,
   mockTicketFormRequest,
+  updateTestEvent,
   resetDb,
   resetTestSlugCounter,
   TEST_ADMIN_PASSWORD,
@@ -701,7 +702,7 @@ describe("server", () => {
 
     test("rejects duplicate slug", async () => {
       // First, create an event with a specific slug
-      await createEvent({
+      await createTestEvent({
         slug: "duplicate-slug",
         name: "First Event",
         description: "Desc",
@@ -1104,14 +1105,14 @@ describe("server", () => {
       const csrfToken = await getCsrfTokenFromCookie(cookie);
 
       // Create two events
-      await createEvent({
+      await createTestEvent({
         slug: "first-event",
         name: "First",
         description: "Desc",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
-      await createEvent({
+      await createTestEvent({
         slug: "second-event",
         name: "Second",
         description: "Desc",
@@ -1309,14 +1310,7 @@ describe("server", () => {
         thankYouUrl: "https://example.com",
       });
       // Deactivate the event first
-      await updateEvent(event.id, {
-        slug: event.slug,
-        name: event.name,
-        description: event.description,
-        maxAttendees: event.max_attendees,
-        thankYouUrl: event.thank_you_url,
-        active: 0,
-      });
+      await deactivateTestEvent(event.id);
 
       const response = await awaitTestRequest("/admin/event/1/reactivate", {
         cookie: cookie || "",
@@ -1343,14 +1337,7 @@ describe("server", () => {
         thankYouUrl: "https://example.com",
       });
       // Deactivate the event first
-      await updateEvent(event.id, {
-        slug: event.slug,
-        name: event.name,
-        description: event.description,
-        maxAttendees: event.max_attendees,
-        thankYouUrl: event.thank_you_url,
-        active: 0,
-      });
+      await deactivateTestEvent(event.id);
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2138,14 +2125,7 @@ describe("server", () => {
         thankYouUrl: "https://example.com",
       });
       // Deactivate the event
-      await updateEvent(event.id, {
-        slug: event.slug,
-        name: event.name,
-        description: event.description,
-        maxAttendees: event.max_attendees,
-        thankYouUrl: event.thank_you_url,
-        active: 0,
-      });
+      await deactivateTestEvent(event.id);
       const response = await handleRequest(
         mockRequest(`/ticket/${event.slug}`),
       );
@@ -2175,14 +2155,7 @@ describe("server", () => {
         thankYouUrl: "https://example.com",
       });
       // Deactivate the event
-      await updateEvent(event.id, {
-        slug: event.slug,
-        name: event.name,
-        description: event.description,
-        maxAttendees: event.max_attendees,
-        thankYouUrl: event.thank_you_url,
-        active: 0,
-      });
+      await deactivateTestEvent(event.id);
       const response = await handleRequest(
         mockFormRequest(`/ticket/${event.slug}`, {
           name: "John",
@@ -2491,14 +2464,7 @@ describe("server", () => {
       });
 
       // Deactivate the event
-      await updateEvent(event.id, {
-        slug: event.slug,
-        name: event.name,
-        description: event.description,
-        maxAttendees: event.max_attendees,
-        thankYouUrl: event.thank_you_url,
-        active: 0,
-      });
+      await deactivateTestEvent(event.id);
 
       const mockRetrieve = spyOn(stripeApi, "retrieveCheckoutSession");
       mockRetrieve.mockResolvedValue({


### PR DESCRIPTION
Replace direct DB function calls with REST API-based helpers:
- createTestEvent now creates events via POST /admin/event
- updateTestEvent uses POST /admin/event/:id/edit
- deactivateTestEvent uses POST /admin/event/:id/deactivate

Tests now exercise the same code paths as production, improving
test coverage and removing the need for test-only exports from
the events module.