### PR TITLE
Add createRequire shim for CJS compatibility in Edge builds

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -216,8 +216,13 @@ const nodeExternals = [
 
 // Banner to inject Node.js globals that many packages expect (per Bunny docs)
 // process.env is populated by Bunny's native secrets at runtime
+// createRequire shim: npm packages bundled as CJS use require() for Node builtins
+// (e.g. Stripe SDK does require("crypto")); esbuild's CJS compat shim checks
+// typeof require, so a module-scoped `var require` makes it resolve correctly
 const NODEJS_GLOBALS_BANNER = `import * as process from "node:process";
 import { Buffer } from "node:buffer";
+import { createRequire as __createRequire } from "node:module";
+var require = __createRequire(import.meta.url);
 globalThis.process ??= process;
 globalThis.Buffer ??= Buffer;
 globalThis.global ??= globalThis;


### PR DESCRIPTION
## Summary
This change adds a `createRequire` shim to the Node.js globals banner in the Edge build configuration to properly support CommonJS packages that use `require()` for Node.js built-in modules.

## Key Changes
- Added `createRequire` import from `node:module` to the NODEJS_GLOBALS_BANNER
- Injected a module-scoped `var require` variable that uses `createRequire(import.meta.url)`
- Updated comments to explain the purpose of the shim for CJS compatibility

## Implementation Details
Many npm packages bundled as CommonJS (e.g., Stripe SDK) use `require()` to import Node.js built-ins like `crypto`. esbuild's CommonJS compatibility shim checks for the existence of `require` using `typeof require`. By providing a module-scoped `var require` variable, we ensure that esbuild's CJS compat layer can properly resolve these require calls in the Edge runtime environment.

https://claude.ai/code/session_01E6AyFz7NCZaxgqRvd6Mh1s