### PR TITLE
Enhance Square webhook signature verification error logging

### DIFF
--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -514,7 +514,10 @@ export const verifyWebhookSignature = async (
   const expectedSignature = await computeSquareSignature(signedPayload, secret);
 
   if (!secureCompare(signature, expectedSignature)) {
-    logError({ code: ErrorCode.SQUARE_SIGNATURE, detail: "mismatch" });
+    logError({
+      code: ErrorCode.SQUARE_SIGNATURE,
+      detail: `mismatch: notificationUrl=${notificationUrl}, receivedLength=${signature.length}, expectedLength=${expectedSignature.length}, receivedPrefix=${signature.slice(0, 8)}..., expectedPrefix=${expectedSignature.slice(0, 8)}...`,
+    });
     return { valid: false, error: "Signature verification failed" };
   }
 


### PR DESCRIPTION
## Summary
Improved error logging for Square webhook signature verification failures by including detailed diagnostic information to aid in debugging signature mismatches.

## Key Changes
- Enhanced the error log message in `verifyWebhookSignature()` to include:
  - The notification URL being verified
  - Length of both received and expected signatures
  - First 8 characters (prefix) of both signatures for comparison
  
This additional context will help identify whether signature mismatches are due to truncation, encoding issues, or other data integrity problems during webhook verification.

## Implementation Details
- The error detail field now contains a formatted string with multiple diagnostic fields instead of a simple "mismatch" message
- Signature prefixes are included (first 8 characters) rather than full signatures to maintain security while providing useful debugging information
- All diagnostic data is only logged when a signature mismatch occurs, with no impact on successful verifications

https://claude.ai/code/session_017eax1vDQTXCFsk1jsKz8du