### PR TITLE
Improve response handling and add cache-control headers

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -207,8 +207,10 @@ export const getCleanUrl = (url: URL): string | null => {
 };
 
 /**
- * Apply security headers to a response
+ * Apply security headers to a response.
  * For embeddable pages, fetches embed host restrictions and adds frame-ancestors.
+ * Adds Cache-Control: private, no-store to dynamic responses (those without
+ * an explicit cache-control header) to prevent CDN caching issues.
  */
 export const applySecurityHeaders = async (
   response: Response,
@@ -219,6 +221,12 @@ export const applySecurityHeaders = async (
 
   for (const [key, value] of Object.entries(securityHeaders)) {
     headers.set(key, value);
+  }
+
+  // Prevent CDN from caching dynamic responses — static assets already set
+  // their own cache-control (e.g. "public, max-age=31536000, immutable")
+  if (!response.headers.has("cache-control")) {
+    headers.set("cache-control", "private, no-store");
   }
 
   if (embeddable) {


### PR DESCRIPTION
## Summary
This PR improves response cloning and adds automatic cache-control headers to prevent CDN caching issues with dynamic responses.

## Key Changes

- **Enhanced response cloning logic**: Modified `cloneResponse()` to intelligently handle text vs. binary content:
  - Text responses (content-type: `text/*` or `application/json`) now use `response.text()` to maintain body as a JS string
  - Binary responses (images, etc.) continue using `Uint8Array` via `arrayBuffer()`
  - This avoids Deno's `readableStreamCollectIntoUint8Array` path which can intermittently fail with "error decoding response body" on edge runtimes
  - Added early return for responses without a body

- **Automatic cache-control headers**: Added logic to `applySecurityHeaders()` to set `Cache-Control: private, no-store` on dynamic responses that don't already have an explicit cache-control header
  - Prevents CDN from caching dynamic content
  - Allows static assets to maintain their own cache-control directives (e.g., "public, max-age=31536000, immutable")

## Implementation Details

- Added `TEXT_CONTENT_TYPES` constant and `isTextContentType()` helper to identify text-based content
- Updated JSDoc comments to explain the rationale for text vs. binary handling
- Cache-control header is only applied when not already present, preserving explicit cache directives

https://claude.ai/code/session_01MV34UtycQRgqPV8FfzCqBX