### PR TITLE
Hash IP addresses for rate limiting storage

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -349,7 +349,7 @@ export const hashIpAddress = async (ip: string): Promise<string> => {
 
   const hmacKey = await crypto.subtle.importKey(
     "raw",
-    keyBytes,
+    keyBytes as BufferSource,
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"],

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -339,6 +339,33 @@ export const hashSessionToken = async (token: string): Promise<string> => {
 };
 
 /**
+ * Hash an IP address using HMAC-SHA256 with DB_ENCRYPTION_KEY
+ * Uses HMAC instead of plain SHA-256 because IPs are a limited keyspace
+ * and would be vulnerable to rainbow table attacks without keyed hashing
+ */
+export const hashIpAddress = async (ip: string): Promise<string> => {
+  const keyString = getEncryptionKeyString();
+  const keyBytes = decodeKeyBytes(keyString);
+
+  const hmacKey = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const encoder = new TextEncoder();
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    hmacKey,
+    encoder.encode(ip),
+  );
+
+  return toBase64(new Uint8Array(signature));
+};
+
+/**
  * =============================================================================
  * Key Encryption Key (KEK) Derivation
  * =============================================================================

--- a/src/lib/db/login-attempts.ts
+++ b/src/lib/db/login-attempts.ts
@@ -2,6 +2,7 @@
  * Login attempts table operations (rate limiting)
  */
 
+import { hashIpAddress } from "#lib/crypto.ts";
 import { executeByField, getDb, queryOne } from "#lib/db/client.ts";
 
 /**
@@ -10,18 +11,19 @@ import { executeByField, getDb, queryOne } from "#lib/db/client.ts";
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
 
-/** Query login attempts for an IP */
-const getLoginAttempts = (ip: string) =>
+/** Query login attempts for a hashed IP */
+const getLoginAttempts = (hashedIp: string) =>
   queryOne<{ attempts: number; locked_until: number | null }>(
     "SELECT attempts, locked_until FROM login_attempts WHERE ip = ?",
-    [ip],
+    [hashedIp],
   );
 
 /**
  * Check if IP is rate limited for login
  */
 export const isLoginRateLimited = async (ip: string): Promise<boolean> => {
-  const row = await getLoginAttempts(ip);
+  const hashedIp = await hashIpAddress(ip);
+  const row = await getLoginAttempts(hashedIp);
   if (!row) return false;
 
   // Check if currently locked out
@@ -31,7 +33,7 @@ export const isLoginRateLimited = async (ip: string): Promise<boolean> => {
 
   // If lockout expired, reset
   if (row.locked_until && row.locked_until <= Date.now()) {
-    await executeByField("login_attempts", "ip", ip);
+    await executeByField("login_attempts", "ip", hashedIp);
     return false;
   }
 
@@ -43,21 +45,22 @@ export const isLoginRateLimited = async (ip: string): Promise<boolean> => {
  * Returns true if the account is now locked
  */
 export const recordFailedLogin = async (ip: string): Promise<boolean> => {
-  const row = await getLoginAttempts(ip);
+  const hashedIp = await hashIpAddress(ip);
+  const row = await getLoginAttempts(hashedIp);
   const newAttempts = (row?.attempts ?? 0) + 1;
 
   if (newAttempts >= MAX_LOGIN_ATTEMPTS) {
     const lockedUntil = Date.now() + LOCKOUT_DURATION_MS;
     await getDb().execute({
       sql: "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)",
-      args: [ip, newAttempts, lockedUntil],
+      args: [hashedIp, newAttempts, lockedUntil],
     });
     return true;
   }
 
   await getDb().execute({
     sql: "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, NULL)",
-    args: [ip, newAttempts],
+    args: [hashedIp, newAttempts],
   });
   return false;
 };
@@ -65,5 +68,7 @@ export const recordFailedLogin = async (ip: string): Promise<boolean> => {
 /**
  * Clear login attempts for an IP (on successful login)
  */
-export const clearLoginAttempts = (ip: string): Promise<void> =>
-  executeByField("login_attempts", "ip", ip);
+export const clearLoginAttempts = async (ip: string): Promise<void> => {
+  const hashedIp = await hashIpAddress(ip);
+  await executeByField("login_attempts", "ip", hashedIp);
+};


### PR DESCRIPTION
Use HMAC-SHA256 with DB_ENCRYPTION_KEY to hash IP addresses before
storing them in the login_attempts table. This prevents exposure of
client IPs if the database is compromised, while still allowing rate
limiting lookups. HMAC is used instead of plain SHA-256 because IPs
are a limited keyspace vulnerable to rainbow table attacks.