### PR TITLE
Replace pipe/pipeAsync overloads with recursive conditional types

### DIFF
--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -3,7 +3,7 @@
  * Curried functions for array operations and composition
  */
 
-// --- Pipe type helpers (used by the 6+ catch-all overload) ---
+// --- Pipe type helpers ---
 
 /** A single-arg function (used as a constraint for pipe/pipeAsync generics) */
 // deno-lint-ignore no-explicit-any
@@ -30,34 +30,10 @@ type PipeReturn<Fns extends [Fn, ...Fn[]]> = ValidChain<Fns> extends true
 
 /**
  * Compose functions left-to-right (pipe)
- * Overloads 1-5 use bidirectional inference for optimal generic resolution.
- * The recursive catch-all handles 6+ functions with full type safety.
+ * Uses recursive conditional types for arbitrary-length type safety.
  */
 export function pipe<A>(): (a: A) => A;
-export function pipe<A, B>(fn1: (a: A) => B): (a: A) => B;
-export function pipe<A, B, C>(
-  fn1: (a: A) => B,
-  fn2: (b: B) => C,
-): (a: A) => C;
-export function pipe<A, B, C, D>(
-  fn1: (a: A) => B,
-  fn2: (b: B) => C,
-  fn3: (c: C) => D,
-): (a: A) => D;
-export function pipe<A, B, C, D, E>(
-  fn1: (a: A) => B,
-  fn2: (b: B) => C,
-  fn3: (c: C) => D,
-  fn4: (d: D) => E,
-): (a: A) => E;
-export function pipe<A, B, C, D, E, F>(
-  fn1: (a: A) => B,
-  fn2: (b: B) => C,
-  fn3: (c: C) => D,
-  fn4: (d: D) => E,
-  fn5: (e: E) => F,
-): (a: A) => F;
-export function pipe<Fns extends [Fn, Fn, Fn, Fn, Fn, Fn, ...Fn[]]>(
+export function pipe<Fns extends [Fn, ...Fn[]]>(
   ...fns: [...Fns]
 ): PipeReturn<Fns>;
 export function pipe(
@@ -302,7 +278,7 @@ export const bracket =
     }
   };
 
-// --- Async pipe type helpers (used by the 5+ catch-all overload) ---
+// --- Async pipe type helpers ---
 
 /** A single-arg async function */
 // deno-lint-ignore no-explicit-any
@@ -334,27 +310,9 @@ type PipeAsyncReturn<Fns extends [AsyncFn, ...AsyncFn[]]> =
 /**
  * Async pipe - compose async functions left-to-right
  * Each function receives the awaited result of the previous one.
- * Overloads 1-4 use bidirectional inference; recursive catch-all handles 5+.
+ * Uses recursive conditional types for arbitrary-length type safety.
  */
-export function pipeAsync<A, B>(
-  fn1: (a: A) => Promise<B>,
-): (a: A) => Promise<B>;
-export function pipeAsync<A, B, C>(
-  fn1: (a: A) => Promise<B>,
-  fn2: (b: B) => Promise<C>,
-): (a: A) => Promise<C>;
-export function pipeAsync<A, B, C, D>(
-  fn1: (a: A) => Promise<B>,
-  fn2: (b: B) => Promise<C>,
-  fn3: (c: C) => Promise<D>,
-): (a: A) => Promise<D>;
-export function pipeAsync<A, B, C, D, E>(
-  fn1: (a: A) => Promise<B>,
-  fn2: (b: B) => Promise<C>,
-  fn3: (c: C) => Promise<D>,
-  fn4: (d: D) => Promise<E>,
-): (a: A) => Promise<E>;
-export function pipeAsync<Fns extends [AsyncFn, AsyncFn, AsyncFn, AsyncFn, AsyncFn, ...AsyncFn[]]>(
+export function pipeAsync<Fns extends [AsyncFn, ...AsyncFn[]]>(
   ...fns: [...Fns]
 ): PipeAsyncReturn<Fns>;
 export function pipeAsync(

--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -3,13 +3,42 @@
  * Curried functions for array operations and composition
  */
 
+// --- Pipe type helpers (used by the 6+ catch-all overload) ---
+
+/** A single-arg function (used as a constraint for pipe/pipeAsync generics) */
+// deno-lint-ignore no-explicit-any
+type Fn = (arg: any) => any;
+
+/** Validates that each fn's return type is assignable to the next fn's parameter */
+type ValidChain<Fns extends Fn[]> = Fns extends [Fn]
+  ? true
+  : Fns extends
+    [infer A extends Fn, infer B extends Fn, ...infer Rest extends Fn[]]
+    ? ReturnType<A> extends Parameters<B>[0] ? ValidChain<[B, ...Rest]>
+      : false
+    : true;
+
+/** Extracts the return type of the last fn in a tuple */
+type LastReturn<Fns extends Fn[]> = Fns extends [...Fn[], infer L extends Fn]
+  ? ReturnType<L>
+  : never;
+
+/** Computes pipe's return type, returning a non-callable error type on mismatch */
+type PipeReturn<Fns extends [Fn, ...Fn[]]> = ValidChain<Fns> extends true
+  ? (arg: Parameters<Fns[0]>[0]) => LastReturn<Fns>
+  : (invalid: never) => never;
+
 /**
  * Compose functions left-to-right (pipe)
- * Supports type transformations through the chain
+ * Overloads 1-5 use bidirectional inference for optimal generic resolution.
+ * The recursive catch-all handles 6+ functions with full type safety.
  */
 export function pipe<A>(): (a: A) => A;
 export function pipe<A, B>(fn1: (a: A) => B): (a: A) => B;
-export function pipe<A, B, C>(fn1: (a: A) => B, fn2: (b: B) => C): (a: A) => C;
+export function pipe<A, B, C>(
+  fn1: (a: A) => B,
+  fn2: (b: B) => C,
+): (a: A) => C;
 export function pipe<A, B, C, D>(
   fn1: (a: A) => B,
   fn2: (b: B) => C,
@@ -28,6 +57,9 @@ export function pipe<A, B, C, D, E, F>(
   fn4: (d: D) => E,
   fn5: (e: E) => F,
 ): (a: A) => F;
+export function pipe<Fns extends [Fn, Fn, Fn, Fn, Fn, Fn, ...Fn[]]>(
+  ...fns: [...Fns]
+): PipeReturn<Fns>;
 export function pipe(
   ...fns: Array<(arg: unknown) => unknown>
 ): (value: unknown) => unknown {
@@ -270,9 +302,39 @@ export const bracket =
     }
   };
 
+// --- Async pipe type helpers (used by the 5+ catch-all overload) ---
+
+/** A single-arg async function */
+// deno-lint-ignore no-explicit-any
+type AsyncFn = (arg: any) => Promise<any>;
+
+/** Validates that each async fn's Awaited return matches the next fn's parameter */
+type ValidAsyncChain<Fns extends AsyncFn[]> = Fns extends [AsyncFn]
+  ? true
+  : Fns extends
+    [infer A extends AsyncFn, infer B extends AsyncFn, ...infer Rest extends AsyncFn[]]
+    ? Awaited<ReturnType<A>> extends Parameters<B>[0]
+      ? ValidAsyncChain<[B, ...Rest]>
+      : false
+    : true;
+
+/** Extracts the Awaited return type of the last async fn */
+type LastAsyncReturn<Fns extends AsyncFn[]> = Fns extends [
+  ...AsyncFn[],
+  infer L extends AsyncFn,
+] ? Awaited<ReturnType<L>>
+  : never;
+
+/** Computes pipeAsync's return type, returning a non-callable error type on mismatch */
+type PipeAsyncReturn<Fns extends [AsyncFn, ...AsyncFn[]]> =
+  ValidAsyncChain<Fns> extends true
+    ? (arg: Parameters<Fns[0]>[0]) => Promise<LastAsyncReturn<Fns>>
+    : (invalid: never) => Promise<never>;
+
 /**
  * Async pipe - compose async functions left-to-right
- * Each function receives the result of the previous one
+ * Each function receives the awaited result of the previous one.
+ * Overloads 1-4 use bidirectional inference; recursive catch-all handles 5+.
  */
 export function pipeAsync<A, B>(
   fn1: (a: A) => Promise<B>,
@@ -292,6 +354,9 @@ export function pipeAsync<A, B, C, D, E>(
   fn3: (c: C) => Promise<D>,
   fn4: (d: D) => Promise<E>,
 ): (a: A) => Promise<E>;
+export function pipeAsync<Fns extends [AsyncFn, AsyncFn, AsyncFn, AsyncFn, AsyncFn, ...AsyncFn[]]>(
+  ...fns: [...Fns]
+): PipeAsyncReturn<Fns>;
 export function pipeAsync(
   ...fns: Array<(arg: unknown) => Promise<unknown>>
 ): (value: unknown) => Promise<unknown> {

--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -57,7 +57,7 @@ const compileDateOptions = (
 ): CalendarDateOption[] => {
   const availableDates = pipe(
     flatMap((event: EventWithCount) => getAvailableDates(event, holidays)),
-    unique,
+    (dates: string[]) => unique(dates),
   )(dailyEvents);
 
   const standardDates = Array.from(standardEventDateMap.keys());

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -68,8 +68,8 @@ export const parseCookies = (request: Request): Map<string, string> => {
 
   return pipe(
     map(toPair),
-    compact,
-    reduce((acc, [key, value]) => {
+    (pairs: (CookiePair | null)[]) => compact(pairs),
+    reduce((acc: Map<string, string>, [key, value]: CookiePair) => {
       acc.set(key, value);
       return acc;
     }, new Map<string, string>()),

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -113,6 +113,19 @@ describe("fp", () => {
     test("works with no functions", () => {
       expect(pipe<number>()(5)).toBe(5);
     });
+
+    test("works with 6+ functions (recursive type catch-all)", () => {
+      const addOne = (x: number) => x + 1;
+      const result = pipe(
+        addOne,
+        double,
+        addOne,
+        double,
+        addOne,
+        double,
+      )(0); // (((((0+1)*2)+1)*2)+1)*2 = ((((1*2)+1)*2)+1)*2 = (((2+1)*2)+1)*2 = ((3*2)+1)*2 = (6+1)*2 = 14
+      expect(result).toBe(14);
+    });
   });
 
   describe("filter", () => {


### PR DESCRIPTION
## Summary
Refactored `pipe` and `pipeAsync` functions to use recursive conditional types instead of fixed-length function overloads, enabling type-safe composition of arbitrary-length function chains.

## Key Changes
- **Replaced overloads with generic constraints**: Removed 5 hardcoded overload signatures for `pipe` and 4 for `pipeAsync`, replacing them with single generic signatures using recursive conditional types
- **Added type helpers**: Introduced `ValidChain`, `LastReturn`, and `PipeReturn` for `pipe`, and `ValidAsyncChain`, `LastAsyncReturn`, and `PipeAsyncReturn` for `pipeAsync` to validate function chains and compute return types
- **Maintained type safety**: Recursive conditional types validate that each function's return type matches the next function's parameter type, with compile-time errors for mismatches
- **Updated call sites**: Modified `parseCookies` in `src/routes/utils.ts` and `compileDateOptions` in `src/routes/admin/calendar.ts` to explicitly annotate intermediate pipe results, ensuring proper type inference through the chain
- **Added test coverage**: Added test case for 6+ function chains to verify the recursive type system works beyond the previous 5-function limit

## Implementation Details
- The recursive conditional types use TypeScript's `infer` keyword to destructure function tuples and validate type compatibility at each step
- `Awaited<>` utility is used in async variants to properly unwrap Promise types for validation
- Explicit type annotations on intermediate results in call sites help TypeScript's type inference work correctly with the new generic approach

https://claude.ai/code/session_0169kF2PLPYv6PCBsVtPN3Fn