### PR TITLE
Simplify QR code module import from dynamic to static

### DIFF
--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -3,13 +3,12 @@
  * Wraps the qrcode npm package to produce inline SVG strings
  */
 
+import QRCodeDefault from "qrcode";
+
 /** QR code module shape (subset of the qrcode npm package API) */
 type QRCodeModule = { toString(text: string, opts: { type: string; margin?: number }): Promise<string> };
 
-// Dynamic import trick: cast the specifier to string to prevent Deno from
-// statically analyzing it (the module is resolved at runtime via import map).
-const modulePath: string = "qrcode";
-const QRCode: QRCodeModule = (await import(modulePath)).default;
+const QRCode: QRCodeModule = QRCodeDefault;
 
 /**
  * Generate an SVG string for a QR code encoding the given text.


### PR DESCRIPTION
## Summary
Refactored the QR code module import from a dynamic import with import map workaround to a standard static import statement.

## Key Changes
- Replaced dynamic import with string casting workaround with a direct static `import` statement
- Removed the `modulePath` variable and associated comment explaining the dynamic import trick
- Simplified the QRCode constant assignment to directly use the imported default export

## Implementation Details
The previous implementation used a dynamic import with a string-cast workaround to prevent Deno from statically analyzing the module specifier, relying on runtime resolution via import map. This has been replaced with a straightforward static import, which is cleaner and more maintainable while still maintaining the same `QRCodeModule` type contract.

https://claude.ai/code/session_01Jx7ejD8EGdVoDdjSibpfvu