### PR TITLE
Fix image serving bug introduced in type assertion cleanup

### DIFF
--- a/src/routes/images.ts
+++ b/src/routes/images.ts
@@ -20,7 +20,7 @@ const handleImageRequest = async (filename: string): Promise<Response> => {
   const data = await downloadImage(filename);
   if (!data) return notFoundResponse();
 
-  return new Response(new Uint8Array(data).buffer as ArrayBuffer, {
+  return new Response(data.buffer as BodyInit, {
     headers: {
       "content-type": mimeType,
       "cache-control": IMAGE_CACHE_CONTROL,


### PR DESCRIPTION
Commit 018d45b attempted to remove type assertions but accidentally
broke image serving by using `new Uint8Array(data).buffer` instead
of `data.buffer`. This created an empty/corrupted buffer.

Restores the working approach of using `data.buffer as BodyInit`
to properly serve the decrypted image data from Bunny CDN.

Fixes: #279