### PR TITLE
Support Stripe checkout in iframes via popup window

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -66,55 +66,51 @@ if (dateInput && closesAtInput) {
   });
 }
 
-/* Stripe checkout popup: opens Stripe in a new window when embedded in an iframe */
+/* Stripe checkout popup: opens Stripe in a new window when embedded in an iframe.
+ * No-JS fallback: the Pay Now link has target="_blank" and works as a plain link. */
 const checkoutPopup = document.querySelector<HTMLElement>("[data-checkout-popup]");
 if (checkoutPopup) {
   const checkoutUrl = checkoutPopup.dataset.checkoutPopup!;
   const waitingEl = checkoutPopup.querySelector<HTMLElement>("[data-checkout-waiting]")!;
-  const resultEl = checkoutPopup.querySelector<HTMLElement>("[data-checkout-result]")!;
   const openLink = checkoutPopup.querySelector<HTMLAnchorElement>("[data-open-checkout]")!;
   let popup: Window | null = null;
 
-  const showResult = (html: string) => {
+  const showPayButton = () => {
     waitingEl.hidden = true;
-    resultEl.innerHTML = html;
-    resultEl.hidden = false;
+    openLink.parentElement!.hidden = false;
   };
 
   // Listen for postMessage from the popup success/cancel page
   window.addEventListener("message", (e) => {
     if (e.origin !== location.origin) return;
     if (e.data?.type === "payment-success") {
-      showResult('<div class="success"><p>Payment successful! Your ticket has been confirmed.</p></div>');
+      // Navigate the iframe to the real success page — single code path
+      location.href = "/ticket/reserved";
     } else if (e.data?.type === "payment-cancel") {
-      showResult(
-        `<p>Payment was cancelled.</p><p><a href="${checkoutUrl}" target="_blank" rel="noopener">Try again</a></p>`,
-      );
+      showPayButton();
     }
   });
 
   // Track popup and detect when it closes without completing
   const pollPopup = () => {
     if (!popup || popup.closed) {
-      // Only show closed message if no result was already shown
-      if (resultEl.hidden) {
-        waitingEl.hidden = true;
-        openLink.parentElement!.hidden = false;
-      }
+      showPayButton();
       return;
     }
     setTimeout(pollPopup, 500);
   };
 
   openLink.addEventListener("click", (e) => {
-    e.preventDefault();
-    popup = window.open(checkoutUrl, "_blank", "noopener=no");
-    if (popup) {
+    // Open without noopener so the popup can access window.opener for postMessage
+    const w = window.open(checkoutUrl, "_blank");
+    if (w) {
+      e.preventDefault();
+      popup = w;
       openLink.parentElement!.hidden = true;
       waitingEl.hidden = false;
       pollPopup();
     }
-    // If popup blocked, the link href+target="_blank" serves as fallback
+    // If popup blocked (w is null), default link action fires — graceful fallback
   });
 }
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -409,8 +409,8 @@ export type CsrfFormResult =
 const DEFAULT_CSRF_COOKIE = "csrf_token";
 
 /** Generate CSRF cookie string. Uses SameSite=None + Partitioned when embedded in a cross-site iframe. */
-export const csrfCookie = (token: string, path: string, cookieName?: string, iframe = false): string =>
-  `${cookieName ?? DEFAULT_CSRF_COOKIE}=${token}; HttpOnly; Secure; SameSite=${iframe ? "None" : "Strict"}; Path=${path}; Max-Age=3600${iframe ? "; Partitioned" : ""}`;
+export const csrfCookie = (token: string, path: string, cookieName?: string, inIframe = false): string =>
+  `${cookieName ?? DEFAULT_CSRF_COOKIE}=${token}; HttpOnly; Secure; SameSite=${inIframe ? "None" : "Strict"}; Path=${path}; Max-Age=3600${inIframe ? "; Partitioned" : ""}`;
 
 /**
  * Parse form with CSRF validation (double-submit cookie pattern)

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -35,16 +35,18 @@ export const paymentPage = (
 export const paymentSuccessPage = (_event: Event, thankYouUrl: string | null): string =>
   String(
     <Layout title="Payment Successful" headExtra={thankYouUrl ? `<meta http-equiv="refresh" content="3;url=${escapeHtml(thankYouUrl)}">` : undefined}>
-        <h1>Payment Successful!</h1>
-        <div class="success">
-          <p>Thank you for your payment. Your ticket has been confirmed.</p>
+        <div data-payment-result="success">
+          <h1>Payment Successful!</h1>
+          <div class="success">
+            <p>Thank you for your payment. Your ticket has been confirmed.</p>
+          </div>
+          {thankYouUrl ? (
+            <>
+              <p>You will be redirected shortly...</p>
+              <p><a href={thankYouUrl}>Click here if you are not redirected</a></p>
+            </>
+          ) : null}
         </div>
-        {thankYouUrl ? (
-          <>
-            <p>You will be redirected shortly...</p>
-            <p><a href={thankYouUrl}>Click here if you are not redirected</a></p>
-          </>
-        ) : null}
     </Layout>
   );
 
@@ -64,9 +66,11 @@ export const reservationSuccessPage = (): string =>
 export const paymentCancelPage = (_event: Event, ticketUrl: string): string =>
   String(
     <Layout title="Payment Cancelled">
-        <h1>Payment Cancelled</h1>
-        <p>Your payment was cancelled. Your ticket reservation has been removed.</p>
-        <p><a href={ticketUrl}><i>Try again</i></a></p>
+        <div data-payment-result="cancel">
+          <h1>Payment Cancelled</h1>
+          <p>Your payment was cancelled. Your ticket reservation has been removed.</p>
+          <p><a href={ticketUrl}><i>Try again</i></a></p>
+        </div>
     </Layout>
   );
 
@@ -81,5 +85,24 @@ export const paymentErrorPage = (message: string): string =>
           <p>{message}</p>
         </div>
         <p><a href="/">Return to home</a></p>
+    </Layout>
+  );
+
+/**
+ * Checkout popup page - shown inside an iframe when Stripe payment is required.
+ * Opens the Stripe checkout URL in a popup window since Stripe cannot run in iframes.
+ */
+export const checkoutPopupPage = (checkoutUrl: string): string =>
+  String(
+    <Layout title="Complete Payment" bodyClass="iframe">
+        <div data-checkout-popup={escapeHtml(checkoutUrl)}>
+          <p>Payment is processed in a new window.</p>
+          <p><a href={checkoutUrl} target="_blank" rel="noopener" data-open-checkout><b>Pay Now</b></a></p>
+          <div data-checkout-waiting hidden>
+            <p>Completing payment in the other window...</p>
+            <p><a href={checkoutUrl} target="_blank" rel="noopener"><small>Click here if the payment window didn't open</small></a></p>
+          </div>
+          <div data-checkout-result hidden></div>
+        </div>
     </Layout>
   );

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -97,10 +97,10 @@ export const checkoutPopupPage = (checkoutUrl: string): string =>
     <Layout title="Complete Payment" bodyClass="iframe">
         <div data-checkout-popup={escapeHtml(checkoutUrl)}>
           <p>Payment is processed in a new window.</p>
-          <p><a href={checkoutUrl} target="_blank" rel="noopener" data-open-checkout><b>Pay Now</b></a></p>
+          <p><a href={checkoutUrl} target="_blank" data-open-checkout><b>Pay Now</b></a></p>
           <div data-checkout-waiting hidden>
             <p>Completing payment in the other window...</p>
-            <p><a href={checkoutUrl} target="_blank" rel="noopener"><small>Click here if the payment window didn't open</small></a></p>
+            <p><a href={checkoutUrl} target="_blank"><small>Click here if the payment window didn't open</small></a></p>
           </div>
         </div>
     </Layout>

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -102,7 +102,6 @@ export const checkoutPopupPage = (checkoutUrl: string): string =>
             <p>Completing payment in the other window...</p>
             <p><a href={checkoutUrl} target="_blank" rel="noopener"><small>Click here if the payment window didn't open</small></a></p>
           </div>
-          <div data-checkout-result hidden></div>
         </div>
     </Layout>
   );

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -53,7 +53,7 @@ export const ticketPage = (
   csrfToken: string,
   error: string | undefined,
   isClosed: boolean,
-  iframe: boolean,
+  inIframe: boolean,
   availableDates: string[] | undefined,
   termsAndConditions: string | null | undefined,
 ): string => {
@@ -66,8 +66,8 @@ export const ticketPage = (
   const isDaily = event.event_type === "daily";
 
   return String(
-    <Layout title={event.name} bodyClass={iframe ? "iframe" : undefined}>
-      {!iframe && (
+    <Layout title={event.name} bodyClass={inIframe ? "iframe" : undefined}>
+      {!inIframe && (
         <>
           <Raw html={renderEventImage(event)} />
           <h1>{event.name}</h1>
@@ -91,7 +91,7 @@ export const ticketPage = (
       ) : isFull ? (
           <div class="error">Sorry, this event is full.</div>
       ) : (
-          <form method="POST" action={`/ticket/${event.slug}${iframe ? "?iframe=true" : ""}`}>
+          <form method="POST" action={`/ticket/${event.slug}${inIframe ? "?iframe=true" : ""}`}>
             <input type="hidden" name="csrf_token" value={csrfToken} />
             <Raw html={renderFields(fields)} />
             {isDaily && availableDates && (
@@ -213,11 +213,11 @@ export const multiTicketPage = (
   error?: string,
   availableDates?: string[],
   termsAndConditions?: string | null,
-  iframe = false,
+  inIframe = false,
 ): string => {
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
   const allClosed = events.every((e) => e.isClosed);
-  const formAction = `/ticket/${slugs.join("+")}${iframe ? "?iframe=true" : ""}`;
+  const formAction = `/ticket/${slugs.join("+")}${inIframe ? "?iframe=true" : ""}`;
   const fieldsSetting = getMultiTicketFieldsSetting(events);
   const fields: Field[] = getTicketFields(fieldsSetting);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
@@ -228,7 +228,7 @@ export const multiTicketPage = (
   )(events);
 
   return String(
-    <Layout title="Reserve Tickets" bodyClass={iframe ? "iframe" : undefined}>
+    <Layout title="Reserve Tickets" bodyClass={inIframe ? "iframe" : undefined}>
       <Raw html={renderError(error)} />
 
       {allUnavailable ? (

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -527,10 +527,9 @@ describe("html", () => {
       expect(html).toContain('data-open-checkout');
     });
 
-    test("includes waiting and result elements", () => {
+    test("includes waiting element for popup state", () => {
       const html = checkoutPopupPage("https://checkout.stripe.com/session123");
       expect(html).toContain("data-checkout-waiting");
-      expect(html).toContain("data-checkout-result");
     });
 
     test("uses iframe body class", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -10,6 +10,7 @@ import { adminSettingsPage } from "#templates/admin/settings.tsx";
 import { type CsvEventInfo, generateAttendeesCsv, generateCalendarCsv } from "#templates/csv.ts";
 import { adminCalendarPage, type CalendarAttendeeRow } from "#templates/admin/calendar.tsx";
 import {
+  checkoutPopupPage,
   paymentCancelPage,
   paymentErrorPage,
   paymentPage,
@@ -484,6 +485,17 @@ describe("html", () => {
       expect(html).toContain('http-equiv="refresh"');
       expect(html).toContain("3;url=https://example.com/thanks");
     });
+
+    test("includes data-payment-result attribute for popup postMessage", () => {
+      const html = paymentSuccessPage(event, null);
+      expect(html).toContain('data-payment-result="success"');
+    });
+
+    test("renders without redirect when thankYouUrl is null", () => {
+      const html = paymentSuccessPage(event, null);
+      expect(html).not.toContain('http-equiv="refresh"');
+      expect(html).not.toContain("redirected");
+    });
   });
 
   describe("paymentCancelPage", () => {
@@ -494,6 +506,42 @@ describe("html", () => {
       expect(html).toContain("Payment Cancelled");
       expect(html).toContain("/ticket/ab12c");
       expect(html).toContain("Try again");
+    });
+
+    test("includes data-payment-result attribute for popup postMessage", () => {
+      const html = paymentCancelPage(event, "/ticket/ab12c");
+      expect(html).toContain('data-payment-result="cancel"');
+    });
+  });
+
+  describe("checkoutPopupPage", () => {
+    test("renders checkout URL in data attribute", () => {
+      const html = checkoutPopupPage("https://checkout.stripe.com/session123");
+      expect(html).toContain('data-checkout-popup="https://checkout.stripe.com/session123"');
+    });
+
+    test("renders Pay Now link with target _blank", () => {
+      const html = checkoutPopupPage("https://checkout.stripe.com/session123");
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain("Pay Now");
+      expect(html).toContain('data-open-checkout');
+    });
+
+    test("includes waiting and result elements", () => {
+      const html = checkoutPopupPage("https://checkout.stripe.com/session123");
+      expect(html).toContain("data-checkout-waiting");
+      expect(html).toContain("data-checkout-result");
+    });
+
+    test("uses iframe body class", () => {
+      const html = checkoutPopupPage("https://checkout.stripe.com/session123");
+      expect(html).toContain('class="iframe"');
+    });
+
+    test("escapes checkout URL", () => {
+      const html = checkoutPopupPage('https://evil.com/"onload="alert(1)');
+      expect(html).toContain("&quot;");
+      expect(html).not.toContain('"onload="');
     });
   });
 


### PR DESCRIPTION
## Summary
Adds support for Stripe payment checkout when the ticket form is embedded in an iframe. Since Stripe cannot run directly in iframes, the checkout is opened in a popup window with postMessage communication to handle payment success/cancellation.

## Key Changes

- **New checkout popup page** (`checkoutPopupPage`): Returns an HTML page with a "Pay Now" button that opens Stripe checkout in a new window, with a no-JS fallback via `target="_blank"`

- **Client-side popup handling** (`src/client/admin.ts`): 
  - Opens checkout URL in a popup window when user clicks "Pay Now"
  - Polls popup state to detect when user closes it without completing payment
  - Listens for postMessage events from payment result pages to handle success/cancellation
  - Shows "Completing payment..." state while popup is open

- **Payment result pages** (`paymentSuccessPage`, `paymentCancelPage`): 
  - Wrapped content in `data-payment-result` attribute
  - When opened in a popup, sends postMessage to parent iframe with result type
  - Success page now renders without redirect when `thankYouUrl` is null (popup case)

- **Checkout flow updates** (`src/routes/public.ts`):
  - Modified `tryCheckoutRedirect` to accept `iframe` parameter
  - Returns popup page instead of redirect when `iframe=true`
  - Updated both single-ticket and multi-ticket checkout flows to pass iframe flag

- **Comprehensive test coverage**: Added 3 new test cases covering single-ticket, multi-ticket, and non-iframe scenarios

## Implementation Details

- Uses `window.open()` without `noopener` to allow popup to access `window.opener` for postMessage
- Graceful fallback: if popup is blocked, the link's default action opens checkout in new tab
- Origin validation on postMessage for security
- Polling interval of 500ms to detect popup closure

https://claude.ai/code/session_01K21sbupPxqDvyUhUa5nJRY