### PR TITLE
Separate failed-payment attendees from main list on event details page

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -169,6 +169,25 @@ const handleAttendeeDelete = attendeeFormAction(async (data, session, form, even
   return redirectOrReturn(form, `/admin/event/${eventId}`);
 });
 
+/**
+ * Handle POST /admin/event/:eventId/attendee/:attendeeId/delete-incomplete
+ * Deletes an attendee with an incomplete payment without requiring name confirmation.
+ * Verifies the attendee is actually incomplete before deleting.
+ */
+const handleDeleteIncomplete = attendeeFormAction(async (data, _session, _form, eventId, attendeeId) => {
+  const hasPaidEvent = data.event.unit_price !== null;
+  const isIncomplete = hasPaidEvent && !data.attendee.payment_id &&
+    Number.parseInt(data.attendee.price_paid, 10) > 0;
+
+  if (!isIncomplete) {
+    return redirect(`/admin/event/${eventId}`);
+  }
+
+  await deleteAttendee(attendeeId);
+  await logActivity(`Incomplete attendee deleted from '${data.event.name}'`, eventId);
+  return redirect(`/admin/event/${eventId}`);
+});
+
 /** Handle POST /admin/event/:eventId/attendee/:attendeeId/checkin */
 const handleAttendeeCheckin = attendeeFormAction(async (data, _session, form, eventId, attendeeId) => {
   const wasCheckedIn = data.attendee.checked_in;
@@ -519,6 +538,7 @@ export const attendeesRoutes = defineRoutes({
   "POST /admin/event/:eventId/attendee": handleAddAttendee,
   "POST /admin/event/:eventId/attendee/:attendeeId/delete": handleAttendeeDelete,
   "DELETE /admin/event/:eventId/attendee/:attendeeId/delete": handleAttendeeDelete,
+  "POST /admin/event/:eventId/attendee/:attendeeId/delete-incomplete": handleDeleteIncomplete,
   "POST /admin/event/:eventId/attendee/:attendeeId/checkin": handleAttendeeCheckin,
   "GET /admin/event/:eventId/attendee/:attendeeId/refund": handleAdminAttendeeRefundGet,
   "POST /admin/event/:eventId/attendee/:attendeeId/refund": handleAttendeeRefund,

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -44,6 +44,56 @@ export const countCheckedIn = (attendees: Attendee[]): number =>
 export const nearCapacity = (event: EventWithCount): boolean =>
   event.attendee_count >= event.max_attendees * 0.9;
 
+/**
+ * Check if an attendee has an incomplete/failed payment.
+ * True when the event is paid, the attendee has no payment reference,
+ * but was charged a non-zero price (distinguishing from admin-added attendees
+ * who have price_paid=0).
+ */
+export const isIncompletePayment = (attendee: Attendee, hasPaidEvent: boolean): boolean =>
+  hasPaidEvent && !attendee.payment_id && Number.parseInt(attendee.price_paid, 10) > 0;
+
+/** Sum the quantity field across a list of attendees */
+const sumQuantity = reduce((sum: number, a: Attendee) => sum + a.quantity, 0);
+
+/** Concatenate strings (curried reducer for use in pipe) */
+const joinStrings = reduce((acc: string, s: string) => acc + s, "");
+
+/** Render a single row in the Failed Payments table */
+const FailedPaymentRow = ({ attendee, eventId }: { attendee: Attendee; eventId: number }): string =>
+  String(
+    <tr>
+      <td>{attendee.name}</td>
+      <td>{attendee.quantity}</td>
+      <td>{new Date(attendee.created).toLocaleString()}</td>
+      <td>
+        <CsrfForm action={`/admin/event/${eventId}/attendee/${attendee.id}/delete-incomplete`} class="inline">
+          <button type="submit" class="link-button danger">Delete</button>
+        </CsrfForm>
+      </td>
+    </tr>
+  );
+
+/** Render a table of attendees with failed/incomplete payments */
+const FailedPaymentsTable = ({ attendees, eventId }: { attendees: Attendee[]; eventId: number }): string =>
+  String(
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Qty</th>
+          <th>Registered</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <Raw html={pipe(
+          map((a: Attendee) => FailedPaymentRow({ attendee: a, eventId })),
+          joinStrings,
+        )(attendees)} />
+      </tbody>
+    </table>
+  );
 
 /** Check-in message to display after toggling */
 export type CheckinMessage = { name: string; status: string } | null;
@@ -112,10 +162,21 @@ export const adminEventPage = ({
   const ticketUrl = `https://${allowedDomain}/ticket/${event.slug}`;
   const { script: embedScriptCode, iframe: embedIframeCode } = buildEmbedSnippets(ticketUrl);
   const isDaily = event.event_type === "daily";
-  const filteredAttendees = filterAttendees(attendees, activeFilter);
   const hasPaidEvent = event.unit_price !== null;
-  const checkedIn = countCheckedIn(attendees);
-  const checkedInRemaining = attendees.length - checkedIn;
+
+  // Separate attendees with incomplete/failed payments from the main list
+  const incompleteAttendees = hasPaidEvent
+    ? filter((a: Attendee) => isIncompletePayment(a, true))(attendees)
+    : [];
+  const completeAttendees = hasPaidEvent
+    ? filter((a: Attendee) => !isIncompletePayment(a, true))(attendees)
+    : attendees;
+  const incompleteQuantitySum = sumQuantity(incompleteAttendees);
+  const adjustedCount = event.attendee_count - incompleteQuantitySum;
+
+  const filteredAttendees = filterAttendees(completeAttendees, activeFilter);
+  const checkedIn = countCheckedIn(completeAttendees);
+  const checkedInRemaining = completeAttendees.length - checkedIn;
   const basePath = `/admin/event/${event.id}`;
   const dateQs = dateFilter ? `?date=${dateFilter}` : "";
   const suffix = filterSuffix(activeFilter);
@@ -203,12 +264,12 @@ export const adminEventPage = ({
                 <th>Attendees{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
                 <td>
                   {isDaily && dateFilter ? (
-                    <span class={attendees.length >= event.max_attendees ? "danger-text" : ""}>
-                      {attendees.length} / {event.max_attendees} &mdash; {event.max_attendees - attendees.length} remain
+                    <span class={completeAttendees.length >= event.max_attendees ? "danger-text" : ""}>
+                      {completeAttendees.length} / {event.max_attendees} &mdash; {event.max_attendees - completeAttendees.length} remain
                     </span>
                   ) : (
-                    <span class={nearCapacity(event) ? "danger-text" : ""}>
-                      {event.attendee_count}{!isDaily && <> / {event.max_attendees} &mdash; {event.max_attendees - event.attendee_count} remain</>}
+                    <span class={adjustedCount >= event.max_attendees * 0.9 ? "danger-text" : ""}>
+                      {adjustedCount}{!isDaily && <> / {event.max_attendees} &mdash; {event.max_attendees - adjustedCount} remain</>}
                     </span>
                   )}
                   {isDaily && !dateFilter && (
@@ -220,14 +281,14 @@ export const adminEventPage = ({
                 <th>Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
                 <td>
                   <span>
-                    {checkedIn} / {attendees.length} &mdash; {checkedInRemaining} remain
+                    {checkedIn} / {completeAttendees.length} &mdash; {checkedInRemaining} remain
                   </span>
                 </td>
               </tr>
               {event.unit_price !== null && (
                 <tr>
                   <th>Total Revenue</th>
-                  <td>{formatCurrency(calculateTotalRevenue(attendees))}</td>
+                  <td>{formatCurrency(calculateTotalRevenue(completeAttendees))}</td>
                 </tr>
               )}
               <tr>
@@ -332,6 +393,16 @@ export const adminEventPage = ({
             })} />
           </div>
         </article>
+
+        {incompleteAttendees.length > 0 && (
+          <article>
+            <h2 id="failed-payments">Failed Payments</h2>
+            <p>{incompleteAttendees.length} attendee(s) with unresolved payments</p>
+            <div class="table-scroll">
+              <Raw html={FailedPaymentsTable({ attendees: incompleteAttendees, eventId: event.id })} />
+            </div>
+          </article>
+        )}
 
         <article>
           <h2 id="add-attendee">Add Attendee</h2>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "#test-compat";
 import { CSS_PATH, EMBED_JS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, IFRAME_RESIZER_PARENT_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
 import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
-import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, countCheckedIn, formatAddressInline, nearCapacity } from "#templates/admin/events.tsx";
+import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, countCheckedIn, formatAddressInline, isIncompletePayment, nearCapacity } from "#templates/admin/events.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
 import { adminEventActivityLogPage, adminGlobalActivityLogPage } from "#templates/admin/activityLog.tsx";
 import { Breadcrumb } from "#templates/admin/nav.tsx";
@@ -1284,8 +1284,8 @@ describe("html", () => {
     test("shows total revenue for paid events", () => {
       const event = testEventWithCount({ unit_price: 1000, attendee_count: 2 });
       const attendees = [
-        testAttendee({ price_paid: "1000" }),
-        testAttendee({ id: 2, price_paid: "2000" }),
+        testAttendee({ price_paid: "1000", payment_id: "pi_test_1" }),
+        testAttendee({ id: 2, price_paid: "2000", payment_id: "pi_test_2" }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
       expect(html).toContain("Total Revenue");
@@ -1349,6 +1349,107 @@ describe("html", () => {
     test("returns true when fully sold out", () => {
       const event = testEventWithCount({ attendee_count: 100, max_attendees: 100 });
       expect(nearCapacity(event)).toBe(true);
+    });
+  });
+
+  describe("isIncompletePayment", () => {
+    test("returns true for paid event attendee with no payment_id and price > 0", () => {
+      const attendee = testAttendee({ payment_id: "", price_paid: "1000" });
+      expect(isIncompletePayment(attendee, true)).toBe(true);
+    });
+
+    test("returns false for free event", () => {
+      const attendee = testAttendee({ payment_id: "", price_paid: "0" });
+      expect(isIncompletePayment(attendee, false)).toBe(false);
+    });
+
+    test("returns false for admin-added attendee on paid event (price_paid=0)", () => {
+      const attendee = testAttendee({ payment_id: "", price_paid: "0" });
+      expect(isIncompletePayment(attendee, true)).toBe(false);
+    });
+
+    test("returns false for completed payment attendee", () => {
+      const attendee = testAttendee({ payment_id: "pi_test_123", price_paid: "1000" });
+      expect(isIncompletePayment(attendee, true)).toBe(false);
+    });
+  });
+
+  describe("adminEventPage failed payments", () => {
+    test("shows Failed Payments section when incomplete attendees exist", () => {
+      const event = testEventWithCount({ unit_price: 1000, attendee_count: 3 });
+      const attendees = [
+        testAttendee({ id: 1, payment_id: "pi_ok", price_paid: "1000" }),
+        testAttendee({ id: 2, payment_id: "", price_paid: "1000" }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).toContain("Failed Payments");
+      expect(html).toContain("1 attendee(s) with unresolved payments");
+      expect(html).toContain("/delete-incomplete");
+    });
+
+    test("hides Failed Payments section when no incomplete attendees", () => {
+      const event = testEventWithCount({ unit_price: 1000, attendee_count: 1 });
+      const attendees = [
+        testAttendee({ id: 1, payment_id: "pi_ok", price_paid: "1000" }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).not.toContain("Failed Payments");
+    });
+
+    test("hides Failed Payments section for free events", () => {
+      const event = testEventWithCount({ unit_price: null, attendee_count: 1 });
+      const attendees = [testAttendee({ id: 1, price_paid: "0" })];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).not.toContain("Failed Payments");
+    });
+
+    test("excludes incomplete attendees from attendee count", () => {
+      const event = testEventWithCount({ unit_price: 1000, attendee_count: 3, max_attendees: 100 });
+      const attendees = [
+        testAttendee({ id: 1, payment_id: "pi_ok", price_paid: "1000" }),
+        testAttendee({ id: 2, payment_id: "", price_paid: "1000" }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      // adjusted count: 3 - 1 (incomplete qty) = 2
+      expect(html).toContain("2 / 100");
+    });
+
+    test("excludes incomplete attendees from checked-in count", () => {
+      const event = testEventWithCount({ unit_price: 1000, attendee_count: 2 });
+      const attendees = [
+        testAttendee({ id: 1, payment_id: "pi_ok", price_paid: "1000", checked_in: true }),
+        testAttendee({ id: 2, payment_id: "", price_paid: "1000", checked_in: true }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      // Only complete attendees count: 1 checked in / 1 total
+      expect(html).toContain("1 / 1");
+    });
+
+    test("excludes incomplete attendees from revenue", () => {
+      const event = testEventWithCount({ unit_price: 1000, attendee_count: 2 });
+      const attendees = [
+        testAttendee({ id: 1, payment_id: "pi_ok", price_paid: "1000" }),
+        testAttendee({ id: 2, payment_id: "", price_paid: "2000" }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).toContain("10.00");
+      expect(html).not.toContain("30.00");
+    });
+
+    test("failed payments table has delete button but no check-in or refund", () => {
+      const event = testEventWithCount({ unit_price: 1000, attendee_count: 1 });
+      const attendees = [
+        testAttendee({ id: 1, name: "Jane Stuck", payment_id: "", price_paid: "1000" }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      const failedSection = html.split("Failed Payments")[1]!.split("Add Attendee")[0]!;
+      expect(failedSection).toContain("Jane Stuck");
+      expect(failedSection).toContain("Delete");
+      expect(failedSection).toContain("/delete-incomplete");
+      expect(failedSection).not.toContain("Check in");
+      expect(failedSection).not.toContain("Check out");
+      expect(failedSection).not.toContain("Refund");
+      expect(failedSection).not.toContain("Re-send Webhook");
     });
   });
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -304,6 +304,91 @@ describe("server (admin attendees)", () => {
     });
   });
 
+  describe("POST /admin/event/:eventId/attendee/:attendeeId/delete-incomplete", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const attendee = await createPaidTestAttendee(event.id, "John Doe", "john@example.com", "", 1000);
+
+      const response = await handleRequest(
+        mockFormRequest(`/admin/event/${event.id}/attendee/${attendee.id}/delete-incomplete`, {}),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("deletes incomplete attendee without name confirmation", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const attendee = await createPaidTestAttendee(event.id, "Jane Stuck", "jane@example.com", "", 1000);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${attendee.id}/delete-incomplete`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expectRedirect(`/admin/event/${event.id}`)(response);
+
+      // Verify attendee was deleted
+      const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
+      const deleted = await getAttendeeRaw(attendee.id);
+      expect(deleted).toBeNull();
+    });
+
+    test("refuses to delete complete attendee via delete-incomplete", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const attendee = await createPaidTestAttendee(event.id, "John Paid", "john@example.com", "pi_test_123", 1000);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${attendee.id}/delete-incomplete`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expectRedirect(`/admin/event/${event.id}`)(response);
+
+      // Verify attendee was NOT deleted (still exists)
+      const rows = await getAttendeesRaw(event.id);
+      expect(rows.length).toBe(1);
+    });
+
+    test("refuses to delete admin-added attendee on paid event via delete-incomplete", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      // Admin-added attendee: no payment_id and price_paid=0
+      const attendee = await createTestAttendee(event.id, event.slug, "Admin Added", "admin@example.com");
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${attendee.id}/delete-incomplete`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expectRedirect(`/admin/event/${event.id}`)(response);
+
+      // Verify attendee was NOT deleted
+      const rows = await getAttendeesRaw(event.id);
+      expect(rows.length).toBe(1);
+    });
+
+    test("returns 404 for non-existent attendee", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/999/delete-incomplete`,
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe("POST /admin/event/:eventId/attendee/:attendeeId/checkin", () => {
     test("redirects to login when not authenticated", async () => {
       const event = await createTestEvent({


### PR DESCRIPTION
Attendees with incomplete payments (paid event, no payment_id, price > 0)
are now excluded from the main attendee count, checked-in count, and revenue.
They appear in a new "Failed Payments" table below the main list with only
a delete button. The delete-incomplete endpoint verifies the attendee is
actually incomplete before deleting, without requiring name confirmation.

https://claude.ai/code/session_01H7xgyhcCK9ozZcHTLoL1gN