### PR TITLE
Add email notifications for registrations (Resend, Postmark, SendGrid)

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -64,6 +64,12 @@ export const CONFIG_KEYS = {
   PHONE_PREFIX: "phone_prefix",
   // Header image (encrypted - Bunny CDN filename)
   HEADER_IMAGE_URL: "header_image_url",
+  // Email provider (plaintext - "resend" | "postmark" | "sendgrid" | "")
+  EMAIL_PROVIDER: "email_provider",
+  // Email API key (encrypted)
+  EMAIL_API_KEY: "email_api_key",
+  // Email from address (encrypted - verified sender address)
+  EMAIL_FROM_ADDRESS: "email_from_address",
 } as const;
 
 /**
@@ -743,6 +749,30 @@ export const updateHeaderImageUrl = async (url: string): Promise<void> => {
   await updateEncryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL, url);
 };
 
+/** Get the configured email provider. Returns null if not configured. */
+export const getEmailProviderFromDb = (): Promise<string | null> =>
+  getSetting(CONFIG_KEYS.EMAIL_PROVIDER);
+
+/** Update the configured email provider. Pass empty string to clear. */
+export const updateEmailProvider = (provider: string): Promise<void> =>
+  setOrDeleteSetting(CONFIG_KEYS.EMAIL_PROVIDER, provider);
+
+/** Get email API key from database (decrypted). Returns null if not configured. */
+export const getEmailApiKeyFromDb = (): Promise<string | null> =>
+  getEncryptedSetting(CONFIG_KEYS.EMAIL_API_KEY);
+
+/** Update email API key (encrypted at rest). Pass empty string to clear. */
+export const updateEmailApiKey = (key: string): Promise<void> =>
+  updateEncryptedSetting(CONFIG_KEYS.EMAIL_API_KEY, key);
+
+/** Get email from address from database (decrypted). Returns null if not configured. */
+export const getEmailFromAddressFromDb = (): Promise<string | null> =>
+  getEncryptedSetting(CONFIG_KEYS.EMAIL_FROM_ADDRESS);
+
+/** Update email from address (encrypted at rest). Pass empty string to clear. */
+export const updateEmailFromAddress = (address: string): Promise<void> =>
+  updateEncryptedSetting(CONFIG_KEYS.EMAIL_FROM_ADDRESS, address);
+
 /**
  * Stubbable API for testing - allows mocking in ES modules
  * Use spyOn(settingsApi, "method") instead of spyOn(settingsModule, "method")
@@ -800,4 +830,10 @@ export const settingsApi = {
   updatePhonePrefix,
   getHeaderImageUrlFromDb,
   updateHeaderImageUrl,
+  getEmailProviderFromDb,
+  updateEmailProvider,
+  getEmailApiKeyFromDb,
+  updateEmailApiKey,
+  getEmailFromAddressFromDb,
+  updateEmailFromAddress,
 };

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -29,15 +29,17 @@ export type EmailConfig = {
   fromAddress: string;
 };
 
-/** Read email config from DB settings. Returns null if not configured. */
+/** Read email config from DB settings. Falls back to business email for fromAddress. Returns null if not configured. */
 export const getEmailConfig = async (): Promise<EmailConfig | null> => {
-  const [provider, apiKey, fromAddress] = await Promise.all([
+  const [provider, apiKey, fromAddress, businessEmail] = await Promise.all([
     getEmailProviderFromDb(),
     getEmailApiKeyFromDb(),
     getEmailFromAddressFromDb(),
+    getBusinessEmailFromDb(),
   ]);
-  if (!provider || !apiKey || !fromAddress) return null;
-  return { provider, apiKey, fromAddress };
+  const from = fromAddress || businessEmail;
+  if (!provider || !apiKey || !from) return null;
+  return { provider, apiKey, fromAddress: from };
 };
 
 /** POST JSON to a URL with custom headers */

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,139 @@
+/**
+ * Email sending module
+ * Sends registration emails via HTTP email APIs (Resend, Postmark, SendGrid)
+ */
+
+import { getBusinessEmailFromDb } from "#lib/business-email.ts";
+import {
+  getEmailApiKeyFromDb,
+  getEmailFromAddressFromDb,
+  getEmailProviderFromDb,
+} from "#lib/db/settings.ts";
+import { ErrorCode, logError } from "#lib/logger.ts";
+import { buildTicketUrl } from "#lib/ticket-url.ts";
+import type { RegistrationEntry } from "#lib/webhook.ts";
+import { registrationConfirmation } from "#templates/email/registration-confirmation.ts";
+import { adminNotification } from "#templates/email/admin-notification.ts";
+
+export type EmailMessage = {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  replyTo?: string;
+};
+
+export type EmailConfig = {
+  provider: string;
+  apiKey: string;
+  fromAddress: string;
+};
+
+/** Read email config from DB settings. Returns null if not configured. */
+export const getEmailConfig = async (): Promise<EmailConfig | null> => {
+  const [provider, apiKey, fromAddress] = await Promise.all([
+    getEmailProviderFromDb(),
+    getEmailApiKeyFromDb(),
+    getEmailFromAddressFromDb(),
+  ]);
+  if (!provider || !apiKey || !fromAddress) return null;
+  return { provider, apiKey, fromAddress };
+};
+
+/** POST JSON to a URL with custom headers */
+const postJson = (url: string, headers: Record<string, string>, body: unknown): Promise<Response> =>
+  fetch(url, { method: "POST", headers: { ...headers, "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+/** Build provider-specific request: [url, extra-headers, body] */
+type ProviderRequest = (config: EmailConfig, msg: EmailMessage) => [string, Record<string, string>, unknown];
+
+const resendRequest: ProviderRequest = (config, msg) => [
+  "https://api.resend.com/emails",
+  { "Authorization": `Bearer ${config.apiKey}` },
+  { from: config.fromAddress, to: [msg.to], reply_to: msg.replyTo, subject: msg.subject, html: msg.html, text: msg.text },
+];
+
+const postmarkRequest: ProviderRequest = (config, msg) => [
+  "https://api.postmarkapp.com/email",
+  { "X-Postmark-Server-Token": config.apiKey, "Accept": "application/json" },
+  { From: config.fromAddress, To: msg.to, ReplyTo: msg.replyTo, Subject: msg.subject, HtmlBody: msg.html, TextBody: msg.text },
+];
+
+const sendgridRequest: ProviderRequest = (config, msg) => [
+  "https://api.sendgrid.com/v3/mail/send",
+  { "Authorization": `Bearer ${config.apiKey}` },
+  {
+    personalizations: [{ to: [{ email: msg.to }] }],
+    from: { email: config.fromAddress },
+    reply_to: msg.replyTo ? { email: msg.replyTo } : undefined,
+    subject: msg.subject,
+    content: [{ type: "text/plain", value: msg.text }, { type: "text/html", value: msg.html }],
+  },
+];
+
+const PROVIDERS: Record<string, ProviderRequest> = {
+  resend: resendRequest,
+  postmark: postmarkRequest,
+  sendgrid: sendgridRequest,
+};
+
+/** Send a single email via the configured provider. Logs errors, never throws. */
+export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise<void> => {
+  const buildRequest = PROVIDERS[config.provider];
+  if (!buildRequest) {
+    logError({ code: ErrorCode.EMAIL_SEND, detail: `unknown provider: ${config.provider}` });
+    return;
+  }
+  try {
+    const [url, headers, body] = buildRequest(config, msg);
+    const response = await postJson(url, headers, body);
+    if (!response.ok) {
+      logError({ code: ErrorCode.EMAIL_SEND, detail: `status=${response.status} to=${msg.to}` });
+    }
+  } catch (error) {
+    logError({
+      code: ErrorCode.EMAIL_SEND,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/**
+ * Send registration confirmation + admin notification emails.
+ * Silently skips if email is not configured.
+ */
+export const sendRegistrationEmails = async (
+  entries: RegistrationEntry[],
+  currency: string,
+): Promise<void> => {
+  const config = await getEmailConfig();
+  if (!config) return;
+
+  const businessEmail = await getBusinessEmailFromDb();
+  const ticketUrl = buildTicketUrl(entries);
+  const replyTo = businessEmail || undefined;
+
+  const confirmation = registrationConfirmation(entries, currency, ticketUrl);
+  const promises: Promise<void>[] = [
+    sendEmail(config, { to: entries[0]!.attendee.email, ...confirmation, replyTo }),
+  ];
+
+  if (businessEmail) {
+    const notification = adminNotification(entries, currency);
+    promises.push(
+      sendEmail(config, { to: businessEmail, ...notification, replyTo: entries[0]!.attendee.email }),
+    );
+  }
+
+  await Promise.allSettled(promises);
+};
+
+/** Send a test email to the business email address. */
+export const sendTestEmail = async (config: EmailConfig, to: string): Promise<void> => {
+  await sendEmail(config, {
+    to,
+    subject: "Test email from your ticket system",
+    html: "<p>This is a test email. Your email configuration is working correctly.</p>",
+    text: "This is a test email. Your email configuration is working correctly.",
+  });
+};

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -42,23 +42,33 @@ export const getEmailConfig = async (): Promise<EmailConfig | null> => {
   return { provider, apiKey, fromAddress: from };
 };
 
-/** POST JSON to a URL with custom headers */
-const postJson = (url: string, headers: Record<string, string>, body: unknown): Promise<Response> =>
-  fetch(url, { method: "POST", headers: { ...headers, "Content-Type": "application/json" }, body: JSON.stringify(body) });
-
 /** Build provider-specific request: [url, extra-headers, body] */
 type ProviderRequest = (config: EmailConfig, msg: EmailMessage) => [string, Record<string, string>, unknown];
 
 const resendRequest: ProviderRequest = (config, msg) => [
   "https://api.resend.com/emails",
   { "Authorization": `Bearer ${config.apiKey}` },
-  { from: config.fromAddress, to: [msg.to], reply_to: msg.replyTo, subject: msg.subject, html: msg.html, text: msg.text },
+  {
+    from: config.fromAddress,
+    to: [msg.to],
+    reply_to: msg.replyTo,
+    subject: msg.subject,
+    html: msg.html,
+    text: msg.text,
+  },
 ];
 
 const postmarkRequest: ProviderRequest = (config, msg) => [
   "https://api.postmarkapp.com/email",
   { "X-Postmark-Server-Token": config.apiKey, "Accept": "application/json" },
-  { From: config.fromAddress, To: msg.to, ReplyTo: msg.replyTo, Subject: msg.subject, HtmlBody: msg.html, TextBody: msg.text },
+  {
+    From: config.fromAddress,
+    To: msg.to,
+    ReplyTo: msg.replyTo,
+    Subject: msg.subject,
+    HtmlBody: msg.html,
+    TextBody: msg.text,
+  },
 ];
 
 const sendgridRequest: ProviderRequest = (config, msg) => [
@@ -69,7 +79,10 @@ const sendgridRequest: ProviderRequest = (config, msg) => [
     from: { email: config.fromAddress },
     reply_to: msg.replyTo ? { email: msg.replyTo } : undefined,
     subject: msg.subject,
-    content: [{ type: "text/plain", value: msg.text }, { type: "text/html", value: msg.html }],
+    content: [
+      { type: "text/plain", value: msg.text },
+      { type: "text/html", value: msg.html },
+    ],
   },
 ];
 
@@ -88,7 +101,11 @@ export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise
   }
   try {
     const [url, headers, body] = buildRequest(config, msg);
-    const response = await postJson(url, headers, body);
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
     if (!response.ok) {
       logError({ code: ErrorCode.EMAIL_SEND, detail: `status=${response.status} to=${msg.to}` });
     }
@@ -102,6 +119,7 @@ export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise
 
 /**
  * Send registration confirmation + admin notification emails.
+ * Entries is an array because one registration can cover multiple events.
  * Silently skips if email is not configured.
  */
 export const sendRegistrationEmails = async (

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -86,6 +86,9 @@ const ERROR_DEFS = {
   // Webhook errors
   WEBHOOK_SEND: ["E_WEBHOOK_SEND", "Webhook send failed"],
 
+  // Email errors
+  EMAIL_SEND: ["E_EMAIL_SEND", "Email send failed"],
+
   // Not found
   NOT_FOUND_EVENT: ["E_NOT_FOUND_EVENT", "Event not found"],
   NOT_FOUND_ATTENDEE: ["E_NOT_FOUND_ATTENDEE", "Attendee not found"],
@@ -234,7 +237,8 @@ export type LogCategory =
   | "Auth"
   | "Stripe"
   | "Square"
-  | "Domain";
+  | "Domain"
+  | "Email";
 
 /**
  * Log a debug message with category prefix

--- a/src/lib/ticket-url.ts
+++ b/src/lib/ticket-url.ts
@@ -1,0 +1,13 @@
+/**
+ * Build the combined ticket URL from attendee tokens
+ */
+
+import { map } from "#fp";
+import { getAllowedDomain } from "#lib/config.ts";
+
+type TokenEntry = { attendee: { ticket_token: string } };
+
+export const buildTicketUrl = (entries: TokenEntry[]): string => {
+  const tokens = map(({ attendee }: TokenEntry) => attendee.ticket_token)(entries);
+  return `https://${getAllowedDomain()}/t/${tokens.join("+")}`;
+};

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -3,12 +3,13 @@
  * Sends consolidated registration data to configured webhook URLs
  */
 
-import { compact, map, unique } from "#fp";
-import { getAllowedDomain } from "#lib/config.ts";
+import { compact, unique } from "#fp";
 import { logActivity } from "#lib/db/activityLog.ts";
+import { sendRegistrationEmails } from "#lib/email.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { addPendingWork } from "#lib/pending-work.ts";
+import { buildTicketUrl } from "#lib/ticket-url.ts";
 import { isPaidEvent, type ContactInfo } from "#lib/types.ts";
 import { nowIso } from "#lib/now.ts";
 import { getBusinessEmailFromDb } from "#lib/business-email.ts";
@@ -61,12 +62,6 @@ export type WebhookAttendee = ContactInfo & {
 export type RegistrationEntry = {
   event: WebhookEvent;
   attendee: WebhookAttendee;
-};
-
-/** Build the combined ticket URL from attendee tokens */
-const buildTicketUrl = (entries: RegistrationEntry[]): string => {
-  const tokens = map(({ attendee }: RegistrationEntry) => attendee.ticket_token)(entries);
-  return `https://${getAllowedDomain()}/t/${tokens.join("+")}`;
 };
 
 /**
@@ -167,7 +162,9 @@ export const logAndNotifyRegistration = async (
   currency: string,
 ): Promise<void> => {
   await logActivity(`Attendee registered for '${event.name}'`, event);
-  addPendingWork(sendRegistrationWebhooks([{ event, attendee }], currency));
+  const entries = [{ event, attendee }];
+  addPendingWork(sendRegistrationWebhooks(entries, currency));
+  addPendingWork(sendRegistrationEmails(entries, currency));
 };
 
 /**
@@ -181,4 +178,5 @@ export const logAndNotifyMultiRegistration = async (
     await logActivity(`Attendee registered for '${event.name}'`, event);
   }
   addPendingWork(sendRegistrationWebhooks(entries, currency));
+  addPendingWork(sendRegistrationEmails(entries, currency));
 };

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -747,9 +747,9 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
 /** Handle POST /admin/settings/email/test - send test email to business email */
 const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
   const config = await getEmailConfig();
-  if (!config) return errorPage("Email not configured", 400, "settings-email-test");
+  if (!config) return errorPage("Email not configured", 400, "settings-email");
   const businessEmail = await getBusinessEmailFromDb();
-  if (!businessEmail) return errorPage("No business email set", 400, "settings-email-test");
+  if (!businessEmail) return errorPage("No business email set", 400, "settings-email");
   await sendTestEmail(config, businessEmail);
   return redirectWithSuccess("/admin/settings", "Test email sent", "settings-email-test");
 });

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -8,6 +8,7 @@ import {
   isValidBusinessEmail,
   updateBusinessEmail,
 } from "#lib/business-email.ts";
+import { getEmailConfig, sendTestEmail } from "#lib/email.ts";
 import { getAllowedDomain, getSquareWebhookSignatureKey } from "#lib/config.ts";
 import { clearSessionCookie } from "#lib/cookies.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
@@ -15,6 +16,8 @@ import { resetDatabase } from "#lib/db/migrations.ts";
 import {
   clearPaymentProvider,
   getEmbedHostsFromDb,
+  getEmailFromAddressFromDb,
+  getEmailProviderFromDb,
   getHeaderImageUrlFromDb,
   getPaymentProviderFromDb,
   getPhonePrefixFromDb,
@@ -30,6 +33,9 @@ import {
   setPaymentProvider,
   setStripeWebhookConfig,
   updateEmbedHosts,
+  updateEmailApiKey,
+  updateEmailFromAddress,
+  updateEmailProvider,
   updateHeaderImageUrl,
   updatePhonePrefix,
   updateShowPublicSite,
@@ -116,6 +122,8 @@ const getSettingsPageState = async () => {
     showPublicSite,
     phonePrefix,
     headerImageUrl,
+    emailProvider,
+    emailFromAddress,
   ] = await Promise.all([
     hasStripeKey(),
     getPaymentProviderFromDb(),
@@ -130,6 +138,8 @@ const getSettingsPageState = async () => {
     getShowPublicSiteFromDb(),
     getPhonePrefixFromDb(),
     getHeaderImageUrlFromDb(),
+    getEmailProviderFromDb(),
+    getEmailFromAddressFromDb(),
   ]);
   return {
     stripeKeyConfigured,
@@ -147,30 +157,15 @@ const getSettingsPageState = async () => {
     phonePrefix,
     headerImageUrl,
     storageEnabled: isStorageEnabled(),
+    emailProvider,
+    emailFromAddress,
   };
 };
 
 /** Render the settings page with current state */
 const renderSettingsPage = async (session: AuthSession) => {
   const state = await getSettingsPageState();
-  return adminSettingsPage(
-    session,
-    state.stripeKeyConfigured,
-    state.paymentProvider,
-    state.squareTokenConfigured,
-    state.squareSandbox,
-    state.squareWebhookConfigured,
-    state.webhookUrl,
-    state.embedHosts,
-    state.termsAndConditions,
-    state.timezone,
-    state.businessEmail,
-    state.theme,
-    state.showPublicSite,
-    state.phonePrefix,
-    state.headerImageUrl,
-    state.storageEnabled,
-  );
+  return adminSettingsPage(session, state);
 };
 
 /** Render settings page with error on a specific form */
@@ -721,6 +716,45 @@ const handleHeaderImageDeletePost = settingsRoute(async (_form, _errorPage) => {
   );
 });
 
+/** Valid email provider values */
+const VALID_EMAIL_PROVIDERS: ReadonlySet<string> = new Set(["resend", "postmark", "sendgrid"]);
+
+/** Handle POST /admin/settings/email - owner only */
+const handleEmailPost = settingsRoute(async (form, errorPage) => {
+  const provider = (form.get("email_provider") ?? "").trim();
+  const apiKey = (form.get("email_api_key") ?? "").trim();
+  const fromAddress = (form.get("email_from_address") ?? "").trim();
+
+  if (provider === "") {
+    await updateEmailProvider("");
+    await updateEmailApiKey("");
+    await updateEmailFromAddress("");
+    await logActivity("Email provider disabled");
+    return redirectWithSuccess("/admin/settings", "Email provider disabled", "settings-email");
+  }
+
+  if (!VALID_EMAIL_PROVIDERS.has(provider)) {
+    return errorPage("Invalid email provider", 400, "settings-email");
+  }
+
+  await updateEmailProvider(provider);
+  if (apiKey) await updateEmailApiKey(apiKey);
+  if (fromAddress) await updateEmailFromAddress(fromAddress);
+  await logActivity(`Email provider set to ${provider}`);
+  return redirectWithSuccess("/admin/settings", "Email settings updated", "settings-email");
+});
+
+/** Handle POST /admin/settings/email/test - send test email to business email */
+const handleEmailTestPost = (request: Request): Promise<Response> =>
+  withOwnerAuthForm(request, async () => {
+    const config = await getEmailConfig();
+    if (!config) return jsonResponse({ success: false, error: "Email not configured" });
+    const businessEmail = await getBusinessEmailFromDb();
+    if (!businessEmail) return jsonResponse({ success: false, error: "No business email set" });
+    await sendTestEmail(config, businessEmail);
+    return jsonResponse({ success: true });
+  });
+
 /**
  * Handle POST /admin/settings/reset-database - owner only
  */
@@ -754,5 +788,7 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/phone-prefix": handlePhonePrefixPost,
   "POST /admin/settings/header-image": handleHeaderImagePost,
   "POST /admin/settings/header-image/delete": handleHeaderImageDeletePost,
+  "POST /admin/settings/email": handleEmailPost,
+  "POST /admin/settings/email/test": handleEmailTestPost,
   "POST /admin/settings/reset-database": handleResetDatabasePost,
 });

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -143,22 +143,22 @@ const getSettingsPageState = async () => {
   ]);
   return {
     stripeKeyConfigured,
-    paymentProvider,
+    paymentProvider: paymentProvider ?? "",
     squareTokenConfigured,
     squareSandbox,
     squareWebhookConfigured: squareWebhookKey !== null,
     webhookUrl: getWebhookUrl(),
-    embedHosts,
-    termsAndConditions,
+    embedHosts: embedHosts ?? "",
+    termsAndConditions: termsAndConditions ?? "",
     timezone,
     businessEmail,
     theme,
     showPublicSite,
     phonePrefix,
-    headerImageUrl,
+    headerImageUrl: headerImageUrl ?? "",
     storageEnabled: isStorageEnabled(),
-    emailProvider,
-    emailFromAddress,
+    emailProvider: emailProvider ?? "",
+    emailFromAddress: emailFromAddress ?? "",
   };
 };
 
@@ -745,15 +745,14 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
 });
 
 /** Handle POST /admin/settings/email/test - send test email to business email */
-const handleEmailTestPost = (request: Request): Promise<Response> =>
-  withOwnerAuthForm(request, async () => {
-    const config = await getEmailConfig();
-    if (!config) return jsonResponse({ success: false, error: "Email not configured" });
-    const businessEmail = await getBusinessEmailFromDb();
-    if (!businessEmail) return jsonResponse({ success: false, error: "No business email set" });
-    await sendTestEmail(config, businessEmail);
-    return jsonResponse({ success: true });
-  });
+const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
+  const config = await getEmailConfig();
+  if (!config) return errorPage("Email not configured", 400, "settings-email-test");
+  const businessEmail = await getBusinessEmailFromDb();
+  if (!businessEmail) return errorPage("No business email set", 400, "settings-email-test");
+  await sendTestEmail(config, businessEmail);
+  return redirectWithSuccess("/admin/settings", "Test email sent", "settings-email-test");
+});
 
 /**
  * Handle POST /admin/settings/reset-database - owner only

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -139,7 +139,7 @@ export const adminSettingsPage = (
             type="email"
             id="email_from_address"
             name="email_from_address"
-            placeholder="tickets@yourdomain.com"
+            placeholder={s.businessEmail || "tickets@yourdomain.com"}
             value={s.emailFromAddress ?? ""}
             autocomplete="off"
           />

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -19,22 +19,22 @@ import { AdminNav } from "#templates/admin/nav.tsx";
 
 export type SettingsPageState = {
   stripeKeyConfigured: boolean;
-  paymentProvider: string | null;
+  paymentProvider: string;
   squareTokenConfigured: boolean;
   squareSandbox: boolean;
   squareWebhookConfigured: boolean;
   webhookUrl: string;
-  embedHosts: string | null;
-  termsAndConditions: string | null;
+  embedHosts: string;
+  termsAndConditions: string;
   timezone: string;
   businessEmail: string;
   theme: string;
   showPublicSite: boolean;
   phonePrefix: string;
-  headerImageUrl: string | null;
+  headerImageUrl: string;
   storageEnabled: boolean;
-  emailProvider: string | null;
-  emailFromAddress: string | null;
+  emailProvider: string;
+  emailFromAddress: string;
 };
 
 /**
@@ -54,7 +54,7 @@ export const adminSettingsPage = (
           <label for="timezone">IANA Timezone</label>
           <select id="timezone" name="timezone" required>
             {Intl.supportedValuesOf("timeZone").map((tz: string) => (
-              <option value={tz} selected={tz === (s.timezone ?? "Europe/London")}>{tz}</option>
+              <option value={tz} selected={tz === s.timezone}>{tz}</option>
             ))}
           </select>
           <button type="submit">Save Timezone</button>
@@ -95,7 +95,7 @@ export const adminSettingsPage = (
             name="phone_prefix"
             step="1"
             min="1"
-            value={s.phonePrefix ?? "44"}
+            value={s.phonePrefix}
             required
           />
           <button type="submit">Save Phone Prefix</button>
@@ -110,7 +110,7 @@ export const adminSettingsPage = (
             id="business_email"
             name="business_email"
             placeholder="contact@example.com"
-            value={s.businessEmail ?? ""}
+            value={s.businessEmail}
             autocomplete="email"
           />
           <button type="submit">Save Business Email</button>
@@ -140,15 +140,16 @@ export const adminSettingsPage = (
             id="email_from_address"
             name="email_from_address"
             placeholder={s.businessEmail || "tickets@yourdomain.com"}
-            value={s.emailFromAddress ?? ""}
+            value={s.emailFromAddress}
             autocomplete="off"
           />
           <button type="submit">Save Email Settings</button>
-          {s.emailProvider && (
-            <button type="button" id="email-test-btn" class="secondary">Send Test Email</button>
-          )}
-          <div id="email-test-result" class="hidden"></div>
         </CsrfForm>
+        {s.emailProvider && (
+        <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
+          <button type="submit" class="secondary">Send Test Email</button>
+        </CsrfForm>
+        )}
 
         <CsrfForm action="/admin/settings/payment-provider" id="settings-payment-provider">
             <h2>Payment Provider</h2>
@@ -264,7 +265,7 @@ export const adminSettingsPage = (
             id="embed_hosts"
             name="embed_hosts"
             placeholder="example.com, *.mysite.org"
-            value={s.embedHosts ?? ""}
+            value={s.embedHosts}
             autocomplete="off"
           />
           <p><small>Use <code>*.example.com</code> to allow all subdomains. Direct visits to the booking page are always allowed.</small></p>
@@ -281,7 +282,7 @@ export const adminSettingsPage = (
             name="terms_and_conditions"
             rows="4"
             placeholder="Enter terms and conditions that attendees must agree to before registering. Leave blank to disable."
-          >{s.termsAndConditions ?? ""}</textarea>
+          >{s.termsAndConditions}</textarea>
           <button type="submit">Save Terms</button>
         </CsrfForm>
 
@@ -327,7 +328,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="theme"
                 value="light"
-                checked={(s.theme ?? "light") === "light"}
+                checked={s.theme === "light"}
               />
               Light
             </label>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -17,29 +17,35 @@ import {
 import { Layout } from "#templates/layout.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
 
+export type SettingsPageState = {
+  stripeKeyConfigured: boolean;
+  paymentProvider: string | null;
+  squareTokenConfigured: boolean;
+  squareSandbox: boolean;
+  squareWebhookConfigured: boolean;
+  webhookUrl: string;
+  embedHosts: string | null;
+  termsAndConditions: string | null;
+  timezone: string;
+  businessEmail: string;
+  theme: string;
+  showPublicSite: boolean;
+  phonePrefix: string;
+  headerImageUrl: string | null;
+  storageEnabled: boolean;
+  emailProvider: string | null;
+  emailFromAddress: string | null;
+};
+
 /**
  * Admin settings page
  */
 export const adminSettingsPage = (
   session: AdminSession,
-  stripeKeyConfigured: boolean,
-  paymentProvider: string | null,
-  squareTokenConfigured: boolean,
-  squareSandbox: boolean,
-  squareWebhookConfigured: boolean,
-  webhookUrl: string,
-  embedHosts?: string | null,
-  termsAndConditions?: string | null,
-  timezone?: string,
-  businessEmail?: string,
-  theme?: string,
-  showPublicSite?: boolean,
-  phonePrefix?: string,
-  headerImageUrl?: string | null,
-  storageEnabled?: boolean,
+  s: SettingsPageState,
 ): string =>
   String(
-    <Layout title="Settings" theme={theme}>
+    <Layout title="Settings" theme={s.theme}>
       <AdminNav session={session} active="/admin/settings" />
 
         <CsrfForm action="/admin/settings/timezone" id="settings-timezone">
@@ -48,26 +54,26 @@ export const adminSettingsPage = (
           <label for="timezone">IANA Timezone</label>
           <select id="timezone" name="timezone" required>
             {Intl.supportedValuesOf("timeZone").map((tz: string) => (
-              <option value={tz} selected={tz === (timezone ?? "Europe/London")}>{tz}</option>
+              <option value={tz} selected={tz === (s.timezone ?? "Europe/London")}>{tz}</option>
             ))}
           </select>
           <button type="submit">Save Timezone</button>
         </CsrfForm>
 
-        {storageEnabled && (
+        {s.storageEnabled && (
         <div>
           <h2>Header Image</h2>
           <p>An optional image displayed at the top of every page. JPEG, PNG, GIF, or WebP — max 256KB.</p>
-          {headerImageUrl && (
+          {s.headerImageUrl && (
             <div>
-              <img src={getImageProxyUrl(headerImageUrl)} alt="Header image" class="event-image-preview" />
+              <img src={getImageProxyUrl(s.headerImageUrl)} alt="Header image" class="event-image-preview" />
               <CsrfForm action="/admin/settings/header-image/delete" id="settings-header-image-delete">
                 <button type="submit">Remove Image</button>
               </CsrfForm>
             </div>
           )}
           <CsrfForm action="/admin/settings/header-image" enctype="multipart/form-data" id="settings-header-image">
-            <label for="header_image">{headerImageUrl ? "Replace Image" : "Upload Image"}</label>
+            <label for="header_image">{s.headerImageUrl ? "Replace Image" : "Upload Image"}</label>
             <input
               type="file"
               id="header_image"
@@ -89,7 +95,7 @@ export const adminSettingsPage = (
             name="phone_prefix"
             step="1"
             min="1"
-            value={phonePrefix ?? "44"}
+            value={s.phonePrefix ?? "44"}
             required
           />
           <button type="submit">Save Phone Prefix</button>
@@ -97,17 +103,51 @@ export const adminSettingsPage = (
 
         <CsrfForm action="/admin/settings/business-email" id="settings-business-email">
             <h2>Business Email</h2>
-          <p>This email will be included in webhook notifications to identify your business.</p>
+          <p>This email will be included in webhook notifications and used as the reply-to address for automated emails.</p>
           <label for="business_email">Business Email</label>
           <input
             type="email"
             id="business_email"
             name="business_email"
             placeholder="contact@example.com"
-            value={businessEmail ?? ""}
+            value={s.businessEmail ?? ""}
             autocomplete="email"
           />
           <button type="submit">Save Business Email</button>
+        </CsrfForm>
+
+        <CsrfForm action="/admin/settings/email" id="settings-email">
+            <h2>Email Notifications</h2>
+          <p>Send confirmation emails to attendees and admin notifications when registrations come in.</p>
+          <label for="email_provider">Email Provider</label>
+          <select id="email_provider" name="email_provider">
+            <option value="" selected={!s.emailProvider}>None (disabled)</option>
+            <option value="resend" selected={s.emailProvider === "resend"}>Resend</option>
+            <option value="postmark" selected={s.emailProvider === "postmark"}>Postmark</option>
+            <option value="sendgrid" selected={s.emailProvider === "sendgrid"}>SendGrid</option>
+          </select>
+          <label for="email_api_key">API Key</label>
+          <input
+            type="password"
+            id="email_api_key"
+            name="email_api_key"
+            placeholder="Enter API key"
+            autocomplete="off"
+          />
+          <label for="email_from_address">From Address</label>
+          <input
+            type="email"
+            id="email_from_address"
+            name="email_from_address"
+            placeholder="tickets@yourdomain.com"
+            value={s.emailFromAddress ?? ""}
+            autocomplete="off"
+          />
+          <button type="submit">Save Email Settings</button>
+          {s.emailProvider && (
+            <button type="button" id="email-test-btn" class="secondary">Send Test Email</button>
+          )}
+          <div id="email-test-result" class="hidden"></div>
         </CsrfForm>
 
         <CsrfForm action="/admin/settings/payment-provider" id="settings-payment-provider">
@@ -119,7 +159,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="payment_provider"
                 value="none"
-                checked={!paymentProvider}
+                checked={!s.paymentProvider}
               />
               None (payments disabled)
             </label>
@@ -128,7 +168,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="payment_provider"
                 value="stripe"
-                checked={paymentProvider === "stripe"}
+                checked={s.paymentProvider === "stripe"}
               />
               Stripe
             </label>
@@ -137,7 +177,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="payment_provider"
                 value="square"
-                checked={paymentProvider === "square"}
+                checked={s.paymentProvider === "square"}
               />
               Square
             </label>
@@ -145,29 +185,29 @@ export const adminSettingsPage = (
           <button type="submit">Save Payment Provider</button>
         </CsrfForm>
 
-        {paymentProvider === "stripe" && (
+        {s.paymentProvider === "stripe" && (
         <CsrfForm action="/admin/settings/stripe" id="settings-stripe">
             <h2>Stripe Settings</h2>
           <p>
-            {stripeKeyConfigured
+            {s.stripeKeyConfigured
               ? "A Stripe secret key is currently configured. Enter a new key below to replace it."
               : "No Stripe key is configured. Enter your Stripe secret key to enable Stripe payments."}
           </p>
           <p><small><a href="/admin/guide#payment-setup">Where do I find this?</a></small></p>
           <Raw html={renderFields(stripeKeyFields)} />
           <button type="submit">Update Stripe Key</button>
-          {stripeKeyConfigured && (
+          {s.stripeKeyConfigured && (
             <button type="button" id="stripe-test-btn" class="secondary">Test Connection</button>
           )}
           <div id="stripe-test-result" class="hidden"></div>
         </CsrfForm>
         )}
 
-        {paymentProvider === "square" && (
+        {s.paymentProvider === "square" && (
         <CsrfForm action="/admin/settings/square" id="settings-square">
             <h2>Square Settings</h2>
           <p>
-            {squareTokenConfigured
+            {s.squareTokenConfigured
               ? "A Square access token is currently configured. Enter new credentials below to replace them."
               : "No Square access token is configured. Enter your Square credentials to enable Square payments."}
           </p>
@@ -177,7 +217,7 @@ export const adminSettingsPage = (
             <input
               type="checkbox"
               name="square_sandbox"
-              checked={squareSandbox}
+              checked={s.squareSandbox}
             />
             Sandbox mode (use Square's test environment)
           </label>
@@ -185,7 +225,7 @@ export const adminSettingsPage = (
         </CsrfForm>
         )}
 
-        {paymentProvider === "square" && squareTokenConfigured && (
+        {s.paymentProvider === "square" && s.squareTokenConfigured && (
         <CsrfForm action="/admin/settings/square-webhook" id="settings-square-webhook">
             <h2>Square Webhook</h2>
           <p>
@@ -198,7 +238,7 @@ export const adminSettingsPage = (
                 <li>Go to your <strong>Square Developer Dashboard</strong> and select your application</li>
                 <li>Navigate to <strong>Webhooks</strong> in the left sidebar</li>
                 <li>Click <strong>Add Subscription</strong></li>
-                <li>Set the <strong>Notification URL</strong> to:<br /><code>{webhookUrl}</code></li>
+                <li>Set the <strong>Notification URL</strong> to:<br /><code>{s.webhookUrl}</code></li>
                 <li>Subscribe to the <strong>payment.updated</strong> event</li>
                 <li>Save the subscription and copy the <strong>Signature Key</strong></li>
                 <li>Paste the signature key below</li>
@@ -206,7 +246,7 @@ export const adminSettingsPage = (
             </aside>
           </article>
           <p>
-            {squareWebhookConfigured
+            {s.squareWebhookConfigured
               ? "A webhook signature key is currently configured. Enter a new key below to replace it."
               : "No webhook signature key is configured. Follow the steps above to set one up."}
           </p>
@@ -224,7 +264,7 @@ export const adminSettingsPage = (
             id="embed_hosts"
             name="embed_hosts"
             placeholder="example.com, *.mysite.org"
-            value={embedHosts ?? ""}
+            value={s.embedHosts ?? ""}
             autocomplete="off"
           />
           <p><small>Use <code>*.example.com</code> to allow all subdomains. Direct visits to the booking page are always allowed.</small></p>
@@ -241,7 +281,7 @@ export const adminSettingsPage = (
             name="terms_and_conditions"
             rows="4"
             placeholder="Enter terms and conditions that attendees must agree to before registering. Leave blank to disable."
-          >{termsAndConditions ?? ""}</textarea>
+          >{s.termsAndConditions ?? ""}</textarea>
           <button type="submit">Save Terms</button>
         </CsrfForm>
 
@@ -261,7 +301,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="show_public_site"
                 value="true"
-                checked={showPublicSite === true}
+                checked={s.showPublicSite === true}
               />
               Yes
             </label>
@@ -270,7 +310,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="show_public_site"
                 value="false"
-                checked={showPublicSite !== true}
+                checked={s.showPublicSite !== true}
               />
               No
             </label>
@@ -287,7 +327,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="theme"
                 value="light"
-                checked={(theme ?? "light") === "light"}
+                checked={(s.theme ?? "light") === "light"}
               />
               Light
             </label>
@@ -296,7 +336,7 @@ export const adminSettingsPage = (
                 type="radio"
                 name="theme"
                 value="dark"
-                checked={theme === "dark"}
+                checked={s.theme === "dark"}
               />
               Dark
             </label>

--- a/src/templates/email/admin-notification.ts
+++ b/src/templates/email/admin-notification.ts
@@ -1,0 +1,41 @@
+/**
+ * Admin notification email template (sent to business email)
+ */
+
+import { type EmailContent, eventNames, type RegistrationEntry, ticketRow, ticketRowHtml } from "#templates/email/shared.ts";
+
+export const adminNotification = (
+  entries: RegistrationEntry[],
+  _currency: string,
+): EmailContent => {
+  const first = entries[0]!;
+  const names = eventNames(entries);
+  const subject = `New registration: ${first.attendee.name} for ${names}`;
+
+  const contactLines = [
+    `Name: ${first.attendee.name}`,
+    first.attendee.email ? `Email: ${first.attendee.email}` : "",
+    first.attendee.phone ? `Phone: ${first.attendee.phone}` : "",
+    first.attendee.address ? `Address: ${first.attendee.address}` : "",
+    first.attendee.special_instructions ? `Notes: ${first.attendee.special_instructions}` : "",
+  ].filter(Boolean);
+
+  const contactHtml = contactLines.map((l) => `<li>${l}</li>`).join("");
+
+  const html = `<div style="font-family:sans-serif;max-width:600px;margin:0 auto">
+<h2>New registration</h2>
+<ul style="list-style:none;padding:0">${contactHtml}</ul>
+<table style="width:100%;border-collapse:collapse;margin:16px 0">
+<tr style="border-bottom:1px solid #ddd"><th style="text-align:left;padding:8px">Event</th><th style="padding:8px">Qty</th><th style="padding:8px">Price</th></tr>
+${entries.map(ticketRowHtml).join("\n")}
+</table>
+</div>`;
+
+  const text = `New registration
+
+${contactLines.join("\n")}
+
+${entries.map(ticketRow).join("\n")}`;
+
+  return { subject, html, text };
+};

--- a/src/templates/email/registration-confirmation.ts
+++ b/src/templates/email/registration-confirmation.ts
@@ -1,0 +1,35 @@
+/**
+ * Registration confirmation email template (sent to attendee)
+ */
+
+import { type EmailContent, eventNames, type RegistrationEntry, ticketRow, ticketRowHtml } from "#templates/email/shared.ts";
+
+export const registrationConfirmation = (
+  entries: RegistrationEntry[],
+  _currency: string,
+  ticketUrl: string,
+): EmailContent => {
+  const names = eventNames(entries);
+  const subject = `Your tickets for ${names}`;
+
+  const html = `<div style="font-family:sans-serif;max-width:600px;margin:0 auto">
+<h2>Thanks for registering!</h2>
+<p>You're confirmed for <strong>${names}</strong>.</p>
+<table style="width:100%;border-collapse:collapse;margin:16px 0">
+<tr style="border-bottom:1px solid #ddd"><th style="text-align:left;padding:8px">Event</th><th style="padding:8px">Qty</th><th style="padding:8px">Price</th></tr>
+${entries.map(ticketRowHtml).join("\n")}
+</table>
+<p><a href="${ticketUrl}" style="display:inline-block;padding:12px 24px;background:#2563eb;color:#fff;text-decoration:none;border-radius:4px">View your tickets</a></p>
+<p style="color:#666;font-size:14px">Or copy this link: ${ticketUrl}</p>
+</div>`;
+
+  const text = `Thanks for registering!
+
+You're confirmed for ${names}.
+
+${entries.map(ticketRow).join("\n")}
+
+View your tickets: ${ticketUrl}`;
+
+  return { subject, html, text };
+};

--- a/src/templates/email/shared.ts
+++ b/src/templates/email/shared.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers for email templates
+ */
+
+import { map } from "#fp";
+import { formatCurrency } from "#lib/currency.ts";
+import { isPaidEvent } from "#lib/types.ts";
+import type { RegistrationEntry } from "#lib/webhook.ts";
+export type { RegistrationEntry };
+
+export type EmailContent = { subject: string; html: string; text: string };
+
+export const eventNames = (entries: RegistrationEntry[]): string =>
+  map(({ event }: RegistrationEntry) => event.name)(entries).join(" and ");
+
+export const ticketRow = ({ event, attendee }: RegistrationEntry): string => {
+  const price = isPaidEvent(event) ? ` — ${formatCurrency(attendee.price_paid)}` : "";
+  const date = attendee.date ? ` (${attendee.date})` : "";
+  return `${event.name}${date}: ${attendee.quantity} ticket${attendee.quantity > 1 ? "s" : ""}${price}`;
+};
+
+export const ticketRowHtml = ({ event, attendee }: RegistrationEntry): string => {
+  const price = isPaidEvent(event) ? `<td>${formatCurrency(attendee.price_paid)}</td>` : "<td></td>";
+  const date = attendee.date ? ` <small>(${attendee.date})</small>` : "";
+  return `<tr><td>${event.name}${date}</td><td>${attendee.quantity}</td>${price}</tr>`;
+};

--- a/test/lib/email-templates.test.ts
+++ b/test/lib/email-templates.test.ts
@@ -138,9 +138,11 @@ describe("adminNotification", () => {
 
   test("text omits empty contact fields", () => {
     const { text } = adminNotification(
-      [makeEntry({}, { address: "", special_instructions: "" })],
+      [makeEntry({}, { email: "", phone: "", address: "", special_instructions: "" })],
       "GBP",
     );
+    expect(text).not.toContain("Email:");
+    expect(text).not.toContain("Phone:");
     expect(text).not.toContain("Address:");
     expect(text).not.toContain("Notes:");
   });
@@ -161,5 +163,23 @@ describe("adminNotification", () => {
     );
     expect(text).toContain("£5");
     resetCurrencyCode();
+  });
+
+  test("includes address when present", () => {
+    const { text, html } = adminNotification(
+      [makeEntry({}, { address: "123 Main St" })],
+      "GBP",
+    );
+    expect(text).toContain("Address: 123 Main St");
+    expect(html).toContain("Address: 123 Main St");
+  });
+
+  test("includes special instructions when present", () => {
+    const { text, html } = adminNotification(
+      [makeEntry({}, { special_instructions: "Wheelchair access" })],
+      "GBP",
+    );
+    expect(text).toContain("Notes: Wheelchair access");
+    expect(html).toContain("Notes: Wheelchair access");
   });
 });

--- a/test/lib/email-templates.test.ts
+++ b/test/lib/email-templates.test.ts
@@ -1,0 +1,165 @@
+import { describe, it as test } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { registrationConfirmation } from "#templates/email/registration-confirmation.ts";
+import { adminNotification } from "#templates/email/admin-notification.ts";
+import type { RegistrationEntry, WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
+import { setCurrencyCodeForTest, resetCurrencyCode } from "#lib/currency.ts";
+
+const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+  id: 1,
+  name: "Test Event",
+  slug: "test-event",
+  webhook_url: "",
+  max_attendees: 100,
+  attendee_count: 10,
+  unit_price: 0,
+  can_pay_more: false,
+  ...overrides,
+});
+
+const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee => ({
+  id: 42,
+  quantity: 1,
+  name: "Jane Doe",
+  email: "jane@example.com",
+  phone: "555-1234",
+  address: "",
+  special_instructions: "",
+  payment_id: "",
+  price_paid: "0",
+  ticket_token: "AABB001122",
+  date: null,
+  ...overrides,
+});
+
+const makeEntry = (
+  eventOverrides?: Partial<WebhookEvent>,
+  attendeeOverrides?: Partial<WebhookAttendee>,
+): RegistrationEntry => ({
+  event: makeEvent(eventOverrides),
+  attendee: makeAttendee(attendeeOverrides),
+});
+
+describe("registrationConfirmation", () => {
+  test("subject contains event name", () => {
+    const { subject } = registrationConfirmation([makeEntry()], "GBP", "https://example.com/t/ABC");
+    expect(subject).toBe("Your tickets for Test Event");
+  });
+
+  test("subject contains multiple event names for multi-event", () => {
+    const entries = [
+      makeEntry({ name: "Event A" }),
+      makeEntry({ name: "Event B" }),
+    ];
+    const { subject } = registrationConfirmation(entries, "GBP", "https://example.com/t/ABC+DEF");
+    expect(subject).toBe("Your tickets for Event A and Event B");
+  });
+
+  test("HTML contains event name and ticket URL", () => {
+    const { html } = registrationConfirmation([makeEntry()], "GBP", "https://example.com/t/ABC");
+    expect(html).toContain("Test Event");
+    expect(html).toContain("https://example.com/t/ABC");
+  });
+
+  test("text contains event name and ticket URL", () => {
+    const { text } = registrationConfirmation([makeEntry()], "GBP", "https://example.com/t/ABC");
+    expect(text).toContain("Test Event");
+    expect(text).toContain("https://example.com/t/ABC");
+  });
+
+  test("shows quantity in text", () => {
+    const { text } = registrationConfirmation(
+      [makeEntry({}, { quantity: 3 })],
+      "GBP",
+      "https://example.com/t/ABC",
+    );
+    expect(text).toContain("3 tickets");
+  });
+
+  test("shows singular ticket for quantity 1", () => {
+    const { text } = registrationConfirmation([makeEntry()], "GBP", "https://example.com/t/ABC");
+    expect(text).toContain("1 ticket");
+    expect(text).not.toContain("1 tickets");
+  });
+
+  test("shows price for paid event", () => {
+    setCurrencyCodeForTest("GBP");
+    const { text } = registrationConfirmation(
+      [makeEntry({ unit_price: 1000 }, { price_paid: "2000", quantity: 2 })],
+      "GBP",
+      "https://example.com/t/ABC",
+    );
+    expect(text).toContain("£20");
+    resetCurrencyCode();
+  });
+
+  test("does not show price for free event", () => {
+    const { text } = registrationConfirmation([makeEntry()], "GBP", "https://example.com/t/ABC");
+    expect(text).not.toContain("£");
+  });
+
+  test("shows date when attendee has date", () => {
+    const { text } = registrationConfirmation(
+      [makeEntry({}, { date: "2025-07-15" })],
+      "GBP",
+      "https://example.com/t/ABC",
+    );
+    expect(text).toContain("2025-07-15");
+  });
+});
+
+describe("adminNotification", () => {
+  test("subject contains attendee name and event name", () => {
+    const { subject } = adminNotification([makeEntry()], "GBP");
+    expect(subject).toBe("New registration: Jane Doe for Test Event");
+  });
+
+  test("subject contains multiple event names for multi-event", () => {
+    const entries = [
+      makeEntry({ name: "Event A" }),
+      makeEntry({ name: "Event B" }),
+    ];
+    const { subject } = adminNotification(entries, "GBP");
+    expect(subject).toBe("New registration: Jane Doe for Event A and Event B");
+  });
+
+  test("HTML contains attendee name and event name", () => {
+    const { html } = adminNotification([makeEntry()], "GBP");
+    expect(html).toContain("Jane Doe");
+    expect(html).toContain("Test Event");
+  });
+
+  test("text contains attendee contact info", () => {
+    const { text } = adminNotification([makeEntry()], "GBP");
+    expect(text).toContain("Name: Jane Doe");
+    expect(text).toContain("Email: jane@example.com");
+    expect(text).toContain("Phone: 555-1234");
+  });
+
+  test("text omits empty contact fields", () => {
+    const { text } = adminNotification(
+      [makeEntry({}, { address: "", special_instructions: "" })],
+      "GBP",
+    );
+    expect(text).not.toContain("Address:");
+    expect(text).not.toContain("Notes:");
+  });
+
+  test("shows quantity in text", () => {
+    const { text } = adminNotification(
+      [makeEntry({}, { quantity: 3 })],
+      "GBP",
+    );
+    expect(text).toContain("3 tickets");
+  });
+
+  test("shows price for paid event", () => {
+    setCurrencyCodeForTest("GBP");
+    const { text } = adminNotification(
+      [makeEntry({ unit_price: 500 }, { price_paid: "500" })],
+      "GBP",
+    );
+    expect(text).toContain("£5");
+    resetCurrencyCode();
+  });
+});

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -153,6 +153,16 @@ describe("email", () => {
       expect(body.content[1]).toEqual({ type: "text/html", value: "<p>Hi</p>" });
     });
 
+    test("sends via SendGrid without reply_to when not provided", async () => {
+      const config: EmailConfig = { ...testConfig, provider: "sendgrid" };
+      const msg: EmailMessage = { to: "user@test.com", subject: "Test", html: "<p>Hi</p>", text: "Hi" };
+
+      await sendEmail(config, msg);
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.reply_to).toBeUndefined();
+    });
+
     test("logs error on non-OK response", async () => {
       restubFetch(() => Promise.resolve(new Response("Error", { status: 500 })));
 
@@ -170,6 +180,16 @@ describe("email", () => {
         await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
         expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("Network error"))).toBe(true);
+      });
+    });
+
+    test("logs non-Error thrown values as strings", async () => {
+      restubFetch(() => Promise.reject("string error"));
+
+      await withErrorSpy(async (errorSpy) => {
+        await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
+        expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("string error"))).toBe(true);
       });
     });
 
@@ -202,6 +222,25 @@ describe("email", () => {
     test("returns null when API key missing", async () => {
       await updateEmailProvider("resend");
       await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      const config = await getEmailConfig();
+      expect(config).toBeNull();
+    });
+
+    test("falls back to business email when from address not set", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateBusinessEmail("biz@example.com");
+      invalidateSettingsCache();
+
+      const config = await getEmailConfig();
+      expect(config).toEqual({ provider: "resend", apiKey: "test-key", fromAddress: "biz@example.com" });
+    });
+
+    test("returns null when neither from address nor business email set", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
       invalidateSettingsCache();
 
       const config = await getEmailConfig();

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { spy, stub } from "@std/testing/mock";
+import {
+  type EmailConfig,
+  type EmailMessage,
+  getEmailConfig,
+  sendEmail,
+  sendRegistrationEmails,
+  sendTestEmail,
+} from "#lib/email.ts";
+import type { RegistrationEntry, WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
+import { createTestDbWithSetup, resetDb } from "#test-utils";
+import {
+  invalidateSettingsCache,
+  updateEmailApiKey,
+  updateEmailFromAddress,
+  updateEmailProvider,
+} from "#lib/db/settings.ts";
+import { updateBusinessEmail } from "#lib/business-email.ts";
+import { bracket, map } from "#fp";
+
+const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+  id: 1,
+  name: "Test Event",
+  slug: "test-event",
+  webhook_url: "",
+  max_attendees: 100,
+  attendee_count: 10,
+  unit_price: 0,
+  can_pay_more: false,
+  ...overrides,
+});
+
+const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee => ({
+  id: 42,
+  quantity: 1,
+  name: "Jane Doe",
+  email: "jane@example.com",
+  phone: "555-1234",
+  address: "",
+  special_instructions: "",
+  payment_id: "",
+  price_paid: "0",
+  ticket_token: "AABB001122",
+  date: null,
+  ...overrides,
+});
+
+const makeEntry = (
+  eventOverrides?: Partial<WebhookEvent>,
+  attendeeOverrides?: Partial<WebhookAttendee>,
+): RegistrationEntry => ({
+  event: makeEvent(eventOverrides),
+  attendee: makeAttendee(attendeeOverrides),
+});
+
+const testConfig: EmailConfig = {
+  provider: "resend",
+  apiKey: "re_test_key",
+  fromAddress: "tickets@example.com",
+};
+
+const withErrorSpy = bracket(
+  () => spy(console, "error"),
+  (s: { restore: () => void }) => s.restore(),
+);
+
+describe("email", () => {
+  // deno-lint-ignore no-explicit-any
+  let fetchStub: any;
+  let originalFetch: typeof fetch;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    fetchStub = stub(globalThis, "fetch", () => Promise.resolve(new Response()));
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    globalThis.fetch = originalFetch;
+    resetDb();
+  });
+
+  const restubFetch = (impl: () => Promise<Response>): void => {
+    fetchStub.restore();
+    fetchStub = stub(globalThis, "fetch", impl);
+  };
+
+  describe("sendEmail", () => {
+    test("sends via Resend with correct URL, headers, and body", async () => {
+      const msg: EmailMessage = {
+        to: "user@test.com",
+        subject: "Test",
+        html: "<p>Hi</p>",
+        text: "Hi",
+        replyTo: "reply@test.com",
+      };
+
+      await sendEmail(testConfig, msg);
+
+      expect(fetchStub.calls.length).toBe(1);
+      const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
+      expect(url).toBe("https://api.resend.com/emails");
+      expect((opts.headers as Record<string, string>)["Authorization"]).toBe("Bearer re_test_key");
+      const body = JSON.parse(opts.body as string);
+      expect(body.from).toBe("tickets@example.com");
+      expect(body.to).toEqual(["user@test.com"]);
+      expect(body.reply_to).toBe("reply@test.com");
+      expect(body.subject).toBe("Test");
+      expect(body.html).toBe("<p>Hi</p>");
+      expect(body.text).toBe("Hi");
+    });
+
+    test("sends via Postmark with correct URL, headers, and body", async () => {
+      const config: EmailConfig = { ...testConfig, provider: "postmark" };
+      const msg: EmailMessage = { to: "user@test.com", subject: "Test", html: "<p>Hi</p>", text: "Hi" };
+
+      await sendEmail(config, msg);
+
+      const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
+      expect(url).toBe("https://api.postmarkapp.com/email");
+      expect((opts.headers as Record<string, string>)["X-Postmark-Server-Token"]).toBe("re_test_key");
+      const body = JSON.parse(opts.body as string);
+      expect(body.From).toBe("tickets@example.com");
+      expect(body.To).toBe("user@test.com");
+      expect(body.Subject).toBe("Test");
+      expect(body.HtmlBody).toBe("<p>Hi</p>");
+      expect(body.TextBody).toBe("Hi");
+    });
+
+    test("sends via SendGrid with correct URL, headers, and body", async () => {
+      const config: EmailConfig = { ...testConfig, provider: "sendgrid" };
+      const msg: EmailMessage = {
+        to: "user@test.com",
+        subject: "Test",
+        html: "<p>Hi</p>",
+        text: "Hi",
+        replyTo: "reply@test.com",
+      };
+
+      await sendEmail(config, msg);
+
+      const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
+      expect(url).toBe("https://api.sendgrid.com/v3/mail/send");
+      expect((opts.headers as Record<string, string>)["Authorization"]).toBe("Bearer re_test_key");
+      const body = JSON.parse(opts.body as string);
+      expect(body.personalizations).toEqual([{ to: [{ email: "user@test.com" }] }]);
+      expect(body.from).toEqual({ email: "tickets@example.com" });
+      expect(body.reply_to).toEqual({ email: "reply@test.com" });
+      expect(body.content[0]).toEqual({ type: "text/plain", value: "Hi" });
+      expect(body.content[1]).toEqual({ type: "text/html", value: "<p>Hi</p>" });
+    });
+
+    test("logs error on non-OK response", async () => {
+      restubFetch(() => Promise.resolve(new Response("Error", { status: 500 })));
+
+      await withErrorSpy(async (errorSpy) => {
+        await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
+        expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("status=500"))).toBe(true);
+      });
+    });
+
+    test("logs error on fetch failure", async () => {
+      restubFetch(() => Promise.reject(new Error("Network error")));
+
+      await withErrorSpy(async (errorSpy) => {
+        await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
+        expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("Network error"))).toBe(true);
+      });
+    });
+
+    test("logs error for unknown provider", async () => {
+      await withErrorSpy(async (errorSpy) => {
+        await sendEmail({ ...testConfig, provider: "invalid" }, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
+        expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("unknown provider"))).toBe(true);
+      });
+    });
+  });
+
+  describe("getEmailConfig", () => {
+    test("returns null when no provider configured", async () => {
+      invalidateSettingsCache();
+      const config = await getEmailConfig();
+      expect(config).toBeNull();
+    });
+
+    test("returns config when all settings present", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      const config = await getEmailConfig();
+      expect(config).toEqual({ provider: "resend", apiKey: "test-key", fromAddress: "from@test.com" });
+    });
+
+    test("returns null when API key missing", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      const config = await getEmailConfig();
+      expect(config).toBeNull();
+    });
+  });
+
+  describe("sendRegistrationEmails", () => {
+    test("skips when email not configured", async () => {
+      await sendRegistrationEmails([makeEntry()], "GBP");
+      expect(fetchStub.calls.length).toBe(0);
+    });
+
+    test("sends confirmation email to attendee", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry()], "GBP");
+
+      expect(fetchStub.calls.length).toBe(1);
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.to).toEqual(["jane@example.com"]);
+      expect(body.subject).toContain("Test Event");
+    });
+
+    test("sends both confirmation and admin notification when business email set", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      await updateBusinessEmail("admin@business.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry()], "GBP");
+
+      expect(fetchStub.calls.length).toBe(2);
+      const recipients = fetchStub.calls.map(
+        (c: { args: unknown[] }) => JSON.parse((c.args as [string, RequestInit])[1].body as string).to,
+      );
+      expect(recipients).toContainEqual(["jane@example.com"]);
+      expect(recipients).toContainEqual(["admin@business.com"]);
+    });
+
+    test("uses business email as reply-to on confirmation", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      await updateBusinessEmail("admin@business.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry()], "GBP");
+
+      const confirmationCall = fetchStub.calls.find((c: { args: unknown[] }) => {
+        const body = JSON.parse((c.args as [string, RequestInit])[1].body as string);
+        return body.to[0] === "jane@example.com";
+      });
+      const body = JSON.parse((confirmationCall.args as [string, RequestInit])[1].body as string);
+      expect(body.reply_to).toBe("admin@business.com");
+    });
+
+    test("uses attendee email as reply-to on admin notification", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      await updateBusinessEmail("admin@business.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry()], "GBP");
+
+      const adminCall = fetchStub.calls.find((c: { args: unknown[] }) => {
+        const body = JSON.parse((c.args as [string, RequestInit])[1].body as string);
+        return body.to[0] === "admin@business.com";
+      });
+      const body = JSON.parse((adminCall.args as [string, RequestInit])[1].body as string);
+      expect(body.reply_to).toBe("jane@example.com");
+    });
+  });
+
+  describe("sendTestEmail", () => {
+    test("sends test email to specified address", async () => {
+      await sendTestEmail(testConfig, "admin@test.com");
+
+      expect(fetchStub.calls.length).toBe(1);
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.to).toEqual(["admin@test.com"]);
+      expect(body.subject).toContain("Test email");
+    });
+  });
+});

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1699,15 +1699,30 @@ describe("html", () => {
   });
 
   describe("adminSettingsPage", () => {
+    const defaultState: import("#templates/admin/settings.tsx").SettingsPageState = {
+      stripeKeyConfigured: false,
+      paymentProvider: null,
+      squareTokenConfigured: false,
+      squareSandbox: false,
+      squareWebhookConfigured: false,
+      webhookUrl: "https://example.com/payment/webhook",
+      embedHosts: null,
+      termsAndConditions: null,
+      timezone: "Europe/London",
+      businessEmail: "",
+      theme: "light",
+      showPublicSite: false,
+      phonePrefix: "44",
+      headerImageUrl: null,
+      storageEnabled: false,
+      emailProvider: null,
+      emailFromAddress: null,
+    };
+
     test("shows square webhook configured message when key is set", () => {
       const html = adminSettingsPage(
         TEST_SESSION,
-        false, // stripeKeyConfigured
-        "square", // paymentProvider
-        true, // squareTokenConfigured
-        false, // squareSandbox
-        true, // squareWebhookConfigured
-        "https://example.com/payment/webhook",
+        { ...defaultState, paymentProvider: "square", squareTokenConfigured: true, squareWebhookConfigured: true },
       );
       expect(html).toContain("A webhook signature key is currently configured");
       expect(html).toContain("Enter a new key below to replace it");
@@ -1716,12 +1731,7 @@ describe("html", () => {
     test("shows square webhook not configured message when key is not set", () => {
       const html = adminSettingsPage(
         TEST_SESSION,
-        false,
-        "square",
-        true,
-        false, // squareSandbox
-        false, // squareWebhookConfigured = false
-        "https://example.com/payment/webhook",
+        { ...defaultState, paymentProvider: "square", squareTokenConfigured: true },
       );
       expect(html).toContain("No webhook signature key is configured");
       expect(html).toContain("Follow the steps above to set one up");
@@ -1730,12 +1740,7 @@ describe("html", () => {
     test("shows sandbox checkbox checked when sandbox mode enabled", () => {
       const html = adminSettingsPage(
         TEST_SESSION,
-        false,
-        "square",
-        true,
-        true, // squareSandbox
-        false,
-        "https://example.com/payment/webhook",
+        { ...defaultState, paymentProvider: "square", squareTokenConfigured: true, squareSandbox: true },
       );
       expect(html).toContain("Sandbox mode");
       expect(html).toContain('name="square_sandbox"');

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1701,22 +1701,22 @@ describe("html", () => {
   describe("adminSettingsPage", () => {
     const defaultState: import("#templates/admin/settings.tsx").SettingsPageState = {
       stripeKeyConfigured: false,
-      paymentProvider: null,
+      paymentProvider: "",
       squareTokenConfigured: false,
       squareSandbox: false,
       squareWebhookConfigured: false,
       webhookUrl: "https://example.com/payment/webhook",
-      embedHosts: null,
-      termsAndConditions: null,
+      embedHosts: "",
+      termsAndConditions: "",
       timezone: "Europe/London",
       businessEmail: "",
       theme: "light",
       showPublicSite: false,
       phonePrefix: "44",
-      headerImageUrl: null,
+      headerImageUrl: "",
       storageEnabled: false,
-      emailProvider: null,
-      emailFromAddress: null,
+      emailProvider: "",
+      emailFromAddress: "",
     };
 
     test("shows square webhook configured message when key is set", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1745,6 +1745,34 @@ describe("html", () => {
       expect(html).toContain("Sandbox mode");
       expect(html).toContain('name="square_sandbox"');
     });
+
+    test("shows email provider selection when configured", () => {
+      const html = adminSettingsPage(
+        TEST_SESSION,
+        { ...defaultState, emailProvider: "resend", emailFromAddress: "from@test.com" },
+      );
+      expect(html).toContain('value="resend"');
+      expect(html).toContain("Send Test Email");
+      expect(html).toContain('value="from@test.com"');
+    });
+
+    test("hides test button when no email provider configured", () => {
+      const html = adminSettingsPage(TEST_SESSION, defaultState);
+      expect(html).not.toContain("Send Test Email");
+    });
+
+    test("uses business email as from address placeholder", () => {
+      const html = adminSettingsPage(
+        TEST_SESSION,
+        { ...defaultState, businessEmail: "biz@example.com" },
+      );
+      expect(html).toContain('placeholder="biz@example.com"');
+    });
+
+    test("uses default placeholder when no business email", () => {
+      const html = adminSettingsPage(TEST_SESSION, defaultState);
+      expect(html).toContain('placeholder="tickets@yourdomain.com"');
+    });
   });
 
   describe("adminCalendarPage", () => {

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2040,6 +2040,209 @@ describe("server (admin settings)", () => {
     });
   });
 
+  describe("POST /admin/settings/email", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/email", {
+          email_provider: "resend",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("saves email provider settings", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "resend",
+            email_api_key: "re_test_123",
+            email_from_address: "tickets@example.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location)).toContain("Email settings updated");
+    });
+
+    test("disables email when provider is empty", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location)).toContain("Email provider disabled");
+    });
+
+    test("rejects invalid email provider", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "invalid-provider",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "Invalid email provider");
+    });
+
+    test("saves provider without updating key when key is empty", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "postmark",
+            email_api_key: "",
+            email_from_address: "",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(decodeURIComponent(response.headers.get("location")!)).toContain("Email settings updated");
+    });
+
+    test("logs activity when email provider is set", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "sendgrid",
+            email_api_key: "sg_key",
+            email_from_address: "from@test.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      const logs = await getAllActivityLog();
+      expect(logs.some((l) => l.message.includes("Email provider set to sendgrid"))).toBe(true);
+    });
+
+    test("settings page displays email configuration section", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain('id="settings-email"');
+      expect(html).toContain("email_provider");
+      expect(html).toContain("Email Notifications");
+    });
+  });
+
+  describe("POST /admin/settings/email/test", () => {
+    test("returns error when email not configured", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email/test",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.success).toBe(false);
+      expect(json.error).toContain("Email not configured");
+    });
+
+    test("returns error when no business email set", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email/test",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.success).toBe(false);
+      expect(json.error).toContain("No business email set");
+    });
+
+    test("sends test email when configured", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+      await setBizEmail("admin@test.com");
+      settingsApi.invalidateSettingsCache();
+
+      await withMocks(
+        () => stub(globalThis, "fetch", () => Promise.resolve(new Response())),
+        async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/email/test",
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          expect(response.status).toBe(200);
+          const json = await response.json();
+          expect(json.success).toBe(true);
+        },
+      );
+    });
+  });
+
+  describe("settings page email provider display", () => {
+    test("shows email provider when configured", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { cookie } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain('value="resend"');
+      expect(html).toContain("Send Test Email");
+    });
+  });
+
   describe("demo mode restrictions", () => {
     beforeEach(() => {
       Deno.env.set("DEMO_MODE", "true");

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2107,6 +2107,21 @@ describe("server (admin settings)", () => {
       await expectHtmlResponse(response, 400, "Invalid email provider");
     });
 
+    test("disables email when provider field is missing", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(decodeURIComponent(response.headers.get("location")!)).toContain("Email provider disabled");
+    });
+
     test("saves provider without updating key when key is empty", async () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2159,7 +2159,7 @@ describe("server (admin settings)", () => {
   });
 
   describe("POST /admin/settings/email/test", () => {
-    test("returns error when email not configured", async () => {
+    test("shows error when email not configured", async () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 
       const response = await handleRequest(
@@ -2170,13 +2170,10 @@ describe("server (admin settings)", () => {
         ),
       );
 
-      expect(response.status).toBe(200);
-      const json = await response.json();
-      expect(json.success).toBe(false);
-      expect(json.error).toContain("Email not configured");
+      await expectHtmlResponse(response, 400, "Email not configured");
     });
 
-    test("returns error when no business email set", async () => {
+    test("shows error when no business email set", async () => {
       const { settingsApi } = await import("#lib/db/settings.ts");
       const { cookie, csrfToken } = await loginAsAdmin();
 
@@ -2192,13 +2189,10 @@ describe("server (admin settings)", () => {
         ),
       );
 
-      expect(response.status).toBe(200);
-      const json = await response.json();
-      expect(json.success).toBe(false);
-      expect(json.error).toContain("No business email set");
+      await expectHtmlResponse(response, 400, "No business email set");
     });
 
-    test("sends test email when configured", async () => {
+    test("sends test email and redirects with success", async () => {
       const { settingsApi } = await import("#lib/db/settings.ts");
       const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
       const { cookie, csrfToken } = await loginAsAdmin();
@@ -2220,9 +2214,9 @@ describe("server (admin settings)", () => {
             ),
           );
 
-          expect(response.status).toBe(200);
-          const json = await response.json();
-          expect(json.success).toBe(true);
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          expect(decodeURIComponent(location)).toContain("Test email sent");
         },
       );
     });


### PR DESCRIPTION
Implements EMAIL_PLAN.md: sends confirmation emails to attendees and
admin notifications to business email via HTTP APIs. Adds email config
to admin settings page with provider selection, API key, from address,
and test email button.

https://claude.ai/code/session_01UbZKr95fCLoVSnhzg5RiBA