### PR TITLE
Encrypt sensitive URLs in events table

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -40,10 +40,10 @@ export const eventsTable = defineTable<Event, EventInput>({
     name: col.encrypted<string>(encrypt, decrypt),
     description: col.encrypted<string>(encrypt, decrypt),
     max_attendees: col.simple<number>(),
-    thank_you_url: col.simple<string>(),
+    thank_you_url: col.encrypted<string>(encrypt, decrypt),
     unit_price: col.simple<number | null>(),
     max_quantity: col.withDefault(() => 1),
-    webhook_url: col.simple<string | null>(),
+    webhook_url: col.encryptedNullable<string>(encrypt, decrypt),
     active: col.withDefault(() => 1),
   },
 });


### PR DESCRIPTION
## Summary
Enhanced security by encrypting sensitive URL fields in the events table that were previously stored in plaintext.

## Changes
- **thank_you_url**: Changed from `col.simple<string>()` to `col.encrypted<string>(encrypt, decrypt)` to encrypt thank you redirect URLs
- **webhook_url**: Changed from `col.simple<string | null>()` to `col.encryptedNullable<string>(encrypt, decrypt)` to encrypt webhook URLs while maintaining nullable support

## Details
These URL fields contain sensitive information that should not be stored in plaintext:
- `thank_you_url` is used for post-event redirects and may contain tracking parameters or sensitive identifiers
- `webhook_url` is used for event notifications and may contain authentication tokens or internal service endpoints

The encryption/decryption functions are already defined and used consistently across other sensitive fields in the table (name, description).