### PR TITLE
Add event duplication feature with autofocus form field support

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -30,6 +30,7 @@ export interface Field {
   hint?: string;
   min?: number;
   pattern?: string;
+  autofocus?: boolean;
   validate?: (value: string) => string | null;
   options?: { value: string; label: string }[];
 }
@@ -89,6 +90,7 @@ export const renderField = (field: Field, value: string = ""): string =>
           placeholder={field.placeholder}
           min={field.min}
           pattern={field.pattern}
+          autofocus={field.autofocus}
         />
       )}
       {field.hint && (

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -37,6 +37,7 @@ import { adminEventActivityLogPage } from "#templates/admin/activityLog.tsx";
 import {
   adminDeactivateEventPage,
   adminDeleteEventPage,
+  adminDuplicateEventPage,
   adminEventEditPage,
   adminEventPage,
   adminReactivateEventPage,
@@ -177,6 +178,9 @@ const eventErrorPage = async (
     ? htmlResponse(renderPage(event, csrfToken, error), 400)
     : notFoundResponse();
 };
+
+/** Handle GET /admin/event/:id/duplicate */
+const handleAdminEventDuplicateGet = withEventPage(adminDuplicateEventPage);
 
 /** Handle GET /admin/event/:id/edit */
 const handleAdminEventEditGet = withEventPage(adminEventEditPage);
@@ -351,6 +355,8 @@ export const eventsRoutes = defineRoutes({
   "POST /admin/event": (request) => handleCreateEvent(request),
   "GET /admin/event/:id": (request, params) =>
     handleAdminEventGet(request, parseEventId(params)),
+  "GET /admin/event/:id/duplicate": (request, params) =>
+    handleAdminEventDuplicateGet(request, parseEventId(params)),
   "GET /admin/event/:id/edit": (request, params) =>
     handleAdminEventEditGet(request, parseEventId(params)),
   "POST /admin/event/:id/edit": (request, params) =>


### PR DESCRIPTION
## Summary
This PR adds the ability to duplicate existing events in the admin panel, allowing users to quickly create new events based on existing ones with pre-filled settings. It also introduces autofocus support for form fields to improve UX.

## Key Changes
- **Form field autofocus**: Added `autofocus` property to the `Field` interface and implemented rendering support in `renderField()` to allow forms to automatically focus on specific inputs
- **Event duplication endpoint**: Created new `GET /admin/event/:id/duplicate` route that displays a pre-filled form with all settings from the source event except the name field (which is cleared for user input)
- **Duplicate event page**: Implemented `adminDuplicateEventPage` template that shows the source event name and renders a form posting to the standard event creation endpoint
- **UI navigation**: Added "Duplicate" link to the event detail page navigation menu
- **Comprehensive tests**: Added test coverage for authentication, 404 handling, form pre-population, and UI visibility

## Implementation Details
- The duplicate form reuses the existing event creation endpoint (`POST /admin/event`), simplifying the backend logic
- The name field is automatically focused using the new autofocus feature to guide users to enter a new event name
- All other event settings (max attendees, pricing, webhook URL, thank you URL, etc.) are pre-populated from the source event
- The feature maintains the same security and validation as the standard event creation flow

https://claude.ai/code/session_01NzDi1ngGHZToSe5M5EEQtL