### PR TITLE
Remove test job from bunny-deploy workflow

### DIFF
--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -9,64 +9,8 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  STRIPE_MOCK_VERSION: "0.188.0"
-
 jobs:
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Cache stripe-mock
-        uses: actions/cache@v4
-        with:
-          path: .bin
-          key: stripe-mock-${{ env.STRIPE_MOCK_VERSION }}-linux-amd64
-
-      - name: Download stripe-mock
-        run: |
-          if [ ! -f .bin/stripe-mock ]; then
-            mkdir -p .bin
-            curl -sL "https://github.com/stripe/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" | tar -xz -C .bin
-            chmod +x .bin/stripe-mock
-          fi
-
-      - name: Install dependencies
-        run: deno install --allow-scripts
-
-      - name: Typecheck
-        run: deno task typecheck
-
-      - name: Lint
-        run: deno task lint
-
-      - name: Copy-paste detection
-        run: deno task cpd
-
-      - name: Start stripe-mock
-        run: |
-          .bin/stripe-mock -http-port 12111 &
-          sleep 2
-          curl -s http://localhost:12111 > /dev/null && echo "stripe-mock is running"
-
-      - name: Run tests with coverage
-        env:
-          STRIPE_MOCK_HOST: localhost
-          STRIPE_MOCK_PORT: "12111"
-          ALLOWED_DOMAIN: localhost
-          DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
-        run: deno task test:coverage
-
   deploy:
-    needs: test
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
Removed the entire `test` job from the bunny-deploy GitHub Actions workflow, including all testing infrastructure setup and execution steps. The `deploy` job no longer depends on the `test` job completing successfully.

## Changes
- Removed the `test` job that included:
  - Deno setup and dependency installation
  - Typecheck, lint, and copy-paste detection tasks
  - Stripe Mock service setup and configuration
  - Test execution with coverage reporting
- Removed the `STRIPE_MOCK_VERSION` environment variable
- Removed the `needs: test` dependency from the `deploy` job

## Notes
This change means the deployment workflow will no longer run tests before deploying. Consider whether tests should be run in a separate workflow or if this was intentional to streamline the deployment process.

https://claude.ai/code/session_01JWbG4efMAhbLac8WCPeMs6