### PR TITLE
Fix empty datetime field returning empty string instead of null

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -190,6 +190,10 @@ const validateSingleField = (
   if (field.type === "datetime") {
     const result = getDatetimeValue(form, field.name);
     if (result === null) return { valid: false, error: DATETIME_PARTIAL_ERROR };
+    if (!result) {
+      if (field.required) return { valid: false, error: `${field.label} is required` };
+      return { valid: true, value: null };
+    }
     trimmed = result;
   } else if (field.type === "checkbox-group") {
     trimmed = form.getAll(field.name).map((v) => v.trim()).filter((v) => v).join(",");

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -721,6 +721,20 @@ describe("forms", () => {
       }
     });
 
+    test("rejects empty required datetime", () => {
+      const requiredDatetime: Field[] = [
+        field({ name: "closes_at", label: "Closes At", type: "datetime", required: true }),
+      ];
+      const result = validateForm(
+        new URLSearchParams({ closes_at_date: "", closes_at_time: "" }),
+        requiredDatetime,
+      );
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error).toBe("Closes At is required");
+      }
+    });
+
     test("rejects when only date is provided", () => {
       const result = validateForm(
         new URLSearchParams({ closes_at_date: "2099-06-15", closes_at_time: "" }),


### PR DESCRIPTION
When both date and time inputs are empty, explicitly return null from validateSingleField instead of relying on parseFieldValue to convert the empty string. This fixes a CI failure where the empty string was not being converted to null as expected.

https://claude.ai/code/session_012vUdU38tKSpcU3YQwUnkQx