### PR TITLE
Refactor route dispatch to use O(1) prefix lookup instead of sequential matching

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -97,71 +97,60 @@ export {
 // Re-export types
 export type { ServerContext } from "#routes/types.ts";
 
-/** Check if path matches a route prefix (paths are normalized to strip trailing slashes) */
-const matchesPrefix = (path: string, prefix: string): boolean =>
-  path === prefix || path.startsWith(`${prefix}/`);
-
-/** Create a lazy-loaded route handler for a path prefix */
-const createLazyRoute =
-  (prefix: string, loadRoute: () => Promise<RouterFn>): RouterFn =>
-  async (request, path, method, server) => {
-    if (!matchesPrefix(path, prefix)) return null;
-    const route = await loadRoute();
-    return route(request, path, method, server);
-  };
-
-/** Route home page requests */
-const routeHome: RouterFn = async (_request, path, method) => {
-  if (path !== "/" || method !== "GET") return null;
-  const { handleHome } = await loadPublicRoutes();
-  return handleHome();
+/** Extract first path segment for O(1) prefix dispatch */
+const getPrefix = (path: string): string => {
+  const i = path.indexOf("/", 1);
+  return i === -1 ? path.slice(1) : path.slice(1, i);
 };
 
-/** Route public site pages (/events, /terms, /contact) */
-const routePublicPages: RouterFn = async (_request, path, method) => {
-  if (path === "/events") {
+/** Create a lazy-loaded route handler (prefix already matched by dispatch map) */
+const lazyRoute =
+  (load: () => Promise<RouterFn>): RouterFn =>
+  async (request, path, method, server) =>
+    (await load())(request, path, method, server);
+
+/** Prefix dispatch table — O(1) lookup replaces the sequential ?? chain */
+const prefixHandlers: Record<string, RouterFn> = {
+  // Exact-match public pages
+  "": async (_request, path, method) => {
+    if (path !== "/" || method !== "GET") return null;
+    const { handleHome } = await loadPublicRoutes();
+    return handleHome();
+  },
+  events: async (_request, path, method) => {
+    if (path !== "/events" || method !== "GET") return null;
     const { handlePublicEvents } = await loadPublicRoutes();
-    if (method === "GET") return handlePublicEvents();
-    return null;
-  }
-  if (path === "/terms" && method === "GET") {
+    return handlePublicEvents();
+  },
+  terms: async (_request, path, method) => {
+    if (path !== "/terms" || method !== "GET") return null;
     const { handlePublicTerms } = await loadPublicRoutes();
     return handlePublicTerms();
-  }
-  if (path === "/contact" && method === "GET") {
+  },
+  contact: async (_request, path, method) => {
+    if (path !== "/contact" || method !== "GET") return null;
     const { handlePublicContact } = await loadPublicRoutes();
     return handlePublicContact();
-  }
-  return null;
+  },
+  // Prefix-matched lazy-loaded route groups
+  admin: lazyRoute(loadAdminRoutes),
+  ticket: lazyRoute(async () => (await loadPublicRoutes()).routeTicket),
+  t: lazyRoute(loadTicketViewRoutes),
+  checkin: lazyRoute(loadCheckinRoutes),
+  image: lazyRoute(loadImageRoutes),
+  payment: lazyRoute(loadPaymentRoutes),
+  join: lazyRoute(loadJoinRoutes),
 };
-
-/** Lazy-loaded route handlers */
-const routeAdminPath = createLazyRoute("/admin", loadAdminRoutes);
-const routeTicketPath = createLazyRoute(
-  "/ticket",
-  async () => (await loadPublicRoutes()).routeTicket,
-);
-const routePaymentPath = createLazyRoute("/payment", loadPaymentRoutes);
-const routeJoinPath = createLazyRoute("/join", loadJoinRoutes);
-const routeTicketViewPath = createLazyRoute("/t", loadTicketViewRoutes);
-const routeCheckinPath = createLazyRoute("/checkin", loadCheckinRoutes);
-const routeImagePath = createLazyRoute("/image", loadImageRoutes);
 
 /**
  * Route main application requests (after setup is complete)
- * Routes are loaded lazily based on path prefix
+ * Uses prefix dispatch for O(1) route group lookup instead of sequential matching
  */
-const routeMainApp: RouterFn = async (request, path, method, server) =>
-  (await routeHome(request, path, method, server)) ??
-  (await routePublicPages(request, path, method, server)) ??
-  (await routeAdminPath(request, path, method, server)) ??
-  (await routeTicketPath(request, path, method, server)) ??
-  (await routeTicketViewPath(request, path, method, server)) ??
-  (await routeCheckinPath(request, path, method, server)) ??
-  (await routeImagePath(request, path, method, server)) ??
-  (await routePaymentPath(request, path, method, server)) ??
-  (await routeJoinPath(request, path, method, server)) ??
-  notFoundResponse();
+const routeMainApp: RouterFn = async (request, path, method, server) => {
+  const prefix = getPrefix(path);
+  if (!Object.hasOwn(prefixHandlers, prefix)) return notFoundResponse();
+  return (await prefixHandlers[prefix]!(request, path, method, server)) ?? notFoundResponse();
+};
 
 /**
  * Handle incoming requests (internal, without security headers)

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -36,16 +36,21 @@ const loadAdminRoutes = once(async () => {
   return routeAdmin;
 });
 
-/** Lazy-load public routes (ticket reservation) */
-const loadPublicRoutes = once(async () => {
+/** Lazy-load public page handlers (home, events, terms, contact) */
+const loadPublicPages = once(async () => {
   const {
     handleHome,
     handlePublicEvents,
     handlePublicTerms,
     handlePublicContact,
-    routeTicket,
   } = await import("#routes/public.ts");
-  return { handleHome, handlePublicEvents, handlePublicTerms, handlePublicContact, routeTicket };
+  return { handleHome, handlePublicEvents, handlePublicTerms, handlePublicContact };
+});
+
+/** Lazy-load ticket reservation router */
+const loadTicketRoutes = once(async () => {
+  const { routeTicket } = await import("#routes/public.ts");
+  return routeTicket;
 });
 
 /** Lazy-load setup routes */
@@ -114,27 +119,27 @@ const prefixHandlers: Record<string, RouterFn> = {
   // Exact-match public pages
   "": async (_request, path, method) => {
     if (path !== "/" || method !== "GET") return null;
-    const { handleHome } = await loadPublicRoutes();
+    const { handleHome } = await loadPublicPages();
     return handleHome();
   },
   events: async (_request, path, method) => {
     if (path !== "/events" || method !== "GET") return null;
-    const { handlePublicEvents } = await loadPublicRoutes();
+    const { handlePublicEvents } = await loadPublicPages();
     return handlePublicEvents();
   },
   terms: async (_request, path, method) => {
     if (path !== "/terms" || method !== "GET") return null;
-    const { handlePublicTerms } = await loadPublicRoutes();
+    const { handlePublicTerms } = await loadPublicPages();
     return handlePublicTerms();
   },
   contact: async (_request, path, method) => {
     if (path !== "/contact" || method !== "GET") return null;
-    const { handlePublicContact } = await loadPublicRoutes();
+    const { handlePublicContact } = await loadPublicPages();
     return handlePublicContact();
   },
   // Prefix-matched lazy-loaded route groups
   admin: lazyRoute(loadAdminRoutes),
-  ticket: lazyRoute(async () => (await loadPublicRoutes()).routeTicket),
+  ticket: lazyRoute(loadTicketRoutes),
   t: lazyRoute(loadTicketViewRoutes),
   checkin: lazyRoute(loadCheckinRoutes),
   image: lazyRoute(loadImageRoutes),


### PR DESCRIPTION
## Summary
Refactored the main application routing logic to use a prefix-based dispatch table for O(1) route group lookup, replacing the previous sequential null-coalescing chain. This improves routing performance and maintainability.

## Key Changes
- **Separated public page handlers from ticket routes**: Split `loadPublicRoutes` into `loadPublicPages` (home, events, terms, contact) and `loadTicketRoutes` (ticket reservation router) for better code organization
- **Introduced prefix dispatch table**: Created `prefixHandlers` object that maps URL prefixes to their corresponding route handlers, enabling constant-time lookup instead of sequential evaluation
- **Simplified route matching logic**: Replaced `createLazyRoute` and `matchesPrefix` utilities with a simpler `lazyRoute` wrapper and `getPrefix` helper that extracts the first path segment
- **Optimized `routeMainApp`**: Changed from a chain of null-coalescing operators (`??`) to a single prefix lookup followed by handler invocation

## Implementation Details
- The `getPrefix` function extracts the first path segment (e.g., "admin" from "/admin/users") in O(1) time
- The `prefixHandlers` map consolidates all route group definitions in one place, making it easier to add or modify routes
- Exact-match routes (home, events, terms, contact) are handled inline within the dispatch table
- Lazy-loaded route groups (admin, ticket, payment, etc.) use the `lazyRoute` wrapper to defer loading until needed
- The dispatch now returns `notFoundResponse()` if a prefix doesn't exist in the handlers map, eliminating the need for sequential fallthrough logic

https://claude.ai/code/session_014bwzk6ssDDTRf6V16TBiYK