### PR TITLE
Add bottom margin to form elements for improved spacing

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -399,6 +399,7 @@ form {
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow) var(--color-shadow);
   display: block;
+  margin-bottom: 2rem;
   max-width: var(--width-card-wide);
   min-width: var(--width-card);
   padding: 1.5rem;


### PR DESCRIPTION
## Summary
Added bottom margin to form elements to improve vertical spacing and visual hierarchy in the layout.

## Changes
- Added `margin-bottom: 2rem;` to the `form` selector in the MVP CSS stylesheet
- This ensures consistent spacing between form elements and subsequent content

## Details
This change improves the visual presentation of forms by providing adequate whitespace below form containers. The 2rem margin aligns with the existing spacing conventions used throughout the design system and prevents forms from appearing cramped against following page elements.