### PR TITLE
Style quantity select dropdown with fixed width

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -533,6 +533,11 @@ label > input[type="time"] {
   width: auto;
 }
 
+label > select[name="quantity"] {
+  width: 6ch;
+  flex: 0 0 auto;
+}
+
 label > input[type="text"],
 label > input[type="password"],
 label > input[type="email"] {


### PR DESCRIPTION
## Summary
Added CSS styling for the quantity select dropdown to give it a fixed width and prevent it from expanding with its container.

## Changes
- Added new CSS rule for `label > select[name="quantity"]` with:
  - Fixed width of `6ch` (6 character units) to accommodate typical quantity values
  - `flex: 0 0 auto` to prevent the element from growing or shrinking in flex layouts

## Details
This styling ensures the quantity selector maintains a compact, consistent appearance within form layouts while preventing it from taking up unnecessary space or being squeezed by flex container behavior.

https://claude.ai/code/session_018jVZ6JZd726NMpsT5X8RgC