### PR TITLE
Change domain validation from rejection to redirect

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -189,7 +189,7 @@ export const createRequestTimer = (): (() => number) => {
 /**
  * Log categories for debug logging
  */
-export type LogCategory = "Setup" | "Webhook" | "Payment" | "Auth" | "Stripe" | "Square";
+export type LogCategory = "Setup" | "Webhook" | "Payment" | "Auth" | "Stripe" | "Square" | "Domain";
 
 /**
  * Log a debug message with category prefix

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -9,12 +9,13 @@ import { loadCurrencyCode } from "#lib/currency.ts";
 import { loadHeaderImage } from "#lib/header-image.ts";
 import { loadTheme } from "#lib/theme.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
-import { createRequestTimer, ErrorCode, logError, logRequest, runWithRequestId } from "#lib/logger.ts";
+import { createRequestTimer, ErrorCode, logDebug, logError, logRequest, runWithRequestId } from "#lib/logger.ts";
 import { flushPendingWork } from "#lib/pending-work.ts";
 import {
   applySecurityHeaders,
+  buildDomainRedirectUrl,
   contentTypeRejectionResponse,
-  domainRejectionResponse,
+  domainRedirectResponse,
   getCleanUrl,
   getDomainRejectionReason,
   isEmbeddablePath,
@@ -228,10 +229,11 @@ export const handleRequest = (
     }
   }
 
-  // Domain validation: reject requests to unauthorized domains
+  // Domain validation: redirect requests from unauthorized domains to the allowed domain
   if (!isValidDomain(request)) {
-    logError({ code: ErrorCode.DOMAIN_REJECTED, detail: getDomainRejectionReason(request) });
-    return logAndReturn(domainRejectionResponse(), method, path, getElapsed);
+    const redirectUrl = buildDomainRedirectUrl(request);
+    logDebug("Domain", `Redirecting to ${redirectUrl} (${getDomainRejectionReason(request)})`);
+    return logAndReturn(domainRedirectResponse(redirectUrl), method, path, getElapsed);
   }
 
   const embeddable = isEmbeddablePath(path);

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -94,6 +94,16 @@ export const isValidDomain = (request: Request): boolean => {
 };
 
 /**
+ * Build a redirect URL to the allowed domain, preserving the original path and query.
+ */
+export const buildDomainRedirectUrl = (request: Request): string => {
+  const url = new URL(request.url);
+  const allowed = getAllowedDomain();
+  const scheme = allowed === "localhost" ? "http" : "https";
+  return `${scheme}://${allowed}${url.pathname}${url.search}`;
+};
+
+/**
  * Build a privacy-safe rejection reason for domain validation failures.
  * Includes the Host header and URL hostname so operators can diagnose
  * why a request was rejected (e.g. Facebook in-app browser sending
@@ -154,13 +164,13 @@ export const contentTypeRejectionResponse = (): Response =>
   });
 
 /**
- * Create domain rejection response
+ * Create domain redirect response (301 to allowed domain)
  */
-export const domainRejectionResponse = (): Response =>
-  new Response(encodeBody("Forbidden: Invalid domain"), {
-    status: 403,
+export const domainRedirectResponse = (redirectUrl: string): Response =>
+  new Response(null, {
+    status: 301,
     headers: {
-      "content-type": "text/plain",
+      location: redirectUrl,
       ...getSecurityHeaders(false),
     },
   });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -327,14 +327,15 @@ describe("server (misc)", () => {
       expect(response.status).toBe(302); // Homepage redirects to /admin/
     });
 
-    test("rejects GET requests to invalid domain", async () => {
+    test("redirects GET requests from invalid domain to allowed domain", async () => {
       const response = await handleRequest(
         mockRequestWithHost("/", "evil.com"),
       );
-      await expectHtmlResponse(response, 403, "Invalid domain");
+      expect(response.status).toBe(301);
+      expect(response.headers.get("location")).toBe("http://localhost/");
     });
 
-    test("rejects POST requests to invalid domain", async () => {
+    test("redirects POST requests from invalid domain to allowed domain", async () => {
       const response = await handleRequest(
         mockRequestWithHost("/admin/login", "evil.com", {
           method: "POST",
@@ -344,7 +345,8 @@ describe("server (misc)", () => {
           body: "password=test",
         }),
       );
-      await expectHtmlResponse(response, 403, "Invalid domain");
+      expect(response.status).toBe(301);
+      expect(response.headers.get("location")).toBe("http://localhost/admin/login");
     });
 
     test("allows requests with valid domain including port", async () => {
@@ -375,13 +377,14 @@ describe("server (misc)", () => {
       expect(response.status).toBe(302);
     });
 
-    test("rejects requests where neither Host header nor URL matches", async () => {
+    test("redirects requests where neither Host header nor URL matches", async () => {
       const request = new Request("http://evil.com/", {});
       const response = await handleRequest(request);
-      await expectHtmlResponse(response, 403, "Invalid domain");
+      expect(response.status).toBe(301);
+      expect(response.headers.get("location")).toBe("http://localhost/");
     });
 
-    test("domain rejection response has security headers", async () => {
+    test("domain redirect response has security headers", async () => {
       const response = await handleRequest(
         mockRequestWithHost("/", "evil.com"),
       );
@@ -390,29 +393,51 @@ describe("server (misc)", () => {
       expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
     });
 
-    test("logs DOMAIN_REJECTED error with host details on rejection", async () => {
-      const errorSpy = spyOn(console, "error");
+    test("logs debug message with host details on domain redirect", async () => {
+      const debugSpy = spyOn(console, "debug");
 
       await handleRequest(mockRequestWithHost("/", "evil.com"));
 
-      const calls = errorSpy.mock.calls.map((c) => c[0] as string);
-      const domainError = calls.find((c) => c.includes("E_DOMAIN_REJECTED"));
-      expect(domainError).toBeDefined();
-      expect(domainError).toContain("host=evil.com");
-      errorSpy.mockRestore();
+      const calls = debugSpy.mock.calls.map((c) => c[0] as string);
+      const domainLog = calls.find((c) => c.includes("[Domain]"));
+      expect(domainLog).toBeDefined();
+      expect(domainLog).toContain("host=evil.com");
+      expect(domainLog).toContain("Redirecting to");
+      debugSpy.mockRestore();
     });
 
-    test("logs missing host header in rejection reason", async () => {
-      const errorSpy = spyOn(console, "error");
+    test("logs missing host header in domain redirect debug message", async () => {
+      const debugSpy = spyOn(console, "debug");
 
       await handleRequest(new Request("http://evil.com/", {}));
 
-      const calls = errorSpy.mock.calls.map((c) => c[0] as string);
-      const domainError = calls.find((c) => c.includes("E_DOMAIN_REJECTED"));
-      expect(domainError).toBeDefined();
-      expect(domainError).toContain("host=missing");
-      expect(domainError).toContain("url=evil.com");
-      errorSpy.mockRestore();
+      const calls = debugSpy.mock.calls.map((c) => c[0] as string);
+      const domainLog = calls.find((c) => c.includes("[Domain]"));
+      expect(domainLog).toBeDefined();
+      expect(domainLog).toContain("host=missing");
+      expect(domainLog).toContain("url=evil.com");
+      debugSpy.mockRestore();
+    });
+
+    test("preserves path and query string in domain redirect", async () => {
+      const response = await handleRequest(
+        mockRequestWithHost("/ticket/my-event?qty=2", "evil.com"),
+      );
+      expect(response.status).toBe(301);
+      expect(response.headers.get("location")).toBe("http://localhost/ticket/my-event?qty=2");
+    });
+
+    test("uses https scheme when allowed domain is not localhost", async () => {
+      Deno.env.set("ALLOWED_DOMAIN", "example.com");
+      try {
+        const response = await handleRequest(
+          mockRequestWithHost("/ticket/my-event", "evil.com"),
+        );
+        expect(response.status).toBe(301);
+        expect(response.headers.get("location")).toBe("https://example.com/ticket/my-event");
+      } finally {
+        Deno.env.set("ALLOWED_DOMAIN", "localhost");
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Changed the domain validation behavior from returning a 403 Forbidden error to issuing a 301 redirect to the allowed domain. This improves user experience by automatically redirecting requests from invalid domains rather than blocking them.

## Key Changes
- **Domain redirect logic**: Requests to invalid domains now redirect (301) to the allowed domain instead of returning a 403 error
- **New utility function**: Added `buildDomainRedirectUrl()` to construct redirect URLs while preserving the original path and query string
- **Scheme handling**: Automatically uses HTTPS for non-localhost allowed domains and HTTP for localhost
- **Response update**: Replaced `domainRejectionResponse()` with `domainRedirectResponse()` that sets the Location header
- **Logging change**: Changed from error logging (`ErrorCode.DOMAIN_REJECTED`) to debug logging with `[Domain]` category prefix
- **Security headers**: Maintained security headers (X-Frame-Options, X-Content-Type-Options, X-Robots-Tag) on redirect responses
- **Test updates**: Updated all domain validation tests to verify redirect behavior, including path/query preservation and scheme selection

## Implementation Details
- The redirect URL is built from the request URL, preserving the original path and query string
- The allowed domain scheme is determined by checking if it's "localhost" (uses HTTP) or another domain (uses HTTPS)
- Debug logging includes the redirect destination and domain rejection reason for diagnostics
- All existing security headers are maintained on the redirect response

https://claude.ai/code/session_01L6u1J6iBS5ZmyN8g5QSTEo