### PR TITLE
Sanitize Stripe error logging to prevent PII leakage

### DIFF
--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -6,6 +6,7 @@ import {
   refundPayment,
   resetStripeClient,
   retrieveCheckoutSession,
+  sanitizeErrorDetail,
   type StripeWebhookEvent,
   verifyWebhookSignature,
 } from "#lib/stripe.ts";
@@ -550,6 +551,61 @@ describe("stripe", () => {
       await setStripeWebhookConfig(secret, "we_test_construction");
       const result = await verifyWebhookSignature(payload, signature);
       expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("sanitizeErrorDetail", () => {
+    test("returns 'unknown' for non-Error values", () => {
+      expect(sanitizeErrorDetail("string error")).toBe("unknown");
+      expect(sanitizeErrorDetail(null)).toBe("unknown");
+      expect(sanitizeErrorDetail(42)).toBe("unknown");
+      expect(sanitizeErrorDetail(undefined)).toBe("unknown");
+    });
+
+    test("returns error name for plain Error without Stripe fields", () => {
+      expect(sanitizeErrorDetail(new Error("sensitive message"))).toBe("Error");
+    });
+
+    test("returns error name for typed errors without Stripe fields", () => {
+      expect(sanitizeErrorDetail(new TypeError("bad type"))).toBe("TypeError");
+    });
+
+    test("extracts Stripe statusCode, code, and type", () => {
+      const err = new Error("Invalid API Key provided: sk_test_****1234");
+      Object.assign(err, {
+        statusCode: 401,
+        code: "api_key_invalid",
+        type: "StripeAuthenticationError",
+      });
+      expect(sanitizeErrorDetail(err)).toBe(
+        "status=401 code=api_key_invalid type=StripeAuthenticationError",
+      );
+    });
+
+    test("extracts partial Stripe fields", () => {
+      const err = new Error("Resource not found");
+      Object.assign(err, { statusCode: 404 });
+      expect(sanitizeErrorDetail(err)).toBe("status=404");
+    });
+
+    test("extracts code and type without statusCode", () => {
+      const err = new Error("Connection failed");
+      Object.assign(err, {
+        code: "ECONNREFUSED",
+        type: "StripeConnectionError",
+      });
+      expect(sanitizeErrorDetail(err)).toBe(
+        "code=ECONNREFUSED type=StripeConnectionError",
+      );
+    });
+
+    test("never includes the raw error message in output", () => {
+      const sensitiveMessage = "Invalid API Key provided: sk_live_realkey123";
+      const err = new Error(sensitiveMessage);
+      Object.assign(err, { statusCode: 401, type: "StripeAuthenticationError" });
+      const detail = sanitizeErrorDetail(err);
+      expect(detail).not.toContain(sensitiveMessage);
+      expect(detail).not.toContain("sk_live");
     });
   });
 });


### PR DESCRIPTION
## Summary
Introduces a `sanitizeErrorDetail()` function to extract privacy-safe error information from Stripe API errors before logging, preventing accidental exposure of sensitive data like API keys or PII that may be contained in raw error messages.

## Changes
- **New `sanitizeErrorDetail()` function**: Extracts only safe, structured error metadata (statusCode, code, type) from Stripe errors while explicitly excluding raw error messages
- **Updated error logging**: Replaced direct `err.message` logging with `sanitizeErrorDetail(err)` in two locations:
  - `safeAsync()` wrapper used throughout the Stripe module
  - `setupWebhookEndpointImpl()` error handler
- **Comprehensive test coverage**: Added 7 test cases covering:
  - Non-Error values (returns "unknown")
  - Plain errors without Stripe fields (returns error name)
  - Full and partial Stripe error field extraction
  - Verification that raw messages are never included in output

## Implementation Details
- The function safely handles unknown error types by checking `instanceof Error` first
- Stripe SDK errors are detected by the presence of `statusCode`, `code`, and `type` properties
- Output format is space-separated key=value pairs for easy parsing and debugging
- Falls back to `err.name` for plain JavaScript errors without Stripe metadata
- All raw error messages are intentionally excluded from logs to prevent accidental secret/PII leakage

https://claude.ai/code/session_01G9BaLqUg8ezX5a1UHXgrpU