### PR TITLE
Add site subnav to admin site editor pages

### DIFF
--- a/src/templates/admin/site.tsx
+++ b/src/templates/admin/site.tsx
@@ -5,7 +5,17 @@
 import { CsrfForm } from "#lib/forms.tsx";
 import type { AdminSession } from "#lib/types.ts";
 import { Layout } from "#templates/layout.tsx";
-import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
+import { AdminNav } from "#templates/admin/nav.tsx";
+
+/** Sub-navigation for site editor pages */
+const SiteSubNav = (): JSX.Element => (
+  <nav>
+    <ul>
+      <li><a href="/admin/site">Homepage</a></li>
+      <li><a href="/admin/site/contact">Contact</a></li>
+    </ul>
+  </nav>
+);
 
 /**
  * Homepage editor - website title + homepage text
@@ -20,6 +30,7 @@ export const adminSiteHomePage = (
   String(
     <Layout title="Site - Home">
       <AdminNav session={session} />
+      <SiteSubNav />
 
       {error && <div class="error">{error}</div>}
       {success && <div class="success">{success}</div>}
@@ -64,7 +75,7 @@ export const adminSiteContactPage = (
   String(
     <Layout title="Site - Contact">
       <AdminNav session={session} />
-      <Breadcrumb href="/admin/site" label="Site" />
+      <SiteSubNav />
 
       {error && <div class="error">{error}</div>}
       {success && <div class="success">{success}</div>}

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -283,6 +283,28 @@ describe("server (admin site)", () => {
     });
   });
 
+  describe("site subnav", () => {
+    test("homepage shows subnav with Homepage and Contact links", async () => {
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/site", { cookie });
+      const html = await response.text();
+      expect(html).toContain('href="/admin/site"');
+      expect(html).toContain('href="/admin/site/contact"');
+      expect(html).toContain("Homepage");
+      expect(html).toContain("Contact");
+    });
+
+    test("contact page shows subnav with Homepage and Contact links", async () => {
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/site/contact", { cookie });
+      const html = await response.text();
+      expect(html).toContain('href="/admin/site"');
+      expect(html).toContain('href="/admin/site/contact"');
+      expect(html).toContain("Homepage");
+      expect(html).toContain("Contact");
+    });
+  });
+
   describe("admin nav", () => {
     test("shows Site link when public site is enabled", async () => {
       await updateShowPublicSite(true);


### PR DESCRIPTION
## Summary
Replaced the breadcrumb navigation on the site editor pages with a consistent sub-navigation component that displays links to both the Homepage and Contact pages.

## Key Changes
- Created a new `SiteSubNav` component that renders navigation links for the site editor section
  - Links to `/admin/site` (Homepage)
  - Links to `/admin/site/contact` (Contact)
- Replaced the `Breadcrumb` component on both the homepage and contact editor pages with `SiteSubNav`
- Removed the unused `Breadcrumb` import from the site template
- Added comprehensive test coverage for the new subnav on both pages

## Implementation Details
- The `SiteSubNav` component is a simple navigation list that appears consistently across all site editor pages
- This provides better navigation between related site editing pages compared to the previous breadcrumb approach
- Tests verify that both the Homepage and Contact pages display the subnav with correct links and labels

https://claude.ai/code/session_019o7cxcMioZb1EsvAqBFSka