### PR TITLE
Fix payment webhook body reading in edge runtime

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -741,21 +741,23 @@ const extractSessionIdFromObject = (obj: Record<string, unknown>): string | null
  * Primary handler for payment completion - more reliable than redirects.
  */
 const handlePaymentWebhook = async (request: Request): Promise<Response> => {
-  const provider = await getActivePaymentProvider();
-  if (!provider) {
-    return plainResponse("Payment provider not configured", 400);
-  }
+  // Read raw body bytes FIRST, before any async work. The Bunny Edge runtime
+  // can garbage-collect the underlying request body resource during awaits
+  // (e.g. dynamic imports in getActivePaymentProvider), causing "BadResource:
+  // Cannot read body as underlying resource unavailable" errors.
+  const payloadBytes = new Uint8Array(await request.arrayBuffer());
 
-  // Get signature header
+  // Get signature header (sync — headers are always available)
   const signature = getWebhookSignatureHeader(request);
   if (!signature) {
     return plainResponse("Missing signature", 400);
   }
 
-  // Read raw body bytes for signature verification. Using arrayBuffer() and
-  // passing raw bytes to the HMAC avoids a text decoding/encoding round-trip
-  // that can silently alter the payload in CDN edge runtimes.
-  const payloadBytes = new Uint8Array(await request.arrayBuffer());
+  const provider = await getActivePaymentProvider();
+  if (!provider) {
+    return plainResponse("Payment provider not configured", 400);
+  }
+
   const payload = new TextDecoder().decode(payloadBytes);
 
   // Use the public-facing domain for signature verification. Square signs the


### PR DESCRIPTION
## Summary
Reordered operations in the payment webhook handler to read the request body before performing async operations. This prevents resource garbage collection issues in Bunny Edge runtime that can cause "BadResource" errors when the underlying request body is deallocated during awaits.

## Key Changes
- Moved `request.arrayBuffer()` call to the beginning of `handlePaymentWebhook`, before any async operations like `getActivePaymentProvider()`
- Reordered provider validation to occur after body reading
- Updated comments to clarify the timing requirements and explain why this ordering is necessary for edge runtime compatibility

## Implementation Details
The Bunny Edge runtime can garbage-collect the underlying request body resource during async operations (such as dynamic imports). By reading the raw body bytes synchronously at the start of the handler, we ensure the resource remains available for signature verification. This avoids silent payload corruption that could occur from text encoding/decoding round-trips in CDN edge environments.

https://claude.ai/code/session_01Kvv8S5X1kMwq8xVE2HSZtJ