### PR TITLE
Implement two-phase locking for payment processing idempotency

### DIFF
--- a/src/lib/db/processed-payments.ts
+++ b/src/lib/db/processed-payments.ts
@@ -1,9 +1,14 @@
 /**
  * Processed payments table operations (idempotency for webhook handling)
  *
- * Tracks Stripe session IDs that have been processed to prevent:
- * - Duplicate attendee creation from webhook retries
- * - Race conditions between redirect and webhook handlers
+ * Uses a two-phase locking pattern to prevent duplicate attendee creation:
+ * 1. reserveSession() - Claims the session with NULL attendee_id
+ * 2. createAttendeeAtomic() - Creates the attendee
+ * 3. finalizeSession() - Updates with the real attendee_id
+ *
+ * If reserveSession fails (session already claimed), we check if it's:
+ * - Finalized (attendee_id set) → return success with existing attendee
+ * - Still processing (attendee_id NULL) → return conflict error
  */
 
 import { getDb, queryOne } from "#lib/db/client.ts";
@@ -11,9 +16,14 @@ import { getDb, queryOne } from "#lib/db/client.ts";
 /** Processed payment record */
 export type ProcessedPayment = {
   stripe_session_id: string;
-  attendee_id: number;
+  attendee_id: number | null;
   processed_at: string;
 };
+
+/** Result of session reservation attempt */
+export type ReserveSessionResult =
+  | { reserved: true }
+  | { reserved: false; existing: ProcessedPayment };
 
 /**
  * Check if a Stripe session has already been processed
@@ -27,28 +37,49 @@ export const isSessionProcessed = (
   );
 
 /**
- * Mark a Stripe session as processed (atomically with attendee creation)
- * Returns false if session was already processed (idempotency check)
+ * Reserve a Stripe session for processing (first phase of two-phase lock)
+ * Inserts with NULL attendee_id to claim the session.
+ * Returns { reserved: true } if we claimed it, or { reserved: false, existing } if already claimed.
  */
-export const markSessionProcessed = async (
+export const reserveSession = async (
   stripeSessionId: string,
-  attendeeId: number,
-): Promise<boolean> => {
+): Promise<ReserveSessionResult> => {
   try {
     await getDb().execute({
-      sql: "INSERT INTO processed_payments (stripe_session_id, attendee_id, processed_at) VALUES (?, ?, ?)",
-      args: [stripeSessionId, attendeeId, new Date().toISOString()],
+      sql: "INSERT INTO processed_payments (stripe_session_id, attendee_id, processed_at) VALUES (?, NULL, ?)",
+      args: [stripeSessionId, new Date().toISOString()],
     });
-    return true;
+    return { reserved: true };
   } catch (e) {
-    // Unique constraint violation - session already processed
     const errorMsg = String(e);
-    if (errorMsg.includes("UNIQUE constraint") || errorMsg.includes("PRIMARY KEY constraint")) {
-      return false;
+    if (
+      errorMsg.includes("UNIQUE constraint") ||
+      errorMsg.includes("PRIMARY KEY constraint")
+    ) {
+      // Session already claimed - get existing record
+      const existing = await isSessionProcessed(stripeSessionId);
+      if (!existing) {
+        // Race condition edge case: record existed but was deleted
+        // Shouldn't happen in practice, treat as reservable
+        return reserveSession(stripeSessionId);
+      }
+      return { reserved: false, existing };
     }
-    // Re-throw unexpected errors (like table not existing)
     throw e;
   }
+};
+
+/**
+ * Finalize a reserved session with the created attendee ID (second phase)
+ */
+export const finalizeSession = async (
+  stripeSessionId: string,
+  attendeeId: number,
+): Promise<void> => {
+  await getDb().execute({
+    sql: "UPDATE processed_payments SET attendee_id = ? WHERE stripe_session_id = ?",
+    args: [attendeeId, stripeSessionId],
+  });
 };
 
 /**

--- a/test/lib/processed-payments.test.ts
+++ b/test/lib/processed-payments.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
 import {
+  finalizeSession,
   getProcessedAttendeeId,
   isSessionProcessed,
-  markSessionProcessed,
+  reserveSession,
 } from "#lib/db/processed-payments.ts";
 import {
   createTestAttendee,
@@ -11,6 +12,16 @@ import {
   resetDb,
   resetTestSlugCounter,
 } from "#test-utils";
+
+/** Helper to simulate the old markSessionProcessed behavior using two-phase locking */
+const processSession = async (sessionId: string, attendeeId: number): Promise<boolean> => {
+  const result = await reserveSession(sessionId);
+  if (!result.reserved) {
+    return false;
+  }
+  await finalizeSession(sessionId, attendeeId);
+  return true;
+};
 
 describe("processed-payments", () => {
   let testAttendeeId: number;
@@ -41,7 +52,7 @@ describe("processed-payments", () => {
     });
 
     test("returns record for processed session", async () => {
-      await markSessionProcessed("cs_processed_123", testAttendeeId);
+      await processSession("cs_processed_123", testAttendeeId);
 
       const result = await isSessionProcessed("cs_processed_123");
       expect(result).not.toBeNull();
@@ -49,26 +60,111 @@ describe("processed-payments", () => {
       expect(result?.attendee_id).toBe(testAttendeeId);
       expect(result?.processed_at).toBeDefined();
     });
+
+    test("returns record with null attendee_id for reserved session", async () => {
+      await reserveSession("cs_reserved_123");
+
+      const result = await isSessionProcessed("cs_reserved_123");
+      expect(result).not.toBeNull();
+      expect(result?.stripe_session_id).toBe("cs_reserved_123");
+      expect(result?.attendee_id).toBeNull();
+      expect(result?.processed_at).toBeDefined();
+    });
   });
 
-  describe("markSessionProcessed", () => {
+  describe("reserveSession", () => {
+    test("returns reserved:true for new session", async () => {
+      const result = await reserveSession("cs_new_session");
+      expect(result.reserved).toBe(true);
+    });
+
+    test("returns reserved:false with existing record for already reserved session", async () => {
+      // First reservation
+      const first = await reserveSession("cs_duplicate_reserve");
+      expect(first.reserved).toBe(true);
+
+      // Second attempt
+      const second = await reserveSession("cs_duplicate_reserve");
+      expect(second.reserved).toBe(false);
+      if (!second.reserved) {
+        expect(second.existing.stripe_session_id).toBe("cs_duplicate_reserve");
+        expect(second.existing.attendee_id).toBeNull();
+      }
+    });
+
+    test("returns reserved:false with attendee_id for finalized session", async () => {
+      // Reserve and finalize
+      await reserveSession("cs_finalized");
+      await finalizeSession("cs_finalized", testAttendeeId);
+
+      // Try to reserve again
+      const result = await reserveSession("cs_finalized");
+      expect(result.reserved).toBe(false);
+      if (!result.reserved) {
+        expect(result.existing.attendee_id).toBe(testAttendeeId);
+      }
+    });
+
+    test("concurrent reservations only one succeeds", async () => {
+      const sessionId = "cs_concurrent_reserve";
+
+      // Simulate concurrent attempts
+      const results = await Promise.all([
+        reserveSession(sessionId),
+        reserveSession(sessionId),
+        reserveSession(sessionId),
+      ]);
+
+      // Only one should succeed
+      const successes = results.filter((r) => r.reserved);
+      expect(successes.length).toBe(1);
+
+      // Others should see the existing record
+      const failures = results.filter((r) => !r.reserved);
+      expect(failures.length).toBe(2);
+      for (const failure of failures) {
+        if (!failure.reserved) {
+          expect(failure.existing.stripe_session_id).toBe(sessionId);
+        }
+      }
+    });
+  });
+
+  describe("finalizeSession", () => {
+    test("updates attendee_id on reserved session", async () => {
+      await reserveSession("cs_to_finalize");
+
+      // Verify attendee_id is null
+      let record = await isSessionProcessed("cs_to_finalize");
+      expect(record?.attendee_id).toBeNull();
+
+      // Finalize
+      await finalizeSession("cs_to_finalize", testAttendeeId);
+
+      // Verify attendee_id is set
+      record = await isSessionProcessed("cs_to_finalize");
+      expect(record?.attendee_id).toBe(testAttendeeId);
+    });
+  });
+
+  describe("two-phase session processing", () => {
     test("returns true for first processing", async () => {
-      const result = await markSessionProcessed("cs_new_session", testAttendeeId);
+      const result = await processSession("cs_new_session_process", testAttendeeId);
       expect(result).toBe(true);
     });
 
     test("returns false for duplicate processing", async () => {
       // First attempt should succeed
-      const first = await markSessionProcessed("cs_duplicate", testAttendeeId);
+      const first = await processSession("cs_duplicate_process", testAttendeeId);
       expect(first).toBe(true);
 
       // Second attempt with same session ID should fail
-      const second = await markSessionProcessed("cs_duplicate", testAttendeeId2);
+      const second = await processSession("cs_duplicate_process", testAttendeeId2);
       expect(second).toBe(false);
     });
 
     test("stores correct attendee ID", async () => {
-      await markSessionProcessed("cs_attendee_test", testAttendeeId);
+      await processSession("cs_attendee_test", testAttendeeId);
 
       const record = await isSessionProcessed("cs_attendee_test");
       expect(record?.attendee_id).toBe(testAttendeeId);
@@ -76,7 +172,7 @@ describe("processed-payments", () => {
 
     test("stores ISO timestamp", async () => {
       const before = new Date().toISOString();
-      await markSessionProcessed("cs_timestamp_test", testAttendeeId);
+      await processSession("cs_timestamp_test", testAttendeeId);
       const after = new Date().toISOString();
 
       const record = await isSessionProcessed("cs_timestamp_test");
@@ -95,10 +191,25 @@ describe("processed-payments", () => {
       expect(result).toBeNull();
     });
 
+    test("returns null for reserved but not finalized session", async () => {
+      await reserveSession("cs_reserved_only");
+
+      const result = await getProcessedAttendeeId("cs_reserved_only");
+      expect(result).toBeNull();
+    });
+
     test("returns attendee ID for processed session", async () => {
-      await markSessionProcessed("cs_with_attendee", testAttendeeId);
+      await processSession("cs_with_attendee", testAttendeeId);
 
       const result = await getProcessedAttendeeId("cs_with_attendee");
+      expect(result).toBe(testAttendeeId);
+    });
+
+    test("returns attendee ID for finalized session", async () => {
+      await reserveSession("cs_finalized_attendee");
+      await finalizeSession("cs_finalized_attendee", testAttendeeId);
+
+      const result = await getProcessedAttendeeId("cs_finalized_attendee");
       expect(result).toBe(testAttendeeId);
     });
   });
@@ -109,9 +220,9 @@ describe("processed-payments", () => {
 
       // Simulate concurrent attempts with different attendees
       const results = await Promise.all([
-        markSessionProcessed(sessionId, testAttendeeId),
-        markSessionProcessed(sessionId, testAttendeeId2),
-        markSessionProcessed(sessionId, testAttendeeId3),
+        processSession(sessionId, testAttendeeId),
+        processSession(sessionId, testAttendeeId2),
+        processSession(sessionId, testAttendeeId3),
       ]);
 
       // Only one should succeed
@@ -121,6 +232,32 @@ describe("processed-payments", () => {
       // The record should exist
       const record = await isSessionProcessed(sessionId);
       expect(record).not.toBeNull();
+    });
+
+    test("two-phase locking prevents duplicate attendee creation", async () => {
+      const sessionId = "cs_two_phase_test";
+
+      // Simulate the race condition scenario:
+      // Request A reserves, Request B tries to reserve
+      const reserveA = await reserveSession(sessionId);
+      expect(reserveA.reserved).toBe(true);
+
+      const reserveB = await reserveSession(sessionId);
+      expect(reserveB.reserved).toBe(false);
+      if (!reserveB.reserved) {
+        // B sees that A has reserved but not finalized
+        expect(reserveB.existing.attendee_id).toBeNull();
+      }
+
+      // A finalizes with attendee
+      await finalizeSession(sessionId, testAttendeeId);
+
+      // Now if C tries to reserve, they see the finalized attendee
+      const reserveC = await reserveSession(sessionId);
+      expect(reserveC.reserved).toBe(false);
+      if (!reserveC.reserved) {
+        expect(reserveC.existing.attendee_id).toBe(testAttendeeId);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
Replaces the simple idempotency check with a two-phase locking pattern to safely handle race conditions in payment processing. This prevents duplicate attendee creation when both the redirect handler and webhook handler process the same payment simultaneously.

## Key Changes

### Database Schema (v1 → v2)
- Made `attendee_id` nullable in `processed_payments` table to support the intermediate "reserved but not finalized" state
- Added migration to safely alter existing databases using SQLite's table recreation pattern

### Payment Processing Flow
- **Phase 1 (Reserve)**: `reserveSession()` claims the session with `NULL` attendee_id, preventing other requests from processing it
- **Phase 2 (Create)**: Atomically creates the attendee with capacity check
- **Phase 3 (Finalize)**: `finalizeSession()` updates the session with the real attendee_id

### Conflict Handling
- If a request finds an already-reserved session with `NULL` attendee_id, it returns a 409 Conflict error (another request is processing)
- If a request finds a finalized session with an attendee_id, it returns success with the existing attendee
- This prevents duplicate attendee creation while handling legitimate retries

### Type Safety Improvements
- Introduced `ValidatedCheckoutSession` type with strict field validation instead of loose `Record<string, unknown>`
- Added `validateCheckoutSession()` type guard to ensure all required Stripe fields are present and correctly typed
- Improved webhook event extraction with explicit field validation

### Error Handling
- Enhanced refund status tracking to accurately report whether refunds succeeded or failed
- Added `formatPaymentError()` helper to provide clear user messaging based on refund status
- Better error logging for failed refunds

### Testing
- Updated tests to use the new two-phase locking API
- Added comprehensive tests for concurrent reservation attempts
- Added tests for the intermediate "reserved but not finalized" state
- Added test demonstrating the two-phase locking prevents duplicate attendee creation

## Implementation Details
- The two-phase lock is enforced by the database's PRIMARY KEY constraint on `stripe_session_id`
- The pattern is safe against concurrent requests arriving at nearly the same time
- Backward compatible: existing finalized sessions continue to work correctly
- No changes to the public API surface for webhook/redirect handlers