### PR TITLE
Add payment setup guide section for Stripe and Square

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -273,6 +273,32 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           </p>
         </Q>
 
+        <Q q="How do I create a Square application?">
+          <p>
+            Before you can accept payments with Square, you need to create an
+            application in the Square Developer Dashboard. This gives you the
+            API credentials the system needs.
+          </p>
+          <ol>
+            <li>
+              Go to the{" "}
+              <a href="https://developer.squareup.com/apps">
+                Square Developer Dashboard
+              </a>{" "}
+              and sign in with your Square account
+            </li>
+            <li>Click the <strong>+</strong> button to create a new application</li>
+            <li>
+              Give it a name (e.g. your organisation or event name) and click{" "}
+              <strong>Save</strong>
+            </li>
+          </ol>
+          <p>
+            Once created, you can find your access token and location ID from
+            the application's pages (see below).
+          </p>
+        </Q>
+
         <Q q="How do I find my Square access token?">
           <ol>
             <li>
@@ -281,7 +307,7 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
                 Square Developer Dashboard
               </a>
             </li>
-            <li>Select your application (or create one if you haven't already)</li>
+            <li>Select your application</li>
             <li>Open the <strong>Credentials</strong> page</li>
             <li>
               Copy the <strong>Access token</strong> for the environment you want

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -236,6 +236,154 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
       </Section>
 
+      <Section title="Payment Setup">
+        <Q q="How do I find my Stripe secret key?">
+          <ol>
+            <li>Log in to your <a href="https://dashboard.stripe.com">Stripe Dashboard</a></li>
+            <li>Click <strong>Developers</strong> in the top navigation bar</li>
+            <li>Select <strong>API keys</strong> from the sidebar</li>
+            <li>
+              Under <strong>Standard keys</strong>, find the{" "}
+              <strong>Secret key</strong> row and click <strong>Reveal</strong>
+            </li>
+            <li>
+              Copy the key &mdash; it starts with <code>sk_live_</code> for live
+              mode or <code>sk_test_</code> for test mode
+            </li>
+            <li>
+              Paste it into the Stripe Secret Key field on the{" "}
+              <a href="/admin/settings">Settings</a> page
+            </li>
+          </ol>
+          <p>
+            <strong>Tip:</strong> Use a <code>sk_test_</code> key first to
+            verify everything works before switching to your live key. Test mode
+            lets you make bookings without real charges.
+          </p>
+        </Q>
+
+        <Q q="Do I need to set up a Stripe webhook myself?">
+          <p>
+            No. When you save your Stripe secret key in{" "}
+            <a href="/admin/settings">Settings</a>, the system automatically
+            creates a webhook endpoint in your Stripe account and stores the
+            signing secret. You can verify it's working by clicking the{" "}
+            <strong>Test Connection</strong> button that appears after saving
+            your key.
+          </p>
+        </Q>
+
+        <Q q="How do I find my Square access token?">
+          <ol>
+            <li>
+              Log in to the{" "}
+              <a href="https://developer.squareup.com/apps">
+                Square Developer Dashboard
+              </a>
+            </li>
+            <li>Select your application (or create one if you haven't already)</li>
+            <li>Open the <strong>Credentials</strong> page</li>
+            <li>
+              Copy the <strong>Access token</strong> for the environment you want
+              (Sandbox for testing, Production for real payments)
+            </li>
+            <li>
+              Paste it into the Square Access Token field on the{" "}
+              <a href="/admin/settings">Settings</a> page
+            </li>
+          </ol>
+        </Q>
+
+        <Q q="How do I find my Square location ID?">
+          <ol>
+            <li>
+              Log in to the{" "}
+              <a href="https://developer.squareup.com/apps">
+                Square Developer Dashboard
+              </a>{" "}
+              and select your application
+            </li>
+            <li>Open the <strong>Locations</strong> page in the sidebar</li>
+            <li>
+              Copy the <strong>Location ID</strong> for the location you want to
+              accept payments at
+            </li>
+          </ol>
+          <p>
+            You can also find your location ID in the main{" "}
+            <a href="https://squareup.com/dashboard">Square Dashboard</a> under{" "}
+            <strong>Account &amp; Settings</strong> &rarr;{" "}
+            <strong>Business information</strong> &rarr;{" "}
+            <strong>Locations</strong>.
+          </p>
+        </Q>
+
+        <Q q="How do I set up the Square webhook?">
+          <p>
+            Unlike Stripe, the Square webhook must be configured manually. After
+            saving your Square access token and location ID:
+          </p>
+          <ol>
+            <li>
+              Go to the{" "}
+              <a href="https://developer.squareup.com/apps">
+                Square Developer Dashboard
+              </a>{" "}
+              and select your application
+            </li>
+            <li>Navigate to <strong>Webhooks</strong> in the sidebar</li>
+            <li>Click <strong>Add Subscription</strong></li>
+            <li>
+              Set the <strong>Notification URL</strong> to the webhook URL shown
+              on your <a href="/admin/settings">Settings</a> page
+            </li>
+            <li>
+              Subscribe to the <strong>payment.updated</strong> event
+            </li>
+            <li>
+              Save the subscription, then copy the{" "}
+              <strong>Signature Key</strong> that Square provides
+            </li>
+            <li>
+              Paste the signature key into the webhook field on your{" "}
+              <a href="/admin/settings">Settings</a> page
+            </li>
+          </ol>
+          <p>
+            The webhook is what tells the system when a payment has been
+            completed, so bookings won't be confirmed until this is set up.
+          </p>
+        </Q>
+
+        <Q q="Should I use test or live credentials?">
+          <p>
+            Start with test credentials to make sure everything is working
+            before accepting real payments. Both Stripe and Square provide
+            separate test environments:
+          </p>
+          <ul>
+            <li>
+              <strong>Stripe:</strong> Use a key starting with{" "}
+              <code>sk_test_</code>. You can make test payments with{" "}
+              <a href="https://docs.stripe.com/testing#cards">
+                Stripe's test card numbers
+              </a>.
+            </li>
+            <li>
+              <strong>Square:</strong> Use your Sandbox access token and
+              location. You can make test payments with{" "}
+              <a href="https://developer.squareup.com/docs/devtools/sandbox/payments">
+                Square's sandbox test values
+              </a>.
+            </li>
+          </ul>
+          <p>
+            When you're ready to go live, replace the test credentials with your
+            production credentials in <a href="/admin/settings">Settings</a>.
+          </p>
+        </Q>
+      </Section>
+
       <Section title="Refunds">
         <Q q="When do automatic refunds happen?">
           <p>

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -236,7 +236,7 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
       </Section>
 
-      <Section title="Payment Setup">
+      <Section id="payment-setup" title="Payment Setup">
         <Q q="How do I find my Stripe secret key?">
           <ol>
             <li>Log in to your <a href="https://dashboard.stripe.com">Stripe Dashboard</a></li>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -110,6 +110,7 @@ export const adminSettingsPage = (
               ? "A Stripe secret key is currently configured. Enter a new key below to replace it."
               : "No Stripe key is configured. Enter your Stripe secret key to enable Stripe payments."}
           </p>
+          <p><small><a href="/admin/guide#payment-setup">Where do I find this?</a></small></p>
           <Raw html={renderFields(stripeKeyFields)} />
           <button type="submit">Update Stripe Key</button>
           {stripeKeyConfigured && (
@@ -127,6 +128,7 @@ export const adminSettingsPage = (
               ? "A Square access token is currently configured. Enter new credentials below to replace them."
               : "No Square access token is configured. Enter your Square credentials to enable Square payments."}
           </p>
+          <p><small><a href="/admin/guide#payment-setup">Where do I find these?</a></small></p>
           <Raw html={renderFields(squareAccessTokenFields)} />
           <button type="submit">Update Square Credentials</button>
         </CsrfForm>
@@ -135,6 +137,9 @@ export const adminSettingsPage = (
         {paymentProvider === "square" && squareTokenConfigured && (
         <CsrfForm action="/admin/settings/square-webhook">
             <h2>Square Webhook</h2>
+          <p>
+            <a href="/admin/guide#payment-setup">See the full setup guide</a>
+          </p>
           <article>
             <aside>
               <p>To receive payment notifications, set up a webhook in your Square Developer Dashboard:</p>

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -60,6 +60,30 @@ describe("server (admin guide)", () => {
       expect(html).toContain("Add Attendee");
     });
 
+    test("contains payment setup section with Stripe instructions", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Payment Setup");
+      expect(html).toContain("Stripe secret key");
+      expect(html).toContain("sk_test_");
+      expect(html).toContain("dashboard.stripe.com");
+    });
+
+    test("contains payment setup section with Square instructions", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Square access token");
+      expect(html).toContain("Square location ID");
+      expect(html).toContain("developer.squareup.com");
+      expect(html).toContain("payment.updated");
+    });
+
+    test("contains test vs live credentials guidance", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("test or live credentials");
+    });
+
     test("contains admin navigation", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -72,6 +72,7 @@ describe("server (admin guide)", () => {
     test("contains payment setup section with Square instructions", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();
+      expect(html).toContain("create a Square application");
       expect(html).toContain("Square access token");
       expect(html).toContain("Square location ID");
       expect(html).toContain("developer.squareup.com");

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -64,6 +64,7 @@ describe("server (admin guide)", () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();
       expect(html).toContain("Payment Setup");
+      expect(html).toContain('id="payment-setup"');
       expect(html).toContain("Stripe secret key");
       expect(html).toContain("sk_test_");
       expect(html).toContain("dashboard.stripe.com");

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -317,6 +317,7 @@ describe("server (admin settings)", () => {
       const html = await response.text();
       expect(html).toContain("No Stripe key is configured");
       expect(html).toContain("Enter your Stripe secret key to enable Stripe payments");
+      expect(html).toContain("/admin/guide#payment-setup");
       expect(html).not.toContain("stripe-test-btn");
     });
 
@@ -600,6 +601,7 @@ describe("server (admin settings)", () => {
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("No Square access token is configured");
+      expect(html).toContain("/admin/guide#payment-setup");
     });
 
     test("settings page shows Square is configured after setting token", async () => {
@@ -1106,6 +1108,7 @@ describe("server (admin settings)", () => {
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("webhook");
+      expect(html).toContain("full setup guide");
     });
 
     test("settings page shows Square webhook configured message", async () => {


### PR DESCRIPTION
## Summary
Added a comprehensive "Payment Setup" section to the admin guide with detailed instructions for configuring both Stripe and Square payment processors.

## Key Changes
- **New Payment Setup Guide Section** with FAQs covering:
  - How to find and configure Stripe secret keys (test vs. live modes)
  - Automatic Stripe webhook setup explanation
  - How to find Square access tokens and location IDs
  - Manual Square webhook configuration steps
  - Guidance on choosing between test and live credentials for both providers
  
- **Test Coverage** added to verify the new guide content:
  - Tests for Stripe-specific instructions and dashboard links
  - Tests for Square-specific instructions and webhook configuration
  - Tests for test vs. live credentials guidance

## Implementation Details
- The new section includes step-by-step instructions with links to relevant dashboards and settings pages
- Includes helpful tips like using test credentials first before switching to live keys
- Explains the key difference that Stripe webhooks are automatic while Square webhooks require manual setup
- Provides links to external documentation for test card numbers and sandbox values
- All instructions reference the `/admin/settings` page where credentials are actually configured

https://claude.ai/code/session_01EKvqqgB3yxfB9TftMifCbr