### PR TITLE
Enforce HTTPS-only URLs for thank_you_url field

### DIFF
--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -15,8 +15,8 @@ const validateSafeUrl = (value: string): string | null => {
 
   try {
     const url = new URL(value);
-    if (url.protocol !== "https:" && url.protocol !== "http:") {
-      return "URL must use https:// or http://";
+    if (url.protocol !== "https:") {
+      return "URL must use https://";
     }
     return null;
   } catch {

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -216,9 +216,16 @@ describe("forms", () => {
 
   describe("eventFields validation", () => {
     test("validates thank_you_url rejects javascript: protocol", () => {
-      expectInvalid("URL must use https:// or http://")(
+      expectInvalid("URL must use https://")(
         eventFields,
         eventForm({ thank_you_url: "javascript:alert(1)" }),
+      );
+    });
+
+    test("validates thank_you_url rejects http: protocol", () => {
+      expectInvalid("URL must use https://")(
+        eventFields,
+        eventForm({ thank_you_url: "http://example.com/thank-you" }),
       );
     });
 


### PR DESCRIPTION
## Summary
Updated URL validation to require HTTPS protocol exclusively, removing support for HTTP URLs in the `thank_you_url` field for security purposes.

## Changes
- Modified `validateSafeUrl()` in `src/templates/fields.ts` to reject HTTP URLs and only allow HTTPS
- Updated validation error message from "URL must use https:// or http://" to "URL must use https://"
- Added test case to verify HTTP URLs are properly rejected
- Updated existing test assertion to match new error message

## Security Impact
This change enforces encrypted connections for thank you page redirects, preventing potential credential exposure or man-in-the-middle attacks when users are redirected after form submission.

https://claude.ai/code/session_01F8UGkunQnPV2NdGpktvL1R