### PR TITLE
Replace PBKDF2 with HKDF for session token key derivation

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -570,7 +570,9 @@ export const unwrapKey = (
 ): Promise<CryptoKey> => unwrapAndImportKey(wrapped, unwrappingKey);
 
 /**
- * Derive a wrapping/unwrapping key from a session token using PBKDF2.
+ * Derive a wrapping/unwrapping key from a session token using HKDF.
+ * HKDF is the correct primitive here: the session token is already
+ * high-entropy, so password-stretching (PBKDF2) is unnecessary.
  * Incorporates DB_ENCRYPTION_KEY in salt to ensure session tokens alone
  * cannot be used to wrap/unwrap keys without access to the encryption key.
  */
@@ -582,16 +584,16 @@ const deriveTokenKey = async (
   const tokenKey = await crypto.subtle.importKey(
     "raw",
     encoder.encode(sessionToken),
-    { name: "PBKDF2" },
+    { name: "HKDF" },
     false,
     ["deriveKey"],
   );
   const salt = encoder.encode(`session-key-wrap:${getEncryptionKeyString()}`);
   return crypto.subtle.deriveKey(
     {
-      name: "PBKDF2",
+      name: "HKDF",
       salt,
-      iterations: 1, // Fast - token is already high entropy
+      info: new Uint8Array(),
       hash: "SHA-256",
     },
     tokenKey,
@@ -802,7 +804,7 @@ export const encryptAttendeePII = async (
 
 /**
  * Private key cache with TTL (10 seconds, matching session cache)
- * Avoids re-running the full unwrap chain (PBKDF2 + AES + RSA import) per request
+ * Avoids re-running the full unwrap chain (HKDF + AES + RSA import) per request
  */
 const privateKeyCache = ttlCache<string, CryptoKey>(10_000);
 


### PR DESCRIPTION
## Summary
Replace PBKDF2 with HKDF for deriving wrapping/unwrapping keys from session tokens, as the session token is already high-entropy and doesn't require password-stretching.

## Changes
- Updated `deriveTokenKey()` to use HKDF instead of PBKDF2 for key derivation
- Removed the `iterations: 1` parameter (PBKDF2-specific) and replaced with `info: new Uint8Array()` (HKDF-specific)
- Updated JSDoc comments to reflect the algorithm change and explain the rationale
- Updated related comments in the private key cache documentation

## Implementation Details
HKDF is the appropriate primitive for this use case because:
- The session token is already high-entropy, eliminating the need for password-stretching
- HKDF is designed for deriving keys from high-entropy input material
- The salt continues to incorporate `DB_ENCRYPTION_KEY` to ensure session tokens alone cannot be used without access to the encryption key

https://claude.ai/code/session_01VyYYATGRKg5iEQWwJLoCSL