### PR TITLE
Refine compact() to only remove null/undefined, not all falsy values

### DIFF
--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -118,11 +118,11 @@ export const uniqueBy =
   };
 
 /**
- * Remove falsy values from array
+ * Remove null and undefined values from array
  */
 export const compact = <T>(
-  array: (T | null | undefined | false | 0 | "")[],
-): T[] => array.filter(Boolean) as T[];
+  array: (T | null | undefined)[],
+): T[] => array.filter((x): x is T => x !== null && x !== undefined);
 
 /**
  * Group array items by a key function

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -143,7 +143,7 @@ export const sendRegistrationWebhooks = async (
 ): Promise<void> => {
   const envWebhookUrl = getEnv("WEBHOOK_URL");
   const webhookUrls = unique(compact([
-    ...entries.map((e) => e.event.webhook_url),
+    ...entries.map((e) => e.event.webhook_url || null),
     envWebhookUrl,
   ]));
   if (webhookUrls.length === 0) return;

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -2,7 +2,6 @@
  * Middleware functions for request processing
  */
 
-import { compact } from "#fp";
 import { getAllowedDomain, getEmbedHosts } from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
@@ -23,15 +22,19 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
  * Embeddable pages omit frame-ancestors here; it's added by applySecurityHeaders
  * if embed host restrictions are configured.
  */
-const buildCspHeader = (embeddable: boolean): string =>
-  compact([
-    !embeddable && "frame-ancestors 'none'",
+const buildCspHeader = (embeddable: boolean): string => {
+  const directives = [
     "default-src 'self'",
     "style-src 'self'",
     "script-src 'self' https://*.squarecdn.com https://js.squareup.com https://js.squareupsandbox.com",
     "connect-src 'self' https://pci-connect.squareup.com https://pci-connect.squareupsandbox.com",
     "form-action 'self' https://checkout.stripe.com",
-  ]).join("; ");
+  ];
+  if (!embeddable) {
+    directives.unshift("frame-ancestors 'none'");
+  }
+  return directives.join("; ");
+};
 
 /**
  * Get security headers for a response

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -245,16 +245,20 @@ describe("fp", () => {
   });
 
   describe("compact", () => {
-    test("removes falsy values", () => {
-      expect(compact([1, null, 2, undefined, 3, false, 0, "", 4])).toEqual([1, 2, 3, 4]);
+    test("removes null and undefined", () => {
+      expect(compact([1, null, 2, undefined, 3, 4])).toEqual([1, 2, 3, 4]);
+    });
+
+    test("preserves 0, empty string, and false", () => {
+      expect(compact([0, "", false, null, undefined])).toEqual([0, "", false]);
     });
 
     test("handles empty array", () => {
       expectEmptyPassthrough(compact);
     });
 
-    test("handles all falsy values", () => {
-      const result = compact([null, undefined, false, 0, ""]);
+    test("removes only null and undefined from mixed array", () => {
+      const result = compact([null, undefined]);
       expect(result).toEqual([]);
     });
   });


### PR DESCRIPTION
## Summary
Changed the `compact()` utility function to only filter out `null` and `undefined` values, rather than all falsy values. This is a more precise behavior that preserves legitimate falsy values like `0`, empty strings, and `false` in arrays.

## Key Changes
- **Updated `compact()` implementation** in `src/fp/index.ts`:
  - Changed type signature to only accept `T | null | undefined` instead of including `false | 0 | ""`
  - Replaced `filter(Boolean)` with explicit null/undefined check: `filter((x): x is T => x !== null && x !== undefined)`
  - Updated JSDoc to reflect the new behavior

- **Refactored `buildCspHeader()` in `src/routes/middleware.ts`:
  - Removed dependency on `compact()` function
  - Replaced functional approach with imperative array building
  - Conditionally adds `frame-ancestors 'none'` directive using `unshift()` instead of relying on `compact()` to filter falsy values

- **Updated `sendRegistrationWebhooks()` in `src/lib/webhook.ts`:
  - Changed `e.event.webhook_url` to `e.event.webhook_url || null` to explicitly convert falsy values to `null` before passing to `compact()`
  - Ensures the function behavior remains unchanged with the stricter `compact()` implementation

- **Updated test suite** in `test/lib/fp.test.ts`:
  - Split the original test into two separate tests to document the new behavior
  - Added test verifying that `0`, empty string, and `false` are preserved
  - Updated test descriptions to clarify the function only removes null/undefined

## Implementation Details
This change makes `compact()` more semantically correct—it now only removes "empty" values (null/undefined) rather than all falsy values, which is the typical behavior in functional programming libraries. Callers that relied on filtering all falsy values must now explicitly convert those values to null before calling `compact()`.

https://claude.ai/code/session_01WZzN2KwEv2swy5Y8GGnzC4