### PR TITLE
Add public ticket view with unique ticket tokens

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -79,6 +79,11 @@ export const generateSecureToken = (): string => {
 };
 
 /**
+ * Generate an 8-byte base64url ticket token for public ticket URLs
+ */
+export const generateTicketToken = (): string => toBase64Url(getRandomBytes(8));
+
+/**
  * Encryption format version prefix
  * Format: enc:1:$base64iv:$base64ciphertext
  */

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -57,3 +57,7 @@ export const executeByField = async (
 export const queryBatch = (
   statements: Array<{ sql: string; args: InValue[] }>,
 ): Promise<ResultSet[]> => getDb().batch(statements, "read");
+
+/** Build SQL placeholders for an IN clause, e.g. "?, ?, ?" */
+export const inPlaceholders = (values: readonly unknown[]): string =>
+  values.map(() => "?").join(", ");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,6 +33,7 @@ export interface Attendee {
   quantity: number;
   price_paid: string | null;
   checked_in: string;
+  ticket_token: string;
 }
 
 export interface Settings {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -52,6 +52,12 @@ const loadJoinRoutes = once(async () => {
   return routeJoin;
 });
 
+/** Lazy-load ticket view routes */
+const loadTicketViewRoutes = once(async () => {
+  const { routeTicketView } = await import("#routes/tickets.ts");
+  return routeTicketView;
+});
+
 // Re-export middleware functions for testing
 export {
   getSecurityHeaders,
@@ -91,6 +97,7 @@ const routeTicketPath = createLazyRoute(
 );
 const routePaymentPath = createLazyRoute("/payment", loadPaymentRoutes);
 const routeJoinPath = createLazyRoute("/join", loadJoinRoutes);
+const routeTicketViewPath = createLazyRoute("/t", loadTicketViewRoutes);
 
 /**
  * Route main application requests (after setup is complete)
@@ -100,6 +107,7 @@ const routeMainApp: RouterFn = async (request, path, method, server) =>
   (await routeHome(request, path, method, server)) ??
   (await routeAdminPath(request, path, method, server)) ??
   (await routeTicketPath(request, path, method, server)) ??
+  (await routeTicketViewPath(request, path, method, server)) ??
   (await routePaymentPath(request, path, method, server)) ??
   (await routeJoinPath(request, path, method, server)) ??
   notFoundResponse();

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -438,7 +438,7 @@ const processMultiFreeReservation = async (
   email: string,
   phone: string,
 ): Promise<{ success: true } | { success: false; error: string }> => {
-  const entries: Array<{ event: MultiTicketEvent["event"]; attendee: { id: number; quantity: number; name: string; email: string; phone: string } }> = [];
+  const entries: Array<{ event: MultiTicketEvent["event"]; attendee: { id: number; quantity: number; name: string; email: string; phone: string; ticket_token: string } }> = [];
   for (const { event, qty } of eventsWithQuantity(events, quantities)) {
     const result = await createAttendeeAtomic(event.id, name, email, null, qty, phone);
     if (!result.success) {

--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -1,0 +1,63 @@
+/**
+ * Public ticket view routes - /t/:tokens
+ * Displays ticket information for attendees using their ticket tokens
+ */
+
+import { compact, map } from "#fp";
+import { getAttendeesByTokens } from "#lib/db/attendees.ts";
+import { getEventWithCount } from "#lib/db/events.ts";
+import type { Attendee } from "#lib/types.ts";
+import type { TicketEntry } from "#templates/tickets.tsx";
+import { ticketViewPage } from "#templates/tickets.tsx";
+import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
+
+/** Pattern to extract tokens from /t/... path */
+const TOKENS_PATTERN = /^\/t\/(.+)$/;
+
+/** Extract tokens string from path */
+const extractTokensFromPath = (path: string): string | null => {
+  const match = path.match(TOKENS_PATTERN);
+  return match?.[1] ?? null;
+};
+
+/** Parse +-separated tokens from a combined string */
+const parseTokens = (tokensStr: string): string[] =>
+  tokensStr.split("+").filter((s) => s.length > 0);
+
+/** Look up the event for an attendee and pair them */
+const resolveEntry = async (attendee: Attendee): Promise<TicketEntry> => {
+  const event = (await getEventWithCount(attendee.event_id))!;
+  return { attendee, event };
+};
+
+/** Resolve all attendees to ticket entries */
+const resolveEntries = (attendees: Attendee[]): Promise<TicketEntry[]> =>
+  Promise.all(map(resolveEntry)(attendees));
+
+/** Handle GET /t/:tokens */
+const handleTicketView = async (tokens: string[]): Promise<Response> => {
+  const attendees = await getAttendeesByTokens(tokens);
+  const validAttendees = compact(attendees);
+
+  if (validAttendees.length === 0) {
+    return notFoundResponse();
+  }
+
+  const entries = await resolveEntries(validAttendees);
+  return htmlResponse(ticketViewPage(entries));
+};
+
+/** Route ticket view requests */
+export const routeTicketView = (
+  _request: Request,
+  path: string,
+  method: string,
+): Promise<Response | null> => {
+  const tokensStr = extractTokensFromPath(path);
+  if (!tokensStr) return Promise.resolve(null);
+
+  if (method !== "GET") return Promise.resolve(null);
+
+  const tokens = parseTokens(tokensStr);
+  return handleTicketView(tokens);
+};

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -1,0 +1,45 @@
+/**
+ * Ticket view page template - displays attendee ticket information
+ */
+
+import { map, pipe } from "#fp";
+import type { Attendee, EventWithCount } from "#lib/types.ts";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { Layout } from "#templates/layout.tsx";
+
+/** Ticket entry: attendee paired with their event */
+export type TicketEntry = {
+  attendee: Attendee;
+  event: EventWithCount;
+};
+
+/** Render a single ticket row */
+const renderTicketRow = ({ event, attendee }: TicketEntry): string =>
+  `<tr><td>${event.name}</td><td>${attendee.quantity}</td></tr>`;
+
+/**
+ * Ticket view page - shows event name and quantity per ticket
+ */
+export const ticketViewPage = (entries: TicketEntry[]): string => {
+  const rows = pipe(
+    map(renderTicketRow),
+    (r: string[]) => r.join(""),
+  )(entries);
+
+  return String(
+    <Layout title="Your Tickets">
+      <h1>Your Tickets</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Quantity</th>
+          </tr>
+        </thead>
+        <tbody>
+          <Raw html={rows} />
+        </tbody>
+      </table>
+    </Layout>
+  );
+};

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -888,6 +888,7 @@ export const testAttendee = (overrides: Partial<Attendee> = {}): Attendee => ({
   quantity: 1,
   price_paid: null,
   checked_in: "false",
+  ticket_token: "test-token-1",
   ...overrides,
 });
 

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -10,6 +10,7 @@ import {
   generateDataKey,
   generateKeyPair,
   generateSecureToken,
+  generateTicketToken,
   hashPassword,
   hashSessionToken,
   hmacHash,
@@ -91,6 +92,24 @@ describe("generateSecureToken", () => {
     // 256/6 = ~43 chars (without padding)
     const token = generateSecureToken();
     expect(token.length).toBe(43);
+  });
+});
+
+describe("generateTicketToken", () => {
+  it("returns a base64url string of 11 characters", () => {
+    // 8 bytes = 64 bits, base64url encodes 6 bits per char
+    // ceil(64/6) = 11 chars (without padding)
+    const token = generateTicketToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(token.length).toBe(11);
+  });
+
+  it("generates unique tokens", () => {
+    const tokens = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      tokens.add(generateTicketToken());
+    }
+    expect(tokens.size).toBe(100);
   });
 });
 

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import {
+  awaitTestRequest,
+  createTestAttendee,
+  createTestDbWithSetup,
+  createTestEvent,
+  getAttendeesRaw,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+describe("ticket view (/t/:tokens)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  test("displays ticket for a single valid token", async () => {
+    const event = await createTestEvent({ maxAttendees: 10 });
+    await createTestAttendee(event.id, event.slug, "Alice", "alice@test.com");
+    const attendees = await getAttendeesRaw(event.id);
+    const token = attendees[0]!.ticket_token;
+
+    const response = await awaitTestRequest(`/t/${token}`);
+    expect(response.status).toBe(200);
+
+    const body = await response.text();
+    expect(body).toContain(event.name);
+    expect(body).toContain("Your Tickets");
+  });
+
+  test("displays tickets for multiple valid tokens", async () => {
+    const eventA = await createTestEvent({ maxAttendees: 10 });
+    const eventB = await createTestEvent({ maxAttendees: 10 });
+    await createTestAttendee(eventA.id, eventA.slug, "Bob", "bob@test.com");
+    await createTestAttendee(eventB.id, eventB.slug, "Bob", "bob@test.com", 2);
+    const attendeesA = await getAttendeesRaw(eventA.id);
+    const attendeesB = await getAttendeesRaw(eventB.id);
+    const tokenA = attendeesA[0]!.ticket_token;
+    const tokenB = attendeesB[0]!.ticket_token;
+
+    const response = await awaitTestRequest(`/t/${tokenA}+${tokenB}`);
+    expect(response.status).toBe(200);
+
+    const body = await response.text();
+    expect(body).toContain(eventA.name);
+    expect(body).toContain(eventB.name);
+  });
+
+  test("returns 404 for invalid token", async () => {
+    const response = await awaitTestRequest("/t/nonexistent-token");
+    expect(response.status).toBe(404);
+  });
+
+  test("returns 404 for empty tokens path", async () => {
+    const response = await awaitTestRequest("/t/");
+    expect(response.status).toBe(404);
+  });
+
+  test("shows quantity per ticket", async () => {
+    const event = await createTestEvent({ maxAttendees: 10, maxQuantity: 5 });
+    await createTestAttendee(event.id, event.slug, "Carol", "carol@test.com", 3);
+    const attendees = await getAttendeesRaw(event.id);
+    const token = attendees[0]!.ticket_token;
+
+    const response = await awaitTestRequest(`/t/${token}`);
+    const body = await response.text();
+    expect(body).toContain("3");
+  });
+
+  test("skips invalid tokens among valid ones", async () => {
+    const event = await createTestEvent({ maxAttendees: 10 });
+    await createTestAttendee(event.id, event.slug, "Dave", "dave@test.com");
+    const attendees = await getAttendeesRaw(event.id);
+    const token = attendees[0]!.ticket_token;
+
+    const response = await awaitTestRequest(`/t/${token}+bad-token`);
+    expect(response.status).toBe(200);
+
+    const body = await response.text();
+    expect(body).toContain(event.name);
+  });
+
+  test("returns null for non-GET methods", async () => {
+    const { routeTicketView } = await import("#routes/tickets.ts");
+    const request = new Request("http://localhost/t/some-token", { method: "POST" });
+    const result = await routeTicketView(request, "/t/some-token", "POST");
+    expect(result).toBeNull();
+  });
+
+  test("attendee has a unique ticket_token after creation", async () => {
+    const event = await createTestEvent({ maxAttendees: 10 });
+    await createTestAttendee(event.id, event.slug, "Frank", "frank@test.com");
+    await createTestAttendee(event.id, event.slug, "Grace", "grace@test.com");
+    const attendees = await getAttendeesRaw(event.id);
+
+    expect(attendees[0]!.ticket_token).not.toBe("");
+    expect(attendees[1]!.ticket_token).not.toBe("");
+    expect(attendees[0]!.ticket_token).not.toBe(attendees[1]!.ticket_token);
+  });
+});

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -29,6 +29,7 @@ const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee
   name: "Jane Doe",
   email: "jane@example.com",
   phone: "555-1234",
+  ticket_token: "test-token-42",
   ...overrides,
 });
 
@@ -62,6 +63,7 @@ describe("webhook", () => {
       expect(payload.price_paid).toBeNull();
       expect(payload.currency).toBe("GBP");
       expect(payload.payment_id).toBeNull();
+      expect(payload.ticket_url).toBe("https://localhost/t/test-token-42");
       expect(payload.tickets).toHaveLength(1);
       expect(payload.tickets[0]!.event_name).toBe("Test Event");
       expect(payload.tickets[0]!.event_slug).toBe("test-event");
@@ -95,11 +97,11 @@ describe("webhook", () => {
       const entries: RegistrationEntry[] = [
         {
           event: makeEvent({ id: 1, name: "Event A", slug: "event-a", unit_price: 300 }),
-          attendee: makeAttendee({ price_paid: "300", payment_id: "pi_multi" }),
+          attendee: makeAttendee({ ticket_token: "tok-a", price_paid: "300", payment_id: "pi_multi" }),
         },
         {
           event: makeEvent({ id: 2, name: "Event B", slug: "event-b", unit_price: 700 }),
-          attendee: makeAttendee({ quantity: 2, price_paid: "1400", payment_id: "pi_multi" }),
+          attendee: makeAttendee({ ticket_token: "tok-b", quantity: 2, price_paid: "1400", payment_id: "pi_multi" }),
         },
       ];
 
@@ -108,6 +110,7 @@ describe("webhook", () => {
       expect(payload.name).toBe("Jane Doe");
       expect(payload.price_paid).toBe(1700);
       expect(payload.payment_id).toBe("pi_multi");
+      expect(payload.ticket_url).toBe("https://localhost/t/tok-a+tok-b");
       expect(payload.tickets).toHaveLength(2);
       expect(payload.tickets[0]!.event_name).toBe("Event A");
       expect(payload.tickets[0]!.unit_price).toBe(300);


### PR DESCRIPTION
## Summary
This PR adds a public ticket viewing feature that allows attendees to view their tickets using unique, shareable ticket tokens. Each attendee receives an 8-byte base64url token upon registration that can be used to access their ticket information via a public URL.

## Key Changes

- **Ticket Token Generation**: Added `generateTicketToken()` function that creates 8-byte base64url tokens (11 characters) for each attendee
- **Database Schema**: Added `ticket_token` column to attendees table with a unique index for fast lookups and backfill migration for existing attendees
- **Ticket Lookup**: Implemented `getAttendeesByTokens()` to retrieve attendees by their tokens while preserving order
- **Public Ticket Routes**: Created `/t/:tokens` endpoint that displays ticket information for one or more attendees (tokens separated by `+`)
- **Ticket View Template**: Added `ticketViewPage` template showing event names and quantities for each ticket
- **Webhook Integration**: Updated webhook payloads to include `ticket_token` field and `ticket_url` (e.g., `https://domain/t/token1+token2`)
- **Utility Functions**: Added `inPlaceholders()` helper for building SQL IN clauses, used in multiple queries

## Implementation Details

- Tokens are generated at attendee creation time and stored encrypted in the database
- The `/t/:tokens` route accepts multiple tokens separated by `+` for viewing multiple tickets in one request
- Invalid/missing tokens are silently skipped, showing only valid tickets
- Database migration automatically backfills existing attendees with random tokens
- Unique index on `ticket_token` ensures fast lookups and prevents duplicates
- Webhook payloads now include ticket URLs for easy sharing with attendees

https://claude.ai/code/session_01Xph1q8utrW3we2s5msrndo