### PR TITLE
Remove default styling from inline elements

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -764,6 +764,9 @@ button.bulk-checkout:hover {
 
 .inline {
   display: inline;
+  box-shadow: none;
+  padding: 0;
+  border: none;
 }
 
 button.link-button {


### PR DESCRIPTION
## Summary
Updated the `.inline` CSS class to remove default button styling (box-shadow, padding, and border) that was being inherited by inline elements.

## Changes
- Added `box-shadow: none;` to prevent shadow effects on inline elements
- Added `padding: 0;` to remove default padding
- Added `border: none;` to remove default borders

## Details
These changes ensure that elements using the `.inline` class display without the standard button styling, allowing for cleaner integration of inline elements into the page layout. This is particularly useful for inline buttons or interactive elements that should blend seamlessly with surrounding content.

https://claude.ai/code/session_01WMLm4M3ajH9mpjH3pz7SPv