### PR TITLE
Add ticket link to free registration success page

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -275,7 +275,8 @@ const processFreeReservation = async (
   }
 
   await logAndNotifyRegistration(event, result.attendee, await getCurrencyCode());
-  return redirect(event.thank_you_url || "/ticket/reserved");
+  if (event.thank_you_url) return redirect(event.thank_you_url);
+  return redirect(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`);
 };
 
 /**
@@ -546,7 +547,7 @@ const processMultiFreeReservation = async (
   quantities: Map<number, number>,
   contact: ContactInfo,
   date: string | null,
-): Promise<{ success: true } | { success: false; error: string }> => {
+): Promise<{ success: true; tokens: string[] } | { success: false; error: string }> => {
   const entries: RegistrationEntry[] = [];
   for (const { event, qty } of eventsWithQuantity(events, quantities)) {
     const eventDate = event.event_type === "daily" ? date : null;
@@ -557,7 +558,7 @@ const processMultiFreeReservation = async (
     entries.push({ event, attendee: result.attendee });
   }
   await logAndNotifyMultiRegistration(entries, await getCurrencyCode());
-  return { success: true };
+  return { success: true, tokens: entries.map((entry) => entry.attendee.ticket_token) };
 };
 
 /** Handle POST for multi-ticket registration */
@@ -665,7 +666,7 @@ const handleMultiTicketPost = (
       return multiTicketResponse(renderCtx)(result.error);
     }
 
-    return redirect("/ticket/reserved");
+    return redirect(`/ticket/reserved?tokens=${encodeURIComponent(result.tokens.join("+"))}`);
   });
 
 /** Slug pattern for extracting slug from path */
@@ -678,8 +679,12 @@ const extractSlugFromPath = (path: string): string | null => {
 };
 
 /** Handle GET /ticket/reserved - reservation success page */
-const handleReservedGet = (): Response =>
-  htmlResponse(reservationSuccessPage());
+const handleReservedGet = (request: Request): Response => {
+  const tokensParam = new URL(request.url).searchParams.get("tokens");
+  const tokens = tokensParam ? tokensParam.split("+").filter((t) => t.length > 0) : [];
+  const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
+  return htmlResponse(reservationSuccessPage(ticketUrl));
+};
 
 /** Route ticket requests - handles both single and multi-ticket */
 export const routeTicket = (
@@ -689,7 +694,7 @@ export const routeTicket = (
 ): Promise<Response | null> => {
   // Handle /ticket/reserved before slug matching
   if (path === "/ticket/reserved" && method === "GET") {
-    return Promise.resolve(handleReservedGet());
+    return Promise.resolve(handleReservedGet(request));
   }
 
   const slug = extractSlugFromPath(path);

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -681,7 +681,8 @@ const extractSlugFromPath = (path: string): string | null => {
 /** Handle GET /ticket/reserved - reservation success page */
 const handleReservedGet = (request: Request): Response => {
   const tokensParam = new URL(request.url).searchParams.get("tokens");
-  const tokens = tokensParam ? tokensParam.split("+").filter((t) => t.length > 0) : [];
+  const normalizedTokens = tokensParam?.replaceAll(" ", "+") ?? "";
+  const tokens = normalizedTokens.split("+").filter((t) => t.length > 0);
   const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
   return htmlResponse(reservationSuccessPage(ticketUrl));
 };

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -56,10 +56,13 @@ export const paymentSuccessPage = (thankYouUrl: string | null, ticketUrl: string
 /**
  * Simple reservation success page (for free events with no thank_you_url)
  */
-export const reservationSuccessPage = (): string =>
+export const reservationSuccessPage = (ticketUrl: string | null): string =>
   String(
     <Layout title="Ticket Reserved">
         <h1>Ticket reserved successfully.</h1>
+        {ticketUrl ? (
+          <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>
+        ) : null}
     </Layout>
   );
 


### PR DESCRIPTION
### Motivation
- Free-event registrations previously redirected to a generic success page with no ticket link, while paid flows showed a ticket URL; free attendees should get the same immediate ticket access.
- Ensure single- and multi-ticket free flows provide the attendee token(s) so the reserved page can render the public ticket link.

### Description
- For single free reservations, return a redirect to `/ticket/reserved?tokens=...` when `thank_you_url` is not configured and include the created attendee token; updated `src/routes/public.ts` accordingly.
- For multi-ticket free reservations, collect created attendee tokens and redirect to `/ticket/reserved?tokens=...`; `processMultiFreeReservation` now returns tokens and the multi flow encodes them in the redirect; changes are in `src/routes/public.ts`.
- Make the reserved-page handler read the `tokens` query param and construct a ticket URL (`/t/<tokens>`) to pass into the template; updated `handleReservedGet` in `src/routes/public.ts`.
- Update the reservation success template to accept an optional `ticketUrl` and render the same “Click here to view your tickets” link used on paid success pages; change in `src/templates/payment.tsx`.
- Adjust server tests in `test/lib/server-public.test.ts` to assert redirects include `tokens` and to verify `/ticket/reserved?tokens=...` renders the ticket link.

### Testing
- Updated unit tests in `test/lib/server-public.test.ts` to assert the new tokenized redirects and reserved-page link rendering, but tests were not executed in this environment due to tooling limitations.
- Attempted to run `deno` tests with `deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/lib/server-public.test.ts test/lib/html.test.ts`, which failed because `deno` is not installed in the environment, so automated tests did not run here.
- Attempted a browser verification using Playwright to visit `/ticket/reserved?tokens=abc123`, which failed because no local application server was running, so no end-to-end screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698febe60818832dbd84b25f8332f97f)