### PR TITLE
Add maximum price cap for pay-more events

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,17 @@ export const isEventType = (s: string): s is EventType =>
 export const isPaidEvent = (event: Pick<Event, "unit_price" | "can_pay_more">): boolean =>
   event.unit_price > 0 || event.can_pay_more;
 
+/** Absolute minimum for the pay-more max price cap (in minor units) */
+export const CAN_PAY_MORE_ABS_MIN = 10000;
+
+/** Multiplier applied to unit_price for the pay-more max price cap */
+export const CAN_PAY_MORE_MULTIPLIER = 10;
+
+/** Calculate the maximum price for a can_pay_more event (in minor units).
+ *  Returns the higher of (10 × minPrice) or 10000. */
+export const canPayMoreMaxPrice = (minPrice: number): number =>
+  Math.max(minPrice * CAN_PAY_MORE_MULTIPLIER, CAN_PAY_MORE_ABS_MIN);
+
 export interface Event {
   id: number;
   name: string;

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -32,6 +32,7 @@ import {
   type RegistrationIntent,
 } from "#lib/payments.ts";
 import type { ContactInfo, EventFields, EventWithCount, Group } from "#lib/types.ts";
+import { canPayMoreMaxPrice } from "#lib/types.ts";
 import { logDebug } from "#lib/logger.ts";
 import {
   logAndNotifyMultiRegistration,
@@ -274,6 +275,7 @@ const parseCustomPrice = (
   form: URLSearchParams,
   fieldName: string,
   minPrice: number,
+  maxPrice: number,
 ): { ok: true; price: number } | { ok: false; error: string } => {
   const raw = (form.get(fieldName) || "").trim();
   if (!raw) {
@@ -286,6 +288,9 @@ const parseCustomPrice = (
   const priceMinor = toMinorUnits(parsed);
   if (priceMinor < minPrice) {
     return { ok: false, error: "Price must be at least the minimum ticket price" };
+  }
+  if (priceMinor > maxPrice) {
+    return { ok: false, error: "Price exceeds the maximum allowed" };
   }
   return { ok: true, price: priceMinor };
 };
@@ -386,7 +391,7 @@ const processTicketReservation = async (
       // Parse custom price for pay-more events
       let customUnitPrice: number | undefined;
       if (event.can_pay_more) {
-        const priceResult = parseCustomPrice(form, "custom_price", event.unit_price);
+        const priceResult = parseCustomPrice(form, "custom_price", event.unit_price, canPayMoreMaxPrice(event.unit_price));
         if (!priceResult.ok) {
           return ticketResponse(event, inIframe, dates, terms)(priceResult.error);
         }
@@ -580,7 +585,7 @@ const submitMultiTicket = (
         if (event.can_pay_more) {
           const qty = quantities.get(event.id) ?? 0;
           if (qty > 0) {
-            const priceResult = parseCustomPrice(form, `custom_price_${event.id}`, event.unit_price);
+            const priceResult = parseCustomPrice(form, `custom_price_${event.id}`, event.unit_price, canPayMoreMaxPrice(event.unit_price));
             if (!priceResult.ok) {
               return multiTicketFormErrorResponse(ctx)(`${event.name}: ${priceResult.error}`);
             }

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -36,6 +36,7 @@ import {
   type WebhookEvent,
 } from "#lib/payments.ts";
 import type { Attendee, ContactInfo, EventWithCount } from "#lib/types.ts";
+import { canPayMoreMaxPrice } from "#lib/types.ts";
 import { getAllowedDomain, getCurrencyCode } from "#lib/config.ts";
 import { logAndNotifyMultiRegistration, logAndNotifyRegistration } from "#lib/webhook.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
@@ -265,9 +266,11 @@ const validateAndPrice = async (
 };
 
 /** Check if the amount charged matches the current event price.
- * For pay-more events, the amount must be >= the expected minimum price. */
+ * For pay-more events, the amount must be >= the expected minimum price and <= the max cap. */
 const hasPriceMismatch = (amountTotal: number, expectedPrice: number, canPayMore: boolean): boolean =>
-  canPayMore ? amountTotal < expectedPrice : amountTotal !== expectedPrice;
+  canPayMore
+    ? amountTotal < expectedPrice || amountTotal > canPayMoreMaxPrice(expectedPrice)
+    : amountTotal !== expectedPrice;
 
 /** Format error for post-payment attendee creation failure */
 const formatPostPaymentError = formatCreationError(
@@ -376,7 +379,7 @@ const processMultiPaymentSession = async (
   // Per-item price validation: each item's p must match its event's rules
   for (const { item, event, expectedPrice } of validatedItems) {
     const itemMismatch = event.can_pay_more
-      ? item.p < expectedPrice   // pay-more: p must be >= minimum (unit_price * q)
+      ? item.p < expectedPrice || item.p > canPayMoreMaxPrice(expectedPrice)  // pay-more: min <= p <= max
       : item.p !== expectedPrice; // fixed: p must equal unit_price * q exactly
     if (itemMismatch) {
       logError({

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -4,6 +4,8 @@
 
 import type { Child } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#lib/types.ts";
+import { CAN_PAY_MORE_ABS_MIN, CAN_PAY_MORE_MULTIPLIER } from "#lib/types.ts";
+import { formatCurrency } from "#lib/currency.ts";
 import { WEBHOOK_EXAMPLE_JSON } from "#lib/webhook-example.ts";
 import { Layout } from "#templates/layout.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
@@ -123,6 +125,22 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             transaction. For example, setting it to 4 lets someone book up to 4
             places at once. The quantity dropdown on the booking form won't
             exceed this number or the remaining capacity, whichever is lower.
+          </p>
+        </Q>
+
+        <Q q="What does 'Allow Pay More' do?">
+          <p>
+            When enabled, attendees can choose their own price instead of paying
+            a fixed amount. The ticket price becomes a minimum and they can pay
+            up to {CAN_PAY_MORE_MULTIPLIER}&times; that amount or{" "}
+            {formatCurrency(CAN_PAY_MORE_ABS_MIN)}, whichever is higher. For
+            example, a {formatCurrency(500)} ticket allows prices up to{" "}
+            {formatCurrency(Math.max(500 * CAN_PAY_MORE_MULTIPLIER, CAN_PAY_MORE_ABS_MIN))},
+            while a {formatCurrency(2000)} ticket allows up to{" "}
+            {formatCurrency(Math.max(2000 * CAN_PAY_MORE_MULTIPLIER, CAN_PAY_MORE_ABS_MIN))}.
+            If the ticket price is zero, it becomes a pay-what-you-want event
+            where attendees can optionally enter any amount up to{" "}
+            {formatCurrency(CAN_PAY_MORE_ABS_MIN)}.
           </p>
         </Q>
 

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -10,6 +10,7 @@ import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
 import { renderMarkdown, renderMarkdownInline } from "#lib/markdown.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
 import type { EventFields, EventWithCount } from "#lib/types.ts";
+import { canPayMoreMaxPrice } from "#lib/types.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { getTicketFields, mergeEventFields } from "#templates/fields.ts";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
@@ -166,9 +167,16 @@ const quantityOptions = (max: number): string =>
     .join("");
 
 /** Render a price input for pay-more events */
-const renderPayMoreInput = (minPrice: number, fieldName = "custom_price"): string =>
-  `<label for="${fieldName}">${minPrice > 0 ? `Your Price (minimum ${formatCurrency(minPrice)})` : "Your Price (optional)"}</label>` +
-  `<input type="text" inputmode="decimal" name="${fieldName}" id="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}"${minPrice > 0 ? " required" : ""} />`;
+const renderPayMoreInput = (minPrice: number, fieldName = "custom_price"): string => {
+  const maxPrice = canPayMoreMaxPrice(minPrice);
+  const rangeHint = minPrice > 0
+    ? `Your Price (${formatCurrency(minPrice)} – ${formatCurrency(maxPrice)})`
+    : `Your Price (optional, up to ${formatCurrency(maxPrice)})`;
+  return (
+    `<label for="${fieldName}">${rangeHint}</label>` +
+    `<input type="text" inputmode="decimal" name="${fieldName}" id="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}"${minPrice > 0 ? " required" : ""} />`
+  );
+};
 
 /** Render terms and conditions block with agreement checkbox */
 const renderTermsAndCheckbox = (terms: string): string =>

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -123,6 +123,14 @@ describe("server (admin guide)", () => {
       expect(html).toContain("Deactivate");
     });
 
+    test("contains allow pay more info with max price", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Allow Pay More");
+      expect(html).toContain("maximum");
+      expect(html).toContain("£100.00");
+    });
+
     test("contains non-transferable tickets info", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3486,6 +3486,41 @@ describe("server (public routes)", () => {
       expectCheckoutRedirect(response);
     });
 
+    test("POST rejects price above maximum", async () => {
+      await setupStripe();
+      const event = await payMoreEvent();
+      const response = await submitTicketForm(event.slug, {
+        name: "Test User", email: "test@example.com", quantity: "1",
+        custom_price: "150.00",
+      });
+      const html = await response.text();
+      expect(html).toContain("maximum");
+    });
+
+    test("POST accepts price at maximum", async () => {
+      await setupStripe();
+      const event = await payMoreEvent();
+      const response = await submitTicketForm(event.slug, {
+        name: "Test User", email: "test@example.com", quantity: "1",
+        custom_price: "100.00",
+      });
+      expectCheckoutRedirect(response);
+    });
+
+    test("GET shows max price in label", async () => {
+      const event = await payMoreEvent();
+      const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
+      const html = await response.text();
+      expect(html).toContain("£100.00");
+    });
+
+    test("GET shows max price for free can_pay_more event", async () => {
+      const event = await payMoreEvent({ unitPrice: 0 });
+      const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
+      const html = await response.text();
+      expect(html).toContain("up to £100.00");
+    });
+
     test("POST rejects empty custom_price", async () => {
       await setupStripe();
       const event = await payMoreEvent();
@@ -3542,6 +3577,20 @@ describe("server (public routes)", () => {
       });
       const html = await response.text();
       expect(html).toContain("minimum");
+    });
+
+    test("POST multi-ticket rejects custom_price above maximum", async () => {
+      await setupStripe();
+      const event1 = await payMoreEvent({ name: "Pay More Max Reject", unitPrice: 500, maxQuantity: 5 });
+      const event2 = await createTestEvent({ name: "Normal Max Reject", unitPrice: 1000, maxAttendees: 50, maxQuantity: 5 });
+      const slug = `${event1.slug}+${event2.slug}`;
+      const response = await submitMultiTicketForm(slug, {
+        name: "John Doe", email: "john@example.com",
+        [`quantity_${event1.id}`]: "1", [`quantity_${event2.id}`]: "1",
+        [`custom_price_${event1.id}`]: "200.00",
+      });
+      const html = await response.text();
+      expect(html).toContain("maximum");
     });
 
     test("POST multi-ticket skips price check for can_pay_more event with qty 0", async () => {

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -2954,6 +2954,60 @@ describe("server (webhooks)", () => {
       }
     });
 
+    test("single-ticket can_pay_more rejects amount above maximum price", async () => {
+      await setupStripe();
+
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 1000,
+        canPayMore: true,
+      });
+
+      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+      const mockVerify = stub(stripePaymentProvider, "verifyWebhookSignature", () => Promise.resolve({
+        valid: true,
+        event: {
+          id: "evt_pay_too_much",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_pay_too_much",
+              payment_status: "paid",
+              payment_intent: "pi_pay_too_much",
+              amount_total: 20000,
+              metadata: webhookMeta({
+                event_id: String(event.id),
+                name: "Overpay User",
+                email: "overpay@example.com",
+                quantity: "1",
+              }),
+            },
+          },
+        },
+      }));
+
+      const mockRefund = stub(stripeApi, "refundPayment", () =>
+        Promise.resolve({ id: "re_pay_too_much" } as unknown as Awaited<
+          ReturnType<typeof stripeApi.refundPayment>
+        >));
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest(
+            {},
+            { "stripe-signature": "sig_valid" },
+          ),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.processed).toBe(false);
+        expect(json.error).toContain("price");
+      } finally {
+        mockVerify.restore();
+        mockRefund.restore();
+      }
+    });
+
     test("multi-ticket rejects metadata with non-integer p", async () => {
       await setupStripe();
 

--- a/test/lib/types.test.ts
+++ b/test/lib/types.test.ts
@@ -1,0 +1,38 @@
+import { describe, it as test } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  canPayMoreMaxPrice,
+  CAN_PAY_MORE_ABS_MIN,
+  CAN_PAY_MORE_MULTIPLIER,
+} from "#lib/types.ts";
+
+describe("canPayMoreMaxPrice", () => {
+  test("returns absolute minimum when 10x price is lower", () => {
+    // 500 * 10 = 5000, which is less than 10000
+    expect(canPayMoreMaxPrice(500)).toBe(CAN_PAY_MORE_ABS_MIN);
+  });
+
+  test("returns 10x price when it exceeds absolute minimum", () => {
+    // 2000 * 10 = 20000, which is greater than 10000
+    expect(canPayMoreMaxPrice(2000)).toBe(2000 * CAN_PAY_MORE_MULTIPLIER);
+  });
+
+  test("returns absolute minimum for zero price", () => {
+    expect(canPayMoreMaxPrice(0)).toBe(CAN_PAY_MORE_ABS_MIN);
+  });
+
+  test("returns absolute minimum at the boundary (price = 1000)", () => {
+    // 1000 * 10 = 10000, which equals the absolute minimum
+    expect(canPayMoreMaxPrice(1000)).toBe(CAN_PAY_MORE_ABS_MIN);
+  });
+
+  test("returns 10x price just above the boundary", () => {
+    // 1001 * 10 = 10010, which is greater than 10000
+    expect(canPayMoreMaxPrice(1001)).toBe(1001 * CAN_PAY_MORE_MULTIPLIER);
+  });
+
+  test("constants have expected values", () => {
+    expect(CAN_PAY_MORE_ABS_MIN).toBe(10000);
+    expect(CAN_PAY_MORE_MULTIPLIER).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
Implements a maximum price cap for "pay more" events to prevent attendees from paying excessively high amounts. The maximum is calculated as 10× the ticket price or £100 (whichever is higher), with special handling for free events.

## Key Changes

- **New utility function**: Added `canPayMoreMaxPrice()` in `types.ts` to calculate the maximum allowed price based on the unit price, with constants `CAN_PAY_MORE_ABS_MIN` (10000 minor units) and `CAN_PAY_MORE_MULTIPLIER` (10)

- **Price validation**: Updated `parseCustomPrice()` in `public.ts` to reject prices exceeding the calculated maximum, with appropriate error messaging

- **Webhook validation**: Enhanced `hasPriceMismatch()` in `webhooks.ts` to validate that webhook payment amounts don't exceed the maximum cap for pay-more events

- **UI improvements**: 
  - Updated price input labels in `public.tsx` to display the price range (minimum – maximum)
  - Added `max` attribute to price input fields for client-side validation
  - Updated admin guide to explain the pay-more feature and its pricing rules

- **Comprehensive testing**: Added unit tests for the `canPayMoreMaxPrice()` function and integration tests covering:
  - Single and multi-ticket rejection of overpayment
  - Acceptance of prices at the maximum
  - UI display of maximum prices for both paid and free pay-more events
  - Webhook handling of overpayment attempts with automatic refunds

## Implementation Details

The maximum price calculation ensures a reasonable upper bound while scaling with the ticket price. For example:
- £5 ticket → max £100 (absolute minimum applies)
- £10 ticket → max £100 (absolute minimum applies)  
- £20 ticket → max £200 (10× multiplier applies)

Free pay-more events allow attendees to pay up to £100 voluntarily.

https://claude.ai/code/session_01PoatLW5ZGVXY1AC934PAMY