### PR TITLE
Conditionally render Stripe settings form based on payment provider

### DIFF
--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -52,6 +52,7 @@ export const adminSettingsPage = (
           <button type="submit">Save Payment Provider</button>
         </form>
 
+        {paymentProvider === "stripe" && (
         <form method="POST" action="/admin/settings/stripe">
             <h2>Stripe Settings</h2>
           <p>
@@ -63,6 +64,7 @@ export const adminSettingsPage = (
           <Raw html={renderFields(stripeKeyFields)} />
           <button type="submit">Update Stripe Key</button>
         </form>
+        )}
 
         <form method="POST" action="/admin/settings">
             <h2>Change Password</h2>

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -551,6 +551,8 @@ describe("server", () => {
     });
 
     test("settings page shows Stripe is not configured initially", async () => {
+      await setPaymentProvider("stripe");
+
       const loginResponse = await handleRequest(
         mockFormRequest("/admin/login", { password: TEST_ADMIN_PASSWORD }),
       );


### PR DESCRIPTION
## Summary
Added conditional rendering to the Stripe settings form so it only displays when Stripe is selected as the payment provider.

## Changes
- Wrapped the Stripe settings form in a conditional check (`{paymentProvider === "stripe" && (...)}`
- The form now only renders when the `paymentProvider` state/prop equals "stripe"
- Prevents users from seeing and potentially modifying Stripe-specific settings when using a different payment provider

## Implementation Details
- Uses a simple boolean check against the `paymentProvider` variable
- Maintains the existing form structure and functionality when the condition is met
- Improves UX by hiding irrelevant configuration options based on the selected payment provider

https://claude.ai/code/session_01QeXHVuYjSgAUSpi8qRUc5d