### PR TITLE
Add remaining_places and total_places to webhook payload

### DIFF
--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -13,6 +13,8 @@ export type WebhookPayload = {
   event_type: "attendee.registered";
   event_id: number;
   event_name: string;
+  remaining_places: number;
+  total_places: number;
   attendee: {
     id: number;
     quantity: number;
@@ -21,7 +23,13 @@ export type WebhookPayload = {
 };
 
 /** Event data needed for webhook notifications */
-type WebhookEvent = { id: number; name: string; webhook_url: string | null };
+type WebhookEvent = {
+  id: number;
+  name: string;
+  webhook_url: string | null;
+  max_attendees: number;
+  attendee_count: number;
+};
 
 /** Attendee data needed for webhook notifications */
 type WebhookAttendee = { id: number; quantity: number };
@@ -36,11 +44,15 @@ export const sendRegistrationWebhook = async (
   eventName: string,
   attendeeId: number,
   quantity: number,
+  maxAttendees: number,
+  attendeeCount: number,
 ): Promise<void> => {
   const payload: WebhookPayload = {
     event_type: "attendee.registered",
     event_id: eventId,
     event_name: eventName,
+    remaining_places: maxAttendees - attendeeCount - quantity,
+    total_places: maxAttendees,
     attendee: {
       id: attendeeId,
       quantity,
@@ -78,6 +90,8 @@ export const notifyWebhook = async (
     event.name,
     attendee.id,
     attendee.quantity,
+    event.max_attendees,
+    event.attendee_count,
   );
 };
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -15,7 +15,7 @@
  */
 
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
-import { getEventWithCount } from "#lib/db/events.ts";
+import { getEvent, getEventWithCount } from "#lib/db/events.ts";
 import {
   isSessionProcessed,
   markSessionProcessed,
@@ -217,7 +217,8 @@ const handlePaymentCancel = withSessionId(async (sid) => {
     return paymentErrorResponse("Invalid payment session data");
   }
 
-  const event = await getEventWithCount(intent.eventId);
+  // Use getEvent (not getEventWithCount) - we only need slug for redirect
+  const event = await getEvent(intent.eventId);
   if (!event) {
     return paymentErrorResponse("Event not found", 404);
   }

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -6,7 +6,7 @@ import { createClient } from "@libsql/client";
 import { clearEncryptionKeyCache } from "#lib/crypto.ts";
 import { setDb } from "#lib/db/client.ts";
 import {
-  getEvent,
+  getEventWithCount,
   getEventWithCountBySlug,
   type EventInput,
 } from "#lib/db/events.ts";
@@ -434,7 +434,7 @@ export const updateTestEvent = async (
   eventId: number,
   updates: Partial<EventInput>,
 ): Promise<Event> => {
-  const existing = await getEvent(eventId);
+  const existing = await getEventWithCount(eventId);
   if (!existing) {
     throw new Error(`Event not found: ${eventId}`);
   }
@@ -452,7 +452,7 @@ export const updateTestEvent = async (
       webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
     },
     async () => {
-      const updated = await getEvent(eventId);
+      const updated = await getEventWithCount(eventId);
       if (!updated) {
         throw new Error(`Event not found after update: ${eventId}`);
       }

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -27,6 +27,8 @@ describe("webhook", () => {
       const eventName = "Test Event";
       const attendeeId = 42;
       const quantity = 2;
+      const maxAttendees = 100;
+      const attendeeCount = 50;
 
       await sendRegistrationWebhook(
         webhookUrl,
@@ -34,6 +36,8 @@ describe("webhook", () => {
         eventName,
         attendeeId,
         quantity,
+        maxAttendees,
+        attendeeCount,
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -46,6 +50,8 @@ describe("webhook", () => {
       expect(payload.event_type).toBe("attendee.registered");
       expect(payload.event_id).toBe(eventId);
       expect(payload.event_name).toBe(eventName);
+      expect(payload.remaining_places).toBe(48); // 100 - 50 - 2
+      expect(payload.total_places).toBe(100);
       expect(payload.attendee.id).toBe(attendeeId);
       expect(payload.attendee.quantity).toBe(quantity);
       expect(payload.timestamp).toBeDefined();
@@ -61,6 +67,8 @@ describe("webhook", () => {
         "Test Event",
         42,
         1,
+        100,
+        50,
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -73,6 +81,8 @@ describe("webhook", () => {
         id: 1,
         name: "Test Event",
         webhook_url: "https://example.com/hook",
+        max_attendees: 100,
+        attendee_count: 10,
       };
       const attendee = {
         id: 99,
@@ -91,6 +101,8 @@ describe("webhook", () => {
         id: 1,
         name: "Test Event",
         webhook_url: null,
+        max_attendees: 100,
+        attendee_count: 10,
       };
       const attendee = {
         id: 99,
@@ -107,6 +119,8 @@ describe("webhook", () => {
         id: 42,
         name: "Big Conference",
         webhook_url: "https://webhook.site/test",
+        max_attendees: 200,
+        attendee_count: 50,
       };
       const attendee = {
         id: 123,
@@ -121,6 +135,8 @@ describe("webhook", () => {
 
       expect(payload.event_id).toBe(42);
       expect(payload.event_name).toBe("Big Conference");
+      expect(payload.remaining_places).toBe(147); // 200 - 50 - 3
+      expect(payload.total_places).toBe(200);
       expect(payload.attendee.id).toBe(123);
       expect(payload.attendee.quantity).toBe(3);
     });


### PR DESCRIPTION
The webhook now includes:
- remaining_places: spots available after this registration
- total_places: total event capacity (max_attendees)

This allows external systems to track event capacity from webhook
notifications without needing to query the API.