### PR TITLE
Fix boolean column read conversion to handle numeric strings

### DIFF
--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -405,6 +405,6 @@ export const col = {
   boolean: (defaultValue: boolean): ColumnDef<boolean> => ({
     default: () => defaultValue,
     write: ((v: boolean) => v ? 1 : 0) as unknown as (v: boolean) => boolean,
-    read: ((v: unknown) => v === 1) as unknown as (v: boolean) => boolean,
+    read: ((v: unknown) => Number(v) === 1) as unknown as (v: boolean) => boolean,
   }),
 };


### PR DESCRIPTION
## Summary
Updated the boolean column read converter to properly handle numeric string values by explicitly converting them to numbers before comparison.

## Key Changes
- Modified the `read` function in the `col.boolean` column definition to use `Number(v) === 1` instead of `v === 1`
- This ensures that numeric strings (e.g., `"1"`, `"0"`) are correctly converted to boolean values, not just strict numeric comparisons

## Implementation Details
The change addresses a type coercion issue where boolean values stored as strings in the database would fail the strict equality check. By explicitly converting the value to a number first, the function now correctly handles:
- Numeric values: `1` → `true`, `0` → `false`
- Numeric strings: `"1"` → `true`, `"0"` → `false`
- Other falsy values: `null`, `undefined`, `""` → `false`

https://claude.ai/code/session_01B8F4X2T927QWycQjbrdWdd