### PR TITLE
Add Stripe connection test endpoint and UI

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -10,6 +10,7 @@ import {
   getStripeSecretKey,
   getStripeWebhookSecret,
 } from "#lib/config.ts";
+import { getStripeWebhookEndpointId } from "#lib/db/settings.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, type ErrorCodeType, logDebug, logError } from "#lib/logger.ts";
 import type {
@@ -168,6 +169,7 @@ export const stripeApi: {
     webhookUrl: string,
     existingEndpointId?: string | null,
   ) => Promise<WebhookSetupResult>;
+  testStripeConnection: () => Promise<StripeConnectionTestResult>;
 } = {
   /** Get or create Stripe client */
   getStripeClient: getClientImpl,
@@ -278,6 +280,60 @@ export const stripeApi: {
     return session;
   },
 
+  /** Test Stripe connection: verify API key and webhook endpoint */
+  testStripeConnection: async (): Promise<StripeConnectionTestResult> => {
+    const result: StripeConnectionTestResult = {
+      ok: false,
+      apiKey: { valid: false },
+      webhook: { configured: false },
+    };
+
+    // Step 1: Test API key by retrieving balance
+    const client = await getClientImpl();
+    if (!client) {
+      result.apiKey.error = "No Stripe secret key configured";
+      return result;
+    }
+
+    try {
+      const balance = await client.balance.retrieve();
+      const hasLiveKey = balance.livemode;
+      result.apiKey = {
+        valid: true,
+        mode: hasLiveKey ? "live" : "test",
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      result.apiKey = { valid: false, error: message };
+      return result;
+    }
+
+    // Step 2: Test webhook endpoint
+    const endpointId = await getStripeWebhookEndpointId();
+    if (!endpointId) {
+      result.webhook = { configured: false, error: "No webhook endpoint ID stored" };
+      return result;
+    }
+
+    try {
+      const endpoint = await client.webhookEndpoints.retrieve(endpointId);
+      result.webhook = {
+        configured: true,
+        endpointId: endpoint.id,
+        url: endpoint.url,
+        status: endpoint.status,
+        enabledEvents: endpoint.enabled_events,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      result.webhook = { configured: false, endpointId, error: message };
+      return result;
+    }
+
+    result.ok = result.apiKey.valid && result.webhook.configured;
+    return result;
+  },
+
   // Placeholder - will be set after setupWebhookEndpointImpl is defined
   setupWebhookEndpoint: null as unknown as (
     secretKey: string,
@@ -381,6 +437,7 @@ export const createMultiCheckoutSession = (
   i: MultiRegistrationIntent,
   b: string,
 ) => stripeApi.createMultiCheckoutSession(i, b);
+export const testStripeConnection = () => stripeApi.testStripeConnection();
 
 /**
  * =============================================================================
@@ -454,6 +511,20 @@ const secureCompare = (a: string, b: string): boolean => {
 /** Stripe webhook event - alias for the provider-agnostic WebhookEvent */
 export type StripeWebhookEvent = WebhookEvent;
 export type { WebhookSetupResult, WebhookVerifyResult };
+
+/** Result of testing the Stripe connection */
+export type StripeConnectionTestResult = {
+  ok: boolean;
+  apiKey: { valid: boolean; error?: string; mode?: string };
+  webhook: {
+    configured: boolean;
+    endpointId?: string;
+    url?: string;
+    status?: string;
+    enabledEvents?: string[];
+    error?: string;
+  };
+};
 
 /**
  * Verify Stripe webhook signature using Web Crypto API.

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -14,7 +14,7 @@ import {
 } from "#lib/db/settings.ts";
 import { resetDatabase } from "#lib/db/migrations/index.ts";
 import { validateForm } from "#lib/forms.tsx";
-import { setupWebhookEndpoint } from "#lib/stripe.ts";
+import { setupWebhookEndpoint, testStripeConnection } from "#lib/stripe.ts";
 import { getAllowedDomain } from "#lib/config.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
 import { clearSessionCookie } from "#routes/admin/utils.ts";
@@ -215,6 +215,20 @@ const handleAdminStripePost = (request: Request): Promise<Response> =>
   });
 
 /**
+ * Handle POST /admin/settings/stripe/test
+ *
+ * Tests that the stored Stripe API key and webhook endpoint are working.
+ * Returns JSON with diagnostic information.
+ */
+const handleStripeTestPost = (request: Request): Promise<Response> =>
+  requireSessionOr(request, async () => {
+    const result = await testStripeConnection();
+    return new Response(JSON.stringify(result), {
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+/**
  * Expected confirmation phrase for database reset
  */
 const RESET_DATABASE_PHRASE =
@@ -254,6 +268,7 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/payment-provider": (request) =>
     handlePaymentProviderPost(request),
   "POST /admin/settings/stripe": (request) => handleAdminStripePost(request),
+  "POST /admin/settings/stripe/test": (request) => handleStripeTestPost(request),
   "POST /admin/settings/reset-database": (request) =>
     handleResetDatabasePost(request),
 });

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -221,7 +221,7 @@ const handleAdminStripePost = (request: Request): Promise<Response> =>
  * Returns JSON with diagnostic information.
  */
 const handleStripeTestPost = (request: Request): Promise<Response> =>
-  requireSessionOr(request, async () => {
+  withAuthForm(request, async () => {
     const result = await testStripeConnection();
     return new Response(JSON.stringify(result), {
       headers: { "content-type": "application/json" },

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -63,7 +63,53 @@ export const adminSettingsPage = (
           <input type="hidden" name="csrf_token" value={csrfToken} />
           <Raw html={renderFields(stripeKeyFields)} />
           <button type="submit">Update Stripe Key</button>
+          {stripeKeyConfigured && (
+            <button type="button" id="stripe-test-btn" class="secondary">Test Connection</button>
+          )}
+          <div id="stripe-test-result" style="display:none"></div>
         </form>
+        )}
+
+        {stripeKeyConfigured && paymentProvider === "stripe" && (
+          <Raw html={`<script>
+document.getElementById('stripe-test-btn')?.addEventListener('click', async function() {
+  var btn = this;
+  var resultDiv = document.getElementById('stripe-test-result');
+  btn.disabled = true;
+  btn.textContent = 'Testing...';
+  resultDiv.style.display = 'none';
+  resultDiv.className = '';
+  try {
+    var res = await fetch('/admin/settings/stripe/test', { method: 'POST', credentials: 'same-origin', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: '' });
+    var data = await res.json();
+    var lines = [];
+    if (data.apiKey.valid) {
+      lines.push('API Key: Valid (' + data.apiKey.mode + ' mode)');
+    } else {
+      lines.push('API Key: Invalid' + (data.apiKey.error ? ' - ' + data.apiKey.error : ''));
+    }
+    if (data.webhook.configured) {
+      lines.push('Webhook: ' + (data.webhook.status || 'configured'));
+      lines.push('URL: ' + data.webhook.url);
+      if (data.webhook.enabledEvents) {
+        lines.push('Events: ' + data.webhook.enabledEvents.join(', '));
+      }
+    } else {
+      lines.push('Webhook: Not configured' + (data.webhook.error ? ' - ' + data.webhook.error : ''));
+    }
+    resultDiv.textContent = lines.join('\\n');
+    resultDiv.className = data.ok ? 'success' : 'error';
+    resultDiv.style.display = 'block';
+    resultDiv.style.whiteSpace = 'pre-wrap';
+  } catch (e) {
+    resultDiv.textContent = 'Connection test failed: ' + e.message;
+    resultDiv.className = 'error';
+    resultDiv.style.display = 'block';
+  }
+  btn.disabled = false;
+  btn.textContent = 'Test Connection';
+});
+</script>`} />
         )}
 
         <form method="POST" action="/admin/settings">

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -80,7 +80,8 @@ document.getElementById('stripe-test-btn')?.addEventListener('click', async func
   resultDiv.style.display = 'none';
   resultDiv.className = '';
   try {
-    var res = await fetch('/admin/settings/stripe/test', { method: 'POST', credentials: 'same-origin', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: '' });
+    var csrfToken = btn.closest('form').querySelector('input[name="csrf_token"]').value;
+    var res = await fetch('/admin/settings/stripe/test', { method: 'POST', credentials: 'same-origin', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: 'csrf_token=' + encodeURIComponent(csrfToken) });
     var data = await res.json();
     var lines = [];
     if (data.apiKey.valid) {

--- a/test/lib/server.test.ts
+++ b/test/lib/server.test.ts
@@ -558,6 +558,20 @@ describe("server", () => {
       expectAdminRedirect(response);
     });
 
+    test("rejects invalid CSRF token", async () => {
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/stripe/test",
+          { csrf_token: "invalid-csrf-token" },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(403);
+      const text = await response.text();
+      expect(text).toContain("Invalid CSRF token");
+    });
+
     test("returns JSON result when API key is not configured", async () => {
       const mockTest = spyOn(stripeApi, "testStripeConnection");
       mockTest.mockResolvedValue({
@@ -567,9 +581,9 @@ describe("server", () => {
       });
 
       try {
-        const { cookie } = await loginAsAdmin();
+        const { cookie, csrfToken } = await loginAsAdmin();
         const response = await handleRequest(
-          mockFormRequest("/admin/settings/stripe/test", {}, cookie),
+          mockFormRequest("/admin/settings/stripe/test", { csrf_token: csrfToken }, cookie),
         );
         expect(response.status).toBe(200);
         expect(response.headers.get("content-type")).toBe("application/json");
@@ -597,9 +611,9 @@ describe("server", () => {
       });
 
       try {
-        const { cookie } = await loginAsAdmin();
+        const { cookie, csrfToken } = await loginAsAdmin();
         const response = await handleRequest(
-          mockFormRequest("/admin/settings/stripe/test", {}, cookie),
+          mockFormRequest("/admin/settings/stripe/test", { csrf_token: csrfToken }, cookie),
         );
         expect(response.status).toBe(200);
         const json = await response.json();
@@ -624,9 +638,9 @@ describe("server", () => {
       });
 
       try {
-        const { cookie } = await loginAsAdmin();
+        const { cookie, csrfToken } = await loginAsAdmin();
         const response = await handleRequest(
-          mockFormRequest("/admin/settings/stripe/test", {}, cookie),
+          mockFormRequest("/admin/settings/stripe/test", { csrf_token: csrfToken }, cookie),
         );
         expect(response.status).toBe(200);
         const json = await response.json();

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -6,6 +6,7 @@ import {
   refundPayment,
   resetStripeClient,
   retrieveCheckoutSession,
+  testStripeConnection,
   type StripeWebhookEvent,
   verifyWebhookSignature,
 } from "#lib/stripe.ts";
@@ -516,6 +517,128 @@ describe("stripe", () => {
         200, // 200 second tolerance - should pass
       );
       expect(resultWithLargeTolerance.valid).toBe(true);
+    });
+  });
+
+  describe("testStripeConnection", () => {
+    test("returns error when no API key configured", async () => {
+      const result = await testStripeConnection();
+      expect(result.ok).toBe(false);
+      expect(result.apiKey.valid).toBe(false);
+      expect(result.apiKey.error).toContain("No Stripe secret key configured");
+    });
+
+    test("returns error when balance.retrieve fails", async () => {
+      await updateStripeKey("sk_test_mock");
+      const client = await getStripeClient();
+      if (!client) throw new Error("Expected client to be defined");
+
+      const balanceSpy = spyOn(client.balance, "retrieve");
+      balanceSpy.mockRejectedValue(new Error("Invalid API Key provided"));
+
+      try {
+        const result = await testStripeConnection();
+        expect(result.ok).toBe(false);
+        expect(result.apiKey.valid).toBe(false);
+        expect(result.apiKey.error).toContain("Invalid API Key provided");
+      } finally {
+        balanceSpy.mockRestore();
+      }
+    });
+
+    test("returns test mode when API key is valid and webhook not configured", async () => {
+      await updateStripeKey("sk_test_mock");
+      const client = await getStripeClient();
+      if (!client) throw new Error("Expected client to be defined");
+
+      const balanceSpy = spyOn(client.balance, "retrieve");
+      balanceSpy.mockResolvedValue({ livemode: false, available: [], pending: [], object: "balance" } as never);
+
+      try {
+        const result = await testStripeConnection();
+        expect(result.ok).toBe(false);
+        expect(result.apiKey.valid).toBe(true);
+        expect(result.apiKey.mode).toBe("test");
+        expect(result.webhook.configured).toBe(false);
+        expect(result.webhook.error).toContain("No webhook endpoint ID stored");
+      } finally {
+        balanceSpy.mockRestore();
+      }
+    });
+
+    test("returns live mode for live key", async () => {
+      await updateStripeKey("sk_live_mock");
+      const client = await getStripeClient();
+      if (!client) throw new Error("Expected client to be defined");
+
+      const balanceSpy = spyOn(client.balance, "retrieve");
+      balanceSpy.mockResolvedValue({ livemode: true, available: [], pending: [], object: "balance" } as never);
+
+      try {
+        const result = await testStripeConnection();
+        expect(result.apiKey.valid).toBe(true);
+        expect(result.apiKey.mode).toBe("live");
+      } finally {
+        balanceSpy.mockRestore();
+      }
+    });
+
+    test("returns webhook error when endpoint retrieval fails", async () => {
+      await updateStripeKey("sk_test_mock");
+      await setStripeWebhookConfig("whsec_test", "we_test_missing");
+      const client = await getStripeClient();
+      if (!client) throw new Error("Expected client to be defined");
+
+      const balanceSpy = spyOn(client.balance, "retrieve");
+      balanceSpy.mockResolvedValue({ livemode: false, available: [], pending: [], object: "balance" } as never);
+
+      const webhookSpy = spyOn(client.webhookEndpoints, "retrieve");
+      webhookSpy.mockRejectedValue(new Error("No such webhook endpoint: we_test_missing"));
+
+      try {
+        const result = await testStripeConnection();
+        expect(result.ok).toBe(false);
+        expect(result.apiKey.valid).toBe(true);
+        expect(result.webhook.configured).toBe(false);
+        expect(result.webhook.error).toContain("No such webhook endpoint");
+      } finally {
+        balanceSpy.mockRestore();
+        webhookSpy.mockRestore();
+      }
+    });
+
+    test("returns full success when API key and webhook are both valid", async () => {
+      await updateStripeKey("sk_test_mock");
+      await setStripeWebhookConfig("whsec_test", "we_test_valid");
+      const client = await getStripeClient();
+      if (!client) throw new Error("Expected client to be defined");
+
+      const balanceSpy = spyOn(client.balance, "retrieve");
+      balanceSpy.mockResolvedValue({ livemode: false, available: [], pending: [], object: "balance" } as never);
+
+      const webhookSpy = spyOn(client.webhookEndpoints, "retrieve");
+      webhookSpy.mockResolvedValue({
+        id: "we_test_valid",
+        url: "https://example.com/payment/webhook",
+        status: "enabled",
+        enabled_events: ["checkout.session.completed"],
+        object: "webhook_endpoint",
+      } as never);
+
+      try {
+        const result = await testStripeConnection();
+        expect(result.ok).toBe(true);
+        expect(result.apiKey.valid).toBe(true);
+        expect(result.apiKey.mode).toBe("test");
+        expect(result.webhook.configured).toBe(true);
+        expect(result.webhook.endpointId).toBe("we_test_valid");
+        expect(result.webhook.url).toBe("https://example.com/payment/webhook");
+        expect(result.webhook.status).toBe("enabled");
+        expect(result.webhook.enabledEvents).toContain("checkout.session.completed");
+      } finally {
+        balanceSpy.mockRestore();
+        webhookSpy.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds a diagnostic tool for administrators to test their Stripe API key and webhook endpoint configuration. It includes a new backend endpoint, frontend UI button, and comprehensive test coverage.

## Key Changes

- **New `testStripeConnection()` function** in `src/lib/stripe.ts`:
  - Tests API key validity by calling `balance.retrieve()`
  - Detects whether the key is in test or live mode
  - Verifies webhook endpoint configuration and retrieves its details
  - Returns structured diagnostic information including endpoint URL, status, and enabled events

- **New POST endpoint** `/admin/settings/stripe/test`:
  - Requires admin authentication
  - Returns JSON with API key and webhook status
  - Provides detailed error messages for troubleshooting

- **Admin UI enhancements** in `src/templates/admin/settings.tsx`:
  - Added "Test Connection" button (visible only when Stripe is configured)
  - Client-side JavaScript to call the test endpoint and display results
  - Shows formatted output with API key mode, webhook status, URL, and enabled events
  - Visual feedback with success/error styling

- **Comprehensive test coverage**:
  - Unit tests for `testStripeConnection()` covering all scenarios (no key, invalid key, test/live modes, webhook errors, full success)
  - Integration tests for the `/admin/settings/stripe/test` endpoint
  - Tests verify authentication, JSON response format, and various failure modes

## Implementation Details

- The test function gracefully handles missing configuration and API errors
- Webhook endpoint ID is retrieved from the database settings
- Results include both success and partial failure states (e.g., valid API key but missing webhook)
- The `ok` flag is only true when both API key and webhook are valid
- Client-side code uses `fetch()` with proper error handling and user feedback

https://claude.ai/code/session_01GByYU2w9NHVCnBu38LCAsr