### PR TITLE
Simplify method calls by passing objects instead of destructured properties

### DIFF
--- a/src/lib/db/activityLog.ts
+++ b/src/lib/db/activityLog.ts
@@ -47,9 +47,9 @@ export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
  */
 export const logActivity = (
   message: string,
-  eventId?: number | null,
+  event?: number | { id: number } | null,
 ): Promise<ActivityLogEntry> =>
-  activityLogTable.insert({ message, eventId: eventId ?? null });
+  activityLogTable.insert({ message, eventId: (typeof event === "object" && event !== null ? event.id : event) ?? null });
 
 /** Query activity log with optional event filter, decrypts messages */
 const queryActivityLog = async (

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -278,12 +278,11 @@ export const getStripeWebhookEndpointId = (): Promise<string | null> => {
  * Store Stripe webhook configuration (secret encrypted, endpoint ID plaintext)
  */
 export const setStripeWebhookConfig = async (
-  webhookSecret: string,
-  endpointId: string,
+  config: { secret: string; endpointId: string },
 ): Promise<void> => {
-  const encryptedSecret = await encrypt(webhookSecret);
+  const encryptedSecret = await encrypt(config.secret);
   await setSetting(CONFIG_KEYS.STRIPE_WEBHOOK_SECRET, encryptedSecret);
-  await setSetting(CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID, endpointId);
+  await setSetting(CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID, config.endpointId);
 };
 
 /**

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -143,7 +143,7 @@ export const logAndNotifyRegistration = async (
   attendee: WebhookAttendee,
   currency: string,
 ): Promise<void> => {
-  await logActivity(`Attendee registered for '${event.name}'`, event.id);
+  await logActivity(`Attendee registered for '${event.name}'`, event);
   await sendRegistrationWebhooks([{ event, attendee }], currency);
 };
 
@@ -155,7 +155,7 @@ export const logAndNotifyMultiRegistration = async (
   currency: string,
 ): Promise<void> => {
   for (const { event } of entries) {
-    await logActivity(`Attendee registered for '${event.name}'`, event.id);
+    await logActivity(`Attendee registered for '${event.name}'`, event);
   }
   await sendRegistrationWebhooks(entries, currency);
 };

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -58,7 +58,7 @@ const handleAdminAttendeeDeleteGet = async (
     return redirect("/admin");
   }
 
-  const privateKey = (await getPrivateKey(session.token, session.wrappedDataKey))!;
+  const privateKey = (await getPrivateKey(session))!;
 
   const data = await loadAttendeeForEvent(eventId, attendeeId, privateKey);
   if (!data) {
@@ -81,7 +81,7 @@ const handleAdminAttendeeDeletePost = (
   attendeeId: number,
 ): Promise<Response> =>
   withAuthForm(request, async (session, form) => {
-    const privateKey = (await getPrivateKey(session.token, session.wrappedDataKey))!;
+    const privateKey = (await getPrivateKey(session))!;
 
     const data = await loadAttendeeForEvent(eventId, attendeeId, privateKey);
     if (!data) {
@@ -134,7 +134,7 @@ const handleAdminAttendeeCheckinPost = (
   attendeeId: number,
 ): Promise<Response> =>
   withAuthForm(request, async (session, form) => {
-    const privateKey = (await getPrivateKey(session.token, session.wrappedDataKey))!;
+    const privateKey = (await getPrivateKey(session))!;
 
     const data = await loadAttendeeForEvent(eventId, attendeeId, privateKey);
     if (!data) {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -128,7 +128,7 @@ const withEventAttendees = async (
     return redirect("/admin");
   }
 
-  const privateKey = (await getPrivateKey(session.token, session.wrappedDataKey))!;
+  const privateKey = (await getPrivateKey(session))!;
 
   // Fetch event and attendees in single DB round-trip
   const result = await getEventWithAttendeesRaw(eventId);
@@ -145,7 +145,7 @@ const withEventAttendees = async (
  */
 const handleCreateEvent = createHandler(eventsResource, {
   onSuccess: async (row) => {
-    await logActivity(`Event '${row.name}' created`, row.id);
+    await logActivity(`Event '${row.name}' created`, row);
     return redirect("/admin");
   },
   onError: () => redirect("/admin"),
@@ -252,7 +252,7 @@ const handleAdminEventExport = (request: Request, eventId: number) =>
   withEventAttendees(request, eventId, async ({ event, attendees }) => {
     const csv = generateAttendeesCsv(attendees);
     const filename = `${event.name.replace(/[^a-zA-Z0-9]/g, "_")}_attendees.csv`;
-    await logActivity(`CSV exported for '${event.name}'`, event.id);
+    await logActivity(`CSV exported for '${event.name}'`, event);
     return new Response(csv, {
       headers: {
         "content-type": "text/csv; charset=utf-8",

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -235,7 +235,7 @@ const handleAdminStripePost = (request: Request): Promise<Response> =>
 
     // Store both the Stripe key and webhook config
     await updateStripeKey(stripeSecretKey);
-    await setStripeWebhookConfig(webhookResult.secret, webhookResult.endpointId);
+    await setStripeWebhookConfig(webhookResult);
 
     // Auto-set payment provider to stripe when key is configured
     await setPaymentProvider("stripe");

--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -27,7 +27,7 @@ const buildAdminView = async (
   if (setCheckedIn !== null) {
     await Promise.all(map((a: Attendee) => updateCheckedIn(a.id, setCheckedIn))(rawAttendees));
   }
-  const privateKey = (await getPrivateKey(session.token, session.wrappedDataKey))!;
+  const privateKey = (await getPrivateKey(session))!;
   const decrypted = await decryptAttendees(rawAttendees, privateKey);
   const attendees = setCheckedIn !== null
     ? map((a: Attendee) => ({ ...a, checked_in: setCheckedIn ? "true" : "false" }))(decrypted)

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -221,7 +221,7 @@ const processFreeReservation = async (
   reservation: ReservationParams,
 ): Promise<Response> => {
   const { event, name, email, phone, quantity, token } = reservation;
-  const result = await createAttendeeAtomic(event.id, name, email, null, quantity, phone);
+  const result = await createAttendeeAtomic({ eventId: event.id, name, email, quantity, phone });
 
   if (!result.success) {
     return ticketResponse(event, token)(formatAtomicError(result.reason));
@@ -438,7 +438,7 @@ const processMultiFreeReservation = async (
 ): Promise<{ success: true } | { success: false; error: string }> => {
   const entries: Array<{ event: MultiTicketEvent["event"]; attendee: { id: number; quantity: number; name: string; email: string; phone: string; ticket_token: string } }> = [];
   for (const { event, qty } of eventsWithQuantity(events, quantities)) {
-    const result = await createAttendeeAtomic(event.id, name, email, null, qty, phone);
+    const result = await createAttendeeAtomic({ eventId: event.id, name, email, quantity: qty, phone });
     if (!result.success) {
       return { success: false, error: formatAtomicError(result.reason, event.name) };
     }

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -115,16 +115,15 @@ export const getAuthenticatedSession = async (
  * Returns null if session doesn't have wrapped_data_key
  */
 export const getPrivateKey = async (
-  token: string,
-  wrappedDataKey: string | null,
+  session: { token: string; wrappedDataKey: string | null },
 ): Promise<CryptoKey | null> => {
-  if (!wrappedDataKey) return null;
+  if (!session.wrappedDataKey) return null;
 
   const wrappedPrivateKey = await getWrappedPrivateKey();
   if (!wrappedPrivateKey) return null;
 
   try {
-    return await getPrivateKeyFromSession(token, wrappedDataKey, wrappedPrivateKey);
+    return await getPrivateKeyFromSession(session.token, session.wrappedDataKey, wrappedPrivateKey);
   } catch {
     return null;
   }

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -214,14 +214,13 @@ type EventPriceValidation =
   | { ok: false; error: string; status?: number };
 
 const validateAndPrice = async (
-  eventId: number,
-  quantity: number,
+  input: { eventId: number; quantity: number },
   includeEventName = false,
 ): Promise<EventPriceValidation> => {
-  const validation = await validateEventForPayment(eventId, includeEventName);
+  const validation = await validateEventForPayment(input.eventId, includeEventName);
   if (!validation.ok) return validation;
   const { event } = validation;
-  const pricePaid = event.unit_price !== null ? event.unit_price * quantity : null;
+  const pricePaid = event.unit_price !== null ? event.unit_price * input.quantity : null;
   return { ok: true, event, pricePaid };
 };
 
@@ -286,9 +285,9 @@ const extractMultiIntent = (
  */
 const processMultiPaymentSession = async (
   sessionId: string,
-  session: ValidatedPaymentSession,
-  intent: MultiIntent,
+  data: { session: ValidatedPaymentSession; intent: MultiIntent },
 ): Promise<PaymentResult> => {
+  const { session, intent } = data;
   // Phase 1: Reserve the session
   const reservation = await reserveSession(sessionId);
 
@@ -313,22 +312,22 @@ const processMultiPaymentSession = async (
   let failureReason: "capacity_exceeded" | "encryption_error" | null = null;
 
   for (const item of intent.items) {
-    const vp = await validateAndPrice(item.e, item.q, true);
+    const vp = await validateAndPrice({ eventId: item.e, quantity: item.q }, true);
     if (!vp.ok) {
       await rollbackAttendees(createdAttendees);
       return refundAndFail(session, vp.error, vp.status);
     }
 
     const { event, pricePaid } = vp;
-    const result = await createAttendeeAtomic(
-      item.e,
-      intent.name,
-      intent.email,
-      session.paymentReference,
-      item.q,
-      intent.phone,
+    const result = await createAttendeeAtomic({
+      eventId: item.e,
+      name: intent.name,
+      email: intent.email,
+      paymentId: session.paymentReference,
+      quantity: item.q,
+      phone: intent.phone,
       pricePaid,
-    );
+    });
 
     if (!result.success) {
       failedEvent = event;
@@ -374,9 +373,9 @@ const processMultiPaymentSession = async (
  */
 const processPaymentSession = async (
   sessionId: string,
-  session: ValidatedPaymentSession,
-  intent: RegistrationIntent,
+  data: { session: ValidatedPaymentSession; intent: RegistrationIntent },
 ): Promise<PaymentResult> => {
+  const { session, intent } = data;
   // Phase 1: Try to reserve the session (claim the lock)
   const reservation = await reserveSession(sessionId);
 
@@ -401,19 +400,15 @@ const processPaymentSession = async (
   // We have the lock - proceed with attendee creation
 
   // Phase 2: Validate event and create attendee atomically with capacity check
-  const vp = await validateAndPrice(intent.eventId, intent.quantity);
+  const vp = await validateAndPrice(intent);
   if (!vp.ok) return refundAndFail(session, vp.error, vp.status);
 
   const { event, pricePaid } = vp;
-  const result = await createAttendeeAtomic(
-    intent.eventId,
-    intent.name,
-    intent.email,
-    session.paymentReference,
-    intent.quantity,
-    intent.phone,
+  const result = await createAttendeeAtomic({
+    ...intent,
+    paymentId: session.paymentReference,
     pricePaid,
-  );
+  });
 
   if (!result.success) {
     return refundAndFail(session, formatPostPaymentError(result.reason));
@@ -453,8 +448,8 @@ const handlePaymentSuccess = withSessionId(async (sessionId) => {
   const { data } = validation;
   const result =
     data.type === "multi"
-      ? await processMultiPaymentSession(sessionId, data.session, data.intent)
-      : await processPaymentSession(sessionId, data.session, data.intent);
+      ? await processMultiPaymentSession(sessionId, data)
+      : await processPaymentSession(sessionId, data);
 
   if (!result.success) {
     return paymentErrorResponse(formatPaymentError(result), result.status);
@@ -648,11 +643,11 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
       return new Response("Invalid multi-ticket session data", { status: 400 });
     }
     eventIdForLog = multiIntent.items[0]?.e;
-    result = await processMultiPaymentSession(session.id, session, multiIntent);
+    result = await processMultiPaymentSession(session.id, { session, intent: multiIntent });
   } else {
     const intent = extractIntent(session);
     eventIdForLog = intent.eventId;
-    result = await processPaymentSession(session.id, session, intent);
+    result = await processPaymentSession(session.id, { session, intent });
   }
 
   if (!result.success) {

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -379,12 +379,12 @@ describe("db", () => {
       });
 
       // Create an attendee BEFORE password change
-      const beforeResult = await createAttendeeAtomic(
-        event.id,
-        "Alice Before",
-        "alice@example.com",
-        "pi_before_change",
-      );
+      const beforeResult = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Alice Before",
+        email: "alice@example.com",
+        paymentId: "pi_before_change",
+      });
       if (!beforeResult.success) throw new Error("Failed to create attendee");
       const attendeeBefore = beforeResult.attendee;
 
@@ -404,12 +404,12 @@ describe("db", () => {
       expect(changeSuccess).toBe(true);
 
       // Create an attendee AFTER password change
-      const afterResult = await createAttendeeAtomic(
-        event.id,
-        "Bob After",
-        "bob@example.com",
-        "pi_after_change",
-      );
+      const afterResult = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Bob After",
+        email: "bob@example.com",
+        paymentId: "pi_after_change",
+      });
       if (!afterResult.success) throw new Error("Failed to create attendee");
       const attendeeAfter = afterResult.attendee;
 
@@ -752,13 +752,13 @@ describe("db", () => {
         thankYouUrl: "https://example.com",
       });
 
-      const result = await createAttendeeAtomic(
-        event.id,
-        "John",
-        "john@example.com",
-        "pi_test",
-        1,
-      );
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John",
+        email: "john@example.com",
+        paymentId: "pi_test",
+        quantity: 1,
+      });
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -773,15 +773,14 @@ describe("db", () => {
         thankYouUrl: "https://example.com",
       });
       // Use createAttendeeAtomic to fill capacity (production code path)
-      await createAttendeeAtomic(event.id, "First", "first@example.com");
+      await createAttendeeAtomic({ eventId: event.id, name: "First", email: "first@example.com" });
 
-      const result = await createAttendeeAtomic(
-        event.id,
-        "Second",
-        "second@example.com",
-        null,
-        1,
-      );
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Second",
+        email: "second@example.com",
+        quantity: 1,
+      });
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -802,11 +801,11 @@ describe("db", () => {
       });
       invalidateSettingsCache();
 
-      const result = await createAttendeeAtomic(
-        event.id,
-        "John",
-        "john@example.com",
-      );
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John",
+        email: "john@example.com",
+      });
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -1436,14 +1435,13 @@ describe("db", () => {
       });
 
       // Create attendee with a non-empty phone to exercise the phone decryption branch
-      const result = await createAttendeeAtomic(
-        event.id,
-        "Phone Person",
-        "phone@example.com",
-        null,
-        1,
-        "+44 7700 900000",
-      );
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Phone Person",
+        email: "phone@example.com",
+        quantity: 1,
+        phone: "+44 7700 900000",
+      });
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -1468,14 +1466,13 @@ describe("db", () => {
       });
 
       // Create attendee with empty email/phone via createAttendeeAtomic
-      const result = await createAttendeeAtomic(
-        event.id,
-        "NoContact Person",
-        "", // empty email
-        null,
-        1,
-        "", // empty phone
-      );
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "NoContact Person",
+        email: "", // empty email
+        quantity: 1,
+        phone: "", // empty phone
+      });
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -1499,15 +1496,14 @@ describe("db", () => {
         unitPrice: 2500,
       });
 
-      const result = await createAttendeeAtomic(
-        event.id,
-        "Paying Customer",
-        "pay@example.com",
-        "pi_test_price",
-        1,
-        "",
-        2500,
-      );
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Paying Customer",
+        email: "pay@example.com",
+        paymentId: "pi_test_price",
+        quantity: 1,
+        pricePaid: 2500,
+      });
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -1662,11 +1658,11 @@ describe("db", () => {
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
       });
-      const attendeeResult = await createAttendeeAtomic(
-        event.id,
-        "Test",
-        "test@example.com",
-      );
+      const attendeeResult = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Test",
+        email: "test@example.com",
+      });
       if (!attendeeResult.success) throw new Error("Failed to create attendee");
 
       await reserveSession("sess_dup");

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -182,7 +182,7 @@ describe("server (misc)", () => {
   describe("routes/utils.ts (getPrivateKey)", () => {
     test("returns null when wrappedDataKey is null", async () => {
       const { getPrivateKey } = await import("#routes/utils.ts");
-      const result = await getPrivateKey("any-token", null);
+      const result = await getPrivateKey({ token: "any-token", wrappedDataKey: null });
       expect(result).toBeNull();
     });
 
@@ -196,13 +196,13 @@ describe("server (misc)", () => {
       invalidateCache();
 
       const { getPrivateKey } = await import("#routes/utils.ts");
-      const result = await getPrivateKey("any-token", "some-wrapped-key");
+      const result = await getPrivateKey({ token: "any-token", wrappedDataKey: "some-wrapped-key" });
       expect(result).toBeNull();
     });
 
     test("returns null when crypto operation throws", async () => {
       const { getPrivateKey } = await import("#routes/utils.ts");
-      const result = await getPrivateKey("any-token", "corrupt-key-data");
+      const result = await getPrivateKey({ token: "any-token", wrappedDataKey: "corrupt-key-data" });
       expect(result).toBeNull();
     });
   });

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -181,7 +181,7 @@ describe("server (payment flow)", () => {
       });
 
       // Fill the event with another attendee (using atomic to simulate production flow)
-      await createAttendeeAtomic(event.id, "First", "first@example.com", "pi_first");
+      await createAttendeeAtomic({ eventId: event.id, name: "First", email: "first@example.com", paymentId: "pi_first" });
 
       await withMocks(
         () => ({
@@ -540,7 +540,7 @@ describe("server (payment flow)", () => {
       });
 
       // Create attendee as if payment was already processed (using atomic to simulate production flow)
-      await createAttendeeAtomic(event.id, "John", "john@example.com", "pi_test_123");
+      await createAttendeeAtomic({ eventId: event.id, name: "John", email: "john@example.com", paymentId: "pi_test_123" });
 
       await withMocks(
         () => spyOn(stripeApi, "retrieveCheckoutSession").mockResolvedValue({
@@ -624,7 +624,7 @@ describe("server (payment flow)", () => {
       });
 
       // Fill the event (using atomic to simulate production flow)
-      await createAttendeeAtomic(event.id, "First", "first@example.com", "pi_first");
+      await createAttendeeAtomic({ eventId: event.id, name: "First", email: "first@example.com", paymentId: "pi_first" });
 
       // Try to register - should fail before Stripe session is created
       const response = await submitTicketForm(event.slug, {
@@ -869,7 +869,7 @@ describe("server (payment flow)", () => {
       });
 
       // Fill the event
-      await createAttendeeAtomic(event.id, "First", "first@example.com", "pi_first");
+      await createAttendeeAtomic({ eventId: event.id, name: "First", email: "first@example.com", paymentId: "pi_first" });
 
       const mockRetrieve = spyOn(stripeApi, "retrieveCheckoutSession");
       mockRetrieve.mockResolvedValue({
@@ -919,7 +919,7 @@ describe("server (payment flow)", () => {
       });
 
       // Fill event2
-      await createAttendeeAtomic(event2.id, "First", "first@example.com", "pi_first");
+      await createAttendeeAtomic({ eventId: event2.id, name: "First", email: "first@example.com", paymentId: "pi_first" });
 
       const mockRetrieve = spyOn(stripeApi, "retrieveCheckoutSession");
       mockRetrieve.mockResolvedValue({

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -403,7 +403,7 @@ describe("server (public routes)", () => {
         maxAttendees: 1,
       });
       // Fill up event2
-      await createAttendeeAtomic(event2.id, "John", "john@example.com", null, 1);
+      await createAttendeeAtomic({ eventId: event2.id, name: "John", email: "john@example.com", quantity: 1 });
 
       const response = await handleRequest(
         mockRequest(`/ticket/${event1.slug}+${event2.slug}`),
@@ -424,7 +424,7 @@ describe("server (public routes)", () => {
         maxAttendees: 1,
         description: "Sold out desc",
       });
-      await createAttendeeAtomic(event2.id, "Jane", "jane@example.com", null, 1);
+      await createAttendeeAtomic({ eventId: event2.id, name: "Jane", email: "jane@example.com", quantity: 1 });
 
       const response = await handleRequest(
         mockRequest(`/ticket/${event1.slug}+${event2.slug}`),
@@ -906,7 +906,7 @@ describe("server (public routes)", () => {
       });
 
       // Fill up event1 to make it sold out
-      await createAttendeeAtomic(event1.id, "First", "first@example.com", null, 1);
+      await createAttendeeAtomic({ eventId: event1.id, name: "First", email: "first@example.com", quantity: 1 });
 
       // GET the multi-ticket page (sold-out event will show Sold Out label)
       const path = `/ticket/${event1.slug}+${event2.slug}`;
@@ -993,7 +993,7 @@ describe("server (public routes)", () => {
       });
 
       // Fill event1
-      await createAttendeeAtomic(event1.id, "First", "first@example.com", "pi_first");
+      await createAttendeeAtomic({ eventId: event1.id, name: "First", email: "first@example.com", paymentId: "pi_first" });
 
       const path = `/ticket/${event1.slug}+${event2.slug}`;
       const getResponse = await handleRequest(mockRequest(path));
@@ -1121,12 +1121,12 @@ describe("server (public routes)", () => {
       const { attendeesApi } = await import("#lib/db/attendees.ts");
       const originalFn = attendeesApi.createAttendeeAtomic;
       let callCount = 0;
-      attendeesApi.createAttendeeAtomic = (...args) => {
+      attendeesApi.createAttendeeAtomic = (input) => {
         callCount++;
         if (callCount === 2) {
           return Promise.resolve({ success: false as const, reason: "capacity_exceeded" as const });
         }
-        return originalFn(...args);
+        return originalFn(input);
       };
 
       try {
@@ -1240,7 +1240,7 @@ describe("server (public routes)", () => {
       });
 
       // Fill event1 to capacity
-      await createAttendeeAtomic(event1.id, "First", "first@example.com", null, 1);
+      await createAttendeeAtomic({ eventId: event1.id, name: "First", email: "first@example.com", quantity: 1 });
 
       const path = `/ticket/${event1.slug}+${event2.slug}`;
       const getResponse = await handleRequest(mockRequest(path));

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -355,7 +355,7 @@ describe("server (webhooks)", () => {
       });
 
       // Fill the event
-      await createAttendeeAtomic(event.id, "First", "first@example.com", "pi_first");
+      await createAttendeeAtomic({ eventId: event.id, name: "First", email: "first@example.com", paymentId: "pi_first" });
 
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
       const mockVerify = spyOn(stripePaymentProvider, "verifyWebhookSignature");
@@ -947,7 +947,7 @@ describe("server (webhooks)", () => {
         unitPrice: 500,
       });
       // Create attendee directly (not via public form which redirects to Stripe for paid events)
-      const result = await createAttendeeAtomic(event.id, "Already Done", "already@example.com", "pi_already_done", 1);
+      const result = await createAttendeeAtomic({ eventId: event.id, name: "Already Done", email: "already@example.com", paymentId: "pi_already_done", quantity: 1 });
       if (!result.success) throw new Error("Failed to create test attendee");
       const attendee = result.attendee;
 
@@ -1073,7 +1073,7 @@ describe("server (webhooks)", () => {
         maxAttendees: 1,
         unitPrice: 500,
       });
-      await createAttendeeAtomic(event2.id, "First", "first@example.com", "pi_first", 1);
+      await createAttendeeAtomic({ eventId: event2.id, name: "First", email: "first@example.com", paymentId: "pi_first", quantity: 1 });
 
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
       const mockVerify = spyOn(stripePaymentProvider, "verifyWebhookSignature");
@@ -1284,7 +1284,7 @@ describe("server (webhooks)", () => {
       });
 
       // Fill event2 to capacity
-      await createAttendeeAtomic(event2.id, "Existing", "existing@example.com", null, 1);
+      await createAttendeeAtomic({ eventId: event2.id, name: "Existing", email: "existing@example.com", quantity: 1 });
 
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
       const mockVerify = spyOn(stripePaymentProvider, "verifyWebhookSignature");
@@ -1340,7 +1340,7 @@ describe("server (webhooks)", () => {
         maxAttendees: 50,
         unitPrice: 500,
       });
-      const attResult = await createAttendeeAtomic(event.id, "WH Del", "whdel@example.com", "pi_del", 1);
+      const attResult = await createAttendeeAtomic({ eventId: event.id, name: "WH Del", email: "whdel@example.com", paymentId: "pi_del", quantity: 1 });
       if (!attResult.success) throw new Error("Failed to create attendee");
 
       // Reserve and finalize the session with the real attendee

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -325,7 +325,7 @@ describe("stripe", () => {
 
     beforeEach(async () => {
       // Set webhook secret in database (encrypted)
-      await setStripeWebhookConfig(TEST_SECRET, "we_test_endpoint");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_test_endpoint" });
     });
 
     test("returns error when webhook secret not configured", async () => {
@@ -585,7 +585,7 @@ describe("stripe", () => {
 
     test("returns webhook error when endpoint retrieval fails", async () => {
       await updateStripeKey("sk_test_mock");
-      await setStripeWebhookConfig("whsec_test", "we_test_missing");
+      await setStripeWebhookConfig({ secret: "whsec_test", endpointId: "we_test_missing" });
       const client = await getStripeClient();
       if (!client) throw new Error("Expected client to be defined");
 
@@ -606,7 +606,7 @@ describe("stripe", () => {
 
     test("returns full success when API key and webhook are both valid", async () => {
       await updateStripeKey("sk_test_mock");
-      await setStripeWebhookConfig("whsec_test", "we_test_valid");
+      await setStripeWebhookConfig({ secret: "whsec_test", endpointId: "we_test_valid" });
       const client = await getStripeClient();
       if (!client) throw new Error("Expected client to be defined");
 
@@ -664,7 +664,7 @@ describe("stripe", () => {
       expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]+$/);
 
       // Signature should be verifiable with the same secret (stored in DB)
-      await setStripeWebhookConfig(secret, "we_test_construction");
+      await setStripeWebhookConfig({ secret, endpointId: "we_test_construction" });
       const result = await verifyWebhookSignature(payload, signature);
       expect(result.valid).toBe(true);
     });
@@ -886,7 +886,7 @@ describe("stripe", () => {
 
     test("handles non-Error thrown value in webhook retrieval", async () => {
       await updateStripeKey("sk_test_mock");
-      await setStripeWebhookConfig("whsec_test", "we_test_nonerror");
+      await setStripeWebhookConfig({ secret: "whsec_test", endpointId: "we_test_nonerror" });
       const client = await getStripeClient();
       if (!client) throw new Error("Expected client to be defined");
 
@@ -1164,7 +1164,7 @@ describe("stripe", () => {
     const TEST_SECRET = "whsec_test_secret_key_for_timestamp_test";
 
     test("handles timestamp value that needs parseInt", async () => {
-      await setStripeWebhookConfig(TEST_SECRET, "we_test_ts");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_test_ts" });
 
       // Create event with proper signature
       const event: StripeWebhookEvent = {
@@ -1183,7 +1183,7 @@ describe("stripe", () => {
     });
 
     test("parses timestamp with parseInt when t key has value", async () => {
-      await setStripeWebhookConfig(TEST_SECRET, "we_test_parse");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_test_parse" });
 
       // Use a timestamp that is a valid number string, exercising Number.parseInt
       const timestamp = Math.floor(Date.now() / 1000);
@@ -1215,7 +1215,7 @@ describe("stripe", () => {
     });
 
     test("treats t key without equals as zero timestamp via parseInt fallback", async () => {
-      await setStripeWebhookConfig(TEST_SECRET, "we_test_nullish");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_test_nullish" });
 
       // Header "t,v1=abc123" - split("=") on "t" gives ["t"], so value is undefined
       // value ?? "0" gives "0", parseInt("0", 10) gives 0
@@ -1231,7 +1231,7 @@ describe("stripe", () => {
     });
 
     test("secureCompare handles strings of different lengths", async () => {
-      await setStripeWebhookConfig(TEST_SECRET, "we_test_len");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_test_len" });
 
       // Provide a signature that has different length than expected
       const timestamp = Math.floor(Date.now() / 1000);
@@ -1473,7 +1473,7 @@ describe("stripe-provider", () => {
   describe("verifyWebhookSignature delegation", () => {
     test("delegates to stripe.ts verifyWebhookSignature", async () => {
       const TEST_SECRET = "whsec_provider_verify_test";
-      await setStripeWebhookConfig(TEST_SECRET, "we_provider_test");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_provider_test" });
 
       const event: StripeWebhookEvent = {
         id: "evt_provider",
@@ -1498,7 +1498,7 @@ describe("stripe-provider", () => {
 
     test("returns error for invalid signature", async () => {
       const TEST_SECRET = "whsec_provider_invalid_test";
-      await setStripeWebhookConfig(TEST_SECRET, "we_provider_inv");
+      await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_provider_inv" });
 
       const timestamp = Math.floor(Date.now() / 1000);
       const result = await stripePaymentProvider.verifyWebhookSignature(


### PR DESCRIPTION
Replace positional arguments with object parameters where multiple args
came from the same object:
- getPrivateKey(session.token, session.wrappedDataKey) → getPrivateKey(session)
- createAttendeeAtomic(id, name, email, ...) → createAttendeeAtomic({ eventId, name, email, ... })
- setStripeWebhookConfig(result.secret, result.endpointId) → setStripeWebhookConfig(result)
- validateAndPrice(intent.eventId, intent.quantity) → validateAndPrice(intent)
- processPaymentSession(id, data.session, data.intent) → processPaymentSession(id, data)
- logActivity(msg, event.id) → logActivity(msg, event) (backwards-compatible)

https://claude.ai/code/session_01GhSGm2KnMmzFMTeTb9gvhU