### PR TITLE
Add Mailgun email provider support

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -112,6 +112,14 @@ const PROVIDERS: Record<string, ProviderRequest> = {
 /** Valid provider names, derived from the PROVIDERS map */
 export const VALID_EMAIL_PROVIDERS: ReadonlySet<string> = new Set(Object.keys(PROVIDERS));
 
+/** Display labels for email providers */
+export const EMAIL_PROVIDER_LABELS: Record<string, string> = {
+  resend: "Resend",
+  postmark: "Postmark",
+  sendgrid: "SendGrid",
+  mailgun: "Mailgun",
+};
+
 /** Send a single email via the configured provider. Logs errors, never throws. */
 export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise<void> => {
   const buildRequest = PROVIDERS[config.provider];

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,6 +1,6 @@
 /**
  * Email sending module
- * Sends registration emails via HTTP email APIs (Resend, Postmark, SendGrid)
+ * Sends registration emails via HTTP email APIs (Resend, Postmark, SendGrid, Mailgun)
  */
 
 import { getBusinessEmailFromDb } from "#lib/business-email.ts";
@@ -86,11 +86,31 @@ const sendgridRequest: ProviderRequest = (config, msg) => [
   },
 ];
 
+const mailgunRequest: ProviderRequest = (config, msg) => {
+  const domain = config.fromAddress.split("@")[1];
+  const form = new FormData();
+  form.append("from", config.fromAddress);
+  form.append("to", msg.to);
+  form.append("subject", msg.subject);
+  form.append("html", msg.html);
+  form.append("text", msg.text);
+  if (msg.replyTo) form.append("h:Reply-To", msg.replyTo);
+  return [
+    `https://api.mailgun.net/v3/${domain}/messages`,
+    { "Authorization": `Basic ${btoa("api:" + config.apiKey)}` },
+    form,
+  ];
+};
+
 const PROVIDERS: Record<string, ProviderRequest> = {
   resend: resendRequest,
   postmark: postmarkRequest,
   sendgrid: sendgridRequest,
+  mailgun: mailgunRequest,
 };
+
+/** Valid provider names, derived from the PROVIDERS map */
+export const VALID_EMAIL_PROVIDERS: ReadonlySet<string> = new Set(Object.keys(PROVIDERS));
 
 /** Send a single email via the configured provider. Logs errors, never throws. */
 export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise<void> => {
@@ -101,10 +121,11 @@ export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise
   }
   try {
     const [url, headers, body] = buildRequest(config, msg);
+    const isFormData = body instanceof FormData;
     const response = await fetch(url, {
       method: "POST",
-      headers: { ...headers, "Content-Type": "application/json" },
-      body: JSON.stringify(body),
+      headers: isFormData ? headers : { ...headers, "Content-Type": "application/json" },
+      body: isFormData ? body : JSON.stringify(body),
     });
     if (!response.ok) {
       logError({ code: ErrorCode.EMAIL_SEND, detail: `status=${response.status} to=${msg.to}` });

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -8,7 +8,7 @@ import {
   isValidBusinessEmail,
   updateBusinessEmail,
 } from "#lib/business-email.ts";
-import { getEmailConfig, sendTestEmail } from "#lib/email.ts";
+import { getEmailConfig, sendTestEmail, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
 import { getAllowedDomain, getSquareWebhookSignatureKey } from "#lib/config.ts";
 import { clearSessionCookie } from "#lib/cookies.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
@@ -716,8 +716,6 @@ const handleHeaderImageDeletePost = settingsRoute(async (_form, _errorPage) => {
   );
 });
 
-/** Valid email provider values */
-const VALID_EMAIL_PROVIDERS: ReadonlySet<string> = new Set(["resend", "postmark", "sendgrid"]);
 
 /** Handle POST /admin/settings/email - owner only */
 const handleEmailPost = settingsRoute(async (form, errorPage) => {

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -124,7 +124,7 @@ export const adminSettingsPage = (
           <select id="email_provider" name="email_provider">
             <option value="" selected={!s.emailProvider}>None (disabled)</option>
             {Array.from(VALID_EMAIL_PROVIDERS).map((p) => (
-              <option value={p} selected={s.emailProvider === p}>{EMAIL_PROVIDER_LABELS[p] ?? p}</option>
+              <option value={p} selected={s.emailProvider === p}>{EMAIL_PROVIDER_LABELS[p]}</option>
             ))}
           </select>
           <label for="email_api_key">API Key</label>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -125,6 +125,7 @@ export const adminSettingsPage = (
             <option value="resend" selected={s.emailProvider === "resend"}>Resend</option>
             <option value="postmark" selected={s.emailProvider === "postmark"}>Postmark</option>
             <option value="sendgrid" selected={s.emailProvider === "sendgrid"}>SendGrid</option>
+            <option value="mailgun" selected={s.emailProvider === "mailgun"}>Mailgun</option>
           </select>
           <label for="email_api_key">API Key</label>
           <input

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -2,6 +2,7 @@
  * Admin settings page template
  */
 
+import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
 import { CsrfForm, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
@@ -122,10 +123,9 @@ export const adminSettingsPage = (
           <label for="email_provider">Email Provider</label>
           <select id="email_provider" name="email_provider">
             <option value="" selected={!s.emailProvider}>None (disabled)</option>
-            <option value="resend" selected={s.emailProvider === "resend"}>Resend</option>
-            <option value="postmark" selected={s.emailProvider === "postmark"}>Postmark</option>
-            <option value="sendgrid" selected={s.emailProvider === "sendgrid"}>SendGrid</option>
-            <option value="mailgun" selected={s.emailProvider === "mailgun"}>Mailgun</option>
+            {Array.from(VALID_EMAIL_PROVIDERS).map((p) => (
+              <option value={p} selected={s.emailProvider === p}>{EMAIL_PROVIDER_LABELS[p] ?? p}</option>
+            ))}
           </select>
           <label for="email_api_key">API Key</label>
           <input

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -163,6 +163,44 @@ describe("email", () => {
       expect(body.reply_to).toBeUndefined();
     });
 
+    test("sends via Mailgun with correct URL, headers, and FormData body", async () => {
+      const config: EmailConfig = { ...testConfig, provider: "mailgun" };
+      const msg: EmailMessage = {
+        to: "user@test.com",
+        subject: "Test",
+        html: "<p>Hi</p>",
+        text: "Hi",
+        replyTo: "reply@test.com",
+      };
+
+      await sendEmail(config, msg);
+
+      expect(fetchStub.calls.length).toBe(1);
+      const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
+      expect(url).toBe("https://api.mailgun.net/v3/example.com/messages");
+      expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
+        `Basic ${btoa("api:re_test_key")}`,
+      );
+      expect(opts.headers as Record<string, string>).not.toHaveProperty("Content-Type");
+      const body = opts.body as FormData;
+      expect(body.get("from")).toBe("tickets@example.com");
+      expect(body.get("to")).toBe("user@test.com");
+      expect(body.get("subject")).toBe("Test");
+      expect(body.get("html")).toBe("<p>Hi</p>");
+      expect(body.get("text")).toBe("Hi");
+      expect(body.get("h:Reply-To")).toBe("reply@test.com");
+    });
+
+    test("sends via Mailgun without h:Reply-To when not provided", async () => {
+      const config: EmailConfig = { ...testConfig, provider: "mailgun" };
+      const msg: EmailMessage = { to: "user@test.com", subject: "Test", html: "<p>Hi</p>", text: "Hi" };
+
+      await sendEmail(config, msg);
+
+      const body = (fetchStub.calls[0].args as [string, RequestInit])[1].body as FormData;
+      expect(body.get("h:Reply-To")).toBeNull();
+    });
+
     test("logs error on non-OK response", async () => {
       restubFetch(() => Promise.resolve(new Response("Error", { status: 500 })));
 


### PR DESCRIPTION
## Summary
This PR adds support for Mailgun as an email provider alongside the existing Resend, Postmark, and SendGrid integrations.

## Key Changes
- **Email provider implementation**: Added `mailgunRequest` function to handle Mailgun API requests using FormData instead of JSON
  - Constructs proper Mailgun API URL from domain extracted from sender address
  - Implements Basic authentication with API key
  - Supports optional Reply-To header via `h:Reply-To` field
- **Request handling**: Updated `sendEmail` to conditionally handle FormData bodies (Mailgun) vs JSON bodies (other providers)
  - Omits `Content-Type` header for FormData requests (browser/fetch handles this automatically)
  - Applies `Content-Type: application/json` only for JSON-based providers
- **Provider validation**: Extracted `VALID_EMAIL_PROVIDERS` constant from settings route to email module for centralized provider list management
- **UI**: Added Mailgun option to email provider dropdown in admin settings
- **Tests**: Added comprehensive test coverage for Mailgun integration including:
  - Correct URL, headers, and FormData body construction
  - Proper handling of optional Reply-To field

## Implementation Details
- Mailgun uses FormData for request body instead of JSON, requiring conditional logic in the fetch call
- The domain for Mailgun API calls is extracted from the `fromAddress` configuration
- Reply-To header is conditionally appended only when provided in the message

https://claude.ai/code/session_01SoJ8WA51yrNyfo2EX4KN87