### PR TITLE
Improve embed hosts setting label clarity

### DIFF
--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -132,7 +132,7 @@ export const adminSettingsPage = (
         )}
 
         <form method="POST" action="/admin/settings/embed-hosts">
-            <h2>Allowed Embed Hosts</h2>
+            <h2>Only allow embedding on these hosts</h2>
           <p>Restrict which websites can embed your booking forms in an iframe. Leave blank to allow embedding from any site.</p>
           <input type="hidden" name="csrf_token" value={session.csrfToken} />
           <label for="embed_hosts">Hosts (comma-separated)</label>

--- a/test/lib/server-embed-hosts.test.ts
+++ b/test/lib/server-embed-hosts.test.ts
@@ -29,7 +29,7 @@ describe("server (embed hosts)", () => {
       const response = await awaitTestRequest("/admin/settings", { cookie });
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Allowed Embed Hosts");
+      expect(html).toContain("Only allow embedding on these hosts");
       expect(html).toContain("embed_hosts");
     });
 


### PR DESCRIPTION
## Summary
Updated the label for the embed hosts configuration setting to be more descriptive and user-friendly.

## Changes
- Changed the heading from "Allowed Embed Hosts" to "Only allow embedding on these hosts" in the admin settings page
- Updated the corresponding test assertion to match the new heading text

## Details
The new heading is more explicit about the behavior of the setting, making it clearer to users that specifying hosts will restrict embedding to only those sites, rather than just listing allowed hosts in a passive way.

https://claude.ai/code/session_01V1Ewx76Acp94Y6i11X1yJc