### PR TITLE
Optimize table update to use RETURNING clause

### DIFF
--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -173,14 +173,14 @@ const buildInsertSql = (name: string, columns: string[]): string => {
   return `INSERT INTO ${name} (${columns.join(", ")}) VALUES (${placeholders})`;
 };
 
-/** Build UPDATE SQL */
+/** Build UPDATE SQL with RETURNING to get updated row in one round trip */
 const buildUpdateSql = (
   name: string,
   columns: string[],
   primaryKey: string,
 ): string => {
   const setClauses = columns.map((col) => `${col} = ?`).join(", ");
-  return `UPDATE ${name} SET ${setClauses} WHERE ${primaryKey} = ?`;
+  return `UPDATE ${name} SET ${setClauses} WHERE ${primaryKey} = ? RETURNING *`;
 };
 
 /**
@@ -284,7 +284,7 @@ export const defineTable = <Row, Input = Row>(config: {
       (inputKeyMap[col] as string) in (input as object),
     )(inputColumns);
 
-  // Update implementation
+  // Update implementation - uses RETURNING * to avoid a second round trip
   const update = async (
     id: InValue,
     input: Partial<Input>,
@@ -302,13 +302,12 @@ export const defineTable = <Row, Input = Row>(config: {
       id,
     ];
 
-    const result = await getDb().execute({
-      sql: buildUpdateSql(name, providedColumns, primaryKey),
+    const row = await queryOne<Row>(
+      buildUpdateSql(name, providedColumns, primaryKey),
       args,
-    });
+    );
 
-    if (result.rowsAffected === 0) return null;
-    return findById(id);
+    return row ? fromDb(row) : null;
   };
 
   // Find by ID implementation


### PR DESCRIPTION
## Summary
Optimized the `update` method in the table definition to use the SQL `RETURNING` clause, eliminating an unnecessary second database round trip when fetching the updated row.

## Key Changes
- Modified `buildUpdateSql` to append `RETURNING *` to UPDATE statements
- Refactored the `update` method to use `queryOne()` with the RETURNING clause instead of executing the update and then calling `findById()`
- Changed from checking `result.rowsAffected` to checking if the returned row exists
- Updated JSDoc comments to clarify the optimization

## Implementation Details
- The update now retrieves the updated row in a single database round trip instead of two separate queries
- The returned row is transformed using the existing `fromDb()` function to maintain consistency with other query methods
- Returns `null` if no row was updated (same behavior as before)

https://claude.ai/code/session_01NgoyBsiGgy4RsT8gtT52xx