### PR TITLE
Allow embedding of multi-slug ticket pages

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -48,7 +48,7 @@ export const getSecurityHeaders = (
  * Paths are normalized to strip trailing slashes
  */
 export const isEmbeddablePath = (path: string): boolean =>
-  /^\/ticket\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(path);
+  /^\/ticket\/[a-z0-9]+(?:-[a-z0-9]+)*(?:\+[a-z0-9]+(?:-[a-z0-9]+)*)*$/.test(path);
 
 /**
  * Extract hostname from Host header (removes port if present)

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -43,12 +43,18 @@ export const getSecurityHeaders = (
   "content-security-policy": buildCspHeader(embeddable),
 });
 
+/** Single slug: alphanumeric segments joined by hyphens (e.g. "a1b2" or "my-event") */
+const SLUG = "[a-z0-9]+(?:-[a-z0-9]+)*";
+
+/** Matches /ticket/ with one or more slugs separated by + */
+const EMBEDDABLE_PATH = new RegExp(`^/ticket/${SLUG}(?:\\+${SLUG})*$`);
+
 /**
  * Check if a path is embeddable (public ticket pages only)
  * Paths are normalized to strip trailing slashes
  */
 export const isEmbeddablePath = (path: string): boolean =>
-  /^\/ticket\/[a-z0-9]+(?:-[a-z0-9]+)*(?:\+[a-z0-9]+(?:-[a-z0-9]+)*)*$/.test(path);
+  EMBEDDABLE_PATH.test(path);
 
 /**
  * Extract hostname from Host header (removes port if present)

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -45,6 +45,21 @@ describe("server (misc)", () => {
         expect(response.headers.get("x-frame-options")).toBeNull();
       });
 
+      test("multi-slug ticket page does NOT have X-Frame-Options (embeddable)", async () => {
+        const event1 = await createTestEvent({
+          maxAttendees: 50,
+          thankYouUrl: "https://example.com",
+        });
+        const event2 = await createTestEvent({
+          maxAttendees: 50,
+          thankYouUrl: "https://example.com",
+        });
+        const response = await handleRequest(
+          mockRequest(`/ticket/${event1.slug}+${event2.slug}`),
+        );
+        expect(response.headers.get("x-frame-options")).toBeNull();
+      });
+
       test("payment pages have X-Frame-Options: DENY", async () => {
         const response = await handleRequest(mockRequest("/payment/success"));
         expect(response.headers.get("x-frame-options")).toBe("DENY");
@@ -76,6 +91,21 @@ describe("server (misc)", () => {
         });
         const response = await handleRequest(
           mockRequest(`/ticket/${event.slug}`),
+        );
+        expect(response.headers.get("content-security-policy")).toBe(baseCsp);
+      });
+
+      test("multi-slug ticket page allows embedding (no frame-ancestors)", async () => {
+        const event1 = await createTestEvent({
+          maxAttendees: 50,
+          thankYouUrl: "https://example.com",
+        });
+        const event2 = await createTestEvent({
+          maxAttendees: 50,
+          thankYouUrl: "https://example.com",
+        });
+        const response = await handleRequest(
+          mockRequest(`/ticket/${event1.slug}+${event2.slug}`),
         );
         expect(response.headers.get("content-security-policy")).toBe(baseCsp);
       });


### PR DESCRIPTION
## Summary
Updated the ticket page embedding logic to support multi-slug URLs (e.g., `/ticket/slug1+slug2`), allowing multiple events to be embedded together in iframes.

## Key Changes
- **Updated regex pattern** in `isEmbeddablePath()` to recognize multi-slug ticket URLs with `+` separators
  - Old pattern: `/^\/ticket\/[a-z0-9]+(?:-[a-z0-9]+)*$/`
  - New pattern: `/^\/ticket\/[a-z0-9]+(?:-[a-z0-9]+)*(?:\+[a-z0-9]+(?:-[a-z0-9]+)*)*$/`
  - This allows zero or more additional slugs separated by `+`

- **Added comprehensive test coverage** for multi-slug ticket pages:
  - Verifies `X-Frame-Options` header is not set (allowing embedding)
  - Verifies `Content-Security-Policy` header uses base policy without `frame-ancestors` restriction

## Implementation Details
The regex change maintains backward compatibility with single-slug URLs while extending support to multi-slug formats. The pattern allows each slug segment to contain alphanumeric characters and hyphens, consistent with existing slug validation.

https://claude.ai/code/session_01J9xifHrSbbwSEMosEPmSXG