### PR TITLE
Implement sensitive field masking for admin settings

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -73,6 +73,16 @@ export const CONFIG_KEYS = {
 } as const;
 
 /**
+ * Sentinel value rendered in password fields for configured secrets.
+ * The actual secret is never sent to the browser — only this placeholder.
+ * On form submission, if the value equals the sentinel, the update is skipped.
+ */
+export const MASK_SENTINEL = "••••••••";
+
+/** Check whether a submitted form value is the mask sentinel (i.e. unchanged) */
+export const isMaskSentinel = (value: string): boolean => value === MASK_SENTINEL;
+
+/**
  * In-memory settings cache. Loads all rows in a single query and
  * serves subsequent reads from memory until the TTL expires or a
  * write invalidates the cache.
@@ -757,6 +767,12 @@ export const getEmailProviderFromDb = (): Promise<string | null> =>
 export const updateEmailProvider = (provider: string): Promise<void> =>
   setOrDeleteSetting(CONFIG_KEYS.EMAIL_PROVIDER, provider);
 
+/** Check if an email API key has been configured in the database */
+export const hasEmailApiKey = async (): Promise<boolean> => {
+  const value = await getSetting(CONFIG_KEYS.EMAIL_API_KEY);
+  return value !== null;
+};
+
 /** Get email API key from database (decrypted). Returns null if not configured. */
 export const getEmailApiKeyFromDb = (): Promise<string | null> =>
   getEncryptedSetting(CONFIG_KEYS.EMAIL_API_KEY);
@@ -832,6 +848,7 @@ export const settingsApi = {
   updateHeaderImageUrl,
   getEmailProviderFromDb,
   updateEmailProvider,
+  hasEmailApiKey,
   getEmailApiKeyFromDb,
   updateEmailApiKey,
   getEmailFromAddressFromDb,

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -28,8 +28,10 @@ import {
   getTermsAndConditionsFromDb,
   getThemeFromDb,
   getTimezoneFromDb,
+  hasEmailApiKey,
   hasSquareToken,
   hasStripeKey,
+  isMaskSentinel,
   MAX_TERMS_LENGTH,
   setPaymentProvider,
   setStripeWebhookConfig,
@@ -58,7 +60,6 @@ import {
 } from "#lib/demo.ts";
 import { parseEmbedHosts, validateEmbedHosts } from "#lib/embed-hosts.ts";
 import {
-  type Field,
   setFormError,
   setFormSuccess,
   validateForm,
@@ -90,12 +91,6 @@ import { adminSettingsPage } from "#templates/admin/settings.tsx";
 import {
   type ChangePasswordFormValues,
   changePasswordFields,
-  type SquareTokenFormValues,
-  type SquareWebhookFormValues,
-  type StripeKeyFormValues,
-  squareAccessTokenFields,
-  squareWebhookFields,
-  stripeKeyFields,
 } from "#templates/fields.ts";
 
 /** Build the webhook URL from the configured domain */
@@ -124,6 +119,7 @@ const getSettingsPageState = async () => {
     phonePrefix,
     headerImageUrl,
     emailProvider,
+    emailApiKeyConfigured,
     emailFromAddress,
   ] = await Promise.all([
     hasStripeKey(),
@@ -140,6 +136,7 @@ const getSettingsPageState = async () => {
     getPhonePrefixFromDb(),
     getHeaderImageUrlFromDb(),
     getEmailProviderFromDb(),
+    hasEmailApiKey(),
     getEmailFromAddressFromDb(),
   ]);
   return {
@@ -159,6 +156,7 @@ const getSettingsPageState = async () => {
     headerImageUrl: headerImageUrl ?? "",
     storageEnabled: isStorageEnabled(),
     emailProvider: emailProvider ?? "",
+    emailApiKeyConfigured,
     emailFromAddress: emailFromAddress ?? "",
     globalWebhookUrl: getEnv("WEBHOOK_URL") ?? "",
   };
@@ -197,19 +195,6 @@ const settingsRoute =
     withOwnerAuthForm(request, (session, form) =>
       handler(form, settingsPageWithError(session), session),
     );
-
-/** Validate form and return values, or an error response */
-const validateSettingsForm = async <T>(
-  form: URLSearchParams,
-  fields: Field[],
-  errorPage: ErrorPageFn,
-  formId: string,
-): Promise<{ values: T } | { response: Response }> => {
-  const result = validateForm<T>(form, fields);
-  if (result.valid) return { values: result.values };
-  const response = await errorPage(result.error, 400, formId);
-  return { response };
-};
 
 /**
  * Handle GET /admin/settings - owner only
@@ -355,15 +340,25 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  const validated = await validateSettingsForm<StripeKeyFormValues>(
-    form,
-    stripeKeyFields,
-    errorPage,
-    "settings-stripe",
-  );
-  if ("response" in validated) return validated.response;
+  const stripeSecretKey = (form.get("stripe_secret_key") || "").trim();
 
-  const { stripe_secret_key: stripeSecretKey } = validated.values;
+  // Sentinel means "keep existing" — no-op
+  if (isMaskSentinel(stripeSecretKey)) {
+    return redirectWithSuccess(
+      "/admin/settings",
+      "Stripe settings unchanged",
+      "settings-stripe",
+    );
+  }
+
+  // Require a key when none is configured
+  if (!stripeSecretKey) {
+    return errorPage(
+      "Stripe Secret Key is required",
+      400,
+      "settings-stripe",
+    );
+  }
 
   // Set up webhook endpoint automatically
   const webhookUrl = getWebhookUrl();
@@ -410,19 +405,29 @@ const handleAdminSquarePost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  const validated = await validateSettingsForm<SquareTokenFormValues>(
-    form,
-    squareAccessTokenFields,
-    errorPage,
-    "settings-square",
-  );
-  if ("response" in validated) return validated.response;
-
-  const { square_access_token: accessToken, square_location_id: locationId } =
-    validated.values;
+  const accessToken = (form.get("square_access_token") || "").trim();
+  const locationId = (form.get("square_location_id") || "").trim();
   const sandbox = form.get("square_sandbox") === "on";
 
-  await updateSquareAccessToken(accessToken);
+  if (!locationId) {
+    return errorPage("Location ID is required", 400, "settings-square");
+  }
+
+  // Require a token when none is configured
+  if (!accessToken && !isMaskSentinel(accessToken) && !(await hasSquareToken())) {
+    return errorPage(
+      "Square Access Token is required",
+      400,
+      "settings-square",
+    );
+  }
+
+  // Only update the token if it's not the sentinel (i.e. user entered a new value)
+  if (!isMaskSentinel(accessToken) && accessToken) {
+    await updateSquareAccessToken(accessToken);
+  }
+
+  // Always allow updating non-secret fields
   await updateSquareLocationId(locationId);
   await updateSquareSandbox(sandbox);
 
@@ -441,15 +446,24 @@ const handleAdminSquarePost = settingsRoute(async (form, errorPage) => {
  * Handle POST /admin/settings/square-webhook - owner only
  */
 const handleAdminSquareWebhookPost = settingsRoute(async (form, errorPage) => {
-  const validated = await validateSettingsForm<SquareWebhookFormValues>(
-    form,
-    squareWebhookFields,
-    errorPage,
-    "settings-square-webhook",
-  );
-  if ("response" in validated) return validated.response;
+  const signatureKey = (form.get("square_webhook_signature_key") || "").trim();
 
-  const { square_webhook_signature_key: signatureKey } = validated.values;
+  // Sentinel means "keep existing" — no-op
+  if (isMaskSentinel(signatureKey)) {
+    return redirectWithSuccess(
+      "/admin/settings",
+      "Square webhook settings unchanged",
+      "settings-square-webhook",
+    );
+  }
+
+  if (!signatureKey) {
+    return errorPage(
+      "Webhook Signature Key is required",
+      400,
+      "settings-square-webhook",
+    );
+  }
 
   await updateSquareWebhookSignatureKey(signatureKey);
 
@@ -738,7 +752,7 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
   }
 
   await updateEmailProvider(provider);
-  if (apiKey) await updateEmailApiKey(apiKey);
+  if (apiKey && !isMaskSentinel(apiKey)) await updateEmailApiKey(apiKey);
   if (fromAddress) await updateEmailFromAddress(fromAddress);
   await logActivity(`Email provider set to ${provider}`);
   return redirectWithSuccess("/admin/settings", "Email settings updated", "settings-email");

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -352,10 +352,19 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Require a key when none is configured
-  if (!stripeSecretKey) {
+  if (!stripeSecretKey && !(await hasStripeKey())) {
     return errorPage(
       "Stripe Secret Key is required",
       400,
+      "settings-stripe",
+    );
+  }
+
+  // Empty with existing key = no change
+  if (!stripeSecretKey) {
+    return redirectWithSuccess(
+      "/admin/settings",
+      "Stripe settings unchanged",
       "settings-stripe",
     );
   }
@@ -414,7 +423,7 @@ const handleAdminSquarePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Require a token when none is configured
-  if (!accessToken && !isMaskSentinel(accessToken) && !(await hasSquareToken())) {
+  if (!accessToken && !(await hasSquareToken())) {
     return errorPage(
       "Square Access Token is required",
       400,
@@ -466,6 +475,7 @@ const handleAdminSquareWebhookPost = settingsRoute(async (form, errorPage) => {
   }
 
   await updateSquareWebhookSignatureKey(signatureKey);
+
 
   await logActivity("Square webhook signature key configured");
   return redirectWithSuccess(

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -2,6 +2,7 @@
  * Admin settings page template
  */
 
+import { MASK_SENTINEL } from "#lib/db/settings.ts";
 import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
 import { CsrfForm, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
@@ -35,6 +36,7 @@ export type SettingsPageState = {
   headerImageUrl: string;
   storageEnabled: boolean;
   emailProvider: string;
+  emailApiKeyConfigured: boolean;
   emailFromAddress: string;
   globalWebhookUrl: string;
 };
@@ -134,6 +136,7 @@ export const adminSettingsPage = (
             id="email_api_key"
             name="email_api_key"
             placeholder="Enter API key"
+            value={s.emailApiKeyConfigured ? MASK_SENTINEL : undefined}
             autocomplete="off"
           />
           <label for="email_from_address">From Address</label>
@@ -197,7 +200,7 @@ export const adminSettingsPage = (
               : "No Stripe key is configured. Enter your Stripe secret key to enable Stripe payments."}
           </p>
           <p><small><a href="/admin/guide#payment-setup">Where do I find this?</a></small></p>
-          <Raw html={renderFields(stripeKeyFields)} />
+          <Raw html={renderFields(stripeKeyFields, s.stripeKeyConfigured ? { stripe_secret_key: MASK_SENTINEL } : {})} />
           <button type="submit">Update Stripe Key</button>
           {s.stripeKeyConfigured && (
             <button type="button" id="stripe-test-btn" class="secondary">Test Connection</button>
@@ -215,7 +218,7 @@ export const adminSettingsPage = (
               : "No Square access token is configured. Enter your Square credentials to enable Square payments."}
           </p>
           <p><small><a href="/admin/guide#payment-setup">Where do I find these?</a></small></p>
-          <Raw html={renderFields(squareAccessTokenFields)} />
+          <Raw html={renderFields(squareAccessTokenFields, s.squareTokenConfigured ? { square_access_token: MASK_SENTINEL } : {})} />
           <label>
             <input
               type="checkbox"
@@ -253,7 +256,7 @@ export const adminSettingsPage = (
               ? "A webhook signature key is currently configured. Enter a new key below to replace it."
               : "No webhook signature key is configured. Follow the steps above to set one up."}
           </p>
-          <Raw html={renderFields(squareWebhookFields)} />
+          <Raw html={renderFields(squareWebhookFields, s.squareWebhookConfigured ? { square_webhook_signature_key: MASK_SENTINEL } : {})} />
           <button type="submit">Update Webhook Key</button>
         </CsrfForm>
         )}

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -696,6 +696,7 @@ export const stripeKeyFields: Field[] = [
     name: "stripe_secret_key",
     label: "Stripe Secret Key",
     type: "password",
+    required: true,
     placeholder: "sk_live_... or sk_test_...",
     hint: "Enter a new key to update",
   },
@@ -709,6 +710,7 @@ export const squareAccessTokenFields: Field[] = [
     name: "square_access_token",
     label: "Square Access Token",
     type: "password",
+    required: true,
     placeholder: "EAAAl...",
     hint: "Your Square application's access token",
   },
@@ -730,6 +732,7 @@ export const squareWebhookFields: Field[] = [
     name: "square_webhook_signature_key",
     label: "Webhook Signature Key",
     type: "password",
+    required: true,
     hint: "The signature key from your Square webhook subscription",
   },
 ];

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -696,7 +696,6 @@ export const stripeKeyFields: Field[] = [
     name: "stripe_secret_key",
     label: "Stripe Secret Key",
     type: "password",
-    required: true,
     placeholder: "sk_live_... or sk_test_...",
     hint: "Enter a new key to update",
   },
@@ -710,7 +709,6 @@ export const squareAccessTokenFields: Field[] = [
     name: "square_access_token",
     label: "Square Access Token",
     type: "password",
-    required: true,
     placeholder: "EAAAl...",
     hint: "Your Square application's access token",
   },
@@ -732,7 +730,6 @@ export const squareWebhookFields: Field[] = [
     name: "square_webhook_signature_key",
     label: "Webhook Signature Key",
     type: "password",
-    required: true,
     hint: "The signature key from your Square webhook subscription",
   },
 ];

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1716,6 +1716,7 @@ describe("html", () => {
       headerImageUrl: "",
       storageEnabled: false,
       emailProvider: "",
+      emailApiKeyConfigured: false,
       emailFromAddress: "",
       globalWebhookUrl: "",
     };

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2273,6 +2273,304 @@ describe("server (admin settings)", () => {
     });
   });
 
+  describe("sensitive field masking", () => {
+    test("shows mask sentinel for configured Stripe key", async () => {
+      const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
+      await setPaymentProvider("stripe");
+
+      await withMocks(
+        () =>
+          stub(stripeApi, "setupWebhookEndpoint", () =>
+            Promise.resolve({
+              success: true,
+              endpointId: "we_test_123",
+              secret: "whsec_test_secret",
+            }),
+          ),
+        async () => {
+          const { cookie, csrfToken } = await loginAsAdmin();
+
+          // Configure a Stripe key
+          await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: "sk_test_real_secret", csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          // Settings page should show sentinel, not the actual key
+          const response = await awaitTestRequest("/admin/settings", { cookie });
+          const html = await response.text();
+          expect(html).toContain(MASK_SENTINEL);
+          expect(html).not.toContain("sk_test_real_secret");
+        },
+      );
+    });
+
+    test("shows mask sentinel for configured Square token", async () => {
+      const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
+      await setPaymentProvider("square");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      // Configure Square credentials
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square",
+          {
+            square_access_token: "EAAAl_real_secret",
+            square_location_id: "L_test_loc",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain(MASK_SENTINEL);
+      expect(html).not.toContain("EAAAl_real_secret");
+    });
+
+    test("shows mask sentinel for configured email API key", async () => {
+      const { MASK_SENTINEL, settingsApi } = await import("#lib/db/settings.ts");
+      const { cookie } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_real_secret_key");
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain(MASK_SENTINEL);
+      expect(html).not.toContain("re_real_secret_key");
+    });
+
+    test("submitting sentinel for Stripe key does not overwrite existing key", async () => {
+      const { MASK_SENTINEL, getStripeSecretKeyFromDb } = await import("#lib/db/settings.ts");
+      await setPaymentProvider("stripe");
+
+      await withMocks(
+        () =>
+          stub(stripeApi, "setupWebhookEndpoint", () =>
+            Promise.resolve({
+              success: true,
+              endpointId: "we_test_123",
+              secret: "whsec_test_secret",
+            }),
+          ),
+        async () => {
+          const { cookie, csrfToken } = await loginAsAdmin();
+
+          // Configure a Stripe key
+          await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: "sk_test_original", csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          // Submit sentinel — should not change the key
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: MASK_SENTINEL, csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          expect(response.status).toBe(302);
+          expect(decodeURIComponent(response.headers.get("location")!)).toContain("unchanged");
+          expect(await getStripeSecretKeyFromDb()).toBe("sk_test_original");
+        },
+      );
+    });
+
+    test("submitting sentinel for Square token preserves token but updates location", async () => {
+      const { MASK_SENTINEL, getSquareAccessTokenFromDb, getSquareLocationIdFromDb } = await import("#lib/db/settings.ts");
+      await setPaymentProvider("square");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      // Configure Square credentials
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square",
+          {
+            square_access_token: "EAAAl_original",
+            square_location_id: "L_original",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      // Submit sentinel for token but new location ID
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square",
+          {
+            square_access_token: MASK_SENTINEL,
+            square_location_id: "L_updated",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(await getSquareAccessTokenFromDb()).toBe("EAAAl_original");
+      expect(await getSquareLocationIdFromDb()).toBe("L_updated");
+    });
+
+    test("submitting sentinel for Square webhook key does not overwrite", async () => {
+      const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      // Configure webhook key
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square-webhook",
+          { square_webhook_signature_key: "sig_original", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      // Submit sentinel
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square-webhook",
+          { square_webhook_signature_key: MASK_SENTINEL, csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(decodeURIComponent(response.headers.get("location")!)).toContain("unchanged");
+    });
+
+    test("submitting sentinel for email API key does not overwrite existing key", async () => {
+      const { MASK_SENTINEL, getEmailApiKeyFromDb } = await import("#lib/db/settings.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      // Configure email with API key
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "resend",
+            email_api_key: "re_original_key",
+            email_from_address: "from@test.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      // Submit sentinel for API key
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "resend",
+            email_api_key: MASK_SENTINEL,
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(await getEmailApiKeyFromDb()).toBe("re_original_key");
+    });
+
+    test("submitting new value still updates the key", async () => {
+      const { getStripeSecretKeyFromDb } = await import("#lib/db/settings.ts");
+      await setPaymentProvider("stripe");
+
+      await withMocks(
+        () =>
+          stub(stripeApi, "setupWebhookEndpoint", () =>
+            Promise.resolve({
+              success: true,
+              endpointId: "we_test_123",
+              secret: "whsec_test_secret",
+            }),
+          ),
+        async () => {
+          const { cookie, csrfToken } = await loginAsAdmin();
+
+          // Configure initial key
+          await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: "sk_test_old", csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          // Submit a new key (not sentinel)
+          await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: "sk_test_new", csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          expect(await getStripeSecretKeyFromDb()).toBe("sk_test_new");
+        },
+      );
+    });
+
+    test("empty Stripe key rejected when no key is configured", async () => {
+      await setPaymentProvider("stripe");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/stripe",
+          { stripe_secret_key: "", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "required");
+    });
+
+    test("empty Square token rejected when no token is configured", async () => {
+      await setPaymentProvider("square");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square",
+          {
+            square_access_token: "",
+            square_location_id: "L_test",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "required");
+    });
+
+    test("empty Square webhook key rejected", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/square-webhook",
+          { square_webhook_signature_key: "", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "required");
+    });
+  });
+
   describe("demo mode restrictions", () => {
     beforeEach(() => {
       Deno.env.set("DEMO_MODE", "true");

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2522,6 +2522,47 @@ describe("server (admin settings)", () => {
       );
     });
 
+    test("empty Stripe key with existing key is a no-op", async () => {
+      const { getStripeSecretKeyFromDb } = await import("#lib/db/settings.ts");
+      await setPaymentProvider("stripe");
+
+      await withMocks(
+        () =>
+          stub(stripeApi, "setupWebhookEndpoint", () =>
+            Promise.resolve({
+              success: true,
+              endpointId: "we_test_123",
+              secret: "whsec_test_secret",
+            }),
+          ),
+        async () => {
+          const { cookie, csrfToken } = await loginAsAdmin();
+
+          // Configure a Stripe key first
+          await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: "sk_test_keep_me", csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          // Submit empty — should preserve existing key
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/stripe",
+              { stripe_secret_key: "", csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          expect(response.status).toBe(302);
+          expect(decodeURIComponent(response.headers.get("location")!)).toContain("unchanged");
+          expect(await getStripeSecretKeyFromDb()).toBe("sk_test_keep_me");
+        },
+      );
+    });
+
     test("empty Stripe key rejected when no key is configured", async () => {
       await setPaymentProvider("stripe");
       const { cookie, csrfToken } = await loginAsAdmin();


### PR DESCRIPTION
## Summary
This PR implements a masking system for sensitive configuration fields (API keys, tokens, webhooks) in the admin settings interface. Sensitive values are never displayed in the browser; instead, a sentinel placeholder is shown. When users submit the form without changing a masked field, the existing value is preserved.

## Key Changes

- **Added mask sentinel system** (`MASK_SENTINEL = "••••••••"`)
  - Exported from `src/lib/db/settings.ts` with helper function `isMaskSentinel()` to detect when a user hasn't changed a field
  - Prevents accidental overwrites of secrets with empty values

- **Updated settings form handlers** to intelligently handle masked fields:
  - Stripe key: Skips update if sentinel is submitted; requires a key only when none is configured
  - Square token: Preserves token if sentinel submitted, but allows updating other fields like location ID
  - Square webhook key: Skips update if sentinel is submitted
  - Email API key: Skips update if sentinel is submitted

- **Modified template rendering** (`src/templates/admin/settings.tsx`):
  - Email API key field now displays `MASK_SENTINEL` when a key is already configured
  - Added `emailApiKeyConfigured` to settings page state to track configuration status

- **Removed field-level validation** from form definitions:
  - Moved validation logic into route handlers for more granular control
  - Allows conditional validation (e.g., only require key if none exists)
  - Removed `validateSettingsForm` helper function as validation is now inline

- **Added comprehensive test coverage** (304 lines):
  - Tests verify sentinel is displayed instead of actual secrets
  - Tests confirm submitting sentinel preserves existing values
  - Tests verify new values still update correctly
  - Tests ensure empty values are rejected when no value is configured

## Implementation Details

The masking approach follows a "show placeholder, preserve on submit" pattern:
1. When rendering a form with a configured secret, the field value is set to the sentinel
2. On form submission, if the submitted value equals the sentinel, the update is skipped
3. If a new value is submitted (not the sentinel), it replaces the existing value
4. Empty submissions are only rejected when no value is currently configured

https://claude.ai/code/session_014DcCCHjJT3gEJXm7roKfLP