### PR TITLE
Optimize attendee decryption by skipping unused contact fields

### DIFF
--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -27,7 +27,7 @@ import type { AdminSession, Attendee, EventWithCount, Group } from "#lib/types.t
 import type { EventEditFormValues, EventFormValues } from "#templates/fields.ts";
 import { defineRoutes } from "#routes/router.ts";
 import type { RouteParamsFor, TypedRouteHandler } from "#routes/router.ts";
-import { csvResponse, getDateFilter, verifyIdentifier, withEventAttendeesAuth } from "#routes/admin/utils.ts";
+import { csvResponse, type DecryptMode, getDateFilter, verifyIdentifier, withEventAttendeesAuth } from "#routes/admin/utils.ts";
 import {
   formDataToParams,
   htmlResponse,
@@ -172,9 +172,10 @@ const withEventAttendees = (
   request: Request,
   eventId: number,
   handler: (ctx: { event: EventWithCount; attendees: Attendee[]; session: AdminSession }) => Response | Promise<Response>,
+  mode: DecryptMode = "full",
 ): Promise<Response> =>
   withEventAttendeesAuth(request, eventId, (event, attendees, session) =>
-    handler({ event, attendees, session }));
+    handler({ event, attendees, session }), mode);
 
 /**
  * Handle GET /admin/event/new (show create event form)
@@ -262,7 +263,7 @@ const renderEventPage = async (request: Request, { id }: { id: number }, activeF
         imageError,
       }),
     );
-  });
+  }, "table");
 };
 
 /** Render event error page */


### PR DESCRIPTION
## Summary
This PR introduces selective decryption of attendee contact fields to reduce expensive RSA decryption operations. Instead of always decrypting all fields, the system now only decrypts contact fields that are configured on the event, and skips payment fields for free events.

## Key Changes

- **New `decryptAttendeesForTable` function**: Decrypts attendees while selectively decrypting only contact fields specified in `eventFields`. Unneeded fields are set to empty strings, avoiding unnecessary RSA+AES hybrid decryption operations.

- **Refactored `decryptAttendee` to `decryptAttendeeFields`**: Internal function now accepts `activeFields` (a set of contact fields to decrypt) and `paidEvent` flag to conditionally skip payment field decryption.

- **New `DecryptMode` type**: Distinguishes between "full" decryption (all fields) and "table" decryption (only configured fields). Updated `withDecryptedAttendees` and `withEventAttendeesAuth` to accept a mode parameter.

- **Updated calendar and events routes**: Modified to use `decryptAttendeesForTable` with merged event fields and paid event detection, reducing decryption overhead when displaying attendee lists.

- **Helper utilities**: Added `mergeEventFields` usage in calendar route to combine fields from multiple events and determine if any are paid.

## Implementation Details

- Core fields (`name`, `ticket_token`, `checked_in`) are always decrypted regardless of configuration
- Payment fields (`payment_id`, `refunded`, `price_paid`) are only decrypted when `paidEvent` is true
- Contact fields (`email`, `phone`, `address`, `special_instructions`) are only decrypted if present in the `eventFields` set
- For a free event collecting only email, this saves up to 6 RSA decryptions per attendee (phone, address, special_instructions, payment_id, refunded, plus 1 symmetric for price_paid)
- Comprehensive test coverage added for all decryption scenarios

https://claude.ai/code/session_01XYvGhVosKN9NkmjMdeWQvb