### PR TITLE
Return HTTP status from email send functions for better error handling

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -92,12 +92,12 @@ const PROVIDERS: Record<string, ProviderRequest> = {
   sendgrid: sendgridRequest,
 };
 
-/** Send a single email via the configured provider. Logs errors, never throws. */
-export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise<void> => {
+/** Send a single email via the configured provider. Logs errors, never throws. Returns HTTP status or undefined on non-HTTP errors. */
+export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise<number | undefined> => {
   const buildRequest = PROVIDERS[config.provider];
   if (!buildRequest) {
     logError({ code: ErrorCode.EMAIL_SEND, detail: `unknown provider: ${config.provider}` });
-    return;
+    return undefined;
   }
   try {
     const [url, headers, body] = buildRequest(config, msg);
@@ -109,11 +109,13 @@ export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise
     if (!response.ok) {
       logError({ code: ErrorCode.EMAIL_SEND, detail: `status=${response.status} to=${msg.to}` });
     }
+    return response.status;
   } catch (error) {
     logError({
       code: ErrorCode.EMAIL_SEND,
       detail: error instanceof Error ? error.message : String(error),
     });
+    return undefined;
   }
 };
 
@@ -134,7 +136,7 @@ export const sendRegistrationEmails = async (
   const replyTo = businessEmail || undefined;
 
   const confirmation = registrationConfirmation(entries, currency, ticketUrl);
-  const promises: Promise<void>[] = [
+  const promises: Promise<number | undefined>[] = [
     sendEmail(config, { to: entries[0]!.attendee.email, ...confirmation, replyTo }),
   ];
 
@@ -148,9 +150,9 @@ export const sendRegistrationEmails = async (
   await Promise.allSettled(promises);
 };
 
-/** Send a test email to the business email address. */
-export const sendTestEmail = async (config: EmailConfig, to: string): Promise<void> => {
-  await sendEmail(config, {
+/** Send a test email to the business email address. Returns HTTP status or undefined on non-HTTP errors. */
+export const sendTestEmail = async (config: EmailConfig, to: string): Promise<number | undefined> => {
+  return await sendEmail(config, {
     to,
     subject: "Test email from your ticket system",
     html: "<p>This is a test email. Your email configuration is working correctly.</p>",

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -751,8 +751,11 @@ const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
   const businessEmail = await getBusinessEmailFromDb();
   if (!businessEmail) return errorPage("No business email set", 400, "settings-email");
   const status = await sendTestEmail(config, businessEmail);
-  if (!status || status < 200 || status >= 300) {
-    return errorPage(`Test email failed (status ${status ?? "unknown"})`, 500, "settings-email");
+  if (!status) {
+    return errorPage("Test email failed (no response)", 502, "settings-email");
+  }
+  if (status >= 300) {
+    return errorPage(`Test email failed (status ${status})`, 502, "settings-email");
   }
   return redirectWithSuccess("/admin/settings", `Test email sent (status ${status})`, "settings-email-test");
 });

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -752,8 +752,11 @@ const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
   if (!config) return errorPage("Email not configured", 400, "settings-email");
   const businessEmail = await getBusinessEmailFromDb();
   if (!businessEmail) return errorPage("No business email set", 400, "settings-email");
-  await sendTestEmail(config, businessEmail);
-  return redirectWithSuccess("/admin/settings", "Test email sent", "settings-email-test");
+  const status = await sendTestEmail(config, businessEmail);
+  if (!status || status < 200 || status >= 300) {
+    return errorPage(`Test email failed (status ${status ?? "unknown"})`, 500, "settings-email");
+  }
+  return redirectWithSuccess("/admin/settings", `Test email sent (status ${status})`, "settings-email-test");
 });
 
 /**

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -98,8 +98,9 @@ describe("email", () => {
         replyTo: "reply@test.com",
       };
 
-      await sendEmail(testConfig, msg);
+      const status = await sendEmail(testConfig, msg);
 
+      expect(status).toBe(200);
       expect(fetchStub.calls.length).toBe(1);
       const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
       expect(url).toBe("https://api.resend.com/emails");
@@ -163,39 +164,43 @@ describe("email", () => {
       expect(body.reply_to).toBeUndefined();
     });
 
-    test("logs error on non-OK response", async () => {
+    test("returns status code on non-OK response", async () => {
       restubFetch(() => Promise.resolve(new Response("Error", { status: 500 })));
 
       await withErrorSpy(async (errorSpy) => {
-        await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const status = await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        expect(status).toBe(500);
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
         expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("status=500"))).toBe(true);
       });
     });
 
-    test("logs error on fetch failure", async () => {
+    test("returns undefined on fetch failure", async () => {
       restubFetch(() => Promise.reject(new Error("Network error")));
 
       await withErrorSpy(async (errorSpy) => {
-        await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const status = await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        expect(status).toBeUndefined();
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
         expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("Network error"))).toBe(true);
       });
     });
 
-    test("logs non-Error thrown values as strings", async () => {
+    test("returns undefined for non-Error thrown values", async () => {
       restubFetch(() => Promise.reject("string error"));
 
       await withErrorSpy(async (errorSpy) => {
-        await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const status = await sendEmail(testConfig, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        expect(status).toBeUndefined();
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
         expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("string error"))).toBe(true);
       });
     });
 
-    test("logs error for unknown provider", async () => {
+    test("returns undefined for unknown provider", async () => {
       await withErrorSpy(async (errorSpy) => {
-        await sendEmail({ ...testConfig, provider: "invalid" }, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const status = await sendEmail({ ...testConfig, provider: "invalid" }, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        expect(status).toBeUndefined();
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
         expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("unknown provider"))).toBe(true);
       });
@@ -321,9 +326,10 @@ describe("email", () => {
   });
 
   describe("sendTestEmail", () => {
-    test("sends test email to specified address", async () => {
-      await sendTestEmail(testConfig, "admin@test.com");
+    test("sends test email and returns status code", async () => {
+      const status = await sendTestEmail(testConfig, "admin@test.com");
 
+      expect(status).toBe(200);
       expect(fetchStub.calls.length).toBe(1);
       const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
       expect(body.to).toEqual(["admin@test.com"]);

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2228,7 +2228,7 @@ describe("server (admin settings)", () => {
       await expectHtmlResponse(response, 400, "No business email set");
     });
 
-    test("sends test email and redirects with success", async () => {
+    test("sends test email and redirects with success including status code", async () => {
       const { settingsApi } = await import("#lib/db/settings.ts");
       const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
       const { cookie, csrfToken } = await loginAsAdmin();
@@ -2252,7 +2252,65 @@ describe("server (admin settings)", () => {
 
           expect(response.status).toBe(302);
           const location = response.headers.get("location")!;
-          expect(decodeURIComponent(location)).toContain("Test email sent");
+          expect(decodeURIComponent(location)).toContain("Test email sent (status 200)");
+        },
+      );
+    });
+
+    test("shows error when email API returns non-2xx status", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+      await setBizEmail("admin@test.com");
+      settingsApi.invalidateSettingsCache();
+
+      await withMocks(
+        () => stub(globalThis, "fetch", () => Promise.resolve(new Response("Forbidden", { status: 403 }))),
+        async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/email/test",
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          const html = await response.text();
+          expect(response.status).toBe(500);
+          expect(html).toContain("Test email failed (status 403)");
+        },
+      );
+    });
+
+    test("shows error when email send encounters network error", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+      await setBizEmail("admin@test.com");
+      settingsApi.invalidateSettingsCache();
+
+      await withMocks(
+        () => stub(globalThis, "fetch", () => Promise.reject(new Error("Network error"))),
+        async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/email/test",
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          const html = await response.text();
+          expect(response.status).toBe(500);
+          expect(html).toContain("Test email failed (status unknown)");
         },
       );
     });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2280,7 +2280,7 @@ describe("server (admin settings)", () => {
           );
 
           const html = await response.text();
-          expect(response.status).toBe(500);
+          expect(response.status).toBe(502);
           expect(html).toContain("Test email failed (status 403)");
         },
       );
@@ -2309,8 +2309,8 @@ describe("server (admin settings)", () => {
           );
 
           const html = await response.text();
-          expect(response.status).toBe(500);
-          expect(html).toContain("Test email failed (status unknown)");
+          expect(response.status).toBe(502);
+          expect(html).toContain("Test email failed (no response)");
         },
       );
     });


### PR DESCRIPTION
## Summary
Modified the email sending functions to return HTTP status codes instead of silently logging errors, enabling callers to handle email delivery failures appropriately.

## Key Changes
- **`sendEmail()` function**: Changed return type from `Promise<void>` to `Promise<number | undefined>`
  - Returns the HTTP response status code on successful requests (including error responses)
  - Returns `undefined` on network errors or configuration issues
  - Still logs all errors for debugging purposes

- **`sendTestEmail()` function**: Updated to return the status from `sendEmail()`
  - Changed return type from `Promise<void>` to `Promise<number | undefined>`

- **Email test endpoint** (`/admin/settings/email/test`):
  - Now checks the returned status code
  - Returns 500 error page with descriptive message if status is missing, < 200, or >= 300
  - Returns success redirect with status code included in message for successful sends (2xx)
  - Displays "status unknown" when network errors occur

- **Test coverage**: Updated and added tests to verify:
  - Status code is returned on successful sends
  - Status code is returned on HTTP error responses
  - Appropriate error messages are shown for API failures and network errors
  - Test descriptions clarified to reflect new behavior

## Implementation Details
- The functions continue to log errors internally for observability
- Callers can now distinguish between HTTP errors (status code returned) and network/configuration errors (undefined returned)
- The admin settings page provides immediate feedback on email configuration issues

https://claude.ai/code/session_01BFv3ZvNGgbUcZhdodR7mmg