### PR TITLE
Show red "Checked out" message and "Check In" button after checkout

### DIFF
--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -36,9 +36,10 @@ const renderAdminView = async (
   attendees: Attendee[],
   csrfToken: string,
   tokens: string[],
+  checkedIn: boolean,
 ): Promise<Response> => {
   const entries = await resolveEntries(attendees);
-  return htmlResponse(checkinAdminPage(entries, csrfToken, `/checkin/${tokens.join("+")}`));
+  return htmlResponse(checkinAdminPage(entries, csrfToken, `/checkin/${tokens.join("+")}`, checkedIn));
 };
 
 /** Handle GET /checkin/:tokens */
@@ -53,7 +54,7 @@ const handleCheckinGet = async (
   if (!session) return htmlResponse(checkinPublicPage());
 
   const updated = await setCheckedInAll(lookup.attendees, true);
-  return renderAdminView(updated, session.csrfToken, tokens);
+  return renderAdminView(updated, session.csrfToken, tokens, true);
 };
 
 /** Handle POST /checkin/:tokens (check-out) */
@@ -63,7 +64,7 @@ const handleCheckinPost = (request: Request, tokens: string[]): Promise<Response
     if (!lookup.ok) return lookup.response;
 
     const updated = await setCheckedInAll(lookup.attendees, false);
-    return renderAdminView(updated, session.csrfToken, tokens);
+    return renderAdminView(updated, session.csrfToken, tokens, false);
   });
 
 /** Route check-in requests */

--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -17,12 +17,13 @@ const renderCheckinRow = ({ event, attendee }: TokenEntry): string =>
   `<tr><td>${event.name}</td><td>${attendee.quantity}</td><td>${attendee.checked_in === "true" ? "Yes" : "No"}</td></tr>`;
 
 /**
- * Admin check-in page - shows attendee details with check-out option
+ * Admin check-in page - shows attendee details with check-in/check-out status
  */
 export const checkinAdminPage = (
   entries: TokenEntry[],
   csrfToken: string,
   checkinPath: string,
+  checkedIn: boolean,
 ): string => {
   const rows = pipe(
     map(renderCheckinRow),
@@ -31,7 +32,9 @@ export const checkinAdminPage = (
 
   return String(
     <Layout title="Check-in">
-      <h1>Check-in Complete</h1>
+      {checkedIn
+        ? <h1>Check-in Complete</h1>
+        : <h1 style="color: red;">Checked out</h1>}
       <table>
         <thead>
           <tr>
@@ -46,7 +49,7 @@ export const checkinAdminPage = (
       </table>
       <form method="POST" action={checkinPath}>
         <input type="hidden" name="csrf_token" value={csrfToken} />
-        <button type="submit">Check Out</button>
+        <button type="submit">{checkedIn ? "Check Out" : "Check In"}</button>
       </form>
     </Layout>
   );

--- a/test/lib/server-checkin.test.ts
+++ b/test/lib/server-checkin.test.ts
@@ -133,6 +133,10 @@ describe("check-in (/checkin/:tokens)", () => {
 
       const body = await response.text();
       expect(body).toContain("No");
+      expect(body).toContain("Checked out");
+      expect(body).toContain("color: red");
+      expect(body).toContain("Check In");
+      expect(body).not.toContain("Check-in Complete");
     });
 
     test("redirects to admin for unauthenticated POST", async () => {


### PR DESCRIPTION
The checkin admin page now reflects the current state: after check-in it
shows "Check-in Complete" with a "Check Out" button, and after checkout it
shows a red "Checked out" heading with a "Check In" button.

https://claude.ai/code/session_01WfsoaCwdPQosmcm8Vmgb7X