### PR TITLE
Reset setup_complete when no users exist and no password to migrate

### DIFF
--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -4,7 +4,7 @@
 
 import { encrypt, encryptAttendeePII, hmacHash } from "#lib/crypto.ts";
 import { getDb } from "#lib/db/client.ts";
-import { getPublicKey, getSetting } from "#lib/db/settings.ts";
+import { getPublicKey, getSetting, setSetting } from "#lib/db/settings.ts";
 
 /**
  * The latest database update identifier - update this when changing schema
@@ -252,6 +252,15 @@ export const initDb = async (): Promise<void> => {
           encryptedAdminLevel,
         ],
       });
+    }
+
+    // Fallback: if setup is complete but no users exist and no admin_password to migrate,
+    // reset setup_complete to force re-setup so the user can create a new admin account
+    if (!existingPasswordHash && hasNoUsers) {
+      const setupComplete = await getSetting("setup_complete");
+      if (setupComplete === "true") {
+        await setSetting("setup_complete", "false");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
This PR adds a fallback mechanism to detect and recover from a broken setup state where the database indicates setup is complete but no users exist and there's no admin password to migrate from.

## Changes
- **Migration logic**: Added a check in `initDb()` that resets `setup_complete` to `false` when:
  - No admin password exists to migrate
  - No users are present in the database
  - Setup was previously marked as complete
  
  This allows users to re-run the setup process and create a new admin account instead of being stuck in an inconsistent state.

- **Imports**: Added `setSetting` to the imports from `#lib/db/settings.ts` to support the new functionality

- **Tests**: Added two comprehensive test cases:
  - Verifies that `setup_complete` is reset when in the broken state (no users, no admin_password, setup marked complete)
  - Verifies that `setup_complete` is NOT reset when users exist (normal operation)

## Implementation Details
The fallback check is placed after the admin password migration logic, ensuring it only triggers when there's genuinely nothing to migrate and the database is in an inconsistent state. This prevents accidental resets during normal operation while providing a recovery path for edge cases.

https://claude.ai/code/session_01KPpY1WsUCRVoQF1WqR6UDy