### PR TITLE
Move header image description inside form element

### DIFF
--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -62,8 +62,6 @@ export const adminSettingsPage = (
 
         {s.storageEnabled && (
         <div>
-          <h2>Header Image</h2>
-          <p>An optional image displayed at the top of every page. JPEG, PNG, GIF, or WebP — max 256KB.</p>
           {s.headerImageUrl && (
             <div>
               <img src={getImageProxyUrl(s.headerImageUrl)} alt="Header image" class="event-image-preview" />
@@ -73,6 +71,8 @@ export const adminSettingsPage = (
             </div>
           )}
           <CsrfForm action="/admin/settings/header-image" enctype="multipart/form-data" id="settings-header-image">
+            <h2>Header Image</h2>
+            <p>An optional image displayed at the top of every page. JPEG, PNG, GIF, or WebP — max 256KB.</p>
             <label for="header_image">{s.headerImageUrl ? "Replace Image" : "Upload Image"}</label>
             <input
               type="file"


### PR DESCRIPTION
## Summary
Reorganized the header image section in the admin settings page by moving the descriptive text and heading inside the form element.

## Key Changes
- Moved the "Header Image" heading and description paragraph from outside the `CsrfForm` component to inside it
- The image preview and upload input remain functionally unchanged
- This ensures the descriptive content is semantically grouped with the form it describes

## Implementation Details
The heading and description text that explains the header image requirements (file types, size limit) are now positioned immediately before the file input field within the form, improving the logical structure and user experience of the form layout.

https://claude.ai/code/session_014aEXDiiKUpvTEZ51m3uWz5