### PR TITLE
Move color-scheme CSS to stylesheet

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -41,7 +41,12 @@
 }
 
 html {
+  color-scheme: light;
   scroll-behavior: smooth;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -27,8 +27,6 @@ interface LayoutProps {
  */
 export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutProps): SafeHtml => {
   const resolvedTheme = theme ?? getTheme();
-  const colorScheme = resolvedTheme === "dark" ? "dark" : "light";
-  const themeStyle = `<style>html { color-scheme: ${colorScheme}; }</style>`;
 
   return new SafeHtml(
     "<!DOCTYPE html>" +
@@ -39,7 +37,6 @@ export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutP
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <title>{title}</title>
           <link rel="stylesheet" href={CSS_PATH} />
-          <Raw html={themeStyle} />
           {headExtra && <Raw html={headExtra} />}
         </head>
         <body class={bodyClass || undefined}>


### PR DESCRIPTION
## Summary
Moved the dynamic `color-scheme` CSS generation from inline styles in the layout template to the main stylesheet, reducing runtime style injection and improving maintainability.

## Key Changes
- Added `color-scheme: light` to the default `html` selector in `mvp.css`
- Added a new `html[data-theme="dark"]` rule in `mvp.css` to set `color-scheme: dark`
- Removed the dynamic `colorScheme` variable and inline `themeStyle` generation from `layout.tsx`
- Removed the `<Raw html={themeStyle} />` injection from the HTML head

## Implementation Details
The `color-scheme` property is now statically defined in the stylesheet and controlled via the `data-theme` attribute on the `html` element, which is already being set by the existing theme system. This eliminates the need for runtime style generation while maintaining the same visual behavior.

https://claude.ai/code/session_01XXn8KzXK6qKVKT6QhvENdj