### PR TITLE
Add autocomplete attributes to form fields

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -38,6 +38,7 @@ export interface Field {
   pattern?: string;
   accept?: string;
   autofocus?: boolean;
+  autocomplete?: string;
   validate?: (value: string) => string | null;
   options?: { value: string; label: string }[];
 }
@@ -154,6 +155,7 @@ export const renderField = (field: Field, value: string = ""): string =>
           maxlength={field.maxlength}
           pattern={field.pattern}
           autofocus={field.autofocus}
+          autocomplete={field.autocomplete}
         />
       )}
       {field.hint && (

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -174,8 +174,8 @@ export const validateUsername = (value: string): string | null => {
  * Login form field definitions
  */
 export const loginFields: Field[] = [
-  { name: "username", label: "Username", type: "text", required: true },
-  { name: "password", label: "Password", type: "password", required: true },
+  { name: "username", label: "Username", type: "text", required: true, autocomplete: "username" },
+  { name: "password", label: "Password", type: "password", required: true, autocomplete: "current-password" },
 ];
 
 /** Validate event fields setting (comma-separated contact field names) */
@@ -419,6 +419,7 @@ const nameField: Field = {
   label: "Your Name",
   type: "text",
   required: true,
+  autocomplete: "name",
 };
 
 /** Email field for ticket forms */
@@ -427,6 +428,7 @@ const emailField: Field = {
   label: "Your Email",
   type: "email",
   required: true,
+  autocomplete: "email",
   validate: validateEmail,
 };
 
@@ -436,6 +438,7 @@ const phoneField: Field = {
   label: "Your Phone Number",
   type: "text",
   required: true,
+  autocomplete: "tel",
   validate: validatePhone,
 };
 
@@ -454,6 +457,7 @@ const addressField: Field = {
   label: "Your Address",
   type: "textarea",
   required: true,
+  autocomplete: "street-address",
   validate: validateAddress,
 };
 
@@ -535,6 +539,7 @@ export const setupFields: Field[] = [
     type: "text",
     required: true,
     hint: "Letters, numbers, hyphens, underscores (2-32 chars)",
+    autocomplete: "username",
     validate: validateUsername,
   },
   {
@@ -543,12 +548,14 @@ export const setupFields: Field[] = [
     type: "password",
     required: true,
     hint: "Minimum 8 characters",
+    autocomplete: "new-password",
   },
   {
     name: "admin_password_confirm",
     label: "Confirm Admin Password *",
     type: "password",
     required: true,
+    autocomplete: "new-password",
   },
   {
     name: "currency_code",
@@ -568,6 +575,7 @@ export const changePasswordFields: Field[] = [
     label: "Current Password",
     type: "password",
     required: true,
+    autocomplete: "current-password",
   },
   {
     name: "new_password",
@@ -575,12 +583,14 @@ export const changePasswordFields: Field[] = [
     type: "password",
     required: true,
     hint: "Minimum 8 characters",
+    autocomplete: "new-password",
   },
   {
     name: "new_password_confirm",
     label: "Confirm New Password",
     type: "password",
     required: true,
+    autocomplete: "new-password",
   },
 ];
 
@@ -667,11 +677,13 @@ export const joinFields: Field[] = [
     type: "password",
     required: true,
     hint: "Minimum 8 characters",
+    autocomplete: "new-password",
   },
   {
     name: "password_confirm",
     label: "Confirm Password",
     type: "password",
     required: true,
+    autocomplete: "new-password",
   },
 ];

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -7,10 +7,14 @@ import {
   validateForm,
 } from "#lib/forms.tsx";
 import {
+  changePasswordFields,
   eventFields,
   getTicketFields,
   holidayFields,
+  joinFields,
+  loginFields,
   mergeEventFields,
+  setupFields,
   validateAddress,
   validateSpecialInstructions,
   validateBookableDays,
@@ -84,6 +88,16 @@ describe("forms", () => {
     test("renders maxlength attribute", () => {
       const html = rendered({ name: "desc", label: "Description", maxlength: 128 });
       expect(html).toContain('maxlength="128"');
+    });
+
+    test("renders autocomplete attribute when provided", () => {
+      const html = rendered({ name: "name", label: "Name", autocomplete: "name" });
+      expect(html).toContain('autocomplete="name"');
+    });
+
+    test("omits autocomplete attribute when not provided", () => {
+      const html = rendered({ name: "name", label: "Name" });
+      expect(html).not.toContain("autocomplete");
     });
 
     test("renders textarea for textarea type", () => {
@@ -555,6 +569,26 @@ describe("forms", () => {
       expect(fields.length).toBe(1);
       expect(fields[0]!.name).toBe("name");
     });
+
+    test("name field has autocomplete=name", () => {
+      const fields = getTicketFields("email");
+      expect(fields[0]!.autocomplete).toBe("name");
+    });
+
+    test("email field has autocomplete=email", () => {
+      const fields = getTicketFields("email");
+      expect(fields[1]!.autocomplete).toBe("email");
+    });
+
+    test("phone field has autocomplete=tel", () => {
+      const fields = getTicketFields("phone");
+      expect(fields[1]!.autocomplete).toBe("tel");
+    });
+
+    test("address field has autocomplete=street-address", () => {
+      const fields = getTicketFields("address");
+      expect(fields[1]!.autocomplete).toBe("street-address");
+    });
   });
 
   describe("mergeEventFields", () => {
@@ -971,6 +1005,37 @@ describe("forms", () => {
         options: [{ value: "Monday", label: "Monday" }],
       });
       expect(html).not.toContain("checked");
+    });
+  });
+
+  describe("field autocomplete attributes", () => {
+    test("login username field has autocomplete=username", () => {
+      expect(loginFields[0]!.autocomplete).toBe("username");
+    });
+
+    test("login password field has autocomplete=current-password", () => {
+      expect(loginFields[1]!.autocomplete).toBe("current-password");
+    });
+
+    test("setup password fields have autocomplete=new-password", () => {
+      const pwField = setupFields.find((f) => f.name === "admin_password");
+      const confirmField = setupFields.find((f) => f.name === "admin_password_confirm");
+      expect(pwField!.autocomplete).toBe("new-password");
+      expect(confirmField!.autocomplete).toBe("new-password");
+    });
+
+    test("change password current field has autocomplete=current-password", () => {
+      expect(changePasswordFields[0]!.autocomplete).toBe("current-password");
+    });
+
+    test("change password new fields have autocomplete=new-password", () => {
+      expect(changePasswordFields[1]!.autocomplete).toBe("new-password");
+      expect(changePasswordFields[2]!.autocomplete).toBe("new-password");
+    });
+
+    test("join password fields have autocomplete=new-password", () => {
+      expect(joinFields[0]!.autocomplete).toBe("new-password");
+      expect(joinFields[1]!.autocomplete).toBe("new-password");
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds HTML `autocomplete` attributes to form fields throughout the application to improve user experience and enable browser autofill functionality.

## Key Changes
- **Field interface update**: Added optional `autocomplete?: string` property to the `Field` interface in `src/lib/forms.tsx`
- **Form rendering**: Updated `renderField()` to render the `autocomplete` attribute when provided
- **Login form**: Added `autocomplete="username"` and `autocomplete="current-password"` to login fields
- **Setup form**: Added `autocomplete="username"`, `autocomplete="new-password"` to admin password fields
- **Change password form**: Added `autocomplete="current-password"` for current password and `autocomplete="new-password"` for new password fields
- **Join form**: Added `autocomplete="new-password"` to password confirmation fields
- **Ticket form fields**: Added appropriate autocomplete attributes:
  - Name field: `autocomplete="name"`
  - Email field: `autocomplete="email"`
  - Phone field: `autocomplete="tel"`
  - Address field: `autocomplete="street-address"`
- **Tests**: Added comprehensive test coverage for autocomplete attribute rendering and field-specific autocomplete values

## Implementation Details
- The `autocomplete` attribute is optional and only rendered when explicitly provided on a field
- Standard HTML autocomplete values are used (e.g., `username`, `current-password`, `new-password`, `email`, `tel`, `street-address`, `name`)
- All password-related fields use appropriate autocomplete values to distinguish between current and new passwords

https://claude.ai/code/session_01Mgk7Yjc2252Pu6WbJAGNgp