### PR TITLE
Parallelize attendee decryption operations with Promise.all

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -42,20 +42,29 @@ const decryptAttendee = async (
   row: Attendee,
   privateKey: CryptoKey,
 ): Promise<Attendee> => {
-  const name = await decryptAttendeePII(row.name, privateKey);
-  const email = await decryptAttendeePII(row.email, privateKey);
-  const phone = await decryptAttendeePII(row.phone, privateKey);
-  const address = await decryptAttendeePII(row.address, privateKey);
-  const special_instructions = await decryptAttendeePII(
-    row.special_instructions,
-    privateKey,
-  );
-  const payment_id = await decryptAttendeePII(row.payment_id, privateKey);
-  const price_paid = await decrypt(row.price_paid);
-  const checked_in = row.checked_in
-    ? await decryptAttendeePII(row.checked_in, privateKey)
-    : "false";
-  const ticket_token = await decryptAttendeePII(row.ticket_token, privateKey);
+  const [
+    name,
+    email,
+    phone,
+    address,
+    special_instructions,
+    payment_id,
+    price_paid,
+    checked_in,
+    ticket_token,
+  ] = await Promise.all([
+    decryptAttendeePII(row.name, privateKey),
+    decryptAttendeePII(row.email, privateKey),
+    decryptAttendeePII(row.phone, privateKey),
+    decryptAttendeePII(row.address, privateKey),
+    decryptAttendeePII(row.special_instructions, privateKey),
+    decryptAttendeePII(row.payment_id, privateKey),
+    decrypt(row.price_paid),
+    row.checked_in
+      ? decryptAttendeePII(row.checked_in, privateKey)
+      : Promise.resolve("false"),
+    decryptAttendeePII(row.ticket_token, privateKey),
+  ]);
   return {
     ...row,
     name,


### PR DESCRIPTION
## Summary
Refactored the `decryptAttendee` function to parallelize multiple decryption operations using `Promise.all` instead of executing them sequentially. This improves performance by allowing independent decryption tasks to run concurrently.

## Key Changes
- Converted sequential `await` calls to parallel execution using `Promise.all`
- All 9 decryption operations (name, email, phone, address, special_instructions, payment_id, price_paid, checked_in, ticket_token) now execute concurrently
- Wrapped the conditional `checked_in` decryption in `Promise.resolve()` to maintain compatibility with `Promise.all`
- Destructured results into individual variables for cleaner code

## Implementation Details
- The refactoring maintains identical functionality while improving performance
- The `checked_in` field's conditional logic is preserved by wrapping the fallback value in `Promise.resolve("false")`
- All decryption operations are independent and have no inter-dependencies, making them safe to parallelize

https://claude.ai/code/session_01J1DxRtMarFyd9XS5qZgxHN