### PR TITLE
Add attendee check-in filtering and include status in CSV export

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -123,13 +123,20 @@ const attendeeDeleteHandler: RouteHandlerFn = (request, params) => {
   return handleAdminAttendeeDeletePost(request, ids.eventId, ids.attendeeId);
 };
 
+/** Map return_filter form value to URL suffix */
+const filterSuffix = (returnFilter: string | null): string => {
+  if (returnFilter === "in") return "/in";
+  if (returnFilter === "out") return "/out";
+  return "";
+};
+
 /** Handle POST /admin/event/:eventId/attendee/:attendeeId/checkin (toggle check-in) */
 const handleAdminAttendeeCheckinPost = (
   request: Request,
   eventId: number,
   attendeeId: number,
 ): Promise<Response> =>
-  withAuthForm(request, async (session) => {
+  withAuthForm(request, async (session, form) => {
     const privateKey = await getPrivateKey(
       session.token,
       session.wrappedDataKey,
@@ -150,8 +157,9 @@ const handleAdminAttendeeCheckinPost = (
 
     const name = encodeURIComponent(data.attendee.name);
     const status = nowCheckedIn ? "in" : "out";
+    const suffix = filterSuffix(form.get("return_filter"));
     return redirect(
-      `/admin/event/${eventId}?checkin_name=${name}&checkin_status=${status}#message`,
+      `/admin/event/${eventId}${suffix}?checkin_name=${name}&checkin_status=${status}#message`,
     );
   });
 

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -41,6 +41,7 @@ import {
   adminEventEditPage,
   adminEventPage,
   adminReactivateEventPage,
+  type AttendeeFilter,
 } from "#templates/admin/events.tsx";
 import { generateAttendeesCsv } from "#templates/csv.ts";
 import { eventFields, slugField } from "#templates/fields.ts";
@@ -159,9 +160,9 @@ const getCheckinMessage = (request: Request): { name: string; status: string } |
 };
 
 /**
- * Handle GET /admin/event/:id
+ * Handle GET /admin/event/:id (with optional filter)
  */
-const handleAdminEventGet = (request: Request, eventId: number) =>
+const handleAdminEventGet = (request: Request, eventId: number, activeFilter: AttendeeFilter = "all") =>
   withEventAttendees(request, eventId, ({ event, attendees, csrfToken }) =>
     htmlResponse(
       adminEventPage(
@@ -170,6 +171,7 @@ const handleAdminEventGet = (request: Request, eventId: number) =>
         getAllowedDomain(),
         csrfToken,
         getCheckinMessage(request),
+        activeFilter,
       ),
     ),
   );
@@ -377,6 +379,10 @@ const parseEventId = (params: RouteParams): number =>
 /** Event routes */
 export const eventsRoutes = defineRoutes({
   "POST /admin/event": (request) => handleCreateEvent(request),
+  "GET /admin/event/:id/in": (request, params) =>
+    handleAdminEventGet(request, parseEventId(params), "in"),
+  "GET /admin/event/:id/out": (request, params) =>
+    handleAdminEventGet(request, parseEventId(params), "out"),
   "GET /admin/event/:id": (request, params) =>
     handleAdminEventGet(request, parseEventId(params)),
   "GET /admin/event/:id/duplicate": (request, params) =>

--- a/src/templates/csv.ts
+++ b/src/templates/csv.ts
@@ -21,12 +21,16 @@ const formatPrice = (pricePaid: string | null): string => {
   return (Number.parseInt(pricePaid, 10) / 100).toFixed(2);
 };
 
+/** Format checked_in value as Yes/No */
+const formatCheckedIn = (checkedIn: string): string =>
+  checkedIn === "true" ? "Yes" : "No";
+
 /**
  * Generate CSV content from attendees.
  * Always includes both Email and Phone columns regardless of event settings.
  */
 export const generateAttendeesCsv = (attendees: Attendee[]): string => {
-  const header = "Name,Email,Phone,Quantity,Registered,Price Paid,Transaction ID";
+  const header = "Name,Email,Phone,Quantity,Registered,Price Paid,Transaction ID,Checked In";
   const rows = pipe(
     map((a: Attendee) =>
       [
@@ -37,6 +41,7 @@ export const generateAttendeesCsv = (attendees: Attendee[]): string => {
         escapeCsvValue(new Date(a.created).toISOString()),
         formatPrice(a.price_paid),
         escapeCsvValue(a.payment_id ?? ""),
+        formatCheckedIn(a.checked_in),
       ].join(","),
     ),
     reduce((acc: string, row: string) => `${acc}\n${row}`, header),

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -251,6 +251,104 @@ describe("server (admin events)", () => {
     });
   });
 
+  describe("GET /admin/event/:id/in", () => {
+    test("redirects to login when not authenticated", async () => {
+      await createTestEvent({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      const response = await handleRequest(mockRequest("/admin/event/1/in"));
+      expect(response.status).toBe(302);
+    });
+
+    test("returns 404 for non-existent event", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/event/999/in", {
+        cookie: cookie,
+      });
+      expect(response.status).toBe(404);
+    });
+
+    test("shows only checked-in attendees", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const event = await createTestEvent({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      const checkedInAttendee = await createTestAttendee(event.id, event.slug, "Checked In User", "in@example.com");
+      await createTestAttendee(event.id, event.slug, "Not Checked User", "out@example.com");
+
+      // Check in the first attendee
+      await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${checkedInAttendee.id}/checkin`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}/in`, {
+        cookie: cookie,
+      });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Checked In User");
+      expect(html).not.toContain("Not Checked User");
+      expect(html).toContain("<strong>Checked In</strong>");
+    });
+  });
+
+  describe("GET /admin/event/:id/out", () => {
+    test("redirects to login when not authenticated", async () => {
+      await createTestEvent({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      const response = await handleRequest(mockRequest("/admin/event/1/out"));
+      expect(response.status).toBe(302);
+    });
+
+    test("returns 404 for non-existent event", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/event/999/out", {
+        cookie: cookie,
+      });
+      expect(response.status).toBe(404);
+    });
+
+    test("shows only checked-out attendees", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const event = await createTestEvent({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      const checkedInAttendee = await createTestAttendee(event.id, event.slug, "Checked In User", "in@example.com");
+      await createTestAttendee(event.id, event.slug, "Not Checked User", "out@example.com");
+
+      // Check in the first attendee
+      await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${checkedInAttendee.id}/checkin`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}/out`, {
+        cookie: cookie,
+      });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).not.toContain("Checked In User");
+      expect(html).toContain("Not Checked User");
+      expect(html).toContain("<strong>Checked Out</strong>");
+    });
+  });
+
   describe("GET /admin/event/:id/export", () => {
     test("redirects to login when not authenticated", async () => {
       await createTestEvent({
@@ -312,6 +410,34 @@ describe("server (admin events)", () => {
       expect(csv).toContain("john@example.com");
       expect(csv).toContain("Jane Smith");
       expect(csv).toContain("jane@example.com");
+    });
+
+    test("returns CSV with Checked In column", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const event = await createTestEvent({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      const attendee = await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      // Check in the attendee
+      await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${attendee.id}/checkin`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}/export`, {
+        cookie: cookie,
+      });
+      const csv = await response.text();
+      expect(csv).toContain(",Checked In");
+      // John Doe is checked in
+      expect(csv).toContain("John Doe");
+      expect(csv).toContain(",Yes");
     });
 
     test("sanitizes slug for filename", async () => {


### PR DESCRIPTION
## Summary
This PR adds the ability to filter attendees by check-in status on the admin event page and includes the check-in status in the CSV export.

## Key Changes

- **Attendee filtering**: Added `/admin/event/:id/in` and `/admin/event/:id/out` routes to display only checked-in or checked-out attendees respectively
- **Filter UI**: Added filter links (All / Checked In / Checked Out) on the event page with the active filter highlighted in bold
- **Return filter preservation**: When toggling check-in status, the form now includes a hidden `return_filter` field that redirects back to the same filtered view
- **CSV export enhancement**: Added "Checked In" column to the attendee CSV export, displaying "Yes" or "No" based on check-in status
- **Type safety**: Introduced `AttendeeFilter` type ("all" | "in" | "out") for type-safe filter handling

## Implementation Details

- The `filterSuffix()` helper converts the `return_filter` form value to the appropriate URL suffix
- The `filterAttendees()` function filters the attendee list based on the active filter before rendering
- The `FilterLink` component renders either a bold label (for active filter) or a clickable link (for inactive filters)
- All existing tests updated to reflect the new CSV column, with comprehensive new tests for filtering functionality

https://claude.ai/code/session_015TJkUJxzDUjt1xBNPy8JAQ