### PR TITLE
Add Nix flake configuration for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cov_profile/
 bunny-script.ts
 src/static/admin.js
 src/static/scanner.js
+.envrc

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs.nixpkgs.url = "nixpkgs";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+    in {
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = [ pkgs.deno ];
+          shellHook = ''
+            echo "tickets dev shell"
+            echo "  deno task start      - run server"
+            echo "  deno task test       - run tests"
+            echo "  deno task build:edge - build for edge"
+            echo "  deno task precommit  - typecheck + lint + cpd + build + test"
+          '';
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Summary
This PR adds Nix flake support to the project, enabling reproducible development environments across different systems and architectures.

## Key Changes
- **Added `flake.nix`**: New Nix flake configuration that defines a development shell with Deno as the primary dependency
  - Supports multiple systems: x86_64-linux, aarch64-linux, x86_64-darwin, and aarch64-darwin
  - Provides a default dev shell with helpful shell hook messages documenting available Deno tasks
  - Includes shortcuts for common development workflows (start, test, build:edge, precommit)
- **Updated `.gitignore`**: Added `.envrc` to ignore direnv configuration files, which are commonly used alongside Nix flakes

## Implementation Details
The flake uses `nixpkgs.lib.genAttrs` to generate dev shells for all supported systems, ensuring consistency across different development machines and CI/CD environments. The shell hook provides clear documentation of available tasks for developers entering the environment.

https://claude.ai/code/session_018z3XrKdbq3dxYpEihGN3rP