### PR TITLE
Convert time helpers from constants to functions

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -72,12 +72,13 @@ export const getAvailableDates = (
   holidays: Holiday[],
 ): string[] => {
   const bookableDays = JSON.parse(event.bookable_days) as string[];
-  const start = addDays(today, event.minimum_days_before);
+  const todayStr = today();
+  const start = addDays(todayStr, event.minimum_days_before);
   const maxDays =
     event.maximum_days_after === 0
       ? MAX_FUTURE_DAYS
       : event.maximum_days_after;
-  const end = addDays(today, maxDays);
+  const end = addDays(todayStr, maxDays);
 
   return pipe(
     filter((d: string) => bookableDays.includes(getDayName(d))),

--- a/src/lib/db/activityLog.ts
+++ b/src/lib/db/activityLog.ts
@@ -36,7 +36,7 @@ export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
     primaryKey: "id",
     schema: {
       id: col.generated<number>(),
-      created: col.withDefault(() => nowIso),
+      created: col.withDefault(() => nowIso()),
       event_id: col.simple<number | null>(),
       message: col.encrypted<string>(encrypt, decrypt),
     },

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -107,7 +107,7 @@ const encryptAttendeeFields = async (
   if (!publicKeyJwk) return null;
 
   return {
-    created: nowIso,
+    created: nowIso(),
     encryptedName: await encryptAttendeePII(name, publicKeyJwk),
     encryptedEmail: email
       ? await encryptAttendeePII(email, publicKeyJwk)

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -67,7 +67,7 @@ export const eventsTable = defineTable<Event, EventInput>({
     description: { default: () => "", write: encrypt, read: decrypt },
     slug: col.encrypted<string>(encrypt, decrypt),
     slug_index: col.simple<string>(),
-    created: col.withDefault(() => nowIso),
+    created: col.withDefault(() => nowIso()),
     max_attendees: col.simple<number>(),
     thank_you_url: col.encryptedNullable<string>(encrypt, decrypt),
     unit_price: col.simple<number | null>(),

--- a/src/lib/db/holidays.ts
+++ b/src/lib/db/holidays.ts
@@ -48,5 +48,5 @@ export const getAllHolidays = (): Promise<Holiday[]> =>
 export const getActiveHolidays = (): Promise<Holiday[]> =>
   queryHolidays({
     sql: "SELECT * FROM holidays WHERE end_date >= ? ORDER BY start_date ASC",
-    args: [today],
+    args: [today()],
   });

--- a/src/lib/db/login-attempts.ts
+++ b/src/lib/db/login-attempts.ts
@@ -34,13 +34,15 @@ export const isLoginRateLimited = (ip: string): Promise<boolean> =>
   withHashedIpAttempts(ip, async (hashedIp, row) => {
     if (!row) return false;
 
+    const currentMs = nowMs();
+
     // Check if currently locked out
-    if (row.locked_until && row.locked_until > nowMs) {
+    if (row.locked_until && row.locked_until > currentMs) {
       return true;
     }
 
     // If lockout expired, reset
-    if (row.locked_until && row.locked_until <= nowMs) {
+    if (row.locked_until && row.locked_until <= currentMs) {
       await executeByField("login_attempts", "ip", hashedIp);
     }
 
@@ -56,7 +58,7 @@ export const recordFailedLogin = (ip: string): Promise<boolean> =>
     const newAttempts = (row?.attempts ?? 0) + 1;
 
     if (newAttempts >= MAX_LOGIN_ATTEMPTS) {
-      const lockedUntil = nowMs + LOCKOUT_DURATION_MS;
+      const lockedUntil = nowMs() + LOCKOUT_DURATION_MS;
       await getDb().execute({
         sql: "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)",
         args: [hashedIp, newAttempts, lockedUntil],

--- a/src/lib/db/processed-payments.ts
+++ b/src/lib/db/processed-payments.ts
@@ -47,7 +47,7 @@ export const isSessionProcessed = (
  */
 export const isReservationStale = (processedAt: string): boolean => {
   const reservedAt = new Date(processedAt).getTime();
-  return nowMs - reservedAt > STALE_RESERVATION_MS;
+  return nowMs() - reservedAt > STALE_RESERVATION_MS;
 };
 
 /**
@@ -67,7 +67,7 @@ export const deleteStaleReservation = async (
  * Called from admin event views to clean up abandoned checkouts.
  */
 export const deleteAllStaleReservations = async (): Promise<number> => {
-  const cutoff = new Date(nowMs - STALE_RESERVATION_MS).toISOString();
+  const cutoff = new Date(nowMs() - STALE_RESERVATION_MS).toISOString();
   const result = await getDb().execute({
     sql: "DELETE FROM processed_payments WHERE attendee_id IS NULL AND processed_at < ?",
     args: [cutoff],
@@ -90,7 +90,7 @@ export const reserveSession = async (
   try {
     await getDb().execute({
       sql: "INSERT INTO processed_payments (payment_session_id, attendee_id, processed_at) VALUES (?, NULL, ?)",
-      args: [sessionId, nowIso],
+      args: [sessionId, nowIso()],
     });
     return { reserved: true };
   } catch (e) {

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -61,7 +61,7 @@ const [getSettingsCacheState, setSettingsCacheState] = lazyRef<SettingsCacheStat
 
 const isCacheValid = (): boolean => {
   const state = getSettingsCacheState();
-  return state.entries !== null && nowMs - state.time < SETTINGS_CACHE_TTL_MS;
+  return state.entries !== null && nowMs() - state.time < SETTINGS_CACHE_TTL_MS;
 };
 
 /**
@@ -74,7 +74,7 @@ export const loadAllSettings = async (): Promise<Map<string, string>> => {
     const { key, value } = row as unknown as Settings;
     cache.set(key, value);
   }
-  setSettingsCacheState({ entries: cache, time: nowMs });
+  setSettingsCacheState({ entries: cache, time: nowMs() });
   return cache;
 };
 

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -235,7 +235,7 @@ export const isInviteValid = async (user: User): Promise<boolean> => {
 
   const decryptedExpiry = await decrypt(user.invite_expiry);
   if (!decryptedExpiry) return false;
-  return new Date(decryptedExpiry) > now;
+  return new Date(decryptedExpiry) > now();
 };
 
 /**

--- a/src/lib/now.ts
+++ b/src/lib/now.ts
@@ -1,15 +1,19 @@
 /**
- * Request-scoped "now" — consistent for the entire edge script lifecycle.
- * Since the edge runtime spins up fresh per request, a module-level
- * const gives a stable reference that won't drift across midnight.
+ * Time helpers — return fresh values on every call.
+ *
+ * On Bunny Edge each request spins up a fresh isolate, so module-level
+ * constants used to work. In Deno.serve (dev) and tests the process
+ * lives across many requests, so functions avoid stale timestamps.
  */
-export const now = new Date();
+
+/** Current time as a Date */
+export const now = (): Date => new Date();
 
 /** Today's date as YYYY-MM-DD */
-export const today = now.toISOString().slice(0, 10);
+export const today = (): string => new Date().toISOString().slice(0, 10);
 
 /** Full ISO-8601 timestamp for created/logged_at fields */
-export const nowIso = now.toISOString();
+export const nowIso = (): string => new Date().toISOString();
 
 /** Epoch milliseconds for numeric comparisons */
-export const nowMs = now.getTime();
+export const nowMs = (): number => Date.now();

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -520,7 +520,7 @@ export const verifyWebhookSignature = async (
   const { timestamp, signatures } = parsed;
 
   // Check timestamp tolerance
-  const nowSecs = Math.floor(nowMs / 1000);
+  const nowSecs = Math.floor(nowMs() / 1000);
   if (Math.abs(nowSecs - timestamp) > toleranceSeconds) {
     logError({ code: ErrorCode.STRIPE_SIGNATURE, detail: "timestamp out of tolerance" });
     return { valid: false, error: "Timestamp outside tolerance window" };
@@ -557,7 +557,7 @@ export const constructTestWebhookEvent = async (
   secret: string,
 ): Promise<{ payload: string; signature: string }> => {
   const payload = JSON.stringify(event);
-  const timestamp = Math.floor(nowMs / 1000);
+  const timestamp = Math.floor(nowMs() / 1000);
   const signedPayload = `${timestamp}.${payload}`;
   const sig = await computeSignature(signedPayload, secret);
 

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -96,7 +96,7 @@ export const buildWebhookPayload = (
       unit_price: event.unit_price,
       quantity: attendee.quantity,
     })),
-    timestamp: nowIso,
+    timestamp: nowIso(),
   };
 };
 

--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -39,7 +39,7 @@ const createLoginSession = async (
 ): Promise<Response> => {
   const token = generateSecureToken();
   const csrfToken = generateSecureToken();
-  const expires = nowMs + 24 * 60 * 60 * 1000;
+  const expires = nowMs() + 24 * 60 * 60 * 1000;
   const wrappedDataKey = await wrapKeyWithToken(dataKey, token);
 
   await createSession(token, csrfToken, expires, wrappedDataKey, userId);

--- a/src/routes/admin/users.ts
+++ b/src/routes/admin/users.ts
@@ -124,7 +124,7 @@ const handleUsersPost = (request: Request): Promise<Response> =>
     // Generate invite code
     const inviteCode = generateSecureToken();
     const codeHash = await hashInviteCode(inviteCode);
-    const expiry = new Date(nowMs + INVITE_EXPIRY_MS).toISOString();
+    const expiry = new Date(nowMs() + INVITE_EXPIRY_MS).toISOString();
 
     await createInvitedUser(
       username,

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -84,7 +84,7 @@ export const getAuthenticatedSession = async (
   const session = await getSession(token);
   if (!session) return null;
 
-  if (session.expires < nowMs) {
+  if (session.expires < nowMs()) {
     await deleteSession(token);
     return null;
   }
@@ -306,7 +306,7 @@ export const withActiveEventBySlug = (
 
 /** Check if an event's registration period has closed */
 export const isRegistrationClosed = (event: { closes_at: string | null }): boolean =>
-  event.closes_at !== null && new Date(event.closes_at).getTime() < nowMs;
+  event.closes_at !== null && new Date(event.closes_at).getTime() < nowMs();
 
 /** Create a formatter for attendee creation failures (capacity_exceeded / encryption_error) */
 export const formatCreationError =
@@ -322,7 +322,7 @@ export const formatCreationError =
 
 /** Format a countdown from now to a future closes_at date, e.g. "3 days and 5 hours from now" */
 export const formatCountdown = (closesAt: string): string => {
-  const diffMs = new Date(closesAt).getTime() - nowMs;
+  const diffMs = new Date(closesAt).getTime() - nowMs();
   if (diffMs <= 0) return "closed";
   const totalHours = Math.floor(diffMs / (1000 * 60 * 60));
   const days = Math.floor(totalHours / 24);

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -68,7 +68,7 @@ describe("dates", () => {
 
     test("excludes holidays", () => {
       // Pick a date range that includes "today + 1" as a holiday
-      const holidayDate = addDays(today, 1);
+      const holidayDate = addDays(today(), 1);
       const holidays = [{ id: 1, name: "Holiday", start_date: holidayDate, end_date: holidayDate }];
 
       const event = testEvent({
@@ -83,8 +83,8 @@ describe("dates", () => {
     });
 
     test("excludes holiday ranges", () => {
-      const holidayStart = addDays(today, 1);
-      const holidayEnd = addDays(today, 3);
+      const holidayStart = addDays(today(), 1);
+      const holidayEnd = addDays(today(), 3);
       const holidays = [{ id: 1, name: "Holiday Range", start_date: holidayStart, end_date: holidayEnd }];
 
       const event = testEvent({
@@ -96,7 +96,7 @@ describe("dates", () => {
 
       const dates = getAvailableDates(event, holidays);
       expect(dates).not.toContain(holidayStart);
-      expect(dates).not.toContain(addDays(today, 2));
+      expect(dates).not.toContain(addDays(today(), 2));
       expect(dates).not.toContain(holidayEnd);
     });
 
@@ -110,7 +110,7 @@ describe("dates", () => {
 
       const dates = getAvailableDates(event, []);
       const earliest = dates[0]!;
-      expect(earliest >= addDays(today, 3)).toBe(true);
+      expect(earliest >= addDays(today(), 3)).toBe(true);
     });
 
     test("uses 730 days when maximum_days_after is 0 (unlimited)", () => {
@@ -124,7 +124,7 @@ describe("dates", () => {
       const dates = getAvailableDates(event, []);
       const latest = dates[dates.length - 1]!;
       // Should extend close to 730 days (2 years)
-      expect(latest >= addDays(today, 700)).toBe(true);
+      expect(latest >= addDays(today(), 700)).toBe(true);
     });
 
     test("respects maximum_days_after when non-zero", () => {
@@ -137,7 +137,7 @@ describe("dates", () => {
 
       const dates = getAvailableDates(event, []);
       const latest = dates[dates.length - 1]!;
-      expect(latest <= addDays(today, 7)).toBe(true);
+      expect(latest <= addDays(today(), 7)).toBe(true);
     });
 
     test("returns empty array when no bookable days match", () => {

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -1828,7 +1828,7 @@ describe("db", () => {
 
     test("reserveSession retries when stale reservation detected", async () => {
       // Insert a reservation with a timestamp old enough relative to frozen nowMs
-      const oldTimestamp = new Date(nowMs - STALE_RESERVATION_MS - 1000).toISOString();
+      const oldTimestamp = new Date(nowMs() - STALE_RESERVATION_MS - 1000).toISOString();
       await getDb().execute({
         sql: "INSERT INTO processed_payments (payment_session_id, attendee_id, processed_at) VALUES (?, NULL, ?)",
         args: ["sess_stale", oldTimestamp],
@@ -1864,7 +1864,7 @@ describe("db", () => {
 
     test("reserveSession retries when stale reservation is detected (recursive path)", async () => {
       // Insert a reservation with a timestamp old enough relative to frozen nowMs
-      const oldTimestamp = new Date(nowMs - STALE_RESERVATION_MS - 1000).toISOString();
+      const oldTimestamp = new Date(nowMs() - STALE_RESERVATION_MS - 1000).toISOString();
       await getDb().execute({
         sql: "INSERT INTO processed_payments (payment_session_id, attendee_id, processed_at) VALUES (?, NULL, ?)",
         args: ["sess_race", oldTimestamp],

--- a/test/lib/processed-payments.test.ts
+++ b/test/lib/processed-payments.test.ts
@@ -10,7 +10,6 @@ import {
   STALE_RESERVATION_MS,
 } from "#lib/db/processed-payments.ts";
 import { getDb } from "#lib/db/client.ts";
-import { nowIso } from "#lib/now.ts";
 import {
   createTestAttendee,
   createTestDbWithSetup,
@@ -182,8 +181,9 @@ describe("processed-payments", () => {
       const record = await isSessionProcessed("cs_timestamp_test");
       expect(record).not.toBeNull();
       expect(record?.processed_at).toBeDefined();
-      // Timestamp should match the frozen nowIso from now.ts
-      expect(record?.processed_at).toBe(nowIso);
+      // Timestamp should be a valid ISO string close to current time
+      const processedMs = new Date(record!.processed_at).getTime();
+      expect(Math.abs(processedMs - Date.now())).toBeLessThan(5000);
     });
   });
 

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -61,7 +61,7 @@ describe("admin calendar", () => {
     });
 
     test("includes attendee dates in dropdown", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -80,8 +80,8 @@ describe("admin calendar", () => {
     });
 
     test("filters attendees by date parameter", async () => {
-      const date1 = addDays(today, 1);
-      const date2 = addDays(today, 2);
+      const date1 = addDays(today(), 1);
+      const date2 = addDays(today(), 2);
       const event = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -106,7 +106,7 @@ describe("admin calendar", () => {
     });
 
     test("shows attendees from multiple daily events for same date", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event1 = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -140,7 +140,7 @@ describe("admin calendar", () => {
     });
 
     test("links event name to event page", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -159,7 +159,7 @@ describe("admin calendar", () => {
     });
 
     test("shows Export CSV link when attendees exist for date", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -179,7 +179,7 @@ describe("admin calendar", () => {
     });
 
     test("does not show Export CSV link when no attendees for date", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -221,7 +221,7 @@ describe("admin calendar", () => {
     });
 
     test("returns CSV with correct headers", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -242,7 +242,7 @@ describe("admin calendar", () => {
     });
 
     test("includes Event and Date columns in CSV", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -265,7 +265,7 @@ describe("admin calendar", () => {
     });
 
     test("includes attendees from multiple events", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       const event1 = await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),
@@ -298,7 +298,7 @@ describe("admin calendar", () => {
     });
 
     test("returns empty CSV when no attendees for date", async () => {
-      const validDate = addDays(today, 1);
+      const validDate = addDays(today(), 1);
       await createTestEvent({
         eventType: "daily",
         bookableDays: JSON.stringify(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]),

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1868,22 +1868,22 @@ describe("server (admin events)", () => {
     });
 
     test("formatCountdown shows days and hours", () => {
-      const future = new Date(nowMs + 3 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000).toISOString();
+      const future = new Date(nowMs() + 3 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000).toISOString();
       expect(formatCountdown(future)).toBe("3 days and 5 hours from now");
     });
 
     test("formatCountdown shows only days when no remaining hours", () => {
-      const future = new Date(nowMs + 2 * 24 * 60 * 60 * 1000 + 10 * 60 * 1000).toISOString();
+      const future = new Date(nowMs() + 2 * 24 * 60 * 60 * 1000 + 10 * 60 * 1000).toISOString();
       expect(formatCountdown(future)).toBe("2 days from now");
     });
 
     test("formatCountdown shows only hours", () => {
-      const future = new Date(nowMs + 5 * 60 * 60 * 1000 + 10 * 60 * 1000).toISOString();
+      const future = new Date(nowMs() + 5 * 60 * 60 * 1000 + 10 * 60 * 1000).toISOString();
       expect(formatCountdown(future)).toBe("5 hours from now");
     });
 
     test("formatCountdown shows minutes when less than an hour", () => {
-      const result = formatCountdown(new Date(nowMs + 30 * 60 * 1000).toISOString());
+      const result = formatCountdown(new Date(nowMs() + 30 * 60 * 1000).toISOString());
       expect(result).toContain("minute");
       expect(result).toContain("from now");
     });
@@ -1893,7 +1893,7 @@ describe("server (admin events)", () => {
     });
 
     test("formatCountdown singular forms", () => {
-      const future = new Date(nowMs + 1 * 24 * 60 * 60 * 1000 + 1 * 60 * 60 * 1000).toISOString();
+      const future = new Date(nowMs() + 1 * 24 * 60 * 60 * 1000 + 1 * 60 * 60 * 1000).toISOString();
       expect(formatCountdown(future)).toBe("1 day and 1 hour from now");
     });
 
@@ -2137,8 +2137,8 @@ describe("server (admin events)", () => {
   });
 
   describe("daily event admin view (Phase 4)", () => {
-    const validDate1 = addDays(today, 1);
-    const validDate2 = addDays(today, 2);
+    const validDate1 = addDays(today(), 1);
+    const validDate2 = addDays(today(), 2);
 
     const createDailyEventWithAttendees = async () => {
       const event = await createTestEvent({

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1620,7 +1620,7 @@ describe("server (public routes)", () => {
 
   describe("daily events (single ticket)", () => {
     // A valid bookable date: tomorrow (today + 1 day)
-    const validDate = addDays(today, 1);
+    const validDate = addDays(today(), 1);
 
     test("GET shows date selector for daily event", async () => {
       const event = await createTestEvent({
@@ -1744,7 +1744,7 @@ describe("server (public routes)", () => {
       expect(response1.status).toBe(302);
 
       // Book different date should succeed
-      const otherDate = addDays(today, 2);
+      const otherDate = addDays(today(), 2);
       const response2 = await submitTicketForm(event.slug, {
         name: "Second User",
         email: "second@example.com",
@@ -1810,7 +1810,7 @@ describe("server (public routes)", () => {
   });
 
   describe("daily events (multi-ticket)", () => {
-    const validDate = addDays(today, 1);
+    const validDate = addDays(today(), 1);
 
     test("GET shows date selector for multi-ticket with daily events", async () => {
       const event1 = await createTestEvent({


### PR DESCRIPTION
## Summary
Refactored time helper exports in `src/lib/now.ts` from module-level constants to functions that return fresh values on each call. This ensures timestamps remain accurate across the entire request lifecycle, particularly important in long-lived processes like Deno.serve (dev) and tests.

## Changes
- **`now`**: Changed from `new Date()` constant to `() => new Date()` function
- **`today`**: Changed from computed string constant to `() => string` function
- **`nowIso`**: Changed from computed ISO string constant to `() => string` function  
- **`nowMs`**: Changed from computed milliseconds constant to `() => number` function using `Date.now()`

Updated all 40+ call sites across the codebase to invoke these as functions:
- Database operations (activity logs, attendees, events, holidays, login attempts, payments, settings, users)
- Stripe webhook verification and test event construction
- Admin authentication and user invitation flows
- Public route utilities (session validation, registration closure checks, countdown formatting)
- Date calculations and filtering
- Test files with updated assertions

## Implementation Details
- While Bunny Edge spins up fresh isolates per request (making module constants safe), Deno.serve and test environments maintain long-lived processes where timestamps would become stale
- Functions ensure consistent, fresh timestamps without requiring manual cache invalidation
- One test assertion updated to use time delta comparison instead of exact string matching, since timestamps are now generated at call time rather than module load time

https://claude.ai/code/session_019TyZNJFZUc13G2889WNRbH