### PR TITLE
Remove legacy name and description columns from events table

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -26,7 +26,6 @@ export const computeSlugIndex = (slug: string): Promise<string> =>
 /**
  * Events table definition
  * slug is encrypted; slug_index is HMAC for lookups
- * Note: Legacy name/description columns may exist in DB but are not used
  */
 export const eventsTable = defineTable<Event, EventInput>({
   name: "events",

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -7,7 +7,7 @@ import { getDb } from "#lib/db/client.ts";
 /**
  * The latest database update identifier - update this when adding new migrations
  */
-export const LATEST_UPDATE = "remove name and description requirements";
+export const LATEST_UPDATE = "drop name and description columns";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -55,13 +55,10 @@ export const initDb = async (): Promise<void> => {
   `);
 
   // Create events table
-  // Note: name and description columns kept for backwards compatibility but are no longer used
   await client.execute(`
     CREATE TABLE IF NOT EXISTS events (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       created TEXT NOT NULL,
-      name TEXT NOT NULL DEFAULT '',
-      description TEXT NOT NULL DEFAULT '',
       max_attendees INTEGER NOT NULL,
       thank_you_url TEXT NOT NULL,
       unit_price INTEGER
@@ -134,6 +131,10 @@ export const initDb = async (): Promise<void> => {
   await runMigration(
     "ALTER TABLE events ADD COLUMN active INTEGER NOT NULL DEFAULT 1",
   );
+
+  // Migration: drop legacy name and description columns (no longer used)
+  await runMigration("ALTER TABLE events DROP COLUMN name");
+  await runMigration("ALTER TABLE events DROP COLUMN description");
 
   // Migration: add wrapped_data_key column to sessions (per-session encryption key)
   // Note: token column now stores hashed tokens, old unhashed tokens will be invalid


### PR DESCRIPTION
## Summary
This PR removes the legacy `name` and `description` columns from the events table that were kept for backwards compatibility but are no longer used by the application. The columns are now dropped via a database migration.

## Key Changes
- **Database Schema**: Removed `name` and `description` columns from the events table initialization and added a migration to drop these columns from existing databases
- **Migration**: Updated `LATEST_UPDATE` identifier to "drop name and description columns" and added migration steps to drop both columns
- **Documentation**: Removed outdated comments about legacy columns being kept for backwards compatibility
- **Tests**: Updated the `defineTable` write transform test to use the actual `slug` and `slug_index` columns from the events table schema instead of the removed `name` and `description` columns, making the test more realistic and aligned with current schema

## Implementation Details
- The migration uses `ALTER TABLE events DROP COLUMN` for both columns, ensuring the changes are applied safely to existing databases
- The test refactoring ensures that future schema changes are validated against realistic column definitions
- All references to the legacy columns in comments have been cleaned up