### PR TITLE
Add hidden event feature to exclude events from public listing

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -42,6 +42,7 @@ export type EventInput = {
   imageUrl?: string;
   nonTransferable?: boolean;
   canPayMore?: boolean;
+  hidden?: boolean;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -140,6 +141,7 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
     image_url: { default: () => "", write: encrypt, read: decrypt },
     non_transferable: col.boolean(false),
     can_pay_more: col.boolean(false),
+    hidden: col.boolean(false),
   });
 
 export const eventsTable: typeof rawEventsTable = {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -9,7 +9,7 @@ import { getPublicKey, getSetting } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "backfill unit_price NULLs to 0";
+export const LATEST_UPDATE = "add hidden column to events";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -462,6 +462,9 @@ export const initDb = async (): Promise<void> => {
   // Migration: backfill existing NULL unit_price values to 0
   // (SQLite cannot ALTER COLUMN to add NOT NULL; application code enforces non-null going forward)
   await runMigration(`UPDATE events SET unit_price = 0 WHERE unit_price IS NULL`);
+
+  // Migration: add hidden column to events (boolean, defaults to false/0)
+  await runMigration(`ALTER TABLE events ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0`);
 
   // Update the version marker
   await getDb().execute({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,7 @@ export interface Event {
   image_url: string;
   non_transferable: boolean;
   can_pay_more: boolean;
+  hidden: boolean;
 }
 
 export interface Attendee extends ContactInfo {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -124,6 +124,7 @@ const extractCommonFields = (values: EventFormValues) => {
     maximumDaysAfter: values.maximum_days_after ?? 90,
     nonTransferable: values.non_transferable === "1",
     canPayMore: values.can_pay_more === "1",
+    hidden: values.hidden === "1",
   };
 };
 

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -240,6 +240,12 @@ export const applySecurityHeaders = async (
     response.headers.set(key, value);
   }
 
+  // Override x-robots-tag for hidden events (signal header set by route handlers)
+  if (response.headers.has("x-robots-noindex")) {
+    response.headers.set("x-robots-tag", "noindex, nofollow");
+    response.headers.delete("x-robots-noindex");
+  }
+
   // Prevent CDN from caching dynamic responses — static assets already set
   // their own cache-control (e.g. "public, max-age=31536000, immutable")
   if (!hasCacheControl) {

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -65,7 +65,7 @@ import {
 /** Load active events for the homepage, sorted and with registration status */
 const loadHomepageEvents = async (): Promise<MultiTicketEvent[]> => {
   const [allEvents, holidays] = await Promise.all([getAllEvents(), getActiveHolidays()]);
-  const sorted = sortEvents(allEvents.filter((e) => e.active), holidays);
+  const sorted = sortEvents(allEvents.filter((e) => e.active && !e.hidden), holidays);
   return sorted.map((e) => buildMultiTicketEvent(e, isRegistrationClosed(e)));
 };
 
@@ -140,6 +140,12 @@ const computeDatesForEvent = async (event: EventWithCount): Promise<string[] | u
   return getAvailableDates(event, await getActiveHolidays());
 };
 
+/** Set noindex signal header on response for hidden events */
+const applyHiddenNoindex = (response: Response, hidden: boolean): Response => {
+  if (hidden) response.headers.set("x-robots-noindex", "true");
+  return response;
+};
+
 /** Handle GET for a single-ticket page */
 const handleSingleTicketGet = (slug: string, request: Request): Promise<Response> =>
   withActiveEventBySlug(slug, async (event) => {
@@ -149,7 +155,10 @@ const handleSingleTicketGet = (slug: string, request: Request): Promise<Response
     const dates = await computeDatesForEvent(event);
     const terms = await getTermsAndConditionsFromDb();
     const baseUrl = getBaseUrl(request);
-    return ticketResponseWithToken(event, closed, inIframe, dates, terms, baseUrl)();
+    return applyHiddenNoindex(
+      ticketResponseWithToken(event, closed, inIframe, dates, terms, baseUrl)(),
+      event.hidden,
+    );
   });
 
 /**
@@ -645,9 +654,11 @@ const handleMultiTicket = async (
     terms,
     inIframe,
   };
-  return request.method === "GET"
+  const response = request.method === "GET"
     ? multiTicketResponse(ctx)()
-    : submitMultiTicket(request, ctx);
+    : await submitMultiTicket(request, ctx);
+  const anyHidden = activeEvents.some((e) => e.event.hidden);
+  return applyHiddenNoindex(response, anyHidden);
 };
 
 const handleMultiTicketBySlugs = (request: Request, slugs: string[]): Promise<Response> =>

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -267,6 +267,12 @@ export const adminEventPage = ({
                   <td>Yes &mdash; ID verification required at entry</td>
                 </tr>
               )}
+              {event.hidden && (
+                <tr>
+                  <th>Hidden</th>
+                  <td>Yes &mdash; not shown in public events list</td>
+                </tr>
+              )}
               {event.event_type === "daily" && (
                 <tr>
                   <th>Bookable Days</th>
@@ -500,6 +506,7 @@ const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   thank_you_url: event.thank_you_url,
   webhook_url: event.webhook_url,
   non_transferable: event.non_transferable ? "1" : "",
+  hidden: event.hidden ? "1" : "",
 });
 
 /** Event fields with autofocus on the name field */

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -272,6 +272,17 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           </p>
         </Q>
 
+        <Q q="Can I hide an event from the public list?">
+          <p>
+            Yes. When editing an event, tick the <strong>Hidden Event</strong>{" "}
+            checkbox. Hidden events won&apos;t appear on the public Events
+            page and their ticket pages will be marked as{" "}
+            <code>noindex, nofollow</code> for search engines. The event is
+            still fully bookable via its direct link or when embedded in an
+            iframe.
+          </p>
+        </Q>
+
         <Q q="How do I edit the homepage and contact page?">
           <p>
             Enable the public site in <strong>Settings</strong>, then open the{" "}

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -39,6 +39,7 @@ export type EventFormValues = {
   non_transferable: string;
   group_id: string;
   can_pay_more: string;
+  hidden: string;
 };
 
 /** Typed values from event edit form (includes slug) */
@@ -396,6 +397,13 @@ export const eventFields: Field[] = [
       { value: "", label: "No" },
       { value: "1", label: "Yes" },
     ],
+  },
+  {
+    name: "hidden",
+    label: "Hidden Event",
+    type: "checkbox-group",
+    hint: "Hide from the public events page and search engines. The event is still bookable via its direct link.",
+    options: [{ value: "1", label: "Hide from public events list" }],
   },
 ];
 

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -884,6 +884,7 @@ export const createTestEvent = (
         input.maximumDaysAfter != null ? String(input.maximumDaysAfter) : "",
       non_transferable: input.nonTransferable ? "1" : "",
       can_pay_more: input.canPayMore ? "1" : "",
+      hidden: input.hidden ? "1" : "",
     },
     async () => {
       // Get the most recently created event (302 redirect guarantees creation succeeded)
@@ -974,6 +975,10 @@ export const updateTestEvent = async (
       ),
       non_transferable:
         (updates.nonTransferable ?? existing.non_transferable) ? "1" : "",
+      can_pay_more:
+        (updates.canPayMore ?? existing.can_pay_more) ? "1" : "",
+      hidden:
+        (updates.hidden ?? existing.hidden) ? "1" : "",
     },
     async () => (await getEventWithCount(eventId)) as EventWithCount,
     "update event",
@@ -1201,6 +1206,7 @@ export const testEvent = (overrides: Partial<Event> = {}): Event => ({
   image_url: "",
   non_transferable: false,
   can_pay_more: false,
+  hidden: false,
   ...overrides,
 });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -3085,4 +3085,79 @@ describe("server (admin events)", () => {
       expect(after.rows.length).toBe(1);
     });
   });
+
+  describe("hidden events", () => {
+    test("creates event with hidden enabled", async () => {
+      const event = await createTestEvent({ hidden: true });
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.hidden).toBe(true);
+    });
+
+    test("creates event with hidden disabled by default", async () => {
+      const event = await createTestEvent();
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.hidden).toBe(false);
+    });
+
+    test("updates event to enable hidden", async () => {
+      const event = await createTestEvent();
+      await updateTestEvent(event.id, { hidden: true });
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const updated = await getEventWithCount(event.id);
+      expect(updated?.hidden).toBe(true);
+    });
+
+    test("updates event to enable can_pay_more via updateTestEvent", async () => {
+      const event = await createTestEvent({ unitPrice: 1000 });
+      await updateTestEvent(event.id, { canPayMore: true });
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const updated = await getEventWithCount(event.id);
+      expect(updated?.can_pay_more).toBe(true);
+    });
+
+    test("updates event to disable hidden", async () => {
+      const event = await createTestEvent({ hidden: true });
+      await updateTestEvent(event.id, { hidden: false });
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const updated = await getEventWithCount(event.id);
+      expect(updated?.hidden).toBe(false);
+    });
+
+    test("admin event detail page shows Hidden row when enabled", async () => {
+      const { event, cookie } = await setupEventAndLogin({
+        hidden: true,
+      });
+      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+        cookie,
+      });
+      await expectHtmlResponse(
+        response,
+        200,
+        "Hidden",
+        "not shown in public events list",
+      );
+    });
+
+    test("admin event detail page does not show Hidden row when disabled", async () => {
+      const { event, cookie } = await setupEventAndLogin();
+      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+        cookie,
+      });
+      const html = await response.text();
+      expect(html).not.toContain("not shown in public events list");
+    });
+
+    test("admin event edit page pre-fills hidden checkbox", async () => {
+      const { event, cookie } = await setupEventAndLogin({
+        hidden: true,
+      });
+      const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
+        cookie,
+      });
+      const html = await response.text();
+      expect(html).toContain("hidden");
+    });
+  });
 });

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -155,6 +155,14 @@ describe("server (admin guide)", () => {
       expect(html).toContain("markdownguide.org/cheat-sheet");
     });
 
+    test("contains hidden events info", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("hide an event");
+      expect(html).toContain("Hidden Event");
+      expect(html).toContain("noindex, nofollow");
+    });
+
     test("contains admin navigation", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -177,6 +177,47 @@ describe("server (public routes)", () => {
       expect(html).not.toContain("Hidden Event");
     });
 
+    test("does not show hidden events in public events list", async () => {
+      await updateShowPublicSite(true);
+      await createTestEvent({ name: "Secret Event", hidden: true });
+      const response = await handleRequest(mockRequest("/events"));
+      const html = await expectHtmlResponse(response, 200, "No events listed.");
+      expect(html).not.toContain("Secret Event");
+    });
+
+    test("shows non-hidden events alongside hidden ones", async () => {
+      await updateShowPublicSite(true);
+      await createTestEvent({ name: "Visible Event" });
+      await createTestEvent({ name: "Secret Event", hidden: true });
+      const response = await handleRequest(mockRequest("/events"));
+      const html = await expectHtmlResponse(response, 200, "Visible Event");
+      expect(html).not.toContain("Secret Event");
+    });
+
+    test("hidden event is still accessible via direct ticket URL", async () => {
+      const event = await createTestEvent({ name: "Secret Event", hidden: true });
+      const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
+      await expectHtmlResponse(response, 200, "Secret Event");
+    });
+
+    test("hidden event ticket page has noindex x-robots-tag", async () => {
+      const event = await createTestEvent({ hidden: true });
+      const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
+      expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    });
+
+    test("non-hidden event ticket page has index x-robots-tag", async () => {
+      const event = await createTestEvent();
+      const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
+      expect(response.headers.get("x-robots-tag")).toBe("index, follow");
+    });
+
+    test("x-robots-noindex signal header is not leaked to client", async () => {
+      const event = await createTestEvent({ hidden: true });
+      const response = await handleRequest(mockRequest(`/ticket/${event.slug}`));
+      expect(response.headers.has("x-robots-noindex")).toBe(false);
+    });
+
     test("shows sold out for events at capacity", async () => {
       await updateShowPublicSite(true);
       const event = await createTestEvent({

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -184,6 +184,7 @@ describe("square", () => {
         image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
       };
       const intent = {
         eventId: 1,
@@ -230,6 +231,7 @@ describe("square", () => {
         image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
       };
       const intent = {
         eventId: 1,
@@ -285,6 +287,7 @@ describe("square", () => {
             image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
           };
           const intent = {
             eventId: 7,
@@ -376,6 +379,7 @@ describe("square", () => {
             image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
           };
           const intent = {
             eventId: 1,
@@ -435,6 +439,7 @@ describe("square", () => {
             image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
           };
           const intent = {
             eventId: 1,
@@ -493,6 +498,7 @@ describe("square", () => {
             image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
           };
           const intent = {
             eventId: 1,
@@ -1786,6 +1792,7 @@ describe("square", () => {
             image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
           };
           const intent = {
             eventId: 1,

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -176,6 +176,7 @@ describe("stripe", () => {
         image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
       };
       const intent = {
         eventId: 1,
@@ -230,6 +231,7 @@ describe("stripe", () => {
         image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
       };
 
       const intent = {
@@ -292,6 +294,7 @@ describe("stripe", () => {
         image_url: "",
         non_transferable: false,
         can_pay_more: false,
+        hidden: false,
       };
       const intent = {
         eventId: 1,


### PR DESCRIPTION
## Summary
This PR adds a "hidden" feature to events that allows administrators to exclude events from the public events list and search engines while keeping them accessible via direct links.

## Key Changes

- **Database Schema**: Added `hidden` column to events table (boolean, defaults to false)
- **Event Model**: Added `hidden` property to Event type and EventInput
- **Admin UI**: 
  - Added "Hidden Event" checkbox field to event creation/edit forms
  - Display hidden status on event detail page with explanation
  - Pre-fill hidden checkbox on edit page
- **Public Routes**:
  - Filter out hidden events from public events list (`/events`)
  - Hidden events remain accessible via direct ticket URL (`/ticket/{slug}`)
  - Set `x-robots-tag: noindex, nofollow` header for hidden event pages to prevent search engine indexing
  - Apply noindex header to multi-ticket pages if any event is hidden
- **Test Coverage**: Comprehensive tests for hidden event behavior including:
  - Creation and updates with hidden flag
  - Admin UI display logic
  - Public listing exclusion
  - Direct URL accessibility
  - Search engine noindex headers
  - Test utilities updated to support hidden parameter

## Implementation Details

- Hidden events are filtered at the data layer in `loadHomepageEvents()` to prevent public visibility
- A new `applyHiddenNoindex()` helper function manages the noindex header signal
- Middleware intercepts the internal `x-robots-noindex` signal header and converts it to the standard `x-robots-tag` header, then removes the signal header to prevent client exposure
- All test fixtures and mocks updated to include the new `hidden` field with default value of false

https://claude.ai/code/session_01K8hJULb6HQxhvd6zMW3mVs