### PR TITLE
Fix flaky seeds test by ensuring unique slugs within batch

### DIFF
--- a/src/lib/seeds.ts
+++ b/src/lib/seeds.ts
@@ -26,7 +26,7 @@ import {
   randomName,
 } from "#lib/demo.ts";
 import { nowIso } from "#lib/now.ts";
-import { generateSlug } from "#lib/slug.ts";
+import { generateUniqueSlug, type SlugWithIndex } from "#lib/slug.ts";
 
 /** Max attendees per seeded event */
 export const SEED_MAX_ATTENDEES = 1000;
@@ -37,13 +37,23 @@ const randomQuantity = (): number => 1 + Math.floor(Math.random() * 4);
 /** Sum an array of numbers */
 const sum = reduce((acc: number, n: number) => acc + n, 0);
 
+/** Generate slugs that are unique within the batch */
+const generateUniqueSlugs = async (count: number): Promise<SlugWithIndex[]> => {
+  const usedSlugs = new Set<string>();
+  const results: SlugWithIndex[] = [];
+  for (let i = 0; i < count; i++) {
+    const result = await generateUniqueSlug(hmacHash, (slug) => Promise.resolve(usedSlugs.has(slug)));
+    usedSlugs.add(result.slug);
+    results.push(result);
+  }
+  return results;
+};
+
 /** Prepare encrypted values for a single event */
-const prepareEvent = async (index: number, maxAttendees: number) => {
+const prepareEvent = async (index: number, maxAttendees: number, slug: string, slugIndex: string) => {
   const name = DEMO_EVENT_NAMES[index % DEMO_EVENT_NAMES.length]!;
   const description = DEMO_EVENT_DESCRIPTIONS[index % DEMO_EVENT_DESCRIPTIONS.length]!;
   const location = DEMO_EVENT_LOCATIONS[index % DEMO_EVENT_LOCATIONS.length]!;
-  const slug = generateSlug();
-  const slugIndex = await hmacHash(slug);
   const created = nowIso();
 
   const [encName, encSlug, encDesc, encLoc, encDate, encThankYou, encWebhook, encClosesAt, encImageUrl] =
@@ -132,9 +142,10 @@ export const createSeeds = async (
   // Each event's max_attendees = total quantity of its attendees
   const eventCapacities = map((quantities: number[]) => sum(quantities))(allQuantities);
 
-  // Prepare all event inserts in parallel
+  // Generate unique slugs sequentially, then prepare events in parallel
+  const slugs = await generateUniqueSlugs(eventCount);
   const eventStatements = await Promise.all(
-    map((i: number) => prepareEvent(i, eventCapacities[i]!))(Array.from({ length: eventCount }, (_, i) => i)),
+    map((i: number) => prepareEvent(i, eventCapacities[i]!, slugs[i]!.slug, slugs[i]!.slugIndex))(Array.from({ length: eventCount }, (_, i) => i)),
   );
 
   // Insert events in a single batch and get their IDs


### PR DESCRIPTION
generateSlug() uses Math.random() to create 5-char slugs from a ~1.15M
pool. When creating 30 events (MAX_SEED_EVENTS), the birthday paradox
gives a ~0.04% chance of slug collision per run. Since slug_index has a
UNIQUE constraint, collisions cause the batch insert to fail, returning
a 500 instead of the expected 200.

Fix by generating all slugs sequentially before the parallel batch,
using generateUniqueSlug() with an in-memory Set to prevent duplicates.

https://claude.ai/code/session_01GBoiF2Btg5rNS4qhzU4pDE