### PR TITLE
Refactor Bunny deployment script to use separate access key secret

### DIFF
--- a/.github/workflows/deploy-clients.yml
+++ b/.github/workflows/deploy-clients.yml
@@ -28,16 +28,16 @@ jobs:
       - name: Deploy to clients
         env:
           BUNNY_SCRIPT_DATA: ${{ secrets.BUNNY_SCRIPT_DATA }}
+          BUNNY_ACCESS_KEY: ${{ secrets.BUNNY_ACCESS_KEY }}
         run: |
           jq -Rs '{"Code": .}' bunny-script.ts > /tmp/code-payload.json
-          while IFS= read -r line; do
-            [ -z "$line" ] && continue
-            script_id="${line%%|*}"
-            api_key="${line#*|}"
+          IFS='|' read -ra script_ids <<< "$BUNNY_SCRIPT_DATA"
+          for script_id in "${script_ids[@]}"; do
+            [ -z "$script_id" ] && continue
             echo "Deploying to script $script_id..."
             response=$(curl -s -w "\n%{http_code}" \
               -X POST "https://api.bunny.net/compute/script/${script_id}/code" \
-              -H "AccessKey: ${api_key}" \
+              -H "AccessKey: ${BUNNY_ACCESS_KEY}" \
               -H "Content-Type: application/json" \
               -d @/tmp/code-payload.json)
             status_code=$(echo "$response" | tail -1)
@@ -52,7 +52,7 @@ jobs:
             echo "  Publishing script $script_id..."
             response=$(curl -s -w "\n%{http_code}" \
               -X POST "https://api.bunny.net/compute/script/${script_id}/publish" \
-              -H "AccessKey: ${api_key}" \
+              -H "AccessKey: ${BUNNY_ACCESS_KEY}" \
               -H "Content-Type: application/json" \
               -d '{}')
             status_code=$(echo "$response" | tail -1)
@@ -64,4 +64,4 @@ jobs:
               echo "   Response: $body"
               exit 1
             fi
-          done <<< "$BUNNY_SCRIPT_DATA"
+          done


### PR DESCRIPTION
## Summary
Refactored the Bunny CDN deployment workflow to separate the API access key from the script data configuration, improving security and configuration management.

## Key Changes
- **Separated secrets**: Moved API access key to a dedicated `BUNNY_ACCESS_KEY` secret instead of embedding it in `BUNNY_SCRIPT_DATA`
- **Simplified data format**: Changed `BUNNY_SCRIPT_DATA` from a pipe-delimited format with embedded keys (`script_id|api_key`) to a simple pipe-delimited list of script IDs
- **Updated parsing logic**: Replaced line-by-line reading with direct array splitting using `IFS='|'` for cleaner script ID extraction
- **Consistent authentication**: All API calls now use the centralized `BUNNY_ACCESS_KEY` environment variable

## Implementation Details
- The script now expects `BUNNY_SCRIPT_DATA` to contain only script IDs separated by pipes (e.g., `script1|script2|script3`)
- The `BUNNY_ACCESS_KEY` secret is used for all authentication headers in both code deployment and publish operations
- Removed the heredoc input redirection (`<<< "$BUNNY_SCRIPT_DATA"`) as it's no longer needed with the new parsing approach

https://claude.ai/code/session_01PDSpk9X3wSdhsPJggPiZX3