### PR TITLE
Replace per-attendee check-in buttons with single bulk button

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -706,33 +706,35 @@ fieldset.agreement {
   }
 }
 
-/* Check-in form (inline, unstyled to look like a text link) */
-form.checkin-form {
-  display: inline;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  background: none;
-}
-
-form.checkin-form button {
-  background: none;
+/* Bulk check-in / check-out button */
+button.bulk-checkin,
+button.bulk-checkout {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1.5rem;
+  margin-bottom: 1rem;
   border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
+  border-radius: var(--border-radius);
+  color: #fff;
+  font-size: 1.25rem;
+  font-weight: bold;
   cursor: pointer;
-  text-decoration: underline;
-  box-shadow: none;
-  min-height: 0;
 }
 
-form.checkin-form button.checkin {
-  color: green;
+button.bulk-checkin {
+  background: #22863a;
 }
 
-form.checkin-form button.checkout {
-  color: red;
+button.bulk-checkin:hover {
+  background: #1a6e2e;
+}
+
+button.bulk-checkout {
+  background: #d73a49;
+}
+
+button.bulk-checkout:hover {
+  background: #b52a37;
 }
 
 /* Check-in success/failure messages */

--- a/test/lib/server-checkin.test.ts
+++ b/test/lib/server-checkin.test.ts
@@ -57,7 +57,7 @@ describe("check-in (/checkin/:tokens)", () => {
 
       const body = await response.text();
       expect(body).toContain("No");
-      expect(body).toContain("Check in");
+      expect(body).toContain("Check In All");
       expect(body).not.toContain('class="success"');
     });
 
@@ -121,7 +121,7 @@ describe("check-in (/checkin/:tokens)", () => {
       expect(body).toContain("3");
     });
 
-    test("shows green check-in button when not checked in", async () => {
+    test("shows green bulk check-in button when not checked in", async () => {
       const event = await createTestEvent({ maxAttendees: 10 });
       await createTestAttendee(event.id, event.slug, "Eve", "eve@test.com");
       const attendees = await getAttendeesRaw(event.id);
@@ -132,7 +132,8 @@ describe("check-in (/checkin/:tokens)", () => {
         cookie: session.cookie,
       });
       const body = await response.text();
-      expect(body).toContain('class="checkin"');
+      expect(body).toContain('class="bulk-checkin"');
+      expect(body).toContain("Check In All");
       expect(body).toContain('value="true"');
     });
   });
@@ -159,7 +160,8 @@ describe("check-in (/checkin/:tokens)", () => {
       expect(body).toContain("Yes");
       expect(body).toContain('class="success"');
       expect(body).toContain("Checked in");
-      expect(body).toContain('class="checkout"');
+      expect(body).toContain('class="bulk-checkout"');
+      expect(body).toContain("Check Out All");
       expect(body).toContain('value="false"');
     });
 


### PR DESCRIPTION
Move the check-in/check-out action from individual table rows to a
single prominent button above the table. The button is fully green
("Check In All") when any attendee is not checked in, and fully red
("Check Out All") when all are checked in.

https://claude.ai/code/session_01Nr7817ihVZmtUT22v9TPMv