### PR TITLE
Redirect root path to admin instead of showing home page

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -1,5 +1,5 @@
 /**
- * Public routes - home page and ticket reservation
+ * Public routes - ticket reservation
  */
 
 import { isPaymentsEnabled } from "#lib/config.ts";
@@ -28,14 +28,12 @@ import {
   withActiveEventBySlug,
 } from "#routes/utils.ts";
 import { ticketFields } from "#templates/fields.ts";
-import { homePage, ticketPage } from "#templates/public.tsx";
+import { ticketPage } from "#templates/public.tsx";
 
 /**
- * Handle GET / (home page)
+ * Handle GET / (home page) - redirect to admin
  */
-export const handleHome = (): Response => {
-  return htmlResponse(homePage());
-};
+export const handleHome = (): Response => redirect("/admin/");
 
 /** Path for ticket CSRF cookies */
 const ticketCsrfPath = (slug: string): string => `/ticket/${slug}`;

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -1,5 +1,5 @@
 /**
- * Public page templates - home and ticket pages
+ * Public page templates - ticket reservation pages
  */
 
 import { renderError, renderFields } from "#lib/forms.tsx";
@@ -7,24 +7,6 @@ import type { EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { ticketFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
-
-/**
- * Home page
- */
-export const homePage = (): string =>
-  String(
-    <Layout title="Ticket Reservation System">
-      <header>
-        <h1>Ticket Reservation System</h1>
-        <p>Welcome to the ticket reservation system.</p>
-        <nav>
-          <ul>
-            <li><a href="/admin/"><b>Admin Login</b></a></li>
-          </ul>
-        </nav>
-      </header>
-    </Layout>
-  );
 
 /**
  * Build quantity select options

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -11,7 +11,7 @@ import {
   paymentPage,
   paymentSuccessPage,
 } from "#templates/payment.tsx";
-import { homePage, notFoundPage, ticketPage } from "#templates/public.tsx";
+import { notFoundPage, ticketPage } from "#templates/public.tsx";
 
 const TEST_CSRF_TOKEN = "test-csrf-token-abc123";
 
@@ -33,14 +33,6 @@ describe("html", () => {
     test("links to MVP.css stylesheet", () => {
       const html = layout("Title", "content");
       expect(html).toContain('<link rel="stylesheet" href="/mvp.css">');
-    });
-  });
-
-  describe("homePage", () => {
-    test("renders home page", () => {
-      const html = homePage();
-      expect(html).toContain("Ticket Reservation System");
-      expect(html).toContain("/admin/");
     });
   });
 

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -3761,7 +3761,7 @@ describe("server", () => {
   describe("Domain validation", () => {
     test("allows requests with valid domain", async () => {
       const response = await handleRequest(mockRequest("/"));
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(302); // Homepage redirects to /admin/
     });
 
     test("rejects GET requests to invalid domain", async () => {
@@ -3792,7 +3792,7 @@ describe("server", () => {
       const response = await handleRequest(
         mockRequestWithHost("/", "localhost:3000"),
       );
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(302); // Homepage redirects to /admin/
     });
 
     test("rejects requests without Host header", async () => {

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -49,11 +49,10 @@ describe("server", () => {
   });
 
   describe("GET /", () => {
-    test("returns home page", async () => {
+    test("redirects to admin", async () => {
       const response = await handleRequest(mockRequest("/"));
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Ticket Reservation System");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toBe("/admin/");
     });
   });
 

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -199,10 +199,10 @@ describe("test-utils", () => {
     });
 
     test("makes GET request and returns response", async () => {
-      const response = await awaitTestRequest("/");
+      const response = await awaitTestRequest("/admin/");
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Ticket");
+      expect(html).toContain("Login");
     });
 
     test("accepts token as second argument", async () => {


### PR DESCRIPTION
## Summary
Removed the public home page and changed the root path (`/`) to redirect directly to the admin login page (`/admin/`). This simplifies the public interface by eliminating an unnecessary landing page.

## Changes
- **Route handler**: Modified `handleHome()` to return a redirect to `/admin/` instead of rendering the home page
- **Templates**: Removed the `homePage()` template function from `public.tsx` as it's no longer needed
- **Tests**: Updated and removed tests to reflect the new redirect behavior
- **Documentation**: Updated file comments to reflect that public routes now only handle ticket reservation

## Implementation Details
- The root path now returns a 302 redirect response to `/admin/`
- Removed ~20 lines of unused home page template code
- All references to `homePage` have been cleaned up from imports and exports