### PR TITLE
Update hosted instance URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A self-hosted ticket reservation system. Runs on Bunny Edge Scripting with libsql (Turso). Encrypts all PII at rest. Handles free and paid events with Stripe or Square.
 
-Licensed under **AGPLv3**. Hosted instances available at [chobble.com](https://chobble.com) for £50/year, no tiers.
+Licensed under **AGPLv3**. Hosted instances available at [tix.chobble.com](https://tix.chobble.com/ticket/register) for £50/year, no tiers.
 
 ## Features
 


### PR DESCRIPTION
## Summary
Updated the documentation to reflect the correct URL for accessing hosted instances of the ticket reservation system.

## Changes
- Updated the hosted instances link from `chobble.com` to `tix.chobble.com/ticket/register` in the README

## Details
This change directs users to the correct subdomain and specific registration endpoint for the hosted service offering, improving the accuracy of the documentation and user experience.

https://claude.ai/code/session_01VhYVyCiGAKVRLiBd3KCcPD