### PR TITLE
Fix intermittent CDN "error decoding response body" errors

### DIFF
--- a/src/edge/bunny-script.ts
+++ b/src/edge/bunny-script.ts
@@ -19,7 +19,7 @@ const initialize = once(async (): Promise<void> => {
 BunnySDK.net.http.serve(async (request: Request): Promise<Response> => {
   try {
     await initialize();
-    return handleRequest(request);
+    return await handleRequest(request);
   } catch (error) {
     // biome-ignore lint/suspicious/noConsole: Edge script error logging
     console.error("[Tickets] Request error:", error);

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -247,7 +247,9 @@ export const cloneResponse = async (
   response: Response,
   headers: Headers,
 ): Promise<Response> => {
-  const body = response.body ? await response.arrayBuffer() : null;
+  const body = response.body
+    ? new Uint8Array(await response.arrayBuffer())
+    : null;
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -2250,6 +2250,30 @@ describe("server (admin events)", () => {
       const result = await withCookie(response, "session=abc; Path=/");
       expect(result.status).toBe(201);
     });
+
+    test("preserves text response body", async () => {
+      const response = new Response("hello world", { status: 200 });
+      const result = await withCookie(response, "session=abc; Path=/");
+      expect(await result.text()).toBe("hello world");
+    });
+
+    test("preserves binary response body", async () => {
+      const bytes = new Uint8Array([0, 1, 2, 128, 255]);
+      const response = new Response(bytes, { status: 200 });
+      const result = await withCookie(response, "session=abc; Path=/");
+      const body = new Uint8Array(await result.arrayBuffer());
+      expect(body.length).toBe(5);
+      expect(body[0]).toBe(0);
+      expect(body[3]).toBe(128);
+      expect(body[4]).toBe(255);
+    });
+
+    test("handles null body response", async () => {
+      const response = new Response(null, { status: 204 });
+      const result = await withCookie(response, "session=abc; Path=/");
+      expect(result.status).toBe(204);
+      expect(result.headers.get("set-cookie")).toBe("session=abc; Path=/");
+    });
   });
 
   describe("daily event type", () => {


### PR DESCRIPTION
Two fixes for the Bunny Edge runtime:

1. cloneResponse: use Uint8Array instead of raw ArrayBuffer for
   materialized response bodies. The Bunny Edge runtime (Deno/Rust-based)
   intermittently fails to decode ArrayBuffer response bodies, producing
   "Unknown: error decoding response body" log entries and 400 responses
   to clients. Uint8Array is more reliably handled across edge runtimes.

2. Edge handler: add missing `await` before handleRequest() so that
   promise rejections are caught by the try/catch block instead of
   propagating as unhandled rejections to the CDN runtime.

https://claude.ai/code/session_01KPZLyZAaaeDbDkrwowqF1Z