### PR TITLE
Fix deploy-clients workflow exit code 22

### DIFF
--- a/.github/workflows/deploy-clients.yml
+++ b/.github/workflows/deploy-clients.yml
@@ -35,7 +35,7 @@ jobs:
             script_id="${line%%|*}"
             api_key="${line#*|}"
             echo "Deploying to script $script_id..."
-            response=$(curl -s --fail-with-body -w "\n%{http_code}" \
+            response=$(curl -s -w "\n%{http_code}" \
               -X POST "https://api.bunny.net/compute/script/${script_id}/code" \
               -H "AccessKey: ${api_key}" \
               -H "Content-Type: application/json" \
@@ -50,7 +50,7 @@ jobs:
               exit 1
             fi
             echo "  Publishing script $script_id..."
-            response=$(curl -s --fail-with-body -w "\n%{http_code}" \
+            response=$(curl -s -w "\n%{http_code}" \
               -X POST "https://api.bunny.net/compute/script/${script_id}/publish" \
               -H "AccessKey: ${api_key}" \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
Remove --fail-with-body from curl commands. This flag causes curl to
exit with code 22 on HTTP 4xx/5xx responses, which terminates the
script immediately under bash set -e (GitHub Actions default) before
the manual status code handling logic can run.

The script already captures HTTP status via -w "\n%{http_code}" and
handles errors with its own if/else blocks, so --fail-with-body is
redundant and harmful here.

https://claude.ai/code/session_01MBxzaCV3e9Se8Hy7cgFjHe