### PR TITLE
Add phone number field support and configurable contact fields

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -5,7 +5,7 @@
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { executeByField, getDb, queryBatch, queryOne } from "#lib/db/client.ts";
 import { col, defineTable } from "#lib/db/table.ts";
-import type { Attendee, Event, EventWithCount } from "#lib/types.ts";
+import type { Attendee, Event, EventFields, EventWithCount } from "#lib/types.ts";
 
 /** Event input fields for create/update (camelCase) */
 export type EventInput = {
@@ -17,6 +17,7 @@ export type EventInput = {
   maxQuantity?: number;
   webhookUrl?: string | null;
   active?: number;
+  fields?: EventFields;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -41,6 +42,7 @@ export const eventsTable = defineTable<Event, EventInput>({
     max_quantity: col.withDefault(() => 1),
     webhook_url: col.encryptedNullable<string>(encrypt, decrypt),
     active: col.withDefault(() => 1),
+    fields: col.withDefault<EventFields>(() => "email"),
   },
 });
 

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -18,7 +18,8 @@ export type FieldType =
   | "email"
   | "url"
   | "password"
-  | "textarea";
+  | "textarea"
+  | "select";
 
 export interface Field {
   name: string;
@@ -30,6 +31,7 @@ export interface Field {
   min?: number;
   pattern?: string;
   validate?: (value: string) => string | null;
+  options?: { value: string; label: string }[];
 }
 
 export interface FieldValues {
@@ -45,6 +47,18 @@ type FieldValidationResult =
   | { valid: false; error: string };
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
+
+/** Render select options HTML */
+const renderSelectOptions = (
+  options: { value: string; label: string }[],
+  selectedValue: string,
+): string =>
+  options
+    .map(
+      (opt) =>
+        `<option value="${escapeHtml(opt.value)}"${opt.value === selectedValue ? " selected" : ""}>${escapeHtml(opt.label)}</option>`,
+    )
+    .join("");
 
 /**
  * Render a single form field
@@ -62,6 +76,10 @@ export const renderField = (field: Field, value: string = ""): string =>
         >
           <Raw html={escapeHtml(value)} />
         </textarea>
+      ) : field.type === "select" && field.options ? (
+        <Raw
+          html={`<select name="${escapeHtml(field.name)}" id="${escapeHtml(field.name)}">${renderSelectOptions(field.options, value)}</select>`}
+        />
       ) : (
         <input
           type={field.type}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -125,7 +125,7 @@ const buildSessionParams = async (
     mode: "payment",
     success_url: cfg.successUrl,
     cancel_url: cfg.cancelUrl,
-    customer_email: cfg.email,
+    ...(cfg.email ? { customer_email: cfg.email } : {}),
     metadata: cfg.metadata,
   };
 };
@@ -195,6 +195,7 @@ export const stripeApi: {
         name: intent.name,
         email: intent.email,
         quantity: String(intent.quantity),
+        ...(intent.phone ? { phone: intent.phone } : {}),
       },
     });
     return config
@@ -241,12 +242,13 @@ export const stripeApi: {
       mode: "payment",
       success_url: `${baseUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/payment/cancel?session_id={CHECKOUT_SESSION_ID}`,
-      customer_email: intent.email,
+      ...(intent.email ? { customer_email: intent.email } : {}),
       metadata: {
         multi: "1",
         name: intent.name,
         email: intent.email,
         items: itemsJson,
+        ...(intent.phone ? { phone: intent.phone } : {}),
       },
     };
 
@@ -269,6 +271,7 @@ export type RegistrationIntent = {
   eventId: number;
   name: string;
   email: string;
+  phone: string;
   quantity: number;
 };
 
@@ -284,6 +287,7 @@ export type MultiRegistrationItem = {
 export type MultiRegistrationIntent = {
   name: string;
   email: string;
+  phone: string;
   items: MultiRegistrationItem[];
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,9 @@
  * Types for the ticket reservation system
  */
 
+/** Contact fields setting for an event */
+export type EventFields = "email" | "phone" | "both";
+
 export interface Event {
   id: number;
   slug: string;
@@ -13,6 +16,7 @@ export interface Event {
   max_quantity: number;
   webhook_url: string | null;
   active: number;
+  fields: EventFields;
 }
 
 export interface Attendee {
@@ -20,6 +24,7 @@ export interface Attendee {
   event_id: number;
   name: string;
   email: string;
+  phone: string;
   created: string;
   stripe_payment_id: string | null;
   quantity: number;

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -20,7 +20,7 @@ import {
 } from "#lib/db/events.ts";
 import { createHandler, updateHandler } from "#lib/rest/handlers.ts";
 import { defineResource } from "#lib/rest/resource.ts";
-import type { Attendee, EventWithCount } from "#lib/types.ts";
+import type { Attendee, EventFields, EventWithCount } from "#lib/types.ts";
 import { defineRoutes, type RouteParams } from "#routes/router.ts";
 import {
   getAuthenticatedSession,
@@ -56,6 +56,7 @@ const extractEventInput = async (
     unitPrice: values.unit_price as number | null,
     maxQuantity: values.max_quantity as number,
     webhookUrl: (values.webhook_url as string) || null,
+    fields: (values.fields as EventFields) || "email",
   };
 };
 

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -14,7 +14,7 @@ import {
   type MultiRegistrationItem,
   type RegistrationIntent,
 } from "#lib/stripe.ts";
-import type { EventWithCount } from "#lib/types.ts";
+import type { EventFields, EventWithCount } from "#lib/types.ts";
 import { logAndNotifyRegistration } from "#lib/webhook.ts";
 import {
   csrfCookie,
@@ -28,7 +28,7 @@ import {
   requireCsrfForm,
   withActiveEventBySlug,
 } from "#routes/utils.ts";
-import { ticketFields } from "#templates/fields.ts";
+import { getTicketFields, mergeEventFields } from "#templates/fields.ts";
 import { reservationSuccessPage } from "#templates/payment.tsx";
 import {
   buildMultiTicketEvent,
@@ -98,6 +98,7 @@ type ReservationParams = {
   event: EventWithCount;
   name: string;
   email: string;
+  phone: string;
   quantity: number;
   token: string;
 };
@@ -128,6 +129,13 @@ const handlePaymentFlow = async (
   );
 };
 
+/** Extract contact details (name, email, phone) from validated form values */
+const extractContact = (values: import("#lib/forms.tsx").FieldValues) => ({
+  name: values.name as string,
+  email: (values.email as string) || "",
+  phone: (values.phone as string) || "",
+});
+
 /** Parse and validate a quantity value from a raw string, capping at max */
 const parseQuantityValue = (raw: string, max: number, minDefault = 1): number => {
   const quantity = Number.parseInt(raw, 10);
@@ -149,20 +157,14 @@ const ticketCsrfError = (event: EventWithCount) => (token: string) =>
 /** Handle paid event registration - check availability, create Stripe session */
 const processPaidReservation = async (
   request: Request,
-  params: ReservationParams,
+  { event, token, ...contact }: ReservationParams,
 ): Promise<Response> => {
-  const { event, name, email, quantity, token } = params;
-  const available = await hasAvailableSpots(event.id, quantity);
+  const available = await hasAvailableSpots(event.id, contact.quantity);
   if (!available) {
     return ticketResponse(event, token)("Sorry, not enough spots available");
   }
 
-  const intent: RegistrationIntent = {
-    eventId: event.id,
-    name,
-    email,
-    quantity,
-  };
+  const intent: RegistrationIntent = { eventId: event.id, ...contact };
   return handlePaymentFlow(request, event, intent, token);
 };
 
@@ -181,8 +183,8 @@ const formatAtomicError = (
 const processFreeReservation = async (
   reservation: ReservationParams,
 ): Promise<Response> => {
-  const { event, name, email, quantity, token } = reservation;
-  const result = await createAttendeeAtomic(event.id, name, email, null, quantity);
+  const { event, name, email, phone, quantity, token } = reservation;
+  const result = await createAttendeeAtomic(event.id, name, email, null, quantity, phone);
 
   if (!result.success) {
     return ticketResponse(event, token)(formatAtomicError(result.reason));
@@ -210,18 +212,17 @@ const processTicketReservation = async (
   if (!csrfResult.ok) return csrfResult.response;
 
   const { form } = csrfResult;
-  const validation = validateForm(form, ticketFields);
+  const fields = getTicketFields(event.fields);
+  const validation = validateForm(form, fields);
   if (!validation.valid) {
     return ticketResponse(event, currentToken)(validation.error);
   }
 
   const quantity = parseQuantity(form, event);
-  const name = validation.values.name as string;
-  const email = validation.values.email as string;
+  const contact = extractContact(validation.values);
   const params: ReservationParams = {
     event,
-    name,
-    email,
+    ...contact,
     quantity,
     token: currentToken,
   };
@@ -380,15 +381,20 @@ const handleMultiPaymentFlow = async (
   );
 };
 
+/** Determine merged fields setting for multi-ticket events */
+const getMultiTicketFieldsSetting = (events: MultiTicketEvent[]): EventFields =>
+  mergeEventFields(events.map((e) => e.event.fields));
+
 /** Handle free multi-ticket registration */
 const processMultiFreeReservation = async (
   events: MultiTicketEvent[],
   quantities: Map<number, number>,
   name: string,
   email: string,
+  phone: string,
 ): Promise<{ success: true } | { success: false; error: string }> => {
   for (const { event, qty } of eventsWithQuantity(events, quantities)) {
-    const result = await createAttendeeAtomic(event.id, name, email, null, qty);
+    const result = await createAttendeeAtomic(event.id, name, email, null, qty, phone);
     if (!result.success) {
       return { success: false, error: formatAtomicError(result.reason, event.slug) };
     }
@@ -418,16 +424,17 @@ const handleMultiTicketPost = (
 
   const { form } = csrfResult;
 
-  // Validate name/email fields
-  const validation = validateForm(form, ticketFields);
+  // Validate fields based on merged event settings
+  const fieldsSetting = getMultiTicketFieldsSetting(activeEvents);
+  const fields = getTicketFields(fieldsSetting);
+  const validation = validateForm(form, fields);
   if (!validation.valid) {
     return multiTicketResponse(slugs, activeEvents, currentToken)(
       validation.error,
     );
   }
 
-  const name = validation.values.name as string;
-  const email = validation.values.email as string;
+  const { name, email, phone } = extractContact(validation.values);
 
   // Parse quantities
   const quantities = parseMultiQuantities(form, activeEvents);
@@ -455,7 +462,7 @@ const handleMultiTicketPost = (
       );
     }
 
-    const intent: MultiRegistrationIntent = { name, email, items };
+    const intent: MultiRegistrationIntent = { name, email, phone, items };
     return handleMultiPaymentFlow(
       request,
       slugs,
@@ -471,6 +478,7 @@ const handleMultiTicketPost = (
     quantities,
     name,
     email,
+    phone,
   );
 
   if (!result.success) {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -82,7 +82,7 @@ const validateCheckoutSession = (
     return null;
   }
 
-  if (!metadata?.name || typeof metadata?.email !== "string") {
+  if (!metadata?.name) {
     return null;
   }
 
@@ -100,7 +100,7 @@ const validateCheckoutSession = (
     metadata: {
       event_id: metadata.event_id,
       name: metadata.name,
-      email: metadata.email,
+      email: metadata.email ?? "",
       phone: metadata.phone,
       quantity: metadata.quantity,
       multi: metadata.multi,

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -47,6 +47,7 @@ type SessionMetadata = {
   event_id?: string;
   name: string;
   email: string;
+  phone?: string;
   quantity?: string;
   multi?: string;
   items?: string;
@@ -81,7 +82,7 @@ const validateCheckoutSession = (
     return null;
   }
 
-  if (!metadata?.name || !metadata?.email) {
+  if (!metadata?.name || typeof metadata?.email !== "string") {
     return null;
   }
 
@@ -100,6 +101,7 @@ const validateCheckoutSession = (
       event_id: metadata.event_id,
       name: metadata.name,
       email: metadata.email,
+      phone: metadata.phone,
       quantity: metadata.quantity,
       multi: metadata.multi,
       items: metadata.items,
@@ -114,6 +116,7 @@ const extractIntent = (
   eventId: Number.parseInt(session.metadata.event_id ?? "0", 10),
   name: session.metadata.name,
   email: session.metadata.email,
+  phone: session.metadata.phone ?? "",
   quantity: Number.parseInt(session.metadata.quantity || "1", 10),
 });
 
@@ -243,6 +246,7 @@ const parseMultiItems = (itemsJson: string): MultiItem[] | null => {
 type MultiIntent = {
   name: string;
   email: string;
+  phone: string;
   items: MultiItem[];
 };
 
@@ -259,6 +263,7 @@ const extractMultiIntent = (
   return {
     name: metadata.name,
     email: metadata.email,
+    phone: metadata.phone ?? "",
     items,
   };
 };
@@ -327,6 +332,7 @@ const processMultiPaymentSession = async (
       intent.email,
       session.payment_intent,
       item.q,
+      intent.phone,
     );
 
     if (!result.success) {
@@ -429,6 +435,7 @@ const processPaymentSession = async (
     intent.email,
     paymentIntentId,
     intent.quantity,
+    intent.phone,
   );
 
   if (!result.success) {
@@ -573,6 +580,7 @@ const extractSessionFromEvent = (
       event_id: obj.metadata.event_id,
       name: obj.metadata.name,
       email: obj.metadata.email,
+      phone: obj.metadata.phone,
       quantity: obj.metadata.quantity,
       multi: obj.metadata.multi,
       items: obj.metadata.items,

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -4,7 +4,7 @@
 
 import { map, pipe, reduce } from "#fp";
 import { type FieldValues, renderError, renderFields } from "#lib/forms.tsx";
-import type { Attendee, EventWithCount } from "#lib/types.ts";
+import type { Attendee, EventFields, EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { eventFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
@@ -12,11 +12,19 @@ import { AdminNav } from "#templates/admin/nav.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
+/** Human-readable labels for fields settings */
+const FIELDS_LABELS: Record<EventFields, string> = {
+  email: "Email",
+  phone: "Phone Number",
+  both: "Email & Phone Number",
+};
+
 const AttendeeRow = ({ a, eventId }: { a: Attendee; eventId: number }): string =>
   String(
     <tr>
       <td>{a.name}</td>
-      <td>{a.email}</td>
+      <td>{a.email || ""}</td>
+      <td>{a.phone || ""}</td>
       <td>{a.quantity}</td>
       <td>{new Date(a.created).toLocaleString()}</td>
       <td>
@@ -43,7 +51,7 @@ export const adminEventPage = (
           map((a: Attendee) => AttendeeRow({ a, eventId: event.id })),
           joinStrings,
         )(attendees)
-      : '<tr><td colspan="5">No attendees yet</td></tr>';
+      : '<tr><td colspan="7">No attendees yet</td></tr>';
 
   return String(
     <Layout title={`Event: ${event.slug}`}>
@@ -78,6 +86,7 @@ export const adminEventPage = (
           <p><strong>Max Tickets Per Purchase:</strong> {event.max_quantity}</p>
           <p><strong>Tickets Sold:</strong> {event.attendee_count}</p>
           <p><strong>Spots Remaining:</strong> {event.max_attendees - event.attendee_count}</p>
+          <p><strong>Contact Fields:</strong> {FIELDS_LABELS[event.fields]}</p>
           {event.thank_you_url ? (
             <p>
               <strong>Thank You URL:</strong>{" "}
@@ -117,6 +126,7 @@ export const adminEventPage = (
             <tr>
               <th>Name</th>
               <th>Email</th>
+              <th>Phone</th>
               <th>Qty</th>
               <th>Registered</th>
               <th>Actions</th>
@@ -137,6 +147,7 @@ const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   slug: event.slug,
   max_attendees: event.max_attendees,
   max_quantity: event.max_quantity,
+  fields: event.fields,
   unit_price: event.unit_price,
   thank_you_url: event.thank_you_url,
   webhook_url: event.webhook_url,

--- a/src/templates/csv.ts
+++ b/src/templates/csv.ts
@@ -16,15 +16,17 @@ const escapeCsvValue = (value: string): string => {
 };
 
 /**
- * Generate CSV content from attendees
+ * Generate CSV content from attendees.
+ * Always includes both Email and Phone columns regardless of event settings.
  */
 export const generateAttendeesCsv = (attendees: Attendee[]): string => {
-  const header = "Name,Email,Quantity,Registered";
+  const header = "Name,Email,Phone,Quantity,Registered";
   const rows = pipe(
     map((a: Attendee) =>
       [
         escapeCsvValue(a.name),
         escapeCsvValue(a.email),
+        escapeCsvValue(a.phone),
         String(a.quantity),
         escapeCsvValue(new Date(a.created).toISOString()),
       ].join(","),

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -389,6 +389,7 @@ export const createTestEvent = (
       slug: input.slug,
       max_attendees: String(input.maxAttendees),
       max_quantity: String(input.maxQuantity ?? 1),
+      fields: input.fields ?? "email",
       thank_you_url: input.thankYouUrl ?? "",
       unit_price: input.unitPrice != null ? String(input.unitPrice) : "",
       webhook_url: input.webhookUrl ?? "",
@@ -442,6 +443,7 @@ export const updateTestEvent = async (
       slug: updates.slug ?? existing.slug,
       max_attendees: String(updates.maxAttendees ?? existing.max_attendees),
       max_quantity: String(updates.maxQuantity ?? existing.max_quantity),
+      fields: updates.fields ?? existing.fields,
       thank_you_url: formatOptional(updates.thankYouUrl, existing.thank_you_url),
       unit_price: formatPrice(updates.unitPrice, existing.unit_price),
       webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
@@ -502,6 +504,7 @@ export const createTestAttendee = async (
   name: string,
   email: string,
   quantity = 1,
+  phone = "",
 ): Promise<Attendee> => {
   const { handleRequest } = await import("#routes");
 
@@ -521,7 +524,7 @@ export const createTestAttendee = async (
 
   // Submit the ticket form
   const response = await handleRequest(
-    mockTicketFormRequest(eventSlug, { name, email, quantity: String(quantity) }, csrfToken),
+    mockTicketFormRequest(eventSlug, { name, email, phone, quantity: String(quantity) }, csrfToken),
   );
 
   // Free events redirect to thank you page (302)

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -56,6 +56,7 @@ describe("html", () => {
           max_quantity: 1,
           webhook_url: null,
           active: 1,
+          fields: "email",
         },
       ];
       const html = adminDashboardPage(events, TEST_CSRF_TOKEN);
@@ -78,6 +79,7 @@ describe("html", () => {
           max_quantity: 1,
           webhook_url: null,
           active: 1,
+          fields: "email",
         },
       ];
       const html = adminDashboardPage(events, TEST_CSRF_TOKEN);
@@ -112,6 +114,7 @@ describe("html", () => {
       max_quantity: 1,
       webhook_url: null,
       active: 1,
+      fields: "email",
     };
 
     test("renders event details", () => {
@@ -154,6 +157,7 @@ describe("html", () => {
           created: "2024-01-01T12:00:00Z",
           stripe_payment_id: null,
           quantity: 1,
+          phone: "",
         },
       ];
       const html = adminEventPage(event, attendees, "localhost");
@@ -171,6 +175,7 @@ describe("html", () => {
           created: "2024-01-01T12:00:00Z",
           stripe_payment_id: null,
           quantity: 1,
+          phone: "",
         },
       ];
       const html = adminEventPage(event, attendees, "localhost");
@@ -180,6 +185,46 @@ describe("html", () => {
     test("includes back link", () => {
       const html = adminEventPage(event, [], "localhost");
       expect(html).toContain("/admin/");
+    });
+
+    test("shows contact fields label", () => {
+      const html = adminEventPage(event, [], "localhost");
+      expect(html).toContain("Contact Fields");
+      expect(html).toContain("Email");
+    });
+
+    test("shows phone contact fields label for phone events", () => {
+      const phoneEvent = { ...event, fields: "phone" as const };
+      const html = adminEventPage(phoneEvent, [], "localhost");
+      expect(html).toContain("Phone Number");
+    });
+
+    test("shows both contact fields label", () => {
+      const bothEvent = { ...event, fields: "both" as const };
+      const html = adminEventPage(bothEvent, [], "localhost");
+      expect(html).toContain("Email &amp; Phone Number");
+    });
+
+    test("shows phone column in attendee table", () => {
+      const html = adminEventPage(event, [], "localhost");
+      expect(html).toContain("<th>Phone</th>");
+    });
+
+    test("shows attendee phone in table row", () => {
+      const attendees: Attendee[] = [
+        {
+          id: 1,
+          event_id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          created: "2024-01-01T12:00:00Z",
+          stripe_payment_id: null,
+          quantity: 1,
+          phone: "+1 555 123 4567",
+        },
+      ];
+      const html = adminEventPage(event, attendees, "localhost");
+      expect(html).toContain("+1 555 123 4567");
     });
   });
 
@@ -196,6 +241,7 @@ describe("html", () => {
       max_quantity: 1,
       webhook_url: null,
       active: 1,
+      fields: "email",
     };
     const csrfToken = "test-csrf-token";
 
@@ -275,6 +321,27 @@ describe("html", () => {
       expect(html).toContain("Reserve Ticket"); // Singular
       expect(html).not.toContain("Reserve Tickets"); // Not plural
     });
+
+    test("shows phone field for phone-only events", () => {
+      const phoneEvent = { ...event, fields: "phone" as const };
+      const html = ticketPage(phoneEvent, csrfToken);
+      expect(html).toContain('name="phone"');
+      expect(html).toContain("Your Phone Number");
+      expect(html).not.toContain('name="email"');
+    });
+
+    test("shows both email and phone for both setting", () => {
+      const bothEvent = { ...event, fields: "both" as const };
+      const html = ticketPage(bothEvent, csrfToken);
+      expect(html).toContain('name="email"');
+      expect(html).toContain('name="phone"');
+    });
+
+    test("shows only email for email setting", () => {
+      const html = ticketPage(event, csrfToken);
+      expect(html).toContain('name="email"');
+      expect(html).not.toContain('name="phone"');
+    });
   });
 
   describe("notFoundPage", () => {
@@ -296,6 +363,7 @@ describe("html", () => {
       max_quantity: 1,
       webhook_url: null,
       active: 1,
+      fields: "email",
     };
 
     const attendee: Attendee = {
@@ -303,6 +371,7 @@ describe("html", () => {
       event_id: 1,
       name: "John Doe",
       email: "john@example.com",
+      phone: "",
       created: "2024-01-01T12:00:00Z",
       stripe_payment_id: null,
       quantity: 1,
@@ -359,6 +428,7 @@ describe("html", () => {
       max_quantity: 1,
       webhook_url: null,
       active: 1,
+      fields: "email",
     };
 
     test("renders success message", () => {
@@ -386,6 +456,7 @@ describe("html", () => {
       max_quantity: 1,
       webhook_url: null,
       active: 1,
+      fields: "email",
     };
 
     test("renders cancel message", () => {
@@ -436,6 +507,7 @@ describe("html", () => {
       max_quantity: 1,
       webhook_url: null,
       active: 1,
+      fields: "email",
     };
 
     test("renders export CSV button", () => {
@@ -448,7 +520,7 @@ describe("html", () => {
   describe("generateAttendeesCsv", () => {
     test("generates CSV header for empty attendees", () => {
       const csv = generateAttendeesCsv([]);
-      expect(csv).toBe("Name,Email,Quantity,Registered");
+      expect(csv).toBe("Name,Email,Phone,Quantity,Registered");
     });
 
     test("generates CSV with attendee data", () => {
@@ -461,11 +533,12 @@ describe("html", () => {
           created: "2024-01-15T10:30:00Z",
           stripe_payment_id: null,
           quantity: 2,
+          phone: "",
         },
       ];
       const csv = generateAttendeesCsv(attendees);
       const lines = csv.split("\n");
-      expect(lines[0]).toBe("Name,Email,Quantity,Registered");
+      expect(lines[0]).toBe("Name,Email,Phone,Quantity,Registered");
       expect(lines[1]).toContain("John Doe");
       expect(lines[1]).toContain("john@example.com");
       expect(lines[1]).toContain(",2,");
@@ -482,6 +555,7 @@ describe("html", () => {
           created: "2024-01-15T10:30:00Z",
           stripe_payment_id: null,
           quantity: 1,
+          phone: "",
         },
       ];
       const csv = generateAttendeesCsv(attendees);
@@ -498,6 +572,7 @@ describe("html", () => {
           created: "2024-01-15T10:30:00Z",
           stripe_payment_id: null,
           quantity: 1,
+          phone: "",
         },
       ];
       const csv = generateAttendeesCsv(attendees);
@@ -514,6 +589,7 @@ describe("html", () => {
           created: "2024-01-15T10:30:00Z",
           stripe_payment_id: null,
           quantity: 1,
+          phone: "",
         },
       ];
       const csv = generateAttendeesCsv(attendees);
@@ -530,6 +606,7 @@ describe("html", () => {
           created: "2024-01-15T10:30:00Z",
           stripe_payment_id: null,
           quantity: 1,
+          phone: "",
         },
         {
           id: 2,
@@ -539,6 +616,7 @@ describe("html", () => {
           created: "2024-01-16T11:00:00Z",
           stripe_payment_id: null,
           quantity: 3,
+          phone: "",
         },
       ];
       const csv = generateAttendeesCsv(attendees);
@@ -546,6 +624,43 @@ describe("html", () => {
       expect(lines).toHaveLength(3);
       expect(lines[1]).toContain("John Doe");
       expect(lines[2]).toContain("Jane Smith");
+    });
+
+    test("includes phone number in CSV output", () => {
+      const attendees: Attendee[] = [
+        {
+          id: 1,
+          event_id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          created: "2024-01-15T10:30:00Z",
+          stripe_payment_id: null,
+          quantity: 1,
+          phone: "+1 555 123 4567",
+        },
+      ];
+      const csv = generateAttendeesCsv(attendees);
+      const lines = csv.split("\n");
+      expect(lines[0]).toBe("Name,Email,Phone,Quantity,Registered");
+      expect(lines[1]).toContain("+1 555 123 4567");
+    });
+
+    test("includes empty phone column when phone not collected", () => {
+      const attendees: Attendee[] = [
+        {
+          id: 1,
+          event_id: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          created: "2024-01-15T10:30:00Z",
+          stripe_payment_id: null,
+          quantity: 1,
+          phone: "",
+        },
+      ];
+      const csv = generateAttendeesCsv(attendees);
+      const lines = csv.split("\n");
+      expect(lines[1]).toContain("john@example.com,,1,");
     });
   });
 });

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -1122,7 +1122,7 @@ describe("server", () => {
         cookie: cookie || "",
       });
       const csv = await response.text();
-      expect(csv).toContain("Name,Email,Quantity,Registered");
+      expect(csv).toContain("Name,Email,Phone,Quantity,Registered");
       expect(csv).toContain("John Doe");
       expect(csv).toContain("john@example.com");
       expect(csv).toContain("Jane Smith");

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -149,11 +149,13 @@ describe("stripe", () => {
         max_quantity: 1,
         webhook_url: null,
         active: 1,
+        fields: "email" as const,
       };
       const intent = {
         eventId: 1,
         name: "John Doe",
         email: "john@example.com",
+        phone: "",
         quantity: 1,
       };
 
@@ -188,12 +190,14 @@ describe("stripe", () => {
         max_quantity: 5,
         webhook_url: null,
         active: 1,
+        fields: "email" as const,
       };
 
       const intent = {
         eventId: 1,
         name: "John Doe",
         email: "john@example.com",
+        phone: "",
         quantity: 2,
       };
 
@@ -235,11 +239,13 @@ describe("stripe", () => {
         max_quantity: 1,
         webhook_url: null,
         active: 1,
+        fields: "email" as const,
       };
       const intent = {
         eventId: 1,
         name: "John",
         email: "john@example.com",
+        phone: "",
         quantity: 1,
       };
       const result = await createCheckoutSessionWithIntent(
@@ -265,11 +271,13 @@ describe("stripe", () => {
         max_quantity: 1,
         webhook_url: null,
         active: 1,
+        fields: "email" as const,
       };
       const intent = {
         eventId: 1,
         name: "John",
         email: "john@example.com",
+        phone: "",
         quantity: 1,
       };
       const result = await createCheckoutSessionWithIntent(


### PR DESCRIPTION
## Summary
This PR adds support for collecting phone numbers from event attendees and allows event organizers to configure which contact fields (email, phone, or both) to collect during registration.

## Key Changes

### Database & Data Model
- Added `phone` column to `attendees` table (encrypted at rest like email)
- Added `fields` column to `events` table to store contact field preferences (`"email"` | `"phone"` | `"both"`)
- Updated migration system to apply schema changes

### Form & Validation
- Added `"select"` field type support to form rendering system
- Implemented phone number validation with regex pattern supporting international formats
- Created `getTicketFields()` function to dynamically generate form fields based on event settings
- Created `mergeEventFields()` function to determine appropriate fields for multi-ticket events

### Registration Flow
- Updated ticket registration to capture phone number when configured
- Modified Stripe integration to include phone in metadata and session parameters
- Updated webhook processing to handle phone data from Stripe sessions
- Made email optional in Stripe `customer_email` field (only set if provided)

### Admin Interface
- Added "Contact Fields" dropdown selector to event creation/editing forms
- Updated attendee table to display phone column
- Added contact fields display on event detail pages
- Updated CSV export to always include phone column (for consistency across all events)

### API & Types
- Extended `Attendee` type with `phone` field
- Extended `Event` type with `fields` setting
- Updated `RegistrationIntent` and `MultiRegistrationIntent` types to include phone
- Updated all database operations to handle phone field encryption/decryption

## Implementation Details

- Phone field uses same hybrid encryption as email (public key for encryption, private key for decryption)
- Phone validation allows digits, spaces, hyphens, parentheses, and plus sign (minimum 6 characters)
- For multi-ticket events with different field settings, the system defaults to collecting both email and phone
- CSV exports always include both email and phone columns regardless of event settings for consistency
- Backward compatible: existing events default to email-only collection

https://claude.ai/code/session_01YP1rfVfQxMTxqFCNrnRsCG