### PR TITLE
Add ticket SVG QR codes and check-in routes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -38,6 +38,7 @@
     "square": "npm:square@^43.0.0",
     "esbuild": "npm:esbuild@^0.20.0",
     "@bunny.net/edgescript-sdk": "npm:@bunny.net/edgescript-sdk@^0.12.0",
+    "qrcode": "npm:qrcode@^1.5.0",
     "@std/assert": "jsr:@std/assert@1",
     "@std/path": "jsr:@std/path@1"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "npm:@libsql/client@0.17": "0.17.0",
     "npm:esbuild@0.20": "0.20.2",
     "npm:jscpd@^4.0.5": "4.0.7",
+    "npm:qrcode@^1.5.0": "1.5.4",
     "npm:square@43": "43.2.1",
     "npm:stripe@17": "17.7.0",
     "npm:typescript@^5.8.0": "5.9.3"
@@ -448,6 +449,12 @@
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
+    "ansi-styles@4.3.0": {
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": [
+        "color-convert"
+      ]
+    },
     "asap@2.0.6": {
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
@@ -514,6 +521,9 @@
         "get-intrinsic"
       ]
     },
+    "camelcase@5.3.1": {
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
     "character-parser@2.2.0": {
       "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
       "dependencies": [
@@ -528,6 +538,23 @@
       "optionalDependencies": [
         "@colors/colors"
       ]
+    },
+    "cliui@6.0.0": {
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": [
+        "string-width",
+        "strip-ansi",
+        "wrap-ansi"
+      ]
+    },
+    "color-convert@2.0.1": {
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": [
+        "color-name"
+      ]
+    },
+    "color-name@1.1.4": {
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors@1.4.0": {
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
@@ -571,6 +598,9 @@
         "ms"
       ]
     },
+    "decamelize@1.2.0": {
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
@@ -582,6 +612,9 @@
     },
     "detect-node@2.1.0": {
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "dijkstrajs@1.0.3": {
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "doctypes@1.1.0": {
       "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="
@@ -706,6 +739,13 @@
         "to-regex-range"
       ]
     },
+    "find-up@4.1.0": {
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": [
+        "locate-path",
+        "path-exists"
+      ]
+    },
     "follow-redirects@1.15.11": {
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
     },
@@ -741,6 +781,9 @@
     },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-caller-file@2.0.5": {
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic@1.3.0": {
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
@@ -935,6 +978,12 @@
       "os": ["darwin", "linux", "win32"],
       "cpu": ["x64", "arm64", "wasm32", "arm"]
     },
+    "locate-path@5.0.0": {
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": [
+        "p-locate"
+      ]
+    },
     "lodash.defaultsdeep@4.6.1": {
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
     },
@@ -1027,6 +1076,24 @@
         "mimic-fn"
       ]
     },
+    "p-limit@2.3.0": {
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": [
+        "p-try"
+      ]
+    },
+    "p-locate@4.1.0": {
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": [
+        "p-limit"
+      ]
+    },
+    "p-try@2.2.0": {
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "path-exists@4.0.0": {
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
@@ -1035,6 +1102,9 @@
     },
     "picomatch@2.3.1": {
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "pngjs@5.0.0": {
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
     "process@0.11.10": {
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
@@ -1146,6 +1216,15 @@
         "once"
       ]
     },
+    "qrcode@1.5.4": {
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dependencies": [
+        "dijkstrajs",
+        "pngjs",
+        "yargs"
+      ],
+      "bin": true
+    },
     "qs@6.14.1": {
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dependencies": [
@@ -1171,6 +1250,12 @@
     "reprism@0.0.11": {
       "integrity": "sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA=="
     },
+    "require-directory@2.1.1": {
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "require-main-filename@2.0.0": {
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
     "resolve@1.22.11": {
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dependencies": [
@@ -1191,6 +1276,9 @@
     },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "set-blocking@2.0.0": {
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "shebang-command@2.0.0": {
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
@@ -1339,6 +1427,9 @@
         "webidl-conversions"
       ]
     },
+    "which-module@2.0.1": {
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "which@2.0.2": {
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
@@ -1355,11 +1446,45 @@
         "babel-walk"
       ]
     },
+    "wrap-ansi@6.2.0": {
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": [
+        "ansi-styles",
+        "string-width",
+        "strip-ansi"
+      ]
+    },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws@8.19.0": {
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
+    },
+    "y18n@4.0.3": {
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "yargs-parser@18.1.3": {
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": [
+        "camelcase",
+        "decamelize"
+      ]
+    },
+    "yargs@15.4.1": {
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": [
+        "cliui",
+        "decamelize",
+        "find-up",
+        "get-caller-file",
+        "require-directory",
+        "require-main-filename",
+        "set-blocking",
+        "string-width",
+        "which-module",
+        "y18n",
+        "yargs-parser"
+      ]
     }
   },
   "workspace": {
@@ -1369,6 +1494,7 @@
       "npm:@bunny.net/edgescript-sdk@0.12",
       "npm:@libsql/client@0.17",
       "npm:esbuild@0.20",
+      "npm:qrcode@^1.5.0",
       "npm:square@43",
       "npm:stripe@17"
     ],

--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -1,0 +1,14 @@
+/**
+ * QR code SVG generation utility
+ * Wraps the qrcode npm package to produce inline SVG strings
+ */
+
+// deno-lint-ignore no-explicit-any
+const QRCode: { toString(text: string, opts: { type: string; margin?: number }): Promise<string> } = (await import("qrcode" as string)).default as any;
+
+/**
+ * Generate an SVG string for a QR code encoding the given text.
+ * Returns a complete <svg> element suitable for inline embedding.
+ */
+export const generateQrSvg = (text: string): Promise<string> =>
+  QRCode.toString(text, { type: "svg", margin: 1 });

--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -1,0 +1,73 @@
+/**
+ * Check-in routes - /checkin/:tokens
+ * GET: Admin auto-checks-in attendees and shows details; non-admin sees message
+ * POST: Admin checks-out attendees and redirects back
+ */
+
+import { map } from "#fp";
+import { updateCheckedIn } from "#lib/db/attendees.ts";
+import type { Attendee } from "#lib/types.ts";
+import { checkinAdminPage, checkinPublicPage } from "#templates/checkin.tsx";
+import {
+  getAuthenticatedSession,
+  htmlResponse,
+  withAuthForm,
+} from "#routes/utils.ts";
+import { createTokenRoute, lookupAttendees, resolveEntries } from "#routes/token-utils.ts";
+
+/** Update one attendee's check-in status and return updated copy */
+const updateAndCopy = async (
+  attendee: Attendee,
+  checkedIn: boolean,
+): Promise<Attendee> => {
+  await updateCheckedIn(attendee.id, checkedIn);
+  return { ...attendee, checked_in: checkedIn ? "true" : "false" };
+};
+
+/** Set checked_in for all attendees and return updated copies */
+const setCheckedInAll = (
+  attendees: Attendee[],
+  checkedIn: boolean,
+): Promise<Attendee[]> =>
+  Promise.all(map((a: Attendee) => updateAndCopy(a, checkedIn))(attendees));
+
+/** Render admin view after check-in/check-out */
+const renderAdminView = async (
+  attendees: Attendee[],
+  csrfToken: string,
+  tokens: string[],
+): Promise<Response> => {
+  const entries = await resolveEntries(attendees);
+  return htmlResponse(checkinAdminPage(entries, csrfToken, `/checkin/${tokens.join("+")}`));
+};
+
+/** Handle GET /checkin/:tokens */
+const handleCheckinGet = async (
+  request: Request,
+  tokens: string[],
+): Promise<Response> => {
+  const lookup = await lookupAttendees(tokens);
+  if (!lookup.ok) return lookup.response;
+
+  const session = await getAuthenticatedSession(request);
+  if (!session) return htmlResponse(checkinPublicPage());
+
+  const updated = await setCheckedInAll(lookup.attendees, true);
+  return renderAdminView(updated, session.csrfToken, tokens);
+};
+
+/** Handle POST /checkin/:tokens (check-out) */
+const handleCheckinPost = (request: Request, tokens: string[]): Promise<Response> =>
+  withAuthForm(request, async (session) => {
+    const lookup = await lookupAttendees(tokens);
+    if (!lookup.ok) return lookup.response;
+
+    const updated = await setCheckedInAll(lookup.attendees, false);
+    return renderAdminView(updated, session.csrfToken, tokens);
+  });
+
+/** Route check-in requests */
+export const routeCheckin = createTokenRoute("checkin", {
+  GET: handleCheckinGet,
+  POST: handleCheckinPost,
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -58,6 +58,12 @@ const loadTicketViewRoutes = once(async () => {
   return routeTicketView;
 });
 
+/** Lazy-load check-in routes */
+const loadCheckinRoutes = once(async () => {
+  const { routeCheckin } = await import("#routes/checkin.ts");
+  return routeCheckin;
+});
+
 // Re-export middleware functions for testing
 export {
   getSecurityHeaders,
@@ -98,6 +104,7 @@ const routeTicketPath = createLazyRoute(
 const routePaymentPath = createLazyRoute("/payment", loadPaymentRoutes);
 const routeJoinPath = createLazyRoute("/join", loadJoinRoutes);
 const routeTicketViewPath = createLazyRoute("/t", loadTicketViewRoutes);
+const routeCheckinPath = createLazyRoute("/checkin", loadCheckinRoutes);
 
 /**
  * Route main application requests (after setup is complete)
@@ -108,6 +115,7 @@ const routeMainApp: RouterFn = async (request, path, method, server) =>
   (await routeAdminPath(request, path, method, server)) ??
   (await routeTicketPath(request, path, method, server)) ??
   (await routeTicketViewPath(request, path, method, server)) ??
+  (await routeCheckinPath(request, path, method, server)) ??
   (await routePaymentPath(request, path, method, server)) ??
   (await routeJoinPath(request, path, method, server)) ??
   notFoundResponse();

--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -1,63 +1,28 @@
 /**
  * Public ticket view routes - /t/:tokens
  * Displays ticket information for attendees using their ticket tokens
+ * Includes an inline SVG QR code encoding the /checkin/:tokens URL
  */
 
-import { compact, map } from "#fp";
-import { getAttendeesByTokens } from "#lib/db/attendees.ts";
-import { getEventWithCount } from "#lib/db/events.ts";
-import type { Attendee } from "#lib/types.ts";
-import type { TicketEntry } from "#templates/tickets.tsx";
+import { getAllowedDomain } from "#lib/config.ts";
+import { generateQrSvg } from "#lib/qr.ts";
 import { ticketViewPage } from "#templates/tickets.tsx";
-import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
+import { htmlResponse } from "#routes/utils.ts";
+import { createTokenRoute, lookupAttendees, resolveEntries } from "#routes/token-utils.ts";
 
-/** Pattern to extract tokens from /t/... path */
-const TOKENS_PATTERN = /^\/t\/(.+)$/;
-
-/** Extract tokens string from path */
-const extractTokensFromPath = (path: string): string | null => {
-  const match = path.match(TOKENS_PATTERN);
-  return match?.[1] ?? null;
-};
-
-/** Parse +-separated tokens from a combined string */
-const parseTokens = (tokensStr: string): string[] =>
-  tokensStr.split("+").filter((s) => s.length > 0);
-
-/** Look up the event for an attendee and pair them */
-const resolveEntry = async (attendee: Attendee): Promise<TicketEntry> => {
-  const event = (await getEventWithCount(attendee.event_id))!;
-  return { attendee, event };
-};
-
-/** Resolve all attendees to ticket entries */
-const resolveEntries = (attendees: Attendee[]): Promise<TicketEntry[]> =>
-  Promise.all(map(resolveEntry)(attendees));
+/** Build the check-in URL for QR code */
+const buildCheckinUrl = (tokens: string[]): string =>
+  `https://${getAllowedDomain()}/checkin/${tokens.join("+")}`;
 
 /** Handle GET /t/:tokens */
-const handleTicketView = async (tokens: string[]): Promise<Response> => {
-  const attendees = await getAttendeesByTokens(tokens);
-  const validAttendees = compact(attendees);
+const handleTicketView = async (_request: Request, tokens: string[]): Promise<Response> => {
+  const result = await lookupAttendees(tokens);
+  if (!result.ok) return result.response;
 
-  if (validAttendees.length === 0) {
-    return notFoundResponse();
-  }
-
-  const entries = await resolveEntries(validAttendees);
-  return htmlResponse(ticketViewPage(entries));
+  const entries = await resolveEntries(result.attendees);
+  const qrSvg = await generateQrSvg(buildCheckinUrl(tokens));
+  return htmlResponse(ticketViewPage(entries, qrSvg));
 };
 
 /** Route ticket view requests */
-export const routeTicketView = (
-  _request: Request,
-  path: string,
-  method: string,
-): Promise<Response | null> => {
-  const tokensStr = extractTokensFromPath(path);
-  if (!tokensStr) return Promise.resolve(null);
-
-  if (method !== "GET") return Promise.resolve(null);
-
-  const tokens = parseTokens(tokensStr);
-  return handleTicketView(tokens);
-};
+export const routeTicketView = createTokenRoute("t", { GET: handleTicketView });

--- a/src/routes/token-utils.ts
+++ b/src/routes/token-utils.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared utilities for token-based routes (/t/:tokens and /checkin/:tokens)
+ */
+
+import { compact, map } from "#fp";
+import { getAttendeesByTokens } from "#lib/db/attendees.ts";
+import { getEventWithCount } from "#lib/db/events.ts";
+import type { Attendee, EventWithCount } from "#lib/types.ts";
+import { notFoundResponse } from "#routes/utils.ts";
+
+/** Attendee paired with its event */
+export type TokenEntry = {
+  attendee: Attendee;
+  event: EventWithCount;
+};
+
+/** Handler type for token-based route methods */
+type TokenMethodHandler = (request: Request, tokens: string[]) => Promise<Response>;
+
+/** Map of HTTP method to handler */
+type TokenMethodMap = Record<string, TokenMethodHandler>;
+
+/** Extract the token segment from a path like /prefix/tokens */
+export const extractTokenSegment = (prefix: string, path: string): string | null => {
+  const pattern = new RegExp(`^/${prefix}/(.+)$`);
+  const match = path.match(pattern);
+  return match?.[1] ?? null;
+};
+
+/** Parse +-separated tokens from a combined string */
+export const parseTokens = (tokensStr: string): string[] =>
+  tokensStr.split("+").filter((s) => s.length > 0);
+
+/** Look up the event for an attendee and pair them */
+const resolveEntry = async (attendee: Attendee): Promise<TokenEntry> => {
+  const event = (await getEventWithCount(attendee.event_id))!;
+  return { attendee, event };
+};
+
+/** Resolve all attendees to entries with their events */
+export const resolveEntries = (attendees: Attendee[]): Promise<TokenEntry[]> =>
+  Promise.all(map(resolveEntry)(attendees));
+
+/** Result of looking up attendees by tokens - either valid attendees or a 404 response */
+export type TokenLookupResult =
+  | { ok: true; attendees: Attendee[] }
+  | { ok: false; response: Response };
+
+/** Look up attendees by tokens, returning 404 if none found */
+export const lookupAttendees = async (tokens: string[]): Promise<TokenLookupResult> => {
+  const attendees = await getAttendeesByTokens(tokens);
+  const valid = compact(attendees);
+  return valid.length === 0
+    ? { ok: false, response: notFoundResponse() }
+    : { ok: true, attendees: valid };
+};
+
+/**
+ * Create a token-based route handler for a given URL prefix.
+ * Extracts tokens from the path, dispatches to method handlers.
+ */
+export const createTokenRoute = (
+  prefix: string,
+  methods: TokenMethodMap,
+) => (
+  request: Request,
+  path: string,
+  method: string,
+): Promise<Response | null> => {
+  const tokensStr = extractTokenSegment(prefix, path);
+  if (!tokensStr) return Promise.resolve(null);
+
+  const handler = methods[method];
+  if (!handler) return Promise.resolve(null);
+
+  return handler(request, parseTokens(tokensStr));
+};

--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -1,0 +1,64 @@
+/**
+ * Check-in page templates
+ * Admin view: attendee details with checked-in status and check-out button
+ * Non-admin view: simple confirmation message
+ */
+
+import { map, pipe } from "#fp";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import type { TokenEntry } from "#routes/token-utils.ts";
+import { Layout } from "#templates/layout.tsx";
+
+/** Re-export for backwards compatibility */
+export type { TokenEntry as CheckinEntry };
+
+/** Render a single attendee detail row (admin view) */
+const renderCheckinRow = ({ event, attendee }: TokenEntry): string =>
+  `<tr><td>${event.name}</td><td>${attendee.quantity}</td><td>${attendee.checked_in === "true" ? "Yes" : "No"}</td></tr>`;
+
+/**
+ * Admin check-in page - shows attendee details with check-out option
+ */
+export const checkinAdminPage = (
+  entries: TokenEntry[],
+  csrfToken: string,
+  checkinPath: string,
+): string => {
+  const rows = pipe(
+    map(renderCheckinRow),
+    (r: string[]) => r.join(""),
+  )(entries);
+
+  return String(
+    <Layout title="Check-in">
+      <h1>Check-in Complete</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Quantity</th>
+            <th>Checked In</th>
+          </tr>
+        </thead>
+        <tbody>
+          <Raw html={rows} />
+        </tbody>
+      </table>
+      <form method="POST" action={checkinPath}>
+        <input type="hidden" name="csrf_token" value={csrfToken} />
+        <button type="submit">Check Out</button>
+      </form>
+    </Layout>
+  );
+};
+
+/**
+ * Non-admin check-in page - simple message telling the user to show this to an admin
+ */
+export const checkinPublicPage = (): string =>
+  String(
+    <Layout title="Check-in">
+      <h1>Check-in</h1>
+      <p>Please show this QR code to an event administrator to check in.</p>
+    </Layout>
+  );

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -1,26 +1,24 @@
 /**
- * Ticket view page template - displays attendee ticket information
+ * Ticket view page template - displays attendee ticket information with QR code
  */
 
 import { map, pipe } from "#fp";
-import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import type { TokenEntry } from "#routes/token-utils.ts";
 import { Layout } from "#templates/layout.tsx";
 
-/** Ticket entry: attendee paired with their event */
-export type TicketEntry = {
-  attendee: Attendee;
-  event: EventWithCount;
-};
+/** Re-export for backwards compatibility */
+export type { TokenEntry as TicketEntry };
 
 /** Render a single ticket row */
-const renderTicketRow = ({ event, attendee }: TicketEntry): string =>
+const renderTicketRow = ({ event, attendee }: TokenEntry): string =>
   `<tr><td>${event.name}</td><td>${attendee.quantity}</td></tr>`;
 
 /**
- * Ticket view page - shows event name and quantity per ticket
+ * Ticket view page - shows event name + quantity per ticket, with inline QR code
+ * The QR code encodes the /checkin/... URL for admin scanning
  */
-export const ticketViewPage = (entries: TicketEntry[]): string => {
+export const ticketViewPage = (entries: TokenEntry[], qrSvg: string): string => {
   const rows = pipe(
     map(renderTicketRow),
     (r: string[]) => r.join(""),
@@ -29,6 +27,9 @@ export const ticketViewPage = (entries: TicketEntry[]): string => {
   return String(
     <Layout title="Your Tickets">
       <h1>Your Tickets</h1>
+      <div style="text-align:center;margin:1em 0">
+        <Raw html={qrSvg} />
+      </div>
       <table>
         <thead>
           <tr>

--- a/test/lib/qr.test.ts
+++ b/test/lib/qr.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "#test-compat";
+import { generateQrSvg } from "#lib/qr.ts";
+
+describe("generateQrSvg", () => {
+  test("returns an SVG string for a URL", async () => {
+    const svg = await generateQrSvg("https://example.com/checkin/test-token");
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+  });
+
+  test("returns different SVGs for different inputs", async () => {
+    const svg1 = await generateQrSvg("https://example.com/a");
+    const svg2 = await generateQrSvg("https://example.com/b");
+    expect(svg1).not.toBe(svg2);
+  });
+});

--- a/test/lib/server-checkin.test.ts
+++ b/test/lib/server-checkin.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import {
+  awaitTestRequest,
+  createTestAttendee,
+  createTestDbWithSetup,
+  createTestEvent,
+  getAttendeesRaw,
+  loginAsAdmin,
+  mockFormRequest,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+describe("check-in (/checkin/:tokens)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("GET /checkin/:tokens (unauthenticated)", () => {
+    test("shows public check-in message for unauthenticated users", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await createTestAttendee(event.id, event.slug, "Alice", "alice@test.com");
+      const attendees = await getAttendeesRaw(event.id);
+      const token = attendees[0]!.ticket_token;
+
+      const response = await awaitTestRequest(`/checkin/${token}`);
+      expect(response.status).toBe(200);
+
+      const body = await response.text();
+      expect(body).toContain("Check-in");
+      expect(body).toContain("show this QR code");
+    });
+
+    test("returns 404 for invalid token", async () => {
+      const response = await awaitTestRequest("/checkin/bad-token");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /checkin/:tokens (authenticated admin)", () => {
+    test("auto-checks-in attendee and shows admin view", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await createTestAttendee(event.id, event.slug, "Bob", "bob@test.com");
+      const attendees = await getAttendeesRaw(event.id);
+      const token = attendees[0]!.ticket_token;
+
+      const session = await loginAsAdmin();
+      const response = await awaitTestRequest(`/checkin/${token}`, {
+        cookie: session.cookie,
+      });
+      expect(response.status).toBe(200);
+
+      const body = await response.text();
+      expect(body).toContain("Check-in Complete");
+      expect(body).toContain("Yes");
+      expect(body).toContain("Check Out");
+    });
+
+    test("auto-checks-in multiple attendees", async () => {
+      const eventA = await createTestEvent({ maxAttendees: 10 });
+      const eventB = await createTestEvent({ maxAttendees: 10 });
+      await createTestAttendee(eventA.id, eventA.slug, "Carol", "carol@test.com");
+      await createTestAttendee(eventB.id, eventB.slug, "Carol", "carol@test.com");
+      const attendeesA = await getAttendeesRaw(eventA.id);
+      const attendeesB = await getAttendeesRaw(eventB.id);
+      const tokenA = attendeesA[0]!.ticket_token;
+      const tokenB = attendeesB[0]!.ticket_token;
+
+      const session = await loginAsAdmin();
+      const response = await awaitTestRequest(`/checkin/${tokenA}+${tokenB}`, {
+        cookie: session.cookie,
+      });
+      expect(response.status).toBe(200);
+
+      const body = await response.text();
+      expect(body).toContain(eventA.name);
+      expect(body).toContain(eventB.name);
+    });
+
+    test("returns 404 for invalid tokens when authenticated", async () => {
+      const session = await loginAsAdmin();
+      const response = await awaitTestRequest("/checkin/bad-token", {
+        cookie: session.cookie,
+      });
+      expect(response.status).toBe(404);
+    });
+
+    test("shows event name and quantity in admin view", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, maxQuantity: 5 });
+      await createTestAttendee(event.id, event.slug, "Dave", "dave@test.com", 3);
+      const attendees = await getAttendeesRaw(event.id);
+      const token = attendees[0]!.ticket_token;
+
+      const session = await loginAsAdmin();
+      const response = await awaitTestRequest(`/checkin/${token}`, {
+        cookie: session.cookie,
+      });
+      const body = await response.text();
+      expect(body).toContain(event.name);
+      expect(body).toContain("3");
+    });
+  });
+
+  describe("POST /checkin/:tokens (check-out)", () => {
+    test("checks out attendees when admin posts with valid CSRF", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await createTestAttendee(event.id, event.slug, "Eve", "eve@test.com");
+      const attendees = await getAttendeesRaw(event.id);
+      const token = attendees[0]!.ticket_token;
+
+      const session = await loginAsAdmin();
+
+      // First check in
+      await awaitTestRequest(`/checkin/${token}`, {
+        cookie: session.cookie,
+      });
+
+      // Then check out via POST
+      const { handleRequest } = await import("#routes");
+      const response = await handleRequest(
+        mockFormRequest(
+          `/checkin/${token}`,
+          { csrf_token: session.csrfToken },
+          session.cookie,
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.text();
+      expect(body).toContain("No");
+    });
+
+    test("redirects to admin for unauthenticated POST", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await createTestAttendee(event.id, event.slug, "Frank", "frank@test.com");
+      const attendees = await getAttendeesRaw(event.id);
+      const token = attendees[0]!.ticket_token;
+
+      const { handleRequest } = await import("#routes");
+      const response = await handleRequest(
+        mockFormRequest(`/checkin/${token}`, { csrf_token: "fake" }),
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toBe("/admin");
+    });
+
+    test("returns 403 for invalid CSRF token", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await createTestAttendee(event.id, event.slug, "Grace", "grace@test.com");
+      const attendees = await getAttendeesRaw(event.id);
+      const token = attendees[0]!.ticket_token;
+
+      const session = await loginAsAdmin();
+      const { handleRequest } = await import("#routes");
+      const response = await handleRequest(
+        mockFormRequest(
+          `/checkin/${token}`,
+          { csrf_token: "wrong-token" },
+          session.cookie,
+        ),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    test("returns 404 for invalid tokens on POST", async () => {
+      const session = await loginAsAdmin();
+      const { handleRequest } = await import("#routes");
+      const response = await handleRequest(
+        mockFormRequest(
+          "/checkin/bad-token",
+          { csrf_token: session.csrfToken },
+          session.cookie,
+        ),
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("route matching", () => {
+    test("returns null for non-matching paths", async () => {
+      const { routeCheckin } = await import("#routes/checkin.ts");
+      const request = new Request("http://localhost/other");
+      const result = await routeCheckin(request, "/other", "GET");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for unsupported methods", async () => {
+      const { routeCheckin } = await import("#routes/checkin.ts");
+      const request = new Request("http://localhost/checkin/tok", { method: "PUT" });
+      const result = await routeCheckin(request, "/checkin/tok", "PUT");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -102,4 +102,16 @@ describe("ticket view (/t/:tokens)", () => {
     expect(attendees[1]!.ticket_token).not.toBe("");
     expect(attendees[0]!.ticket_token).not.toBe(attendees[1]!.ticket_token);
   });
+
+  test("includes inline SVG QR code in ticket view", async () => {
+    const event = await createTestEvent({ maxAttendees: 10 });
+    await createTestAttendee(event.id, event.slug, "Eve", "eve@test.com");
+    const attendees = await getAttendeesRaw(event.id);
+    const token = attendees[0]!.ticket_token;
+
+    const response = await awaitTestRequest(`/t/${token}`);
+    const body = await response.text();
+    expect(body).toContain("<svg");
+    expect(body).toContain("</svg>");
+  });
 });


### PR DESCRIPTION
- Add qrcode npm dependency for SVG QR code generation
- Create src/lib/qr.ts wrapper for QR code SVG generation
- Update ticket view template to display inline SVG QR code
- Create /checkin/:tokens routes (GET auto-checks-in for admins, POST checks out)
- Extract shared token route utilities into src/routes/token-utils.ts
- Add check-in template with admin/public views
- Add comprehensive tests for QR generation, ticket view, and check-in routes

https://claude.ai/code/session_017K7bjChxsVTcPHRZkN22qZ