### PR TITLE
Add email notifications documentation to admin guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 
 These measures aim to raise the cost of common attacks. They do not guarantee security against all scenarios — proper operational practices (key management, access control, monitoring) are equally important.
 
+### Email Notifications
+- Automatic confirmation email to attendees and notification email to admins on each registration
+- Five HTTP API providers: Resend, Postmark, SendGrid, Mailgun (US/EU)
+- Configured in admin settings — optional, system works without it
+
 ### Webhooks
 - Outbound POST on every registration (free or paid) to per-event and/or global webhook URLs
 - Payload: name, email, phone, address, amount, currency, payment ID, ticket URL, per-ticket details

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -890,6 +890,102 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
       </Section>
 
+      <Section title="Email Notifications">
+        <Q q="What are email notifications?">
+          <p>
+            When configured, the system automatically sends two emails after
+            each successful registration: a <strong>confirmation email</strong>{" "}
+            to the attendee with their ticket details and link, and a{" "}
+            <strong>notification email</strong> to the business email address
+            letting you know someone has booked. Emails are sent in the
+            background and won't delay the booking process.
+          </p>
+        </Q>
+
+        <Q q="Which email providers are supported?">
+          <p>
+            Five providers are supported, all using HTTP APIs (no SMTP
+            required):
+          </p>
+          <ul>
+            <li><strong>Resend</strong></li>
+            <li><strong>Postmark</strong></li>
+            <li><strong>SendGrid</strong></li>
+            <li><strong>Mailgun (US)</strong></li>
+            <li><strong>Mailgun (EU)</strong></li>
+          </ul>
+          <p>
+            All providers work the same way &mdash; choose whichever you
+            already have an account with or whichever offers a free tier that
+            suits your volume.
+          </p>
+        </Q>
+
+        <Q q="How do I set up email?">
+          <ol>
+            <li>
+              Go to <a href="/admin/settings">Settings</a> and find the{" "}
+              <strong>Email</strong> section
+            </li>
+            <li>
+              Choose your email provider from the dropdown
+            </li>
+            <li>
+              Paste your provider's API key into the{" "}
+              <strong>API Key</strong> field
+            </li>
+            <li>
+              Enter a <strong>From Address</strong> &mdash; this is the sender
+              address that appears on outgoing emails. If left blank, the
+              business email address is used instead
+            </li>
+            <li>Save the settings</li>
+          </ol>
+          <p>
+            The from address must be a verified sender in your email provider's
+            account, otherwise emails will be rejected. Check your provider's
+            documentation for how to verify a sender domain or address.
+          </p>
+        </Q>
+
+        <Q q="How do I test that email is working?">
+          <p>
+            After saving your email settings, a <strong>Send Test
+            Email</strong> button appears. Click it to send a test email to
+            your business email address. If the test fails, you'll see an
+            error with the HTTP status code from your provider &mdash; check
+            that your API key is correct and your from address is verified.
+          </p>
+        </Q>
+
+        <Q q="What if email is not configured?">
+          <p>
+            Email is entirely optional. If no provider is selected, the system
+            skips sending emails silently. Registrations, payments, webhooks,
+            and everything else continue to work normally.
+          </p>
+        </Q>
+
+        <Q q="What does the confirmation email contain?">
+          <p>
+            The attendee receives an email with the event name(s), quantity,
+            price paid, and a clickable link to their ticket page. For
+            multi-event bookings, all events are listed in a single email. The
+            business email is set as the reply-to address so attendees can
+            reply directly to you.
+          </p>
+        </Q>
+
+        <Q q="What does the admin notification email contain?">
+          <p>
+            You receive an email showing the attendee's name, email, phone,
+            address, and any special instructions, along with the event
+            name(s), quantity, and price. The attendee's email is set as the
+            reply-to address so you can reply directly to them.
+          </p>
+        </Q>
+      </Section>
+
       <Section title="Settings Overview">
         <Q q="What settings are available?">
           <p>
@@ -912,6 +1008,10 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             <li>
               <strong>Payment provider</strong> &mdash; Stripe, Square, or
               none
+            </li>
+            <li>
+              <strong>Email provider</strong> &mdash; Resend, Postmark,
+              SendGrid, or Mailgun for automatic registration emails
             </li>
             <li>
               <strong>Embed hosts</strong> &mdash; restrict which websites can

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -893,12 +893,13 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
       <Section title="Email Notifications">
         <Q q="What are email notifications?">
           <p>
-            When configured, the system automatically sends two emails after
+            When configured, the system can send up to two emails after
             each successful registration: a <strong>confirmation email</strong>{" "}
-            to the attendee with their ticket details and link, and a{" "}
+            to the attendee (if they provided an email address) with their
+            ticket details and link, and a{" "}
             <strong>notification email</strong> to the business email address
-            letting you know someone has booked. Emails are sent in the
-            background and won't delay the booking process.
+            (if one is set) letting you know someone has booked. Emails are
+            sent in the background and won't delay the booking process.
           </p>
         </Q>
 


### PR DESCRIPTION
## Summary
Added comprehensive documentation for the email notifications feature to the admin guide, including setup instructions, provider information, and details about confirmation and notification emails. Also updated the README with a brief overview of the email notifications capability.

## Key Changes
- **Admin Guide**: Added new "Email Notifications" section with 7 Q&A entries covering:
  - What email notifications are and how they work
  - Supported email providers (Resend, Postmark, SendGrid, Mailgun US/EU)
  - Step-by-step setup instructions
  - Testing procedures
  - Behavior when email is not configured
  - Content details for both confirmation and admin notification emails
- **Settings Overview**: Updated the settings list to include email provider as a configurable option
- **README**: Added "Email Notifications" section highlighting the feature and its configuration

## Implementation Details
- Documentation follows the existing Q&A format used throughout the admin guide
- Includes practical guidance on API key configuration and sender verification requirements
- Clarifies that email is optional and the system functions normally without it
- Provides clear expectations about email content for both attendees and admins

https://claude.ai/code/session_01Fczb66Z5Qc6NK6d6kE3HFp