### PR TITLE
Fix dark mode and reorder theme setting before reset database

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -26,19 +26,17 @@
   --width-content: 1300px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root[color-mode="user"] {
-    --color-accent: #0097fc4f;
-    --color-bg: #333;
-    --color-bg-secondary: #555;
-    --color-link: #0097fc;
-    --color-secondary: #e20de9;
-    --color-secondary-accent: #e20de94f;
-    --color-shadow: #bbbbbb20;
-    --color-table: #0097fc;
-    --color-text: #f7f7f7;
-    --color-text-secondary: #aaa;
-  }
+:root[data-theme="dark"] {
+  --color-accent: #0097fc4f;
+  --color-bg: #333;
+  --color-bg-secondary: #555;
+  --color-link: #0097fc;
+  --color-secondary: #e20de9;
+  --color-secondary-accent: #e20de94f;
+  --color-shadow: #bbbbbb20;
+  --color-table: #0097fc;
+  --color-text: #f7f7f7;
+  --color-text-secondary: #aaa;
 }
 
 html {
@@ -687,15 +685,13 @@ article > h2:first-child {
   margin-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root[color-mode="user"] .error {
-    background: #442222;
-    color: #ff6666;
-  }
-  :root[color-mode="user"] .success {
-    background: #224422;
-    color: #66ff66;
-  }
+[data-theme="dark"] .error {
+  background: #442222;
+  color: #ff6666;
+}
+[data-theme="dark"] .success {
+  background: #224422;
+  color: #66ff66;
 }
 
 /* Danger elements */
@@ -722,12 +718,10 @@ input[type="submit"].danger:hover {
   border-color: var(--color-danger-hover);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root[color-mode="user"] .danger,
-  :root[color-mode="user"] a.danger {
-    --color-danger: #ff4444;
-    --color-danger-hover: #cc0000;
-  }
+[data-theme="dark"] .danger,
+[data-theme="dark"] a.danger {
+  --color-danger: #ff4444;
+  --color-danger-hover: #cc0000;
 }
 
 /* Agreement/disclaimer styling */
@@ -753,16 +747,14 @@ fieldset.agreement {
   border-radius: 999px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root[color-mode="user"] .password-warning {
-    color: #ff4444;
-  }
-  :root[color-mode="user"] .danger-text {
-    color: #ff4444;
-  }
-  :root[color-mode="user"] .badge-refunded {
-    background-color: #ff4444;
-  }
+[data-theme="dark"] .password-warning {
+  color: #ff4444;
+}
+[data-theme="dark"] .danger-text {
+  color: #ff4444;
+}
+[data-theme="dark"] .badge-refunded {
+  background-color: #ff4444;
 }
 
 /* Bulk check-in / check-out button */
@@ -957,11 +949,9 @@ button.secondary:hover {
   border-color: var(--color-secondary-hover);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root[color-mode="user"] button.secondary {
-    --color-secondary: #888;
-    --color-secondary-hover: #aaa;
-  }
+[data-theme="dark"] button.secondary {
+  --color-secondary: #888;
+  --color-secondary-hover: #aaa;
 }
 
 /* Ticket slider */
@@ -1035,10 +1025,8 @@ button.secondary:hover {
   height: auto;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root[color-mode="user"] .ticket-card {
-    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
-  }
+[data-theme="dark"] .ticket-card {
+  box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* Owner debug footer */

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -194,28 +194,6 @@ export const adminSettingsPage = (
           <button type="submit">Change Password</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/reset-database" csrfToken={session.csrfToken}>
-            <h2>Reset Database</h2>
-          <article>
-            <aside>
-              <p><strong>Warning:</strong> This will permanently delete all events, attendees, settings, and other data. This action cannot be undone.</p>
-            </aside>
-          </article>
-          <p>To reset the database, type the following phrase into the box below:</p>
-          <p><strong>"The site will be fully reset and all data will be lost."</strong></p>
-          <label for="confirm_phrase">Confirmation phrase</label>
-          <input
-            type="text"
-            id="confirm_phrase"
-            name="confirm_phrase"
-            autocomplete="off"
-            required
-          />
-          <button type="submit" class="danger">
-            Reset Database
-          </button>
-        </CsrfForm>
-
         <CsrfForm action="/admin/settings/theme" csrfToken={session.csrfToken}>
             <h2>Site Theme</h2>
           <p>Choose between light and dark themes for the site interface.</p>
@@ -240,6 +218,28 @@ export const adminSettingsPage = (
             </label>
           </fieldset>
           <button type="submit">Save Theme</button>
+        </CsrfForm>
+
+        <CsrfForm action="/admin/settings/reset-database" csrfToken={session.csrfToken}>
+            <h2>Reset Database</h2>
+          <article>
+            <aside>
+              <p><strong>Warning:</strong> This will permanently delete all events, attendees, settings, and other data. This action cannot be undone.</p>
+            </aside>
+          </article>
+          <p>To reset the database, type the following phrase into the box below:</p>
+          <p><strong>"The site will be fully reset and all data will be lost."</strong></p>
+          <label for="confirm_phrase">Confirmation phrase</label>
+          <input
+            type="text"
+            id="confirm_phrase"
+            name="confirm_phrase"
+            autocomplete="off"
+            required
+          />
+          <button type="submit" class="danger">
+            Reset Database
+          </button>
         </CsrfForm>
     </Layout>
   );

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -30,7 +30,7 @@ export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutP
   return new SafeHtml(
     "<!DOCTYPE html>" +
     (
-      <html lang="en">
+      <html lang="en" data-theme={theme || "light"}>
         <head>
           <meta charset="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -39,7 +39,7 @@ export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutP
           <Raw html={themeStyle} />
           {headExtra && <Raw html={headExtra} />}
         </head>
-        <body class={bodyClass || undefined} data-theme={theme || "light"}>
+        <body class={bodyClass || undefined}>
           <main>
             {children}
           </main>


### PR DESCRIPTION
Dark mode wasn't working because mvp.css dark styles were gated behind
@media (prefers-color-scheme: dark) with :root[color-mode="user"] - a
selector never matched. Replace with [data-theme="dark"] selectors and
move data-theme attribute from <body> to <html> (:root) so CSS variable
overrides take effect.

Also move the Site Theme form before Reset Database on the settings page.

https://claude.ai/code/session_01DUZnTCRKrPmNRUvA4Z9mer