### PR TITLE
Refactor imperative loops to FP utilities

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -2,6 +2,7 @@
  * Middleware functions for request processing
  */
 
+import { compact } from "#fp";
 import { getAllowedDomain } from "#lib/config.ts";
 
 /** Cached allowed domain (read once at startup) */
@@ -19,22 +20,16 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
  * Build CSP header value
  * Restricts resources to self and prevents clickjacking for non-embeddable pages
  */
-const buildCspHeader = (embeddable: boolean): string => {
-  const directives: string[] = [];
-
-  // Frame ancestors - prevent clickjacking (except for embeddable pages)
-  if (!embeddable) {
-    directives.push("frame-ancestors 'none'");
-  }
-
-  // Restrict resource loading to self (prevents loading from unexpected domains)
-  directives.push("default-src 'self'");
-  directives.push("style-src 'self' 'unsafe-inline'"); // Allow inline styles
-  directives.push("script-src 'self' 'unsafe-inline'"); // Allow inline scripts
-  directives.push("form-action 'self'"); // Restrict form submissions to self
-
-  return directives.join("; ");
-};
+const buildCspHeader = (embeddable: boolean): string =>
+  compact([
+    // Frame ancestors - prevent clickjacking (except for embeddable pages)
+    !embeddable && "frame-ancestors 'none'",
+    // Restrict resource loading to self (prevents loading from unexpected domains)
+    "default-src 'self'",
+    "style-src 'self' 'unsafe-inline'", // Allow inline styles
+    "script-src 'self' 'unsafe-inline'", // Allow inline scripts
+    "form-action 'self'", // Restrict form submissions to self
+  ]).join("; ");
 
 /**
  * Get security headers for a response

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -2,6 +2,7 @@
  * Declarative router with pattern matching
  */
 
+import { reduce } from "#fp";
 import type { ServerContext } from "#routes/types.ts";
 
 /** Route parameters extracted from URL patterns */
@@ -78,24 +79,22 @@ const parseRoutePattern = (
  */
 const compileRoutes = (
   routes: Record<string, RouteHandlerFn>,
-): Map<string, CompiledRoute[]> => {
-  const compiled = new Map<string, CompiledRoute[]>();
-
-  for (const [pattern, handler] of Object.entries(routes)) {
-    const { method, path } = parseRoutePattern(pattern);
-    const regex = compilePattern(path);
-
-    const methodRoutes = compiled.get(method) ?? [];
-    methodRoutes.push({
-      regex,
-      paramNames: regex.paramNames,
-      handler,
-    });
-    compiled.set(method, methodRoutes);
-  }
-
-  return compiled;
-};
+): Map<string, CompiledRoute[]> =>
+  reduce(
+    (compiled: Map<string, CompiledRoute[]>, [pattern, handler]: [string, RouteHandlerFn]) => {
+      const { method, path } = parseRoutePattern(pattern);
+      const regex = compilePattern(path);
+      const methodRoutes = compiled.get(method) ?? [];
+      methodRoutes.push({
+        regex,
+        paramNames: regex.paramNames,
+        handler,
+      });
+      compiled.set(method, methodRoutes);
+      return compiled;
+    },
+    new Map<string, CompiledRoute[]>(),
+  )(Object.entries(routes));
 
 /**
  * Extract params from regex match using param names


### PR DESCRIPTION
- middleware.ts: Use compact() for CSP header building
- router.ts: Use reduce() for route compilation
- table.ts: Use mapAsync(), compact(), reduce() for DB operations