### PR TITLE
Optimize Fragment rendering with fast-path for SafeHtml

### DIFF
--- a/src/lib/jsx/jsx-runtime.ts
+++ b/src/lib/jsx/jsx-runtime.ts
@@ -126,6 +126,11 @@ const renderAttr = (key: string, value: unknown): string => {
 export const jsx = (tag: string | Component, props: Props | null): SafeHtml => {
   const { children, ...attrs } = props ?? {};
 
+  // Fragment fast-path: pass through single SafeHtml child without re-wrapping
+  if (tag === Fragment) {
+    return isSafeHtml(children) ? children : new SafeHtml(renderChild(children));
+  }
+
   // Component function - call it with props
   if (typeof tag === "function") {
     const result = tag({ ...attrs, children });
@@ -153,8 +158,8 @@ export { jsx as jsxs, jsx as jsxDEV };
 /**
  * Fragment - just renders children without wrapper
  */
-export const Fragment = ({ children }: Props): SafeHtml =>
-  new SafeHtml(renderChild(children));
+export const Fragment = ({ children }: Props): string =>
+  renderChild(children);
 
 /**
  * Raw HTML insertion (use sparingly, bypasses escaping)

--- a/test/lib/jsx-runtime.test.ts
+++ b/test/lib/jsx-runtime.test.ts
@@ -109,6 +109,13 @@ describe("jsx-runtime", () => {
       const result = Fragment({ children: "<script>" });
       expect(result.toString()).toBe("&lt;script&gt;");
     });
+
+    test("passes through single SafeHtml child without re-wrapping", () => {
+      const inner = new SafeHtml("<b>bold</b>");
+      const result = jsx(Fragment, { children: inner });
+      expect(result).toBe(inner);
+      expect(result.toString()).toBe("<b>bold</b>");
+    });
   });
 
   describe("Raw", () => {


### PR DESCRIPTION
## Summary
This change optimizes Fragment rendering by adding a fast-path that avoids unnecessary re-wrapping of SafeHtml children, and simplifies the Fragment component's return type.

## Key Changes
- Added a fast-path check in the `jsx` function to handle Fragment tags specially: if a Fragment receives a single SafeHtml child, it returns it directly without re-wrapping
- Changed the `Fragment` component's return type from `SafeHtml` to `string` to return raw rendered output
- The Fragment component now calls `renderChild()` directly instead of wrapping the result in a new `SafeHtml` instance

## Implementation Details
The optimization recognizes that when rendering a Fragment with a SafeHtml child, there's no need to unwrap and re-wrap the HTML. The fast-path check `isSafeHtml(children) ? children : new SafeHtml(renderChild(children))` allows SafeHtml children to pass through unchanged while still handling other child types appropriately. This reduces unnecessary object allocation and processing for a common use case.

https://claude.ai/code/session_019bToPiNp9F3zCopRrGQCtC