### PR TITLE
Make mobile nav links flow in a row instead of a column

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -218,10 +218,7 @@ nav ul li ul li a {
 @media (max-width: 768px) {
   nav {
     flex-wrap: wrap;
-  }
-
-  nav ul li {
-    width: 100%;
+    justify-content: flex-start;
   }
 
   nav ul li ul {


### PR DESCRIPTION
Remove width: 100% on mobile nav items so they stay horizontal
like desktop, and left-align instead of center.

https://claude.ai/code/session_01ErruN77xB8GbF1Ab2spk17