### PR TITLE
Add public ticket URL display to admin event page

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -165,6 +165,12 @@ export const adminEventPage = (
                 </td>
               </tr>
               <tr>
+                <th>Public URL</th>
+                <td>
+                  <a href={ticketUrl}>{`${allowedDomain}/ticket/${event.slug}`}</a>
+                </td>
+              </tr>
+              <tr>
                 <th><label for={`thank-you-url-${event.id}`}>Thank You URL</label></th>
                 <td>
                   {event.thank_you_url ? (

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -113,6 +113,13 @@ describe("html", () => {
       expect(html).toContain("this.select()");
     });
 
+    test("shows public URL with allowed domain", () => {
+      const html = adminEventPage(event, [], "example.com", TEST_CSRF_TOKEN);
+      expect(html).toContain("Public URL");
+      expect(html).toContain('href="https://example.com/ticket/ab12c"');
+      expect(html).toContain("example.com/ticket/ab12c");
+    });
+
     test("shows embed code with allowed domain", () => {
       const html = adminEventPage(event, [], "example.com", TEST_CSRF_TOKEN);
       expect(html).toContain("Embed Code");


### PR DESCRIPTION
## Summary
Added a new "Public URL" field to the admin event page that displays the publicly accessible ticket URL for an event.

## Changes
- Display the public ticket URL in the admin event details table
- URL format: `{allowedDomain}/ticket/{event.slug}`
- Added corresponding test to verify the public URL is rendered correctly with the allowed domain

## Implementation Details
- The public URL is displayed as a clickable link in a new table row
- Uses the existing `ticketUrl` variable and `allowedDomain` parameter
- Positioned before the "Thank You URL" field in the event details table
- Test verifies both the label and the full URL are present in the rendered HTML

https://claude.ai/code/session_01QKMh5yHuvEopi2d95LKYCo