### PR TITLE
Add guide page styling with increased h3 margin

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1362,3 +1362,8 @@ button.secondary:hover {
 #email_provider:has(option[value=""]:checked) ~ #email_from_address {
   display: none;
 }
+
+/* Guide page */
+body.guide h3 {
+  margin-top: 3rem;
+}

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -43,7 +43,7 @@ const Q = ({
  */
 export const adminGuidePage = (adminSession: AdminSession): string =>
   String(
-    <Layout title="Guide">
+    <Layout title="Guide" bodyClass="guide">
       <AdminNav session={adminSession} active="/admin/guide" />
 
       <h2>Guide</h2>


### PR DESCRIPTION
## Summary
This PR adds CSS styling specifically for the guide page to improve visual spacing of heading elements.

## Changes
- Added `bodyClass="guide"` to the guide page layout to enable page-specific styling
- Added CSS rule for guide page h3 elements with `margin-top: 3rem` to increase spacing between sections

## Implementation Details
The changes use a body class selector pattern to scope the h3 margin styling only to the guide page, preventing unintended side effects on other pages. This provides better visual hierarchy and readability for guide content sections.

https://claude.ai/code/session_01JU6LW6S5ho3QG52LGZ7brb