### PR TITLE
Add global webhook URL support for registration notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Environment variables are configured as **Bunny native secrets** in the Bunny Ed
 ### Optional
 
 - `PORT` - Server port (defaults to 3000, local dev only)
+- `WEBHOOK_URL` - Global webhook URL for registration notifications (sends in addition to per-event webhook URLs)
 
 ### Stripe Configuration
 

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -6,6 +6,7 @@
 import { compact, map, unique } from "#fp";
 import { getAllowedDomain } from "#lib/config.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
+import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 
 /** Single ticket in the webhook payload */
@@ -125,7 +126,11 @@ export const sendRegistrationWebhooks = async (
   entries: RegistrationEntry[],
   currency: string,
 ): Promise<void> => {
-  const webhookUrls = unique(compact(entries.map((e) => e.event.webhook_url)));
+  const envWebhookUrl = getEnv("WEBHOOK_URL");
+  const webhookUrls = unique(compact([
+    ...entries.map((e) => e.event.webhook_url),
+    envWebhookUrl,
+  ]));
   if (webhookUrls.length === 0) return;
 
   const payload = buildWebhookPayload(entries, currency);

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -170,6 +170,10 @@ describe("webhook", () => {
   });
 
   describe("sendRegistrationWebhooks", () => {
+    afterEach(() => {
+      Deno.env.delete("WEBHOOK_URL");
+    });
+
     test("sends to all unique webhook URLs", async () => {
       const entries: RegistrationEntry[] = [
         {
@@ -228,7 +232,7 @@ describe("webhook", () => {
       expect(url).toBe("https://hook.com");
     });
 
-    test("does nothing when all webhook URLs are null", async () => {
+    test("does nothing when all webhook URLs are null and WEBHOOK_URL is not set", async () => {
       const entries: RegistrationEntry[] = [
         {
           event: makeEvent({ webhook_url: null }),
@@ -239,6 +243,55 @@ describe("webhook", () => {
       await sendRegistrationWebhooks(entries, "GBP");
 
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test("sends to WEBHOOK_URL env var in addition to event webhook URLs", async () => {
+      Deno.env.set("WEBHOOK_URL", "https://global-hook.com");
+      const entries: RegistrationEntry[] = [
+        {
+          event: makeEvent({ webhook_url: "https://event-hook.com" }),
+          attendee: makeAttendee(),
+        },
+      ];
+
+      await sendRegistrationWebhooks(entries, "GBP");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const urls = fetchSpy.mock.calls.map(
+        (call: [string, RequestInit]) => call[0],
+      );
+      expect(urls).toContain("https://event-hook.com");
+      expect(urls).toContain("https://global-hook.com");
+    });
+
+    test("sends to WEBHOOK_URL even when no events have webhook URLs", async () => {
+      Deno.env.set("WEBHOOK_URL", "https://global-hook.com");
+      const entries: RegistrationEntry[] = [
+        {
+          event: makeEvent({ webhook_url: null }),
+          attendee: makeAttendee(),
+        },
+      ];
+
+      await sendRegistrationWebhooks(entries, "GBP");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://global-hook.com");
+    });
+
+    test("deduplicates WEBHOOK_URL when it matches an event webhook URL", async () => {
+      Deno.env.set("WEBHOOK_URL", "https://same-hook.com");
+      const entries: RegistrationEntry[] = [
+        {
+          event: makeEvent({ webhook_url: "https://same-hook.com" }),
+          attendee: makeAttendee(),
+        },
+      ];
+
+      await sendRegistrationWebhooks(entries, "GBP");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -286,6 +339,26 @@ describe("webhook", () => {
       await logAndNotifyRegistration(event, attendee, "GBP");
 
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test("sends to WEBHOOK_URL env var when event has no webhook_url", async () => {
+      Deno.env.set("WEBHOOK_URL", "https://global-hook.com");
+      const { logAndNotifyRegistration } = await import("#lib/webhook.ts");
+      const dbEvent = await createTestEvent();
+      const event = makeEvent({
+        id: dbEvent.id,
+        name: dbEvent.name,
+        slug: dbEvent.slug,
+        webhook_url: null,
+      });
+      const attendee = makeAttendee();
+
+      await logAndNotifyRegistration(event, attendee, "GBP");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://global-hook.com");
+      Deno.env.delete("WEBHOOK_URL");
     });
   });
 
@@ -349,6 +422,30 @@ describe("webhook", () => {
       await logAndNotifyMultiRegistration(entries, "USD");
 
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test("sends to WEBHOOK_URL env var for multi-event registration", async () => {
+      Deno.env.set("WEBHOOK_URL", "https://global-hook.com");
+      const { logAndNotifyMultiRegistration } = await import("#lib/webhook.ts");
+      const dbEventA = await createTestEvent();
+      const dbEventB = await createTestEvent();
+      const entries: RegistrationEntry[] = [
+        {
+          event: makeEvent({ id: dbEventA.id, webhook_url: null }),
+          attendee: makeAttendee(),
+        },
+        {
+          event: makeEvent({ id: dbEventB.id, webhook_url: null }),
+          attendee: makeAttendee(),
+        },
+      ];
+
+      await logAndNotifyMultiRegistration(entries, "USD");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://global-hook.com");
+      Deno.env.delete("WEBHOOK_URL");
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds support for a global `WEBHOOK_URL` environment variable that enables sending registration notifications to a centralized webhook endpoint in addition to per-event webhook URLs.

## Changes
- **Configuration**: Added `WEBHOOK_URL` optional environment variable to documentation (CLAUDE.md)
- **Implementation**: Modified `sendRegistrationWebhooks()` to include the global webhook URL alongside event-specific URLs
- **Deduplication**: Leveraged existing `unique()` utility to prevent duplicate webhook calls when the global URL matches an event URL
- **Testing**: Added comprehensive test coverage including:
  - Sending to global webhook in addition to event webhooks
  - Sending to global webhook when events have no webhook URLs
  - Deduplication when global and event URLs match
  - Integration tests for `logAndNotifyRegistration()` and `logAndNotifyMultiRegistration()`
  - Proper cleanup of environment variables in test teardown

## Implementation Details
The global webhook URL is retrieved via `getEnv("WEBHOOK_URL")` and merged with per-event webhook URLs before deduplication. This ensures backward compatibility while providing a fallback mechanism for registration notifications when individual events don't have configured webhooks.

https://claude.ai/code/session_01GG96xCi6EjqyAqa1wtFR6p