### PR TITLE
Add Square payment integration to CSP headers

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -26,7 +26,8 @@ const buildCspHeader = (embeddable: boolean): string =>
     !embeddable && "frame-ancestors 'none'",
     "default-src 'self'",
     "style-src 'self' 'unsafe-inline'",
-    "script-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' https://*.squarecdn.com https://js.squareup.com",
+    "connect-src 'self' https://pci-connect.squareup.com",
     "form-action 'self' https://checkout.stripe.com",
   ]).join("; ");
 

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -60,7 +60,7 @@ describe("server (misc)", () => {
 
     describe("Content-Security-Policy", () => {
       const baseCsp =
-        "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; form-action 'self' https://checkout.stripe.com";
+        "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://*.squarecdn.com https://js.squareup.com; connect-src 'self' https://pci-connect.squareup.com; form-action 'self' https://checkout.stripe.com";
 
       test("non-embeddable pages have frame-ancestors 'none' and security restrictions", async () => {
         const response = await handleRequest(mockRequest("/"));


### PR DESCRIPTION
## Summary
Updated Content Security Policy (CSP) headers to support Square payment processing integration alongside the existing Stripe integration.

## Changes
- **script-src directive**: Added `https://*.squarecdn.com` and `https://js.squareup.com` to allow loading Square's JavaScript libraries
- **connect-src directive**: Added new directive with `https://pci-connect.squareup.com` to allow API connections to Square's PCI-compliant endpoint
- **Tests**: Updated CSP header test expectations to reflect the new Square-related directives

## Implementation Details
These changes enable the application to:
- Load Square's payment form and SDK scripts from their CDN
- Establish secure connections to Square's payment processing endpoints
- Maintain security by using specific domain allowlists rather than broad wildcards

The changes follow the same pattern as the existing Stripe integration, ensuring consistent security practices across payment providers.

https://claude.ai/code/session_01EXV3E2F7uLEpLthFmaxKyq