### PR TITLE
Add encrypted price_paid column to attendees and include in CSV export

### DIFF
--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -7,7 +7,7 @@ import { getDb } from "#lib/db/client.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "add phone and fields columns";
+export const LATEST_UPDATE = "add phone, fields, and price_paid columns";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -136,6 +136,9 @@ export const initDb = async (): Promise<void> => {
   `);
   await runMigration(`DROP TABLE IF EXISTS processed_payments`);
   await runMigration(`ALTER TABLE processed_payments_new RENAME TO processed_payments`);
+
+  // Migration: add price_paid column to attendees (encrypted with DB_ENCRYPTION_KEY)
+  await runMigration(`ALTER TABLE attendees ADD COLUMN price_paid TEXT`);
 
   // Create activity_log table (unencrypted, admin-only view)
   await runMigration(`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface Attendee {
   created: string;
   stripe_payment_id: string | null;
   quantity: number;
+  price_paid: string | null;
 }
 
 export interface Settings {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -326,6 +326,7 @@ const processMultiPaymentSession = async (
       );
     }
 
+    const pricePaid = event.unit_price !== null ? event.unit_price * item.q : null;
     const result = await createAttendeeAtomic(
       item.e,
       intent.name,
@@ -333,6 +334,7 @@ const processMultiPaymentSession = async (
       session.payment_intent,
       item.q,
       intent.phone,
+      pricePaid,
     );
 
     if (!result.success) {
@@ -429,6 +431,7 @@ const processPaymentSession = async (
 
   // Phase 2: Create attendee atomically with capacity check
   const paymentIntentId = session.payment_intent;
+  const pricePaid = event.unit_price !== null ? event.unit_price * intent.quantity : null;
   const result = await createAttendeeAtomic(
     intent.eventId,
     intent.name,
@@ -436,6 +439,7 @@ const processPaymentSession = async (
     paymentIntentId,
     intent.quantity,
     intent.phone,
+    pricePaid,
   );
 
   if (!result.success) {

--- a/src/templates/csv.ts
+++ b/src/templates/csv.ts
@@ -15,12 +15,20 @@ const escapeCsvValue = (value: string): string => {
   return value;
 };
 
+/** Format price in cents as decimal string (e.g. 1000 -> "10.00") */
+const formatPrice = (pricePaid: string | null): string => {
+  if (pricePaid === null) return "";
+  const cents = Number.parseInt(pricePaid, 10);
+  if (Number.isNaN(cents)) return "";
+  return (cents / 100).toFixed(2);
+};
+
 /**
  * Generate CSV content from attendees.
  * Always includes both Email and Phone columns regardless of event settings.
  */
 export const generateAttendeesCsv = (attendees: Attendee[]): string => {
-  const header = "Name,Email,Phone,Quantity,Registered";
+  const header = "Name,Email,Phone,Quantity,Registered,Price Paid,Transaction ID";
   const rows = pipe(
     map((a: Attendee) =>
       [
@@ -29,6 +37,8 @@ export const generateAttendeesCsv = (attendees: Attendee[]): string => {
         escapeCsvValue(a.phone),
         String(a.quantity),
         escapeCsvValue(new Date(a.created).toISOString()),
+        formatPrice(a.price_paid),
+        escapeCsvValue(a.stripe_payment_id ?? ""),
       ].join(","),
     ),
     reduce((acc: string, row: string) => `${acc}\n${row}`, header),


### PR DESCRIPTION
Store the amount paid per attendee row (unit_price * quantity) encrypted
with DB_ENCRYPTION_KEY (symmetric AES-256-GCM) so the system can read it
for future refunds. Add price_paid and transaction ID columns to CSV export.

https://claude.ai/code/session_01WFhmHE7U171bx7AsyThCNR