### PR TITLE
Add owner-only debug footer to admin pages

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -157,6 +157,7 @@ const result = await esbuild.build({
   format: "esm",
   minify: true,
   bundle: true,
+  external: ["node:async_hooks"],
   plugins: [esmShExternalsPlugin, inlineAssetsPlugin],
   banner: { js: NODEJS_GLOBALS_BANNER },
 });

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,10 +1,15 @@
 /**
  * Database client setup and core utilities
+ *
+ * When query logging is enabled (owner debug footer), the core query
+ * functions (queryOne, queryAll, queryBatch, executeByField) time each
+ * call and record the SQL via the query-log module.
  */
 
 import { type Client, createClient, type InValue, type ResultSet } from "@libsql/client";
 import { lazyRef } from "#fp";
 import { getEnv } from "#lib/env.ts";
+import { addQueryLogEntry, isQueryLogEnabled, trackQuery } from "#lib/db/query-log.ts";
 
 const createDbClient = (): Client => {
   const url = getEnv("DB_URL");
@@ -38,7 +43,7 @@ export const queryOne = async <T>(
   sql: string,
   args: InValue[],
 ): Promise<T | null> => {
-  const result = await getDb().execute({ sql, args });
+  const result = await trackQuery(sql, () => getDb().execute({ sql, args }));
   const rows = resultRows<T>(result);
   return rows.length === 0 ? null : rows[0]!;
 };
@@ -48,9 +53,10 @@ export const queryAll = async <T>(
   sql: string,
   args?: InValue[],
 ): Promise<T[]> => {
-  const result = args
-    ? await getDb().execute({ sql, args })
-    : await getDb().execute(sql);
+  const result = await trackQuery(
+    sql,
+    () => args ? getDb().execute({ sql, args }) : getDb().execute(sql),
+  );
   return resultRows<T>(result);
 };
 
@@ -60,19 +66,24 @@ export const executeByField = async (
   field: string,
   value: InValue,
 ): Promise<void> => {
-  await getDb().execute({
-    sql: `DELETE FROM ${table} WHERE ${field} = ?`,
-    args: [value],
-  });
+  const sql = `DELETE FROM ${table} WHERE ${field} = ?`;
+  await trackQuery(sql, () => getDb().execute({ sql, args: [value] }));
 };
 
 /**
  * Execute multiple queries in a single round-trip using Turso batch API.
  * Significantly reduces latency for remote databases.
  */
-export const queryBatch = (
+export const queryBatch = async (
   statements: Array<{ sql: string; args: InValue[] }>,
-): Promise<ResultSet[]> => getDb().batch(statements, "read");
+): Promise<ResultSet[]> => {
+  if (!isQueryLogEnabled()) return getDb().batch(statements, "read");
+  const start = performance.now();
+  const results = await getDb().batch(statements, "read");
+  const elapsed = performance.now() - start;
+  for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed);
+  return results;
+};
 
 /** Build SQL placeholders for an IN clause, e.g. "?, ?, ?" */
 export const inPlaceholders = (values: readonly unknown[]): string =>

--- a/src/lib/db/query-log.ts
+++ b/src/lib/db/query-log.ts
@@ -1,0 +1,50 @@
+/**
+ * Request-scoped SQL query logging for the owner debug footer.
+ *
+ * Call `enableQueryLog()` at the start of a request and `getQueryLog()`
+ * after the response body has been built to retrieve every tracked query.
+ */
+
+/** A single logged query */
+export type QueryLogEntry = { sql: string; durationMs: number };
+
+/** Mutable state held in a const object to satisfy the no-let lint rule */
+const state: { enabled: boolean; entries: QueryLogEntry[] } = {
+  enabled: false,
+  entries: [],
+};
+
+/** Enable query logging and clear previous entries */
+export const enableQueryLog = (): void => {
+  state.enabled = true;
+  state.entries = [];
+};
+
+/** Disable query logging and clear entries */
+export const disableQueryLog = (): void => {
+  state.enabled = false;
+  state.entries = [];
+};
+
+/** Whether query logging is currently active */
+export const isQueryLogEnabled = (): boolean => state.enabled;
+
+/** Record a query (no-op when logging is disabled) */
+export const addQueryLogEntry = (sql: string, durationMs: number): void => {
+  if (state.enabled) state.entries.push({ sql, durationMs });
+};
+
+/** Return a snapshot of all logged queries */
+export const getQueryLog = (): QueryLogEntry[] => [...state.entries];
+
+/** Run an async DB operation and log it when tracking is active */
+export const trackQuery = async <T>(
+  sql: string,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  if (!state.enabled) return fn();
+  const start = performance.now();
+  const result = await fn();
+  state.entries.push({ sql, durationMs: performance.now() - start });
+  return result;
+};

--- a/src/lib/db/query-log.ts
+++ b/src/lib/db/query-log.ts
@@ -5,43 +5,54 @@
  * after the response body has been built to retrieve every tracked query.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /** A single logged query */
 export type QueryLogEntry = { sql: string; durationMs: number };
 
-/** Mutable state held in a const object to satisfy the no-let lint rule */
-const state: { enabled: boolean; entries: QueryLogEntry[] } = {
-  enabled: false,
-  entries: [],
-};
+type QueryLogState = { enabled: boolean; entries: QueryLogEntry[] };
+
+const asyncLocalStorage = new AsyncLocalStorage<QueryLogState>();
+const fallbackState: QueryLogState = { enabled: false, entries: [] };
+
+const getState = (): QueryLogState => asyncLocalStorage.getStore() ?? fallbackState;
+
+export const runWithQueryLogContext = <T>(
+  fn: () => T,
+): T => asyncLocalStorage.run({ enabled: false, entries: [] }, fn);
 
 /** Enable query logging and clear previous entries */
 export const enableQueryLog = (): void => {
+  const state = getState();
   state.enabled = true;
   state.entries = [];
 };
 
 /** Disable query logging and clear entries */
 export const disableQueryLog = (): void => {
+  const state = getState();
   state.enabled = false;
   state.entries = [];
 };
 
 /** Whether query logging is currently active */
-export const isQueryLogEnabled = (): boolean => state.enabled;
+export const isQueryLogEnabled = (): boolean => getState().enabled;
 
 /** Record a query (no-op when logging is disabled) */
 export const addQueryLogEntry = (sql: string, durationMs: number): void => {
+  const state = getState();
   if (state.enabled) state.entries.push({ sql, durationMs });
 };
 
 /** Return a snapshot of all logged queries */
-export const getQueryLog = (): QueryLogEntry[] => [...state.entries];
+export const getQueryLog = (): QueryLogEntry[] => [...getState().entries];
 
 /** Run an async DB operation and log it when tracking is active */
 export const trackQuery = async <T>(
   sql: string,
   fn: () => Promise<T>,
 ): Promise<T> => {
+  const state = getState();
   if (!state.enabled) return fn();
   const start = performance.now();
   const result = await fn();

--- a/src/lib/db/query.ts
+++ b/src/lib/db/query.ts
@@ -2,6 +2,7 @@ import type { InStatement } from "@libsql/client";
 
 import { mapAsync } from "#fp";
 import { getDb, resultRows } from "#lib/db/client.ts";
+import { trackQuery } from "#lib/db/query-log.ts";
 
 /**
  * Execute a statement and map result rows through an async transformer.
@@ -12,6 +13,7 @@ export const queryAndMap = <Row, Out>(
   toOut: (row: Row) => Promise<Out>,
 ) =>
 async (stmt: InStatement): Promise<Out[]> => {
-  const result = await getDb().execute(stmt);
+  const sql = typeof stmt === "string" ? stmt : stmt.sql;
+  const result = await trackQuery(sql, () => getDb().execute(stmt));
   return mapAsync(toOut)(resultRows<Row>(result));
 };

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -65,8 +65,9 @@ export const routeAdmin: RouterFn = async (request, path, method, server) => {
     if (!isOwner) return response;
 
     if (response.status !== 200) return response;
-    const contentType = response.headers.get("content-type");
-    if (!contentType || !contentType.includes("text/html")) return response;
+    if (!response.headers.get("content-type")!.includes("text/html")) {
+      return response;
+    }
 
     const html = await response.text();
     const footer = ownerFooterHtml(

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -1,7 +1,11 @@
 /**
  * Admin routes - combined from individual route modules
+ *
+ * GET requests are wrapped to track SQL queries and inject an
+ * owner-only debug footer showing render time and query details.
  */
 
+import { disableQueryLog, enableQueryLog, getQueryLog } from "#lib/db/query-log.ts";
 import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
@@ -15,6 +19,8 @@ import { settingsRoutes } from "#routes/admin/settings.ts";
 import { scannerRoutes } from "#routes/admin/scanner.ts";
 import { usersRoutes } from "#routes/admin/users.ts";
 import { createRouter } from "#routes/router.ts";
+import { getAuthenticatedSession } from "#routes/utils.ts";
+import { ownerFooterHtml } from "#templates/admin/footer.tsx";
 
 /** Combined admin routes */
 const adminRoutes = {
@@ -32,5 +38,46 @@ const adminRoutes = {
   ...scannerRoutes,
 };
 
-/** Route admin requests using declarative router */
-export const routeAdmin = createRouter(adminRoutes);
+const innerRouter = createRouter(adminRoutes);
+
+type RouterFn = ReturnType<typeof createRouter>;
+
+/**
+ * Route admin requests.
+ * For GET requests, enables query tracking and injects the owner debug
+ * footer into HTML responses when the authenticated user is an owner.
+ */
+export const routeAdmin: RouterFn = async (request, path, method, server) => {
+  if (method !== "GET") {
+    return innerRouter(request, path, method, server);
+  }
+
+  // Check owner status before tracking so the auth queries aren't logged
+  const session = await getAuthenticatedSession(request);
+  const isOwner = session?.adminLevel === "owner";
+
+  if (isOwner) enableQueryLog();
+  const startTime = performance.now();
+
+  try {
+    const response = await innerRouter(request, path, method, server);
+    if (!response) return null;
+    if (!isOwner) return response;
+
+    if (response.status !== 200) return response;
+    const contentType = response.headers.get("content-type");
+    if (!contentType || !contentType.includes("text/html")) return response;
+
+    const html = await response.text();
+    const footer = ownerFooterHtml(
+      performance.now() - startTime,
+      getQueryLog(),
+    );
+    return new Response(html.replace("</body>", footer + "</body>"), {
+      status: response.status,
+      headers: response.headers,
+    });
+  } finally {
+    if (isOwner) disableQueryLog();
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -174,7 +174,7 @@ const logAndReturn = (
 /**
  * Handle incoming requests with security headers and domain validation
  */
-export const handleRequest = async (
+export const handleRequest = (
   request: Request,
   server?: ServerContext,
 ): Promise<Response> => {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@
 import { once } from "#fp";
 import { isSetupComplete } from "#lib/config.ts";
 import { loadCurrencyCode } from "#lib/currency.ts";
+import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { createRequestTimer, logRequest } from "#lib/logger.ts";
 import {
   applySecurityHeaders,
@@ -177,6 +178,7 @@ export const handleRequest = async (
   request: Request,
   server?: ServerContext,
 ): Promise<Response> => {
+  return runWithQueryLogContext(async () => {
   const { path, method } = parseRequest(request);
   const getElapsed = createRequestTimer();
 
@@ -195,4 +197,5 @@ export const handleRequest = async (
 
   const response = await handleRequestInternal(request, path, method, server);
   return logAndReturn(await applySecurityHeaders(response, embeddable), method, path, getElapsed);
+  });
 };

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1029,3 +1029,15 @@ button.secondary:hover {
     box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
   }
 }
+
+/* Owner debug footer */
+.debug-footer {
+  margin-top: 5rem;
+  font-size: smaller;
+  opacity: 0.6;
+}
+
+.debug-footer ul {
+  font-family: monospace;
+  font-size: small;
+}

--- a/src/templates/admin/footer.tsx
+++ b/src/templates/admin/footer.tsx
@@ -9,10 +9,11 @@ export const ownerFooterHtml = (
   renderTimeMs: number,
   queries: QueryLogEntry[],
 ): string =>
-  `<footer style="margin-top:5rem;font-size:smaller;opacity:0.6">` +
+  `<footer class="debug-footer">` +
+  `<p><a href="https://github.com/chobbledotcom/tickets">Chobble Tickets</a></p>` +
   `<details>` +
-  `<summary>Chobble Tickets | ${renderTimeMs.toFixed(0)}ms</summary>` +
-  `<ul style="font-family:monospace;font-size:small">` +
+  `<summary>${renderTimeMs.toFixed(0)}ms</summary>` +
+  `<ul>` +
   queries
     .map(
       (q) =>

--- a/src/templates/admin/footer.tsx
+++ b/src/templates/admin/footer.tsx
@@ -1,0 +1,32 @@
+/**
+ * Owner-only debug footer showing render time and SQL queries
+ */
+
+import type { QueryLogEntry } from "#lib/db/query-log.ts";
+
+/** Render the owner debug footer as an HTML string for injection before </body> */
+export const ownerFooterHtml = (
+  renderTimeMs: number,
+  queries: QueryLogEntry[],
+): string =>
+  `<footer style="margin-top:5rem;font-size:smaller;opacity:0.6">` +
+  `<details>` +
+  `<summary>Chobble Tickets | ${renderTimeMs.toFixed(0)}ms</summary>` +
+  `<ul style="font-family:monospace;font-size:small">` +
+  queries
+    .map(
+      (q) =>
+        `<li>${escapeFooterHtml(q.sql)} &mdash; ${q.durationMs.toFixed(1)}ms</li>`,
+    )
+    .join("") +
+  `</ul>` +
+  `</details>` +
+  `</footer>`;
+
+/** Minimal HTML escaping for SQL strings in the footer */
+const escapeFooterHtml = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -4,7 +4,13 @@ import { ownerFooterHtml } from "#templates/admin/footer.tsx";
 describe("ownerFooterHtml", () => {
   test("renders summary with render time", () => {
     const html = ownerFooterHtml(42.7, []);
-    expect(html).toContain("Chobble Tickets | 43ms");
+    expect(html).toContain("43ms");
+  });
+
+  test("links to the GitHub repo", () => {
+    const html = ownerFooterHtml(10, []);
+    expect(html).toContain('href="https://github.com/chobbledotcom/tickets"');
+    expect(html).toContain("Chobble Tickets</a>");
   });
 
   test("wraps content in a details/summary element", () => {
@@ -21,23 +27,9 @@ describe("ownerFooterHtml", () => {
     expect(html).toContain("</footer>");
   });
 
-  test("applies 5rem margin-top", () => {
+  test("uses the debug-footer CSS class", () => {
     const html = ownerFooterHtml(10, []);
-    expect(html).toContain("margin-top:5rem");
-  });
-
-  test("uses smaller font and 0.6 opacity", () => {
-    const html = ownerFooterHtml(10, []);
-    expect(html).toContain("font-size:smaller");
-    expect(html).toContain("opacity:0.6");
-  });
-
-  test("renders queries in monospace font", () => {
-    const html = ownerFooterHtml(10, [
-      { sql: "SELECT * FROM events", durationMs: 5.2 },
-    ]);
-    expect(html).toContain("font-family:monospace");
-    expect(html).toContain("font-size:small");
+    expect(html).toContain('class="debug-footer"');
   });
 
   test("lists each query with its duration", () => {

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "#test-compat";
+import { ownerFooterHtml } from "#templates/admin/footer.tsx";
+
+describe("ownerFooterHtml", () => {
+  test("renders summary with render time", () => {
+    const html = ownerFooterHtml(42.7, []);
+    expect(html).toContain("Chobble Tickets | 43ms");
+  });
+
+  test("wraps content in a details/summary element", () => {
+    const html = ownerFooterHtml(10, []);
+    expect(html).toContain("<details>");
+    expect(html).toContain("<summary>");
+    expect(html).toContain("</summary>");
+    expect(html).toContain("</details>");
+  });
+
+  test("renders inside a footer element", () => {
+    const html = ownerFooterHtml(10, []);
+    expect(html).toContain("<footer");
+    expect(html).toContain("</footer>");
+  });
+
+  test("applies 5rem margin-top", () => {
+    const html = ownerFooterHtml(10, []);
+    expect(html).toContain("margin-top:5rem");
+  });
+
+  test("uses smaller font and 0.6 opacity", () => {
+    const html = ownerFooterHtml(10, []);
+    expect(html).toContain("font-size:smaller");
+    expect(html).toContain("opacity:0.6");
+  });
+
+  test("renders queries in monospace font", () => {
+    const html = ownerFooterHtml(10, [
+      { sql: "SELECT * FROM events", durationMs: 5.2 },
+    ]);
+    expect(html).toContain("font-family:monospace");
+    expect(html).toContain("font-size:small");
+  });
+
+  test("lists each query with its duration", () => {
+    const html = ownerFooterHtml(20, [
+      { sql: "SELECT * FROM events", durationMs: 5.2 },
+      { sql: "SELECT * FROM users WHERE id = ?", durationMs: 3.1 },
+    ]);
+    expect(html).toContain("SELECT * FROM events");
+    expect(html).toContain("5.2ms");
+    expect(html).toContain("SELECT * FROM users WHERE id = ?");
+    expect(html).toContain("3.1ms");
+  });
+
+  test("escapes HTML in SQL strings", () => {
+    const html = ownerFooterHtml(10, [
+      { sql: "SELECT '<script>' FROM t", durationMs: 1.0 },
+    ]);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  test("renders empty query list gracefully", () => {
+    const html = ownerFooterHtml(5, []);
+    expect(html).toContain("<ul");
+    expect(html).toContain("</ul>");
+    expect(html).not.toContain("<li>");
+  });
+});

--- a/test/lib/owner-footer.test.ts
+++ b/test/lib/owner-footer.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import { handleRequest } from "#routes";
+import {
+  adminGet,
+  awaitTestRequest,
+  createTestDbWithSetup,
+  createTestEvent,
+  loginAsAdmin,
+  mockAdminLoginRequest,
+  mockFormRequest,
+  mockRequest,
+  requireJoinCsrfToken,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+describe("owner debug footer", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  test("owner sees footer on admin dashboard", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    expect(html).toContain("Chobble Tickets |");
+    expect(html).toContain("<details>");
+    expect(html).toContain("<summary>");
+  });
+
+  test("footer contains SQL queries", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    expect(html).toContain("SELECT");
+    expect(html).toContain("ms</li>");
+  });
+
+  test("footer is inside a <footer> element before </body>", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    const footerIdx = html.indexOf("<footer");
+    const bodyCloseIdx = html.indexOf("</body>");
+    expect(footerIdx).toBeGreaterThan(-1);
+    expect(bodyCloseIdx).toBeGreaterThan(footerIdx);
+  });
+
+  test("footer has correct styling", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    expect(html).toContain("margin-top:5rem");
+    expect(html).toContain("opacity:0.6");
+    expect(html).toContain("font-size:smaller");
+  });
+
+  test("unauthenticated users do not see footer", async () => {
+    const response = await handleRequest(mockRequest("/admin/"));
+    const html = await response.text();
+    expect(html).not.toContain("Chobble Tickets |");
+  });
+
+  test("manager does not see footer", async () => {
+    // Create and activate a manager user
+    const { cookie: ownerCookie, csrfToken: ownerCsrf } = await loginAsAdmin();
+
+    const inviteResponse = await handleRequest(
+      mockFormRequest("/admin/users", {
+        username: "manager1",
+        admin_level: "manager",
+        csrf_token: ownerCsrf,
+      }, ownerCookie),
+    );
+    const inviteUrl = inviteResponse.headers.get("location") ?? "";
+    const inviteMatch = inviteUrl.match(/invite=([^&]+)/);
+    const inviteLink = decodeURIComponent(inviteMatch![1] as string);
+    const inviteToken = inviteLink.split("/join/")[1]!;
+
+    // Set password for manager
+    const joinPageResponse = await handleRequest(mockRequest(`/join/${inviteToken}`));
+    const joinHtml = await joinPageResponse.text();
+    const joinCsrf = requireJoinCsrfToken(joinHtml);
+    await handleRequest(
+      mockFormRequest(`/join/${inviteToken}`, {
+        password: "managerpass123",
+        password_confirm: "managerpass123",
+        csrf_token: joinCsrf,
+      }),
+    );
+
+    // Activate the manager
+    await handleRequest(
+      mockFormRequest("/admin/users/2/activate", {
+        csrf_token: ownerCsrf,
+      }, ownerCookie),
+    );
+
+    // Login as manager
+    const loginResponse = await handleRequest(
+      await mockAdminLoginRequest({
+        username: "manager1",
+        password: "managerpass123",
+      }),
+    );
+    const managerCookie = loginResponse.headers.get("set-cookie") ?? "";
+
+    // Manager GET should not contain the footer
+    const response = await awaitTestRequest("/admin/", { cookie: managerCookie });
+    const html = await response.text();
+    expect(html).toContain("Events");
+    expect(html).not.toContain("Chobble Tickets |");
+  });
+
+  test("footer not injected for POST responses", async () => {
+    const { cookie, csrfToken } = await loginAsAdmin();
+    // POST to logout — it returns a redirect, not HTML, so no footer
+    const response = await handleRequest(
+      mockFormRequest("/admin/logout", { csrf_token: csrfToken }, cookie),
+    );
+    const body = await response.text();
+    expect(body).not.toContain("Chobble Tickets |");
+  });
+
+  test("owner sees footer on other admin pages", async () => {
+    const { response } = await adminGet("/admin/settings");
+    const html = await response.text();
+    expect(html).toContain("Chobble Tickets |");
+  });
+
+  test("footer not injected for non-HTML GET responses", async () => {
+    const event = await createTestEvent({ maxAttendees: 10 });
+    const { response } = await adminGet(`/admin/event/${event.id}/export`);
+    expect(response.headers.get("content-type")).toContain("text/csv");
+    const body = await response.text();
+    expect(body).not.toContain("Chobble Tickets |");
+  });
+
+  test("returns null for unmatched admin GET routes", async () => {
+    // A path that doesn't match any admin route falls through to 404
+    const { response } = await adminGet("/admin/nonexistent-page-xyz");
+    expect(response.status).toBe(404);
+  });
+});

--- a/test/lib/owner-footer.test.ts
+++ b/test/lib/owner-footer.test.ts
@@ -27,7 +27,7 @@ describe("owner debug footer", () => {
   test("owner sees footer on admin dashboard", async () => {
     const { response } = await adminGet("/admin/");
     const html = await response.text();
-    expect(html).toContain("Chobble Tickets |");
+    expect(html).toContain("Chobble Tickets");
     expect(html).toContain("<details>");
     expect(html).toContain("<summary>");
   });
@@ -48,18 +48,16 @@ describe("owner debug footer", () => {
     expect(bodyCloseIdx).toBeGreaterThan(footerIdx);
   });
 
-  test("footer has correct styling", async () => {
+  test("footer uses debug-footer CSS class", async () => {
     const { response } = await adminGet("/admin/");
     const html = await response.text();
-    expect(html).toContain("margin-top:5rem");
-    expect(html).toContain("opacity:0.6");
-    expect(html).toContain("font-size:smaller");
+    expect(html).toContain('class="debug-footer"');
   });
 
   test("unauthenticated users do not see footer", async () => {
     const response = await handleRequest(mockRequest("/admin/"));
     const html = await response.text();
-    expect(html).not.toContain("Chobble Tickets |");
+    expect(html).not.toContain("Chobble Tickets");
   });
 
   test("manager does not see footer", async () => {
@@ -110,7 +108,7 @@ describe("owner debug footer", () => {
     const response = await awaitTestRequest("/admin/", { cookie: managerCookie });
     const html = await response.text();
     expect(html).toContain("Events");
-    expect(html).not.toContain("Chobble Tickets |");
+    expect(html).not.toContain("Chobble Tickets");
   });
 
   test("footer not injected for POST responses", async () => {
@@ -120,13 +118,13 @@ describe("owner debug footer", () => {
       mockFormRequest("/admin/logout", { csrf_token: csrfToken }, cookie),
     );
     const body = await response.text();
-    expect(body).not.toContain("Chobble Tickets |");
+    expect(body).not.toContain("Chobble Tickets");
   });
 
   test("owner sees footer on other admin pages", async () => {
     const { response } = await adminGet("/admin/settings");
     const html = await response.text();
-    expect(html).toContain("Chobble Tickets |");
+    expect(html).toContain("Chobble Tickets");
   });
 
   test("footer not injected for non-HTML GET responses", async () => {
@@ -134,7 +132,7 @@ describe("owner debug footer", () => {
     const { response } = await adminGet(`/admin/event/${event.id}/export`);
     expect(response.headers.get("content-type")).toContain("text/csv");
     const body = await response.text();
-    expect(body).not.toContain("Chobble Tickets |");
+    expect(body).not.toContain("Chobble Tickets");
   });
 
   test("returns null for unmatched admin GET routes", async () => {

--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "#test-compat";
+import {
+  addQueryLogEntry,
+  disableQueryLog,
+  enableQueryLog,
+  getQueryLog,
+  isQueryLogEnabled,
+} from "#lib/db/query-log.ts";
+
+describe("query-log", () => {
+  afterEach(() => {
+    disableQueryLog();
+  });
+
+  describe("enableQueryLog / disableQueryLog", () => {
+    test("starts disabled", () => {
+      expect(isQueryLogEnabled()).toBe(false);
+    });
+
+    test("enableQueryLog enables tracking", () => {
+      enableQueryLog();
+      expect(isQueryLogEnabled()).toBe(true);
+    });
+
+    test("disableQueryLog disables tracking", () => {
+      enableQueryLog();
+      disableQueryLog();
+      expect(isQueryLogEnabled()).toBe(false);
+    });
+  });
+
+  describe("addQueryLogEntry", () => {
+    test("records entries when enabled", () => {
+      enableQueryLog();
+      addQueryLogEntry("SELECT 1", 1.5);
+      addQueryLogEntry("SELECT 2", 2.3);
+      const log = getQueryLog();
+      expect(log).toHaveLength(2);
+      expect(log[0]!.sql).toBe("SELECT 1");
+      expect(log[0]!.durationMs).toBe(1.5);
+      expect(log[1]!.sql).toBe("SELECT 2");
+      expect(log[1]!.durationMs).toBe(2.3);
+    });
+
+    test("ignores entries when disabled", () => {
+      addQueryLogEntry("SELECT 1", 1.0);
+      expect(getQueryLog()).toHaveLength(0);
+    });
+  });
+
+  describe("enableQueryLog resets previous entries", () => {
+    test("clears log on enable", () => {
+      enableQueryLog();
+      addQueryLogEntry("SELECT old", 1.0);
+      expect(getQueryLog()).toHaveLength(1);
+
+      enableQueryLog();
+      expect(getQueryLog()).toHaveLength(0);
+    });
+  });
+
+  describe("getQueryLog returns a snapshot", () => {
+    test("returned array is independent of internal state", () => {
+      enableQueryLog();
+      addQueryLogEntry("SELECT 1", 1.0);
+      const snapshot = getQueryLog();
+      addQueryLogEntry("SELECT 2", 2.0);
+      expect(snapshot).toHaveLength(1);
+      expect(getQueryLog()).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
Shows "Chobble Tickets | <render time>ms" as a <details> summary on
admin GET pages when logged in as an owner. The collapsed details list
each SQL query with its timing in monospace. Styled with 5rem margin-top,
smaller font, and 0.6 opacity. Manager and unauthenticated users see
no footer. Auth queries are excluded by checking owner status before
enabling the query log.

https://claude.ai/code/session_01XDYjX28vcXwcXwjSrNP7ff