### PR TITLE
Hide daily-only fields when event type is standard

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -821,6 +821,13 @@ form > button {
   margin: 0;
 }
 
+/* Hide daily-only fields when event type is "standard" */
+form:has(select[name="event_type"] option[value="standard"]:checked) > label:has([name="bookable_days"]),
+form:has(select[name="event_type"] option[value="standard"]:checked) > label:has([name="minimum_days_before"]),
+form:has(select[name="event_type"] option[value="standard"]:checked) > label:has([name="maximum_days_after"]) {
+  display: none;
+}
+
 /* Utility classes for strict CSP (no inline styles) */
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
Added CSS rules to conditionally hide daily-specific form fields when the event type is set to "standard".

## Key Changes
- Added CSS selector using `:has()` pseudo-class to target form labels containing daily-only fields (`bookable_days`, `minimum_days_before`, `maximum_days_after`)
- These fields are now hidden when the `event_type` select element has the "standard" option selected
- Uses CSS-only approach without requiring JavaScript, maintaining compatibility with strict Content Security Policy (CSP)

## Implementation Details
- Leverages the `:has()` pseudo-class selector for parent-based conditional styling
- Targets three related form fields that are only relevant for daily event types
- Follows the existing pattern of utility classes for strict CSP compliance

https://claude.ai/code/session_01VmoUc6986JMxTy1JTde249