### PR TITLE
Render owner debug footer inline to fix Bunny Edge issues

### DIFF
--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -1,11 +1,13 @@
 /**
  * Admin routes - combined from individual route modules
  *
- * GET requests are wrapped to track SQL queries and inject an
- * owner-only debug footer showing render time and query details.
+ * GET requests are wrapped to enable SQL query logging for owner users.
+ * The owner debug footer is rendered inline by the Layout template when
+ * query logging is active, avoiding response body re-reading which
+ * intermittently fails on Bunny Edge.
  */
 
-import { enableQueryLog, getQueryLog } from "#lib/db/query-log.ts";
+import { enableQueryLog } from "#lib/db/query-log.ts";
 import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
@@ -20,7 +22,6 @@ import { scannerRoutes } from "#routes/admin/scanner.ts";
 import { usersRoutes } from "#routes/admin/users.ts";
 import { createRouter } from "#routes/router.ts";
 import { getAuthenticatedSession } from "#routes/utils.ts";
-import { ownerFooterHtml } from "#templates/admin/footer.tsx";
 
 /** Combined admin routes */
 const adminRoutes = {
@@ -44,8 +45,8 @@ type RouterFn = ReturnType<typeof createRouter>;
 
 /**
  * Route admin requests.
- * For GET requests, enables query tracking and injects the owner debug
- * footer into HTML responses when the authenticated user is an owner.
+ * For GET requests by owners, enables query logging so the Layout template
+ * renders the debug footer inline (no response body re-reading needed).
  */
 export const routeAdmin: RouterFn = async (request, path, method, server) => {
   if (method !== "GET") {
@@ -54,29 +55,7 @@ export const routeAdmin: RouterFn = async (request, path, method, server) => {
 
   // Check owner status before tracking so the auth queries aren't logged
   const session = await getAuthenticatedSession(request);
-  const isOwner = session?.adminLevel === "owner";
+  if (session?.adminLevel === "owner") enableQueryLog();
 
-  if (isOwner) enableQueryLog();
-  const startTime = performance.now();
-
-  const response = await innerRouter(request, path, method, server);
-  if (!response) return null;
-  if (!isOwner) return response;
-
-  if (response.status !== 200) return response;
-  if (!response.headers.get("content-type")!.includes("text/html")) {
-    return response;
-  }
-
-  const html = await response.text();
-  const footer = ownerFooterHtml(
-    performance.now() - startTime,
-    getQueryLog(),
-  );
-  // Delete content-length so the runtime recalculates it for the modified body
-  response.headers.delete("content-length");
-  return new Response(html.replace("</body>", footer + "</body>"), {
-    status: response.status,
-    headers: response.headers,
-  });
+  return innerRouter(request, path, method, server);
 };

--- a/src/templates/admin/footer.tsx
+++ b/src/templates/admin/footer.tsx
@@ -2,7 +2,12 @@
  * Owner-only debug footer showing render time and SQL queries
  */
 
-import type { QueryLogEntry } from "#lib/db/query-log.ts";
+import {
+  type QueryLogEntry,
+  getQueryLog,
+  getQueryLogStartTime,
+  isQueryLogEnabled,
+} from "#lib/db/query-log.ts";
 
 /** Render the owner debug footer as an HTML string for injection before </body> */
 export const ownerFooterHtml = (
@@ -23,6 +28,16 @@ export const ownerFooterHtml = (
   `</ul>` +
   `</details>` +
   `</footer>`;
+
+/**
+ * Return the owner debug footer HTML if query logging is active, otherwise "".
+ * Called from the Layout template so the footer is part of the HTML string
+ * before it is wrapped in a Response, avoiding response.text() on Bunny Edge.
+ */
+export const renderOwnerDebugFooter = (): string =>
+  isQueryLogEnabled()
+    ? ownerFooterHtml(performance.now() - getQueryLogStartTime(), getQueryLog())
+    : "";
 
 /** Minimal HTML escaping for SQL strings in the footer */
 const escapeFooterHtml = (s: string): string =>

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -5,6 +5,7 @@
 import { type Child, Raw, SafeHtml } from "#jsx/jsx-runtime.ts";
 import { CSS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
 import { getTheme } from "#lib/theme.ts";
+import { renderOwnerDebugFooter } from "#templates/admin/footer.tsx";
 
 export const escapeHtml = (str: string): string =>
   str
@@ -47,6 +48,7 @@ export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutP
           </main>
           {bodyClass?.includes("iframe") && <script src={IFRAME_RESIZER_CHILD_JS_PATH}></script>}
           <script src={JS_PATH} defer></script>
+          <Raw html={renderOwnerDebugFooter()} />
         </body>
       </html>
     )

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "#test-compat";
-import { ownerFooterHtml } from "#templates/admin/footer.tsx";
+import { enableQueryLog, runWithQueryLogContext } from "#lib/db/query-log.ts";
+import { ownerFooterHtml, renderOwnerDebugFooter } from "#templates/admin/footer.tsx";
 
 describe("ownerFooterHtml", () => {
   test("renders summary with render time", () => {
@@ -56,5 +57,23 @@ describe("ownerFooterHtml", () => {
     expect(html).toContain("<ul");
     expect(html).toContain("</ul>");
     expect(html).not.toContain("<li>");
+  });
+});
+
+describe("renderOwnerDebugFooter", () => {
+  test("returns empty string when query logging is not active", () => {
+    runWithQueryLogContext(() => {
+      expect(renderOwnerDebugFooter()).toBe("");
+    });
+  });
+
+  test("returns footer HTML when query logging is active", () => {
+    runWithQueryLogContext(() => {
+      enableQueryLog();
+      const html = renderOwnerDebugFooter();
+      expect(html).toContain('<footer class="debug-footer">');
+      expect(html).toContain("Chobble Tickets");
+      expect(html).toContain("ms</summary>");
+    });
   });
 });

--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -3,6 +3,7 @@ import {
   addQueryLogEntry,
   enableQueryLog,
   getQueryLog,
+  getQueryLogStartTime,
   isQueryLogEnabled,
   runWithQueryLogContext,
 } from "#lib/db/query-log.ts";
@@ -68,6 +69,35 @@ describe("query-log", () => {
         addQueryLogEntry("SELECT 2", 2.0);
         expect(snapshot).toHaveLength(1);
         expect(getQueryLog()).toHaveLength(2);
+      });
+    });
+  });
+
+  describe("getQueryLogStartTime", () => {
+    test("returns 0 before logging is enabled", () => {
+      runWithQueryLogContext(() => {
+        expect(getQueryLogStartTime()).toBe(0);
+      });
+    });
+
+    test("records start time when enableQueryLog is called", () => {
+      runWithQueryLogContext(() => {
+        const before = performance.now();
+        enableQueryLog();
+        const after = performance.now();
+        const startTime = getQueryLogStartTime();
+        expect(startTime).toBeGreaterThanOrEqual(before);
+        expect(startTime).toBeLessThanOrEqual(after);
+      });
+    });
+
+    test("resets start time on subsequent enableQueryLog calls", () => {
+      runWithQueryLogContext(() => {
+        enableQueryLog();
+        const first = getQueryLogStartTime();
+        enableQueryLog();
+        const second = getQueryLogStartTime();
+        expect(second).toBeGreaterThanOrEqual(first);
       });
     });
   });


### PR DESCRIPTION
## Summary
Refactored the owner debug footer rendering to avoid response body re-reading, which intermittently fails on Bunny Edge. The footer is now rendered inline by the Layout template as part of the HTML string, rather than being injected after the response is created.

## Key Changes
- **Moved footer rendering from route handler to Layout template**: The `routeAdmin` function no longer reads the response body, modifies it, and creates a new Response. Instead, `renderOwnerDebugFooter()` is called directly in the Layout template.
- **Added query log start time tracking**: Extended `QueryLogState` to track when `enableQueryLog()` is called, allowing the footer to calculate render time without needing to pass it through the route handler.
- **New `renderOwnerDebugFooter()` function**: Returns the footer HTML if query logging is active, or an empty string otherwise. This function is called from the Layout template.
- **Simplified route handler**: The `routeAdmin` function now only enables query logging for owner users and delegates to the inner router, eliminating the response body manipulation logic.
- **Updated tests**: Added tests for `getQueryLogStartTime()` and the new `renderOwnerDebugFooter()` function to verify the query logging context is properly tracked.

## Implementation Details
- The `enableQueryLog()` function now records `performance.now()` as the start time when called
- The Layout template imports and calls `renderOwnerDebugFooter()` to inject the footer before the closing `

https://claude.ai/code/session_018AYfxF9THtmiMCbKYZrcGc