### PR TITLE
Refactor CSRF token handling to use module-scoped store

### DIFF
--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -13,6 +13,9 @@ import { nowMs } from "#lib/now.ts";
 const SIGNED_PREFIX = "s1.";
 const DEFAULT_MAX_AGE_S = 3600; // 1 hour
 
+/** Most recently generated CSRF token, readable synchronously by CsrfForm */
+const _tokenStore = { value: "" };
+
 /** Default message for invalid/expired CSRF form submissions */
 export const CSRF_INVALID_FORM_MESSAGE =
   "Invalid or expired form. Please try again.";
@@ -31,8 +34,12 @@ export const signCsrfToken = async (): Promise<string> => {
   const nonce = generateSecureToken();
   const message = buildMessage(timestamp, nonce);
   const hmac = toBase64Url(await hmacHash(message));
-  return `${message}.${hmac}`;
+  _tokenStore.value = `${message}.${hmac}`;
+  return _tokenStore.value;
 };
+
+/** Get the most recently generated CSRF token (for synchronous JSX rendering) */
+export const getCurrentCsrfToken = (): string => _tokenStore.value;
 
 /** Check whether a token uses the signed format */
 export const isSignedCsrfToken = (token: string): boolean =>

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -3,6 +3,7 @@
  */
 
 import { map, pipe, reduce } from "#fp";
+import { getCurrentCsrfToken } from "#lib/csrf.ts";
 import { type Child, Raw } from "#jsx/jsx-runtime.ts";
 
 const escapeHtml = (str: string): string =>
@@ -264,19 +265,20 @@ export const renderError = (error?: string): string =>
 /**
  * Form component that always includes CSRF token.
  * Renders a POST form with a hidden csrf_token input.
+ * Reads the token from the module-scoped store set by signCsrfToken(),
+ * which is always called before rendering begins.
  * Supports extra attributes like class and enctype for multipart forms.
  */
 export const CsrfForm = (
-  { action, csrfToken, children, ...rest }: {
+  { action, children, ...rest }: {
     action: string;
-    csrfToken: string;
     children?: Child;
     class?: string;
     enctype?: string;
   },
 ): JSX.Element => (
   <form method="POST" action={action} {...rest}>
-    <input type="hidden" name="csrf_token" value={csrfToken} />
+    <input type="hidden" name="csrf_token" value={getCurrentCsrfToken()} />
     {children}
   </form>
 );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,7 +95,6 @@ export const isAdminLevel = (s: string): s is AdminLevel =>
 
 /** Session data needed by admin page templates */
 export type AdminSession = {
-  readonly csrfToken: string;
   readonly adminLevel: AdminLevel;
 };
 

--- a/src/routes/admin/dashboard.ts
+++ b/src/routes/admin/dashboard.ts
@@ -16,8 +16,8 @@ import { adminLoginPage } from "#templates/admin/login.tsx";
 
 /** Login page response helper */
 export const loginResponse = async (error?: string, status = 200): Promise<Response> => {
-  const csrfToken = await signCsrfToken();
-  return htmlResponse(adminLoginPage(csrfToken, error), status);
+  await signCsrfToken();
+  return htmlResponse(adminLoginPage(error), status);
 };
 
 /**

--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -46,7 +46,7 @@ const renderAdminView = async (
   const privateKey = (await getPrivateKey(session))!;
   const decrypted = await decryptAttendees(rawAttendees, privateKey);
   const entries = await resolveEntries(decrypted);
-  return htmlResponse(checkinAdminPage(entries, session.csrfToken, `/checkin/${tokens.join("+")}`, message, getAllowedDomain()));
+  return htmlResponse(checkinAdminPage(entries, `/checkin/${tokens.join("+")}`, message, getAllowedDomain()));
 };
 
 /** Handle GET /checkin/:tokens - show current status */

--- a/src/routes/join.ts
+++ b/src/routes/join.ts
@@ -64,8 +64,8 @@ type InviteCodeParams = { code: string };
  */
 const handleJoinGet = (_request: Request, { code }: InviteCodeParams): Promise<Response> =>
   withValidInvite(code, async (code, _user, username) => {
-    const csrfToken = await signCsrfToken();
-    return htmlResponse(joinPage(code, username, undefined, csrfToken));
+    await signCsrfToken();
+    return htmlResponse(joinPage(code, username));
   });
 
 /**
@@ -75,29 +75,27 @@ const handleJoinPost = (request: Request, { code }: InviteCodeParams): Promise<R
   withValidInvite(code, (code, user, username) =>
     withCsrfForm(
       request,
-      (newToken, message, status) =>
-        htmlResponse(joinPage(code, username, message, newToken), status),
+      (message, status) =>
+        htmlResponse(joinPage(code, username, message), status),
       async (form) => {
-        const formCsrf = form.get("csrf_token")!;
-
         // Validate password fields
         const validation = validateForm<JoinFormValues>(form, joinFields);
         if (!validation.valid) {
-          return htmlResponse(joinPage(code, username, validation.error, formCsrf), 400);
+          return htmlResponse(joinPage(code, username, validation.error), 400);
         }
 
         const { password, password_confirm: passwordConfirm } = validation.values;
 
         if (password.length < 8) {
           return htmlResponse(
-            joinPage(code, username, "Password must be at least 8 characters", formCsrf),
+            joinPage(code, username, "Password must be at least 8 characters"),
             400,
           );
         }
 
         if (password !== passwordConfirm) {
           return htmlResponse(
-            joinPage(code, username, "Passwords do not match", formCsrf),
+            joinPage(code, username, "Passwords do not match"),
             400,
           );
         }

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -40,7 +40,7 @@ export const adminDeleteAttendeePage = (
 
         <p>To delete this attendee, you must type their name "{attendee.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/attendee/${attendee.id}/delete`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/attendee/${attendee.id}/delete`}>
           {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
           <label for="confirm_name">Attendee name</label>
           <input
@@ -91,7 +91,7 @@ export const adminRefundAttendeePage = (
 
         <p>To refund this attendee, you must type their name "{attendee.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/attendee/${attendee.id}/refund`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/attendee/${attendee.id}/refund`}>
           {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
           <label for="confirm_name">Attendee name</label>
           <input
@@ -131,7 +131,7 @@ export const adminRefundAllAttendeesPage = (
 
         <p>To refund all attendees, you must type the event name "{event.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/refund-all`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/refund-all`}>
           <label for="confirm_name">Event name</label>
           <input
             type="text"
@@ -172,7 +172,7 @@ const renderEventSelector = (
 };
 
 /** Render payment details section (read-only) */
-const PaymentDetails = ({ attendee, csrfToken }: { attendee: Attendee; csrfToken: string }): string => {
+const PaymentDetails = ({ attendee }: { attendee: Attendee }): string => {
   if (!attendee.payment_id) return "";
   const pricePaid = Number.parseInt(attendee.price_paid, 10);
   const isRefunded = attendee.refunded;
@@ -192,7 +192,6 @@ const PaymentDetails = ({ attendee, csrfToken }: { attendee: Attendee; csrfToken
       </p>
       <CsrfForm
         action={`/admin/attendees/${attendee.id}/refresh-payment`}
-        csrfToken={csrfToken}
         class="inline"
       >
         <button type="submit">Refresh payment status</button>
@@ -219,9 +218,9 @@ export const adminEditAttendeePage = (
 
         <h2>Edit Attendee</h2>
 
-        <Raw html={PaymentDetails({ attendee, csrfToken: session.csrfToken })} />
+        <Raw html={PaymentDetails({ attendee })} />
 
-        <CsrfForm action={`/admin/attendees/${attendee.id}`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/attendees/${attendee.id}`}>
           {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
 
           <label for="name">
@@ -314,7 +313,7 @@ export const adminResendWebhookPage = (
 
         <p>To re-send the webhook for this attendee, you must type their name "{attendee.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/attendee/${attendee.id}/resend-webhook`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/attendee/${attendee.id}/resend-webhook`}>
           {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
           <label for="confirm_name">Attendee name</label>
           <input

--- a/src/templates/admin/calendar.tsx
+++ b/src/templates/admin/calendar.tsx
@@ -86,7 +86,6 @@ export const adminCalendarPage = (
             <Raw html={AttendeeTable({
               rows: tableRows,
               allowedDomain,
-              csrfToken: session.csrfToken,
               showEvent: true,
               showDate: false,
               returnUrl,

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -308,7 +308,6 @@ export const adminEventPage = ({
             <Raw html={AttendeeTable({
               rows: tableRows,
               allowedDomain,
-              csrfToken: session.csrfToken,
               showEvent: false,
               showDate: isDaily,
               activeFilter,
@@ -334,7 +333,7 @@ export const adminEventPage = ({
               {addAttendeeMessage.error}
             </p>
           )}
-          <CsrfForm action={`/admin/event/${event.id}/attendee`} csrfToken={session.csrfToken}>
+          <CsrfForm action={`/admin/event/${event.id}/attendee`}>
             <Raw html={renderFields(getAddAttendeeFields(event.fields, event.event_type === "daily"))} />
             <button type="submit">Add Attendee</button>
           </CsrfForm>
@@ -394,7 +393,7 @@ export const adminEventNewPage = (
       <Breadcrumb href="/admin/" label="Events" />
       <h1>Add Event</h1>
       <Raw html={renderError(error)} />
-      <CsrfForm action="/admin/event" csrfToken={session.csrfToken} enctype="multipart/form-data">
+      <CsrfForm action="/admin/event" enctype="multipart/form-data">
         <Raw html={renderFields(fields)} />
         <EventGroupSelect groups={groups} selectedGroupId={0} />
         <button type="submit">Create Event</button>
@@ -421,7 +420,7 @@ export const adminDuplicateEventPage = (
       <AdminNav session={session} />
         <h2>Duplicate Event</h2>
         <p>Creating a new event based on <strong>{event.name}</strong>.</p>
-        <CsrfForm action="/admin/event" csrfToken={session.csrfToken} enctype="multipart/form-data">
+        <CsrfForm action="/admin/event" enctype="multipart/form-data">
           <Raw html={renderFields(fields, values)} />
           <EventGroupSelect groups={groups} selectedGroupId={event.group_id} />
           <button type="submit">Create Event</button>
@@ -445,7 +444,7 @@ export const adminEventEditPage = (
     <Layout title={`Edit: ${event.name}`}>
       <AdminNav session={session} />
         <Raw html={renderError(error)} />
-        <CsrfForm action={`/admin/event/${event.id}/edit`} csrfToken={session.csrfToken} enctype="multipart/form-data">
+        <CsrfForm action={`/admin/event/${event.id}/edit`} enctype="multipart/form-data">
           <Raw html={renderFields(fields, eventToFieldValues(event))} />
           <EventGroupSelect groups={groups} selectedGroupId={event.group_id} />
           <Raw html={renderField(slugField, String(event.slug))} />
@@ -455,7 +454,7 @@ export const adminEventEditPage = (
           <button type="submit">Save Changes</button>
         </CsrfForm>
         {storageEnabled && event.image_url && (
-          <CsrfForm action={`/admin/event/${event.id}/image/delete`} csrfToken={session.csrfToken}>
+          <CsrfForm action={`/admin/event/${event.id}/image/delete`}>
             <button type="submit" class="secondary">Remove Image</button>
           </CsrfForm>
         )}
@@ -484,7 +483,7 @@ export const adminDeleteEventPage = (
 
         <p>To delete this event, type its name "{event.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/delete`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/delete`}>
           <label for="confirm_identifier">Event name</label>
           <input
             type="text"
@@ -528,7 +527,7 @@ export const adminDeactivateEventPage = (
 
         <p>To deactivate this event, type its name "{event.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/deactivate`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/deactivate`}>
           <label for="confirm_identifier">Event name</label>
           <input
             type="text"
@@ -567,7 +566,7 @@ export const adminReactivateEventPage = (
 
         <p>To reactivate this event, type its name "{event.name}" into the box below:</p>
 
-        <CsrfForm action={`/admin/event/${event.id}/reactivate`} csrfToken={session.csrfToken}>
+        <CsrfForm action={`/admin/event/${event.id}/reactivate`}>
           <label for="confirm_identifier">Event name</label>
           <input
             type="text"

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -84,7 +84,7 @@ export const adminGroupNewPage = (
       <Breadcrumb href="/admin/groups" label="Groups" />
       <h1>Add Group</h1>
       <Raw html={renderError(error)} />
-      <CsrfForm action="/admin/group" csrfToken={session.csrfToken}>
+      <CsrfForm action="/admin/group">
         <Raw html={renderFields(groupCreateFields, groupToFieldValues())} />
         <button type="submit">Create Group</button>
       </CsrfForm>
@@ -105,7 +105,7 @@ export const adminGroupEditPage = (
       <Breadcrumb href={`/admin/group/${group.id}`} label={group.name} />
       <h1>Edit Group</h1>
       <Raw html={renderError(error)} />
-      <CsrfForm action={`/admin/group/${group.id}/edit`} csrfToken={session.csrfToken}>
+      <CsrfForm action={`/admin/group/${group.id}/edit`}>
         <Raw html={renderFields(groupFields, groupToFieldValues(group))} />
         <button type="submit">Save Changes</button>
       </CsrfForm>
@@ -133,7 +133,7 @@ export const adminGroupDeletePage = (
         Events in this group will not be deleted -- they will be moved out of the group.
       </p>
       <p>Type the group name to confirm:</p>
-      <CsrfForm action={`/admin/group/${group.id}/delete`} csrfToken={session.csrfToken}>
+      <CsrfForm action={`/admin/group/${group.id}/delete`}>
         <label>
           Group Name
           <input type="text" name="confirm_identifier" required />
@@ -236,7 +236,7 @@ export const adminGroupDetailPage = (
       {ungroupedEvents.length > 0 && (
         <>
           <h2>Add Events to Group</h2>
-          <CsrfForm action={`/admin/group/${group.id}/add-events`} csrfToken={session.csrfToken}>
+          <CsrfForm action={`/admin/group/${group.id}/add-events`}>
             {ungroupedEvents.map((e) => (
               <label>
                 <input type="checkbox" name="event_ids" value={String(e.id)} />

--- a/src/templates/admin/holidays.tsx
+++ b/src/templates/admin/holidays.tsx
@@ -80,7 +80,7 @@ export const adminHolidayNewPage = (
       <Breadcrumb href="/admin/holidays" label="Holidays" />
       <h1>Add Holiday</h1>
       <Raw html={renderError(error)} />
-      <CsrfForm action="/admin/holiday" csrfToken={session.csrfToken}>
+      <CsrfForm action="/admin/holiday">
         <Raw html={renderFields(holidayFields)} />
         <button type="submit">Create Holiday</button>
       </CsrfForm>
@@ -101,7 +101,7 @@ export const adminHolidayEditPage = (
       <Breadcrumb href="/admin/holidays" label="Holidays" />
       <h1>Edit Holiday</h1>
       <Raw html={renderError(error)} />
-      <CsrfForm action={`/admin/holiday/${holiday.id}/edit`} csrfToken={session.csrfToken}>
+      <CsrfForm action={`/admin/holiday/${holiday.id}/edit`}>
         <Raw html={renderFields(holidayFields, holidayToFieldValues(holiday))} />
         <button type="submit">Save Changes</button>
       </CsrfForm>
@@ -126,7 +126,7 @@ export const adminHolidayDeletePage = (
         Are you sure you want to delete the holiday <strong>{holiday.name}</strong> ({holiday.start_date} to {holiday.end_date})?
       </p>
       <p>Type the holiday name to confirm:</p>
-      <CsrfForm action={`/admin/holiday/${holiday.id}/delete`} csrfToken={session.csrfToken}>
+      <CsrfForm action={`/admin/holiday/${holiday.id}/delete`}>
         <label>
           Holiday Name
           <input type="text" name="confirm_identifier" required />

--- a/src/templates/admin/login.tsx
+++ b/src/templates/admin/login.tsx
@@ -10,11 +10,11 @@ import { Layout } from "#templates/layout.tsx";
 /**
  * Admin login page
  */
-export const adminLoginPage = (csrfToken: string, error?: string): string =>
+export const adminLoginPage = (error?: string): string =>
   String(
     <Layout title="Login">
       <Raw html={renderError(error)} />
-      <CsrfForm action="/admin/login" csrfToken={csrfToken}>
+      <CsrfForm action="/admin/login">
         <Raw html={renderFields(loginFields)} />
         <button type="submit">Login</button>
       </CsrfForm>

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -26,7 +26,7 @@ export const AdminNav = ({ session }: AdminNavProps): JSX.Element => (
       {session.adminLevel === "owner" && <li><a href="/admin/sessions">Sessions</a></li>}
       <li><a href="/admin/guide">Guide</a></li>
       <li>
-        <CsrfForm action="/admin/logout" csrfToken={session.csrfToken} class="inline">
+        <CsrfForm action="/admin/logout" class="inline">
           <button type="submit">Logout</button>
         </CsrfForm>
       </li>

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -2,6 +2,7 @@
  * Admin QR scanner page template
  */
 
+import { getCurrentCsrfToken } from "#lib/csrf.ts";
 import type { AdminSession, EventWithCount } from "#lib/types.ts";
 import { SCANNER_JS_PATH } from "#src/config/asset-paths.ts";
 import { Layout } from "#templates/layout.tsx";
@@ -17,7 +18,7 @@ export const adminScannerPage = (
   String(
     <Layout
       title={`Scanner: ${event.name}`}
-      headExtra={`<meta name="csrf-token" content="${session.csrfToken}" /><script src="${SCANNER_JS_PATH}" defer></script>`}
+      headExtra={`<meta name="csrf-token" content="${getCurrentCsrfToken()}" /><script src="${SCANNER_JS_PATH}" defer></script>`}
     >
       <AdminNav session={session} />
       <h1>Scanner</h1>

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -74,7 +74,7 @@ export const adminSessionsPage = (
         <>
           <br />
 
-            <CsrfForm action="/admin/sessions" csrfToken={adminSession.csrfToken} class="one-button">
+            <CsrfForm action="/admin/sessions" class="one-button">
               <button type="submit" class="danger">
                 Log out of all other sessions ({otherSessionCount})
               </button>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -40,7 +40,7 @@ export const adminSettingsPage = (
       {error && <div class="error">{error}</div>}
       {success && <div class="success">{success}</div>}
 
-        <CsrfForm action="/admin/settings/timezone" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/timezone">
             <h2>Timezone</h2>
           <p>All dates and times will be interpreted and displayed in this timezone.</p>
           <label for="timezone">IANA Timezone</label>
@@ -52,7 +52,7 @@ export const adminSettingsPage = (
           <button type="submit">Save Timezone</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/business-email" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/business-email">
             <h2>Business Email</h2>
           <p>This email will be included in webhook notifications to identify your business.</p>
           <label for="business_email">Business Email</label>
@@ -67,7 +67,7 @@ export const adminSettingsPage = (
           <button type="submit">Save Business Email</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/payment-provider" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/payment-provider">
             <h2>Payment Provider</h2>
           <p>Choose which payment provider to use for paid events.</p>
           <fieldset>
@@ -103,7 +103,7 @@ export const adminSettingsPage = (
         </CsrfForm>
 
         {paymentProvider === "stripe" && (
-        <CsrfForm action="/admin/settings/stripe" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/stripe">
             <h2>Stripe Settings</h2>
           <p>
             {stripeKeyConfigured
@@ -120,7 +120,7 @@ export const adminSettingsPage = (
         )}
 
         {paymentProvider === "square" && (
-        <CsrfForm action="/admin/settings/square" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/square">
             <h2>Square Settings</h2>
           <p>
             {squareTokenConfigured
@@ -133,7 +133,7 @@ export const adminSettingsPage = (
         )}
 
         {paymentProvider === "square" && squareTokenConfigured && (
-        <CsrfForm action="/admin/settings/square-webhook" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/square-webhook">
             <h2>Square Webhook</h2>
           <article>
             <aside>
@@ -159,7 +159,7 @@ export const adminSettingsPage = (
         </CsrfForm>
         )}
 
-        <CsrfForm action="/admin/settings/embed-hosts" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/embed-hosts">
             <h2>Only allow embedding on these hosts</h2>
           <p>Restrict which websites can embed your booking forms in an iframe. Leave blank to allow embedding from any site.</p>
           <label for="embed_hosts">Hosts (comma-separated)</label>
@@ -175,7 +175,7 @@ export const adminSettingsPage = (
           <button type="submit">Save Embed Hosts</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/terms" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/terms">
             <h2>Terms and Conditions</h2>
           <p>If set, users must agree to these terms before reserving tickets.</p>
           <label for="terms_and_conditions">Terms and Conditions</label>
@@ -188,14 +188,14 @@ export const adminSettingsPage = (
           <button type="submit">Save Terms</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings">
             <h2>Change Password</h2>
           <p>Changing your password will log you out of all sessions.</p>
           <Raw html={renderFields(changePasswordFields)} />
           <button type="submit">Change Password</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/show-events-on-homepage" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/show-events-on-homepage">
             <h2>Show events on homepage?</h2>
           <p>When enabled, the homepage will display all upcoming active events as a booking page instead of redirecting to the admin area.</p>
           <fieldset>
@@ -221,7 +221,7 @@ export const adminSettingsPage = (
           <button type="submit">Save</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/theme" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/theme">
             <h2>Site Theme</h2>
           <p>Choose between light and dark themes for the site interface.</p>
           <fieldset>
@@ -247,7 +247,7 @@ export const adminSettingsPage = (
           <button type="submit">Save Theme</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/reset-database" csrfToken={session.csrfToken}>
+        <CsrfForm action="/admin/settings/reset-database">
             <h2>Reset Database</h2>
           <article>
             <aside>

--- a/src/templates/admin/users.tsx
+++ b/src/templates/admin/users.tsx
@@ -78,14 +78,14 @@ export const adminUsersPage = (
                 <td>{userStatus(user)}</td>
                 <td>
                   {user.hasPassword && !user.hasDataKey && (
-                    <CsrfForm class="inline" action={`/admin/users/${user.id}/activate`} csrfToken={session.csrfToken}>
+                    <CsrfForm class="inline" action={`/admin/users/${user.id}/activate`}>
                       <button type="submit">Activate</button>
                     </CsrfForm>
                   )}
                 </td>
                 <td>
                   {user.adminLevel !== "owner" && (
-                    <CsrfForm class="inline" action={`/admin/users/${user.id}/delete`} csrfToken={session.csrfToken}>
+                    <CsrfForm class="inline" action={`/admin/users/${user.id}/delete`}>
                       <button type="submit">Delete</button>
                     </CsrfForm>
                   )}
@@ -111,7 +111,7 @@ export const adminUserNewPage = (
       <Breadcrumb href="/admin/users" label="Users" />
       <h1>Invite User</h1>
       <Raw html={renderError(error)} />
-      <CsrfForm action="/admin/users" csrfToken={session.csrfToken}>
+      <CsrfForm action="/admin/users">
         <Raw html={renderFields(inviteUserFields)} />
         <button type="submit">Create Invite</button>
       </CsrfForm>

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -23,7 +23,6 @@ export type AttendeeTableRow = {
 export type AttendeeTableOptions = {
   rows: AttendeeTableRow[];
   allowedDomain: string;
-  csrfToken: string;
   showEvent: boolean;
   showDate: boolean;
   activeFilter?: string;
@@ -115,10 +114,9 @@ const returnSuffix = (returnUrl: string | undefined): string =>
   returnUrl ? `?return_url=${encodeURIComponent(returnUrl)}` : "";
 
 /** Render the check-in/check-out button form */
-const CheckinButton = ({ a, eventId, csrfToken, activeFilter, returnUrl }: {
+const CheckinButton = ({ a, eventId, activeFilter, returnUrl }: {
   a: Attendee;
   eventId: number;
-  csrfToken: string;
   activeFilter: string;
   returnUrl: string | undefined;
 }): string => {
@@ -128,7 +126,6 @@ const CheckinButton = ({ a, eventId, csrfToken, activeFilter, returnUrl }: {
   return String(
     <CsrfForm
       action={`/admin/event/${eventId}/attendee/${a.id}/checkin`}
-      csrfToken={csrfToken}
       class="inline"
     >
       <input type="hidden" name="return_filter" value={activeFilter} />
@@ -182,7 +179,6 @@ const StatusCell = ({ row, opts }: {
   return CheckinButton({
     a: row.attendee,
     eventId: row.eventId,
-    csrfToken: opts.csrfToken,
     activeFilter: opts.activeFilter ?? "all",
     returnUrl: opts.returnUrl,
   });

--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -19,7 +19,6 @@ export type { TokenEntry as CheckinEntry };
  */
 export const checkinAdminPage = (
   entries: TokenEntry[],
-  csrfToken: string,
   checkinPath: string,
   message: string | null,
   allowedDomain: string,
@@ -43,7 +42,7 @@ export const checkinAdminPage = (
     <Layout title="Check-in">
       <h1>Check-in</h1>
       {message && <p class="success">{message}</p>}
-      <CsrfForm action={checkinPath} csrfToken={csrfToken}>
+      <CsrfForm action={checkinPath}>
         <input type="hidden" name="check_in" value={nextValue} />
         <button type="submit" class={buttonClass}>{buttonLabel}</button>
       </CsrfForm>
@@ -51,7 +50,6 @@ export const checkinAdminPage = (
         <Raw html={AttendeeTable({
           rows: tableRows,
           allowedDomain,
-          csrfToken,
           showEvent: true,
           showDate,
           returnUrl: checkinPath,

--- a/src/templates/join.tsx
+++ b/src/templates/join.tsx
@@ -13,15 +13,14 @@ import { Layout } from "#templates/layout.tsx";
 export const joinPage = (
   code: string,
   username: string,
-  error: string | undefined,
-  csrfToken: string,
+  error?: string,
 ): string =>
   String(
     <Layout title="Set Your Password">
       <h1>Welcome, {username}</h1>
       <p>Set your password to complete your account setup.</p>
       <Raw html={renderError(error)} />
-      <CsrfForm action={`/join/${code}`} csrfToken={csrfToken}>
+      <CsrfForm action={`/join/${code}`}>
         <Raw html={renderFields(joinFields)} />
         <button type="submit">Set Password</button>
       </CsrfForm>

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -17,7 +17,6 @@ import { escapeHtml, Layout } from "#templates/layout.tsx";
  */
 export const homepagePage = (
   events: MultiTicketEvent[],
-  csrfToken: string,
   error?: string,
   availableDates?: string[],
   termsAndConditions?: string | null,
@@ -51,7 +50,7 @@ export const homepagePage = (
       {allUnavailable ? (
         <div class="error">{allClosed ? "Registration closed." : "Sorry, all events are sold out."}</div>
       ) : (
-        <CsrfForm action="/" csrfToken={csrfToken}>
+        <CsrfForm action="/">
           <Raw html={renderFields(fields)} />
           {hasDaily && availableDates && (
             <Raw html={renderDateSelector(availableDates)} />
@@ -131,7 +130,6 @@ const renderTermsAndCheckbox = (terms: string): string =>
  */
 export const ticketPage = (
   event: EventWithCount,
-  csrfToken: string,
   error: string | undefined,
   isClosed: boolean,
   inIframe: boolean,
@@ -173,7 +171,7 @@ export const ticketPage = (
       ) : isFull ? (
           <div class="error">Sorry, this event is full.</div>
       ) : (
-          <CsrfForm action={`/ticket/${event.slug}${inIframe ? "?iframe=true" : ""}`} csrfToken={csrfToken}>
+          <CsrfForm action={`/ticket/${event.slug}${inIframe ? "?iframe=true" : ""}`}>
             <Raw html={renderFields(fields)} />
             {isDaily && availableDates && (
               <Raw html={renderDateSelector(availableDates)} />
@@ -302,7 +300,6 @@ const getMultiTicketFieldsSetting = (events: MultiTicketEvent[]): EventFields =>
 export const multiTicketPage = (
   events: MultiTicketEvent[],
   slugs: string[],
-  csrfToken: string,
   error?: string,
   availableDates?: string[],
   termsAndConditions?: string | null,
@@ -327,7 +324,7 @@ export const multiTicketPage = (
       {allUnavailable ? (
         <div class="error">{allClosed ? "Registration closed." : "Sorry, all events are sold out."}</div>
       ) : (
-        <CsrfForm action={formAction} csrfToken={csrfToken}>
+        <CsrfForm action={formAction}>
           <Raw html={renderFields(fields)} />
           {hasDaily && availableDates && (
             <Raw html={renderDateSelector(availableDates)} />

--- a/src/templates/setup.tsx
+++ b/src/templates/setup.tsx
@@ -58,13 +58,13 @@ const DataControllerAgreement = (): JSX.Element => (
 /**
  * Initial setup page
  */
-export const setupPage = (error: string | undefined, csrfToken: string): string =>
+export const setupPage = (error?: string): string =>
   String(
     <Layout title="Setup">
         <h1>Initial Setup</h1>
         <p>Welcome! Please configure your ticket reservation system.</p>
         <Raw html={renderError(error)} />
-        <CsrfForm action="/setup/" csrfToken={csrfToken}>
+        <CsrfForm action="/setup/">
           <Raw html={renderFields(setupFields, { currency_code: "GBP" })} />
           <DataControllerAgreement />
           <button type="submit">Complete Setup</button>

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -1,9 +1,15 @@
+import { beforeAll } from "#test-compat";
 import { describe, expect, test } from "#test-compat";
+import { getCurrentCsrfToken, signCsrfToken } from "#lib/csrf.ts";
 import { AttendeeTable, type AttendeeTableOptions, type AttendeeTableRow, formatAddressInline, sortAttendeeRows } from "#templates/attendee-table.tsx";
-import { testAttendee } from "#test-utils";
+import { setupTestEncryptionKey, testAttendee } from "#test-utils";
 
-const CSRF_TOKEN = "test-csrf-token";
 const ALLOWED_DOMAIN = "example.com";
+
+beforeAll(async () => {
+  setupTestEncryptionKey();
+  await signCsrfToken();
+});
 
 const makeRow = (overrides: Partial<AttendeeTableRow> = {}): AttendeeTableRow => ({
   attendee: testAttendee(),
@@ -16,7 +22,6 @@ const makeRow = (overrides: Partial<AttendeeTableRow> = {}): AttendeeTableRow =>
 const makeOpts = (overrides: Partial<AttendeeTableOptions> = {}): AttendeeTableOptions => ({
   rows: [makeRow()],
   allowedDomain: ALLOWED_DOMAIN,
-  csrfToken: CSRF_TOKEN,
   showEvent: false,
   showDate: false,
   ...overrides,
@@ -206,7 +211,7 @@ describe("AttendeeTable", () => {
 
     test("includes csrf token in form", () => {
       const html = AttendeeTable(makeOpts());
-      expect(html).toContain(`value="${CSRF_TOKEN}"`);
+      expect(html).toContain(`value="${getCurrentCsrfToken()}"`);
     });
 
     test("form action points to correct endpoint", () => {

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "#test-compat";
+import { beforeAll, describe, expect, test } from "#test-compat";
+import { getCurrentCsrfToken, signCsrfToken } from "#lib/csrf.ts";
 import {
   CsrfForm,
   type Field,
@@ -27,7 +28,13 @@ import {
   expectInvalid,
   expectInvalidForm,
   expectValid,
+  setupTestEncryptionKey,
 } from "#test-utils";
+
+beforeAll(async () => {
+  setupTestEncryptionKey();
+  await signCsrfToken();
+});
 
 /** Helper: build a Field definition with minimal boilerplate. */
 const field = (
@@ -1072,28 +1079,28 @@ describe("forms", () => {
 
   describe("CsrfForm", () => {
     test("renders form with POST method and action", () => {
-      const html = String(CsrfForm({ action: "/submit", csrfToken: "tok123" }));
+      const html = String(CsrfForm({ action: "/submit" }));
       expect(html).toContain('<form method="POST" action="/submit"');
       expect(html).toContain("</form>");
     });
 
-    test("includes hidden csrf_token input", () => {
-      const html = String(CsrfForm({ action: "/submit", csrfToken: "tok123" }));
-      expect(html).toContain('<input type="hidden" name="csrf_token" value="tok123"');
+    test("includes hidden csrf_token input with stored token", () => {
+      const html = String(CsrfForm({ action: "/submit" }));
+      expect(html).toContain(`<input type="hidden" name="csrf_token" value="${getCurrentCsrfToken()}"`);
     });
 
     test("passes through class attribute", () => {
-      const html = String(CsrfForm({ action: "/submit", csrfToken: "tok123", class: "inline" }));
+      const html = String(CsrfForm({ action: "/submit", class: "inline" }));
       expect(html).toContain('class="inline"');
     });
 
     test("passes through enctype for multipart forms", () => {
-      const html = String(CsrfForm({ action: "/upload", csrfToken: "tok123", enctype: "multipart/form-data" }));
+      const html = String(CsrfForm({ action: "/upload", enctype: "multipart/form-data" }));
       expect(html).toContain('enctype="multipart/form-data"');
     });
 
     test("renders children inside the form", () => {
-      const html = String(CsrfForm({ action: "/submit", csrfToken: "tok123", children: "Submit here" }));
+      const html = String(CsrfForm({ action: "/submit", children: "Submit here" }));
       expect(html).toContain("Submit here");
       expect(html).toContain("</form>");
     });


### PR DESCRIPTION
## Summary
Refactored CSRF token handling to eliminate passing tokens through function parameters and template props. Instead, tokens are now stored in a module-scoped store after signing, allowing synchronous access during JSX rendering without threading tokens through the call stack.

## Key Changes

- **CSRF Token Storage**: Added `_tokenStore` in `src/lib/csrf.ts` to maintain the most recently generated token, with a new `getCurrentCsrfToken()` function for synchronous access
- **CsrfForm Component**: Removed `csrfToken` prop requirement; now reads from the module store via `getCurrentCsrfToken()`
- **Route Handlers**: Simplified all route handlers by removing token parameter passing:
  - `handleHome`, `handleHomePost`, `handleJoinGet`, `handleJoinPost`
  - `handleSetupGet`, `handleSetupPost`
  - `handleSingleTicketGet`, `processTicketReservation`
  - Admin dashboard login response
- **Template Functions**: Removed `csrfToken` parameters from:
  - `adminLoginPage`, `setupPage`, `joinPage`, `ticketPage`, `homepagePage`, `multiTicketPage`
  - `checkinAdminPage`, `adminScannerPage`
  - All admin form pages (events, groups, holidays, users, settings, attendees)
- **Session Type**: Removed `csrfToken` field from `AuthSession` and `AdminSession` types
- **Form Utilities**: Updated `requireCsrfForm` and `withCsrfForm` to no longer pass tokens to callbacks
- **Test Setup**: Added `beforeAll` hooks in tests to initialize encryption key and sign initial token before rendering

## Implementation Details

- The token store is populated by `signCsrfToken()` before any rendering occurs, ensuring `getCurrentCsrfToken()` always has a valid token available
- This approach maintains security (tokens are still signed and validated) while simplifying the codebase by eliminating token threading through dozens of function signatures
- Tests now use `setupTestEncryptionKey()` and `signCsrfToken()` in `beforeAll` hooks to establish the token store before assertions
- The refactoring is backward compatible at the HTTP level—CSRF validation and token generation remain unchanged

https://claude.ai/code/session_015mAs58S88pmBtujh2csL33