### PR TITLE
Add non-transferable ticket support with ID verification

### DIFF
--- a/src/client/scanner.js
+++ b/src/client/scanner.js
@@ -17,9 +17,10 @@ const extractToken = (data) => {
 };
 
 /** POST to scan API */
-const postScan = async (eventId, token, csrfToken, force) => {
+const postScan = async (eventId, token, csrfToken, { force, idVerified } = {}) => {
   const body = { token };
   if (force) body.force = true;
+  if (idVerified) body.id_verified = true;
 
   const res = await fetch(`/admin/event/${eventId}/scan`, {
     method: "POST",
@@ -117,10 +118,20 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
             `${result.name} is registered for "${result.eventName}", not this event. Check in anyway?`,
           );
           if (ok) {
-            const forced = await postScan(eventId, token, csrfToken, true);
+            const forced = await postScan(eventId, token, csrfToken, { force: true });
             handleResult(statusEl, forced);
           } else {
             showStatus(statusEl, `Skipped ${result.name}`, "warning");
+          }
+        } else if (result.status === "verify_id") {
+          const ok = confirm(
+            `Does their ID match "${result.name}"?`,
+          );
+          if (ok) {
+            const verified = await postScan(eventId, token, csrfToken, { idVerified: true });
+            handleResult(statusEl, verified);
+          } else {
+            showStatus(statusEl, `ID does not match ${result.name}`, "error");
           }
         } else {
           handleResult(statusEl, result);

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -544,7 +544,6 @@ export const updateAttendee = async (
     input.special_instructions,
     publicKeyJwk,
   );
-
   await getDb().execute({
     sql: "UPDATE attendees SET name = ?, email = ?, phone = ?, address = ?, special_instructions = ?, event_id = ? WHERE id = ?",
     args: [

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -40,6 +40,7 @@ export type EventInput = {
   minimumDaysBefore?: number;
   maximumDaysAfter?: number;
   imageUrl?: string;
+  nonTransferable?: boolean;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -121,11 +122,7 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
     unit_price: col.simple<number | null>(),
     max_quantity: col.withDefault(() => 1),
     webhook_url: { default: () => "", write: encrypt, read: decrypt },
-    active: col.converted<boolean>({
-      default: () => true,
-      write: (v) => v ? 1 : 0,
-      read: (v) => v === 1,
-    }),
+    active: col.boolean(true),
     fields: col.withDefault<EventFields>(() => "email"),
     closes_at: col.transform<string | null>(writeClosesAt, readClosesAt),
     event_type: col.withDefault<EventType>(() => "standard"),
@@ -140,6 +137,7 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
     minimum_days_before: col.withDefault(() => 1),
     maximum_days_after: col.withDefault(() => 90),
     image_url: { default: () => "", write: encrypt, read: decrypt },
+    non_transferable: col.boolean(false),
   });
 
 export const eventsTable: typeof rawEventsTable = {

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -9,7 +9,7 @@ import { getPublicKey, getSetting } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "backfill null thank_you_url and webhook_url";
+export const LATEST_UPDATE = "add non_transferable to events";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -452,6 +452,9 @@ export const initDb = async (): Promise<void> => {
   // Migration: backfill NULL thank_you_url and webhook_url with encrypted empty strings
   await backfillEncryptedColumn("events", "thank_you_url", `thank_you_url IS NULL`);
   await backfillEncryptedColumn("events", "webhook_url", `webhook_url IS NULL`);
+
+  // Migration: add non_transferable column to events (boolean, default false)
+  await runMigration(`ALTER TABLE events ADD COLUMN non_transferable INTEGER NOT NULL DEFAULT 0`);
 
   // Update the version marker
   await getDb().execute({

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -400,4 +400,11 @@ export const col = {
     write: config.write as (v: App) => App,
     read: config.read as (v: App) => App,
   }),
+
+  /** Boolean column stored as INTEGER (0/1) in the database */
+  boolean: (defaultValue: boolean): ColumnDef<boolean> => ({
+    default: () => defaultValue,
+    write: ((v: boolean) => v ? 1 : 0) as unknown as (v: boolean) => boolean,
+    read: ((v: boolean) => v === (1 as unknown as boolean)) as (v: boolean) => boolean,
+  }),
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface Event {
   minimum_days_before: number;
   maximum_days_after: number;
   image_url: string;
+  non_transferable: boolean;
 }
 
 export interface Attendee extends ContactInfo {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -90,6 +90,7 @@ const extractCommonFields = (values: EventFormValues) => {
     bookableDays: parseBookableDays(values.bookable_days),
     minimumDaysBefore: values.minimum_days_before ?? 1,
     maximumDaysAfter: values.maximum_days_after ?? 90,
+    nonTransferable: values.non_transferable === "1",
   };
 };
 

--- a/src/routes/admin/scanner.ts
+++ b/src/routes/admin/scanner.ts
@@ -57,6 +57,7 @@ const handleScanPost = (request: Request, { id }: { id: number }): Promise<Respo
 
     const token = body.token;
     const force = body.force === true;
+    const idVerified = body.id_verified === true;
 
     const privateKey = await getPrivateKey(session);
     if (!privateKey) {
@@ -96,9 +97,19 @@ const handleScanPost = (request: Request, { id }: { id: number }): Promise<Respo
       });
     }
 
+    // Non-transferable event - require ID verification before check-in
+    const event = await getEventWithCount(force ? attendee.event_id : id);
+    if (event?.non_transferable && !idVerified) {
+      return jsonResponse({
+        status: "verify_id",
+        name: attendee.name,
+        quantity: attendee.quantity,
+      });
+    }
+
     // Check them in
     await updateCheckedIn(attendee.id, true);
-    const eventName = await getEventName(attendee.event_id);
+    const eventName = event?.name ?? await getEventName(attendee.event_id);
     await logActivity(`Attendee checked in via scanner for '${eventName}'`, attendee.event_id);
 
     return jsonResponse({

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -258,6 +258,12 @@ export const adminEventPage = ({
                 <th>Event Type</th>
                 <td>{event.event_type === "daily" ? "Daily" : "Standard"}</td>
               </tr>
+              {event.non_transferable && (
+                <tr>
+                  <th>Non-Transferable</th>
+                  <td>Yes &mdash; ID verification required at entry</td>
+                </tr>
+              )}
               {event.event_type === "daily" && (
                 <tr>
                   <th>Bookable Days</th>
@@ -489,6 +495,7 @@ const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   closes_at: formatDatetimeLocal(event.closes_at),
   thank_you_url: event.thank_you_url,
   webhook_url: event.webhook_url,
+  non_transferable: event.non_transferable ? "1" : "",
 });
 
 /** Event fields with autofocus on the name field */

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -36,6 +36,7 @@ export type EventFormValues = {
   bookable_days: string;
   minimum_days_before: number | null;
   maximum_days_after: number | null;
+  non_transferable: string;
   group_id: string;
 };
 
@@ -377,6 +378,16 @@ export const eventFields: Field[] = [
     placeholder: "https://example.com/webhook",
     hint: "Receives POST with attendee name, email, and phone on registration",
     validate: validateSafeUrl,
+  },
+  {
+    name: "non_transferable",
+    label: "Non-Transferable Tickets",
+    type: "select",
+    hint: "Requires attendees to show ID matching the ticket name at entry",
+    options: [
+      { value: "", label: "No" },
+      { value: "1", label: "Yes" },
+    ],
   },
 ];
 

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -49,6 +49,10 @@ const renderTicketCard = ({ entry, qrSvg, token }: TicketCard): string => {
     ? `<div class="ticket-card-price">Price: ${escapeHtml(formatCurrency(pricePaid))}</div>`
     : "";
 
+  const nonTransferableHtml = event.non_transferable
+    ? `<div class="ticket-card-notice">Non-transferable &mdash; ID required at entry</div>`
+    : "";
+
   return `
     <div class="ticket-card">
       ${imageHtml}
@@ -56,6 +60,7 @@ const renderTicketCard = ({ entry, qrSvg, token }: TicketCard): string => {
       ${eventDateHtml}
       ${locationHtml}
       ${descriptionHtml}
+      ${nonTransferableHtml}
       ${attendeeDateHtml}
       <div class="ticket-card-quantity">Quantity: ${attendee.quantity}</div>
       ${priceHtml}

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -820,6 +820,7 @@ export const createTestEvent = (
         : "",
       minimum_days_before: input.minimumDaysBefore != null ? String(input.minimumDaysBefore) : "",
       maximum_days_after: input.maximumDaysAfter != null ? String(input.maximumDaysAfter) : "",
+      non_transferable: input.nonTransferable ? "1" : "",
     },
     async () => {
       // Get the most recently created event (302 redirect guarantees creation succeeded)
@@ -909,6 +910,7 @@ export const updateTestEvent = async (
         : formatBookableDaysForForm(existing.bookable_days),
       minimum_days_before: String(updates.minimumDaysBefore ?? existing.minimum_days_before),
       maximum_days_after: String(updates.maximumDaysAfter ?? existing.maximum_days_after),
+      non_transferable: (updates.nonTransferable ?? existing.non_transferable) ? "1" : "",
     },
     async () =>
       (await getEventWithCount(eventId)) as EventWithCount,
@@ -1115,6 +1117,7 @@ export const testEvent = (overrides: Partial<Event> = {}): Event => ({
   minimum_days_before: 0,
   maximum_days_after: 0,
   image_url: "",
+  non_transferable: false,
   ...overrides,
 });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -2472,6 +2472,65 @@ describe("server (admin events)", () => {
       expectStatus(400)(response);
     });
 
+    test("creates event with non_transferable flag", async () => {
+      const event = await createTestEvent({ nonTransferable: true });
+
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.non_transferable).toBe(true);
+    });
+
+    test("creates event without non_transferable by default", async () => {
+      const event = await createTestEvent();
+
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.non_transferable).toBe(false);
+    });
+
+    test("admin event detail page shows non-transferable row when enabled", async () => {
+      const { event, cookie } = await setupEventAndLogin({ nonTransferable: true });
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+        cookie,
+      });
+      await expectHtmlResponse(
+        response,
+        200,
+        "Non-Transferable",
+        "ID verification required at entry",
+      );
+    });
+
+    test("admin event detail page does not show non-transferable row when disabled", async () => {
+      const { event, cookie } = await setupEventAndLogin();
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+        cookie,
+      });
+      const html = await response.text();
+      expect(html).not.toContain("Non-Transferable");
+    });
+
+    test("admin event edit page pre-fills non-transferable select", async () => {
+      const { event, cookie } = await setupEventAndLogin({ nonTransferable: true });
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
+        cookie,
+      });
+      const html = await expectHtmlResponse(response, 200, "Non-Transferable Tickets");
+      expect(html).toContain('value="1" selected');
+    });
+
+    test("updates event to enable non_transferable", async () => {
+      const event = await createTestEvent();
+      await updateTestEvent(event.id, { nonTransferable: true });
+
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const updated = await getEventWithCount(event.id);
+      expect(updated?.non_transferable).toBe(true);
+    });
+
     test("rejects invalid bookable_days value", async () => {
       const { cookie, csrfToken } = await setupEventAndLogin({ name: "Edit Target" });
 

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -423,6 +423,97 @@ describe("QR Scanner", () => {
       expect(result.message).toBe("Decryption unavailable");
     });
 
+    test("returns verify_id for non-transferable event without id_verified", async () => {
+      const { event, token, session } = await setupScanTest(
+        "Alice",
+        "alice@test.com",
+        { nonTransferable: true },
+      );
+      const response = await handleRequest(
+        mockScanRequest(event.id, { token }, session.cookie, session.csrfToken),
+      );
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+      expect(result.status).toBe("verify_id");
+      expect(result.name).toBe("Alice");
+      expect(result.quantity).toBe(1);
+    });
+
+    test("checks in non-transferable attendee with id_verified flag", async () => {
+      const { event, token, session } = await setupScanTest(
+        "Bob",
+        "bob@test.com",
+        { nonTransferable: true },
+      );
+      const response = await handleRequest(
+        mockScanRequest(
+          event.id,
+          { token, id_verified: true },
+          session.cookie,
+          session.csrfToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+      expect(result.status).toBe("checked_in");
+      expect(result.name).toBe("Bob");
+    });
+
+    test("checks in transferable event without id_verified", async () => {
+      const { event, token, session } = await setupScanTest(
+        "Carol",
+        "carol@test.com",
+      );
+      const response = await handleRequest(
+        mockScanRequest(event.id, { token }, session.cookie, session.csrfToken),
+      );
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+      expect(result.status).toBe("checked_in");
+      expect(result.name).toBe("Carol");
+    });
+
+    test("force check-in with deleted event falls back to getEventName", async () => {
+      const { getDb } = await import("#lib/db/client.ts");
+      const { computeTicketTokenIndex } = await import("#lib/crypto.ts");
+      const { token } = await createTestAttendeeWithToken(
+        "Eve",
+        "eve@test.com",
+      );
+      const eventB = await createTestEvent({ maxAttendees: 10 });
+      const session = await loginAsAdmin();
+
+      // Point attendee at a non-existent event to simulate orphan
+      // Keep foreign keys off for the full request since logActivity also references event_id
+      const tokenIndex = await computeTicketTokenIndex(token);
+      await getDb().execute({ sql: "PRAGMA foreign_keys = OFF", args: [] });
+      await getDb().execute({
+        sql: "UPDATE attendees SET event_id = 99999 WHERE ticket_token_index = ?",
+        args: [tokenIndex],
+      });
+
+      // Force check-in from event B — event 99999 doesn't exist, so event is null
+      // and eventName falls back to getEventName which returns "Unknown event"
+      const response = await handleRequest(
+        mockScanRequest(
+          eventB.id,
+          { token, force: true },
+          session.cookie,
+          session.csrfToken,
+        ),
+      );
+
+      await getDb().execute({ sql: "PRAGMA foreign_keys = ON", args: [] });
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+      expect(result.status).toBe("checked_in");
+      expect(result.name).toBe("Eve");
+    });
+
     test("logs activity when checking in via scanner", async () => {
       const { event, token, session } = await setupScanTest(
         "Eve",

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -297,4 +297,32 @@ describe("ticket view (/t/:tokens)", () => {
     expect(body).toContain("ticket-card-token");
     expect(body).toContain(token);
   });
+
+  test("shows non-transferable notice for non-transferable event", async () => {
+    const { token } = await createTestAttendeeWithToken(
+      "Alice Smith",
+      "alice@test.com",
+      { nonTransferable: true },
+    );
+
+    const response = await awaitTestRequest(`/t/${token}`);
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("ticket-card-notice");
+    expect(body).toContain("Non-transferable");
+    expect(body).toContain("ID required at entry");
+  });
+
+  test("does not show non-transferable notice for transferable event", async () => {
+    const { token } = await createTestAttendeeWithToken(
+      "Bob Jones",
+      "bob@test.com",
+    );
+
+    const response = await awaitTestRequest(`/t/${token}`);
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).not.toContain("ticket-card-notice");
+    expect(body).not.toContain("Non-transferable");
+  });
 });

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -169,6 +169,7 @@ describe("square", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
       const intent = {
         eventId: 1,
@@ -213,6 +214,7 @@ describe("square", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
       const intent = {
         eventId: 1,
@@ -257,6 +259,7 @@ describe("square", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
       const intent = {
         eventId: 1,
@@ -309,6 +312,7 @@ describe("square", () => {
             minimum_days_before: 1,
             maximum_days_after: 90,
             image_url: "",
+            non_transferable: false,
           };
           const intent = {
             eventId: 7,
@@ -397,6 +401,7 @@ describe("square", () => {
             minimum_days_before: 1,
             maximum_days_after: 90,
             image_url: "",
+            non_transferable: false,
           };
           const intent = {
             eventId: 1,
@@ -453,6 +458,7 @@ describe("square", () => {
             minimum_days_before: 1,
             maximum_days_after: 90,
             image_url: "",
+            non_transferable: false,
           };
           const intent = {
             eventId: 1,
@@ -508,6 +514,7 @@ describe("square", () => {
             minimum_days_before: 1,
             maximum_days_after: 90,
             image_url: "",
+            non_transferable: false,
           };
           const intent = {
             eventId: 1,
@@ -1774,6 +1781,7 @@ describe("square", () => {
             minimum_days_before: 1,
             maximum_days_after: 90,
             image_url: "",
+            non_transferable: false,
           };
           const intent = {
             eventId: 1,

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -173,6 +173,7 @@ describe("stripe", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
       const intent = {
         eventId: 1,
@@ -225,6 +226,7 @@ describe("stripe", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
 
       const intent = {
@@ -285,6 +287,7 @@ describe("stripe", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
       const intent = {
         eventId: 1,
@@ -328,6 +331,7 @@ describe("stripe", () => {
         minimum_days_before: 1,
         maximum_days_after: 90,
         image_url: "",
+        non_transferable: false,
       };
       const intent = {
         eventId: 1,


### PR DESCRIPTION
## Summary
This PR adds support for non-transferable tickets that require ID verification at event entry. Event organizers can now mark events as non-transferable, which requires attendees to present an ID matching their ticket name during check-in.

## Key Changes

- **Database Schema**: Added `non_transferable` boolean column to events table with migration support
- **Event Management**: 
  - Added "Non-Transferable Tickets" field to event creation/edit forms
  - Display non-transferable status on event detail pages
  - Pre-fill the field when editing existing events
- **Scanner Flow**:
  - Modified scanner API to return `verify_id` status for non-transferable events without ID verification
  - Added `id_verified` flag to scanner POST requests
  - Updated client-side scanner to prompt for ID verification with confirmation dialog
  - Support force check-in with fallback to `getEventName` when event is deleted
- **Ticket Display**: Show "Non-transferable — ID required at entry" notice on ticket view pages
- **Type System**: 
  - Added `non_transferable` field to Event interface
  - Added `nonTransferable` to EventInput type
  - Added `non_transferable` to EventFormValues type
- **Utilities**: 
  - Created `col.boolean()` helper for boolean column definitions with 0/1 storage
  - Updated test utilities to support `nonTransferable` parameter

## Implementation Details

- Non-transferable events require the `id_verified` flag in the scanner API request before check-in is allowed
- The scanner client prompts "Does their ID match [name]?" and sends `id_verified: true` on confirmation
- Transferable events (default) skip ID verification and check in immediately
- The check-in logic uses the event from the attendee's record when forcing check-in, with fallback to event name lookup if the event is deleted

https://claude.ai/code/session_01VdWPcGASPgmiUF4YqqjQ2p