### PR TITLE
Add password loss warning to setup agreement

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -660,3 +660,19 @@ input[type="submit"].danger:hover {
     --color-danger-hover: #cc0000;
   }
 }
+
+/* Agreement/disclaimer styling */
+fieldset.agreement {
+  margin-top: 2rem;
+}
+
+.password-warning {
+  color: #cc0000;
+  font-weight: bold;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[color-mode="user"] .password-warning {
+    color: #ff4444;
+  }
+}

--- a/src/templates/setup.tsx
+++ b/src/templates/setup.tsx
@@ -42,6 +42,10 @@ const DataControllerAgreement = (): JSX.Element => (
         account
       </li>
     </ol>
+    <p class="password-warning">
+      If you lose your password you will be <u>permanently</u> unable to view attendee lists. Do not
+      lose your password.
+    </p>
     <div class="field">
       <label>
         <input type="checkbox" name="accept_agreement" value="yes" required />I understand and


### PR DESCRIPTION
## Summary
Added a prominent warning message to the data controller agreement section during setup, alerting users about the permanent consequences of losing their password.

## Changes
- **src/templates/setup.tsx**: Added a password warning message above the agreement checkbox that emphasizes the permanent inability to view attendee lists if the password is lost
- **src/static/mvp.css**: Added styling for the new warning message with:
  - `.password-warning` class with bold red text (#cc0000)
  - Dark mode support with a lighter red (#ff4444) for better contrast when `prefers-color-scheme: dark` is enabled
  - `fieldset.agreement` margin adjustment for improved spacing

## Implementation Details
The warning uses semantic HTML with an underlined "permanently" to emphasize the critical nature of password security. The styling is consistent with the existing danger color scheme used elsewhere in the application and includes proper dark mode support.