### PR TITLE
Fix Bunny script deployment payload handling

### DIFF
--- a/.github/workflows/deploy-clients.yml
+++ b/.github/workflows/deploy-clients.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           BUNNY_SCRIPT_DATA: ${{ secrets.BUNNY_SCRIPT_DATA }}
         run: |
-          code=$(jq -Rs '{"Code": .}' bunny-script.ts)
+          jq -Rs '{"Code": .}' bunny-script.ts > /tmp/code-payload.json
           while IFS= read -r line; do
             [ -z "$line" ] && continue
             script_id="${line%%|*}"
@@ -39,7 +39,7 @@ jobs:
               -X POST "https://api.bunny.net/compute/script/${script_id}/code" \
               -H "AccessKey: ${api_key}" \
               -H "Content-Type: application/json" \
-              -d "$code")
+              -d @/tmp/code-payload.json)
             status_code=$(echo "$response" | tail -1)
             body=$(echo "$response" | sed '$d')
             if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then


### PR DESCRIPTION
## Summary
Refactored the Bunny script deployment workflow to improve payload handling and prevent potential issues with large script files or special characters in the curl command.

## Key Changes
- Changed from inline variable substitution to file-based payload delivery
  - Previously: `code` variable was created and passed directly via `-d "$code"` 
  - Now: JSON payload is written to `/tmp/code-payload.json` and passed via `-d @/tmp/code-payload.json`

## Implementation Details
This change improves robustness by:
- Avoiding shell variable expansion issues with large or complex script content
- Using curl's file input syntax (`@filename`) which is more reliable for JSON payloads
- Reducing the risk of special characters or newlines in the script breaking the command
- Making the payload handling more explicit and easier to debug

https://claude.ai/code/session_01L49JhR9mLzNNa1xtr51qxx