### PR TITLE
Split mapAsync into mapSequential and mapParallel

### DIFF
--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -305,9 +305,9 @@ export function pipeAsync(
 }
 
 /**
- * Map over a promise-returning function (async map)
+ * Map over a promise-returning function sequentially (one at a time)
  */
-export const mapAsync =
+export const mapSequential =
   <T, U>(fn: (item: T) => Promise<U>) =>
   async (array: T[]): Promise<U[]> => {
     const results: U[] = [];

--- a/src/fp/index.ts
+++ b/src/fp/index.ts
@@ -317,6 +317,14 @@ export const mapSequential =
     return results;
   };
 
+/**
+ * Map over a promise-returning function in parallel (Promise.all)
+ */
+export const mapParallel =
+  <T, U>(fn: (item: T) => Promise<U>) =>
+  (array: T[]): Promise<U[]> =>
+    Promise.all(array.map(fn));
+
 /** Bounded LRU cache returned by boundedLru() */
 export type BoundedLru<K, V> = {
   get: (key: K) => V | undefined;

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -2,7 +2,7 @@
  * Groups table operations
  */
 
-import { collectionCache, mapSequential } from "#fp";
+import { collectionCache, mapParallel } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
@@ -139,7 +139,7 @@ const queryGroupEvents = async (
     [groupId],
   );
 
-  return mapSequential(decryptEventWithCount)(rows);
+  return mapParallel(decryptEventWithCount)(rows);
 };
 
 /**
@@ -167,7 +167,7 @@ export const getUngroupedEvents = async (): Promise<EventWithCount[]> => {
      ORDER BY e.created DESC, e.id DESC`,
   );
 
-  return mapSequential(decryptEventWithCount)(rows);
+  return mapParallel(decryptEventWithCount)(rows);
 };
 
 /**

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -2,7 +2,7 @@
  * Groups table operations
  */
 
-import { collectionCache, mapAsync } from "#fp";
+import { collectionCache, mapSequential } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
@@ -139,7 +139,7 @@ const queryGroupEvents = async (
     [groupId],
   );
 
-  return mapAsync(decryptEventWithCount)(rows);
+  return mapSequential(decryptEventWithCount)(rows);
 };
 
 /**
@@ -167,7 +167,7 @@ export const getUngroupedEvents = async (): Promise<EventWithCount[]> => {
      ORDER BY e.created DESC, e.id DESC`,
   );
 
-  return mapAsync(decryptEventWithCount)(rows);
+  return mapSequential(decryptEventWithCount)(rows);
 };
 
 /**

--- a/src/lib/db/query.ts
+++ b/src/lib/db/query.ts
@@ -1,4 +1,4 @@
-import { mapAsync } from "#fp";
+import { mapSequential } from "#fp";
 import { getDb, resultRows } from "#lib/db/client.ts";
 import { trackQuery } from "#lib/db/query-log.ts";
 
@@ -12,5 +12,5 @@ export const queryAndMap = <Row, Out>(
 ) =>
 async (sql: string): Promise<Out[]> => {
   const result = await trackQuery(sql, () => getDb().execute(sql));
-  return mapAsync(toOut)(resultRows<Row>(result));
+  return mapSequential(toOut)(resultRows<Row>(result));
 };

--- a/src/lib/db/query.ts
+++ b/src/lib/db/query.ts
@@ -1,4 +1,4 @@
-import { mapSequential } from "#fp";
+import { mapParallel } from "#fp";
 import { getDb, resultRows } from "#lib/db/client.ts";
 import { trackQuery } from "#lib/db/query-log.ts";
 
@@ -12,5 +12,5 @@ export const queryAndMap = <Row, Out>(
 ) =>
 async (sql: string): Promise<Out[]> => {
   const result = await trackQuery(sql, () => getDb().execute(sql));
-  return mapSequential(toOut)(resultRows<Row>(result));
+  return mapParallel(toOut)(resultRows<Row>(result));
 };

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -9,7 +9,7 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { compact, filter, mapSequential, reduce } from "#fp";
+import { compact, filter, mapParallel, reduce } from "#fp";
 import { getDb, queryAll, queryOne } from "#lib/db/client.ts";
 
 /**
@@ -207,7 +207,7 @@ export const defineTable = <Row, Input = Row>(config: {
 
   // Transform a row from DB (apply read transforms)
   const fromDb = async (row: Row): Promise<Row> => {
-    const entries = await mapSequential(async (col: keyof Row & string) => {
+    const entries = await mapParallel(async (col: keyof Row & string) => {
       const def = schema[col];
       const value = row[col];
       if (def.read && value !== null) {
@@ -237,7 +237,7 @@ export const defineTable = <Row, Input = Row>(config: {
   const toDbValues = async (
     input: Input | Partial<Input>,
   ): Promise<Record<string, InValue>> => {
-    const entries = await mapSequential((col: string) => processColumn(col, input))(inputColumns);
+    const entries = await mapParallel((col: string) => processColumn(col, input))(inputColumns);
     return Object.fromEntries(compact(entries));
   };
 
@@ -331,7 +331,7 @@ export const defineTable = <Row, Input = Row>(config: {
   // Find all implementation
   const findAll = async (): Promise<Row[]> => {
     const rows = await queryAll<Row>(`SELECT * FROM ${name}`);
-    return mapSequential(fromDb)(rows);
+    return mapParallel(fromDb)(rows);
   };
 
   return {

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -9,7 +9,7 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { compact, filter, mapAsync, reduce } from "#fp";
+import { compact, filter, mapSequential, reduce } from "#fp";
 import { getDb, queryAll, queryOne } from "#lib/db/client.ts";
 
 /**
@@ -207,7 +207,7 @@ export const defineTable = <Row, Input = Row>(config: {
 
   // Transform a row from DB (apply read transforms)
   const fromDb = async (row: Row): Promise<Row> => {
-    const entries = await mapAsync(async (col: keyof Row & string) => {
+    const entries = await mapSequential(async (col: keyof Row & string) => {
       const def = schema[col];
       const value = row[col];
       if (def.read && value !== null) {
@@ -237,7 +237,7 @@ export const defineTable = <Row, Input = Row>(config: {
   const toDbValues = async (
     input: Input | Partial<Input>,
   ): Promise<Record<string, InValue>> => {
-    const entries = await mapAsync((col: string) => processColumn(col, input))(inputColumns);
+    const entries = await mapSequential((col: string) => processColumn(col, input))(inputColumns);
     return Object.fromEntries(compact(entries));
   };
 
@@ -331,7 +331,7 @@ export const defineTable = <Row, Input = Row>(config: {
   // Find all implementation
   const findAll = async (): Promise<Row[]> => {
     const rows = await queryAll<Row>(`SELECT * FROM ${name}`);
-    return mapAsync(fromDb)(rows);
+    return mapSequential(fromDb)(rows);
   };
 
   return {

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -12,7 +12,7 @@ import {
   isDefined,
   lazyRef,
   map,
-  mapAsync,
+  mapSequential,
   memoize,
   ok,
   once,
@@ -454,20 +454,20 @@ describe("fp", () => {
     });
   });
 
-  describe("mapAsync", () => {
+  describe("mapSequential", () => {
     const asyncDouble = (x: number) => Promise.resolve(x * 2);
 
     test("maps array with async function", async () => {
-      expect(await mapAsync(asyncDouble)([2, 3, 4])).toEqual([4, 6, 8]);
+      expect(await mapSequential(asyncDouble)([2, 3, 4])).toEqual([4, 6, 8]);
     });
 
     test("preserves order with async operations", async () => {
       const wait = (ms: number) => Promise.resolve(ms);
-      expect(await mapAsync(wait)([30, 10, 20])).toEqual([30, 10, 20]);
+      expect(await mapSequential(wait)([30, 10, 20])).toEqual([30, 10, 20]);
     });
 
     test("handles empty array", async () => {
-      expect(await mapAsync(asyncDouble)([])).toEqual([]);
+      expect(await mapSequential(asyncDouble)([])).toEqual([]);
     });
   });
 

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -12,6 +12,7 @@ import {
   isDefined,
   lazyRef,
   map,
+  mapParallel,
   mapSequential,
   memoize,
   ok,
@@ -468,6 +469,38 @@ describe("fp", () => {
 
     test("handles empty array", async () => {
       expect(await mapSequential(asyncDouble)([])).toEqual([]);
+    });
+  });
+
+  describe("mapParallel", () => {
+    const asyncDouble = (x: number) => Promise.resolve(x * 2);
+
+    test("maps array with async function", async () => {
+      expect(await mapParallel(asyncDouble)([2, 3, 4])).toEqual([4, 6, 8]);
+    });
+
+    test("preserves result order regardless of completion order", async () => {
+      const delayed = (ms: number) =>
+        new Promise<number>((resolve) => setTimeout(() => resolve(ms), ms));
+      expect(await mapParallel(delayed)([30, 10, 20])).toEqual([30, 10, 20]);
+    });
+
+    test("handles empty array", async () => {
+      expect(await mapParallel(asyncDouble)([])).toEqual([]);
+    });
+
+    test("runs operations concurrently", async () => {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const track = async (x: number) => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((r) => setTimeout(r, 10));
+        concurrent--;
+        return x;
+      };
+      await mapParallel(track)([1, 2, 3]);
+      expect(maxConcurrent).toBe(3);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR refactors the async mapping functionality by splitting the single `mapAsync` function into two distinct functions with different execution strategies: `mapSequential` for sequential execution and `mapParallel` for concurrent execution.

## Key Changes
- **Renamed `mapAsync` to `mapSequential`**: Maintains the original sequential behavior where promises are awaited one at a time
- **Added new `mapParallel` function**: Uses `Promise.all()` to execute all async operations concurrently while preserving result order
- **Updated all call sites**: Replaced `mapAsync` imports and usages with `mapParallel` throughout the codebase where concurrent execution is appropriate:
  - `src/lib/db/table.ts`: Database row transformations (read/write operations)
  - `src/lib/db/groups.ts`: Event decryption operations
  - `src/lib/db/query.ts`: Query result mapping
- **Added comprehensive tests**: New test suite for `mapParallel` including a concurrency verification test

## Implementation Details
- `mapSequential`: Iterates through array items and awaits each promise sequentially, maintaining strict order and preventing concurrent execution
- `mapParallel`: Maps all items to promises and uses `Promise.all()` for concurrent execution, which is more efficient for I/O-bound operations like database queries and decryption
- Both functions maintain the same curried API signature for consistency with the rest of the fp library

https://claude.ai/code/session_01QKum7Y2tPD4vNYE5zdfvGn