### PR TITLE
Generalize not found page to handle any resource type

### DIFF
--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -91,14 +91,11 @@ export const ticketPage = (
 };
 
 /**
- * Event not found page
+ * Not found page
  */
 export const notFoundPage = (): string =>
   String(
     <Layout title="Not Found">
-      <header>
-        <h1>Event Not Found</h1>
-        <p>The event you're looking for doesn't exist.</p>
-      </header>
+      <h1>Not Found</h1>
     </Layout>
   );

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -319,8 +319,7 @@ describe("html", () => {
   describe("notFoundPage", () => {
     test("renders not found message", () => {
       const html = notFoundPage();
-      expect(html).toContain("Not Found");
-      expect(html).toContain("doesn't exist");
+      expect(html).toContain("<h1>Not Found</h1>");
     });
   });
 

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -2247,7 +2247,7 @@ describe("server", () => {
       );
       expect(response.status).toBe(404);
       const html = await response.text();
-      expect(html).toContain("Event Not Found");
+      expect(html).toContain("<h1>Not Found</h1>");
     });
   });
 


### PR DESCRIPTION
## Summary
Updated the not found page to be more generic and reusable for any missing resource, rather than being specific to events.

## Changes
- Simplified the `notFoundPage` template by removing event-specific messaging
  - Changed heading from "Event Not Found" to "Not Found"
  - Removed the descriptive paragraph about events
  - Removed unnecessary header wrapper element
- Updated corresponding test to match the new generic heading text

## Details
This change makes the not found page more flexible for future use cases where it might need to handle missing resources beyond just events (e.g., tickets, users, etc.). The simplified markup also reduces unnecessary DOM nesting while maintaining the same visual hierarchy.