### PR TITLE
Convert refunded field from string to boolean type

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -55,7 +55,7 @@ const decryptAttendee = async (
     payment_id,
     price_paid,
     checked_in,
-    refunded,
+    refundedStr,
     ticket_token,
   ] = await Promise.all([
     decryptAttendeePII(row.name, privateKey),
@@ -66,7 +66,8 @@ const decryptAttendee = async (
     decryptAttendeePII(row.payment_id, privateKey),
     decrypt(row.price_paid),
     decryptBoolField(row.checked_in, privateKey),
-    decryptBoolField(row.refunded, privateKey),
+    // Raw DB value is an encrypted string; cast needed since Attendee type declares boolean
+    decryptBoolField(row.refunded as unknown as string, privateKey),
     decryptAttendeePII(row.ticket_token, privateKey),
   ]);
   return {
@@ -79,7 +80,7 @@ const decryptAttendee = async (
     payment_id,
     price_paid,
     checked_in,
-    refunded,
+    refunded: refundedStr === "true",
     ticket_token,
   };
 };
@@ -193,7 +194,7 @@ const buildAttendeeResult = (input: BuildAttendeeInput): Attendee => ({
   quantity: input.quantity,
   price_paid: String(input.pricePaid),
   checked_in: "false",
-  refunded: "false",
+  refunded: false,
   ticket_token: input.ticketToken,
   ticket_token_index: input.ticketTokenIndex,
   date: input.date,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,7 +67,7 @@ export interface Attendee extends ContactInfo {
   quantity: number;
   price_paid: string;
   checked_in: string;
-  refunded: string;
+  refunded: boolean;
   ticket_token: string;
   ticket_token_index: string;
   date: string | null;

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -740,19 +740,28 @@ fieldset.agreement {
   font-weight: bold;
 }
 
-.danger-text,
-.badge-refunded {
+.danger-text {
   color: #cc0000;
   font-weight: bold;
+}
+
+.badge-refunded {
+  font-size: 0.75em;
+  color: #fff;
+  background-color: #cc0000;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root[color-mode="user"] .password-warning {
     color: #ff4444;
   }
-  :root[color-mode="user"] .danger-text,
-  :root[color-mode="user"] .badge-refunded {
+  :root[color-mode="user"] .danger-text {
     color: #ff4444;
+  }
+  :root[color-mode="user"] .badge-refunded {
+    background-color: #ff4444;
   }
 }
 

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -175,7 +175,7 @@ const renderEventSelector = (
 const PaymentDetails = ({ attendee, csrfToken }: { attendee: Attendee; csrfToken: string }): string => {
   if (!attendee.payment_id) return "";
   const pricePaid = Number.parseInt(attendee.price_paid, 10);
-  const isRefunded = attendee.refunded === "true";
+  const isRefunded = attendee.refunded;
 
   return String(
     <article>

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -202,7 +202,7 @@ const AttendeeRow = ({ row, vis, opts }: {
       </td>
       {vis.showEvent && <td><a href={`/admin/event/${row.eventId}`}>{row.eventName}</a></td>}
       {vis.showDate && <td>{a.date ? formatDateLabel(a.date) : ""}</td>}
-      <td>{a.name}</td>
+      <td>{a.name}{a.refunded === "true" && <> <span class="badge-refunded">refunded</span></>}</td>
       {vis.showEmail && <td>{a.email || ""}</td>}
       {vis.showPhone && <td>{a.phone || ""}</td>}
       {vis.showAddress && <td>{formatAddressInline(a.address)}</td>}

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -142,7 +142,7 @@ const CheckinButton = ({ a, eventId, csrfToken, activeFilter, returnUrl }: {
 
 /** Check if attendee is eligible for refund (has payment, not yet refunded) */
 const isRefundable = (row: AttendeeTableRow): boolean =>
-  row.hasPaidEvent && !!row.attendee.payment_id && row.attendee.refunded !== "true";
+  row.hasPaidEvent && !!row.attendee.payment_id && !row.attendee.refunded;
 
 /** Render the actions cell for a row */
 const ActionsCell = ({ row, returnUrl }: { row: AttendeeTableRow; returnUrl: string | undefined }): string => {
@@ -176,7 +176,7 @@ const StatusCell = ({ row, opts }: {
   row: AttendeeTableRow;
   opts: AttendeeTableOptions;
 }): string => {
-  if (row.attendee.refunded === "true") {
+  if (row.attendee.refunded) {
     return String(<span class="badge-refunded">Refunded</span>);
   }
   return CheckinButton({
@@ -202,7 +202,7 @@ const AttendeeRow = ({ row, vis, opts }: {
       </td>
       {vis.showEvent && <td><a href={`/admin/event/${row.eventId}`}>{row.eventName}</a></td>}
       {vis.showDate && <td>{a.date ? formatDateLabel(a.date) : ""}</td>}
-      <td>{a.name}{a.refunded === "true" && <> <span class="badge-refunded">refunded</span></>}</td>
+      <td>{a.name}{a.refunded && <> <span class="badge-refunded">refunded</span></>}</td>
       {vis.showEmail && <td>{a.email || ""}</td>}
       {vis.showPhone && <td>{a.phone || ""}</td>}
       {vis.showAddress && <td>{formatAddressInline(a.address)}</td>}

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1046,7 +1046,7 @@ export const testAttendee = (overrides: Partial<Attendee> = {}): Attendee => ({
   quantity: 1,
   price_paid: "0",
   checked_in: "false",
-  refunded: "false",
+  refunded: false,
   ticket_token: "test-token-1",
   ticket_token_index: "test-token-index-1",
   date: null,

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -253,7 +253,7 @@ describe("AttendeeTable", () => {
     test("hides Refund link when attendee is already refunded", () => {
       const rows = [makeRow({
         hasPaidEvent: true,
-        attendee: testAttendee({ payment_id: "pay_123", refunded: "true" }),
+        attendee: testAttendee({ payment_id: "pay_123", refunded: true }),
       })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).not.toContain("/refund");
@@ -262,20 +262,20 @@ describe("AttendeeTable", () => {
 
   describe("refunded badge", () => {
     test("shows Refunded badge for refunded attendee", () => {
-      const rows = [makeRow({ attendee: testAttendee({ refunded: "true" }) })];
+      const rows = [makeRow({ attendee: testAttendee({ refunded: true }) })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).toContain("Refunded");
     });
 
     test("does not show Check in button for refunded attendee", () => {
-      const rows = [makeRow({ attendee: testAttendee({ refunded: "true" }) })];
+      const rows = [makeRow({ attendee: testAttendee({ refunded: true }) })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).not.toContain("Check in");
       expect(html).not.toContain("Check out");
     });
 
     test("shows Check in button for non-refunded attendee", () => {
-      const rows = [makeRow({ attendee: testAttendee({ refunded: "false" }) })];
+      const rows = [makeRow({ attendee: testAttendee({ refunded: false }) })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).toContain("Check in");
       expect(html).not.toContain("Refunded");


### PR DESCRIPTION
## Summary
This PR refactors the `refunded` field in the `Attendee` type from a string (`"true"`/`"false"`) to a proper boolean type. This improves type safety and simplifies refund status checks throughout the codebase.

## Key Changes
- **Type definition**: Changed `Attendee.refunded` from `string` to `boolean` in `src/lib/types.ts`
- **Database decryption**: Updated `decryptAttendee()` to properly convert the encrypted string value to a boolean
- **Attendee creation**: Changed default value from `"false"` to `false` in `buildAttendeeResult()`
- **Refund checks**: Simplified all refund status comparisons from `=== "true"` to truthy checks (`!a.refunded` or `a.refunded`)
- **UI styling**: Enhanced `.badge-refunded` CSS class with proper badge styling (background color, padding, border-radius)
- **Dark mode support**: Updated dark mode styles to apply `background-color` instead of `color` for the refunded badge
- **Template updates**: Updated all template files to work with boolean refund status
- **Tests**: Updated test utilities and test cases to use boolean values

## Implementation Details
- The database stores the refunded value as an encrypted string, so a type cast is used during decryption with an explanatory comment
- All refund status checks now use idiomatic boolean logic instead of string comparisons
- The refunded badge now has proper visual styling as a colored pill-shaped element
- Test utilities were updated to maintain consistency with the new boolean type

https://claude.ai/code/session_01FhmnzMaD69pWeKRxnK7bFc