### PR TITLE
Support Square payment redirect with orderId parameter

### DIFF
--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -133,10 +133,12 @@ export interface PaymentProvider {
 
   /**
    * Verify a webhook request's signature and parse the event payload.
+   * @param webhookUrl - The webhook endpoint URL derived from the incoming request
    */
   verifyWebhookSignature(
     payload: string,
     signature: string,
+    webhookUrl: string,
   ): Promise<WebhookVerifyResult>;
 
   /**

--- a/src/lib/square-provider.ts
+++ b/src/lib/square-provider.ts
@@ -12,7 +12,6 @@
  * - Webhook setup is manual (user provides signature key from dashboard)
  */
 
-import { getAllowedDomain } from "#lib/config.ts";
 import { logDebug } from "#lib/logger.ts";
 import {
   extractSessionMetadata,
@@ -95,10 +94,9 @@ export const squarePaymentProvider: PaymentProvider = {
   verifyWebhookSignature(
     payload: string,
     signature: string,
+    webhookUrl: string,
   ): Promise<WebhookVerifyResult> {
-    const domain = getAllowedDomain();
-    const notificationUrl = `https://${domain}/payment/webhook`;
-    return verifyWebhookSignature(payload, signature, notificationUrl);
+    return verifyWebhookSignature(payload, signature, webhookUrl);
   },
 
   refundPayment(paymentReference: string): Promise<boolean> {

--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -198,7 +198,7 @@ const createPaymentLinkImpl = (
           metadata: params.metadata,
         },
         checkoutOptions: {
-          redirectUrl: `${params.baseUrl}/payment/success?session_id={ORDER_ID}`,
+          redirectUrl: `${params.baseUrl}/payment/success`,
         },
         prePopulatedData: {
           buyerEmail: params.email,

--- a/src/lib/stripe-provider.ts
+++ b/src/lib/stripe-provider.ts
@@ -80,6 +80,7 @@ export const stripePaymentProvider: PaymentProvider = {
   async verifyWebhookSignature(
     payload: string,
     signature: string,
+    _webhookUrl: string,
   ): Promise<WebhookVerifyResult> {
     const result = await verifyWebhookSignature(payload, signature);
     if (!result.valid) {

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -1424,6 +1424,7 @@ describe("square", () => {
       const result = await squarePaymentProvider.verifyWebhookSignature(
         '{"test": true}',
         "fakesig",
+        "https://example.com/payment/webhook",
       );
       expect(result.valid).toBe(false);
     });

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -328,7 +328,7 @@ describe("square", () => {
 
           // Verify checkout options
           expect(args.checkoutOptions.redirectUrl).toBe(
-            "https://tickets.example.com/payment/success?session_id={ORDER_ID}",
+            "https://tickets.example.com/payment/success",
           );
 
           // Verify pre-populated data
@@ -676,7 +676,7 @@ describe("square", () => {
           // Verify location and checkout options
           expect(args.order.locationId).toBe("L_multi_loc");
           expect(args.checkoutOptions.redirectUrl).toBe(
-            "https://tickets.example.com/payment/success?session_id={ORDER_ID}",
+            "https://tickets.example.com/payment/success",
           );
           expect(args.prePopulatedData.buyerEmail).toBe("alice@example.com");
           expect(args.prePopulatedData.buyerPhoneNumber).toBe("555-1111");

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -1656,6 +1656,7 @@ describe("stripe-provider", () => {
       const result = await stripePaymentProvider.verifyWebhookSignature(
         payload,
         signature,
+        "https://example.com/payment/webhook",
       );
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -1671,6 +1672,7 @@ describe("stripe-provider", () => {
       const result = await stripePaymentProvider.verifyWebhookSignature(
         '{"test": true}',
         `t=${timestamp},v1=invalid_sig`,
+        "https://example.com/payment/webhook",
       );
 
       expect(result.valid).toBe(false);


### PR DESCRIPTION
## Summary
This PR adds support for Square's payment redirect flow by handling the `orderId` query parameter in addition to Stripe's `session_id` parameter. It also improves webhook signature verification by deriving the webhook URL from the incoming request, which is necessary for Square's HMAC signature computation.

## Key Changes
- **Payment success handler**: Updated `handlePaymentSuccess` to accept both `session_id` (Stripe) and `orderId` (Square) query parameters
- **Webhook URL derivation**: Modified webhook signature verification to accept and use the webhook URL derived from the incoming request, rather than constructing it from configuration
- **Square provider**: Removed hardcoded domain-based URL construction and now accepts the webhook URL as a parameter
- **Stripe provider**: Updated signature verification method signature to accept the `webhookUrl` parameter (unused but required by interface)
- **Square checkout**: Simplified the redirect URL to `/payment/success` without the `{ORDER_ID}` template variable, allowing Square to append `orderId` as a query parameter instead

## Implementation Details
- The webhook URL is now constructed in the webhook handler using `getBaseUrl(request)` to ensure it matches exactly what was registered with the payment provider
- This approach is particularly important for Square, which requires the exact registered URL to compute the correct HMAC signature
- Tests updated to reflect the simplified redirect URL and new parameter handling

https://claude.ai/code/session_018tLMsm3FaG1DAoeW6GUYb2