### PR TITLE
Fix ReadableStream issues on Bunny Edge by materializing response bodies

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -6,6 +6,7 @@ import { compact } from "#fp";
 import { getAllowedDomain, getEmbedHosts } from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
+import { cloneResponse } from "#routes/utils.ts";
 
 /**
  * Security headers for all responses
@@ -157,9 +158,5 @@ export const applySecurityHeaders = async (
     }
   }
 
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
+  return cloneResponse(response, headers);
 };

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -233,12 +233,28 @@ export const getSearchParam = (
 };
 
 /**
+ * Clone a response with new headers, materializing the body to avoid
+ * ReadableStream pass-through issues on Bunny Edge.
+ */
+export const cloneResponse = async (
+  response: Response,
+  headers: Headers,
+): Promise<Response> => {
+  const body = response.body ? await response.arrayBuffer() : null;
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+/**
  * Add cookie header to response
  */
-export const withCookie = (response: Response, cookie: string): Response => {
+export const withCookie = (response: Response, cookie: string): Promise<Response> => {
   const headers = new Headers(response.headers);
   headers.append("set-cookie", cookie);
-  return new Response(response.body, { status: response.status, headers });
+  return cloneResponse(response, headers);
 };
 
 /** Handler function that takes a value and returns a Response */

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -2227,26 +2227,26 @@ describe("server (admin events)", () => {
   });
 
   describe("withCookie", () => {
-    test("adds a cookie to a response without existing cookies", () => {
+    test("adds a cookie to a response without existing cookies", async () => {
       const response = new Response("body", { status: 200 });
-      const result = withCookie(response, "session=abc; Path=/");
+      const result = await withCookie(response, "session=abc; Path=/");
       expect(result.headers.get("set-cookie")).toBe("session=abc; Path=/");
     });
 
-    test("preserves existing set-cookie headers when adding another", () => {
+    test("preserves existing set-cookie headers when adding another", async () => {
       const headers = new Headers();
       headers.append("set-cookie", "first=one; Path=/");
       const response = new Response("body", { status: 200, headers });
-      const result = withCookie(response, "second=two; Path=/");
+      const result = await withCookie(response, "second=two; Path=/");
       const cookies = result.headers.getSetCookie();
       expect(cookies.length).toBe(2);
       expect(cookies).toContain("first=one; Path=/");
       expect(cookies).toContain("second=two; Path=/");
     });
 
-    test("preserves response status", () => {
+    test("preserves response status", async () => {
       const response = new Response("body", { status: 201 });
-      const result = withCookie(response, "session=abc; Path=/");
+      const result = await withCookie(response, "session=abc; Path=/");
       expect(result.status).toBe(201);
     });
   });


### PR DESCRIPTION
## Summary
This PR fixes ReadableStream pass-through issues on Bunny Edge by materializing response bodies before cloning them. A new `cloneResponse` utility function is introduced to handle response cloning with proper body materialization, and existing code is refactored to use this utility.

## Key Changes
- **New `cloneResponse` utility**: Added a new async function that clones a Response while materializing the body using `arrayBuffer()` to avoid ReadableStream pass-through issues on Bunny Edge
- **Updated `withCookie` function**: Changed return type from `Response` to `Promise<Response>` and refactored to use the new `cloneResponse` utility instead of directly creating a new Response
- **Refactored `applySecurityHeaders`**: Updated to use the new `cloneResponse` utility, eliminating duplicate response cloning logic
- **Updated tests**: Modified all `withCookie` tests to be async and await the function calls

## Implementation Details
The `cloneResponse` function handles the body materialization by:
1. Converting the response body to an `ArrayBuffer` if it exists
2. Creating a new Response with the materialized body and provided headers
3. Preserving the original response status and statusText

This approach ensures that response bodies are fully materialized before being passed through, preventing issues with ReadableStream handling on the Bunny Edge platform.

https://claude.ai/code/session_019GhckNY2CyJsjizU8KLsEz