### PR TITLE
Avoid re-reading response bodies by mutating headers in-place

### DIFF
--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -73,6 +73,8 @@ export const routeAdmin: RouterFn = async (request, path, method, server) => {
     performance.now() - startTime,
     getQueryLog(),
   );
+  // Delete content-length so the runtime recalculates it for the modified body
+  response.headers.delete("content-length");
   return new Response(html.replace("</body>", footer + "</body>"), {
     status: response.status,
     headers: response.headers,

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -239,51 +239,13 @@ export const getSearchParam = (
   return url.searchParams.get(key) ?? "";
 };
 
-/** Content-type prefixes that represent text (safe to read via response.text()) */
-const TEXT_CONTENT_TYPES = ["text/", "application/json"];
-
-/** Check if a content-type header value represents text content */
-const isTextContentType = (contentType: string): boolean =>
-  TEXT_CONTENT_TYPES.some((prefix) => contentType.startsWith(prefix));
-
 /**
- * Clone a response with new headers, materializing the body to avoid
- * ReadableStream pass-through issues on Bunny Edge.
- *
- * Text responses use response.text() to keep the body as a JS string,
- * avoiding Deno's readableStreamCollectIntoUint8Array path which can
- * intermittently fail with "error decoding response body" on edge runtimes.
- * Binary responses (images etc.) still use Uint8Array.
+ * Add cookie header to response.
+ * Mutates headers in-place to avoid re-reading the response body.
  */
-export const cloneResponse = async (
-  response: Response,
-  headers: Headers,
-): Promise<Response> => {
-  if (!response.body) {
-    return new Response(null, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  }
-  const contentType = response.headers.get("content-type") ?? "";
-  const body = isTextContentType(contentType)
-    ? await response.text()
-    : new Uint8Array(await response.arrayBuffer());
-  return new Response(body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-};
-
-/**
- * Add cookie header to response
- */
-export const withCookie = (response: Response, cookie: string): Promise<Response> => {
-  const headers = new Headers(response.headers);
-  headers.append("set-cookie", cookie);
-  return cloneResponse(response, headers);
+export const withCookie = (response: Response, cookie: string): Response => {
+  response.headers.append("set-cookie", cookie);
+  return response;
 };
 
 /** Handler function that takes a value and returns a Response */


### PR DESCRIPTION
## Summary
This PR eliminates unnecessary response body re-reading by mutating response headers in-place instead of cloning responses. This addresses intermittent "error decoding response body" failures on Bunny Edge runtime.

## Key Changes
- **Removed `cloneResponse()` function** from `src/routes/utils.ts` that was materializing response bodies to work around ReadableStream issues
- **Simplified `withCookie()`** to directly mutate the response headers and return the response synchronously, eliminating the need to re-read the body
- **Updated `applySecurityHeaders()`** in `src/routes/middleware.ts` to mutate response headers in-place instead of creating a new Headers object and cloning the response
- **Added explicit `content-length` deletion** in `src/routes/admin/index.ts` when modifying response body, allowing the runtime to recalculate it

## Implementation Details
- All header mutations now happen directly on `response.headers` rather than creating intermediate `Headers` objects
- The `hasCacheControl` check is performed before setting security headers to avoid redundant header lookups
- CSP header construction now reads from the response headers directly instead of the intermediate headers object
- These changes maintain the same security and functionality while avoiding the body materialization that was causing edge runtime failures

https://claude.ai/code/session_01E5CvnmAwfnH2Go3JYAY7xP