### PR TITLE
Add CSRF protection to admin login with double-submit cookie pattern

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -612,12 +612,8 @@ export const loginAsAdmin = async (): Promise<{
       loginCsrfToken,
     ),
   );
-  const cookie = loginResponse.headers.get("set-cookie") || "";
-  const csrfToken = await getCsrfTokenFromCookie(cookie);
-
-  if (!csrfToken) {
-    throw new Error("Failed to get CSRF token for admin login");
-  }
+  const cookie = loginResponse.headers.get("set-cookie")!;
+  const csrfToken = (await getCsrfTokenFromCookie(cookie))!;
 
   return { cookie, csrfToken };
 };

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -162,6 +162,14 @@ describe("server (admin auth)", () => {
     });
   });
 
+  describe("GET /admin/logout", () => {
+    test("redirects and clears cookie when unauthenticated", async () => {
+      const response = await handleRequest(mockRequest("/admin/logout"));
+      expectAdminRedirect(response);
+      expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+    });
+  });
+
   describe("GET /admin/sessions", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/sessions"));


### PR DESCRIPTION
## Summary
Implements CSRF (Cross-Site Request Forgery) protection for the admin login endpoint using the double-submit cookie pattern. This prevents unauthorized login attempts from malicious third-party sites.

## Key Changes
- **CSRF Token Generation & Validation**: Added CSRF token generation on the login page GET request and validation on POST request using a double-submit cookie pattern
- **Login Page Updates**: Modified `GET /admin/login` to generate a secure CSRF token and set it as an `HttpOnly`, `Secure`, `SameSite=Strict` cookie, then pass the token to the login form template
- **Login Form Validation**: Enhanced `POST /admin/login` to validate that the CSRF token from the cookie matches the token submitted in the form before processing credentials
- **Logout Route Enhancement**: Added support for `POST /admin/logout` in addition to the existing `GET /admin/logout`
- **Cookie Configuration**: CSRF token cookie uses `__Host-` prefix with strict security settings (HttpOnly, Secure, SameSite=Strict, 1-hour expiration)
- **Test Updates**: Updated test utilities to properly handle CSRF token extraction from login response cookies

## Implementation Details
- The CSRF token is generated using the existing `generateSecureToken()` utility
- Validation uses the new `validateCsrfToken()` utility function to compare cookie and form tokens
- Invalid or expired CSRF tokens return a 403 Forbidden response with an error message
- The login form template now receives the CSRF token as a parameter to include in the form submission

https://claude.ai/code/session_016z4yRGLWjGjgTtinpz3Pem