### PR TITLE
Apply theme variables to scanner confirm modal

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1191,6 +1191,10 @@ button.secondary:hover {
   justify-content: center;
 }
 
+#scanner-confirm.hidden {
+  display: none;
+}
+
 #scanner-confirm-backdrop {
   position: absolute;
   top: 0;
@@ -1210,7 +1214,8 @@ button.secondary:hover {
   width: 320px;
   text-align: center;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
-  background: #fff;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
 #scanner-confirm-close {
@@ -1223,7 +1228,7 @@ button.secondary:hover {
   line-height: 1;
   padding: 0.25rem 0.5rem;
   cursor: pointer;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 #scanner-confirm p {
@@ -1253,8 +1258,8 @@ button.secondary:hover {
 }
 
 #scanner-confirm-no {
-  background: #fff;
-  color: #333;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
 /* Stripe test result */


### PR DESCRIPTION
## Summary
Updated the scanner confirmation modal styling to use CSS custom properties for theme support, enabling proper dark mode and light mode appearance.

## Key Changes
- Added `.hidden` class rule to `#scanner-confirm` for display control
- Replaced hardcoded colors with CSS custom properties:
  - `background: #fff` → `background: var(--color-bg)`
  - `color: #333` → `color: var(--color-text)`
  - `color: #666` → `color: var(--color-text-secondary)`
- Applied theme variables to:
  - Modal background and text color
  - Close button text color
  - "No" button background and text color

## Implementation Details
These changes ensure the scanner confirm modal respects the application's theme settings, providing consistent styling across light and dark modes by leveraging the existing CSS custom property system used throughout the application.

https://claude.ai/code/session_015gkEnidhtchaoMiSfpzH9G