### PR TITLE
Handle hostname_already_registered as success in domain validation

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -10,7 +10,11 @@ import { ErrorCode, logError } from "#lib/logger.ts";
 
 const BUNNY_API_BASE = "https://api.bunny.net";
 
-type BunnyApiResult = { ok: true } | { ok: false; error: string };
+type BunnyApiResult =
+  | { ok: true }
+  | { ok: false; error: string; errorKey?: string };
+
+const HOSTNAME_ALREADY_REGISTERED = "pullzone.hostname_already_registered";
 
 interface BunnyHostname {
   Value: string;
@@ -81,11 +85,13 @@ const pullZonePost = async (
 
   const text = await response.text();
   let message = text;
+  let errorKey: string | undefined;
   try {
     const json = JSON.parse(text);
     if (json.Message) message = json.Message;
+    if (json.ErrorKey) errorKey = json.ErrorKey;
   } catch { /* use raw text */ }
-  return { ok: false, error: `${label} failed (${response.status}): ${message}` };
+  return { ok: false, error: `${label} failed (${response.status}): ${message}`, errorKey };
 };
 
 /**
@@ -109,7 +115,10 @@ const validateCustomDomainImpl = async (
     { Hostname: hostname },
     "Add hostname",
   );
-  if (!hostnameResult.ok) {
+  if (
+    !hostnameResult.ok &&
+    hostnameResult.errorKey !== HOSTNAME_ALREADY_REGISTERED
+  ) {
     logError({ code: ErrorCode.CDN_REQUEST, detail: hostnameResult.error });
     return hostnameResult;
   }

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -336,9 +336,9 @@ describe("bunny-cdn", () => {
     test("extracts Message from JSON error response", async () => {
       await withFixedPullZoneId(async () => {
         const jsonBody = JSON.stringify({
-          ErrorKey: "pullzone.hostname_already_registered",
+          ErrorKey: "pullzone.some_other_error",
           Field: "Hostname",
-          Message: "The hostname is already registered.",
+          Message: "Something went wrong.",
         });
         await withMocks(
           () =>
@@ -353,8 +353,39 @@ describe("bunny-cdn", () => {
             expect(result).toEqual({
               ok: false,
               error:
-                "Add hostname failed (400): The hostname is already registered.",
+                "Add hostname failed (400): Something went wrong.",
+              errorKey: "pullzone.some_other_error",
             });
+          },
+        );
+      });
+    });
+
+    test("treats hostname_already_registered as success", async () => {
+      await withFixedPullZoneId(async () => {
+        let callCount = 0;
+        const jsonBody = JSON.stringify({
+          ErrorKey: "pullzone.hostname_already_registered",
+          Field: "Hostname",
+          Message: "The hostname is already registered.",
+        });
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () => {
+              callCount++;
+              if (callCount === 1) {
+                return Promise.resolve(
+                  new Response(jsonBody, { status: 400 }),
+                );
+              }
+              return Promise.resolve(new Response(null, { status: 204 }));
+            }),
+          async () => {
+            const result = await bunnyCdnApi.validateCustomDomain(
+              "cdn.example.com",
+            );
+            expect(result).toEqual({ ok: true });
+            expect(callCount).toBe(2);
           },
         );
       });


### PR DESCRIPTION
## Summary
Modified the custom domain validation logic to treat the `pullzone.hostname_already_registered` error as a successful outcome, since a hostname that's already registered doesn't need to be added again.

## Key Changes
- Updated `BunnyApiResult` type to include an optional `errorKey` field for error responses
- Modified `pullZonePost` to extract and return the `ErrorKey` from JSON error responses
- Added special handling in `validateCustomDomainImpl` to continue validation when `hostname_already_registered` error is encountered, rather than treating it as a failure
- Added test case verifying that `hostname_already_registered` errors trigger a retry that succeeds
- Updated existing test to use a generic error case instead of the hostname-already-registered scenario

## Implementation Details
- The `HOSTNAME_ALREADY_REGISTERED` constant is defined to avoid magic strings
- When the add hostname request fails with `hostname_already_registered`, the validation now proceeds to the next step (setForceSSL) instead of returning an error
- The error response now includes the `errorKey` field to allow callers to distinguish between different error types

https://claude.ai/code/session_01SCkprvfh32LjL58KwYc2Uj