### PR TITLE
Refactor nullable data handling with orNotFound utility

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -27,6 +27,7 @@ import {
   getSearchParam,
   htmlResponse,
   notFoundResponse,
+  orNotFound,
   redirect,
   requireSessionOr,
   withAuthForm,
@@ -70,15 +71,6 @@ const loadAttendeeForEvent = async (
   return { attendee, event: result.event };
 };
 
-/** Load data or return 404 if not found */
-const withLoaded = async <T>(
-  load: Promise<T | null>,
-  handler: (data: T) => Response | Promise<Response>,
-): Promise<Response> => {
-  const data = await load;
-  return data ? handler(data) : notFoundResponse();
-};
-
 /** Load attendee with auth, returning 404 if not found */
 const withAttendee = (
   session: AuthSession,
@@ -86,7 +78,7 @@ const withAttendee = (
   attendeeId: number,
   handler: (data: AttendeeWithEvent) => Response | Promise<Response>,
 ): Promise<Response> =>
-  withLoaded(loadAttendeeForEvent(session, eventId, attendeeId), handler);
+  orNotFound(loadAttendeeForEvent(session, eventId, attendeeId), handler);
 
 /** Route params for event-scoped routes */
 type EventRouteParams = { id: number };
@@ -431,7 +423,7 @@ const withEditAttendee = (
   attendeeId: number,
   handler: (data: EditAttendeeData) => Response | Promise<Response>,
 ): Promise<Response> =>
-  withLoaded(loadAttendeeForEdit(session, attendeeId), handler);
+  orNotFound(loadAttendeeForEdit(session, attendeeId), handler);
 
 /** Handle GET /admin/attendees/:attendeeId */
 const handleEditAttendeeGet = (

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -2,7 +2,7 @@
  * Admin attendee management routes
  */
 
-import { filter } from "#fp";
+import { compact, filter, uniqueBy } from "#fp";
 import { logActivity } from "#lib/db/activityLog.ts";
 import {
   createAttendeeAtomic,
@@ -70,16 +70,23 @@ const loadAttendeeForEvent = async (
   return { attendee, event: result.event };
 };
 
+/** Load data or return 404 if not found */
+const withLoaded = async <T>(
+  load: Promise<T | null>,
+  handler: (data: T) => Response | Promise<Response>,
+): Promise<Response> => {
+  const data = await load;
+  return data ? handler(data) : notFoundResponse();
+};
+
 /** Load attendee with auth, returning 404 if not found */
-const withAttendee = async (
+const withAttendee = (
   session: AuthSession,
   eventId: number,
   attendeeId: number,
   handler: (data: AttendeeWithEvent) => Response | Promise<Response>,
-): Promise<Response> => {
-  const data = await loadAttendeeForEvent(session, eventId, attendeeId);
-  return data ? handler(data) : notFoundResponse();
-};
+): Promise<Response> =>
+  withLoaded(loadAttendeeForEvent(session, eventId, attendeeId), handler);
 
 /** Route params for event-scoped routes */
 type EventRouteParams = { id: number };
@@ -398,24 +405,7 @@ const getEventsForSelector = async (currentEventId: number): Promise<EventWithCo
   const allEvents = await getAllEvents();
   const currentEvent = allEvents.find((e) => e.id === currentEventId);
   const activeEvents = filter((e: EventWithCount) => e.active)(allEvents);
-
-  // Build unique list: current event + active events
-  const eventIds = new Set<number>();
-  const uniqueEvents: EventWithCount[] = [];
-
-  if (currentEvent) {
-    eventIds.add(currentEvent.id);
-    uniqueEvents.push(currentEvent);
-  }
-
-  for (const event of activeEvents) {
-    if (!eventIds.has(event.id)) {
-      eventIds.add(event.id);
-      uniqueEvents.push(event);
-    }
-  }
-
-  return uniqueEvents;
+  return uniqueBy((e: EventWithCount) => e.id)(compact([currentEvent, ...activeEvents]));
 };
 
 /** Load attendee with all events for edit page */
@@ -436,14 +426,12 @@ const loadAttendeeForEdit = async (
 type EditAttendeeData = NonNullable<Awaited<ReturnType<typeof loadAttendeeForEdit>>>;
 
 /** Load attendee for edit, returning 404 if not found */
-const withEditAttendee = async (
+const withEditAttendee = (
   session: AuthSession,
   attendeeId: number,
   handler: (data: EditAttendeeData) => Response | Promise<Response>,
-): Promise<Response> => {
-  const data = await loadAttendeeForEdit(session, attendeeId);
-  return data ? handler(data) : notFoundResponse();
-};
+): Promise<Response> =>
+  withLoaded(loadAttendeeForEdit(session, attendeeId), handler);
 
 /** Handle GET /admin/attendees/:attendeeId */
 const handleEditAttendeeGet = (

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -33,6 +33,7 @@ import {
   getSearchParam,
   htmlResponse,
   notFoundResponse,
+  orNotFound,
   redirect,
   requireSessionOr,
   withAuthForm,
@@ -287,12 +288,9 @@ const withEventAndGroupsPage =
     renderPage: (event: EventWithCount, groups: Group[], session: AdminSession) => string,
   ): TypedRouteHandler<"GET /admin/event/:id"> =>
   (request, params) =>
-    requireSessionOr(request, async (session) => {
-      const ctx = await getEventAndGroups(params.id);
-      return ctx
-        ? htmlResponse(renderPage(ctx.event, ctx.groups, session))
-        : notFoundResponse();
-    });
+    requireSessionOr(request, (session) =>
+      orNotFound(getEventAndGroups(params.id), (ctx) =>
+        htmlResponse(renderPage(ctx.event, ctx.groups, session))));
 
 const handleAdminEventDuplicateGet: TypedRouteHandler<"GET /admin/event/:id/duplicate"> = withEventAndGroupsPage(
   adminDuplicateEventPage,
@@ -372,19 +370,14 @@ const handleEventWithConfirmation = (
   errorMsg: string,
   action: (event: EventWithCount) => Promise<Response>,
 ): Promise<Response> =>
-  withAuthForm(request, async (session, form) => {
-    const event = await getEventWithCount(id);
-    if (!event) {
-      return notFoundResponse();
-    }
-
-    const confirmIdentifier = form.get("confirm_identifier") ?? "";
-    if (!verifyIdentifier(event.name, confirmIdentifier)) {
-      return eventErrorPage(event, renderPage, session, errorMsg);
-    }
-
-    return action(event);
-  });
+  withAuthForm(request, (session, form) =>
+    orNotFound(getEventWithCount(id), (event) => {
+      const confirmIdentifier = form.get("confirm_identifier") ?? "";
+      if (!verifyIdentifier(event.name, confirmIdentifier)) {
+        return eventErrorPage(event, renderPage, session, errorMsg);
+      }
+      return action(event);
+    }));
 
 const CONFIRM_NAME_MSG = "Event name does not match. Please type the exact name to confirm.";
 
@@ -414,13 +407,9 @@ const handleAdminEventDeleteGet = withEventPage(adminDeleteEventPage);
  * Uses batched query to fetch event + activity log in a single DB round-trip.
  */
 const handleAdminEventLog: TypedRouteHandler<"GET /admin/event/:id/log"> = (request, { id }) =>
-  requireSessionOr(request, async (session) => {
-    const result = await getEventWithActivityLog(id);
-    if (!result) {
-      return notFoundResponse();
-    }
-    return htmlResponse(adminEventActivityLogPage(result.event, result.entries, session));
-  });
+  requireSessionOr(request, (session) =>
+    orNotFound(getEventWithActivityLog(id), (result) =>
+      htmlResponse(adminEventActivityLogPage(result.event, result.entries, session))));
 
 /** Perform event deletion */
 const performDelete = async (event: EventWithCount): Promise<Response> => {
@@ -440,25 +429,20 @@ const handleAdminEventDelete: TypedRouteHandler<"POST /admin/event/:id/delete"> 
         "Event name does not match. Please type the exact name to confirm deletion.",
         performDelete,
       )
-    : withAuthForm(request, async () => {
-        const event = await getEventWithCount(id);
-        return event ? performDelete(event) : notFoundResponse();
-      });
+    : withAuthForm(request, () =>
+        orNotFound(getEventWithCount(id), performDelete));
 
 /** Handle POST /admin/event/:id/image/delete (delete event image) */
 const handleImageDelete: TypedRouteHandler<"POST /admin/event/:id/image/delete"> = (request, { id }) =>
-  withAuthForm(request, async () => {
-    const event = await getEventWithCount(id);
-    if (!event) return notFoundResponse();
-
-    if (event.image_url) {
-      await tryDeleteImage(event.image_url, event.id, "image removal");
-      await eventsTable.update(id, { imageUrl: "" });
-      await logActivity(`Image removed for '${event.name}'`, event);
-    }
-
-    return redirect(`/admin/event/${id}`);
-  });
+  withAuthForm(request, () =>
+    orNotFound(getEventWithCount(id), async (event) => {
+      if (event.image_url) {
+        await tryDeleteImage(event.image_url, event.id, "image removal");
+        await eventsTable.update(id, { imageUrl: "" });
+        await logActivity(`Image removed for '${event.name}'`, event);
+      }
+      return redirect(`/admin/event/${id}`);
+    }));
 
 /** Create a handler that renders the event page with a specific attendee filter */
 const eventPageHandler = (activeFilter?: AttendeeFilter): TypedRouteHandler<"GET /admin/event/:id"> =>

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -29,7 +29,7 @@ import { createOwnerCrudHandlers } from "#routes/admin/owner-crud.ts";
 import { requirePrivateKey } from "#routes/admin/utils.ts";
 import { defineRoutes } from "#routes/router.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
-import { htmlResponse, notFoundResponse, redirect, requireOwnerOr, withOwnerAuthForm } from "#routes/utils.ts";
+import { htmlResponse, orNotFound, redirect, requireOwnerOr, withOwnerAuthForm } from "#routes/utils.ts";
 import {
   adminGroupDeletePage,
   adminGroupDetailPage,
@@ -115,18 +115,15 @@ const crudCreate = createOwnerCrudHandlers({ ...crudConfig, resource: groupsCrea
 const crud = createOwnerCrudHandlers({ ...crudConfig, resource: groupsResource });
 
 /** Look up group by id, return 404 if not found */
-const withGroupOr404 = async (
+const withGroup = (
   id: number,
   handler: (group: Group) => Response | Promise<Response>,
-): Promise<Response> => {
-  const group = await groupsTable.findById(id);
-  return group ? handler(group) : notFoundResponse();
-};
+): Promise<Response> => orNotFound(groupsTable.findById(id), handler);
 
 /** Handle GET /admin/group/:id - group detail page */
 const handleGroupDetail: TypedRouteHandler<"GET /admin/group/:id"> = (request, { id }) =>
   requireOwnerOr(request, (session) =>
-    withGroupOr404(id, async (group) => {
+    withGroup(id, async (group) => {
       const [events, ungroupedEvents, holidays] = await Promise.all([
         getEventsByGroupId(id),
         getUngroupedEvents(),
@@ -154,7 +151,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/group/:id"> = (request, {
 /** Handle POST /admin/group/:id/add-events - assign ungrouped events to group */
 const handleAddEventsToGroup: TypedRouteHandler<"POST /admin/group/:id/add-events"> = (request, { id }) =>
   withOwnerAuthForm(request, (_session, form) =>
-    withGroupOr404(id, async (group) => {
+    withGroup(id, async (group) => {
       const eventIds = form.getAll("event_ids").map(Number).filter((n) => n > 0);
       if (eventIds.length > 0) {
         await assignEventsToGroup(eventIds, id);

--- a/src/routes/admin/owner-crud.ts
+++ b/src/routes/admin/owner-crud.ts
@@ -1,7 +1,7 @@
 import { logActivity } from "#lib/db/activityLog.ts";
 import type { NamedResource } from "#lib/rest/resource.ts";
 import type { AdminSession } from "#lib/types.ts";
-import { htmlResponse, notFoundResponse, redirect, requireOwnerOr, withOwnerAuthForm } from "#routes/utils.ts";
+import { htmlResponse, notFoundResponse, orNotFound, redirect, requireOwnerOr, withOwnerAuthForm } from "#routes/utils.ts";
 
 type OwnerCrudConfig<Row, Input> = {
   singular: string;
@@ -16,15 +16,6 @@ type OwnerCrudConfig<Row, Input> = {
   renderDelete: (row: Row, session: AdminSession, error?: string) => string;
   getName: (row: Row) => string;
   deleteConfirmError: string;
-};
-
-const withRowOr404 = async <Row, Input>(
-  resource: NamedResource<Row, Input>,
-  id: number,
-  handler: (row: Row) => Response | Promise<Response>,
-): Promise<Response> => {
-  const row = await resource.table.findById(id);
-  return row ? handler(row) : notFoundResponse();
 };
 
 export const createOwnerCrudHandlers = <Row, Input>(cfg: OwnerCrudConfig<Row, Input>) => {
@@ -50,7 +41,7 @@ export const createOwnerCrudHandlers = <Row, Input>(cfg: OwnerCrudConfig<Row, In
   ) =>
   (request: Request, id: number): Promise<Response> =>
     requireOwnerOr(request, (session) =>
-      withRowOr404(cfg.resource, id, (row) => htmlResponse(render(row, session))));
+      orNotFound(cfg.resource.table.findById(id), (row) => htmlResponse(render(row, session))));
 
   const logAndRedirect = async (verb: string, name: string, path?: string): Promise<Response> => {
     await logActivity(`${cfg.singular} '${name}' ${verb}`);
@@ -85,7 +76,7 @@ export const createOwnerCrudHandlers = <Row, Input>(cfg: OwnerCrudConfig<Row, In
       return logAndRedirect("updated", cfg.getName(result.row), cfg.getRowPath?.(result.row));
     }
     if ("notFound" in result) return notFoundResponse();
-    return withRowOr404(cfg.resource, id, (row) =>
+    return orNotFound(cfg.resource.table.findById(id), (row) =>
       htmlResponse(cfg.renderEdit(row, session, result.error), 400)
     );
   };
@@ -96,7 +87,7 @@ export const createOwnerCrudHandlers = <Row, Input>(cfg: OwnerCrudConfig<Row, In
 
   const deleteHandler = (id: number) =>
   (session: AdminSession, form: URLSearchParams): Promise<Response> =>
-    withRowOr404(cfg.resource, id, async (row) => {
+    orNotFound(cfg.resource.table.findById(id),async (row) => {
       const confirm = String(form.get("confirm_identifier"));
       const nameMatches = cfg.resource.verifyName(row, confirm);
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -2,7 +2,7 @@
  * Shared utilities for route handlers
  */
 
-import { compact, err, map, ok, pipe, type Result, reduce } from "#fp";
+import { compact, map, pipe, reduce } from "#fp";
 import {
   generateSecureToken,
   getPrivateKeyFromSession,
@@ -257,35 +257,26 @@ export const withCookie = (response: Response, cookie: string): Response => {
   return response;
 };
 
-/** Handler function that takes a value and returns a Response */
-type EventHandler = (event: EventWithCount) => Response | Promise<Response>;
-
 /**
- * Unwrap Result with handler - returns error response or applies handler to value
+ * Resolve a nullable promise, calling handler if found or returning 404.
+ * Use for any route that loads a model and should 404 when missing.
  */
-const unwrapResult = (
-  result: Result<EventWithCount>,
-  handler: EventHandler,
-): Promise<Response> | Response =>
-  result.ok ? handler(result.value) : result.response;
-
-/**
- * Fetch event or return 404 response
- */
-export const fetchEventOr404 = async (
-  eventId: number,
-): Promise<Result<EventWithCount>> => {
-  const event = await getEventWithCount(eventId);
-  return event ? ok(event) : err(notFoundResponse());
+export const orNotFound = async <T>(
+  load: Promise<T | null>,
+  handler: (data: T) => Response | Promise<Response>,
+): Promise<Response> => {
+  const data = await load;
+  return data ? handler(data) : notFoundResponse();
 };
 
-/**
- * Handle event with Result - unwrap to Response
- */
-export const withEvent = async (
+/** Handler function that takes an event and returns a Response */
+type EventHandler = (event: EventWithCount) => Response | Promise<Response>;
+
+/** Load event by ID or return 404 */
+export const withEvent = (
   eventId: number,
   handler: EventHandler,
-): Promise<Response> => unwrapResult(await fetchEventOr404(eventId), handler);
+): Promise<Response> => orNotFound(getEventWithCount(eventId), handler);
 
 /**
  * Curried event page GET handler: renderPage -> (request, { id }) -> Response.
@@ -302,24 +293,11 @@ export const withEventPage =
       ),
     );
 
-/**
- * Fetch event by slug or return 404 response.
- */
-export const fetchEventBySlugOr404 = async (
-  slug: string,
-): Promise<Result<EventWithCount>> => {
-  const event = await getEventWithCountBySlug(slug);
-  return event ? ok(event) : err(notFoundResponse());
-};
-
-/**
- * Handle event by slug with Result - unwrap to Response
- */
-export const withEventBySlug = async (
+/** Load event by slug or return 404 */
+export const withEventBySlug = (
   slug: string,
   handler: EventHandler,
-): Promise<Response> =>
-  unwrapResult(await fetchEventBySlugOr404(slug), handler);
+): Promise<Response> => orNotFound(getEventWithCountBySlug(slug), handler);
 
 /** Check if event is active, return 404 if not */
 const requireActiveEvent =


### PR DESCRIPTION
## Summary
This PR refactors how the codebase handles loading data that may not exist, replacing multiple ad-hoc patterns with a unified `orNotFound` utility function. This improves code consistency, reduces duplication, and makes the intent clearer throughout the application.

## Key Changes

- **Introduced `orNotFound` utility**: A generic async function that resolves a nullable promise and either calls a handler with the data or returns a 404 response. This replaces several custom patterns:
  - Removed `fetchEventOr404` and `unwrapResult` (Result-based pattern)
  - Removed `fetchEventBySlugOr404` 
  - Removed `withRowOr404` from owner-crud
  - Removed `withGroupOr404` from groups (renamed to `withGroup`)

- **Simplified route handlers**: Converted multiple handlers to use `orNotFound`:
  - `withEventAndGroupsPage` in admin/events.ts
  - `handleEventWithConfirmation` in admin/events.ts
  - `handleAdminEventLog` in admin/events.ts
  - `handleAdminEventDelete` in admin/events.ts
  - `handleImageDelete` in admin/events.ts
  - `withAttendee` in admin/attendees.ts
  - `withEditAttendee` in admin/attendees.ts
  - Group detail and event assignment handlers in admin/groups.ts

- **Refactored `withEvent` and `withEventBySlug`**: Now use `orNotFound` internally instead of Result-based unwrapping

- **Simplified event selector logic**: Replaced manual deduplication in `getEventsForSelector` with `uniqueBy` from the fp library

- **Updated imports**: Removed unused `err` and `ok` from utils.ts, added `orNotFound` to relevant route files

## Implementation Details

The `orNotFound` utility provides a consistent pattern for:
1. Awaiting a nullable promise (e.g., database query)
2. Calling a handler function if data exists
3. Returning a 404 response if data is null

This eliminates the need for conditional checks and Result types throughout the codebase, making handlers more readable and reducing boilerplate.

https://claude.ai/code/session_01DDAm4TzoiTijs4eGt2Hcjc