### PR TITLE
Add merge_group trigger to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
Updated the GitHub Actions test workflow to run on merge queue events in addition to pull requests and pushes to main.

## Changes
- Added `merge_group` trigger to the test workflow configuration
  - This enables the test workflow to automatically run when a pull request enters the merge queue
  - Ensures code quality checks pass before merging via GitHub's merge queue feature

## Details
The `merge_group` event trigger is part of GitHub's merge queue functionality, which provides an additional layer of protection by re-running tests on queued pull requests before they are merged. This helps prevent race conditions and ensures that all code merged to main has passed the latest test suite.

https://claude.ai/code/session_0158G4wKK9iwXXVaCFUVFg5B