### PR TITLE
Update Bunny CDN deployment to include publish step

### DIFF
--- a/.github/workflows/deploy-clients.yml
+++ b/.github/workflows/deploy-clients.yml
@@ -29,16 +29,39 @@ jobs:
         env:
           BUNNY_SCRIPT_DATA: ${{ secrets.BUNNY_SCRIPT_DATA }}
         run: |
+          code=$(jq -Rs '{"Code": .}' bunny-script.ts)
           while IFS= read -r line; do
             [ -z "$line" ] && continue
             script_id="${line%%|*}"
             api_key="${line#*|}"
             echo "Deploying to script $script_id..."
-            curl -s --fail-with-body \
+            response=$(curl -s --fail-with-body -w "\n%{http_code}" \
               -X POST "https://api.bunny.net/compute/script/${script_id}/code" \
               -H "AccessKey: ${api_key}" \
-              -H "Content-Type: application/javascript" \
-              --data-binary @bunny-script.ts \
-              && echo " ✓ Deployed to $script_id" \
-              || { echo " ✗ Failed to deploy to $script_id"; exit 1; }
+              -H "Content-Type: application/json" \
+              -d "$code")
+            status_code=$(echo "$response" | tail -1)
+            body=$(echo "$response" | sed '$d')
+            if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then
+              echo " ✓ Code uploaded to $script_id (HTTP $status_code)"
+            else
+              echo " ✗ Failed to upload code to $script_id (HTTP $status_code)"
+              echo "   Response: $body"
+              exit 1
+            fi
+            echo "  Publishing script $script_id..."
+            response=$(curl -s --fail-with-body -w "\n%{http_code}" \
+              -X POST "https://api.bunny.net/compute/script/${script_id}/publish" \
+              -H "AccessKey: ${api_key}" \
+              -H "Content-Type: application/json" \
+              -d '{}')
+            status_code=$(echo "$response" | tail -1)
+            body=$(echo "$response" | sed '$d')
+            if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then
+              echo " ✓ Published $script_id (HTTP $status_code)"
+            else
+              echo " ✗ Failed to publish $script_id (HTTP $status_code)"
+              echo "   Response: $body"
+              exit 1
+            fi
           done <<< "$BUNNY_SCRIPT_DATA"


### PR DESCRIPTION
## Summary
Updated the Bunny CDN deployment workflow to properly handle script code uploads and publishing as separate API calls, with improved error handling and response logging.

## Key Changes
- **API Request Format**: Changed from sending raw binary file to sending JSON-formatted code payload
  - Code is now wrapped in a JSON object: `{"Code": <script_content>}`
  - Content-Type header updated from `application/javascript` to `application/json`
  
- **Two-Step Deployment Process**: Split deployment into distinct code upload and publish steps
  - First request uploads the script code to the `/code` endpoint
  - Second request publishes the script via the `/publish` endpoint
  
- **Enhanced Error Handling**: Improved response handling and error reporting
  - Captures HTTP status codes from responses for better diagnostics
  - Extracts and displays response body on failures
  - Provides clear success/failure messages with HTTP status codes
  - Validates status codes are in the 2xx range before considering deployment successful

## Implementation Details
- Uses `jq` to properly format the TypeScript code as JSON
- Captures both response body and HTTP status code using curl's `-w` flag
- Parses multi-line curl response (body + status code) using `tail` and `sed`
- Maintains the same loop structure for processing multiple script deployments from `BUNNY_SCRIPT_DATA`

https://claude.ai/code/session_011AUq63GtRGJotevfWpemXC