### PR TITLE
Add X-Robots-Tag header to prevent search engine indexing

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -14,6 +14,7 @@ const ALLOWED_DOMAIN = getAllowedDomain();
 const BASE_SECURITY_HEADERS: Record<string, string> = {
   "x-content-type-options": "nosniff",
   "referrer-policy": "strict-origin-when-cross-origin",
+  "x-robots-tag": "noindex, nofollow",
 };
 
 /**

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -3561,6 +3561,11 @@ describe("server", () => {
         );
       });
 
+      test("responses have X-Robots-Tag: noindex, nofollow", async () => {
+        const response = await handleRequest(mockRequest("/"));
+        expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+      });
+
       test("ticket pages also have base security headers", async () => {
         const event = await createTestEvent({
           name: "Event",
@@ -3575,6 +3580,7 @@ describe("server", () => {
         expect(response.headers.get("referrer-policy")).toBe(
           "strict-origin-when-cross-origin",
         );
+        expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
       });
     });
   });
@@ -3664,6 +3670,7 @@ describe("server", () => {
       );
       expect(response.headers.get("x-frame-options")).toBe("DENY");
       expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds the `X-Robots-Tag: noindex, nofollow` header to all server responses to prevent search engines from indexing and following links on this application.

## Changes
- Added `x-robots-tag` header to the `BASE_SECURITY_HEADERS` configuration in the middleware
- Updated existing tests to verify the header is present on all responses
- Added new test case to explicitly validate the `X-Robots-Tag` header

## Implementation Details
The `X-Robots-Tag` header is now included in all HTTP responses as part of the base security headers. This directive instructs search engine crawlers to:
- `noindex`: Not include this page in search engine indexes
- `nofollow`: Not follow any links on this page

This is applied globally across all routes and responses, ensuring consistent behavior throughout the application.