### PR TITLE
Extract collectionCache helper and cache holidays/groups collections

### DIFF
--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -357,6 +357,42 @@ export const boundedLru = <K, V>(maxSize: number): BoundedLru<K, V> => {
   };
 };
 
+/** Collection cache returned by collectionCache() */
+export type CollectionCache<T> = {
+  getAll: () => Promise<T[]>;
+  invalidate: () => void;
+};
+
+/**
+ * Create an in-memory collection cache with TTL.
+ * Loads all items via fetchAll on first access or after invalidation/expiry,
+ * then serves from memory until the TTL expires or invalidate() is called.
+ * Accepts an optional clock function for testing.
+ */
+export const collectionCache = <T>(
+  fetchAll: () => Promise<T[]>,
+  ttlMs: number,
+  now: () => number = Date.now,
+): CollectionCache<T> => {
+  const [getState, setState] = lazyRef<{ items: T[] | null; time: number }>(
+    () => ({ items: null, time: 0 }),
+  );
+  return {
+    getAll: async (): Promise<T[]> => {
+      const state = getState();
+      if (state.items !== null && now() - state.time < ttlMs) {
+        return state.items;
+      }
+      const items = await fetchAll();
+      setState({ items, time: now() });
+      return items;
+    },
+    invalidate: (): void => {
+      setState(null);
+    },
+  };
+};
+
 /** TTL cache returned by ttlCache() */
 export type TtlCache<K, V> = {
   get: (key: K) => V | undefined;

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ResultSet } from "@libsql/client";
-import { filter as fpFilter, lazyRef } from "#fp";
+import { filter as fpFilter, collectionCache } from "#fp";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { executeByField, getDb, inPlaceholders, queryAll, queryBatch, resultRows } from "#lib/db/client.ts";
 import { encryptedNameSchema, idAndEncryptedSlugSchema } from "#lib/db/common-schema.ts";
@@ -103,25 +103,6 @@ export const writeEventDate = (v: string): Promise<string> =>
  */
 export const EVENTS_CACHE_TTL_MS = 60_000;
 
-type EventsCacheState = {
-  events: EventWithCount[] | null;
-  time: number;
-};
-
-const [getEventsCacheState, setEventsCacheState] = lazyRef<EventsCacheState>(
-  () => ({ events: null, time: 0 }),
-);
-
-const isEventsCacheValid = (): boolean => {
-  const state = getEventsCacheState();
-  return state.events !== null && nowMs() - state.time < EVENTS_CACHE_TTL_MS;
-};
-
-/** Invalidate the events cache (for testing or after writes). */
-export const invalidateEventsCache = (): void => {
-  setEventsCacheState(null);
-};
-
 /**
  * Events table definition
  * slug is encrypted; slug_index is HMAC for lookups
@@ -182,7 +163,7 @@ export const eventsTable: typeof rawEventsTable = {
 
 /** Find a cached event by ID */
 const findCachedEventById = async (id: number): Promise<EventWithCount | null> => {
-  const events = await loadAllEventsCached();
+  const events = await eventsCache.getAll();
   return events.find((e) => e.id === id) ?? null;
 };
 
@@ -248,21 +229,22 @@ const queryEventsWithCounts = async (
   return Promise.all(rows.map((row) => decryptAndAttachCount(row, row.attendee_count)));
 };
 
-/**
- * Load all events with counts into the in-memory cache with a single query.
- */
-const loadAllEventsCached = async (): Promise<EventWithCount[]> => {
-  if (isEventsCacheValid()) return getEventsCacheState().events!;
-  const events = await queryEventsWithCounts();
-  setEventsCacheState({ events, time: nowMs() });
-  return events;
+const eventsCache = collectionCache(
+  () => queryEventsWithCounts(),
+  EVENTS_CACHE_TTL_MS,
+  nowMs,
+);
+
+/** Invalidate the events cache (for testing or after writes). */
+export const invalidateEventsCache = (): void => {
+  eventsCache.invalidate();
 };
 
 /**
  * Get all events with attendee counts (from cache)
  */
 export const getAllEvents = (): Promise<EventWithCount[]> =>
-  loadAllEventsCached();
+  eventsCache.getAll();
 
 /**
  * Get event with attendee count (from cache)
@@ -277,7 +259,7 @@ export const getEventWithCountBySlug = async (
   slug: string,
 ): Promise<EventWithCount | null> => {
   const slugIndex = await computeSlugIndex(slug);
-  const events = await loadAllEventsCached();
+  const events = await eventsCache.getAll();
   return events.find((e) => e.slug_index === slugIndex) ?? null;
 };
 
@@ -311,7 +293,7 @@ export const getEventWithAttendeesRaw = async (
 
 /** Get cached events filtered by event_type */
 const getCachedEventsByType = async (type: EventType): Promise<EventWithCount[]> => {
-  const events = await loadAllEventsCached();
+  const events = await eventsCache.getAll();
   return fpFilter((e: EventWithCount) => e.event_type === type)(events);
 };
 
@@ -414,7 +396,7 @@ export const getEventsBySlugsBatch = async (
   // Compute slug indices for all slugs
   const slugIndices = await Promise.all(slugs.map(computeSlugIndex));
 
-  const events = await loadAllEventsCached();
+  const events = await eventsCache.getAll();
   const eventBySlugIndex = new Map<string, EventWithCount>();
   for (const event of events) {
     eventBySlugIndex.set(event.slug_index, event);

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -2,7 +2,7 @@
  * Groups table operations
  */
 
-import { mapAsync } from "#fp";
+import { collectionCache, mapAsync } from "#fp";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
 import { encryptedNameSchema, idAndEncryptedSlugSchema } from "#lib/db/common-schema.ts";
@@ -23,33 +23,66 @@ export type GroupInput = {
 export const computeGroupSlugIndex = (slug: string): Promise<string> =>
   hmacHash(slug);
 
-/** Groups table with CRUD operations */
-export const groupsTable = defineIdTable<Group, GroupInput>("groups", {
+/**
+ * In-memory groups cache. Loads all groups in a single query and
+ * serves subsequent reads from memory until the TTL expires or a
+ * write invalidates the cache.
+ */
+export const GROUPS_CACHE_TTL_MS = 60_000;
+
+/** Raw groups table with CRUD operations */
+const rawGroupsTable = defineIdTable<Group, GroupInput>("groups", {
   ...encryptedNameSchema(encrypt, decrypt),
   ...idAndEncryptedSlugSchema(encrypt, decrypt),
   terms_and_conditions: { default: () => "", write: encrypt, read: decrypt },
 });
 
 /** Execute a query and decrypt the resulting group rows */
-const queryGroups = queryAndMap<Group, Group>((row) => groupsTable.fromDb(row));
+const queryGroups = queryAndMap<Group, Group>((row) => rawGroupsTable.fromDb(row));
+
+const groupsCache = collectionCache(
+  () => queryGroups("SELECT * FROM groups ORDER BY id ASC"),
+  GROUPS_CACHE_TTL_MS,
+);
+
+/** Invalidate the groups cache (for testing or after writes). */
+export const invalidateGroupsCache = (): void => {
+  groupsCache.invalidate();
+};
+
+/** Groups table with CRUD operations — writes auto-invalidate the cache */
+export const groupsTable: typeof rawGroupsTable = {
+  ...rawGroupsTable,
+  insert: async (input) => {
+    const result = await rawGroupsTable.insert(input);
+    invalidateGroupsCache();
+    return result;
+  },
+  update: async (id, input) => {
+    const result = await rawGroupsTable.update(id, input);
+    invalidateGroupsCache();
+    return result;
+  },
+  deleteById: async (id) => {
+    await rawGroupsTable.deleteById(id);
+    invalidateGroupsCache();
+  },
+};
 
 /**
- * Get all groups, decrypted, ordered by id
+ * Get all groups, decrypted, ordered by id (from cache)
  */
 export const getAllGroups = (): Promise<Group[]> =>
-  queryGroups("SELECT * FROM groups ORDER BY id ASC");
+  groupsCache.getAll();
 
 /**
- * Get a single group by slug_index
+ * Get a single group by slug_index (from cache)
  */
 export const getGroupBySlugIndex = async (
   slugIndex: string,
 ): Promise<Group | null> => {
-  const result = await queryGroups({
-    sql: "SELECT * FROM groups WHERE slug_index = ? LIMIT 1",
-    args: [slugIndex],
-  });
-  return result[0] ?? null;
+  const groups = await groupsCache.getAll();
+  return groups.find((g) => g.slug_index === slugIndex) ?? null;
 };
 
 /**

--- a/src/lib/db/holidays.ts
+++ b/src/lib/db/holidays.ts
@@ -2,6 +2,7 @@
  * Holidays table operations
  */
 
+import { collectionCache, filter } from "#fp";
 import { decrypt, encrypt } from "#lib/crypto.ts";
 import { getTz } from "#lib/config.ts";
 import { todayInTz } from "#lib/timezone.ts";
@@ -16,8 +17,15 @@ export type HolidayInput = {
   endDate: string;
 };
 
-/** Holidays table with CRUD operations — name is encrypted, dates are plaintext */
-export const holidaysTable = defineTable<Holiday, HolidayInput>({
+/**
+ * In-memory holidays cache. Loads all holidays in a single query and
+ * serves subsequent reads from memory until the TTL expires or a
+ * write invalidates the cache.
+ */
+export const HOLIDAYS_CACHE_TTL_MS = 60_000;
+
+/** Raw holidays table with CRUD operations — name is encrypted, dates are plaintext */
+const rawHolidaysTable = defineTable<Holiday, HolidayInput>({
   name: "holidays",
   primaryKey: "id",
   schema: {
@@ -29,22 +37,49 @@ export const holidaysTable = defineTable<Holiday, HolidayInput>({
 });
 
 /** Execute a query and decrypt the resulting holiday rows */
-const queryHolidays = queryAndMap<Holiday, Holiday>((row) => holidaysTable.fromDb(row));
+const queryHolidays = queryAndMap<Holiday, Holiday>((row) => rawHolidaysTable.fromDb(row));
+
+const holidaysCache = collectionCache(
+  () => queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC"),
+  HOLIDAYS_CACHE_TTL_MS,
+);
+
+/** Invalidate the holidays cache (for testing or after writes). */
+export const invalidateHolidaysCache = (): void => {
+  holidaysCache.invalidate();
+};
+
+/** Holidays table with CRUD operations — writes auto-invalidate the cache */
+export const holidaysTable: typeof rawHolidaysTable = {
+  ...rawHolidaysTable,
+  insert: async (input) => {
+    const result = await rawHolidaysTable.insert(input);
+    invalidateHolidaysCache();
+    return result;
+  },
+  update: async (id, input) => {
+    const result = await rawHolidaysTable.update(id, input);
+    invalidateHolidaysCache();
+    return result;
+  },
+  deleteById: async (id) => {
+    await rawHolidaysTable.deleteById(id);
+    invalidateHolidaysCache();
+  },
+};
 
 /**
- * Get all holidays, decrypted, ordered by start_date
+ * Get all holidays, decrypted, ordered by start_date (from cache)
  */
 export const getAllHolidays = (): Promise<Holiday[]> =>
-  queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC");
+  holidaysCache.getAll();
 
 /**
- * Get active holidays (end_date >= today) for date computation.
+ * Get active holidays (end_date >= today) for date computation (from cache).
  * "today" is computed in the configured timezone.
  */
-export const getActiveHolidays = (): Promise<Holiday[]> => {
-  const tz = getTz();
-  return queryHolidays({
-    sql: "SELECT * FROM holidays WHERE end_date >= ? ORDER BY start_date ASC",
-    args: [todayInTz(tz)],
-  });
+export const getActiveHolidays = async (): Promise<Holiday[]> => {
+  const today = todayInTz(getTz());
+  const holidays = await holidaysCache.getAll();
+  return filter((h: Holiday) => h.end_date >= today)(holidays);
 };

--- a/src/lib/db/query.ts
+++ b/src/lib/db/query.ts
@@ -1,19 +1,16 @@
-import type { InStatement } from "@libsql/client";
-
 import { mapAsync } from "#fp";
 import { getDb, resultRows } from "#lib/db/client.ts";
 import { trackQuery } from "#lib/db/query-log.ts";
 
 /**
- * Execute a statement and map result rows through an async transformer.
+ * Execute a SQL query and map result rows through an async transformer.
  *
  * Useful for running a query and decrypting/transforming each row via `table.fromDb`.
  */
 export const queryAndMap = <Row, Out>(
   toOut: (row: Row) => Promise<Out>,
 ) =>
-async (stmt: InStatement): Promise<Out[]> => {
-  const sql = typeof stmt === "string" ? stmt : stmt.sql;
-  const result = await trackQuery(sql, () => getDb().execute(stmt));
+async (sql: string): Promise<Out[]> => {
+  const result = await trackQuery(sql, () => getDb().execute(sql));
   return mapAsync(toOut)(resultRows<Row>(result));
 };

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -2,7 +2,7 @@
  * Users table operations
  */
 
-import { lazyRef } from "#fp";
+import { collectionCache } from "#fp";
 import {
   decrypt,
   deriveKEK,
@@ -14,7 +14,7 @@ import {
   wrapKey,
 } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
-import { now, nowMs } from "#lib/now.ts";
+import { now } from "#lib/now.ts";
 import { isAdminLevel, type AdminLevel, type User } from "#lib/types.ts";
 
 /**
@@ -24,33 +24,19 @@ import { isAdminLevel, type AdminLevel, type User } from "#lib/types.ts";
  */
 export const USERS_CACHE_TTL_MS = 60_000;
 
-type UsersCacheState = {
-  users: User[] | null;
-  time: number;
-};
-
-const [getUsersCacheState, setUsersCacheState] = lazyRef<UsersCacheState>(
-  () => ({ users: null, time: 0 }),
-);
-
-const isUsersCacheValid = (): boolean => {
-  const state = getUsersCacheState();
-  return state.users !== null && nowMs() - state.time < USERS_CACHE_TTL_MS;
-};
-
 const USER_SELECT =
   "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users ORDER BY id ASC";
 
-const loadAllUsers = async (): Promise<User[]> => {
-  if (isUsersCacheValid()) return getUsersCacheState().users!;
-  const users = await queryAll<User>(USER_SELECT);
-  setUsersCacheState({ users, time: nowMs() });
-  return users;
-};
+const usersCache = collectionCache(
+  () => queryAll<User>(USER_SELECT),
+  USERS_CACHE_TTL_MS,
+);
+
+const loadAllUsers = (): Promise<User[]> => usersCache.getAll();
 
 /** Invalidate the users cache (for testing or after writes). */
 export const invalidateUsersCache = (): void => {
-  setUsersCacheState(null);
+  usersCache.invalidate();
 };
 
 /** Shared user creation logic */

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -8,13 +8,14 @@ import { getSessionCookieName } from "#lib/cookies.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { resetCurrencyCode, setCurrencyCodeForTest, toMajorUnits } from "#lib/currency.ts";
 import { setDb } from "#lib/db/client.ts";
-import type { GroupInput } from "#lib/db/groups.ts";
+import { invalidateGroupsCache, type GroupInput } from "#lib/db/groups.ts";
 import {
   getEventWithCount,
   invalidateEventsCache,
   type EventInput,
 } from "#lib/db/events.ts";
 import { initDb, LATEST_UPDATE } from "#lib/db/migrations/index.ts";
+import { invalidateHolidaysCache } from "#lib/db/holidays.ts";
 import { getSession, resetSessionCache } from "#lib/db/sessions.ts";
 import { clearSetupCompleteCache, completeSetup, invalidateSettingsCache, updateTimezone } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
@@ -120,6 +121,8 @@ const prepareTestClient = async (): Promise<{ reused: boolean }> => {
   resetSessionCache();
   invalidateUsersCache();
   invalidateEventsCache();
+  invalidateHolidaysCache();
+  invalidateGroupsCache();
 
   if (cachedClient && await isSchemaIntact(cachedClient)) {
     setDb(cachedClient);
@@ -233,6 +236,8 @@ export const resetDb = (): void => {
   invalidateSettingsCache();
   invalidateUsersCache();
   invalidateEventsCache();
+  invalidateHolidaysCache();
+  invalidateGroupsCache();
   resetSessionCache();
   resetTestSession();
   resetCurrencyCode();

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "#test-compat";
 import {
   boundedLru,
   bracket,
+  collectionCache,
   compact,
   err,
   filter,
@@ -583,6 +584,83 @@ describe("fp", () => {
       time = 101;
       expect(cache.get("a")).toBe(undefined); // expired (set at 0, now 101)
       expect(cache.get("b")).toBe(2); // still valid (set at 60, now 101)
+    });
+  });
+
+  describe("collectionCache", () => {
+    test("fetches items on first call", async () => {
+      const calls: number[] = [];
+      const cache = collectionCache(
+        () => { calls.push(1); return Promise.resolve([1, 2, 3]); },
+        100,
+      );
+      const result = await cache.getAll();
+      expect(result).toEqual([1, 2, 3]);
+      expect(calls.length).toBe(1);
+    });
+
+    test("returns cached items within TTL", async () => {
+      let time = 0;
+      const calls: number[] = [];
+      const cache = collectionCache(
+        () => { calls.push(1); return Promise.resolve([1, 2, 3]); },
+        100,
+        () => time,
+      );
+      await cache.getAll();
+      time = 50;
+      const result = await cache.getAll();
+      expect(result).toEqual([1, 2, 3]);
+      expect(calls.length).toBe(1);
+    });
+
+    test("refetches after TTL expires", async () => {
+      let time = 0;
+      const calls: number[] = [];
+      const cache = collectionCache(
+        () => { calls.push(1); return Promise.resolve([calls.length]); },
+        100,
+        () => time,
+      );
+      await cache.getAll();
+      expect(calls.length).toBe(1);
+      time = 101;
+      const result = await cache.getAll();
+      expect(result).toEqual([2]);
+      expect(calls.length).toBe(2);
+    });
+
+    test("refetches after invalidate", async () => {
+      const calls: number[] = [];
+      const cache = collectionCache(
+        () => { calls.push(1); return Promise.resolve([calls.length]); },
+        100,
+        () => 0,
+      );
+      await cache.getAll();
+      expect(calls.length).toBe(1);
+      cache.invalidate();
+      const result = await cache.getAll();
+      expect(result).toEqual([2]);
+      expect(calls.length).toBe(2);
+    });
+
+    test("invalidate resets TTL timer", async () => {
+      let time = 0;
+      const calls: number[] = [];
+      const cache = collectionCache(
+        () => { calls.push(1); return Promise.resolve([calls.length]); },
+        100,
+        () => time,
+      );
+      await cache.getAll();
+      time = 80;
+      cache.invalidate();
+      await cache.getAll();
+      time = 150; // 150 - 80 = 70, within TTL of the refetch
+      const result = await cache.getAll();
+      expect(result).toEqual([2]);
+      expect(calls.length).toBe(2);
     });
   });
 });


### PR DESCRIPTION
Add a shared collectionCache FP utility that encapsulates the TTL +
lazyRef pattern used by events and users. Refactor all four collection
caches (events, users, holidays, groups) to use it, replacing ~50 lines
of duplicated boilerplate with a single reusable function.

- Add collectionCache<T>(fetchAll, ttlMs, now?) to #fp
- Refactor events cache from manual lazyRef to collectionCache
- Refactor users cache from manual lazyRef to collectionCache
- Add 60s TTL cache to holidays with write-through invalidation
- Add 60s TTL cache to groups with write-through invalidation
- getActiveHolidays now filters from cache instead of querying DB
- getGroupBySlugIndex now searches from cache instead of querying DB
- Simplify queryAndMap to accept string (object form was dead code)
- Invalidate holidays/groups caches in test setup/teardown

https://claude.ai/code/session_012VFKDZHiU7RWqhmji8tmvZ