### PR TITLE
Restore informative event log messages and reorganize log routes

### DIFF
--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -133,7 +133,7 @@ export const logAndNotifyRegistration = async (
   attendee: WebhookAttendee,
   currency: string,
 ): Promise<void> => {
-  await logActivity("Attendee registered", event.id);
+  await logActivity(`Attendee registered for '${event.name}'`, event.id);
   await sendRegistrationWebhooks([{ event, attendee }], currency);
 };
 
@@ -145,7 +145,7 @@ export const logAndNotifyMultiRegistration = async (
   currency: string,
 ): Promise<void> => {
   for (const { event } of entries) {
-    await logActivity("Attendee registered", event.id);
+    await logActivity(`Attendee registered for '${event.name}'`, event.id);
   }
   await sendRegistrationWebhooks(entries, currency);
 };

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -107,7 +107,7 @@ const handleAdminAttendeeDeletePost = (
     }
 
     await deleteAttendee(attendeeId);
-    await logActivity("Attendee deleted", eventId);
+    await logActivity(`Attendee deleted from '${data.event.name}'`, eventId);
     return redirect(`/admin/event/${eventId}`);
   });
 

--- a/src/routes/admin/dashboard.ts
+++ b/src/routes/admin/dashboard.ts
@@ -25,16 +25,22 @@ const handleAdminGet = (request: Request): Promise<Response> =>
     () => loginResponse(),
   );
 
+/** Maximum number of log entries to display */
+const LOG_DISPLAY_LIMIT = 200;
+
 /**
- * Handle GET /admin/activity-log
+ * Handle GET /admin/log
  */
-const handleAdminActivityLog = (request: Request): Promise<Response> =>
-  requireSessionOr(request, async () =>
-    htmlResponse(adminGlobalActivityLogPage(await getAllActivityLog())),
-  );
+const handleAdminLog = (request: Request): Promise<Response> =>
+  requireSessionOr(request, async () => {
+    const entries = await getAllActivityLog(LOG_DISPLAY_LIMIT + 1);
+    const truncated = entries.length > LOG_DISPLAY_LIMIT;
+    const displayEntries = truncated ? entries.slice(0, LOG_DISPLAY_LIMIT) : entries;
+    return htmlResponse(adminGlobalActivityLogPage(displayEntries, truncated));
+  });
 
 /** Dashboard routes */
 export const dashboardRoutes = defineRoutes({
   "GET /admin": (request) => handleAdminGet(request),
-  "GET /admin/activity-log": (request) => handleAdminActivityLog(request),
+  "GET /admin/log": (request) => handleAdminLog(request),
 });

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -138,7 +138,7 @@ const withEventAttendees = async (
  */
 const handleCreateEvent = createHandler(eventsResource, {
   onSuccess: async (row) => {
-    await logActivity("Event created", row.id);
+    await logActivity(`Event '${row.name}' created`, row.id);
     return redirect("/admin");
   },
   onError: () => redirect("/admin"),
@@ -223,7 +223,7 @@ const handleAdminEventExport = (request: Request, eventId: number) =>
   withEventAttendees(request, eventId, async (event, attendees) => {
     const csv = generateAttendeesCsv(attendees);
     const filename = `${event.name.replace(/[^a-zA-Z0-9]/g, "_")}_attendees.csv`;
-    await logActivity("CSV exported", event.id);
+    await logActivity(`CSV exported for '${event.name}'`, event.id);
     return new Response(csv, {
       headers: {
         "content-type": "text/csv; charset=utf-8",
@@ -260,7 +260,7 @@ const handleAdminEventDeactivatePost = (
     }
 
     await eventsTable.update(eventId, { active: 0 });
-    await logActivity("Event deactivated", eventId);
+    await logActivity(`Event '${event.name}' deactivated`, eventId);
     return redirect(`/admin/event/${eventId}`);
   });
 
@@ -286,7 +286,7 @@ const handleAdminEventReactivatePost = (
     }
 
     await eventsTable.update(eventId, { active: 1 });
-    await logActivity("Event reactivated", eventId);
+    await logActivity(`Event '${event.name}' reactivated`, eventId);
     return redirect(`/admin/event/${eventId}`);
   });
 
@@ -294,10 +294,10 @@ const handleAdminEventReactivatePost = (
 const handleAdminEventDeleteGet = withEventPage(adminDeleteEventPage);
 
 /**
- * Handle GET /admin/event/:id/activity-log
+ * Handle GET /admin/event/:id/log
  * Uses batched query to fetch event + activity log in a single DB round-trip.
  */
-const handleAdminEventActivityLog = (
+const handleAdminEventLog = (
   request: Request,
   eventId: number,
 ): Promise<Response> =>
@@ -343,7 +343,7 @@ const handleAdminEventDelete = (
     const attendeeCount = event.attendee_count;
     await deleteEvent(eventId);
     await logActivity(
-      `Event deleted (${attendeeCount} attendee(s) removed)`,
+      `Event '${event.name}' deleted (${attendeeCount} attendee(s) removed)`,
     );
     return redirect("/admin");
   });
@@ -365,8 +365,8 @@ export const eventsRoutes = defineRoutes({
     handleAdminEventEditPost(request, parseEventId(params)),
   "GET /admin/event/:id/export": (request, params) =>
     handleAdminEventExport(request, parseEventId(params)),
-  "GET /admin/event/:id/activity-log": (request, params) =>
-    handleAdminEventActivityLog(request, parseEventId(params)),
+  "GET /admin/event/:id/log": (request, params) =>
+    handleAdminEventLog(request, parseEventId(params)),
   "GET /admin/event/:id/deactivate": (request, params) =>
     handleAdminEventDeactivateGet(request, parseEventId(params)),
   "POST /admin/event/:id/deactivate": (request, params) =>

--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -36,9 +36,9 @@ export const adminEventActivityLogPage = (
   entries: ActivityLogEntry[],
 ): string =>
   String(
-    <Layout title={`Activity Log: ${event.name}`}>
+    <Layout title={`Log: ${event.name}`}>
       <AdminNav />
-        <h2>Activity Log</h2>
+        <h2>Log</h2>
         <table>
           <thead>
             <tr>
@@ -58,11 +58,12 @@ export const adminEventActivityLogPage = (
  */
 export const adminGlobalActivityLogPage = (
   entries: ActivityLogEntry[],
+  truncated = false,
 ): string =>
   String(
-    <Layout title="Activity Log">
+    <Layout title="Log">
       <AdminNav />
-        <h2>Activity Log</h2>
+        <h2>Log</h2>
         <table>
           <thead>
             <tr>
@@ -74,5 +75,6 @@ export const adminGlobalActivityLogPage = (
             <Raw html={activityLogRows(entries)} />
           </tbody>
         </table>
+        {truncated && <p>Showing the most recent 200 entries.</p>}
     </Layout>
   );

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -76,7 +76,7 @@ export const adminEventPage = (
           <ul>
             <li><a href={`/admin/event/${event.id}/edit`}>Edit</a></li>
             <li><a href={`/admin/event/${event.id}/duplicate`}>Duplicate</a></li>
-            <li><a href={`/admin/event/${event.id}/activity-log`}>Activity Log</a></li>
+            <li><a href={`/admin/event/${event.id}/log`}>Log</a></li>
             <li><a href={`/admin/event/${event.id}/export`}>Export CSV</a></li>
             {event.active === 1 ? (
               <li><a href={`/admin/event/${event.id}/deactivate`} class="danger">Deactivate</a></li>

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -10,6 +10,7 @@ export const AdminNav = (): JSX.Element => (
     <ul>
       <li><a href="/admin/">Events</a></li>
       <li><a href="/admin/settings">Settings</a></li>
+      <li><a href="/admin/log">Log</a></li>
       <li><a href="/admin/sessions">Sessions</a></li>
       <li><a href="/admin/logout">Logout</a></li>
     </ul>

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -1299,7 +1299,7 @@ describe("db", () => {
       await logActivity("Action for event 2", event2.id);
 
       const event1Log = await getEventActivityLog(event1.id);
-      // REST API also logs "Created event", so we have 3 entries for event 1
+      // REST API also logs event creation, so we have 3 entries for event 1
       expect(event1Log.length).toBe(3);
       expect(event1Log[0]?.message).toBe("Another action for event 1");
       expect(event1Log[1]?.message).toBe("Action for event 1");
@@ -1335,7 +1335,7 @@ describe("db", () => {
       await logActivity("Event action", event.id);
 
       const entries = await getAllActivityLog();
-      // REST API logs "Created event", so we have 3 entries total
+      // REST API logs event creation, so we have 3 entries total
       expect(entries.length).toBe(3);
     });
 
@@ -1374,7 +1374,7 @@ describe("db", () => {
       expect(result?.event.id).toBe(event.id);
       expect(result?.event.name).toBe("Batch Test Event");
       expect(result?.event.attendee_count).toBe(0);
-      // REST API logs "Created event" + our 2 = 3
+      // REST API logs event creation + our 2 = 3
       expect(result?.entries.length).toBe(3);
       expect(result?.entries[0]?.message).toBe("Second action");
       expect(result?.entries[1]?.message).toBe("First action");

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -524,7 +524,7 @@ describe("html", () => {
       const html = adminEventActivityLogPage(event, entries);
       expect(html).toContain("Ticket reserved");
       expect(html).toContain("Payment received");
-      expect(html).toContain("Activity Log");
+      expect(html).toContain("Log");
     });
 
     test("renders empty state when no entries", () => {
@@ -541,12 +541,28 @@ describe("html", () => {
       ];
       const html = adminGlobalActivityLogPage(entries);
       expect(html).toContain("System started");
-      expect(html).toContain("Activity Log");
+      expect(html).toContain("Log");
     });
 
     test("renders empty state when no entries", () => {
       const html = adminGlobalActivityLogPage([]);
       expect(html).toContain("No activity recorded yet");
+    });
+
+    test("shows truncation message when truncated", () => {
+      const entries = [
+        { id: 1, created: "2024-01-15T10:30:00Z", event_id: null, message: "Action" },
+      ];
+      const html = adminGlobalActivityLogPage(entries, true);
+      expect(html).toContain("Showing the most recent 200 entries");
+    });
+
+    test("does not show truncation message when not truncated", () => {
+      const entries = [
+        { id: 1, created: "2024-01-15T10:30:00Z", event_id: null, message: "Action" },
+      ];
+      const html = adminGlobalActivityLogPage(entries, false);
+      expect(html).not.toContain("Showing the most recent 200 entries");
     });
   });
 


### PR DESCRIPTION
- Include event names in all activity log messages (e.g. "Attendee registered
  for 'Christmas Party'" instead of just "Attendee registered")
- Rename event log route from /admin/event/:id/activity-log to /admin/event/:id/log
- Rename global log route from /admin/activity-log to /admin/log
- Add "Log" link to top nav between Settings and Sessions
- Show last 200 entries on global log page with truncation message
- Rename link text from "Activity Log" to "Log" throughout

https://claude.ai/code/session_01Mjo8Z41QeNJgwwBhu9rQph