### PR TITLE
Change checked_in field from string to boolean type

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -80,8 +80,8 @@ const decryptAttendeeFields = async (
     decryptField(row.special_instructions, privateKey, "special_instructions", activeFields),
     paidEvent ? decryptAttendeePII(row.payment_id, privateKey) : Promise.resolve(""),
     paidEvent ? decrypt(row.price_paid) : Promise.resolve("0"),
-    decryptBoolField(row.checked_in, privateKey),
-    // Raw DB value is an encrypted string; cast needed since Attendee type declares boolean
+    // Raw DB values are encrypted strings; cast needed since Attendee type declares boolean
+    decryptBoolField(row.checked_in as unknown as string, privateKey),
     paidEvent ? decryptBoolField(row.refunded as unknown as string, privateKey) : Promise.resolve("false"),
     decryptAttendeePII(row.ticket_token, privateKey),
   ]);
@@ -94,7 +94,7 @@ const decryptAttendeeFields = async (
     special_instructions,
     payment_id,
     price_paid,
-    checked_in,
+    checked_in: checked_in === "true",
     refunded: refundedStr === "true",
     ticket_token,
   };
@@ -227,7 +227,7 @@ const buildAttendeeResult = (input: BuildAttendeeInput): Attendee => ({
   payment_id: input.paymentId,
   quantity: input.quantity,
   price_paid: String(input.pricePaid),
-  checked_in: "false",
+  checked_in: false,
   refunded: false,
   ticket_token: input.ticketToken,
   ticket_token_index: input.ticketTokenIndex,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,7 +66,7 @@ export interface Attendee extends ContactInfo {
   payment_id: string;
   quantity: number;
   price_paid: string;
-  checked_in: string;
+  checked_in: boolean;
   refunded: boolean;
   ticket_token: string;
   ticket_token_index: string;

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -171,7 +171,7 @@ const handleAttendeeDelete = attendeeFormAction(async (data, session, form, even
 
 /** Handle POST /admin/event/:eventId/attendee/:attendeeId/checkin */
 const handleAttendeeCheckin = attendeeFormAction(async (data, _session, form, eventId, attendeeId) => {
-  const wasCheckedIn = data.attendee.checked_in === "true";
+  const wasCheckedIn = data.attendee.checked_in;
   const nowCheckedIn = !wasCheckedIn;
 
   await updateCheckedIn(attendeeId, nowCheckedIn);

--- a/src/routes/admin/scanner.ts
+++ b/src/routes/admin/scanner.ts
@@ -88,7 +88,7 @@ const handleScanPost = (request: Request, { id }: { id: number }): Promise<Respo
     }
 
     // Already checked in
-    if (attendee.checked_in === "true") {
+    if (attendee.checked_in) {
       return jsonResponse({
         status: "already_checked_in",
         name: attendee.name,

--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -84,7 +84,7 @@ const handleCheckinPost = (request: Request, tokens: string[]): Promise<Response
     const totalTickets = sumTicketCount(eligible);
     const uncheckedTickets = sumTicketCount(
       eligible,
-      (attendee) => attendee.checked_in !== "true",
+      (attendee) => !attendee.checked_in,
     );
     await Promise.all(map((a: Attendee) => updateCheckedIn(a.id, checkedIn))(eligible));
 

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -37,7 +37,7 @@ export const calculateTotalRevenue = (attendees: Attendee[]): number =>
 
 /** Count how many attendees are checked in */
 export const countCheckedIn = (attendees: Attendee[]): number =>
-  filter((a: Attendee) => a.checked_in === "true")(attendees).length;
+  filter((a: Attendee) => a.checked_in)(attendees).length;
 
 
 /** Check if event is within 10% of capacity */
@@ -53,8 +53,8 @@ export type AddAttendeeMessage = { name: string } | { edited: string } | { error
 
 /** Filter attendees by check-in status */
 const filterAttendees = (attendees: Attendee[], activeFilter: AttendeeFilter): Attendee[] => {
-  if (activeFilter === "in") return filter((a: Attendee) => a.checked_in === "true")(attendees);
-  if (activeFilter === "out") return filter((a: Attendee) => a.checked_in !== "true")(attendees);
+  if (activeFilter === "in") return filter((a: Attendee) => a.checked_in)(attendees);
+  if (activeFilter === "out") return filter((a: Attendee) => !a.checked_in)(attendees);
   return attendees;
 };
 

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -35,6 +35,10 @@ export const calculateTotalRevenue = (attendees: Attendee[]): number =>
   reduce((sum: number, a: Attendee) =>
     sum + Number.parseInt(a.price_paid, 10), 0)(attendees);
 
+/** Count how many attendees are checked in */
+export const countCheckedIn = (attendees: Attendee[]): number =>
+  filter((a: Attendee) => a.checked_in === "true")(attendees).length;
+
 
 /** Check if event is within 10% of capacity */
 export const nearCapacity = (event: EventWithCount): boolean =>
@@ -110,6 +114,8 @@ export const adminEventPage = ({
   const isDaily = event.event_type === "daily";
   const filteredAttendees = filterAttendees(attendees, activeFilter);
   const hasPaidEvent = event.unit_price !== null;
+  const checkedIn = countCheckedIn(attendees);
+  const checkedInRemaining = attendees.length - checkedIn;
   const basePath = `/admin/event/${event.id}`;
   const dateQs = dateFilter ? `?date=${dateFilter}` : "";
   const suffix = filterSuffix(activeFilter);
@@ -206,6 +212,14 @@ export const adminEventPage = ({
                   {isDaily && !dateFilter && (
                     <>{" "}<small>Capacity of {event.max_attendees} applies per date</small></>
                   )}
+                </td>
+              </tr>
+              <tr>
+                <th>Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
+                <td>
+                  <span>
+                    {checkedIn} / {attendees.length} &mdash; {checkedInRemaining} remain
+                  </span>
                 </td>
               </tr>
               {event.unit_price !== null && (

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -122,7 +122,7 @@ const CheckinButton = ({ a, eventId, activeFilter, returnUrl }: {
   activeFilter: string;
   returnUrl: string | undefined;
 }): string => {
-  const isCheckedIn = a.checked_in === "true";
+  const isCheckedIn = a.checked_in;
   const label = isCheckedIn ? "Check out" : "Check in";
   const buttonClass = isCheckedIn ? "link-button checkout" : "link-button checkin";
   return String(

--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -34,7 +34,7 @@ export const checkinAdminPage = (
     })),
   )(entries);
 
-  const allCheckedIn = entries.every((e) => e.attendee.checked_in === "true");
+  const allCheckedIn = entries.every((e) => e.attendee.checked_in);
   const buttonLabel = allCheckedIn ? "Check Out All" : "Check In All";
   const buttonClass = allCheckedIn ? "bulk-checkout" : "bulk-checkin";
   const nextValue = allCheckedIn ? "false" : "true";

--- a/src/templates/csv.ts
+++ b/src/templates/csv.ts
@@ -31,8 +31,8 @@ const formatPrice = (pricePaid: string): string =>
   toMajorUnits(Number.parseInt(pricePaid, 10));
 
 /** Format checked_in value as Yes/No */
-const formatCheckedIn = (checkedIn: string): string =>
-  checkedIn === "true" ? "Yes" : "No";
+const formatCheckedIn = (checkedIn: boolean): string =>
+  checkedIn ? "Yes" : "No";
 
 /** Build standard attendee CSV columns (shared by all CSV generators) */
 const attendeeCols = (a: Attendee, domain: string): string[] => [

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1045,7 +1045,7 @@ export const testAttendee = (overrides: Partial<Attendee> = {}): Attendee => ({
   payment_id: "",
   quantity: 1,
   price_paid: "0",
-  checked_in: "false",
+  checked_in: false,
   refunded: false,
   ticket_token: "test-token-1",
   ticket_token_index: "test-token-index-1",

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -214,14 +214,14 @@ describe("AttendeeTable", () => {
 
   describe("check-in button", () => {
     test("shows Check in for unchecked attendee", () => {
-      const rows = [makeRow({ attendee: testAttendee({ checked_in: "false" }) })];
+      const rows = [makeRow({ attendee: testAttendee({ checked_in: false }) })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).toContain("Check in");
       expect(html).toContain('class="link-button checkin"');
     });
 
     test("shows Check out for checked-in attendee", () => {
-      const rows = [makeRow({ attendee: testAttendee({ checked_in: "true" }) })];
+      const rows = [makeRow({ attendee: testAttendee({ checked_in: true }) })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).toContain("Check out");
       expect(html).toContain('class="link-button checkout"');

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -1851,7 +1851,7 @@ describe("db", () => {
       expect(attendees[0]?.name).toBe("Core Fields");
       expect(attendees[0]?.ticket_token).toBeTruthy();
       expect(attendees[0]?.payment_id).toBe("pi_test_core");
-      expect(attendees[0]?.checked_in).toBe("false");
+      expect(attendees[0]?.checked_in).toBe(false);
       expect(attendees[0]?.refunded).toBe(false);
       expect(attendees[0]?.price_paid).toBe("1500");
       // Contact fields not listed should be empty
@@ -1914,7 +1914,7 @@ describe("db", () => {
       expect(attendees[0]?.name).toBe("Free Attendee");
       expect(attendees[0]?.email).toBe("free@example.com");
       expect(attendees[0]?.ticket_token).toBeTruthy();
-      expect(attendees[0]?.checked_in).toBe("false");
+      expect(attendees[0]?.checked_in).toBe(false);
       // Payment fields skipped for free events
       expect(attendees[0]?.payment_id).toBe("");
       expect(attendees[0]?.price_paid).toBe("0");
@@ -2371,7 +2371,7 @@ describe("db", () => {
       const privateKey = await getTestPrivateKey();
       const rows = await getAttendeesRaw(event.id);
       const decrypted = await decryptAttendees(rows, privateKey);
-      expect(decrypted[0]?.checked_in).toBe("true");
+      expect(decrypted[0]?.checked_in).toBe(true);
     });
 
     test("updates checked_in back to false", async () => {
@@ -2384,7 +2384,7 @@ describe("db", () => {
       const privateKey = await getTestPrivateKey();
       const rows = await getAttendeesRaw(event.id);
       const decrypted = await decryptAttendees(rows, privateKey);
-      expect(decrypted[0]?.checked_in).toBe("false");
+      expect(decrypted[0]?.checked_in).toBe(false);
     });
   });
 
@@ -2401,10 +2401,10 @@ describe("db", () => {
 
       const privateKey = await getTestPrivateKey();
       const rows = await getAttendeesRaw(event.id);
-      expect(rows[0]?.checked_in).toBe("");
+      expect(rows[0]?.checked_in as unknown).toBe("");
 
       const decrypted = await decryptAttendees(rows, privateKey);
-      expect(decrypted[0]?.checked_in).toBe("false");
+      expect(decrypted[0]?.checked_in).toBe(false);
     });
   });
 
@@ -2431,12 +2431,12 @@ describe("db", () => {
 
       // Verify the backfill encrypted the value (no longer empty)
       const rows = await getAttendeesRaw(event.id);
-      expect(rows[0]?.checked_in).not.toBe("");
+      expect(rows[0]?.checked_in as unknown).not.toBe("");
 
       // Verify it decrypts to "false"
       const privateKey = await getTestPrivateKey();
       const decrypted = await decryptAttendees(rows, privateKey);
-      expect(decrypted[0]?.checked_in).toBe("false");
+      expect(decrypted[0]?.checked_in).toBe(false);
     });
   });
 
@@ -2513,7 +2513,7 @@ describe("db", () => {
       expect(before[0]?.phone).toBe("");
       expect(before[0]?.address).toBe("");
       expect(before[0]?.special_instructions).toBe("");
-      expect(before[0]?.checked_in).toBe("");
+      expect(before[0]?.checked_in as unknown).toBe("");
 
       // Clear version marker and re-run migrations
       await getDb().execute("DELETE FROM settings WHERE key = 'latest_db_update'");
@@ -2530,8 +2530,8 @@ describe("db", () => {
       expect(after[0]?.address).toContain("hyb:1:");
       expect(after[0]?.special_instructions).not.toBe("");
       expect(after[0]?.special_instructions).toContain("hyb:1:");
-      expect(after[0]?.checked_in).not.toBe("");
-      expect(after[0]?.checked_in).toContain("hyb:1:");
+      expect(after[0]?.checked_in as unknown).not.toBe("");
+      expect(after[0]?.checked_in as unknown as string).toContain("hyb:1:");
 
       // Verify they decrypt correctly
       const privateKey = await getTestPrivateKey();
@@ -2540,7 +2540,7 @@ describe("db", () => {
       expect(decrypted[0]?.phone).toBe("");
       expect(decrypted[0]?.address).toBe("");
       expect(decrypted[0]?.special_instructions).toBe("");
-      expect(decrypted[0]?.checked_in).toBe("false");
+      expect(decrypted[0]?.checked_in).toBe(false);
     });
 
     test("handles partial corruption gracefully", async () => {
@@ -2645,7 +2645,7 @@ describe("db", () => {
 
       // Verify corrupted state
       const before = await getAttendeesRaw(event.id);
-      expect(before[0]?.checked_in).toBe("");
+      expect(before[0]?.checked_in as unknown).toBe("");
 
       // Clear version marker and re-run migrations
       await getDb().execute("DELETE FROM settings WHERE key = 'latest_db_update'");
@@ -2654,13 +2654,13 @@ describe("db", () => {
 
       // Verify checked_in is now encrypted
       const after = await getAttendeesRaw(event.id);
-      expect(after[0]?.checked_in).not.toBe("");
-      expect(after[0]?.checked_in).toContain("hyb:1:");
+      expect(after[0]?.checked_in as unknown).not.toBe("");
+      expect(after[0]?.checked_in as unknown as string).toContain("hyb:1:");
 
       // Verify it decrypts correctly to "false"
       const privateKey = await getTestPrivateKey();
       const decrypted = await decryptAttendees(after, privateKey);
-      expect(decrypted[0]?.checked_in).toBe("false");
+      expect(decrypted[0]?.checked_in).toBe(false);
     });
   });
 

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -162,9 +162,9 @@ describe("html", () => {
 
     test("shows checked in count and remaining", () => {
       const attendees = [
-        testAttendee({ id: 1, checked_in: "true" }),
-        testAttendee({ id: 2, checked_in: "false" }),
-        testAttendee({ id: 3, checked_in: "false" }),
+        testAttendee({ id: 1, checked_in: true }),
+        testAttendee({ id: 2, checked_in: false }),
+        testAttendee({ id: 3, checked_in: false }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
       expect(html).toContain("Checked In");
@@ -890,14 +890,14 @@ describe("html", () => {
     });
 
     test("includes Checked In as Yes for checked-in attendee", () => {
-      const attendees = [testAttendee({ checked_in: "true" })];
+      const attendees = [testAttendee({ checked_in: true })];
       const csv = generateAttendeesCsv(attendees);
       const lines = csv.split("\n");
       expect(lines[1]).toContain(",Yes,");
     });
 
     test("includes Checked In as No for not checked-in attendee", () => {
-      const attendees = [testAttendee({ checked_in: "false" })];
+      const attendees = [testAttendee({ checked_in: false })];
       const csv = generateAttendeesCsv(attendees);
       const lines = csv.split("\n");
       expect(lines[1]).toContain(",No,");
@@ -976,8 +976,8 @@ describe("html", () => {
     test("filters to only checked-in attendees when filter is in", () => {
       const event = testEventWithCount({ attendee_count: 2 });
       const attendees = [
-        testAttendee({ id: 1, name: "Checked In User", checked_in: "true" }),
-        testAttendee({ id: 2, name: "Not Checked In User", checked_in: "false" }),
+        testAttendee({ id: 1, name: "Checked In User", checked_in: true }),
+        testAttendee({ id: 2, name: "Not Checked In User", checked_in: false }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION, activeFilter: "in" });
       expect(html).toContain("Checked In User");
@@ -987,8 +987,8 @@ describe("html", () => {
     test("filters to only checked-out attendees when filter is out", () => {
       const event = testEventWithCount({ attendee_count: 2 });
       const attendees = [
-        testAttendee({ id: 1, name: "Alice InPerson", checked_in: "true" }),
-        testAttendee({ id: 2, name: "Bob Remote", checked_in: "false" }),
+        testAttendee({ id: 1, name: "Alice InPerson", checked_in: true }),
+        testAttendee({ id: 2, name: "Bob Remote", checked_in: false }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION, activeFilter: "out" });
       expect(html).not.toContain("Alice InPerson");
@@ -998,8 +998,8 @@ describe("html", () => {
     test("shows all attendees when filter is all", () => {
       const event = testEventWithCount({ attendee_count: 2 });
       const attendees = [
-        testAttendee({ id: 1, name: "Checked In User", checked_in: "true" }),
-        testAttendee({ id: 2, name: "Not Checked In User", checked_in: "false" }),
+        testAttendee({ id: 1, name: "Checked In User", checked_in: true }),
+        testAttendee({ id: 2, name: "Not Checked In User", checked_in: false }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION, activeFilter: "all" });
       expect(html).toContain("Checked In User");
@@ -1008,7 +1008,7 @@ describe("html", () => {
 
     test("includes return_filter hidden field in checkin form", () => {
       const event = testEventWithCount({ attendee_count: 1 });
-      const attendees = [testAttendee({ checked_in: "true" })];
+      const attendees = [testAttendee({ checked_in: true })];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION, activeFilter: "in" });
       expect(html).toContain('name="return_filter"');
       expect(html).toContain('value="in"');
@@ -1212,17 +1212,17 @@ describe("html", () => {
 
     test("counts attendees with checked_in true", () => {
       const attendees = [
-        testAttendee({ id: 1, checked_in: "true" }),
-        testAttendee({ id: 2, checked_in: "false" }),
-        testAttendee({ id: 3, checked_in: "true" }),
+        testAttendee({ id: 1, checked_in: true }),
+        testAttendee({ id: 2, checked_in: false }),
+        testAttendee({ id: 3, checked_in: true }),
       ];
       expect(countCheckedIn(attendees)).toBe(2);
     });
 
     test("returns 0 when none checked in", () => {
       const attendees = [
-        testAttendee({ id: 1, checked_in: "false" }),
-        testAttendee({ id: 2, checked_in: "false" }),
+        testAttendee({ id: 1, checked_in: false }),
+        testAttendee({ id: 2, checked_in: false }),
       ];
       expect(countCheckedIn(attendees)).toBe(0);
     });
@@ -1673,7 +1673,7 @@ describe("html", () => {
         quantity: 2,
         price_paid: "2000",
         payment_id: "pi_abc",
-        checked_in: "true",
+        checked_in: true,
       })];
       const csv = generateCalendarCsv(attendees);
       const lines = csv.split("\n");

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "#test-compat";
 import { CSS_PATH, EMBED_JS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, IFRAME_RESIZER_PARENT_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
 import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
-import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, formatAddressInline, nearCapacity } from "#templates/admin/events.tsx";
+import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, countCheckedIn, formatAddressInline, nearCapacity } from "#templates/admin/events.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
 import { adminEventActivityLogPage, adminGlobalActivityLogPage } from "#templates/admin/activityLog.tsx";
 import { Breadcrumb } from "#templates/admin/nav.tsx";
@@ -151,6 +151,25 @@ describe("html", () => {
       expect(html).toContain("Attendees");
       expect(html).toContain("2 / 100");
       expect(html).toContain("98 remain");
+    });
+
+    test("shows checked in row with 0 of 0 when no attendees", () => {
+      const html = adminEventPage({ event, attendees: [], allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).toContain("Checked In");
+      expect(html).toContain("0 / 0");
+      expect(html).toContain("0 remain");
+    });
+
+    test("shows checked in count and remaining", () => {
+      const attendees = [
+        testAttendee({ id: 1, checked_in: "true" }),
+        testAttendee({ id: 2, checked_in: "false" }),
+        testAttendee({ id: 3, checked_in: "false" }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).toContain("Checked In");
+      expect(html).toContain("1 / 3");
+      expect(html).toContain("2 remain");
     });
 
     test("shows thank you URL in copyable input", () => {
@@ -1183,6 +1202,29 @@ describe("html", () => {
         testAttendee({ id: 2, quantity: 2 }),
       ];
       expect(calculateTotalRevenue(attendees)).toBe(1500);
+    });
+  });
+
+  describe("countCheckedIn", () => {
+    test("returns 0 for empty attendees", () => {
+      expect(countCheckedIn([])).toBe(0);
+    });
+
+    test("counts attendees with checked_in true", () => {
+      const attendees = [
+        testAttendee({ id: 1, checked_in: "true" }),
+        testAttendee({ id: 2, checked_in: "false" }),
+        testAttendee({ id: 3, checked_in: "true" }),
+      ];
+      expect(countCheckedIn(attendees)).toBe(2);
+    });
+
+    test("returns 0 when none checked in", () => {
+      const attendees = [
+        testAttendee({ id: 1, checked_in: "false" }),
+        testAttendee({ id: 2, checked_in: "false" }),
+      ];
+      expect(countCheckedIn(attendees)).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR changes the `checked_in` field in the `Attendee` type from a string (`"true"`/`"false"`) to a boolean type, improving type safety and code clarity throughout the application.

## Key Changes

- **Type Definition**: Updated `Attendee.checked_in` from `string` to `boolean` in `src/lib/types.ts`

- **Database Layer**: Modified `src/lib/db/attendees.ts` to:
  - Convert decrypted string values to boolean when building attendee objects
  - Update `buildAttendeeResult` to initialize `checked_in` as `false` (boolean) instead of `"false"` (string)
  - Add type casts for raw encrypted database values that remain as strings

- **Template Updates**: 
  - Updated `src/templates/admin/events.tsx` to:
    - Add new `countCheckedIn()` function to count checked-in attendees
    - Display a "Checked In" row showing count and remaining attendees
    - Update filter logic to use boolean comparisons instead of string comparisons
  - Updated `src/templates/csv.ts` to accept boolean for `formatCheckedIn()` function
  - Updated `src/templates/attendee-table.tsx` and `src/templates/checkin.tsx` to use boolean comparisons

- **Route Handlers**: Updated check-in logic in:
  - `src/routes/admin/attendees.ts`
  - `src/routes/admin/scanner.ts`
  - `src/routes/checkin.ts`
  - All now use boolean comparisons instead of string equality checks

- **Test Updates**: 
  - Updated all test files to use boolean values (`true`/`false`) instead of string values (`"true"`/`"false"`)
  - Added comprehensive tests for the new `countCheckedIn()` function
  - Added tests for the new "Checked In" display row in the admin event page
  - Added type casts for raw database values that remain encrypted strings

## Implementation Details

The raw database values remain as encrypted strings, but they are converted to booleans when decrypted and loaded into `Attendee` objects. This maintains backward compatibility with the database while providing better type safety in the application code.

https://claude.ai/code/session_014AUBqkqdTq4MZvk532bDJj