### PR TITLE
Add header image support to settings page and layout

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -107,8 +107,8 @@ export const IMAGE_ERROR_MESSAGES: Record<ImageValidationError, string> = {
 /** Try to delete an image from CDN storage, logging errors on failure */
 export const tryDeleteImage = async (
   filename: string,
+  eventId: number | undefined,
   detail: string,
-  eventId?: number,
 ): Promise<void> => {
   try {
     await deleteImage(filename);

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -53,16 +53,12 @@ import {
 import {
   IMAGE_ERROR_MESSAGES,
   isStorageEnabled,
-  tryDeleteImage as tryDeleteImageBase,
+  tryDeleteImage,
   uploadImage,
   validateImage,
 } from "#lib/storage.ts";
 import { generateAttendeesCsv } from "#templates/csv.ts";
 import { eventFields, groupIdField, slugField } from "#templates/fields.ts";
-
-/** Try to delete an event image from CDN storage, logging errors with event ID */
-const tryDeleteImage = (filename: string, eventId: number, detail: string): Promise<void> =>
-  tryDeleteImageBase(filename, detail, eventId);
 
 /** Generate a unique event slug, retrying on collision */
 const generateUniqueEventSlug = (excludeEventId?: number) =>

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -523,7 +523,7 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
     // Delete old header image if one exists
     const existingUrl = await getHeaderImageUrlFromDb();
     if (existingUrl) {
-      await tryDeleteImage(existingUrl, `header image: ${existingUrl}`);
+      await tryDeleteImage(existingUrl, undefined, `header image: ${existingUrl}`);
     }
 
     const filename = await uploadImage(data, validation.detectedType);
@@ -539,7 +539,7 @@ const handleHeaderImageDeletePost = settingsRoute(async (_form, errorPage) => {
     return errorPage("No header image to remove", 400);
   }
 
-  await tryDeleteImage(existingUrl, `header image: ${existingUrl}`);
+  await tryDeleteImage(existingUrl, undefined, `header image: ${existingUrl}`);
   await updateHeaderImageUrl("");
   await logActivity("Header image removed");
   return redirectWithSuccess("/admin/settings", "Header image removed");

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -10,15 +10,14 @@ import {
   updateHeaderImageUrl,
 } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
-import { encrypt, encryptBytes } from "#lib/crypto.ts";
-import { getDb } from "#lib/db/client.ts";
-import { createSession } from "#lib/db/sessions.ts";
-import { invalidateUsersCache } from "#lib/db/users.ts";
-import { getSessionCookieName } from "#lib/cookies.ts";
+import { encryptBytes } from "#lib/crypto.ts";
 import {
+  adminGet,
   createTestDbWithSetup,
+  createTestManagerSession,
   expectHtmlResponse,
   loginAsAdmin,
+  mockFormRequest,
   mockMultipartRequest,
   mockRequest,
   resetDb,
@@ -27,24 +26,6 @@ import {
 
 /** JPEG magic bytes for a valid test image */
 const JPEG_HEADER = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
-
-/** Create a form POST request with cookie */
-const formPostRequest = (
-  path: string,
-  data: Record<string, string>,
-  cookie: string,
-): Request => {
-  const body = new URLSearchParams(data).toString();
-  return new Request(`http://localhost${path}`, {
-    method: "POST",
-    body,
-    headers: {
-      "content-type": "application/x-www-form-urlencoded",
-      cookie,
-      host: "localhost",
-    },
-  });
-};
 
 /** Mock fetch to intercept Bunny CDN API calls */
 const withStorageMock = async (
@@ -187,38 +168,26 @@ describe("server (header image settings)", () => {
 
   describe("GET /admin/settings (header image section)", () => {
     test("shows header image section when storage is enabled", async () => {
-      const { cookie } = await loginAsAdmin();
-      const response = await handleRequest(
-        mockRequest("/admin/settings", { headers: { cookie } }),
-      );
+      const { response } = await adminGet("/admin/settings");
       await expectHtmlResponse(response, 200, "Header Image");
     });
 
     test("hides header image section when storage is disabled", async () => {
       Deno.env.delete("STORAGE_ZONE_NAME");
       Deno.env.delete("STORAGE_ZONE_KEY");
-      const { cookie } = await loginAsAdmin();
-      const response = await handleRequest(
-        mockRequest("/admin/settings", { headers: { cookie } }),
-      );
+      const { response } = await adminGet("/admin/settings");
       const html = await response.text();
       expect(html).not.toContain("Header Image");
     });
 
     test("shows remove button when header image is set", async () => {
       await updateHeaderImageUrl("existing.jpg");
-      const { cookie } = await loginAsAdmin();
-      const response = await handleRequest(
-        mockRequest("/admin/settings", { headers: { cookie } }),
-      );
+      const { response } = await adminGet("/admin/settings");
       await expectHtmlResponse(response, 200, "Remove Image", "/image/existing.jpg");
     });
 
     test("shows upload button when no header image exists", async () => {
-      const { cookie } = await loginAsAdmin();
-      const response = await handleRequest(
-        mockRequest("/admin/settings", { headers: { cookie } }),
-      );
+      const { response } = await adminGet("/admin/settings");
       await expectHtmlResponse(response, 200, "Upload Image");
     });
   });
@@ -295,36 +264,13 @@ describe("server (header image settings)", () => {
     });
 
     test("returns 403 for non-owner admin", async () => {
-      const { hmacHash } = await import("#lib/crypto.ts");
-      const managerIdx = await hmacHash("headerimgmgr");
-      await getDb().execute({
-        sql:
-          `INSERT INTO users (username_hash, username_index, password_hash, wrapped_data_key, admin_level)
-              VALUES (?, ?, ?, ?, ?)`,
-        args: [
-          await encrypt("headerimgmgr"),
-          managerIdx,
-          "",
-          null,
-          await encrypt("manager"),
-        ],
-      });
-      invalidateUsersCache();
-
-      await createSession(
-        "mgr-header-session",
-        "mgr-header-csrf",
-        Date.now() + 3600000,
-        null,
-        2,
-      );
-
+      const managerCookie = await createTestManagerSession("mgr-header-session", "headerimgmgr");
       const { signCsrfToken } = await import("#lib/csrf.ts");
       const signedCsrf = await signCsrfToken();
       const request = mockMultipartRequest(
         "/admin/settings/header-image",
         { csrf_token: signedCsrf },
-        `${getSessionCookieName()}=mgr-header-session`,
+        managerCookie,
         {
           fieldName: "header_image",
           name: "logo.jpg",
@@ -426,7 +372,7 @@ describe("server (header image settings)", () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 
       await withStorageMock(async () => {
-        const request = formPostRequest(
+        const request = mockFormRequest(
           "/admin/settings/header-image/delete",
           { csrf_token: csrfToken },
           cookie,
@@ -443,7 +389,7 @@ describe("server (header image settings)", () => {
     test("returns error when no header image exists", async () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 
-      const request = formPostRequest(
+      const request = mockFormRequest(
         "/admin/settings/header-image/delete",
         { csrf_token: csrfToken },
         cookie,
@@ -462,7 +408,7 @@ describe("server (header image settings)", () => {
       };
 
       try {
-        const request = formPostRequest(
+        const request = mockFormRequest(
           "/admin/settings/header-image/delete",
           { csrf_token: csrfToken },
           cookie,
@@ -482,19 +428,13 @@ describe("server (header image settings)", () => {
   describe("header image in layout", () => {
     test("renders header image in page when set", async () => {
       await updateHeaderImageUrl("my-header.jpg");
-      const { cookie } = await loginAsAdmin();
-      const response = await handleRequest(
-        mockRequest("/admin/settings", { headers: { cookie } }),
-      );
+      const { response } = await adminGet("/admin/settings");
       await expectHtmlResponse(response, 200, 'class="header-image"', "/image/my-header.jpg");
     });
 
     test("does not render header image when not set", async () => {
       resetHeaderImage();
-      const { cookie } = await loginAsAdmin();
-      const response = await handleRequest(
-        mockRequest("/admin/settings", { headers: { cookie } }),
-      );
+      const { response } = await adminGet("/admin/settings");
       const html = await response.text();
       expect(html).not.toContain('class="header-image"');
     });


### PR DESCRIPTION
Header images use the same format restrictions (JPEG, PNG, GIF, WebP),
256KB size limit, encryption, and proxy serving as event images.

- Add HEADER_IMAGE_URL config key to settings DB
- Add sync-accessible header image loader (like theme.ts pattern)
- Add upload/delete routes at /admin/settings/header-image
- Add header image section to settings template with upload/remove UI
- Render header image in Layout before navigation with .header-image class
- Extract shared IMAGE_ERROR_MESSAGES and tryDeleteImage to storage.ts
- Add withOwnerAuthMultipartForm helper for owner-only multipart routes
- Add 28 tests covering all functionality with 100% coverage

https://claude.ai/code/session_01RsRePkkLgtqCesRoqAMu73