### PR TITLE
Add custom domain validation with immediate verification on save

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -828,9 +828,22 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
 
   await updateCustomDomain(raw);
   await logActivity(`Custom domain set to ${raw}`);
+
+  // Attempt validation immediately after saving
+  const result = await validateCustomDomain(raw);
+  if (result.ok) {
+    await updateCustomDomainLastValidated();
+    await logActivity(`Custom domain validated: ${raw}`);
+    return redirectWithSuccess(
+      "/admin/settings",
+      "Custom domain saved and validated",
+      "settings-custom-domain",
+    );
+  }
+
   return redirectWithSuccess(
     "/admin/settings",
-    "Custom domain saved",
+    "Custom domain saved (validation pending — see instructions below)",
     "settings-custom-domain",
   );
 });

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -373,6 +373,13 @@ export const adminSettingsPage = (
 
           {s.customDomain && (
           <CsrfForm action="/admin/settings/custom-domain/validate" id="settings-custom-domain-validate">
+            {!s.customDomainLastValidated && (
+            <article>
+              <aside role="alert">
+                <p><strong>Your custom domain is not yet validated.</strong> It will not work until validation is complete.</p>
+              </aside>
+            </article>
+            )}
             <article>
               <aside>
                 <p>To use your custom domain, create a <strong>CNAME</strong> record:</p>

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2782,6 +2782,26 @@ describe("server (admin settings)", () => {
       expect(html).toContain("localhost");
     });
 
+    test("shows warning when custom domain is not validated", async () => {
+      setBunnyEnv();
+      await updateCustomDomain("tickets.example.com");
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain("not yet validated");
+      expect(html).toContain("will not work until validation is complete");
+    });
+
+    test("does not show warning when custom domain is validated", async () => {
+      setBunnyEnv();
+      await updateCustomDomain("tickets.example.com");
+      await updateCustomDomainLastValidated();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).not.toContain("not yet validated");
+    });
+
     test("shows last validated timestamp when domain has been validated", async () => {
       setBunnyEnv();
       await updateCustomDomain("tickets.example.com");
@@ -2805,31 +2825,67 @@ describe("server (admin settings)", () => {
         expect(response.status).toBe(400);
       });
 
-      test("saves a valid custom domain", async () => {
+      test("saves and validates domain when validation succeeds", async () => {
         setBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            custom_domain: "tickets.example.com",
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location")!;
-        expect(decodeURIComponent(location)).toContain("Custom domain saved");
-        expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          const response = await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          expect(decodeURIComponent(location)).toContain("Custom domain saved and validated");
+          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+          expect(await getCustomDomainLastValidatedFromDb()).not.toBeNull();
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("saves domain with pending message when validation fails", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () =>
+          Promise.resolve({ ok: false as const, error: "DNS not configured" });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          const response = await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          expect(decodeURIComponent(location)).toContain("validation pending");
+          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+          expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
       });
 
       test("normalizes domain to lowercase", async () => {
         setBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            custom_domain: "Tickets.Example.COM",
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "Tickets.Example.COM",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
       });
 
       test("clears custom domain when empty", async () => {
@@ -2877,15 +2933,40 @@ describe("server (admin settings)", () => {
 
       test("logs activity when domain is set", async () => {
         setBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            custom_domain: "tickets.example.com",
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        const log = await getAllActivityLog();
-        expect(log.some((e) => e.message.includes("Custom domain set to tickets.example.com"))).toBe(true);
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          const log = await getAllActivityLog();
+          expect(log.some((e) => e.message.includes("Custom domain set to tickets.example.com"))).toBe(true);
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("logs validation activity when save triggers successful validation", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          const log = await getAllActivityLog();
+          expect(log.some((e) => e.message.includes("Custom domain validated"))).toBe(true);
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
       });
     });
 


### PR DESCRIPTION
## Summary
This PR enhances the custom domain feature by adding immediate validation when a domain is saved, providing users with real-time feedback on whether their domain configuration is valid.

## Key Changes
- **Immediate validation on save**: When a user saves a custom domain, the system now attempts to validate it immediately via the BunnyCDN API
- **Validation status tracking**: Added `customDomainLastValidated` tracking to distinguish between unvalidated and validated domains
- **User feedback improvements**: 
  - Success message changes to "Custom domain saved and validated" when validation succeeds
  - Pending message "Custom domain saved (validation pending — see instructions below)" when validation fails
  - New warning banner displayed when domain is not yet validated
- **Activity logging**: Added logging for successful domain validation events
- **Test coverage**: Comprehensive test updates including:
  - Tests for warning display when domain is unvalidated
  - Tests for successful validation flow
  - Tests for pending validation flow
  - Tests for validation activity logging

## Implementation Details
- The validation attempt is non-blocking; if validation fails, the domain is still saved but marked as pending
- The UI displays a prominent alert when a custom domain exists but hasn't been validated yet
- All existing domain normalization and clearing functionality remains unchanged
- Tests mock the `bunnyCdnApi.validateCustomDomain` function to simulate both success and failure scenarios

https://claude.ai/code/session_01EAWmpXFaoP6maXkJVBZUJC