### PR TITLE
Handle SessionKeyError with cookie clearing and redirect

### DIFF
--- a/src/routes/admin/utils.ts
+++ b/src/routes/admin/utils.ts
@@ -6,7 +6,7 @@ import { decryptAttendees, decryptAttendeesForTable } from "#lib/db/attendees.ts
 import { getEventWithAttendeesRaw } from "#lib/db/events.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import type { validateForm } from "#lib/forms.tsx";
-import { type AuthSession, encodeBody, getPrivateKey, notFoundResponse, requireSessionOr } from "#routes/utils.ts";
+import { type AuthSession, encodeBody, getPrivateKey, notFoundResponse, requireSessionOr, SessionKeyError } from "#routes/utils.ts";
 
 /** Form field definition type */
 export type FormFields = Parameters<typeof validateForm>[1];
@@ -43,7 +43,7 @@ export const csvResponse = (csv: string, filename: string): Response =>
 /** Get the admin private key from session, throwing if unavailable */
 export const requirePrivateKey = async (session: AuthSession): Promise<CryptoKey> => {
   const key = await getPrivateKey(session);
-  if (!key) throw new Error("Private key unavailable for session");
+  if (!key) throw new SessionKeyError();
   return key;
 };
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -25,7 +25,8 @@ import {
 import type { createRouter } from "#routes/router.ts";
 import { routeStatic } from "#routes/static.ts";
 import type { ServerContext } from "#routes/types.ts";
-import { notFoundResponse, parseRequest, redirect, temporaryErrorResponse } from "#routes/utils.ts";
+import { notFoundResponse, parseRequest, redirect, SessionKeyError, temporaryErrorResponse } from "#routes/utils.ts";
+import { clearSessionCookie } from "#lib/cookies.ts";
 
 /** Router function type - reuse from router.ts */
 type RouterFn = ReturnType<typeof createRouter>;
@@ -243,6 +244,9 @@ export const handleRequest = (
     return logAndReturn(await applySecurityHeaders(response, embeddable), method, path, getElapsed);
   } catch (error) {
     logError({ code: ErrorCode.CDN_REQUEST, detail: String(error) });
+    if (error instanceof SessionKeyError) {
+      return logAndReturn(redirect("/admin", clearSessionCookie()), method, path, getElapsed);
+    }
     return logAndReturn(temporaryErrorResponse(), method, path, getElapsed);
   }
   } finally {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -23,6 +23,13 @@ import { notFoundPage, temporaryErrorPage } from "#templates/public.tsx";
 // Re-export for use by other route modules
 export { generateSecureToken };
 
+/** Thrown when a session's private key cannot be derived (e.g. wrappedDataKey missing or unwrap failure) */
+export class SessionKeyError extends Error {
+  constructor() {
+    super("Private key unavailable for session");
+  }
+}
+
 /**
  * Shared TextEncoder for pre-encoding string response bodies to Uint8Array.
  * Bunny Edge's runtime intermittently fails to decode JS string bodies

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -289,15 +289,14 @@ describe("server (misc)", () => {
   });
 
   describe("routes/admin/utils.ts (requirePrivateKey)", () => {
-    test("throws when private key is unavailable", async () => {
+    test("throws SessionKeyError when private key is unavailable", async () => {
       const { requirePrivateKey } = await import("#routes/admin/utils.ts");
+      const { SessionKeyError } = await import("#routes/utils.ts");
       const session = {
         token: "any-token",
         wrappedDataKey: null,
       } as Parameters<typeof requirePrivateKey>[0];
-      await expect(requirePrivateKey(session)).rejects.toThrow(
-        "Private key unavailable",
-      );
+      await expect(requirePrivateKey(session)).rejects.toThrow(SessionKeyError);
     });
   });
 
@@ -643,6 +642,30 @@ describe("server (misc)", () => {
       expect(response.headers.get("content-type")).toBe(
         "text/html; charset=utf-8",
       );
+    });
+
+    test("SessionKeyError clears cookie and redirects to /admin", async () => {
+      const { cookie } = await loginAsAdmin();
+      const { getDb: getDbFn } = await import("#lib/db/client.ts");
+      const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
+
+      // Remove wrapped_private_key so requirePrivateKey throws SessionKeyError
+      await getDbFn().execute({
+        sql: "DELETE FROM settings WHERE key = 'wrapped_private_key'",
+        args: [],
+      });
+      invalidateSettingsCache();
+
+      // Hit admin dashboard (GET /admin with session) which calls requirePrivateKey
+      const response = await handleRequest(
+        mockRequest("/admin", { headers: { cookie } }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin");
+      const setCookie = response.headers.get("set-cookie")!;
+      expect(setCookie).toContain("session=");
+      expect(setCookie).toContain("Max-Age=0");
     });
   });
 });


### PR DESCRIPTION
## Summary
Introduced a new `SessionKeyError` exception class to handle cases where a session's private key cannot be derived, and implemented proper error handling to clear the session cookie and redirect to `/admin` when this error occurs.

## Key Changes
- **New `SessionKeyError` class** in `src/routes/utils.ts`: A dedicated error type thrown when a session's private key is unavailable (e.g., missing `wrappedDataKey` or unwrap failure)
- **Updated `requirePrivateKey`** in `src/routes/admin/utils.ts`: Now throws `SessionKeyError` instead of a generic `Error` when the private key cannot be derived
- **Added error handling** in `src/routes/index.ts`: Catches `SessionKeyError` in the main request handler, clears the session cookie, and redirects to `/admin`
- **Updated test** in `test/lib/server-misc.test.ts`: Modified existing test to verify `SessionKeyError` is thrown, and added new integration test verifying the full error handling flow (cookie clearing and redirect)

## Implementation Details
- The `SessionKeyError` provides a clear, semantic way to distinguish session key derivation failures from other errors
- When caught in the request handler, it triggers `clearSessionCookie()` to invalidate the session before redirecting, preventing the user from being stuck in a redirect loop
- The error handling is placed before the generic `temporaryErrorResponse()` fallback, ensuring proper session cleanup

https://claude.ai/code/session_0151YKo2jLr8FysQvQ3etDZs