### PR TITLE
Add attendee quantity management to admin interface

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -521,6 +521,7 @@ export type UpdateAttendeeInput = {
   address: string;
   special_instructions: string;
   event_id: number;
+  quantity: number;
 };
 
 /**
@@ -545,7 +546,7 @@ export const updateAttendee = async (
     publicKeyJwk,
   );
   await getDb().execute({
-    sql: "UPDATE attendees SET name = ?, email = ?, phone = ?, address = ?, special_instructions = ?, event_id = ? WHERE id = ?",
+    sql: "UPDATE attendees SET name = ?, email = ?, phone = ?, address = ?, special_instructions = ?, event_id = ?, quantity = ? WHERE id = ?",
     args: [
       encryptedName,
       encryptedEmail,
@@ -553,7 +554,9 @@ export const updateAttendee = async (
       encryptedAddress,
       encryptedSpecialInstructions,
       input.event_id,
+      input.quantity,
       attendeeId,
     ],
   });
+  invalidateEventsCache();
 };

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -8,6 +8,7 @@ import {
   createAttendeeAtomic,
   decryptAttendeeOrNull,
   deleteAttendee,
+  hasAvailableSpots,
   markRefunded,
   updateAttendee,
   updateCheckedIn,
@@ -448,6 +449,11 @@ const editAttendeePost = (
     withAuthForm(request, (session, form) =>
       withEditAttendee(session, attendeeId, (data) => handler(session, form, data, attendeeId)));
 
+/** Parse a quantity value from a form field, clamping to [1, max] */
+function parseQuantity(value: string, max: number): number {
+  return Math.max(1, Math.min(max, Math.floor(Number(value) || 1)));
+}
+
 /** Handle POST /admin/attendees/:attendeeId */
 async function editAttendeeHandler(
   session: AuthSession, form: URLSearchParams, data: EditAttendeeData, attendeeId: number,
@@ -468,7 +474,26 @@ async function editAttendeeHandler(
     return htmlResponse(adminEditAttendeePage(data, session, "Event is required", returnUrl), 400);
   }
 
-  await updateAttendee(attendeeId, { name, email, phone, address, special_instructions, event_id });
+  const targetEvent = event_id === data.event.id ? data.event : await getEventWithCount(event_id);
+  if (!targetEvent) {
+    return htmlResponse(adminEditAttendeePage(data, session, "Event not found", returnUrl), 400);
+  }
+
+  const quantity = parseQuantity(form.get("quantity") || "1", targetEvent.max_quantity);
+
+  // Check capacity when quantity increases or event changes
+  const quantityDelta = quantity - data.attendee.quantity;
+  const eventChanged = event_id !== data.attendee.event_id;
+  if (quantityDelta > 0 || eventChanged) {
+    // For event change, check full quantity against new event; for same event, check only the delta
+    const spotsNeeded = eventChanged ? quantity : quantityDelta;
+    const available = await hasAvailableSpots(event_id, spotsNeeded, data.attendee.date);
+    if (!available) {
+      return htmlResponse(adminEditAttendeePage(data, session, "Not enough spots available", returnUrl), 400);
+    }
+  }
+
+  await updateAttendee(attendeeId, { name, email, phone, address, special_instructions, event_id, quantity });
   await logActivity(`Attendee '${name}' updated`, event_id);
 
   return redirectOrReturn(form, `/admin/event/${event_id}?edited=${encodeURIComponent(name)}#attendees`);

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -273,6 +273,19 @@ export const adminEditAttendeePage = (
             >{attendee.special_instructions || ""}</textarea>
           </label>
 
+          <label for="quantity">
+            Quantity
+            <input
+              type="number"
+              id="quantity"
+              name="quantity"
+              value={String(attendee.quantity)}
+              min="1"
+              max={String(event.max_quantity)}
+              required
+            />
+          </label>
+
           <Raw html={renderEventSelector(event.id, allEvents)} />
 
           <button type="submit">Save Changes</button>

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1246,6 +1246,7 @@ describe("server (admin attendees)", () => {
             address: "456 Oak Ave",
             special_instructions: "Wheelchair access",
             event_id: String(event.id),
+            quantity: "1",
             csrf_token: csrfToken,
           },
           cookie,
@@ -1503,6 +1504,246 @@ describe("server (admin attendees)", () => {
       expect(response.headers.get("location")).toBe(
         `/admin/event/${event.id}?edited=Jane%20Smith#attendees`,
       );
+    });
+
+    test("updates attendee quantity", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "3",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
+      const updated = await getAttendeeRaw(attendee.id);
+      expect(updated!.quantity).toBe(3);
+    });
+
+    test("shows quantity field on edit form", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie },
+      );
+      await expectHtmlResponse(response, 200, 'name="quantity"', 'max="5"');
+    });
+
+    test("clamps quantity to event max_quantity", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 3 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "10",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
+      const updated = await getAttendeeRaw(attendee.id);
+      expect(updated!.quantity).toBe(3);
+    });
+
+    test("rejects quantity increase when not enough spots", async () => {
+      const event = await createTestEvent({ maxAttendees: 2, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "3",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 400, "Not enough spots available");
+    });
+
+    test("allows decreasing quantity without capacity check", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+        3,
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "1",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
+      const updated = await getAttendeeRaw(attendee.id);
+      expect(updated!.quantity).toBe(1);
+    });
+
+    test("rejects non-existent event_id on quantity update", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: "9999",
+            quantity: "2",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 400, "Event not found");
+    });
+
+    test("treats invalid quantity as 1", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "abc",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
+      const updated = await getAttendeeRaw(attendee.id);
+      expect(updated!.quantity).toBe(1);
+    });
+
+    test("defaults missing quantity to 1", async () => {
+      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeRaw } = await import("#lib/db/attendees.ts");
+      const updated = await getAttendeeRaw(attendee.id);
+      expect(updated!.quantity).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds the ability to manage attendee quantities in the admin interface, allowing administrators to update how many spots an attendee is reserving for an event.

## Key Changes
- **Quantity field in edit form**: Added a number input field to the attendee edit page that displays and allows modification of attendee quantity, constrained by the event's `max_quantity`
- **Quantity update logic**: Implemented validation when updating attendee quantities:
  - Clamps quantity to valid range [1, max_quantity]
  - Checks available event capacity when quantity increases or event is changed
  - Allows decreasing quantity without capacity validation
  - Validates that the target event exists
  - Treats invalid/missing quantity values as 1
- **Database updates**: Extended `updateAttendee` function to persist quantity changes and invalidate the events cache
- **Comprehensive test coverage**: Added 8 new test cases covering:
  - Basic quantity updates
  - Quantity field rendering with max constraint
  - Clamping to event max_quantity
  - Capacity validation on increases
  - Decreasing without capacity checks
  - Invalid event handling
  - Invalid quantity input handling
  - Missing quantity field defaults

## Implementation Details
- New `parseQuantity()` helper function handles quantity parsing and clamping to [1, max]
- Capacity checks distinguish between quantity increases (delta check) and event changes (full quantity check)
- Uses existing `hasAvailableSpots()` function to validate available capacity
- Form validation provides user-friendly error messages for capacity issues

https://claude.ai/code/session_01A87hm4FMfTj3caK22jp7am