### PR TITLE
Migrate single-admin credentials to multi-user system

### DIFF
--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -9,7 +9,7 @@ import { getPublicKey, getSetting } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "add multi-user admin";
+export const LATEST_UPDATE = "migrate admin user";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)


### PR DESCRIPTION
## Summary
This PR adds a database migration that automatically converts existing single-admin installations to the new multi-user system by migrating legacy admin credentials from the settings table to the users table.

## Key Changes
- **Migration Logic**: Added a new migration in `initDb()` that:
  - Detects pre-multi-user installations by checking for `admin_password` in settings and an empty users table
  - Creates an "admin" user with "owner" admin level
  - Migrates the existing password hash and wrapped data key to the new users table
  - Encrypts sensitive fields (username, password hash, admin level) for consistency with the new schema

- **Crypto Utilities**: Imported `hmacHash` from crypto module to generate the username index for the migrated admin user

- **Settings Access**: Added `getSetting` import to retrieve legacy admin credentials from the settings table

- **Test Coverage**: Added comprehensive test suite covering:
  - Successful migration of admin credentials when conditions are met
  - Skipping migration when users already exist (multi-user system already in place)
  - Skipping migration when no legacy admin password exists

## Implementation Details
- The migration is idempotent and only runs when both conditions are met: legacy credentials exist AND no users are present
- All sensitive data is encrypted before insertion into the users table, maintaining security consistency
- The migrated user is assigned "owner" admin level to preserve administrative privileges
- The wrapped data key is preserved as-is during migration to maintain data access

https://claude.ai/code/session_01BcoUxT1z3nqYHd35bcXSVT