### PR TITLE
Increase bottom margin for scrollable tables

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -583,7 +583,7 @@ dialog hr {
 
 /* Tables */
 .table-scroll {
-  margin: 2rem 0;
+  margin: 2rem 0 7rem;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
## Summary
Adjusted the bottom margin of scrollable table containers to provide better spacing at the end of the page.

## Changes
- Modified `.table-scroll` bottom margin from `0` to `7rem` to add additional spacing below scrollable tables

## Details
This change ensures that scrollable tables have adequate bottom padding when positioned near the end of a page, preventing content from being cut off or appearing cramped when users scroll to the end of the table.

https://claude.ai/code/session_011ngzj2GW3B4SavkiuFXwMW