### PR TITLE
Add Stripe secret key as admin-configurable setting

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,18 +1,21 @@
 /**
  * Configuration module for ticket reservation system
  * Reads configuration from database (set during setup phase)
- * Stripe keys come from environment variables for security
+ * Stripe secret key is configured via admin settings (stored encrypted in DB)
  */
 
-import { getCurrencyCodeFromDb, isSetupComplete } from "#lib/db/settings.ts";
+import {
+  getCurrencyCodeFromDb,
+  getStripeSecretKeyFromDb,
+  isSetupComplete,
+} from "#lib/db/settings.ts";
 
 /**
- * Get Stripe secret key from environment variable
- * Returns null if not set (payments disabled)
+ * Get Stripe secret key from database (encrypted)
+ * Returns null if not configured (payments disabled)
  */
-export const getStripeSecretKey = (): string | null => {
-  const key = Deno.env.get("STRIPE_SECRET_KEY");
-  return key && key.trim() !== "" ? key : null;
+export const getStripeSecretKey = (): Promise<string | null> => {
+  return getStripeSecretKeyFromDb();
 };
 
 /**
@@ -36,8 +39,8 @@ export const getStripeWebhookSecret = (): string | null => {
 /**
  * Check if Stripe payments are enabled
  */
-export const isPaymentsEnabled = (): boolean => {
-  return getStripeSecretKey() !== null;
+export const isPaymentsEnabled = async (): Promise<boolean> => {
+  return (await getStripeSecretKey()) !== null;
 };
 
 /**

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -69,7 +69,7 @@ const withClient = async <T>(
 
 /** Internal getStripeClient implementation */
 const getClientImpl = async (): Promise<Stripe | null> => {
-  const secretKey = getStripeSecretKey();
+  const secretKey = await getStripeSecretKey();
   if (!secretKey) return null;
 
   try {

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -68,9 +68,13 @@ export const handleTicketGet = (slug: string): Promise<Response> =>
 /**
  * Check if payment is required for an event
  */
-const requiresPayment = (event: { unit_price: number | null }): boolean => {
+const requiresPayment = async (
+  event: { unit_price: number | null },
+): Promise<boolean> => {
   return (
-    isPaymentsEnabled() && event.unit_price !== null && event.unit_price > 0
+    (await isPaymentsEnabled()) &&
+    event.unit_price !== null &&
+    event.unit_price > 0
   );
 };
 
@@ -205,7 +209,7 @@ const processTicketReservation = async (
     token: currentToken,
   };
 
-  if (requiresPayment(event)) {
+  if (await requiresPayment(event)) {
     return processPaidReservation(request, params);
   }
   return processFreeReservation(params);

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -4,20 +4,41 @@
 
 import { renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
-import { changePasswordFields } from "#templates/fields.ts";
+import { changePasswordFields, stripeKeyFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
 
 /**
  * Admin settings page
- * Note: Stripe keys are now configured via environment variables
  */
-export const adminSettingsPage = (csrfToken: string, error?: string): string =>
+export const adminSettingsPage = (
+  csrfToken: string,
+  stripeKeyConfigured: boolean,
+  error?: string,
+  success?: string,
+): string =>
   String(
     <Layout title="Settings">
       <AdminNav />
 
       {error && <div class="error">{error}</div>}
+      {success && <div class="success">{success}</div>}
+
+      <section>
+        <form method="POST" action="/admin/settings/stripe">
+          <header>
+            <h2>Stripe Settings</h2>
+          </header>
+          <p>
+            {stripeKeyConfigured
+              ? "A Stripe secret key is currently configured. Enter a new key below to replace it."
+              : "No Stripe key is configured. Payments are disabled."}
+          </p>
+          <input type="hidden" name="csrf_token" value={csrfToken} />
+          <Raw html={renderFields(stripeKeyFields)} />
+          <button type="submit">Update Stripe Key</button>
+        </form>
+      </section>
 
       <section>
         <form method="POST" action="/admin/settings">

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -190,3 +190,17 @@ export const changePasswordFields: Field[] = [
     required: true,
   },
 ];
+
+/**
+ * Stripe key settings form field definitions
+ */
+export const stripeKeyFields: Field[] = [
+  {
+    name: "stripe_secret_key",
+    label: "Stripe Secret Key",
+    type: "password",
+    required: true,
+    placeholder: "sk_live_... or sk_test_...",
+    hint: "Enter a new key to update",
+  },
+];


### PR DESCRIPTION
- Add STRIPE_SECRET_KEY to CONFIG_KEYS in settings.ts
- Add hasStripeKey(), getStripeSecretKeyFromDb(), and updateStripeKey()
  functions to store Stripe key encrypted in database
- Update config.ts getStripeSecretKey() to read from DB (now async)
- Update isPaymentsEnabled() to be async
- Add stripeKeyFields to fields.ts for form validation
- Update admin settings template to show Stripe key configuration form
- Add POST /admin/settings/stripe route handler
- Update all callers of getStripeSecretKey/isPaymentsEnabled to use async
- Update all tests to use database-based Stripe key instead of env var