### PR TITLE
Expand refunds documentation with comprehensive FAQ section

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -159,9 +159,88 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
 
         <Q q="How do refunds work?">
           <p>
-            Automatic refunds happen only when the event sells out during
-            payment. For all other refunds, use your payment provider's
-            dashboard (Stripe or Square) directly.
+            See the <strong>Refunds</strong> section below for full details on
+            automatic refunds, admin-issued refunds, and bulk refunds.
+          </p>
+        </Q>
+      </Section>
+
+      <Section title="Refunds">
+        <Q q="When do automatic refunds happen?">
+          <p>
+            Automatic refunds only happen in one scenario: when an event sells
+            out while someone is completing payment. Their place is held for 5
+            minutes during checkout, but if another buyer fills the last spot
+            first, the slower payer is automatically refunded and shown a message
+            explaining the event is full. In multi-event bookings, if any single
+            event fails (e.g. one of the combined events is full), the entire
+            payment is refunded &mdash; not just the portion for the sold-out
+            event.
+          </p>
+        </Q>
+
+        <Q q="How do I refund an individual attendee?">
+          <p>
+            Open the event's attendee list, find the attendee, and click{" "}
+            <strong>Refund</strong>. You'll see a confirmation page showing
+            their name, email, quantity, and the amount paid. Type the
+            attendee's name to confirm and submit. The refund is issued through
+            your payment provider (Stripe or Square) and is always a full
+            refund.
+          </p>
+        </Q>
+
+        <Q q="How do I refund all attendees for an event?">
+          <p>
+            On the event page, click <strong>Refund All</strong> in the
+            navigation bar. Type the event name to confirm. Each attendee with a
+            recorded payment is refunded one by one. If some refunds fail (e.g.
+            a payment was already refunded via the provider dashboard), you'll
+            see a summary of how many succeeded and how many failed.
+          </p>
+        </Q>
+
+        <Q q="Are partial refunds supported?">
+          <p>
+            No. The system always issues a full refund for the total amount
+            paid. If you need to issue a partial refund, do it directly through
+            your payment provider's dashboard (Stripe or Square).
+          </p>
+        </Q>
+
+        <Q q="What happens to the attendee after a refund?">
+          <p>
+            The attendee <strong>remains registered</strong>. A refund only
+            clears their payment record &mdash; it does not remove them from the
+            event. If you also want to remove them, delete the attendee
+            separately after refunding.
+          </p>
+        </Q>
+
+        <Q q="Can I refund an attendee who booked a free event?">
+          <p>
+            No. The Refund button only appears for attendees who have a recorded
+            payment. Free-event attendees have no payment to refund.
+          </p>
+        </Q>
+
+        <Q q="What if a refund fails?">
+          <p>
+            The most common reason is that the payment was already refunded
+            directly through Stripe or Square. You'll see an error message like
+            "Refund failed. The payment may have already been refunded." If your
+            payment provider is no longer configured, refunds will also fail
+            because there's no provider to process them through.
+          </p>
+        </Q>
+
+        <Q q="Can I refund the same attendee twice?">
+          <p>
+            No. After a successful refund the attendee's payment record is
+            cleared, so the Refund button no longer appears. If you attempt to
+            refund a payment that was already refunded via the provider
+            dashboard, the provider will reject it and you'll see a failure
+            message.
           </p>
         </Q>
       </Section>


### PR DESCRIPTION
## Summary
Expanded the admin guide's refunds documentation from a brief note to a comprehensive FAQ section covering automatic refunds, admin-issued refunds, bulk refunds, and common edge cases.

## Key Changes
- Replaced the single-paragraph refunds answer with a reference to a new dedicated "Refunds" section
- Added a new "Refunds" section with 8 detailed Q&A entries covering:
  - When automatic refunds occur (event sells out during checkout)
  - How to refund individual attendees via the attendee list
  - How to bulk refund all attendees for an event using "Refund All"
  - Clarification that only full refunds are supported (partial refunds require manual provider action)
  - Behavior after refund (attendee remains registered, payment record cleared)
  - Refund eligibility for free events (not applicable)
  - Common refund failure scenarios and troubleshooting
  - Prevention of duplicate refunds

## Notable Details
- Documentation explains the 5-minute hold period during checkout and multi-event booking refund behavior
- Includes specific UI guidance (button names, confirmation steps)
- Addresses payment provider integration (Stripe/Square) and failure modes
- Clarifies the distinction between refunding (clearing payment) and deleting (removing attendee)

https://claude.ai/code/session_01UVj6fHb23uwAYZzXRuBa5d