### PR TITLE
Delete activity log entries when deleting an event

### DIFF
--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -203,6 +203,7 @@ export const deleteEvent = async (eventId: number): Promise<void> => {
   await executeBatch([
     { sql: "DELETE FROM processed_payments WHERE attendee_id IN (SELECT id FROM attendees WHERE event_id = ?)", args: [eventId] },
     { sql: "DELETE FROM attendees WHERE event_id = ?", args: [eventId] },
+    { sql: "DELETE FROM activity_log WHERE event_id = ?", args: [eventId] },
     { sql: "DELETE FROM events WHERE id = ?", args: [eventId] },
   ]);
   invalidateEventsCache();

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -615,7 +615,7 @@ export const adminDeleteEventPage = (
 
         <article>
           <aside>
-            <p><strong>Warning:</strong> This will permanently delete the event, all {event.attendee_count} attendee(s), and any associated payment records.</p>
+            <p><strong>Warning:</strong> This will permanently delete the event, all {event.attendee_count} attendee(s), any associated payment records, and all activity log entries for this event.</p>
           </aside>
         </article>
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -666,6 +666,26 @@ describe("db", () => {
       expect(processed).toBeNull();
     });
 
+    test("deleteEvent removes activity log entries for the event", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+
+      await logActivity("Action for event", event.id);
+      await logActivity("Another action", event.id);
+      await logActivity("Global action");
+
+      await deleteEvent(event.id);
+
+      const eventLog = await getEventActivityLog(event.id);
+      expect(eventLog).toEqual([]);
+
+      const allLog = await getAllActivityLog();
+      expect(allLog).toHaveLength(1);
+      expect(allLog[0]!.message).toBe("Global action");
+    });
+
     test("deleteEvent works with no attendees", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,


### PR DESCRIPTION
Activity log entries associated with an event are now deleted as part
of the batch deletion cascade. The delete confirmation page also
mentions that log entries will be removed.

https://claude.ai/code/session_01Wpb9DV7Piom6eyom7jK7GA