### PR TITLE
Migrate inline styles to CSS classes for better maintainability

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -146,8 +146,8 @@ if (btn instanceof HTMLButtonElement) {
     const resultDiv = document.getElementById("stripe-test-result")!;
     btn.disabled = true;
     btn.textContent = "Testing...";
-    resultDiv.style.display = "none";
-    resultDiv.className = "";
+    resultDiv.classList.add("hidden");
+    resultDiv.classList.remove("success", "error");
     try {
       const csrfInput = btn.closest("form")?.querySelector<HTMLInputElement>('input[name="csrf_token"]');
       const csrfToken = csrfInput?.value ?? "";
@@ -178,13 +178,12 @@ if (btn instanceof HTMLButtonElement) {
         );
       }
       resultDiv.textContent = lines.join("\n");
-      resultDiv.className = data.ok ? "success" : "error";
-      resultDiv.style.display = "block";
-      resultDiv.style.whiteSpace = "pre-wrap";
+      resultDiv.classList.remove("hidden", "success", "error");
+      resultDiv.classList.add(data.ok ? "success" : "error", "stripe-test-result");
     } catch (e) {
       resultDiv.textContent = `Connection test failed: ${e instanceof Error ? e.message : "Unknown error"}`;
-      resultDiv.className = "error";
-      resultDiv.style.display = "block";
+      resultDiv.classList.remove("hidden", "success", "error");
+      resultDiv.classList.add("error", "stripe-test-result");
     }
     btn.disabled = false;
     btn.textContent = "Test Connection";

--- a/src/client/scanner.js
+++ b/src/client/scanner.js
@@ -33,31 +33,16 @@ const postScan = async (eventId, token, csrfToken, force) => {
   return res.json();
 };
 
-/** Status type style mappings (inline to avoid CSP issues with style tags) */
-const STATUS_STYLES = {
-  success: { bg: "#d4edda", color: "#155724", border: "#c3e6cb" },
-  warning: { bg: "#fff3cd", color: "#856404", border: "#ffeeba" },
-  error: { bg: "#f8d7da", color: "#721c24", border: "#f5c6cb" },
-};
-
 const formatTicketCount = (count) => {
   const safeCount = Number.isFinite(count) ? count : 1;
   return `${safeCount} ticket${safeCount === 1 ? "" : "s"}`;
 };
 
-/** Show a status message with color */
+/** Show a status message with color via CSS classes */
 const showStatus = (el, message, type) => {
-  const s = STATUS_STYLES[type];
   el.textContent = message;
-  el.style.display = "block";
-  el.style.padding = "0.75rem 1rem";
-  el.style.borderRadius = "4px";
-  el.style.marginBottom = "1rem";
-  el.style.fontWeight = "bold";
-  el.style.fontSize = "1.1rem";
-  el.style.background = s.bg;
-  el.style.color = s.color;
-  el.style.border = `1px solid ${s.border}`;
+  el.classList.remove("hidden", "scanner-status-success", "scanner-status-warning", "scanner-status-error");
+  el.classList.add("scanner-status", `scanner-status-${type}`);
 };
 
 /** Handle a scan result and display status */
@@ -184,8 +169,8 @@ const init = () => {
       });
       video.srcObject = stream;
       await video.play();
-      startBtn.style.display = "none";
-      video.style.display = "block";
+      startBtn.classList.add("hidden");
+      video.classList.remove("hidden");
       showStatus(statusEl, "Scanning...", "success");
       startScanner(video, canvas, statusEl, eventId, csrfToken);
     } catch {

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1057,3 +1057,47 @@ button.secondary:hover {
   font-size: smaller;
   opacity: 0.6;
 }
+
+/* Scanner video element */
+#scanner-video {
+  width: 100%;
+  max-width: 500px;
+  border-radius: 4px;
+}
+
+/* Inactive dashboard row */
+.inactive-row {
+  opacity: 0.5;
+}
+
+/* Scanner status messages */
+.scanner-status {
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.scanner-status-success {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.scanner-status-warning {
+  background: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
+}
+
+.scanner-status-error {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+/* Stripe test result */
+.stripe-test-result {
+  white-space: pre-wrap;
+}

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -13,9 +13,8 @@ const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 export const EventRow = ({ e }: { e: EventWithCount }): string => {
   const isInactive = !e.active;
-  const rowStyle = isInactive ? 'opacity: 0.5;' : '';
   return String(
-    <tr style={rowStyle || undefined}>
+    <tr class={isInactive ? "inactive-row" : undefined}>
       <td><Raw html={renderEventImage(e, "event-thumbnail")} /><a href={`/admin/event/${e.id}`}>{e.name}</a></td>
       <td class="cell-description">{e.description}</td>
       <td>{isInactive ? "Inactive" : "Active"}</td>

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -24,14 +24,14 @@ export const adminScannerPage = (
       <p><a href={`/admin/event/${event.id}`}>&larr; {event.name}</a></p>
 
       <article>
-        <div id="scanner-status" style="display:none"></div>
+        <div id="scanner-status" class="hidden"></div>
 
         <video
           id="scanner-video"
           data-event-id={String(event.id)}
           playsinline
           muted
-          style="display:none; width:100%; max-width:500px; border-radius:4px"
+          class="hidden"
         ></video>
 
         <button id="scanner-start" type="button">

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1048,7 +1048,7 @@ describe("html", () => {
     test("renders inactive event with reduced opacity", () => {
       const events = [testEventWithCount({ active: false, attendee_count: 5 })];
       const html = adminDashboardPage(events, TEST_SESSION, "localhost");
-      expect(html).toContain("opacity: 0.5");
+      expect(html).toContain("inactive-row");
       expect(html).toContain("Inactive");
     });
   });


### PR DESCRIPTION
## Summary
This PR refactors the codebase to move inline styles from JavaScript and template files into dedicated CSS classes in the stylesheet. This improves maintainability, reduces code duplication, and makes styling changes easier to manage in a centralized location.

## Key Changes
- **CSS Stylesheet Updates** (`mvp.css`):
  - Added `.scanner-video` class for video element styling
  - Added `.inactive-row` class for dashboard row opacity
  - Added `.scanner-status` base class and three status variants (`.scanner-status-success`, `.scanner-status-warning`, `.scanner-status-error`) for scanner status messages
  - Added `.stripe-test-result` class for test result formatting

- **Scanner Module** (`scanner.js`):
  - Removed inline `STATUS_STYLES` object that defined color values
  - Refactored `showStatus()` function to use CSS classes instead of inline style assignments
  - Updated visibility toggles to use `.hidden` class instead of `display` style manipulation

- **Admin Module** (`admin.ts`):
  - Replaced inline style assignments with CSS class manipulation for result div visibility and formatting
  - Updated Stripe test result display to use `.stripe-test-result` class

- **Templates**:
  - Removed inline `style` attributes from scanner status div and video element in `scanner.tsx`
  - Replaced inline opacity style with `.inactive-row` class in `dashboard.tsx`

- **Tests**:
  - Updated test assertion to check for `inactive-row` class instead of inline opacity style

## Implementation Details
- All styling logic is now centralized in the CSS file, making it easier to adjust colors, spacing, and other visual properties
- JavaScript code is simplified by removing style object definitions and inline style assignments
- Uses CSS class toggling via `classList` API for better performance and cleaner code
- Maintains the same visual appearance and functionality while improving code organization

https://claude.ai/code/session_01BnGy193Fi27ctpS6obFUqk