### PR TITLE
Add "Show events on homepage" setting

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -50,6 +50,8 @@ export const CONFIG_KEYS = {
   BUSINESS_EMAIL: "business_email",
   // Theme setting (plaintext - light or dark)
   THEME: "theme",
+  // Show events on homepage (plaintext - "true" or "false")
+  SHOW_EVENTS_ON_HOMEPAGE: "show_events_on_homepage",
 } as const;
 
 /**
@@ -537,6 +539,22 @@ export const updateTheme = async (theme: string): Promise<void> => {
 };
 
 /**
+ * Get the "show events on homepage" setting from database.
+ * Returns true if the setting is "true", false otherwise.
+ */
+export const getShowEventsOnHomepageFromDb = async (): Promise<boolean> => {
+  const value = await getSetting(CONFIG_KEYS.SHOW_EVENTS_ON_HOMEPAGE);
+  return value === "true";
+};
+
+/**
+ * Update the "show events on homepage" setting.
+ */
+export const updateShowEventsOnHomepage = async (show: boolean): Promise<void> => {
+  await setSetting(CONFIG_KEYS.SHOW_EVENTS_ON_HOMEPAGE, show ? "true" : "false");
+};
+
+/**
  * Stubbable API for testing - allows mocking in ES modules
  * Use spyOn(settingsApi, "method") instead of spyOn(settingsModule, "method")
  */
@@ -576,4 +594,6 @@ export const settingsApi = {
   updateTimezone,
   getThemeFromDb,
   updateTheme,
+  getShowEventsOnHomepageFromDb,
+  updateShowEventsOnHomepage,
 };

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -8,6 +8,7 @@ import {
   clearPaymentProvider,
   getEmbedHostsFromDb,
   getPaymentProviderFromDb,
+  getShowEventsOnHomepageFromDb,
   getStripeWebhookEndpointId,
   getTermsAndConditionsFromDb,
   getThemeFromDb,
@@ -18,6 +19,7 @@ import {
   setPaymentProvider,
   setStripeWebhookConfig,
   updateEmbedHosts,
+  updateShowEventsOnHomepage,
   updateSquareAccessToken,
   updateSquareLocationId,
   updateSquareWebhookSignatureKey,
@@ -81,6 +83,7 @@ const getSettingsPageState = async () => {
   const timezone = await getTimezoneFromDb();
   const businessEmail = await getBusinessEmailFromDb();
   const theme = await getThemeFromDb();
+  const showEventsOnHomepage = await getShowEventsOnHomepageFromDb();
   return {
     stripeKeyConfigured,
     paymentProvider,
@@ -92,6 +95,7 @@ const getSettingsPageState = async () => {
     timezone,
     businessEmail,
     theme,
+    showEventsOnHomepage,
   };
 };
 
@@ -116,6 +120,7 @@ const renderSettingsPage = async (
     state.timezone,
     state.businessEmail,
     state.theme,
+    state.showEventsOnHomepage,
   );
 };
 
@@ -437,6 +442,20 @@ const processThemeForm: SettingsFormHandler = async (form, errorPage) => {
 /** Handle POST /admin/settings/theme - owner only */
 const handleThemePost = settingsRoute(processThemeForm);
 
+/** Validate and save show-events-on-homepage from form submission */
+const processShowEventsOnHomepageForm: SettingsFormHandler = async (form) => {
+  const value = form.get("show_events_on_homepage") === "true";
+  await updateShowEventsOnHomepage(value);
+  await logActivity(`Show events on homepage ${value ? "enabled" : "disabled"}`);
+  return redirectWithSuccess(
+    "/admin/settings",
+    value ? "Events will now be shown on the homepage" : "Homepage will redirect to admin",
+  );
+};
+
+/** Handle POST /admin/settings/show-events-on-homepage - owner only */
+const handleShowEventsOnHomepagePost = settingsRoute(processShowEventsOnHomepageForm);
+
 /**
  * Expected confirmation phrase for database reset
  */
@@ -476,5 +495,6 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/timezone": handleTimezonePost,
   "POST /admin/settings/business-email": handleBusinessEmailPost,
   "POST /admin/settings/theme": handleThemePost,
+  "POST /admin/settings/show-events-on-homepage": handleShowEventsOnHomepagePost,
   "POST /admin/settings/reset-database": handleResetDatabasePost,
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -34,8 +34,8 @@ const loadAdminRoutes = once(async () => {
 
 /** Lazy-load public routes (ticket reservation) */
 const loadPublicRoutes = once(async () => {
-  const { handleHome, routeTicket } = await import("#routes/public.ts");
-  return { handleHome, routeTicket };
+  const { handleHome, handleHomePost, routeTicket } = await import("#routes/public.ts");
+  return { handleHome, handleHomePost, routeTicket };
 });
 
 /** Lazy-load setup routes */
@@ -101,10 +101,12 @@ const createLazyRoute =
   };
 
 /** Route home page requests */
-const routeHome: RouterFn = async (_, path, method) => {
-  if (path !== "/" || method !== "GET") return null;
-  const { handleHome } = await loadPublicRoutes();
-  return handleHome();
+const routeHome: RouterFn = async (request, path, method) => {
+  if (path !== "/") return null;
+  const { handleHome, handleHomePost } = await loadPublicRoutes();
+  if (method === "GET") return handleHome();
+  if (method === "POST") return handleHomePost(request);
+  return null;
 };
 
 /** Lazy-loaded route handlers */

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1040,3 +1040,10 @@ button.secondary:hover {
   font-family: monospace;
   font-size: small;
 }
+
+/* Homepage footer (Login link) */
+.homepage-footer {
+  margin-top: 5rem;
+  font-size: smaller;
+  opacity: 0.6;
+}

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -31,6 +31,7 @@ export const adminSettingsPage = (
   timezone?: string,
   businessEmail?: string,
   theme?: string,
+  showEventsOnHomepage?: boolean,
 ): string =>
   String(
     <Layout title="Settings" theme={theme}>
@@ -192,6 +193,32 @@ export const adminSettingsPage = (
           <p>Changing your password will log you out of all sessions.</p>
           <Raw html={renderFields(changePasswordFields)} />
           <button type="submit">Change Password</button>
+        </CsrfForm>
+
+        <CsrfForm action="/admin/settings/show-events-on-homepage" csrfToken={session.csrfToken}>
+            <h2>Show events on homepage?</h2>
+          <p>When enabled, the homepage will display all upcoming active events as a booking page instead of redirecting to the admin area.</p>
+          <fieldset>
+            <label>
+              <input
+                type="radio"
+                name="show_events_on_homepage"
+                value="true"
+                checked={showEventsOnHomepage === true}
+              />
+              Yes
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="show_events_on_homepage"
+                value="false"
+                checked={showEventsOnHomepage !== true}
+              />
+              No
+            </label>
+          </fieldset>
+          <button type="submit">Save</button>
         </CsrfForm>
 
         <CsrfForm action="/admin/settings/theme" csrfToken={session.csrfToken}>


### PR DESCRIPTION
When enabled, the homepage displays all active events as a multi-event
booking page instead of redirecting to /admin/. Shows a "No events
listed" message when no active events exist. Includes a Login link
styled like the debug footer at the bottom of the page.

https://claude.ai/code/session_01BkagFLxypFHp2bVFUEbqzT