### PR TITLE
Add iframe mode support to multi-ticket registration flow

### DIFF
--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -408,9 +408,9 @@ export type CsrfFormResult =
 /** Default cookie name for public form CSRF tokens */
 const DEFAULT_CSRF_COOKIE = "csrf_token";
 
-/** Generate CSRF cookie string. Uses SameSite=None when embedded in a cross-site iframe. */
+/** Generate CSRF cookie string. Uses SameSite=None + Partitioned when embedded in a cross-site iframe. */
 export const csrfCookie = (token: string, path: string, cookieName?: string, iframe = false): string =>
-  `${cookieName ?? DEFAULT_CSRF_COOKIE}=${token}; HttpOnly; Secure; SameSite=${iframe ? "None" : "Strict"}; Path=${path}; Max-Age=3600`;
+  `${cookieName ?? DEFAULT_CSRF_COOKIE}=${token}; HttpOnly; Secure; SameSite=${iframe ? "None" : "Strict"}; Path=${path}; Max-Age=3600${iframe ? "; Partitioned" : ""}`;
 
 /**
  * Parse form with CSRF validation (double-submit cookie pattern)

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -213,10 +213,11 @@ export const multiTicketPage = (
   error?: string,
   availableDates?: string[],
   termsAndConditions?: string | null,
+  iframe = false,
 ): string => {
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
   const allClosed = events.every((e) => e.isClosed);
-  const formAction = `/ticket/${slugs.join("+")}`;
+  const formAction = `/ticket/${slugs.join("+")}${iframe ? "?iframe=true" : ""}`;
   const fieldsSetting = getMultiTicketFieldsSetting(events);
   const fields: Field[] = getTicketFields(fieldsSetting);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
@@ -227,7 +228,7 @@ export const multiTicketPage = (
   )(events);
 
   return String(
-    <Layout title="Reserve Tickets">
+    <Layout title="Reserve Tickets" bodyClass={iframe ? "iframe" : undefined}>
       <Raw html={renderError(error)} />
 
       {allUnavailable ? (

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1118,6 +1118,25 @@ describe("html", () => {
       expect(html).toContain("Rule one<br>Rule two");
       expect(html).toContain('name="agree_terms"');
     });
+
+    test("appends ?iframe=true to form action in iframe mode", () => {
+      const events = [
+        buildMultiTicketEvent(testEventWithCount({ id: 1, slug: "ab12c", name: "Event A", attendee_count: 0 })),
+      ];
+      const html = multiTicketPage(events, ["ab12c"], TEST_CSRF_TOKEN, undefined, undefined, undefined, true);
+      expect(html).toContain('action="/ticket/ab12c?iframe=true"');
+      expect(html).toContain('class="iframe"');
+    });
+
+    test("does not append ?iframe=true without iframe mode", () => {
+      const events = [
+        buildMultiTicketEvent(testEventWithCount({ id: 1, slug: "ab12c", name: "Event A", attendee_count: 0 })),
+      ];
+      const html = multiTicketPage(events, ["ab12c"], TEST_CSRF_TOKEN);
+      expect(html).toContain('action="/ticket/ab12c"');
+      expect(html).not.toContain("?iframe=true");
+      expect(html).not.toContain('class="iframe"');
+    });
   });
 
   describe("adminSettingsPage", () => {


### PR DESCRIPTION
## Summary
This PR extends iframe mode support to the multi-ticket registration flow, ensuring consistent behavior between single-ticket and multi-ticket pages when embedded in cross-site iframes.

## Key Changes
- **Multi-ticket GET/POST handlers**: Updated `handleMultiTicketGet` and `handleMultiTicketPost` to detect and pass iframe mode through the request chain
- **CSRF cookie handling**: Modified `csrfCookie` function to include `Partitioned` attribute when in iframe mode (SameSite=None + Partitioned), improving third-party cookie compatibility
- **Response builders**: Updated `multiTicketResponseWithCookie` and `multiTicketResponse` to accept and propagate the `iframe` boolean parameter through the response chain
- **Template updates**: Modified `multiTicketPage` to:
  - Accept `iframe` parameter
  - Append `?iframe=true` query parameter to form action in iframe mode
  - Apply `iframe` CSS class to body element for styling
- **Type safety**: Added explicit generic type parameter to `makeCsrfResponseBuilder` for better type inference with the new iframe parameter

## Implementation Details
- The iframe detection uses the existing `isIframeRequest()` utility function
- The iframe flag is threaded through all validation error paths to ensure consistent cookie attributes
- Tests added to verify SameSite=None + Partitioned cookie attributes in iframe mode for multi-ticket pages
- Tests verify form action includes `?iframe=true` query parameter in iframe mode

https://claude.ai/code/session_01S4gWvNnw8RzSsnwxTQCvWq