### PR TITLE
Disable cache-busting for embed script asset path

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -88,7 +88,11 @@ const esmShExternalsPlugin: Plugin = {
 const buildAssetPathsModule = (): string =>
   ASSET_DEFS
     .filter(([, , , pathConst]) => pathConst)
-    .map(([filename, , , pathConst]) => `export const ${pathConst} = "/${filename}?ts=${BUILD_TS}";`)
+    .map(([filename, , , pathConst]) => {
+      // Embed script should always use latest version without cache-busting
+      const cacheBuster = pathConst === "EMBED_JS_PATH" ? "" : `?ts=${BUILD_TS}`;
+      return `export const ${pathConst} = "/${filename}${cacheBuster}";`;
+    })
     .join("\n");
 
 /** Build the inline assets module with pre-read content and handler functions */


### PR DESCRIPTION
## Summary
Modified the asset paths module generation to exclude cache-busting query parameters for the embed script, ensuring it always uses the latest version without version-specific caching.

## Key Changes
- Updated `buildAssetPathsModule()` to conditionally apply cache-busting timestamps
- The `EMBED_JS_PATH` constant now generates a path without the `?ts=${BUILD_TS}` query parameter
- All other asset paths continue to include the timestamp-based cache-buster for proper versioning

## Implementation Details
The change introduces a conditional check that identifies the embed script path and omits the cache-busting query string for that specific asset while maintaining the existing behavior for all other assets. This allows the embed script to be served without version constraints while keeping other assets properly versioned.

https://claude.ai/code/session_01N1USoCzkvvZ4qiFk7JW9Vx