### PR TITLE
Log reason when domain validation returns 403

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -92,6 +92,9 @@ export const ErrorCode = {
   // Configuration errors
   CONFIG_MISSING: "E_CONFIG_MISSING",
 
+  // Domain validation errors
+  DOMAIN_REJECTED: "E_DOMAIN_REJECTED",
+
   // CDN/network errors (transient edge failures)
   CDN_REQUEST: "E_CDN_REQUEST",
 } as const;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,6 +13,7 @@ import {
   contentTypeRejectionResponse,
   domainRejectionResponse,
   getCleanUrl,
+  getDomainRejectionReason,
   isEmbeddablePath,
   isValidContentType,
   isValidDomain,
@@ -198,6 +199,7 @@ export const handleRequest = (
 
   // Domain validation: reject requests to unauthorized domains
   if (!isValidDomain(request)) {
+    logError({ code: ErrorCode.DOMAIN_REJECTED, detail: getDomainRejectionReason(request) });
     return logAndReturn(domainRejectionResponse(), method, path, getElapsed);
   }
 

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -93,6 +93,20 @@ export const isValidDomain = (request: Request): boolean => {
 };
 
 /**
+ * Build a privacy-safe rejection reason for domain validation failures.
+ * Includes the Host header and URL hostname so operators can diagnose
+ * why a request was rejected (e.g. Facebook in-app browser sending
+ * unexpected headers).
+ */
+export const getDomainRejectionReason = (request: Request): string => {
+  const host = request.headers.get("host");
+  const urlHost = new URL(request.url).host;
+  return host
+    ? `host=${normalizeHostname(host)} url=${normalizeHostname(urlHost)}`
+    : `host=missing url=${normalizeHostname(urlHost)}`;
+};
+
+/**
  * Check if path is a webhook endpoint that accepts JSON
  */
 export const isWebhookPath = (path: string): boolean =>

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -228,6 +228,7 @@ describe("logger", () => {
       expect(ErrorCode.AUTH_CSRF_MISMATCH).toBe("E_AUTH_CSRF_MISMATCH");
       expect(ErrorCode.STRIPE_SIGNATURE).toBe("E_STRIPE_SIGNATURE");
       expect(ErrorCode.WEBHOOK_SEND).toBe("E_WEBHOOK_SEND");
+      expect(ErrorCode.DOMAIN_REJECTED).toBe("E_DOMAIN_REJECTED");
     });
   });
 


### PR DESCRIPTION
Adds E_DOMAIN_REJECTED error code and logs the actual Host header
and URL hostname when a request is rejected, so the cause of 403s
(e.g. from Facebook in-app browser) is visible in Bunny logs.

https://claude.ai/code/session_01NtQukLK6jRxakQc9tTXr77