### PR TITLE
Support iframe embedding with SameSite=None CSRF cookies

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -70,11 +70,14 @@ const makeCsrfResponseBuilder =
 const ticketCsrfPath = (slug: string): string => `/ticket/${slug}`;
 
 /** Ticket response with CSRF cookie */
-const ticketResponseWithCookie = makeCsrfResponseBuilder(
-  (event: EventWithCount, _isClosed: boolean, _iframe: boolean, _dates: string[] | undefined, _terms: string | null | undefined) => ticketCsrfPath(event.slug),
-  (token, error, event, isClosed, iframe, dates, terms) => ticketPage(event, token, error, isClosed, iframe, dates, terms),
-  (_event, _isClosed, iframe) => iframe,
-);
+const ticketResponseWithCookie =
+  (event: EventWithCount, isClosed: boolean, iframe: boolean, dates: string[] | undefined, terms: string | null | undefined) =>
+  (token: string) =>
+  (error?: string, status = 200) =>
+    htmlResponseWithCookie(csrfCookie(token, ticketCsrfPath(event.slug), undefined, iframe))(
+      ticketPage(event, token, error, isClosed, iframe, dates, terms),
+      status,
+    );
 
 /** Curried error response: render(error) → (error, status) → Response */
 const errorResponse =

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -70,14 +70,13 @@ const makeCsrfResponseBuilder =
 const ticketCsrfPath = (slug: string): string => `/ticket/${slug}`;
 
 /** Ticket response with CSRF cookie */
-const ticketResponseWithCookie =
-  (event: EventWithCount, isClosed: boolean, iframe: boolean, dates: string[] | undefined, terms: string | null | undefined) =>
-  (token: string) =>
-  (error?: string, status = 200) =>
-    htmlResponseWithCookie(csrfCookie(token, ticketCsrfPath(event.slug), undefined, iframe))(
-      ticketPage(event, token, error, isClosed, iframe, dates, terms),
-      status,
-    );
+const ticketResponseWithCookie = makeCsrfResponseBuilder<
+  [EventWithCount, boolean, boolean, string[] | undefined, string | null | undefined]
+>(
+  (event) => ticketCsrfPath(event.slug),
+  (token, error, event, isClosed, iframe, dates, terms) => ticketPage(event, token, error, isClosed, iframe, dates, terms),
+  (_ev, _cl, iframe) => iframe,
+);
 
 /** Curried error response: render(error) → (error, status) → Response */
 const errorResponse =

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -408,9 +408,9 @@ export type CsrfFormResult =
 /** Default cookie name for public form CSRF tokens */
 const DEFAULT_CSRF_COOKIE = "csrf_token";
 
-/** Generate CSRF cookie string */
-export const csrfCookie = (token: string, path: string, cookieName = DEFAULT_CSRF_COOKIE): string =>
-  `${cookieName}=${token}; HttpOnly; Secure; SameSite=Strict; Path=${path}; Max-Age=3600`;
+/** Generate CSRF cookie string. Uses SameSite=None when embedded in a cross-site iframe. */
+export const csrfCookie = (token: string, path: string, cookieName?: string, iframe = false): string =>
+  `${cookieName ?? DEFAULT_CSRF_COOKIE}=${token}; HttpOnly; Secure; SameSite=${iframe ? "None" : "Strict"}; Path=${path}; Max-Age=3600`;
 
 /**
  * Parse form with CSRF validation (double-submit cookie pattern)

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -91,7 +91,7 @@ export const ticketPage = (
       ) : isFull ? (
           <div class="error">Sorry, this event is full.</div>
       ) : (
-          <form method="POST" action={`/ticket/${event.slug}`}>
+          <form method="POST" action={`/ticket/${event.slug}${iframe ? "?iframe=true" : ""}`}>
             <input type="hidden" name="csrf_token" value={csrfToken} />
             <Raw html={renderFields(fields)} />
             {isDaily && availableDates && (


### PR DESCRIPTION
## Summary
This PR adds support for embedding the ticket booking form in cross-site iframes by implementing conditional CSRF cookie handling based on iframe context.

## Key Changes
- **CSRF Cookie SameSite Policy**: Modified `csrfCookie()` to use `SameSite=None` when the request includes `?iframe=true` parameter, and `SameSite=Strict` for regular requests. This allows cookies to be sent in cross-site iframe contexts while maintaining security for standard requests.

- **Iframe Parameter Propagation**: Updated the ticket page rendering to:
  - Detect iframe mode via `isIframeRequest()` helper
  - Pass iframe state through the request processing pipeline
  - Include `?iframe=true` in form action URLs when in iframe mode, ensuring POST requests maintain iframe context

- **Response Builder Enhancement**: Extended `makeCsrfResponseBuilder()` to accept an optional `getIframe` callback, allowing response builders to conditionally apply iframe-specific cookie settings.

- **Error Handling**: Ensured CSRF validation errors in iframe mode also return cookies with `SameSite=None` to maintain consistency.

- **Type Safety**: Updated `TicketContext` type to include the `iframe` boolean flag, ensuring iframe state is available throughout the ticket reservation flow.

## Implementation Details
- The iframe detection is based on the presence of `?iframe=true` query parameter in the request URL
- All ticket page responses (success, validation errors, CSRF errors) respect the iframe mode setting
- The change is backward compatible—requests without the iframe parameter continue to use the stricter `SameSite=Strict` policy

https://claude.ai/code/session_019Ls9HEakSjozdePG4deotD