### PR TITLE
Fix attendee count mismatch by using quantity sums consistently

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -35,10 +35,16 @@ export const calculateTotalRevenue = (attendees: Attendee[]): number =>
   reduce((sum: number, a: Attendee) =>
     sum + Number.parseInt(a.price_paid, 10), 0)(attendees);
 
-/** Count how many attendees are checked in */
+/** Count how many people are checked in (summing quantity per registration) */
 export const countCheckedIn = (attendees: Attendee[]): number =>
-  filter((a: Attendee) => a.checked_in)(attendees).length;
+  pipe(
+    filter((a: Attendee) => a.checked_in),
+    reduce((sum: number, a: Attendee) => sum + a.quantity, 0),
+  )(attendees);
 
+/** Count how many attendee rows are checked in (ignoring quantity) */
+export const countCheckedInRows = (attendees: Attendee[]): number =>
+  filter((a: Attendee) => a.checked_in)(attendees).length;
 
 /** Check if event is within 10% of capacity */
 export const nearCapacity = (event: EventWithCount): boolean =>
@@ -54,7 +60,7 @@ export const isIncompletePayment = (attendee: Attendee, hasPaidEvent: boolean): 
   hasPaidEvent && !attendee.payment_id && Number.parseInt(attendee.price_paid, 10) > 0;
 
 /** Sum the quantity field across a list of attendees */
-const sumQuantity = reduce((sum: number, a: Attendee) => sum + a.quantity, 0);
+export const sumQuantity = reduce((sum: number, a: Attendee) => sum + a.quantity, 0);
 
 /** Concatenate strings (curried reducer for use in pipe) */
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
@@ -173,10 +179,14 @@ export const adminEventPage = ({
     : attendees;
   const incompleteQuantitySum = sumQuantity(incompleteAttendees);
   const adjustedCount = event.attendee_count - incompleteQuantitySum;
+  const completeQuantitySum = sumQuantity(completeAttendees);
 
+  const hasMultiQuantity = completeQuantitySum !== completeAttendees.length;
   const filteredAttendees = filterAttendees(completeAttendees, activeFilter);
-  const checkedIn = countCheckedIn(completeAttendees);
-  const checkedInRemaining = completeAttendees.length - checkedIn;
+  const ticketsCheckedIn = countCheckedIn(completeAttendees);
+  const ticketsCheckedInRemaining = completeQuantitySum - ticketsCheckedIn;
+  const attendeesCheckedIn = countCheckedInRows(completeAttendees);
+  const attendeesCheckedInRemaining = completeAttendees.length - attendeesCheckedIn;
   const basePath = `/admin/event/${event.id}`;
   const dateQs = dateFilter ? `?date=${dateFilter}` : "";
   const suffix = filterSuffix(activeFilter);
@@ -264,8 +274,8 @@ export const adminEventPage = ({
                 <th>Attendees{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
                 <td>
                   {isDaily && dateFilter ? (
-                    <span class={completeAttendees.length >= event.max_attendees ? "danger-text" : ""}>
-                      {completeAttendees.length} / {event.max_attendees} &mdash; {event.max_attendees - completeAttendees.length} remain
+                    <span class={completeQuantitySum >= event.max_attendees ? "danger-text" : ""}>
+                      {completeQuantitySum} / {event.max_attendees} &mdash; {event.max_attendees - completeQuantitySum} remain
                     </span>
                   ) : (
                     <span class={adjustedCount >= event.max_attendees * 0.9 ? "danger-text" : ""}>
@@ -277,14 +287,35 @@ export const adminEventPage = ({
                   )}
                 </td>
               </tr>
-              <tr>
-                <th>Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
-                <td>
-                  <span>
-                    {checkedIn} / {completeAttendees.length} &mdash; {checkedInRemaining} remain
-                  </span>
-                </td>
-              </tr>
+              {hasMultiQuantity ? (
+                <>
+                  <tr>
+                    <th>Attendees Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
+                    <td>
+                      <span>
+                        {attendeesCheckedIn} / {completeAttendees.length} &mdash; {attendeesCheckedInRemaining} remain
+                      </span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Tickets Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
+                    <td>
+                      <span>
+                        {ticketsCheckedIn} / {completeQuantitySum} &mdash; {ticketsCheckedInRemaining} remain
+                      </span>
+                    </td>
+                  </tr>
+                </>
+              ) : (
+                <tr>
+                  <th>Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
+                  <td>
+                    <span>
+                      {ticketsCheckedIn} / {completeQuantitySum} &mdash; {ticketsCheckedInRemaining} remain
+                    </span>
+                  </td>
+                </tr>
+              )}
               {event.unit_price !== null && (
                 <tr>
                   <th>Total Revenue</th>

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -11,7 +11,7 @@ import type { AdminSession, Attendee, EventWithCount, Group } from "#lib/types.t
 import { groupCreateFields, groupFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 import { EventRow } from "#templates/admin/dashboard.tsx";
-import { calculateTotalRevenue, countCheckedIn } from "#templates/admin/events.tsx";
+import { calculateTotalRevenue, countCheckedIn, countCheckedInRows, sumQuantity } from "#templates/admin/events.tsx";
 import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
 import { AttendeeTable, type AttendeeTableRow } from "#templates/attendee-table.tsx";
 
@@ -190,8 +190,12 @@ export const adminGroupDetailPage = (
   const ticketUrl = `https://${allowedDomain}/ticket/${group.slug}`;
   const { script: embedScriptCode, iframe: embedIframeCode } = buildEmbedSnippets(ticketUrl);
   const hasPaidEvent = events.some((e) => e.unit_price !== null);
-  const checkedIn = countCheckedIn(attendees);
-  const checkedInRemaining = attendees.length - checkedIn;
+  const attendeeQuantitySum = sumQuantity(attendees);
+  const hasMultiQuantity = attendeeQuantitySum !== attendees.length;
+  const ticketsCheckedIn = countCheckedIn(attendees);
+  const ticketsCheckedInRemaining = attendeeQuantitySum - ticketsCheckedIn;
+  const attendeesCheckedIn = countCheckedInRows(attendees);
+  const attendeesCheckedInRemaining = attendees.length - attendeesCheckedIn;
   const totalCount = totalAttendeeCount(events);
   const tableRows = buildAttendeeRows(attendees, events);
 
@@ -224,10 +228,23 @@ export const adminGroupDetailPage = (
                 <th>Attendees</th>
                 <td>{totalCount}</td>
               </tr>
-              <tr>
-                <th>Checked In</th>
-                <td>{checkedIn} / {attendees.length} &mdash; {checkedInRemaining} remain</td>
-              </tr>
+              {hasMultiQuantity ? (
+                <>
+                  <tr>
+                    <th>Attendees Checked In</th>
+                    <td>{attendeesCheckedIn} / {attendees.length} &mdash; {attendeesCheckedInRemaining} remain</td>
+                  </tr>
+                  <tr>
+                    <th>Tickets Checked In</th>
+                    <td>{ticketsCheckedIn} / {attendeeQuantitySum} &mdash; {ticketsCheckedInRemaining} remain</td>
+                  </tr>
+                </>
+              ) : (
+                <tr>
+                  <th>Checked In</th>
+                  <td>{ticketsCheckedIn} / {attendeeQuantitySum} &mdash; {ticketsCheckedInRemaining} remain</td>
+                </tr>
+              )}
               {hasPaidEvent && (
                 <tr>
                   <th>Total Revenue</th>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "#test-compat";
 import { CSS_PATH, EMBED_JS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, IFRAME_RESIZER_PARENT_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
 import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
-import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, countCheckedIn, formatAddressInline, isIncompletePayment, nearCapacity } from "#templates/admin/events.tsx";
+import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, countCheckedIn, countCheckedInRows, formatAddressInline, isIncompletePayment, nearCapacity } from "#templates/admin/events.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
 import { adminEventActivityLogPage, adminGlobalActivityLogPage } from "#templates/admin/activityLog.tsx";
 import { Breadcrumb } from "#templates/admin/nav.tsx";
@@ -222,6 +222,44 @@ describe("html", () => {
       expect(html).toContain("Checked In");
       expect(html).toContain("1 / 3");
       expect(html).toContain("2 remain");
+    });
+
+    test("shows dual checked-in rows when attendees have multi-quantity", () => {
+      const attendees = [
+        testAttendee({ id: 1, checked_in: true, quantity: 2 }),
+        testAttendee({ id: 2, checked_in: false, quantity: 3 }),
+      ];
+      const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      // Attendees Checked In: 1 row / 2 rows, 1 remain
+      expect(html).toContain("Attendees Checked In");
+      expect(html).toContain("1 / 2");
+      expect(html).toContain("1 remain");
+      // Tickets Checked In: 2 qty / 5 total qty, 3 remain
+      expect(html).toContain("Tickets Checked In");
+      expect(html).toContain("2 / 5");
+      expect(html).toContain("3 remain");
+    });
+
+    test("dual checked-in rows show daily suffix when daily event with dateFilter", () => {
+      const dailyEvent = testEventWithCount({ event_type: "daily", attendee_count: 5 });
+      const attendees = [
+        testAttendee({ id: 1, checked_in: true, quantity: 2 }),
+        testAttendee({ id: 2, checked_in: false, quantity: 3 }),
+      ];
+      const html = adminEventPage({ event: dailyEvent, attendees, allowedDomain: "localhost", session: TEST_SESSION, dateFilter: "2026-03-15" });
+      expect(html).toContain("Attendees Checked In (Sunday 15 March 2026)");
+      expect(html).toContain("Tickets Checked In (Sunday 15 March 2026)");
+    });
+
+    test("dual checked-in rows show total suffix when daily event without dateFilter", () => {
+      const dailyEvent = testEventWithCount({ event_type: "daily", attendee_count: 5 });
+      const attendees = [
+        testAttendee({ id: 1, checked_in: true, quantity: 2 }),
+        testAttendee({ id: 2, checked_in: false, quantity: 3 }),
+      ];
+      const html = adminEventPage({ event: dailyEvent, attendees, allowedDomain: "localhost", session: TEST_SESSION });
+      expect(html).toContain("Attendees Checked In (total)");
+      expect(html).toContain("Tickets Checked In (total)");
     });
 
     test("shows thank you URL in copyable input", () => {
@@ -1262,7 +1300,7 @@ describe("html", () => {
       expect(countCheckedIn([])).toBe(0);
     });
 
-    test("counts attendees with checked_in true", () => {
+    test("sums quantity for attendees with checked_in true", () => {
       const attendees = [
         testAttendee({ id: 1, checked_in: true }),
         testAttendee({ id: 2, checked_in: false }),
@@ -1277,6 +1315,30 @@ describe("html", () => {
         testAttendee({ id: 2, checked_in: false }),
       ];
       expect(countCheckedIn(attendees)).toBe(0);
+    });
+
+    test("sums quantity for multi-quantity checked-in registrations", () => {
+      const attendees = [
+        testAttendee({ id: 1, checked_in: true, quantity: 3 }),
+        testAttendee({ id: 2, checked_in: false, quantity: 2 }),
+        testAttendee({ id: 3, checked_in: true, quantity: 1 }),
+      ];
+      expect(countCheckedIn(attendees)).toBe(4);
+    });
+  });
+
+  describe("countCheckedInRows", () => {
+    test("returns 0 for empty attendees", () => {
+      expect(countCheckedInRows([])).toBe(0);
+    });
+
+    test("counts rows regardless of quantity", () => {
+      const attendees = [
+        testAttendee({ id: 1, checked_in: true, quantity: 3 }),
+        testAttendee({ id: 2, checked_in: false, quantity: 2 }),
+        testAttendee({ id: 3, checked_in: true, quantity: 1 }),
+      ];
+      expect(countCheckedInRows(attendees)).toBe(2);
     });
   });
 

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -445,6 +445,22 @@ describe("server (admin groups)", () => {
       expect(html).toContain("2 remain");
     });
 
+    test("shows dual checked-in rows when attendees have multi-quantity", async () => {
+      const group = await createTestGroup({ name: "Multi Qty Group", slug: "multi-qty-group" });
+      const event = await createTestEvent({ name: "Multi Qty Event", groupId: group.id, maxAttendees: 20, maxQuantity: 5 });
+      await createTestAttendee(event.id, event.slug, "Alice", "alice@multi.com", 3);
+      await createTestAttendee(event.id, event.slug, "Bob", "bob@multi.com");
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      expectStatus(200)(response);
+      const html = await response.text();
+      expect(html).toContain("Attendees Checked In");
+      expect(html).toContain("Tickets Checked In");
+      // 0 / 2 attendees checked in, 0 / 4 tickets checked in
+      expect(html).toContain("0 / 2");
+      expect(html).toContain("0 / 4");
+    });
+
     test("shows attendees table with event name column", async () => {
       const group = await createTestGroup({ name: "Table Group", slug: "table-group" });
       const event = await createTestEvent({ name: "Table Event", groupId: group.id, maxAttendees: 10 });


### PR DESCRIPTION
The "Attendees" count used SUM(quantity) from the database (counting
people), while "Checked In" used .length (counting rows). When
registrations have quantity > 1, these diverged. Now both metrics
count by quantity. When any registration has quantity > 1, two rows
are shown: "Attendees Checked In" (rows) and "Tickets Checked In"
(quantity sums). Also fixes the daily+dateFilter attendees count.

https://claude.ai/code/session_01EoEiBLAHuLkp37ZjxxbiD1