### PR TITLE
Fix flaky process leak detection in build-edge tests

### DIFF
--- a/test/lib/build-edge.test.ts
+++ b/test/lib/build-edge.test.ts
@@ -3,7 +3,11 @@ import { expect } from "@std/expect";
 import * as esbuild from "esbuild";
 import { minifyCss } from "../../scripts/css-minify.ts";
 
-describe("build-edge", () => {
+describe({
+  name: "build-edge",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, () => {
   afterAll(async () => {
     await esbuild.stop();
   });


### PR DESCRIPTION
esbuild spawns a long-lived child process on first transform() call, which is reused across tests and cleaned up in afterAll via esbuild.stop(). Deno's test sanitizer was intermittently flagging this as a leak since it checks resources per-test. Disable sanitizeResources and sanitizeOps on the describe block since the subprocess lifecycle is intentionally managed.

https://claude.ai/code/session_016nzSMW82gPveL5sAmJikb5