### PR TITLE
Add duplicate token detection to scanner with debouncing

### DIFF
--- a/src/client/scanner.js
+++ b/src/client/scanner.js
@@ -86,6 +86,8 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
   const ctx = canvas.getContext("2d");
   let lastScanTime = 0;
   let processing = false;
+  let lastToken = null;
+  let lastTokenTimer = 0;
 
   const scan = () => {
     if (video.readyState < video.HAVE_ENOUGH_DATA) {
@@ -118,8 +120,16 @@ const startScanner = (video, canvas, statusEl, eventId, csrfToken) => {
       return;
     }
 
+    if (token === lastToken) {
+      setTimeout(scan, SCAN_INTERVAL_MS);
+      return;
+    }
+
     processing = true;
     lastScanTime = Date.now();
+    clearTimeout(lastTokenTimer);
+    lastToken = token;
+    lastTokenTimer = setTimeout(() => { lastToken = null; }, FADE_DELAY_MS);
 
     postScan(eventId, token, csrfToken)
       .then(async (result) => {


### PR DESCRIPTION
## Summary
This change adds duplicate token detection and debouncing logic to the barcode scanner to prevent processing the same scanned token multiple times in quick succession.

## Key Changes
- Added `lastToken` and `lastTokenTimer` state variables to track the most recently scanned token
- Implemented early return when the same token is scanned consecutively, avoiding redundant processing
- Added automatic token reset after a configurable delay (`FADE_DELAY_MS`) to allow re-scanning the same token after a timeout period
- Clear any pending token reset timer when a new token is processed

## Implementation Details
- When a token is scanned, it's compared against `lastToken` to detect duplicates
- If a duplicate is detected, the scan loop continues without processing the token
- Upon successful token processing, a timer is set to clear `lastToken` after `FADE_DELAY_MS`, allowing the same token to be scanned again after the delay expires
- The timer is cleared and reset each time a new token is processed, ensuring the delay is measured from the last successful scan

https://claude.ai/code/session_017iucRG6A3CrZ4YJwiJ3gPa