### PR TITLE
Add desktop navigation styling and breakpoint documentation

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -226,7 +226,7 @@ nav ul li ul li a {
     margin: 0 auto 7rem;
     position: sticky;
     top: 1rem;
-    background: white;
+    background: var(--color-bg);
     width: fit-content;
     padding: 0 2rem;
     border-radius: var(--border-radius);

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -24,6 +24,7 @@
   --width-card-medium: 460px;
   --width-card-wide: 800px;
   --width-content: 1300px;
+  /* Breakpoint: desktop ≥ 769px, mobile ≤ 768px (use in @media rules) */
 }
 
 :root[data-theme="dark"] {
@@ -216,6 +217,20 @@ nav ul li ul li a {
     box-shadow: none;
     display: block;
     position: static;
+  }
+}
+
+/* Nav for Desktop */
+@media (min-width: 769px) {
+  nav {
+    margin: 0 auto 7rem;
+    position: sticky;
+    top: 1rem;
+    background: white;
+    width: fit-content;
+    padding: 0 2rem;
+    border-radius: var(--border-radius);
+    z-index: 10;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the navigation styling for desktop viewports and adds documentation for the responsive design breakpoints used throughout the stylesheet.

## Key Changes
- Added a CSS custom property comment documenting the breakpoint convention: desktop ≥ 769px, mobile ≤ 768px
- Implemented desktop-specific navigation styles with a new `@media (min-width: 769px)` rule that:
  - Centers the navigation with `margin: 0 auto 7rem`
  - Makes the navigation sticky with `position: sticky` and `top: 1rem`
  - Applies background color, padding, and border-radius for a card-like appearance
  - Sets `z-index: 10` to ensure the sticky nav stays above other content
  - Uses `width: fit-content` to size the nav based on its content

## Implementation Details
The desktop navigation styling creates a sticky, centered navigation bar that remains visible as users scroll, improving navigation accessibility on larger screens. The breakpoint documentation clarifies the mobile/desktop threshold for future CSS media query implementations.

https://claude.ai/code/session_01QoY5HfVefZG2jaQaQZ994Q