### PR TITLE
Make event name clickable in admin dashboard

### DIFF
--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -17,7 +17,7 @@ const EventRow = ({ e }: { e: EventWithCount }): string => {
   const rowStyle = isInactive ? 'opacity: 0.5;' : '';
   return String(
     <tr style={rowStyle || undefined}>
-      <td>{e.name}</td>
+      <td><a href={`/admin/event/${e.id}`}>{e.name}</a></td>
       <td>{isInactive ? "Inactive" : "Active"}</td>
       <td>{e.attendee_count} / {e.max_attendees}</td>
       <td>{new Date(e.created).toLocaleDateString()}</td>


### PR DESCRIPTION
The event name in the events table now links to the event detail page,
in addition to the existing "View" link in the Actions column.