### PR TITLE
Strip trailing zeros from currency formatting

### DIFF
--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -34,8 +34,11 @@ export const getDecimalPlaces = (currencyCode: string): number =>
 export const formatCurrency = (minorUnits: number | string): string => {
   const places = getDecimalPlaces(state.code);
   const divisor = 10 ** places;
-  return new Intl.NumberFormat("en", { style: "currency", currency: state.code })
-    .format(Number(minorUnits) / divisor);
+  return new Intl.NumberFormat("en", {
+    style: "currency",
+    currency: state.code,
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(Number(minorUnits) / divisor);
 };
 
 /**

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -170,7 +170,7 @@ const quantityOptions = (max: number): string =>
 const renderPayMoreInput = (minPrice: number, fieldName = "custom_price"): string => {
   const maxPrice = canPayMoreMaxPrice(minPrice);
   const rangeHint = minPrice > 0
-    ? `Your Price (${formatCurrency(minPrice)} – ${formatCurrency(maxPrice)})`
+    ? `Your Price (${formatCurrency(minPrice)} minimum)`
     : `Your Price (optional, up to ${formatCurrency(maxPrice)})`;
   return (
     `<label>${rangeHint}` +

--- a/test/lib/currency.test.ts
+++ b/test/lib/currency.test.ts
@@ -59,7 +59,7 @@ describe("currency", () => {
 
     test("formats GBP zero amount", () => {
       setCurrencyCodeForTest("GBP");
-      expect(formatCurrency(0)).toBe("£0.00");
+      expect(formatCurrency(0)).toBe("£0");
     });
 
     test("formats USD with dollar symbol", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1349,7 +1349,7 @@ describe("html", () => {
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
       expect(html).toContain("Total Revenue");
-      expect(html).toContain("30.00");
+      expect(html).toContain("£30");
     });
 
     test("does not show total revenue for free events", () => {
@@ -1359,11 +1359,11 @@ describe("html", () => {
       expect(html).not.toContain("Total Revenue");
     });
 
-    test("shows 0.00 revenue for paid event with no attendees", () => {
+    test("shows zero revenue for paid event with no attendees", () => {
       const event = testEventWithCount({ unit_price: 1000, attendee_count: 0 });
       const html = adminEventPage({ event, attendees: [], allowedDomain: "localhost", session: TEST_SESSION });
       expect(html).toContain("Total Revenue");
-      expect(html).toContain("0.00");
+      expect(html).toContain("£0");
     });
   });
 
@@ -1492,8 +1492,8 @@ describe("html", () => {
         testAttendee({ id: 2, payment_id: "", price_paid: "2000" }),
       ];
       const html = adminEventPage({ event, attendees, allowedDomain: "localhost", session: TEST_SESSION });
-      expect(html).toContain("10.00");
-      expect(html).not.toContain("30.00");
+      expect(html).toContain("£10");
+      expect(html).not.toContain("£30");
     });
 
     test("failed payments table has delete button but no check-in or refund", () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -128,7 +128,7 @@ describe("server (admin guide)", () => {
       const html = await response.text();
       expect(html).toContain("Allow Pay More");
       expect(html).toContain("maximum");
-      expect(html).toContain("£100.00");
+      expect(html).toContain("£100");
     });
 
     test("contains non-transferable tickets info", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3399,8 +3399,7 @@ describe("server (public routes)", () => {
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
       expect(html).toContain('name="custom_price"');
-      expect(html).toContain("Your Price (£10.00");
-      expect(html).toContain("£100.00)");
+      expect(html).toContain("Your Price (£10 minimum)");
       expect(html).toContain('value="10.00"');
       expect(html).toContain("required");
     });
@@ -3417,7 +3416,7 @@ describe("server (public routes)", () => {
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
       expect(html).toContain('name="custom_price"');
-      expect(html).toContain("Your Price (optional, up to £100.00)");
+      expect(html).toContain("Your Price (optional, up to £100)");
       expect(html).toContain('min="0.00"');
     });
 
@@ -3426,7 +3425,7 @@ describe("server (public routes)", () => {
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
       expect(html).toContain('name="custom_price"');
-      expect(html).toContain("Your Price (optional, up to £100.00)");
+      expect(html).toContain("Your Price (optional, up to £100)");
       expect(html).toContain('value="0.00" min="0.00" max="100.00"');
     });
 
@@ -3518,18 +3517,18 @@ describe("server (public routes)", () => {
       expectCheckoutRedirect(response);
     });
 
-    test("GET shows max price in label", async () => {
+    test("GET shows min price in label", async () => {
       const event = await payMoreEvent();
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
-      expect(html).toContain("£100.00");
+      expect(html).toContain("£10 minimum");
     });
 
     test("GET shows max price for free can_pay_more event", async () => {
       const event = await payMoreEvent({ unitPrice: 0 });
       const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
       const html = await response.text();
-      expect(html).toContain("up to £100.00");
+      expect(html).toContain("up to £100");
     });
 
     test("POST rejects empty custom_price for paid can_pay_more event", async () => {

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -159,7 +159,7 @@ describe("server (admin refunds)", () => {
     test("shows refund confirmation page for paid attendee", async () => {
       const ctx = await setupRefundTest("pi_test_123");
       const response = await awaitTestRequest(refundUrl(ctx.event.id, ctx.attendee.id), { cookie: ctx.cookie });
-      await expectHtmlResponse(response, 200, "Refund Attendee", "John Doe", "type their name", "5.00");
+      await expectHtmlResponse(response, 200, "Refund Attendee", "John Doe", "type their name", "£5");
     });
 
     test("includes return_url as hidden field when provided", async () => {


### PR DESCRIPTION
## Summary
Updated currency formatting to remove trailing zeros from currency amounts, making prices display more naturally (e.g., "£10" instead of "£10.00").

## Key Changes
- Modified `formatCurrency()` in `src/lib/currency.ts` to use `trailingZeroDisplay: "stripIfInteger"` option in `Intl.NumberFormat`, which removes unnecessary decimal places for whole numbers
- Updated `renderPayMoreInput()` in `src/templates/public.tsx` to simplify the price range hint from "£10.00 – £100.00" to "£10 minimum" for paid events with pay-more enabled
- Updated all related test expectations across multiple test files to match the new formatting:
  - `test/lib/currency.test.ts`: Zero amounts now display as "£0" instead of "£0.00"
  - `test/lib/server-public.test.ts`: Price labels and hints updated to use simplified format
  - `test/lib/html.test.ts`: Revenue displays updated (e.g., "£30" instead of "30.00")
  - `test/lib/server-guide.test.ts`: Maximum price display updated
  - `test/lib/server-refunds.test.ts`: Refund amount display updated

## Implementation Details
The change leverages the `trailingZeroDisplay` option available in modern `Intl.NumberFormat` implementations to automatically strip trailing zeros while preserving the currency symbol and proper formatting for amounts with decimal places (e.g., "£10.50" remains unchanged).

https://claude.ai/code/session_018qqxvMak3zLpVz2QtGu9SD