### PR TITLE
Support legacy multi-ticket payments without per-item prices

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -295,7 +295,7 @@ const isMultiItem = (v: unknown): v is MultiItem => {
   const { e, q, p } = v as Record<string, unknown>;
   return typeof e === "number" && Number.isInteger(e) && e > 0 &&
     typeof q === "number" && Number.isInteger(q) && q >= 1 &&
-    typeof p === "number" && Number.isInteger(p) && p >= 0;
+    (p === undefined || (typeof p === "number" && Number.isInteger(p) && p >= 0));
 };
 
 /** Parse multi-ticket items from metadata */
@@ -303,7 +303,8 @@ const parseMultiItems = (itemsJson: string): MultiItem[] | null => {
   try {
     const parsed: unknown = JSON.parse(itemsJson);
     if (!Array.isArray(parsed) || !parsed.every(isMultiItem)) return null;
-    return parsed;
+    // Default p to 0 when absent — backfilled in processMultiPaymentSession
+    return map((item: MultiItem) => ({ ...item, p: item.p ?? 0 }))(parsed);
   } catch {
     return null;
   }
@@ -334,6 +335,21 @@ const extractMultiIntent = (
     date: metadata.date ?? null,
     items,
   };
+};
+
+/** Log a price mismatch and refund the session */
+const priceMismatchRefund = (
+  session: ValidatedPaymentSession,
+  detail: string,
+  eventId?: number,
+): Promise<PaymentResult> => {
+  logError({ code: ErrorCode.PAYMENT_SESSION, detail });
+  return refundAndFail(
+    session,
+    "The price for one or more events changed while you were completing payment.",
+    undefined,
+    eventId,
+  );
 };
 
 /**
@@ -376,45 +392,49 @@ const processMultiPaymentSession = async (
     expectedTotal += vp.expectedPrice;
   }
 
-  // Per-item price validation: each item's p must match its event's rules
-  for (const { item, event, expectedPrice } of validatedItems) {
-    const itemMismatch = event.can_pay_more
-      ? item.p < expectedPrice || item.p > getMaxPrice(event)  // pay-more: min <= p <= max
-      : item.p !== expectedPrice; // fixed: p must equal unit_price * q exactly
-    if (itemMismatch) {
-      logError({
-        code: ErrorCode.PAYMENT_SESSION,
-        detail: `Multi-ticket per-item price mismatch for event ${event.id}: metadata p=${item.p} but expected ${expectedPrice} (can_pay_more=${event.can_pay_more})`,
-      });
-      return refundAndFail(
-        session,
-        "The price for one or more events changed while you were completing payment.",
-        undefined,
-        event.id,
-      );
-    }
-  }
+  // When items have per-item prices, validate each against the event's rules
+  const hasPerItemPrices = intent.items.some((item) => item.p > 0);
 
-  // Cart total must equal the sum of per-item prices
-  const metadataTotal = validatedItems.reduce((sum, { item }) => sum + item.p, 0);
-  if (session.amountTotal !== metadataTotal) {
-    logError({
-      code: ErrorCode.PAYMENT_SESSION,
-      detail: `Multi-ticket total mismatch: provider charged ${session.amountTotal} but sum(p) = ${metadataTotal}`,
-    });
-    return refundAndFail(
-      session,
-      "The price for one or more events changed while you were completing payment.",
-      undefined,
-      validatedItems[0]?.event.id,
-    );
+  if (hasPerItemPrices) {
+    for (const { item, event, expectedPrice } of validatedItems) {
+      const itemMismatch = event.can_pay_more
+        ? item.p < expectedPrice || item.p > getMaxPrice(event)  // pay-more: min <= p <= max
+        : item.p !== expectedPrice; // fixed: p must equal unit_price * q exactly
+      if (itemMismatch) {
+        return priceMismatchRefund(session,
+          `Multi-ticket per-item price mismatch for event ${event.id}: metadata p=${item.p} but expected ${expectedPrice} (can_pay_more=${event.can_pay_more})`,
+          event.id);
+      }
+    }
+
+    // Cart total must equal the sum of per-item prices
+    const metadataTotal = validatedItems.reduce((sum, { item }) => sum + item.p, 0);
+    if (session.amountTotal !== metadataTotal) {
+      return priceMismatchRefund(session,
+        `Multi-ticket total mismatch: provider charged ${session.amountTotal} but sum(p) = ${metadataTotal}`,
+        validatedItems[0]?.event.id);
+    }
+  } else {
+    // No per-item prices: validate that provider charged at least the expected total
+    if (session.amountTotal < expectedTotal) {
+      return priceMismatchRefund(session,
+        `Multi-ticket total mismatch: provider charged ${session.amountTotal} but expected at least ${expectedTotal}`,
+        validatedItems[0]?.event.id);
+    }
   }
 
   const createdAttendees: { attendee: Attendee; event: EventWithCount }[] = [];
   let failedEvent: EventWithCount | null = null;
   let failureReason: "capacity_exceeded" | "encryption_error" | null = null;
 
-  for (const { item, event } of validatedItems) {
+  if (!hasPerItemPrices) {
+    logError({
+      code: ErrorCode.PAYMENT_SESSION,
+      detail: `Multi-ticket session ${session.id} missing per-item prices, using expected prices (possible old payment)`,
+    });
+  }
+
+  for (const { item, event, expectedPrice } of validatedItems) {
 
     const result = await createAttendeeAtomic({
       eventId: item.e,
@@ -425,7 +445,7 @@ const processMultiPaymentSession = async (
       phone: intent.phone,
       address: intent.address,
       special_instructions: intent.special_instructions,
-      pricePaid: item.p,
+      pricePaid: hasPerItemPrices ? item.p : expectedPrice,
       date: event.event_type === "daily" ? intent.date : null,
     });
 
@@ -707,6 +727,8 @@ const extractSessionFromEvent = (
       name: metadata.name,
       email: metadata.email,
       phone: metadata.phone as string | undefined,
+      address: metadata.address as string | undefined,
+      special_instructions: metadata.special_instructions as string | undefined,
       quantity: metadata.quantity as string | undefined,
       multi: metadata.multi as string | undefined,
       items: metadata.items as string | undefined,
@@ -750,11 +772,13 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   // Get signature header (sync — headers are always available)
   const signature = getWebhookSignatureHeader(request);
   if (!signature) {
+    logError({ code: ErrorCode.PAYMENT_SESSION, detail: "Webhook missing signature header" });
     return plainResponse("Missing signature", 400);
   }
 
   const provider = await getActivePaymentProvider();
   if (!provider) {
+    logError({ code: ErrorCode.PAYMENT_SESSION, detail: "Webhook received but payment provider not configured" });
     return plainResponse("Payment provider not configured", 400);
   }
 
@@ -791,6 +815,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
     const sessionId = extractSessionIdFromObject(obj);
 
     if (!sessionId) {
+      logError({ code: ErrorCode.PAYMENT_SESSION, detail: "Webhook event missing session ID" });
       return plainResponse("Invalid session data", 400);
     }
 
@@ -801,6 +826,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
 
     session = await provider.retrieveSession(sessionId);
     if (!session) {
+      logError({ code: ErrorCode.PAYMENT_SESSION, detail: `Failed to retrieve session ${sessionId}` });
       return plainResponse("Invalid session data", 400);
     }
   }
@@ -830,6 +856,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   if (isMulti) {
     const multiIntent = extractMultiIntent(session);
     if (!multiIntent) {
+      logError({ code: ErrorCode.PAYMENT_SESSION, detail: `Invalid multi-ticket session data for ${session.id}` });
       return plainResponse("Invalid multi-ticket session data", 400);
     }
     eventIdForLog = multiIntent.items[0]?.e;

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -308,6 +308,125 @@ describe("server (webhooks)", () => {
       }
     });
 
+    test("multi-ticket webhook processes items without per-item price", async () => {
+      await setupStripe();
+
+      const event1 = await createTestEvent({
+        name: "Legacy Multi 1",
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      const event2 = await createTestEvent({
+        name: "Legacy Multi 2",
+        maxAttendees: 50,
+        unitPrice: 1000,
+      });
+
+      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+      // Items without p field — legacy sessions created before per-item price tracking
+      const mockVerify = stub(stripePaymentProvider, "verifyWebhookSignature", () => Promise.resolve({
+        valid: true,
+        event: {
+          id: "evt_legacy_multi",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_legacy_multi",
+              payment_status: "paid",
+              payment_intent: "pi_legacy_multi",
+              amount_total: 2000,
+              metadata: webhookMeta({
+                name: "Legacy User",
+                email: "legacy@example.com",
+                multi: "1",
+                items: JSON.stringify([
+                  { e: event1.id, q: 2 },
+                  { e: event2.id, q: 1 },
+                ]),
+              }),
+            },
+          },
+        },
+      }));
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest(
+            {},
+            { "stripe-signature": "sig_valid" },
+          ),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.received).toBe(true);
+        expect(json.processed).toBe(true);
+
+        // Verify attendees were created for both events
+        const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+        const attendees1 = await getAttendeesRaw(event1.id);
+        const attendees2 = await getAttendeesRaw(event2.id);
+        expect(attendees1.length).toBe(1);
+        expect(attendees1[0]?.quantity).toBe(2);
+        expect(attendees2.length).toBe(1);
+        expect(attendees2[0]?.quantity).toBe(1);
+      } finally {
+        mockVerify.restore();
+      }
+    });
+
+    test("multi-ticket webhook without per-item prices refunds when amount too low", async () => {
+      await setupStripe();
+
+      const event1 = await createTestEvent({
+        name: "Underpaid Multi",
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+
+      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+      const mockVerify = stub(stripePaymentProvider, "verifyWebhookSignature", () => Promise.resolve({
+        valid: true,
+        event: {
+          id: "evt_underpaid",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_underpaid",
+              payment_status: "paid",
+              payment_intent: "pi_underpaid",
+              amount_total: 100, // Far less than expected 500
+              metadata: webhookMeta({
+                name: "Underpaid User",
+                email: "underpaid@example.com",
+                multi: "1",
+                items: JSON.stringify([{ e: event1.id, q: 1 }]),
+              }),
+            },
+          },
+        },
+      }));
+
+      const mockRefund = stub(stripeApi, "refundPayment", () => Promise.resolve({ id: "re_test" } as unknown as Awaited<
+        ReturnType<typeof stripeApi.refundPayment>
+      >));
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest(
+            {},
+            { "stripe-signature": "sig_valid" },
+          ),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.processed).toBe(false);
+        expect(json.error).toContain("price");
+      } finally {
+        mockVerify.restore();
+        mockRefund.restore();
+      }
+    });
+
     test("webhook returns error for invalid multi-ticket items", async () => {
       await setupStripe();
 


### PR DESCRIPTION
## Summary
This PR adds backward compatibility for multi-ticket payment sessions created before per-item price tracking was implemented. Legacy sessions that lack individual item prices (`p` field) are now processed gracefully by validating against expected totals rather than per-item prices.

## Key Changes
- **Modified price validation logic**: When items lack per-item prices, the webhook now validates that the total charged is at least the expected amount, rather than requiring exact per-item price matches
- **Default price field handling**: Items without a `p` field are now defaulted to `0` during parsing, allowing the system to distinguish between legacy sessions (all `p=0`) and modern sessions (with actual prices)
- **Refactored validation flow**: Separated per-item price validation from legacy total validation into distinct code paths
- **Improved error handling**: Added logging for webhook processing failures (missing signature, provider not configured, invalid session data, etc.)
- **Extended session extraction**: Added support for extracting `address` and `special_instructions` metadata fields from webhook events
- **New helper function**: Introduced `priceMismatchRefund()` to consolidate refund logic and reduce duplication

## Notable Implementation Details
- Legacy sessions are identified by checking if any item has `p > 0`; if all items have `p = 0`, the session is treated as legacy
- For legacy sessions, `pricePaid` is set to the calculated `expectedPrice` rather than the metadata `p` value
- An error log is emitted when processing legacy sessions to help track their usage
- The validation ensures that underpaid legacy sessions are still refunded if the charged amount falls below the expected total

https://claude.ai/code/session_01JcJemHc1NJP8oxkiNnZmS3