### PR TITLE
Fix missing closes_at and ticket_token columns in new-site migrations

### DIFF
--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -9,7 +9,7 @@ import { getPublicKey, getSetting } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "backfill NULL price_paid and payment_id with encrypted defaults";
+export const LATEST_UPDATE = "ensure closes_at and ticket_token exist in base schema";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -86,7 +86,8 @@ export const initDb = async (): Promise<void> => {
       slug TEXT,
       slug_index TEXT,
       active INTEGER NOT NULL DEFAULT 1,
-      fields TEXT NOT NULL DEFAULT 'email'
+      fields TEXT NOT NULL DEFAULT 'email',
+      closes_at TEXT
     )
   `);
 
@@ -106,6 +107,7 @@ export const initDb = async (): Promise<void> => {
       payment_id TEXT,
       quantity INTEGER NOT NULL DEFAULT 1,
       phone TEXT NOT NULL DEFAULT '',
+      ticket_token TEXT NOT NULL DEFAULT '',
       FOREIGN KEY (event_id) REFERENCES events(id)
     )
   `);


### PR DESCRIPTION
### Motivation
- New site setups were failing with "no such column" errors because `closes_at` and `ticket_token` were only added in later ALTER migrations, leaving fresh databases missing those columns during early queries. 
- Ensure the initial schema contains these columns so fresh installs don't hit runtime SQL errors. 
- Force the migration checker to re-run for installs that were previously marked up-to-date but lack the columns.

### Description
- Add `closes_at TEXT` to the `CREATE TABLE events` statement so new databases include the column from creation. 
- Add `ticket_token TEXT NOT NULL DEFAULT ''` to the `CREATE TABLE attendees` statement so new databases include the token column from creation. 
- Update `LATEST_UPDATE` to a new value (`"ensure closes_at and ticket_token exist in base schema"`) so the migration run path re-evaluates and self-heals existing installations. 

### Testing
- Attempted to run the database tests with `deno test test/lib/db.test.ts`, but the test run could not be executed because `deno` is not available in this execution environment (failed with `command not found`), so no automated tests were completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990baf0166c832d8f95ab1e1e1b45bd)