### PR TITLE
Simplify deployment options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ This is not "open core" — every feature is available under **AGPLv3** with no 
 
 ## Deploy
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)
-[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)
-[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)
+Deploy to: **[Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)**, **[Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)**, **[DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)**, **[Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)**
 
 Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is not "open core" — every feature is available under **AGPLv3** with no 
 
 ## Deploy
 
-Deploy to: **[Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)**, **[Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)**, **[DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)**, **[Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)**
+Deploy to: **[Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)**, **[Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)**, **[DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)**, or **[Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)**
 
 Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is not "open core" — every feature is available under **AGPLv3** with no 
 
 ## Deploy
 
-Deploy to: **[Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)**, **[Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)**, **[DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)**, or **[Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)**
+Deploy to: **[DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)**, **[Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)**, **[Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)**, or **[Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)**
 
 Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 


### PR DESCRIPTION
## Summary
Refactored the deployment section in the README to present deployment platform options in a more compact and readable format.

## Changes
- Replaced individual deployment badge buttons with a single line of text links
- Consolidated four separate badge images (Render, Heroku, DigitalOcean, Koyeb) into inline markdown links
- Maintained all deployment platform links and their functionality
- Improved visual hierarchy by using bold text for platform names

## Details
The deployment links remain fully functional and point to the same deployment endpoints. This change reduces visual clutter in the README while making the deployment options more scannable and easier to maintain.

https://claude.ai/code/session_01NUR2zSHQ3WDfurMauhf7M2