### PR TITLE
Fix dark mode to apply globally and constrain description column text

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,35 @@
+/**
+ * Theme state for sync access by JSX templates
+ *
+ * The theme is loaded from settings and stored for sync access
+ * by the Layout component. Called once per request in routes/index.ts
+ * before templates render.
+ */
+
+import { getThemeFromDb } from "#lib/db/settings.ts";
+
+/** Sync-accessible theme, populated by loadTheme() */
+const state = { theme: "light" };
+
+/**
+ * Load theme from settings into sync-accessible state.
+ * Called once per request in routes/index.ts before templates render.
+ * Settings are already cached so this is cheap on repeat calls.
+ */
+export const loadTheme = async (): Promise<string> => {
+  state.theme = await getThemeFromDb();
+  return state.theme;
+};
+
+/** Get the current theme ("light" or "dark") */
+export const getTheme = (): string => state.theme;
+
+/** For testing: set the theme directly */
+export const setThemeForTest = (t: string): void => {
+  state.theme = t;
+};
+
+/** For testing: reset the theme to default */
+export const resetTheme = (): void => {
+  state.theme = "light";
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@
 import { once } from "#fp";
 import { isSetupComplete } from "#lib/config.ts";
 import { loadCurrencyCode } from "#lib/currency.ts";
+import { loadTheme } from "#lib/theme.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { createRequestTimer, ErrorCode, logError, logRequest, runWithRequestId } from "#lib/logger.ts";
 import {
@@ -163,6 +164,7 @@ const handleRequestInternal = async (
   }
 
   await loadCurrencyCode();
+  await loadTheme();
   return (await routeMainApp(request, path, method, server))!;
 };
 

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -620,6 +620,13 @@ table input {
   margin: 0;
 }
 
+td.cell-description {
+  font-size: 0.85em;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Quotes */
 blockquote {
   display: block;

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -17,7 +17,7 @@ export const EventRow = ({ e }: { e: EventWithCount }): string => {
   return String(
     <tr style={rowStyle || undefined}>
       <td><Raw html={renderEventImage(e, "event-thumbnail")} /><a href={`/admin/event/${e.id}`}>{e.name}</a></td>
-      <td>{e.description}</td>
+      <td class="cell-description">{e.description}</td>
       <td>{isInactive ? "Inactive" : "Active"}</td>
       <td>{e.attendee_count} / {e.max_attendees}</td>
       <td>{new Date(e.created).toLocaleDateString()}</td>

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -4,6 +4,7 @@
 
 import { type Child, Raw, SafeHtml } from "#jsx/jsx-runtime.ts";
 import { CSS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
+import { getTheme } from "#lib/theme.ts";
 
 export const escapeHtml = (str: string): string =>
   str
@@ -24,13 +25,14 @@ interface LayoutProps {
  * Wrap content in MVP.css semantic HTML layout
  */
 export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutProps): SafeHtml => {
-  const colorScheme = theme === "dark" ? "dark" : "light";
+  const resolvedTheme = theme ?? getTheme();
+  const colorScheme = resolvedTheme === "dark" ? "dark" : "light";
   const themeStyle = `<style>html { color-scheme: ${colorScheme}; }</style>`;
 
   return new SafeHtml(
     "<!DOCTYPE html>" +
     (
-      <html lang="en" data-theme={theme || "light"}>
+      <html lang="en" data-theme={resolvedTheme}>
         <head>
           <meta charset="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -261,6 +261,9 @@ describe("code quality", () => {
       // Reset cached currency code between tests
       "lib/currency.ts:setCurrencyCodeForTest",
       "lib/currency.ts:resetCurrencyCode",
+      // Reset cached theme between tests
+      "lib/theme.ts:setThemeForTest",
+      "lib/theme.ts:resetTheme",
       // Token format check used by CSRF tests (production verifies via verifySignedCsrfToken)
       "lib/csrf.ts:isSignedCsrfToken",
       // Response cookie helper used by auth tests (production sets cookies directly)

--- a/test/lib/theme.test.ts
+++ b/test/lib/theme.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import {
+  getTheme,
+  loadTheme,
+  resetTheme,
+  setThemeForTest,
+} from "#lib/theme.ts";
+import { createTestDbWithSetup, resetDb, setupTestEncryptionKey } from "#test-utils";
+import { updateTheme } from "#lib/db/settings.ts";
+
+describe("theme", () => {
+  afterEach(() => {
+    resetTheme();
+  });
+
+  describe("getTheme", () => {
+    test("defaults to light", () => {
+      expect(getTheme()).toBe("light");
+    });
+
+    test("returns value set by setThemeForTest", () => {
+      setThemeForTest("dark");
+      expect(getTheme()).toBe("dark");
+    });
+  });
+
+  describe("resetTheme", () => {
+    test("resets to light after being set to dark", () => {
+      setThemeForTest("dark");
+      resetTheme();
+      expect(getTheme()).toBe("light");
+    });
+  });
+
+  describe("loadTheme", () => {
+    beforeEach(async () => {
+      setupTestEncryptionKey();
+      await createTestDbWithSetup();
+      resetTheme();
+    });
+
+    afterEach(() => {
+      resetDb();
+    });
+
+    test("loads light theme from database by default", async () => {
+      const theme = await loadTheme();
+      expect(theme).toBe("light");
+    });
+
+    test("loads dark theme after updating database", async () => {
+      await updateTheme("dark");
+      const theme = await loadTheme();
+      expect(theme).toBe("dark");
+    });
+
+    test("makes theme available via getTheme after loading", async () => {
+      await updateTheme("dark");
+      await loadTheme();
+      expect(getTheme()).toBe("dark");
+    });
+  });
+});


### PR DESCRIPTION
Dark mode was only working on the settings page because it was the only
page passing the theme prop to Layout. Create a theme state module
(following the loadCurrencyCode pattern) so Layout reads the theme from
sync state loaded once per request, making dark mode work on all pages.

Also add cell-description CSS class to constrain the description column
in the events table with smaller font-size, max-width, and ellipsis
overflow.

https://claude.ai/code/session_01XUfyoGz4scruXJ5Uya1nWu