### PR TITLE
Improve ticket token visibility and format (#443)

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -91,9 +91,9 @@ const toUpperHex = (bytes: Uint8Array): string => {
 };
 
 /**
- * Generate an 8-byte uppercase hex ticket token for public ticket URLs
+ * Generate a 5-byte uppercase hex ticket token for public ticket URLs
  */
-export const generateTicketToken = (): string => toUpperHex(getRandomBytes(8));
+export const generateTicketToken = (): string => toUpperHex(getRandomBytes(5));
 
 /**
  * Encryption format version prefix

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -80,9 +80,20 @@ export const generateSecureToken = (): string => {
 };
 
 /**
- * Generate an 8-byte base64url ticket token for public ticket URLs
+ * Convert bytes to uppercase hex string
  */
-export const generateTicketToken = (): string => toBase64Url(getRandomBytes(8));
+const toUpperHex = (bytes: Uint8Array): string => {
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex.toUpperCase();
+};
+
+/**
+ * Generate an 8-byte uppercase hex ticket token for public ticket URLs
+ */
+export const generateTicketToken = (): string => toUpperHex(getRandomBytes(8));
 
 /**
  * Encryption format version prefix

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -20,6 +20,7 @@ export type WebhookTicket = {
   unit_price: number | null;
   quantity: number;
   date: string | null;
+  ticket_token: string;
 };
 
 /** Consolidated payload sent to webhook endpoints */
@@ -98,6 +99,7 @@ export const buildWebhookPayload = async (
       unit_price: event.unit_price,
       quantity: attendee.quantity,
       date: attendee.date,
+      ticket_token: attendee.ticket_token,
     })),
     timestamp: nowIso(),
     business_email: businessEmail,

--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -19,6 +19,7 @@ const buildCheckinUrl = (token: string): string =>
 const buildTicketCard = async (entry: TokenEntry, token: string): Promise<TicketCard> => ({
   entry,
   qrSvg: await generateQrSvg(buildCheckinUrl(token)),
+  token,
 });
 
 /** Handle GET /t/:tokens */

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -17,6 +17,7 @@ export type { TokenEntry as TicketEntry };
 export type TicketCard = {
   entry: TokenEntry;
   qrSvg: string;
+  token: string;
 };
 
 /** Pluralize ticket count */
@@ -24,7 +25,7 @@ const ticketCount = (count: number): string =>
   count === 1 ? "1 Ticket" : `${count} Tickets`;
 
 /** Render a single ticket card */
-const renderTicketCard = ({ entry, qrSvg }: TicketCard): string => {
+const renderTicketCard = ({ entry, qrSvg, token }: TicketCard): string => {
   const { event, attendee } = entry;
   const imageHtml = renderEventImage(event, "ticket-card-image");
   const eventDateHtml = event.date
@@ -59,6 +60,7 @@ const renderTicketCard = ({ entry, qrSvg }: TicketCard): string => {
       <div class="ticket-card-quantity">Quantity: ${attendee.quantity}</div>
       ${priceHtml}
       <div class="ticket-card-qr">${qrSvg}</div>
+      <div class="ticket-card-token">${escapeHtml(token)}</div>
     </div>
   `;
 };

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -96,12 +96,17 @@ describe("generateSecureToken", () => {
 });
 
 describe("generateTicketToken", () => {
-  it("returns a base64url string of 11 characters", () => {
-    // 8 bytes = 64 bits, base64url encodes 6 bits per char
-    // ceil(64/6) = 11 chars (without padding)
+  it("returns an uppercase hex string of 16 characters", () => {
+    // 8 bytes = 16 hex characters
     const token = generateTicketToken();
-    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
-    expect(token.length).toBe(11);
+    expect(token).toMatch(/^[0-9A-F]+$/);
+    expect(token.length).toBe(16);
+  });
+
+  it("contains no dashes or underscores", () => {
+    const token = generateTicketToken();
+    expect(token).not.toContain("-");
+    expect(token).not.toContain("_");
   });
 
   it("generates unique tokens", () => {

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -96,11 +96,11 @@ describe("generateSecureToken", () => {
 });
 
 describe("generateTicketToken", () => {
-  it("returns an uppercase hex string of 16 characters", () => {
-    // 8 bytes = 16 hex characters
+  it("returns an uppercase hex string of 10 characters", () => {
+    // 5 bytes = 10 hex characters
     const token = generateTicketToken();
     expect(token).toMatch(/^[0-9A-F]+$/);
-    expect(token.length).toBe(16);
+    expect(token.length).toBe(10);
   });
 
   it("contains no dashes or underscores", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -2099,6 +2099,7 @@ describe("html", () => {
 
   describe("ticketViewPage event date and location", () => {
     const qrSvg = "<svg>test</svg>";
+    const token = "AABB0011CCDDEEFF";
 
     test("shows event date when entry has non-empty event date", () => {
       const cards = [
@@ -2108,6 +2109,7 @@ describe("html", () => {
             attendee: testAttendee(),
           },
           qrSvg,
+          token,
         },
       ];
       const html = ticketViewPage(cards);
@@ -2122,6 +2124,7 @@ describe("html", () => {
             attendee: testAttendee(),
           },
           qrSvg,
+          token,
         },
       ];
       const html = ticketViewPage(cards);
@@ -2136,6 +2139,7 @@ describe("html", () => {
             attendee: testAttendee(),
           },
           qrSvg,
+          token,
         },
       ];
       const html = ticketViewPage(cards);
@@ -2150,6 +2154,7 @@ describe("html", () => {
             attendee: testAttendee(),
           },
           qrSvg,
+          token,
         },
       ];
       const html = ticketViewPage(cards);
@@ -2164,6 +2169,7 @@ describe("html", () => {
             attendee: testAttendee(),
           },
           qrSvg,
+          token,
         },
       ];
       const html = ticketViewPage(cards);
@@ -2179,6 +2185,7 @@ describe("html", () => {
             attendee: testAttendee({ id: 1 }),
           },
           qrSvg: "<svg>qr1</svg>",
+          token: "AABB0011CCDDEEF1",
         },
         {
           entry: {
@@ -2186,6 +2193,7 @@ describe("html", () => {
             attendee: testAttendee({ id: 2 }),
           },
           qrSvg: "<svg>qr2</svg>",
+          token: "AABB0011CCDDEEF2",
         },
       ];
       const html = ticketViewPage(cards);
@@ -2285,6 +2293,7 @@ describe("html", () => {
 
     describe("ticketViewPage ticket count", () => {
       const qrSvg = '<svg class="qr"><rect/></svg>';
+      const token = "AABB0011CCDDEEFF";
 
       test("shows '1 Ticket' for single ticket", () => {
         setupStorage();
@@ -2295,6 +2304,7 @@ describe("html", () => {
               attendee: testAttendee({ id: 1 }),
             },
             qrSvg,
+            token,
           },
         ];
         const html = ticketViewPage(cards);
@@ -2311,6 +2321,7 @@ describe("html", () => {
               attendee: testAttendee({ id: 1 }),
             },
             qrSvg,
+            token: "AABB0011CCDDEEF1",
           },
           {
             entry: {
@@ -2318,6 +2329,7 @@ describe("html", () => {
               attendee: testAttendee({ id: 2 }),
             },
             qrSvg,
+            token: "AABB0011CCDDEEF2",
           },
         ];
         const html = ticketViewPage(cards);
@@ -2328,6 +2340,7 @@ describe("html", () => {
 
     describe("ticketViewPage with image", () => {
       const qrSvg = '<svg class="qr"><rect/></svg>';
+      const token = "AABB0011CCDDEEFF";
 
       test("shows image when event has image_url", () => {
         setupStorage();
@@ -2338,6 +2351,7 @@ describe("html", () => {
               attendee: testAttendee(),
             },
             qrSvg,
+            token,
           },
         ];
         const html = ticketViewPage(cards);
@@ -2355,6 +2369,7 @@ describe("html", () => {
               attendee: testAttendee(),
             },
             qrSvg,
+            token,
           },
         ];
         const html = ticketViewPage(cards);

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -288,4 +288,13 @@ describe("ticket view (/t/:tokens)", () => {
     const body = await response.text();
     expect(body).not.toContain("ticket-card-price");
   });
+
+  test("displays ticket token on ticket page", async () => {
+    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
+
+    const response = await awaitTestRequest(`/t/${token}`);
+    const body = await response.text();
+    expect(body).toContain("ticket-card-token");
+    expect(body).toContain(token);
+  });
 });

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -85,6 +85,7 @@ describe("webhook", () => {
       expect(payload.tickets[0]!.unit_price).toBeNull();
       expect(payload.tickets[0]!.quantity).toBe(1);
       expect(payload.tickets[0]!.date).toBeNull();
+      expect(payload.tickets[0]!.ticket_token).toBe("test-token-42");
       expect(payload.timestamp).toBeDefined();
       expect(payload.business_email).toBe("");
     });
@@ -131,9 +132,11 @@ describe("webhook", () => {
       expect(payload.tickets).toHaveLength(2);
       expect(payload.tickets[0]!.event_name).toBe("Event A");
       expect(payload.tickets[0]!.unit_price).toBe(300);
+      expect(payload.tickets[0]!.ticket_token).toBe("tok-a");
       expect(payload.tickets[1]!.event_name).toBe("Event B");
       expect(payload.tickets[1]!.unit_price).toBe(700);
       expect(payload.tickets[1]!.quantity).toBe(2);
+      expect(payload.tickets[1]!.ticket_token).toBe("tok-b");
     });
 
     test("includes date in ticket when attendee has a date", async () => {

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -33,7 +33,7 @@ const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee
   special_instructions: "",
   payment_id: "",
   price_paid: "0",
-  ticket_token: "test-token-42",
+  ticket_token: "AABB001122",
   date: null,
   ...overrides,
 });
@@ -78,14 +78,14 @@ describe("webhook", () => {
       expect(payload.price_paid).toBeNull();
       expect(payload.currency).toBe("GBP");
       expect(payload.payment_id).toBeNull();
-      expect(payload.ticket_url).toBe("https://localhost/t/test-token-42");
+      expect(payload.ticket_url).toBe("https://localhost/t/AABB001122");
       expect(payload.tickets).toHaveLength(1);
       expect(payload.tickets[0]!.event_name).toBe("Test Event");
       expect(payload.tickets[0]!.event_slug).toBe("test-event");
       expect(payload.tickets[0]!.unit_price).toBeNull();
       expect(payload.tickets[0]!.quantity).toBe(1);
       expect(payload.tickets[0]!.date).toBeNull();
-      expect(payload.tickets[0]!.ticket_token).toBe("test-token-42");
+      expect(payload.tickets[0]!.ticket_token).toBe("AABB001122");
       expect(payload.timestamp).toBeDefined();
       expect(payload.business_email).toBe("");
     });
@@ -115,11 +115,11 @@ describe("webhook", () => {
       const entries: RegistrationEntry[] = [
         {
           event: makeEvent({ id: 1, name: "Event A", slug: "event-a", unit_price: 300 }),
-          attendee: makeAttendee({ ticket_token: "tok-a", price_paid: "300", payment_id: "pi_multi" }),
+          attendee: makeAttendee({ ticket_token: "AA00BB11CC", price_paid: "300", payment_id: "pi_multi" }),
         },
         {
           event: makeEvent({ id: 2, name: "Event B", slug: "event-b", unit_price: 700 }),
-          attendee: makeAttendee({ ticket_token: "tok-b", quantity: 2, price_paid: "1400", payment_id: "pi_multi" }),
+          attendee: makeAttendee({ ticket_token: "DD22EE33FF", quantity: 2, price_paid: "1400", payment_id: "pi_multi" }),
         },
       ];
 
@@ -128,15 +128,15 @@ describe("webhook", () => {
       expect(payload.name).toBe("Jane Doe");
       expect(payload.price_paid).toBe(1700);
       expect(payload.payment_id).toBe("pi_multi");
-      expect(payload.ticket_url).toBe("https://localhost/t/tok-a+tok-b");
+      expect(payload.ticket_url).toBe("https://localhost/t/AA00BB11CC+DD22EE33FF");
       expect(payload.tickets).toHaveLength(2);
       expect(payload.tickets[0]!.event_name).toBe("Event A");
       expect(payload.tickets[0]!.unit_price).toBe(300);
-      expect(payload.tickets[0]!.ticket_token).toBe("tok-a");
+      expect(payload.tickets[0]!.ticket_token).toBe("AA00BB11CC");
       expect(payload.tickets[1]!.event_name).toBe("Event B");
       expect(payload.tickets[1]!.unit_price).toBe(700);
       expect(payload.tickets[1]!.quantity).toBe(2);
-      expect(payload.tickets[1]!.ticket_token).toBe("tok-b");
+      expect(payload.tickets[1]!.ticket_token).toBe("DD22EE33FF");
     });
 
     test("includes date in ticket when attendee has a date", async () => {
@@ -156,11 +156,11 @@ describe("webhook", () => {
       const entries: RegistrationEntry[] = [
         {
           event: makeEvent({ id: 1, name: "Daily Event", slug: "daily-event" }),
-          attendee: makeAttendee({ ticket_token: "tok-a", date: "2025-07-15" }),
+          attendee: makeAttendee({ ticket_token: "AA00BB11CC", date: "2025-07-15" }),
         },
         {
           event: makeEvent({ id: 2, name: "Standard Event", slug: "standard-event" }),
-          attendee: makeAttendee({ ticket_token: "tok-b", date: null }),
+          attendee: makeAttendee({ ticket_token: "DD22EE33FF", date: null }),
         },
       ];
 


### PR DESCRIPTION
- Change token generation from base64url to uppercase hex (no dashes/underscores)
- Add ticket_token field to webhook payload for each ticket
- Display ticket token on /t/:ticket_id ticket pages

https://claude.ai/code/session_01HLY4Ru9xcGw2hxvmiGo3Vt