### PR TITLE
Enhance dark theme with improved colors and gradient background

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -19,7 +19,7 @@
   --hover-brightness: 1.2;
   --justify-important: left;
   --justify-normal: left;
-  --line-height: 1.5;
+  --line-height: 1.8;
   --width-card: 285px;
   --width-card-medium: 460px;
   --width-card-wide: 800px;
@@ -29,15 +29,22 @@
 
 :root[data-theme="dark"] {
   --color-accent: #0097fc4f;
-  --color-bg: #333;
-  --color-bg-secondary: #555;
-  --color-link: #0097fc;
+  --color-bg: #01001c;
+  --color-bg-secondary: #460066;
+  --color-link: #95d5ff;
   --color-secondary: #e20de9;
   --color-secondary-accent: #e20de94f;
   --color-shadow: #00000022;
-  --color-table: #0097fc;
+  --color-table: #95d5ff;
   --color-text: #f7f7f7;
   --color-text-secondary: #aaa;
+}
+
+[data-theme="dark"] body {
+  background: #23062b;
+  background: linear-gradient(342deg, rgb(16, 2, 19) 0%, rgb(5, 5, 61) 35%, rgb(22, 1, 23) 100%);
+  background-size: 100% 100%;
+  background-attachment: fixed;
 }
 
 html {


### PR DESCRIPTION
## Summary
Updated the dark theme styling to provide a more visually appealing and cohesive design with a custom gradient background and refined color palette.

## Key Changes
- **Line height**: Increased from 1.5 to 1.8 for improved readability and spacing
- **Dark theme color palette**: 
  - Background changed from `#333` to `#01001c` (deep purple-black)
  - Secondary background changed from `#555` to `#460066` (rich purple)
  - Link color changed from `#0097fc` to `#95d5ff` (lighter cyan)
  - Table color updated from `#0097fc` to `#95d5ff` to match link color
- **Dark theme background**: Added a fixed gradient background that transitions through deep purples and blues (from `#10021 3` through `#050 53d` to `#160117`)

## Implementation Details
- The gradient background uses `background-attachment: fixed` to create a parallax effect that remains stationary while scrolling
- The gradient is defined at 342 degrees with three color stops for a smooth, multi-tonal purple-blue aesthetic
- All color changes maintain the existing dark theme structure while creating a more modern, cohesive visual identity

https://claude.ai/code/session_01DRwF7zAFswqxZDhjboGZHS