### PR TITLE
Add header image support to settings page and layout

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -62,6 +62,8 @@ export const CONFIG_KEYS = {
   CONTACT_PAGE_TEXT: "contact_page_text",
   // Phone prefix (plaintext - country calling code, e.g. "44")
   PHONE_PREFIX: "phone_prefix",
+  // Header image (encrypted - Bunny CDN filename)
+  HEADER_IMAGE_URL: "header_image_url",
 } as const;
 
 /**
@@ -728,6 +730,15 @@ export const updatePhonePrefix = async (prefix: string): Promise<void> => {
   await setSetting(CONFIG_KEYS.PHONE_PREFIX, prefix);
 };
 
+/** Get header image URL from database (decrypted). Returns null if not set. */
+export const getHeaderImageUrlFromDb = (): Promise<string | null> =>
+  getEncryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL);
+
+/** Update header image URL (encrypted at rest). Pass empty string to clear. */
+export const updateHeaderImageUrl = async (url: string): Promise<void> => {
+  await updateEncryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL, url);
+};
+
 /**
  * Stubbable API for testing - allows mocking in ES modules
  * Use spyOn(settingsApi, "method") instead of spyOn(settingsModule, "method")
@@ -783,4 +794,6 @@ export const settingsApi = {
   updateContactPageText,
   getPhonePrefixFromDb,
   updatePhonePrefix,
+  getHeaderImageUrlFromDb,
+  updateHeaderImageUrl,
 };

--- a/src/lib/header-image.ts
+++ b/src/lib/header-image.ts
@@ -1,0 +1,35 @@
+/**
+ * Header image state for sync access by JSX templates
+ *
+ * The header image URL is loaded from settings and stored for sync access
+ * by the Layout component. Called once per request in routes/index.ts
+ * before templates render.
+ */
+
+import { getHeaderImageUrlFromDb } from "#lib/db/settings.ts";
+
+/** Sync-accessible header image URL, populated by loadHeaderImage() */
+const state = { url: null as string | null };
+
+/**
+ * Load header image URL from settings into sync-accessible state.
+ * Called once per request in routes/index.ts before templates render.
+ * Settings are already cached so this is cheap on repeat calls.
+ */
+export const loadHeaderImage = async (): Promise<string | null> => {
+  state.url = await getHeaderImageUrlFromDb();
+  return state.url;
+};
+
+/** Get the current header image URL, or null if not set */
+export const getHeaderImageUrl = (): string | null => state.url;
+
+/** For testing: set the header image URL directly */
+export const setHeaderImageForTest = (url: string | null): void => {
+  state.url = url;
+};
+
+/** For testing: reset the header image state */
+export const resetHeaderImage = (): void => {
+  state.url = null;
+};

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -8,6 +8,7 @@
 import * as BunnyStorageSDK from "@bunny.net/storage-sdk";
 import { decryptBytes, encryptBytes } from "#lib/crypto.ts";
 import { getEnv, requireEnv } from "#lib/env.ts";
+import { ErrorCode, logError } from "#lib/logger.ts";
 
 /** Maximum image file size in bytes (256KB) */
 const MAX_IMAGE_SIZE = 256 * 1024;
@@ -94,6 +95,26 @@ export const validateImage = (
   }
 
   return { valid: true, detectedType };
+};
+
+/** User-facing messages for image validation errors */
+export const IMAGE_ERROR_MESSAGES: Record<ImageValidationError, string> = {
+  too_large: "Image exceeds the 256KB size limit",
+  invalid_type: "Image must be a JPEG, PNG, GIF, or WebP file",
+  invalid_content: "File does not appear to be a valid image",
+};
+
+/** Try to delete an image from CDN storage, logging errors on failure */
+export const tryDeleteImage = async (
+  filename: string,
+  detail: string,
+  eventId?: number,
+): Promise<void> => {
+  try {
+    await deleteImage(filename);
+  } catch {
+    logError({ code: ErrorCode.STORAGE_DELETE, detail, eventId });
+  }
 };
 
 /** Generate a random filename with the correct extension */

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -11,7 +11,6 @@ import {
   getEventWithActivityLog,
   logActivity,
 } from "#lib/db/activityLog.ts";
-import { ErrorCode, logError } from "#lib/logger.ts";
 import { deleteAllStaleReservations } from "#lib/db/processed-payments.ts";
 import {
   computeSlugIndex,
@@ -52,23 +51,18 @@ import {
   type AttendeeFilter,
 } from "#templates/admin/events.tsx";
 import {
-  deleteImage,
-  type ImageValidationError,
+  IMAGE_ERROR_MESSAGES,
   isStorageEnabled,
+  tryDeleteImage as tryDeleteImageBase,
   uploadImage,
   validateImage,
 } from "#lib/storage.ts";
 import { generateAttendeesCsv } from "#templates/csv.ts";
 import { eventFields, groupIdField, slugField } from "#templates/fields.ts";
 
-/** Try to delete an image from CDN storage, logging errors on failure */
-const tryDeleteImage = async (filename: string, eventId: number, detail: string): Promise<void> => {
-  try {
-    await deleteImage(filename);
-  } catch {
-    logError({ code: ErrorCode.STORAGE_DELETE, eventId, detail });
-  }
-};
+/** Try to delete an event image from CDN storage, logging errors with event ID */
+const tryDeleteImage = (filename: string, eventId: number, detail: string): Promise<void> =>
+  tryDeleteImageBase(filename, detail, eventId);
 
 /** Generate a unique event slug, retrying on collision */
 const generateUniqueEventSlug = (excludeEventId?: number) =>
@@ -135,13 +129,6 @@ const eventsResource = defineResource({
   nameField: "name",
   validate: validateGroupExists,
 });
-
-/** User-facing messages for image validation errors */
-const IMAGE_ERROR_MESSAGES: Record<ImageValidationError, string> = {
-  too_large: "Image exceeds the 256KB size limit",
-  invalid_type: "Image must be a JPEG, PNG, GIF, or WebP file",
-  invalid_content: "File does not appear to be a valid image",
-};
 
 /** Process image from multipart form and attach to event. Returns error message if validation fails. */
 const processFormImage = async (

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -7,6 +7,7 @@ import { logActivity } from "#lib/db/activityLog.ts";
 import {
   clearPaymentProvider,
   getEmbedHostsFromDb,
+  getHeaderImageUrlFromDb,
   getPaymentProviderFromDb,
   getPhonePrefixFromDb,
   getShowPublicSiteFromDb,
@@ -21,6 +22,7 @@ import {
   setPaymentProvider,
   setStripeWebhookConfig,
   updateEmbedHosts,
+  updateHeaderImageUrl,
   updatePhonePrefix,
   updateShowPublicSite,
   updateSquareAccessToken,
@@ -45,6 +47,13 @@ import { getUserById, verifyUserPassword } from "#lib/db/users.ts";
 import { validateForm } from "#lib/forms.tsx";
 import { setupWebhookEndpoint, testStripeConnection } from "#lib/stripe.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
+import {
+  IMAGE_ERROR_MESSAGES,
+  isStorageEnabled,
+  tryDeleteImage,
+  uploadImage,
+  validateImage,
+} from "#lib/storage.ts";
 import { clearSessionCookie } from "#lib/cookies.ts";
 import { defineRoutes } from "#routes/router.ts";
 import {
@@ -56,6 +65,7 @@ import {
   redirectWithSuccess,
   requireOwnerOr,
   withOwnerAuthForm,
+  withOwnerAuthMultipartForm,
 } from "#routes/utils.ts";
 import { adminSettingsPage } from "#templates/admin/settings.tsx";
 import {
@@ -91,6 +101,8 @@ const getSettingsPageState = async () => {
   const theme = await getThemeFromDb();
   const showPublicSite = await getShowPublicSiteFromDb();
   const phonePrefix = await getPhonePrefixFromDb();
+  const headerImageUrl = await getHeaderImageUrlFromDb();
+  const storageEnabled = isStorageEnabled();
   return {
     stripeKeyConfigured,
     paymentProvider,
@@ -105,6 +117,8 @@ const getSettingsPageState = async () => {
     theme,
     showPublicSite,
     phonePrefix,
+    headerImageUrl,
+    storageEnabled,
   };
 };
 
@@ -132,6 +146,8 @@ const renderSettingsPage = async (
     state.theme,
     state.showPublicSite,
     state.phonePrefix,
+    state.headerImageUrl,
+    state.storageEnabled,
   );
 };
 
@@ -483,6 +499,52 @@ const processPhonePrefixForm: SettingsFormHandler = async (form, errorPage) => {
 /** Handle POST /admin/settings/phone-prefix - owner only */
 const handlePhonePrefixPost = settingsRoute(processPhonePrefixForm);
 
+/** Handle POST /admin/settings/header-image - owner only (multipart) */
+const handleHeaderImagePost = (request: Request): Promise<Response> =>
+  withOwnerAuthMultipartForm(request, async (session, formData) => {
+    if (!isStorageEnabled()) {
+      const html = await renderSettingsPage(session, "Image storage is not configured", "");
+      return htmlResponse(html, 400);
+    }
+
+    const entry = formData.get("header_image");
+    if (!(entry instanceof File) || entry.size === 0) {
+      const html = await renderSettingsPage(session, "No image file provided", "");
+      return htmlResponse(html, 400);
+    }
+
+    const data = new Uint8Array(await entry.arrayBuffer());
+    const validation = validateImage(data, entry.type);
+    if (!validation.valid) {
+      const html = await renderSettingsPage(session, IMAGE_ERROR_MESSAGES[validation.error], "");
+      return htmlResponse(html, 400);
+    }
+
+    // Delete old header image if one exists
+    const existingUrl = await getHeaderImageUrlFromDb();
+    if (existingUrl) {
+      await tryDeleteImage(existingUrl, `header image: ${existingUrl}`);
+    }
+
+    const filename = await uploadImage(data, validation.detectedType);
+    await updateHeaderImageUrl(filename);
+    await logActivity("Header image uploaded");
+    return redirectWithSuccess("/admin/settings", "Header image uploaded");
+  });
+
+/** Handle POST /admin/settings/header-image/delete - owner only */
+const handleHeaderImageDeletePost = settingsRoute(async (_form, errorPage) => {
+  const existingUrl = await getHeaderImageUrlFromDb();
+  if (!existingUrl) {
+    return errorPage("No header image to remove", 400);
+  }
+
+  await tryDeleteImage(existingUrl, `header image: ${existingUrl}`);
+  await updateHeaderImageUrl("");
+  await logActivity("Header image removed");
+  return redirectWithSuccess("/admin/settings", "Header image removed");
+});
+
 /**
  * Expected confirmation phrase for database reset
  */
@@ -524,5 +586,7 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/theme": handleThemePost,
   "POST /admin/settings/show-public-site": handleShowPublicSitePost,
   "POST /admin/settings/phone-prefix": handlePhonePrefixPost,
+  "POST /admin/settings/header-image": handleHeaderImagePost,
+  "POST /admin/settings/header-image/delete": handleHeaderImageDeletePost,
   "POST /admin/settings/reset-database": handleResetDatabasePost,
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@
 import { once } from "#fp";
 import { isSetupComplete } from "#lib/config.ts";
 import { loadCurrencyCode } from "#lib/currency.ts";
+import { loadHeaderImage } from "#lib/header-image.ts";
 import { loadTheme } from "#lib/theme.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { createRequestTimer, ErrorCode, logError, logRequest, runWithRequestId } from "#lib/logger.ts";
@@ -189,6 +190,7 @@ const handleRequestInternal = async (
 
   await loadCurrencyCode();
   await loadTheme();
+  await loadHeaderImage();
   return (await routeMainApp(request, path, method, server))!;
 };
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -517,6 +517,16 @@ export const withAuthMultipartForm = async (
   return handler(session, formData);
 };
 
+/** Handle multipart form request with owner auth + CSRF validation. */
+export const withOwnerAuthMultipartForm = (
+  request: Request,
+  handler: MultipartFormHandler,
+): Promise<Response> =>
+  withAuthMultipartForm(request, (session, formData) => {
+    if (session.adminLevel !== "owner") return htmlResponse("Forbidden", 403);
+    return handler(session, formData);
+  });
+
 /** Create JSON response */
 export const jsonResponse = (data: unknown, status = 200): Response =>
   new Response(encodeBody(JSON.stringify(data)), {

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -995,6 +995,13 @@ form:has(select[name="event_type"] option[value="daily"]:checked) > label:has([n
   margin-bottom: 0.5rem;
 }
 
+/* Header image */
+.header-image {
+  max-width: 100%;
+  display: block;
+  margin: 0 auto 3rem;
+}
+
 /* Secondary button */
 button.secondary {
   --color-secondary: #6c757d;

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { getImageProxyUrl } from "#lib/storage.ts";
 import type { AdminSession } from "#lib/types.ts";
 import {
   changePasswordFields,
@@ -34,6 +35,8 @@ export const adminSettingsPage = (
   theme?: string,
   showPublicSite?: boolean,
   phonePrefix?: string,
+  headerImageUrl?: string | null,
+  storageEnabled?: boolean,
 ): string =>
   String(
     <Layout title="Settings" theme={theme}>
@@ -53,6 +56,31 @@ export const adminSettingsPage = (
           </select>
           <button type="submit">Save Timezone</button>
         </CsrfForm>
+
+        {storageEnabled && (
+        <div>
+          <h2>Header Image</h2>
+          <p>An optional image displayed at the top of every page. JPEG, PNG, GIF, or WebP — max 256KB.</p>
+          {headerImageUrl && (
+            <div>
+              <img src={getImageProxyUrl(headerImageUrl)} alt="Header image" class="event-image-preview" />
+              <CsrfForm action="/admin/settings/header-image/delete">
+                <button type="submit">Remove Image</button>
+              </CsrfForm>
+            </div>
+          )}
+          <CsrfForm action="/admin/settings/header-image" enctype="multipart/form-data">
+            <label for="header_image">{headerImageUrl ? "Replace Image" : "Upload Image"}</label>
+            <input
+              type="file"
+              id="header_image"
+              name="header_image"
+              accept="image/jpeg,image/png,image/gif,image/webp"
+            />
+            <button type="submit">Upload</button>
+          </CsrfForm>
+        </div>
+        )}
 
         <CsrfForm action="/admin/settings/phone-prefix">
             <h2>Phone Prefix</h2>

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -4,6 +4,8 @@
 
 import { type Child, Raw, SafeHtml } from "#jsx/jsx-runtime.ts";
 import { CSS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, JS_PATH } from "#src/config/asset-paths.ts";
+import { getHeaderImageUrl } from "#lib/header-image.ts";
+import { getImageProxyUrl } from "#lib/storage.ts";
 import { getTheme } from "#lib/theme.ts";
 import { renderDebugFooter } from "#templates/admin/footer.tsx";
 
@@ -27,6 +29,7 @@ interface LayoutProps {
  */
 export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutProps): SafeHtml => {
   const resolvedTheme = theme ?? getTheme();
+  const headerImage = getHeaderImageUrl();
 
   return new SafeHtml(
     "<!DOCTYPE html>" +
@@ -41,6 +44,7 @@ export const Layout = ({ title, bodyClass, headExtra, children, theme }: LayoutP
         </head>
         <body class={bodyClass || undefined}>
           <main>
+            {headerImage && <img src={getImageProxyUrl(headerImage)} alt="" class="header-image" />}
             {children}
           </main>
           {bodyClass?.includes("iframe") && <script src={IFRAME_RESIZER_CHILD_JS_PATH}></script>}

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -264,6 +264,9 @@ describe("code quality", () => {
       // Reset cached theme between tests
       "lib/theme.ts:setThemeForTest",
       "lib/theme.ts:resetTheme",
+      // Reset cached header image between tests
+      "lib/header-image.ts:setHeaderImageForTest",
+      "lib/header-image.ts:resetHeaderImage",
       // Token format check used by CSRF tests (production verifies via verifySignedCsrfToken)
       "lib/csrf.ts:isSignedCsrfToken",
       // Response cookie helper used by auth tests (production sets cookies directly)

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -1,0 +1,538 @@
+import { afterEach, beforeEach, describe, expect, test } from "#test-compat";
+import {
+  getHeaderImageUrl,
+  loadHeaderImage,
+  resetHeaderImage,
+  setHeaderImageForTest,
+} from "#lib/header-image.ts";
+import {
+  getHeaderImageUrlFromDb,
+  updateHeaderImageUrl,
+} from "#lib/db/settings.ts";
+import { handleRequest } from "#routes";
+import { encrypt, encryptBytes } from "#lib/crypto.ts";
+import { getDb } from "#lib/db/client.ts";
+import { createSession } from "#lib/db/sessions.ts";
+import { invalidateUsersCache } from "#lib/db/users.ts";
+import { getSessionCookieName } from "#lib/cookies.ts";
+import {
+  createTestDbWithSetup,
+  expectHtmlResponse,
+  loginAsAdmin,
+  mockMultipartRequest,
+  mockRequest,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+/** JPEG magic bytes for a valid test image */
+const JPEG_HEADER = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
+
+/** Create a form POST request with cookie */
+const formPostRequest = (
+  path: string,
+  data: Record<string, string>,
+  cookie: string,
+): Request => {
+  const body = new URLSearchParams(data).toString();
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    body,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      cookie,
+      host: "localhost",
+    },
+  });
+};
+
+/** Mock fetch to intercept Bunny CDN API calls */
+const withStorageMock = async (
+  fn: (fetchCalls: string[]) => Promise<void>,
+): Promise<void> => {
+  const originalFetch = globalThis.fetch;
+  const fetchCalls: string[] = [];
+  globalThis.fetch = (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    fetchCalls.push(url);
+    if (url.includes("storage.bunnycdn.com") || url.includes("b-cdn.net")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ HttpCode: 201, Message: "OK" }), {
+          status: 201,
+        }),
+      );
+    }
+    return originalFetch(input, init);
+  };
+
+  try {
+    await fn(fetchCalls);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+};
+
+describe("header image", () => {
+  afterEach(() => {
+    resetHeaderImage();
+  });
+
+  describe("getHeaderImageUrl", () => {
+    test("defaults to null", () => {
+      expect(getHeaderImageUrl()).toBeNull();
+    });
+
+    test("returns value set by setHeaderImageForTest", () => {
+      setHeaderImageForTest("test-image.jpg");
+      expect(getHeaderImageUrl()).toBe("test-image.jpg");
+    });
+  });
+
+  describe("resetHeaderImage", () => {
+    test("resets to null after being set", () => {
+      setHeaderImageForTest("test-image.jpg");
+      resetHeaderImage();
+      expect(getHeaderImageUrl()).toBeNull();
+    });
+  });
+
+  describe("loadHeaderImage", () => {
+    beforeEach(async () => {
+      resetTestSlugCounter();
+      await createTestDbWithSetup();
+      resetHeaderImage();
+    });
+
+    afterEach(() => {
+      resetDb();
+    });
+
+    test("returns null when no header image is set", async () => {
+      const url = await loadHeaderImage();
+      expect(url).toBeNull();
+    });
+
+    test("returns filename after updating database", async () => {
+      await updateHeaderImageUrl("my-header.jpg");
+      const url = await loadHeaderImage();
+      expect(url).toBe("my-header.jpg");
+    });
+
+    test("makes header image available via getHeaderImageUrl after loading", async () => {
+      await updateHeaderImageUrl("my-header.png");
+      await loadHeaderImage();
+      expect(getHeaderImageUrl()).toBe("my-header.png");
+    });
+
+    test("returns null after clearing header image", async () => {
+      await updateHeaderImageUrl("my-header.jpg");
+      await updateHeaderImageUrl("");
+      const url = await loadHeaderImage();
+      expect(url).toBeNull();
+    });
+  });
+});
+
+describe("header image settings DB", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  test("getHeaderImageUrlFromDb returns null when not set", async () => {
+    const url = await getHeaderImageUrlFromDb();
+    expect(url).toBeNull();
+  });
+
+  test("getHeaderImageUrlFromDb returns decrypted filename after update", async () => {
+    await updateHeaderImageUrl("abc123.jpg");
+    const url = await getHeaderImageUrlFromDb();
+    expect(url).toBe("abc123.jpg");
+  });
+
+  test("updateHeaderImageUrl with empty string clears the setting", async () => {
+    await updateHeaderImageUrl("abc123.jpg");
+    await updateHeaderImageUrl("");
+    const url = await getHeaderImageUrlFromDb();
+    expect(url).toBeNull();
+  });
+});
+
+describe("server (header image settings)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    resetHeaderImage();
+    await createTestDbWithSetup();
+    Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+    Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+  });
+
+  afterEach(() => {
+    resetDb();
+    resetHeaderImage();
+    Deno.env.delete("STORAGE_ZONE_NAME");
+    Deno.env.delete("STORAGE_ZONE_KEY");
+  });
+
+  describe("GET /admin/settings (header image section)", () => {
+    test("shows header image section when storage is enabled", async () => {
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/settings", { headers: { cookie } }),
+      );
+      await expectHtmlResponse(response, 200, "Header Image");
+    });
+
+    test("hides header image section when storage is disabled", async () => {
+      Deno.env.delete("STORAGE_ZONE_NAME");
+      Deno.env.delete("STORAGE_ZONE_KEY");
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/settings", { headers: { cookie } }),
+      );
+      const html = await response.text();
+      expect(html).not.toContain("Header Image");
+    });
+
+    test("shows remove button when header image is set", async () => {
+      await updateHeaderImageUrl("existing.jpg");
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/settings", { headers: { cookie } }),
+      );
+      await expectHtmlResponse(response, 200, "Remove Image", "/image/existing.jpg");
+    });
+
+    test("shows upload button when no header image exists", async () => {
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/settings", { headers: { cookie } }),
+      );
+      await expectHtmlResponse(response, 200, "Upload Image");
+    });
+  });
+
+  describe("POST /admin/settings/header-image", () => {
+    test("uploads header image successfully", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withStorageMock(async () => {
+        const request = mockMultipartRequest(
+          "/admin/settings/header-image",
+          { csrf_token: csrfToken },
+          cookie,
+          {
+            fieldName: "header_image",
+            name: "logo.jpg",
+            data: JPEG_HEADER,
+            contentType: "image/jpeg",
+          },
+        );
+        const response = await handleRequest(request);
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toContain("/admin/settings");
+
+        const url = await getHeaderImageUrlFromDb();
+        expect(url).not.toBeNull();
+        expect(url).toMatch(/\.jpg$/);
+      });
+    });
+
+    test("rejects invalid image type", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withStorageMock(async () => {
+        const request = mockMultipartRequest(
+          "/admin/settings/header-image",
+          { csrf_token: csrfToken },
+          cookie,
+          {
+            fieldName: "header_image",
+            name: "doc.pdf",
+            data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+            contentType: "application/pdf",
+          },
+        );
+        const response = await handleRequest(request);
+        await expectHtmlResponse(response, 400, "JPEG, PNG, GIF, or WebP");
+      });
+    });
+
+    test("rejects oversized image", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const oversized = new Uint8Array(257 * 1024);
+      oversized[0] = 0xFF;
+      oversized[1] = 0xD8;
+      oversized[2] = 0xFF;
+
+      await withStorageMock(async () => {
+        const request = mockMultipartRequest(
+          "/admin/settings/header-image",
+          { csrf_token: csrfToken },
+          cookie,
+          {
+            fieldName: "header_image",
+            name: "big.jpg",
+            data: oversized,
+            contentType: "image/jpeg",
+          },
+        );
+        const response = await handleRequest(request);
+        await expectHtmlResponse(response, 400, "256KB");
+      });
+    });
+
+    test("returns 403 for non-owner admin", async () => {
+      const { hmacHash } = await import("#lib/crypto.ts");
+      const managerIdx = await hmacHash("headerimgmgr");
+      await getDb().execute({
+        sql:
+          `INSERT INTO users (username_hash, username_index, password_hash, wrapped_data_key, admin_level)
+              VALUES (?, ?, ?, ?, ?)`,
+        args: [
+          await encrypt("headerimgmgr"),
+          managerIdx,
+          "",
+          null,
+          await encrypt("manager"),
+        ],
+      });
+      invalidateUsersCache();
+
+      await createSession(
+        "mgr-header-session",
+        "mgr-header-csrf",
+        Date.now() + 3600000,
+        null,
+        2,
+      );
+
+      const { signCsrfToken } = await import("#lib/csrf.ts");
+      const signedCsrf = await signCsrfToken();
+      const request = mockMultipartRequest(
+        "/admin/settings/header-image",
+        { csrf_token: signedCsrf },
+        `${getSessionCookieName()}=mgr-header-session`,
+        {
+          fieldName: "header_image",
+          name: "logo.jpg",
+          data: JPEG_HEADER,
+          contentType: "image/jpeg",
+        },
+      );
+      const response = await handleRequest(request);
+      expect(response.status).toBe(403);
+    });
+
+    test("rejects request with no file", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const request = mockMultipartRequest(
+        "/admin/settings/header-image",
+        { csrf_token: csrfToken },
+        cookie,
+      );
+      const response = await handleRequest(request);
+      await expectHtmlResponse(response, 400, "No image file provided");
+    });
+
+    test("returns error when storage is not configured", async () => {
+      Deno.env.delete("STORAGE_ZONE_NAME");
+      Deno.env.delete("STORAGE_ZONE_KEY");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const request = mockMultipartRequest(
+        "/admin/settings/header-image",
+        { csrf_token: csrfToken },
+        cookie,
+        {
+          fieldName: "header_image",
+          name: "logo.jpg",
+          data: JPEG_HEADER,
+          contentType: "image/jpeg",
+        },
+      );
+      const response = await handleRequest(request);
+      await expectHtmlResponse(response, 400, "Image storage is not configured");
+    });
+
+    test("deletes old header image when uploading new one", async () => {
+      await updateHeaderImageUrl("old-header.jpg");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withStorageMock(async (fetchCalls) => {
+        const request = mockMultipartRequest(
+          "/admin/settings/header-image",
+          { csrf_token: csrfToken },
+          cookie,
+          {
+            fieldName: "header_image",
+            name: "new-logo.jpg",
+            data: JPEG_HEADER,
+            contentType: "image/jpeg",
+          },
+        );
+        const response = await handleRequest(request);
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toContain("/admin/settings");
+
+        const deleteCall = fetchCalls.find((url) =>
+          url.includes("old-header.jpg")
+        );
+        expect(deleteCall).not.toBeUndefined();
+
+        const url = await getHeaderImageUrlFromDb();
+        expect(url).toMatch(/\.jpg$/);
+        expect(url).not.toBe("old-header.jpg");
+      });
+    });
+
+    test("rejects mismatched magic bytes", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withStorageMock(async () => {
+        const request = mockMultipartRequest(
+          "/admin/settings/header-image",
+          { csrf_token: csrfToken },
+          cookie,
+          {
+            fieldName: "header_image",
+            name: "fake.jpg",
+            data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            contentType: "image/jpeg",
+          },
+        );
+        const response = await handleRequest(request);
+        await expectHtmlResponse(response, 400, "valid image");
+      });
+    });
+  });
+
+  describe("POST /admin/settings/header-image/delete", () => {
+    test("removes header image", async () => {
+      await updateHeaderImageUrl("to-delete.jpg");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await withStorageMock(async () => {
+        const request = formPostRequest(
+          "/admin/settings/header-image/delete",
+          { csrf_token: csrfToken },
+          cookie,
+        );
+        const response = await handleRequest(request);
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toContain("/admin/settings");
+
+        const url = await getHeaderImageUrlFromDb();
+        expect(url).toBeNull();
+      });
+    });
+
+    test("returns error when no header image exists", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const request = formPostRequest(
+        "/admin/settings/header-image/delete",
+        { csrf_token: csrfToken },
+        cookie,
+      );
+      const response = await handleRequest(request);
+      await expectHtmlResponse(response, 400, "No header image to remove");
+    });
+
+    test("succeeds even when storage delete throws", async () => {
+      await updateHeaderImageUrl("failing.jpg");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (): Promise<Response> => {
+        return Promise.reject(new Error("CDN unreachable"));
+      };
+
+      try {
+        const request = formPostRequest(
+          "/admin/settings/header-image/delete",
+          { csrf_token: csrfToken },
+          cookie,
+        );
+        const response = await handleRequest(request);
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toContain("/admin/settings");
+
+        const url = await getHeaderImageUrlFromDb();
+        expect(url).toBeNull();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  describe("header image in layout", () => {
+    test("renders header image in page when set", async () => {
+      await updateHeaderImageUrl("my-header.jpg");
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/settings", { headers: { cookie } }),
+      );
+      await expectHtmlResponse(response, 200, 'class="header-image"', "/image/my-header.jpg");
+    });
+
+    test("does not render header image when not set", async () => {
+      resetHeaderImage();
+      const { cookie } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockRequest("/admin/settings", { headers: { cookie } }),
+      );
+      const html = await response.text();
+      expect(html).not.toContain('class="header-image"');
+    });
+  });
+
+  describe("header image proxy", () => {
+    test("serves header image via proxy route", async () => {
+      const imageData = JPEG_HEADER;
+      const encrypted = await encryptBytes(imageData);
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (input: string | URL | Request): Promise<Response> => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
+        if (url.includes("storage.bunnycdn.com")) {
+          return Promise.resolve(
+            // deno-lint-ignore no-explicit-any
+            new Response(encrypted as any, { status: 200 }),
+          );
+        }
+        return originalFetch(input);
+      };
+
+      try {
+        const response = await handleRequest(
+          mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
+        );
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("image/jpeg");
+        expect(response.headers.get("cache-control")).toContain("immutable");
+        const body = new Uint8Array(await response.arrayBuffer());
+        expect(body).toEqual(imageData);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+});


### PR DESCRIPTION
Header images use the same format restrictions (JPEG, PNG, GIF, WebP),
256KB size limit, encryption, and proxy serving as event images.

- Add HEADER_IMAGE_URL config key to settings DB
- Add sync-accessible header image loader (like theme.ts pattern)
- Add upload/delete routes at /admin/settings/header-image
- Add header image section to settings template with upload/remove UI
- Render header image in Layout before navigation with .header-image class
- Extract shared IMAGE_ERROR_MESSAGES and tryDeleteImage to storage.ts
- Add withOwnerAuthMultipartForm helper for owner-only multipart routes
- Add 28 tests covering all functionality with 100% coverage

https://claude.ai/code/session_01RsRePkkLgtqCesRoqAMu73