### PR TITLE
Skip refund for unknown events in payment webhooks

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -175,6 +175,20 @@ const refundAndFail = async (
   return { success: false, error, status, refunded };
 };
 
+/**
+ * Handle event validation failure: skip refund for unknown events (404)
+ * since the webhook may be intended for a different instance sharing the same
+ * payment provider account. For known-event failures (inactive, closed),
+ * refund so the customer gets their money back.
+ */
+const validationFailure = (
+  session: ValidatedPaymentSession,
+  validation: { error: string; status?: number },
+): Promise<PaymentResult> =>
+  validation.status === 404
+    ? Promise.resolve({ success: false, error: validation.error, status: 404 })
+    : refundAndFail(session, validation.error, validation.status);
+
 /** Rollback created attendees (multi-ticket failure recovery) */
 const rollbackAttendees = async (
   attendees: { attendee: Attendee }[],
@@ -331,9 +345,7 @@ const processMultiPaymentSession = async (
 
   for (const item of intent.items) {
     const vp = await validateAndPrice({ eventId: item.e, quantity: item.q }, true);
-    if (!vp.ok) {
-      return refundAndFail(session, vp.error, vp.status);
-    }
+    if (!vp.ok) return validationFailure(session, vp);
     validatedItems.push({ item, event: vp.event, expectedPrice: vp.expectedPrice });
     expectedTotal += vp.expectedPrice;
   }
@@ -439,7 +451,7 @@ const processPaymentSession = async (
 
   // Phase 2: Validate event and create attendee atomically with capacity check
   const vp = await validateAndPrice(intent);
-  if (!vp.ok) return refundAndFail(session, vp.error, vp.status);
+  if (!vp.ok) return validationFailure(session, vp);
 
   const { event, expectedPrice } = vp;
 


### PR DESCRIPTION
## Summary
This PR changes the payment webhook handling to skip refunds when an event is not found (404 error), since the webhook may be intended for a different instance sharing the same payment provider account. Refunds are still issued for known-event failures (inactive, closed events) to ensure customers get their money back.

## Key Changes
- **New `validationFailure` helper function** in `src/routes/webhooks.ts`: Distinguishes between 404 (unknown event) and other validation failures, skipping refunds only for 404 errors
- **Updated `processMultiPaymentSession` and `processPaymentSession`**: Both now use `validationFailure` instead of always calling `refundAndFail` for validation errors
- **Test updates**: Removed mock refund setup and added assertions verifying that `refundPayment` is not called when events are not found, across both webhook and payment flow tests

## Implementation Details
The new `validationFailure` function returns a failed result without refunding when `validation.status === 404`, while delegating to `refundAndFail` for other error statuses. This prevents unnecessary refunds for webhooks that may belong to different instances, while preserving the refund behavior for legitimate event-related failures.

https://claude.ai/code/session_01HCvtT3YjpceenNxUUNwjff