### PR TITLE
Refactor nav transition handling to use CSS class

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -130,9 +130,8 @@ if (checkoutPopup) {
   const nav = document.querySelector<HTMLElement>("#main-nav");
   if (nav) {
     if (location.hash) {
-      nav.style.transition = "none";
-      nav.classList.add("nav-hidden");
-      requestAnimationFrame(() => { nav.style.transition = ""; });
+      nav.classList.add("nav-no-transition", "nav-hidden");
+      requestAnimationFrame(() => { nav.classList.remove("nav-no-transition"); });
     }
     let lastY = scrollY;
     let ticking = false;

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1363,6 +1363,11 @@ button.secondary:hover {
   display: none;
 }
 
+/* No-transition helper (used by admin nav scroll-hide) */
+.nav-no-transition {
+  transition: none !important;
+}
+
 /* Guide page */
 body.guide h3 {
   margin-top: 3rem;


### PR DESCRIPTION
## Summary
Refactored the navigation bar transition handling to use a CSS class instead of inline style manipulation, improving code maintainability and separation of concerns.

## Key Changes
- Moved transition style logic from inline JavaScript (`nav.style.transition`) to a dedicated CSS class (`.nav-no-transition`)
- Updated the admin nav scroll-hide mechanism to add/remove the `nav-no-transition` class instead of directly manipulating the transition property
- Added `.nav-no-transition` helper class to `mvp.css` with `transition: none !important` to disable transitions when needed

## Implementation Details
The refactoring maintains the same behavior: when the page has a hash location, the nav is immediately hidden without transition by:
1. Adding both `nav-no-transition` and `nav-hidden` classes simultaneously
2. Using `requestAnimationFrame` to remove the `nav-no-transition` class, allowing subsequent transitions to work normally

This approach is cleaner and follows CSS-in-CSS best practices rather than mixing inline style manipulation with class-based styling.

https://claude.ai/code/session_012aMJipor8T1xz8Mff243bP