### PR TITLE
Fix Facebook in-app browser 403 by making domain validation more robust

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -80,6 +80,7 @@ export {
   isEmbeddablePath,
   isValidContentType,
   isValidDomain,
+  normalizeHostname,
 } from "#routes/middleware.ts";
 
 // Re-export types


### PR DESCRIPTION
The domain validation was strictly comparing the Host header against
ALLOWED_DOMAIN. This fails in environments where the Host header is
absent (HTTP/2 :authority pseudo-header) or rewritten (CDN proxies,
Facebook in-app browser). The fix:

- Falls back to request URL hostname when Host header doesn't match
- Normalizes comparison: case-insensitive, strips trailing FQDN dot
- Handles port stripping (existing behavior, preserved)

https://claude.ai/code/session_017DEMnqZkoRo973xws8qDpV