### PR TITLE
Add ntfy error notifications for production monitoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Environment variables are configured as **Bunny native secrets** in the Bunny Ed
 
 - `PORT` - Server port (defaults to 3000, local dev only)
 - `WEBHOOK_URL` - Global webhook URL for registration notifications (sends in addition to per-event webhook URLs)
+- `NTFY_URL` - Ntfy endpoint URL for error notifications (e.g. `https://ntfy.sh/your-topic`). Sends domain and error code only, no personal or encrypted data.
 
 ### Stripe Configuration
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,7 +3,10 @@
  *
  * - Request logging: logs method, path (slugs redacted), status, duration
  * - Error logging: logs classified error codes without PII
+ * - Ntfy notifications: optional error pings to a configured ntfy URL
  */
+
+import { sendNtfyError } from "#lib/ntfy.ts";
 
 /**
  * Error codes for classified error logging
@@ -137,6 +140,8 @@ export const logError = (context: ErrorContext): void => {
 
   // biome-ignore lint/suspicious/noConsole: Intentional error logging
   console.error(parts.join(" "));
+
+  sendNtfyError(code);
 };
 
 /**

--- a/src/lib/ntfy.ts
+++ b/src/lib/ntfy.ts
@@ -1,0 +1,30 @@
+/**
+ * Ntfy error notification module
+ * Sends error pings to a configured ntfy URL
+ * Only includes domain and error code - no personal or encrypted data
+ */
+
+import { getAllowedDomain } from "#lib/config.ts";
+import { getEnv } from "#lib/env.ts";
+
+/**
+ * Send an error notification to the configured ntfy URL
+ * Fire and forget - delivery failures are silently ignored
+ */
+export const sendNtfyError = (code: string): void => {
+  const ntfyUrl = getEnv("NTFY_URL");
+  if (!ntfyUrl) return;
+
+  const domain = getAllowedDomain();
+
+  fetch(ntfyUrl, {
+    method: "POST",
+    headers: {
+      "Title": `${domain} error`,
+      "Tags": "warning",
+    },
+    body: code,
+  }).catch(() => {
+    // Silently ignore ntfy delivery failures
+  });
+};

--- a/src/lib/ntfy.ts
+++ b/src/lib/ntfy.ts
@@ -9,7 +9,7 @@ import { getEnv } from "#lib/env.ts";
 
 /**
  * Send an error notification to the configured ntfy URL
- * Fire and forget - delivery failures are silently ignored
+ * Fire and forget - delivery failures are logged but don't propagate
  */
 export const sendNtfyError = (code: string): void => {
   const ntfyUrl = getEnv("NTFY_URL");
@@ -25,6 +25,7 @@ export const sendNtfyError = (code: string): void => {
     },
     body: code,
   }).catch(() => {
-    // Silently ignore ntfy delivery failures
+    // biome-ignore lint/suspicious/noConsole: Can't use logError here (would cause infinite loop)
+    console.error("[Error] E_NTFY_SEND");
   });
 };

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -151,6 +151,22 @@ describe("logger", () => {
         '[Error] E_NOT_FOUND_EVENT event=1 attendee=2 detail="inactive"',
       );
     });
+
+    test("sends ntfy notification when NTFY_URL is configured", () => {
+      Deno.env.set("NTFY_URL", "https://ntfy.sh/test-topic");
+      // deno-lint-ignore no-explicit-any
+      const fetchSpy: any = spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+
+      logError({ code: ErrorCode.DB_QUERY });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://ntfy.sh/test-topic");
+      expect(options.body).toBe("E_DB_QUERY");
+
+      fetchSpy.mockRestore();
+      Deno.env.delete("NTFY_URL");
+    });
   });
 
   describe("logDebug", () => {

--- a/test/lib/ntfy.test.ts
+++ b/test/lib/ntfy.test.ts
@@ -57,14 +57,19 @@ describe("ntfy", () => {
       expect(headers["Tags"]).toBe("warning");
     });
 
-    test("silently ignores fetch errors", () => {
+    test("logs error when fetch fails", async () => {
       Deno.env.set("NTFY_URL", "https://ntfy.sh/my-topic");
       fetchSpy.mockRejectedValue(new Error("Network error"));
+      const errorSpy = spyOn(console, "error");
 
-      // Should not throw
       sendNtfyError(ErrorCode.WEBHOOK_SEND);
 
+      // Wait for the rejected promise's .catch handler to run
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith("[Error] E_NTFY_SEND");
+      errorSpy.mockRestore();
     });
   });
 });

--- a/test/lib/ntfy.test.ts
+++ b/test/lib/ntfy.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "#test-compat";
+import { sendNtfyError } from "#lib/ntfy.ts";
+import { ErrorCode } from "#lib/logger.ts";
+
+describe("ntfy", () => {
+  // deno-lint-ignore no-explicit-any
+  let fetchSpy: any;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+    Deno.env.delete("NTFY_URL");
+  });
+
+  describe("sendNtfyError", () => {
+    test("does nothing when NTFY_URL is not set", () => {
+      sendNtfyError(ErrorCode.DB_CONNECTION);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test("sends POST to ntfy URL with error code as body", () => {
+      Deno.env.set("NTFY_URL", "https://ntfy.sh/my-topic");
+
+      sendNtfyError(ErrorCode.DB_CONNECTION);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://ntfy.sh/my-topic");
+      expect(options.method).toBe("POST");
+      expect(options.body).toBe("E_DB_CONNECTION");
+    });
+
+    test("includes domain in Title header", () => {
+      Deno.env.set("NTFY_URL", "https://ntfy.sh/my-topic");
+
+      sendNtfyError(ErrorCode.CAPACITY_EXCEEDED);
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = options.headers as Record<string, string>;
+      expect(headers["Title"]).toBe("localhost error");
+    });
+
+    test("includes warning tag in headers", () => {
+      Deno.env.set("NTFY_URL", "https://ntfy.sh/my-topic");
+
+      sendNtfyError(ErrorCode.STRIPE_SIGNATURE);
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = options.headers as Record<string, string>;
+      expect(headers["Tags"]).toBe("warning");
+    });
+
+    test("silently ignores fetch errors", () => {
+      Deno.env.set("NTFY_URL", "https://ntfy.sh/my-topic");
+      fetchSpy.mockRejectedValue(new Error("Network error"));
+
+      // Should not throw
+      sendNtfyError(ErrorCode.WEBHOOK_SEND);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds optional error notification integration with ntfy.sh to alert on production errors. When `NTFY_URL` is configured, all logged errors are sent as notifications to the specified ntfy endpoint.

## Key Changes
- **New ntfy module** (`src/lib/ntfy.ts`): Implements `sendNtfyError()` function that sends error codes to a configured ntfy URL with domain context and warning tags
- **Logger integration**: Modified `logError()` in `src/lib/logger.ts` to call `sendNtfyError()` after logging each error
- **Comprehensive test coverage**: Added full test suite for ntfy module covering:
  - No-op behavior when `NTFY_URL` is not set
  - Correct POST request formatting with error code as body
  - Proper header inclusion (Title with domain, Tags with warning)
  - Error handling and logging when fetch fails
- **Documentation**: Updated `CLAUDE.md` to document the new `NTFY_URL` environment variable

## Implementation Details
- Fire-and-forget pattern: fetch failures are caught and logged to console without propagating
- Only sends domain and error code (no PII or sensitive data)
- Avoids infinite loops by using `console.error()` directly in the catch handler rather than `logError()`
- Integration is optional and gracefully disabled when `NTFY_URL` is not configured

https://claude.ai/code/session_011BWydbaKQs5fWxVqYb2nLu