### PR TITLE
Use inline form style for check-in/check-out buttons in attendees table

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -42,7 +42,7 @@ const CheckinButton = ({ a, eventId, csrfToken, activeFilter }: { a: Attendee; e
     <form
       method="POST"
       action={`/admin/event/${eventId}/attendee/${a.id}/checkin`}
-      class="checkin-form"
+      class="checkin-form inline"
     >
       <input type="hidden" name="csrf_token" value={csrfToken} />
       <input type="hidden" name="return_filter" value={activeFilter} />


### PR DESCRIPTION
The checkin form in the attendees table was using default form styling
(border, padding, box-shadow), making it bulky. Add the existing
"inline" class to match the pattern used in the users table.

https://claude.ai/code/session_014S3vc6otairSg1YPu1RyXL