### PR TITLE
Add payment provider recommendation to admin guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -202,6 +202,17 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           </p>
         </Q>
 
+        <Q q="Which payment provider do you recommend?">
+          <p>
+            <strong>Stripe</strong>. The setup is a fair bit easier &mdash; you
+            just paste in your secret key and the webhook is created
+            automatically. With Square you need to create a developer
+            application, find your location ID, and manually configure the
+            webhook yourself. Both work well once set up, but Stripe gets you
+            going faster.
+          </p>
+        </Q>
+
         <Q q="What happens when someone books a paid ticket?">
           <p>
             They fill in the booking form, then are redirected to your payment

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -48,6 +48,13 @@ describe("server (admin guide)", () => {
       expect(html).toContain("Facebook Sharing Debugger");
     });
 
+    test("contains payment provider recommendation", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Which payment provider do you recommend?");
+      expect(html).toContain("setup is a fair bit easier");
+    });
+
     test("contains payment reservation info", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();


### PR DESCRIPTION
## Summary
Added a new FAQ section to the admin guide recommending Stripe as the preferred payment provider, along with a comparison of setup complexity between Stripe and Square.

## Changes
- **Admin Guide Template**: Added a new Q&A section explaining why Stripe is recommended over Square, highlighting that Stripe has easier setup (automatic webhook creation) compared to Square's manual configuration requirements
- **Test Coverage**: Added a test case to verify the new payment provider recommendation content is present in the admin guide page

## Implementation Details
The new FAQ entry is positioned logically in the guide between the social sharing section and the payment reservation information section, providing users with guidance on payment provider selection before they encounter payment-related workflows.

https://claude.ai/code/session_01QxNuEKuYHFT7o8NjWhnHFD