### PR TITLE
Add ID to main navigation element for better targeting

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -125,9 +125,9 @@ if (checkoutPopup) {
   });
 }
 
-/* Scroll-hide nav: hide sticky nav on scroll down, show on scroll up or at top */
+/* Scroll-hide nav: hide sticky main nav on scroll down, show on scroll up or at top */
 {
-  const nav = document.querySelector("nav");
+  const nav = document.querySelector<HTMLElement>("#main-nav");
   if (nav) {
     if (location.hash) {
       nav.style.transition = "none";

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -231,7 +231,7 @@ nav ul li ul li a {
 
 /* Nav for Desktop */
 @media (min-width: 769px) {
-  nav {
+  nav#main-nav {
     margin: 0 auto 7rem;
     position: sticky;
     top: 1rem;
@@ -242,7 +242,7 @@ nav ul li ul li a {
     z-index: 10;
     transition: transform 0.25s ease, opacity 0.25s ease;
   }
-  nav.nav-hidden {
+  nav#main-nav.nav-hidden {
     transform: translateY(-150%);
     opacity: 0;
   }

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -20,7 +20,7 @@ const navLink = (href: string, label: string, active: string): JSX.Element => (
  * Users, Settings, and Sessions links only shown to owners
  */
 export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
-  <nav>
+  <nav id="main-nav">
     <ul>
       {navLink("/admin/", "Events", active)}
       {navLink("/admin/calendar", "Calendar", active)}


### PR DESCRIPTION
## Summary
This PR adds an `id="main-nav"` attribute to the main navigation element to enable more specific CSS and JavaScript targeting, replacing generic `nav` selectors.

## Key Changes
- Added `id="main-nav"` to the `<nav>` element in the admin navigation template
- Updated CSS selectors in `mvp.css` from `nav` to `nav#main-nav` for desktop navigation styles (sticky positioning and hidden state)
- Updated JavaScript selector in `admin.ts` from `document.querySelector("nav")` to `document.querySelector<HTMLElement>("#main-nav")` with proper TypeScript typing
- Updated comment to clarify that the scroll-hide behavior applies to the "main nav"

## Implementation Details
- The change maintains backward compatibility while making the navigation targeting more explicit and maintainable
- TypeScript generic type `<HTMLElement>` is now properly specified in the querySelector call
- All three files (template, styles, and script) are updated consistently to use the new ID-based selector

https://claude.ai/code/session_011mp9nsnuf5EpHESZ9jkZM3