### PR TITLE
Add line breaks before submit buttons in admin settings

### DIFF
--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -219,6 +219,7 @@ export const adminSettingsPage = (
             data-default-tpl={DEFAULT_TEMPLATES.confirmation.text}
           >{s.confirmationTemplates.text}</textarea>
           <a href="#" data-fill-default="confirmation_text"><small>Edit default template</small></a>
+          <br />
           <button type="submit">Save Confirmation Template</button>
         </CsrfForm>
 
@@ -252,6 +253,7 @@ export const adminSettingsPage = (
             data-default-tpl={DEFAULT_TEMPLATES.admin.text}
           >{s.adminTemplates.text}</textarea>
           <a href="#" data-fill-default="admin_text"><small>Edit default template</small></a>
+          <br />
           <button type="submit">Save Admin Notification Template</button>
         </CsrfForm>
 


### PR DESCRIPTION
## Summary
This PR adds line break elements (`<br />`) before the submit buttons in the admin settings template forms to improve visual spacing and layout.

## Key Changes
- Added `<br />` element before "Save Confirmation Template" button in the confirmation template form
- Added `<br />` element before "Save Admin Notification Template" button in the admin notification template form

## Details
These changes ensure consistent spacing between the template edit links and their corresponding submit buttons, improving the visual hierarchy and readability of the admin settings page forms.

https://claude.ai/code/session_01YKHvvzkCyPPX7qyJ6HUTox