### PR TITLE
Add attendee stats and table to group detail page

### DIFF
--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -2,8 +2,12 @@
  * Admin group management routes - owner only
  */
 
+import { map } from "#fp";
 import { logActivity } from "#lib/db/activityLog.ts";
+import { decryptAttendeesForTable } from "#lib/db/attendees.ts";
 import { getAllowedDomain } from "#lib/config.ts";
+import { getAttendeesByEventIds } from "#lib/db/events.ts";
+import { mergeEventFields } from "#lib/event-fields.ts";
 import {
   assignEventsToGroup,
   computeGroupSlugIndex,
@@ -16,11 +20,13 @@ import {
   type GroupInput,
 } from "#lib/db/groups.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
+import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
 import { defineNamedResource } from "#lib/rest/resource.ts";
 import { generateUniqueSlug, normalizeSlug } from "#lib/slug.ts";
 import { sortEvents } from "#lib/sort-events.ts";
-import type { Group } from "#lib/types.ts";
+import type { Attendee, Group } from "#lib/types.ts";
 import { createOwnerCrudHandlers } from "#routes/admin/owner-crud.ts";
+import { requirePrivateKey } from "#routes/admin/utils.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { htmlResponse, notFoundResponse, redirect, requireOwnerOr, withOwnerAuthForm } from "#routes/utils.ts";
 import {
@@ -128,8 +134,23 @@ const handleGroupDetail = (
         getUngroupedEvents(),
         getActiveHolidays(),
       ]);
+      const sortedEvents = sortEvents(events, holidays);
+      const eventIds = map((e: { id: number }) => e.id)(sortedEvents);
+      let attendees: Attendee[] = [];
+      let phonePrefix: string | undefined;
+      if (eventIds.length > 0) {
+        const privateKey = await requirePrivateKey(session);
+        const fields = mergeEventFields(map((e: { fields: string }) => e.fields)(sortedEvents));
+        const hasPaidEvent = sortedEvents.some((e) => e.unit_price !== null);
+        const [rawAttendees, prefix] = await Promise.all([
+          getAttendeesByEventIds(eventIds),
+          getPhonePrefixFromDb(),
+        ]);
+        attendees = await decryptAttendeesForTable(rawAttendees, privateKey, fields, hasPaidEvent);
+        phonePrefix = prefix;
+      }
       const allowedDomain = getAllowedDomain();
-      return htmlResponse(adminGroupDetailPage(group, sortEvents(events, holidays), sortEvents(ungroupedEvents, holidays), session, allowedDomain));
+      return htmlResponse(adminGroupDetailPage(group, sortedEvents, sortEvents(ungroupedEvents, holidays), attendees, session, allowedDomain, phonePrefix));
     }));
 
 /** Handle POST /admin/group/:id/add-events - assign ungrouped events to group */

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -3,14 +3,17 @@
  */
 
 import { map, pipe, reduce } from "#fp";
+import { formatCurrency } from "#lib/currency.ts";
 import { buildEmbedSnippets } from "#lib/embed.ts";
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
-import type { AdminSession, EventWithCount, Group } from "#lib/types.ts";
+import type { AdminSession, Attendee, EventWithCount, Group } from "#lib/types.ts";
 import { groupCreateFields, groupFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 import { EventRow } from "#templates/admin/dashboard.tsx";
+import { calculateTotalRevenue, countCheckedIn } from "#templates/admin/events.tsx";
 import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
+import { AttendeeTable, type AttendeeTableRow } from "#templates/attendee-table.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
@@ -143,6 +146,30 @@ export const adminGroupDeletePage = (
     </Layout>,
   );
 
+/** Build AttendeeTableRows from attendees with event lookup */
+const buildAttendeeRows = (
+  attendees: Attendee[],
+  events: EventWithCount[],
+): AttendeeTableRow[] => {
+  const eventMap = new Map(map((e: EventWithCount) => [e.id, e] as const)(events));
+  return pipe(
+    map((a: Attendee): AttendeeTableRow => {
+      const event = eventMap.get(a.event_id)!;
+      return {
+        attendee: a,
+        eventId: event.id,
+        eventName: event.name,
+        hasPaidEvent: event.unit_price !== null,
+      };
+    }),
+  )(attendees);
+};
+
+/** Sum attendee_count across all events in the group */
+const totalAttendeeCount = reduce(
+  (sum: number, e: EventWithCount) => sum + e.attendee_count, 0,
+);
+
 /**
  * Admin group detail page - shows group info, events in group, and add-events form
  */
@@ -150,8 +177,10 @@ export const adminGroupDetailPage = (
   group: Group,
   events: EventWithCount[],
   ungroupedEvents: EventWithCount[],
+  attendees: Attendee[],
   session: AdminSession,
   allowedDomain: string,
+  phonePrefix?: string,
 ): string => {
   const eventRows =
     events.length > 0
@@ -160,6 +189,11 @@ export const adminGroupDetailPage = (
 
   const ticketUrl = `https://${allowedDomain}/ticket/${group.slug}`;
   const { script: embedScriptCode, iframe: embedIframeCode } = buildEmbedSnippets(ticketUrl);
+  const hasPaidEvent = events.some((e) => e.unit_price !== null);
+  const checkedIn = countCheckedIn(attendees);
+  const checkedInRemaining = attendees.length - checkedIn;
+  const totalCount = totalAttendeeCount(events);
+  const tableRows = buildAttendeeRows(attendees, events);
 
   return String(
     <Layout title={group.name}>
@@ -178,7 +212,7 @@ export const adminGroupDetailPage = (
       <article>
         <h2>Group Details</h2>
         <div class="table-scroll">
-          <table>
+          <table class="event-details-table">
             <tbody>
               <tr>
                 <th>Public URL</th>
@@ -186,6 +220,20 @@ export const adminGroupDetailPage = (
                   <a href={ticketUrl}>{`${allowedDomain}/ticket/${group.slug}`}</a>
                 </td>
               </tr>
+              <tr>
+                <th>Attendees</th>
+                <td>{totalCount}</td>
+              </tr>
+              <tr>
+                <th>Checked In</th>
+                <td>{checkedIn} / {attendees.length} &mdash; {checkedInRemaining} remain</td>
+              </tr>
+              {hasPaidEvent && (
+                <tr>
+                  <th>Total Revenue</th>
+                  <td>{formatCurrency(calculateTotalRevenue(attendees))}</td>
+                </tr>
+              )}
               <tr>
                 <th><label for={`embed-script-${group.id}`}>Embed Script</label></th>
                 <td>
@@ -232,6 +280,20 @@ export const adminGroupDetailPage = (
           </tbody>
         </table>
       </div>
+
+      <article>
+        <h2 id="attendees">Attendees</h2>
+        <div class="table-scroll">
+          <Raw html={AttendeeTable({
+            rows: tableRows,
+            allowedDomain,
+            showEvent: true,
+            showDate: events.some((e) => e.event_type === "daily"),
+            returnUrl: `/admin/group/${group.id}#attendees`,
+            phonePrefix,
+          })} />
+        </div>
+      </article>
 
       {ungroupedEvents.length > 0 && (
         <>

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -7,6 +7,7 @@ import {
   adminGet,
   adminFormPost,
   awaitTestRequest,
+  createTestAttendee,
   createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
@@ -372,6 +373,81 @@ describe("server (admin groups)", () => {
       expectStatus(200)(response);
       const html = await response.text();
       expect(html).not.toContain("Add Events to Group");
+    });
+
+    test("shows attendee count and checked-in stats", async () => {
+      const group = await createTestGroup({ name: "Stats Group", slug: "stats-group" });
+      const event = await createTestEvent({ name: "Stats Event", groupId: group.id, maxAttendees: 20 });
+      await createTestAttendee(event.id, event.slug, "Alice", "alice@test.com");
+      await createTestAttendee(event.id, event.slug, "Bob", "bob@test.com");
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).toContain("Attendees");
+      expect(html).toContain("Checked In");
+      expect(html).toContain("0 / 2");
+      expect(html).toContain("2 remain");
+    });
+
+    test("shows attendees table with event name column", async () => {
+      const group = await createTestGroup({ name: "Table Group", slug: "table-group" });
+      const event = await createTestEvent({ name: "Table Event", groupId: group.id, maxAttendees: 10 });
+      await createTestAttendee(event.id, event.slug, "Charlie", "charlie@test.com");
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).toContain("Charlie");
+      expect(html).toContain("Table Event");
+      expect(html).toContain(`/admin/event/${event.id}`);
+    });
+
+    test("shows total revenue for paid events", async () => {
+      const group = await createTestGroup({ name: "Revenue Group", slug: "revenue-group" });
+      const event = await createTestEvent({ name: "Paid Event", groupId: group.id, maxAttendees: 10, unitPrice: 1000 });
+      await createTestAttendee(event.id, event.slug, "Donor", "donor@test.com");
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).toContain("Total Revenue");
+    });
+
+    test("hides total revenue for free events", async () => {
+      const group = await createTestGroup({ name: "Free Group", slug: "free-group" });
+      await createTestEvent({ name: "Free Event", groupId: group.id, maxAttendees: 10 });
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).not.toContain("Total Revenue");
+    });
+
+    test("shows attendees from multiple events in group", async () => {
+      const group = await createTestGroup({ name: "Multi Group", slug: "multi-group" });
+      const event1 = await createTestEvent({ name: "Event Alpha", groupId: group.id, maxAttendees: 10 });
+      const event2 = await createTestEvent({ name: "Event Beta", groupId: group.id, maxAttendees: 10 });
+      await createTestAttendee(event1.id, event1.slug, "Alice Alpha", "alice@test.com");
+      await createTestAttendee(event2.id, event2.slug, "Bob Beta", "bob@test.com");
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).toContain("Alice Alpha");
+      expect(html).toContain("Bob Beta");
+      expect(html).toContain("Event Alpha");
+      expect(html).toContain("Event Beta");
+    });
+
+    test("shows no attendees message for group with events but no registrations", async () => {
+      const group = await createTestGroup({ name: "No Reg Group", slug: "no-reg-group" });
+      await createTestEvent({ name: "Empty Event", groupId: group.id, maxAttendees: 10 });
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).toContain("No attendees yet");
     });
   });
 


### PR DESCRIPTION
Show total attendees, checked-in count, and total revenue (for paid
events) in the group details section. Render a full AttendeeTable
aggregating attendees across all events in the group, with event
name column shown for cross-event visibility.

https://claude.ai/code/session_01QnGDUrWzMXnpRExw54RHuV