### PR TITLE
Fix TypeScript type errors: unitPrice null vs undefined, missing can_…

### DIFF
--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -100,7 +100,7 @@ const extractCommonFields = (values: EventFormValues) => {
   const date = rawDate ? normalizeDatetime(rawDate, "date") : rawDate;
   const unitPrice = values.unit_price
     ? toMinorUnits(Number.parseFloat(values.unit_price))
-    : null;
+    : undefined;
   const closesAt = values.closes_at
     ? normalizeDatetime(values.closes_at, "closes_at")
     : values.closes_at;

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -63,6 +63,7 @@ describe("webhook example", () => {
       max_attendees: 100,
       attendee_count: 10,
       unit_price: EXAMPLE_EVENT.unit_price,
+      can_pay_more: false,
     },
     attendee: {
       id: 1,


### PR DESCRIPTION
…pay_more

- Change unitPrice fallback from `null` to `undefined` in extractCommonFields to match EventInput type definition (number | undefined)
- Add missing `can_pay_more` property to webhook test fixture to satisfy WebhookEvent type

https://claude.ai/code/session_015RqjMJCy3xLRPiEPLJADAM