### PR TITLE
Add name confirmation to event deactivate/reactivate actions

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -204,6 +204,7 @@ export const adminDeleteEventPage = (
 export const adminDeactivateEventPage = (
   event: EventWithCount,
   csrfToken: string,
+  error?: string,
 ): string =>
   String(
     <Layout title={`Deactivate: ${event.name}`}>
@@ -211,6 +212,8 @@ export const adminDeactivateEventPage = (
       <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
 
       <section>
+        {error && <div class="error">{error}</div>}
+
         <article>
           <aside>
             <p><strong>Warning:</strong> Deactivating this event will:</p>
@@ -223,8 +226,19 @@ export const adminDeactivateEventPage = (
           </aside>
         </article>
 
+        <p>To deactivate this event, you must type its name "{event.name}" into the box below:</p>
+
         <form method="POST" action={`/admin/event/${event.id}/deactivate`}>
           <input type="hidden" name="csrf_token" value={csrfToken} />
+          <label for="confirm_name">Event name</label>
+          <input
+            type="text"
+            id="confirm_name"
+            name="confirm_name"
+            placeholder={event.name}
+            autocomplete="off"
+            required
+          />
           <button type="submit" class="danger">
             Deactivate Event
           </button>
@@ -239,6 +253,7 @@ export const adminDeactivateEventPage = (
 export const adminReactivateEventPage = (
   event: EventWithCount,
   csrfToken: string,
+  error?: string,
 ): string =>
   String(
     <Layout title={`Reactivate: ${event.name}`}>
@@ -246,6 +261,8 @@ export const adminReactivateEventPage = (
       <Breadcrumb href={`/admin/event/${event.id}`} label={event.name} />
 
       <section>
+        {error && <div class="error">{error}</div>}
+
         <article>
           <aside>
             <p>Reactivating this event will make it available for registrations again.</p>
@@ -253,8 +270,19 @@ export const adminReactivateEventPage = (
           </aside>
         </article>
 
+        <p>To reactivate this event, you must type its name "{event.name}" into the box below:</p>
+
         <form method="POST" action={`/admin/event/${event.id}/reactivate`}>
           <input type="hidden" name="csrf_token" value={csrfToken} />
+          <label for="confirm_name">Event name</label>
+          <input
+            type="text"
+            id="confirm_name"
+            name="confirm_name"
+            placeholder={event.name}
+            autocomplete="off"
+            required
+          />
           <button type="submit">
             Reactivate Event
           </button>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -464,38 +464,33 @@ export const updateTestEvent = async (
 };
 
 /**
+ * Change event active status via the REST API
+ */
+const changeEventStatus =
+  (action: "deactivate" | "reactivate") =>
+  async (eventId: number): Promise<void> => {
+    const event = await getEventWithCount(eventId);
+    if (!event) {
+      throw new Error(`Event not found: ${eventId}`);
+    }
+
+    return authenticatedFormRequest(
+      `/admin/event/${eventId}/${action}`,
+      { confirm_name: event.name },
+      async () => {},
+      `${action} event`,
+    );
+  };
+
+/**
  * Deactivate an event via the REST API
  */
-export const deactivateTestEvent = async (eventId: number): Promise<void> => {
-  const event = await getEventWithCount(eventId);
-  if (!event) {
-    throw new Error(`Event not found: ${eventId}`);
-  }
-
-  return authenticatedFormRequest(
-    `/admin/event/${eventId}/deactivate`,
-    { confirm_name: event.name },
-    async () => {},
-    "deactivate event",
-  );
-};
+export const deactivateTestEvent = changeEventStatus("deactivate");
 
 /**
  * Reactivate an event via the REST API
  */
-export const reactivateTestEvent = async (eventId: number): Promise<void> => {
-  const event = await getEventWithCount(eventId);
-  if (!event) {
-    throw new Error(`Event not found: ${eventId}`);
-  }
-
-  return authenticatedFormRequest(
-    `/admin/event/${eventId}/reactivate`,
-    { confirm_name: event.name },
-    async () => {},
-    "reactivate event",
-  );
-};
+export const reactivateTestEvent = changeEventStatus("reactivate");
 
 export type { EventInput };
 

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -466,13 +466,36 @@ export const updateTestEvent = async (
 /**
  * Deactivate an event via the REST API
  */
-export const deactivateTestEvent = (eventId: number): Promise<void> =>
-  authenticatedFormRequest(
+export const deactivateTestEvent = async (eventId: number): Promise<void> => {
+  const event = await getEventWithCount(eventId);
+  if (!event) {
+    throw new Error(`Event not found: ${eventId}`);
+  }
+
+  return authenticatedFormRequest(
     `/admin/event/${eventId}/deactivate`,
-    {},
+    { confirm_name: event.name },
     async () => {},
     "deactivate event",
   );
+};
+
+/**
+ * Reactivate an event via the REST API
+ */
+export const reactivateTestEvent = async (eventId: number): Promise<void> => {
+  const event = await getEventWithCount(eventId);
+  if (!event) {
+    throw new Error(`Event not found: ${eventId}`);
+  }
+
+  return authenticatedFormRequest(
+    `/admin/event/${eventId}/reactivate`,
+    { confirm_name: event.name },
+    async () => {},
+    "reactivate event",
+  );
+};
 
 export type { EventInput };
 

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -1349,6 +1349,9 @@ describe("server", () => {
       const html = await response.text();
       expect(html).toContain("Deactivate Event");
       expect(html).toContain("Return a 404");
+      expect(html).toContain('name="confirm_name"');
+      expect(html).toContain("type its name");
+      expect(html).toContain("Test Event");
     });
   });
 
@@ -1384,7 +1387,7 @@ describe("server", () => {
       const response = await handleRequest(
         mockFormRequest(
           "/admin/event/1/deactivate",
-          { csrf_token: csrfToken || "" },
+          { csrf_token: csrfToken || "", confirm_name: "Test Event" },
           cookie,
         ),
       );
@@ -1395,6 +1398,32 @@ describe("server", () => {
       const { getEventWithCount } = await import("#lib/db/events.ts");
       const event = await getEventWithCount(1);
       expect(event?.active).toBe(0);
+    });
+
+    test("returns error when name does not match", async () => {
+      const loginResponse = await handleRequest(
+        mockFormRequest("/admin/login", { password: TEST_ADMIN_PASSWORD }),
+      );
+      const cookie = loginResponse.headers.get("set-cookie") || "";
+      const csrfToken = await getCsrfTokenFromCookie(cookie);
+
+      await createTestEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/event/1/deactivate",
+          { csrf_token: csrfToken || "", confirm_name: "Wrong Name" },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("Event name does not match");
     });
   });
 
@@ -1435,6 +1464,8 @@ describe("server", () => {
       const html = await response.text();
       expect(html).toContain("Reactivate Event");
       expect(html).toContain("available for registrations");
+      expect(html).toContain('name="confirm_name"');
+      expect(html).toContain("type its name");
     });
   });
 
@@ -1458,7 +1489,7 @@ describe("server", () => {
       const response = await handleRequest(
         mockFormRequest(
           "/admin/event/1/reactivate",
-          { csrf_token: csrfToken || "" },
+          { csrf_token: csrfToken || "", confirm_name: "Test Event" },
           cookie,
         ),
       );
@@ -1469,6 +1500,34 @@ describe("server", () => {
       const { getEventWithCount } = await import("#lib/db/events.ts");
       const activeEvent = await getEventWithCount(1);
       expect(activeEvent?.active).toBe(1);
+    });
+
+    test("returns error when name does not match", async () => {
+      const loginResponse = await handleRequest(
+        mockFormRequest("/admin/login", { password: TEST_ADMIN_PASSWORD }),
+      );
+      const cookie = loginResponse.headers.get("set-cookie") || "";
+      const csrfToken = await getCsrfTokenFromCookie(cookie);
+
+      const event = await createTestEvent({
+        name: "Test Event",
+        description: "Desc",
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      // Deactivate the event first
+      await deactivateTestEvent(event.id);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/event/1/reactivate",
+          { csrf_token: csrfToken || "", confirm_name: "Wrong Name" },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("Event name does not match");
     });
   });
 


### PR DESCRIPTION
## Summary
Add a name confirmation requirement to the event deactivate and reactivate admin actions to prevent accidental status changes. Users must now type the exact event name to confirm these destructive operations.

## Key Changes
- **Route handlers**: Updated `handleAdminEventDeactivatePost` and `handleAdminEventReactivatePost` to require name confirmation via form input
  - Replaced generic `setActiveHandler` with explicit handlers that validate the confirmation name
  - Added error handling that returns a 400 response with error message if name doesn't match
  - Added activity logging for both deactivate and reactivate actions
  
- **Templates**: Enhanced both `adminDeactivateEventPage` and `adminReactivateEventPage`
  - Added optional `error` parameter to display validation errors
  - Added text input field requiring users to type the event name
  - Added instructional text explaining the confirmation requirement
  
- **Test utilities**: Updated test helpers to support the new confirmation requirement
  - Modified `deactivateTestEvent` to fetch event and pass `confirm_name` in form data
  - Added new `reactivateTestEvent` helper function with same pattern
  
- **Tests**: Added comprehensive test coverage
  - Verified confirmation field appears in GET responses
  - Verified successful deactivate/reactivate with correct name
  - Added new tests for validation errors when name doesn't match

## Implementation Details
- Uses existing `verifyName` utility function for case-sensitive name matching
- Maintains CSRF token protection on both GET and POST requests
- Returns user to event detail page on success, or back to confirmation page with error on failure
- Activity logging captures the event name for audit trail