### PR TITLE
HTML-escape event.name and description in template literals

### DIFF
--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -7,14 +7,14 @@
 import { map, pipe } from "#fp";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { TokenEntry } from "#routes/token-utils.ts";
-import { Layout } from "#templates/layout.tsx";
+import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /** Re-export for backwards compatibility */
 export type { TokenEntry as CheckinEntry };
 
 /** Render a single attendee detail row (admin view) */
 const renderCheckinRow = ({ event, attendee }: TokenEntry): string =>
-  `<tr><td>${event.name}</td><td>${attendee.quantity}</td><td>${attendee.checked_in === "true" ? "Yes" : "No"}</td></tr>`;
+  `<tr><td>${escapeHtml(event.name)}</td><td>${attendee.quantity}</td><td>${attendee.checked_in === "true" ? "Yes" : "No"}</td></tr>`;
 
 /**
  * Admin check-in page - shows attendee details with check-in/check-out status

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -8,7 +8,7 @@ import { renderError, renderFields } from "#lib/forms.tsx";
 import type { EventFields, EventWithCount } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { getTicketFields, mergeEventFields } from "#templates/fields.ts";
-import { Layout } from "#templates/layout.tsx";
+import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /** Quantity values parsed from multi-ticket form */
 export type MultiTicketQuantities = Map<number, number>;
@@ -44,7 +44,7 @@ export const ticketPage = (
           <h1>{event.name}</h1>
           {event.description && (
             <div style="font-size: 0.9em; margin: 0.5rem 0 1rem;">
-              <Raw html={event.description} />
+              <Raw html={escapeHtml(event.description)} />
             </div>
           )}
         </>
@@ -110,7 +110,7 @@ export const buildMultiTicketEvent = (
 /** Render description HTML for multi-ticket event row */
 const renderMultiEventDescription = (description: string): string =>
   description
-    ? `<div style="font-size: 0.9em; margin: 0.25rem 0 0.5rem;">${description}</div>`
+    ? `<div style="font-size: 0.9em; margin: 0.25rem 0 0.5rem;">${escapeHtml(description)}</div>`
     : "";
 
 /** Render quantity selector for a single event in multi-ticket form */
@@ -121,7 +121,7 @@ const renderMultiEventRow = (info: MultiTicketEvent): string => {
   if (isClosed) {
     return `
       <div class="multi-ticket-row sold-out">
-        <label>${event.name}</label>
+        <label>${escapeHtml(event.name)}</label>
         <span class="sold-out-label">Registration Closed</span>
       </div>
     `;
@@ -130,7 +130,7 @@ const renderMultiEventRow = (info: MultiTicketEvent): string => {
   if (isSoldOut) {
     return `
       <div class="multi-ticket-row sold-out">
-        <label>${event.name}</label>
+        <label>${escapeHtml(event.name)}</label>
         ${renderMultiEventDescription(event.description)}
         <span class="sold-out-label">Sold Out</span>
       </div>
@@ -143,7 +143,7 @@ const renderMultiEventRow = (info: MultiTicketEvent): string => {
 
   return `
     <div class="multi-ticket-row">
-      <label for="${fieldName}">${event.name}</label>
+      <label for="${fieldName}">${escapeHtml(event.name)}</label>
       ${renderMultiEventDescription(event.description)}
       <select name="${fieldName}" id="${fieldName}">
         ${options}

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -5,14 +5,14 @@
 import { map, pipe } from "#fp";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { TokenEntry } from "#routes/token-utils.ts";
-import { Layout } from "#templates/layout.tsx";
+import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /** Re-export for backwards compatibility */
 export type { TokenEntry as TicketEntry };
 
 /** Render a single ticket row */
 const renderTicketRow = ({ event, attendee }: TokenEntry): string =>
-  `<tr><td>${event.name}</td><td>${attendee.quantity}</td></tr>`;
+  `<tr><td>${escapeHtml(event.name)}</td><td>${attendee.quantity}</td></tr>`;
 
 /**
  * Ticket view page - shows event name + quantity per ticket, with inline QR code

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -137,7 +137,7 @@ describe("server (public routes)", () => {
       );
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("A <b>great</b> event");
+      expect(html).toContain("A &lt;b&gt;great&lt;/b&gt; event");
       expect(html).toContain("font-size: 0.9em");
     });
 
@@ -199,7 +199,7 @@ describe("server (public routes)", () => {
       const html = await response.text();
       expect(html).not.toContain('class="iframe"');
       expect(html).toContain("<h1>");
-      expect(html).toContain("A <b>great</b> event");
+      expect(html).toContain("A &lt;b&gt;great&lt;/b&gt; event");
     });
   });
 


### PR DESCRIPTION
These values were interpolated directly into Raw HTML strings without
escaping, creating stored XSS risk. Apply escapeHtml() to all
event.name and event.description values rendered via template literals
in tickets.tsx, checkin.tsx, and public.tsx.

https://claude.ai/code/session_01KmzPdj4cuaY1h8hiAVWjaT