### PR TITLE
Auto-discover Bunny CDN pull zone ID instead of requiring env var

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -1,23 +1,75 @@
 /**
  * Bunny CDN pull zone API integration.
  * Adds a custom hostname to a pull zone and enables force SSL.
- * Only used when BUNNY_API_KEY and BUNNY_PULL_ZONE_ID env vars are set.
+ * Only used when BUNNY_API_KEY env var is set.
+ * The pull zone ID is discovered automatically by matching hostnames.
  */
 
-import { getBunnyApiKey, getBunnyPullZoneId } from "#lib/config.ts";
+import { getBunnyApiKey, getCdnHostname } from "#lib/config.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 
 const BUNNY_API_BASE = "https://api.bunny.net";
 
 type BunnyApiResult = { ok: true } | { ok: false; error: string };
 
+interface BunnyHostname {
+  Value: string;
+}
+
+interface BunnyPullZone {
+  Id: number;
+  Hostnames: BunnyHostname[];
+}
+
+interface BunnyPullZoneListResponse {
+  Items: BunnyPullZone[];
+  HasMoreItems: boolean;
+}
+
+/**
+ * Find the pull zone ID by listing all pull zones and matching the one
+ * whose hostname matches the CDN hostname (ALLOWED_DOMAIN with
+ * .bunny.run replaced by .b-cdn.net).
+ */
+const findPullZoneIdImpl = async (): Promise<
+  { ok: true; id: number } | { ok: false; error: string }
+> => {
+  const cdnHostname = getCdnHostname();
+  const response = await fetch(`${BUNNY_API_BASE}/pullzone?perPage=1000`, {
+    headers: { AccessKey: getBunnyApiKey() },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    return {
+      ok: false,
+      error: `List pull zones failed (${response.status}): ${text}`,
+    };
+  }
+
+  const data: BunnyPullZoneListResponse = await response.json();
+  const zone = data.Items.find((z) =>
+    z.Hostnames.some((h) => h.Value === cdnHostname)
+  );
+
+  if (!zone) {
+    return {
+      ok: false,
+      error: `No pull zone found with hostname ${cdnHostname}`,
+    };
+  }
+
+  return { ok: true, id: zone.Id };
+};
+
 /** POST to a Bunny CDN pull zone endpoint with JSON body. */
 const pullZonePost = async (
+  pullZoneId: number,
   action: string,
   body: Record<string, unknown>,
   label: string,
 ): Promise<BunnyApiResult> => {
-  const url = `${BUNNY_API_BASE}/pullzone/${getBunnyPullZoneId()}/${action}`;
+  const url = `${BUNNY_API_BASE}/pullzone/${pullZoneId}/${action}`;
 
   const response = await fetch(url, {
     method: "POST",
@@ -38,7 +90,16 @@ const pullZonePost = async (
 const validateCustomDomainImpl = async (
   hostname: string,
 ): Promise<BunnyApiResult> => {
+  const zoneResult = await bunnyCdnApi.findPullZoneId();
+  if (!zoneResult.ok) {
+    logError({ code: ErrorCode.CDN_REQUEST, detail: zoneResult.error });
+    return zoneResult;
+  }
+
+  const pullZoneId = zoneResult.id;
+
   const hostnameResult = await pullZonePost(
+    pullZoneId,
     "addHostname",
     { Hostname: hostname },
     "Add hostname",
@@ -49,6 +110,7 @@ const validateCustomDomainImpl = async (
   }
 
   const sslResult = await pullZonePost(
+    pullZoneId,
     "setForceSSL",
     { Hostname: hostname, ForceSSL: true },
     "Set force SSL",
@@ -64,6 +126,7 @@ const validateCustomDomainImpl = async (
 /** Stubbable API for testing */
 export const bunnyCdnApi = {
   validateCustomDomain: validateCustomDomainImpl,
+  findPullZoneId: findPullZoneIdImpl,
 };
 
 /** Validate a custom domain (delegates to bunnyCdnApi for testability). */

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -27,17 +27,17 @@ interface BunnyPullZoneListResponse {
 }
 
 /**
- * Find the pull zone ID by listing all pull zones and matching the one
- * whose hostname matches the CDN hostname (ALLOWED_DOMAIN with
- * .bunny.run replaced by .b-cdn.net).
+ * Find the pull zone ID by searching pull zones for the CDN hostname
+ * (ALLOWED_DOMAIN with .bunny.run replaced by .b-cdn.net).
  */
 const findPullZoneIdImpl = async (): Promise<
   { ok: true; id: number } | { ok: false; error: string }
 > => {
   const cdnHostname = getCdnHostname();
-  const response = await fetch(`${BUNNY_API_BASE}/pullzone?perPage=1000`, {
-    headers: { AccessKey: getBunnyApiKey() },
-  });
+  const response = await fetch(
+    `${BUNNY_API_BASE}/pullzone?search=${encodeURIComponent(cdnHostname)}`,
+    { headers: { AccessKey: getBunnyApiKey() } },
+  );
 
   if (!response.ok) {
     const text = await response.text();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -142,23 +142,14 @@ export { isSetupComplete };
 
 /**
  * Check if Bunny CDN pull zone management is enabled
- * Requires both BUNNY_API_KEY and BUNNY_PULL_ZONE_ID to be set
+ * Requires BUNNY_API_KEY to be set
  */
-export const isBunnyCdnEnabled = (): boolean => {
-  const apiKey = getEnv("BUNNY_API_KEY");
-  const pullZoneId = getEnv("BUNNY_PULL_ZONE_ID");
-  return !!apiKey && !!pullZoneId;
-};
+export const isBunnyCdnEnabled = (): boolean => !!getEnv("BUNNY_API_KEY");
 
 /**
  * Get the Bunny CDN API key from environment
  */
 export const getBunnyApiKey = (): string => requireEnv("BUNNY_API_KEY");
-
-/**
- * Get the Bunny CDN pull zone ID from environment
- */
-export const getBunnyPullZoneId = (): string => requireEnv("BUNNY_PULL_ZONE_ID");
 
 /**
  * Get the CDN hostname derived from ALLOWED_DOMAIN.

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -156,7 +156,7 @@ describe("bunny-cdn", () => {
           await bunnyCdnApi.findPullZoneId();
           expect(calls).toHaveLength(1);
           expect(calls.at(0)!.url).toBe(
-            "https://api.bunny.net/pullzone?perPage=1000",
+            "https://api.bunny.net/pullzone?search=mysite.b-cdn.net",
           );
           expect(calls.at(0)!.init!.headers).toEqual({
             AccessKey: "test-bunny-key",

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -4,7 +4,6 @@ import { stub } from "@std/testing/mock";
 import { bunnyCdnApi, validateCustomDomain } from "#lib/bunny-cdn.ts";
 import {
   getBunnyApiKey,
-  getBunnyPullZoneId,
   getCdnHostname,
   isBunnyCdnEnabled,
 } from "#lib/config.ts";
@@ -19,36 +18,19 @@ import { createTestDb, resetDb, withMocks } from "#test-utils";
 describe("bunny-cdn", () => {
   describe("isBunnyCdnEnabled", () => {
     const origApiKey = Deno.env.get("BUNNY_API_KEY");
-    const origPullZoneId = Deno.env.get("BUNNY_PULL_ZONE_ID");
 
     afterEach(() => {
       if (origApiKey) Deno.env.set("BUNNY_API_KEY", origApiKey);
       else Deno.env.delete("BUNNY_API_KEY");
-      if (origPullZoneId) Deno.env.set("BUNNY_PULL_ZONE_ID", origPullZoneId);
-      else Deno.env.delete("BUNNY_PULL_ZONE_ID");
     });
 
-    test("returns false when neither env var is set", () => {
+    test("returns false when BUNNY_API_KEY is not set", () => {
       Deno.env.delete("BUNNY_API_KEY");
-      Deno.env.delete("BUNNY_PULL_ZONE_ID");
       expect(isBunnyCdnEnabled()).toBe(false);
     });
 
-    test("returns false when only BUNNY_API_KEY is set", () => {
+    test("returns true when BUNNY_API_KEY is set", () => {
       Deno.env.set("BUNNY_API_KEY", "test-key");
-      Deno.env.delete("BUNNY_PULL_ZONE_ID");
-      expect(isBunnyCdnEnabled()).toBe(false);
-    });
-
-    test("returns false when only BUNNY_PULL_ZONE_ID is set", () => {
-      Deno.env.delete("BUNNY_API_KEY");
-      Deno.env.set("BUNNY_PULL_ZONE_ID", "12345");
-      expect(isBunnyCdnEnabled()).toBe(false);
-    });
-
-    test("returns true when both env vars are set", () => {
-      Deno.env.set("BUNNY_API_KEY", "test-key");
-      Deno.env.set("BUNNY_PULL_ZONE_ID", "12345");
       expect(isBunnyCdnEnabled()).toBe(true);
     });
   });
@@ -97,114 +79,304 @@ describe("bunny-cdn", () => {
     });
   });
 
-  describe("getBunnyApiKey / getBunnyPullZoneId", () => {
+  describe("getBunnyApiKey", () => {
     const origApiKey = Deno.env.get("BUNNY_API_KEY");
-    const origPullZoneId = Deno.env.get("BUNNY_PULL_ZONE_ID");
 
     afterEach(() => {
       if (origApiKey) Deno.env.set("BUNNY_API_KEY", origApiKey);
       else Deno.env.delete("BUNNY_API_KEY");
-      if (origPullZoneId) Deno.env.set("BUNNY_PULL_ZONE_ID", origPullZoneId);
-      else Deno.env.delete("BUNNY_PULL_ZONE_ID");
     });
 
     test("getBunnyApiKey returns the env var value", () => {
       Deno.env.set("BUNNY_API_KEY", "my-api-key");
       expect(getBunnyApiKey()).toBe("my-api-key");
     });
-
-    test("getBunnyPullZoneId returns the env var value", () => {
-      Deno.env.set("BUNNY_PULL_ZONE_ID", "99999");
-      expect(getBunnyPullZoneId()).toBe("99999");
-    });
   });
 
-  describe("validateCustomDomain (real implementation)", () => {
+  describe("findPullZoneId", () => {
     const origApiKey = Deno.env.get("BUNNY_API_KEY");
-    const origPullZoneId = Deno.env.get("BUNNY_PULL_ZONE_ID");
+    const origDomain = Deno.env.get("ALLOWED_DOMAIN");
 
     beforeEach(() => {
       Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
-      Deno.env.set("BUNNY_PULL_ZONE_ID", "12345");
+      Deno.env.set("ALLOWED_DOMAIN", "mysite.bunny.run");
     });
 
     afterEach(() => {
       if (origApiKey) Deno.env.set("BUNNY_API_KEY", origApiKey);
       else Deno.env.delete("BUNNY_API_KEY");
-      if (origPullZoneId) Deno.env.set("BUNNY_PULL_ZONE_ID", origPullZoneId);
-      else Deno.env.delete("BUNNY_PULL_ZONE_ID");
+      if (origDomain) Deno.env.set("ALLOWED_DOMAIN", origDomain);
+      else Deno.env.delete("ALLOWED_DOMAIN");
     });
 
-    test("returns ok when both API calls succeed", async () => {
+    test("returns pull zone ID when matching hostname is found", async () => {
       await withMocks(
-        () => stub(globalThis, "fetch", () => Promise.resolve(new Response(null, { status: 204 }))),
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  Items: [
+                    { Id: 111, Hostnames: [{ Value: "other.b-cdn.net" }] },
+                    { Id: 222, Hostnames: [{ Value: "mysite.b-cdn.net" }] },
+                  ],
+                  HasMoreItems: false,
+                }),
+              ),
+            )),
         async () => {
-          const result = await bunnyCdnApi.validateCustomDomain("cdn.example.com");
-          expect(result).toEqual({ ok: true });
+          const result = await bunnyCdnApi.findPullZoneId();
+          expect(result).toEqual({ ok: true, id: 222 });
         },
       );
+    });
+
+    test("sends correct request to Bunny API", async () => {
+      const calls: { url: string; init: RequestInit | undefined }[] = [];
+      await withMocks(
+        () =>
+          stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request, init?: RequestInit) => {
+              calls.push({ url: String(input), init });
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    Items: [
+                      { Id: 42, Hostnames: [{ Value: "mysite.b-cdn.net" }] },
+                    ],
+                    HasMoreItems: false,
+                  }),
+                ),
+              );
+            },
+          ),
+        async () => {
+          await bunnyCdnApi.findPullZoneId();
+          expect(calls).toHaveLength(1);
+          expect(calls.at(0)!.url).toBe(
+            "https://api.bunny.net/pullzone?perPage=1000",
+          );
+          expect(calls.at(0)!.init!.headers).toEqual({
+            AccessKey: "test-bunny-key",
+          });
+        },
+      );
+    });
+
+    test("returns error when no matching pull zone is found", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  Items: [
+                    { Id: 111, Hostnames: [{ Value: "other.b-cdn.net" }] },
+                  ],
+                  HasMoreItems: false,
+                }),
+              ),
+            )),
+        async () => {
+          const result = await bunnyCdnApi.findPullZoneId();
+          expect(result).toEqual({
+            ok: false,
+            error: "No pull zone found with hostname mysite.b-cdn.net",
+          });
+        },
+      );
+    });
+
+    test("returns error when API request fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response("Unauthorized", { status: 401 }),
+            )),
+        async () => {
+          const result = await bunnyCdnApi.findPullZoneId();
+          expect(result).toEqual({
+            ok: false,
+            error: "List pull zones failed (401): Unauthorized",
+          });
+        },
+      );
+    });
+  });
+
+  describe("validateCustomDomain (real implementation)", () => {
+    const origApiKey = Deno.env.get("BUNNY_API_KEY");
+    const origDomain = Deno.env.get("ALLOWED_DOMAIN");
+
+    beforeEach(() => {
+      Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
+      Deno.env.set("ALLOWED_DOMAIN", "mysite.bunny.run");
+    });
+
+    afterEach(() => {
+      if (origApiKey) Deno.env.set("BUNNY_API_KEY", origApiKey);
+      else Deno.env.delete("BUNNY_API_KEY");
+      if (origDomain) Deno.env.set("ALLOWED_DOMAIN", origDomain);
+      else Deno.env.delete("ALLOWED_DOMAIN");
+    });
+
+    /** Helper: stub findPullZoneId to return a fixed ID */
+    const withFixedPullZoneId = (
+      fn: () => Promise<void>,
+    ): Promise<void> => {
+      const original = bunnyCdnApi.findPullZoneId;
+      bunnyCdnApi.findPullZoneId = () =>
+        Promise.resolve({ ok: true as const, id: 12345 });
+      return fn().finally(() => {
+        bunnyCdnApi.findPullZoneId = original;
+      });
+    };
+
+    test("returns ok when all API calls succeed", async () => {
+      await withFixedPullZoneId(async () => {
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () =>
+              Promise.resolve(new Response(null, { status: 204 }))),
+          async () => {
+            const result = await bunnyCdnApi.validateCustomDomain(
+              "cdn.example.com",
+            );
+            expect(result).toEqual({ ok: true });
+          },
+        );
+      });
     });
 
     test("sends correct requests to Bunny API", async () => {
-      const calls: { url: string; init: RequestInit }[] = [];
-      await withMocks(
-        () => stub(globalThis, "fetch", (input: string | URL | Request, init?: RequestInit) => {
-          calls.push({ url: String(input), init: init! });
-          return Promise.resolve(new Response(null, { status: 204 }));
-        }),
-        async () => {
-          await bunnyCdnApi.validateCustomDomain("cdn.example.com");
-          expect(calls).toHaveLength(2);
-          const addCall = calls.at(0)!;
-          const sslCall = calls.at(1)!;
-          expect(addCall.url).toBe("https://api.bunny.net/pullzone/12345/addHostname");
-          expect(addCall.init.method).toBe("POST");
-          expect(addCall.init.headers).toEqual({ AccessKey: "test-bunny-key", "Content-Type": "application/json" });
-          expect(JSON.parse(addCall.init.body as string)).toEqual({ Hostname: "cdn.example.com" });
-          expect(sslCall.url).toBe("https://api.bunny.net/pullzone/12345/setForceSSL");
-          expect(JSON.parse(sslCall.init.body as string)).toEqual({ Hostname: "cdn.example.com", ForceSSL: true });
-        },
-      );
+      await withFixedPullZoneId(async () => {
+        const calls: { url: string; init: RequestInit }[] = [];
+        await withMocks(
+          () =>
+            stub(
+              globalThis,
+              "fetch",
+              (input: string | URL | Request, init?: RequestInit) => {
+                calls.push({ url: String(input), init: init! });
+                return Promise.resolve(new Response(null, { status: 204 }));
+              },
+            ),
+          async () => {
+            await bunnyCdnApi.validateCustomDomain("cdn.example.com");
+            expect(calls).toHaveLength(2);
+            const addCall = calls.at(0)!;
+            const sslCall = calls.at(1)!;
+            expect(addCall.url).toBe(
+              "https://api.bunny.net/pullzone/12345/addHostname",
+            );
+            expect(addCall.init.method).toBe("POST");
+            expect(addCall.init.headers).toEqual({
+              AccessKey: "test-bunny-key",
+              "Content-Type": "application/json",
+            });
+            expect(JSON.parse(addCall.init.body as string)).toEqual({
+              Hostname: "cdn.example.com",
+            });
+            expect(sslCall.url).toBe(
+              "https://api.bunny.net/pullzone/12345/setForceSSL",
+            );
+            expect(JSON.parse(sslCall.init.body as string)).toEqual({
+              Hostname: "cdn.example.com",
+              ForceSSL: true,
+            });
+          },
+        );
+      });
+    });
+
+    test("returns error when findPullZoneId fails", async () => {
+      const original = bunnyCdnApi.findPullZoneId;
+      bunnyCdnApi.findPullZoneId = () =>
+        Promise.resolve({
+          ok: false as const,
+          error: "No pull zone found with hostname mysite.b-cdn.net",
+        });
+      try {
+        const result = await bunnyCdnApi.validateCustomDomain(
+          "cdn.example.com",
+        );
+        expect(result).toEqual({
+          ok: false,
+          error: "No pull zone found with hostname mysite.b-cdn.net",
+        });
+      } finally {
+        bunnyCdnApi.findPullZoneId = original;
+      }
     });
 
     test("returns error when addHostname fails", async () => {
-      await withMocks(
-        () => stub(globalThis, "fetch", () =>
-          Promise.resolve(new Response("Hostname already exists", { status: 400 }))),
-        async () => {
-          const result = await bunnyCdnApi.validateCustomDomain("cdn.example.com");
-          expect(result).toEqual({ ok: false, error: "Add hostname failed (400): Hostname already exists" });
-        },
-      );
+      await withFixedPullZoneId(async () => {
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () =>
+              Promise.resolve(
+                new Response("Hostname already exists", { status: 400 }),
+              )),
+          async () => {
+            const result = await bunnyCdnApi.validateCustomDomain(
+              "cdn.example.com",
+            );
+            expect(result).toEqual({
+              ok: false,
+              error: "Add hostname failed (400): Hostname already exists",
+            });
+          },
+        );
+      });
     });
 
     test("does not call setForceSSL when addHostname fails", async () => {
-      let callCount = 0;
-      await withMocks(
-        () => stub(globalThis, "fetch", () => {
-          callCount++;
-          return Promise.resolve(new Response("Bad request", { status: 400 }));
-        }),
-        async () => {
-          await bunnyCdnApi.validateCustomDomain("cdn.example.com");
-          expect(callCount).toBe(1);
-        },
-      );
+      await withFixedPullZoneId(async () => {
+        let callCount = 0;
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () => {
+              callCount++;
+              return Promise.resolve(
+                new Response("Bad request", { status: 400 }),
+              );
+            }),
+          async () => {
+            await bunnyCdnApi.validateCustomDomain("cdn.example.com");
+            expect(callCount).toBe(1);
+          },
+        );
+      });
     });
 
     test("returns error when setForceSSL fails", async () => {
-      let callCount = 0;
-      await withMocks(
-        () => stub(globalThis, "fetch", () => {
-          callCount++;
-          if (callCount === 1) return Promise.resolve(new Response(null, { status: 204 }));
-          return Promise.resolve(new Response("SSL error", { status: 500 }));
-        }),
-        async () => {
-          const result = await bunnyCdnApi.validateCustomDomain("cdn.example.com");
-          expect(result).toEqual({ ok: false, error: "Set force SSL failed (500): SSL error" });
-        },
-      );
+      await withFixedPullZoneId(async () => {
+        let callCount = 0;
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () => {
+              callCount++;
+              if (callCount === 1) {
+                return Promise.resolve(new Response(null, { status: 204 }));
+              }
+              return Promise.resolve(
+                new Response("SSL error", { status: 500 }),
+              );
+            }),
+          async () => {
+            const result = await bunnyCdnApi.validateCustomDomain(
+              "cdn.example.com",
+            );
+            expect(result).toEqual({
+              ok: false,
+              error: "Set force SSL failed (500): SSL error",
+            });
+          },
+        );
+      });
     });
   });
 

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2735,11 +2735,9 @@ describe("server (admin settings)", () => {
   describe("custom domain", () => {
     const setBunnyEnv = () => {
       Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
-      Deno.env.set("BUNNY_PULL_ZONE_ID", "12345");
     };
     const clearBunnyEnv = () => {
       Deno.env.delete("BUNNY_API_KEY");
-      Deno.env.delete("BUNNY_PULL_ZONE_ID");
     };
 
     afterEach(() => {


### PR DESCRIPTION
## Summary
Removes the requirement for the `BUNNY_PULL_ZONE_ID` environment variable by implementing automatic pull zone discovery. The pull zone ID is now found by searching the Bunny CDN API for a pull zone with a hostname matching the configured CDN hostname.

## Key Changes
- **Removed `BUNNY_PULL_ZONE_ID` environment variable requirement**: `isBunnyCdnEnabled()` now only checks for `BUNNY_API_KEY`
- **Removed `getBunnyPullZoneId()` function**: No longer needed since the ID is discovered dynamically
- **Added `findPullZoneId()` function**: New API method that queries Bunny CDN's pull zone list endpoint, searching for a zone with a hostname matching the derived CDN hostname (ALLOWED_DOMAIN with `.bunny.run` replaced by `.b-cdn.net`)
- **Updated `validateCustomDomain()`**: Now calls `findPullZoneId()` first to obtain the pull zone ID before making hostname and SSL configuration requests
- **Updated tests**: Refactored test suite to remove `BUNNY_PULL_ZONE_ID` references and added comprehensive tests for the new `findPullZoneId()` function, including error cases

## Implementation Details
- The CDN hostname is derived from the existing `getCdnHostname()` config function
- Pull zone discovery uses the Bunny API's `/pullzone?search=` endpoint with the AccessKey header
- If no matching pull zone is found, an error is returned and logged before attempting hostname validation
- The `findPullZoneId()` method is exposed on the `bunnyCdnApi` object for testability

https://claude.ai/code/session_01MM7ESFaAYtYa4DUmEiDYCq