### PR TITLE
Add iframe support to reservation success page

### DIFF
--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -56,9 +56,9 @@ export const paymentSuccessPage = (thankYouUrl: string | null, ticketUrl: string
 /**
  * Simple reservation success page (for free events with no thank_you_url)
  */
-export const reservationSuccessPage = (ticketUrl: string | null): string =>
+export const reservationSuccessPage = (ticketUrl: string | null, inIframe = false): string =>
   String(
-    <Layout title="Ticket Reserved">
+    <Layout title="Ticket Reserved" bodyClass={inIframe ? "iframe" : undefined}>
         <h1>Ticket reserved successfully.</h1>
         {ticketUrl ? (
           <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -15,6 +15,7 @@ import {
   paymentErrorPage,
   paymentPage,
   paymentSuccessPage,
+  reservationSuccessPage,
 } from "#templates/payment.tsx";
 import { eventFields } from "#templates/fields.ts";
 import { buildMultiTicketEvent, multiTicketPage, notFoundPage, renderEventImage, ticketPage } from "#templates/public.tsx";
@@ -570,6 +571,20 @@ describe("html", () => {
       const html = checkoutPopupPage('https://evil.com/"onload="alert(1)');
       expect(html).toContain("&quot;");
       expect(html).not.toContain('"onload="');
+    });
+  });
+
+  describe("reservationSuccessPage", () => {
+    test("includes iframe-resizer child script in iframe mode", () => {
+      const html = reservationSuccessPage("/t/abc123", true);
+      expect(html).toContain("iframe-resizer-child.js");
+      expect(html).toContain('class="iframe"');
+    });
+
+    test("excludes iframe-resizer child script when not in iframe mode", () => {
+      const html = reservationSuccessPage("/t/abc123");
+      expect(html).not.toContain("iframe-resizer-child.js");
+      expect(html).not.toContain('class="iframe"');
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds iframe support to the reservation success page for free ticket events. When a user completes a free ticket reservation through an iframe, the success page now properly detects the iframe context and includes the iframe-resizer child script to enable automatic height resizing.

## Key Changes
- **Reservation flow**: Modified `processFreeReservation` and `handleMultiTicketPost` to propagate the `iframe=true` query parameter when redirecting to the reservation success page
- **Success page handler**: Updated `handleReservedGet` to detect iframe context and pass it to the template
- **Template rendering**: Enhanced `reservationSuccessPage` to accept an `inIframe` parameter and conditionally include the iframe-resizer child script and apply the `iframe` CSS class
- **Test coverage**: Added comprehensive tests for:
  - iframe-resizer script inclusion when `iframe=true` parameter is present
  - Absence of iframe-resizer script when parameter is not present
  - Proper propagation of `iframe=true` parameter through the redirect flow

## Implementation Details
- Uses the existing `isIframeRequest()` utility to detect iframe context from the request URL
- The iframe parameter is preserved through redirects using query string parameters
- The Layout component's `bodyClass` prop is utilized to apply styling when in iframe mode
- Maintains backward compatibility - the `inIframe` parameter defaults to `false`

https://claude.ai/code/session_01NajtYM4LJMmVeAeVdN1Gtw