### PR TITLE
Add deployment configuration for multiple cloud platforms

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,27 @@
+spec:
+  name: chobble-tickets
+  services:
+    - name: web
+      github:
+        repo: chobbledotcom/tickets
+        branch: main
+        deploy_on_push: true
+      dockerfile_path: Dockerfile
+      http_port: 3000
+      instance_count: 1
+      instance_size_slug: basic-xxs
+      routes:
+        - path: /
+      envs:
+        - key: DB_URL
+          scope: RUN_TIME
+          type: SECRET
+        - key: DB_TOKEN
+          scope: RUN_TIME
+          type: SECRET
+        - key: DB_ENCRYPTION_KEY
+          scope: RUN_TIME
+          type: SECRET
+        - key: ALLOWED_DOMAIN
+          scope: RUN_TIME
+          type: GENERAL

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A self-hosted ticket reservation system. Runs on Bunny Edge Scripting with libsq
 
 Licensed under **AGPLv3**. Hosted instances available at [tix.chobble.com](https://tix.chobble.com/ticket/register) for £50/year, no tiers.
 
+## Deploy
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)
+[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)
+
+Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
+
 ## Features
 
 ### Events

--- a/app.json
+++ b/app.json
@@ -1,0 +1,25 @@
+{
+  "name": "chobble-tickets",
+  "description": "A self-hosted ticket reservation system with encryption, Stripe/Square payments, and QR check-in.",
+  "repository": "https://github.com/chobbledotcom/tickets",
+  "logo": "https://tix.chobble.com/favicon.ico",
+  "stack": "container",
+  "env": {
+    "DB_URL": {
+      "description": "libsql database URL (e.g. libsql://your-db.turso.io or file:/data/tickets.db)",
+      "required": true
+    },
+    "DB_TOKEN": {
+      "description": "Database auth token (required for remote databases)",
+      "required": false
+    },
+    "DB_ENCRYPTION_KEY": {
+      "description": "32-byte base64-encoded AES-256 encryption key",
+      "required": true
+    },
+    "ALLOWED_DOMAIN": {
+      "description": "Domain for security validation (e.g. your-app.herokuapp.com)",
+      "required": true
+    }
+  }
+}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,16 @@
+app = "chobble-tickets"
+primary_region = "lhr"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+[mounts]
+  source = "tickets_data"
+  destination = "/data"

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: chobble-tickets
+    runtime: docker
+    plan: starter
+    dockerfilePath: ./Dockerfile
+    envVars:
+      - key: DB_URL
+        sync: false
+      - key: DB_TOKEN
+        sync: false
+      - key: DB_ENCRYPTION_KEY
+        sync: false
+      - key: ALLOWED_DOMAIN
+        sync: false
+      - key: PORT
+        value: "3000"


### PR DESCRIPTION
## Summary
This PR adds deployment configuration files and documentation to enable easy one-click deployments to multiple cloud platforms including Render, Heroku, DigitalOcean, Koyeb, and Fly.io.

## Key Changes
- **app.json**: Added Heroku deployment manifest with environment variable definitions for database URL, token, encryption key, and allowed domain
- **heroku.yml**: Added Docker build configuration for Heroku deployments
- **render.yaml**: Added Render deployment configuration with service definition and environment variables
- **.do/deploy.template.yaml**: Added DigitalOcean App Platform deployment template with service configuration
- **fly.toml**: Added Fly.io configuration with Docker build settings, HTTP service configuration, and persistent volume mount for data storage
- **README.md**: Updated with deployment buttons and links for all supported platforms, plus note about Docker host compatibility

## Notable Details
- All platform configurations reference the same Dockerfile for consistency
- Environment variables (DB_URL, DB_TOKEN, DB_ENCRYPTION_KEY, ALLOWED_DOMAIN) are consistently defined across all platforms
- Fly.io configuration includes persistent storage mount at `/data` and auto-scaling settings
- DigitalOcean and Render configurations mark environment variables as non-synced to prevent accidental overwrites
- README now provides clear deployment options for users while maintaining the existing AGPLv3 licensing information

https://claude.ai/code/session_0175hREfJLCZnFRabujUDuMo