### PR TITLE
Fix Deno.env shim to override existing env in Bunny Edge runtime

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -89,9 +89,11 @@ globalThis.global ??= globalThis;
 `;
 
 // Create Deno.env shim with inlined environment variables
+// Force override Deno.env since Bunny Edge is Deno-based and has its own Deno.env
+// that doesn't have access to our build-time environment variables
 const DENO_ENV_SHIM = `const __INLINED_ENV__ = ${JSON.stringify(ENV_VARS)};
 globalThis.Deno ??= {};
-globalThis.Deno.env ??= { get: (key) => __INLINED_ENV__[key] };
+globalThis.Deno.env = { get: (key) => __INLINED_ENV__[key] };
 `;
 
 const result = await esbuild.build({


### PR DESCRIPTION
The previous code used ??= which only sets the value if null/undefined.
Since Bunny Edge is a Deno-based runtime, globalThis.Deno.env already
exists, so the inlined environment variables were never applied.

This caused DB_ENCRYPTION_KEY (and other env vars) to be undefined
at runtime despite being correctly set during build.