### PR TITLE
Add event activity log for admin visibility

### DIFF
--- a/src/lib/db/activityLog.ts
+++ b/src/lib/db/activityLog.ts
@@ -1,0 +1,85 @@
+/**
+ * Activity log operations
+ *
+ * Simple activity logging for admin visibility.
+ * Not encrypted, no personal info - just action descriptions.
+ */
+
+import { getDb, queryOne } from "#lib/db/client.ts";
+import { col, defineTable } from "#lib/db/table.ts";
+
+/** Activity log entry */
+export interface ActivityLogEntry {
+  id: number;
+  created: string;
+  event_id: number | null;
+  message: string;
+}
+
+/** Activity log input for create */
+export type ActivityLogInput = {
+  eventId?: number | null;
+  message: string;
+};
+
+/**
+ * Activity log table definition
+ */
+export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
+  {
+    name: "activity_log",
+    primaryKey: "id",
+    schema: {
+      id: col.generated<number>(),
+      created: col.withDefault(() => new Date().toISOString()),
+      event_id: col.simple<number | null>(),
+      message: col.simple<string>(),
+    },
+  },
+);
+
+/**
+ * Log an activity
+ */
+export const logActivity = (
+  message: string,
+  eventId?: number | null,
+): Promise<ActivityLogEntry> =>
+  activityLogTable.insert({ message, eventId: eventId ?? null });
+
+/**
+ * Get activity log entries for an event (most recent first)
+ */
+export const getEventActivityLog = async (
+  eventId: number,
+  limit = 100,
+): Promise<ActivityLogEntry[]> => {
+  const result = await getDb().execute({
+    sql: `SELECT * FROM activity_log WHERE event_id = ? ORDER BY created DESC LIMIT ?`,
+    args: [eventId, limit],
+  });
+  return result.rows as unknown as ActivityLogEntry[];
+};
+
+/**
+ * Get all activity log entries (most recent first)
+ */
+export const getAllActivityLog = async (
+  limit = 100,
+): Promise<ActivityLogEntry[]> => {
+  const result = await getDb().execute({
+    sql: `SELECT * FROM activity_log ORDER BY created DESC LIMIT ?`,
+    args: [limit],
+  });
+  return result.rows as unknown as ActivityLogEntry[];
+};
+
+/**
+ * Get a single activity log entry by ID
+ */
+export const getActivityLogEntry = (
+  id: number,
+): Promise<ActivityLogEntry | null> => queryOne<ActivityLogEntry>(
+  `SELECT * FROM activity_log WHERE id = ?`,
+  [id],
+);

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -7,7 +7,7 @@ import { getDb } from "#lib/db/client.ts";
 /**
  * The latest database update identifier - update this when adding new migrations
  */
-export const LATEST_UPDATE = "session token hashing and wrapped data key";
+export const LATEST_UPDATE = "activity log table";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -136,6 +136,17 @@ export const initDb = async (): Promise<void> => {
       ip TEXT PRIMARY KEY,
       attempts INTEGER NOT NULL DEFAULT 0,
       locked_until INTEGER
+    )
+  `);
+
+  // Create activity_log table (unencrypted, admin-only view)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS activity_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      created TEXT NOT NULL,
+      event_id INTEGER,
+      message TEXT NOT NULL,
+      FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE SET NULL
     )
   `);
 

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -2,6 +2,7 @@
  * Admin attendee management routes
  */
 
+import { logActivity } from "#lib/db/activityLog.ts";
 import { deleteAttendee, getAttendee } from "#lib/db/attendees.ts";
 import { getEventWithCount } from "#lib/db/events.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
@@ -102,6 +103,10 @@ const handleAdminAttendeeDeletePost = (
     }
 
     await deleteAttendee(attendeeId);
+    await logActivity(
+      `Deleted an attendee from event '${data.event.name}'`,
+      eventId,
+    );
     return redirect(`/admin/event/${eventId}`);
   });
 

--- a/src/routes/admin/dashboard.ts
+++ b/src/routes/admin/dashboard.ts
@@ -2,9 +2,11 @@
  * Admin dashboard route
  */
 
+import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { getAllEvents } from "#lib/db/events.ts";
 import { defineRoutes } from "#routes/router.ts";
-import { htmlResponse, withSession } from "#routes/utils.ts";
+import { htmlResponse, requireSessionOr, withSession } from "#routes/utils.ts";
+import { adminGlobalActivityLogPage } from "#templates/admin/activityLog.tsx";
 import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
 
@@ -23,7 +25,16 @@ const handleAdminGet = (request: Request): Promise<Response> =>
     () => loginResponse(),
   );
 
+/**
+ * Handle GET /admin/activity-log
+ */
+const handleAdminActivityLog = (request: Request): Promise<Response> =>
+  requireSessionOr(request, async () =>
+    htmlResponse(adminGlobalActivityLogPage(await getAllActivityLog())),
+  );
+
 /** Dashboard routes */
 export const dashboardRoutes = defineRoutes({
   "GET /admin": (request) => handleAdminGet(request),
+  "GET /admin/activity-log": (request) => handleAdminActivityLog(request),
 });

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -3,6 +3,10 @@
  */
 
 import type { InValue } from "@libsql/client";
+import {
+  getEventActivityLog,
+  logActivity,
+} from "#lib/db/activityLog.ts";
 import { getAttendees } from "#lib/db/attendees.ts";
 import {
   deleteEvent,
@@ -11,11 +15,7 @@ import {
   getEventWithCount,
   isSlugTaken,
 } from "#lib/db/events.ts";
-import {
-  createHandler,
-  deleteHandler,
-  updateHandler,
-} from "#lib/rest/handlers.ts";
+import { createHandler, updateHandler } from "#lib/rest/handlers.ts";
 import { defineResource } from "#lib/rest/resource.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { defineRoutes, type RouteParams } from "#routes/router.ts";
@@ -29,6 +29,7 @@ import {
   withAuthForm,
   withEvent,
 } from "#routes/utils.ts";
+import { adminEventActivityLogPage } from "#templates/admin/activityLog.tsx";
 import {
   adminDeactivateEventPage,
   adminDeleteEventPage,
@@ -76,7 +77,7 @@ const eventsResource = defineResource({
 const withEventAttendees = async (
   request: Request,
   eventId: number,
-  handler: (event: EventWithCount, attendees: Attendee[]) => Response,
+  handler: (event: EventWithCount, attendees: Attendee[]) => Response | Promise<Response>,
 ): Promise<Response> => {
   const session = await getAuthenticatedSession(request);
   if (!session) {
@@ -98,7 +99,10 @@ const withEventAttendees = async (
  * Handle POST /admin/event (create event)
  */
 const handleCreateEvent = createHandler(eventsResource, {
-  onSuccess: () => redirect("/admin"),
+  onSuccess: async (row) => {
+    await logActivity(`Created event '${row.name}'`, row.id);
+    return redirect("/admin");
+  },
   onError: () => redirect("/admin"),
 });
 
@@ -154,9 +158,10 @@ const handleAdminEventEditPost = updateHandler(eventsResource, {
  * Handle GET /admin/event/:id/export (CSV export)
  */
 const handleAdminEventExport = (request: Request, eventId: number) =>
-  withEventAttendees(request, eventId, (event, attendees) => {
+  withEventAttendees(request, eventId, async (event, attendees) => {
     const csv = generateAttendeesCsv(attendees);
     const filename = `${event.name.replace(/[^a-zA-Z0-9]/g, "_")}_attendees.csv`;
+    await logActivity(`Exported CSV for '${event.name}'`, event.id);
     return new Response(csv, {
       headers: {
         "content-type": "text/csv; charset=utf-8",
@@ -191,18 +196,53 @@ const handleAdminEventReactivatePost = setActiveHandler(1);
 /** Handle GET /admin/event/:id/delete (show confirmation page) */
 const handleAdminEventDeleteGet = withEventPage(adminDeleteEventPage);
 
-/** Handle DELETE /admin/event/:id (delete event, optionally verify name) */
-const handleAdminEventDelete = deleteHandler(eventsResource, {
-  onSuccess: () => redirect("/admin"),
-  onVerifyFailed: (id, _row, session) =>
-    eventErrorPage(
-      id as number,
-      adminDeleteEventPage,
-      session.csrfToken,
-      "Event name does not match. Please type the exact name to confirm deletion.",
-    ),
-  onNotFound: notFoundResponse,
-});
+/** Handle GET /admin/event/:id/activity-log */
+const handleAdminEventActivityLog = (
+  request: Request,
+  eventId: number,
+): Promise<Response> =>
+  requireSessionOr(request, async () => {
+    const event = await getEventWithCount(eventId);
+    if (!event) {
+      return notFoundResponse();
+    }
+    const entries = await getEventActivityLog(eventId);
+    return htmlResponse(adminEventActivityLogPage(event, entries));
+  });
+
+/** Verify name matches for deletion confirmation (case-insensitive, trimmed) */
+const verifyName = (expected: string, provided: string): boolean =>
+  expected.trim().toLowerCase() === provided.trim().toLowerCase();
+
+/** Handle DELETE /admin/event/:id (delete event with logging) */
+const handleAdminEventDelete = (
+  request: Request,
+  eventId: number,
+): Promise<Response> =>
+  withAuthForm(request, async (session, form) => {
+    const event = await getEventWithCount(eventId);
+    if (!event) {
+      return notFoundResponse();
+    }
+
+    const confirmName = form.get("confirm_name") ?? "";
+    if (!verifyName(event.name, confirmName)) {
+      return eventErrorPage(
+        eventId,
+        adminDeleteEventPage,
+        session.csrfToken,
+        "Event name does not match. Please type the exact name to confirm deletion.",
+      );
+    }
+
+    const attendeeCount = event.attendee_count;
+    const eventName = event.name;
+    await deleteEvent(eventId);
+    await logActivity(
+      `Deleted event '${eventName}' and ${attendeeCount} attendee(s)`,
+    );
+    return redirect("/admin");
+  });
 
 /** Parse event ID from params */
 const parseEventId = (params: RouteParams): number =>
@@ -219,6 +259,8 @@ export const eventsRoutes = defineRoutes({
     handleAdminEventEditPost(request, parseEventId(params)),
   "GET /admin/event/:id/export": (request, params) =>
     handleAdminEventExport(request, parseEventId(params)),
+  "GET /admin/event/:id/activity-log": (request, params) =>
+    handleAdminEventActivityLog(request, parseEventId(params)),
   "GET /admin/event/:id/deactivate": (request, params) =>
     handleAdminEventDeactivateGet(request, parseEventId(params)),
   "POST /admin/event/:id/deactivate": (request, params) =>

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -3,7 +3,6 @@
  */
 
 import { isPaymentsEnabled } from "#lib/config.ts";
-import { logActivity } from "#lib/db/activityLog.ts";
 import { createAttendeeAtomic, hasAvailableSpots } from "#lib/db/attendees.ts";
 import { validateForm } from "#lib/forms.tsx";
 import {
@@ -11,7 +10,7 @@ import {
   type RegistrationIntent,
 } from "#lib/stripe.ts";
 import type { EventWithCount } from "#lib/types.ts";
-import { notifyWebhook } from "#lib/webhook.ts";
+import { logAndNotifyRegistration } from "#lib/webhook.ts";
 import {
   createRouter,
   defineRoutes,
@@ -170,8 +169,7 @@ const processFreeReservation = async (
     return ticketResponse(event, token)(message);
   }
 
-  await logActivity(`Added an attendee to event '${event.name}'`, event.id);
-  await notifyWebhook(event, result.attendee);
+  await logAndNotifyRegistration(event, result.attendee);
   return redirect(event.thank_you_url);
 };
 

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -3,6 +3,7 @@
  */
 
 import { isPaymentsEnabled } from "#lib/config.ts";
+import { logActivity } from "#lib/db/activityLog.ts";
 import { createAttendeeAtomic, hasAvailableSpots } from "#lib/db/attendees.ts";
 import { validateForm } from "#lib/forms.tsx";
 import {
@@ -169,6 +170,7 @@ const processFreeReservation = async (
     return ticketResponse(event, token)(message);
   }
 
+  await logActivity(`Added an attendee to event '${event.name}'`, event.id);
   await notifyWebhook(event, result.attendee);
   return redirect(event.thank_you_url);
 };

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -8,7 +8,6 @@
  * 4. If capacity exceeded after payment, auto-refund and show error
  */
 
-import { logActivity } from "#lib/db/activityLog.ts";
 import {
   type CreateAttendeeResult,
   createAttendeeAtomic,
@@ -20,7 +19,7 @@ import {
   retrieveCheckoutSession,
 } from "#lib/stripe.ts";
 import type { Event } from "#lib/types.ts";
-import { notifyWebhook } from "#lib/webhook.ts";
+import { logAndNotifyRegistration } from "#lib/webhook.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import {
   getSearchParam,
@@ -164,8 +163,7 @@ const handlePaymentSuccess = withSessionId(async (sessionId) => {
     return handleFailedCreation(result, paymentIntentId);
   }
 
-  await logActivity(`Added an attendee to event '${event.name}'`, event.id);
-  await notifyWebhook(event, result.attendee);
+  await logAndNotifyRegistration(event, result.attendee);
   return htmlResponse(paymentSuccessPage(event, event.thank_you_url));
 });
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -8,6 +8,7 @@
  * 4. If capacity exceeded after payment, auto-refund and show error
  */
 
+import { logActivity } from "#lib/db/activityLog.ts";
 import {
   type CreateAttendeeResult,
   createAttendeeAtomic,
@@ -163,6 +164,7 @@ const handlePaymentSuccess = withSessionId(async (sessionId) => {
     return handleFailedCreation(result, paymentIntentId);
   }
 
+  await logActivity(`Added an attendee to event '${event.name}'`, event.id);
   await notifyWebhook(event, result.attendee);
   return htmlResponse(paymentSuccessPage(event, event.thank_you_url));
 });

--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -19,22 +19,23 @@ const ActivityLogRow = ({ entry }: { entry: ActivityLogEntry }): string =>
     </tr>
   );
 
+/** Generate activity log table rows */
+const activityLogRows = (entries: ActivityLogEntry[]): string =>
+  entries.length > 0
+    ? pipe(
+        map((entry: ActivityLogEntry) => ActivityLogRow({ entry })),
+        joinStrings,
+      )(entries)
+    : '<tr><td colspan="2">No activity recorded yet</td></tr>';
+
 /**
  * Admin activity log page for a specific event
  */
 export const adminEventActivityLogPage = (
   event: EventWithCount,
   entries: ActivityLogEntry[],
-): string => {
-  const rows =
-    entries.length > 0
-      ? pipe(
-          map((entry: ActivityLogEntry) => ActivityLogRow({ entry })),
-          joinStrings,
-        )(entries)
-      : '<tr><td colspan="2">No activity recorded yet</td></tr>';
-
-  return String(
+): string =>
+  String(
     <Layout title={`Activity Log: ${event.name}`}>
       <AdminNav />
       <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
@@ -49,10 +50,37 @@ export const adminEventActivityLogPage = (
             </tr>
           </thead>
           <tbody>
-            <Raw html={rows} />
+            <Raw html={activityLogRows(entries)} />
           </tbody>
         </table>
       </section>
     </Layout>
   );
-};
+
+/**
+ * Admin global activity log page (all events)
+ */
+export const adminGlobalActivityLogPage = (
+  entries: ActivityLogEntry[],
+): string =>
+  String(
+    <Layout title="Activity Log">
+      <AdminNav />
+      <Breadcrumb href="/admin/" label="Dashboard" />
+
+      <section>
+        <h2>Activity Log</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Raw html={activityLogRows(entries)} />
+          </tbody>
+        </table>
+      </section>
+    </Layout>
+  );

--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -1,0 +1,58 @@
+/**
+ * Admin activity log page template
+ */
+
+import { map, pipe, reduce } from "#fp";
+import type { ActivityLogEntry } from "#lib/db/activityLog.ts";
+import type { EventWithCount } from "#lib/types.ts";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { Layout } from "#templates/layout.tsx";
+import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
+
+const joinStrings = reduce((acc: string, s: string) => acc + s, "");
+
+const ActivityLogRow = ({ entry }: { entry: ActivityLogEntry }): string =>
+  String(
+    <tr>
+      <td>{new Date(entry.created).toLocaleString()}</td>
+      <td>{entry.message}</td>
+    </tr>
+  );
+
+/**
+ * Admin activity log page for a specific event
+ */
+export const adminEventActivityLogPage = (
+  event: EventWithCount,
+  entries: ActivityLogEntry[],
+): string => {
+  const rows =
+    entries.length > 0
+      ? pipe(
+          map((entry: ActivityLogEntry) => ActivityLogRow({ entry })),
+          joinStrings,
+        )(entries)
+      : '<tr><td colspan="2">No activity recorded yet</td></tr>';
+
+  return String(
+    <Layout title={`Activity Log: ${event.name}`}>
+      <AdminNav />
+      <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
+
+      <section>
+        <h2>Activity Log</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Raw html={rows} />
+          </tbody>
+        </table>
+      </section>
+    </Layout>
+  );
+};

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -52,6 +52,8 @@ export const adminEventPage = (
         <nav>
           <a href={`/admin/event/${event.id}/edit`}>Edit</a>
           {" | "}
+          <a href={`/admin/event/${event.id}/activity-log`}>Activity Log</a>
+          {" | "}
           {event.active === 1 ? (
             <a href={`/admin/event/${event.id}/deactivate`} class="danger">Deactivate</a>
           ) : (

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, jest, test } from "#test-compa
 import { createClient } from "@libsql/client";
 import { decryptWithKey, importPrivateKey } from "#lib/crypto.ts";
 import {
-  getActivityLogEntry,
   getAllActivityLog,
   getEventActivityLog,
   logActivity,
@@ -1348,19 +1347,6 @@ describe("db", () => {
 
       const entries = await getAllActivityLog(2);
       expect(entries.length).toBe(2);
-    });
-
-    test("getActivityLogEntry returns entry by ID", async () => {
-      const created = await logActivity("Test action");
-      const fetched = await getActivityLogEntry(created.id);
-
-      expect(fetched).not.toBeNull();
-      expect(fetched?.message).toBe("Test action");
-    });
-
-    test("getActivityLogEntry returns null for non-existent entry", async () => {
-      const entry = await getActivityLogEntry(999);
-      expect(entry).toBeNull();
     });
   });
 });

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -2,6 +2,12 @@ import { afterEach, beforeEach, describe, expect, jest, test } from "#test-compa
 import { createClient } from "@libsql/client";
 import { decryptWithKey, importPrivateKey } from "#lib/crypto.ts";
 import {
+  getActivityLogEntry,
+  getAllActivityLog,
+  getEventActivityLog,
+  logActivity,
+} from "#lib/db/activityLog.ts";
+import {
   createAttendeeAtomic,
   deleteAttendee,
   getAttendee,
@@ -1238,6 +1244,123 @@ describe("db", () => {
       // But the DB should have the transformed value (read transform lowercases)
       const fromDb = await testTable.findById(row.id);
       expect(fromDb?.name).toBe("test event"); // Read transform lowercases the uppercased "TEST EVENT"
+    });
+  });
+
+  describe("activity log", () => {
+    test("logActivity creates log entry with message", async () => {
+      const entry = await logActivity("Test action");
+
+      expect(entry.id).toBe(1);
+      expect(entry.message).toBe("Test action");
+      expect(entry.event_id).toBeNull();
+      expect(entry.created).toBeDefined();
+    });
+
+    test("logActivity creates log entry with event ID", async () => {
+      const event = await createTestEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      const entry = await logActivity("Created event 'Test Event'", event.id);
+
+      expect(entry.event_id).toBe(event.id);
+      expect(entry.message).toBe("Created event 'Test Event'");
+    });
+
+    test("getEventActivityLog returns entries for specific event", async () => {
+      const event1 = await createTestEvent({
+        name: "Event 1",
+        description: "Desc",
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      const event2 = await createTestEvent({
+        name: "Event 2",
+        description: "Desc",
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+
+      await logActivity("Action for event 1", event1.id);
+      await logActivity("Another action for event 1", event1.id);
+      await logActivity("Action for event 2", event2.id);
+
+      const event1Log = await getEventActivityLog(event1.id);
+      expect(event1Log.length).toBe(2);
+      expect(event1Log[0]?.message).toBe("Another action for event 1");
+      expect(event1Log[1]?.message).toBe("Action for event 1");
+    });
+
+    test("getEventActivityLog returns empty array when no entries", async () => {
+      const entries = await getEventActivityLog(999);
+      expect(entries).toEqual([]);
+    });
+
+    test("getEventActivityLog respects limit", async () => {
+      const event = await createTestEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+
+      await logActivity("Action 1", event.id);
+      await logActivity("Action 2", event.id);
+      await logActivity("Action 3", event.id);
+
+      const entries = await getEventActivityLog(event.id, 2);
+      expect(entries.length).toBe(2);
+    });
+
+    test("getAllActivityLog returns all entries", async () => {
+      const event = await createTestEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+
+      await logActivity("Global action");
+      await logActivity("Event action", event.id);
+
+      const entries = await getAllActivityLog();
+      expect(entries.length).toBe(2);
+    });
+
+    test("getAllActivityLog returns entries in descending order", async () => {
+      await logActivity("First action");
+      await logActivity("Second action");
+      await logActivity("Third action");
+
+      const entries = await getAllActivityLog();
+      expect(entries[0]?.message).toBe("Third action");
+      expect(entries[1]?.message).toBe("Second action");
+      expect(entries[2]?.message).toBe("First action");
+    });
+
+    test("getAllActivityLog respects limit", async () => {
+      await logActivity("Action 1");
+      await logActivity("Action 2");
+      await logActivity("Action 3");
+
+      const entries = await getAllActivityLog(2);
+      expect(entries.length).toBe(2);
+    });
+
+    test("getActivityLogEntry returns entry by ID", async () => {
+      const created = await logActivity("Test action");
+      const fetched = await getActivityLogEntry(created.id);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched?.message).toBe("Test action");
+    });
+
+    test("getActivityLogEntry returns null for non-existent entry", async () => {
+      const entry = await getActivityLogEntry(999);
+      expect(entry).toBeNull();
     });
   });
 });


### PR DESCRIPTION
- Add activity_log table to database migrations
- Create activityLog.ts module with log/query functions
- Log event creation, deletion, and CSV export
- Log attendee add (free and paid) and delete
- Add /admin/event/:id/activity-log route and template
- Add Activity Log link to event page navigation
- Add comprehensive tests for activity log operations

The log is visible to admins only, unencrypted, and contains
no personal information - just action descriptions like
"Created event 'foo'" or "Deleted an attendee from event 'bar'".