### PR TITLE
Change CI trigger from pull_request to push on branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 name: Test
 
 on:
-  pull_request:
+  push:
+    branches-ignore: [main]
   merge_group:
 
 env:


### PR DESCRIPTION
Replace pull_request trigger with push (branches-ignore: main) so tests
run on every push to any branch, giving early feedback before a PR is
opened. The merge_group trigger remains to test the final merge commit.

https://claude.ai/code/session_01XaKhpHMbuWLRB38UFcgdfE