### PR TITLE
Redirect GET /admin/login to /admin to avoid 404

### DIFF
--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -131,6 +131,7 @@ const handleAdminLogout = (request: Request): Promise<Response> =>
 
 /** Authentication routes */
 export const authRoutes = defineRoutes({
+  "GET /admin/login": () => redirect("/admin"),
   "POST /admin/login": (request, _, server) =>
     handleAdminLogin(request, server),
   "GET /admin/logout": (request) => handleAdminLogout(request),

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -52,6 +52,13 @@ describe("server (admin auth)", () => {
     });
   });
 
+  describe("GET /admin/login", () => {
+    test("redirects to /admin", async () => {
+      const response = await handleRequest(mockRequest("/admin/login"));
+      expectAdminRedirect(response);
+    });
+  });
+
   describe("POST /admin/login", () => {
     test("validates required password field", async () => {
       const response = await handleRequest(


### PR DESCRIPTION
The login form POSTs to /admin/login, but visiting that URL via GET
(e.g., refreshing after a failed login) returned a 404 since only
the POST route was defined. Now GET /admin/login redirects to /admin
where the login page is served.

https://claude.ai/code/session_01Vmc4ar7VMGcXWVNUcRKRWY