### PR TITLE
Add CSS minification to build process

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -6,11 +6,15 @@
 
 import * as esbuild from "esbuild";
 import type { Plugin } from "esbuild";
+import { minifyCss } from "./css-minify.ts";
 
 // Read static assets at build time for inlining
+const rawCss = await Deno.readTextFile("./src/static/mvp.css");
+const minifiedCss = await minifyCss(rawCss);
+
 const STATIC_ASSETS: Record<string, string> = {
   "favicon.svg": await Deno.readTextFile("./src/static/favicon.svg"),
-  "mvp.css": await Deno.readTextFile("./src/static/mvp.css"),
+  "mvp.css": minifiedCss,
 };
 
 /**

--- a/scripts/css-minify.ts
+++ b/scripts/css-minify.ts
@@ -1,0 +1,16 @@
+/**
+ * CSS minification utility using esbuild
+ */
+
+import * as esbuild from "esbuild";
+
+/**
+ * Minify CSS using esbuild's transform API
+ */
+export async function minifyCss(css: string): Promise<string> {
+  const result = await esbuild.transform(css, {
+    loader: "css",
+    minify: true,
+  });
+  return result.code;
+}

--- a/test/lib/build-edge.test.ts
+++ b/test/lib/build-edge.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "#test-compat";
+import { minifyCss } from "../../scripts/css-minify.ts";
+
+describe("build-edge", () => {
+  describe("minifyCss", () => {
+    test("removes whitespace and newlines", async () => {
+      const input = `
+        .foo {
+          color: red;
+          margin: 10px;
+        }
+      `;
+      const result = await minifyCss(input);
+      // esbuild minifies CSS by removing unnecessary whitespace
+      // Result may have trailing newline but no internal newlines
+      expect(result.trim()).not.toContain("\n");
+      expect(result).toContain(".foo");
+      expect(result).toContain("color:");
+      expect(result).toContain("red");
+    });
+
+    test("removes comments", async () => {
+      const input = `
+        /* This is a comment */
+        .bar { color: blue; }
+      `;
+      const result = await minifyCss(input);
+      expect(result).not.toContain("comment");
+      expect(result).toContain(".bar");
+    });
+
+    test("shortens color values where possible", async () => {
+      const input = ".test { color: #ffffff; }";
+      const result = await minifyCss(input);
+      // esbuild may shorten #ffffff to #fff
+      expect(result).toMatch(/#fff(?:fff)?/);
+    });
+
+    test("preserves valid CSS syntax", async () => {
+      const input = `
+        :root {
+          --color-primary: #791a81;
+        }
+        .btn {
+          background: var(--color-primary);
+          padding: 1rem 2rem;
+        }
+      `;
+      const result = await minifyCss(input);
+      expect(result).toContain("--color-primary");
+      expect(result).toContain("var(--color-primary)");
+    });
+
+    test("handles empty input", async () => {
+      const result = await minifyCss("");
+      expect(result).toBe("");
+    });
+
+    test("handles media queries", async () => {
+      const input = `
+        @media (max-width: 768px) {
+          .mobile { display: block; }
+        }
+      `;
+      const result = await minifyCss(input);
+      expect(result).toContain("@media");
+      expect(result).toContain("max-width:");
+      expect(result).toContain("768px");
+      expect(result).toContain(".mobile");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds CSS minification to the edge build process, reducing the size of inlined CSS assets by removing unnecessary whitespace, comments, and optimizing color values.

## Changes
- **New module**: `scripts/css-minify.ts` - Utility function that minifies CSS using esbuild's transform API with the `minify` option enabled
- **Updated build script**: `scripts/build-edge.ts` - Modified to minify `mvp.css` before inlining it into static assets
- **New test suite**: `test/lib/build-edge.test.ts` - Comprehensive tests for the `minifyCss` function covering:
  - Whitespace and newline removal
  - Comment stripping
  - Color value optimization
  - CSS variable preservation
  - Media query handling
  - Edge cases (empty input)

## Implementation Details
- Uses esbuild's existing `transform` API with `loader: "css"` and `minify: true` options, avoiding additional dependencies
- CSS is minified at build time, so there's no runtime performance impact
- The minified CSS is inlined into the build output, maintaining the existing asset inlining strategy

https://claude.ai/code/session_01E5wQ8ea8f1y3ke3qyxyXQV