### PR TITLE
Add configurable embed host restrictions with CSP frame-ancestors

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,7 @@
 
 import {
   getCurrencyCodeFromDb,
+  getEmbedHostsFromDb,
   getPaymentProviderFromDb,
   getSquareAccessTokenFromDb,
   getSquareLocationIdFromDb,
@@ -106,6 +107,13 @@ export const getCurrencyCode = (): Promise<string> => {
 export const getAllowedDomain = (): string => {
   return getEnv("ALLOWED_DOMAIN") as string;
 };
+
+/**
+ * Get allowed embed hosts from database (encrypted)
+ * Returns null if not configured (embedding allowed from anywhere)
+ */
+export const getEmbedHosts = (): Promise<string | null> =>
+  getEmbedHostsFromDb();
 
 /**
  * Check if initial setup has been completed

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -109,11 +109,15 @@ export const getAllowedDomain = (): string => {
 };
 
 /**
- * Get allowed embed hosts from database (encrypted)
- * Returns null if not configured (embedding allowed from anywhere)
+ * Get allowed embed hosts from database (encrypted, parsed to array)
+ * Returns empty array if not configured (embedding allowed from anywhere)
  */
-export const getEmbedHosts = (): Promise<string | null> =>
-  getEmbedHostsFromDb();
+export const getEmbedHosts = async (): Promise<string[]> => {
+  const raw = await getEmbedHostsFromDb();
+  if (!raw) return [];
+  const { parseEmbedHosts } = await import("#lib/embed-hosts.ts");
+  return parseEmbedHosts(raw);
+};
 
 /**
  * Check if initial setup has been completed

--- a/src/lib/embed-hosts.ts
+++ b/src/lib/embed-hosts.ts
@@ -1,0 +1,65 @@
+/**
+ * Embed host validation and parsing utilities
+ */
+
+import { filter, map, pipe } from "#fp";
+
+/**
+ * Valid host pattern: a hostname with optional wildcard prefix.
+ * Allowed forms:
+ *   - "example.com"
+ *   - "sub.example.com"
+ *   - "*.example.com"
+ * Rejects:
+ *   - Ports, paths, protocols, spaces
+ *   - Bare "*" (too broad)
+ *   - "**.example.com" or "*example.com"
+ */
+const HOST_PATTERN = /^(?:\*\.)?[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/;
+
+/**
+ * Validate a single host pattern
+ * Returns null if valid, or an error message if invalid
+ */
+export const validateHostPattern = (host: string): string | null => {
+  if (host === "") return "Empty host pattern";
+  if (host === "*") return "Bare wildcard '*' is not allowed — use '*.example.com'";
+  if (!HOST_PATTERN.test(host)) {
+    return `Invalid host pattern: '${host}' — must be a hostname like 'example.com' or '*.example.com'`;
+  }
+  return null;
+};
+
+/**
+ * Parse a comma-separated list of hosts into trimmed, lowercased entries.
+ * Filters out empty strings from trailing commas etc.
+ */
+export const parseEmbedHosts = (input: string): string[] =>
+  pipe(
+    map((s: string) => s.trim().toLowerCase()),
+    filter((s: string) => s !== ""),
+  )(input.split(","));
+
+/**
+ * Validate a comma-separated list of host patterns.
+ * Returns null if all valid, or the first error message.
+ */
+export const validateEmbedHosts = (input: string): string | null => {
+  const hosts = parseEmbedHosts(input);
+  for (const host of hosts) {
+    const error = validateHostPattern(host);
+    if (error) return error;
+  }
+  return null;
+};
+
+/**
+ * Build a frame-ancestors CSP value from allowed embed hosts.
+ * Returns null if no hosts are configured (allow embedding from anywhere).
+ */
+export const buildFrameAncestors = (embedHosts: string | null): string | null => {
+  if (!embedHosts) return null;
+  const hosts = parseEmbedHosts(embedHosts);
+  if (hosts.length === 0) return null;
+  return `frame-ancestors 'self' ${hosts.join(" ")}`;
+};

--- a/src/lib/embed-hosts.ts
+++ b/src/lib/embed-hosts.ts
@@ -55,11 +55,9 @@ export const validateEmbedHosts = (input: string): string | null => {
 
 /**
  * Build a frame-ancestors CSP value from allowed embed hosts.
- * Returns null if no hosts are configured (allow embedding from anywhere).
+ * Returns null if the list is empty (allow embedding from anywhere).
  */
-export const buildFrameAncestors = (embedHosts: string | null): string | null => {
-  if (!embedHosts) return null;
-  const hosts = parseEmbedHosts(embedHosts);
+export const buildFrameAncestors = (hosts: string[]): string | null => {
   if (hosts.length === 0) return null;
   return `frame-ancestors 'self' ${hosts.join(" ")}`;
 };

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -5,12 +5,14 @@
 
 import {
   clearPaymentProvider,
+  getEmbedHostsFromDb,
   getPaymentProviderFromDb,
   getStripeWebhookEndpointId,
   hasSquareToken,
   hasStripeKey,
   setPaymentProvider,
   setStripeWebhookConfig,
+  updateEmbedHosts,
   updateSquareAccessToken,
   updateSquareLocationId,
   updateSquareWebhookSignatureKey,
@@ -21,6 +23,7 @@ import {
   getSquareWebhookSignatureKey,
   getAllowedDomain,
 } from "#lib/config.ts";
+import { validateEmbedHosts, parseEmbedHosts } from "#lib/embed-hosts.ts";
 import { resetDatabase } from "#lib/db/migrations/index.ts";
 import { getUserById, verifyUserPassword } from "#lib/db/users.ts";
 import { validateForm } from "#lib/forms.tsx";
@@ -59,12 +62,14 @@ const getSettingsPageState = async () => {
   const squareWebhookKey = await getSquareWebhookSignatureKey();
   const squareWebhookConfigured = squareWebhookKey !== null;
   const webhookUrl = getWebhookUrl();
+  const embedHosts = await getEmbedHostsFromDb();
   return {
     stripeKeyConfigured,
     paymentProvider,
     squareTokenConfigured,
     squareWebhookConfigured,
     webhookUrl,
+    embedHosts,
   };
 };
 
@@ -84,6 +89,7 @@ const renderSettingsPage = async (
     state.squareTokenConfigured,
     state.squareWebhookConfigured,
     state.webhookUrl,
+    state.embedHosts,
   );
 };
 
@@ -300,6 +306,34 @@ const handleStripeTestPost = (request: Request): Promise<Response> =>
   });
 
 /**
+ * Handle POST /admin/settings/embed-hosts - owner only
+ */
+const handleEmbedHostsPost = (request: Request): Promise<Response> =>
+  withOwnerAuthForm(request, async (session, form) => {
+    const settingsPageWithError = async (error: string, status: number) =>
+      htmlResponse(await renderSettingsPage(session, error), status);
+
+    const raw = form.get("embed_hosts") ?? "";
+    const trimmed = raw.trim();
+
+    // Empty = clear restriction
+    if (trimmed === "") {
+      await updateEmbedHosts("");
+      return redirectWithSuccess("/admin/settings", "Embed host restrictions removed");
+    }
+
+    const error = validateEmbedHosts(trimmed);
+    if (error) {
+      return settingsPageWithError(error, 400);
+    }
+
+    // Normalize: trim, lowercase, rejoin
+    const normalized = parseEmbedHosts(trimmed).join(", ");
+    await updateEmbedHosts(normalized);
+    return redirectWithSuccess("/admin/settings", "Allowed embed hosts updated");
+  });
+
+/**
  * Expected confirmation phrase for database reset
  */
 const RESET_DATABASE_PHRASE =
@@ -338,6 +372,7 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/square-webhook": (request) =>
     handleAdminSquareWebhookPost(request),
   "POST /admin/settings/stripe/test": (request) => handleStripeTestPost(request),
+  "POST /admin/settings/embed-hosts": (request) => handleEmbedHostsPost(request),
   "POST /admin/settings/reset-database": (request) =>
     handleResetDatabasePost(request),
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { once } from "#fp";
-import { getEmbedHosts, isSetupComplete } from "#lib/config.ts";
+import { isSetupComplete } from "#lib/config.ts";
 import { createRequestTimer, logRequest } from "#lib/logger.ts";
 import {
   applySecurityHeaders,
@@ -184,6 +184,5 @@ export const handleRequest = async (
   }
 
   const response = await handleRequestInternal(request, path, method, server);
-  const embedHosts = embeddable ? await getEmbedHosts() : null;
-  return logAndReturn(applySecurityHeaders(response, embeddable, embedHosts), method, path, getElapsed);
+  return logAndReturn(await applySecurityHeaders(response, embeddable), method, path, getElapsed);
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { once } from "#fp";
-import { isSetupComplete } from "#lib/config.ts";
+import { getEmbedHosts, isSetupComplete } from "#lib/config.ts";
 import { createRequestTimer, logRequest } from "#lib/logger.ts";
 import {
   applySecurityHeaders,
@@ -184,5 +184,6 @@ export const handleRequest = async (
   }
 
   const response = await handleRequestInternal(request, path, method, server);
-  return logAndReturn(applySecurityHeaders(response, embeddable), method, path, getElapsed);
+  const embedHosts = embeddable ? await getEmbedHosts() : null;
+  return logAndReturn(applySecurityHeaders(response, embeddable, embedHosts), method, path, getElapsed);
 };

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -26,6 +26,7 @@ export const adminSettingsPage = (
   squareTokenConfigured?: boolean,
   squareWebhookConfigured?: boolean,
   webhookUrl?: string,
+  embedHosts?: string | null,
 ): string =>
   String(
     <Layout title="Settings">
@@ -172,6 +173,23 @@ document.getElementById('stripe-test-btn')?.addEventListener('click', async func
           <button type="submit">Update Webhook Key</button>
         </form>
         )}
+
+        <form method="POST" action="/admin/settings/embed-hosts">
+            <h2>Allowed Embed Hosts</h2>
+          <p>Restrict which websites can embed your booking forms in an iframe. Leave blank to allow embedding from any site.</p>
+          <input type="hidden" name="csrf_token" value={session.csrfToken} />
+          <label for="embed_hosts">Hosts (comma-separated)</label>
+          <input
+            type="text"
+            id="embed_hosts"
+            name="embed_hosts"
+            placeholder="example.com, *.mysite.org"
+            value={embedHosts ?? ""}
+            autocomplete="off"
+          />
+          <p><small>Use <code>*.example.com</code> to allow all subdomains. Direct visits to the booking page are always allowed.</small></p>
+          <button type="submit">Save Embed Hosts</button>
+        </form>
 
         <form method="POST" action="/admin/settings">
             <h2>Change Password</h2>

--- a/test/lib/embed-hosts.test.ts
+++ b/test/lib/embed-hosts.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "#test-compat";
+import {
+  buildFrameAncestors,
+  parseEmbedHosts,
+  validateEmbedHosts,
+  validateHostPattern,
+} from "#lib/embed-hosts.ts";
+
+describe("embed-hosts", () => {
+  describe("validateHostPattern", () => {
+    test("accepts simple hostname", () => {
+      expect(validateHostPattern("example.com")).toBeNull();
+    });
+
+    test("accepts subdomain hostname", () => {
+      expect(validateHostPattern("sub.example.com")).toBeNull();
+    });
+
+    test("accepts wildcard subdomain", () => {
+      expect(validateHostPattern("*.example.com")).toBeNull();
+    });
+
+    test("accepts deeply nested subdomain", () => {
+      expect(validateHostPattern("a.b.c.example.com")).toBeNull();
+    });
+
+    test("accepts hostname with hyphens", () => {
+      expect(validateHostPattern("my-site.example.com")).toBeNull();
+    });
+
+    test("rejects empty string", () => {
+      expect(validateHostPattern("")).toBe("Empty host pattern");
+    });
+
+    test("rejects bare wildcard", () => {
+      const result = validateHostPattern("*");
+      expect(result).toContain("Bare wildcard");
+    });
+
+    test("rejects hostname with port", () => {
+      const result = validateHostPattern("example.com:8080");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects hostname with protocol", () => {
+      const result = validateHostPattern("https://example.com");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects hostname with path", () => {
+      const result = validateHostPattern("example.com/path");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects hostname with spaces", () => {
+      const result = validateHostPattern("example .com");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects single label hostname", () => {
+      const result = validateHostPattern("localhost");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects double wildcard", () => {
+      const result = validateHostPattern("**.example.com");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects wildcard without dot prefix", () => {
+      const result = validateHostPattern("*example.com");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("rejects uppercase characters", () => {
+      const result = validateHostPattern("Example.com");
+      expect(result).toContain("Invalid host pattern");
+    });
+  });
+
+  describe("parseEmbedHosts", () => {
+    test("parses comma-separated hosts", () => {
+      const result = parseEmbedHosts("example.com, mysite.org");
+      expect(result).toEqual(["example.com", "mysite.org"]);
+    });
+
+    test("trims whitespace", () => {
+      const result = parseEmbedHosts("  example.com ,  mysite.org  ");
+      expect(result).toEqual(["example.com", "mysite.org"]);
+    });
+
+    test("lowercases entries", () => {
+      const result = parseEmbedHosts("Example.COM, MySite.ORG");
+      expect(result).toEqual(["example.com", "mysite.org"]);
+    });
+
+    test("filters empty entries from trailing comma", () => {
+      const result = parseEmbedHosts("example.com,");
+      expect(result).toEqual(["example.com"]);
+    });
+
+    test("filters empty entries from leading comma", () => {
+      const result = parseEmbedHosts(",example.com");
+      expect(result).toEqual(["example.com"]);
+    });
+
+    test("returns empty array for empty string", () => {
+      const result = parseEmbedHosts("");
+      expect(result).toEqual([]);
+    });
+
+    test("returns empty array for whitespace only", () => {
+      const result = parseEmbedHosts("   ");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("validateEmbedHosts", () => {
+    test("accepts valid comma-separated hosts", () => {
+      expect(validateEmbedHosts("example.com, *.mysite.org")).toBeNull();
+    });
+
+    test("accepts single host", () => {
+      expect(validateEmbedHosts("example.com")).toBeNull();
+    });
+
+    test("returns error for invalid host in list", () => {
+      const result = validateEmbedHosts("example.com, *");
+      expect(result).toContain("Bare wildcard");
+    });
+
+    test("returns error for host with port", () => {
+      const result = validateEmbedHosts("example.com:443");
+      expect(result).toContain("Invalid host pattern");
+    });
+
+    test("returns null for empty input (no hosts)", () => {
+      expect(validateEmbedHosts("")).toBeNull();
+    });
+  });
+
+  describe("buildFrameAncestors", () => {
+    test("returns null when embedHosts is null", () => {
+      expect(buildFrameAncestors(null)).toBeNull();
+    });
+
+    test("returns null when embedHosts is empty string", () => {
+      expect(buildFrameAncestors("")).toBeNull();
+    });
+
+    test("builds frame-ancestors with single host", () => {
+      expect(buildFrameAncestors("example.com")).toBe(
+        "frame-ancestors 'self' example.com",
+      );
+    });
+
+    test("builds frame-ancestors with multiple hosts", () => {
+      expect(buildFrameAncestors("example.com, *.mysite.org")).toBe(
+        "frame-ancestors 'self' example.com *.mysite.org",
+      );
+    });
+
+    test("returns null for whitespace-only input", () => {
+      expect(buildFrameAncestors("  ,  ")).toBeNull();
+    });
+  });
+});

--- a/test/lib/embed-hosts.test.ts
+++ b/test/lib/embed-hosts.test.ts
@@ -140,28 +140,20 @@ describe("embed-hosts", () => {
   });
 
   describe("buildFrameAncestors", () => {
-    test("returns null when embedHosts is null", () => {
-      expect(buildFrameAncestors(null)).toBeNull();
-    });
-
-    test("returns null when embedHosts is empty string", () => {
-      expect(buildFrameAncestors("")).toBeNull();
+    test("returns null for empty array", () => {
+      expect(buildFrameAncestors([])).toBeNull();
     });
 
     test("builds frame-ancestors with single host", () => {
-      expect(buildFrameAncestors("example.com")).toBe(
+      expect(buildFrameAncestors(["example.com"])).toBe(
         "frame-ancestors 'self' example.com",
       );
     });
 
     test("builds frame-ancestors with multiple hosts", () => {
-      expect(buildFrameAncestors("example.com, *.mysite.org")).toBe(
+      expect(buildFrameAncestors(["example.com", "*.mysite.org"])).toBe(
         "frame-ancestors 'self' example.com *.mysite.org",
       );
-    });
-
-    test("returns null for whitespace-only input", () => {
-      expect(buildFrameAncestors("  ,  ")).toBeNull();
     });
   });
 });

--- a/test/lib/server-embed-hosts.test.ts
+++ b/test/lib/server-embed-hosts.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import { updateEmbedHosts } from "#lib/db/settings.ts";
+import { handleRequest } from "#routes";
+import {
+  awaitTestRequest,
+  createTestDbWithSetup,
+  createTestEvent,
+  loginAsAdmin,
+  mockFormRequest,
+  mockRequest,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+describe("server (embed hosts)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("GET /admin/settings (embed hosts section)", () => {
+    test("shows embed hosts section on settings page", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Allowed Embed Hosts");
+      expect(html).toContain("embed_hosts");
+    });
+
+    test("shows current embed hosts value when configured", async () => {
+      await updateEmbedHosts("example.com, *.mysite.org");
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("example.com, *.mysite.org");
+    });
+
+    test("shows empty field when no embed hosts configured", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain('value=""');
+    });
+  });
+
+  describe("POST /admin/settings/embed-hosts", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/embed-hosts", {
+          embed_hosts: "example.com",
+        }),
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin");
+    });
+
+    test("rejects invalid CSRF token", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "example.com",
+            csrf_token: "invalid-csrf-token",
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(403);
+      const text = await response.text();
+      expect(text).toContain("Invalid CSRF token");
+    });
+
+    test("saves valid embed hosts", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "example.com, *.mysite.org",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location)).toContain("Allowed embed hosts updated");
+    });
+
+    test("normalizes hosts to lowercase", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "Example.COM, *.MySite.ORG",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      // Verify by checking the settings page
+      const settingsResponse = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await settingsResponse.text();
+      expect(html).toContain("example.com, *.mysite.org");
+    });
+
+    test("clears embed hosts when empty", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      // First set some hosts
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "example.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      // Now clear them
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location)).toContain("Embed host restrictions removed");
+    });
+
+    test("rejects invalid host pattern", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "example.com, *",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("Bare wildcard");
+    });
+
+    test("rejects host with protocol", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          {
+            embed_hosts: "https://example.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("Invalid host pattern");
+    });
+
+    test("handles missing embed_hosts field gracefully", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/embed-hosts",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location)).toContain("Embed host restrictions removed");
+    });
+  });
+
+  describe("CSP frame-ancestors with embed hosts", () => {
+    test("ticket page has no frame-ancestors when no embed hosts configured", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      const response = await handleRequest(
+        mockRequest(`/ticket/${event.slug}`),
+      );
+      const csp = response.headers.get("content-security-policy")!;
+      expect(csp).not.toContain("frame-ancestors");
+    });
+
+    test("ticket page has frame-ancestors when embed hosts configured", async () => {
+      await updateEmbedHosts("example.com, *.mysite.org");
+
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      const response = await handleRequest(
+        mockRequest(`/ticket/${event.slug}`),
+      );
+      const csp = response.headers.get("content-security-policy")!;
+      expect(csp).toContain("frame-ancestors 'self' example.com *.mysite.org");
+    });
+
+    test("non-embeddable pages still have frame-ancestors none regardless of embed hosts", async () => {
+      await updateEmbedHosts("example.com");
+
+      const response = await handleRequest(mockRequest("/"));
+      const csp = response.headers.get("content-security-policy")!;
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).not.toContain("example.com");
+    });
+
+    test("ticket page has no X-Frame-Options when embed hosts configured", async () => {
+      await updateEmbedHosts("example.com");
+
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      const response = await handleRequest(
+        mockRequest(`/ticket/${event.slug}`),
+      );
+      expect(response.headers.get("x-frame-options")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds support for restricting which websites can embed booking forms in iframes through a new "Allowed Embed Hosts" admin setting. When configured, the server sets appropriate Content Security Policy (CSP) `frame-ancestors` directives to enforce these restrictions.

## Key Changes

- **New embed hosts configuration**: Added database storage and admin UI for managing allowed embed hosts with encryption at rest
- **Host validation utilities**: Created `embed-hosts.ts` with comprehensive validation for host patterns (supports wildcards like `*.example.com`)
- **CSP integration**: Modified security headers middleware to dynamically set `frame-ancestors` based on configured hosts
- **Admin settings page**: Added form to configure comma-separated list of allowed embed hosts
- **Comprehensive tests**: Added unit tests for validation logic and integration tests for CSP behavior

## Implementation Details

- **Validation**: Hosts must be valid domain names with optional wildcard prefix (`*.example.com`). Rejects bare wildcards, ports, protocols, and paths.
- **Normalization**: User input is trimmed, lowercased, and rejoined for consistency
- **Security**: Embed hosts are encrypted in the database using existing encryption utilities
- **CSP behavior**: 
  - When no hosts configured: embeddable pages allow framing from anywhere (no `frame-ancestors` directive)
  - When hosts configured: embeddable pages can only be framed by `'self'` and specified hosts
  - Non-embeddable pages always have `frame-ancestors 'none'` regardless of configuration
- **Backward compatible**: Existing behavior unchanged when feature is not configured

## Testing
- Unit tests for host pattern validation and CSP building
- Integration tests for admin form submission and CSP header generation
- Tests verify both valid and invalid input handling

https://claude.ai/code/session_01BTQPoWjeQaQMcr4RADZi2a