### PR TITLE
Add free SSL certificate loading to custom domain validation

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -66,6 +66,22 @@ const findPullZoneIdImpl = async (): Promise<
   return { ok: true, id: zone.Id };
 };
 
+/** Parse a Bunny API error response into a BunnyApiResult. */
+const parseBunnyError = async (
+  response: Response,
+  label: string,
+): Promise<BunnyApiResult & { ok: false }> => {
+  const text = await response.text();
+  let message = text;
+  let errorKey: string | undefined;
+  try {
+    const json = JSON.parse(text);
+    if (json.Message) message = json.Message;
+    if (json.ErrorKey) errorKey = json.ErrorKey;
+  } catch { /* use raw text */ }
+  return { ok: false, error: `${label} failed (${response.status}): ${message}`, errorKey };
+};
+
 /** POST to a Bunny CDN pull zone endpoint with JSON body. */
 const pullZonePost = async (
   pullZoneId: number,
@@ -82,16 +98,24 @@ const pullZonePost = async (
   });
 
   if (response.status === 204 || response.ok) return { ok: true };
+  return parseBunnyError(response, label);
+};
 
-  const text = await response.text();
-  let message = text;
-  let errorKey: string | undefined;
-  try {
-    const json = JSON.parse(text);
-    if (json.Message) message = json.Message;
-    if (json.ErrorKey) errorKey = json.ErrorKey;
-  } catch { /* use raw text */ }
-  return { ok: false, error: `${label} failed (${response.status}): ${message}`, errorKey };
+/** Request a free Let's Encrypt certificate for a hostname on a pull zone. */
+const loadFreeCertificate = async (
+  _pullZoneId: number,
+  hostname: string,
+): Promise<BunnyApiResult> => {
+  const url =
+    `${BUNNY_API_BASE}/pullzone/loadFreeCertificate?hostname=${encodeURIComponent(hostname)}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { AccessKey: getBunnyApiKey() },
+  });
+
+  if (response.ok) return { ok: true };
+  return parseBunnyError(response, "Load free certificate");
 };
 
 /**
@@ -121,6 +145,12 @@ const validateCustomDomainImpl = async (
   ) {
     logError({ code: ErrorCode.CDN_REQUEST, detail: hostnameResult.error });
     return hostnameResult;
+  }
+
+  const certResult = await loadFreeCertificate(pullZoneId, hostname);
+  if (!certResult.ok) {
+    logError({ code: ErrorCode.CDN_REQUEST, detail: certResult.error });
+    return certResult;
   }
 
   const sslResult = await pullZonePost(

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -253,37 +253,45 @@ describe("bunny-cdn", () => {
 
     test("sends correct requests to Bunny API", async () => {
       await withFixedPullZoneId(async () => {
-        const calls: { url: string; init: RequestInit }[] = [];
+        const calls: { url: string; init: RequestInit | undefined }[] = [];
         await withMocks(
           () =>
             stub(
               globalThis,
               "fetch",
               (input: string | URL | Request, init?: RequestInit) => {
-                calls.push({ url: String(input), init: init! });
+                calls.push({ url: String(input), init });
                 return Promise.resolve(new Response(null, { status: 204 }));
               },
             ),
           async () => {
             await bunnyCdnApi.validateCustomDomain("cdn.example.com");
-            expect(calls).toHaveLength(2);
+            expect(calls).toHaveLength(3);
             const addCall = calls.at(0)!;
-            const sslCall = calls.at(1)!;
+            const certCall = calls.at(1)!;
+            const sslCall = calls.at(2)!;
             expect(addCall.url).toBe(
               "https://api.bunny.net/pullzone/12345/addHostname",
             );
-            expect(addCall.init.method).toBe("POST");
-            expect(addCall.init.headers).toEqual({
+            expect(addCall.init!.method).toBe("POST");
+            expect(addCall.init!.headers).toEqual({
               AccessKey: "test-bunny-key",
               "Content-Type": "application/json",
             });
-            expect(JSON.parse(addCall.init.body as string)).toEqual({
+            expect(JSON.parse(addCall.init!.body as string)).toEqual({
               Hostname: "cdn.example.com",
+            });
+            expect(certCall.url).toBe(
+              "https://api.bunny.net/pullzone/loadFreeCertificate?hostname=cdn.example.com",
+            );
+            expect(certCall.init!.method).toBe("GET");
+            expect(certCall.init!.headers).toEqual({
+              AccessKey: "test-bunny-key",
             });
             expect(sslCall.url).toBe(
               "https://api.bunny.net/pullzone/12345/setForceSSL",
             );
-            expect(JSON.parse(sslCall.init.body as string)).toEqual({
+            expect(JSON.parse(sslCall.init!.body as string)).toEqual({
               Hostname: "cdn.example.com",
               ForceSSL: true,
             });
@@ -385,7 +393,7 @@ describe("bunny-cdn", () => {
               "cdn.example.com",
             );
             expect(result).toEqual({ ok: true });
-            expect(callCount).toBe(2);
+            expect(callCount).toBe(3);
           },
         );
       });
@@ -410,7 +418,7 @@ describe("bunny-cdn", () => {
       });
     });
 
-    test("returns error when setForceSSL fails", async () => {
+    test("returns error when loadFreeCertificate fails", async () => {
       await withFixedPullZoneId(async () => {
         let callCount = 0;
         await withMocks(
@@ -418,6 +426,57 @@ describe("bunny-cdn", () => {
             stub(globalThis, "fetch", () => {
               callCount++;
               if (callCount === 1) {
+                return Promise.resolve(new Response(null, { status: 204 }));
+              }
+              return Promise.resolve(
+                new Response("Certificate error", { status: 400 }),
+              );
+            }),
+          async () => {
+            const result = await bunnyCdnApi.validateCustomDomain(
+              "cdn.example.com",
+            );
+            expect(result).toEqual({
+              ok: false,
+              error:
+                "Load free certificate failed (400): Certificate error",
+            });
+            expect(callCount).toBe(2);
+          },
+        );
+      });
+    });
+
+    test("does not call setForceSSL when loadFreeCertificate fails", async () => {
+      await withFixedPullZoneId(async () => {
+        let callCount = 0;
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () => {
+              callCount++;
+              if (callCount <= 1) {
+                return Promise.resolve(new Response(null, { status: 204 }));
+              }
+              return Promise.resolve(
+                new Response("Certificate error", { status: 400 }),
+              );
+            }),
+          async () => {
+            await bunnyCdnApi.validateCustomDomain("cdn.example.com");
+            expect(callCount).toBe(2);
+          },
+        );
+      });
+    });
+
+    test("returns error when setForceSSL fails", async () => {
+      await withFixedPullZoneId(async () => {
+        let callCount = 0;
+        await withMocks(
+          () =>
+            stub(globalThis, "fetch", () => {
+              callCount++;
+              if (callCount <= 2) {
                 return Promise.resolve(new Response(null, { status: 204 }));
               }
               return Promise.resolve(


### PR DESCRIPTION
## Summary
Enhanced the custom domain validation flow to include loading a free Let's Encrypt certificate before forcing SSL. This ensures a certificate is available before enabling SSL enforcement on the domain.

## Key Changes
- **New `loadFreeCertificate` function**: Added a dedicated API call to request a free Let's Encrypt certificate for a hostname via the Bunny CDN API
- **Updated validation flow**: Modified `validateCustomDomainImpl` to call `loadFreeCertificate` after adding the hostname but before forcing SSL
- **Refactored error handling**: Extracted common Bunny API error parsing logic into a new `parseBunnyError` utility function to reduce code duplication
- **Improved type safety**: Changed `init` parameter type from `RequestInit` to `RequestInit | undefined` to accurately reflect optional initialization

## Implementation Details
- The `loadFreeCertificate` function makes a GET request to `/pullzone/loadFreeCertificate?hostname=...` endpoint
- Error handling is consistent with existing API calls, returning structured error responses with status codes and messages
- The validation now performs three sequential API calls: add hostname → load certificate → force SSL
- If certificate loading fails, the process stops and returns an error without attempting to force SSL

https://claude.ai/code/session_01U32ENpqkdAJvfrtMMjiLTj