### PR TITLE
Reduce iframe embed height calculations by 3rem

### DIFF
--- a/src/lib/embed.ts
+++ b/src/lib/embed.ts
@@ -6,7 +6,7 @@ import type { EventFields } from "#lib/types.ts";
 import { parseEventFields } from "#lib/event-fields.ts";
 
 const TEXTAREA_FIELDS: readonly string[] = ["address", "special_instructions"];
-const BASE_HEIGHT = 14;
+const BASE_HEIGHT = 11;
 const INPUT_HEIGHT = 4;
 const TEXTAREA_HEIGHT = 6;
 

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -826,7 +826,10 @@ body.iframe main {
 }
 
 body.iframe form {
+  border: none;
+  box-shadow: none;
   margin-bottom: 0;
+  padding: 0;
 }
 
 /* Multi-booking event list */

--- a/test/lib/embed.test.ts
+++ b/test/lib/embed.test.ts
@@ -3,36 +3,36 @@ import { buildEmbedCode, computeIframeHeight } from "#lib/embed.ts";
 
 describe("embed", () => {
   describe("computeIframeHeight", () => {
-    test("returns 14rem for empty fields (name only)", () => {
-      expect(computeIframeHeight("")).toBe("14rem");
+    test("returns 11rem for empty fields (name only)", () => {
+      expect(computeIframeHeight("")).toBe("11rem");
     });
 
-    test("returns 18rem for email-only", () => {
-      expect(computeIframeHeight("email")).toBe("18rem");
+    test("returns 15rem for email-only", () => {
+      expect(computeIframeHeight("email")).toBe("15rem");
     });
 
-    test("returns 18rem for phone-only", () => {
-      expect(computeIframeHeight("phone")).toBe("18rem");
+    test("returns 15rem for phone-only", () => {
+      expect(computeIframeHeight("phone")).toBe("15rem");
     });
 
-    test("returns 22rem for email,phone", () => {
-      expect(computeIframeHeight("email,phone")).toBe("22rem");
+    test("returns 19rem for email,phone", () => {
+      expect(computeIframeHeight("email,phone")).toBe("19rem");
     });
 
-    test("returns 20rem for address-only (textarea)", () => {
-      expect(computeIframeHeight("address")).toBe("20rem");
+    test("returns 17rem for address-only (textarea)", () => {
+      expect(computeIframeHeight("address")).toBe("17rem");
     });
 
-    test("returns 20rem for special_instructions-only (textarea)", () => {
-      expect(computeIframeHeight("special_instructions")).toBe("20rem");
+    test("returns 17rem for special_instructions-only (textarea)", () => {
+      expect(computeIframeHeight("special_instructions")).toBe("17rem");
     });
 
-    test("returns 28rem for email,phone,address", () => {
-      expect(computeIframeHeight("email,phone,address")).toBe("28rem");
+    test("returns 25rem for email,phone,address", () => {
+      expect(computeIframeHeight("email,phone,address")).toBe("25rem");
     });
 
-    test("returns 34rem for all four fields", () => {
-      expect(computeIframeHeight("email,phone,address,special_instructions")).toBe("34rem");
+    test("returns 31rem for all four fields", () => {
+      expect(computeIframeHeight("email,phone,address,special_instructions")).toBe("31rem");
     });
   });
 
@@ -40,13 +40,13 @@ describe("embed", () => {
     test("produces iframe with url, iframe param, and computed height", () => {
       const result = buildEmbedCode("https://example.com/ticket/test", "email");
       expect(result).toBe(
-        '<iframe src="https://example.com/ticket/test?iframe=true" loading="lazy" style="border: none; width: 100%; height: 18rem">Loading..</iframe>',
+        '<iframe src="https://example.com/ticket/test?iframe=true" loading="lazy" style="border: none; width: 100%; height: 15rem">Loading..</iframe>',
       );
     });
 
     test("uses height from merged fields", () => {
       const result = buildEmbedCode("https://example.com/ticket/a+b", "email,phone,address");
-      expect(result).toContain("height: 28rem");
+      expect(result).toContain("height: 25rem");
       expect(result).toContain("https://example.com/ticket/a+b?iframe=true");
     });
   });

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -142,34 +142,34 @@ describe("html", () => {
       expect(html).toContain("readonly");
     });
 
-    test("embed code uses 18rem height for email-only events", () => {
+    test("embed code uses 15rem height for email-only events", () => {
       const emailEvent = testEventWithCount({ attendee_count: 2, fields: "email" });
       const html = adminEventPage({ event: emailEvent, attendees: [], allowedDomain: "example.com", session: TEST_SESSION });
-      expect(html).toContain("height: 18rem");
+      expect(html).toContain("height: 15rem");
     });
 
-    test("embed code uses 22rem height for email,phone fields events", () => {
+    test("embed code uses 19rem height for email,phone fields events", () => {
       const bothEvent = testEventWithCount({ attendee_count: 2, fields: "email,phone" });
       const html = adminEventPage({ event: bothEvent, attendees: [], allowedDomain: "example.com", session: TEST_SESSION });
-      expect(html).toContain("height: 22rem");
+      expect(html).toContain("height: 19rem");
     });
 
-    test("embed code uses 20rem height for address-only events", () => {
+    test("embed code uses 17rem height for address-only events", () => {
       const addressEvent = testEventWithCount({ attendee_count: 2, fields: "address" });
       const html = adminEventPage({ event: addressEvent, attendees: [], allowedDomain: "example.com", session: TEST_SESSION });
-      expect(html).toContain("height: 20rem");
+      expect(html).toContain("height: 17rem");
     });
 
-    test("embed code uses 28rem height for email,phone,address events", () => {
+    test("embed code uses 25rem height for email,phone,address events", () => {
       const allFieldsEvent = testEventWithCount({ attendee_count: 2, fields: "email,phone,address" });
       const html = adminEventPage({ event: allFieldsEvent, attendees: [], allowedDomain: "example.com", session: TEST_SESSION });
-      expect(html).toContain("height: 28rem");
+      expect(html).toContain("height: 25rem");
     });
 
-    test("embed code uses 18rem height for phone-only events", () => {
+    test("embed code uses 15rem height for phone-only events", () => {
       const phoneEvent = testEventWithCount({ attendee_count: 2, fields: "phone" });
       const html = adminEventPage({ event: phoneEvent, attendees: [], allowedDomain: "example.com", session: TEST_SESSION });
-      expect(html).toContain("height: 18rem");
+      expect(html).toContain("height: 15rem");
     });
 
     test("renders empty attendees state", () => {


### PR DESCRIPTION
## Summary
Adjusted the iframe height calculations for embedded event forms to be more compact, reducing the base height and updating all corresponding test expectations.

## Key Changes
- **Base height reduction**: Decreased `BASE_HEIGHT` constant from 14rem to 11rem in `src/lib/embed.ts`, reducing all computed heights by 3rem
- **Form styling improvements**: Updated `body.iframe form` styles in `src/static/mvp.css` to remove borders, box shadows, and padding for a cleaner embedded appearance
- **Test updates**: Updated all 16 test cases across two test files to reflect the new height values:
  - Empty fields: 14rem → 11rem
  - Single input fields (email/phone): 18rem → 15rem
  - Textarea fields (address/special_instructions): 20rem → 17rem
  - Multiple field combinations adjusted proportionally (e.g., 22rem → 19rem, 28rem → 25rem, 34rem → 31rem)

## Implementation Details
The height reduction is uniform across all field configurations, maintaining the relative spacing between different form layouts while reducing overall iframe footprint. The form styling changes remove visual borders and shadows that were unnecessary in the embedded context, creating a more seamless integration with host pages.

https://claude.ai/code/session_012eDap3mmf3da9m6QACC8AX