### PR TITLE
Include event name in activity logs for attendee check-ins

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -176,7 +176,7 @@ const handleAttendeeCheckin = attendeeFormAction(async (data, _session, form, ev
   await updateCheckedIn(attendeeId, nowCheckedIn);
 
   const action = nowCheckedIn ? "checked in" : "checked out";
-  await logActivity(`Attendee ${action}`, eventId);
+  await logActivity(`Attendee ${action} for '${data.event.name}'`, eventId);
 
   const returnUrl = getReturnUrlFromForm(form);
   if (returnUrl) return redirect(returnUrl);

--- a/src/routes/admin/scanner.ts
+++ b/src/routes/admin/scanner.ts
@@ -90,7 +90,8 @@ const handleScanPost = (request: Request, { id }: { id: number }): Promise<Respo
 
     // Check them in
     await updateCheckedIn(attendee.id, true);
-    await logActivity(`Attendee checked in via scanner`, attendee.event_id);
+    const eventName = await getEventName(attendee.event_id);
+    await logActivity(`Attendee checked in via scanner for '${eventName}'`, attendee.event_id);
 
     return jsonResponse({
       status: "checked_in",

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -353,7 +353,7 @@ describe("QR Scanner", () => {
         { cookie: session.cookie },
       );
       const logBody = await logResponse.text();
-      expect(logBody).toContain("checked in via scanner");
+      expect(logBody).toContain("checked in via scanner for 'Test Event 1'");
     });
   });
 


### PR DESCRIPTION
## Summary
Enhanced activity logging for attendee check-ins to include the event name, providing better context in audit logs.

## Key Changes
- **Scanner check-in logging**: Modified `handleScanPost` to fetch and include the event name when logging scanner-based check-ins
- **Manual check-in logging**: Updated `handleAttendeeCheckin` to include the event name from the attendee data when logging manual check-ins
- **Test update**: Updated the corresponding test assertion to expect the new log format with event name included

## Implementation Details
- The scanner route now calls `getEventName()` to retrieve the event name before logging the activity
- The manual check-in route leverages the already-available `data.event.name` from the form data, avoiding an additional database query
- Both log messages now follow the format: `"Attendee [action] for '[Event Name]'"` for improved clarity and traceability

https://claude.ai/code/session_019ZJqKeLrFCQLJVUm8T5ngM