### PR TITLE
Fix "error decoding response body" by pre-encoding all string bodies to Uint8Array

### DIFF
--- a/src/edge/bunny-script.ts
+++ b/src/edge/bunny-script.ts
@@ -8,8 +8,7 @@ import { once } from "#fp";
 import { validateEncryptionKey } from "#lib/crypto.ts";
 import { initDb } from "#lib/db/migrations/index.ts";
 import { handleRequest } from "#routes";
-
-const encoder = new TextEncoder();
+import { encodeBody } from "#routes/utils.ts";
 
 const initialize = once(async (): Promise<void> => {
   validateEncryptionKey();
@@ -26,7 +25,7 @@ BunnySDK.net.http.serve(async (request: Request): Promise<Response> => {
     // biome-ignore lint/suspicious/noConsole: Edge script error logging
     console.error("[Tickets] Request error:", error);
     return new Response(
-      encoder.encode('<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="refresh" content="2"><title>Temporary Error</title></head><body><h1>Temporary Error</h1><p>Something went wrong loading this page. Retrying automatically&hellip;</p></body></html>'),
+      encodeBody('<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="refresh" content="2"><title>Temporary Error</title></head><body><h1>Temporary Error</h1><p>Something went wrong loading this page. Retrying automatically&hellip;</p></body></html>'),
       {
         status: 503,
         headers: { "content-type": "text/html; charset=utf-8" },

--- a/src/edge/bunny-script.ts
+++ b/src/edge/bunny-script.ts
@@ -9,6 +9,8 @@ import { validateEncryptionKey } from "#lib/crypto.ts";
 import { initDb } from "#lib/db/migrations/index.ts";
 import { handleRequest } from "#routes";
 
+const encoder = new TextEncoder();
+
 const initialize = once(async (): Promise<void> => {
   validateEncryptionKey();
   await initDb();
@@ -24,7 +26,7 @@ BunnySDK.net.http.serve(async (request: Request): Promise<Response> => {
     // biome-ignore lint/suspicious/noConsole: Edge script error logging
     console.error("[Tickets] Request error:", error);
     return new Response(
-      '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="refresh" content="2"><title>Temporary Error</title></head><body><h1>Temporary Error</h1><p>Something went wrong loading this page. Retrying automatically&hellip;</p></body></html>',
+      encoder.encode('<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="refresh" content="2"><title>Temporary Error</title></head><body><h1>Temporary Error</h1><p>Something went wrong loading this page. Retrying automatically&hellip;</p></body></html>'),
       {
         status: 503,
         headers: { "content-type": "text/html; charset=utf-8" },

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -51,6 +51,7 @@ import {
   type AuthSession,
   getSearchParam,
   htmlResponse,
+  jsonResponse,
   redirect,
   redirectWithSuccess,
   requireOwnerOr,
@@ -341,9 +342,7 @@ const handleAdminSquareWebhookPost = settingsRoute(async (form, errorPage) => {
 const handleStripeTestPost = (request: Request): Promise<Response> =>
   withOwnerAuthForm(request, async () => {
     const result = await testStripeConnection();
-    return new Response(JSON.stringify(result), {
-      headers: { "content-type": "application/json" },
-    });
+    return jsonResponse(result);
   });
 
 /**

--- a/src/routes/admin/utils.ts
+++ b/src/routes/admin/utils.ts
@@ -6,7 +6,7 @@ import { decryptAttendees, decryptAttendeesForTable } from "#lib/db/attendees.ts
 import { getEventWithAttendeesRaw } from "#lib/db/events.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import type { validateForm } from "#lib/forms.tsx";
-import { type AuthSession, getPrivateKey, notFoundResponse, requireSessionOr } from "#routes/utils.ts";
+import { type AuthSession, encodeBody, getPrivateKey, notFoundResponse, requireSessionOr } from "#routes/utils.ts";
 
 /** Form field definition type */
 export type FormFields = Parameters<typeof validateForm>[1];
@@ -31,11 +31,9 @@ export const getDateFilter = (request: Request): string | null => {
   return date;
 };
 
-const encoder = new TextEncoder();
-
 /** Build a CSV file download response */
 export const csvResponse = (csv: string, filename: string): Response =>
-  new Response(encoder.encode(csv), {
+  new Response(encodeBody(csv), {
     headers: {
       "content-type": "text/csv; charset=utf-8",
       "content-disposition": `attachment; filename="${filename}"`,

--- a/src/routes/admin/utils.ts
+++ b/src/routes/admin/utils.ts
@@ -31,9 +31,11 @@ export const getDateFilter = (request: Request): string | null => {
   return date;
 };
 
+const encoder = new TextEncoder();
+
 /** Build a CSV file download response */
 export const csvResponse = (csv: string, filename: string): Response =>
-  new Response(csv, {
+  new Response(encoder.encode(csv), {
     headers: {
       "content-type": "text/csv; charset=utf-8",
       "content-disposition": `attachment; filename="${filename}"`,

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -3,6 +3,7 @@
  */
 
 import { dirname, fromFileUrl, join } from "@std/path";
+import { encodeBody } from "#routes/utils.ts";
 
 const currentDir = dirname(fromFileUrl(import.meta.url));
 const staticDir = join(currentDir, "..", "static");
@@ -12,11 +13,9 @@ const CACHE_HEADERS = {
   "cache-control": "public, max-age=31536000, immutable",
 };
 
-const encoder = new TextEncoder();
-
 /** Create a handler that serves a static file with the given content type */
 const staticHandler = (filename: string, contentType: string): (() => Response) => {
-  const content = encoder.encode(Deno.readTextFileSync(join(staticDir, filename)));
+  const content = encodeBody(Deno.readTextFileSync(join(staticDir, filename)));
   return () =>
     new Response(content, {
       headers: { "content-type": contentType, ...CACHE_HEADERS },

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -12,9 +12,11 @@ const CACHE_HEADERS = {
   "cache-control": "public, max-age=31536000, immutable",
 };
 
+const encoder = new TextEncoder();
+
 /** Create a handler that serves a static file with the given content type */
 const staticHandler = (filename: string, contentType: string): (() => Response) => {
-  const content = Deno.readTextFileSync(join(staticDir, filename));
+  const content = encoder.encode(Deno.readTextFileSync(join(staticDir, filename)));
   return () =>
     new Response(content, {
       headers: { "content-type": contentType, ...CACHE_HEADERS },

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -2,7 +2,9 @@
  * Health check route
  */
 
-const HEALTH_RESPONSE = new TextEncoder().encode(JSON.stringify({ status: "ok" }));
+import { encodeBody } from "#routes/utils.ts";
+
+const HEALTH_RESPONSE = encodeBody(JSON.stringify({ status: "ok" }));
 
 /**
  * Handle health check request - returns JSON status

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -2,7 +2,7 @@
  * Health check route
  */
 
-const HEALTH_RESPONSE = JSON.stringify({ status: "ok" });
+const HEALTH_RESPONSE = new TextEncoder().encode(JSON.stringify({ status: "ok" }));
 
 /**
  * Handle health check request - returns JSON status

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -6,8 +6,7 @@ import { compact } from "#fp";
 import { getAllowedDomain, getEmbedHosts } from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
-
-const encoder = new TextEncoder();
+import { encodeBody } from "#routes/utils.ts";
 
 /**
  * Security headers for all responses
@@ -146,7 +145,7 @@ export const isValidContentType = (request: Request, path: string): boolean => {
  * Create Content-Type rejection response
  */
 export const contentTypeRejectionResponse = (): Response =>
-  new Response(encoder.encode("Bad Request: Invalid Content-Type"), {
+  new Response(encodeBody("Bad Request: Invalid Content-Type"), {
     status: 400,
     headers: {
       "content-type": "text/plain",
@@ -158,7 +157,7 @@ export const contentTypeRejectionResponse = (): Response =>
  * Create domain rejection response
  */
 export const domainRejectionResponse = (): Response =>
-  new Response(encoder.encode("Forbidden: Invalid domain"), {
+  new Response(encodeBody("Forbidden: Invalid domain"), {
     status: 403,
     headers: {
       "content-type": "text/plain",

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -7,6 +7,8 @@ import { getAllowedDomain, getEmbedHosts } from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
 
+const encoder = new TextEncoder();
+
 /**
  * Security headers for all responses
  */
@@ -144,7 +146,7 @@ export const isValidContentType = (request: Request, path: string): boolean => {
  * Create Content-Type rejection response
  */
 export const contentTypeRejectionResponse = (): Response =>
-  new Response("Bad Request: Invalid Content-Type", {
+  new Response(encoder.encode("Bad Request: Invalid Content-Type"), {
     status: 400,
     headers: {
       "content-type": "text/plain",
@@ -156,7 +158,7 @@ export const contentTypeRejectionResponse = (): Response =>
  * Create domain rejection response
  */
 export const domainRejectionResponse = (): Response =>
-  new Response("Forbidden: Invalid domain", {
+  new Response(encoder.encode("Forbidden: Invalid domain"), {
     status: 403,
     headers: {
       "content-type": "text/plain",

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -24,6 +24,16 @@ import { notFoundPage, temporaryErrorPage } from "#templates/public.tsx";
 export { generateSecureToken };
 
 /**
+ * Shared TextEncoder for pre-encoding string response bodies to Uint8Array.
+ * Bunny Edge's runtime intermittently fails to decode JS string bodies
+ * ("Unknown: error decoding response body"). Pre-encoding to bytes
+ * bypasses the runtime's string-to-UTF8 path entirely.
+ */
+const encoder = new TextEncoder();
+export const encodeBody = (text: string): BodyInit =>
+  encoder.encode(text) as unknown as BodyInit;
+
+/**
  * Get client IP from request
  * Note: This server runs directly on edge, not behind a proxy,
  * so we use the direct connection IP from the server context.
@@ -135,7 +145,7 @@ export const getPrivateKey = async (
  * Create HTML response
  */
 export const htmlResponse = (html: string, status = 200): Response =>
-  new Response(html, {
+  new Response(encodeBody(html), {
     status,
     headers: { "content-type": "text/html; charset=utf-8" },
   });
@@ -509,7 +519,7 @@ export const withAuthMultipartForm = async (
 
 /** Create JSON response */
 export const jsonResponse = (data: unknown, status = 200): Response =>
-  new Response(JSON.stringify(data), {
+  new Response(encodeBody(JSON.stringify(data)), {
     status,
     headers: { "content-type": "application/json; charset=utf-8" },
   });

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -524,6 +524,13 @@ export const jsonResponse = (data: unknown, status = 200): Response =>
     headers: { "content-type": "application/json; charset=utf-8" },
   });
 
+/** Create plain text response */
+export const plainResponse = (text: string, status = 200): Response =>
+  new Response(encodeBody(text), {
+    status,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+
 type JsonHandler = (session: AuthSession, body: Record<string, unknown>) => Response | Promise<Response>;
 
 /**

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -681,9 +681,11 @@ const extractSessionFromEvent = (
   };
 };
 
+const encoder = new TextEncoder();
+
 /** JSON response acknowledging a webhook event without processing */
 const webhookAckResponse = (extra?: Record<string, unknown>): Response =>
-  new Response(JSON.stringify({ received: true, ...extra }), {
+  new Response(encoder.encode(JSON.stringify({ received: true, ...extra })), {
     status: 200,
     headers: { "content-type": "application/json" },
   });
@@ -712,13 +714,13 @@ const extractSessionIdFromObject = (obj: Record<string, unknown>): string | null
 const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   const provider = await getActivePaymentProvider();
   if (!provider) {
-    return new Response("Payment provider not configured", { status: 400 });
+    return new Response(encoder.encode("Payment provider not configured"), { status: 400 });
   }
 
   // Get signature header
   const signature = getWebhookSignatureHeader(request);
   if (!signature) {
-    return new Response("Missing signature", { status: 400 });
+    return new Response(encoder.encode("Missing signature"), { status: 400 });
   }
 
   // Read raw body bytes for signature verification. Using arrayBuffer() and
@@ -736,7 +738,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   // Verify signature (pass raw bytes so HMAC is computed on exact received bytes)
   const verification = await provider.verifyWebhookSignature(payload, signature, webhookUrl, payloadBytes);
   if (!verification.valid) {
-    return new Response(verification.error, { status: 400 });
+    return new Response(encoder.encode(verification.error), { status: 400 });
   }
 
   const event = verification.event;
@@ -758,7 +760,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
     const sessionId = extractSessionIdFromObject(obj);
 
     if (!sessionId) {
-      return new Response("Invalid session data", { status: 400 });
+      return new Response(encoder.encode("Invalid session data"), { status: 400 });
     }
 
     // For Square payment.updated: check payment status before retrieving order
@@ -768,7 +770,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
 
     session = await provider.retrieveSession(sessionId);
     if (!session) {
-      return new Response("Invalid session data", { status: 400 });
+      return new Response(encoder.encode("Invalid session data"), { status: 400 });
     }
   }
 
@@ -797,7 +799,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   if (isMulti) {
     const multiIntent = extractMultiIntent(session);
     if (!multiIntent) {
-      return new Response("Invalid multi-ticket session data", { status: 400 });
+      return new Response(encoder.encode("Invalid multi-ticket session data"), { status: 400 });
     }
     eventIdForLog = multiIntent.items[0]?.e;
     result = await processMultiPaymentSession(session.id, { session, intent: multiIntent });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -45,7 +45,9 @@ import {
   getSearchParam,
   htmlResponse,
   isRegistrationClosed,
+  jsonResponse,
   paymentErrorResponse,
+  plainResponse,
   redirect,
 } from "#routes/utils.ts";
 import { paymentCancelPage, paymentSuccessPage } from "#templates/payment.tsx";
@@ -681,14 +683,9 @@ const extractSessionFromEvent = (
   };
 };
 
-const encoder = new TextEncoder();
-
 /** JSON response acknowledging a webhook event without processing */
 const webhookAckResponse = (extra?: Record<string, unknown>): Response =>
-  new Response(encoder.encode(JSON.stringify({ received: true, ...extra })), {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
+  jsonResponse({ received: true, ...extra });
 
 /** Detect which provider sent the webhook based on request headers */
 const getWebhookSignatureHeader = (
@@ -714,13 +711,13 @@ const extractSessionIdFromObject = (obj: Record<string, unknown>): string | null
 const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   const provider = await getActivePaymentProvider();
   if (!provider) {
-    return new Response(encoder.encode("Payment provider not configured"), { status: 400 });
+    return plainResponse("Payment provider not configured", 400);
   }
 
   // Get signature header
   const signature = getWebhookSignatureHeader(request);
   if (!signature) {
-    return new Response(encoder.encode("Missing signature"), { status: 400 });
+    return plainResponse("Missing signature", 400);
   }
 
   // Read raw body bytes for signature verification. Using arrayBuffer() and
@@ -738,7 +735,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   // Verify signature (pass raw bytes so HMAC is computed on exact received bytes)
   const verification = await provider.verifyWebhookSignature(payload, signature, webhookUrl, payloadBytes);
   if (!verification.valid) {
-    return new Response(encoder.encode(verification.error), { status: 400 });
+    return plainResponse(verification.error, 400);
   }
 
   const event = verification.event;
@@ -760,7 +757,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
     const sessionId = extractSessionIdFromObject(obj);
 
     if (!sessionId) {
-      return new Response(encoder.encode("Invalid session data"), { status: 400 });
+      return plainResponse("Invalid session data", 400);
     }
 
     // For Square payment.updated: check payment status before retrieving order
@@ -770,7 +767,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
 
     session = await provider.retrieveSession(sessionId);
     if (!session) {
-      return new Response(encoder.encode("Invalid session data"), { status: 400 });
+      return plainResponse("Invalid session data", 400);
     }
   }
 
@@ -799,7 +796,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   if (isMulti) {
     const multiIntent = extractMultiIntent(session);
     if (!multiIntent) {
-      return new Response(encoder.encode("Invalid multi-ticket session data"), { status: 400 });
+      return plainResponse("Invalid multi-ticket session data", 400);
     }
     eventIdForLog = multiIntent.items[0]?.e;
     result = await processMultiPaymentSession(session.id, { session, intent: multiIntent });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -391,7 +391,7 @@ describe("server (admin settings)", () => {
             mockFormRequest("/admin/settings/stripe/test", { csrf_token: csrfToken }, cookie),
           );
           expect(response.status).toBe(200);
-          expect(response.headers.get("content-type")).toBe("application/json");
+          expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
           const json = await response.json();
           expect(json.ok).toBe(false);
           expect(json.apiKey.valid).toBe(false);


### PR DESCRIPTION
The Bunny Edge runtime intermittently fails to decode Response objects
whose body source is a JavaScript string ("Unknown: error decoding
response body", 400 to clients). This happened on all paths including
static assets — ruling out all previous fixes which targeted body
re-reading (response.text() / response.clone()).

Root cause: when a JS string is passed to `new Response(string)`, the
runtime must internally convert it to UTF-8 bytes. This conversion
path has an intermittent failure in Bunny Edge. Responses with
Uint8Array/ArrayBuffer bodies (like images) are unaffected because
no string-to-bytes conversion is needed.

Fix: pre-encode all string bodies via TextEncoder.encode() before
passing to `new Response()`, bypassing the runtime's string decoding
path entirely. Applied to htmlResponse, jsonResponse, staticHandler,
health check, middleware rejections, CSV downloads, webhook responses,
and the edge handler error page.

https://claude.ai/code/session_012HhjR2DqFXgSU8dpWmWnp5