### PR TITLE
Add theme selection feature to admin settings

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -48,6 +48,8 @@ export const CONFIG_KEYS = {
   TIMEZONE: "timezone",
   // Business email (encrypted)
   BUSINESS_EMAIL: "business_email",
+  // Theme setting (plaintext - light or dark)
+  THEME: "theme",
 } as const;
 
 /**
@@ -518,6 +520,23 @@ export const updateTimezone = async (tz: string): Promise<void> => {
 };
 
 /**
+ * Get the configured theme from database.
+ * Returns "light" or "dark", defaulting to "light".
+ */
+export const getThemeFromDb = async (): Promise<string> => {
+  const value = await getSetting(CONFIG_KEYS.THEME);
+  return value === "dark" ? "dark" : "light";
+};
+
+/**
+ * Update the configured theme.
+ */
+export const updateTheme = async (theme: string): Promise<void> => {
+  const validTheme = theme === "dark" ? "dark" : "light";
+  await setSetting(CONFIG_KEYS.THEME, validTheme);
+};
+
+/**
  * Stubbable API for testing - allows mocking in ES modules
  * Use spyOn(settingsApi, "method") instead of spyOn(settingsModule, "method")
  */
@@ -555,4 +574,6 @@ export const settingsApi = {
   updateTermsAndConditions,
   getTimezoneFromDb,
   updateTimezone,
+  getThemeFromDb,
+  updateTheme,
 };

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -30,6 +30,7 @@ export const adminSettingsPage = (
   termsAndConditions?: string | null,
   timezone?: string,
   businessEmail?: string,
+  theme?: string,
 ): string =>
   String(
     <Layout title="Settings">
@@ -63,6 +64,32 @@ export const adminSettingsPage = (
             autocomplete="email"
           />
           <button type="submit">Save Business Email</button>
+        </CsrfForm>
+
+        <CsrfForm action="/admin/settings/theme" csrfToken={session.csrfToken}>
+            <h2>Site Theme</h2>
+          <p>Choose between light and dark themes for the site interface.</p>
+          <fieldset>
+            <label>
+              <input
+                type="radio"
+                name="theme"
+                value="light"
+                checked={(theme ?? "light") === "light"}
+              />
+              Light
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="theme"
+                value="dark"
+                checked={theme === "dark"}
+              />
+              Dark
+            </label>
+          </fieldset>
+          <button type="submit">Save Theme</button>
         </CsrfForm>
 
         <CsrfForm action="/admin/settings/payment-provider" csrfToken={session.csrfToken}>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -33,7 +33,7 @@ export const adminSettingsPage = (
   theme?: string,
 ): string =>
   String(
-    <Layout title="Settings">
+    <Layout title="Settings" theme={theme}>
       <AdminNav session={session} />
 
       {error && <div class="error">{error}</div>}

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -66,32 +66,6 @@ export const adminSettingsPage = (
           <button type="submit">Save Business Email</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/theme" csrfToken={session.csrfToken}>
-            <h2>Site Theme</h2>
-          <p>Choose between light and dark themes for the site interface.</p>
-          <fieldset>
-            <label>
-              <input
-                type="radio"
-                name="theme"
-                value="light"
-                checked={(theme ?? "light") === "light"}
-              />
-              Light
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="theme"
-                value="dark"
-                checked={theme === "dark"}
-              />
-              Dark
-            </label>
-          </fieldset>
-          <button type="submit">Save Theme</button>
-        </CsrfForm>
-
         <CsrfForm action="/admin/settings/payment-provider" csrfToken={session.csrfToken}>
             <h2>Payment Provider</h2>
           <p>Choose which payment provider to use for paid events.</p>
@@ -240,6 +214,32 @@ export const adminSettingsPage = (
           <button type="submit" class="danger">
             Reset Database
           </button>
+        </CsrfForm>
+
+        <CsrfForm action="/admin/settings/theme" csrfToken={session.csrfToken}>
+            <h2>Site Theme</h2>
+          <p>Choose between light and dark themes for the site interface.</p>
+          <fieldset>
+            <label>
+              <input
+                type="radio"
+                name="theme"
+                value="light"
+                checked={(theme ?? "light") === "light"}
+              />
+              Light
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="theme"
+                value="dark"
+                checked={theme === "dark"}
+              />
+              Dark
+            </label>
+          </fieldset>
+          <button type="submit">Save Theme</button>
         </CsrfForm>
     </Layout>
   );

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -17,13 +17,17 @@ interface LayoutProps {
   bodyClass?: string;
   headExtra?: string;
   children?: Child;
+  theme?: string;
 }
 
 /**
  * Wrap content in MVP.css semantic HTML layout
  */
-export const Layout = ({ title, bodyClass, headExtra, children }: LayoutProps): SafeHtml =>
-  new SafeHtml(
+export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutProps): SafeHtml => {
+  const colorScheme = theme === "dark" ? "dark" : "light";
+  const themeStyle = `<style>html { color-scheme: ${colorScheme}; }</style>`;
+
+  return new SafeHtml(
     "<!DOCTYPE html>" +
     (
       <html lang="en">
@@ -32,9 +36,10 @@ export const Layout = ({ title, bodyClass, headExtra, children }: LayoutProps): 
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <title>{title}</title>
           <link rel="stylesheet" href={CSS_PATH} />
+          <Raw html={themeStyle} />
           {headExtra && <Raw html={headExtra} />}
         </head>
-        <body class={bodyClass || undefined}>
+        <body class={bodyClass || undefined} data-theme={theme || "light"}>
           <main>
             {children}
           </main>
@@ -44,4 +49,5 @@ export const Layout = ({ title, bodyClass, headExtra, children }: LayoutProps): 
       </html>
     )
   );
+};
 

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -1549,6 +1549,23 @@ describe("server (admin settings)", () => {
       expect(html).toContain("Invalid theme selection");
     });
 
+    test("rejects missing theme field", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/theme",
+          {
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("Invalid theme selection");
+    });
+
     test("updates theme to dark successfully", async () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 


### PR DESCRIPTION
## Summary
This PR adds a theme selection feature that allows administrators to choose between light and dark themes for the site interface. The theme preference is persisted in the database and applied globally across the application.

## Key Changes
- **Database layer** (`src/lib/db/settings.ts`):
  - Added `THEME` configuration key to store theme preference
  - Implemented `getThemeFromDb()` to retrieve the current theme (defaults to "light")
  - Implemented `updateTheme()` to persist theme changes to the database

- **Admin settings route** (`src/routes/admin/settings.ts`):
  - Added theme retrieval to settings page state
  - Created `processThemeForm()` handler to validate and save theme selection
  - Added POST endpoint `/admin/settings/theme` with CSRF protection and owner-only access
  - Validates that theme is either "light" or "dark"

- **Admin settings UI** (`src/templates/admin/settings.tsx`):
  - Added theme selection form with radio buttons for light/dark options
  - Displays current theme selection state
  - Integrated with CSRF form protection

- **Layout component** (`src/templates/layout.tsx`):
  - Added `theme` prop to Layout component
  - Applied CSS `color-scheme` property based on selected theme
  - Added `data-theme` attribute to body element for CSS styling hooks

- **Test coverage** (`test/lib/server-settings.test.ts`):
  - Added comprehensive test suite for theme endpoint covering:
    - Authentication requirement
    - CSRF token validation
    - Invalid theme rejection
    - Successful theme updates (light and dark)
    - Database persistence verification
    - Settings page display of current selection

## Implementation Details
- Theme defaults to "light" if not configured
- Theme validation ensures only "light" or "dark" values are accepted
- Changes are logged via activity logging
- Users are redirected with success message after theme update
- The theme preference is applied via CSS `color-scheme` property for native browser support

https://claude.ai/code/session_01QEwkoypXV7pGgDpYf7Hf7C