### PR TITLE
Use SquareEnvironment enum for client configuration

### DIFF
--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Square } from "square";
+import { SquareEnvironment } from "square";
 import { lazyRef, map, once } from "#fp";
 import {
   getCurrencyCode,
@@ -143,7 +144,7 @@ const createSquareClient = async (accessToken: string, sandbox: boolean) => {
   const SquareClient = await loadSquare();
   return new SquareClient({
     token: accessToken,
-    environment: sandbox ? "sandbox" : "production",
+    environment: sandbox ? SquareEnvironment.Sandbox : SquareEnvironment.Production,
   });
 };
 


### PR DESCRIPTION
## Summary
Updated the Square client initialization to use the `SquareEnvironment` enum instead of string literals for the environment configuration.

## Key Changes
- Added import of `SquareEnvironment` from the "square" package
- Replaced string-based environment values (`"sandbox"` and `"production"`) with their corresponding enum values (`SquareEnvironment.Sandbox` and `SquareEnvironment.Production`)

## Implementation Details
This change improves type safety by leveraging the Square SDK's enum type for environment configuration. Using the enum instead of string literals provides better IDE support, prevents typos, and makes the code more maintainable by relying on the SDK's defined constants rather than magic strings.

https://claude.ai/code/session_01LVL5Tt3pzF5rxuSp3Xs3pF