### PR TITLE
Display booked dates in ticket and check-in views for daily events

### DIFF
--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -5,6 +5,7 @@
  */
 
 import { map, pipe } from "#fp";
+import { formatDateLabel } from "#lib/dates.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { TokenEntry } from "#routes/token-utils.ts";
 import { Layout } from "#templates/layout.tsx";
@@ -12,12 +13,13 @@ import { Layout } from "#templates/layout.tsx";
 /** Re-export for backwards compatibility */
 export type { TokenEntry as CheckinEntry };
 
-/** Render a single attendee detail row (admin view) */
-const renderCheckinRow = ({ event, attendee }: TokenEntry): string => {
+/** Render a single attendee detail row (admin view), optionally including a date column */
+const renderCheckinRow = (showDate: boolean, { event, attendee }: TokenEntry): string => {
   const isCheckedIn = attendee.checked_in === "true";
   return String(
     <tr>
       <td><a href={`/admin/event/${event.id}`}>{event.name}</a></td>
+      {showDate && <td>{attendee.date ? formatDateLabel(attendee.date) : ""}</td>}
       <td>{attendee.name}</td>
       <td>{attendee.email || ""}</td>
       <td>{attendee.phone || ""}</td>
@@ -36,8 +38,9 @@ export const checkinAdminPage = (
   checkinPath: string,
   message: string | null,
 ): string => {
+  const showDate = entries.some((e) => e.attendee.date !== null);
   const rows = pipe(
-    map((e: TokenEntry) => renderCheckinRow(e)),
+    map((e: TokenEntry) => renderCheckinRow(showDate, e)),
     (r: string[]) => r.join(""),
   )(entries);
 
@@ -60,6 +63,7 @@ export const checkinAdminPage = (
           <thead>
             <tr>
               <th>Event</th>
+              {showDate && <th>Date</th>}
               <th>Name</th>
               <th>Email</th>
               <th>Phone</th>

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -2,7 +2,7 @@
  * Ticket view page template - displays attendee ticket information with QR code
  */
 
-import { map, pipe } from "#fp";
+import { formatDateLabel } from "#lib/dates.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { TokenEntry } from "#routes/token-utils.ts";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
@@ -10,19 +10,17 @@ import { escapeHtml, Layout } from "#templates/layout.tsx";
 /** Re-export for backwards compatibility */
 export type { TokenEntry as TicketEntry };
 
-/** Render a single ticket row */
-const renderTicketRow = ({ event, attendee }: TokenEntry): string =>
-  `<tr><td>${escapeHtml(event.name)}</td><td>${attendee.quantity}</td></tr>`;
-
 /**
  * Ticket view page - shows event name + quantity per ticket, with inline QR code
  * The QR code encodes the /checkin/... URL for admin scanning
  */
 export const ticketViewPage = (entries: TokenEntry[], qrSvg: string): string => {
-  const rows = pipe(
-    map(renderTicketRow),
-    (r: string[]) => r.join(""),
-  )(entries);
+  const showDate = entries.some((e) => e.attendee.date !== null);
+  let rows = "";
+  for (const { event, attendee } of entries) {
+    const dateCol = showDate ? `<td>${attendee.date ? formatDateLabel(attendee.date) : ""}</td>` : "";
+    rows += `<tr><td>${escapeHtml(event.name)}</td>${dateCol}<td>${attendee.quantity}</td></tr>`;
+  }
 
   return String(
     <Layout title="Your Tickets">
@@ -35,6 +33,7 @@ export const ticketViewPage = (entries: TokenEntry[], qrSvg: string): string => 
           <thead>
             <tr>
               <th>Event</th>
+              {showDate && <th>Date</th>}
               <th>Quantity</th>
             </tr>
           </thead>


### PR DESCRIPTION
## Summary
Add support for displaying booked dates in ticket and check-in admin views when attendees have selected specific dates for daily events. The date column is conditionally shown only when at least one attendee has a date associated with their booking.

## Changes
- **checkin.tsx**: Modified `renderCheckinRow` to accept a `showDate` parameter and conditionally render a date column. Updated `checkinAdminPage` to detect if any entries have dates and pass this flag to row rendering.
- **tickets.tsx**: Refactored `ticketViewPage` to conditionally display a date column. Replaced functional pipeline with imperative loop for clearer date column logic. Removed unused `renderTicketRow` helper function.
- **test/server-checkin.test.ts**: Added tests verifying date display in admin check-in view for daily events and confirming date column is hidden for standard events.
- **test/server-tickets.test.ts**: Added comprehensive tests covering:
  - Date display for daily event tickets
  - Mixed daily and standard event tickets on same view (shows date column with empty cells for standard events)
  - Date column hidden when only standard events present

## Implementation Details
- Date column visibility is determined by checking if any attendee in the entries has a non-null date value
- Uses existing `formatDateLabel` utility for consistent date formatting
- Maintains backward compatibility by only showing the date column when relevant
- Tests cover edge cases including mixed event types on a single ticket view

https://claude.ai/code/session_01Ep4HhiWfpgYwPZem2zSr5X