### PR TITLE
Add 30-minute decrypted page content cache (#407)

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -70,6 +70,44 @@ export const CONFIG_KEYS = {
  */
 export const SETTINGS_CACHE_TTL_MS = 5_000;
 
+/**
+ * Decrypted page content cache. Pages like homepage, contact, terms
+ * and website title change very rarely, so we cache the decrypted
+ * values for 30 minutes per edge instance, avoiding repeated
+ * AES-GCM decryption and DB round-trips on every public page view.
+ * Invalidated immediately when content is saved via admin routes.
+ */
+const PAGE_CACHE_TTL_MS = 30 * 60 * 1_000;
+
+type PageCacheEntry = { value: string | null; time: number };
+
+const [getPageCacheMap, setPageCacheMap] = lazyRef<Map<string, PageCacheEntry>>(
+  () => new Map(),
+);
+
+const getPageCacheEntry = (key: string): string | null | undefined => {
+  const entry = getPageCacheMap().get(key);
+  if (!entry) return undefined;
+  if (nowMs() - entry.time >= PAGE_CACHE_TTL_MS) {
+    getPageCacheMap().delete(key);
+    return undefined;
+  }
+  return entry.value;
+};
+
+const setPageCacheEntry = (key: string, value: string | null): void => {
+  getPageCacheMap().set(key, { value, time: nowMs() });
+};
+
+const invalidatePageCacheEntry = (key: string): void => {
+  getPageCacheMap().delete(key);
+};
+
+/** Clear the entire page content cache (for testing or after bulk changes). */
+export const invalidatePageCache = (): void => {
+  setPageCacheMap(null);
+};
+
 type SettingsCacheState = {
   entries: Map<string, string> | null;
   time: number;
@@ -99,11 +137,13 @@ export const loadAllSettings = async (): Promise<Map<string, string>> => {
 
 /**
  * Invalidate the settings cache (for testing or after writes).
- * Also clears the permanent timezone cache since it derives from settings.
+ * Also clears the permanent timezone cache since it derives from settings,
+ * and the page content cache since it derives from encrypted settings.
  */
 export const invalidateSettingsCache = (): void => {
   setSettingsCacheState(null);
   invalidateTimezoneCache();
+  invalidatePageCache();
 };
 
 /**
@@ -483,19 +523,25 @@ export const updateEmbedHosts = async (hosts: string): Promise<void> => {
 export const MAX_TERMS_LENGTH = 10_240;
 
 /**
- * Get terms and conditions text from database (uses settings cache).
+ * Get terms and conditions text from database (30m cached).
  * Returns null if not configured.
  */
 export const getTermsAndConditionsFromDb = async (): Promise<string | null> => {
-  return await getSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS);
+  const cached = getPageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS);
+  if (cached !== undefined) return cached;
+  const value = await getSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS);
+  setPageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS, value);
+  return value;
 };
 
 /**
  * Update terms and conditions text
  * Pass empty string to clear
  */
-export const updateTermsAndConditions = (text: string): Promise<void> =>
-  setOrDeleteSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS, text);
+export const updateTermsAndConditions = async (text: string): Promise<void> => {
+  await setOrDeleteSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS, text);
+  invalidatePageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS);
+};
 
 /**
  * Permanent timezone cache. Timezone changes very rarely, so we cache it
@@ -613,29 +659,44 @@ export const MAX_WEBSITE_TITLE_LENGTH = 128;
 /** Max length for page text content */
 export const MAX_PAGE_TEXT_LENGTH = 2048;
 
-/** Get the website title from database (decrypted). */
+/** Get a page setting with 30m decrypted content cache. */
+const getCachedPageSetting = async (key: string): Promise<string | null> => {
+  const cached = getPageCacheEntry(key);
+  if (cached !== undefined) return cached;
+  const value = await getEncryptedSetting(key);
+  setPageCacheEntry(key, value);
+  return value;
+};
+
+/** Get the website title from database (decrypted, 30m cached). */
 export const getWebsiteTitleFromDb = (): Promise<string | null> =>
-  getEncryptedSetting(CONFIG_KEYS.WEBSITE_TITLE);
+  getCachedPageSetting(CONFIG_KEYS.WEBSITE_TITLE);
 
 /** Update the website title (encrypted at rest). Pass empty string to clear. */
-export const updateWebsiteTitle = (text: string): Promise<void> =>
-  updateEncryptedSetting(CONFIG_KEYS.WEBSITE_TITLE, text);
+export const updateWebsiteTitle = async (text: string): Promise<void> => {
+  await updateEncryptedSetting(CONFIG_KEYS.WEBSITE_TITLE, text);
+  invalidatePageCacheEntry(CONFIG_KEYS.WEBSITE_TITLE);
+};
 
-/** Get the homepage text from database (decrypted). */
+/** Get the homepage text from database (decrypted, 30m cached). */
 export const getHomepageTextFromDb = (): Promise<string | null> =>
-  getEncryptedSetting(CONFIG_KEYS.HOMEPAGE_TEXT);
+  getCachedPageSetting(CONFIG_KEYS.HOMEPAGE_TEXT);
 
 /** Update the homepage text (encrypted at rest). Pass empty string to clear. */
-export const updateHomepageText = (text: string): Promise<void> =>
-  updateEncryptedSetting(CONFIG_KEYS.HOMEPAGE_TEXT, text);
+export const updateHomepageText = async (text: string): Promise<void> => {
+  await updateEncryptedSetting(CONFIG_KEYS.HOMEPAGE_TEXT, text);
+  invalidatePageCacheEntry(CONFIG_KEYS.HOMEPAGE_TEXT);
+};
 
-/** Get the contact page text from database (decrypted). */
+/** Get the contact page text from database (decrypted, 30m cached). */
 export const getContactPageTextFromDb = (): Promise<string | null> =>
-  getEncryptedSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT);
+  getCachedPageSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT);
 
 /** Update the contact page text (encrypted at rest). Pass empty string to clear. */
-export const updateContactPageText = (text: string): Promise<void> =>
-  updateEncryptedSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT, text);
+export const updateContactPageText = async (text: string): Promise<void> => {
+  await updateEncryptedSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT, text);
+  invalidatePageCacheEntry(CONFIG_KEYS.CONTACT_PAGE_TEXT);
+};
 
 /**
  * Get the configured phone prefix from database.
@@ -663,6 +724,7 @@ export const settingsApi = {
   setSetting,
   loadAllSettings,
   invalidateSettingsCache,
+  invalidatePageCache,
   isSetupComplete,
   clearSetupCompleteCache,
   getPublicKey,

--- a/test/lib/page-cache.test.ts
+++ b/test/lib/page-cache.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "#test-compat";
+import {
+  getContactPageTextFromDb,
+  getHomepageTextFromDb,
+  getTermsAndConditionsFromDb,
+  getWebsiteTitleFromDb,
+  invalidatePageCache,
+  invalidateSettingsCache,
+  updateContactPageText,
+  updateHomepageText,
+  updateTermsAndConditions,
+  updateWebsiteTitle,
+} from "#lib/db/settings.ts";
+
+/** 30 minutes in ms - matches PAGE_CACHE_TTL_MS in settings.ts */
+const PAGE_CACHE_TTL_MS = 30 * 60 * 1_000;
+import {
+  createTestDbWithSetup,
+  resetDb,
+} from "#test-utils";
+
+describe("page content cache", () => {
+  beforeEach(async () => {
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    resetDb();
+  });
+
+  describe("getWebsiteTitleFromDb", () => {
+    test("returns null when not set", async () => {
+      expect(await getWebsiteTitleFromDb()).toBeNull();
+    });
+
+    test("returns decrypted value after update", async () => {
+      await updateWebsiteTitle("My Site");
+      expect(await getWebsiteTitleFromDb()).toBe("My Site");
+    });
+
+    test("serves cached value on repeated reads", async () => {
+      await updateWebsiteTitle("Cached Title");
+      const first = await getWebsiteTitleFromDb();
+      const second = await getWebsiteTitleFromDb();
+      expect(first).toBe("Cached Title");
+      expect(second).toBe("Cached Title");
+    });
+
+    test("returns updated value after update invalidates cache", async () => {
+      await updateWebsiteTitle("Old Title");
+      expect(await getWebsiteTitleFromDb()).toBe("Old Title");
+      await updateWebsiteTitle("New Title");
+      expect(await getWebsiteTitleFromDb()).toBe("New Title");
+    });
+
+    test("returns null after clearing with empty string", async () => {
+      await updateWebsiteTitle("Title");
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      await updateWebsiteTitle("");
+      expect(await getWebsiteTitleFromDb()).toBeNull();
+    });
+  });
+
+  describe("getHomepageTextFromDb", () => {
+    test("returns null when not set", async () => {
+      expect(await getHomepageTextFromDb()).toBeNull();
+    });
+
+    test("returns decrypted value after update", async () => {
+      await updateHomepageText("Welcome!");
+      expect(await getHomepageTextFromDb()).toBe("Welcome!");
+    });
+
+    test("returns updated value after update invalidates cache", async () => {
+      await updateHomepageText("Old text");
+      expect(await getHomepageTextFromDb()).toBe("Old text");
+      await updateHomepageText("New text");
+      expect(await getHomepageTextFromDb()).toBe("New text");
+    });
+  });
+
+  describe("getContactPageTextFromDb", () => {
+    test("returns null when not set", async () => {
+      expect(await getContactPageTextFromDb()).toBeNull();
+    });
+
+    test("returns decrypted value after update", async () => {
+      await updateContactPageText("Contact us here");
+      expect(await getContactPageTextFromDb()).toBe("Contact us here");
+    });
+
+    test("returns updated value after update invalidates cache", async () => {
+      await updateContactPageText("Old contact");
+      expect(await getContactPageTextFromDb()).toBe("Old contact");
+      await updateContactPageText("New contact");
+      expect(await getContactPageTextFromDb()).toBe("New contact");
+    });
+  });
+
+  describe("getTermsAndConditionsFromDb", () => {
+    test("returns null when not set", async () => {
+      expect(await getTermsAndConditionsFromDb()).toBeNull();
+    });
+
+    test("returns value after update", async () => {
+      await updateTermsAndConditions("Terms text");
+      expect(await getTermsAndConditionsFromDb()).toBe("Terms text");
+    });
+
+    test("returns updated value after update invalidates cache", async () => {
+      await updateTermsAndConditions("Old terms");
+      expect(await getTermsAndConditionsFromDb()).toBe("Old terms");
+      await updateTermsAndConditions("New terms");
+      expect(await getTermsAndConditionsFromDb()).toBe("New terms");
+    });
+
+    test("returns null after clearing with empty string", async () => {
+      await updateTermsAndConditions("Terms");
+      expect(await getTermsAndConditionsFromDb()).toBe("Terms");
+      await updateTermsAndConditions("");
+      expect(await getTermsAndConditionsFromDb()).toBeNull();
+    });
+  });
+
+  describe("TTL expiry", () => {
+    test("serves cached value within TTL", async () => {
+      jest.useFakeTimers();
+      const startTime = Date.now();
+      jest.setSystemTime(startTime);
+
+      await updateWebsiteTitle("Cached");
+      expect(await getWebsiteTitleFromDb()).toBe("Cached");
+
+      // Advance time to just before TTL expiry
+      jest.setSystemTime(startTime + PAGE_CACHE_TTL_MS - 1);
+      expect(await getWebsiteTitleFromDb()).toBe("Cached");
+    });
+
+    test("re-fetches after TTL expires", async () => {
+      jest.useFakeTimers();
+      const startTime = Date.now();
+      jest.setSystemTime(startTime);
+
+      await updateWebsiteTitle("Original");
+      // Populate cache
+      expect(await getWebsiteTitleFromDb()).toBe("Original");
+
+      // Directly update the DB without going through updateWebsiteTitle
+      // (simulates another instance writing) - we use updateWebsiteTitle
+      // which invalidates, then re-read to populate cache
+      invalidatePageCache();
+      await updateWebsiteTitle("Updated");
+      expect(await getWebsiteTitleFromDb()).toBe("Updated");
+
+      // Advance past TTL - should still work since cache was repopulated
+      jest.setSystemTime(startTime + PAGE_CACHE_TTL_MS + 1);
+      // Cache expired, re-fetches from DB
+      expect(await getWebsiteTitleFromDb()).toBe("Updated");
+    });
+  });
+
+  describe("invalidatePageCache", () => {
+    test("clears all cached page entries", async () => {
+      await updateWebsiteTitle("Title");
+      await updateHomepageText("Homepage");
+      await updateContactPageText("Contact");
+      await updateTermsAndConditions("Terms");
+
+      // Populate all caches
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      expect(await getHomepageTextFromDb()).toBe("Homepage");
+      expect(await getContactPageTextFromDb()).toBe("Contact");
+      expect(await getTermsAndConditionsFromDb()).toBe("Terms");
+
+      // Clear all
+      invalidatePageCache();
+
+      // Values should still be correct (re-fetched from DB)
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      expect(await getHomepageTextFromDb()).toBe("Homepage");
+      expect(await getContactPageTextFromDb()).toBe("Contact");
+      expect(await getTermsAndConditionsFromDb()).toBe("Terms");
+    });
+  });
+
+  describe("invalidateSettingsCache clears page cache", () => {
+    test("page cache is cleared when settings cache is invalidated", async () => {
+      await updateWebsiteTitle("Title");
+      // Populate page cache
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+
+      // invalidateSettingsCache should also clear the page cache
+      invalidateSettingsCache();
+
+      // Still returns correct value (re-fetched from DB)
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+    });
+  });
+
+  describe("cross-key isolation", () => {
+    test("updating one page does not invalidate other page caches", async () => {
+      jest.useFakeTimers();
+      const startTime = Date.now();
+      jest.setSystemTime(startTime);
+
+      await updateWebsiteTitle("Title");
+      await updateHomepageText("Homepage");
+
+      // Populate both caches
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      expect(await getHomepageTextFromDb()).toBe("Homepage");
+
+      // Update only homepage - title cache should remain valid
+      await updateHomepageText("New Homepage");
+
+      // Advance time but still within TTL
+      jest.setSystemTime(startTime + PAGE_CACHE_TTL_MS - 1000);
+
+      // Title should still be served from cache (no re-fetch needed)
+      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      // Homepage should reflect the update
+      expect(await getHomepageTextFromDb()).toBe("New Homepage");
+    });
+  });
+
+  describe("null value caching", () => {
+    test("caches null values to avoid repeated lookups", async () => {
+      // First read - cache miss, returns null
+      expect(await getWebsiteTitleFromDb()).toBeNull();
+      // Second read - should serve from cache (null is a valid cached value)
+      expect(await getWebsiteTitleFromDb()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Cache decrypted page content (website title, homepage text, contact
page text, terms) for 30 minutes per edge instance. This avoids
repeated AES-GCM decryption and DB round-trips on every public page
view for content that rarely changes.

The cache is invalidated immediately when content is saved via admin
routes, and also cleared when the settings cache is invalidated.

https://claude.ai/code/session_01RY3BmJEoaAeJWFapdd9SEB