### PR TITLE
Refactor Square SDK lazy loading to include SquareEnvironment

### DIFF
--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -11,7 +11,6 @@
  */
 
 import type { Square } from "square";
-import { SquareEnvironment } from "square";
 import { lazyRef, map, once } from "#fp";
 import {
   getCurrencyCode,
@@ -129,8 +128,8 @@ export const enforceMetadataLimits = (
 
 /** Lazy-load Square SDK only when needed */
 const loadSquare = once(async () => {
-  const { SquareClient } = await import("square");
-  return SquareClient;
+  const { SquareClient, SquareEnvironment } = await import("square");
+  return { SquareClient, SquareEnvironment };
 });
 
 type SquareCache = { accessToken: string; sandbox: boolean };
@@ -141,7 +140,7 @@ const [getCache, setCache] = lazyRef<SquareCache>(() => {
 
 /** Create a Square client instance with the correct environment */
 const createSquareClient = async (accessToken: string, sandbox: boolean) => {
-  const SquareClient = await loadSquare();
+  const { SquareClient, SquareEnvironment } = await loadSquare();
   return new SquareClient({
     token: accessToken,
     environment: sandbox ? SquareEnvironment.Sandbox : SquareEnvironment.Production,


### PR DESCRIPTION
## Summary
Refactored the Square SDK lazy loading mechanism to dynamically import `SquareEnvironment` alongside `SquareClient`, eliminating the need for a static import at the module level.

## Key Changes
- Removed static import of `SquareEnvironment` from the top of the file
- Updated `loadSquare()` to dynamically import both `SquareClient` and `SquareEnvironment` from the "square" package
- Changed `loadSquare()` return value from a single class to an object containing both `SquareClient` and `SquareEnvironment`
- Updated `createSquareClient()` to destructure both exports from the `loadSquare()` call

## Implementation Details
This change maintains the lazy-loading pattern for the Square SDK while ensuring all required dependencies are loaded together. By importing `SquareEnvironment` dynamically rather than statically, we reduce the module's initial load footprint and keep all Square SDK dependencies co-located in the lazy-loading function.

https://claude.ai/code/session_01MR4bnUKnXWfXmY3pwyVDno