### PR TITLE
Reduce padding on buttons and links in MVP stylesheet

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -323,7 +323,7 @@ input[type="submit"] {
   font-weight: bold;
   line-height: var(--line-height);
   margin: 0.5rem 0;
-  padding: 1rem 2rem;
+  padding: 0.2rem 1rem;
 }
 
 button,
@@ -357,7 +357,7 @@ a i {
   border-radius: var(--border-radius);
   color: var(--color-link);
   display: inline-block;
-  padding: 1rem 2rem;
+  padding: 0.2rem 1rem;
 }
 
 article aside a {


### PR DESCRIPTION
## Summary
This PR reduces the padding on interactive elements (buttons, submit inputs, and links) in the MVP CSS framework to create a more compact UI.

## Changes
- Reduced `input[type="submit"]` padding from `1rem 2rem` to `0.2rem 1rem`
- Reduced button and link padding from `1rem 2rem` to `0.2rem 1rem`

## Details
The padding adjustments affect:
- Submit input buttons
- Standard buttons and button-like elements
- Inline links styled as buttons

This change makes these interactive elements more space-efficient while maintaining usability and visual hierarchy.

https://claude.ai/code/session_01YE448oxFyiJdgLZvnNyPy2