### PR TITLE
Replace HKDF with PBKDF2 for session token key derivation

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -570,9 +570,7 @@ export const unwrapKey = (
 ): Promise<CryptoKey> => unwrapAndImportKey(wrapped, unwrappingKey);
 
 /**
- * Derive a wrapping/unwrapping key from a session token using HKDF.
- * HKDF is the correct primitive here: the session token is already
- * high-entropy, so password-stretching (PBKDF2) is unnecessary.
+ * Derive a wrapping/unwrapping key from a session token using PBKDF2.
  * Incorporates DB_ENCRYPTION_KEY in salt to ensure session tokens alone
  * cannot be used to wrap/unwrap keys without access to the encryption key.
  */
@@ -584,16 +582,16 @@ const deriveTokenKey = async (
   const tokenKey = await crypto.subtle.importKey(
     "raw",
     encoder.encode(sessionToken),
-    { name: "HKDF" },
+    { name: "PBKDF2" },
     false,
     ["deriveKey"],
   );
   const salt = encoder.encode(`session-key-wrap:${getEncryptionKeyString()}`);
   return crypto.subtle.deriveKey(
     {
-      name: "HKDF",
+      name: "PBKDF2",
       salt,
-      info: new Uint8Array(),
+      iterations: 1, // Fast - token is already high entropy
       hash: "SHA-256",
     },
     tokenKey,
@@ -804,7 +802,7 @@ export const encryptAttendeePII = async (
 
 /**
  * Private key cache with TTL (10 seconds, matching session cache)
- * Avoids re-running the full unwrap chain (HKDF + AES + RSA import) per request
+ * Avoids re-running the full unwrap chain (PBKDF2 + AES + RSA import) per request
  */
 const privateKeyCache = ttlCache<string, CryptoKey>(10_000);
 


### PR DESCRIPTION
## Summary
This change replaces HKDF with PBKDF2 as the key derivation function for deriving wrapping/unwrapping keys from session tokens.

## Key Changes
- Updated `deriveTokenKey()` function to use PBKDF2 instead of HKDF for key derivation
- Changed the algorithm name from "HKDF" to "PBKDF2" in both the `importKey()` and `deriveKey()` calls
- Replaced HKDF-specific parameters (`info: new Uint8Array()`) with PBKDF2-specific parameters (`iterations: 1`)
- Updated documentation comments to reflect the use of PBKDF2 and clarify that the single iteration is acceptable because the session token is already high-entropy
- Updated related comment in the private key cache documentation to reference PBKDF2 instead of HKDF

## Implementation Details
The change maintains the same security properties by:
- Keeping the salt derivation unchanged (incorporating `DB_ENCRYPTION_KEY`)
- Using SHA-256 as the hash algorithm
- Setting iterations to 1 since the session token is already high-entropy, making password-stretching unnecessary
- Preserving the same key derivation workflow and integration with the rest of the encryption chain

https://claude.ai/code/session_01GurbAvNyUp1rpy4RocbmJ2