### PR TITLE
Allow Stripe checkout redirect in Content-Security-Policy

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -29,7 +29,7 @@ const buildCspHeader = (embeddable: boolean): string =>
     "default-src 'self'",
     "style-src 'self' 'unsafe-inline'", // Allow inline styles
     "script-src 'self' 'unsafe-inline'", // Allow inline scripts
-    "form-action 'self'", // Restrict form submissions to self
+    "form-action 'self' https://checkout.stripe.com", // Restrict form submissions to self + Stripe checkout redirect
   ]).join("; ");
 
 /**

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -3645,7 +3645,7 @@ describe("server", () => {
 
     describe("Content-Security-Policy", () => {
       const baseCsp =
-        "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; form-action 'self'";
+        "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; form-action 'self' https://checkout.stripe.com";
 
       test("non-embeddable pages have frame-ancestors 'none' and security restrictions", async () => {
         const response = await handleRequest(mockRequest("/"));


### PR DESCRIPTION
## Summary
Updated the Content-Security-Policy (CSP) header to permit form submissions to Stripe's checkout domain, enabling seamless payment processing integration.

## Changes
- Modified the `form-action` CSP directive to allow `https://checkout.stripe.com` in addition to `'self'`
- Updated the corresponding test case to reflect the new CSP header value

## Details
The `form-action` directive now permits form submissions to both same-origin requests (`'self'`) and Stripe's checkout endpoint (`https://checkout.stripe.com`). This change is necessary to support payment flows that redirect users to Stripe's hosted checkout page while maintaining security restrictions on other form submission targets.

https://claude.ai/code/session_01Pgg8zPHPxw7NTkjSaYUJd1