### PR TITLE
Add FAQ section for public links sharing issues

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -173,6 +173,26 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
       </Section>
 
+      <Section title="Public Links">
+        <Q q="Why do I get a 403 error when sharing my link on Facebook?">
+          <p>
+            When you first share a link from a new domain on Facebook, Facebook
+            may return a 403 error. This is because Facebook doesn't recognise
+            the domain yet &mdash; the error comes from Facebook itself and
+            doesn't even reach your site.
+          </p>
+          <p>
+            To fix this, paste your public link into the{" "}
+            <a href="https://developers.facebook.com/tools/debug/">
+              Facebook Sharing Debugger
+            </a>{" "}
+            and click <strong>Scrape Again</strong> if the result looks wrong.
+            Once Facebook has successfully scraped the URL, future shares should
+            work normally.
+          </p>
+        </Q>
+      </Section>
+
       <Section title="Payments">
         <Q q="Which payment providers are supported?">
           <p>

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -41,6 +41,13 @@ describe("server (admin guide)", () => {
       expect(html).toContain("Check-in");
     });
 
+    test("contains public links section", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Public Links");
+      expect(html).toContain("Facebook Sharing Debugger");
+    });
+
     test("contains payment reservation info", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();


### PR DESCRIPTION
## Summary
Added a new "Public Links" section to the admin guide with a FAQ entry addressing Facebook sharing errors.

## Changes
- Added a new "Public Links" section to the admin guide template with a Q&A entry explaining 403 errors when sharing links on Facebook
- Included troubleshooting steps directing users to the Facebook Sharing Debugger tool
- Added corresponding test coverage to verify the new section and content are present in the rendered guide

## Implementation Details
- The new section is positioned between the existing sections in the guide hierarchy
- Includes a link to Facebook's official Sharing Debugger tool
- Explains that 403 errors originate from Facebook's domain verification process and provides clear resolution steps

https://claude.ai/code/session_01SSRrHDDsYE8LBJrzmrRZ6f