### PR TITLE
Lazy load QR code module with dynamic import

### DIFF
--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -3,16 +3,21 @@
  * Wraps the qrcode npm package to produce inline SVG strings
  */
 
-import QRCodeDefault from "qrcode";
+import { once } from "#fp";
 
 /** QR code module shape (subset of the qrcode npm package API) */
 type QRCodeModule = { toString(text: string, opts: { type: string; margin?: number }): Promise<string> };
 
-const QRCode: QRCodeModule = QRCodeDefault;
+const loadQRCode = once(async (): Promise<QRCodeModule> => {
+  const { default: QRCode } = await import("qrcode");
+  return QRCode;
+});
 
 /**
  * Generate an SVG string for a QR code encoding the given text.
  * Returns a complete <svg> element suitable for inline embedding.
  */
-export const generateQrSvg = (text: string): Promise<string> =>
-  QRCode.toString(text, { type: "svg", margin: 1 });
+export const generateQrSvg = async (text: string): Promise<string> => {
+  const QRCode = await loadQRCode();
+  return QRCode.toString(text, { type: "svg", margin: 1 });
+};


### PR DESCRIPTION
## Summary
Refactored the QR code module loading to use dynamic imports instead of static imports, enabling lazy loading of the qrcode dependency only when needed.

## Key Changes
- Replaced static `import` statement with dynamic `import()` inside an async function
- Wrapped the dynamic import with the `once()` utility to ensure the module is loaded only once, with subsequent calls returning the cached result
- Updated `generateQrSvg()` to be async and await the lazy-loaded QR code module before use

## Implementation Details
- The `loadQRCode()` function uses the `once()` higher-order function from the fp module to memoize the async module loading operation
- This approach defers the qrcode dependency loading until the first time a QR code is actually generated, reducing initial bundle size and load time
- The module is cached after the first load, so subsequent calls don't re-import the dependency

https://claude.ai/code/session_01REX1hjeZw3BUNR1ZaMXxfY