### PR TITLE
Add request-scoped session memoization via AsyncLocalStorage

### DIFF
--- a/src/lib/session-context.ts
+++ b/src/lib/session-context.ts
@@ -1,0 +1,35 @@
+/**
+ * Request-scoped session memoization via AsyncLocalStorage
+ *
+ * Caches the result of getAuthenticatedSession so that multiple calls
+ * within the same request (e.g. routeAdmin pre-check + route handler)
+ * only hit the database once.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { AuthSession } from "#routes/utils.ts";
+
+/** Sentinel value distinguishing "resolved to null" from "not yet resolved" */
+type SessionState = { value: AuthSession | null; resolved: boolean };
+
+const sessionStore = new AsyncLocalStorage<SessionState>();
+
+/** Run a function within a session-memoization scope */
+export const runWithSessionContext = <T>(fn: () => T): T =>
+  sessionStore.run({ value: null, resolved: false }, fn);
+
+/** Return the cached session if already resolved, or undefined if not yet resolved */
+export const getCachedSession = (): AuthSession | null | undefined => {
+  const state = sessionStore.getStore();
+  if (!state || !state.resolved) return undefined;
+  return state.value;
+};
+
+/** Store the resolved session in the current request scope */
+export const setCachedSession = (session: AuthSession | null): void => {
+  const state = sessionStore.getStore();
+  if (state) {
+    state.value = session;
+    state.resolved = true;
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -11,6 +11,7 @@ import { loadTheme } from "#lib/theme.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { createRequestTimer, ErrorCode, logDebug, logError, logRequest, runWithRequestId } from "#lib/logger.ts";
 import { flushPendingWork } from "#lib/pending-work.ts";
+import { runWithSessionContext } from "#lib/session-context.ts";
 import {
   applySecurityHeaders,
   buildDomainRedirectUrl,
@@ -208,7 +209,7 @@ export const handleRequest = (
   request: Request,
   server?: ServerContext,
 ): Promise<Response> => {
-  return runWithRequestId(() => runWithQueryLogContext(async () => {
+  return runWithRequestId(() => runWithQueryLogContext(() => runWithSessionContext(async () => {
   const { url, path, method } = parseRequest(request);
   const getElapsed = createRequestTimer();
 
@@ -252,5 +253,5 @@ export const handleRequest = (
   } finally {
     await flushPendingWork();
   }
-  }));
+  })));
 };

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -14,6 +14,7 @@ import { deleteSession, getSession } from "#lib/db/sessions.ts";
 import { getWrappedPrivateKey } from "#lib/db/settings.ts";
 import { decryptAdminLevel, getUserById } from "#lib/db/users.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
+import { getCachedSession, setCachedSession } from "#lib/session-context.ts";
 import { nowMs } from "#lib/now.ts";
 import type { AdminLevel, AdminSession, EventWithCount } from "#lib/types.ts";
 import type { ServerContext } from "#routes/types.ts";
@@ -95,15 +96,25 @@ export const parseCookies = (request: Request): Map<string, string> => {
 export const getAuthenticatedSession = async (
   request: Request,
 ): Promise<AuthSession | null> => {
+  const cached = getCachedSession();
+  if (cached !== undefined) return cached;
+
   const cookies = parseCookies(request);
   const token = cookies.get(getSessionCookieName());
-  if (!token) return null;
+  if (!token) {
+    setCachedSession(null);
+    return null;
+  }
 
   const session = await getSession(token);
-  if (!session) return null;
+  if (!session) {
+    setCachedSession(null);
+    return null;
+  }
 
   if (session.expires < nowMs()) {
     await deleteSession(token);
+    setCachedSession(null);
     return null;
   }
 
@@ -115,18 +126,21 @@ export const getAuthenticatedSession = async (
       detail: "Session references non-existent user, invalidating",
     });
     await deleteSession(token);
+    setCachedSession(null);
     return null;
   }
 
   const adminLevel = await decryptAdminLevel(user);
   await signCsrfToken();
 
-  return {
+  const result: AuthSession = {
     token,
     wrappedDataKey: session.wrapped_data_key,
     userId: session.user_id,
     adminLevel,
   };
+  setCachedSession(result);
+  return result;
 };
 
 /**

--- a/test/lib/session-context.test.ts
+++ b/test/lib/session-context.test.ts
@@ -1,0 +1,75 @@
+import { describe, it as test } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  getCachedSession,
+  runWithSessionContext,
+  setCachedSession,
+} from "#lib/session-context.ts";
+import type { AuthSession } from "#routes/utils.ts";
+
+const makeSession = (token = "tok"): AuthSession => ({
+  token,
+  wrappedDataKey: null,
+  userId: 1,
+  adminLevel: "owner",
+});
+
+describe("session-context", () => {
+  describe("getCachedSession", () => {
+    test("returns undefined outside a context", () => {
+      expect(getCachedSession()).toBeUndefined();
+    });
+
+    test("returns undefined before session is resolved", () => {
+      runWithSessionContext(() => {
+        expect(getCachedSession()).toBeUndefined();
+      });
+    });
+
+    test("returns null after caching null", () => {
+      runWithSessionContext(() => {
+        setCachedSession(null);
+        expect(getCachedSession()).toBeNull();
+      });
+    });
+
+    test("returns session after caching a session", () => {
+      const session = makeSession();
+      runWithSessionContext(() => {
+        setCachedSession(session);
+        expect(getCachedSession()).toBe(session);
+      });
+    });
+  });
+
+  describe("setCachedSession", () => {
+    test("is a no-op outside a context", () => {
+      setCachedSession(makeSession());
+      expect(getCachedSession()).toBeUndefined();
+    });
+  });
+
+  describe("runWithSessionContext", () => {
+    test("isolates contexts between nested runs", () => {
+      const outer = makeSession("outer");
+      const inner = makeSession("inner");
+
+      runWithSessionContext(() => {
+        setCachedSession(outer);
+
+        runWithSessionContext(() => {
+          expect(getCachedSession()).toBeUndefined();
+          setCachedSession(inner);
+          expect(getCachedSession()!.token).toBe("inner");
+        });
+
+        expect(getCachedSession()!.token).toBe("outer");
+      });
+    });
+
+    test("returns the value from the wrapped function", () => {
+      const result = runWithSessionContext(() => 42);
+      expect(result).toBe(42);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements request-scoped session caching to avoid redundant database queries when `getAuthenticatedSession()` is called multiple times within the same request context.

## Key Changes
- **New module `src/lib/session-context.ts`**: Provides session memoization utilities using Node's `AsyncLocalStorage`
  - `runWithSessionContext()`: Creates an isolated session scope for a request
  - `getCachedSession()`: Retrieves cached session if already resolved
  - `setCachedSession()`: Stores resolved session in current scope
  
- **Updated `src/routes/utils.ts`**: Integrated session caching into `getAuthenticatedSession()`
  - Returns cached session if available without database lookup
  - Caches both successful sessions and null results (no valid session)
  - Caches on all early-exit paths (missing token, expired session, invalid user)

- **Updated `src/routes/index.ts`**: Wrapped request handler with session context
  - Added `runWithSessionContext()` wrapper in `handleRequest()` to establish session scope for entire request

- **New test suite `test/lib/session-context.test.ts`**: Comprehensive tests covering
  - Cache behavior outside/inside context
  - Distinction between unresolved and null states
  - Context isolation between nested runs
  - Return value passthrough

## Implementation Details
- Uses a sentinel `SessionState` object with `resolved` flag to distinguish "not yet resolved" from "resolved to null"
- Contexts are properly isolated for nested `runWithSessionContext()` calls
- Session caching is transparent to callers—no API changes to `getAuthenticatedSession()`

https://claude.ai/code/session_01LgZjWkbJrA5hFUGGPB42HZ