### PR TITLE
Add in-memory caching for events and users with TTL

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -16,7 +16,7 @@ import {
   generateTicketToken,
 } from "#lib/crypto.ts";
 import { getDb, inPlaceholders, queryAll, queryOne } from "#lib/db/client.ts";
-import { getEventWithCount } from "#lib/db/events.ts";
+import { getEventWithCount, invalidateEventsCache } from "#lib/db/events.ts";
 import { deleteProcessedPaymentsForAttendee } from "#lib/db/processed-payments.ts";
 import { nowIso } from "#lib/now.ts";
 import { getPublicKey } from "#lib/db/settings.ts";
@@ -271,6 +271,7 @@ export const getAttendee = async (
 export const deleteAttendee = async (attendeeId: number): Promise<void> => {
   await deleteProcessedPaymentsForAttendee(attendeeId);
   await attendeesTable.deleteById(attendeeId);
+  invalidateEventsCache();
 };
 
 /** Result of atomic attendee creation */
@@ -423,6 +424,7 @@ export const attendeesApi = {
       return { success: false, reason: "capacity_exceeded" };
     }
 
+    invalidateEventsCache();
     return {
       success: true,
       attendee: buildAttendeeResult({

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -3,14 +3,15 @@
  */
 
 import type { ResultSet } from "@libsql/client";
+import { filter as fpFilter, lazyRef } from "#fp";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
-import { executeByField, getDb, inPlaceholders, queryAll, queryBatch, queryOne, resultRows } from "#lib/db/client.ts";
+import { executeByField, getDb, inPlaceholders, queryAll, queryBatch, resultRows } from "#lib/db/client.ts";
 import { encryptedNameSchema, idAndEncryptedSlugSchema } from "#lib/db/common-schema.ts";
 import { deleteProcessedPaymentsForEvent } from "#lib/db/processed-payments.ts";
 import { defineIdTable } from "#lib/db/define-id-table.ts";
 import { col } from "#lib/db/table.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
-import { nowIso } from "#lib/now.ts";
+import { nowIso, nowMs } from "#lib/now.ts";
 import { VALID_DAY_NAMES } from "#templates/fields.ts";
 import type { Attendee, Event, EventFields, EventType, EventWithCount } from "#lib/types.ts";
 
@@ -96,10 +97,37 @@ export const writeEventDate = (v: string): Promise<string> =>
   encryptDatetime(v, "date");
 
 /**
+ * In-memory events cache. Loads all events with attendee counts
+ * in a single query and serves subsequent reads from memory until
+ * the TTL expires or a write invalidates the cache.
+ */
+export const EVENTS_CACHE_TTL_MS = 60_000;
+
+type EventsCacheState = {
+  events: EventWithCount[] | null;
+  time: number;
+};
+
+const [getEventsCacheState, setEventsCacheState] = lazyRef<EventsCacheState>(
+  () => ({ events: null, time: 0 }),
+);
+
+const isEventsCacheValid = (): boolean => {
+  const state = getEventsCacheState();
+  return state.events !== null && nowMs() - state.time < EVENTS_CACHE_TTL_MS;
+};
+
+/** Invalidate the events cache (for testing or after writes). */
+export const invalidateEventsCache = (): void => {
+  setEventsCacheState(null);
+};
+
+/**
  * Events table definition
  * slug is encrypted; slug_index is HMAC for lookups
+ * Write methods (insert, update, deleteById) auto-invalidate the events cache.
  */
-export const eventsTable = defineIdTable<Event, EventInput>("events", {
+const rawEventsTable = defineIdTable<Event, EventInput>("events", {
     ...idAndEncryptedSlugSchema(encrypt, decrypt),
     ...encryptedNameSchema(encrypt, decrypt),
     description: { default: () => "", write: encrypt, read: decrypt },
@@ -133,12 +161,36 @@ export const eventsTable = defineIdTable<Event, EventInput>("events", {
     image_url: { default: () => "", write: encrypt, read: decrypt },
   });
 
+export const eventsTable: typeof rawEventsTable = {
+  ...rawEventsTable,
+  insert: async (input) => {
+    const result = await rawEventsTable.insert(input);
+    invalidateEventsCache();
+    return result;
+  },
+  update: async (id, input) => {
+    const result = await rawEventsTable.update(id, input);
+    invalidateEventsCache();
+    return result;
+  },
+  deleteById: async (id) => {
+    await rawEventsTable.deleteById(id);
+    invalidateEventsCache();
+  },
+};
+
+
+/** Find a cached event by ID */
+const findCachedEventById = async (id: number): Promise<EventWithCount | null> => {
+  const events = await loadAllEventsCached();
+  return events.find((e) => e.id === id) ?? null;
+};
 
 /**
- * Get a single event by ID
+ * Get a single event by ID (from cache)
  */
 export const getEvent = (id: number): Promise<Event | null> =>
-  eventsTable.findById(id);
+  findCachedEventById(id);
 
 /**
  * Check if a slug is already in use (optionally excluding a specific event ID)
@@ -197,47 +249,36 @@ const queryEventsWithCounts = async (
 };
 
 /**
- * Get all events with attendee counts (sum of quantities)
- * Uses custom JOIN query - not covered by table abstraction
+ * Load all events with counts into the in-memory cache with a single query.
  */
-export const getAllEvents = (): Promise<EventWithCount[]> =>
-  queryEventsWithCounts();
-
-/**
- * Get event with attendee count (sum of quantities)
- * Uses custom JOIN query - not covered by table abstraction
- */
-export const getEventWithCount = async (
-  id: number,
-): Promise<EventWithCount | null> => {
-  const row = await queryOne<EventWithCount>(
-    `SELECT e.*, COALESCE(SUM(a.quantity), 0) as attendee_count
-     FROM events e
-     LEFT JOIN attendees a ON e.id = a.event_id
-     WHERE e.id = ?
-     GROUP BY e.id`,
-    [id],
-  );
-  return row ? decryptAndAttachCount(row, row.attendee_count) : null;
+const loadAllEventsCached = async (): Promise<EventWithCount[]> => {
+  if (isEventsCacheValid()) return getEventsCacheState().events!;
+  const events = await queryEventsWithCounts();
+  setEventsCacheState({ events, time: nowMs() });
+  return events;
 };
 
 /**
- * Get event with attendee count by slug (uses slug_index for lookup)
- * Uses custom JOIN query - not covered by table abstraction
+ * Get all events with attendee counts (from cache)
+ */
+export const getAllEvents = (): Promise<EventWithCount[]> =>
+  loadAllEventsCached();
+
+/**
+ * Get event with attendee count (from cache)
+ */
+export const getEventWithCount = (id: number): Promise<EventWithCount | null> =>
+  findCachedEventById(id);
+
+/**
+ * Get event with attendee count by slug (from cache)
  */
 export const getEventWithCountBySlug = async (
   slug: string,
 ): Promise<EventWithCount | null> => {
   const slugIndex = await computeSlugIndex(slug);
-  const row = await queryOne<EventWithCount>(
-    `SELECT e.*, COALESCE(SUM(a.quantity), 0) as attendee_count
-     FROM events e
-     LEFT JOIN attendees a ON e.id = a.event_id
-     WHERE e.slug_index = ?
-     GROUP BY e.id`,
-    [slugIndex],
-  );
-  return row ? decryptAndAttachCount(row, row.attendee_count) : null;
+  const events = await loadAllEventsCached();
+  return events.find((e) => e.slug_index === slugIndex) ?? null;
 };
 
 /** Result type for combined event + attendees query */
@@ -268,18 +309,24 @@ export const getEventWithAttendeesRaw = async (
   return { event: await decryptAndAttachCount(eventRow, count), attendeesRaw };
 };
 
-/**
- * Get all daily events with attendee counts (no attendees loaded).
- */
-export const getAllDailyEvents = (): Promise<EventWithCount[]> =>
-  queryEventsWithCounts("WHERE e.event_type = 'daily'");
+/** Get cached events filtered by event_type */
+const getCachedEventsByType = async (type: EventType): Promise<EventWithCount[]> => {
+  const events = await loadAllEventsCached();
+  return fpFilter((e: EventWithCount) => e.event_type === type)(events);
+};
 
 /**
- * Get all standard events with attendee counts (no attendees loaded).
+ * Get all daily events with attendee counts (from cache).
+ */
+export const getAllDailyEvents = (): Promise<EventWithCount[]> =>
+  getCachedEventsByType("daily");
+
+/**
+ * Get all standard events with attendee counts (from cache).
  * Used by the calendar view to include one-time events on their scheduled date.
  */
 export const getAllStandardEvents = (): Promise<EventWithCount[]> =>
-  queryEventsWithCounts("WHERE e.event_type = 'standard'");
+  getCachedEventsByType("standard");
 
 /**
  * Get distinct attendee dates for daily events.
@@ -355,7 +402,7 @@ export const getEventWithAttendeeRaw = async (
 };
 
 /**
- * Get multiple events by slugs in a single database round-trip.
+ * Get multiple events by slugs (from cache).
  * Returns events in the same order as the input slugs.
  * Missing or inactive events are returned as null.
  */
@@ -367,21 +414,9 @@ export const getEventsBySlugsBatch = async (
   // Compute slug indices for all slugs
   const slugIndices = await Promise.all(slugs.map(computeSlugIndex));
 
-  // Build a single query with IN clause for all slug indices
-  const rows = await queryAll<EventWithCount>(
-    `SELECT e.*, COALESCE(SUM(a.quantity), 0) as attendee_count
-          FROM events e
-          LEFT JOIN attendees a ON e.id = a.event_id
-          WHERE e.slug_index IN (${inPlaceholders(slugIndices)})
-          GROUP BY e.id`,
-    slugIndices,
-  );
-
-  const decryptedEvents = await Promise.all(rows.map((row) => decryptAndAttachCount(row, row.attendee_count)));
-
-  // Create a map of slug_index -> event for ordering
+  const events = await loadAllEventsCached();
   const eventBySlugIndex = new Map<string, EventWithCount>();
-  for (const event of decryptedEvents) {
+  for (const event of events) {
     eventBySlugIndex.set(event.slug_index, event);
   }
 

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -8,7 +8,7 @@ import { getDb, queryAll } from "#lib/db/client.ts";
 import { encryptedNameSchema, idAndEncryptedSlugSchema } from "#lib/db/common-schema.ts";
 import { defineIdTable } from "#lib/db/define-id-table.ts";
 import { queryAndMap } from "#lib/db/query.ts";
-import { eventsTable } from "#lib/db/events.ts";
+import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
 import type { Event, EventWithCount, Group } from "#lib/types.ts";
 
 /** Group input fields for create/update (camelCase) */
@@ -147,6 +147,7 @@ export const assignEventsToGroup = async (
       args: [groupId, eventId],
     });
   }
+  if (eventIds.length > 0) invalidateEventsCache();
 };
 
 /**
@@ -157,4 +158,5 @@ export const resetGroupEvents = async (groupId: number): Promise<void> => {
     sql: "UPDATE events SET group_id = 0 WHERE group_id = ?",
     args: [groupId],
   });
+  invalidateEventsCache();
 };

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -18,7 +18,7 @@ import {
 import { getDb, queryAll } from "#lib/db/client.ts";
 import { nowMs } from "#lib/now.ts";
 import { deleteAllSessions } from "#lib/db/sessions.ts";
-import { createUser } from "#lib/db/users.ts";
+import { createUser, invalidateUsersCache } from "#lib/db/users.ts";
 import type { Settings } from "#lib/types.ts";
 
 /**
@@ -68,7 +68,7 @@ export const CONFIG_KEYS = {
  * serves subsequent reads from memory until the TTL expires or a
  * write invalidates the cache.
  */
-export const SETTINGS_CACHE_TTL_MS = 5_000;
+export const SETTINGS_CACHE_TTL_MS = 60_000;
 
 /**
  * Decrypted page content cache. Pages like homepage, contact, terms
@@ -410,6 +410,7 @@ export const updateUserPassword = async (
     sql: "UPDATE users SET password_hash = ?, wrapped_data_key = ? WHERE id = ?",
     args: [encryptedNewHash, newWrappedDataKey, userId],
   });
+  invalidateUsersCache();
 
   // Invalidate all sessions (force re-login with new password)
   await deleteAllSessions();

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -2,6 +2,7 @@
  * Users table operations
  */
 
+import { lazyRef } from "#fp";
 import {
   decrypt,
   deriveKEK,
@@ -12,9 +13,45 @@ import {
   verifyPassword,
   wrapKey,
 } from "#lib/crypto.ts";
-import { getDb, queryAll, queryOne } from "#lib/db/client.ts";
-import { now } from "#lib/now.ts";
+import { getDb, queryAll } from "#lib/db/client.ts";
+import { now, nowMs } from "#lib/now.ts";
 import { isAdminLevel, type AdminLevel, type User } from "#lib/types.ts";
+
+/**
+ * In-memory users cache. Loads all rows in a single query and
+ * serves subsequent reads from memory until the TTL expires or a
+ * write invalidates the cache.
+ */
+export const USERS_CACHE_TTL_MS = 60_000;
+
+type UsersCacheState = {
+  users: User[] | null;
+  time: number;
+};
+
+const [getUsersCacheState, setUsersCacheState] = lazyRef<UsersCacheState>(
+  () => ({ users: null, time: 0 }),
+);
+
+const isUsersCacheValid = (): boolean => {
+  const state = getUsersCacheState();
+  return state.users !== null && nowMs() - state.time < USERS_CACHE_TTL_MS;
+};
+
+const USER_SELECT =
+  "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users ORDER BY id ASC";
+
+const loadAllUsers = async (): Promise<User[]> => {
+  if (isUsersCacheValid()) return getUsersCacheState().users!;
+  const users = await queryAll<User>(USER_SELECT);
+  setUsersCacheState({ users, time: nowMs() });
+  return users;
+};
+
+/** Invalidate the users cache (for testing or after writes). */
+export const invalidateUsersCache = (): void => {
+  setUsersCacheState(null);
+};
 
 /** Shared user creation logic */
 const insertUser = async (opts: {
@@ -46,6 +83,7 @@ const insertUser = async (opts: {
     ],
   });
 
+  invalidateUsersCache();
   const id = Number(result.lastInsertRowid);
   return {
     id,
@@ -82,26 +120,23 @@ export const createInvitedUser = (
   insertUser({ username, adminLevel, passwordHash: "", wrappedDataKey: null, inviteCodeHash, inviteExpiry });
 
 /**
- * Look up a user by username (using blind index)
+ * Look up a user by username (using blind index, from cache)
  */
 export const getUserByUsername = async (
   username: string,
 ): Promise<User | null> => {
   const usernameIndex = await hmacHash(username.toLowerCase());
-  return queryOne<User>(
-    "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users WHERE username_index = ?",
-    [usernameIndex],
-  );
+  const users = await loadAllUsers();
+  return users.find((u) => u.username_index === usernameIndex) ?? null;
 };
 
 /**
- * Get a user by ID
+ * Get a user by ID (from cache)
  */
-export const getUserById = (id: number): Promise<User | null> =>
-  queryOne<User>(
-    "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users WHERE id = ?",
-    [id],
-  );
+export const getUserById = async (id: number): Promise<User | null> => {
+  const users = await loadAllUsers();
+  return users.find((u) => u.id === id) ?? null;
+};
 
 /**
  * Check if a username is already taken
@@ -112,12 +147,9 @@ export const isUsernameTaken = async (username: string): Promise<boolean> => {
 };
 
 /**
- * Get all users (for admin user management page)
+ * Get all users (for admin user management page, from cache)
  */
-export const getAllUsers = (): Promise<User[]> =>
-  queryAll<User>(
-    "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users ORDER BY id ASC",
-  );
+export const getAllUsers = (): Promise<User[]> => loadAllUsers();
 
 /**
  * Verify a user's password (decrypt stored hash, then verify)
@@ -165,6 +197,7 @@ export const setUserPassword = async (
     sql: "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
     args: [encryptedHash, encryptedNull, encryptedNull, userId],
   });
+  invalidateUsersCache();
 
   return passwordHash;
 };
@@ -184,6 +217,7 @@ export const activateUser = async (
     sql: "UPDATE users SET wrapped_data_key = ? WHERE id = ?",
     args: [wrappedDataKey, userId],
   });
+  invalidateUsersCache();
 };
 
 /**
@@ -198,6 +232,7 @@ export const deleteUser = async (userId: number): Promise<void> => {
     sql: "DELETE FROM users WHERE id = ?",
     args: [userId],
   });
+  invalidateUsersCache();
 };
 
 /**
@@ -270,4 +305,5 @@ export const usersApi = {
   hashInviteCode,
   isInviteValid,
   hasPassword,
+  invalidateUsersCache,
 };

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -11,11 +11,13 @@ import { setDb } from "#lib/db/client.ts";
 import type { GroupInput } from "#lib/db/groups.ts";
 import {
   getEventWithCount,
+  invalidateEventsCache,
   type EventInput,
 } from "#lib/db/events.ts";
 import { initDb, LATEST_UPDATE } from "#lib/db/migrations/index.ts";
 import { getSession, resetSessionCache } from "#lib/db/sessions.ts";
 import { clearSetupCompleteCache, completeSetup, invalidateSettingsCache, updateTimezone } from "#lib/db/settings.ts";
+import { invalidateUsersCache } from "#lib/db/users.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
 
 /**
@@ -116,6 +118,8 @@ const prepareTestClient = async (): Promise<{ reused: boolean }> => {
   setupTestEncryptionKey();
   clearSetupCompleteCache();
   resetSessionCache();
+  invalidateUsersCache();
+  invalidateEventsCache();
 
   if (cachedClient && await isSchemaIntact(cachedClient)) {
     setDb(cachedClient);
@@ -227,6 +231,8 @@ export const resetDb = (): void => {
   setDb(null);
   clearSetupCompleteCache();
   invalidateSettingsCache();
+  invalidateUsersCache();
+  invalidateEventsCache();
   resetSessionCache();
   resetTestSession();
   resetCurrencyCode();
@@ -1604,7 +1610,7 @@ export const createTestManagerSession = async (
   const { deriveKEK, encrypt: enc, hmacHash, unwrapKey, wrapKeyWithToken } = await import("#lib/crypto.ts");
   const { getDb } = await import("#lib/db/client.ts");
   const { createSession } = await import("#lib/db/sessions.ts");
-  const { getUserByUsername, verifyUserPassword } = await import("#lib/db/users.ts");
+  const { getUserByUsername, verifyUserPassword, invalidateUsersCache: invalidateUsers } = await import("#lib/db/users.ts");
 
   // Get the system DATA_KEY via the admin user (always exists after createTestDbWithSetup)
   const user = (await getUserByUsername(TEST_ADMIN_USERNAME))!;
@@ -1620,6 +1626,7 @@ export const createTestManagerSession = async (
           VALUES (?, ?, ?, ?, ?)`,
     args: [await enc(username), managerIdx, "", managerWrappedKey, await enc("manager")],
   });
+  invalidateUsers();
 
   // Find the manager user ID
   const result = await getDb().execute("SELECT id FROM users ORDER BY id DESC LIMIT 1");

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -3,6 +3,7 @@ import type { InStatement } from "@libsql/client";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { getDb } from "#lib/db/client.ts";
 import { addDays } from "#lib/dates.ts";
+import { invalidateEventsCache } from "#lib/db/events.ts";
 import { todayInTz } from "#lib/timezone.ts";
 
 import { handleRequest } from "#routes";
@@ -1791,6 +1792,7 @@ describe("server (admin events)", () => {
           // Delete the event from DB so getEventWithCount returns null
           const { getDb } = await import("#lib/db/client.ts");
           await getDb().execute({ sql: "DELETE FROM events WHERE id = ?", args: [id as number] });
+          invalidateEventsCache();
         }
         return row;
       });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -3,6 +3,7 @@ import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { getEmbedHostsFromDb, getTimezoneFromDb, setPaymentProvider, updateTermsAndConditions } from "#lib/db/settings.ts";
 import { stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
+import { invalidateUsersCache } from "#lib/db/users.ts";
 import {
   awaitTestRequest,
   createTestDbWithSetup,
@@ -212,6 +213,7 @@ describe("server (admin settings)", () => {
         sql: "UPDATE users SET wrapped_data_key = ?",
         args: ["corrupted-key-data"],
       });
+      invalidateUsersCache();
 
       const response = await handleRequest(
         mockFormRequest(

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -10,6 +10,7 @@ import {
   getAllUsers,
   getUserByUsername,
   hasPassword,
+  invalidateUsersCache,
   isInviteValid,
   verifyUserPassword,
 } from "#lib/db/users.ts";
@@ -154,6 +155,7 @@ describe("server (multi-user admin)", () => {
           await encrypt("manager"),
         ],
       });
+      invalidateUsersCache();
 
       // Create a session for the manager user
       const managerUserId = 2;
@@ -508,6 +510,7 @@ describe("server (multi-user admin)", () => {
       const { clearSetupCompleteCache, invalidateSettingsCache: invalidateCache } = await import("#lib/db/settings.ts");
       clearSetupCompleteCache();
       invalidateCache();
+      invalidateUsersCache();
 
       const response = await handleRequest(mockRequest("/setup/"));
       expect(response.status).toBe(200);
@@ -810,6 +813,7 @@ describe("server (multi-user admin)", () => {
           null,
         ],
       });
+      invalidateUsersCache();
 
       const user = await getUserByUsername("no-expiry-user");
       const valid = await isInviteValid(user!);
@@ -832,6 +836,7 @@ describe("server (multi-user admin)", () => {
           null,
         ],
       });
+      invalidateUsersCache();
 
       const user = await getUserByUsername("badlevel-user");
       await expect(decryptAdminLevel(user!)).rejects.toThrow("Invalid admin level");
@@ -853,6 +858,7 @@ describe("server (multi-user admin)", () => {
           await encrypt(""),
         ],
       });
+      invalidateUsersCache();
 
       const user = await getUserByUsername("empty-expiry-user");
       const valid = await isInviteValid(user!);
@@ -877,6 +883,7 @@ describe("server (multi-user admin)", () => {
           await encrypt("manager"),
         ],
       });
+      invalidateUsersCache();
 
       await createSession("mgr-form-session", "mgr-form-csrf", Date.now() + 3600000, null, 2);
 
@@ -945,6 +952,7 @@ describe("server (multi-user admin)", () => {
         sql: "UPDATE users SET wrapped_data_key = 'corrupted_key' WHERE id = 1",
         args: [],
       });
+      invalidateUsersCache();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -973,6 +981,7 @@ describe("server (multi-user admin)", () => {
         sql: "DELETE FROM users WHERE id = 1",
         args: [],
       });
+      invalidateUsersCache();
 
       const response = await handleRequest(
         mockFormRequest(


### PR DESCRIPTION
## Summary
Implements in-memory caching with time-to-live (TTL) for events and users to reduce database queries. Both caches load all records in a single query and serve subsequent reads from memory until the TTL expires or a write operation invalidates the cache.

## Key Changes

- **Events Cache**: 
  - Added `EVENTS_CACHE_TTL_MS` (60 seconds) with `loadAllEventsCached()` function
  - Wrapped `eventsTable` to auto-invalidate cache on insert/update/deleteById operations
  - Refactored `getEvent()`, `getAllEvents()`, `getEventWithCount()`, `getEventWithCountBySlug()`, `getAllDailyEvents()`, and `getAllStandardEvents()` to use cached data
  - Eliminated individual event queries in favor of filtering the cached dataset
  - Added `invalidateEventsCache()` export for testing and manual invalidation

- **Users Cache**:
  - Added `USERS_CACHE_TTL_MS` (60 seconds) with `loadAllUsers()` function
  - Refactored `getUserByUsername()` and `getUserById()` to search cached users instead of querying database
  - Refactored `getAllUsers()` to use cached data
  - Added cache invalidation in `insertUser()`, `setUserPassword()`, `activateUser()`, and `deleteUser()`
  - Added `invalidateUsersCache()` export for testing and manual invalidation

- **Cache Invalidation**:
  - Events cache invalidated when attendees are deleted (affects attendee counts)
  - Events cache invalidated when events are assigned to/from groups
  - Users cache invalidated in settings when user password is updated
  - Test utilities call cache invalidation functions during setup/teardown

- **Settings Cache TTL**: Increased from 5 seconds to 60 seconds for consistency

## Implementation Details

- Uses `lazyRef` utility for thread-safe cache state management
- Cache validity checked via timestamp comparison against TTL
- All cache reads are async to maintain API compatibility
- Filtering operations use functional programming utilities (`fpFilter`)
- Removed direct `queryOne()` calls for individual lookups, consolidating to single bulk queries

https://claude.ai/code/session_01Q3wzRdkSiUZ4iACdW731w1