### PR TITLE
Remove border from fieldset elements in mvp.css

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -867,7 +867,7 @@ body.iframe form {
   padding-left: 0;
 }
 
-/* Checkbox group (used by form framework) */
+fieldset,
 .checkbox-group {
   border: 0;
   padding: 0;

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -867,7 +867,10 @@ body.iframe form {
   padding-left: 0;
 }
 
-fieldset,
+fieldset {
+  border: 0;
+}
+
 .checkbox-group {
   border: 0;
   padding: 0;


### PR DESCRIPTION
Adds fieldset to the existing border-reset rule so radio and checkbox
groups (e.g. dark mode, payment provider, homepage toggle) no longer
render with the default browser fieldset border.

https://claude.ai/code/session_01NcUK98VThRvDqps7p7U3VA