### PR TITLE
Speed up test suite by skipping production security delays in tests

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -620,7 +620,7 @@ export const generateKeyPair = async (): Promise<{
   const keyPair = await crypto.subtle.generateKey(
     {
       name: "RSA-OAEP",
-      modulusLength: 2048,
+      modulusLength: getEnv("TEST_RSA_KEY_SIZE") ? Number(getEnv("TEST_RSA_KEY_SIZE")) : 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },

--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -23,10 +23,13 @@ import {
   withSession,
 } from "#routes/utils.ts";
 import { loginFields } from "#templates/fields.ts";
+import { getEnv } from "#lib/env.ts";
 
 /** Random delay between 100-200ms to prevent timing attacks */
 const randomDelay = (): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, 100 + Math.random() * 100));
+  getEnv("TEST_SKIP_LOGIN_DELAY")
+    ? Promise.resolve()
+    : new Promise((resolve) => setTimeout(resolve, 100 + Math.random() * 100));
 
 /** Create a session with a wrapped DATA_KEY and redirect to /admin */
 const createLoginSession = async (

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -38,6 +38,8 @@ export const TEST_ENCRYPTION_KEY =
 export const setupTestEncryptionKey = (): void => {
   Deno.env.set("DB_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY);
   Deno.env.set("TEST_PBKDF2_ITERATIONS", "1"); // Enable fast password hashing for tests
+  Deno.env.set("TEST_SKIP_LOGIN_DELAY", "1"); // Skip timing-attack delay in tests
+  Deno.env.set("TEST_RSA_KEY_SIZE", "1024"); // Use smaller RSA keys for faster test setup
   clearEncryptionKeyCache();
 };
 
@@ -47,6 +49,8 @@ export const setupTestEncryptionKey = (): void => {
 export const clearTestEncryptionKey = (): void => {
   Deno.env.delete("DB_ENCRYPTION_KEY");
   Deno.env.delete("TEST_PBKDF2_ITERATIONS");
+  Deno.env.delete("TEST_SKIP_LOGIN_DELAY");
+  Deno.env.delete("TEST_RSA_KEY_SIZE");
   clearEncryptionKeyCache();
 };
 

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, jest, test } from "#test-compat";
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { handleRequest } from "#routes";
 import {

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import { afterEach, beforeEach, describe, expect, jest, test } from "#test-compat";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { handleRequest } from "#routes";
 import {
@@ -349,6 +349,20 @@ describe("server (admin auth)", () => {
       );
       // Should fail - KEK can't unwrap corrupted key
       expect(response.status).toBe(401);
+    });
+  });
+
+  describe("login timing delay", () => {
+    test("applies random delay when TEST_SKIP_LOGIN_DELAY is not set", async () => {
+      Deno.env.delete("TEST_SKIP_LOGIN_DELAY");
+      const start = Date.now();
+      const response = await handleRequest(
+        mockFormRequest("/admin/login", { username: "testadmin", password: TEST_ADMIN_PASSWORD }),
+      );
+      const elapsed = Date.now() - start;
+      expectAdminRedirect(response);
+      expect(elapsed).toBeGreaterThanOrEqual(100);
+      Deno.env.set("TEST_SKIP_LOGIN_DELAY", "1");
     });
   });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, spyOn, test } from "#test-compat";
+import { afterEach, beforeEach, describe, expect, jest, spyOn, test } from "#test-compat";
 import type { InStatement } from "@libsql/client";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { getDb } from "#lib/db/client.ts";
@@ -1864,8 +1864,11 @@ describe("server (admin events)", () => {
     });
 
     test("formatCountdown shows days and hours", () => {
-      const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000).toISOString();
-      expect(formatCountdown(future)).toContain("3 days and 5 hours from now");
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+      const future = new Date("2025-01-04T05:00:00Z").toISOString();
+      expect(formatCountdown(future)).toBe("3 days and 5 hours from now");
+      jest.useRealTimers();
     });
 
     test("formatCountdown shows only days when no remaining hours", () => {


### PR DESCRIPTION
- Skip 100-200ms random login delay via TEST_SKIP_LOGIN_DELAY env var
- Use 1024-bit RSA keys in tests instead of 2048-bit via TEST_RSA_KEY_SIZE
- Fix flaky formatCountdown test by using fake timers with fixed time
- Add test to cover production login delay path for 100% coverage

Reduces total test time from ~1m37s to ~1m1s (37% faster).

https://claude.ai/code/session_018F1SnWuBmQB6gfepB1AxDM