### PR TITLE
Add admin ability to re-send webhooks for attendees

### DIFF
--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -145,3 +145,54 @@ export const adminRefundAllAttendeesPage = (
         </form>
     </Layout>
   );
+
+/**
+ * Admin re-send webhook confirmation page
+ */
+export const adminResendWebhookPage = (
+  event: EventWithCount,
+  attendee: Attendee,
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title={`Re-send Webhook: ${attendee.name}`}>
+      <AdminNav session={session} />
+        {error && <div class="error">{error}</div>}
+
+        <article>
+          <aside>
+            <p><strong>Note:</strong> This will re-send the registration webhook for this attendee to all configured webhook URLs.</p>
+          </aside>
+        </article>
+
+        <article>
+          <h2>Attendee Details</h2>
+          <p><strong>Name:</strong> {attendee.name}</p>
+          <p><strong>Email:</strong> {attendee.email}</p>
+          <p><strong>Quantity:</strong> {attendee.quantity}</p>
+          {attendee.price_paid && (
+            <p><strong>Amount Paid:</strong> {formatCurrency(attendee.price_paid)}</p>
+          )}
+          <p><strong>Registered:</strong> {new Date(attendee.created).toLocaleString()}</p>
+        </article>
+
+        <p>To re-send the webhook for this attendee, you must type their name "{attendee.name}" into the box below:</p>
+
+        <form method="POST" action={`/admin/event/${event.id}/attendee/${attendee.id}/resend-webhook`}>
+          <input type="hidden" name="csrf_token" value={session.csrfToken} />
+          <label for="confirm_name">Attendee name</label>
+          <input
+            type="text"
+            id="confirm_name"
+            name="confirm_name"
+            placeholder={attendee.name}
+            autocomplete="off"
+            required
+          />
+          <button type="submit">
+            Re-send Webhook
+          </button>
+        </form>
+    </Layout>
+  );

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -100,6 +100,10 @@ const AttendeeRow = ({ a, eventId, csrfToken, activeFilter, allowedDomain, showD
         <a href={`/admin/event/${eventId}/attendee/${a.id}/delete`} class="danger">
           Delete
         </a>
+        {" "}
+        <a href={`/admin/event/${eventId}/attendee/${a.id}/resend-webhook`}>
+          Re-send Webhook
+        </a>
       </td>
     </tr>
   );


### PR DESCRIPTION
## Summary
This PR adds functionality for admins to manually re-send registration webhooks for individual attendees. This is useful when webhooks fail to deliver or need to be retried.

## Key Changes
- **New GET endpoint** (`/admin/event/:eventId/attendee/:attendeeId/resend-webhook`): Displays a confirmation page showing attendee details and requiring the admin to type the attendee's name to confirm the action
- **New POST endpoint** (`/admin/event/:eventId/attendee/:attendeeId/resend-webhook`): Processes the webhook re-send request with name verification and CSRF protection
- **New template** (`adminResendWebhookPage`): Confirmation page displaying attendee information (name, email, quantity, amount paid if applicable, registration date) with a form requiring name confirmation
- **UI update**: Added "Re-send Webhook" link in the attendee row actions on the admin events page
- **Activity logging**: Logs webhook re-send actions to the event activity log
- **Comprehensive test coverage**: Added 16 tests covering authentication, authorization, validation, and successful webhook re-send scenarios

## Implementation Details
- Uses existing `attendeeGetRoute` and `attendeeFormAction` helpers for consistent route handling
- Reuses `logAndNotifyRegistration` from the webhook module to send the webhook
- Implements name confirmation pattern (similar to delete operations) to prevent accidental re-sends
- Displays amount paid information for paid attendees using `formatCurrency`
- Includes CSRF token validation for POST requests
- Returns appropriate HTTP status codes (404 for missing resources, 403 for invalid CSRF, 400 for validation errors)

https://claude.ai/code/session_01NRJkyZFAm6d94pcrSry6Tt