### PR TITLE
Refactor form field rendering to use implicit label association

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -51,11 +51,10 @@ const joinStrings = reduce((acc: string, s: string) => acc + s, "");
  */
 export const renderField = (field: Field, value: string = ""): string =>
   String(
-    <div class="form-group">
-      <label for={field.name}>{field.label}</label>
+    <label>
+      {field.label}
       {field.type === "textarea" ? (
         <textarea
-          id={field.name}
           name={field.name}
           rows="3"
           required={field.required}
@@ -66,7 +65,6 @@ export const renderField = (field: Field, value: string = ""): string =>
       ) : (
         <input
           type={field.type}
-          id={field.name}
           name={field.name}
           value={value || undefined}
           required={field.required}
@@ -80,7 +78,7 @@ export const renderField = (field: Field, value: string = ""): string =>
           {field.hint}
         </small>
       )}
-    </div>
+    </label>
   );
 
 /**

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -17,10 +17,11 @@ describe("forms", () => {
         type: "text",
       };
       const html = renderField(field);
-      expect(html).toContain('<label for="username">Username</label>');
+      expect(html).toContain("<label>");
+      expect(html).toContain("Username");
       expect(html).toContain('type="text"');
-      expect(html).toContain('id="username"');
       expect(html).toContain('name="username"');
+      expect(html).toContain("</label>");
     });
 
     test("renders required attribute", () => {


### PR DESCRIPTION
## Summary
Refactored the `renderField` function to use implicit label-input association instead of explicit `id` and `for` attributes. This simplifies the HTML structure while maintaining accessibility.

## Key Changes
- Replaced `<div class="form-group">` wrapper with `<label>` element as the container
- Removed `id` attributes from `<input>` and `<textarea>` elements
- Removed `for` attribute from `<label>` element
- Updated tests to reflect the new HTML structure

## Implementation Details
The change leverages implicit label association where form controls are nested directly within their `<label>` element. This approach:
- Reduces HTML boilerplate by eliminating the need for matching `id`/`for` attributes
- Maintains full accessibility - screen readers and browsers still properly associate labels with inputs
- Simplifies the component by removing the wrapper div
- Results in cleaner, more semantic HTML

The form controls remain fully functional and accessible without the explicit id/for relationship.