### PR TITLE
Check payment status directly instead of relying on order state

### DIFF
--- a/src/lib/square-provider.ts
+++ b/src/lib/square-provider.ts
@@ -81,19 +81,11 @@ export const squarePaymentProvider: PaymentProvider = {
       return null;
     }
 
-    // Determine payment status from order state and tenders
+    // Determine payment status from the payment itself (most reliable source)
     const paymentReference = order.tenders?.[0]?.paymentId ?? "";
 
-    // Square order state "COMPLETED" means payment is done.
-    // However, the order state may lag behind the actual payment —
-    // the redirect arrives before Square updates the order state from OPEN
-    // to COMPLETED. When the order isn't COMPLETED yet but has a tender
-    // with a paymentId, check the payment status directly.
     let paymentStatus: ValidatedPaymentSession["paymentStatus"] = "unpaid";
-
-    if (order.state === "COMPLETED") {
-      paymentStatus = "paid";
-    } else if (paymentReference) {
+    if (paymentReference) {
       const payment = await retrievePayment(paymentReference);
       if (payment?.status === "COMPLETED") {
         paymentStatus = "paid";

--- a/src/lib/square-provider.ts
+++ b/src/lib/square-provider.ts
@@ -84,9 +84,21 @@ export const squarePaymentProvider: PaymentProvider = {
     // Determine payment status from order state and tenders
     const paymentReference = order.tenders?.[0]?.paymentId ?? "";
 
-    // Square order state "COMPLETED" means payment is done
-    const paymentStatus: ValidatedPaymentSession["paymentStatus"] =
-      order.state === "COMPLETED" ? "paid" : "unpaid";
+    // Square order state "COMPLETED" means payment is done.
+    // However, the order state may lag behind the actual payment —
+    // the redirect arrives before Square updates the order state from OPEN
+    // to COMPLETED. When the order isn't COMPLETED yet but has a tender
+    // with a paymentId, check the payment status directly.
+    let paymentStatus: ValidatedPaymentSession["paymentStatus"] = "unpaid";
+
+    if (order.state === "COMPLETED") {
+      paymentStatus = "paid";
+    } else if (paymentReference) {
+      const payment = await retrievePayment(paymentReference);
+      if (payment?.status === "COMPLETED") {
+        paymentStatus = "paid";
+      }
+    }
 
     return {
       id: order.id,

--- a/test/lib/square-provider.test.ts
+++ b/test/lib/square-provider.test.ts
@@ -30,6 +30,109 @@ describe("square-provider", () => {
         },
       );
     });
+
+    test("returns paid when order state is COMPLETED", async () => {
+      await withMocks(
+        () => spyOn(squareApi, "retrieveOrder").mockResolvedValue({
+          id: "order_completed",
+          metadata: { name: "Alice", email: "alice@example.com", event_id: "1", quantity: "1" },
+          tenders: [{ id: "tender_1", paymentId: "pay_1" }],
+          state: "COMPLETED",
+          totalMoney: { amount: BigInt(1000), currency: "USD" },
+        }),
+        async () => {
+          const result = await squarePaymentProvider.retrieveSession("order_completed");
+          expect(result).not.toBeNull();
+          expect(result!.paymentStatus).toBe("paid");
+          expect(result!.paymentReference).toBe("pay_1");
+        },
+      );
+    });
+
+    test("returns paid when order state is OPEN but payment is COMPLETED", async () => {
+      await withMocks(
+        () => ({
+          order: spyOn(squareApi, "retrieveOrder").mockResolvedValue({
+            id: "order_open",
+            metadata: { name: "Bob", email: "bob@example.com", event_id: "1", quantity: "1" },
+            tenders: [{ id: "tender_1", paymentId: "pay_2" }],
+            state: "OPEN",
+            totalMoney: { amount: BigInt(1000), currency: "USD" },
+          }),
+          payment: spyOn(squareApi, "retrievePayment").mockResolvedValue({
+            id: "pay_2",
+            status: "COMPLETED",
+          }),
+        }),
+        async (mocks) => {
+          const result = await squarePaymentProvider.retrieveSession("order_open");
+          expect(result).not.toBeNull();
+          expect(result!.paymentStatus).toBe("paid");
+          expect(result!.paymentReference).toBe("pay_2");
+          expect(mocks.payment).toHaveBeenCalledWith("pay_2");
+        },
+      );
+    });
+
+    test("returns unpaid when order state is OPEN and payment is not COMPLETED", async () => {
+      await withMocks(
+        () => ({
+          order: spyOn(squareApi, "retrieveOrder").mockResolvedValue({
+            id: "order_open",
+            metadata: { name: "Carol", email: "carol@example.com", event_id: "1", quantity: "1" },
+            tenders: [{ id: "tender_1", paymentId: "pay_3" }],
+            state: "OPEN",
+            totalMoney: { amount: BigInt(1000), currency: "USD" },
+          }),
+          payment: spyOn(squareApi, "retrievePayment").mockResolvedValue({
+            id: "pay_3",
+            status: "PENDING",
+          }),
+        }),
+        async () => {
+          const result = await squarePaymentProvider.retrieveSession("order_open");
+          expect(result).not.toBeNull();
+          expect(result!.paymentStatus).toBe("unpaid");
+        },
+      );
+    });
+
+    test("returns unpaid when order state is OPEN and no tenders exist", async () => {
+      await withMocks(
+        () => spyOn(squareApi, "retrieveOrder").mockResolvedValue({
+          id: "order_no_tenders",
+          metadata: { name: "Dave", email: "dave@example.com", event_id: "1", quantity: "1" },
+          state: "OPEN",
+          totalMoney: { amount: BigInt(1000), currency: "USD" },
+        }),
+        async () => {
+          const result = await squarePaymentProvider.retrieveSession("order_no_tenders");
+          expect(result).not.toBeNull();
+          expect(result!.paymentStatus).toBe("unpaid");
+        },
+      );
+    });
+
+    test("does not call retrievePayment when order state is COMPLETED", async () => {
+      await withMocks(
+        () => ({
+          order: spyOn(squareApi, "retrieveOrder").mockResolvedValue({
+            id: "order_done",
+            metadata: { name: "Eve", email: "eve@example.com", event_id: "1", quantity: "1" },
+            tenders: [{ id: "tender_1", paymentId: "pay_4" }],
+            state: "COMPLETED",
+            totalMoney: { amount: BigInt(1000), currency: "USD" },
+          }),
+          payment: spyOn(squareApi, "retrievePayment").mockResolvedValue(null),
+        }),
+        async (mocks) => {
+          const result = await squarePaymentProvider.retrieveSession("order_done");
+          expect(result).not.toBeNull();
+          expect(result!.paymentStatus).toBe("paid");
+          expect(mocks.payment).not.toHaveBeenCalled();
+        },
+      );
+    });
   });
 
   describe("isPaymentRefunded", () => {

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -1268,7 +1268,7 @@ describe("square", () => {
 
   describe("squarePaymentProvider integration", () => {
     test("retrieveSession maps COMPLETED order to paid status", async () => {
-      const { client, ordersGet } = createMockClient();
+      const { client, ordersGet, paymentsGet } = createMockClient();
       ordersGet.mockResolvedValue({
         order: {
           id: "order_paid",
@@ -1283,6 +1283,9 @@ describe("square", () => {
           state: "COMPLETED",
           totalMoney: { amount: BigInt(5000), currency: "USD" },
         },
+      });
+      paymentsGet.mockResolvedValue({
+        payment: { id: "pay_abc", status: "COMPLETED" },
       });
 
       await withMocks(
@@ -1379,7 +1382,7 @@ describe("square", () => {
     });
 
     test("retrieveSession returns amountTotal from order totalMoney", async () => {
-      const { client, ordersGet } = createMockClient();
+      const { client, ordersGet, paymentsGet } = createMockClient();
       ordersGet.mockResolvedValue({
         order: {
           id: "order_with_amount",
@@ -1393,6 +1396,9 @@ describe("square", () => {
           state: "COMPLETED",
           totalMoney: { amount: BigInt(6000), currency: "GBP" },
         },
+      });
+      paymentsGet.mockResolvedValue({
+        payment: { id: "pay_total_123", status: "COMPLETED" },
       });
 
       await withMocks(
@@ -1410,7 +1416,7 @@ describe("square", () => {
 
     test("retrieveSession handles multi-ticket order", async () => {
       const items = JSON.stringify([{ e: 1, q: 2 }, { e: 2, q: 1 }]);
-      const { client, ordersGet } = createMockClient();
+      const { client, ordersGet, paymentsGet } = createMockClient();
       ordersGet.mockResolvedValue({
         order: {
           id: "order_multi",
@@ -1424,6 +1430,9 @@ describe("square", () => {
           state: "COMPLETED",
           totalMoney: { amount: BigInt(3000), currency: "USD" },
         },
+      });
+      paymentsGet.mockResolvedValue({
+        payment: { id: "pay_multi", status: "COMPLETED" },
       });
 
       await withMocks(


### PR DESCRIPTION
## Summary
Updated the Square payment provider to determine payment status by querying the actual payment object instead of inferring it from the order state. This provides a more reliable source of truth for payment completion.

## Key Changes
- Modified `squarePaymentProvider.retrieveSession()` to call `retrievePayment()` when a payment reference exists
- Changed payment status logic from checking `order.state === "COMPLETED"` to checking `payment.status === "COMPLETED"`
- This allows accurate payment status detection even when order state is `OPEN` but payment is already completed
- Updated all related integration tests to mock the `paymentsGet` call and verify the new behavior

## Implementation Details
- The payment reference is extracted from `order.tenders[0].paymentId` as before
- If a payment reference exists, the actual payment object is retrieved and its status is checked
- Payment status is set to "paid" only when the payment status is explicitly "COMPLETED"
- All other cases (no payment reference, payment not completed, etc.) default to "unpaid"
- This change makes the payment status determination more robust and independent of order state transitions

https://claude.ai/code/session_01APrxFm698yuhrEyNC7ceK9