### PR TITLE
Replace custom scroll message with iframe-resizer's scrollToOffset

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -70,10 +70,11 @@ if (dateInput && closesAtInput) {
 
 /* Scroll parent page so the iframe is visible on checkout and success pages.
  * parentIframe is created synchronously by iframe-resizer-child (loaded before
- * this deferred script) and buffers calls until the parent handshake completes. */
+ * this deferred script) and buffers calls until the parent handshake completes.
+ * scrollToOffset(0, 0) scrolls the parent to the iframe's top-left corner. */
 if (document.querySelector("[data-scroll-into-view]")) {
-  const { parentIframe } = window as unknown as { parentIframe?: { sendMessage: (msg: unknown) => void } };
-  parentIframe?.sendMessage({ type: "scrollIntoView" });
+  const { parentIframe } = window as unknown as { parentIframe?: { scrollToOffset: (x: number, y: number) => void } };
+  parentIframe?.scrollToOffset(0, 0);
 }
 
 /* Stripe checkout popup: opens Stripe in a new window when embedded in an iframe.

--- a/src/client/embed.ts
+++ b/src/client/embed.ts
@@ -28,16 +28,10 @@
     const iframeResize = (window as unknown as {
       iframeResize: (options: {
         license: string;
-        onMessage?: (data: { iframe: HTMLIFrameElement; message: Record<string, unknown> }) => void;
       }, target: HTMLIFrameElement) => void;
     }).iframeResize;
     iframeResize({
       license: "GPLv3",
-      onMessage: ({ iframe: iframeEl, message }) => {
-        if (message?.type === "scrollIntoView") {
-          iframeEl.scrollIntoView({ behavior: "smooth", block: "start" });
-        }
-      },
     }, iframe);
   };
 


### PR DESCRIPTION
## Summary
This PR refactors the iframe scroll-into-view functionality to use iframe-resizer's built-in `scrollToOffset` method instead of a custom messaging system.

## Key Changes
- **admin.ts**: Updated to call `parentIframe.scrollToOffset(0, 0)` instead of sending a custom `scrollIntoView` message
- **embed.ts**: Removed the `onMessage` handler that was listening for custom `scrollIntoView` messages and manually calling `scrollIntoView()` on the iframe element
- Updated TypeScript type definitions to reflect the new `scrollToOffset` method signature

## Implementation Details
- The `scrollToOffset(0, 0)` call scrolls the parent page to the iframe's top-left corner, achieving the same result as the previous custom messaging approach
- This leverages iframe-resizer's native API rather than maintaining custom message handling, reducing code complexity
- The change maintains the same functionality while simplifying the communication pattern between the iframe and parent page

https://claude.ai/code/session_01N4oDySYZZeGxqEkN9PXTMx