### PR TITLE
Extract Message field from JSON error responses in Bunny CDN API

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -80,7 +80,12 @@ const pullZonePost = async (
   if (response.status === 204 || response.ok) return { ok: true };
 
   const text = await response.text();
-  return { ok: false, error: `${label} failed (${response.status}): ${text}` };
+  let message = text;
+  try {
+    const json = JSON.parse(text);
+    if (json.Message) message = json.Message;
+  } catch { /* use raw text */ }
+  return { ok: false, error: `${label} failed (${response.status}): ${message}` };
 };
 
 /**

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -333,6 +333,33 @@ describe("bunny-cdn", () => {
       });
     });
 
+    test("extracts Message from JSON error response", async () => {
+      await withFixedPullZoneId(async () => {
+        const jsonBody = JSON.stringify({
+          ErrorKey: "pullzone.hostname_already_registered",
+          Field: "Hostname",
+          Message: "The hostname is already registered.",
+        });
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () =>
+              Promise.resolve(
+                new Response(jsonBody, { status: 400 }),
+              )),
+          async () => {
+            const result = await bunnyCdnApi.validateCustomDomain(
+              "cdn.example.com",
+            );
+            expect(result).toEqual({
+              ok: false,
+              error:
+                "Add hostname failed (400): The hostname is already registered.",
+            });
+          },
+        );
+      });
+    });
+
     test("does not call setForceSSL when addHostname fails", async () => {
       await withFixedPullZoneId(async () => {
         let callCount = 0;


### PR DESCRIPTION
## Summary
Improved error handling in the Bunny CDN API client to extract and display user-friendly error messages from JSON error responses, rather than returning raw JSON strings.

## Key Changes
- Modified `pullZonePost` function to parse JSON error responses and extract the `Message` field when available
- Falls back to raw response text if the response is not valid JSON or lacks a `Message` field
- Added test case to verify that the `Message` field is correctly extracted from JSON error responses

## Implementation Details
The error handling now attempts to parse the response body as JSON and checks for a `Message` property. If found, this message is used in the error response instead of the raw text. This provides clearer, more user-friendly error messages (e.g., "The hostname is already registered." instead of the full JSON object). The implementation gracefully handles non-JSON responses by catching parse errors and using the original text as a fallback.

https://claude.ai/code/session_01TsCVDqPbciNWfHyXtQvqZk