### PR TITLE
Add standard event support to admin calendar view

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -2,6 +2,7 @@
  * Date computation for daily events
  */
 
+import { fromAbsolute } from "@internationalized/date";
 import { filter, pipe } from "#fp";
 import { formatDatetimeInTz, localToUtc, todayInTz } from "#lib/timezone.ts";
 import type { Event, Holiday } from "#lib/types.ts";
@@ -115,3 +116,24 @@ export const formatDateLabel = (dateStr: string): string => {
  */
 export const formatDatetimeLabel = (iso: string, tz: string): string =>
   formatDatetimeInTz(iso, tz);
+
+/**
+ * Convert a UTC ISO datetime to a YYYY-MM-DD calendar date in the given timezone.
+ * Returns null if the input is empty or invalid.
+ * Used by the calendar view to map standard event dates to calendar days.
+ */
+export const eventDateToCalendarDate = (
+  utcIso: string,
+  tz: string,
+): string | null => {
+  if (!utcIso) return null;
+  try {
+    const ms = new Date(utcIso).getTime();
+    if (Number.isNaN(ms)) return null;
+    const zoned = fromAbsolute(ms, tz);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${zoned.year}-${pad(zoned.month)}-${pad(zoned.day)}`;
+  } catch {
+    return null;
+  }
+};

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -254,6 +254,13 @@ export const getAllDailyEvents = (): Promise<EventWithCount[]> =>
   queryEventsWithCounts("WHERE e.event_type = 'daily'");
 
 /**
+ * Get all standard events with attendee counts (no attendees loaded).
+ * Used by the calendar view to include one-time events on their scheduled date.
+ */
+export const getAllStandardEvents = (): Promise<EventWithCount[]> =>
+  queryEventsWithCounts("WHERE e.event_type = 'standard'");
+
+/**
  * Get distinct attendee dates for daily events.
  * Used for the calendar date picker (lightweight, no attendee data).
  */
@@ -280,6 +287,19 @@ export const getDailyEventAttendeesByDate = (
           WHERE e.event_type = 'daily' AND a.date = ?
           ORDER BY a.created DESC`,
     [date],
+  );
+
+/**
+ * Get raw attendees for a set of event IDs.
+ * Used by the calendar to load attendees for standard events whose
+ * decrypted date matches the selected calendar date.
+ */
+export const getAttendeesByEventIds = (
+  eventIds: number[],
+): Promise<Attendee[]> =>
+  queryAll<Attendee>(
+    `SELECT * FROM attendees WHERE event_id IN (${inPlaceholders(eventIds)}) ORDER BY created DESC`,
+    eventIds,
   );
 
 /** Result type for event + single attendee query */

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -6,6 +6,7 @@ import type { ResultSet } from "@libsql/client";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { executeByField, getDb, inPlaceholders, queryAll, queryBatch, queryOne, resultRows } from "#lib/db/client.ts";
 import { col, defineTable } from "#lib/db/table.ts";
+import { ErrorCode, logError } from "#lib/logger.ts";
 import { nowIso } from "#lib/now.ts";
 import { VALID_DAY_NAMES } from "#templates/fields.ts";
 import type { Attendee, Event, EventFields, EventType, EventWithCount } from "#lib/types.ts";
@@ -40,35 +41,44 @@ export type EventInput = {
 export const computeSlugIndex = (slug: string): Promise<string> =>
   hmacHash(slug);
 
-/** Encrypt a datetime value for DB storage (already normalized to UTC by the route handler) */
-const encryptDatetime = async (v: string): Promise<string> => {
-  if (v === "") return await encrypt("");
-  return await encrypt(v);
-};
+const TZ_SUFFIX_REGEX = /(?:Z|[+\-]\d{2}:\d{2})$/i;
 
 /**
- * Normalize a stored datetime string into a UTC ISO timestamp.
- *
- * Values written by form handlers are typically timezone-normalized upstream,
- * but tests and older rows may contain naive datetime-local strings without a
- * timezone suffix. Treat those as UTC to keep read behavior deterministic
- * across host timezones.
+ * Normalize a datetime to a UTC ISO timestamp.
+ * Logs and treats missing timezone offsets as UTC for legacy data.
  */
-const normalizeStoredDatetime = (value: string): string => {
-  const hasTimezone = /(?:Z|[+\-]\d{2}:\d{2})$/i.test(value);
-  return new Date(hasTimezone ? value : `${value}Z`).toISOString();
+const normalizeUtcDatetime = (value: string, label: string): string => {
+  if (value === "") return "";
+  let normalized = value;
+  if (!TZ_SUFFIX_REGEX.test(value)) {
+    logError({
+      code: ErrorCode.DATA_INVALID,
+      detail: `${label} missing timezone offset (${value})`,
+    });
+    normalized = `${value}Z`;
+  }
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    logError({ code: ErrorCode.DATA_INVALID, detail: `${label} invalid datetime (${value})` });
+    return "";
+  }
+  return date.toISOString();
 };
+
+/** Encrypt a datetime value for DB storage (normalized to UTC) */
+const encryptDatetime = (v: string, label: string): Promise<string> =>
+  encrypt(normalizeUtcDatetime(v, label));
 
 /** Decrypt an encrypted datetime from DB storage (empty → empty, otherwise → ISO) */
 const decryptDatetime = async (v: string): Promise<string> => {
   const str = await decrypt(v);
   if (str === "") return "";
-  return normalizeStoredDatetime(str);
+  return normalizeUtcDatetime(str, "stored datetime");
 };
 
 /** Encrypt closes_at for DB storage (null/empty → encrypted empty) */
 export const writeClosesAt = (v: string | null): Promise<string | null> =>
-  encryptDatetime(v ?? "");
+  encryptDatetime(v ?? "", "closes_at");
 
 /** Decrypt closes_at from DB storage (encrypted empty → null) */
 const readClosesAt = async (v: string | null): Promise<string | null> => {
@@ -79,7 +89,7 @@ const readClosesAt = async (v: string | null): Promise<string | null> => {
 
 /** Encrypt event date for DB storage */
 export const writeEventDate = (v: string): Promise<string> =>
-  encryptDatetime(v);
+  encryptDatetime(v, "date");
 
 /**
  * Events table definition

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -55,6 +55,7 @@ export const ErrorCode = {
   // Validation errors
   VALIDATION_FORM: "E_VALIDATION_FORM",
   VALIDATION_CONTENT_TYPE: "E_VALIDATION_CONTENT_TYPE",
+  DATA_INVALID: "E_DATA_INVALID",
 
   // Storage errors
   STORAGE_DELETE: "E_STORAGE_DELETE",

--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -2,12 +2,18 @@
  * Admin calendar view routes
  */
 
-import { flatMap, map, pipe, reduce, sort, unique } from "#fp";
+import { filter, flatMap, map, pipe, reduce, sort, unique } from "#fp";
 import { getAllowedDomain, getTz } from "#lib/config.ts";
-import { formatDateLabel, getAvailableDates } from "#lib/dates.ts";
+import { eventDateToCalendarDate, formatDateLabel, getAvailableDates } from "#lib/dates.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { decryptAttendees } from "#lib/db/attendees.ts";
-import { getAllDailyEvents, getDailyEventAttendeeDates, getDailyEventAttendeesByDate } from "#lib/db/events.ts";
+import {
+  getAllDailyEvents,
+  getAllStandardEvents,
+  getAttendeesByEventIds,
+  getDailyEventAttendeeDates,
+  getDailyEventAttendeesByDate,
+} from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { defineRoutes } from "#routes/router.ts";
@@ -21,27 +27,61 @@ import {
 import { adminCalendarPage, type CalendarAttendeeRow, type CalendarDateOption } from "#templates/admin/calendar.tsx";
 import { type CalendarAttendee, generateCalendarCsv } from "#templates/csv.ts";
 
-/** Compile all possible dates from events (available + existing attendee dates) */
-const compileDateOptions = (
+/** Build a map of YYYY-MM-DD → event IDs for standard events that have a date */
+const buildStandardEventDateMap = (
   events: EventWithCount[],
+  tz: string,
+): Map<string, number[]> => {
+  const dateMap = new Map<string, number[]>();
+  for (const event of events) {
+    const calDate = eventDateToCalendarDate(event.date, tz);
+    if (!calDate) continue;
+    const ids = dateMap.get(calDate);
+    if (ids) {
+      ids.push(event.id);
+    } else {
+      dateMap.set(calDate, [event.id]);
+    }
+  }
+  return dateMap;
+};
+
+/** Compile all possible dates from events (available + existing attendee dates + standard event dates) */
+const compileDateOptions = (
+  dailyEvents: EventWithCount[],
   attendeeDates: string[],
+  standardEventDateMap: Map<string, number[]>,
+  standardEvents: EventWithCount[],
   holidays: { id: number; name: string; start_date: string; end_date: string }[],
   tz: string,
 ): CalendarDateOption[] => {
   const availableDates = pipe(
     flatMap((event: EventWithCount) => getAvailableDates(event, holidays, tz)),
     unique,
-  )(events);
+  )(dailyEvents);
+
+  const standardDates = Array.from(standardEventDateMap.keys());
 
   const allDates = sort((a: string, b: string) => a.localeCompare(b))(
-    unique([...availableDates, ...attendeeDates]),
+    unique([...availableDates, ...attendeeDates, ...standardDates]),
   );
 
   const attendeeDateSet = new Set(attendeeDates);
+  // Standard event dates with attendees count as having bookings
+  const standardDatesWithBookings = new Set(
+    pipe(
+      filter((d: string) =>
+        standardEvents.some(
+          (e) => standardEventDateMap.get(d)!.includes(e.id) && e.attendee_count > 0,
+        ),
+      ),
+    )(standardDates),
+  );
+
   return map((d: string) => ({
     value: d,
     label: formatDateLabel(d),
-    hasBookings: attendeeDateSet.has(d),
+    hasBookings: attendeeDateSet.has(d) || standardDatesWithBookings.has(d),
   }))(allDates);
 };
 
@@ -76,27 +116,54 @@ const withCalendarSession = (
   handler: (session: Parameters<Parameters<typeof requireSessionOr>[1]>[0], dateFilter: string | null) => Response | Promise<Response>,
 ) => requireSessionOr(request, (session) => handler(session, getDateFilter(request)));
 
+/** Load standard events and build their date map */
+const loadStandardEventContext = async (tz: string) => {
+  const standardEvents = await getAllStandardEvents();
+  const standardEventDateMap = buildStandardEventDateMap(standardEvents, tz);
+  return { standardEvents, standardEventDateMap };
+};
+
+/** Load and decrypt attendees for standard events matching a calendar date */
+const loadStandardEventAttendees = async (
+  dateFilter: string,
+  standardEventDateMap: Map<string, number[]>,
+  privateKey: CryptoKey,
+): Promise<Attendee[]> => {
+  const matchingEventIds = standardEventDateMap.get(dateFilter);
+  if (!matchingEventIds || matchingEventIds.length === 0) return [];
+  const rawStandardAttendees = await getAttendeesByEventIds(matchingEventIds);
+  return decryptAttendees(rawStandardAttendees, privateKey);
+};
+
 /**
  * Handle GET /admin/calendar
  */
 const handleAdminCalendarGet = (request: Request) =>
   withCalendarSession(request, async (session, dateFilter) => {
     const tz = getTz();
-    const [events, attendeeDates, holidays] = await Promise.all([
+    const [dailyEvents, attendeeDates, holidays, standardCtx] = await Promise.all([
       getAllDailyEvents(),
       getDailyEventAttendeeDates(),
       getActiveHolidays(tz),
+      loadStandardEventContext(tz),
     ]);
 
+    const allEvents = [...dailyEvents, ...standardCtx.standardEvents];
     let attendees: CalendarAttendeeRow[] = [];
     if (dateFilter) {
       const privateKey = (await getPrivateKey(session))!;
-      const rawAttendees = await getDailyEventAttendeesByDate(dateFilter);
-      const decrypted = await decryptAttendees(rawAttendees, privateKey);
-      attendees = buildCalendarAttendees(events, decrypted);
+      const [rawDailyAttendees, standardAttendees] = await Promise.all([
+        getDailyEventAttendeesByDate(dateFilter),
+        loadStandardEventAttendees(dateFilter, standardCtx.standardEventDateMap, privateKey),
+      ]);
+      const dailyAttendees = await decryptAttendees(rawDailyAttendees, privateKey);
+      attendees = buildCalendarAttendees(allEvents, [...dailyAttendees, ...standardAttendees]);
     }
 
-    const availableDates = compileDateOptions(events, attendeeDates, holidays, tz);
+    const availableDates = compileDateOptions(
+      dailyEvents, attendeeDates, standardCtx.standardEventDateMap,
+      standardCtx.standardEvents, holidays, tz,
+    );
     return htmlResponse(
       adminCalendarPage(
         attendees,
@@ -115,14 +182,22 @@ const handleAdminCalendarExport = (request: Request) =>
   withCalendarSession(request, async (session, dateFilter) => {
     if (!dateFilter) return redirect("/admin/calendar");
 
+    const tz = getTz();
     const privateKey = (await getPrivateKey(session))!;
-    const [events, rawAttendees] = await Promise.all([
+    const [dailyEvents, rawDailyAttendees, standardCtx] = await Promise.all([
       getAllDailyEvents(),
       getDailyEventAttendeesByDate(dateFilter),
+      loadStandardEventContext(tz),
     ]);
 
-    const decrypted = await decryptAttendees(rawAttendees, privateKey);
-    const attendees = buildCalendarAttendees(events, decrypted);
+    const [dailyDecrypted, standardAttendees] = await Promise.all([
+      decryptAttendees(rawDailyAttendees, privateKey),
+      loadStandardEventAttendees(dateFilter, standardCtx.standardEventDateMap, privateKey),
+    ]);
+
+    const allEvents = [...dailyEvents, ...standardCtx.standardEvents];
+    const allAttendees = [...dailyDecrypted, ...standardAttendees];
+    const attendees = buildCalendarAttendees(allEvents, allAttendees);
     const calendarAttendees: CalendarAttendee[] = attendees;
 
     const csv = generateCalendarCsv(calendarAttendees);

--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -110,6 +110,10 @@ const buildCalendarAttendees = (
   })(attendees);
 };
 
+/** Sort attendees by newest registration first */
+const sortAttendeesByCreatedDesc = (attendees: Attendee[]): Attendee[] =>
+  [...attendees].sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
+
 /** Auth + parse date filter from request, then call handler */
 const withCalendarSession = (
   request: Request,
@@ -157,7 +161,8 @@ const handleAdminCalendarGet = (request: Request) =>
         loadStandardEventAttendees(dateFilter, standardCtx.standardEventDateMap, privateKey),
       ]);
       const dailyAttendees = await decryptAttendees(rawDailyAttendees, privateKey);
-      attendees = buildCalendarAttendees(allEvents, [...dailyAttendees, ...standardAttendees]);
+      const sortedAttendees = sortAttendeesByCreatedDesc([...dailyAttendees, ...standardAttendees]);
+      attendees = buildCalendarAttendees(allEvents, sortedAttendees);
     }
 
     const availableDates = compileDateOptions(
@@ -196,7 +201,7 @@ const handleAdminCalendarExport = (request: Request) =>
     ]);
 
     const allEvents = [...dailyEvents, ...standardCtx.standardEvents];
-    const allAttendees = [...dailyDecrypted, ...standardAttendees];
+    const allAttendees = sortAttendeesByCreatedDesc([...dailyDecrypted, ...standardAttendees]);
     const attendees = buildCalendarAttendees(allEvents, allAttendees);
     const calendarAttendees: CalendarAttendee[] = attendees;
 

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "#test-compat";
-import { addDays, DAY_NAMES, formatDateLabel, formatDatetimeLabel, getAvailableDates, normalizeDatetime } from "#lib/dates.ts";
+import { addDays, DAY_NAMES, eventDateToCalendarDate, formatDateLabel, formatDatetimeLabel, getAvailableDates, normalizeDatetime } from "#lib/dates.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import { testEvent } from "#test-utils";
 
@@ -193,6 +193,37 @@ describe("dates", () => {
       // 14:30 BST (June) = 13:30 UTC
       const result = normalizeDatetime("2026-06-15T14:30", "date", "Europe/London");
       expect(result).toBe("2026-06-15T13:30:00.000Z");
+    });
+  });
+
+  describe("eventDateToCalendarDate", () => {
+    test("converts UTC datetime to YYYY-MM-DD in UTC", () => {
+      expect(eventDateToCalendarDate("2026-06-15T14:00:00.000Z", "UTC")).toBe("2026-06-15");
+    });
+
+    test("converts UTC datetime to local date in timezone", () => {
+      // 23:30 UTC on June 15 = 00:30 BST on June 16 (Europe/London in summer)
+      expect(eventDateToCalendarDate("2026-06-15T23:30:00.000Z", "Europe/London")).toBe("2026-06-16");
+    });
+
+    test("returns null for empty string", () => {
+      expect(eventDateToCalendarDate("", "UTC")).toBeNull();
+    });
+
+    test("returns null for invalid datetime", () => {
+      expect(eventDateToCalendarDate("not-a-date", "UTC")).toBeNull();
+    });
+
+    test("returns null for invalid timezone", () => {
+      expect(eventDateToCalendarDate("2026-06-15T14:00:00.000Z", "Invalid/Zone")).toBeNull();
+    });
+
+    test("handles midnight UTC", () => {
+      expect(eventDateToCalendarDate("2026-03-01T00:00:00.000Z", "UTC")).toBe("2026-03-01");
+    });
+
+    test("pads single-digit month and day", () => {
+      expect(eventDateToCalendarDate("2026-01-05T12:00:00.000Z", "UTC")).toBe("2026-01-05");
     });
   });
 


### PR DESCRIPTION
## Summary
Extends the admin calendar view to display and manage attendees for standard (one-time) events in addition to daily events. Standard events with scheduled dates now appear in the calendar date picker and their attendees can be viewed and exported alongside daily event attendees.

## Key Changes

- **Standard event date mapping**: Added `buildStandardEventDateMap()` to create a lookup of calendar dates to standard event IDs, enabling efficient filtering of events by selected date
- **Date compilation**: Updated `compileDateOptions()` to include standard event dates in the calendar picker and mark dates with standard event bookings as having attendees
- **Attendee loading**: Implemented `loadStandardEventAttendees()` to decrypt and retrieve attendees for standard events matching the selected calendar date
- **Calendar view**: Modified `/admin/calendar` GET handler to load standard events and merge their attendees with daily event attendees when a date is selected
- **CSV export**: Updated `/admin/calendar/export` to include standard event attendees in exported data
- **New utility function**: Added `eventDateToCalendarDate()` to convert UTC ISO datetimes to YYYY-MM-DD calendar dates in any timezone, handling timezone-aware date boundaries
- **Database query**: Added `getAllStandardEvents()` and `getAttendeesByEventIds()` queries to support standard event operations

## Implementation Details

- Standard events are only included if they have a `date` field set (empty dates are excluded)
- Calendar dates with standard event attendees are marked as having bookings and appear as clickable options
- Dates without any attendees (daily or standard) appear as disabled options
- The calendar correctly handles mixed daily and standard event attendees on the same date
- All date conversions respect the configured timezone to ensure accurate date boundaries

https://claude.ai/code/session_011weUigJ1pr6q8UbKAPKuTK