### PR TITLE
Remove default margin from table input elements

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -570,6 +570,10 @@ table tr:nth-child(even) {
   background-color: var(--color-accent);
 }
 
+table input {
+  margin: 0;
+}
+
 /* Quotes */
 blockquote {
   display: block;


### PR DESCRIPTION
## Summary
This change removes the default margin applied to input elements within tables by adding a CSS rule that explicitly sets `margin: 0` for `table input` selectors.

## Changes
- Added a new CSS rule for `table input` elements to reset their margin to 0
- This prevents unwanted spacing around input fields when used inside table cells

## Details
The modification addresses styling inconsistencies where input elements inherit or apply default margins within table layouts. By explicitly setting `margin: 0`, input fields in tables will now have consistent, compact spacing without extra whitespace. This is a common CSS reset pattern to ensure form elements display predictably within tabular data.

https://claude.ai/code/session_019ZJFs9FDhoKNJLNbAYskhn