### PR TITLE
Reorder admin dashboard sections: move newest attendees below multi-booking

### DIFF
--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -152,10 +152,6 @@ export const adminDashboardPage = (
 
       <p><a href="/admin/event/new">Add Event</a></p>
 
-      {newestAttendees.length > 0 && (
-        <Raw html={newestAttendeesSection(newestAttendees, events)} />
-      )}
-
       <div class="table-scroll">
         <table>
           <thead>
@@ -175,6 +171,10 @@ export const adminDashboardPage = (
 
       {activeEvents.length >= 2 && (
         <Raw html={multiBookingSection(activeEvents)} />
+      )}
+
+      {newestAttendees.length > 0 && (
+        <Raw html={newestAttendeesSection(newestAttendees, events)} />
       )}
     </Layout>
   );


### PR DESCRIPTION
## Summary
Reorganized the layout of the admin dashboard by moving the "newest attendees" section to appear after the "multi-booking" section instead of before the events table.

## Changes
- Moved the `newestAttendeesSection` component from its original position (before the events table) to the end of the dashboard layout (after the `multiBookingSection`)
- No functional changes to the components themselves, only a reordering of their display sequence

## Details
This change affects the visual hierarchy and information flow on the admin dashboard. The newest attendees section now appears as the final section on the page, following the active events table and multi-booking information, which may provide a more logical reading order for administrators reviewing dashboard data.

https://claude.ai/code/session_01Kk8UozwkWkn91j1YgPZK6i