### PR TITLE
Improve price input styling and accessibility

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -539,6 +539,11 @@ label > input[type="email"] {
   width: auto;
 }
 
+label > input[inputmode="decimal"] {
+  flex: 0 0 auto;
+  width: 8ch;
+}
+
 label > textarea {
   width: 100%;
 }

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -173,8 +173,8 @@ const renderPayMoreInput = (minPrice: number, fieldName = "custom_price"): strin
     ? `Your Price (${formatCurrency(minPrice)} – ${formatCurrency(maxPrice)})`
     : `Your Price (optional, up to ${formatCurrency(maxPrice)})`;
   return (
-    `<label for="${fieldName}">${rangeHint}</label>` +
-    `<input type="text" inputmode="decimal" name="${fieldName}" id="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}"${minPrice > 0 ? " required" : ""} />`
+    `<label>${rangeHint}` +
+    `<input type="text" inputmode="decimal" name="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}"${minPrice > 0 ? " required" : ""} /></label>`
   );
 };
 


### PR DESCRIPTION
## Summary
This PR improves the styling and accessibility of the custom price input field by adjusting CSS rules and restructuring the HTML label markup.

## Key Changes
- **CSS**: Added a new style rule for `input[inputmode="decimal"]` elements to constrain their width to 8 characters and prevent flex expansion
- **HTML Structure**: Refactored the price input label to use implicit association by nesting the input inside the label element, removing the explicit `for` and `id` attributes

## Implementation Details
The changes work together to improve the user experience:
1. The input field is now nested within its label element, which is a valid and often preferred accessibility pattern
2. The new CSS rule ensures decimal inputs have a reasonable fixed width (8 characters) rather than expanding to fill available space
3. The `flex: 0 0 auto` property prevents the input from growing or shrinking within flex containers

https://claude.ai/code/session_01VBZEE2A2AoxqA7zGBpu2Ec