### PR TITLE
Encrypt event metadata and activity log messages

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -339,11 +339,11 @@ export const hashSessionToken = async (token: string): Promise<string> => {
 };
 
 /**
- * Hash an IP address using HMAC-SHA256 with DB_ENCRYPTION_KEY
- * Uses HMAC instead of plain SHA-256 because IPs are a limited keyspace
- * and would be vulnerable to rainbow table attacks without keyed hashing
+ * HMAC-SHA256 hash using DB_ENCRYPTION_KEY
+ * Used for blind indexes and hashing limited keyspace values
+ * Returns deterministic output for same input (unlike encrypt)
  */
-export const hashIpAddress = async (ip: string): Promise<string> => {
+export const hmacHash = async (value: string): Promise<string> => {
   const keyString = getEncryptionKeyString();
   const keyBytes = decodeKeyBytes(keyString);
 
@@ -359,11 +359,18 @@ export const hashIpAddress = async (ip: string): Promise<string> => {
   const signature = await crypto.subtle.sign(
     "HMAC",
     hmacKey,
-    encoder.encode(ip),
+    encoder.encode(value),
   );
 
   return toBase64(new Uint8Array(signature));
 };
+
+/**
+ * Hash an IP address using HMAC-SHA256 with DB_ENCRYPTION_KEY
+ * Uses HMAC instead of plain SHA-256 because IPs are a limited keyspace
+ * and would be vulnerable to rainbow table attacks without keyed hashing
+ */
+export const hashIpAddress = (ip: string): Promise<string> => hmacHash(ip);
 
 /**
  * =============================================================================

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -366,13 +366,6 @@ export const hmacHash = async (value: string): Promise<string> => {
 };
 
 /**
- * Hash an IP address using HMAC-SHA256 with DB_ENCRYPTION_KEY
- * Uses HMAC instead of plain SHA-256 because IPs are a limited keyspace
- * and would be vulnerable to rainbow table attacks without keyed hashing
- */
-export const hashIpAddress = (ip: string): Promise<string> => hmacHash(ip);
-
-/**
  * =============================================================================
  * Key Encryption Key (KEK) Derivation
  * =============================================================================

--- a/src/lib/db/activityLog.ts
+++ b/src/lib/db/activityLog.ts
@@ -1,10 +1,11 @@
 /**
  * Activity log operations
  *
- * Simple activity logging for admin visibility.
- * Not encrypted, no personal info - just action descriptions.
+ * Activity logging for admin visibility.
+ * Messages are encrypted - only admins can read them.
  */
 
+import { decrypt, encrypt } from "#lib/crypto.ts";
 import { getDb } from "#lib/db/client.ts";
 import { col, defineTable } from "#lib/db/table.ts";
 
@@ -24,6 +25,7 @@ export type ActivityLogInput = {
 
 /**
  * Activity log table definition
+ * message is encrypted - decrypted only for admin view
  */
 export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
   {
@@ -33,7 +35,7 @@ export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
       id: col.generated<number>(),
       created: col.withDefault(() => new Date().toISOString()),
       event_id: col.simple<number | null>(),
-      message: col.simple<string>(),
+      message: col.encrypted<string>(encrypt, decrypt),
     },
   },
 );
@@ -47,7 +49,7 @@ export const logActivity = (
 ): Promise<ActivityLogEntry> =>
   activityLogTable.insert({ message, eventId: eventId ?? null });
 
-/** Query activity log with optional event filter */
+/** Query activity log with optional event filter, decrypts messages */
 const queryActivityLog = async (
   eventId: number | null,
   limit: number,
@@ -58,7 +60,8 @@ const queryActivityLog = async (
     sql: `SELECT * FROM activity_log ${whereClause} ORDER BY created DESC, id DESC LIMIT ?`,
     args,
   });
-  return result.rows as unknown as ActivityLogEntry[];
+  const rows = result.rows as unknown as ActivityLogEntry[];
+  return Promise.all(rows.map((row) => activityLogTable.fromDb(row)));
 };
 
 /**

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -2,6 +2,7 @@
  * Events table operations
  */
 
+import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { executeByField, getDb, queryOne } from "#lib/db/client.ts";
 import { col, defineTable } from "#lib/db/table.ts";
 import type { Event, EventWithCount } from "#lib/types.ts";
@@ -9,6 +10,7 @@ import type { Event, EventWithCount } from "#lib/types.ts";
 /** Event input fields for create/update (camelCase) */
 export type EventInput = {
   slug: string;
+  slugIndex: string;
   name: string;
   description: string;
   maxAttendees: number;
@@ -19,18 +21,24 @@ export type EventInput = {
   active?: number;
 };
 
+/** Compute slug index from slug for blind index lookup */
+export const computeSlugIndex = (slug: string): Promise<string> =>
+  hmacHash(slug);
+
 /**
  * Events table definition
+ * name, description, slug are encrypted; slug_index is HMAC for lookups
  */
 export const eventsTable = defineTable<Event, EventInput>({
   name: "events",
   primaryKey: "id",
   schema: {
     id: col.generated<number>(),
-    slug: col.simple<string>(),
+    slug: col.encrypted<string>(encrypt, decrypt),
+    slug_index: col.simple<string>(),
     created: col.withDefault(() => new Date().toISOString()),
-    name: col.simple<string>(),
-    description: col.simple<string>(),
+    name: col.encrypted<string>(encrypt, decrypt),
+    description: col.encrypted<string>(encrypt, decrypt),
     max_attendees: col.simple<number>(),
     thank_you_url: col.simple<string>(),
     unit_price: col.simple<number | null>(),
@@ -49,15 +57,17 @@ export const getEvent = (id: number): Promise<Event | null> =>
 
 /**
  * Check if a slug is already in use (optionally excluding a specific event ID)
+ * Uses slug_index for lookup (blind index)
  */
 export const isSlugTaken = async (
   slug: string,
   excludeEventId?: number,
 ): Promise<boolean> => {
+  const slugIndex = await computeSlugIndex(slug);
   const sql = excludeEventId
-    ? "SELECT 1 FROM events WHERE slug = ? AND id != ?"
-    : "SELECT 1 FROM events WHERE slug = ?";
-  const args = excludeEventId ? [slug, excludeEventId] : [slug];
+    ? "SELECT 1 FROM events WHERE slug_index = ? AND id != ?"
+    : "SELECT 1 FROM events WHERE slug_index = ?";
+  const args = excludeEventId ? [slugIndex, excludeEventId] : [slugIndex];
   const result = await getDb().execute({ sql, args });
   return result.rows.length > 0;
 };
@@ -72,6 +82,14 @@ export const deleteEvent = async (eventId: number): Promise<void> => {
   await eventsTable.deleteById(eventId);
 };
 
+/** Decrypt event fields after raw query (for JOIN queries) */
+const decryptEventWithCount = async (
+  row: EventWithCount,
+): Promise<EventWithCount> => {
+  const event = await eventsTable.fromDb(row as unknown as Event);
+  return { ...event, attendee_count: row.attendee_count };
+};
+
 /**
  * Get all events with attendee counts (sum of quantities)
  * Uses custom JOIN query - not covered by table abstraction
@@ -84,17 +102,18 @@ export const getAllEvents = async (): Promise<EventWithCount[]> => {
     GROUP BY e.id
     ORDER BY e.created DESC
   `);
-  return result.rows as unknown as EventWithCount[];
+  const rows = result.rows as unknown as EventWithCount[];
+  return Promise.all(rows.map(decryptEventWithCount));
 };
 
 /**
  * Get event with attendee count (sum of quantities)
  * Uses custom JOIN query - not covered by table abstraction
  */
-export const getEventWithCount = (
+export const getEventWithCount = async (
   id: number,
-): Promise<EventWithCount | null> =>
-  queryOne<EventWithCount>(
+): Promise<EventWithCount | null> => {
+  const row = await queryOne<EventWithCount>(
     `SELECT e.*, COALESCE(SUM(a.quantity), 0) as attendee_count
      FROM events e
      LEFT JOIN attendees a ON e.id = a.event_id
@@ -102,19 +121,24 @@ export const getEventWithCount = (
      GROUP BY e.id`,
     [id],
   );
+  return row ? decryptEventWithCount(row) : null;
+};
 
 /**
- * Get event with attendee count by slug
+ * Get event with attendee count by slug (uses slug_index for lookup)
  * Uses custom JOIN query - not covered by table abstraction
  */
-export const getEventWithCountBySlug = (
+export const getEventWithCountBySlug = async (
   slug: string,
-): Promise<EventWithCount | null> =>
-  queryOne<EventWithCount>(
+): Promise<EventWithCount | null> => {
+  const slugIndex = await computeSlugIndex(slug);
+  const row = await queryOne<EventWithCount>(
     `SELECT e.*, COALESCE(SUM(a.quantity), 0) as attendee_count
      FROM events e
      LEFT JOIN attendees a ON e.id = a.event_id
-     WHERE e.slug = ?
+     WHERE e.slug_index = ?
      GROUP BY e.id`,
-    [slug],
+    [slugIndex],
   );
+  return row ? decryptEventWithCount(row) : null;
+};

--- a/src/lib/db/login-attempts.ts
+++ b/src/lib/db/login-attempts.ts
@@ -2,7 +2,7 @@
  * Login attempts table operations (rate limiting)
  */
 
-import { hashIpAddress } from "#lib/crypto.ts";
+import { hmacHash } from "#lib/crypto.ts";
 import { executeByField, getDb, queryOne } from "#lib/db/client.ts";
 
 /**
@@ -18,7 +18,7 @@ const withHashedIpAttempts = async <T>(
   ip: string,
   handler: (hashedIp: string, row: LoginAttemptRow | null) => Promise<T>,
 ): Promise<T> => {
-  const hashedIp = await hashIpAddress(ip);
+  const hashedIp = await hmacHash(ip);
   const row = await queryOne<LoginAttemptRow>(
     "SELECT attempts, locked_until FROM login_attempts WHERE ip = ?",
     [hashedIp],
@@ -74,6 +74,6 @@ export const recordFailedLogin = (ip: string): Promise<boolean> =>
  * Clear login attempts for an IP (on successful login)
  */
 export const clearLoginAttempts = async (ip: string): Promise<void> => {
-  const hashedIp = await hashIpAddress(ip);
+  const hashedIp = await hmacHash(ip);
   await executeByField("login_attempts", "ip", hashedIp);
 };

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -7,7 +7,7 @@ import { getDb } from "#lib/db/client.ts";
 /**
  * The latest database update identifier - update this when adding new migrations
  */
-export const LATEST_UPDATE = "add processed_payments and activity_log tables";
+export const LATEST_UPDATE = "add slug_index column for encrypted slug lookup";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -116,9 +116,17 @@ export const initDb = async (): Promise<void> => {
   // Migration: add slug column to events (unique identifier for public URLs)
   await runMigration("ALTER TABLE events ADD COLUMN slug TEXT");
 
-  // Migration: create index on slug for fast lookups
+  // Migration: create index on slug for fast lookups (legacy, slug is now encrypted)
   await runMigration(
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_slug ON events(slug)",
+  );
+
+  // Migration: add slug_index column for blind index lookup (slug is now encrypted)
+  await runMigration("ALTER TABLE events ADD COLUMN slug_index TEXT");
+
+  // Migration: create index on slug_index for fast lookups
+  await runMigration(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_slug_index ON events(slug_index)",
   );
 
   // Migration: add active column to events (default true for existing events)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@
 export interface Event {
   id: number;
   slug: string;
+  slug_index: string;
   created: string;
   name: string;
   description: string;

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -9,6 +9,7 @@ import {
 } from "#lib/db/activityLog.ts";
 import { getAttendees } from "#lib/db/attendees.ts";
 import {
+  computeSlugIndex,
   deleteEvent,
   type EventInput,
   eventsTable,
@@ -40,17 +41,23 @@ import {
 import { generateAttendeesCsv } from "#templates/csv.ts";
 import { eventFields } from "#templates/fields.ts";
 
-/** Extract event input from validated form */
-const extractEventInput = (values: Record<string, unknown>): EventInput => ({
-  slug: values.slug as string,
-  name: values.name as string,
-  description: values.description as string,
-  maxAttendees: values.max_attendees as number,
-  thankYouUrl: values.thank_you_url as string,
-  unitPrice: values.unit_price as number | null,
-  maxQuantity: values.max_quantity as number,
-  webhookUrl: (values.webhook_url as string) || null,
-});
+/** Extract event input from validated form (async to compute slugIndex) */
+const extractEventInput = async (
+  values: Record<string, unknown>,
+): Promise<EventInput> => {
+  const slug = values.slug as string;
+  return {
+    slug,
+    slugIndex: await computeSlugIndex(slug),
+    name: values.name as string,
+    description: values.description as string,
+    maxAttendees: values.max_attendees as number,
+    thankYouUrl: values.thank_you_url as string,
+    unitPrice: values.unit_price as number | null,
+    maxQuantity: values.max_quantity as number,
+    webhookUrl: (values.webhook_url as string) || null,
+  };
+};
 
 /** Validate slug uniqueness */
 const validateEventInput = async (

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -6,8 +6,6 @@ import { createClient } from "@libsql/client";
 import { clearEncryptionKeyCache } from "#lib/crypto.ts";
 import { setDb } from "#lib/db/client.ts";
 import {
-  computeSlugIndex,
-  eventsTable,
   getEvent,
   getEventWithCountBySlug,
   type EventInput,
@@ -311,10 +309,10 @@ export const generateTestSlug = (): string => {
   return `test-event-${slugCounter.value}`;
 };
 
-/** Default test event input with slug */
+/** Default test event input with slug (slugIndex computed by REST API) */
 export const testEventInput = (
-  overrides: Partial<EventInput> = {},
-): EventInput => ({
+  overrides: Partial<Omit<EventInput, "slugIndex">> = {},
+): Omit<EventInput, "slugIndex"> => ({
   slug: generateTestSlug(),
   name: "Test Event",
   description: "Test Description",
@@ -476,18 +474,6 @@ export const deactivateTestEvent = (eventId: number): Promise<void> =>
   );
 
 export type { EventInput };
-
-/**
- * Insert an event directly into the database (bypassing REST API)
- * Use this when you need to avoid auto-logging or use a custom setup
- * Automatically computes slugIndex from slug
- */
-export const insertTestEventDirect = async (
-  input: Omit<EventInput, "slugIndex">,
-): Promise<Event> => {
-  const slugIndex = await computeSlugIndex(input.slug);
-  return eventsTable.insert({ ...input, slugIndex });
-};
 
 import type { Attendee } from "#lib/types.ts";
 import { getAttendeesRaw } from "#lib/db/attendees.ts";

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -6,6 +6,8 @@ import { createClient } from "@libsql/client";
 import { clearEncryptionKeyCache } from "#lib/crypto.ts";
 import { setDb } from "#lib/db/client.ts";
 import {
+  computeSlugIndex,
+  eventsTable,
   getEvent,
   getEventWithCountBySlug,
   type EventInput,
@@ -474,6 +476,18 @@ export const deactivateTestEvent = (eventId: number): Promise<void> =>
   );
 
 export type { EventInput };
+
+/**
+ * Insert an event directly into the database (bypassing REST API)
+ * Use this when you need to avoid auto-logging or use a custom setup
+ * Automatically computes slugIndex from slug
+ */
+export const insertTestEventDirect = async (
+  input: Omit<EventInput, "slugIndex">,
+): Promise<Event> => {
+  const slugIndex = await computeSlugIndex(input.slug);
+  return eventsTable.insert({ ...input, slugIndex });
+};
 
 import type { Attendee } from "#lib/types.ts";
 import { getAttendeesRaw } from "#lib/db/attendees.ts";

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -10,9 +10,9 @@ import {
   generateDataKey,
   generateKeyPair,
   generateSecureToken,
-  hashIpAddress,
   hashPassword,
   hashSessionToken,
+  hmacHash,
   hybridDecrypt,
   hybridEncrypt,
   importPrivateKey,
@@ -302,7 +302,7 @@ describe("session token hashing", () => {
   });
 });
 
-describe("IP address hashing", () => {
+describe("hmacHash", () => {
   beforeEach(() => {
     setupTestEncryptionKey();
   });
@@ -313,19 +313,19 @@ describe("IP address hashing", () => {
 
   it("produces consistent hash for same IP", async () => {
     const ip = "192.168.1.1";
-    const hash1 = await hashIpAddress(ip);
-    const hash2 = await hashIpAddress(ip);
+    const hash1 = await hmacHash(ip);
+    const hash2 = await hmacHash(ip);
     expect(hash1).toBe(hash2);
   });
 
   it("produces different hashes for different IPs", async () => {
-    const hash1 = await hashIpAddress("192.168.1.1");
-    const hash2 = await hashIpAddress("192.168.1.2");
+    const hash1 = await hmacHash("192.168.1.1");
+    const hash2 = await hmacHash("192.168.1.2");
     expect(hash1).not.toBe(hash2);
   });
 
   it("returns base64 encoded string", async () => {
-    const hash = await hashIpAddress("10.0.0.1");
+    const hash = await hmacHash("10.0.0.1");
     // HMAC-SHA-256 produces 32 bytes, base64 encodes to 44 characters (with padding)
     expect(hash.length).toBe(44);
     expect(hash).toMatch(/^[A-Za-z0-9+/]+=*$/);
@@ -333,7 +333,7 @@ describe("IP address hashing", () => {
 
   it("produces different hashes with different encryption keys", async () => {
     const ip = "192.168.1.1";
-    const hash1 = await hashIpAddress(ip);
+    const hash1 = await hmacHash(ip);
 
     // Change the encryption key
     clearTestEncryptionKey();
@@ -342,7 +342,7 @@ describe("IP address hashing", () => {
       "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=",
     );
 
-    const hash2 = await hashIpAddress(ip);
+    const hash2 = await hmacHash(ip);
     expect(hash1).not.toBe(hash2);
 
     // Restore original key
@@ -351,13 +351,13 @@ describe("IP address hashing", () => {
   });
 
   it("handles IPv6 addresses", async () => {
-    const hash = await hashIpAddress("2001:db8::1");
+    const hash = await hmacHash("2001:db8::1");
     expect(hash.length).toBe(44);
     expect(hash).toMatch(/^[A-Za-z0-9+/]+=*$/);
   });
 
   it("handles special fallback value", async () => {
-    const hash = await hashIpAddress("direct");
+    const hash = await hmacHash("direct");
     expect(hash.length).toBe(44);
     expect(hash).toMatch(/^[A-Za-z0-9+/]+=*$/);
   });

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -53,7 +53,6 @@ import {
 import {
   createTestAttendee,
   createTestEvent,
-  insertTestEventDirect,
   resetTestSession,
   resetTestSlugCounter,
   setupTestEncryptionKey,
@@ -244,14 +243,13 @@ describe("db", () => {
     });
 
     test("password change allows decryption of both old and new attendee records", async () => {
-      const oldPassword = "oldpassword123";
       const newPassword = "newpassword456";
 
-      // Setup with initial password
-      await completeSetup(oldPassword, "GBP");
+      // Setup with TEST_ADMIN_PASSWORD so createTestEvent works
+      await completeSetup(TEST_ADMIN_PASSWORD, "GBP");
 
-      // Create an event directly (not via REST API since we're using a custom password)
-      const event = await insertTestEventDirect({
+      // Create an event via REST API
+      const event = await createTestEvent({
         slug: "password-test-event",
         name: "Password Test Event",
         description: "Test event for password change scenario",
@@ -270,7 +268,7 @@ describe("db", () => {
       const attendeeBefore = beforeResult.attendee;
 
       // Change the password
-      const changeSuccess = await updateAdminPassword(oldPassword, newPassword);
+      const changeSuccess = await updateAdminPassword(TEST_ADMIN_PASSWORD, newPassword);
       expect(changeSuccess).toBe(true);
 
       // Create an attendee AFTER password change
@@ -1196,15 +1194,14 @@ describe("db", () => {
     });
 
     test("getEventActivityLog returns entries for specific event", async () => {
-      // Use direct DB insert to avoid auto-logging from REST API
-      const event1 = await insertTestEventDirect({
+      const event1 = await createTestEvent({
         slug: "event-1",
         name: "Event 1",
         description: "Desc",
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
       });
-      const event2 = await insertTestEventDirect({
+      const event2 = await createTestEvent({
         slug: "event-2",
         name: "Event 2",
         description: "Desc",
@@ -1217,7 +1214,8 @@ describe("db", () => {
       await logActivity("Action for event 2", event2.id);
 
       const event1Log = await getEventActivityLog(event1.id);
-      expect(event1Log.length).toBe(2);
+      // REST API also logs "Created event", so we have 3 entries for event 1
+      expect(event1Log.length).toBe(3);
       expect(event1Log[0]?.message).toBe("Another action for event 1");
       expect(event1Log[1]?.message).toBe("Action for event 1");
     });
@@ -1244,8 +1242,7 @@ describe("db", () => {
     });
 
     test("getAllActivityLog returns all entries", async () => {
-      // Use direct DB insert to avoid auto-logging from REST API
-      const event = await insertTestEventDirect({
+      const event = await createTestEvent({
         slug: "test-event",
         name: "Test Event",
         description: "Desc",
@@ -1257,7 +1254,8 @@ describe("db", () => {
       await logActivity("Event action", event.id);
 
       const entries = await getAllActivityLog();
-      expect(entries.length).toBe(2);
+      // REST API logs "Created event", so we have 3 entries total
+      expect(entries.length).toBe(3);
     });
 
     test("getAllActivityLog returns entries in descending order", async () => {

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -53,6 +53,7 @@ import {
 import {
   createTestAttendee,
   createTestEvent,
+  insertTestEventDirect,
   resetTestSession,
   resetTestSlugCounter,
   setupTestEncryptionKey,
@@ -250,7 +251,7 @@ describe("db", () => {
       await completeSetup(oldPassword, "GBP");
 
       // Create an event directly (not via REST API since we're using a custom password)
-      const event = await eventsTable.insert({
+      const event = await insertTestEventDirect({
         slug: "password-test-event",
         name: "Password Test Event",
         description: "Test event for password change scenario",
@@ -1196,14 +1197,14 @@ describe("db", () => {
 
     test("getEventActivityLog returns entries for specific event", async () => {
       // Use direct DB insert to avoid auto-logging from REST API
-      const event1 = await eventsTable.insert({
+      const event1 = await insertTestEventDirect({
         slug: "event-1",
         name: "Event 1",
         description: "Desc",
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
       });
-      const event2 = await eventsTable.insert({
+      const event2 = await insertTestEventDirect({
         slug: "event-2",
         name: "Event 2",
         description: "Desc",
@@ -1244,7 +1245,7 @@ describe("db", () => {
 
     test("getAllActivityLog returns all entries", async () => {
       // Use direct DB insert to avoid auto-logging from REST API
-      const event = await eventsTable.insert({
+      const event = await insertTestEventDirect({
         slug: "test-event",
         name: "Test Event",
         description: "Desc",

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -76,6 +76,7 @@ describe("html", () => {
         {
           id: 1,
           slug: "event-1",
+          slug_index: "event-1-index",
           name: "Event 1",
           description: "Desc 1",
           max_attendees: 100,
@@ -99,6 +100,7 @@ describe("html", () => {
         {
           id: 1,
           slug: "test-event",
+          slug_index: "test-event-index",
           name: "<script>evil()</script>",
           description: "Desc",
           max_attendees: 100,
@@ -134,6 +136,7 @@ describe("html", () => {
     const event: EventWithCount = {
       id: 1,
       slug: "test-event",
+      slug_index: "test-event-index",
       name: "Test Event",
       description: "Test Description",
       max_attendees: 100,
@@ -212,6 +215,7 @@ describe("html", () => {
     const event: EventWithCount = {
       id: 1,
       slug: "test-event",
+      slug_index: "test-event-index",
       name: "Test Event",
       description: "Test Description",
       max_attendees: 100,
@@ -324,6 +328,7 @@ describe("html", () => {
     const event: Event = {
       id: 1,
       slug: "test-event",
+      slug_index: "test-event-index",
       name: "Test Event",
       description: "Test Description",
       max_attendees: 100,
@@ -389,6 +394,7 @@ describe("html", () => {
     const event: Event = {
       id: 1,
       slug: "test-event",
+      slug_index: "test-event-index",
       name: "Test Event",
       description: "Test Description",
       max_attendees: 100,
@@ -418,6 +424,7 @@ describe("html", () => {
     const event: Event = {
       id: 1,
       slug: "test-event",
+      slug_index: "test-event-index",
       name: "Test Event",
       description: "Test Description",
       max_attendees: 100,
@@ -469,6 +476,7 @@ describe("html", () => {
     const event: EventWithCount = {
       id: 1,
       slug: "test-event",
+      slug_index: "test-event-index",
       name: "Test Event",
       description: "Test Description",
       max_attendees: 100,

--- a/test/lib/rest.test.ts
+++ b/test/lib/rest.test.ts
@@ -118,12 +118,12 @@ describe("rest/resource", () => {
   });
 
   describe("parseInput", () => {
-    test("parses valid form data into Input", () => {
+    test("parses valid form data into Input", async () => {
       const table = createTestTable();
       const resource = defineResource({ table, fields: testFields, toInput });
 
       const form = new URLSearchParams({ name: "Test", value: "42" });
-      const result = resource.parseInput(form);
+      const result = await resource.parseInput(form);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -131,12 +131,12 @@ describe("rest/resource", () => {
       }
     });
 
-    test("returns error for missing required field", () => {
+    test("returns error for missing required field", async () => {
       const table = createTestTable();
       const resource = defineResource({ table, fields: testFields, toInput });
 
       const form = new URLSearchParams({ name: "Test" }); // missing value
-      const result = resource.parseInput(form);
+      const result = await resource.parseInput(form);
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -144,12 +144,12 @@ describe("rest/resource", () => {
       }
     });
 
-    test("returns error for empty required field", () => {
+    test("returns error for empty required field", async () => {
       const table = createTestTable();
       const resource = defineResource({ table, fields: testFields, toInput });
 
       const form = new URLSearchParams({ name: "", value: "42" });
-      const result = resource.parseInput(form);
+      const result = await resource.parseInput(form);
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -159,13 +159,13 @@ describe("rest/resource", () => {
   });
 
   describe("parsePartialInput", () => {
-    test("parses only provided fields", () => {
+    test("parses only provided fields", async () => {
       const table = createTestTable();
       const resource = defineResource({ table, fields: testFields, toInput });
 
       // Only provide name, value not present in form
       const form = new URLSearchParams({ name: "Updated" });
-      const result = resource.parsePartialInput(form);
+      const result = await resource.parsePartialInput(form);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -174,13 +174,13 @@ describe("rest/resource", () => {
       }
     });
 
-    test("validates provided fields", () => {
+    test("validates provided fields", async () => {
       const table = createTestTable();
       const resource = defineResource({ table, fields: testFields, toInput });
 
       // Provide name but it's empty (should fail validation)
       const form = new URLSearchParams({ name: "" });
-      const result = resource.parsePartialInput(form);
+      const result = await resource.parsePartialInput(form);
 
       expect(result.ok).toBe(false);
     });

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -140,6 +140,7 @@ describe("stripe", () => {
       const event = {
         id: 1,
         slug: "test-event",
+        slug_index: "test-event-index",
         name: "Test Event",
         description: "Test Description",
         created: new Date().toISOString(),
@@ -178,6 +179,7 @@ describe("stripe", () => {
       const event = {
         id: 1,
         slug: "test-event",
+        slug_index: "test-event-index",
         name: "Test Event",
         description: "Test Description",
         created: new Date().toISOString(),
@@ -224,6 +226,7 @@ describe("stripe", () => {
       const event = {
         id: 1,
         slug: "test-event",
+        slug_index: "test-event-index",
         name: "Test",
         description: "Desc",
         created: new Date().toISOString(),
@@ -253,6 +256,7 @@ describe("stripe", () => {
       const event = {
         id: 1,
         slug: "test-event",
+        slug_index: "test-event-index",
         name: "Test",
         description: "Desc",
         created: new Date().toISOString(),


### PR DESCRIPTION
- Add hmacHash function to crypto.ts for blind index creation
- Encrypt event name, description, and slug using AES-256-GCM
- Add slug_index column with HMAC for deterministic lookup
- Encrypt activity log messages (decrypted only for admin view)
- Update resource.ts to support async toInput functions
- Add migration for slug_index column
- Add insertTestEventDirect helper for tests that bypass REST API

This ensures the host cannot see sensitive event metadata when
browsing the database directly. The slug_index enables lookup by
slug without exposing the plaintext slug value.