### PR TITLE
Reduce jscpd duplication in server-images.test.ts by 53%

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { type Client, createClient } from "@libsql/client";
+import { bracket } from "#fp";
 import { clearEncryptionKeyCache } from "#lib/crypto.ts";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
@@ -340,6 +341,56 @@ export const mockMultipartRequest = (
 };
 
 /**
+ * Extract URL string from a fetch input parameter (Request, URL, or string).
+ * Useful in fetch mocks to inspect the requested URL regardless of input type.
+ */
+export const urlFromFetchInput = (input: string | URL | Request): string =>
+  typeof input === "string"
+    ? input
+    : input instanceof URL
+    ? input.toString()
+    : input.url;
+
+/**
+ * Swap globalThis.fetch for the duration of a callback, using bracket for safe restore.
+ * The original fetch is passed to the callback so it can be used as a fallback.
+ *
+ * @example
+ * await withFetchMock(async (originalFetch) => {
+ *   globalThis.fetch = () => Promise.resolve(new Response("mocked"));
+ *   const res = await handleRequest(mockRequest("/api"));
+ *   expect(res.status).toBe(200);
+ * });
+ */
+export const withFetchMock = bracket(
+  () => globalThis.fetch,
+  (original) => { globalThis.fetch = original; },
+);
+
+/**
+ * Install a URL-based fetch handler on globalThis.fetch.
+ * For each request, calls `handler(url, init)`. If the handler returns null,
+ * the call falls through to the provided `fallback` fetch.
+ *
+ * @example
+ * installUrlHandler(originalFetch, (url) =>
+ *   url.includes("cdn.example.com") ? Promise.resolve(new Response("ok")) : null,
+ * );
+ */
+export const installUrlHandler = (
+  fallback: typeof globalThis.fetch,
+  handler: (url: string, init?: RequestInit) => Promise<Response> | null,
+): void => {
+  globalThis.fetch = (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = urlFromFetchInput(input);
+    return handler(url, init) ?? fallback(input, init);
+  };
+};
+
+/**
  * Wait for a specified number of milliseconds
  */
 export const wait = (ms: number): Promise<void> =>
@@ -645,6 +696,22 @@ export const loginAsAdmin = async (): Promise<{
   const csrfToken = await signCsrfToken();
 
   return { cookie, csrfToken };
+};
+
+/**
+ * Create a test event and log in as admin in one call.
+ * Shorthand for the extremely common `createTestEvent()` + `loginAsAdmin()` combo.
+ */
+export const setupEventAndLogin = async (
+  overrides?: Parameters<typeof createTestEvent>[0],
+): Promise<{
+  event: Event;
+  cookie: string;
+  csrfToken: string;
+}> => {
+  const event = await createTestEvent(overrides);
+  const { cookie, csrfToken } = await loginAsAdmin();
+  return { event, cookie, csrfToken };
 };
 
 /** Get or create an authenticated session for test helpers (cached) */

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -26,6 +26,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setupEventAndLogin,
   withMocks,
 } from "#test-utils";
 import { paymentsApi } from "#lib/payments.ts";
@@ -303,8 +304,7 @@ describe("server (admin attendees)", () => {
 
   describe("routes/admin/attendees.ts (parseAttendeeIds)", () => {
     test("returns 404 for non-existent attendee on delete page", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Att Del 404",
         maxAttendees: 50,
       });
@@ -326,8 +326,7 @@ describe("server (admin attendees)", () => {
 
   describe("routes/admin/attendees.ts (parseAttendeeIds)", () => {
     test("exercises parseAttendeeIds via POST route with valid params", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Parse Ids Test",
         maxAttendees: 50,
       });
@@ -364,8 +363,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("deletes incomplete attendee without name confirmation", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const { event, cookie, csrfToken } = await setupEventAndLogin({ maxAttendees: 100, unitPrice: 1000 });
       const attendee = await createPaidTestAttendee(event.id, "Jane Stuck", "jane@example.com", "", 1000);
 
       const response = await handleRequest(
@@ -384,8 +382,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("refuses to delete complete attendee via delete-incomplete", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const { event, cookie, csrfToken } = await setupEventAndLogin({ maxAttendees: 100, unitPrice: 1000 });
       const attendee = await createPaidTestAttendee(event.id, "John Paid", "john@example.com", "pi_test_123", 1000);
 
       const response = await handleRequest(
@@ -403,8 +400,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("refuses to delete admin-added attendee on paid event via delete-incomplete", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const { event, cookie, csrfToken } = await setupEventAndLogin({ maxAttendees: 100, unitPrice: 1000 });
       // Admin-added attendee: no payment_id and price_paid=0
       const attendee = await createTestAttendee(event.id, event.slug, "Admin Added", "admin@example.com");
 
@@ -423,8 +419,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("returns 404 for non-existent attendee", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({ maxAttendees: 100, unitPrice: 1000 });
+      const { event, cookie, csrfToken } = await setupEventAndLogin({ maxAttendees: 100, unitPrice: 1000 });
 
       const response = await handleRequest(
         mockFormRequest(
@@ -642,8 +637,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("rejects invalid CSRF token", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
       const response = await handleRequest(
         mockFormRequest(
@@ -679,11 +673,10 @@ describe("server (admin attendees)", () => {
     });
 
     test("adds attendee to email event", async () => {
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         fields: "email",
       });
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -707,11 +700,10 @@ describe("server (admin attendees)", () => {
     });
 
     test("adds attendee to phone event", async () => {
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         fields: "phone",
       });
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -733,11 +725,10 @@ describe("server (admin attendees)", () => {
     });
 
     test("adds attendee to both event", async () => {
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         fields: "email,phone",
       });
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -761,8 +752,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("redirects with error on validation failure", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin({ maxAttendees: 100 });
 
       const response = await handleRequest(
         mockFormRequest(
@@ -812,8 +802,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("redirects with error on encryption failure", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin({ maxAttendees: 100 });
 
       await withMocks(
         () =>
@@ -847,7 +836,7 @@ describe("server (admin attendees)", () => {
       const { todayInTz } = await import("#lib/timezone.ts");
       const futureDate = addDays(todayInTz("UTC"), 7);
 
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         eventType: "daily",
         bookableDays: [
@@ -860,7 +849,6 @@ describe("server (admin attendees)", () => {
           "Sunday",
         ],
       });
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -884,8 +872,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("event page shows add attendee form", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
       const response = await awaitTestRequest(
         `/admin/event/${event.id}`,
@@ -902,8 +889,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("event page shows success message when ?added param present", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
       const response = await awaitTestRequest(
         `/admin/event/${event.id}?added=Jane%20Doe`,
@@ -913,8 +899,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("event page shows error message when ?add_error param present", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
       const response = await awaitTestRequest(
         `/admin/event/${event.id}?add_error=Not%20enough%20spots`,
@@ -1333,8 +1318,7 @@ describe("server (admin attendees)", () => {
     });
 
     test("event page shows edit success message", async () => {
-      const event = await createTestEvent({ maxAttendees: 100 });
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
       const response = await awaitTestRequest(
         `/admin/event/${event.id}?edited=Jane%20Doe`,

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -32,6 +32,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setupEventAndLogin,
   submitTicketForm,
   updateTestEvent,
 } from "#test-utils";
@@ -213,13 +214,11 @@ describe("server (admin events)", () => {
 
     test("rejects duplicate slug", async () => {
       // First, create an event with a specific name
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Duplicate Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
-
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       // Try to create another event with the same name (generates same slug)
       const response = await handleRequest(
@@ -256,9 +255,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows event details when authenticated", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -271,9 +268,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows Edit link on event page", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -309,9 +304,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows duplicate form pre-filled with event settings but no name", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         name: "Original Event",
         maxAttendees: 75,
         thankYouUrl: "https://example.com/thanks",
@@ -341,9 +334,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows Duplicate link on event detail page", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -377,9 +368,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows only checked-in attendees", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -434,9 +423,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows only checked-out attendees", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -495,9 +482,7 @@ describe("server (admin events)", () => {
     });
 
     test("returns CSV with correct headers when authenticated", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -516,9 +501,7 @@ describe("server (admin events)", () => {
     });
 
     test("returns CSV with attendee data", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -552,9 +535,7 @@ describe("server (admin events)", () => {
     });
 
     test("returns CSV with Checked In column", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -588,9 +569,7 @@ describe("server (admin events)", () => {
     });
 
     test("sanitizes slug for filename", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         name: "Test Event Special",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -625,9 +604,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows edit form when authenticated", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com/thanks",
@@ -690,9 +667,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects request with invalid CSRF token", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -715,9 +690,7 @@ describe("server (admin events)", () => {
     });
 
     test("validates required fields", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -740,9 +713,7 @@ describe("server (admin events)", () => {
     });
 
     test("updates event when authenticated", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -781,13 +752,11 @@ describe("server (admin events)", () => {
         name: "Group Two",
         slug: "group-two",
       });
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Group Switch Event",
         groupId: group1.id,
         maxAttendees: 50,
       });
-
-      const { cookie, csrfToken } = await loginAsAdmin();
       const response = await handleRequest(
         mockFormRequest(
           `/admin/event/${event.id}/edit`,
@@ -810,11 +779,10 @@ describe("server (admin events)", () => {
     });
 
     test("rejects non-existent group_id on edit", async () => {
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Edit Bad Group",
         maxAttendees: 50,
       });
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -834,9 +802,7 @@ describe("server (admin events)", () => {
     });
 
     test("updates event slug", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Slug Update Test",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -864,9 +830,7 @@ describe("server (admin events)", () => {
     });
 
     test("normalizes slug on update (spaces, uppercase)", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Normalize Test",
         maxAttendees: 50,
       });
@@ -892,9 +856,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects invalid slug characters", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Invalid Slug Test",
         maxAttendees: 50,
       });
@@ -957,11 +919,10 @@ describe("server (admin events)", () => {
         name: "Slug Group",
         slug: "slug-group",
       });
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Event Slug Collision",
         maxAttendees: 50,
       });
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -984,9 +945,7 @@ describe("server (admin events)", () => {
     });
 
     test("allows keeping the same slug on update", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Same Slug Test",
         maxAttendees: 50,
       });
@@ -1035,9 +994,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows deactivate confirmation page when authenticated", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -1070,9 +1027,7 @@ describe("server (admin events)", () => {
     });
 
     test("deactivates event and redirects", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -1093,9 +1048,7 @@ describe("server (admin events)", () => {
     });
 
     test("returns error when identifier does not match", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1125,9 +1078,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows reactivate confirmation page when authenticated", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -1150,9 +1101,7 @@ describe("server (admin events)", () => {
 
   describe("POST /admin/event/:id/reactivate", () => {
     test("reactivates event and redirects", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -1175,9 +1124,7 @@ describe("server (admin events)", () => {
     });
 
     test("returns error when name does not match", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1218,9 +1165,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows delete confirmation page when authenticated", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1271,9 +1216,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects invalid CSRF token", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1293,9 +1236,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects mismatched event identifier", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1315,9 +1256,7 @@ describe("server (admin events)", () => {
     });
 
     test("deletes event with matching identifier (case insensitive)", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1342,9 +1281,7 @@ describe("server (admin events)", () => {
     });
 
     test("deletes event with matching identifier (trimmed)", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1364,9 +1301,7 @@ describe("server (admin events)", () => {
     });
 
     test("deletes event and all attendees", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1557,9 +1492,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows log for existing event", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Event Log",
         maxAttendees: 50,
       });
@@ -1604,9 +1537,7 @@ describe("server (admin events)", () => {
 
   describe("admin/events.ts (event delete handler via onDelete)", () => {
     test("delete event handler cleans up associated data", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "On Delete Test",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1638,9 +1569,7 @@ describe("server (admin events)", () => {
 
   describe("admin/events.ts (eventErrorPage with deleted event)", () => {
     test("edit validation returns 400 with error when event exists", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "First Edit Err",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1667,9 +1596,7 @@ describe("server (admin events)", () => {
 
   describe("admin/events.ts (form.get fallbacks)", () => {
     test("deactivate event without confirm_identifier uses empty fallback", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Deactivate Fallback",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1687,9 +1614,7 @@ describe("server (admin events)", () => {
     });
 
     test("reactivate event without confirm_identifier uses empty fallback", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Reactivate Fallback",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1708,9 +1633,7 @@ describe("server (admin events)", () => {
     });
 
     test("delete event without confirm_identifier uses empty fallback", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Delete Fallback",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -1746,8 +1669,7 @@ describe("server (admin events)", () => {
     });
 
     test("shows edit page with error when name is empty", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event1 = await createTestEvent({
+      const { event: event1, cookie, csrfToken } = await setupEventAndLogin({
         name: "Edit Orig",
         maxAttendees: 50,
       });
@@ -1770,8 +1692,7 @@ describe("server (admin events)", () => {
 
   describe("POST /admin/event/:id/delete with custom onDelete", () => {
     test("deletes event and cascades to attendees", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Cascade Delete",
         maxAttendees: 50,
       });
@@ -1801,8 +1722,7 @@ describe("server (admin events)", () => {
 
   describe("routes/admin/events.ts (event error page)", () => {
     test("shows edit error page for existing event with validation error", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event1 = await createTestEvent({
+      const { event: event1, cookie, csrfToken } = await setupEventAndLogin({
         name: "Event Err 1",
         maxAttendees: 50,
       });
@@ -1823,8 +1743,7 @@ describe("server (admin events)", () => {
     });
 
     test("event delete cascades to attendees using custom onDelete", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Cascade Del Test",
         maxAttendees: 50,
       });
@@ -1903,8 +1822,7 @@ describe("server (admin events)", () => {
 
   describe("admin event onDelete handler", () => {
     test("deleting an event triggers the onDelete handler which calls deleteEvent", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Delete OnDelete Test",
         maxAttendees: 10,
       });
@@ -1970,8 +1888,7 @@ describe("server (admin events)", () => {
 
   describe("edit event notFound race condition", () => {
     test("returns 404 when event is deleted during edit update", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         name: "Race Condition Event",
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
@@ -2044,8 +1961,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event detail page shows closes_at with countdown when set", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({ closesAt: "2099-06-15T14:30" });
+      const { event, cookie } = await setupEventAndLogin({ closesAt: "2099-06-15T14:30" });
 
       const response = await awaitTestRequest(`/admin/event/${event.id}`, {
         cookie,
@@ -2060,8 +1976,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event detail page shows 'No deadline' when closes_at is null", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
 
       const response = await awaitTestRequest(`/admin/event/${event.id}`, {
         cookie,
@@ -2070,8 +1985,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event edit page shows closes_at in form", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({ closesAt: "2099-06-15T14:30" });
+      const { event, cookie } = await setupEventAndLogin({ closesAt: "2099-06-15T14:30" });
 
       const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
         cookie,
@@ -2086,8 +2000,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event detail page shows 'closed' countdown for past closes_at", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({ closesAt: "2024-01-01T00:00" });
+      const { event, cookie } = await setupEventAndLogin({ closesAt: "2024-01-01T00:00" });
 
       const response = await awaitTestRequest(`/admin/event/${event.id}`, {
         cookie,
@@ -2174,8 +2087,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects invalid closes_at format", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2233,8 +2145,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin detail page shows Event Date and Location when set", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         date: "2026-06-15T14:00",
         location: "Village Hall",
       });
@@ -2252,8 +2163,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin detail page hides Event Date and Location when empty", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
       const response = await awaitTestRequest(`/admin/event/${event.id}`, {
         cookie,
       });
@@ -2264,8 +2174,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin edit page pre-fills date as split inputs", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({ date: "2026-06-15T14:00" });
+      const { event, cookie } = await setupEventAndLogin({ date: "2026-06-15T14:00" });
       const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
         cookie,
       });
@@ -2278,8 +2187,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin edit page pre-fills location", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({ location: "Village Hall" });
+      const { event, cookie } = await setupEventAndLogin({ location: "Village Hall" });
       const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
         cookie,
       });
@@ -2287,8 +2195,7 @@ describe("server (admin events)", () => {
     });
 
     test("CSV export includes Event Date and Event Location columns", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         date: "2026-06-15T14:00",
         location: "Village Hall",
       });
@@ -2307,8 +2214,7 @@ describe("server (admin events)", () => {
     });
 
     test("CSV export omits Event Date and Event Location when empty", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
       await createTestAttendee(event.id, event.slug, "Bob", "bob@test.com");
       const response = await awaitTestRequest(
         `/admin/event/${event.id}/export`,
@@ -2321,8 +2227,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects invalid event date on edit", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
       const response = await handleRequest(
         mockFormRequest(
           `/admin/event/${event.id}/edit`,
@@ -2432,8 +2337,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event detail page shows Daily type for daily events", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         eventType: "daily",
         bookableDays: ["Monday", "Tuesday"],
         minimumDaysBefore: 3,
@@ -2458,8 +2362,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event detail page shows Standard type without daily config", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
 
       const response = await awaitTestRequest(`/admin/event/${event.id}`, {
         cookie,
@@ -2475,8 +2378,7 @@ describe("server (admin events)", () => {
     });
 
     test("admin event edit page pre-fills daily config", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         eventType: "daily",
         bookableDays: ["Wednesday", "Friday"],
         minimumDaysBefore: 5,
@@ -2529,8 +2431,7 @@ describe("server (admin events)", () => {
     });
 
     test("duplicate page pre-fills daily event config", async () => {
-      const { cookie } = await loginAsAdmin();
-      await createTestEvent({
+      const { cookie } = await setupEventAndLogin({
         eventType: "daily",
         bookableDays: ["Tuesday", "Thursday"],
         minimumDaysBefore: 2,
@@ -2572,8 +2473,7 @@ describe("server (admin events)", () => {
     });
 
     test("rejects invalid bookable_days value", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      await createTestEvent({ name: "Edit Target" });
+      const { cookie, csrfToken } = await setupEventAndLogin({ name: "Edit Target" });
 
       const { getEventWithCount } = await import("#lib/db/events.ts");
       const event = (await getEventWithCount(1))!;
@@ -2601,8 +2501,7 @@ describe("server (admin events)", () => {
 
   describe("audit logging (event edit)", () => {
     test("logs activity when event is updated", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
       });
@@ -2699,8 +2598,7 @@ describe("server (admin events)", () => {
     });
 
     test("does not show Date column for standard events", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
 
       const response = await awaitTestRequest(`/admin/event/${event.id}`, {
         cookie,
@@ -2780,8 +2678,7 @@ describe("server (admin events)", () => {
     });
 
     test("ignores ?date= for standard events", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
       await createTestAttendee(
         event.id,
         event.slug,
@@ -2811,8 +2708,7 @@ describe("server (admin events)", () => {
     });
 
     test("CSV export excludes Date column for standard events", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent();
+      const { event, cookie } = await setupEventAndLogin();
       await createTestAttendee(
         event.id,
         event.slug,
@@ -2888,8 +2784,7 @@ describe("server (admin events)", () => {
 
   describe("stale reservation cleanup on admin event view", () => {
     test("cleans up stale reservations when viewing an event", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Cleanup Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",
@@ -2925,8 +2820,7 @@ describe("server (admin events)", () => {
     });
 
     test("does not clean up fresh reservations when viewing an event", async () => {
-      const { cookie } = await loginAsAdmin();
-      const event = await createTestEvent({
+      const { event, cookie } = await setupEventAndLogin({
         name: "Fresh Reservation Test",
         maxAttendees: 100,
         thankYouUrl: "https://example.com",

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -13,7 +13,6 @@ import {
   resetTestSlugCounter,
   setupEventAndLogin,
   updateTestEvent,
-  urlFromFetchInput,
   withFetchMock,
 } from "#test-utils";
 import { encryptBytes } from "#lib/crypto.ts";
@@ -135,10 +134,10 @@ const submitImageDelete = (
   );
 
 /** Assert a 302 redirect whose location contains `image_error=` and a decoded substring */
-const expectImageErrorRedirect = async (
+const expectImageErrorRedirect = (
   response: Response,
   errorSubstring: string,
-): Promise<void> => {
+): void => {
   expect(response.status).toBe(302);
   const location = response.headers.get("location") ?? "";
   expect(location).toContain("image_error=");

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -1,17 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
 import { handleRequest } from "#routes";
-import { bracket } from "#fp";
 import {
   createTestDbWithSetup,
   createTestEvent,
   expectHtmlResponse,
+  installUrlHandler,
   loginAsAdmin,
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setupEventAndLogin,
   updateTestEvent,
+  urlFromFetchInput,
+  withFetchMock,
 } from "#test-utils";
 import { encryptBytes } from "#lib/crypto.ts";
 import { toMajorUnits } from "#lib/currency.ts";
@@ -26,45 +29,9 @@ const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
 /** Reusable proxy route test path */
 const PROXY_PATH = "/image/abc123-def4-5678-9abc-def012345678";
 
-/** Extract URL string from a fetch input parameter */
-const urlFromInput = (input: string | URL | Request): string =>
-  typeof input === "string"
-    ? input
-    : input instanceof URL
-    ? input.toString()
-    : input.url;
-
 /** Standard CDN 201 success response */
 const cdnOkResponse = (): Response =>
   new Response(JSON.stringify({ HttpCode: 201, Message: "OK" }), { status: 201 });
-
-/**
- * Install a URL-based fetch handler. Calls `handler(url, init)` for each request;
- * if the handler returns null, the call falls through to `fallback`.
- */
-const installUrlHandler = (
-  fallback: typeof globalThis.fetch,
-  handler: (url: string, init?: RequestInit) => Promise<Response> | null,
-): void => {
-  globalThis.fetch = (
-    input: string | URL | Request,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const url = urlFromInput(input);
-    return handler(url, init) ?? fallback(input, init);
-  };
-};
-
-/** Swap globalThis.fetch for the duration of a callback, using bracket for safe restore */
-const withFetchMock = bracket(
-  () => {
-    const original = globalThis.fetch;
-    return original;
-  },
-  (original) => {
-    globalThis.fetch = original;
-  },
-);
 
 /** Mock fetch to intercept Bunny CDN API calls, forwarding others to real fetch */
 const withStorageMock = (
@@ -93,13 +60,6 @@ const withCdnProxy = (
     );
     await fn();
   });
-
-/** Create a test event and log in as admin — common setup for most tests */
-const setupEventAndLogin = async () => {
-  const event = await createTestEvent();
-  const { cookie, csrfToken } = await loginAsAdmin();
-  return { event, cookie, csrfToken };
-};
 
 /** Build form data for event edit with all required fields */
 const editFormData = async (

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
 import { handleRequest } from "#routes";
+import { bracket } from "#fp";
 import {
   createTestDbWithSetup,
   createTestEvent,
   expectHtmlResponse,
   loginAsAdmin,
+  mockFormRequest,
   mockMultipartRequest,
   mockRequest,
   resetDb,
@@ -18,55 +20,85 @@ import { eventsTable, getEventWithCount } from "#lib/db/events.ts";
 /** JPEG magic bytes for a valid test image */
 const JPEG_HEADER = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
 
-/** Create a form POST request with cookie */
-const formPostRequest = (
-  path: string,
-  data: Record<string, string>,
-  cookie: string,
-): Request => {
-  const body = new URLSearchParams(data).toString();
-  return new Request(`http://localhost${path}`, {
-    method: "POST",
-    body,
-    headers: {
-      "content-type": "application/x-www-form-urlencoded",
-      cookie,
-      host: "localhost",
-    },
-  });
-};
+/** PDF magic bytes for an invalid image type test */
+const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
 
-/** Mock fetch to intercept Bunny CDN API calls */
-const withStorageMock = async (
-  fn: (fetchCalls: string[]) => Promise<void>,
-): Promise<void> => {
-  const originalFetch = globalThis.fetch;
-  const fetchCalls: string[] = [];
+/** Reusable proxy route test path */
+const PROXY_PATH = "/image/abc123-def4-5678-9abc-def012345678";
+
+/** Extract URL string from a fetch input parameter */
+const urlFromInput = (input: string | URL | Request): string =>
+  typeof input === "string"
+    ? input
+    : input instanceof URL
+    ? input.toString()
+    : input.url;
+
+/** Standard CDN 201 success response */
+const cdnOkResponse = (): Response =>
+  new Response(JSON.stringify({ HttpCode: 201, Message: "OK" }), { status: 201 });
+
+/**
+ * Install a URL-based fetch handler. Calls `handler(url, init)` for each request;
+ * if the handler returns null, the call falls through to `fallback`.
+ */
+const installUrlHandler = (
+  fallback: typeof globalThis.fetch,
+  handler: (url: string, init?: RequestInit) => Promise<Response> | null,
+): void => {
   globalThis.fetch = (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    const url = typeof input === "string"
-      ? input
-      : input instanceof URL
-      ? input.toString()
-      : input.url;
-    fetchCalls.push(url);
-    if (url.includes("storage.bunnycdn.com") || url.includes("b-cdn.net")) {
-      return Promise.resolve(
-        new Response(JSON.stringify({ HttpCode: 201, Message: "OK" }), {
-          status: 201,
-        }),
-      );
-    }
-    return originalFetch(input, init);
+    const url = urlFromInput(input);
+    return handler(url, init) ?? fallback(input, init);
   };
+};
 
-  try {
+/** Swap globalThis.fetch for the duration of a callback, using bracket for safe restore */
+const withFetchMock = bracket(
+  () => {
+    const original = globalThis.fetch;
+    return original;
+  },
+  (original) => {
+    globalThis.fetch = original;
+  },
+);
+
+/** Mock fetch to intercept Bunny CDN API calls, forwarding others to real fetch */
+const withStorageMock = (
+  fn: (fetchCalls: string[]) => Promise<void>,
+): Promise<void> =>
+  withFetchMock(async (originalFetch) => {
+    const fetchCalls: string[] = [];
+    installUrlHandler(originalFetch, (url) => {
+      fetchCalls.push(url);
+      if (url.includes("storage.bunnycdn.com") || url.includes("b-cdn.net")) {
+        return Promise.resolve(cdnOkResponse());
+      }
+      return null;
+    });
     await fn(fetchCalls);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  });
+
+/** Mock fetch where CDN requests return a fixed response, others pass through */
+const withCdnProxy = (
+  respond: () => Response,
+  fn: () => Promise<void>,
+): Promise<void> =>
+  withFetchMock(async (originalFetch) => {
+    installUrlHandler(originalFetch, (url) =>
+      url.includes("storage.bunnycdn.com") ? Promise.resolve(respond()) : null,
+    );
+    await fn();
+  });
+
+/** Create a test event and log in as admin — common setup for most tests */
+const setupEventAndLogin = async () => {
+  const event = await createTestEvent();
+  const { cookie, csrfToken } = await loginAsAdmin();
+  return { event, cookie, csrfToken };
 };
 
 /** Build form data for event edit with all required fields */
@@ -99,6 +131,105 @@ const editFormData = async (
   };
 };
 
+/** Submit an edit-form multipart request with an image file attached */
+const submitEditImage = async (
+  eventId: number,
+  cookie: string,
+  csrfToken: string,
+  file: { name: string; data: Uint8Array; contentType: string },
+): Promise<Response> => {
+  const fields = await editFormData(eventId, csrfToken);
+  return handleRequest(
+    mockMultipartRequest(`/admin/event/${eventId}/edit`, fields, cookie, {
+      fieldName: "image",
+      ...file,
+    }),
+  );
+};
+
+/** Submit a JPEG image via the edit form (most common upload case) */
+const submitEditJpeg = (
+  eventId: number,
+  cookie: string,
+  csrfToken: string,
+  filename: string,
+): Promise<Response> =>
+  submitEditImage(eventId, cookie, csrfToken, {
+    name: filename,
+    data: JPEG_HEADER,
+    contentType: "image/jpeg",
+  });
+
+/** Submit a POST to /admin/event/:id/image/delete */
+const submitImageDelete = (
+  eventId: number,
+  cookie: string,
+  csrfToken: string,
+): Promise<Response> =>
+  handleRequest(
+    mockFormRequest(
+      `/admin/event/${eventId}/image/delete`,
+      { csrf_token: csrfToken },
+      cookie,
+    ),
+  );
+
+/** Assert a 302 redirect whose location contains `image_error=` and a decoded substring */
+const expectImageErrorRedirect = async (
+  response: Response,
+  errorSubstring: string,
+): Promise<void> => {
+  expect(response.status).toBe(302);
+  const location = response.headers.get("location") ?? "";
+  expect(location).toContain("image_error=");
+  expect(decodeURIComponent(location)).toContain(errorSubstring);
+};
+
+/** Shared form fields for creating a new event via POST /admin/event */
+const newEventFormFields = (
+  csrfToken: string,
+  name: string,
+): Record<string, string> => ({
+  csrf_token: csrfToken,
+  name,
+  description: "",
+  date_date: "",
+  date_time: "",
+  location: "",
+  max_attendees: "50",
+  max_quantity: "1",
+  fields: "email",
+  thank_you_url: "",
+  unit_price: "",
+  webhook_url: "",
+  closes_at_date: "",
+  closes_at_time: "",
+  event_type: "standard",
+  bookable_days: "Monday,Tuesday,Wednesday,Thursday,Friday",
+  minimum_days_before: "",
+  maximum_days_after: "",
+});
+
+/** Submit a create-event form with an image file attached */
+const submitCreateImage = (
+  cookie: string,
+  csrfToken: string,
+  eventName: string,
+  file: { name: string; data: Uint8Array; contentType: string },
+): Promise<Response> =>
+  handleRequest(
+    mockMultipartRequest(
+      "/admin/event",
+      newEventFormFields(csrfToken, eventName),
+      cookie,
+      { fieldName: "image", ...file },
+    ),
+  );
+
+/** Request the image proxy route */
+const proxyRequest = (ext = "jpg"): Promise<Response> =>
+  handleRequest(mockRequest(`${PROXY_PATH}.${ext}`));
+
 describe("server (event images)", () => {
   beforeEach(async () => {
     resetTestSlugCounter();
@@ -117,22 +248,9 @@ describe("server (event images)", () => {
     test("ignores image when storage is not configured", async () => {
       Deno.env.delete("STORAGE_ZONE_NAME");
       Deno.env.delete("STORAGE_ZONE_KEY");
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      const fields = await editFormData(event.id, csrfToken);
-      const request = mockMultipartRequest(
-        `/admin/event/${event.id}/edit`,
-        fields,
-        cookie,
-        {
-          fieldName: "image",
-          name: "test.jpg",
-          data: JPEG_HEADER,
-          contentType: "image/jpeg",
-        },
-      );
-      const response = await handleRequest(request);
+      const response = await submitEditJpeg(event.id, cookie, csrfToken, "test.jpg");
       expect(response.status).toBe(302);
       const updated = await getEventWithCount(event.id);
       expect(updated?.image_url).toBe("");
@@ -147,106 +265,56 @@ describe("server (event images)", () => {
     });
 
     test("redirects with image error for invalid image type", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      const fields = await editFormData(event.id, csrfToken);
-      const request = mockMultipartRequest(
-        `/admin/event/${event.id}/edit`,
-        fields,
-        cookie,
-        {
-          fieldName: "image",
-          name: "test.pdf",
-          data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
-          contentType: "application/pdf",
-        },
-      );
       await withStorageMock(async () => {
-        const response = await handleRequest(request);
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("image_error=");
-        expect(decodeURIComponent(location)).toContain(
-          "JPEG, PNG, GIF, or WebP",
-        );
+        const response = await submitEditImage(event.id, cookie, csrfToken, {
+          name: "test.pdf",
+          data: PDF_BYTES,
+          contentType: "application/pdf",
+        });
+        await expectImageErrorRedirect(response, "JPEG, PNG, GIF, or WebP");
         const updated = await getEventWithCount(event.id);
         expect(updated?.image_url).toBe("");
       });
     });
 
     test("redirects with image error for oversized image", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
       const oversized = new Uint8Array(257 * 1024);
       oversized[0] = 0xFF;
       oversized[1] = 0xD8;
       oversized[2] = 0xFF;
-      const fields = await editFormData(event.id, csrfToken);
-      const request = mockMultipartRequest(
-        `/admin/event/${event.id}/edit`,
-        fields,
-        cookie,
-        {
-          fieldName: "image",
+
+      await withStorageMock(async () => {
+        const response = await submitEditImage(event.id, cookie, csrfToken, {
           name: "big.jpg",
           data: oversized,
           contentType: "image/jpeg",
-        },
-      );
-      await withStorageMock(async () => {
-        const response = await handleRequest(request);
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("image_error=");
-        expect(decodeURIComponent(location)).toContain("256KB");
+        });
+        await expectImageErrorRedirect(response, "256KB");
       });
     });
 
     test("redirects with image error for mismatched magic bytes", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      const fields = await editFormData(event.id, csrfToken);
-      const request = mockMultipartRequest(
-        `/admin/event/${event.id}/edit`,
-        fields,
-        cookie,
-        {
-          fieldName: "image",
+      await withStorageMock(async () => {
+        const response = await submitEditImage(event.id, cookie, csrfToken, {
           name: "fake.jpg",
           data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
           contentType: "image/jpeg",
-        },
-      );
-      await withStorageMock(async () => {
-        const response = await handleRequest(request);
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("image_error=");
-        expect(decodeURIComponent(location)).toContain("valid image");
+        });
+        await expectImageErrorRedirect(response, "valid image");
       });
     });
 
     test("uploads image and updates event via edit form", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
       await withStorageMock(async () => {
-        const fields = await editFormData(event.id, csrfToken);
-        const request = mockMultipartRequest(
-          `/admin/event/${event.id}/edit`,
-          fields,
-          cookie,
-          {
-            fieldName: "image",
-            name: "photo.jpg",
-            data: JPEG_HEADER,
-            contentType: "image/jpeg",
-          },
-        );
-        const response = await handleRequest(request);
+        const response = await submitEditJpeg(event.id, cookie, csrfToken, "photo.jpg");
         expect(response.status).toBe(302);
         expect(response.headers.get("location")).toBe(
           `/admin/event/${event.id}`,
@@ -259,25 +327,11 @@ describe("server (event images)", () => {
     });
 
     test("deletes old image when uploading new one via edit form", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
-
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
       await eventsTable.update(event.id, { imageUrl: "old-image.jpg" });
 
       await withStorageMock(async (fetchCalls) => {
-        const fields = await editFormData(event.id, csrfToken);
-        const request = mockMultipartRequest(
-          `/admin/event/${event.id}/edit`,
-          fields,
-          cookie,
-          {
-            fieldName: "image",
-            name: "new-photo.jpg",
-            data: JPEG_HEADER,
-            contentType: "image/jpeg",
-          },
-        );
-        const response = await handleRequest(request);
+        const response = await submitEditJpeg(event.id, cookie, csrfToken, "new-photo.jpg");
         expect(response.status).toBe(302);
 
         const deleteCall = fetchCalls.find((url) =>
@@ -288,53 +342,25 @@ describe("server (event images)", () => {
     });
 
     test("succeeds even when old image delete throws", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
       await eventsTable.update(event.id, { imageUrl: "old-failing.jpg" });
 
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (
-        input: string | URL | Request,
-        init?: RequestInit,
-      ): Promise<Response> => {
-        const url = typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-        if (url.includes("old-failing.jpg")) {
-          return Promise.reject(new Error("CDN delete failed"));
-        }
-        if (url.includes("storage.bunnycdn.com")) {
-          return Promise.resolve(
-            new Response(JSON.stringify({ HttpCode: 201, Message: "OK" }), {
-              status: 201,
-            }),
-          );
-        }
-        return originalFetch(input, init);
-      };
+      await withFetchMock(async (originalFetch) => {
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("old-failing.jpg")) {
+            return Promise.reject(new Error("CDN delete failed"));
+          }
+          if (url.includes("storage.bunnycdn.com")) {
+            return Promise.resolve(cdnOkResponse());
+          }
+          return null;
+        });
 
-      try {
-        const fields = await editFormData(event.id, csrfToken);
-        const request = mockMultipartRequest(
-          `/admin/event/${event.id}/edit`,
-          fields,
-          cookie,
-          {
-            fieldName: "image",
-            name: "new.jpg",
-            data: JPEG_HEADER,
-            contentType: "image/jpeg",
-          },
-        );
-        const response = await handleRequest(request);
+        const response = await submitEditJpeg(event.id, cookie, csrfToken, "new.jpg");
         expect(response.status).toBe(302);
         const updated = await getEventWithCount(event.id);
         expect(updated?.image_url).toMatch(/\.jpg$/);
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+      });
     });
   });
 
@@ -343,37 +369,10 @@ describe("server (event images)", () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 
       await withStorageMock(async () => {
-        const request = mockMultipartRequest(
-          "/admin/event",
-          {
-            csrf_token: csrfToken,
-            name: "Image Test Event",
-            description: "",
-            date_date: "",
-            date_time: "",
-            location: "",
-            max_attendees: "50",
-            max_quantity: "1",
-            fields: "email",
-            thank_you_url: "",
-            unit_price: "",
-            webhook_url: "",
-            closes_at_date: "",
-            closes_at_time: "",
-            event_type: "standard",
-            bookable_days: "Monday,Tuesday,Wednesday,Thursday,Friday",
-            minimum_days_before: "",
-            maximum_days_after: "",
-          },
-          cookie,
-          {
-            fieldName: "image",
-            name: "photo.jpg",
-            data: JPEG_HEADER,
-            contentType: "image/jpeg",
-          },
+        const response = await submitCreateImage(
+          cookie, csrfToken, "Image Test Event",
+          { name: "photo.jpg", data: JPEG_HEADER, contentType: "image/jpeg" },
         );
-        const response = await handleRequest(request);
         expect(response.status).toBe(302);
 
         const { getAllEvents } = await import("#lib/db/events.ts");
@@ -388,37 +387,10 @@ describe("server (event images)", () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 
       await withStorageMock(async () => {
-        const request = mockMultipartRequest(
-          "/admin/event",
-          {
-            csrf_token: csrfToken,
-            name: "Bad Image Event",
-            description: "",
-            date_date: "",
-            date_time: "",
-            location: "",
-            max_attendees: "50",
-            max_quantity: "1",
-            fields: "email",
-            thank_you_url: "",
-            unit_price: "",
-            webhook_url: "",
-            closes_at_date: "",
-            closes_at_time: "",
-            event_type: "standard",
-            bookable_days: "Monday,Tuesday,Wednesday,Thursday,Friday",
-            minimum_days_before: "",
-            maximum_days_after: "",
-          },
-          cookie,
-          {
-            fieldName: "image",
-            name: "test.pdf",
-            data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
-            contentType: "application/pdf",
-          },
+        const response = await submitCreateImage(
+          cookie, csrfToken, "Bad Image Event",
+          { name: "test.pdf", data: PDF_BYTES, contentType: "application/pdf" },
         );
-        const response = await handleRequest(request);
         expect(response.status).toBe(302);
         const location = response.headers.get("location") ?? "";
         expect(location).toContain("/admin?image_error=");
@@ -453,8 +425,7 @@ describe("server (event images)", () => {
     });
 
     test("displays image error on event detail page", async () => {
-      const event = await createTestEvent();
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin();
 
       const response = await handleRequest(
         mockRequest(
@@ -471,8 +442,7 @@ describe("server (event images)", () => {
     });
 
     test("does not display image error when query param is absent", async () => {
-      const event = await createTestEvent();
-      const { cookie } = await loginAsAdmin();
+      const { event, cookie } = await setupEventAndLogin();
 
       const response = await handleRequest(
         mockRequest(`/admin/event/${event.id}`, { headers: { cookie } }),
@@ -484,18 +454,11 @@ describe("server (event images)", () => {
 
   describe("POST /admin/event/:id/image/delete", () => {
     test("removes image from event and storage", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
-
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
       await eventsTable.update(event.id, { imageUrl: "to-delete.jpg" });
 
       await withStorageMock(async () => {
-        const request = formPostRequest(
-          `/admin/event/${event.id}/image/delete`,
-          { csrf_token: csrfToken },
-          cookie,
-        );
-        const response = await handleRequest(request);
+        const response = await submitImageDelete(event.id, cookie, csrfToken);
         expect(response.status).toBe(302);
         expect(response.headers.get("location")).toBe(
           `/admin/event/${event.id}`,
@@ -507,15 +470,9 @@ describe("server (event images)", () => {
     });
 
     test("redirects when event has no image", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      const request = formPostRequest(
-        `/admin/event/${event.id}/image/delete`,
-        { csrf_token: csrfToken },
-        cookie,
-      );
-      const response = await handleRequest(request);
+      const response = await submitImageDelete(event.id, cookie, csrfToken);
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe(`/admin/event/${event.id}`);
     });
@@ -523,38 +480,24 @@ describe("server (event images)", () => {
     test("returns 404 for non-existent event", async () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 
-      const request = formPostRequest(
-        "/admin/event/9999/image/delete",
-        { csrf_token: csrfToken },
-        cookie,
-      );
-      const response = await handleRequest(request);
+      const response = await submitImageDelete(9999, cookie, csrfToken);
       expect(response.status).toBe(404);
     });
 
     test("succeeds even when storage delete throws", async () => {
-      const event = await createTestEvent();
-      const { cookie, csrfToken } = await loginAsAdmin();
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
       await eventsTable.update(event.id, { imageUrl: "failing.jpg" });
 
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (): Promise<Response> => {
-        return Promise.reject(new Error("CDN unreachable"));
-      };
-
-      try {
-        const request = formPostRequest(
-          `/admin/event/${event.id}/image/delete`,
-          { csrf_token: csrfToken },
-          cookie,
+      await withFetchMock(async (originalFetch) => {
+        installUrlHandler(originalFetch, () =>
+          Promise.reject(new Error("CDN unreachable")),
         );
-        const response = await handleRequest(request);
+
+        const response = await submitImageDelete(event.id, cookie, csrfToken);
         expect(response.status).toBe(302);
         const updated = await getEventWithCount(event.id);
         expect(updated?.image_url).toBe("");
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+      });
     });
   });
 
@@ -563,114 +506,58 @@ describe("server (event images)", () => {
       const imageData = JPEG_HEADER;
       const encrypted = await encryptBytes(imageData);
 
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (input: string | URL | Request): Promise<Response> => {
-        const url = typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-        if (url.includes("storage.bunnycdn.com")) {
-          return Promise.resolve(
-            // deno-lint-ignore no-explicit-any
-            new Response(encrypted as any, { status: 200 }),
-          );
-        }
-        return originalFetch(input);
-      };
-
-      try {
-        const response = await handleRequest(
-          mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-        );
-        expect(response.status).toBe(200);
-        expect(response.headers.get("content-type")).toBe("image/jpeg");
-        expect(response.headers.get("cache-control")).toContain("immutable");
-        const body = new Uint8Array(await response.arrayBuffer());
-        expect(body).toEqual(imageData);
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+      await withCdnProxy(
+        // deno-lint-ignore no-explicit-any
+        () => new Response(encrypted as any, { status: 200 }),
+        async () => {
+          const response = await proxyRequest();
+          expect(response.status).toBe(200);
+          expect(response.headers.get("content-type")).toBe("image/jpeg");
+          expect(response.headers.get("cache-control")).toContain("immutable");
+          const body = new Uint8Array(await response.arrayBuffer());
+          expect(body).toEqual(imageData);
+        },
+      );
     });
 
     test("returns 404 when file does not exist in storage", async () => {
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (input: string | URL | Request): Promise<Response> => {
-        const url = typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-        if (url.includes("storage.bunnycdn.com")) {
-          return Promise.resolve(new Response("Not Found", { status: 404 }));
-        }
-        return originalFetch(input);
-      };
-
-      try {
-        const response = await handleRequest(
-          mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-        );
-        expect(response.status).toBe(404);
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+      await withCdnProxy(
+        () => new Response("Not Found", { status: 404 }),
+        async () => {
+          expect((await proxyRequest()).status).toBe(404);
+        },
+      );
     });
 
     test("propagates non-404 storage errors as 503", async () => {
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (input: string | URL | Request): Promise<Response> => {
-        const url = typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-        if (url.includes("storage.bunnycdn.com")) {
-          return Promise.resolve(new Response("Unauthorized", { status: 401 }));
-        }
-        return originalFetch(input);
-      };
-
-      try {
-        const response = await handleRequest(
-          mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-        );
-        await expectHtmlResponse(response, 503, "Temporary Error");
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+      await withCdnProxy(
+        () => new Response("Unauthorized", { status: 401 }),
+        async () => {
+          await expectHtmlResponse(await proxyRequest(), 503, "Temporary Error");
+        },
+      );
     });
 
     test("returns 404 for unknown extension", async () => {
-      const response = await handleRequest(
-        mockRequest("/image/abc123-def4-5678-9abc-def012345678.bmp"),
-      );
-      expect(response.status).toBe(404);
+      expect((await proxyRequest("bmp")).status).toBe(404);
     });
 
     test("returns 404 when storage is not enabled", async () => {
       Deno.env.delete("STORAGE_ZONE_NAME");
       Deno.env.delete("STORAGE_ZONE_KEY");
-      const response = await handleRequest(
-        mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-      );
-      expect(response.status).toBe(404);
+      expect((await proxyRequest()).status).toBe(404);
     });
 
     test("returns 404 for non-GET method", async () => {
-      const request = new Request(
-        "http://localhost/image/abc123-def4-5678-9abc-def012345678.jpg",
-        {
-          method: "POST",
-          body: "test",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            host: "localhost",
-          },
+      const request = new Request(`http://localhost${PROXY_PATH}.jpg`, {
+        method: "POST",
+        body: "test",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          host: "localhost",
         },
-      );
-      const response = await handleRequest(request);
-      expect(response.status).toBe(404);
+      });
+      expect((await handleRequest(request)).status).toBe(404);
     });
 
     test("returns 404 for filename without extension", async () => {

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -15,6 +15,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setupEventAndLogin,
   withMocks,
 } from "#test-utils";
 import type { Attendee, Event } from "#lib/types.ts";
@@ -130,8 +131,7 @@ describe("server (admin refunds)", () => {
     });
 
     test("returns 404 for non-existent attendee", async () => {
-      await createTestEvent({ maxAttendees: 100 });
-      const { cookie } = await loginAsAdmin();
+      const { cookie } = await setupEventAndLogin({ maxAttendees: 100 });
       const response = await awaitTestRequest(refundUrl(1, 999), { cookie });
       expect(response.status).toBe(404);
     });

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -16,6 +16,7 @@ import {
   loginAsAdmin,
   resetDb,
   resetTestSlugCounter,
+  setupEventAndLogin,
 } from "#test-utils";
 import { isJsonApiPath } from "#routes/middleware.ts";
 
@@ -304,8 +305,7 @@ describe("QR Scanner", () => {
     });
 
     test("returns not_found for invalid token", async () => {
-      const event = await createTestEvent({ maxAttendees: 10 });
-      const session = await loginAsAdmin();
+      const { event, ...session } = await setupEventAndLogin({ maxAttendees: 10 });
       const response = await handleRequest(
         mockScanRequest(
           event.id,
@@ -338,8 +338,7 @@ describe("QR Scanner", () => {
     });
 
     test("returns 403 for invalid CSRF token", async () => {
-      const event = await createTestEvent({ maxAttendees: 10 });
-      const session = await loginAsAdmin();
+      const { event, ...session } = await setupEventAndLogin({ maxAttendees: 10 });
       const response = await handleRequest(
         mockScanRequest(
           event.id,
@@ -353,8 +352,7 @@ describe("QR Scanner", () => {
     });
 
     test("returns 400 for missing token in body", async () => {
-      const event = await createTestEvent({ maxAttendees: 10 });
-      const session = await loginAsAdmin();
+      const { event, ...session } = await setupEventAndLogin({ maxAttendees: 10 });
       const response = await handleRequest(
         mockScanRequest(event.id, {}, session.cookie, session.csrfToken),
       );
@@ -363,8 +361,7 @@ describe("QR Scanner", () => {
     });
 
     test("returns 403 when x-csrf-token header is absent", async () => {
-      const event = await createTestEvent({ maxAttendees: 10 });
-      const session = await loginAsAdmin();
+      const { event, ...session } = await setupEventAndLogin({ maxAttendees: 10 });
       const response = await handleRequest(
         new Request(`http://localhost/admin/event/${event.id}/scan`, {
           method: "POST",
@@ -381,8 +378,7 @@ describe("QR Scanner", () => {
     });
 
     test("returns 400 for malformed JSON body", async () => {
-      const event = await createTestEvent({ maxAttendees: 10 });
-      const session = await loginAsAdmin();
+      const { event, ...session } = await setupEventAndLogin({ maxAttendees: 10 });
       const response = await handleRequest(
         new Request(`http://localhost/admin/event/${event.id}/scan`, {
           method: "POST",
@@ -404,8 +400,7 @@ describe("QR Scanner", () => {
     test("returns 500 when private key is unavailable", async () => {
       const { getDb } = await import("#lib/db/client.ts");
       const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
-      const event = await createTestEvent({ maxAttendees: 10 });
-      const session = await loginAsAdmin();
+      const { event, ...session } = await setupEventAndLogin({ maxAttendees: 10 });
 
       // Remove wrapped_private_key from settings to make key derivation fail
       await getDb().execute({

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -19,7 +19,6 @@ import { invalidateUsersCache } from "#lib/db/users.ts";
 import {
   awaitTestRequest,
   createTestDbWithSetup,
-  createTestEvent,
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirect,
@@ -29,6 +28,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setupEventAndLogin,
   TEST_ADMIN_PASSWORD,
   withMocks,
 } from "#test-utils";
@@ -776,13 +776,11 @@ describe("server (admin settings)", () => {
 
     test("resets database and redirects to setup on correct phrase", async () => {
       // Create some data first
-      await createTestEvent({
+      const { cookie, csrfToken } = await setupEventAndLogin({
         name: "Test Event",
         maxAttendees: 100,
         thankYouUrl: "https://example.com/thanks",
       });
-
-      const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
         mockFormRequest(

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -17,7 +17,15 @@ import {
 } from "#lib/stripe.ts";
 import { stripePaymentProvider } from "#lib/stripe-provider.ts";
 import { setStripeWebhookConfig, updateStripeKey } from "#lib/db/settings.ts";
-import { createTestDb, resetDb, testEvent, withMocks } from "#test-utils";
+import {
+  createTestDb,
+  installUrlHandler,
+  resetDb,
+  testEvent,
+  urlFromFetchInput,
+  withFetchMock,
+  withMocks,
+} from "#test-utils";
 
 describe("stripe", () => {
   let originalMockHost: string | undefined;
@@ -1068,25 +1076,23 @@ describe("stripe", () => {
 
     test("returns success when endpoint.secret is present", async () => {
       // Wrap fetch to intercept the webhook_endpoints create response and inject a secret
-      const originalFetch = globalThis.fetch;
-      const fetchSpy = spyOn(globalThis, "fetch");
-      fetchSpy.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const response = await originalFetch(input, init);
-        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      await withFetchMock(async (originalFetch) => {
+        globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          const response = await originalFetch(input, init);
+          const url = urlFromFetchInput(input as string | URL | Request);
 
-        // Intercept POST to webhook_endpoints (create) and add secret to response
-        if (url.includes("/v1/webhook_endpoints") && init?.method === "POST") {
-          const body = await response.json();
-          body.secret = "whsec_test_injected_secret";
-          return new Response(JSON.stringify(body), {
-            status: response.status,
-            headers: response.headers,
-          });
-        }
-        return response;
-      });
+          // Intercept POST to webhook_endpoints (create) and add secret to response
+          if (url.includes("/v1/webhook_endpoints") && init?.method === "POST") {
+            const body = await response.json();
+            body.secret = "whsec_test_injected_secret";
+            return new Response(JSON.stringify(body), {
+              status: response.status,
+              headers: response.headers,
+            });
+          }
+          return response;
+        };
 
-      try {
         const result = await setupWebhookEndpoint(
           "sk_test_mock",
           "https://example.com/webhook/success-test",
@@ -1097,19 +1103,14 @@ describe("stripe", () => {
           expect(result.endpointId).toBeDefined();
           expect(result.secret).toBe("whsec_test_injected_secret");
         }
-      } finally {
-        fetchSpy.mockRestore();
-      }
+      });
     });
 
     test("returns error when createStripeClient or API call throws", async () => {
-      // Mock fetch to throw on all requests, exercising the outer catch block (lines 388-392)
-      const fetchSpy = spyOn(globalThis, "fetch");
-      fetchSpy.mockImplementation(() => {
-        throw new Error("Network unavailable");
-      });
+      // Mock fetch to throw on all requests, exercising the outer catch block
+      await withFetchMock(async () => {
+        globalThis.fetch = () => { throw new Error("Network unavailable"); };
 
-      try {
         const result = await setupWebhookEndpoint(
           "sk_test_mock",
           "https://example.com/webhook/error-test",
@@ -1121,26 +1122,19 @@ describe("stripe", () => {
           expect(typeof result.error).toBe("string");
           expect(result.error!.length > 0).toBe(true);
         }
-      } finally {
-        fetchSpy.mockRestore();
-      }
+      });
     });
 
     test("catches error when deleting existing endpoint ID fails", async () => {
       // Mock fetch so that ALL DELETE requests throw (Stripe SDK retries, so we must fail all)
-      const originalFetch = globalThis.fetch;
-      const fetchSpy = spyOn(globalThis, "fetch");
-      fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const method = init?.method ?? "GET";
-        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-        // Fail all DELETE requests for the specific endpoint to bypass SDK retries
-        if (method === "DELETE" && url.includes("we_should_fail_to_delete")) {
-          throw new Error("Delete failed");
-        }
-        return originalFetch(input, init);
-      });
+      await withFetchMock(async (originalFetch) => {
+        installUrlHandler(originalFetch, (url, init) => {
+          if ((init?.method ?? "GET") === "DELETE" && url.includes("we_should_fail_to_delete")) {
+            throw new Error("Delete failed");
+          }
+          return null;
+        });
 
-      try {
         const result = await setupWebhookEndpoint(
           "sk_test_mock",
           "https://example.com/webhook/delete-error-test-unique",
@@ -1150,26 +1144,19 @@ describe("stripe", () => {
         // The function should continue past the failed delete and still attempt to create
         expect(result).toBeDefined();
         expect(typeof result.success).toBe("boolean");
-      } finally {
-        fetchSpy.mockRestore();
-      }
+      });
     });
 
     test("returns error when list endpoints throws", async () => {
       // Mock fetch so that the list call (GET) throws, exercising the outer catch
-      const originalFetch = globalThis.fetch;
-      const fetchSpy = spyOn(globalThis, "fetch");
-      fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-        const method = init?.method ?? "GET";
-        // The Stripe SDK sends GET for list. Intercept GET requests to webhook_endpoints
-        if (method === "GET" && url.includes("/v1/webhook_endpoints")) {
-          throw new Error("List endpoints failed");
-        }
-        return originalFetch(input, init);
-      });
+      await withFetchMock(async (originalFetch) => {
+        installUrlHandler(originalFetch, (url, init) => {
+          if ((init?.method ?? "GET") === "GET" && url.includes("/v1/webhook_endpoints")) {
+            throw new Error("List endpoints failed");
+          }
+          return null;
+        });
 
-      try {
         const result = await setupWebhookEndpoint(
           "sk_test_mock",
           "https://example.com/webhook/list-error-test",
@@ -1181,19 +1168,14 @@ describe("stripe", () => {
           expect(typeof result.error).toBe("string");
           expect(result.error!.length > 0).toBe(true);
         }
-      } finally {
-        fetchSpy.mockRestore();
-      }
+      });
     });
 
     test("returns stringified error when non-Error is thrown", async () => {
       // Mock fetch to throw a string (not an Error) to hit the String(err) path
-      const fetchSpy = spyOn(globalThis, "fetch");
-      fetchSpy.mockImplementation(() => {
-        throw "string_error"; // non-Error value
-      });
+      await withFetchMock(async () => {
+        globalThis.fetch = () => { throw "string_error"; }; // non-Error value
 
-      try {
         const result = await setupWebhookEndpoint(
           "sk_test_mock",
           "https://example.com/webhook/non-error-throw",
@@ -1205,9 +1187,7 @@ describe("stripe", () => {
           expect(typeof result.error).toBe("string");
           expect(result.error!.length > 0).toBe(true);
         }
-      } finally {
-        fetchSpy.mockRestore();
-      }
+      });
     });
   });
 

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -46,6 +46,7 @@ import {
   testRequest,
   updateTestEvent,
   updateTestGroup,
+  urlFromFetchInput,
   wait,
 } from "#test-utils";
 
@@ -1222,6 +1223,24 @@ describe("test-compat", () => {
       expect(Date.now()).toBe(5000);
       jest.useRealTimers();
       expect(Date.now()).toBeGreaterThanOrEqual(realNow);
+    });
+  });
+
+  describe("urlFromFetchInput", () => {
+    test("returns string input unchanged", () => {
+      expect(urlFromFetchInput("https://example.com/path")).toBe(
+        "https://example.com/path",
+      );
+    });
+
+    test("converts URL object to string", () => {
+      const url = new URL("https://example.com/path");
+      expect(urlFromFetchInput(url)).toBe("https://example.com/path");
+    });
+
+    test("extracts url from Request object", () => {
+      const request = new Request("https://example.com/path");
+      expect(urlFromFetchInput(request)).toBe("https://example.com/path");
     });
   });
 });


### PR DESCRIPTION
Refactored the worst jscpd offender (45 → 21 clones) using:
- bracket from #fp for safe fetch mock save/restore
- installUrlHandler to eliminate repeated fetch signature patterns
- Extracted helpers: submitEditJpeg, submitImageDelete, submitCreateImage,
  setupEventAndLogin, expectImageErrorRedirect, withCdnProxy, proxyRequest
- Replaced local formPostRequest with mockFormRequest from #test-utils
- Consolidated constants: PROXY_PATH, PDF_BYTES, cdnOkResponse

https://claude.ai/code/session_01SPRmcnT1sq5iftSgfSxX1w