### PR TITLE
Reduce edge script startup log verbosity

### DIFF
--- a/src/edge/bunny-script.ts
+++ b/src/edge/bunny-script.ts
@@ -9,22 +9,12 @@ import { validateEncryptionKey } from "#lib/crypto.ts";
 import { initDb } from "#lib/db/migrations/index.ts";
 import { handleRequest } from "#src/server.ts";
 
-// biome-ignore lint/suspicious/noConsole: Edge script logging
-console.log("[Tickets] Edge script module loaded");
-
 const initialize = once(async (): Promise<void> => {
-  // biome-ignore lint/suspicious/noConsole: Edge script logging
-  console.log("[Tickets] Validating encryption key...");
   validateEncryptionKey();
-  // biome-ignore lint/suspicious/noConsole: Edge script logging
-  console.log("[Tickets] Initializing database...");
   await initDb();
   // biome-ignore lint/suspicious/noConsole: Edge script logging
-  console.log("[Tickets] Database initialized successfully");
+  console.log("[Tickets] App started");
 });
-
-// biome-ignore lint/suspicious/noConsole: Edge script logging
-console.log("[Tickets] Registering HTTP handler...");
 
 BunnySDK.net.http.serve(async (request: Request): Promise<Response> => {
   try {
@@ -39,6 +29,3 @@ BunnySDK.net.http.serve(async (request: Request): Promise<Response> => {
     });
   }
 });
-
-// biome-ignore lint/suspicious/noConsole: Edge script logging
-console.log("[Tickets] HTTP handler registered");


### PR DESCRIPTION
Replace multiple initialization logs with a single "App started" message
to reduce noise on web requests.