### PR TITLE
Improve test coverage and assertions for pay-more events

### DIFF
--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3398,32 +3398,35 @@ describe("server (public routes)", () => {
       const event = await payMoreEvent();
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
-      expect(html).toContain("custom_price");
-      expect(html).toContain("Your Price");
-      expect(html).toContain("10.00");
+      expect(html).toContain('name="custom_price"');
+      expect(html).toContain("Your Price (minimum");
+      expect(html).toContain('value="10.00"');
+      expect(html).toContain("required");
     });
 
     test("GET does not show price input when can_pay_more is disabled", async () => {
       const event = await createTestEvent({ unitPrice: 1000, maxAttendees: 50 });
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
-      expect(html).not.toContain("custom_price");
+      expect(html).not.toContain('name="custom_price"');
     });
 
     test("GET shows price input for can_pay_more events with zero unit_price", async () => {
       const event = await payMoreEvent({ unitPrice: undefined });
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
-      expect(html).toContain("custom_price");
-      expect(html).toContain("optional");
+      expect(html).toContain('name="custom_price"');
+      expect(html).toContain("Your Price (optional)");
+      expect(html).toContain('min="0.00"');
     });
 
     test("GET shows optional price input for free can_pay_more events", async () => {
       const event = await payMoreEvent({ unitPrice: 0 });
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
-      expect(html).toContain("custom_price");
-      expect(html).toContain("optional");
+      expect(html).toContain('name="custom_price"');
+      expect(html).toContain("Your Price (optional)");
+      expect(html).toContain('value="0.00" min="0.00" />');
     });
 
     test("POST free can_pay_more with custom price redirects to checkout", async () => {
@@ -3443,6 +3446,11 @@ describe("server (public routes)", () => {
         custom_price: "",
       });
       expect(response.status).toBe(302);
+      const location = response.headers.get("location") || "";
+      expect(location).not.toContain("checkout");
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const attendees = await getAttendeesRaw(event.id);
+      expect(attendees.length).toBe(1);
     });
 
     test("POST free can_pay_more with zero price registers for free", async () => {
@@ -3452,11 +3460,14 @@ describe("server (public routes)", () => {
         custom_price: "0",
       });
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).not.toContain("checkout");
+      const location = response.headers.get("location") || "";
+      expect(location).not.toContain("checkout");
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const attendees = await getAttendeesRaw(event.id);
+      expect(attendees.length).toBe(1);
     });
 
     test("POST rejects price below minimum", async () => {
-      await setupStripe();
       const event = await payMoreEvent();
       const response = await submitTicketForm(event.slug, {
         name: "Test User", email: "test@example.com", quantity: "1",
@@ -3486,8 +3497,7 @@ describe("server (public routes)", () => {
       expectCheckoutRedirect(response);
     });
 
-    test("POST rejects empty custom_price", async () => {
-      await setupStripe();
+    test("POST rejects empty custom_price for paid can_pay_more event", async () => {
       const event = await payMoreEvent();
       const response = await submitTicketForm(event.slug, {
         name: "Test User", email: "test@example.com", quantity: "1",
@@ -3498,11 +3508,20 @@ describe("server (public routes)", () => {
     });
 
     test("POST rejects invalid custom_price", async () => {
-      await setupStripe();
       const event = await payMoreEvent();
       const response = await submitTicketForm(event.slug, {
         name: "Test User", email: "test@example.com", quantity: "1",
         custom_price: "abc",
+      });
+      const html = await response.text();
+      expect(html).toContain("valid price");
+    });
+
+    test("POST rejects negative custom_price", async () => {
+      const event = await payMoreEvent();
+      const response = await submitTicketForm(event.slug, {
+        name: "Test User", email: "test@example.com", quantity: "1",
+        custom_price: "-5.00",
       });
       const html = await response.text();
       expect(html).toContain("valid price");
@@ -3513,8 +3532,8 @@ describe("server (public routes)", () => {
       const event2 = await createTestEvent({ name: "Normal Multi", unitPrice: 1000, maxAttendees: 50 });
       const response = await handleRequest(mockRequest(`/ticket/${event1.slug}+${event2.slug}`));
       const html = await response.text();
-      expect(html).toContain(`custom_price_${event1.id}`);
-      expect(html).not.toContain(`custom_price_${event2.id}`);
+      expect(html).toContain(`name="custom_price_${event1.id}"`);
+      expect(html).not.toContain(`name="custom_price_${event2.id}"`);
     });
 
     test("POST multi-ticket with can_pay_more redirects to checkout", async () => {
@@ -3531,7 +3550,6 @@ describe("server (public routes)", () => {
     });
 
     test("POST multi-ticket rejects custom_price below minimum", async () => {
-      await setupStripe();
       const event1 = await payMoreEvent({ name: "Pay More Reject", unitPrice: 500, maxQuantity: 5 });
       const event2 = await createTestEvent({ name: "Normal Reject", unitPrice: 1000, maxAttendees: 50, maxQuantity: 5 });
       const slug = `${event1.slug}+${event2.slug}`;
@@ -3587,8 +3605,16 @@ describe("server (public routes)", () => {
       const { cookie } = await loginAsAdmin();
       const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, { cookie });
       const html = await response.text();
-      expect(html).toContain("can_pay_more");
-      expect(html).toContain("checked");
+      expect(html).toContain('name="can_pay_more" value="1" checked');
+    });
+
+    test("admin edit page shows can_pay_more unchecked for disabled event", async () => {
+      const event = await createTestEvent({ unitPrice: 1000, maxAttendees: 50 });
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, { cookie });
+      const html = await response.text();
+      expect(html).toContain('name="can_pay_more"');
+      expect(html).not.toContain('name="can_pay_more" value="1" checked');
     });
   });
 });

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -2900,6 +2900,69 @@ describe("server (webhooks)", () => {
       }
     });
 
+    test("multi-ticket rejects amount above event price when can_pay_more is disabled", async () => {
+      await setupStripe();
+
+      const event1 = await createTestEvent({
+        name: "No Pay More",
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      const event2 = await createTestEvent({
+        name: "Normal Price",
+        maxAttendees: 50,
+        unitPrice: 1000,
+      });
+
+      // Same metadata shape as the pay-more test, but event1 has can_pay_more=false
+      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+      const mockVerify = stub(stripePaymentProvider, "verifyWebhookSignature", () => Promise.resolve({
+        valid: true,
+        event: {
+          id: "evt_no_pay_more",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_no_pay_more",
+              payment_status: "paid",
+              payment_intent: "pi_no_pay_more",
+              amount_total: 3000,
+              metadata: webhookMeta({
+                multi: "1",
+                name: "Over Payer",
+                email: "over@example.com",
+                items: JSON.stringify([
+                  { e: event1.id, q: 1, p: 2000 },
+                  { e: event2.id, q: 1, p: 1000 },
+                ]),
+              }),
+            },
+          },
+        },
+      }));
+
+      const mockRefund = stub(stripeApi, "refundPayment", () =>
+        Promise.resolve({ id: "re_no_pay_more" } as unknown as Awaited<
+          ReturnType<typeof stripeApi.refundPayment>
+        >));
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest(
+            {},
+            { "stripe-signature": "sig_valid" },
+          ),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.processed).toBe(false);
+        expect(json.error).toContain("price");
+      } finally {
+        mockVerify.restore();
+        mockRefund.restore();
+      }
+    });
+
     test("single-ticket can_pay_more rejects amount below minimum price", async () => {
       await setupStripe();
 


### PR DESCRIPTION
## Summary
This PR enhances test coverage and improves assertion specificity for the "pay more" (custom pricing) feature across webhook and public route handlers. The changes focus on making tests more robust by checking for specific HTML attributes and adding missing test cases.

## Key Changes

- **New webhook test**: Added test case for multi-ticket checkout that rejects amounts above event price when `can_pay_more` is disabled, ensuring proper validation and refund handling
- **Improved HTML assertions**: Updated assertions in public route tests to check for specific HTML attributes (`name=`, `value=`, `min=`) rather than just substring matches, making tests more precise and less prone to false positives
- **Enhanced form validation tests**: 
  - Added test for rejecting negative custom prices
  - Clarified test naming for empty custom_price validation (now specifies "for paid can_pay_more event")
  - Removed unnecessary `setupStripe()` calls from tests that don't require Stripe setup
- **Admin page test coverage**: Added test case to verify `can_pay_more` checkbox displays as unchecked for events with disabled pay-more feature
- **Improved checkout assertions**: Enhanced multi-ticket and free event tests to verify actual attendee creation and checkout redirect behavior more thoroughly

## Notable Implementation Details

- Tests now validate the complete form submission flow including database state verification
- HTML attribute-based assertions are more maintainable and catch unintended HTML structure changes
- Removed redundant Stripe setup calls to improve test performance and clarity

https://claude.ai/code/session_01Mj5SCyVBbsSnNMJGhFGvoj