### PR TITLE
Allow date-only input for event datetime fields

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -89,7 +89,7 @@ const renderDatetimeInputs = (
   `<input type="date" name="${escapeHtml(name)}_date" placeholder="Date"${date ? ` value="${escapeHtml(date)}"` : ""}>`
   + `<input type="time" name="${escapeHtml(name)}_time" placeholder="Time"${time ? ` value="${escapeHtml(time)}"` : ""}>`;
 
-const DATETIME_PARTIAL_ERROR = "Please enter both a date and time, or leave both blank";
+const DATETIME_PARTIAL_ERROR = "Please enter a date when providing a time, or leave both blank";
 
 /** Combine date and time form values into a datetime string, or null on partial fill */
 const getDatetimeValue = (
@@ -99,6 +99,7 @@ const getDatetimeValue = (
   const date = (form.get(`${name}_date`) || "").trim();
   const time = (form.get(`${name}_time`) || "").trim();
   if (date && time) return `${date}T${time}`;
+  if (date && !time) return `${date}T00:00`;
   if (!date && !time) return "";
   return null;
 };

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -889,14 +889,14 @@ describe("forms", () => {
       }
     });
 
-    test("rejects when only date is provided", () => {
+    test("defaults time to 00:00 when only date is provided", () => {
       const result = validateForm(
         new URLSearchParams({ closes_at_date: "2099-06-15", closes_at_time: "" }),
         datetimeField,
       );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Please enter both a date and time, or leave both blank");
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.values.closes_at).toBe("2099-06-15T00:00");
       }
     });
 
@@ -907,7 +907,7 @@ describe("forms", () => {
       );
       expect(result.valid).toBe(false);
       if (!result.valid) {
-        expect(result.error).toBe("Please enter both a date and time, or leave both blank");
+        expect(result.error).toBe("Please enter a date when providing a time, or leave both blank");
       }
     });
   });


### PR DESCRIPTION
Default time to 00:00 when only a date is provided, instead of
rejecting with a partial-fill error. Time-only input (no date) still
shows an error.

https://claude.ai/code/session_013yNWszYsNnF3eyp4gabmhK