### PR TITLE
Add anchor links to attendees section for better navigation

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -210,18 +210,18 @@ export const adminEventPage = (
           </table>
         </article>
 
-        <h2>Attendees</h2>
+        <h2 id="attendees">Attendees</h2>
         {checkinMessage && (
           <p id="message" class={checkedInClass}>
             Checked {checkinMessage.name} {checkedInLabel}
           </p>
         )}
         <p>
-          <Raw html={FilterLink({ href: basePath, label: "All", active: activeFilter === "all" })} />
+          <Raw html={FilterLink({ href: `${basePath}#attendees`, label: "All", active: activeFilter === "all" })} />
           {" / "}
-          <Raw html={FilterLink({ href: `${basePath}/in`, label: "Checked In", active: activeFilter === "in" })} />
+          <Raw html={FilterLink({ href: `${basePath}/in#attendees`, label: "Checked In", active: activeFilter === "in" })} />
           {" / "}
-          <Raw html={FilterLink({ href: `${basePath}/out`, label: "Checked Out", active: activeFilter === "out" })} />
+          <Raw html={FilterLink({ href: `${basePath}/out#attendees`, label: "Checked Out", active: activeFilter === "out" })} />
         </p>
         <table>
           <thead>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -536,8 +536,8 @@ describe("html", () => {
       const attendees = [testAttendee()];
       const html = adminEventPage(event, attendees, "localhost", TEST_CSRF_TOKEN);
       expect(html).toContain("<strong>All</strong>");
-      expect(html).toContain(`href="/admin/event/${event.id}/in"`);
-      expect(html).toContain(`href="/admin/event/${event.id}/out"`);
+      expect(html).toContain(`href="/admin/event/${event.id}/in#attendees"`);
+      expect(html).toContain(`href="/admin/event/${event.id}/out#attendees"`);
     });
 
     test("bolds Checked In when filter is in", () => {
@@ -545,7 +545,7 @@ describe("html", () => {
       const attendees = [testAttendee()];
       const html = adminEventPage(event, attendees, "localhost", TEST_CSRF_TOKEN, null, "in");
       expect(html).toContain("<strong>Checked In</strong>");
-      expect(html).toContain(`href="/admin/event/${event.id}"`);
+      expect(html).toContain(`href="/admin/event/${event.id}#attendees"`);
     });
 
     test("bolds Checked Out when filter is out", () => {


### PR DESCRIPTION
## Summary
This PR adds anchor links (`#attendees`) to the attendees section filter links in the admin event page, allowing users to jump directly to the attendees table when switching between filter views.

## Changes
- Added `id="attendees"` to the Attendees heading for anchor targeting
- Updated all filter link hrefs to include `#attendees` anchor:
  - "All" filter link
  - "Checked In" filter link
  - "Checked Out" filter link
- Updated corresponding test assertions to verify the anchor links are present in the generated HTML

## Implementation Details
When users click on filter options (All, Checked In, Checked Out), the page will now automatically scroll to the attendees section rather than staying at the top of the page. This improves UX by keeping the user's focus on the relevant content after applying a filter.

https://claude.ai/code/session_01R3csfwXfhq3H1DaNfrsvpV