### PR TITLE
Add success message to return_url after attendee edit

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -499,7 +499,13 @@ async function editAttendeeHandler(
   await updateAttendee(attendeeId, { name, email, phone, address, special_instructions, event_id, quantity });
   await logActivity(`Attendee '${name}' updated`, event_id);
 
-  return redirectOrReturn(form, `/admin/event/${event_id}?edited=${encodeURIComponent(name)}#attendees`);
+  const successMessage = `Attendee '${name}' updated`;
+  if (returnUrl) {
+    const url = new URL(returnUrl, "http://localhost");
+    url.searchParams.set("success", successMessage);
+    return redirect(url.pathname + url.search + url.hash);
+  }
+  return redirect(`/admin/event/${event_id}?edited=${encodeURIComponent(name)}#attendees`);
 }
 const handleEditAttendeePost = editAttendeePost(editAttendeeHandler);
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1289,6 +1289,42 @@ describe("server (admin attendees)", () => {
       expect(html).toContain("Wheelchair access");
     });
 
+    test("appends success message to return_url after edit", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const { cookie, csrfToken } = await loginAsAdmin();
+      const returnUrl = "/admin/calendar?date=2026-03-15#attendees";
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "1",
+            csrf_token: csrfToken,
+            return_url: returnUrl,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(location).toContain("/admin/calendar");
+      expect(location).toContain("success=");
+      expect(location).toContain("John+Doe");
+      expect(location).toContain("#attendees");
+    });
+
     test("allows moving attendee to different event", async () => {
       const event1 = await createTestEvent({
         name: "Event 1",


### PR DESCRIPTION
## Summary
Updated the attendee edit handler to append a success message to the `return_url` parameter when provided, allowing users to be redirected back to their original location with confirmation of the update.

## Key Changes
- Modified `editAttendeeHandler` in `src/routes/admin/attendees.ts` to check for a `return_url` parameter
- When `return_url` is provided, the handler now appends a `success` query parameter containing the update message and preserves the URL hash
- Falls back to the original redirect behavior (`/admin/event/{id}`) when no `return_url` is specified
- Added comprehensive test case to verify the success message is properly appended to the return URL with all components intact (path, query params, and hash)

## Implementation Details
- Uses the `URL` API to safely parse and manipulate the return URL
- Preserves the original URL structure including hash fragments (e.g., `#attendees`)
- Success message format: `"Attendee '{name}' updated"`
- Maintains backward compatibility by only using the new behavior when `return_url` is explicitly provided

https://claude.ai/code/session_01RYWSqkqGSBSetymfdv5UTG