### PR TITLE
Fix swapped "Attendees Checked In" and "Tickets Checked In" labels

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -290,7 +290,7 @@ export const adminEventPage = ({
               {hasMultiQuantity ? (
                 <>
                   <tr>
-                    <th>Attendees Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
+                    <th>Tickets Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
                     <td>
                       <span>
                         {attendeesCheckedIn} / {completeAttendees.length} &mdash; {attendeesCheckedInRemaining} remain
@@ -298,7 +298,7 @@ export const adminEventPage = ({
                     </td>
                   </tr>
                   <tr>
-                    <th>Tickets Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
+                    <th>Attendees Checked In{isDaily ? dateFilter ? ` (${formatDateLabel(dateFilter)})` : " (total)" : ""}</th>
                     <td>
                       <span>
                         {ticketsCheckedIn} / {completeQuantitySum} &mdash; {ticketsCheckedInRemaining} remain

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -231,11 +231,11 @@ export const adminGroupDetailPage = (
               {hasMultiQuantity ? (
                 <>
                   <tr>
-                    <th>Attendees Checked In</th>
+                    <th>Tickets Checked In</th>
                     <td>{attendeesCheckedIn} / {attendees.length} &mdash; {attendeesCheckedInRemaining} remain</td>
                   </tr>
                   <tr>
-                    <th>Tickets Checked In</th>
+                    <th>Attendees Checked In</th>
                     <td>{ticketsCheckedIn} / {attendeeQuantitySum} &mdash; {ticketsCheckedInRemaining} remain</td>
                   </tr>
                 </>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -230,12 +230,12 @@ describe("html", () => {
         testAttendee({ id: 2, checked_in: false, quantity: 3 }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
-      // Attendees Checked In: 1 row / 2 rows, 1 remain
-      expect(html).toContain("Attendees Checked In");
+      // Tickets Checked In: 1 row / 2 rows, 1 remain
+      expect(html).toContain("Tickets Checked In");
       expect(html).toContain("1 / 2");
       expect(html).toContain("1 remain");
-      // Tickets Checked In: 2 qty / 5 total qty, 3 remain
-      expect(html).toContain("Tickets Checked In");
+      // Attendees Checked In: 2 qty / 5 total qty, 3 remain
+      expect(html).toContain("Attendees Checked In");
       expect(html).toContain("2 / 5");
       expect(html).toContain("3 remain");
     });

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -456,7 +456,7 @@ describe("server (admin groups)", () => {
       const html = await response.text();
       expect(html).toContain("Attendees Checked In");
       expect(html).toContain("Tickets Checked In");
-      // 0 / 2 attendees checked in, 0 / 4 tickets checked in
+      // 0 / 2 tickets checked in, 0 / 4 attendees checked in
       expect(html).toContain("0 / 2");
       expect(html).toContain("0 / 4");
     });


### PR DESCRIPTION
Database "attendees" (rows) map to customer-facing "tickets", and
database "quantity" maps to customer-facing "attendees". The labels
were the wrong way around in both event and group detail tables.

https://claude.ai/code/session_01NfENfrUdVN2xhpHGhw9nji