### PR TITLE
Add Data Controller Agreement acceptance to setup flow

### DIFF
--- a/src/routes/setup.ts
+++ b/src/routes/setup.ts
@@ -68,6 +68,17 @@ const validateSetupForm = (form: URLSearchParams): SetupValidation => {
   const passwordConfirm = values.admin_password_confirm as string;
   const currency = ((values.currency_code as string) || "GBP").toUpperCase();
 
+  // Check Data Controller Agreement acceptance
+  const acceptAgreement = form.get("accept_agreement");
+  if (acceptAgreement !== "yes") {
+    // biome-ignore lint/suspicious/noConsole: Debug logging for edge script
+    console.log("[Setup] Agreement not accepted");
+    return {
+      valid: false,
+      error: "You must accept the Data Controller Agreement to continue",
+    };
+  }
+
   if (password.length < 8) {
     // biome-ignore lint/suspicious/noConsole: Debug logging for edge script
     console.log("[Setup] Password too short:", password.length);

--- a/src/templates/setup.tsx
+++ b/src/templates/setup.tsx
@@ -8,6 +8,50 @@ import { setupFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
 /**
+ * Data Controller Agreement - displayed during setup
+ * Users must accept these terms to complete setup
+ */
+const DataControllerAgreement = (): JSX.Element => (
+  <fieldset class="agreement">
+    <legend>Data Controller Agreement</legend>
+    <p>By completing setup, you confirm:</p>
+    <ol>
+      <li>
+        <strong>You are the data controller</strong> - You decide what data to collect and are
+        responsible for your own GDPR/data protection compliance
+      </li>
+      <li>
+        <strong>We are a data processor</strong> - We store your encrypted data but cannot access
+        attendee information without your admin password
+      </li>
+      <li>
+        <strong>Your data is encrypted</strong> - Attendee names, emails, and payment references are
+        encrypted at rest. Only you can decrypt them by logging in
+      </li>
+      <li>
+        <strong>Your responsibilities</strong> - You are responsible for providing a privacy policy,
+        having lawful basis for collecting data, responding to data subject requests, and compliance
+        with your local data protection laws
+      </li>
+      <li>
+        <strong>Breach notification</strong> - We will notify you promptly if we detect a security
+        incident affecting your data
+      </li>
+      <li>
+        <strong>Deletion</strong> - Your data is deleted when you delete your events or close your
+        account
+      </li>
+    </ol>
+    <div class="field">
+      <label>
+        <input type="checkbox" name="accept_agreement" value="yes" required />I understand and
+        accept these terms
+      </label>
+    </div>
+  </fieldset>
+);
+
+/**
  * Initial setup page
  */
 export const setupPage = (error?: string, csrfToken?: string): string =>
@@ -22,6 +66,7 @@ export const setupPage = (error?: string, csrfToken?: string): string =>
         <form method="POST" action="/setup/">
           {csrfToken && <input type="hidden" name="csrf_token" value={csrfToken} />}
           <Raw html={renderFields(setupFields, { currency_code: "GBP" })} />
+          <DataControllerAgreement />
           <button type="submit">Complete Setup</button>
         </form>
       </section>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -176,6 +176,7 @@ export const getSetupCsrfToken = (setCookie: string | null): string | null =>
 
 /**
  * Create a mock setup POST request with CSRF token
+ * Automatically includes accept_agreement: "yes" unless explicitly overridden
  */
 export const mockSetupFormRequest = (
   data: Record<string, string>,
@@ -183,7 +184,7 @@ export const mockSetupFormRequest = (
 ): Request => {
   return mockFormRequest(
     "/setup",
-    { ...data, csrf_token: csrfToken },
+    { accept_agreement: "yes", ...data, csrf_token: csrfToken },
     `setup_csrf=${csrfToken}`,
   );
 };

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -3229,6 +3229,7 @@ describe("server", () => {
         expect(html).toContain("Initial Setup");
         expect(html).toContain("Admin Password");
         expect(html).toContain("Currency Code");
+        expect(html).toContain("Data Controller Agreement");
       });
 
       test("GET /setup (without trailing slash) shows setup page", async () => {
@@ -3388,6 +3389,28 @@ describe("server", () => {
         expect(html).toContain("Currency code must be 3 uppercase letters");
       });
 
+      test("POST /setup/ without accepting agreement shows error", async () => {
+        const getResponse = await handleRequest(mockRequest("/setup/"));
+        const csrfToken = getSetupCsrfToken(
+          getResponse.headers.get("set-cookie"),
+        );
+
+        const response = await handleRequest(
+          mockSetupFormRequest(
+            {
+              admin_password: "mypassword123",
+              admin_password_confirm: "mypassword123",
+              currency_code: "GBP",
+              accept_agreement: "", // Explicitly not accepting
+            },
+            csrfToken as string,
+          ),
+        );
+        expect(response.status).toBe(400);
+        const html = await response.text();
+        expect(html).toContain("must accept the Data Controller Agreement");
+      });
+
       test("POST /setup/ normalizes lowercase currency to uppercase", async () => {
         const getResponse = await handleRequest(mockRequest("/setup/"));
         const csrfToken = getSetupCsrfToken(
@@ -3488,6 +3511,7 @@ describe("server", () => {
               admin_password: "mypassword123",
               admin_password_confirm: "mypassword123",
               currency_code: "GBP",
+              accept_agreement: "yes",
               csrf_token: csrfToken as string,
             }).toString(),
           }),
@@ -3542,6 +3566,7 @@ describe("server", () => {
               admin_password: "mypassword123",
               admin_password_confirm: "mypassword123",
               currency_code: "GBP",
+              accept_agreement: "yes",
               csrf_token: csrfToken as string,
             }).toString(),
           }),


### PR DESCRIPTION
## Summary
This PR adds a mandatory Data Controller Agreement that users must accept during the initial setup process. The agreement clarifies the data controller/processor relationship, encryption practices, and user responsibilities regarding GDPR and data protection compliance.

## Key Changes
- **Backend validation**: Added check in `validateSetupForm()` to require `accept_agreement: "yes"` before setup can be completed
- **UI component**: Created `DataControllerAgreement` component displaying 6 key points about data handling, encryption, and user responsibilities
- **Form integration**: Added the agreement fieldset to the setup form, positioned before the submit button
- **Test coverage**: 
  - Added test verifying agreement text appears on setup page
  - Added test confirming setup fails with 400 status when agreement is not accepted
  - Updated existing setup tests to include `accept_agreement: "yes"` in form data
- **Test utilities**: Updated `mockSetupFormRequest()` to automatically include `accept_agreement: "yes"` by default, reducing boilerplate in tests

## Implementation Details
- The agreement covers: data controller status, processor role, encryption at rest, user responsibilities, breach notification, and data deletion
- Validation occurs server-side before any setup processing
- Debug logging added for agreement rejection (consistent with existing validation patterns)
- All existing tests updated to pass the new validation requirement