### PR TITLE
Add cache stats to debug footer and expand to all admins

### DIFF
--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -361,6 +361,7 @@ export const boundedLru = <K, V>(maxSize: number): BoundedLru<K, V> => {
 export type CollectionCache<T> = {
   getAll: () => Promise<T[]>;
   invalidate: () => void;
+  size: () => number;
 };
 
 /**
@@ -390,6 +391,7 @@ export const collectionCache = <T>(
     invalidate: (): void => {
       setState(null);
     },
+    size: (): number => getState().items?.length ?? 0,
   };
 };
 
@@ -398,6 +400,7 @@ export type TtlCache<K, V> = {
   get: (key: K) => V | undefined;
   set: (key: K, value: V) => void;
   clear: () => void;
+  size: () => number;
 };
 
 /**
@@ -426,5 +429,6 @@ export const ttlCache = <K, V>(
     clear: (): void => {
       cache.clear();
     },
+    size: (): number => cache.size,
   };
 };

--- a/src/lib/cache-registry.ts
+++ b/src/lib/cache-registry.ts
@@ -1,0 +1,30 @@
+/**
+ * Global cache stats registry.
+ * Cache modules register stat providers at load time;
+ * the debug footer reads them at render time.
+ */
+
+/** A single cache's stats snapshot */
+export type CacheStat = {
+  readonly name: string;
+  readonly entries: number;
+  readonly capacity?: number;
+};
+
+type CacheStatProvider = () => CacheStat;
+
+const providers: CacheStatProvider[] = [];
+
+/** Register a cache stat provider (called at module load time) */
+export const registerCache = (provider: CacheStatProvider): void => {
+  providers.push(provider);
+};
+
+/** Collect stats from all registered caches */
+export const getAllCacheStats = (): CacheStat[] =>
+  providers.map((p) => p());
+
+/** Reset the registry (for testing) */
+export const resetCacheRegistry = (): void => {
+  providers.length = 0;
+};

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -4,6 +4,7 @@
  */
 
 import { boundedLru, lazyRef, ttlCache } from "#fp";
+import { registerCache } from "#lib/cache-registry.ts";
 import { getEnv } from "#lib/env.ts";
 
 /**
@@ -712,6 +713,12 @@ export const hybridEncrypt = async (
  */
 const hybridDecryptCache = boundedLru<string, string>(10_000);
 
+registerCache(() => ({
+  name: "decrypt",
+  entries: hybridDecryptCache.size(),
+  capacity: 10_000,
+}));
+
 /**
  * Decrypt data using hybrid encryption
  * Expects format: hyb:1:$base64WrappedKey:$base64iv:$base64ciphertext
@@ -804,6 +811,8 @@ export const encryptAttendeePII = async (
  * Avoids re-running the full unwrap chain (PBKDF2 + AES + RSA import) per request
  */
 const privateKeyCache = ttlCache<string, CryptoKey>(10_000);
+
+registerCache(() => ({ name: "privateKeys", entries: privateKeyCache.size() }));
 
 /**
  * Derive the private key from session credentials

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,7 +1,7 @@
 /**
  * Database client setup and core utilities
  *
- * When query logging is enabled (owner debug footer), the core query
+ * When query logging is enabled (admin debug footer), the core query
  * functions (queryOne, queryAll, queryBatch, executeByField) time each
  * call and record the SQL via the query-log module.
  */

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -4,6 +4,7 @@
 
 import type { ResultSet } from "@libsql/client";
 import { filter as fpFilter, collectionCache } from "#fp";
+import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { executeByField, getDb, inPlaceholders, queryAll, queryBatch, resultRows } from "#lib/db/client.ts";
 import { encryptedNameSchema, idAndEncryptedSlugSchema } from "#lib/db/common-schema.ts";
@@ -234,6 +235,8 @@ const eventsCache = collectionCache(
   EVENTS_CACHE_TTL_MS,
   nowMs,
 );
+
+registerCache(() => ({ name: "events", entries: eventsCache.size() }));
 
 /** Invalidate the events cache (for testing or after writes). */
 export const invalidateEventsCache = (): void => {

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -3,6 +3,7 @@
  */
 
 import { collectionCache, mapAsync } from "#fp";
+import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
 import { encryptedNameSchema, idAndEncryptedSlugSchema } from "#lib/db/common-schema.ts";
@@ -44,6 +45,8 @@ const groupsCache = collectionCache(
   () => queryGroups("SELECT * FROM groups ORDER BY id ASC"),
   GROUPS_CACHE_TTL_MS,
 );
+
+registerCache(() => ({ name: "groups", entries: groupsCache.size() }));
 
 /** Invalidate the groups cache (for testing or after writes). */
 export const invalidateGroupsCache = (): void => {

--- a/src/lib/db/holidays.ts
+++ b/src/lib/db/holidays.ts
@@ -3,6 +3,7 @@
  */
 
 import { collectionCache, filter } from "#fp";
+import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt } from "#lib/crypto.ts";
 import { getTz } from "#lib/config.ts";
 import { todayInTz } from "#lib/timezone.ts";
@@ -43,6 +44,8 @@ const holidaysCache = collectionCache(
   () => queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC"),
   HOLIDAYS_CACHE_TTL_MS,
 );
+
+registerCache(() => ({ name: "holidays", entries: holidaysCache.size() }));
 
 /** Invalidate the holidays cache (for testing or after writes). */
 export const invalidateHolidaysCache = (): void => {

--- a/src/lib/db/query-log.ts
+++ b/src/lib/db/query-log.ts
@@ -1,5 +1,5 @@
 /**
- * Request-scoped SQL query logging for the owner debug footer.
+ * Request-scoped SQL query logging for the admin debug footer.
  *
  * Call `enableQueryLog()` at the start of a request and `getQueryLog()`
  * after the response body has been built to retrieve every tracked query.

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -2,6 +2,7 @@
  * Sessions table operations
  */
 
+import { registerCache } from "#lib/cache-registry.ts";
 import { hashSessionToken } from "#lib/crypto.ts";
 import { executeByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
 
@@ -15,6 +16,8 @@ import type { Session } from "#lib/types.ts";
 const SESSION_CACHE_TTL_MS = 10_000;
 type CacheEntry = { session: Session | null; cachedAt: number };
 const sessionCache = new Map<string, CacheEntry>();
+
+registerCache(() => ({ name: "sessions", entries: sessionCache.size }));
 
 /**
  * Get cached session if still valid

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -3,6 +3,7 @@
  */
 
 import { lazyRef } from "#fp";
+import { registerCache } from "#lib/cache-registry.ts";
 import { DEFAULT_TIMEZONE } from "#lib/timezone.ts";
 import {
   decrypt,
@@ -121,6 +122,18 @@ const isCacheValid = (): boolean => {
   const state = getSettingsCacheState();
   return state.entries !== null && nowMs() - state.time < SETTINGS_CACHE_TTL_MS;
 };
+
+const settingsCacheSize = (): number => {
+  const { entries } = getSettingsCacheState();
+  return entries ? entries.size : 0;
+};
+
+registerCache(() => ({ name: "settings", entries: settingsCacheSize() }));
+
+registerCache(() => ({
+  name: "pageContent",
+  entries: getPageCacheMap().size,
+}));
 
 /**
  * Load every setting row into the in-memory cache with a single query.

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -3,6 +3,7 @@
  */
 
 import { collectionCache } from "#fp";
+import { registerCache } from "#lib/cache-registry.ts";
 import {
   decrypt,
   deriveKEK,
@@ -33,6 +34,8 @@ const usersCache = collectionCache(
 );
 
 const loadAllUsers = (): Promise<User[]> => usersCache.getAll();
+
+registerCache(() => ({ name: "users", entries: usersCache.size() }));
 
 /** Invalidate the users cache (for testing or after writes). */
 export const invalidateUsersCache = (): void => {

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -1,10 +1,10 @@
 /**
  * Admin routes - combined from individual route modules
  *
- * GET requests are wrapped to enable SQL query logging for owner users.
- * The owner debug footer is rendered inline by the Layout template when
- * query logging is active, avoiding response body re-reading which
- * intermittently fails on Bunny Edge.
+ * GET requests are wrapped to enable SQL query logging for admin users
+ * (owners and managers). The debug footer is rendered inline by the
+ * Layout template when query logging is active, avoiding response body
+ * re-reading which intermittently fails on Bunny Edge.
  */
 
 import { enableQueryLog } from "#lib/db/query-log.ts";
@@ -48,17 +48,17 @@ type RouterFn = ReturnType<typeof createRouter>;
 
 /**
  * Route admin requests.
- * For GET requests by owners, enables query logging so the Layout template
- * renders the debug footer inline (no response body re-reading needed).
+ * For GET requests by authenticated admins (owner or manager), enables
+ * query logging so the Layout template renders the debug footer inline.
  */
 export const routeAdmin: RouterFn = async (request, path, method, server) => {
   if (method !== "GET") {
     return innerRouter(request, path, method, server);
   }
 
-  // Check owner status before tracking so the auth queries aren't logged
+  // Check admin status before tracking so the auth queries aren't logged
   const session = await getAuthenticatedSession(request);
-  if (session?.adminLevel === "owner") {
+  if (session) {
     enableQueryLog();
     await loadAllSettings();
   }

--- a/src/templates/admin/footer.tsx
+++ b/src/templates/admin/footer.tsx
@@ -1,7 +1,9 @@
 /**
- * Owner-only debug footer showing render time and SQL queries
+ * Admin debug footer showing render time, SQL queries, and cache stats
  */
 
+import { reduce } from "#fp";
+import { type CacheStat, getAllCacheStats } from "#lib/cache-registry.ts";
 import {
   type QueryLogEntry,
   getQueryLog,
@@ -9,37 +11,78 @@ import {
   isQueryLogEnabled,
 } from "#lib/db/query-log.ts";
 
-/** Render the owner debug footer as an HTML string for injection before </body> */
-export const ownerFooterHtml = (
-  renderTimeMs: number,
-  queries: QueryLogEntry[],
-): string =>
-  `<footer class="debug-footer">` +
-  `<p><a href="https://github.com/chobbledotcom/tickets">Chobble Tickets</a></p>` +
-  `<details>` +
-  `<summary>${renderTimeMs.toFixed(0)}ms</summary>` +
-  `<ul>` +
-  queries
-    .map(
-      (q) =>
-        `<li>${escapeFooterHtml(q.sql)} &mdash; ${q.durationMs.toFixed(1)}ms</li>`,
-    )
-    .join("") +
-  `</ul>` +
-  `</details>` +
-  `</footer>`;
+/** Data passed to the footer renderer */
+export type DebugFooterData = {
+  readonly renderTimeMs: number;
+  readonly queries: QueryLogEntry[];
+  readonly cacheStats: CacheStat[];
+};
+
+const sumDurations = reduce(
+  (total: number, q: QueryLogEntry) => total + q.durationMs,
+  0,
+);
+
+/** Render a single cache stat line */
+const renderCacheStat = (stat: CacheStat): string =>
+  stat.capacity
+    ? `<li>${escapeFooterHtml(stat.name)}: ${stat.entries}/${stat.capacity}</li>`
+    : `<li>${escapeFooterHtml(stat.name)}: ${stat.entries}</li>`;
+
+/** Render the admin debug footer as an HTML string for injection before </body> */
+export const debugFooterHtml = (data: DebugFooterData): string => {
+  const { renderTimeMs, queries, cacheStats } = data;
+  const totalSqlMs = sumDurations(queries);
+  const otherMs = renderTimeMs - totalSqlMs;
+  const totalCacheEntries = reduce(
+    (total: number, s: CacheStat) => total + s.entries,
+    0,
+  )(cacheStats);
+
+  return (
+    `<footer class="debug-footer">` +
+    `<p><a href="https://github.com/chobbledotcom/tickets">Chobble Tickets</a></p>` +
+    `<details>` +
+    `<summary>${renderTimeMs.toFixed(0)}ms` +
+    ` &middot; ${queries.length} quer${queries.length === 1 ? "y" : "ies"} ${totalSqlMs.toFixed(0)}ms` +
+    ` &middot; ${totalCacheEntries} cached</summary>` +
+    `<p>Render: ${renderTimeMs.toFixed(1)}ms` +
+    ` (sql ${totalSqlMs.toFixed(1)}ms + other ${otherMs.toFixed(1)}ms)</p>` +
+    (queries.length > 0
+      ? `<details><summary>SQL queries</summary><ul>` +
+        queries
+          .map(
+            (q) =>
+              `<li>${escapeFooterHtml(q.sql)} &mdash; ${q.durationMs.toFixed(1)}ms</li>`,
+          )
+          .join("") +
+        `</ul></details>`
+      : "") +
+    (cacheStats.length > 0
+      ? `<details><summary>Caches (${cacheStats.length})</summary><ul>` +
+        cacheStats.map(renderCacheStat).join("") +
+        `</ul></details>`
+      : "") +
+    `</details>` +
+    `</footer>`
+  );
+};
 
 /**
- * Return the owner debug footer HTML if query logging is active, otherwise "".
+ * Return the admin debug footer HTML if query logging is active, otherwise "".
  * Called from the Layout template so the footer is part of the HTML string
  * before it is wrapped in a Response, avoiding response.text() on Bunny Edge.
  */
-export const renderOwnerDebugFooter = (): string =>
+export const renderDebugFooter = (): string =>
   isQueryLogEnabled()
-    ? ownerFooterHtml(performance.now() - getQueryLogStartTime(), getQueryLog())
+    ? debugFooterHtml({
+        renderTimeMs: performance.now() - getQueryLogStartTime(),
+        queries: getQueryLog(),
+        cacheStats: getAllCacheStats(),
+      })
     : "";
 
-/** Minimal HTML escaping for SQL strings in the footer */
+/** Minimal HTML escaping for strings in the footer */
 const escapeFooterHtml = (s: string): string =>
   s
     .replace(/&/g, "&amp;")

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -5,7 +5,7 @@
 import { type Child, Raw, SafeHtml } from "#jsx/jsx-runtime.ts";
 import { CSS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
 import { getTheme } from "#lib/theme.ts";
-import { renderOwnerDebugFooter } from "#templates/admin/footer.tsx";
+import { renderDebugFooter } from "#templates/admin/footer.tsx";
 
 export const escapeHtml = (str: string): string =>
   str
@@ -45,7 +45,7 @@ export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutP
           </main>
           {bodyClass?.includes("iframe") && <script src={IFRAME_RESIZER_CHILD_JS_PATH}></script>}
           <script src={JS_PATH} defer></script>
-          <Raw html={renderOwnerDebugFooter()} />
+          <Raw html={renderDebugFooter()} />
         </body>
       </html>
     )

--- a/test/lib/cache-registry.test.ts
+++ b/test/lib/cache-registry.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "#test-compat";
+import {
+  getAllCacheStats,
+  registerCache,
+  resetCacheRegistry,
+} from "#lib/cache-registry.ts";
+
+describe("cache-registry", () => {
+  afterEach(() => {
+    resetCacheRegistry();
+  });
+
+  test("returns empty array when no caches registered", () => {
+    expect(getAllCacheStats()).toEqual([]);
+  });
+
+  test("returns stats from registered caches", () => {
+    registerCache(() => ({ name: "test", entries: 5 }));
+    const stats = getAllCacheStats();
+    expect(stats).toHaveLength(1);
+    expect(stats[0]!.name).toBe("test");
+    expect(stats[0]!.entries).toBe(5);
+  });
+
+  test("supports capacity field", () => {
+    registerCache(() => ({ name: "lru", entries: 100, capacity: 10000 }));
+    const stats = getAllCacheStats();
+    expect(stats[0]!.capacity).toBe(10000);
+  });
+
+  test("collects stats from multiple caches", () => {
+    registerCache(() => ({ name: "a", entries: 1 }));
+    registerCache(() => ({ name: "b", entries: 2 }));
+    registerCache(() => ({ name: "c", entries: 3 }));
+    const stats = getAllCacheStats();
+    expect(stats).toHaveLength(3);
+  });
+
+  test("calls providers each time to get fresh stats", () => {
+    let count = 0;
+    registerCache(() => ({ name: "dynamic", entries: ++count }));
+    expect(getAllCacheStats()[0]!.entries).toBe(1);
+    expect(getAllCacheStats()[0]!.entries).toBe(2);
+  });
+
+  test("resetCacheRegistry clears all providers", () => {
+    registerCache(() => ({ name: "test", entries: 1 }));
+    expect(getAllCacheStats()).toHaveLength(1);
+    resetCacheRegistry();
+    expect(getAllCacheStats()).toHaveLength(0);
+  });
+});

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -268,6 +268,8 @@ describe("code quality", () => {
       "lib/csrf.ts:isSignedCsrfToken",
       // Response cookie helper used by auth tests (production sets cookies directly)
       "routes/utils.ts:withCookie",
+      // Reset cache registry between tests
+      "lib/cache-registry.ts:resetCacheRegistry",
     ];
 
     /**

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -1,21 +1,21 @@
 import { describe, expect, test } from "#test-compat";
 import { enableQueryLog, runWithQueryLogContext } from "#lib/db/query-log.ts";
-import { ownerFooterHtml, renderOwnerDebugFooter } from "#templates/admin/footer.tsx";
+import { debugFooterHtml, renderDebugFooter } from "#templates/admin/footer.tsx";
 
-describe("ownerFooterHtml", () => {
+describe("debugFooterHtml", () => {
   test("renders summary with render time", () => {
-    const html = ownerFooterHtml(42.7, []);
+    const html = debugFooterHtml({ renderTimeMs: 42.7, queries: [], cacheStats: [] });
     expect(html).toContain("43ms");
   });
 
   test("links to the GitHub repo", () => {
-    const html = ownerFooterHtml(10, []);
+    const html = debugFooterHtml({ renderTimeMs: 10, queries: [], cacheStats: [] });
     expect(html).toContain('href="https://github.com/chobbledotcom/tickets"');
     expect(html).toContain("Chobble Tickets</a>");
   });
 
   test("wraps content in a details/summary element", () => {
-    const html = ownerFooterHtml(10, []);
+    const html = debugFooterHtml({ renderTimeMs: 10, queries: [], cacheStats: [] });
     expect(html).toContain("<details>");
     expect(html).toContain("<summary>");
     expect(html).toContain("</summary>");
@@ -23,21 +23,25 @@ describe("ownerFooterHtml", () => {
   });
 
   test("renders inside a footer element", () => {
-    const html = ownerFooterHtml(10, []);
+    const html = debugFooterHtml({ renderTimeMs: 10, queries: [], cacheStats: [] });
     expect(html).toContain("<footer");
     expect(html).toContain("</footer>");
   });
 
   test("uses the debug-footer CSS class", () => {
-    const html = ownerFooterHtml(10, []);
+    const html = debugFooterHtml({ renderTimeMs: 10, queries: [], cacheStats: [] });
     expect(html).toContain('class="debug-footer"');
   });
 
   test("lists each query with its duration", () => {
-    const html = ownerFooterHtml(20, [
-      { sql: "SELECT * FROM events", durationMs: 5.2 },
-      { sql: "SELECT * FROM users WHERE id = ?", durationMs: 3.1 },
-    ]);
+    const html = debugFooterHtml({
+      renderTimeMs: 20,
+      queries: [
+        { sql: "SELECT * FROM events", durationMs: 5.2 },
+        { sql: "SELECT * FROM users WHERE id = ?", durationMs: 3.1 },
+      ],
+      cacheStats: [],
+    });
     expect(html).toContain("SELECT * FROM events");
     expect(html).toContain("5.2ms");
     expect(html).toContain("SELECT * FROM users WHERE id = ?");
@@ -45,35 +49,116 @@ describe("ownerFooterHtml", () => {
   });
 
   test("escapes HTML in SQL strings", () => {
-    const html = ownerFooterHtml(10, [
-      { sql: "SELECT '<script>' FROM t", durationMs: 1.0 },
-    ]);
+    const html = debugFooterHtml({
+      renderTimeMs: 10,
+      queries: [{ sql: "SELECT '<script>' FROM t", durationMs: 1.0 }],
+      cacheStats: [],
+    });
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
   });
 
   test("renders empty query list gracefully", () => {
-    const html = ownerFooterHtml(5, []);
-    expect(html).toContain("<ul");
-    expect(html).toContain("</ul>");
-    expect(html).not.toContain("<li>");
+    const html = debugFooterHtml({ renderTimeMs: 5, queries: [], cacheStats: [] });
+    expect(html).toContain("0 queries");
+    expect(html).not.toContain("SQL queries");
   });
+
+  test("shows query count and total SQL time in summary", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 50,
+      queries: [
+        { sql: "SELECT 1", durationMs: 10 },
+        { sql: "SELECT 2", durationMs: 15 },
+      ],
+      cacheStats: [],
+    });
+    expect(html).toContain("2 queries 25ms");
+  });
+
+  test("shows singular query for single query", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 20,
+      queries: [{ sql: "SELECT 1", durationMs: 5 }],
+      cacheStats: [],
+    });
+    expect(html).toContain("1 query 5ms");
+  });
+
+  test("shows render time breakdown with sql vs other", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 100,
+      queries: [
+        { sql: "SELECT 1", durationMs: 30 },
+        { sql: "SELECT 2", durationMs: 20 },
+      ],
+      cacheStats: [],
+    });
+    expect(html).toContain("sql 50.0ms");
+    expect(html).toContain("other 50.0ms");
+  });
+
+  test("shows cache stats section", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 10,
+      queries: [],
+      cacheStats: [
+        { name: "sessions", entries: 3 },
+        { name: "decrypt", entries: 150, capacity: 10000 },
+      ],
+    });
+    expect(html).toContain("Caches (2)");
+    expect(html).toContain("sessions: 3");
+    expect(html).toContain("decrypt: 150/10000");
+  });
+
+  test("shows total cached entries in summary", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 10,
+      queries: [],
+      cacheStats: [
+        { name: "users", entries: 5 },
+        { name: "events", entries: 10 },
+      ],
+    });
+    expect(html).toContain("15 cached");
+  });
+
+  test("omits cache section when no caches registered", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 10,
+      queries: [],
+      cacheStats: [],
+    });
+    expect(html).not.toContain("Caches");
+  });
+
+  test("escapes HTML in cache names", () => {
+    const html = debugFooterHtml({
+      renderTimeMs: 10,
+      queries: [],
+      cacheStats: [{ name: "<script>", entries: 1 }],
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
 });
 
-describe("renderOwnerDebugFooter", () => {
+describe("renderDebugFooter", () => {
   test("returns empty string when query logging is not active", () => {
     runWithQueryLogContext(() => {
-      expect(renderOwnerDebugFooter()).toBe("");
+      expect(renderDebugFooter()).toBe("");
     });
   });
 
   test("returns footer HTML when query logging is active", () => {
     runWithQueryLogContext(() => {
       enableQueryLog();
-      const html = renderOwnerDebugFooter();
+      const html = renderDebugFooter();
       expect(html).toContain('<footer class="debug-footer">');
       expect(html).toContain("Chobble Tickets");
-      expect(html).toContain("ms</summary>");
+      expect(html).toContain("ms");
     });
   });
 });

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -585,6 +585,21 @@ describe("fp", () => {
       expect(cache.get("a")).toBe(undefined); // expired (set at 0, now 101)
       expect(cache.get("b")).toBe(2); // still valid (set at 60, now 101)
     });
+
+    test("size returns number of entries", () => {
+      const cache = ttlCache<string, number>(1000);
+      expect(cache.size()).toBe(0);
+      cache.set("a", 1);
+      cache.set("b", 2);
+      expect(cache.size()).toBe(2);
+    });
+
+    test("size decreases after clear", () => {
+      const cache = ttlCache<string, number>(1000);
+      cache.set("a", 1);
+      cache.clear();
+      expect(cache.size()).toBe(0);
+    });
   });
 
   describe("collectionCache", () => {
@@ -661,6 +676,33 @@ describe("fp", () => {
       const result = await cache.getAll();
       expect(result).toEqual([2]);
       expect(calls.length).toBe(2);
+    });
+
+    test("size returns 0 before first load", () => {
+      const cache = collectionCache(
+        () => Promise.resolve([1, 2, 3]),
+        100,
+      );
+      expect(cache.size()).toBe(0);
+    });
+
+    test("size returns item count after load", async () => {
+      const cache = collectionCache(
+        () => Promise.resolve([1, 2, 3]),
+        100,
+      );
+      await cache.getAll();
+      expect(cache.size()).toBe(3);
+    });
+
+    test("size returns 0 after invalidate", async () => {
+      const cache = collectionCache(
+        () => Promise.resolve([1, 2, 3]),
+        100,
+      );
+      await cache.getAll();
+      cache.invalidate();
+      expect(cache.size()).toBe(0);
     });
   });
 });

--- a/test/lib/owner-footer.test.ts
+++ b/test/lib/owner-footer.test.ts
@@ -14,7 +14,7 @@ import {
   resetTestSlugCounter,
 } from "#test-utils";
 
-describe("owner debug footer", () => {
+describe("admin debug footer", () => {
   beforeEach(async () => {
     resetTestSlugCounter();
     await createTestDbWithSetup();
@@ -39,6 +39,25 @@ describe("owner debug footer", () => {
     expect(html).toContain("ms</li>");
   });
 
+  test("footer shows query count in summary", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    expect(html).toMatch(/\d+ quer(y|ies)/);
+  });
+
+  test("footer shows timing breakdown", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    expect(html).toContain("sql ");
+    expect(html).toContain("other ");
+  });
+
+  test("footer shows cache stats", async () => {
+    const { response } = await adminGet("/admin/");
+    const html = await response.text();
+    expect(html).toContain("cached");
+  });
+
   test("footer is inside a <footer> element before </body>", async () => {
     const { response } = await adminGet("/admin/");
     const html = await response.text();
@@ -60,7 +79,7 @@ describe("owner debug footer", () => {
     expect(html).not.toContain("Chobble Tickets");
   });
 
-  test("manager does not see footer", async () => {
+  test("manager sees footer", async () => {
     // Create and activate a manager user
     const { cookie: ownerCookie, csrfToken: ownerCsrf } = await loginAsAdmin();
 
@@ -104,11 +123,12 @@ describe("owner debug footer", () => {
     );
     const managerCookie = loginResponse.headers.get("set-cookie") ?? "";
 
-    // Manager GET should not contain the footer
+    // Manager GET should now contain the footer
     const response = await awaitTestRequest("/admin/", { cookie: managerCookie });
     const html = await response.text();
     expect(html).toContain("Events");
-    expect(html).not.toContain("Chobble Tickets");
+    expect(html).toContain("Chobble Tickets");
+    expect(html).toContain("debug-footer");
   });
 
   test("footer not injected for POST responses", async () => {

--- a/test/lib/page-cache.test.ts
+++ b/test/lib/page-cache.test.ts
@@ -217,6 +217,24 @@ describe("page content cache", () => {
     });
   });
 
+  describe("cache stats after invalidation", () => {
+    test("settings cache reports 0 entries after invalidation", async () => {
+      const { getAllCacheStats } = await import("#lib/cache-registry.ts");
+
+      // Load settings to populate cache
+      const { loadAllSettings } = await import("#lib/db/settings.ts");
+      await loadAllSettings();
+
+      const before = getAllCacheStats().find((s) => s.name === "settings");
+      expect(before!.entries).toBeGreaterThan(0);
+
+      invalidateSettingsCache();
+
+      const after = getAllCacheStats().find((s) => s.name === "settings");
+      expect(after!.entries).toBe(0);
+    });
+  });
+
   describe("null value caching", () => {
     test("serves cached null when value is added to DB within TTL", async () => {
       // First read populates page cache with null

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -208,12 +208,12 @@ describe("admin calendar", () => {
 
     test("does not show standard attendees when no standard events match date", async () => {
       const event = await createTestEvent({ name: "Concert", date: "2026-06-15T14:00" });
-      await submitTicketForm(event.slug, { name: "Fan", email: "fan@test.com" });
+      await submitTicketForm(event.slug, { name: "Concert Fan", email: "fan@test.com" });
 
       // Request a completely different date
       const response = await awaitTestRequest("/admin/calendar?date=2026-07-01", { cookie });
       const html = await response.text();
-      expect(html).not.toContain("Fan");
+      expect(html).not.toContain("Concert Fan");
     });
 
     test("standard event date without attendees shows as disabled", async () => {


### PR DESCRIPTION
## Summary
Refactored the debug footer to display cache statistics alongside query metrics, and expanded it to show for all authenticated admin users (owners and managers) rather than just owners.

## Key Changes

- **Renamed footer functions** for clarity: `ownerFooterHtml` → `debugFooterHtml`, `renderOwnerDebugFooter` → `renderDebugFooter`
- **Created cache registry system** (`cache-registry.ts`) to collect stats from all caches at render time:
  - Caches register stat providers at module load time
  - Footer reads all stats when rendering
  - Supports optional capacity field for bounded caches
- **Enhanced footer display** with:
  - Query count and total SQL time in summary line
  - Render time breakdown showing SQL vs other time
  - Collapsible cache stats section showing entries and capacity
  - Total cached entries count in summary
- **Registered cache stats** across the application:
  - Settings cache
  - Page content cache
  - Hybrid decrypt cache (with capacity)
  - Private keys cache
  - Session cache
  - Users cache
  - Events cache
  - Groups cache
  - Holidays cache
- **Added `size()` method** to `ttlCache` and `collectionCache` types to support stat collection
- **Expanded footer visibility** to all authenticated admins (changed condition from `adminLevel === "owner"` to just checking session exists)
- **Updated tests** to reflect new footer structure and expanded visibility

## Implementation Details

The cache registry uses a simple provider pattern where each cache module registers a function that returns current stats. This avoids tight coupling and allows stats to be collected dynamically at render time, ensuring accurate entry counts even as caches are modified during request handling.

The footer now uses nested `<details>` elements for SQL queries and cache stats, keeping the main summary concise while allowing users to drill down into details.

https://claude.ai/code/session_01DXdVr2Gu6VRPBE8abzo4SQ