### PR TITLE
Redirect /admin/login to /admin/ when already authenticated

### DIFF
--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -19,6 +19,7 @@ import { defineRoutes } from "#routes/router.ts";
 import type { ServerContext } from "#routes/types.ts";
 import {
   generateSecureToken,
+  getAuthenticatedSession,
   getClientIp,
   parseFormData,
   redirect,
@@ -134,8 +135,12 @@ const handleAdminLogout = (request: Request): Promise<Response> =>
     return redirect("/admin", clearSessionCookie());
   });
 
-/** Handle GET /admin/login */
-const handleLoginGet = (): Promise<Response> => loginResponse();
+/** Handle GET /admin/login - redirect to dashboard if already authenticated */
+const handleLoginGet = async (request: Request): Promise<Response> => {
+  const session = await getAuthenticatedSession(request);
+  if (session) return redirect("/admin");
+  return loginResponse();
+};
 
 /** Authentication routes */
 export const authRoutes = defineRoutes({

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -56,6 +56,13 @@ describe("server (admin auth)", () => {
       // Login page contains a signed CSRF token in the form
       expect(html).toMatch(/name="csrf_token" value="s1\./);
     });
+
+    test("redirects to /admin when already authenticated", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/login", { cookie });
+      expectAdminRedirect(response);
+    });
   });
 
   describe("POST /admin/login", () => {


### PR DESCRIPTION
Users visiting the login page while already logged in are now
redirected to the admin dashboard instead of seeing the login form.

https://claude.ai/code/session_01DGP32at3NoQgUyPHzmcnVm