### PR TITLE
Fix rejected __Host-admin_login_csrf cookie by using Path=/

### DIFF
--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -34,7 +34,7 @@ const activityLogRows = (entries: ActivityLogEntry[]): string =>
 export const adminEventActivityLogPage = (
   event: EventWithCount,
   entries: ActivityLogEntry[],
-  session?: AdminSession,
+  session: AdminSession,
 ): string =>
   String(
     <Layout title={`Log: ${event.name}`}>
@@ -62,7 +62,7 @@ export const adminEventActivityLogPage = (
 export const adminGlobalActivityLogPage = (
   entries: ActivityLogEntry[],
   truncated = false,
-  session?: AdminSession,
+  session: AdminSession,
 ): string =>
   String(
     <Layout title="Log">

--- a/src/templates/admin/login.tsx
+++ b/src/templates/admin/login.tsx
@@ -10,11 +10,12 @@ import { Layout } from "#templates/layout.tsx";
 /**
  * Admin login page
  */
-export const adminLoginPage = (error?: string): string =>
+export const adminLoginPage = (csrfToken: string, error?: string): string =>
   String(
     <Layout title="Login">
       <Raw html={renderError(error)} />
       <form method="POST" action="/admin/login">
+        <input type="hidden" name="csrf_token" value={csrfToken} />
         <Raw html={renderFields(loginFields)} />
         <button type="submit">Login</button>
       </form>

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -5,25 +5,30 @@
 import type { AdminSession } from "#lib/types.ts";
 
 interface AdminNavProps {
-  session?: AdminSession;
+  session: AdminSession;
 }
 
 /**
  * Universal admin navigation - shown at top of all admin pages
  * Users, Settings, and Sessions links only shown to owners
  */
-export const AdminNav = ({ session }: AdminNavProps = {}): JSX.Element => (
+export const AdminNav = ({ session }: AdminNavProps): JSX.Element => (
   <nav>
     <ul>
       <li><a href="/admin/">Events</a></li>
       <li><a href="/admin/calendar">Calendar</a></li>
-      {session?.adminLevel === "owner" && <li><a href="/admin/users">Users</a></li>}
-      {session?.adminLevel === "owner" && <li><a href="/admin/settings">Settings</a></li>}
-      {session?.adminLevel === "owner" && <li><a href="/admin/log">Log</a></li>}
-      {session?.adminLevel === "owner" && <li><a href="/admin/holidays">Holidays</a></li>}
-      {session?.adminLevel === "owner" && <li><a href="/admin/sessions">Sessions</a></li>}
+      {session.adminLevel === "owner" && <li><a href="/admin/users">Users</a></li>}
+      {session.adminLevel === "owner" && <li><a href="/admin/settings">Settings</a></li>}
+      {session.adminLevel === "owner" && <li><a href="/admin/log">Log</a></li>}
+      {session.adminLevel === "owner" && <li><a href="/admin/holidays">Holidays</a></li>}
+      {session.adminLevel === "owner" && <li><a href="/admin/sessions">Sessions</a></li>}
       <li><a href="/admin/guide">Guide</a></li>
-      <li><a href="/admin/logout">Logout</a></li>
+      <li>
+        <form class="inline" method="POST" action="/admin/logout">
+          <input type="hidden" name="csrf_token" value={session.csrfToken} />
+          <button type="submit">Logout</button>
+        </form>
+      </li>
     </ul>
   </nav>
 );

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -277,6 +277,20 @@ export const mockFormRequest = (
   });
 };
 
+
+/**
+ * Create a mock admin login POST request with CSRF token cookie pair
+ */
+export const mockAdminLoginRequest = (
+  data: Record<string, string>,
+  csrfToken = "test-admin-login-csrf",
+): Request =>
+  mockFormRequest(
+    "/admin/login",
+    { ...data, csrf_token: csrfToken },
+    `__Host-admin_login_csrf=${csrfToken}`,
+  );
+
 /**
  * Create a mock multipart POST request with optional file upload.
  * Text fields are added as form entries, and an optional file is appended.
@@ -349,6 +363,13 @@ const getCookieValue = (
   const match = setCookie.match(new RegExp(`${name}=([^;]+)`));
   return match?.[1] ?? null;
 };
+
+
+/**
+ * Extract admin login CSRF token from set-cookie header
+ */
+export const getAdminLoginCsrfToken = (setCookie: string | null): string | null =>
+  getCookieValue(setCookie, "__Host-admin_login_csrf");
 
 /**
  * Extract setup CSRF token from set-cookie header
@@ -576,8 +597,20 @@ export const loginAsAdmin = async (): Promise<{
   csrfToken: string;
 }> => {
   const { handleRequest } = await import("#routes");
+
+  const loginPageResponse = await handleRequest(mockRequest("/admin/"));
+  const loginPageCookie = loginPageResponse.headers.get("set-cookie");
+  const loginCsrfToken = getAdminLoginCsrfToken(loginPageCookie);
+
+  if (!loginCsrfToken) {
+    throw new Error("Failed to get CSRF token for admin login");
+  }
+
   const loginResponse = await handleRequest(
-    mockFormRequest("/admin/login", { username: TEST_ADMIN_USERNAME, password: TEST_ADMIN_PASSWORD }),
+    mockAdminLoginRequest(
+      { username: TEST_ADMIN_USERNAME, password: TEST_ADMIN_PASSWORD },
+      loginCsrfToken,
+    ),
   );
   const cookie = loginResponse.headers.get("set-cookie") || "";
   const csrfToken = await getCsrfTokenFromCookie(cookie);

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -30,7 +30,7 @@ describe("asset-paths", () => {
   });
 
   test("pages include CSS_PATH in stylesheet link", () => {
-    const html = adminLoginPage();
+    const html = adminLoginPage(TEST_CSRF_TOKEN);
     expect(html).toContain(`href="${CSS_PATH}"`);
     expect(html).toContain('rel="stylesheet"');
   });
@@ -40,7 +40,7 @@ describe("asset-paths", () => {
   });
 
   test("pages include JS_PATH in deferred script tag", () => {
-    const html = adminLoginPage();
+    const html = adminLoginPage(TEST_CSRF_TOKEN);
     expect(html).toContain(`src="${JS_PATH}"`);
     expect(html).toContain("defer");
   });
@@ -49,20 +49,21 @@ describe("asset-paths", () => {
 describe("html", () => {
   describe("adminLoginPage", () => {
     test("renders login form", () => {
-      const html = adminLoginPage();
+      const html = adminLoginPage(TEST_CSRF_TOKEN);
       expect(html).toContain("Login");
       expect(html).toContain('action="/admin/login"');
       expect(html).toContain('type="password"');
+      expect(html).toContain('name="csrf_token"');
     });
 
     test("shows error when provided", () => {
-      const html = adminLoginPage("Invalid password");
+      const html = adminLoginPage(TEST_CSRF_TOKEN, "Invalid password");
       expect(html).toContain("Invalid password");
       expect(html).toContain('class="error"');
     });
 
     test("escapes error message", () => {
-      const html = adminLoginPage("<script>evil()</script>");
+      const html = adminLoginPage(TEST_CSRF_TOKEN, "<script>evil()</script>");
       expect(html).toContain("&lt;script&gt;");
     });
   });
@@ -827,7 +828,7 @@ describe("html", () => {
         { id: 1, created: "2024-01-15T10:30:00Z", event_id: 1, message: "Ticket reserved" },
         { id: 2, created: "2024-01-15T11:00:00Z", event_id: 1, message: "Payment received" },
       ];
-      const html = adminEventActivityLogPage(event, entries);
+      const html = adminEventActivityLogPage(event, entries, TEST_SESSION);
       expect(html).toContain("Ticket reserved");
       expect(html).toContain("Payment received");
       expect(html).toContain("Log");
@@ -835,7 +836,7 @@ describe("html", () => {
 
     test("renders empty state when no entries", () => {
       const event = testEventWithCount();
-      const html = adminEventActivityLogPage(event, []);
+      const html = adminEventActivityLogPage(event, [], TEST_SESSION);
       expect(html).toContain("No activity recorded yet");
     });
   });
@@ -845,13 +846,13 @@ describe("html", () => {
       const entries = [
         { id: 1, created: "2024-01-15T10:30:00Z", event_id: null, message: "System started" },
       ];
-      const html = adminGlobalActivityLogPage(entries);
+      const html = adminGlobalActivityLogPage(entries, false, TEST_SESSION);
       expect(html).toContain("System started");
       expect(html).toContain("Log");
     });
 
     test("renders empty state when no entries", () => {
-      const html = adminGlobalActivityLogPage([]);
+      const html = adminGlobalActivityLogPage([], false, TEST_SESSION);
       expect(html).toContain("No activity recorded yet");
     });
 
@@ -859,7 +860,7 @@ describe("html", () => {
       const entries = [
         { id: 1, created: "2024-01-15T10:30:00Z", event_id: null, message: "Action" },
       ];
-      const html = adminGlobalActivityLogPage(entries, true);
+      const html = adminGlobalActivityLogPage(entries, true, TEST_SESSION);
       expect(html).toContain("Showing the most recent 200 entries");
     });
 
@@ -867,7 +868,7 @@ describe("html", () => {
       const entries = [
         { id: 1, created: "2024-01-15T10:30:00Z", event_id: null, message: "Action" },
       ];
-      const html = adminGlobalActivityLogPage(entries, false);
+      const html = adminGlobalActivityLogPage(entries, false, TEST_SESSION);
       expect(html).not.toContain("Showing the most recent 200 entries");
     });
   });

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -4,6 +4,7 @@ import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestDbWithSetup,
+  mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
   resetDb,
@@ -53,8 +54,22 @@ describe("server (admin auth)", () => {
   });
 
   describe("GET /admin/login", () => {
-    test("redirects to /admin", async () => {
+    test("shows login page", async () => {
       const response = await handleRequest(mockRequest("/admin/login"));
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Login");
+      const setCookie = response.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("__Host-admin_login_csrf=");
+      expect(setCookie).toContain("Path=/;");
+      expect(setCookie).not.toContain("Path=/admin/login;");
+    });
+
+    test("redirects to /admin when already authenticated", async () => {
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/login", { headers: { cookie } }),
+      );
       expectAdminRedirect(response);
     });
   });
@@ -62,7 +77,7 @@ describe("server (admin auth)", () => {
   describe("POST /admin/login", () => {
     test("validates required password field", async () => {
       const response = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password: "" }),
+        mockAdminLoginRequest({ username: "testadmin", password: "" }),
       );
       expect(response.status).toBe(400);
       const html = await response.text();
@@ -71,7 +86,7 @@ describe("server (admin auth)", () => {
 
     test("rejects wrong password", async () => {
       const response = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password: "wrong" }),
+        mockAdminLoginRequest({ username: "testadmin", password: "wrong" }),
       );
       expect(response.status).toBe(401);
       const html = await response.text();
@@ -81,23 +96,31 @@ describe("server (admin auth)", () => {
     test("accepts correct password and sets cookie", async () => {
       const password = TEST_ADMIN_PASSWORD;
       const response = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password }),
+        mockAdminLoginRequest({ username: "testadmin", password }),
       );
       expectAdminRedirect(response);
       expect(response.headers.get("set-cookie")).toContain("__Host-session=");
     });
 
+
+    test("rejects login when CSRF cookie is missing", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/login", {
+          username: "testadmin",
+          password: TEST_ADMIN_PASSWORD,
+          csrf_token: "missing-cookie-token",
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      const html = await response.text();
+      expect(html).toContain("Invalid or expired form");
+    });
+
     test("returns 429 when rate limited", async () => {
       // Rate limiting uses direct connection IP (falls back to "direct" in tests)
       const makeRequest = () =>
-        new Request("http://localhost/admin/login", {
-          method: "POST",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            host: "localhost",
-          },
-          body: new URLSearchParams({ username: "testadmin", password: "wrong" }).toString(),
-        });
+        mockAdminLoginRequest({ username: "testadmin", password: "wrong" });
 
       // Make 5 failed attempts to trigger lockout
       for (let i = 0; i < 5; i++) {
@@ -117,14 +140,7 @@ describe("server (admin auth)", () => {
         requestIP: () => ({ address: "192.168.1.100" }),
       };
 
-      const request = new Request("http://localhost/admin/login", {
-        method: "POST",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          host: "localhost",
-        },
-        body: new URLSearchParams({ username: "testadmin", password: "wrong" }).toString(),
-      });
+      const request = mockAdminLoginRequest({ username: "testadmin", password: "wrong" });
 
       // Make request with server context
       const response = await handleRequest(request, mockServer);
@@ -138,14 +154,7 @@ describe("server (admin auth)", () => {
         requestIP: () => null,
       };
 
-      const request = new Request("http://localhost/admin/login", {
-        method: "POST",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          host: "localhost",
-        },
-        body: new URLSearchParams({ username: "testadmin", password: "wrong" }).toString(),
-      });
+      const request = mockAdminLoginRequest({ username: "testadmin", password: "wrong" });
 
       // Make request with server context
       const response = await handleRequest(request, mockServer);
@@ -154,9 +163,11 @@ describe("server (admin auth)", () => {
     });
   });
 
-  describe("GET /admin/logout", () => {
-    test("clears session and redirects", async () => {
-      const response = await handleRequest(mockRequest("/admin/logout"));
+  describe("POST /admin/logout", () => {
+    test("redirects and clears cookie when unauthenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/logout", { csrf_token: "invalid" }),
+      );
       expectAdminRedirect(response);
       expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
     });
@@ -316,7 +327,7 @@ describe("server (admin auth)", () => {
   describe("logout with valid session", () => {
     test("deletes session from database", async () => {
       // Log in first
-      const { cookie } = await loginAsAdmin();
+      const { cookie, csrfToken } = await loginAsAdmin();
       const token = cookie.split("=")[1]?.split(";")[0] || "";
 
       expect(token).not.toBe("");
@@ -324,7 +335,10 @@ describe("server (admin auth)", () => {
       expect(sessionBefore).not.toBeNull();
 
       // Now logout
-      const logoutResponse = await awaitTestRequest("/admin/logout", token);
+      const logoutResponse = await awaitTestRequest("/admin/logout", {
+        cookie,
+        data: { csrf_token: csrfToken },
+      });
       expect(logoutResponse.status).toBe(302);
 
       // Verify session was deleted
@@ -343,7 +357,7 @@ describe("server (admin auth)", () => {
       });
 
       const response = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password: TEST_ADMIN_PASSWORD }),
+        mockAdminLoginRequest({ username: "testadmin", password: TEST_ADMIN_PASSWORD }),
       );
       // Should return 403 - user exists but is not activated
       expect(response.status).toBe(403);
@@ -362,7 +376,7 @@ describe("server (admin auth)", () => {
       });
 
       const response = await handleRequest(
-        mockFormRequest("/admin/login", {
+        mockAdminLoginRequest({
           username: "testadmin",
           password: TEST_ADMIN_PASSWORD,
         }),
@@ -377,7 +391,7 @@ describe("server (admin auth)", () => {
       Deno.env.delete("TEST_SKIP_LOGIN_DELAY");
       const start = Date.now();
       const response = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password: TEST_ADMIN_PASSWORD }),
+        mockAdminLoginRequest({ username: "testadmin", password: TEST_ADMIN_PASSWORD }),
       );
       const elapsed = Date.now() - start;
       expectAdminRedirect(response);
@@ -397,7 +411,7 @@ describe("server (admin auth)", () => {
 
       // Login should fail with 403 since user is not activated
       const response = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password: TEST_ADMIN_PASSWORD }),
+        mockAdminLoginRequest({ username: "testadmin", password: TEST_ADMIN_PASSWORD }),
       );
       expect(response.status).toBe(403);
       const html = await response.text();

--- a/test/lib/server-holidays.test.ts
+++ b/test/lib/server-holidays.test.ts
@@ -9,6 +9,7 @@ import {
   createTestHoliday,
   deleteTestHoliday,
   loginAsAdmin,
+  mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
   resetDb,
@@ -82,7 +83,7 @@ describe("server (admin holidays)", () => {
 
       // Login as manager
       const loginResponse = await handleRequest(
-        mockFormRequest("/admin/login", {
+        mockAdminLoginRequest({
           username: "manager1",
           password: "managerpass123",
         }),

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -13,6 +13,7 @@ import {
   expectAdminRedirect,
   expectRedirect,
   loginAsAdmin,
+  mockAdminLoginRequest,
   TEST_ADMIN_PASSWORD,
   withMocks,
 } from "#test-utils";
@@ -196,7 +197,7 @@ describe("server (admin settings)", () => {
 
       // Verify new password works
       const newLoginResponse = await handleRequest(
-        mockFormRequest("/admin/login", { username: "testadmin", password: "newpassword123" }),
+        mockAdminLoginRequest({ username: "testadmin", password: "newpassword123" }),
       );
       expectAdminRedirect(newLoginResponse);
     });

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -19,6 +19,7 @@ import {
   expectAdminRedirect,
   expectRedirect,
   loginAsAdmin,
+  mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
   resetDb,
@@ -378,7 +379,7 @@ describe("server (multi-user admin)", () => {
   describe("login flow", () => {
     test("login with username and password", async () => {
       const response = await handleRequest(
-        mockFormRequest("/admin/login", {
+        mockAdminLoginRequest({
           username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         }),
@@ -390,7 +391,7 @@ describe("server (multi-user admin)", () => {
 
     test("login with wrong username returns 401", async () => {
       const response = await handleRequest(
-        mockFormRequest("/admin/login", {
+        mockAdminLoginRequest({
           username: "nonexistent",
           password: TEST_ADMIN_PASSWORD,
         }),
@@ -400,7 +401,7 @@ describe("server (multi-user admin)", () => {
 
     test("login with wrong password returns 401", async () => {
       const response = await handleRequest(
-        mockFormRequest("/admin/login", {
+        mockAdminLoginRequest({
           username: TEST_ADMIN_USERNAME,
           password: "wrongpassword",
         }),

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -21,6 +21,7 @@ import {
   generateTestEventName,
   getCsrfTokenFromCookie,
   getSetupCsrfToken,
+  getAdminLoginCsrfToken,
   getTicketCsrfToken,
   invalidateTestDbCache,
   loginAsAdmin,
@@ -270,6 +271,23 @@ describe("test-utils", () => {
         "__Host-session=nonexistent-token-abc",
       );
       expect(result).toBe(null);
+    });
+  });
+
+
+  describe("getAdminLoginCsrfToken", () => {
+    test("returns null when set-cookie header is null", () => {
+      expect(getAdminLoginCsrfToken(null)).toBe(null);
+    });
+
+    test("returns null when set-cookie has no admin login csrf cookie", () => {
+      expect(getAdminLoginCsrfToken("other_cookie=value")).toBe(null);
+    });
+
+    test("extracts admin login csrf value from set-cookie header", () => {
+      expect(getAdminLoginCsrfToken("__Host-admin_login_csrf=abc123; Path=/")).toBe(
+        "abc123",
+      );
     });
   });
 
@@ -551,6 +569,19 @@ describe("test-utils", () => {
   });
 
   describe("loginAsAdmin error path", () => {
+    test("throws when login page does not provide login CSRF cookie", async () => {
+      await createTestDbWithSetup();
+      const routes = await import("#routes");
+      const handleRequestSpy = spyOn(routes, "handleRequest")
+        .mockResolvedValue(new Response("ok", { status: 200 }));
+
+      await expect(loginAsAdmin()).rejects.toThrow(
+        "Failed to get CSRF token for admin login",
+      );
+
+      handleRequestSpy.mockRestore();
+    });
+
     test("throws when CSRF token cannot be obtained from login response", async () => {
       // createTestDb without setup means no admin password exists
       // so login will fail and no session cookie is set


### PR DESCRIPTION
### Motivation
- Browsers reject `__Host-` cookies unless `Path=/`, so the admin login CSRF cookie being set with `Path=/admin/login` caused browsers to drop it and POST `/admin/login` to arrive without the CSRF cookie, making CSRF validation fail and logins loop on “Invalid or expired form.”

### Description
- Set the admin login CSRF cookie to use `Path=/` when rendering the login page by changing the cookie string in `src/routes/admin/dashboard.ts` to `Path=/` so the `__Host-` prefix is valid. 
- Strengthened tests to assert the login CSRF cookie is emitted with `Path=/;` and not `Path=/admin/login;` by updating `test/lib/server-auth.test.ts` and related test helpers. 
- Added/used test utilities to extract and submit the admin login CSRF token (`getAdminLoginCsrfToken`, `mockAdminLoginRequest`) and updated `loginAsAdmin` to obtain the login CSRF cookie before posting credentials in tests.

### Testing
- Ran `git diff --check` as a sanity check and it succeeded. 
- Ran `bun test test/lib/server-auth.test.ts` which surfaced an unrelated test-environment error (`Cannot find module '@std/assert'`) causing the test run to error in this container. 
- Updated tests and helper functions compile-time changes locally and assertions for cookie Path were added (test execution blocked by the missing test dependency in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd4455f1c832da2d9fbdb24eabe8b)