### PR TITLE
Fix formatCountdown test to include minutes in timestamp

### DIFF
--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1880,7 +1880,7 @@ describe("server (admin events)", () => {
     });
 
     test("formatCountdown shows days and hours", () => {
-      const future = new Date(nowMs() + 3 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000).toISOString();
+      const future = new Date(nowMs() + 3 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000 + 30 * 60 * 1000).toISOString();
       expect(formatCountdown(future)).toBe("3 days and 5 hours from now");
     });
 


### PR DESCRIPTION
## Summary
Updated the test case for `formatCountdown` to include 30 minutes in the future timestamp, ensuring the test data more accurately reflects the expected behavior.

## Key Changes
- Modified the `formatCountdown shows days and hours` test to add 30 minutes (`30 * 60 * 1000`) to the future date calculation
- The test now uses a timestamp that is 3 days, 5 hours, and 30 minutes in the future instead of just 3 days and 5 hours

## Details
This change ensures the test timestamp includes minutes, which may be important for:
- Testing edge cases in countdown formatting logic
- Ensuring the function correctly handles and truncates/rounds time values
- Verifying that minutes don't affect the "days and hours" output format

https://claude.ai/code/session_01HSojpbs2rQ7dFJsfBV3gEE