### PR TITLE
Use batch queries to reduce database round-trips

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -54,18 +54,25 @@ export const getAttendeesRaw = async (eventId: number): Promise<Attendee[]> => {
 };
 
 /**
- * Get attendees for an event (decrypted)
- * Requires private key for decryption - only available to authenticated sessions
+ * Decrypt a list of raw attendees.
+ * Used when attendees are fetched via batch query.
  */
-export const getAttendees = async (
-  eventId: number,
+export const decryptAttendees = (
+  rows: Attendee[],
   privateKey: CryptoKey,
-): Promise<Attendee[]> => {
-  const rows = await getAttendeesRaw(eventId);
-  return Promise.all(
-    map((row: Attendee) => decryptAttendee(row, privateKey))(rows),
-  );
-};
+): Promise<Attendee[]> =>
+  Promise.all(map((row: Attendee) => decryptAttendee(row, privateKey))(rows));
+
+/**
+ * Decrypt a single raw attendee, handling null input.
+ * Used when attendee is fetched via batch query.
+ */
+export const decryptAttendeeOrNull = (
+  row: Attendee | null,
+  privateKey: CryptoKey,
+): Promise<Attendee | null> =>
+  row ? decryptAttendee(row, privateKey) : Promise.resolve(null);
+
 
 /** Encrypted attendee data for insertion */
 type EncryptedAttendeeData = {

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -2,7 +2,7 @@
  * Database client setup and core utilities
  */
 
-import { type Client, createClient, type InValue } from "@libsql/client";
+import { type Client, createClient, type InValue, type ResultSet } from "@libsql/client";
 import { lazyRef } from "#fp";
 
 const createDbClient = (): Client => {
@@ -48,3 +48,11 @@ export const executeByField = async (
     args: [value],
   });
 };
+
+/**
+ * Execute multiple queries in a single round-trip using Turso batch API.
+ * Significantly reduces latency for remote databases.
+ */
+export const queryBatch = (
+  statements: Array<{ sql: string; args: InValue[] }>,
+): Promise<ResultSet[]> => getDb().batch(statements, "read");

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -244,6 +244,12 @@ describe("code quality", () => {
       "lib/stripe.ts:constructTestWebhookEvent",
       // Convenience wrapper for idempotency checks (production uses isSessionProcessed directly)
       "lib/db/processed-payments.ts:getProcessedAttendeeId",
+      // Raw attendee fetch for testing encrypted data (production uses batched getEventWithAttendeesRaw)
+      "lib/db/attendees.ts:getAttendeesRaw",
+      // Single attendee fetch for tests (production uses batched getEventWithAttendeeRaw)
+      "lib/db/attendees.ts:getAttendee",
+      // Event activity log fetch for tests (production uses batched getEventWithActivityLog)
+      "lib/db/activityLog.ts:getEventActivityLog",
     ];
 
     /**

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -8,9 +8,10 @@ import {
 } from "#lib/db/activityLog.ts";
 import {
   createAttendeeAtomic,
+  decryptAttendees,
   deleteAttendee,
   getAttendee,
-  getAttendees,
+  getAttendeesRaw,
   hasAvailableSpots,
 } from "#lib/db/attendees.ts";
 import { getDb, setDb } from "#lib/db/client.ts";
@@ -550,7 +551,8 @@ describe("db", () => {
       await deleteEvent(event.id);
 
       const privateKey = await getTestPrivateKey();
-      const attendees = await getAttendees(event.id, privateKey);
+      const raw = await getAttendeesRaw(event.id);
+      const attendees = await decryptAttendees(raw, privateKey);
       expect(attendees).toEqual([]);
     });
 
@@ -611,17 +613,18 @@ describe("db", () => {
       expect(fetched).toBeNull();
     });
 
-    test("getAttendees returns empty array when no attendees", async () => {
+    test("decryptAttendees returns empty array when no attendees", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
       });
       const privateKey = await getTestPrivateKey();
-      const attendees = await getAttendees(event.id, privateKey);
+      const raw = await getAttendeesRaw(event.id);
+      const attendees = await decryptAttendees(raw, privateKey);
       expect(attendees).toEqual([]);
     });
 
-    test("getAttendees returns attendees for event", async () => {
+    test("decryptAttendees returns decrypted attendees for event", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
@@ -630,7 +633,8 @@ describe("db", () => {
       await createTestAttendee(event.id, event.slug, "Jane", "jane@example.com");
 
       const privateKey = await getTestPrivateKey();
-      const attendees = await getAttendees(event.id, privateKey);
+      const raw = await getAttendeesRaw(event.id);
+      const attendees = await decryptAttendees(raw, privateKey);
       expect(attendees.length).toBe(2);
     });
 


### PR DESCRIPTION
## Summary
Optimize database performance by using batch queries to fetch related data in a single round-trip instead of multiple sequential queries. This significantly reduces latency, especially for remote databases like Turso.

## Key Changes

- **Added `queryBatch` utility** in `client.ts` to execute multiple queries in a single database round-trip using Turso's batch API
- **Created batch query functions** for common data access patterns:
  - `getEventWithAttendeesRaw()` - fetch event + all attendees together
  - `getEventWithAttendeeRaw()` - fetch event + single attendee together
  - `getEventWithActivityLog()` - fetch event + activity log entries together
- **Refactored attendee decryption** by extracting `decryptAttendees()` and `decryptAttendeeOrNull()` helpers to support batch query workflows
- **Updated route handlers** to use new batch query functions:
  - `/admin/event/:id/attendees` - now uses single batch query
  - `/admin/event/:id/activity-log` - now uses single batch query
  - `/admin/event/:eventId/attendee/:attendeeId/delete` - now uses single batch query
- **Updated tests** to reflect refactored attendee functions and added allowlist entries for raw fetch functions used in tests

## Implementation Details

The batch queries maintain the same decryption and validation logic as before, but execute the database fetches together. This reduces remote database latency from 2+ round-trips to 1, while keeping the code structure clean and maintainable.

Raw fetch functions (`getAttendeesRaw`, `getAttendee`, `getEventActivityLog`) are preserved for testing purposes and added to the code quality allowlist.