### PR TITLE
Hide email config fields when provider is set to None

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1354,3 +1354,11 @@ button.secondary:hover {
     color: #666;
   }
 }
+
+/* Hide email API key and from address fields when provider is "None" */
+#email_provider:has(option[value=""]:checked) ~ label[for="email_api_key"],
+#email_provider:has(option[value=""]:checked) ~ #email_api_key,
+#email_provider:has(option[value=""]:checked) ~ label[for="email_from_address"],
+#email_provider:has(option[value=""]:checked) ~ #email_from_address {
+  display: none;
+}


### PR DESCRIPTION
## Summary
Added CSS styling to conditionally hide email API key and from address input fields when the email provider is set to "None".

## Key Changes
- Added CSS rule using the `:has()` pseudo-class selector to detect when the email provider dropdown has the empty value option selected
- Hides the following elements when provider is "None":
  - `email_api_key` label and input field
  - `email_from_address` label and input field

## Implementation Details
- Uses the CSS `:has()` pseudo-class to check if `#email_provider` contains a checked option with an empty value
- Applies `display: none` to sibling elements that follow the provider dropdown
- This provides a better UX by hiding irrelevant configuration fields when no email provider is selected

https://claude.ai/code/session_01Lg6JgXgCJhUwF4ukArsob7