### PR TITLE
Add padding to iframe body element

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -825,6 +825,10 @@ button.link-button.checkout {
 }
 
 /* Iframe embed mode */
+body.iframe {
+  padding: 0.5rem;
+}
+
 body.iframe main {
   padding: 0;
 }


### PR DESCRIPTION
## Summary
Added padding to the `body.iframe` selector to provide consistent spacing in iframe embed mode.

## Changes
- Added `padding: 0.5rem` to `body.iframe` CSS rule to ensure proper spacing around embedded content
- This complements the existing `padding: 0` on `body.iframe main` to create a consistent layout with outer padding and inner content without padding

## Implementation Details
The new padding rule is applied at the body level for iframe embeds, allowing the iframe container itself to have breathing room while the main content area remains flush (padding: 0). This provides a balanced visual presentation for embedded content.

https://claude.ai/code/session_01MFkABKs9uvdyDKodpggD7X