### PR TITLE
Add ticket links to reservation and payment success pages

### DIFF
--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -32,14 +32,16 @@ export const paymentPage = (
 /**
  * Payment success page - with optional redirect
  */
-export const paymentSuccessPage = (_event: Event, thankYouUrl: string | null): string =>
-  String(
+export const paymentSuccessPage = (_event: Event, thankYouUrl: string | null, ticketTokens: string[]): string => {
+  const ticketUrl = `/t/${ticketTokens.join("+")}`;
+  return String(
     <Layout title="Payment Successful" headExtra={thankYouUrl ? `<meta http-equiv="refresh" content="3;url=${escapeHtml(thankYouUrl)}">` : undefined}>
         <div data-payment-result="success">
           <h1>Payment Successful!</h1>
           <div class="success">
             <p>Thank you for your payment. Your ticket has been confirmed.</p>
           </div>
+          <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>
           {thankYouUrl ? (
             <>
               <p>You will be redirected shortly...</p>
@@ -49,16 +51,20 @@ export const paymentSuccessPage = (_event: Event, thankYouUrl: string | null): s
         </div>
     </Layout>
   );
+};
 
 /**
  * Simple reservation success page (for free events with no thank_you_url)
  */
-export const reservationSuccessPage = (): string =>
-  String(
+export const reservationSuccessPage = (ticketTokens: string[]): string => {
+  const ticketUrl = `/t/${ticketTokens.join("+")}`;
+  return String(
     <Layout title="Ticket Reserved">
         <h1>Ticket reserved successfully.</h1>
+        <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>
     </Layout>
   );
+};
 
 /**
  * Payment cancelled page

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -904,6 +904,16 @@ export const expectRedirect =
 export const expectAdminRedirect: (response: Response) => Response =
   expectRedirect("/admin");
 
+/** Assert redirect to /ticket/reserved with ticket IDs */
+export const expectReservedRedirect = (response: Response): Response => {
+  expect(response.status).toBe(302);
+  const location = response.headers.get("location");
+  expect(location).toBeTruthy();
+  expect(location?.startsWith("/ticket/reserved")).toBe(true);
+  expect(location).toContain("tickets=");
+  return response;
+};
+
 /** Assert a result object has ok:false with the expected error string. */
 export const expectResultError =
   (expectedError: string) =>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -475,26 +475,40 @@ describe("html", () => {
     const event = testEvent({ unit_price: 1000 });
 
     test("renders success message", () => {
-      const html = paymentSuccessPage(event, "https://example.com/thanks");
+      const html = paymentSuccessPage(event, "https://example.com/thanks", ["abc123"]);
       expect(html).toContain("Payment Successful");
       expect(html).toContain("https://example.com/thanks");
     });
 
     test("includes meta refresh redirect", () => {
-      const html = paymentSuccessPage(event, "https://example.com/thanks");
+      const html = paymentSuccessPage(event, "https://example.com/thanks", ["abc123"]);
       expect(html).toContain('http-equiv="refresh"');
       expect(html).toContain("3;url=https://example.com/thanks");
     });
 
     test("includes data-payment-result attribute for popup postMessage", () => {
-      const html = paymentSuccessPage(event, null);
+      const html = paymentSuccessPage(event, null, ["abc123"]);
       expect(html).toContain('data-payment-result="success"');
     });
 
     test("renders without redirect when thankYouUrl is null", () => {
-      const html = paymentSuccessPage(event, null);
+      const html = paymentSuccessPage(event, null, ["abc123"]);
       expect(html).not.toContain('http-equiv="refresh"');
       expect(html).not.toContain("redirected");
+    });
+
+    test("includes link to view tickets with single ticket", () => {
+      const html = paymentSuccessPage(event, null, ["abc123"]);
+      expect(html).toContain('href="/t/abc123"');
+      expect(html).toContain("Click here to view your tickets");
+      expect(html).toContain('target="_blank"');
+    });
+
+    test("includes link to view tickets with multiple tickets", () => {
+      const html = paymentSuccessPage(event, null, ["abc123", "def456", "ghi789"]);
+      expect(html).toContain('href="/t/abc123+def456+ghi789"');
+      expect(html).toContain("Click here to view your tickets");
+      expect(html).toContain('target="_blank"');
     });
   });
 

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -17,6 +17,7 @@ import {
   resetDb,
   resetTestSlugCounter,
   expectRedirect,
+  expectReservedRedirect,
   setupStripe,
   submitTicketForm,
   updateTestEvent,
@@ -731,7 +732,7 @@ describe("server (public routes)", () => {
         [`quantity_${event1.id}`]: "2",
         [`quantity_${event2.id}`]: "1",
       });
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
 
       // Verify attendees were created
       const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -758,7 +759,7 @@ describe("server (public routes)", () => {
         [`quantity_${event1.id}`]: "1",
         [`quantity_${event2.id}`]: "0",
       });
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
 
       // Verify only event1 has an attendee
       const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -785,7 +786,7 @@ describe("server (public routes)", () => {
         [`quantity_${event1.id}`]: "10", // Request more than max
         [`quantity_${event2.id}`]: "0",
       });
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
 
       // Verify quantity was capped
       const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -823,7 +824,7 @@ describe("server (public routes)", () => {
         email: "john@example.com",
       });
       // Should redirect to success page
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
     });
   });
 
@@ -1001,7 +1002,7 @@ describe("server (public routes)", () => {
         ),
       );
 
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
 
       // Verify attendees created for both events
       const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -1104,7 +1105,7 @@ describe("server (public routes)", () => {
           `csrf_token=${csrfToken}`,
         ),
       );
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
     });
 
     test("multi-ticket with invalid quantity form value falls back to 0", async () => {
@@ -1138,7 +1139,7 @@ describe("server (public routes)", () => {
           `csrf_token=${csrfToken}`,
         ),
       );
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
 
       // Only event2 should have an attendee
       const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -1268,7 +1269,7 @@ describe("server (public routes)", () => {
       );
 
       // Free registration path since provider is cleared and isPaymentsEnabled returns false
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
       resetStripeClient();
     });
   });
@@ -1430,7 +1431,7 @@ describe("server (public routes)", () => {
         }, `csrf_token=${csrfToken}`),
       );
       // Should succeed for event2 only
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
     });
   });
 
@@ -1493,7 +1494,7 @@ describe("server (public routes)", () => {
           `csrf_token=${csrfToken}`,
         ),
       );
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
 
       // Verify only event2 got an attendee
       const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -2167,7 +2168,7 @@ describe("server (public routes)", () => {
           `csrf_token=${csrfToken}`,
         ),
       );
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
     });
 
     test("POST redirects to checkout for paid multi-ticket daily events", async () => {
@@ -2392,7 +2393,7 @@ describe("server (public routes)", () => {
           `csrf_token=${csrfToken}`,
         ),
       );
-      expectRedirect("/ticket/reserved")(response);
+      expectReservedRedirect(response);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR enhances the user experience after ticket registration by adding direct links to view tickets on both the reservation success page (for free events) and the payment success page (for paid events). Ticket tokens are now passed through URL parameters to enable this functionality.

## Key Changes
- **Reservation flow**: Modified `processFreeReservation` and `processMultiFreeReservation` to pass ticket tokens via URL parameters (`?tickets=`) when redirecting to `/ticket/reserved`
- **Payment flow**: Updated `processPaymentSession` and `processMultiPaymentSession` to include ticket tokens in the result, which are then passed to the success page
- **Success pages**: Enhanced both `reservationSuccessPage` and `paymentSuccessPage` templates to display a link allowing users to view their tickets immediately after registration
- **Route handler**: Modified `handleReservedGet` to extract ticket tokens from URL parameters and pass them to the template
- **Webhook handling**: Updated `alreadyProcessedResult` to retrieve and include ticket tokens for idempotent payment processing
- **Test utilities**: Added `expectReservedRedirect` helper to verify redirects include the `tickets=` parameter
- **Tests**: Updated all test assertions to use the new `expectReservedRedirect` helper instead of generic redirect checks

## Implementation Details
- Ticket tokens are joined with `+` as a separator in URLs (e.g., `/t/abc123+def456`)
- The ticket view link opens in a new tab (`target="_blank"`)
- For multi-ticket registrations, all ticket tokens are included in a single URL
- The implementation maintains backward compatibility with custom `thank_you_url` redirects

https://claude.ai/code/session_01APrFGoxNcitzkggM1tjh7f