### PR TITLE
Change justify-important alignment from center to left

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -17,7 +17,7 @@
   --color-scrollbar: #cacae8;
   --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   --hover-brightness: 1.2;
-  --justify-important: center;
+  --justify-important: left;
   --justify-normal: left;
   --line-height: 1.5;
   --width-card: 285px;


### PR DESCRIPTION
## Summary
Updated the default alignment for important justified content from center to left alignment in the MVP CSS framework.

## Changes
- Modified `--justify-important` CSS custom property from `center` to `left` in the root variables

## Details
This change affects how elements using the `justify-important` utility class are aligned. The new left alignment provides better consistency with the `--justify-normal` property, which is also set to `left`. This may improve visual hierarchy and layout consistency across the application.

https://claude.ai/code/session_017ZkL25whvGfZdQbyN7Y2S1