### PR TITLE
Replace blocking confirm() with non-blocking dialog for scanner

### DIFF
--- a/src/client/scanner.js
+++ b/src/client/scanner.js
@@ -114,7 +114,7 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
     postScan(eventId, token, csrfToken)
       .then(async (result) => {
         if (result.status === "wrong_event") {
-          const ok = confirm(
+          const ok = await showConfirm(
             `${result.name} is registered for "${result.eventName}", not this event. Check in anyway?`,
           );
           if (ok) {
@@ -124,7 +124,7 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
             showStatus(statusEl, `Skipped ${result.name}`, "warning");
           }
         } else if (result.status === "verify_id") {
-          const ok = confirm(
+          const ok = await showConfirm(
             `Does their ID match "${result.name}"?`,
           );
           if (ok) {
@@ -147,6 +147,37 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
   };
 
   scan();
+};
+
+/**
+ * Non-blocking confirm using the <dialog> element.
+ * Returns a Promise<boolean> without freezing the camera feed.
+ */
+const showConfirm = (message) => {
+  const dialog = document.getElementById("scanner-confirm");
+  const msgEl = document.getElementById("scanner-confirm-message");
+  const yesBtn = document.getElementById("scanner-confirm-yes");
+  const noBtn = document.getElementById("scanner-confirm-no");
+
+  msgEl.textContent = message;
+
+  return new Promise((resolve) => {
+    const cleanup = (value) => {
+      yesBtn.removeEventListener("click", onYes);
+      noBtn.removeEventListener("click", onNo);
+      dialog.removeEventListener("cancel", onCancel);
+      dialog.close();
+      resolve(value);
+    };
+    const onYes = () => cleanup(true);
+    const onNo = () => cleanup(false);
+    const onCancel = () => cleanup(false);
+
+    yesBtn.addEventListener("click", onYes);
+    noBtn.addEventListener("click", onNo);
+    dialog.addEventListener("cancel", onCancel);
+    dialog.showModal();
+  });
 };
 
 /** Initialize scanner when DOM is ready */

--- a/src/client/scanner.js
+++ b/src/client/scanner.js
@@ -158,6 +158,7 @@ const showConfirm = (message) => {
   const msgEl = document.getElementById("scanner-confirm-message");
   const yesBtn = document.getElementById("scanner-confirm-yes");
   const noBtn = document.getElementById("scanner-confirm-no");
+  const closeBtn = document.getElementById("scanner-confirm-close");
 
   msgEl.textContent = message;
 
@@ -165,16 +166,19 @@ const showConfirm = (message) => {
     const cleanup = (value) => {
       yesBtn.removeEventListener("click", onYes);
       noBtn.removeEventListener("click", onNo);
+      closeBtn.removeEventListener("click", onClose);
       dialog.removeEventListener("cancel", onCancel);
       dialog.close();
       resolve(value);
     };
     const onYes = () => cleanup(true);
     const onNo = () => cleanup(false);
+    const onClose = () => cleanup(false);
     const onCancel = () => cleanup(false);
 
     yesBtn.addEventListener("click", onYes);
     noBtn.addEventListener("click", onNo);
+    closeBtn.addEventListener("click", onClose);
     dialog.addEventListener("cancel", onCancel);
     dialog.showModal();
   });

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1178,6 +1178,52 @@ button.secondary:hover {
   }
 }
 
+/* Scanner confirm dialog - non-blocking replacement for confirm() */
+#scanner-confirm {
+  border: none;
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 90vw;
+  width: 320px;
+  text-align: center;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+#scanner-confirm::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+#scanner-confirm p {
+  margin: 0 0 1.25rem;
+  font-size: 1.1rem;
+}
+
+.scanner-confirm-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.scanner-confirm-actions button {
+  min-width: 80px;
+  padding: 0.6rem 1.25rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+
+#scanner-confirm-yes {
+  background: #155724;
+  color: #fff;
+  border-color: #155724;
+}
+
+#scanner-confirm-no {
+  background: #fff;
+  color: #333;
+}
+
 /* Stripe test result */
 .stripe-test-result {
   white-space: pre-wrap;

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1180,6 +1180,7 @@ button.secondary:hover {
 
 /* Scanner confirm dialog - non-blocking replacement for confirm() */
 #scanner-confirm {
+  position: relative;
   border: none;
   border-radius: 8px;
   padding: 1.5rem;
@@ -1187,6 +1188,19 @@ button.secondary:hover {
   width: 320px;
   text-align: center;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+#scanner-confirm-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  color: #666;
 }
 
 #scanner-confirm::backdrop {

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -41,6 +41,7 @@ export const adminScannerPage = (
         </button>
 
         <dialog id="scanner-confirm">
+          <button id="scanner-confirm-close" type="button" aria-label="Close">&times;</button>
           <p id="scanner-confirm-message"></p>
           <div class="scanner-confirm-actions">
             <button id="scanner-confirm-yes" type="button">Yes</button>

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -39,6 +39,14 @@ export const adminScannerPage = (
         <button id="scanner-start" type="button">
           Start Camera
         </button>
+
+        <dialog id="scanner-confirm">
+          <p id="scanner-confirm-message"></p>
+          <div class="scanner-confirm-actions">
+            <button id="scanner-confirm-yes" type="button">Yes</button>
+            <button id="scanner-confirm-no" type="button">No</button>
+          </div>
+        </dialog>
       </article>
     </Layout>
   );

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -137,6 +137,7 @@ describe("QR Scanner", () => {
         "scanner-start",
         `data-event-id="${event.id}"`,
         "scanner.js",
+        "scanner-confirm",
       );
     });
 


### PR DESCRIPTION
## Summary
Replace the blocking `confirm()` dialog with a custom non-blocking `<dialog>` element implementation for the QR scanner. This prevents the camera feed from freezing when confirmation prompts are displayed.

## Key Changes
- **Added custom confirm dialog UI**: Created a styled `<dialog>` element with Yes/No buttons and a close button in the scanner template
- **Implemented `showConfirm()` function**: New Promise-based function that displays the dialog without blocking the event loop, allowing the camera feed to continue running
- **Updated scanner logic**: Replaced two `confirm()` calls with `await showConfirm()` for "wrong_event" and "verify_id" scenarios
- **Added styling**: Comprehensive CSS for the dialog including backdrop, buttons, and layout with proper spacing and shadows
- **Updated tests**: Added "scanner-confirm" to the expected DOM elements in scanner tests

## Implementation Details
- The `showConfirm()` function returns a `Promise<boolean>` that resolves when the user clicks Yes/No or closes the dialog
- Event listeners are properly cleaned up after each dialog interaction to prevent memory leaks
- The dialog uses the native `<dialog>` element's `showModal()` method and `cancel` event for proper accessibility
- Styling matches the existing MVP.css design system with consistent spacing and color scheme

https://claude.ai/code/session_01XzSo9151eruchPSRRLnfqE