### PR TITLE
Auto-generate group slugs on creation, allow customization on edit

### DIFF
--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -50,3 +50,23 @@ export const validateSlug = (slug: string): string | null => {
   if (!SLUG_PATTERN.test(slug)) return "Slug may only contain lowercase letters, numbers, and hyphens";
   return null;
 };
+
+/** Slug-with-index pair */
+export type SlugWithIndex = { slug: string; slugIndex: string };
+
+/**
+ * Generate a unique slug by retrying until one is not taken.
+ * @param computeIndex - hash the slug for blind-index lookup
+ * @param isTaken - check cross-table uniqueness
+ */
+export const generateUniqueSlug = async (
+  computeIndex: (slug: string) => Promise<string>,
+  isTaken: (slug: string) => Promise<boolean>,
+): Promise<SlugWithIndex> => {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const slug = generateSlug();
+    const slugIndex = await computeIndex(slug);
+    if (!await isTaken(slug)) return { slug, slugIndex };
+  }
+  throw new Error("Failed to generate unique slug after 10 attempts");
+};

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -44,7 +44,13 @@ export type EventEditFormValues = EventFormValues & {
   slug: string;
 };
 
-/** Typed values from group form validation */
+/** Typed values from group create form validation (no slug - auto-generated) */
+export type GroupCreateFormValues = {
+  name: string;
+  terms_and_conditions: string;
+};
+
+/** Typed values from group edit form validation (includes slug) */
 export type GroupFormValues = {
   name: string;
   slug: string;
@@ -428,10 +434,8 @@ export const groupIdField: Field = {
   type: "text",
 };
 
-/**
- * Group form field definitions
- */
-export const groupFields: Field[] = [
+/** Group form fields for creation (no slug - auto-generated) */
+export const groupCreateFields: Field[] = [
   {
     name: "name",
     label: "Group Name",
@@ -439,13 +443,19 @@ export const groupFields: Field[] = [
     required: true,
     placeholder: "Summer Fete",
   },
-  slugField,
   {
     name: "terms_and_conditions",
     label: "Terms and Conditions (optional)",
     type: "textarea",
     hint: "If set, overrides the global terms and conditions for this group ticket page",
   },
+];
+
+/** Group form field definitions (edit - includes slug) */
+export const groupFields: Field[] = [
+  groupCreateFields[0]!,
+  slugField,
+  groupCreateFields[1]!,
 ];
 
 /** Name field shown on all ticket forms */

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1219,22 +1219,22 @@ export const testGroup = (overrides: Partial<Group> = {}): Group => ({
 });
 
 /**
- * Create a group via the REST API
+ * Create a group via the REST API.
+ * Slug is auto-generated on creation. If a slug is provided,
+ * the group is updated after creation to set the desired slug.
  */
-export const createTestGroup = (
+export const createTestGroup = async (
   overrides: Partial<Omit<GroupInput, "slugIndex">> = {},
 ): Promise<Group> => {
   const input = {
     name: overrides.name ?? "Test Group",
-    slug: overrides.slug ?? "test-group",
     termsAndConditions: overrides.termsAndConditions ?? "",
   };
 
-  return authenticatedFormRequest(
+  const group = await authenticatedFormRequest(
     "/admin/group",
     {
       name: input.name,
-      slug: input.slug,
       terms_and_conditions: input.termsAndConditions,
     },
     async () => {
@@ -1244,6 +1244,16 @@ export const createTestGroup = (
     },
     "create group",
   );
+
+  if (overrides.slug) {
+    return updateTestGroup(group.id, {
+      name: group.name,
+      slug: overrides.slug,
+      termsAndConditions: group.terms_and_conditions,
+    });
+  }
+
+  return group;
 };
 
 /**

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -1174,7 +1174,7 @@ describe("test-compat", () => {
       await createTestDbWithSetup();
       const group = await createTestGroup();
       expect(group.name).toBe("Test Group");
-      expect(group.slug).toBe("test-group");
+      expect(group.slug.length).toBe(5);
       expect(group.terms_and_conditions).toBe("");
     });
 


### PR DESCRIPTION
## Summary
This PR changes the group creation workflow to auto-generate unique slugs instead of requiring users to provide them. Slugs can still be customized later via the edit form.

## Key Changes
- **Auto-generated slugs on creation**: Groups now get a randomly generated 5-character slug when created, eliminating slug collision validation during creation
- **Separate create/edit forms**: Split group form fields into `groupCreateFields` (no slug) and `groupFields` (with slug for editing)
- **Separate CRUD handlers**: Created distinct `crudCreate` and `crud` handlers to use different resources and field sets for POST vs PUT operations
- **New slug generation utility**: Added `generateUniqueSlug()` function in `slug.ts` that retries until finding an available slug across multiple tables
- **Group detail enhancements**: Added public URL, embed script, and embed iframe display options to the group detail page
- **Updated test utilities**: Modified `createTestGroup()` to auto-generate slugs on creation and optionally update to a custom slug afterward
- **Reused slug generation**: Updated event creation to use the new shared `generateUniqueSlug()` utility

## Implementation Details
- The `generateUniqueSlug()` function accepts a `computeIndex` callback and `isTaken` predicate, making it reusable across different entity types
- Group creation no longer validates slug uniqueness since it's auto-generated
- The edit form retains slug validation to prevent collisions when users customize the slug
- Test expectations updated to verify auto-generated slugs are 5 characters long
- Group detail page now displays embed options using `buildEmbedSnippets()` helper

https://claude.ai/code/session_01VAFCBdc3jkKvR29MBQXgd1