### PR TITLE
Improve webhook error logging with detailed error messages

### DIFF
--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -112,13 +112,22 @@ export const sendWebhook = async (
   payload: WebhookPayload,
 ): Promise<void> => {
   try {
-    await fetch(webhookUrl, {
+    const response = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
-  } catch {
-    logError({ code: ErrorCode.WEBHOOK_SEND });
+    if (!response.ok) {
+      logError({
+        code: ErrorCode.WEBHOOK_SEND,
+        detail: `status=${response.status}`,
+      });
+    }
+  } catch (error) {
+    logError({
+      code: ErrorCode.WEBHOOK_SEND,
+      detail: error instanceof Error ? error.message : String(error),
+    });
   }
 };
 

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -238,6 +238,74 @@ describe("webhook", () => {
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
+
+    test("logs error message on fetch error", async () => {
+      const errorSpy = spyOn(console, "error");
+      fetchSpy.mockRejectedValue(new Error("Connection refused"));
+
+      const payload = await buildWebhookPayload(
+        [{ event: makeEvent(), attendee: makeAttendee() }],
+        "GBP",
+      );
+
+      await sendWebhook("https://example.com/webhook", payload);
+
+      const calls = errorSpy.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((c) => c.includes("E_WEBHOOK_SEND") && c.includes("Connection refused"))).toBe(true);
+
+      errorSpy.mockRestore();
+    });
+
+    test("logs non-Error thrown values as strings", async () => {
+      const errorSpy = spyOn(console, "error");
+      fetchSpy.mockRejectedValue("socket hang up");
+
+      const payload = await buildWebhookPayload(
+        [{ event: makeEvent(), attendee: makeAttendee() }],
+        "GBP",
+      );
+
+      await sendWebhook("https://example.com/webhook", payload);
+
+      const calls = errorSpy.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((c) => c.includes("E_WEBHOOK_SEND") && c.includes("socket hang up"))).toBe(true);
+
+      errorSpy.mockRestore();
+    });
+
+    test("logs status on non-2xx response", async () => {
+      const errorSpy = spyOn(console, "error");
+      fetchSpy.mockResolvedValue(new Response("Not Found", { status: 404 }));
+
+      const payload = await buildWebhookPayload(
+        [{ event: makeEvent(), attendee: makeAttendee() }],
+        "GBP",
+      );
+
+      await sendWebhook("https://example.com/webhook", payload);
+
+      const calls = errorSpy.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((c) => c.includes("E_WEBHOOK_SEND") && c.includes("status=404"))).toBe(true);
+
+      errorSpy.mockRestore();
+    });
+
+    test("does not log error on successful 2xx response", async () => {
+      const errorSpy = spyOn(console, "error");
+      fetchSpy.mockResolvedValue(new Response("OK", { status: 200 }));
+
+      const payload = await buildWebhookPayload(
+        [{ event: makeEvent(), attendee: makeAttendee() }],
+        "GBP",
+      );
+
+      await sendWebhook("https://example.com/webhook", payload);
+
+      const calls = errorSpy.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((c) => c.includes("E_WEBHOOK_SEND"))).toBe(false);
+
+      errorSpy.mockRestore();
+    });
   });
 
   describe("sendRegistrationWebhooks", () => {


### PR DESCRIPTION
## Summary
Enhanced webhook error handling to provide more detailed error information when webhook sends fail, making it easier to diagnose and debug webhook delivery issues.

## Key Changes
- **Enhanced error logging**: Modified `sendWebhook()` to capture and log detailed error information instead of silently failing
  - Logs HTTP status codes for non-2xx responses (e.g., `status=404`)
  - Logs error messages for fetch failures (e.g., connection errors)
  - Handles both Error objects and non-Error thrown values (strings, etc.)
- **Added comprehensive test coverage**: Four new test cases verify the error logging behavior:
  - Logs error message on fetch errors
  - Logs non-Error thrown values as strings
  - Logs HTTP status on non-2xx responses
  - Does not log errors on successful 2xx responses

## Implementation Details
The `sendWebhook()` function now:
1. Captures the fetch response to check the status code
2. Logs errors with a `detail` field containing either the HTTP status or the error message
3. Properly handles both Error instances and arbitrary thrown values by converting them to strings
4. Only logs errors for actual failures, not for successful responses

https://claude.ai/code/session_01W264C3oBXfrJ7Q9gkcLzNN