### PR TITLE
Add npm package bundling and improve error handling

### DIFF
--- a/src/edge/bunny-script.ts
+++ b/src/edge/bunny-script.ts
@@ -23,9 +23,12 @@ BunnySDK.net.http.serve(async (request: Request): Promise<Response> => {
   } catch (error) {
     // biome-ignore lint/suspicious/noConsole: Edge script error logging
     console.error("[Tickets] Request error:", error);
-    return new Response(JSON.stringify({ error: "Internal server error" }), {
-      status: 500,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="refresh" content="2"><title>Temporary Error</title></head><body><h1>Temporary Error</h1><p>Something went wrong loading this page. Retrying automatically&hellip;</p></body></html>',
+      {
+        status: 503,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      },
+    );
   }
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -91,6 +91,9 @@ export const ErrorCode = {
 
   // Configuration errors
   CONFIG_MISSING: "E_CONFIG_MISSING",
+
+  // CDN/network errors (transient edge failures)
+  CDN_REQUEST: "E_CDN_REQUEST",
 } as const;
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -18,7 +18,7 @@ import { nowMs } from "#lib/now.ts";
 import type { AdminLevel, AdminSession, EventWithCount } from "#lib/types.ts";
 import type { ServerContext } from "#routes/types.ts";
 import { paymentErrorPage } from "#templates/payment.tsx";
-import { notFoundPage } from "#templates/public.tsx";
+import { notFoundPage, temporaryErrorPage } from "#templates/public.tsx";
 
 // Re-export for use by other route modules
 export { generateSecureToken };
@@ -152,6 +152,13 @@ export const notFoundResponse = (): Response =>
  */
 export const paymentErrorResponse = (message: string, status = 400): Response =>
   htmlResponse(paymentErrorPage(message), status);
+
+/**
+ * Create temporary error response (e.g. transient CDN failures)
+ * Returns a styled page with auto-refresh so the user retries automatically
+ */
+export const temporaryErrorResponse = (): Response =>
+  htmlResponse(temporaryErrorPage(), 503);
 
 /**
  * Create redirect response

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -124,6 +124,18 @@ export const notFoundPage = (): string =>
     </Layout>
   );
 
+/**
+ * Temporary error page with auto-refresh
+ * Used when a transient CDN or network error occurs
+ */
+export const temporaryErrorPage = (): string =>
+  String(
+    <Layout title="Temporary Error" headExtra='<meta http-equiv="refresh" content="2" />'>
+      <h1>Temporary Error</h1>
+      <p>Something went wrong loading this page. Retrying automatically&hellip;</p>
+    </Layout>
+  );
+
 /** Event info for multi-ticket display */
 export type MultiTicketEvent = {
   event: EventWithCount;

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -19,7 +19,7 @@ import {
   reservationSuccessPage,
 } from "#templates/payment.tsx";
 import { eventFields } from "#templates/fields.ts";
-import { buildMultiTicketEvent, multiTicketPage, notFoundPage, renderEventImage, ticketPage } from "#templates/public.tsx";
+import { buildMultiTicketEvent, multiTicketPage, notFoundPage, renderEventImage, temporaryErrorPage, ticketPage } from "#templates/public.tsx";
 import { ticketViewPage } from "#templates/tickets.tsx";
 import { testAttendee, testEvent, testEventWithCount, testGroup } from "#test-utils";
 
@@ -447,6 +447,16 @@ describe("html", () => {
     test("renders not found message", () => {
       const html = notFoundPage();
       expect(html).toContain("<h1>Not Found</h1>");
+    });
+  });
+
+  describe("temporaryErrorPage", () => {
+    test("renders error message with auto-refresh", () => {
+      const html = temporaryErrorPage();
+      expect(html).toContain("<h1>Temporary Error</h1>");
+      expect(html).toContain("Retrying automatically");
+      expect(html).toContain('http-equiv="refresh"');
+      expect(html).toContain('content="2"');
     });
   });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1854,21 +1854,22 @@ describe("server (admin events)", () => {
       });
 
       try {
-        await expect(
-          handleRequest(
-            mockFormRequest(
-              "/admin/event",
-              {
-                name: "Collision Event",
-                max_attendees: "50",
-                max_quantity: "1",
-                thank_you_url: "https://example.com",
-                csrf_token: csrfToken,
-              },
-              cookie,
-            ),
+        const response = await handleRequest(
+          mockFormRequest(
+            "/admin/event",
+            {
+              name: "Collision Event",
+              max_attendees: "50",
+              max_quantity: "1",
+              thank_you_url: "https://example.com",
+              csrf_token: csrfToken,
+            },
+            cookie,
           ),
-        ).rejects.toThrow("Failed to generate unique slug after 10 attempts");
+        );
+        expect(response.status).toBe(503);
+        const text = await response.text();
+        expect(text).toContain("Temporary Error");
       } finally {
         spy.mockRestore();
       }

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -514,7 +514,7 @@ describe("server (event images)", () => {
       }
     });
 
-    test("propagates non-404 storage errors", async () => {
+    test("propagates non-404 storage errors as 503", async () => {
       const originalFetch = globalThis.fetch;
       globalThis.fetch = (input: string | URL | Request): Promise<Response> => {
         const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
@@ -525,9 +525,10 @@ describe("server (event images)", () => {
       };
 
       try {
-        await expect(
-          handleRequest(mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg")),
-        ).rejects.toThrow();
+        const response = await handleRequest(mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"));
+        expect(response.status).toBe(503);
+        const text = await response.text();
+        expect(text).toContain("Temporary Error");
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
 import { handleRequest, isValidContentType } from "#routes";
+import { temporaryErrorResponse } from "#routes/utils.ts";
 import {
   createTestDb,
   createTestDbWithSetup,
@@ -409,6 +410,18 @@ describe("server (misc)", () => {
         mockRequest("/this-path-definitely-does-not-exist-anywhere"),
       );
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe("CDN/transient error handling", () => {
+    test("temporaryErrorResponse returns 503 with styled HTML and auto-refresh", async () => {
+      const response = temporaryErrorResponse();
+      expect(response.status).toBe(503);
+      const text = await response.text();
+      expect(text).toContain("Temporary Error");
+      expect(text).toContain("Retrying automatically");
+      expect(text).toContain('http-equiv="refresh"');
+      expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
     });
   });
 


### PR DESCRIPTION
## Summary
This PR enhances the Edge build system to bundle npm packages directly instead of relying solely on CDN externalization, and improves error handling across the application with graceful 503 responses for transient failures.

## Key Changes

### Build System Improvements
- **NPM Package Bundling**: Added `BUNDLED_PACKAGES` set to specify packages that should be bundled directly from Deno's npm cache (libsql, Bunny SDKs, Stripe, QR code, etc.) rather than externalized to esm.sh CDN
- **Deno NPM Cache Resolver**: Implemented `denoNpmResolverPlugin` to resolve bundled packages from Deno's npm cache, with support for:
  - Package.json `exports` field resolution with browser/import/default condition priority
  - Fallback to `browser`, `module`, and `main` fields
  - Subpath overrides via `EDGE_SUBPATHS` (e.g., `@libsql/client` → `/web`)
  - Transitive dependency resolution
- **Node.js Externals**: Properly externalize all Node.js built-in modules per Bunny documentation
- **Bundle Size Validation**: Added 10MB script size limit check with clear error messaging
- **Production Optimization**: Added `NODE_ENV=production` define for better tree-shaking

### Error Handling
- **Graceful Degradation**: Wrapped main request handler in try-catch to return 503 responses for transient errors instead of throwing
- **Temporary Error Page**: Created `temporaryErrorPage()` with auto-refresh meta tag (2-second retry) for better UX during CDN/network failures
- **Consistent Error Responses**: Updated Edge script and all error paths to return styled HTML 503 responses with auto-refresh
- **Error Logging**: Added `CDN_REQUEST` error code for tracking transient failures

### Test Updates
- Updated tests to expect 503 responses with HTML content instead of thrown exceptions
- Added test coverage for `temporaryErrorResponse()` function
- Updated test descriptions to reflect new 503 behavior

## Implementation Details
- The npm resolver discovers Deno's cache path dynamically via `deno info --json`
- Condition resolution follows browser-first priority matching platform detection
- File resolution handles both ESM and CJS entry points with proper extension handling
- Edge script error handling now returns user-friendly HTML with automatic retry instead of JSON errors

https://claude.ai/code/session_01HnHyUQdFUB7kG8NAexuqfx