### PR TITLE
Fix event image overflow on smaller screens

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -942,7 +942,7 @@ form:has(select[name="event_type"] option[value="daily"]:checked) > label:has([n
 
 /* Event images */
 .event-image {
-  max-width: var(--width-card-wide);
+  max-width: min(100%, var(--width-card-wide));
   border-radius: 4px;
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
Updated the `.event-image` CSS rule to prevent images from exceeding their container width on smaller viewports.

## Changes
- Modified `max-width` property from `var(--width-card-wide)` to `min(100%, var(--width-card-wide))`
  - This ensures event images respect the smaller of either the container width (100%) or the card-wide variable
  - Prevents horizontal overflow on mobile and narrow screens while maintaining the intended max-width on larger displays

## Implementation Details
The `min()` CSS function provides a responsive constraint that adapts to viewport size without requiring additional media queries. This is a progressive enhancement that maintains backward compatibility while improving the mobile user experience.

https://claude.ai/code/session_01QxNYjPYKVnd3GEv7iBDhmy