### PR TITLE
Remove slug format validation from request handling

### DIFF
--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -9,22 +9,6 @@
 const DIGITS = "0123456789";
 const LETTERS = "abcdefgh";
 const ALPHABET = DIGITS + LETTERS;
-const SLUG_LENGTH = 5;
-const MIN_DIGITS = 2;
-const MIN_LETTERS = 2;
-
-/** Validate a slug format (5 chars from the allowed alphabet, ≥2 digits, ≥2 letters) */
-export const isValidSlug = (slug: string): boolean => {
-  if (slug.length !== SLUG_LENGTH) return false;
-  let digitCount = 0;
-  let letterCount = 0;
-  for (const ch of slug) {
-    if (DIGITS.includes(ch)) digitCount++;
-    else if (LETTERS.includes(ch)) letterCount++;
-    else return false;
-  }
-  return digitCount >= MIN_DIGITS && letterCount >= MIN_LETTERS;
-};
 
 /** Pick a random character from a string */
 const randomChar = (chars: string): string =>

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -10,7 +10,6 @@ import {
   unwrapKeyWithToken,
 } from "#lib/crypto.ts";
 import { getEventWithCount, getEventWithCountBySlug } from "#lib/db/events.ts";
-import { isValidSlug } from "#lib/slug.ts";
 import { deleteSession, getSession } from "#lib/db/sessions.ts";
 import { getWrappedPrivateKey } from "#lib/db/settings.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
@@ -278,12 +277,10 @@ export const withEvent = async (
 
 /**
  * Fetch event by slug or return 404 response.
- * Validates slug format before DB lookup to avoid unnecessary queries.
  */
 export const fetchEventBySlugOr404 = async (
   slug: string,
 ): Promise<Result<EventWithCount>> => {
-  if (!isValidSlug(slug)) return err(notFoundResponse());
   const event = await getEventWithCountBySlug(slug);
   return event ? ok(event) : err(notFoundResponse());
 };

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -106,13 +106,8 @@ describe("server (public routes)", () => {
   });
 
   describe("GET /ticket/:slug", () => {
-    test("returns 404 for invalid slug format", async () => {
+    test("returns 404 for non-existent slug", async () => {
       const response = await handleRequest(mockRequest("/ticket/non-existent"));
-      expect(response.status).toBe(404);
-    });
-
-    test("returns 404 for valid slug format that does not exist", async () => {
-      const response = await handleRequest(mockRequest("/ticket/ab99c"));
       expect(response.status).toBe(404);
     });
 
@@ -147,19 +142,9 @@ describe("server (public routes)", () => {
   });
 
   describe("POST /ticket/:slug", () => {
-    test("returns 404 for non-existent event with invalid slug", async () => {
+    test("returns 404 for non-existent slug", async () => {
       const response = await handleRequest(
         mockFormRequest("/ticket/non-existent", {
-          name: "John",
-          email: "john@example.com",
-        }),
-      );
-      expect(response.status).toBe(404);
-    });
-
-    test("returns 404 for non-existent event with valid slug format", async () => {
-      const response = await handleRequest(
-        mockFormRequest("/ticket/ab99c", {
           name: "John",
           email: "john@example.com",
         }),

--- a/test/lib/slug.test.ts
+++ b/test/lib/slug.test.ts
@@ -1,51 +1,37 @@
 import { describe, expect, test } from "#test-compat";
-import { isValidSlug, generateSlug } from "#lib/slug.ts";
+import { generateSlug } from "#lib/slug.ts";
 
 describe("slug", () => {
-  describe("isValidSlug", () => {
-    test("accepts valid 5-char slug with digits and letters", () => {
-      expect(isValidSlug("ab12c")).toBe(true);
-      expect(isValidSlug("01abc")).toBe(true);
-      expect(isValidSlug("9a8bc")).toBe(true);
-    });
-
-    test("rejects slug with wrong length", () => {
-      expect(isValidSlug("ab1c")).toBe(false);
-      expect(isValidSlug("ab12cd")).toBe(false);
-      expect(isValidSlug("")).toBe(false);
-    });
-
-    test("rejects slug with invalid characters", () => {
-      expect(isValidSlug("ab12z")).toBe(false);
-      expect(isValidSlug("AB12c")).toBe(false);
-      expect(isValidSlug("ab-2c")).toBe(false);
-    });
-
-    test("rejects slug with fewer than 2 digits", () => {
-      expect(isValidSlug("abcde")).toBe(false);
-      expect(isValidSlug("abcd1")).toBe(false);
-    });
-
-    test("rejects slug with fewer than 2 letters", () => {
-      expect(isValidSlug("12345")).toBe(false);
-      expect(isValidSlug("1234a")).toBe(false);
-    });
-
-    test("accepts slug with exactly 2 digits and 2 letters", () => {
-      expect(isValidSlug("12ab3")).toBe(true);
-      expect(isValidSlug("a1b23")).toBe(true);
-    });
-  });
-
   describe("generateSlug", () => {
-    test("generates a valid slug", () => {
-      const slug = generateSlug();
-      expect(isValidSlug(slug)).toBe(true);
-    });
-
     test("generates 5-character slugs", () => {
       const slug = generateSlug();
       expect(slug.length).toBe(5);
+    });
+
+    test("generates slugs from valid alphabet", () => {
+      const validChars = "0123456789abcdefgh";
+      for (let i = 0; i < 50; i++) {
+        const slug = generateSlug();
+        for (const ch of slug) {
+          expect(validChars.includes(ch)).toBe(true);
+        }
+      }
+    });
+
+    test("generates slugs with at least 2 digits and 2 letters", () => {
+      const digits = "0123456789";
+      const letters = "abcdefgh";
+      for (let i = 0; i < 50; i++) {
+        const slug = generateSlug();
+        let digitCount = 0;
+        let letterCount = 0;
+        for (const ch of slug) {
+          if (digits.includes(ch)) digitCount++;
+          else if (letters.includes(ch)) letterCount++;
+        }
+        expect(digitCount >= 2).toBe(true);
+        expect(letterCount >= 2).toBe(true);
+      }
     });
 
     test("generates different slugs on multiple calls", () => {
@@ -55,13 +41,6 @@ describe("slug", () => {
       }
       // With ~1.15M combinations, 20 slugs should all be unique
       expect(slugs.size).toBe(20);
-    });
-
-    test("all generated slugs pass validation", () => {
-      for (let i = 0; i < 50; i++) {
-        const slug = generateSlug();
-        expect(isValidSlug(slug)).toBe(true);
-      }
     });
   });
 });


### PR DESCRIPTION
## Summary
Remove the `isValidSlug` function and its validation logic from the request handling path. Slug format validation is now delegated entirely to the database layer, simplifying the API and reducing redundant checks.

## Changes
- **Removed `isValidSlug` function** from `src/lib/slug.ts` along with related constants (`SLUG_LENGTH`, `MIN_DIGITS`, `MIN_LETTERS`)
- **Removed validation check** from `fetchEventBySlugOr404` in `src/routes/utils.ts` - now directly queries the database without pre-validating slug format
- **Updated tests** in `test/lib/slug.test.ts` to remove validation tests and focus on generation behavior
- **Simplified route tests** in `test/lib/server-public.test.ts` by removing separate test cases for invalid vs. valid slug formats - both now return 404 through the same code path

## Implementation Details
The validation logic is no longer needed at the request handling layer since:
- The database query will naturally return no results for any invalid slug format
- This eliminates an unnecessary validation step and reduces code complexity
- The behavior remains the same from the user's perspective (404 for non-existent slugs)
- Tests now verify that `generateSlug` produces valid slugs through property-based assertions rather than explicit validation

https://claude.ai/code/session_01FRFXJsTfkEz72V7zFZ3eDc