### PR TITLE
Pass raw request bytes to webhook signature verification

### DIFF
--- a/src/lib/payment-crypto.ts
+++ b/src/lib/payment-crypto.ts
@@ -17,9 +17,10 @@ export const secureCompare = (a: string, b: string): boolean => {
   return result === 0;
 };
 
-/** Compute HMAC-SHA256 using Web Crypto API, returning raw ArrayBuffer */
+/** Compute HMAC-SHA256 using Web Crypto API, returning raw ArrayBuffer.
+ *  Accepts either a UTF-8 string or raw bytes for the data parameter. */
 export const computeHmacSha256 = async (
-  data: string,
+  data: string | Uint8Array,
   secret: string,
 ): Promise<ArrayBuffer> => {
   const encoder = new TextEncoder();
@@ -30,7 +31,10 @@ export const computeHmacSha256 = async (
     false,
     ["sign"],
   );
-  return crypto.subtle.sign("HMAC", key, encoder.encode(data));
+  const dataBytes = typeof data === "string"
+    ? encoder.encode(data)
+    : new Uint8Array(data);
+  return crypto.subtle.sign("HMAC", key, dataBytes);
 };
 
 /** Convert ArrayBuffer to hex string */

--- a/src/lib/payment-crypto.ts
+++ b/src/lib/payment-crypto.ts
@@ -17,10 +17,9 @@ export const secureCompare = (a: string, b: string): boolean => {
   return result === 0;
 };
 
-/** Compute HMAC-SHA256 using Web Crypto API, returning raw ArrayBuffer.
- *  Accepts either a UTF-8 string or raw bytes for the data parameter. */
+/** Compute HMAC-SHA256 using Web Crypto API, returning raw ArrayBuffer */
 export const computeHmacSha256 = async (
-  data: string | Uint8Array,
+  data: Uint8Array,
   secret: string,
 ): Promise<ArrayBuffer> => {
   const encoder = new TextEncoder();
@@ -31,10 +30,7 @@ export const computeHmacSha256 = async (
     false,
     ["sign"],
   );
-  const dataBytes = typeof data === "string"
-    ? encoder.encode(data)
-    : new Uint8Array(data);
-  return crypto.subtle.sign("HMAC", key, dataBytes);
+  return crypto.subtle.sign("HMAC", key, new Uint8Array(data));
 };
 
 /** Convert ArrayBuffer to hex string */

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -139,13 +139,13 @@ export interface PaymentProvider {
   /**
    * Verify a webhook request's signature and parse the event payload.
    * @param webhookUrl - The webhook endpoint URL derived from the incoming request
-   * @param payloadBytes - Raw body bytes for HMAC computation (avoids text round-trip)
+   * @param payloadBytes - Raw body bytes from request.arrayBuffer()
    */
   verifyWebhookSignature(
     payload: string,
     signature: string,
     webhookUrl: string,
-    payloadBytes?: Uint8Array,
+    payloadBytes: Uint8Array,
   ): Promise<WebhookVerifyResult>;
 
   /**

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -139,11 +139,13 @@ export interface PaymentProvider {
   /**
    * Verify a webhook request's signature and parse the event payload.
    * @param webhookUrl - The webhook endpoint URL derived from the incoming request
+   * @param payloadBytes - Raw body bytes for HMAC computation (avoids text round-trip)
    */
   verifyWebhookSignature(
     payload: string,
     signature: string,
     webhookUrl: string,
+    payloadBytes?: Uint8Array,
   ): Promise<WebhookVerifyResult>;
 
   /**

--- a/src/lib/square-provider.ts
+++ b/src/lib/square-provider.ts
@@ -101,8 +101,9 @@ export const squarePaymentProvider: PaymentProvider = {
     payload: string,
     signature: string,
     webhookUrl: string,
+    payloadBytes?: Uint8Array,
   ): Promise<WebhookVerifyResult> {
-    return verifyWebhookSignature(payload, signature, webhookUrl);
+    return verifyWebhookSignature(payload, signature, webhookUrl, payloadBytes);
   },
 
   refundPayment(paymentReference: string): Promise<boolean> {

--- a/src/lib/square-provider.ts
+++ b/src/lib/square-provider.ts
@@ -101,7 +101,7 @@ export const squarePaymentProvider: PaymentProvider = {
     payload: string,
     signature: string,
     webhookUrl: string,
-    payloadBytes?: Uint8Array,
+    payloadBytes: Uint8Array,
   ): Promise<WebhookVerifyResult> {
     return verifyWebhookSignature(payload, signature, webhookUrl, payloadBytes);
   },

--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -481,14 +481,12 @@ export const refundPayment = (id: string) => squareApi.refundPayment(id);
 
 /** Compute HMAC-SHA256 and return base64-encoded result (Square format) */
 const computeSquareSignature = async (
-  data: string | Uint8Array,
+  data: Uint8Array,
   secret: string,
 ): Promise<string> => hmacToBase64(await computeHmacSha256(data, secret));
 
-/** Concatenate notification URL bytes with raw body bytes for HMAC signing.
- *  Uses raw body bytes directly to avoid text decoding/encoding round-trip
- *  that can alter the payload in edge runtimes (e.g. Bunny CDN). */
-const buildSignedPayloadBytes = (
+/** Concatenate notification URL bytes with raw body bytes for HMAC signing */
+const buildSignedPayload = (
   notificationUrl: string,
   bodyBytes: Uint8Array,
 ): Uint8Array => {
@@ -503,16 +501,19 @@ const buildSignedPayloadBytes = (
  * Verify Square webhook signature using Web Crypto API.
  * Square signs: HMAC-SHA256(signature_key, notification_url + raw_body)
  *
+ * Uses raw body bytes directly for HMAC computation to avoid a text
+ * decoding/encoding round-trip that can alter the payload in CDN edge runtimes.
+ *
  * @param payload - Raw request body as string (used for JSON parsing)
  * @param signature - x-square-hmacsha256-signature header value
  * @param notificationUrl - The webhook notification URL registered with Square
- * @param payloadBytes - Raw body bytes for HMAC computation (avoids text round-trip)
+ * @param payloadBytes - Raw body bytes from request.arrayBuffer()
  */
 export const verifyWebhookSignature = async (
   payload: string,
   signature: string,
-  notificationUrl?: string,
-  payloadBytes?: Uint8Array,
+  notificationUrl: string,
+  payloadBytes: Uint8Array,
 ): Promise<WebhookVerifyResult> => {
   const secret = await getSquareWebhookSignatureKey();
   if (!secret) {
@@ -520,23 +521,14 @@ export const verifyWebhookSignature = async (
     return { valid: false, error: "Webhook signature key not configured" };
   }
 
-  if (!notificationUrl) {
-    logError({ code: ErrorCode.SQUARE_SIGNATURE, detail: "notification URL required" });
-    return { valid: false, error: "Notification URL required for verification" };
-  }
-
   // Square signs: notification_url + raw_body
-  // Use raw bytes when available to avoid text decoding/encoding round-trip
-  // that can alter the payload in CDN edge runtimes.
-  const signedData: string | Uint8Array = payloadBytes
-    ? buildSignedPayloadBytes(notificationUrl, payloadBytes)
-    : notificationUrl + payload;
+  const signedData = buildSignedPayload(notificationUrl, payloadBytes);
   const expectedSignature = await computeSquareSignature(signedData, secret);
 
   if (!secureCompare(signature, expectedSignature)) {
     logError({
       code: ErrorCode.SQUARE_SIGNATURE,
-      detail: `mismatch: notificationUrl=${notificationUrl}, receivedLength=${signature.length}, expectedLength=${expectedSignature.length}, receivedPrefix=${signature.slice(0, 8)}..., expectedPrefix=${expectedSignature.slice(0, 8)}..., bodyLength=${payloadBytes?.length ?? payload.length}`,
+      detail: `mismatch: notificationUrl=${notificationUrl}, receivedLength=${signature.length}, expectedLength=${expectedSignature.length}, receivedPrefix=${signature.slice(0, 8)}..., expectedPrefix=${expectedSignature.slice(0, 8)}..., bodyLength=${payloadBytes.length}`,
     });
     return { valid: false, error: "Signature verification failed" };
   }
@@ -561,6 +553,8 @@ export const constructTestWebhookEvent = async (
   notificationUrl: string,
 ): Promise<{ payload: string; signature: string }> => {
   const body = JSON.stringify(event);
-  const signature = await computeSquareSignature(notificationUrl + body, secret);
+  const bodyBytes = new TextEncoder().encode(body);
+  const signedPayload = buildSignedPayload(notificationUrl, bodyBytes);
+  const signature = await computeSquareSignature(signedPayload, secret);
   return { payload: body, signature };
 };

--- a/src/lib/stripe-provider.ts
+++ b/src/lib/stripe-provider.ts
@@ -81,6 +81,7 @@ export const stripePaymentProvider: PaymentProvider = {
     payload: string,
     signature: string,
     _webhookUrl: string,
+    _payloadBytes: Uint8Array,
   ): Promise<WebhookVerifyResult> {
     const result = await verifyWebhookSignature(payload, signature);
     if (!result.valid) {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -472,7 +472,8 @@ const parseSignatureHeader = (
 const computeSignature = async (
   payload: string,
   secret: string,
-): Promise<string> => hmacToHex(await computeHmacSha256(payload, secret));
+): Promise<string> =>
+  hmacToHex(await computeHmacSha256(new TextEncoder().encode(payload), secret));
 
 /** Stripe webhook event - alias for the provider-agnostic WebhookEvent */
 export type StripeWebhookEvent = WebhookEvent;

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -1657,6 +1657,7 @@ describe("stripe-provider", () => {
         payload,
         signature,
         "https://example.com/payment/webhook",
+        new TextEncoder().encode(payload),
       );
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -1669,10 +1670,12 @@ describe("stripe-provider", () => {
       await setStripeWebhookConfig({ secret: TEST_SECRET, endpointId: "we_provider_inv" });
 
       const timestamp = Math.floor(Date.now() / 1000);
+      const body = '{"test": true}';
       const result = await stripePaymentProvider.verifyWebhookSignature(
-        '{"test": true}',
+        body,
         `t=${timestamp},v1=invalid_sig`,
         "https://example.com/payment/webhook",
+        new TextEncoder().encode(body),
       );
 
       expect(result.valid).toBe(false);


### PR DESCRIPTION
## Summary
Updated webhook signature verification to accept and use raw request body bytes directly, avoiding text encoding/decoding round-trips that can silently alter payloads in CDN edge runtimes.

## Key Changes
- **Modified `computeHmacSha256`** to accept `Uint8Array` instead of `string`, eliminating unnecessary encoding steps
- **Updated `verifyWebhookSignature`** to require `payloadBytes: Uint8Array` parameter and use it directly for HMAC computation instead of re-encoding the string payload
- **Made `notificationUrl` required** in `verifyWebhookSignature` (removed optional check)
- **Added `buildSignedPayload` helper** to properly concatenate notification URL bytes with raw body bytes for HMAC signing
- **Updated webhook handler** to read raw bytes via `request.arrayBuffer()` and pass them to signature verification
- **Updated all callers** (Square provider, Stripe provider, tests) to pass raw body bytes from `new TextEncoder().encode(payload)` or `request.arrayBuffer()`
- **Updated test suite** to pass `Uint8Array` to `computeHmacSha256` and provide raw bytes to `verifyWebhookSignature`

## Implementation Details
- The change preserves the string payload for JSON parsing while using raw bytes for cryptographic operations
- This prevents potential payload corruption from text encoding/decoding round-trips that can occur in CDN edge runtimes
- The signature verification now computes HMAC on the exact bytes received from the network, improving reliability
- All payment providers (Square, Stripe) now follow the same pattern of accepting raw payload bytes

https://claude.ai/code/session_01Bkxeq7PtRcuvryPpzuHuUu