### PR TITLE
Reject payments with price mismatches and refund automatically

### DIFF
--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -189,6 +189,7 @@ describe("server (payment flow)", () => {
             id: "cs_test",
             payment_status: "paid",
             payment_intent: "pi_second",
+            amount_total: 1000,
             metadata: {
               event_id: String(event.id),
               name: "Second",
@@ -499,6 +500,7 @@ describe("server (payment flow)", () => {
           id: "cs_test_paid",
           payment_status: "paid",
           payment_intent: "pi_test_123",
+          amount_total: 1000,
           metadata: {
             event_id: String(event.id),
             name: "John",
@@ -547,6 +549,7 @@ describe("server (payment flow)", () => {
           id: "cs_test_paid",
           payment_status: "paid",
           payment_intent: "pi_test_123",
+          amount_total: 1000,
           metadata: {
             event_id: String(event.id),
             name: "John",
@@ -588,6 +591,7 @@ describe("server (payment flow)", () => {
           id: "cs_test_paid",
           payment_status: "paid",
           payment_intent: "pi_test_123",
+          amount_total: 3000,
           metadata: {
             event_id: String(event.id),
             name: "John",
@@ -656,6 +660,7 @@ describe("server (payment flow)", () => {
             id: "cs_test",
             payment_status: "paid",
             payment_intent: "pi_test_123",
+            amount_total: 1000,
             metadata: {
               event_id: String(event.id),
               name: "John",
@@ -716,6 +721,7 @@ describe("server (payment flow)", () => {
         id: "cs_multi_success",
         payment_status: "paid",
         payment_intent: "pi_multi_success",
+        amount_total: 2500,
         metadata: {
           name: "Multi Payer",
           email: "multi@example.com",
@@ -876,6 +882,7 @@ describe("server (payment flow)", () => {
         id: "cs_refund_fail",
         payment_status: "paid",
         payment_intent: "pi_refund_fail",
+        amount_total: 1000,
         metadata: {
           event_id: String(event.id),
           name: "Refund Fail",
@@ -926,6 +933,7 @@ describe("server (payment flow)", () => {
         id: "cs_multi_rollback",
         payment_status: "paid",
         payment_intent: "pi_multi_rollback",
+        amount_total: 1500,
         metadata: {
           name: "Rollback User",
           email: "rollback@example.com",
@@ -977,6 +985,7 @@ describe("server (payment flow)", () => {
         id: "cs_single_thankyou",
         payment_status: "paid",
         payment_intent: "pi_single_thankyou",
+        amount_total: 500,
         metadata: {
           event_id: String(event.id),
           name: "Single",
@@ -1012,6 +1021,7 @@ describe("server (payment flow)", () => {
         id: "cs_dupe_session",
         payment_status: "paid",
         payment_intent: "pi_dupe",
+        amount_total: 1000,
         metadata: {
           event_id: String(event.id),
           name: "Dupe",


### PR DESCRIPTION
## Summary
Changed the payment processing logic to reject checkout sessions when event prices have changed since the checkout was created, and automatically refund the payment. Previously, the system would log a warning and accept the payment using the actual charged amount.

## Key Changes

- **Price mismatch detection**: Replaced `resolvePricePaid()` function with `hasPriceMismatch()` that returns a boolean instead of silently accepting mismatched amounts
- **Single-ticket payments**: Now reject and refund when `amountTotal` differs from the current event price, returning an error message to the user
- **Multi-ticket payments**: Now reject and refund when the total charged differs from the sum of current event prices, instead of proportionally scaling prices
- **Redirect flow**: Added price mismatch validation to the `/payment/success` redirect endpoint with user-facing error messaging
- **Refund integration**: Both webhook and redirect flows now call `refundPayment()` when a mismatch is detected
- **Test updates**: Updated test cases to verify rejection behavior, refund attempts, and that no attendees are created when prices have changed

## Implementation Details

- The `hasPriceMismatch()` check is applied consistently in both `processPaymentSession()` and `processMultiPaymentSession()`
- When a mismatch is detected, `refundAndFail()` is called with a user-friendly error message
- Removed the proportional price scaling logic that was previously used for multi-ticket mismatches
- Added `amount_total` field to test fixtures to properly simulate Stripe checkout sessions
- Error messages distinguish between single-event and multi-event scenarios

https://claude.ai/code/session_011YZAjxeagQeE3EU7GMBqo5