### PR TITLE
Refactor boundedLru to use doubly-linked list for O(1) tracking

### DIFF
--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -327,33 +327,61 @@ export type BoundedLru<K, V> = {
 
 /**
  * Create a bounded LRU (Least Recently Used) cache.
- * Evicts the oldest entry when capacity is reached.
- * Uses Map insertion order for O(1) LRU tracking.
+ * Evicts the least-recently-used entry when capacity is reached.
+ * Uses a doubly-linked list for O(1) LRU tracking so that
+ * get() does not mutate the key-value index.
  */
 export const boundedLru = <K, V>(maxSize: number): BoundedLru<K, V> => {
-  const cache = new Map<K, V>();
+  type Node = { key: K; value: V; prev: Node; next: Node };
+  const index = new Map<K, Node>();
+  // Sentinel nodes eliminate null-checks in detach/append
+  const head = {} as Node;
+  const tail = {} as Node;
+  head.next = tail;
+  tail.prev = head;
+
+  const detach = (n: Node): void => {
+    n.prev.next = n.next;
+    n.next.prev = n.prev;
+  };
+  const append = (n: Node): void => {
+    n.prev = tail.prev;
+    n.next = tail;
+    tail.prev.next = n;
+    tail.prev = n;
+  };
+
   return {
     get: (key: K): V | undefined => {
-      const value = cache.get(key);
-      if (value !== undefined) {
-        // Move to end (most recently used)
-        cache.delete(key);
-        cache.set(key, value);
-      }
-      return value;
+      const node = index.get(key);
+      if (!node) return undefined;
+      detach(node);
+      append(node);
+      return node.value;
     },
     set: (key: K, value: V): void => {
-      if (cache.has(key)) {
-        cache.delete(key);
-      } else if (cache.size >= maxSize) {
-        cache.delete(cache.keys().next().value!);
+      const existing = index.get(key);
+      if (existing) {
+        detach(existing);
+        existing.value = value;
+        append(existing);
+      } else {
+        if (index.size >= maxSize) {
+          const oldest = head.next;
+          detach(oldest);
+          index.delete(oldest.key);
+        }
+        const node = { key, value } as Node;
+        append(node);
+        index.set(key, node);
       }
-      cache.set(key, value);
     },
     clear: (): void => {
-      cache.clear();
+      index.clear();
+      head.next = tail;
+      tail.prev = head;
     },
-    size: (): number => cache.size,
+    size: (): number => index.size,
   };
 };
 


### PR DESCRIPTION
## Summary
Refactored the `boundedLru` cache implementation to use a doubly-linked list instead of relying on Map insertion order for LRU tracking. This ensures that `get()` operations do not mutate the underlying data structure while maintaining O(1) performance characteristics.

## Key Changes
- **Data structure**: Replaced `Map<K, V>` with a doubly-linked list backed by `Map<K, Node>` index
- **Non-mutating reads**: The `get()` method now updates LRU order without modifying the index Map, preventing unintended side effects
- **Sentinel nodes**: Added head and tail sentinel nodes to eliminate null-checks in list operations
- **Helper methods**: Introduced `detach()` and `append()` utilities for clean node manipulation
- **Updated logic**: Refactored `set()` to handle node creation, reuse, and eviction with explicit list operations

## Implementation Details
- The doubly-linked list maintains insertion order with most-recently-used entries toward the tail
- Eviction removes the least-recently-used entry (head.next) when capacity is exceeded
- Existing keys are updated in-place by detaching and re-appending their nodes
- The `clear()` method now resets both the index and list pointers

https://claude.ai/code/session_016f1PAaZ1HPSypJgAg7AfKv