### PR TITLE
Replace dialog element with custom overlay for scanner confirm

### DIFF
--- a/src/client/scanner.js
+++ b/src/client/scanner.js
@@ -150,11 +150,11 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
 };
 
 /**
- * Non-blocking confirm using the <dialog> element.
+ * Non-blocking confirm overlay centered on the camera feed.
  * Returns a Promise<boolean> without freezing the camera feed.
  */
 const showConfirm = (message) => {
-  const dialog = document.getElementById("scanner-confirm");
+  const overlay = document.getElementById("scanner-confirm");
   const msgEl = document.getElementById("scanner-confirm-message");
   const yesBtn = document.getElementById("scanner-confirm-yes");
   const noBtn = document.getElementById("scanner-confirm-no");
@@ -167,20 +167,22 @@ const showConfirm = (message) => {
       yesBtn.removeEventListener("click", onYes);
       noBtn.removeEventListener("click", onNo);
       closeBtn.removeEventListener("click", onClose);
-      dialog.removeEventListener("cancel", onCancel);
-      dialog.close();
+      document.removeEventListener("keydown", onKeydown);
+      overlay.classList.add("hidden");
       resolve(value);
     };
     const onYes = () => cleanup(true);
     const onNo = () => cleanup(false);
     const onClose = () => cleanup(false);
-    const onCancel = () => cleanup(false);
+    const onKeydown = (e) => {
+      if (e.key === "Escape") cleanup(false);
+    };
 
     yesBtn.addEventListener("click", onYes);
     noBtn.addEventListener("click", onNo);
     closeBtn.addEventListener("click", onClose);
-    dialog.addEventListener("cancel", onCancel);
-    dialog.showModal();
+    document.addEventListener("keydown", onKeydown);
+    overlay.classList.remove("hidden");
   });
 };
 

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1178,16 +1178,39 @@ button.secondary:hover {
   }
 }
 
-/* Scanner confirm dialog - non-blocking replacement for confirm() */
+/* Scanner confirm overlay - centered on video like scanner-status */
 #scanner-confirm {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#scanner-confirm-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+}
+
+#scanner-confirm-box {
   position: relative;
   border: none;
   border-radius: 8px;
   padding: 1.5rem;
-  max-width: 90vw;
+  max-width: 90%;
   width: 320px;
   text-align: center;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+  background: #fff;
 }
 
 #scanner-confirm-close {
@@ -1201,10 +1224,6 @@ button.secondary:hover {
   padding: 0.25rem 0.5rem;
   cursor: pointer;
   color: #666;
-}
-
-#scanner-confirm::backdrop {
-  background: rgba(0, 0, 0, 0.5);
 }
 
 #scanner-confirm p {

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -34,20 +34,22 @@ export const adminScannerPage = (
             class="hidden"
           ></video>
           <div id="scanner-status" class="hidden"></div>
+          <div id="scanner-confirm" class="hidden">
+            <div id="scanner-confirm-backdrop"></div>
+            <div id="scanner-confirm-box">
+              <button id="scanner-confirm-close" type="button" aria-label="Close">&times;</button>
+              <p id="scanner-confirm-message"></p>
+              <div class="scanner-confirm-actions">
+                <button id="scanner-confirm-yes" type="button">Yes</button>
+                <button id="scanner-confirm-no" type="button">No</button>
+              </div>
+            </div>
+          </div>
         </div>
 
         <button id="scanner-start" type="button">
           Start Camera
         </button>
-
-        <dialog id="scanner-confirm">
-          <button id="scanner-confirm-close" type="button" aria-label="Close">&times;</button>
-          <p id="scanner-confirm-message"></p>
-          <div class="scanner-confirm-actions">
-            <button id="scanner-confirm-yes" type="button">Yes</button>
-            <button id="scanner-confirm-no" type="button">No</button>
-          </div>
-        </dialog>
       </article>
     </Layout>
   );


### PR DESCRIPTION
## Summary
Replaced the HTML `<dialog>` element with a custom overlay implementation for the scanner confirm dialog. This change provides better control over positioning and styling while maintaining the same non-blocking confirmation behavior.

## Key Changes
- **HTML Structure**: Converted `<dialog id="scanner-confirm">` to a custom overlay div with backdrop and content box elements
  - Added `#scanner-confirm-backdrop` for the semi-transparent overlay
  - Added `#scanner-confirm-box` to wrap the dialog content
  - Moved the confirm dialog inside the scanner container for proper positioning relative to the video feed

- **CSS Styling**: Rewrote styles to implement custom overlay positioning
  - `#scanner-confirm` now uses `position: absolute` with flexbox centering instead of dialog defaults
  - Added dedicated styles for backdrop and box elements
  - Changed `max-width` from `90vw` to `90%` for better containment within the scanner container
  - Removed `::backdrop` pseudo-element styling (no longer applicable)

- **JavaScript Logic**: Updated event handling to work with the custom overlay
  - Replaced `dialog.showModal()` / `dialog.close()` with class-based visibility toggling (`hidden` class)
  - Replaced `dialog` "cancel" event listener with document-level "keydown" listener for Escape key handling
  - Maintained the same Promise-based API and cleanup behavior

## Implementation Details
The overlay is now positioned absolutely within the scanner container, allowing it to be centered over the video feed similar to the scanner-status element. The custom implementation provides more flexibility for styling and positioning while maintaining the non-blocking confirmation behavior that prevents the camera feed from freezing.

https://claude.ai/code/session_01VPN6Fv9UwqnYxuEtTuML29