### PR TITLE
Add edge build to CI and precommit to catch bundle resolution errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Copy-paste detection
         run: deno task cpd
 
+      - name: Build edge script
+        run: deno task build:edge
+
       - name: Start stripe-mock
         run: |
           .bin/stripe-mock -http-port 12111 &

--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,7 @@
     "fmt": "deno fmt src test scripts",
     "typecheck": "deno check src/**/*.ts src/**/*.tsx test/**/*.ts",
     "cpd": "deno run -A npm:jscpd src --config .jscpd.json",
-    "precommit": "deno task typecheck && deno task lint && deno task cpd && deno task test:coverage"
+    "precommit": "deno task typecheck && deno task lint && deno task cpd && deno task build:edge && deno task test:coverage"
   },
   "imports": {
     "#fp": "./src/fp/index.ts",


### PR DESCRIPTION
The deploy workflow failed because @bunny.net/storage-sdk was not in
the hardcoded esbuild externals list. While that was fixed in #252 by
deriving externals from deno.json, neither the test CI workflow nor the
precommit task ran the edge build, so the breakage was not caught before
merging.

https://claude.ai/code/session_01NGCrPedxycVhvCzDEzp52z