### PR TITLE
Persist errors to activity log for admin visibility

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,6 +8,7 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
+import { logActivity } from "#lib/db/activityLog.ts";
 import { sendNtfyError } from "#lib/ntfy.ts";
 import { addPendingWork, runWithPendingWork } from "#lib/pending-work.ts";
 
@@ -101,6 +102,45 @@ export const ErrorCode = {
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
 
+/** Human-readable labels for error codes (shown in admin activity log) */
+export const errorCodeLabel: Record<ErrorCodeType, string> = {
+  [ErrorCode.DB_CONNECTION]: "Database connection failed",
+  [ErrorCode.DB_QUERY]: "Database query failed",
+  [ErrorCode.CAPACITY_EXCEEDED]: "Capacity exceeded",
+  [ErrorCode.DECRYPT_FAILED]: "Decryption failed",
+  [ErrorCode.ENCRYPT_FAILED]: "Encryption failed",
+  [ErrorCode.KEY_DERIVATION]: "Key derivation failed",
+  [ErrorCode.AUTH_INVALID_SESSION]: "Invalid session",
+  [ErrorCode.AUTH_EXPIRED]: "Session expired",
+  [ErrorCode.AUTH_CSRF_MISMATCH]: "CSRF mismatch",
+  [ErrorCode.AUTH_RATE_LIMITED]: "Rate limited",
+  [ErrorCode.PAYMENT_SIGNATURE]: "Payment signature verification failed",
+  [ErrorCode.PAYMENT_SESSION]: "Payment session error",
+  [ErrorCode.PAYMENT_REFUND]: "Payment refund failed",
+  [ErrorCode.PAYMENT_CHECKOUT]: "Payment checkout failed",
+  [ErrorCode.PAYMENT_WEBHOOK_SETUP]: "Payment webhook setup failed",
+  [ErrorCode.STRIPE_SIGNATURE]: "Stripe signature verification failed",
+  [ErrorCode.STRIPE_SESSION]: "Stripe session retrieval failed",
+  [ErrorCode.STRIPE_REFUND]: "Stripe refund failed",
+  [ErrorCode.STRIPE_CHECKOUT]: "Stripe checkout failed",
+  [ErrorCode.STRIPE_WEBHOOK_SETUP]: "Stripe webhook setup failed",
+  [ErrorCode.SQUARE_SIGNATURE]: "Square signature verification failed",
+  [ErrorCode.SQUARE_SESSION]: "Square session retrieval failed",
+  [ErrorCode.SQUARE_REFUND]: "Square refund failed",
+  [ErrorCode.SQUARE_CHECKOUT]: "Square checkout failed",
+  [ErrorCode.SQUARE_ORDER]: "Square order validation failed",
+  [ErrorCode.VALIDATION_FORM]: "Form validation error",
+  [ErrorCode.VALIDATION_CONTENT_TYPE]: "Invalid content type",
+  [ErrorCode.DATA_INVALID]: "Invalid data",
+  [ErrorCode.STORAGE_DELETE]: "Storage delete failed",
+  [ErrorCode.WEBHOOK_SEND]: "Webhook send failed",
+  [ErrorCode.NOT_FOUND_EVENT]: "Event not found",
+  [ErrorCode.NOT_FOUND_ATTENDEE]: "Attendee not found",
+  [ErrorCode.CONFIG_MISSING]: "Configuration missing",
+  [ErrorCode.DOMAIN_REJECTED]: "Domain rejected",
+  [ErrorCode.CDN_REQUEST]: "CDN request failed",
+};
+
 /**
  * Redact dynamic segments from paths for privacy-safe logging
  * Replaces:
@@ -146,7 +186,7 @@ export const logRequest = (entry: RequestLogEntry): void => {
 /**
  * Error log context (privacy-safe metadata only)
  */
-type ErrorContext = {
+export type ErrorContext = {
   /** Error code for classification */
   code: ErrorCodeType;
   /** Optional: event ID (not slug) */
@@ -157,9 +197,32 @@ type ErrorContext = {
   detail?: string;
 };
 
+/** Format an error context into a human-readable activity log message */
+export const formatErrorMessage = (context: ErrorContext): string => {
+  const label = errorCodeLabel[context.code];
+  return context.detail ? `Error: ${label} (${context.detail})` : `Error: ${label}`;
+};
+
+/** Guard against recursive logError→logActivity→logError loops */
+const errorPersistGuard = { active: false };
+
+/** Persist error to activity log, swallowing failures to prevent cascading errors */
+const persistErrorToActivityLog = async (context: ErrorContext): Promise<void> => {
+  if (errorPersistGuard.active) return;
+  errorPersistGuard.active = true;
+  try {
+    await logActivity(formatErrorMessage(context), context.eventId ?? null);
+  } catch {
+    // Swallow DB errors to avoid cascading failures
+  } finally {
+    errorPersistGuard.active = false;
+  }
+};
+
 /**
- * Log a classified error to console.error
- * Only logs error codes and safe metadata, never PII
+ * Log a classified error to console.error and persist to the activity log.
+ * Console output uses error codes and safe metadata (never PII).
+ * Activity log entry is encrypted and visible to admins on the log pages.
  */
 export const logError = (context: ErrorContext): void => {
   const { code, eventId, attendeeId, detail } = context;
@@ -175,6 +238,7 @@ export const logError = (context: ErrorContext): void => {
   console.error(`${getLogPrefix()}${parts.join(" ")}`);
 
   addPendingWork(sendNtfyError(code));
+  addPendingWork(persistErrorToActivityLog(context));
 };
 
 /**

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -32,114 +32,89 @@ export const runWithRequestId = <T>(fn: () => T): T =>
   requestIdStorage.run(generateRequestId(), () => runWithPendingWork(fn));
 
 /**
- * Error codes for classified error logging
- * Format: E_CATEGORY_DETAIL
+ * Error code definitions: each key maps to [wire code, human-readable label].
+ * Single source of truth — ErrorCode and errorCodeLabel are derived from this.
  */
-export const ErrorCode = {
+const ERROR_DEFS = {
   // Database errors
-  DB_CONNECTION: "E_DB_CONNECTION",
-  DB_QUERY: "E_DB_QUERY",
+  DB_CONNECTION: ["E_DB_CONNECTION", "Database connection failed"],
+  DB_QUERY: ["E_DB_QUERY", "Database query failed"],
 
   // Capacity/availability errors
-  CAPACITY_EXCEEDED: "E_CAPACITY_EXCEEDED",
+  CAPACITY_EXCEEDED: ["E_CAPACITY_EXCEEDED", "Capacity exceeded"],
 
   // Encryption/decryption errors
-  DECRYPT_FAILED: "E_DECRYPT_FAILED",
-  ENCRYPT_FAILED: "E_ENCRYPT_FAILED",
-  KEY_DERIVATION: "E_KEY_DERIVATION",
+  DECRYPT_FAILED: ["E_DECRYPT_FAILED", "Decryption failed"],
+  ENCRYPT_FAILED: ["E_ENCRYPT_FAILED", "Encryption failed"],
+  KEY_DERIVATION: ["E_KEY_DERIVATION", "Key derivation failed"],
 
   // Authentication errors
-  AUTH_INVALID_SESSION: "E_AUTH_INVALID_SESSION",
-  AUTH_EXPIRED: "E_AUTH_EXPIRED",
-  AUTH_CSRF_MISMATCH: "E_AUTH_CSRF_MISMATCH",
-  AUTH_RATE_LIMITED: "E_AUTH_RATE_LIMITED",
+  AUTH_INVALID_SESSION: ["E_AUTH_INVALID_SESSION", "Invalid session"],
+  AUTH_EXPIRED: ["E_AUTH_EXPIRED", "Session expired"],
+  AUTH_CSRF_MISMATCH: ["E_AUTH_CSRF_MISMATCH", "CSRF mismatch"],
+  AUTH_RATE_LIMITED: ["E_AUTH_RATE_LIMITED", "Rate limited"],
 
   // Payment provider errors (provider-agnostic)
-  PAYMENT_SIGNATURE: "E_PAYMENT_SIGNATURE",
-  PAYMENT_SESSION: "E_PAYMENT_SESSION",
-  PAYMENT_REFUND: "E_PAYMENT_REFUND",
-  PAYMENT_CHECKOUT: "E_PAYMENT_CHECKOUT",
-  PAYMENT_WEBHOOK_SETUP: "E_PAYMENT_WEBHOOK_SETUP",
+  PAYMENT_SIGNATURE: ["E_PAYMENT_SIGNATURE", "Payment signature verification failed"],
+  PAYMENT_SESSION: ["E_PAYMENT_SESSION", "Payment session error"],
+  PAYMENT_REFUND: ["E_PAYMENT_REFUND", "Payment refund failed"],
+  PAYMENT_CHECKOUT: ["E_PAYMENT_CHECKOUT", "Payment checkout failed"],
+  PAYMENT_WEBHOOK_SETUP: ["E_PAYMENT_WEBHOOK_SETUP", "Payment webhook setup failed"],
 
   // Stripe-specific errors (used by stripe.ts internals)
-  STRIPE_SIGNATURE: "E_STRIPE_SIGNATURE",
-  STRIPE_SESSION: "E_STRIPE_SESSION",
-  STRIPE_REFUND: "E_STRIPE_REFUND",
-  STRIPE_CHECKOUT: "E_STRIPE_CHECKOUT",
-  STRIPE_WEBHOOK_SETUP: "E_STRIPE_WEBHOOK_SETUP",
+  STRIPE_SIGNATURE: ["E_STRIPE_SIGNATURE", "Stripe signature verification failed"],
+  STRIPE_SESSION: ["E_STRIPE_SESSION", "Stripe session retrieval failed"],
+  STRIPE_REFUND: ["E_STRIPE_REFUND", "Stripe refund failed"],
+  STRIPE_CHECKOUT: ["E_STRIPE_CHECKOUT", "Stripe checkout failed"],
+  STRIPE_WEBHOOK_SETUP: ["E_STRIPE_WEBHOOK_SETUP", "Stripe webhook setup failed"],
 
   // Square-specific errors (used by square.ts internals)
-  SQUARE_SIGNATURE: "E_SQUARE_SIGNATURE",
-  SQUARE_SESSION: "E_SQUARE_SESSION",
-  SQUARE_REFUND: "E_SQUARE_REFUND",
-  SQUARE_CHECKOUT: "E_SQUARE_CHECKOUT",
-  SQUARE_ORDER: "E_SQUARE_ORDER",
+  SQUARE_SIGNATURE: ["E_SQUARE_SIGNATURE", "Square signature verification failed"],
+  SQUARE_SESSION: ["E_SQUARE_SESSION", "Square session retrieval failed"],
+  SQUARE_REFUND: ["E_SQUARE_REFUND", "Square refund failed"],
+  SQUARE_CHECKOUT: ["E_SQUARE_CHECKOUT", "Square checkout failed"],
+  SQUARE_ORDER: ["E_SQUARE_ORDER", "Square order validation failed"],
 
   // Validation errors
-  VALIDATION_FORM: "E_VALIDATION_FORM",
-  VALIDATION_CONTENT_TYPE: "E_VALIDATION_CONTENT_TYPE",
-  DATA_INVALID: "E_DATA_INVALID",
+  VALIDATION_FORM: ["E_VALIDATION_FORM", "Form validation error"],
+  VALIDATION_CONTENT_TYPE: ["E_VALIDATION_CONTENT_TYPE", "Invalid content type"],
+  DATA_INVALID: ["E_DATA_INVALID", "Invalid data"],
 
   // Storage errors
-  STORAGE_DELETE: "E_STORAGE_DELETE",
+  STORAGE_DELETE: ["E_STORAGE_DELETE", "Storage delete failed"],
 
   // Webhook errors
-  WEBHOOK_SEND: "E_WEBHOOK_SEND",
+  WEBHOOK_SEND: ["E_WEBHOOK_SEND", "Webhook send failed"],
 
   // Not found
-  NOT_FOUND_EVENT: "E_NOT_FOUND_EVENT",
-  NOT_FOUND_ATTENDEE: "E_NOT_FOUND_ATTENDEE",
+  NOT_FOUND_EVENT: ["E_NOT_FOUND_EVENT", "Event not found"],
+  NOT_FOUND_ATTENDEE: ["E_NOT_FOUND_ATTENDEE", "Attendee not found"],
 
   // Configuration errors
-  CONFIG_MISSING: "E_CONFIG_MISSING",
+  CONFIG_MISSING: ["E_CONFIG_MISSING", "Configuration missing"],
 
   // Domain validation errors
-  DOMAIN_REJECTED: "E_DOMAIN_REJECTED",
+  DOMAIN_REJECTED: ["E_DOMAIN_REJECTED", "Domain rejected"],
 
   // CDN/network errors (transient edge failures)
-  CDN_REQUEST: "E_CDN_REQUEST",
+  CDN_REQUEST: ["E_CDN_REQUEST", "CDN request failed"],
 } as const;
+
+type ErrorDefs = typeof ERROR_DEFS;
+
+/** Error code strings for use in logError calls */
+export const ErrorCode: { [K in keyof ErrorDefs]: ErrorDefs[K][0] } =
+  Object.fromEntries(
+    Object.entries(ERROR_DEFS).map(([k, [code]]) => [k, code]),
+  ) as { [K in keyof ErrorDefs]: ErrorDefs[K][0] };
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
 
 /** Human-readable labels for error codes (shown in admin activity log) */
-export const errorCodeLabel: Record<ErrorCodeType, string> = {
-  [ErrorCode.DB_CONNECTION]: "Database connection failed",
-  [ErrorCode.DB_QUERY]: "Database query failed",
-  [ErrorCode.CAPACITY_EXCEEDED]: "Capacity exceeded",
-  [ErrorCode.DECRYPT_FAILED]: "Decryption failed",
-  [ErrorCode.ENCRYPT_FAILED]: "Encryption failed",
-  [ErrorCode.KEY_DERIVATION]: "Key derivation failed",
-  [ErrorCode.AUTH_INVALID_SESSION]: "Invalid session",
-  [ErrorCode.AUTH_EXPIRED]: "Session expired",
-  [ErrorCode.AUTH_CSRF_MISMATCH]: "CSRF mismatch",
-  [ErrorCode.AUTH_RATE_LIMITED]: "Rate limited",
-  [ErrorCode.PAYMENT_SIGNATURE]: "Payment signature verification failed",
-  [ErrorCode.PAYMENT_SESSION]: "Payment session error",
-  [ErrorCode.PAYMENT_REFUND]: "Payment refund failed",
-  [ErrorCode.PAYMENT_CHECKOUT]: "Payment checkout failed",
-  [ErrorCode.PAYMENT_WEBHOOK_SETUP]: "Payment webhook setup failed",
-  [ErrorCode.STRIPE_SIGNATURE]: "Stripe signature verification failed",
-  [ErrorCode.STRIPE_SESSION]: "Stripe session retrieval failed",
-  [ErrorCode.STRIPE_REFUND]: "Stripe refund failed",
-  [ErrorCode.STRIPE_CHECKOUT]: "Stripe checkout failed",
-  [ErrorCode.STRIPE_WEBHOOK_SETUP]: "Stripe webhook setup failed",
-  [ErrorCode.SQUARE_SIGNATURE]: "Square signature verification failed",
-  [ErrorCode.SQUARE_SESSION]: "Square session retrieval failed",
-  [ErrorCode.SQUARE_REFUND]: "Square refund failed",
-  [ErrorCode.SQUARE_CHECKOUT]: "Square checkout failed",
-  [ErrorCode.SQUARE_ORDER]: "Square order validation failed",
-  [ErrorCode.VALIDATION_FORM]: "Form validation error",
-  [ErrorCode.VALIDATION_CONTENT_TYPE]: "Invalid content type",
-  [ErrorCode.DATA_INVALID]: "Invalid data",
-  [ErrorCode.STORAGE_DELETE]: "Storage delete failed",
-  [ErrorCode.WEBHOOK_SEND]: "Webhook send failed",
-  [ErrorCode.NOT_FOUND_EVENT]: "Event not found",
-  [ErrorCode.NOT_FOUND_ATTENDEE]: "Attendee not found",
-  [ErrorCode.CONFIG_MISSING]: "Configuration missing",
-  [ErrorCode.DOMAIN_REJECTED]: "Domain rejected",
-  [ErrorCode.CDN_REQUEST]: "CDN request failed",
-};
+export const errorCodeLabel: Record<ErrorCodeType, string> =
+  Object.fromEntries(
+    Object.values(ERROR_DEFS).map(([code, label]) => [code, label]),
+  ) as Record<ErrorCodeType, string>;
 
 /**
  * Redact dynamic segments from paths for privacy-safe logging

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -122,12 +122,11 @@ export const sendWebhook = async (
       body: JSON.stringify(payload),
     });
     if (!response.ok) {
+      const eventName = payload.tickets.map((t) => t.event_name).join(", ");
       logError({
         code: ErrorCode.WEBHOOK_SEND,
-        detail: `status=${response.status}`,
+        detail: `status=${response.status} for '${eventName}'`,
       });
-      const eventName = payload.tickets.map((t) => t.event_name).join(", ");
-      await logActivity(`Webhook failed (status ${response.status}) for '${eventName}'`);
     }
   } catch (error) {
     logError({

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -4,12 +4,18 @@ import { type Spy, spy, stub } from "@std/testing/mock";
 import {
   createRequestTimer,
   ErrorCode,
+  errorCodeLabel,
+  type ErrorCodeType,
+  type ErrorContext,
+  formatErrorMessage,
   logDebug,
   logError,
   logRequest,
   redactPath,
   runWithRequestId,
 } from "#lib/logger.ts";
+import { getAllActivityLog } from "#lib/db/activityLog.ts";
+import { createTestDbWithSetup, createTestEvent, resetDb } from "#test-utils";
 
 describe("logger", () => {
   describe("redactPath", () => {
@@ -204,6 +210,79 @@ describe("logger", () => {
 
       fetchStub.restore();
       Deno.env.delete("NTFY_URL");
+    });
+
+    describe("activity log persistence", () => {
+      beforeEach(async () => {
+        await createTestDbWithSetup();
+        // Drain floating promises from earlier logError calls in the parent block
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        resetDb();
+        await createTestDbWithSetup();
+      });
+
+      afterEach(() => {
+        resetDb();
+      });
+
+      test("persists error to activity log", async () => {
+        logError({ code: ErrorCode.STRIPE_CHECKOUT, detail: "session creation failed" });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const entries = await getAllActivityLog();
+        const match = entries.find((e) => e.message === "Error: Stripe checkout failed (session creation failed)");
+        expect(match).toBeDefined();
+        expect(match!.event_id).toBeNull();
+      });
+
+      test("persists error with event ID to activity log", async () => {
+        const event = await createTestEvent();
+        logError({ code: ErrorCode.PAYMENT_REFUND, eventId: event.id, detail: "refund declined" });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const entries = await getAllActivityLog();
+        const match = entries.find((e) => e.message === "Error: Payment refund failed (refund declined)");
+        expect(match).toBeDefined();
+        expect(match!.event_id).toBe(event.id);
+      });
+
+      test("persists error without detail to activity log", async () => {
+        logError({ code: ErrorCode.DB_CONNECTION });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const entries = await getAllActivityLog();
+        const match = entries.find((e) => e.message === "Error: Database connection failed");
+        expect(match).toBeDefined();
+      });
+    });
+  });
+
+  describe("errorCodeLabel", () => {
+    test("has a label for every error code", () => {
+      for (const code of Object.values(ErrorCode)) {
+        expect(errorCodeLabel[code as ErrorCodeType]).toBeDefined();
+      }
+    });
+  });
+
+  describe("formatErrorMessage", () => {
+    test("formats error with detail", () => {
+      const context: ErrorContext = { code: ErrorCode.STRIPE_CHECKOUT, detail: "timeout" };
+      expect(formatErrorMessage(context)).toBe("Error: Stripe checkout failed (timeout)");
+    });
+
+    test("formats error without detail", () => {
+      const context: ErrorContext = { code: ErrorCode.DB_CONNECTION };
+      expect(formatErrorMessage(context)).toBe("Error: Database connection failed");
+    });
+
+    test("formats payment session error with detail", () => {
+      const context: ErrorContext = {
+        code: ErrorCode.PAYMENT_SESSION,
+        eventId: 42,
+        detail: "price mismatch",
+      };
+      expect(formatErrorMessage(context)).toBe("Error: Payment session error (price mismatch)");
     });
   });
 

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -312,26 +312,45 @@ describe("webhook", () => {
     });
 
     test("logs activity on non-2xx response", async () => {
+      // Drain floating promises from earlier logError calls, then reset DB
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      resetDb();
+      await createTestDbWithSetup();
+
       await withErrorSpy(async () => {
         restubFetch(() => Promise.resolve(new Response("Bad Gateway", { status: 502 })));
         const payload = await buildWebhookPayload(defaultEntries(), "GBP");
         await sendWebhook("https://example.com/webhook", payload);
       });
+      // Wait for pending logError→logActivity to flush
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const entries = await getAllActivityLog();
-      expect(entries).toHaveLength(1);
-      expect(entries[0]!.message).toBe("Webhook failed (status 502) for 'Test Event'");
+      const match = entries.find((e) => e.message === "Error: Webhook send failed (status=502 for 'Test Event')");
+      expect(match).toBeDefined();
     });
 
     test("does not log activity on successful response", async () => {
+      // Drain and reset to avoid contamination from prior error tests
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      resetDb();
+      await createTestDbWithSetup();
+
       const payload = await buildWebhookPayload(defaultEntries(), "GBP");
       await sendWebhook("https://example.com/webhook", payload);
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const entries = await getAllActivityLog();
-      expect(entries).toHaveLength(0);
+      const errorEntries = entries.filter((e) => e.message.startsWith("Error:"));
+      expect(errorEntries).toHaveLength(0);
     });
 
     test("logs comma-separated event names for multi-event payload", async () => {
+      // Drain and reset to avoid contamination from prior error tests
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      resetDb();
+      await createTestDbWithSetup();
+
       await withErrorSpy(async () => {
         restubFetch(() => Promise.resolve(new Response("Error", { status: 500 })));
         const entries: RegistrationEntry[] = [
@@ -341,10 +360,12 @@ describe("webhook", () => {
         const payload = await buildWebhookPayload(entries, "GBP");
         await sendWebhook("https://example.com/webhook", payload);
       });
+      // Wait for pending logError→logActivity to flush
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const entries = await getAllActivityLog();
-      expect(entries).toHaveLength(1);
-      expect(entries[0]!.message).toBe("Webhook failed (status 500) for 'Event A, Event B'");
+      const match = entries.find((e) => e.message === "Error: Webhook send failed (status=500 for 'Event A, Event B')");
+      expect(match).toBeDefined();
     });
   });
 


### PR DESCRIPTION
logError now writes to the activity_log table so Stripe, Square, payment,
and other errors appear on both event-specific and global log pages.
Previously only webhook send failures were logged to the activity log.

- Add human-readable errorCodeLabel map for all error codes
- Add formatErrorMessage to build admin-friendly log messages
- logError persists to activity_log via addPendingWork (fire-and-forget)
- Guard against recursive failures if DB write itself errors
- Remove duplicate logActivity call from webhook.ts (logError handles it)
- Update webhook error detail to include event names

https://claude.ai/code/session_01GG6NfF9bdeG6zr7ahYM7Lj