### PR TITLE
Harden payment success ticket link and align tests

### DIFF
--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -41,7 +41,7 @@ export const paymentSuccessPage = (thankYouUrl: string | null, ticketUrl: string
             <p>Thank you for your payment. Your ticket has been confirmed.</p>
           </div>
           {ticketUrl ? (
-            <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>
+            <p><a href={ticketUrl} target="_blank" rel="noopener noreferrer">Click here to view your tickets</a></p>
           ) : null}
           {thankYouUrl ? (
             <>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -499,6 +499,7 @@ describe("html", () => {
       const html = paymentSuccessPage(null, "/t/abc123+def456");
       expect(html).toContain('href="/t/abc123+def456"');
       expect(html).toContain('target="_blank"');
+      expect(html).toContain('rel="noopener noreferrer"');
       expect(html).toContain("Click here to view your tickets");
     });
 


### PR DESCRIPTION
### Motivation
- Improve security of the newly-added `_blank` ticket link on the payment success page by preventing opener access from the new tab.

### Description
- Add `rel="noopener noreferrer"` to the ticket link in `paymentSuccessPage` so the `/t/<tokens>` link that opens in a new tab is hardened.
- Update `test/lib/html.test.ts` to assert the presence of the new `rel` attribute so template tests remain consistent with the markup.

### Testing
- Attempted to run `deno task test:coverage` but the environment lacks `deno` (error: `bash: deno: command not found`), so the full test suite was not executed.
- Updated unit assertion in `test/lib/html.test.ts` to check for `rel="noopener noreferrer"`, and no other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe91397b8832d985186c1a0693f69)