### PR TITLE
Add user-facing validation error handling for payment processors

### DIFF
--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -40,10 +40,15 @@ export type MultiRegistrationIntent = ContactInfo & {
   items: MultiRegistrationItem[];
 };
 
-/** Result of creating a checkout session */
+/** Result of creating a checkout session.
+ * - Success: { sessionId, checkoutUrl }
+ * - User-facing error (e.g. invalid phone): { error }
+ * - Internal/unknown failure: null */
 export type CheckoutSessionResult = {
   sessionId: string;
   checkoutUrl: string;
+} | {
+  error: string;
 } | null;
 
 /** Metadata attached to a validated payment session */

--- a/src/lib/square-provider.ts
+++ b/src/lib/square-provider.ts
@@ -30,6 +30,7 @@ import {
 } from "#lib/square.ts";
 import type { Event } from "#lib/types.ts";
 import type {
+  CheckoutSessionResult,
   MultiRegistrationIntent,
   PaymentProvider,
   RegistrationIntent,
@@ -41,7 +42,7 @@ import type {
 /** Wrap a checkout operation, converting PaymentUserError to { error } result */
 const withUserError = async <T extends { orderId: string; url: string }>(
   op: () => Promise<T | null>,
-): Promise<import("#lib/payments.ts").CheckoutSessionResult> => {
+): Promise<CheckoutSessionResult> => {
   try {
     const result = await op();
     return toCheckoutResult(result?.orderId, result?.url, "Square");

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -208,6 +208,10 @@ const runCheckoutFlow = (
       const baseUrl = getBaseUrl(request);
       logDebug("Payment", `Creating checkout session baseUrl=${baseUrl}`);
       const result = await createSession(provider, baseUrl);
+      if (result && "error" in result) {
+        logDebug("Payment", `Checkout validation error for ${label}: ${result.error}`);
+        return onError(result.error, 400);
+      }
       logDebug("Payment", `Checkout result for ${label}: ${result ? `url=${result.checkoutUrl}` : "null"}`);
       return tryCheckoutRedirect(result?.checkoutUrl, inIframe, () => {
         logDebug("Payment", `Checkout redirect failed for ${label}: no session URL`);

--- a/test/lib/square-provider.test.ts
+++ b/test/lib/square-provider.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "#test-compat";
 import { squarePaymentProvider } from "#lib/square-provider.ts";
 import { squareApi } from "#lib/square.ts";
-import { createTestDb, resetDb } from "#test-utils";
+import { PaymentUserError } from "#lib/payment-helpers.ts";
+import { createTestDb, resetDb, testEvent, withMocks } from "#test-utils";
 
 describe("square-provider", () => {
   beforeEach(async () => {
@@ -66,6 +67,78 @@ describe("square-provider", () => {
       const result = await squarePaymentProvider.isPaymentRefunded("pay_123");
       expect(result).toBe(false);
       restore();
+    });
+  });
+
+  describe("createCheckoutSession", () => {
+    test("returns error result when createPaymentLink throws PaymentUserError", async () => {
+      const event = testEvent({ unit_price: 1000, fields: "email" as const });
+      const intent = {
+        eventId: 1,
+        name: "John",
+        email: "john@example.com",
+        phone: "bad",
+        address: "",
+        special_instructions: "",
+        quantity: 1,
+      };
+      await withMocks(
+        () => spyOn(squareApi, "createPaymentLink").mockImplementation(() => {
+          throw new PaymentUserError("The payment processor rejected the phone number as invalid. Please correct it and try again.");
+        }),
+        async () => {
+          const result = await squarePaymentProvider.createCheckoutSession(event, intent, "http://localhost");
+          expect(result).not.toBeNull();
+          expect(result).toHaveProperty("error");
+          expect((result as { error: string }).error).toContain("phone number");
+        },
+      );
+    });
+
+    test("returns null when createPaymentLink throws a generic error", async () => {
+      const event = testEvent({ unit_price: 1000, fields: "email" as const });
+      const intent = {
+        eventId: 1,
+        name: "John",
+        email: "john@example.com",
+        phone: "",
+        address: "",
+        special_instructions: "",
+        quantity: 1,
+      };
+      await withMocks(
+        () => spyOn(squareApi, "createPaymentLink").mockImplementation(() => {
+          throw new Error("Network failure");
+        }),
+        async () => {
+          const result = await squarePaymentProvider.createCheckoutSession(event, intent, "http://localhost");
+          expect(result).toBeNull();
+        },
+      );
+    });
+  });
+
+  describe("createMultiCheckoutSession", () => {
+    test("returns error result when createMultiPaymentLink throws PaymentUserError", async () => {
+      const intent = {
+        name: "John",
+        email: "bad",
+        phone: "",
+        address: "",
+        special_instructions: "",
+        items: [{ eventId: 1, quantity: 1, unitPrice: 1000, slug: "evt", name: "Evt" }],
+      };
+      await withMocks(
+        () => spyOn(squareApi, "createMultiPaymentLink").mockImplementation(() => {
+          throw new PaymentUserError("The payment processor rejected the email address as invalid. Please correct it and try again.");
+        }),
+        async () => {
+          const result = await squarePaymentProvider.createMultiCheckoutSession(intent, "http://localhost");
+          expect(result).not.toBeNull();
+          expect(result).toHaveProperty("error");
+          expect((result as { error: string }).error).toContain("email address");
+        },
+      );
     });
   });
 

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -3,12 +3,15 @@ import {
   constructTestWebhookEvent,
   enforceMetadataLimits,
   getSquareClient,
+  parseSquareApiErrors,
   resetSquareClient,
   retrievePayment,
   squareApi,
+  toUserFacingSquareError,
   verifyWebhookSignature,
 } from "#lib/square.ts";
 import { squarePaymentProvider } from "#lib/square-provider.ts";
+import { PaymentUserError } from "#lib/payment-helpers.ts";
 import type { WebhookEvent } from "#lib/payments.ts";
 import {
   updateSquareAccessToken,
@@ -724,6 +727,189 @@ describe("square", () => {
     });
   });
 
+  describe("parseSquareApiErrors", () => {
+    test("parses errors from Square SDK error message format", () => {
+      const err = new Error(
+        'Status code: 400 Body: { "errors": [ { "category": "INVALID_REQUEST_ERROR", "code": "INVALID_PHONE_NUMBER", "detail": "Invalid phone number.", "field": "pre_populated_data.buyer_phone_number" } ] }',
+      );
+      const errors = parseSquareApiErrors(err);
+      expect(errors).not.toBeNull();
+      expect(errors).toHaveLength(1);
+      const first = errors![0]!;
+      expect(first.code).toBe("INVALID_PHONE_NUMBER");
+      expect(first.field).toBe("pre_populated_data.buyer_phone_number");
+    });
+
+    test("returns null for non-Error values", () => {
+      expect(parseSquareApiErrors("string error")).toBeNull();
+      expect(parseSquareApiErrors(42)).toBeNull();
+      expect(parseSquareApiErrors(null)).toBeNull();
+    });
+
+    test("returns null when error message has no Body section", () => {
+      const err = new Error("Network timeout");
+      expect(parseSquareApiErrors(err)).toBeNull();
+    });
+
+    test("returns null when Body text does not match expected format", () => {
+      const err = new Error("Status code: 500 Body: not json");
+      expect(parseSquareApiErrors(err)).toBeNull();
+    });
+
+    test("returns null when Body matches braces but is not valid JSON", () => {
+      const err = new Error("Status code: 400 Body: { invalid json content }");
+      expect(parseSquareApiErrors(err)).toBeNull();
+    });
+
+    test("returns null when Body has no errors array", () => {
+      const err = new Error('Status code: 400 Body: { "message": "bad" }');
+      expect(parseSquareApiErrors(err)).toBeNull();
+    });
+
+    test("parses multiple errors", () => {
+      const err = new Error(
+        'Status code: 400 Body: { "errors": [ { "category": "INVALID_REQUEST_ERROR", "code": "INVALID_PHONE_NUMBER", "field": "pre_populated_data.buyer_phone_number" }, { "category": "INVALID_REQUEST_ERROR", "code": "INVALID_EMAIL_ADDRESS", "field": "pre_populated_data.buyer_email" } ] }',
+      );
+      const errors = parseSquareApiErrors(err);
+      expect(errors).toHaveLength(2);
+    });
+  });
+
+  describe("toUserFacingSquareError", () => {
+    test("returns message for invalid phone number", () => {
+      const errors = [
+        {
+          category: "INVALID_REQUEST_ERROR",
+          code: "INVALID_PHONE_NUMBER",
+          detail: "Invalid phone number.",
+          field: "pre_populated_data.buyer_phone_number",
+        },
+      ];
+      const msg = toUserFacingSquareError(errors);
+      expect(msg).toContain("phone number");
+      expect(msg).toContain("invalid");
+    });
+
+    test("returns message for invalid email", () => {
+      const errors = [
+        {
+          category: "INVALID_REQUEST_ERROR",
+          code: "INVALID_EMAIL_ADDRESS",
+          detail: "Invalid email address.",
+          field: "pre_populated_data.buyer_email",
+        },
+      ];
+      const msg = toUserFacingSquareError(errors);
+      expect(msg).toContain("email address");
+      expect(msg).toContain("invalid");
+    });
+
+    test("returns null for non-user-facing errors", () => {
+      const errors = [
+        {
+          category: "API_ERROR",
+          code: "INTERNAL_SERVER_ERROR",
+          detail: "Something went wrong.",
+        },
+      ];
+      expect(toUserFacingSquareError(errors)).toBeNull();
+    });
+
+    test("returns null for INVALID_REQUEST_ERROR without a known field", () => {
+      const errors = [
+        {
+          category: "INVALID_REQUEST_ERROR",
+          code: "MISSING_REQUIRED_PARAMETER",
+          detail: "Missing required field.",
+          field: "order.location_id",
+        },
+      ];
+      expect(toUserFacingSquareError(errors)).toBeNull();
+    });
+
+    test("returns null for empty errors array", () => {
+      expect(toUserFacingSquareError([])).toBeNull();
+    });
+
+    test("returns first matching user-facing error", () => {
+      const errors = [
+        { category: "API_ERROR", code: "INTERNAL_SERVER_ERROR" },
+        {
+          category: "INVALID_REQUEST_ERROR",
+          code: "INVALID_PHONE_NUMBER",
+          field: "pre_populated_data.buyer_phone_number",
+        },
+      ];
+      const msg = toUserFacingSquareError(errors);
+      expect(msg).toContain("phone number");
+    });
+  });
+
+  describe("createPaymentLink with validation errors", () => {
+    test("throws PaymentUserError for invalid phone number from Square API", async () => {
+      await updateSquareAccessToken("EAAAl_test_123");
+      await updateSquareLocationId("L_loc_456");
+      const { client, checkoutCreate } = createMockClient();
+      checkoutCreate.mockRejectedValue(
+        new Error(
+          'Status code: 400 Body: { "errors": [ { "category": "INVALID_REQUEST_ERROR", "code": "INVALID_PHONE_NUMBER", "detail": "Invalid phone number.", "field": "pre_populated_data.buyer_phone_number" } ] }',
+        ),
+      );
+
+      await withMocks(
+        () => spyOn(squareApi, "getSquareClient").mockResolvedValue(client),
+        async () => {
+          const event = testEvent({ unit_price: 1000, fields: "email" as const });
+          const intent = {
+            eventId: 1,
+            name: "John",
+            email: "john@example.com",
+            phone: "bad-phone",
+            address: "",
+            special_instructions: "",
+            quantity: 1,
+          };
+
+          try {
+            await squareApi.createPaymentLink(event, intent, "http://localhost");
+            expect(true).toBe(false); // should not reach here
+          } catch (err) {
+            expect(err instanceof PaymentUserError).toBe(true);
+            expect((err as PaymentUserError).message).toContain("phone number");
+          }
+        },
+      );
+    });
+
+    test("returns null for non-user-facing Square API errors", async () => {
+      await updateSquareAccessToken("EAAAl_test_123");
+      await updateSquareLocationId("L_loc_456");
+      const { client, checkoutCreate } = createMockClient();
+      checkoutCreate.mockRejectedValue(
+        new Error("Status code: 500 Body: { \"errors\": [ { \"category\": \"API_ERROR\", \"code\": \"INTERNAL_SERVER_ERROR\" } ] }"),
+      );
+
+      await withMocks(
+        () => spyOn(squareApi, "getSquareClient").mockResolvedValue(client),
+        async () => {
+          const event = testEvent({ unit_price: 1000, fields: "email" as const });
+          const intent = {
+            eventId: 1,
+            name: "John",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            quantity: 1,
+          };
+
+          const result = await squareApi.createPaymentLink(event, intent, "http://localhost");
+          expect(result).toBeNull();
+        },
+      );
+    });
+  });
+
   describe("retrieveOrder", () => {
     test("returns null when access token not set", async () => {
       const result = await squareApi.retrieveOrder("order_123");
@@ -1357,8 +1543,10 @@ describe("square", () => {
             "http://localhost",
           );
           expect(result).not.toBeNull();
-          expect(result!.sessionId).toBe("order_prov");
-          expect(result!.checkoutUrl).toBe("https://square.link/prov");
+          expect(result).toHaveProperty("sessionId");
+          const success = result as { sessionId: string; checkoutUrl: string };
+          expect(success.sessionId).toBe("order_prov");
+          expect(success.checkoutUrl).toBe("https://square.link/prov");
         },
       );
     });
@@ -1390,8 +1578,10 @@ describe("square", () => {
             "http://localhost",
           );
           expect(result).not.toBeNull();
-          expect(result!.sessionId).toBe("order_mprov");
-          expect(result!.checkoutUrl).toBe("https://square.link/mprov");
+          expect(result).toHaveProperty("sessionId");
+          const success = result as { sessionId: string; checkoutUrl: string };
+          expect(success.sessionId).toBe("order_mprov");
+          expect(success.checkoutUrl).toBe("https://square.link/mprov");
         },
       );
     });


### PR DESCRIPTION
## Summary
This PR adds proper handling and user-facing error messages for payment validation errors (e.g., invalid phone numbers or email addresses) from payment processors like Square. Previously, these validation errors were silently swallowed; now they're caught, converted to user-friendly messages, and displayed to the user.

## Key Changes

- **New `PaymentUserError` class** in `payment-helpers.ts`: A custom error subclass that distinguishes user-facing validation errors from internal failures. These errors propagate through `safeAsync()` instead of being caught and logged.

- **Square API error parsing** in `square.ts`:
  - `parseSquareApiErrors()`: Extracts structured error entries from Square SDK error messages
  - `toUserFacingSquareError()`: Converts Square validation errors on user-provided fields (phone, email) to friendly messages
  - `rethrowAsUserError()`: Catches Square API errors and re-throws as `PaymentUserError` when appropriate

- **Updated `CheckoutSessionResult` type** in `payments.ts`: Now supports three outcomes:
  - Success: `{ sessionId, checkoutUrl }`
  - User-facing error: `{ error: string }`
  - Internal failure: `null`

- **Provider error handling** in `square-provider.ts`: New `withUserError()` wrapper converts `PaymentUserError` exceptions to `{ error }` results while letting other errors return `null`.

- **Request handling** in `public.ts`: Checkout flow now checks for validation errors in the result and returns a 400 response with the user-friendly message.

- **Updated `safeAsync()`** in `payment-helpers.ts`: Re-throws `PaymentUserError` so validation messages propagate to the user instead of being logged as internal errors.

## Implementation Details

- Square field labels are mapped to user-friendly names via `SQUARE_FIELD_LABELS` constant
- Error messages follow a consistent pattern: "The payment processor rejected the [field] as invalid. Please correct it and try again."
- Only `INVALID_REQUEST_ERROR` category errors on known user-provided fields are converted to user-facing messages; other errors are re-thrown as-is
- Comprehensive test coverage for parsing, conversion, and end-to-end flows

https://claude.ai/code/session_014HLQ7acXsYrJtrqRTix52r