### PR TITLE
Fix form input width calculation with border-box sizing

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -485,12 +485,10 @@ textarea {
 input[type="text"],
 input[type="password"],
 input[type="email"],
-textarea {
-  width: calc(100% - 1.6rem);
-}
-
+textarea,
 input[type="file"] {
-  width: calc(100% - 1.6rem);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 input[readonly],


### PR DESCRIPTION
## Summary
Refactored form input width styling to use `box-sizing: border-box` instead of manual width calculations, providing more consistent and maintainable styling across all input types.

## Key Changes
- Consolidated duplicate width rules for `textarea` and `input[type="file"]`
- Changed width from `calc(100% - 1.6rem)` to `100%` with `box-sizing: border-box`
- Applied consistent sizing to all affected input elements (text, password, email, textarea, and file inputs)

## Implementation Details
The `box-sizing: border-box` approach ensures that padding and borders are included in the width calculation, eliminating the need for manual offset calculations. This simplifies the CSS and reduces the risk of layout inconsistencies when styling is modified in the future.

https://claude.ai/code/session_01CwEQpQsiTWXjexkJCjenSM