### PR TITLE
Fix iframe resize initialization race condition

### DIFF
--- a/src/client/embed.ts
+++ b/src/client/embed.ts
@@ -19,10 +19,25 @@
   parentScript.src = `${origin}/iframe-resizer-parent.js`;
   parentScript.async = true;
   parentScript.fetchPriority = "high";
-  parentScript.onload = () => {
+
+  let scriptLoaded = false;
+  let iframeLoaded = false;
+
+  const initResize = () => {
+    if (!scriptLoaded || !iframeLoaded) return;
     const iframeResize = (window as unknown as { iframeResize: (options: { license: string }, target: HTMLIFrameElement) => void })
       .iframeResize;
     iframeResize({ license: script.dataset.license || "GPLv3" }, iframe);
+  };
+
+  parentScript.onload = () => {
+    scriptLoaded = true;
+    initResize();
+  };
+
+  iframe.onload = () => {
+    iframeLoaded = true;
+    initResize();
   };
 
   script.after(iframe, parentScript);


### PR DESCRIPTION
## Summary
Fixed a race condition in the iframe embed initialization where `iframeResize` could be called before both the parent script and iframe had finished loading.

## Key Changes
- Introduced `scriptLoaded` and `iframeLoaded` flags to track the loading state of both the parent script and iframe
- Created an `initResize()` function that only calls `iframeResize` when both the script and iframe have finished loading
- Split the original `parentScript.onload` handler into separate handlers for both the script and iframe, each setting their respective flag and calling `initResize()`

## Implementation Details
The previous implementation would call `iframeResize` as soon as the parent script loaded, without waiting for the iframe to be ready. This could cause the resize initialization to fail if the iframe wasn't fully loaded yet. The new approach ensures both resources are ready before attempting to initialize the resize functionality, preventing potential timing issues.

https://claude.ai/code/session_01NJtEZXmxrCeBPXZoh9as8D