### PR TITLE
Increase content width and add table header label styling

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -23,7 +23,7 @@
   --width-card: 285px;
   --width-card-medium: 460px;
   --width-card-wide: 800px;
-  --width-content: 800px;
+  --width-content: 1300px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -602,6 +602,10 @@ table thead tr:first-child th:first-child {
 
 table thead tr:first-child th:last-child {
   border-top-right-radius: var(--border-radius);
+}
+
+table > th > label {
+  text-align: var(--justify-important);
 }
 
 table thead th:first-child,


### PR DESCRIPTION
## Summary
This PR updates the MVP CSS stylesheet to improve layout width and add styling for table header labels.

## Key Changes
- Increased `--width-content` CSS variable from 800px to 1300px to allow for wider content layouts
- Added new CSS rule for `table > th > label` elements to align them using the `--justify-important` variable

## Implementation Details
The content width increase provides more horizontal space for page layouts, while the new table header label styling ensures consistent alignment of labels within table headers using the existing `--justify-important` CSS variable for alignment.

https://claude.ai/code/session_01EwgDEPHxfguYtLJAduSKR4