### PR TITLE
Add content-type header to redirect responses

### DIFF
--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -165,7 +165,10 @@ export const paymentErrorResponse = (message: string, status = 400): Response =>
  * Create redirect response
  */
 export const redirect = (url: string, cookie?: string): Response => {
-  const headers: HeadersInit = { location: url };
+  const headers: HeadersInit = {
+    location: url,
+    "content-type": "text/html; charset=utf-8",
+  };
   if (cookie) {
     headers["set-cookie"] = cookie;
   }


### PR DESCRIPTION
## Summary
Updated the redirect response utility function to include a `content-type` header with UTF-8 charset encoding.

## Changes
- Added `"content-type": "text/html; charset=utf-8"` header to all redirect responses created by the `redirect()` utility function
- This ensures proper content type declaration for redirect responses, improving HTTP compliance and browser handling

## Implementation Details
The content-type header is now included by default in all redirect responses, alongside the existing `location` header and optional `set-cookie` header. This change applies uniformly to all uses of the redirect utility function throughout the application.

https://claude.ai/code/session_01RBXPFtx2SF8xXKBUfnmCQk