### PR TITLE
Add test demonstrating session invalidation bug after encryption key rotation

### DIFF
--- a/test/lib/old-session-key.test.ts
+++ b/test/lib/old-session-key.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import { clearEncryptionKeyCache } from "#lib/crypto.ts";
+import { resetSessionCache } from "#lib/db/sessions.ts";
+import {
+  createTestDbWithSetup,
+  mockFormRequest,
+  resetDb,
+  TEST_ADMIN_PASSWORD,
+  TEST_ENCRYPTION_KEY,
+} from "#test-utils";
+import { handleRequest } from "#src/server.ts";
+import { getAuthenticatedSession, getPrivateKey } from "#routes/utils.ts";
+
+// Set ALLOWED_DOMAIN for security middleware (required for login)
+Deno.env.set("ALLOWED_DOMAIN", "localhost");
+
+/**
+ * A different test encryption key (also 32 bytes base64-encoded)
+ * Simulates what happens when DB_ENCRYPTION_KEY is rotated
+ */
+const DIFFERENT_ENCRYPTION_KEY =
+  "ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=";
+
+/** Helper to create request with session cookie */
+const requestWithSession = (path: string, cookie: string): Request =>
+  new Request(`http://localhost${path}`, {
+    headers: { cookie, host: "localhost" },
+  });
+
+describe("old session key handling", () => {
+  beforeEach(async () => {
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    // Restore original encryption key for cleanup
+    Deno.env.set("DB_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY);
+    clearEncryptionKeyCache();
+    resetDb();
+  });
+
+  test("user with old session key sees blank screen when DB_ENCRYPTION_KEY changes", async () => {
+    // Step 1: Login to get a valid session with wrapped_data_key
+    const loginResponse = await handleRequest(
+      mockFormRequest("/admin/login", { password: TEST_ADMIN_PASSWORD }),
+    );
+    expect(loginResponse.status).toBe(302);
+    const sessionCookie = loginResponse.headers.get("set-cookie") || "";
+    expect(sessionCookie).toContain("__Host-session=");
+
+    // Step 2: Verify session works before key change
+    const responseBefore = await handleRequest(
+      requestWithSession("/admin/", sessionCookie),
+    );
+    expect(responseBefore.status).toBe(200);
+    const htmlBefore = await responseBefore.text();
+    expect(htmlBefore).toContain("Logout"); // User is authenticated
+
+    // Verify crypto works before key change
+    const sessionBefore = await getAuthenticatedSession(
+      requestWithSession("/admin/", sessionCookie),
+    );
+    expect(sessionBefore).not.toBeNull();
+    const privateKeyBefore = await getPrivateKey(
+      sessionBefore!.token,
+      sessionBefore!.wrappedDataKey,
+    );
+    expect(privateKeyBefore).not.toBeNull(); // Crypto works fine
+
+    // Step 3: Simulate DB_ENCRYPTION_KEY rotation (e.g., security incident, key compromise)
+    Deno.env.set("DB_ENCRYPTION_KEY", DIFFERENT_ENCRYPTION_KEY);
+    clearEncryptionKeyCache();
+    resetSessionCache();
+
+    // Step 4: User returns with their old session cookie
+    // BUG: The session appears valid but crypto operations silently fail
+    const responseAfter = await handleRequest(
+      requestWithSession("/admin/", sessionCookie),
+    );
+
+    // BUG DEMONSTRATION:
+    // The user sees the admin dashboard (200 OK, "Logout" link visible)
+    // but their session is effectively broken - they cannot decrypt any PII
+    expect(responseAfter.status).toBe(200);
+    const htmlAfter = await responseAfter.text();
+    expect(htmlAfter).toContain("Logout"); // User appears logged in
+
+    // The session is returned as "valid" even though crypto is broken
+    const sessionAfter = await getAuthenticatedSession(
+      requestWithSession("/admin/", sessionCookie),
+    );
+    expect(sessionAfter).not.toBeNull(); // Session appears valid
+    expect(sessionAfter?.wrappedDataKey).toBeDefined(); // Has wrapped key
+
+    // BUT: The private key derivation fails silently
+    // This is because wrappedDataKey was encrypted with the OLD DB_ENCRYPTION_KEY
+    // but unwrapKeyWithToken uses the NEW key in its PBKDF2 salt
+    const privateKeyAfter = await getPrivateKey(
+      sessionAfter!.token,
+      sessionAfter!.wrappedDataKey,
+    );
+    expect(privateKeyAfter).toBeNull(); // Crypto silently fails!
+
+    // EXPECTED BEHAVIOR:
+    // User should be redirected to login (302 to /admin/) when their session
+    // has an invalid wrapped_data_key, rather than being shown a broken dashboard
+    //
+    // ACTUAL BEHAVIOR (BUG):
+    // - User sees the dashboard (appears logged in)
+    // - Any page that tries to decrypt attendee PII will either:
+    //   a) Show encrypted/garbled data
+    //   b) Throw an error causing 500/blank screen
+    //   c) Silently fail showing empty data
+    // - User is stuck and doesn't know they need to re-login
+    //
+    // FIX OPTIONS:
+    // 1. Validate wrapped_data_key can be unwrapped in getAuthenticatedSession()
+    // 2. Add a "key version" to wrapped_data_key and invalidate on mismatch
+    // 3. Delete all sessions when DB_ENCRYPTION_KEY changes (ops procedure)
+
+    console.log(
+      "BUG CONFIRMED: User has valid-looking session but crypto operations fail",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test that demonstrates a critical security bug where user sessions remain "valid" after the `DB_ENCRYPTION_KEY` is rotated, but their wrapped data keys can no longer be decrypted. Users see the dashboard but cannot access encrypted PII, creating a confusing and broken experience.

## Changes
- **Added `test/lib/old-session-key.test.ts`**: New test suite that reproduces the session key rotation bug
  - Logs in a user and obtains a valid session with `wrapped_data_key`
  - Verifies the session and crypto operations work correctly
  - Simulates a `DB_ENCRYPTION_KEY` rotation (security incident scenario)
  - Demonstrates that the session still appears valid but crypto silently fails
  - Documents the expected vs. actual behavior with detailed comments

## Key Implementation Details
- Uses test utilities to create a database with admin user setup
- Simulates encryption key rotation by changing `DB_ENCRYPTION_KEY` environment variable
- Verifies that `getAuthenticatedSession()` returns a non-null session even with an invalid wrapped key
- Confirms that `getPrivateKey()` returns null when trying to decrypt with the new key
- Includes detailed comments explaining the bug, its impact, and potential fix options

## Bug Context
When `DB_ENCRYPTION_KEY` is rotated:
1. Old sessions' `wrapped_data_key` values were encrypted with the old key
2. The new key cannot decrypt these values
3. However, sessions are not invalidated, so users remain "logged in"
4. Any attempt to access encrypted data fails silently or throws errors
5. Users are confused and don't know they need to re-login

This test serves as documentation of the issue and a baseline for implementing a fix.