### PR TITLE
Add ticket column to admin attendees table and CSV export

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -53,13 +53,14 @@ const CheckinButton = ({ a, eventId, csrfToken, activeFilter }: { a: Attendee; e
   );
 };
 
-const AttendeeRow = ({ a, eventId, csrfToken, activeFilter }: { a: Attendee; eventId: number; csrfToken: string; activeFilter: AttendeeFilter }): string =>
+const AttendeeRow = ({ a, eventId, csrfToken, activeFilter, allowedDomain }: { a: Attendee; eventId: number; csrfToken: string; activeFilter: AttendeeFilter; allowedDomain: string }): string =>
   String(
     <tr>
       <td>{a.name}</td>
       <td>{a.email || ""}</td>
       <td>{a.phone || ""}</td>
       <td>{a.quantity}</td>
+      <td><a href={`https://${allowedDomain}/t/${a.ticket_token}`}>{a.ticket_token}</a></td>
       <td>{new Date(a.created).toLocaleString()}</td>
       <td>
         <Raw html={CheckinButton({ a, eventId, csrfToken, activeFilter })} />
@@ -103,10 +104,10 @@ export const adminEventPage = (
   const attendeeRows =
     filteredAttendees.length > 0
       ? pipe(
-          map((a: Attendee) => AttendeeRow({ a, eventId: event.id, csrfToken: session.csrfToken, activeFilter })),
+          map((a: Attendee) => AttendeeRow({ a, eventId: event.id, csrfToken: session.csrfToken, activeFilter, allowedDomain })),
           joinStrings,
         )(filteredAttendees)
-      : '<tr><td colspan="7">No attendees yet</td></tr>';
+      : '<tr><td colspan="8">No attendees yet</td></tr>';
 
   const checkedInLabel = checkinMessage?.status === "in" ? "in" : "out";
   const checkedInClass = checkinMessage?.status === "in" ? "checkin-message-in" : "checkin-message-out";
@@ -238,6 +239,7 @@ export const adminEventPage = (
                 <th>Email</th>
                 <th>Phone</th>
                 <th>Qty</th>
+                <th>Ticket</th>
                 <th>Registered</th>
                 <th></th>
                 <th></th>

--- a/src/templates/csv.ts
+++ b/src/templates/csv.ts
@@ -3,6 +3,7 @@
  */
 
 import { map, pipe, reduce } from "#fp";
+import { getAllowedDomain } from "#lib/config.ts";
 import type { Attendee } from "#lib/types.ts";
 
 /**
@@ -30,7 +31,8 @@ const formatCheckedIn = (checkedIn: string): string =>
  * Always includes both Email and Phone columns regardless of event settings.
  */
 export const generateAttendeesCsv = (attendees: Attendee[]): string => {
-  const header = "Name,Email,Phone,Quantity,Registered,Price Paid,Transaction ID,Checked In";
+  const domain = getAllowedDomain();
+  const header = "Name,Email,Phone,Quantity,Registered,Price Paid,Transaction ID,Checked In,Ticket Token,Ticket URL";
   const rows = pipe(
     map((a: Attendee) =>
       [
@@ -42,6 +44,8 @@ export const generateAttendeesCsv = (attendees: Attendee[]): string => {
         formatPrice(a.price_paid),
         escapeCsvValue(a.payment_id ?? ""),
         formatCheckedIn(a.checked_in),
+        escapeCsvValue(a.ticket_token),
+        escapeCsvValue(`https://${domain}/t/${a.ticket_token}`),
       ].join(","),
     ),
     reduce((acc: string, row: string) => `${acc}\n${row}`, header),


### PR DESCRIPTION
The attendees table on /admin/event/:id/ now includes a Ticket column
showing each attendee's token as a link to their public ticket page
at /t/:token. The CSV export also includes Ticket Token and Ticket URL
columns.

https://claude.ai/code/session_01Y1J9AEKxfwxN168i8AJ3pK