### PR TITLE
Fix nav scroll behavior when hash is present in URL

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -129,7 +129,12 @@ if (checkoutPopup) {
 {
   const nav = document.querySelector("nav");
   if (nav) {
-    let lastY = 0;
+    if (location.hash) {
+      nav.style.transition = "none";
+      nav.classList.add("nav-hidden");
+      requestAnimationFrame(() => { nav.style.transition = ""; });
+    }
+    let lastY = scrollY;
     let ticking = false;
     document.addEventListener("scroll", () => {
       if (ticking) return;


### PR DESCRIPTION
## Summary
Fixed the navigation bar scroll behavior to properly handle cases where a URL hash is present on page load.

## Key Changes
- Initialize nav scroll tracking with current `scrollY` value instead of 0, preventing incorrect scroll delta calculations
- Add logic to hide the nav element immediately when a hash is present in the URL, using `requestAnimationFrame` to ensure smooth transitions after the initial state change

## Implementation Details
When a URL contains a hash (e.g., `#section`), the nav is now:
1. Temporarily hidden by disabling transitions (`transition: none`)
2. Given the `nav-hidden` class to apply hidden styling
3. Transitions are re-enabled via `requestAnimationFrame` to allow smooth animations on subsequent scroll events

The `lastY` initialization change from `0` to `scrollY` ensures that the scroll event listener correctly calculates scroll direction and distance from the actual starting scroll position, rather than assuming the page starts at the top.

https://claude.ai/code/session_01ACgC89zmdcc1z4ku5LvaHw