### PR TITLE
Fix flaky formatCountdown test by mocking Date.now()

### DIFF
--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1889,8 +1889,15 @@ describe("server (admin events)", () => {
     });
 
     test("formatCountdown singular forms", () => {
-      const future = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000 + 1 * 60 * 60 * 1000).toISOString();
-      expect(formatCountdown(future)).toBe("1 day and 1 hour from now");
+      const now = Date.now();
+      const spy = spyOn(Date, "now");
+      spy.mockReturnValue(now);
+      try {
+        const future = new Date(now + 1 * 24 * 60 * 60 * 1000 + 1 * 60 * 60 * 1000).toISOString();
+        expect(formatCountdown(future)).toBe("1 day and 1 hour from now");
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     test("rejects invalid closes_at format", async () => {


### PR DESCRIPTION
## Summary
Fixed a flaky test in the `formatCountdown` test suite by mocking `Date.now()` to ensure consistent and predictable test results.

## Key Changes
- Added `spyOn(Date, "now")` to mock the current time during the test
- Captured the current time before mocking to ensure the future date calculation is relative to a fixed point in time
- Wrapped the test logic in a try/finally block to guarantee the mock is restored after the test completes
- This prevents test failures caused by time-dependent assertions when the test runs across second/minute boundaries

## Implementation Details
The test was previously vulnerable to race conditions where the time between calculating the `future` date and executing the assertion could cause the countdown to be off by a time unit. By mocking `Date.now()`, we ensure that both the future date calculation and the assertion use the exact same reference time, making the test deterministic and reliable.

https://claude.ai/code/session_016GEgXNXPXgYrc37q6jKX7E