### PR TITLE
Improve email template editing UX with default template preview

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -57,6 +57,18 @@ if (multiUrl) {
   }
 }
 
+/* Fill default template: clicking "Edit default template" fills the textarea */
+for (const link of document.querySelectorAll<HTMLAnchorElement>("[data-fill-default]")) {
+  link.addEventListener("click", (e) => {
+    e.preventDefault();
+    const ta = document.getElementById(link.dataset.fillDefault!) as HTMLTextAreaElement | null;
+    if (ta && !ta.value) {
+      ta.value = ta.dataset.defaultTpl ?? "";
+      ta.focus();
+    }
+  });
+}
+
 /* Auto-populate closes_at from event date when closes_at is empty */
 const dateInput = document.querySelector<HTMLInputElement>('input[name="date"]');
 const closesAtInput = document.querySelector<HTMLInputElement>('input[name="closes_at"]');

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -206,15 +206,19 @@ export const adminSettingsPage = (
             id="confirmation_html"
             name="html"
             rows="8"
-            placeholder={DEFAULT_TEMPLATES.confirmation.html}
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.confirmation.html}
           >{s.confirmationTemplates.html}</textarea>
+          <a href="#" data-fill-default="confirmation_html"><small>Edit default template</small></a>
           <label for="confirmation_text">Plain Text Body</label>
           <textarea
             id="confirmation_text"
             name="text"
             rows="6"
-            placeholder={DEFAULT_TEMPLATES.confirmation.text}
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.confirmation.text}
           >{s.confirmationTemplates.text}</textarea>
+          <a href="#" data-fill-default="confirmation_text"><small>Edit default template</small></a>
           <button type="submit">Save Confirmation Template</button>
         </CsrfForm>
 
@@ -235,15 +239,19 @@ export const adminSettingsPage = (
             id="admin_html"
             name="html"
             rows="8"
-            placeholder={DEFAULT_TEMPLATES.admin.html}
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.admin.html}
           >{s.adminTemplates.html}</textarea>
+          <a href="#" data-fill-default="admin_html"><small>Edit default template</small></a>
           <label for="admin_text">Plain Text Body</label>
           <textarea
             id="admin_text"
             name="text"
             rows="6"
-            placeholder={DEFAULT_TEMPLATES.admin.text}
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.admin.text}
           >{s.adminTemplates.text}</textarea>
+          <a href="#" data-fill-default="admin_text"><small>Edit default template</small></a>
           <button type="submit">Save Admin Notification Template</button>
         </CsrfForm>
 

--- a/test/lib/email-templates-admin.test.ts
+++ b/test/lib/email-templates-admin.test.ts
@@ -53,6 +53,28 @@ describe("admin email templates", () => {
       expect(html).toContain("Your tickets for");
       expect(html).toContain("New registration");
     });
+
+    test("uses 'Leave blank' placeholder for html/text bodies", async () => {
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain('placeholder="Leave blank to use default template"');
+    });
+
+    test("shows edit default template links for html/text bodies", async () => {
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain('data-fill-default="confirmation_html"');
+      expect(html).toContain('data-fill-default="confirmation_text"');
+      expect(html).toContain('data-fill-default="admin_html"');
+      expect(html).toContain('data-fill-default="admin_text"');
+      expect(html).toContain("Edit default template");
+    });
+
+    test("includes default templates as data attributes", async () => {
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain("data-default-tpl=");
+    });
   });
 
   describe("POST /admin/settings/email-templates/confirmation", () => {


### PR DESCRIPTION
## Summary
Enhanced the email template editor in admin settings to make it easier for users to view and edit default templates. Instead of showing the full template text as a placeholder (which was truncated), users can now see a helpful "Leave blank to use default template" message and click a link to populate the textarea with the default template content.

## Key Changes
- **Updated placeholder text**: Changed from displaying the full default template to a user-friendly message "Leave blank to use default template" for both HTML and plain text email bodies
- **Added data attributes**: Store default template content in `data-default-tpl` attributes on textareas for client-side access
- **Added "Edit default template" links**: New clickable links next to each textarea that populate the field with the default template when clicked (only if the field is empty)
- **Implemented client-side handler**: Added JavaScript in `admin.ts` to handle the "Edit default template" link clicks, filling the corresponding textarea with the default template content and focusing it
- **Added test coverage**: Three new tests verify the placeholder text, edit links, and data attributes are present in the rendered HTML

## Implementation Details
- The default template content is stored in `data-default-tpl` attributes rather than being embedded in the placeholder, allowing for better UX and preventing text truncation
- The client-side handler only fills the textarea if it's currently empty, preventing accidental overwrites of user edits
- The feature gracefully degrades if JavaScript is disabled (links won't work but the form remains functional)

https://claude.ai/code/session_01UzhdpddYXJNqDXV8HZJPsb