### PR TITLE
Add admin refund functionality for event attendees

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -12,10 +12,7 @@ import { getEventWithAttendeeRaw } from "#lib/db/events.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { getActivePaymentProvider } from "#lib/payments.ts";
 import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
-import {
-  defineRoutes,
-  type RouteHandlerFn,
-} from "#routes/router.ts";
+import { defineRoutes } from "#routes/router.ts";
 import { requirePrivateKey, verifyIdentifier, withDecryptedAttendees, withEventAttendeesAuth } from "#routes/admin/utils.ts";
 import {
   type AuthSession,
@@ -98,15 +95,6 @@ const filterSuffix = (returnFilter: string | null): string => {
   return "";
 };
 
-/** Route handler that parses attendee IDs and wraps withAttendeeForm */
-type AttendeeFormHandler = (
-  data: AttendeeWithEvent, session: AuthSession, form: URLSearchParams, eventId: number, attendeeId: number,
-) => Response | Promise<Response>;
-const attendeeFormRoute = (handler: AttendeeFormHandler): RouteHandlerFn =>
-  (request, params) =>
-    withAttendeeForm(request, params.eventId as number, params.attendeeId as number, (data, session, form) =>
-      handler(data, session, form, params.eventId as number, params.attendeeId as number));
-
 /** Verify confirm_name matches attendee name, returning error page on mismatch */
 const verifyAttendeeName = (
   data: AttendeeWithEvent,
@@ -122,12 +110,24 @@ const verifyAttendeeName = (
   return null;
 };
 
+/** Attendee form handler that receives typed IDs */
+type AttendeeFormAction = (
+  data: AttendeeWithEvent, session: AuthSession, form: URLSearchParams,
+  eventId: number, attendeeId: number,
+) => Response | Promise<Response>;
+
+/** Create an attendee form handler with typed IDs */
+const attendeeFormAction = (handler: AttendeeFormAction) =>
+  (request: Request, eventId: number, attendeeId: number): Promise<Response> =>
+    withAttendeeForm(request, eventId, attendeeId, (data, session, form) =>
+      handler(data, session, form, eventId, attendeeId));
+
 /** Handle GET /admin/event/:eventId/attendee/:attendeeId/delete */
 const handleAdminAttendeeDeleteGet = attendeeGetRoute((data, session) =>
   htmlResponse(adminDeleteAttendeePage(data.event, data.attendee, session)));
 
-/** Delete attendee handler with name verification */
-const attendeeDeleteHandler = attendeeFormRoute(async (data, session, form, eventId, attendeeId) => {
+/** Handle POST /admin/event/:eventId/attendee/:attendeeId/delete */
+const handleAttendeeDelete = attendeeFormAction(async (data, session, form, eventId, attendeeId) => {
   const error = verifyAttendeeName(data, session, form, adminDeleteAttendeePage,
     "Attendee name does not match. Please type the exact name to confirm deletion.");
   if (error) return error;
@@ -137,8 +137,8 @@ const attendeeDeleteHandler = attendeeFormRoute(async (data, session, form, even
   return redirect(`/admin/event/${eventId}`);
 });
 
-/** Checkin toggle handler */
-const attendeeCheckinHandler = attendeeFormRoute(async (data, _session, form, eventId, attendeeId) => {
+/** Handle POST /admin/event/:eventId/attendee/:attendeeId/checkin */
+const handleAttendeeCheckin = attendeeFormAction(async (data, _session, form, eventId, attendeeId) => {
   const wasCheckedIn = data.attendee.checked_in === "true";
   const nowCheckedIn = !wasCheckedIn;
 
@@ -165,8 +165,8 @@ const handleAdminAttendeeRefundGet = attendeeGetRoute((data, session) =>
     ? htmlResponse(adminRefundAttendeePage(data.event, data.attendee, session))
     : refundError(data, session, NO_PAYMENT_ERROR));
 
-/** Refund attendee handler with name verification */
-const attendeeRefundHandler = attendeeFormRoute(async (data, session, form, eventId) => {
+/** Handle POST /admin/event/:eventId/attendee/:attendeeId/refund */
+const handleAttendeeRefund = attendeeFormAction(async (data, session, form, eventId) => {
   const nameError = verifyAttendeeName(data, session, form, adminRefundAttendeePage,
     "Attendee name does not match. Please type the exact name to confirm refund.");
   if (nameError) return nameError;
@@ -269,22 +269,22 @@ const handleAdminRefundAllPost = (
     withDecryptedAttendees(session, eventId, (event, attendees) =>
       processRefundAll(event, attendees, session, form)));
 
-/** Bind :eventId and :attendeeId params to a GET handler */
-const attendeeGetHandler = (
-  handler: (request: Request, eventId: number, attendeeId: number) => Promise<Response>,
-): RouteHandlerFn =>
-  (request, params) => handler(request, params.eventId as number, params.attendeeId as number);
-
 /** Attendee routes */
 export const attendeesRoutes = defineRoutes({
-  "GET /admin/event/:eventId/attendee/:attendeeId/delete": attendeeGetHandler(handleAdminAttendeeDeleteGet),
-  "POST /admin/event/:eventId/attendee/:attendeeId/delete": attendeeDeleteHandler,
-  "DELETE /admin/event/:eventId/attendee/:attendeeId/delete": attendeeDeleteHandler,
-  "POST /admin/event/:eventId/attendee/:attendeeId/checkin": attendeeCheckinHandler,
-  "GET /admin/event/:eventId/attendee/:attendeeId/refund": attendeeGetHandler(handleAdminAttendeeRefundGet),
-  "POST /admin/event/:eventId/attendee/:attendeeId/refund": attendeeRefundHandler,
-  "GET /admin/event/:id/refund-all": (request, params) =>
-    handleAdminRefundAllGet(request, params.id as number),
-  "POST /admin/event/:id/refund-all": (request, params) =>
-    handleAdminRefundAllPost(request, params.id as number),
+  "GET /admin/event/:eventId/attendee/:attendeeId/delete": (request, { eventId, attendeeId }) =>
+    handleAdminAttendeeDeleteGet(request, eventId, attendeeId),
+  "POST /admin/event/:eventId/attendee/:attendeeId/delete": (request, { eventId, attendeeId }) =>
+    handleAttendeeDelete(request, eventId, attendeeId),
+  "DELETE /admin/event/:eventId/attendee/:attendeeId/delete": (request, { eventId, attendeeId }) =>
+    handleAttendeeDelete(request, eventId, attendeeId),
+  "POST /admin/event/:eventId/attendee/:attendeeId/checkin": (request, { eventId, attendeeId }) =>
+    handleAttendeeCheckin(request, eventId, attendeeId),
+  "GET /admin/event/:eventId/attendee/:attendeeId/refund": (request, { eventId, attendeeId }) =>
+    handleAdminAttendeeRefundGet(request, eventId, attendeeId),
+  "POST /admin/event/:eventId/attendee/:attendeeId/refund": (request, { eventId, attendeeId }) =>
+    handleAttendeeRefund(request, eventId, attendeeId),
+  "GET /admin/event/:id/refund-all": (request, { id }) =>
+    handleAdminRefundAllGet(request, id),
+  "POST /admin/event/:id/refund-all": (request, { id }) =>
+    handleAdminRefundAllPost(request, id),
 });

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -9,41 +9,53 @@ import {
   updateCheckedIn,
 } from "#lib/db/attendees.ts";
 import { getEventWithAttendeeRaw } from "#lib/db/events.ts";
-import type { Attendee, EventWithCount } from "#lib/types.ts";
+import { ErrorCode, logError } from "#lib/logger.ts";
+import { getActivePaymentProvider } from "#lib/payments.ts";
+import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
 import {
   defineRoutes,
   type RouteHandlerFn,
   type RouteParams,
 } from "#routes/router.ts";
-import { verifyIdentifier } from "#routes/admin/utils.ts";
+import { parseEventId, requirePrivateKey, verifyIdentifier, withDecryptedAttendees, withEventAttendeesAuth } from "#routes/admin/utils.ts";
 import {
   type AuthSession,
-  getPrivateKey,
   htmlResponse,
   notFoundResponse,
   redirect,
   requireSessionOr,
   withAuthForm,
 } from "#routes/utils.ts";
-import { adminDeleteAttendeePage } from "#templates/admin/attendees.tsx";
+import {
+  adminDeleteAttendeePage,
+  adminRefundAllAttendeesPage,
+  adminRefundAttendeePage,
+} from "#templates/admin/attendees.tsx";
 
 /** Attendee with event data */
 type AttendeeWithEvent = { attendee: Attendee; event: EventWithCount };
 
+/** No-payment error message */
+const NO_PAYMENT_ERROR = "This attendee has no payment to refund.";
+const NO_PROVIDER_ERROR = "No payment provider configured.";
+const NO_REFUNDABLE_ERROR = "No attendees have payments to refund.";
+const REFUND_FAILED_ERROR = "Refund failed. The payment may have already been refunded.";
+
 /**
  * Load attendee ensuring it belongs to the specified event.
  * Uses batched query to fetch event + attendee in a single DB round-trip.
+ * Decrypts attendee PII using the admin private key.
  */
 const loadAttendeeForEvent = async (
+  session: AuthSession,
   eventId: number,
   attendeeId: number,
-  privateKey: CryptoKey,
 ): Promise<AttendeeWithEvent | null> => {
-  // Fetch event and attendee in single DB round-trip
+  const pk = await requirePrivateKey(session);
   const result = await getEventWithAttendeeRaw(eventId, attendeeId);
   if (!result) return null;
 
-  const attendee = await decryptAttendeeOrNull(result.attendeeRaw, privateKey);
+  const attendee = await decryptAttendeeOrNull(result.attendeeRaw, pk);
   if (!attendee || attendee.event_id !== eventId) return null;
 
   return { attendee, event: result.event };
@@ -56,22 +68,17 @@ const withAttendee = async (
   attendeeId: number,
   handler: (data: AttendeeWithEvent) => Response | Promise<Response>,
 ): Promise<Response> => {
-  const privateKey = (await getPrivateKey(session))!;
-  const data = await loadAttendeeForEvent(eventId, attendeeId, privateKey);
+  const data = await loadAttendeeForEvent(session, eventId, attendeeId);
   return data ? handler(data) : notFoundResponse();
 };
 
-/** Handle GET /admin/event/:eventId/attendee/:attendeeId/delete */
-const handleAdminAttendeeDeleteGet = (
-  request: Request,
-  eventId: number,
-  attendeeId: number,
-): Promise<Response> =>
-  requireSessionOr(request, (session) =>
-    withAttendee(session, eventId, attendeeId, (data) =>
-      htmlResponse(adminDeleteAttendeePage(data.event, data.attendee, session)),
-    ),
-  );
+/** Auth + load attendee GET handler (shared by delete and refund GET routes) */
+const attendeeGetRoute = (
+  handler: (data: AttendeeWithEvent, session: AuthSession) => Response | Promise<Response>,
+) =>
+  (request: Request, eventId: number, attendeeId: number): Promise<Response> =>
+    requireSessionOr(request, (session) =>
+      withAttendee(session, eventId, attendeeId, (data) => handler(data, session)));
 
 /** Auth + load attendee from form handler */
 const withAttendeeForm = (
@@ -110,20 +117,30 @@ const attendeeFormRoute = (handler: AttendeeFormHandler): RouteHandlerFn =>
       handler(data, session, form, eventId, attendeeId));
   };
 
-/** Delete attendee handler with name verification */
-const attendeeDeleteHandler = attendeeFormRoute(async (data, session, form, eventId, attendeeId) => {
+/** Verify confirm_name matches attendee name, returning error page on mismatch */
+const verifyAttendeeName = (
+  data: AttendeeWithEvent,
+  session: AuthSession,
+  form: URLSearchParams,
+  renderPage: (event: EventWithCount, attendee: Attendee, session: AdminSession, error: string) => string,
+  errorMsg: string,
+): Response | null => {
   const confirmName = form.get("confirm_name") ?? "";
   if (!verifyIdentifier(data.attendee.name, confirmName)) {
-    return htmlResponse(
-      adminDeleteAttendeePage(
-        data.event,
-        data.attendee,
-        session,
-        "Attendee name does not match. Please type the exact name to confirm deletion.",
-      ),
-      400,
-    );
+    return htmlResponse(renderPage(data.event, data.attendee, session, errorMsg), 400);
   }
+  return null;
+};
+
+/** Handle GET /admin/event/:eventId/attendee/:attendeeId/delete */
+const handleAdminAttendeeDeleteGet = attendeeGetRoute((data, session) =>
+  htmlResponse(adminDeleteAttendeePage(data.event, data.attendee, session)));
+
+/** Delete attendee handler with name verification */
+const attendeeDeleteHandler = attendeeFormRoute(async (data, session, form, eventId, attendeeId) => {
+  const error = verifyAttendeeName(data, session, form, adminDeleteAttendeePage,
+    "Attendee name does not match. Please type the exact name to confirm deletion.");
+  if (error) return error;
 
   await deleteAttendee(attendeeId);
   await logActivity(`Attendee deleted from '${data.event.name}'`, eventId);
@@ -148,16 +165,140 @@ const attendeeCheckinHandler = attendeeFormRoute(async (data, _session, form, ev
   );
 });
 
+/** Render refund error for a single attendee */
+const refundError = (data: AttendeeWithEvent, session: AuthSession, msg: string): Response =>
+  htmlResponse(adminRefundAttendeePage(data.event, data.attendee, session, msg), 400);
+
+/** Handle GET /admin/event/:eventId/attendee/:attendeeId/refund */
+const handleAdminAttendeeRefundGet = attendeeGetRoute((data, session) =>
+  data.attendee.payment_id
+    ? htmlResponse(adminRefundAttendeePage(data.event, data.attendee, session))
+    : refundError(data, session, NO_PAYMENT_ERROR));
+
+/** Refund attendee handler with name verification */
+const attendeeRefundHandler = attendeeFormRoute(async (data, session, form, eventId) => {
+  const nameError = verifyAttendeeName(data, session, form, adminRefundAttendeePage,
+    "Attendee name does not match. Please type the exact name to confirm refund.");
+  if (nameError) return nameError;
+
+  if (!data.attendee.payment_id) return refundError(data, session, NO_PAYMENT_ERROR);
+
+  const provider = await getActivePaymentProvider();
+  if (!provider) return refundError(data, session, NO_PROVIDER_ERROR);
+
+  const refunded = await provider.refundPayment(data.attendee.payment_id);
+  if (!refunded) {
+    logError({
+      code: ErrorCode.PAYMENT_REFUND,
+      detail: `Admin refund failed for attendee ${data.attendee.id}, payment ${data.attendee.payment_id}`,
+    });
+    return refundError(data, session, REFUND_FAILED_ERROR);
+  }
+
+  await logActivity(`Refund issued for attendee '${data.attendee.name}'`, eventId);
+  return redirect(`/admin/event/${eventId}`);
+});
+
+/** Filter attendees that have a payment_id (refundable) */
+const getRefundable = (attendees: Attendee[]): Attendee[] =>
+  attendees.filter((a) => a.payment_id !== null);
+
+/** Handle GET /admin/event/:id/refund-all */
+const handleAdminRefundAllGet = (
+  request: Request,
+  eventId: number,
+): Promise<Response> =>
+  withEventAttendeesAuth(request, eventId, (event, attendees, session) => {
+    const count = getRefundable(attendees).length;
+    return count === 0
+      ? htmlResponse(adminRefundAllAttendeesPage(event, 0, session, NO_REFUNDABLE_ERROR), 400)
+      : htmlResponse(adminRefundAllAttendeesPage(event, count, session));
+  });
+
+/** Process bulk refund for all refundable attendees */
+const processRefundAll = async (
+  event: EventWithCount,
+  attendees: Attendee[],
+  session: AuthSession,
+  form: URLSearchParams,
+  eventId: number,
+): Promise<Response> => {
+  const refundable = getRefundable(attendees);
+  const nameConfirmed = verifyIdentifier(event.name, form.get("confirm_name") ?? "");
+  if (!nameConfirmed) {
+    return htmlResponse(
+      adminRefundAllAttendeesPage(event, refundable.length, session,
+        "Event name does not match. Please type the exact name to confirm."),
+      400,
+    );
+  }
+
+  if (refundable.length === 0) {
+    return htmlResponse(adminRefundAllAttendeesPage(event, 0, session, NO_REFUNDABLE_ERROR), 400);
+  }
+
+  const provider = await getActivePaymentProvider();
+  if (!provider) {
+    return htmlResponse(
+      adminRefundAllAttendeesPage(event, refundable.length, session, NO_PROVIDER_ERROR), 400);
+  }
+
+  let refundedCount = 0;
+  let failedCount = 0;
+  for (const attendee of refundable) {
+    const refunded = await provider.refundPayment(attendee.payment_id!);
+    if (refunded) {
+      refundedCount++;
+    } else {
+      failedCount++;
+      logError({
+        code: ErrorCode.PAYMENT_REFUND,
+        detail: `Admin bulk refund failed for attendee ${attendee.id}, payment ${attendee.payment_id}`,
+      });
+    }
+  }
+
+  if (failedCount > 0) {
+    await logActivity(`Bulk refund: ${refundedCount} succeeded, ${failedCount} failed for '${event.name}'`, eventId);
+    return htmlResponse(
+      adminRefundAllAttendeesPage(event, refundable.length, session,
+        `${refundedCount} refund(s) succeeded, ${failedCount} failed. Some payments may have already been refunded.`),
+      400,
+    );
+  }
+
+  await logActivity(`Bulk refund: all ${refundedCount} attendee(s) refunded for '${event.name}'`, eventId);
+  return redirect(`/admin/event/${eventId}`);
+};
+
+/** Handle POST /admin/event/:id/refund-all */
+const handleAdminRefundAllPost = (
+  request: Request,
+  eventId: number,
+): Promise<Response> =>
+  withAuthForm(request, (session, form) =>
+    withDecryptedAttendees(session, eventId, (event, attendees) =>
+      processRefundAll(event, attendees, session, form, eventId)));
+
+/** Route handler that parses attendee IDs for GET routes */
+const attendeeGetHandler = (
+  handler: (request: Request, eventId: number, attendeeId: number) => Promise<Response>,
+): RouteHandlerFn =>
+  (request, params) => {
+    const ids = parseAttendeeIds(params);
+    return handler(request, ids.eventId, ids.attendeeId);
+  };
+
 /** Attendee routes */
 export const attendeesRoutes = defineRoutes({
-  "GET /admin/event/:eventId/attendee/:attendeeId/delete": (
-    request,
-    params,
-  ) => {
-    const ids = parseAttendeeIds(params);
-    return handleAdminAttendeeDeleteGet(request, ids.eventId, ids.attendeeId);
-  },
+  "GET /admin/event/:eventId/attendee/:attendeeId/delete": attendeeGetHandler(handleAdminAttendeeDeleteGet),
   "POST /admin/event/:eventId/attendee/:attendeeId/delete": attendeeDeleteHandler,
   "DELETE /admin/event/:eventId/attendee/:attendeeId/delete": attendeeDeleteHandler,
   "POST /admin/event/:eventId/attendee/:attendeeId/checkin": attendeeCheckinHandler,
+  "GET /admin/event/:eventId/attendee/:attendeeId/refund": attendeeGetHandler(handleAdminAttendeeRefundGet),
+  "POST /admin/event/:eventId/attendee/:attendeeId/refund": attendeeRefundHandler,
+  "GET /admin/event/:id/refund-all": (request, params) =>
+    handleAdminRefundAllGet(request, parseEventId(params)),
+  "POST /admin/event/:id/refund-all": (request, params) =>
+    handleAdminRefundAllPost(request, parseEventId(params)),
 });

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -23,8 +23,8 @@ import { defineResource } from "#lib/rest/resource.ts";
 import { generateSlug, normalizeSlug } from "#lib/slug.ts";
 import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
 import type { EventEditFormValues, EventFormValues } from "#templates/fields.ts";
-import { defineRoutes } from "#routes/router.ts";
-import { csvResponse, getDateFilter, parseEventId, verifyIdentifier, withEventAttendeesAuth } from "#routes/admin/utils.ts";
+import { defineRoutes, type RouteHandlerFn } from "#routes/router.ts";
+import { csvResponse, getDateFilter, verifyIdentifier, withEventAttendeesAuth } from "#routes/admin/utils.ts";
 import {
   htmlResponse,
   notFoundResponse,
@@ -351,37 +351,27 @@ const handleAdminEventDelete = (
         return event ? performDelete(event) : notFoundResponse();
       });
 
+/** Bind :id param to an event handler */
+type EventHandler = (request: Request, eventId: number) => Response | Promise<Response>;
+const eventRoute = (handler: EventHandler): RouteHandlerFn =>
+  (request, params) => handler(request, params.id as number);
+
 /** Event routes */
 export const eventsRoutes = defineRoutes({
   "POST /admin/event": (request) => handleCreateEvent(request),
-  "GET /admin/event/:id/in": (request, params) =>
-    handleAdminEventGet(request, parseEventId(params), "in"),
-  "GET /admin/event/:id/out": (request, params) =>
-    handleAdminEventGet(request, parseEventId(params), "out"),
-  "GET /admin/event/:id": (request, params) =>
-    handleAdminEventGet(request, parseEventId(params)),
-  "GET /admin/event/:id/duplicate": (request, params) =>
-    handleAdminEventDuplicateGet(request, parseEventId(params)),
-  "GET /admin/event/:id/edit": (request, params) =>
-    handleAdminEventEditGet(request, parseEventId(params)),
-  "POST /admin/event/:id/edit": (request, params) =>
-    handleAdminEventEditPost(request, parseEventId(params)),
-  "GET /admin/event/:id/export": (request, params) =>
-    handleAdminEventExport(request, parseEventId(params)),
-  "GET /admin/event/:id/log": (request, params) =>
-    handleAdminEventLog(request, parseEventId(params)),
-  "GET /admin/event/:id/deactivate": (request, params) =>
-    handleAdminEventDeactivateGet(request, parseEventId(params)),
-  "POST /admin/event/:id/deactivate": (request, params) =>
-    handleAdminEventDeactivatePost(request, parseEventId(params)),
-  "GET /admin/event/:id/reactivate": (request, params) =>
-    handleAdminEventReactivateGet(request, parseEventId(params)),
-  "POST /admin/event/:id/reactivate": (request, params) =>
-    handleAdminEventReactivatePost(request, parseEventId(params)),
-  "GET /admin/event/:id/delete": (request, params) =>
-    handleAdminEventDeleteGet(request, parseEventId(params)),
-  "POST /admin/event/:id/delete": (request, params) =>
-    handleAdminEventDelete(request, parseEventId(params)),
-  "DELETE /admin/event/:id/delete": (request, params) =>
-    handleAdminEventDelete(request, parseEventId(params)),
+  "GET /admin/event/:id/in": eventRoute((req, id) => handleAdminEventGet(req, id, "in")),
+  "GET /admin/event/:id/out": eventRoute((req, id) => handleAdminEventGet(req, id, "out")),
+  "GET /admin/event/:id": eventRoute(handleAdminEventGet),
+  "GET /admin/event/:id/duplicate": eventRoute(handleAdminEventDuplicateGet),
+  "GET /admin/event/:id/edit": eventRoute(handleAdminEventEditGet),
+  "POST /admin/event/:id/edit": eventRoute(handleAdminEventEditPost),
+  "GET /admin/event/:id/export": eventRoute(handleAdminEventExport),
+  "GET /admin/event/:id/log": eventRoute(handleAdminEventLog),
+  "GET /admin/event/:id/deactivate": eventRoute(handleAdminEventDeactivateGet),
+  "POST /admin/event/:id/deactivate": eventRoute(handleAdminEventDeactivatePost),
+  "GET /admin/event/:id/reactivate": eventRoute(handleAdminEventReactivateGet),
+  "POST /admin/event/:id/reactivate": eventRoute(handleAdminEventReactivatePost),
+  "GET /admin/event/:id/delete": eventRoute(handleAdminEventDeleteGet),
+  "POST /admin/event/:id/delete": eventRoute(handleAdminEventDelete),
+  "DELETE /admin/event/:id/delete": eventRoute(handleAdminEventDelete),
 });

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -23,7 +23,7 @@ import { defineResource } from "#lib/rest/resource.ts";
 import { generateSlug, normalizeSlug } from "#lib/slug.ts";
 import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
 import type { EventEditFormValues, EventFormValues } from "#templates/fields.ts";
-import { defineRoutes, type RouteHandlerFn } from "#routes/router.ts";
+import { defineRoutes } from "#routes/router.ts";
 import { csvResponse, getDateFilter, verifyIdentifier, withEventAttendeesAuth } from "#routes/admin/utils.ts";
 import {
   htmlResponse,
@@ -351,27 +351,22 @@ const handleAdminEventDelete = (
         return event ? performDelete(event) : notFoundResponse();
       });
 
-/** Bind :id param to an event handler */
-type EventHandler = (request: Request, eventId: number) => Response | Promise<Response>;
-const eventRoute = (handler: EventHandler): RouteHandlerFn =>
-  (request, params) => handler(request, params.id as number);
-
 /** Event routes */
 export const eventsRoutes = defineRoutes({
   "POST /admin/event": (request) => handleCreateEvent(request),
-  "GET /admin/event/:id/in": eventRoute((req, id) => handleAdminEventGet(req, id, "in")),
-  "GET /admin/event/:id/out": eventRoute((req, id) => handleAdminEventGet(req, id, "out")),
-  "GET /admin/event/:id": eventRoute(handleAdminEventGet),
-  "GET /admin/event/:id/duplicate": eventRoute(handleAdminEventDuplicateGet),
-  "GET /admin/event/:id/edit": eventRoute(handleAdminEventEditGet),
-  "POST /admin/event/:id/edit": eventRoute(handleAdminEventEditPost),
-  "GET /admin/event/:id/export": eventRoute(handleAdminEventExport),
-  "GET /admin/event/:id/log": eventRoute(handleAdminEventLog),
-  "GET /admin/event/:id/deactivate": eventRoute(handleAdminEventDeactivateGet),
-  "POST /admin/event/:id/deactivate": eventRoute(handleAdminEventDeactivatePost),
-  "GET /admin/event/:id/reactivate": eventRoute(handleAdminEventReactivateGet),
-  "POST /admin/event/:id/reactivate": eventRoute(handleAdminEventReactivatePost),
-  "GET /admin/event/:id/delete": eventRoute(handleAdminEventDeleteGet),
-  "POST /admin/event/:id/delete": eventRoute(handleAdminEventDelete),
-  "DELETE /admin/event/:id/delete": eventRoute(handleAdminEventDelete),
+  "GET /admin/event/:id/in": (request, { id }) => handleAdminEventGet(request, id, "in"),
+  "GET /admin/event/:id/out": (request, { id }) => handleAdminEventGet(request, id, "out"),
+  "GET /admin/event/:id": (request, { id }) => handleAdminEventGet(request, id),
+  "GET /admin/event/:id/duplicate": (request, { id }) => handleAdminEventDuplicateGet(request, id),
+  "GET /admin/event/:id/edit": (request, { id }) => handleAdminEventEditGet(request, id),
+  "POST /admin/event/:id/edit": (request, { id }) => handleAdminEventEditPost(request, id),
+  "GET /admin/event/:id/export": (request, { id }) => handleAdminEventExport(request, id),
+  "GET /admin/event/:id/log": (request, { id }) => handleAdminEventLog(request, id),
+  "GET /admin/event/:id/deactivate": (request, { id }) => handleAdminEventDeactivateGet(request, id),
+  "POST /admin/event/:id/deactivate": (request, { id }) => handleAdminEventDeactivatePost(request, id),
+  "GET /admin/event/:id/reactivate": (request, { id }) => handleAdminEventReactivateGet(request, id),
+  "POST /admin/event/:id/reactivate": (request, { id }) => handleAdminEventReactivatePost(request, id),
+  "GET /admin/event/:id/delete": (request, { id }) => handleAdminEventDeleteGet(request, id),
+  "POST /admin/event/:id/delete": (request, { id }) => handleAdminEventDelete(request, id),
+  "DELETE /admin/event/:id/delete": (request, { id }) => handleAdminEventDelete(request, id),
 });

--- a/src/routes/admin/holidays.ts
+++ b/src/routes/admin/holidays.ts
@@ -7,7 +7,7 @@ import { getAllHolidays, type HolidayInput, holidaysTable } from "#lib/db/holida
 import { validateForm } from "#lib/forms.tsx";
 import { defineResource } from "#lib/rest/resource.ts";
 import type { AdminSession, Holiday } from "#lib/types.ts";
-import { defineRoutes, type RouteHandlerFn } from "#routes/router.ts";
+import { defineRoutes } from "#routes/router.ts";
 import { verifyIdentifier } from "#routes/admin/utils.ts";
 import {
   htmlResponse,
@@ -64,7 +64,7 @@ const handleHolidayNewGet = (request: Request): Promise<Response> =>
   );
 
 /** Handle POST /admin/holiday (create) */
-const handleHolidayCreate: RouteHandlerFn = (request) =>
+const handleHolidayCreate = (request: Request) =>
   withOwnerAuthForm(request, async (session, form) => {
     const result = await holidaysResource.create(form);
     if (result.ok) {
@@ -153,18 +153,13 @@ const handleHolidayDeletePost = (
     }),
   );
 
-/** Bind :id param to a holiday handler */
-type HolidayHandler = (request: Request, holidayId: number) => Response | Promise<Response>;
-const holidayRoute = (handler: HolidayHandler): RouteHandlerFn =>
-  (request, params) => handler(request, params.id as number);
-
 /** Holiday routes */
 export const holidaysRoutes = defineRoutes({
   "GET /admin/holidays": (request) => handleHolidaysGet(request),
   "GET /admin/holiday/new": (request) => handleHolidayNewGet(request),
   "POST /admin/holiday": handleHolidayCreate,
-  "GET /admin/holiday/:id/edit": holidayRoute(handleHolidayEditGet),
-  "POST /admin/holiday/:id/edit": holidayRoute(handleHolidayEditPost),
-  "GET /admin/holiday/:id/delete": holidayRoute(handleHolidayDeleteGet),
-  "POST /admin/holiday/:id/delete": holidayRoute(handleHolidayDeletePost),
+  "GET /admin/holiday/:id/edit": (request, { id }) => handleHolidayEditGet(request, id),
+  "POST /admin/holiday/:id/edit": (request, { id }) => handleHolidayEditPost(request, id),
+  "GET /admin/holiday/:id/delete": (request, { id }) => handleHolidayDeleteGet(request, id),
+  "POST /admin/holiday/:id/delete": (request, { id }) => handleHolidayDeletePost(request, id),
 });

--- a/src/routes/admin/holidays.ts
+++ b/src/routes/admin/holidays.ts
@@ -7,7 +7,7 @@ import { getAllHolidays, type HolidayInput, holidaysTable } from "#lib/db/holida
 import { validateForm } from "#lib/forms.tsx";
 import { defineResource } from "#lib/rest/resource.ts";
 import type { AdminSession, Holiday } from "#lib/types.ts";
-import { defineRoutes, type RouteHandlerFn, type RouteParams } from "#routes/router.ts";
+import { defineRoutes, type RouteHandlerFn } from "#routes/router.ts";
 import { verifyIdentifier } from "#routes/admin/utils.ts";
 import {
   htmlResponse,
@@ -153,21 +153,18 @@ const handleHolidayDeletePost = (
     }),
   );
 
-/** Parse holiday ID from params */
-const parseHolidayId = (params: RouteParams): number =>
-  Number.parseInt(params.id as string, 10);
+/** Bind :id param to a holiday handler */
+type HolidayHandler = (request: Request, holidayId: number) => Response | Promise<Response>;
+const holidayRoute = (handler: HolidayHandler): RouteHandlerFn =>
+  (request, params) => handler(request, params.id as number);
 
 /** Holiday routes */
 export const holidaysRoutes = defineRoutes({
   "GET /admin/holidays": (request) => handleHolidaysGet(request),
   "GET /admin/holiday/new": (request) => handleHolidayNewGet(request),
   "POST /admin/holiday": handleHolidayCreate,
-  "GET /admin/holiday/:id/edit": (request, params) =>
-    handleHolidayEditGet(request, parseHolidayId(params)),
-  "POST /admin/holiday/:id/edit": (request, params) =>
-    handleHolidayEditPost(request, parseHolidayId(params)),
-  "GET /admin/holiday/:id/delete": (request, params) =>
-    handleHolidayDeleteGet(request, parseHolidayId(params)),
-  "POST /admin/holiday/:id/delete": (request, params) =>
-    handleHolidayDeletePost(request, parseHolidayId(params)),
+  "GET /admin/holiday/:id/edit": holidayRoute(handleHolidayEditGet),
+  "POST /admin/holiday/:id/edit": holidayRoute(handleHolidayEditPost),
+  "GET /admin/holiday/:id/delete": holidayRoute(handleHolidayDeleteGet),
+  "POST /admin/holiday/:id/delete": holidayRoute(handleHolidayDeletePost),
 });

--- a/src/routes/admin/users.ts
+++ b/src/routes/admin/users.ts
@@ -18,7 +18,7 @@ import {
 import { validateForm } from "#lib/forms.tsx";
 import { getAllowedDomain } from "#lib/config.ts";
 import { nowMs } from "#lib/now.ts";
-import { defineRoutes, type RouteParams } from "#routes/router.ts";
+import { defineRoutes, type RouteHandlerFn } from "#routes/router.ts";
 import {
   type AuthSession,
   generateSecureToken,
@@ -158,9 +158,8 @@ const withUserAction = (
   });
 
 /** Route handler that delegates to withUserAction with parsed ID */
-const userActionRoute = (handler: UserActionHandler) =>
-  (request: Request, params: RouteParams): Promise<Response> =>
-    withUserAction(request, Number(params.id), handler);
+const userActionRoute = (handler: UserActionHandler): RouteHandlerFn =>
+  (request, params) => withUserAction(request, params.id as number, handler);
 
 /**
  * Handle POST /admin/users/:id/activate

--- a/src/routes/admin/utils.ts
+++ b/src/routes/admin/utils.ts
@@ -6,7 +6,6 @@ import { decryptAttendees } from "#lib/db/attendees.ts";
 import { getEventWithAttendeesRaw } from "#lib/db/events.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import type { validateForm } from "#lib/forms.tsx";
-import type { RouteParams } from "#routes/router.ts";
 import { type AuthSession, getPrivateKey, notFoundResponse, requireSessionOr } from "#routes/utils.ts";
 
 /** Form field definition type */
@@ -43,10 +42,6 @@ export const csvResponse = (csv: string, filename: string): Response =>
       "content-disposition": `attachment; filename="${filename}"`,
     },
   });
-
-/** Parse event ID from params (route pattern guarantees :id exists as \d+) */
-export const parseEventId = (params: RouteParams): number =>
-  Number.parseInt(params.id!, 10);
 
 /** Get the admin private key from session (non-null assertion — callers are inside authenticated handlers) */
 export const requirePrivateKey = async (session: AuthSession): Promise<CryptoKey> =>

--- a/src/routes/join.ts
+++ b/src/routes/join.ts
@@ -58,7 +58,7 @@ const withValidInvite = async (
   params: RouteParams,
   handler: (code: string, user: User, username: string) => Response | Promise<Response>,
 ): Promise<Response> => {
-  const code = params.code!;
+  const code = params.code as string;
   const result = await validateInvite(code);
   return result instanceof Response ? result : handler(code, result.user, result.username);
 };

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -6,6 +6,10 @@ import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
 import { Layout } from "#templates/layout.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
 
+/** Format cents as a display string (e.g. 2999 -> "29.99") */
+const formatPrice = (cents: string): string =>
+  (Number.parseInt(cents, 10) / 100).toFixed(2);
+
 /**
  * Admin delete attendee confirmation page
  */
@@ -49,6 +53,97 @@ export const adminDeleteAttendeePage = (
           />
           <button type="submit" class="danger">
             Delete Attendee
+          </button>
+        </form>
+    </Layout>
+  );
+
+/**
+ * Admin refund attendee confirmation page
+ */
+export const adminRefundAttendeePage = (
+  event: EventWithCount,
+  attendee: Attendee,
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title={`Refund Attendee: ${attendee.name}`}>
+      <AdminNav session={session} />
+        {error && <div class="error">{error}</div>}
+
+        <article>
+          <aside>
+            <p><strong>Warning:</strong> This will issue a full refund for this attendee's payment. The attendee will remain registered.</p>
+          </aside>
+        </article>
+
+        <article>
+          <h2>Attendee Details</h2>
+          <p><strong>Name:</strong> {attendee.name}</p>
+          <p><strong>Email:</strong> {attendee.email}</p>
+          <p><strong>Quantity:</strong> {attendee.quantity}</p>
+          {attendee.price_paid && (
+            <p><strong>Amount Paid:</strong> {formatPrice(attendee.price_paid)}</p>
+          )}
+          <p><strong>Registered:</strong> {new Date(attendee.created).toLocaleString()}</p>
+        </article>
+
+        <p>To refund this attendee, you must type their name "{attendee.name}" into the box below:</p>
+
+        <form method="POST" action={`/admin/event/${event.id}/attendee/${attendee.id}/refund`}>
+          <input type="hidden" name="csrf_token" value={session.csrfToken} />
+          <label for="confirm_name">Attendee name</label>
+          <input
+            type="text"
+            id="confirm_name"
+            name="confirm_name"
+            placeholder={attendee.name}
+            autocomplete="off"
+            required
+          />
+          <button type="submit" class="danger">
+            Refund Attendee
+          </button>
+        </form>
+    </Layout>
+  );
+
+/**
+ * Admin refund all attendees confirmation page
+ */
+export const adminRefundAllAttendeesPage = (
+  event: EventWithCount,
+  refundableCount: number,
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title={`Refund All: ${event.name}`}>
+      <AdminNav session={session} />
+        {error && <div class="error">{error}</div>}
+
+        <article>
+          <aside>
+            <p><strong>Warning:</strong> This will issue a full refund for all {refundableCount} attendee(s) with payments. Attendees will remain registered.</p>
+          </aside>
+        </article>
+
+        <p>To refund all attendees, you must type the event name "{event.name}" into the box below:</p>
+
+        <form method="POST" action={`/admin/event/${event.id}/refund-all`}>
+          <input type="hidden" name="csrf_token" value={session.csrfToken} />
+          <label for="confirm_name">Event name</label>
+          <input
+            type="text"
+            id="confirm_name"
+            name="confirm_name"
+            placeholder={event.name}
+            autocomplete="off"
+            required
+          />
+          <button type="submit" class="danger">
+            Refund All Attendees
           </button>
         </form>
     </Layout>

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -57,7 +57,7 @@ const CheckinButton = ({ a, eventId, csrfToken, activeFilter }: { a: Attendee; e
   );
 };
 
-const AttendeeRow = ({ a, eventId, csrfToken, activeFilter, allowedDomain, showDate }: { a: Attendee; eventId: number; csrfToken: string; activeFilter: AttendeeFilter; allowedDomain: string; showDate: boolean }): string =>
+const AttendeeRow = ({ a, eventId, csrfToken, activeFilter, allowedDomain, showDate, hasPaidEvent }: { a: Attendee; eventId: number; csrfToken: string; activeFilter: AttendeeFilter; allowedDomain: string; showDate: boolean; hasPaidEvent: boolean }): string =>
   String(
     <tr>
       <td>
@@ -71,6 +71,12 @@ const AttendeeRow = ({ a, eventId, csrfToken, activeFilter, allowedDomain, showD
       <td><a href={`https://${allowedDomain}/t/${a.ticket_token}`}>{a.ticket_token}</a></td>
       <td>{new Date(a.created).toLocaleString()}</td>
       <td>
+        {hasPaidEvent && a.payment_id && (
+          <a href={`/admin/event/${eventId}/attendee/${a.id}/refund`} class="danger">
+            Refund
+          </a>
+        )}
+        {" "}
         <a href={`/admin/event/${eventId}/attendee/${a.id}/delete`} class="danger">
           Delete
         </a>
@@ -126,11 +132,12 @@ export const adminEventPage = (
   const embedCode = `<iframe src="${ticketUrl}?iframe=true" loading="lazy" style="border: none; width: 100%; height: ${iframeHeight}">Loading..</iframe>`;
   const isDaily = event.event_type === "daily";
   const filteredAttendees = filterAttendees(attendees, activeFilter);
+  const hasPaidEvent = event.unit_price !== null;
   const colSpan = isDaily ? 9 : 8;
   const attendeeRows =
     filteredAttendees.length > 0
       ? pipe(
-          map((a: Attendee) => AttendeeRow({ a, eventId: event.id, csrfToken: session.csrfToken, activeFilter, allowedDomain, showDate: isDaily })),
+          map((a: Attendee) => AttendeeRow({ a, eventId: event.id, csrfToken: session.csrfToken, activeFilter, allowedDomain, showDate: isDaily, hasPaidEvent })),
           joinStrings,
         )(filteredAttendees)
       : `<tr><td colspan="${colSpan}">No attendees yet</td></tr>`;
@@ -152,6 +159,9 @@ export const adminEventPage = (
             <li><a href={`/admin/event/${event.id}/duplicate`}>Duplicate</a></li>
             <li><a href={`/admin/event/${event.id}/log`}>Log</a></li>
             <li><a href={`/admin/event/${event.id}/export${dateFilter ? `?date=${dateFilter}` : ""}`}>Export CSV</a></li>
+            {hasPaidEvent && (
+              <li><a href={`/admin/event/${event.id}/refund-all`} class="danger">Refund All</a></li>
+            )}
             {event.active === 1 ? (
               <li><a href={`/admin/event/${event.id}/deactivate`} class="danger">Deactivate</a></li>
             ) : (

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -300,7 +300,7 @@ describe("server (misc)", () => {
   describe("routes/router.ts (slug and generic param coverage)", () => {
     test("createRouter matches slug param pattern correctly", async () => {
       const { createRouter } = await import("#routes/router.ts");
-      let capturedParams: Record<string, string | undefined> = {};
+      let capturedParams: Record<string, string | number | undefined> = {};
       const router = createRouter({
         "GET /item/:slug": (_req, params) => {
           capturedParams = params;
@@ -317,7 +317,7 @@ describe("server (misc)", () => {
 
     test("createRouter matches generic (non-id non-slug) param pattern", async () => {
       const { createRouter } = await import("#routes/router.ts");
-      let capturedParams: Record<string, string | undefined> = {};
+      let capturedParams: Record<string, string | number | undefined> = {};
       const router = createRouter({
         "GET /file/:name": (_req, params) => {
           capturedParams = params;

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -1,0 +1,677 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import { spyOn } from "#test-compat";
+import { handleRequest } from "#routes";
+import {
+  awaitTestRequest,
+  createTestAttendee,
+  createTestDbWithSetup,
+  createTestEvent,
+  mockFormRequest,
+  mockRequest,
+  resetDb,
+  resetTestSlugCounter,
+  expectAdminRedirect,
+  loginAsAdmin,
+  withMocks,
+} from "#test-utils";
+import { paymentsApi } from "#lib/payments.ts";
+
+describe("server (admin refunds)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("GET /admin/event/:eventId/attendee/:attendeeId/refund", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 100,
+        unitPrice: 500,
+      });
+      const attendee = await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      const response = await handleRequest(
+        mockRequest(`/admin/event/${event.id}/attendee/${attendee.id}/refund`),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("returns 404 for non-existent event", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        "/admin/event/999/attendee/1/refund",
+        { cookie },
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 404 for non-existent attendee", async () => {
+      await createTestEvent({ maxAttendees: 100 });
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        "/admin/event/1/attendee/999/refund",
+        { cookie },
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 404 when attendee belongs to different event", async () => {
+      const event1 = await createTestEvent({ name: "Event 1", maxAttendees: 100 });
+      const event2 = await createTestEvent({ name: "Event 2", maxAttendees: 100 });
+      const attendee = await createTestAttendee(event2.id, event2.slug, "John Doe", "john@example.com");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event1.id}/attendee/${attendee.id}/refund`,
+        { cookie },
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("shows error when attendee has no payment", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      const attendee = await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}/attendee/${attendee.id}/refund`,
+        { cookie },
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("no payment to refund");
+    });
+
+    test("shows refund confirmation page for paid attendee", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      // Create attendee with payment_id via the atomic API
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Jane Smith",
+        email: "jane@example.com",
+        paymentId: "pi_test_123",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+        { cookie },
+      );
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Refund Attendee");
+      expect(html).toContain("Jane Smith");
+      expect(html).toContain("type their name");
+      expect(html).toContain("5.00");
+    });
+  });
+
+  describe("POST /admin/event/:eventId/attendee/:attendeeId/refund", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const attendee = await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      const response = await handleRequest(
+        mockFormRequest(`/admin/event/${event.id}/attendee/${attendee.id}/refund`, {
+          confirm_name: "John Doe",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("rejects invalid CSRF token", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_test_456",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+          { confirm_name: "John Doe", csrf_token: "invalid-token" },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    test("rejects mismatched attendee name", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_test_789",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+          { confirm_name: "Wrong Name", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("does not match");
+    });
+
+    test("returns error when attendee has no payment", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      const attendee = await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${attendee.id}/refund`,
+          { confirm_name: "John Doe", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("no payment to refund");
+    });
+
+    test("returns error when no payment provider configured", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_test_noprov",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+          { confirm_name: "John Doe", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("No payment provider configured");
+    });
+
+    test("successfully refunds attendee payment", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_test_success",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withMocks(
+        () => spyOn(paymentsApi, "getConfiguredProvider").mockResolvedValue("stripe" as ReturnType<typeof paymentsApi.getConfiguredProvider> extends Promise<infer T> ? T : never),
+        async () => {
+          const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+          const mockRefund = spyOn(stripePaymentProvider, "refundPayment").mockResolvedValue(true);
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+                { confirm_name: "John Doe", csrf_token: csrfToken },
+                cookie,
+              ),
+            );
+            expect(response.status).toBe(302);
+            expect(response.headers.get("location")).toBe(`/admin/event/${event.id}`);
+            expect(mockRefund).toHaveBeenCalled();
+          } finally {
+            mockRefund.mockRestore?.();
+          }
+        },
+      );
+    });
+
+    test("shows error when refund fails", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_test_fail",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withMocks(
+        () => spyOn(paymentsApi, "getConfiguredProvider").mockResolvedValue("stripe" as ReturnType<typeof paymentsApi.getConfiguredProvider> extends Promise<infer T> ? T : never),
+        async () => {
+          const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+          const mockRefund = spyOn(stripePaymentProvider, "refundPayment").mockResolvedValue(false);
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+                { confirm_name: "John Doe", csrf_token: csrfToken },
+                cookie,
+              ),
+            );
+            expect(response.status).toBe(400);
+            const html = await response.text();
+            expect(html).toContain("Refund failed");
+          } finally {
+            mockRefund.mockRestore?.();
+          }
+        },
+      );
+    });
+
+    test("handles missing confirm_name field", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_test_missing",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${result.attendee.id}/refund`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("does not match");
+    });
+  });
+
+  describe("GET /admin/event/:id/refund-all", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+
+      const response = await handleRequest(
+        mockRequest(`/admin/event/${event.id}/refund-all`),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("returns 404 for non-existent event", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        "/admin/event/999/refund-all",
+        { cookie },
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("shows error when no attendees have payments", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}/refund-all`,
+        { cookie },
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("No attendees have payments to refund");
+    });
+
+    test("shows refund all confirmation page with refundable count", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Paid User",
+        email: "paid@example.com",
+        paymentId: "pi_paid_1",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      // Also add a free attendee (no payment_id)
+      await createTestAttendee(event.id, event.slug, "Free User", "free@example.com");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}/refund-all`,
+        { cookie },
+      );
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Refund All");
+      expect(html).toContain("1 attendee(s) with payments");
+      expect(html).toContain("type the event name");
+    });
+  });
+
+  describe("POST /admin/event/:id/refund-all", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+
+      const response = await handleRequest(
+        mockFormRequest(`/admin/event/${event.id}/refund-all`, {
+          confirm_name: event.name,
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("returns 404 for non-existent event", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/event/999/refund-all",
+          { confirm_name: "Test", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("rejects mismatched event name", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_refundall_1",
+        quantity: 1,
+        pricePaid: 500,
+      });
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/refund-all`,
+          { confirm_name: "Wrong Event Name", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("does not match");
+    });
+
+    test("rejects when confirm_name is missing", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_refundall_missing",
+        quantity: 1,
+        pricePaid: 500,
+      });
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/refund-all`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("does not match");
+    });
+
+    test("returns error when no attendees have payments", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      await createTestAttendee(event.id, event.slug, "John Doe", "john@example.com");
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/refund-all`,
+          { confirm_name: event.name, csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("No attendees have payments to refund");
+    });
+
+    test("returns error when no payment provider configured", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "John Doe",
+        email: "john@example.com",
+        paymentId: "pi_noprov_all",
+        quantity: 1,
+        pricePaid: 500,
+      });
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/refund-all`,
+          { confirm_name: event.name, csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("No payment provider configured");
+    });
+
+    test("successfully refunds all attendees", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "User One",
+        email: "one@example.com",
+        paymentId: "pi_all_1",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "User Two",
+        email: "two@example.com",
+        paymentId: "pi_all_2",
+        quantity: 1,
+        pricePaid: 500,
+      });
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withMocks(
+        () => spyOn(paymentsApi, "getConfiguredProvider").mockResolvedValue("stripe" as ReturnType<typeof paymentsApi.getConfiguredProvider> extends Promise<infer T> ? T : never),
+        async () => {
+          const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+          const mockRefund = spyOn(stripePaymentProvider, "refundPayment").mockResolvedValue(true);
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                `/admin/event/${event.id}/refund-all`,
+                { confirm_name: event.name, csrf_token: csrfToken },
+                cookie,
+              ),
+            );
+            expect(response.status).toBe(302);
+            expect(response.headers.get("location")).toBe(`/admin/event/${event.id}`);
+            expect(mockRefund).toHaveBeenCalledTimes(2);
+          } finally {
+            mockRefund.mockRestore?.();
+          }
+        },
+      );
+    });
+
+    test("reports partial failure when some refunds fail", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Good User",
+        email: "good@example.com",
+        paymentId: "pi_partial_ok",
+        quantity: 1,
+        pricePaid: 500,
+      });
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Bad User",
+        email: "bad@example.com",
+        paymentId: "pi_partial_fail",
+        quantity: 1,
+        pricePaid: 500,
+      });
+
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      let callNum = 0;
+      await withMocks(
+        () => spyOn(paymentsApi, "getConfiguredProvider").mockResolvedValue("stripe" as ReturnType<typeof paymentsApi.getConfiguredProvider> extends Promise<infer T> ? T : never),
+        async () => {
+          const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+          const mockRefund = spyOn(stripePaymentProvider, "refundPayment").mockImplementation(() => {
+            callNum++;
+            // First refund succeeds, second fails
+            return Promise.resolve(callNum <= 1);
+          });
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                `/admin/event/${event.id}/refund-all`,
+                { confirm_name: event.name, csrf_token: csrfToken },
+                cookie,
+              ),
+            );
+            expect(response.status).toBe(400);
+            const html = await response.text();
+            expect(html).toContain("1 refund(s) succeeded");
+            expect(html).toContain("1 failed");
+          } finally {
+            mockRefund.mockRestore?.();
+          }
+        },
+      );
+    });
+  });
+
+  describe("event page UI", () => {
+    test("shows Refund link for paid attendees on paid events", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Paid User",
+        email: "paid@example.com",
+        paymentId: "pi_ui_1",
+        quantity: 1,
+        pricePaid: 500,
+      });
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}`,
+        { cookie },
+      );
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("/refund");
+      expect(html).toContain("Refund All");
+    });
+
+    test("does not show Refund link for free events", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      await createTestAttendee(event.id, event.slug, "Free User", "free@example.com");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}`,
+        { cookie },
+      );
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).not.toContain("Refund All");
+    });
+
+    test("does not show Refund link for attendees without payment_id on paid events", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 500 });
+      // Create a free attendee on a paid event (no payment_id)
+      await createTestAttendee(event.id, event.slug, "No Payment User", "nopay@example.com");
+
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}`,
+        { cookie },
+      );
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      // The event nav should still show Refund All (because it's a paid event)
+      expect(html).toContain("Refund All");
+      // But the attendee row should NOT show an individual refund link
+      // since the attendee has no payment_id
+      expect(html).not.toContain("/refund\"");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive refund capabilities to the admin panel, allowing administrators to refund individual attendees or all attendees at once for paid events.

## Key Changes

### New Refund Routes & Handlers
- **GET/POST `/admin/event/:eventId/attendee/:attendeeId/refund`** - Refund a single attendee with name confirmation
- **GET/POST `/admin/event/:id/refund-all`** - Refund all attendees with payments for an event with event name confirmation
- Both routes include proper authentication, CSRF protection, and validation

### Template Updates
- Added `adminRefundAttendeePage()` - Confirmation page for single attendee refunds showing attendee details and amount paid
- Added `adminRefundAllAttendeesPage()` - Confirmation page for bulk refunds with refundable attendee count
- Added `formatPrice()` helper to display cents as currency (e.g., 2999 → "29.99")
- Updated event attendee list UI to show refund links for paid attendees on paid events

### Admin Utilities Refactoring
- Extracted `withEventAttendeesAuth()` helper to handle event + attendees loading with auth and decryption
- Added `requirePrivateKey()` to get admin private key from session
- Consolidated attendee loading logic to reduce duplication across routes

### Router Type Improvements
- Enhanced `router.ts` with type-level route param inference using TypeScript generics
- Added `TypedRouteHandler<Pattern>` for compile-time type safety of route parameters
- Numeric ID parameters (ending in `Id` or named `id`) are now automatically parsed to numbers at runtime
- Updated `RouteParams` type to reflect that ID params are numbers, not strings

### Refund Logic
- Validates attendee has a `payment_id` before allowing refund
- Checks that a payment provider is configured
- Calls provider's `refundPayment()` method
- Logs refund activity and redirects on success
- Handles partial failures in bulk refunds with detailed error reporting
- Shows appropriate error messages for various failure scenarios

### Test Coverage
- Comprehensive test suite (677 lines) covering:
  - Authentication and authorization checks
  - Single attendee refund flow with name verification
  - Bulk refund flow with event name verification
  - Error cases (no payment, no provider, refund failures)
  - UI integration (refund links shown/hidden appropriately)
  - Partial failure scenarios in bulk operations

## Notable Implementation Details
- Refund confirmation pages require exact name/event name match to prevent accidental refunds
- Attendees remain registered after refund (refund is payment-only)
- Bulk refund reports success/failure counts for each attendee
- Refund links only appear for attendees with `payment_id` on paid events
- Uses existing payment provider abstraction for extensibility

https://claude.ai/code/session_0169op5s1xhbtos16L3KYx6J