### PR TITLE
Invalidate events cache when deleting events by ID

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -154,6 +154,10 @@ export const eventsTable: typeof rawEventsTable = {
     invalidateEventsCache();
     return result;
   },
+  deleteById: async (id) => {
+    await rawEventsTable.deleteById(id);
+    invalidateEventsCache();
+  },
 };
 
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -676,6 +676,22 @@ describe("db", () => {
       expect(fetched).toBeNull();
     });
 
+    test("eventsTable.deleteById invalidates cache", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+
+      // Populate cache
+      const before = await getEvent(event.id);
+      expect(before).not.toBeNull();
+
+      await eventsTable.deleteById(event.id);
+
+      const after = await getEvent(event.id);
+      expect(after).toBeNull();
+    });
+
     test("isSlugTaken with excludeEventId excludes that event", async () => {
       const event = await createTestEvent({
         name: "Slug Taken Test",


### PR DESCRIPTION
## Summary
Added cache invalidation to the `deleteById` method in the events table to ensure that deleted events are properly removed from the cache.

## Key Changes
- Implemented `deleteById` method wrapper in `eventsTable` that calls the underlying `rawEventsTable.deleteById()` and then invalidates the events cache
- Added test case to verify that the cache is properly invalidated when an event is deleted by ID

## Implementation Details
The `deleteById` method follows the same pattern as other cache-invalidating operations in the events table (like `update`). When an event is deleted, `invalidateEventsCache()` is called to ensure subsequent queries will fetch fresh data from the database rather than returning stale cached results.

https://claude.ai/code/session_014aDk1uMwPNtP7Y8PecaUn3