### PR TITLE
Add registration deadline support with closes_at field

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -20,6 +20,7 @@ export type EventInput = {
   webhookUrl?: string | null;
   active?: number;
   fields?: EventFields;
+  closesAt?: string | null;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -47,6 +48,7 @@ export const eventsTable = defineTable<Event, EventInput>({
     webhook_url: col.encryptedNullable<string>(encrypt, decrypt),
     active: col.withDefault(() => 1),
     fields: col.withDefault<EventFields>(() => "email"),
+    closes_at: col.simple<string | null>(),
   },
 });
 

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -9,7 +9,7 @@ import { getPublicKey } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "add attendee checked_in column";
+export const LATEST_UPDATE = "add event closes_at timestamp";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -191,6 +191,9 @@ export const initDb = async (): Promise<void> => {
       args: [encryptedFalse],
     });
   }
+
+  // Migration: add closes_at column to events (nullable ISO timestamp for registration deadline)
+  await runMigration(`ALTER TABLE events ADD COLUMN closes_at TEXT`);
 
   // Update the version marker
   await getDb().execute({

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -19,7 +19,8 @@ export type FieldType =
   | "url"
   | "password"
   | "textarea"
-  | "select";
+  | "select"
+  | "datetime-local";
 
 export interface Field {
   name: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface Event {
   webhook_url: string | null;
   active: number;
   fields: EventFields;
+  closes_at: string | null;
 }
 
 export interface Attendee {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -72,7 +72,7 @@ const extractEventInput = async (
     maxQuantity: values.max_quantity as number,
     webhookUrl: (values.webhook_url as string) || null,
     fields: (values.fields as EventFields) || "email",
-    closesAt: (values.closes_at as string) || null,
+    closesAt: (values.closes_at as string) || "",
   };
 };
 
@@ -93,7 +93,7 @@ const extractEventUpdateInput = async (
     maxQuantity: values.max_quantity as number,
     webhookUrl: (values.webhook_url as string) || null,
     fields: (values.fields as EventFields) || "email",
-    closesAt: (values.closes_at as string) || null,
+    closesAt: (values.closes_at as string) || "",
   };
 };
 

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -72,6 +72,7 @@ const extractEventInput = async (
     maxQuantity: values.max_quantity as number,
     webhookUrl: (values.webhook_url as string) || null,
     fields: (values.fields as EventFields) || "email",
+    closesAt: (values.closes_at as string) || null,
   };
 };
 
@@ -92,6 +93,7 @@ const extractEventUpdateInput = async (
     maxQuantity: values.max_quantity as number,
     webhookUrl: (values.webhook_url as string) || null,
     fields: (values.fields as EventFields) || "email",
+    closesAt: (values.closes_at as string) || null,
   };
 };
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -291,6 +291,20 @@ export const withActiveEventBySlug = (
 export const isRegistrationClosed = (event: { closes_at: string | null }): boolean =>
   event.closes_at !== null && new Date(event.closes_at).getTime() < Date.now();
 
+/** Format a countdown from now to a future closes_at date, e.g. "3 days and 5 hours from now" */
+export const formatCountdown = (closesAt: string): string => {
+  const diffMs = new Date(closesAt).getTime() - Date.now();
+  if (diffMs <= 0) return "closed";
+  const totalHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  const pl = (n: number, unit: string) => `${n} ${unit}${n !== 1 ? "s" : ""}`;
+  if (days > 0 && hours > 0) return `${pl(days, "day")} and ${pl(hours, "hour")} from now`;
+  if (days > 0) return `${pl(days, "day")} from now`;
+  if (hours > 0) return `${pl(hours, "hour")} from now`;
+  return `${pl(Math.max(1, Math.floor(diffMs / (1000 * 60))), "minute")} from now`;
+};
+
 /** Session with CSRF token and wrapped data key for private key derivation */
 export type AuthSession = {
   token: string;

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -287,6 +287,10 @@ export const withActiveEventBySlug = (
   fn: (event: EventWithCount) => Response | Promise<Response>,
 ): Promise<Response> => withEventBySlug(slug, requireActiveEvent(fn));
 
+/** Check if an event's registration period has closed */
+export const isRegistrationClosed = (event: { closes_at: string | null }): boolean =>
+  event.closes_at !== null && new Date(event.closes_at).getTime() < Date.now();
+
 /** Session with CSRF token and wrapped data key for private key derivation */
 export type AuthSession = {
   token: string;

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -130,6 +130,11 @@ export const adminEventPage = (
             <p><strong>Total Revenue:</strong> {formatRevenue(calculateTotalRevenue(attendees))}</p>
           )}
           <p><strong>Contact Fields:</strong> {FIELDS_LABELS[event.fields]}</p>
+          {event.closes_at ? (
+            <p><strong>Registration Closes:</strong> {new Date(event.closes_at).toLocaleString()} (UTC)</p>
+          ) : (
+            <p><strong>Registration Closes:</strong> <em>No deadline</em></p>
+          )}
           {event.thank_you_url ? (
             <p>
               <strong>Thank You URL:</strong>{" "}
@@ -192,6 +197,13 @@ export const adminEventPage = (
 /**
  * Convert event to form field values
  */
+/** Format closes_at for datetime-local input (YYYY-MM-DDTHH:MM) */
+const formatClosesAt = (closesAt: string | null): string | null => {
+  if (!closesAt) return null;
+  // datetime-local expects YYYY-MM-DDTHH:MM format
+  return closesAt.slice(0, 16);
+};
+
 const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   name: event.name,
   description: event.description,
@@ -200,6 +212,7 @@ const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   max_quantity: event.max_quantity,
   fields: event.fields,
   unit_price: event.unit_price,
+  closes_at: formatClosesAt(event.closes_at),
   thank_you_url: event.thank_you_url,
   webhook_url: event.webhook_url,
 });

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -7,6 +7,7 @@ import type { Field } from "#lib/forms.tsx";
 import { type FieldValues, renderError, renderField, renderFields } from "#lib/forms.tsx";
 import type { Attendee, EventFields, EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { formatCountdown } from "#routes/utils.ts";
 import { eventFields, slugField } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
@@ -131,7 +132,7 @@ export const adminEventPage = (
           )}
           <p><strong>Contact Fields:</strong> {FIELDS_LABELS[event.fields]}</p>
           {event.closes_at ? (
-            <p><strong>Registration Closes:</strong> {new Date(event.closes_at).toLocaleString()} (UTC)</p>
+            <p><strong>Registration Closes:</strong> {event.closes_at} (UTC) <small><em>({formatCountdown(event.closes_at)})</em></small></p>
           ) : (
             <p><strong>Registration Closes:</strong> <em>No deadline</em></p>
           )}
@@ -194,10 +195,7 @@ export const adminEventPage = (
   );
 };
 
-/**
- * Convert event to form field values
- */
-/** Format closes_at for datetime-local input (YYYY-MM-DDTHH:MM) */
+/** Format closes_at ISO string for datetime-local input (YYYY-MM-DDTHH:MM) */
 const formatClosesAt = (closesAt: string | null): string | null => {
   if (!closesAt) return null;
   // datetime-local expects YYYY-MM-DDTHH:MM format

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -87,10 +87,12 @@ const validateDescription = (value: string): string | null =>
     : null;
 
 /**
- * Validate closes_at is a valid date if provided
+ * Validate closes_at is a valid date if provided.
+ * Normalizes datetime-local format to UTC ISO before parsing.
  */
 const validateClosesAt = (value: string): string | null => {
-  const date = new Date(value);
+  const normalized = value.length === 16 ? `${value}:00.000Z` : value;
+  const date = new Date(normalized);
   if (Number.isNaN(date.getTime())) {
     return "Please enter a valid date and time";
   }

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -87,6 +87,17 @@ const validateDescription = (value: string): string | null =>
     : null;
 
 /**
+ * Validate closes_at is a valid date if provided
+ */
+const validateClosesAt = (value: string): string | null => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Please enter a valid date and time";
+  }
+  return null;
+};
+
+/**
  * Event form field definitions (shared between create and edit)
  */
 export const eventFields: Field[] = [
@@ -140,6 +151,13 @@ export const eventFields: Field[] = [
     min: 0,
     placeholder: "e.g. 1000 for 10.00",
     validate: validateNonNegativePrice,
+  },
+  {
+    name: "closes_at",
+    label: "Registration Closes At (optional)",
+    type: "datetime-local",
+    hint: "Leave blank for no deadline. Times are in UTC.",
+    validate: validateClosesAt,
   },
   {
     name: "thank_you_url",

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -598,6 +598,7 @@ export const createTestEvent = (
       thank_you_url: input.thankYouUrl ?? "",
       unit_price: input.unitPrice != null ? String(input.unitPrice) : "",
       webhook_url: input.webhookUrl ?? "",
+      closes_at: input.closesAt ?? "",
     },
     async () => {
       // Get the most recently created event
@@ -657,6 +658,7 @@ export const updateTestEvent = async (
       thank_you_url: formatOptional(updates.thankYouUrl, existing.thank_you_url),
       unit_price: formatPrice(updates.unitPrice, existing.unit_price),
       webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
+      closes_at: updates.closesAt !== undefined ? (updates.closesAt ?? "") : (existing.closes_at ?? ""),
     },
     async () =>
       (await getEventWithCount(eventId)) as EventWithCount,
@@ -828,6 +830,7 @@ export const testEvent = (overrides: Partial<Event> = {}): Event => ({
   unit_price: null,
   max_quantity: 1,
   webhook_url: null,
+  closes_at: null,
   active: 1,
   fields: "email",
   ...overrides,

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -634,6 +634,13 @@ const formatOptional = (
 ): string =>
   update !== undefined ? update ?? "" : existing ?? "";
 
+/** Format closes_at for form submission (truncate existing ISO to datetime-local) */
+const formatClosesAt = (
+  update: string | undefined,
+  existing: string | null,
+): string =>
+  update !== undefined ? update : (existing?.slice(0, 16) ?? "");
+
 /**
  * Update an event via the REST API
  */
@@ -658,7 +665,7 @@ export const updateTestEvent = async (
       thank_you_url: formatOptional(updates.thankYouUrl, existing.thank_you_url),
       unit_price: formatPrice(updates.unitPrice, existing.unit_price),
       webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
-      closes_at: updates.closesAt !== undefined ? (updates.closesAt ?? "") : (existing.closes_at?.slice(0, 16) ?? ""),
+      closes_at: formatClosesAt(updates.closesAt, existing.closes_at),
     },
     async () =>
       (await getEventWithCount(eventId)) as EventWithCount,

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -658,7 +658,7 @@ export const updateTestEvent = async (
       thank_you_url: formatOptional(updates.thankYouUrl, existing.thank_you_url),
       unit_price: formatPrice(updates.unitPrice, existing.unit_price),
       webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
-      closes_at: updates.closesAt !== undefined ? (updates.closesAt ?? "") : (existing.closes_at ?? ""),
+      closes_at: updates.closesAt !== undefined ? (updates.closesAt ?? "") : (existing.closes_at?.slice(0, 16) ?? ""),
     },
     async () =>
       (await getEventWithCount(eventId)) as EventWithCount,

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -17,6 +17,7 @@ import {
 } from "#lib/db/attendees.ts";
 import { getDb, setDb } from "#lib/db/client.ts";
 import {
+  computeSlugIndex,
   deleteEvent,
   eventsTable,
   getAllEvents,
@@ -26,6 +27,7 @@ import {
   getEventWithAttendeesRaw,
   getEventWithCount,
   isSlugTaken,
+  writeClosesAt,
 } from "#lib/db/events.ts";
 import {
   clearLoginAttempts,
@@ -1929,6 +1931,185 @@ describe("db", () => {
       const privateKey = await getTestPrivateKey();
       const decrypted = await decryptAttendees(rows, privateKey);
       expect(decrypted[0]?.checked_in).toBe("false");
+    });
+  });
+
+  describe("writeClosesAt", () => {
+    test("encrypts empty string for no deadline", async () => {
+      const { decrypt } = await import("#lib/crypto.ts");
+      const result = await writeClosesAt("");
+      expect(typeof result).toBe("string");
+      expect(result).not.toBe("");
+      const decrypted = await decrypt(result as unknown as string);
+      expect(decrypted).toBe("");
+    });
+
+    test("encrypts null as empty string", async () => {
+      const { decrypt } = await import("#lib/crypto.ts");
+      const result = await writeClosesAt(null);
+      const decrypted = await decrypt(result as unknown as string);
+      expect(decrypted).toBe("");
+    });
+
+    test("normalizes datetime-local format to full ISO", async () => {
+      const { decrypt } = await import("#lib/crypto.ts");
+      const result = await writeClosesAt("2099-06-15T14:30");
+      const decrypted = await decrypt(result as unknown as string);
+      expect(decrypted).toBe("2099-06-15T14:30:00.000Z");
+    });
+
+    test("handles already-normalized ISO string", async () => {
+      const { decrypt } = await import("#lib/crypto.ts");
+      const result = await writeClosesAt("2099-06-15T14:30:00.000Z");
+      const decrypted = await decrypt(result as unknown as string);
+      expect(decrypted).toBe("2099-06-15T14:30:00.000Z");
+    });
+
+    test("throws on invalid datetime string", async () => {
+      await expect(writeClosesAt("not-a-date")).rejects.toThrow("Invalid closes_at");
+    });
+  });
+
+  describe("closes_at read transform", () => {
+    test("returns null for no-deadline event", async () => {
+      const event = await eventsTable.insert({
+        name: "test", slug: "test-read-1",
+        slugIndex: await computeSlugIndex("test-read-1"),
+        maxAttendees: 100, closesAt: "",
+      });
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.closes_at).toBeNull();
+    });
+
+    test("returns normalized ISO string for valid datetime", async () => {
+      const event = await eventsTable.insert({
+        name: "test", slug: "test-read-2",
+        slugIndex: await computeSlugIndex("test-read-2"),
+        maxAttendees: 100, closesAt: "2099-12-31T23:59",
+      });
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.closes_at).toBe("2099-12-31T23:59:00.000Z");
+    });
+
+
+  });
+
+  describe("closes_at migration backfill", () => {
+    test("backfills NULL closes_at to encrypted empty string", async () => {
+      const slugIdx = await computeSlugIndex("test-mig-1");
+      await getDb().execute({
+        sql: `INSERT INTO events (name, slug, slug_index, max_attendees, created, closes_at) VALUES (?, ?, ?, ?, ?, NULL)`,
+        args: ["raw-name", "raw-slug", slugIdx, 100, new Date().toISOString()],
+      });
+
+      // Update the version marker to force re-migration
+      await getDb().execute(
+        "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
+      );
+      await initDb();
+
+      // Verify the event now has encrypted closes_at (not NULL)
+      const rows = await getDb().execute(
+        `SELECT closes_at FROM events WHERE slug_index = ?`,
+        [slugIdx],
+      );
+      const raw = rows.rows[0]?.closes_at as string | null;
+      expect(raw).not.toBeNull();
+      // Verify it decrypts to empty string (no deadline)
+      const { decrypt } = await import("#lib/crypto.ts");
+      const decrypted = await decrypt(raw as string);
+      expect(decrypted).toBe("");
+    });
+
+    test("skips already-encrypted closes_at values", async () => {
+      const { encrypt, decrypt } = await import("#lib/crypto.ts");
+      const encrypted = await encrypt("2099-06-15T14:30:00.000Z");
+      const slugIdx = await computeSlugIndex("test-mig-2");
+      await getDb().execute({
+        sql: `INSERT INTO events (name, slug, slug_index, max_attendees, created, closes_at) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["enc-name", "enc-slug", slugIdx, 100, new Date().toISOString(), encrypted],
+      });
+
+      await getDb().execute(
+        "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
+      );
+      await initDb();
+
+      // Verify it still decrypts correctly (not double-encrypted)
+      const rows = await getDb().execute(
+        `SELECT closes_at FROM events WHERE slug_index = ?`,
+        [slugIdx],
+      );
+      const raw = rows.rows[0]?.closes_at as string | null;
+      const decrypted = await decrypt(raw as string);
+      expect(decrypted).toBe("2099-06-15T14:30:00.000Z");
+    });
+
+    test("backfills plain text empty string to encrypted empty string", async () => {
+      const slugIdx = await computeSlugIndex("test-mig-3");
+      await getDb().execute({
+        sql: `INSERT INTO events (name, slug, slug_index, max_attendees, created, closes_at) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["empty-name", "empty-slug", slugIdx, 100, new Date().toISOString(), ""],
+      });
+
+      await getDb().execute(
+        "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
+      );
+      await initDb();
+
+      const rows = await getDb().execute(
+        `SELECT closes_at FROM events WHERE slug_index = ?`,
+        [slugIdx],
+      );
+      const raw = rows.rows[0]?.closes_at as string | null;
+      const { decrypt } = await import("#lib/crypto.ts");
+      const decrypted = await decrypt(raw as string);
+      expect(decrypted).toBe("");
+    });
+
+    test("backfills plain text full ISO datetime to encrypted", async () => {
+      const slugIdx = await computeSlugIndex("test-mig-4");
+      await getDb().execute({
+        sql: `INSERT INTO events (name, slug, slug_index, max_attendees, created, closes_at) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["iso-name", "iso-slug", slugIdx, 100, new Date().toISOString(), "2099-03-01T10:00:00.000Z"],
+      });
+
+      await getDb().execute(
+        "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
+      );
+      await initDb();
+
+      const rows = await getDb().execute(
+        `SELECT closes_at FROM events WHERE slug_index = ?`,
+        [slugIdx],
+      );
+      const raw = rows.rows[0]?.closes_at as string | null;
+      const { decrypt } = await import("#lib/crypto.ts");
+      const decrypted = await decrypt(raw as string);
+      expect(decrypted).toBe("2099-03-01T10:00:00.000Z");
+    });
+
+    test("backfills plain text short datetime to encrypted normalized ISO", async () => {
+      const slugIdx = await computeSlugIndex("test-mig-5");
+      await getDb().execute({
+        sql: `INSERT INTO events (name, slug, slug_index, max_attendees, created, closes_at) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["plain-name", "plain-slug", slugIdx, 100, new Date().toISOString(), "2099-03-01T10:00"],
+      });
+
+      await getDb().execute(
+        "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
+      );
+      await initDb();
+
+      // Verify it's now encrypted and normalized
+      const rows = await getDb().execute(
+        `SELECT closes_at FROM events WHERE slug_index = ?`,
+        [slugIdx],
+      );
+      const raw = rows.rows[0]?.closes_at as string | null;
+      const { decrypt } = await import("#lib/crypto.ts");
+      const decrypted = await decrypt(raw as string);
+      expect(decrypted).toBe("2099-03-01T10:00:00.000Z");
     });
   });
 });

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -139,6 +139,7 @@ describe("square", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
       const intent = {
         eventId: 1,
@@ -172,6 +173,7 @@ describe("square", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
       const intent = {
         eventId: 1,
@@ -205,6 +207,7 @@ describe("square", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
       const intent = {
         eventId: 1,
@@ -246,6 +249,7 @@ describe("square", () => {
             webhook_url: null,
             active: 1,
             fields: "email" as const,
+            closes_at: null,
           };
           const intent = {
             eventId: 7,
@@ -323,6 +327,7 @@ describe("square", () => {
             webhook_url: null,
             active: 1,
             fields: "email" as const,
+            closes_at: null,
           };
           const intent = {
             eventId: 1,
@@ -368,6 +373,7 @@ describe("square", () => {
             webhook_url: null,
             active: 1,
             fields: "email" as const,
+            closes_at: null,
           };
           const intent = {
             eventId: 1,
@@ -412,6 +418,7 @@ describe("square", () => {
             webhook_url: null,
             active: 1,
             fields: "email" as const,
+            closes_at: null,
           };
           const intent = {
             eventId: 1,
@@ -1177,6 +1184,7 @@ describe("square", () => {
             webhook_url: null,
             active: 1,
             fields: "email" as const,
+            closes_at: null,
           };
           const intent = {
             eventId: 1,

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -155,6 +155,7 @@ describe("stripe", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
       const intent = {
         eventId: 1,
@@ -196,6 +197,7 @@ describe("stripe", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
 
       const intent = {
@@ -245,6 +247,7 @@ describe("stripe", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
       const intent = {
         eventId: 1,
@@ -277,6 +280,7 @@ describe("stripe", () => {
         webhook_url: null,
         active: 1,
         fields: "email" as const,
+        closes_at: null,
       };
       const intent = {
         eventId: 1,

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -582,6 +582,14 @@ describe("test-utils", () => {
       expect(updated.unit_price).toBe(2500);
       expect(updated.max_attendees).toBe(50);
     });
+
+    test("preserves existing closesAt when update does not specify closesAt", async () => {
+      const event = await createTestEvent({ closesAt: "2099-06-15T14:30" });
+      expect(event.closes_at).toBe("2099-06-15T14:30:00.000Z");
+      const updated = await updateTestEvent(event.id, { maxAttendees: 50 });
+      expect(updated.closes_at).toBe("2099-06-15T14:30:00.000Z");
+      expect(updated.max_attendees).toBe(50);
+    });
   });
 
   describe("createTestEvent with null thankYouUrl", () => {


### PR DESCRIPTION
## Summary
This PR adds support for event registration deadlines by introducing a `closes_at` field to events. Admins can now set an optional UTC timestamp when registration should close, and the system will prevent new registrations and refund payments if registration has closed.

## Key Changes

- **Database Schema**: Added `closes_at` TEXT column to events table (nullable, stores ISO timestamp)
- **Admin Interface**: 
  - New "Registration Closes At" field in event creation/edit forms (datetime-local input)
  - Display of registration deadline on event detail pages
  - Validation for valid date/time format
- **Public Registration**:
  - Single ticket page shows "Registration closed." message when deadline has passed
  - Multi-ticket page shows "Registration Closed" label for individual closed events
  - Form submissions rejected with "registration closed while you were submitting" message if deadline passes between form load and submission
- **Payment Processing**:
  - Stripe webhook handlers check if registration has closed and refund payments with appropriate error messages
  - Rollback of created attendees if registration closes during multi-ticket payment processing
- **Utility Functions**: Added `isRegistrationClosed()` helper to check if event deadline has passed
- **Tests**: Comprehensive test coverage for all scenarios (create/update with closes_at, closed event display, submission blocking, payment refunds)

## Implementation Details

- The `closes_at` field stores ISO 8601 timestamps (YYYY-MM-DDTHH:MM format) in UTC
- Registration is considered closed when `closes_at` is not null and the timestamp is in the past
- The check is performed at multiple points: form display, form submission, and payment completion
- Closed events are treated similarly to sold-out events in multi-ticket scenarios (maxPurchasable = 0)
- All existing tests updated to include the new `closes_at` field in test event objects

https://claude.ai/code/session_01D5pF5iPdZHG6gKxdV3SAUE