### PR TITLE
Add robots.txt endpoint with crawler restrictions

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -24,9 +24,11 @@ const minifiedCss = await minifyCss(rawCss);
 const JS = "application/javascript; charset=utf-8";
 const CSS = "text/css; charset=utf-8";
 const SVG = "image/svg+xml";
+const TEXT = "text/plain; charset=utf-8";
 
 /** Asset definitions: [filename, exportName, contentType, pathConstant] */
 const ASSET_DEFS: [string, string, string, string][] = [
+  ["robots.txt", "handleRobotsTxt", TEXT, ""],
   ["favicon.svg", "handleFavicon", SVG, ""],
   ["mvp.css", "handleMvpCss", CSS, "CSS_PATH"],
   ["admin.js", "handleAdminJs", JS, "JS_PATH"],

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -24,7 +24,9 @@ const staticHandler = (filename: string, contentType: string): (() => Response) 
 const JS = "application/javascript; charset=utf-8";
 const CSS = "text/css; charset=utf-8";
 const SVG = "image/svg+xml";
+const TEXT = "text/plain; charset=utf-8";
 
+export const handleRobotsTxt = staticHandler("robots.txt", TEXT);
 export const handleFavicon = staticHandler("favicon.svg", SVG);
 export const handleMvpCss = staticHandler("mvp.css", CSS);
 export const handleAdminJs = staticHandler("admin.js", JS);

--- a/src/routes/static.ts
+++ b/src/routes/static.ts
@@ -9,6 +9,7 @@ import {
   handleIframeResizerChildJs,
   handleIframeResizerParentJs,
   handleMvpCss,
+  handleRobotsTxt,
   handleScannerJs,
 } from "#routes/assets.ts";
 import { handleHealthCheck } from "#routes/health.ts";
@@ -17,6 +18,7 @@ import { createRouter, defineRoutes } from "#routes/router.ts";
 /** Static routes definition */
 const staticRoutes = defineRoutes({
   "GET /health": () => handleHealthCheck(),
+  "GET /robots.txt": () => handleRobotsTxt(),
   "GET /favicon.ico": () => handleFavicon(),
   "GET /mvp.css": () => handleMvpCss(),
   "GET /admin.js": () => handleAdminJs(),

--- a/src/static/robots.txt
+++ b/src/static/robots.txt
@@ -1,0 +1,6 @@
+User-agent: facebookexternalhit
+Allow: /events/
+Disallow: /
+
+User-agent: *
+Disallow: /

--- a/src/static/robots.txt
+++ b/src/static/robots.txt
@@ -1,6 +1,3 @@
-User-agent: facebookexternalhit
-Allow: /events/
-Disallow: /
-
 User-agent: *
+Allow: /events/
 Disallow: /

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -63,6 +63,45 @@ describe("server (public routes)", () => {
     });
   });
 
+  describe("GET /robots.txt", () => {
+    test("returns plain text robots.txt", async () => {
+      const response = await handleRequest(mockRequest("/robots.txt"));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe(
+        "text/plain; charset=utf-8",
+      );
+    });
+
+    test("allows facebookexternalhit on /events/", async () => {
+      const response = await handleRequest(mockRequest("/robots.txt"));
+      const body = await response.text();
+      expect(body).toContain("User-agent: facebookexternalhit");
+      expect(body).toContain("Allow: /events/");
+    });
+
+    test("disallows all other crawlers", async () => {
+      const response = await handleRequest(mockRequest("/robots.txt"));
+      const body = await response.text();
+      expect(body).toContain("User-agent: *");
+      expect(body).toContain("Disallow: /");
+    });
+
+    test("returns 404 for non-GET requests to /robots.txt", async () => {
+      const response = await awaitTestRequest("/robots.txt", {
+        method: "POST",
+        data: {},
+      });
+      expect(response.status).toBe(404);
+    });
+
+    test("has long cache headers", async () => {
+      const response = await handleRequest(mockRequest("/robots.txt"));
+      expect(response.headers.get("cache-control")).toBe(
+        "public, max-age=31536000, immutable",
+      );
+    });
+  });
+
   describe("GET /favicon.ico", () => {
     test("returns SVG favicon", async () => {
       const response = await handleRequest(mockRequest("/favicon.ico"));

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -72,17 +72,11 @@ describe("server (public routes)", () => {
       );
     });
 
-    test("allows facebookexternalhit on /events/", async () => {
-      const response = await handleRequest(mockRequest("/robots.txt"));
-      const body = await response.text();
-      expect(body).toContain("User-agent: facebookexternalhit");
-      expect(body).toContain("Allow: /events/");
-    });
-
-    test("disallows all other crawlers", async () => {
+    test("allows crawlers on /events/ but disallows everything else", async () => {
       const response = await handleRequest(mockRequest("/robots.txt"));
       const body = await response.text();
       expect(body).toContain("User-agent: *");
+      expect(body).toContain("Allow: /events/");
       expect(body).toContain("Disallow: /");
     });
 


### PR DESCRIPTION
## Summary
This PR adds a `/robots.txt` endpoint that controls search engine crawler access to the application. The robots.txt file allows crawlers to access the `/events/` path while disallowing access to all other routes.

## Key Changes
- Created `src/static/robots.txt` with directives to allow `/events/` and disallow all other paths
- Added `handleRobotsTxt` handler in `src/routes/assets.ts` using the existing `staticHandler` utility
- Registered the `GET /robots.txt` route in `src/routes/static.ts`
- Added comprehensive test coverage in `test/lib/server-public.test.ts` validating:
  - Correct HTTP 200 response with `text/plain; charset=utf-8` content type
  - Proper robots.txt directives in response body
  - HTTP 404 for non-GET requests
  - Long cache headers (`public, max-age=31536000, immutable`)

## Implementation Details
- Reused the existing `staticHandler` utility pattern for consistency with other static assets (favicon, CSS, JS)
- Added `TEXT` constant for `text/plain; charset=utf-8` content type
- Configured aggressive caching (1 year) with immutable flag, appropriate for static robots.txt content

https://claude.ai/code/session_015bHnqXduxdCuRNSkMBJvCo