### PR TITLE
Cache all settings in memory to avoid per-key DB round-trips

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -41,25 +41,68 @@ export const CONFIG_KEYS = {
 } as const;
 
 /**
- * Get a setting value
+ * In-memory settings cache. Loads all rows in a single query and
+ * serves subsequent reads from memory until the TTL expires or a
+ * write invalidates the cache.
  */
-export const getSetting = async (key: string): Promise<string | null> => {
-  const result = await getDb().execute({
-    sql: "SELECT value FROM settings WHERE key = ?",
-    args: [key],
-  });
-  if (result.rows.length === 0) return null;
-  return (result.rows[0] as unknown as Settings).value;
+export const SETTINGS_CACHE_TTL_MS = 5_000;
+
+type SettingsCacheState = {
+  entries: Map<string, string> | null;
+  time: number;
+};
+
+const [getSettingsCacheState, setSettingsCacheState] = lazyRef<SettingsCacheState>(
+  () => ({ entries: null, time: 0 }),
+);
+
+const isCacheValid = (): boolean => {
+  const state = getSettingsCacheState();
+  return state.entries !== null && Date.now() - state.time < SETTINGS_CACHE_TTL_MS;
 };
 
 /**
- * Set a setting value
+ * Load every setting row into the in-memory cache with a single query.
+ */
+export const loadAllSettings = async (): Promise<Map<string, string>> => {
+  const result = await getDb().execute("SELECT key, value FROM settings");
+  const cache = new Map<string, string>();
+  for (const row of result.rows) {
+    const { key, value } = row as unknown as Settings;
+    cache.set(key, value);
+  }
+  setSettingsCacheState({ entries: cache, time: Date.now() });
+  return cache;
+};
+
+/**
+ * Invalidate the settings cache (for testing or after writes).
+ */
+export const invalidateSettingsCache = (): void => {
+  setSettingsCacheState(null);
+};
+
+/**
+ * Get a setting value. Reads from the in-memory cache, loading all
+ * settings in one query on first access or after TTL expiry.
+ */
+export const getSetting = async (key: string): Promise<string | null> => {
+  const cache = isCacheValid()
+    ? getSettingsCacheState().entries!
+    : await loadAllSettings();
+  return cache.get(key) ?? null;
+};
+
+/**
+ * Set a setting value. Invalidates the cache so the next read
+ * will pick up the new value.
  */
 export const setSetting = async (key: string, value: string): Promise<void> => {
   await getDb().execute({
     sql: "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
     args: [key, value],
   });
+  invalidateSettingsCache();
 };
 
 /**
@@ -180,6 +223,7 @@ export const clearPaymentProvider = async (): Promise<void> => {
     sql: "DELETE FROM settings WHERE key = ?",
     args: [CONFIG_KEYS.PAYMENT_PROVIDER],
   });
+  invalidateSettingsCache();
 };
 
 /**
@@ -366,6 +410,8 @@ export const settingsApi = {
   completeSetup,
   getSetting,
   setSetting,
+  loadAllSettings,
+  invalidateSettingsCache,
   isSetupComplete,
   clearSetupCompleteCache,
   getPublicKey,

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -11,7 +11,7 @@ import {
 } from "#lib/db/events.ts";
 import { initDb, LATEST_UPDATE } from "#lib/db/migrations/index.ts";
 import { getSession, resetSessionCache } from "#lib/db/sessions.ts";
-import { clearSetupCompleteCache, completeSetup } from "#lib/db/settings.ts";
+import { clearSetupCompleteCache, completeSetup, invalidateSettingsCache } from "#lib/db/settings.ts";
 import type { Attendee, Event, EventWithCount } from "#lib/types.ts";
 
 /**
@@ -212,6 +212,7 @@ export const createTestDbWithSetup = async (
 export const resetDb = (): void => {
   setDb(null);
   clearSetupCompleteCache();
+  invalidateSettingsCache();
   resetSessionCache();
   resetTestSession();
 };

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -236,6 +236,8 @@ describe("code quality", () => {
       "lib/stripe.ts:resetStripeClient",
       // Reset cached setup complete status between tests
       "lib/db/settings.ts:clearSetupCompleteCache",
+      // Reset cached settings between tests
+      "lib/db/settings.ts:invalidateSettingsCache",
       // Reset cached sessions between tests
       "lib/db/sessions.ts:resetSessionCache",
       // DB version constant used in production but test pattern doesn't detect constant comparison

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -61,6 +61,7 @@ import {
   getStripeSecretKeyFromDb,
   getWrappedPrivateKey,
   hasStripeKey,
+  invalidateSettingsCache,
   isSetupComplete,
   setPaymentProvider,
   setSetting,
@@ -799,6 +800,7 @@ describe("db", () => {
         sql: "DELETE FROM settings WHERE key = ?",
         args: [CONFIG_KEYS.PUBLIC_KEY],
       });
+      invalidateSettingsCache();
 
       const result = await createAttendeeAtomic(
         event.id,
@@ -1957,6 +1959,7 @@ describe("db", () => {
       await getDb().execute(
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
 
       // Re-run migrations - should backfill checked_in
       await initDb();
@@ -1987,6 +1990,7 @@ describe("db", () => {
       await getDb().execute(
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
 
       // Re-run migrations - should backfill ticket_token
       await initDb();
@@ -2070,6 +2074,7 @@ describe("db", () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
       await initDb();
 
       // Verify the event now has encrypted closes_at (not NULL)
@@ -2097,6 +2102,7 @@ describe("db", () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
       await initDb();
 
       // Verify it still decrypts correctly (not double-encrypted)
@@ -2124,6 +2130,7 @@ describe("db", () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
       await initDb();
 
       // Verify an owner user was created
@@ -2152,6 +2159,7 @@ describe("db", () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
       await initDb();
 
       // Verify no additional user was created
@@ -2167,6 +2175,7 @@ describe("db", () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
+      invalidateSettingsCache();
       await initDb();
 
       // Verify no user was created

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -188,10 +188,12 @@ describe("server (misc)", () => {
 
     test("returns null when wrappedPrivateKey is not set in DB", async () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
+      const { invalidateSettingsCache: invalidateCache } = await import("#lib/db/settings.ts");
       await getDbFn().execute({
         sql: "DELETE FROM settings WHERE key = 'wrapped_private_key'",
         args: [],
       });
+      invalidateCache();
 
       const { getPrivateKey } = await import("#routes/utils.ts");
       const result = await getPrivateKey("any-token", "some-wrapped-key");

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -614,8 +614,9 @@ describe("server (multi-user admin)", () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
       await getDbFn().execute("DELETE FROM settings");
       await getDbFn().execute("DELETE FROM users");
-      const { clearSetupCompleteCache } = await import("#lib/db/settings.ts");
+      const { clearSetupCompleteCache, invalidateSettingsCache: invalidateCache } = await import("#lib/db/settings.ts");
       clearSetupCompleteCache();
+      invalidateCache();
 
       const response = await handleRequest(mockRequest("/setup/"));
       expect(response.status).toBe(200);


### PR DESCRIPTION
Replace individual getSetting queries with a single SELECT that loads
all settings into an in-memory Map, cached with a 5-second TTL. This
eliminates 2-5 remote DB round-trips per page load since nearly every
route needs at least one setting.

Writes (setSetting, clearPaymentProvider) invalidate the cache
immediately. Uses the lazyRef pattern for mutable state to satisfy
code-quality rules.

https://claude.ai/code/session_018TV5HKqWpHFRpSdZzrVnqV