### PR TITLE
Refactor label styling to use flexbox layout

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -417,7 +417,6 @@ form header {
 }
 
 input,
-label,
 select,
 textarea {
   display: block;
@@ -464,20 +463,42 @@ textarea[readonly] {
 }
 
 label {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: baseline;
   font-weight: bold;
   margin-bottom: 0.2rem;
+  font-size: inherit;
+  max-width: var(--width-card-wide);
+}
+
+@media (max-width: 768px) {
+  label {
+    width: 100%;
+  }
 }
 
 label > small {
   color: #666;
-  display: block;
   font-weight: normal;
-  margin-top: 0.25rem;
+  width: 100%;
 }
 
 label > select,
 label > input {
+  flex: 1;
   margin-bottom: 0;
+}
+
+label > input[type="text"],
+label > input[type="password"],
+label > input[type="email"] {
+  width: auto;
+}
+
+label > textarea {
+  width: 100%;
 }
 
 /* Popups */

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -491,6 +491,12 @@ label > input {
   margin-bottom: 0;
 }
 
+label > input[type="date"],
+label > input[type="time"] {
+  flex: 0 0 auto;
+  width: auto;
+}
+
 label > input[type="text"],
 label > input[type="password"],
 label > input[type="email"] {


### PR DESCRIPTION
## Summary
Refactored the label element styling in the MVP CSS framework to use a modern flexbox layout, improving the presentation and responsiveness of form labels with inline inputs and helper text.

## Key Changes
- Removed `label` from the block-level form elements selector to allow custom display styling
- Converted `label` to use `display: flex` with `flex-wrap: wrap` and `gap: 1rem` for better spacing control
- Added `align-items: baseline` to vertically align label text with form inputs
- Implemented responsive behavior with a media query that sets labels to full width on screens ≤768px
- Updated `label > small` styling to use `width: 100%` instead of `display: block` for consistent flex layout
- Added `flex: 1` to `label > select` and `label > input` to allow flexible sizing
- Added specific width rules for text-based inputs (`text`, `password`, `email`) to use `width: auto`
- Set `label > textarea` to `width: 100%` for full-width textarea inputs
- Added `font-size: inherit` and `max-width: var(--width-card-wide)` to label for better consistency

## Implementation Details
The refactoring maintains backward compatibility while providing a more flexible layout system. Labels can now contain inline form elements that wrap appropriately, with helper text (`<small>`) spanning the full width below the input. The flexbox approach provides better alignment and spacing control compared to the previous block-based layout.

https://claude.ai/code/session_01VkMnp35hd43CouSZc7EY6c