### PR TITLE
Add non-transferable tickets and attendee editing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Licensed under **AGPLv3**. Hosted instances available at [tix.chobble.com](https
 - Multi-booking link builder on the dashboard for generating combined-event URLs
 - Embeddable via iframe with configurable CSP frame-ancestors
 - Custom thank-you URL or default confirmation page
+- Non-transferable tickets — per-event toggle requiring ID verification at check-in
 - Manual attendee creation from the admin event page (walk-ins, comps)
 
 ### Payments
@@ -29,12 +30,14 @@ Licensed under **AGPLv3**. Hosted instances available at [tix.chobble.com](https
 - Each ticket gets a unique URL (`/t/:token`) with a QR code
 - Staff scan QR to reach check-in page, toggle check-in/out
 - Built-in QR scanner — open from an event page, uses device camera, check-in-only (no accidental check-outs)
+- ID verification prompt for non-transferable events before completing check-in
 - Cross-event detection: scanner warns if a ticket belongs to a different event
 - Multi-ticket view for multi-event bookings (`/t/token1+token2`)
 
 ### Admin
 - Event CRUD, duplicate, deactivate/reactivate, delete (requires typing event name)
 - Attendee list with date filtering (daily events), check-in status filtering
+- Attendee editing — update name, contact details, quantity, or reassign to a different event
 - CSV export (respects filters)
 - Per-event activity log (creation, updates, check-ins, exports, deletions)
 - Holiday/blackout date management for daily events
@@ -123,7 +126,7 @@ deno task test:coverage  # Tests with coverage report
 deno task lint           # Lint
 deno task fmt            # Format
 deno task typecheck      # Type check
-deno task precommit      # All checks (typecheck, lint, cpd, test:coverage)
+deno task precommit      # All checks (typecheck, lint, cpd, build:edge, test:coverage)
 ```
 
 ## Tech Stack

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -189,6 +189,28 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           </p>
         </Q>
 
+        <Q q="What are non-transferable tickets?">
+          <p>
+            When you enable <strong>Non-Transferable</strong> on an event,
+            attendees see a notice on their ticket saying "Non-transferable
+            — ID required at entry". At check-in, the QR scanner prompts
+            door staff to verify the attendee's ID matches the name on the
+            ticket before completing check-in. This helps prevent ticket
+            touting.
+          </p>
+        </Q>
+
+        <Q q="How do I edit an attendee?">
+          <p>
+            Open the event's attendee list, find the attendee, and click{" "}
+            <strong>Edit</strong>. You can update their name, email, phone,
+            address, special instructions, and quantity. You can also reassign
+            them to a different event using the event dropdown. Quantity changes
+            are validated against the event's capacity and maximum tickets per
+            purchase.
+          </p>
+        </Q>
+
         <Q q="How do I add terms and conditions?">
           <p>
             In <strong>Settings</strong>, enter your terms in the "Terms and
@@ -632,8 +654,9 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             Open an event and click <strong>Scanner</strong>. Tap{" "}
             <strong>Start Camera</strong> to begin (grants camera permission on
             first use). Point the camera at an attendee's QR code and check-in
-            happens automatically. A 2-second cooldown prevents duplicate scans.
-            The scanner works best with the rear camera on mobile devices.
+            happens automatically. Duplicate scans of the same ticket are
+            suppressed while the success message is visible. The scanner works
+            best with the rear camera on mobile devices.
           </p>
         </Q>
 
@@ -659,10 +682,16 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             <strong>Checked in</strong> &mdash; shows the attendee's name and
             ticket count (e.g. "Jo checked in (2 tickets)").{" "}
             <strong>Already checked in</strong> &mdash; they were already
-            marked as arrived. <strong>Ticket not found</strong> &mdash; the QR
+            marked as arrived.{" "}
+            <strong>Refunded</strong> &mdash; the attendee has been refunded
+            and cannot be checked in.{" "}
+            <strong>Ticket not found</strong> &mdash; the QR
             code doesn't match any registration.{" "}
             <strong>Different event</strong> &mdash; a confirmation dialogue
-            asks whether to check them in anyway.
+            asks whether to check them in anyway.{" "}
+            <strong>ID verification</strong> &mdash; for non-transferable
+            events, staff are asked to confirm the attendee's ID matches
+            the ticket name before check-in proceeds.
           </p>
         </Q>
       </Section>

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -654,9 +654,8 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             Open an event and click <strong>Scanner</strong>. Tap{" "}
             <strong>Start Camera</strong> to begin (grants camera permission on
             first use). Point the camera at an attendee's QR code and check-in
-            happens automatically. Duplicate scans of the same ticket are
-            suppressed while the success message is visible. The scanner works
-            best with the rear camera on mobile devices.
+            happens automatically. The scanner works best with the rear camera
+            on mobile devices.
           </p>
         </Q>
 

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -123,6 +123,21 @@ describe("server (admin guide)", () => {
       expect(html).toContain("Deactivate");
     });
 
+    test("contains non-transferable tickets info", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("non-transferable");
+      expect(html).toContain("ID required at entry");
+      expect(html).toContain("ticket touting");
+    });
+
+    test("contains attendee editing info", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("edit an attendee");
+      expect(html).toContain("reassign");
+    });
+
     test("contains text formatting section", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();


### PR DESCRIPTION
## Summary
This PR adds documentation and test coverage for two new features: non-transferable tickets with ID verification at check-in, and attendee editing capabilities in the admin interface.

## Key Changes

- **Non-transferable tickets documentation**: Added FAQ entry explaining how the non-transferable feature works, including the "ID required at entry" notice and ID verification at check-in to prevent ticket touting

- **Attendee editing documentation**: Added FAQ entry describing how admins can edit attendee details (name, email, phone, address, special instructions, quantity) and reassign attendees to different events

- **Scanner documentation updates**: 
  - Removed outdated reference to 2-second cooldown for duplicate scans
  - Added documentation for ID verification prompt that appears during check-in for non-transferable events
  - Clarified scanner response messages including new "Refunded" status

- **Test coverage**: Added two new test cases to verify the admin guide contains information about non-transferable tickets and attendee editing

- **README updates**: 
  - Added non-transferable tickets to features list
  - Added ID verification prompt to check-in features
  - Added attendee editing to admin features
  - Updated precommit task description to include `build:edge`

## Implementation Details
The changes are primarily documentation-focused, updating the admin guide template and README to reflect existing or newly implemented functionality. The test additions ensure the guide content remains accurate as the codebase evolves.

https://claude.ai/code/session_01XoTs3jorgLxFiLhdsohzFL