### PR TITLE
Add placeholder attributes to datetime input fields

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -82,8 +82,8 @@ const renderDatetimeInputs = (
   name: string,
   { date, time }: { date: string; time: string },
 ): string =>
-  `<input type="date" name="${escapeHtml(name)}_date"${date ? ` value="${escapeHtml(date)}"` : ""}>`
-  + `<input type="time" name="${escapeHtml(name)}_time"${time ? ` value="${escapeHtml(time)}"` : ""}>`;
+  `<input type="date" name="${escapeHtml(name)}_date" placeholder="Date"${date ? ` value="${escapeHtml(date)}"` : ""}>`
+  + `<input type="time" name="${escapeHtml(name)}_time" placeholder="Time"${time ? ` value="${escapeHtml(time)}"` : ""}>`;
 
 const DATETIME_PARTIAL_ERROR = "Please enter both a date and time, or leave both blank";
 

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -751,8 +751,10 @@ describe("forms", () => {
       const html = rendered({ name: "closes_at", label: "Closes At", type: "datetime" });
       expect(html).toContain('type="date"');
       expect(html).toContain('name="closes_at_date"');
+      expect(html).toContain('placeholder="Date"');
       expect(html).toContain('type="time"');
       expect(html).toContain('name="closes_at_time"');
+      expect(html).toContain('placeholder="Time"');
     });
 
     test("renders split inputs with value", () => {


### PR DESCRIPTION
## Summary
Added placeholder attributes to date and time input fields in the datetime input renderer to improve user experience and provide clearer field guidance.

## Changes
- Added `placeholder="Date"` attribute to the date input field in `renderDatetimeInputs()`
- Added `placeholder="Time"` attribute to the time input field in `renderDatetimeInputs()`
- Updated corresponding test assertions to verify the presence of these placeholder attributes

## Implementation Details
The placeholders are inserted directly into the HTML string generation for the datetime inputs, appearing before the conditional value attribute. This provides users with visual cues about what type of input is expected in each field without requiring additional labels or documentation.

https://claude.ai/code/session_0172bBUm6yxiGtwhJNq3KYai