### PR TITLE
Simplify public events page to show individual event listings

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -38,12 +38,11 @@ const loadPublicRoutes = once(async () => {
   const {
     handleHome,
     handlePublicEvents,
-    handlePublicEventsPost,
     handlePublicTerms,
     handlePublicContact,
     routeTicket,
   } = await import("#routes/public.ts");
-  return { handleHome, handlePublicEvents, handlePublicEventsPost, handlePublicTerms, handlePublicContact, routeTicket };
+  return { handleHome, handlePublicEvents, handlePublicTerms, handlePublicContact, routeTicket };
 });
 
 /** Lazy-load setup routes */
@@ -116,11 +115,10 @@ const routeHome: RouterFn = async (_request, path, method) => {
 };
 
 /** Route public site pages (/events, /terms, /contact) */
-const routePublicPages: RouterFn = async (request, path, method) => {
+const routePublicPages: RouterFn = async (_request, path, method) => {
   if (path === "/events") {
-    const { handlePublicEvents, handlePublicEventsPost } = await loadPublicRoutes();
+    const { handlePublicEvents } = await loadPublicRoutes();
     if (method === "GET") return handlePublicEvents();
-    if (method === "POST") return handlePublicEventsPost(request);
     return null;
   }
   if (path === "/terms" && method === "GET") {

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -87,35 +87,11 @@ export const handleHome = (): Promise<Response> =>
 /** Handle GET /events - public events listing */
 export const handlePublicEvents = (): Promise<Response> =>
   requirePublicSite(async () => {
-    const events = await loadHomepageEvents();
-    const [dates, terms, websiteTitle] = await Promise.all([
-      computeSharedDates(events),
-      getTermsAndConditionsFromDb(),
+    const [events, websiteTitle] = await Promise.all([
+      loadHomepageEvents(),
       getWebsiteTitleFromDb(),
-      signCsrfToken(),
     ]);
-    return htmlResponse(homepagePage(events, undefined, dates ?? [], terms, websiteTitle));
-  });
-
-/** Handle POST /events - public events form submission */
-export const handlePublicEventsPost = (request: Request): Promise<Response> =>
-  requirePublicSite(async () => {
-    const activeEvents = await loadHomepageEvents();
-    if (activeEvents.length === 0) return redirect("/events");
-
-    const [dates, terms] = await Promise.all([
-      computeSharedDates(activeEvents),
-      getTermsAndConditionsFromDb(),
-      signCsrfToken(),
-    ]);
-    const ctx: MultiTicketCtx = {
-      slugs: activeEvents.map((e) => e.event.slug),
-      events: activeEvents,
-      dates: dates ?? [],
-      terms: terms ?? "",
-      inIframe: false,
-    };
-    return submitMultiTicket(request, ctx);
+    return htmlResponse(homepagePage(events, websiteTitle));
   });
 
 /** Handle GET /terms - public terms and conditions page */


### PR DESCRIPTION
## Summary
Refactored the public events page from a multi-ticket booking form to a simple event listing page with individual "Book now" links to each event's ticket page.

## Key Changes
- **Removed multi-ticket form submission**: Eliminated the POST /events endpoint and form-based ticket booking flow
- **Simplified event display**: Replaced the complex multi-event form with individual event listings showing:
  - Event name, location, date, and description
  - Individual "Book now" links to `/ticket/{slug}` for available events
  - "Sold Out" status for events at capacity
  - "Registration Closed" status for events past their closes_at date
- **Removed form-related features**: Eliminated CSRF token handling, terms and conditions display, and date selector from the events page
- **Updated tests**: Refactored test suite to reflect the new listing-based approach, removing multi-ticket form submission tests and adding tests for individual event details display
- **Simplified route handling**: Removed POST method handling from the /events route, now only supports GET requests

## Implementation Details
- Created new `renderEventListing()` helper function to render individual event cards with conditional status messages
- Simplified `homepagePage()` function signature by removing form-related parameters (error, availableDates, termsAndConditions)
- Updated `handlePublicEvents()` to only fetch necessary data (events and website title) without CSRF tokens or terms
- Event details (location, date, description) are now displayed inline on the listing page rather than in a form context

https://claude.ai/code/session_01Sw7fQNmAfW8ZXsm94dq4m5