### PR TITLE
Convert public.ts from hand-rolled routing to defineRoutes + createRo…

### DIFF
--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -68,8 +68,8 @@ const isNumericParam = (name: string): boolean =>
 const getParamPattern = (name: string): string => {
   // Params ending in Id match digits only (e.g., eventId, attendeeId)
   if (isNumericParam(name)) return "(\\d+)";
-  // Slugs match lowercase alphanumeric with hyphens
-  if (name === "slug") return "([a-z0-9]+(?:-[a-z0-9]+)*)";
+  // Slugs match lowercase alphanumeric with hyphens and + (for multi-ticket URLs)
+  if (name === "slug") return "([a-z0-9]+(?:[-+][a-z0-9]+)*)";
   // Default: match any non-slash characters
   return "([^/]+)";
 };


### PR DESCRIPTION
…uter

Replace the manual if/else method+path matching in routeTicket with the declarative defineRoutes pattern used by all other route files. Extend the router slug pattern to allow + separators for multi-ticket URLs.

https://claude.ai/code/session_01Qvm61cTd7vqctUu5FXKuFC