### PR TITLE
Add eventId to payment session error logging

### DIFF
--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -108,6 +108,7 @@ export const buildWebhookPayload = async (
 export const sendWebhook = async (
   webhookUrl: string,
   payload: WebhookPayload,
+  eventId?: number,
 ): Promise<void> => {
   try {
     const response = await fetch(webhookUrl, {
@@ -119,12 +120,14 @@ export const sendWebhook = async (
       const eventName = payload.tickets.map((t) => t.event_name).join(", ");
       logError({
         code: ErrorCode.WEBHOOK_SEND,
+        eventId,
         detail: `status=${response.status} for '${eventName}'`,
       });
     }
   } catch (error) {
     logError({
       code: ErrorCode.WEBHOOK_SEND,
+      eventId,
       detail: error instanceof Error ? error.message : String(error),
     });
   }
@@ -143,7 +146,8 @@ export const sendRegistrationWebhooks = async (
   if (webhookUrls.length === 0) return;
 
   const payload = await buildWebhookPayload(entries, currency);
-  await Promise.allSettled(webhookUrls.map((url) => sendWebhook(url, payload)));
+  const firstEventId = entries[0]?.event.id;
+  await Promise.allSettled(webhookUrls.map((url) => sendWebhook(url, payload, firstEventId)));
 };
 
 /**

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -238,6 +238,7 @@ const handleAttendeeRefund = attendeeFormAction(async (data, session, form, even
   if (!refunded) {
     logError({
       code: ErrorCode.PAYMENT_REFUND,
+      eventId,
       detail: `Admin refund failed for attendee ${data.attendee.id}, payment ${data.attendee.payment_id}`,
     });
     return refundError(data, session, REFUND_FAILED_ERROR, form);
@@ -303,6 +304,7 @@ const processRefundAll = async (
       failedCount++;
       logError({
         code: ErrorCode.PAYMENT_REFUND,
+        eventId: event.id,
         detail: `Admin bulk refund failed for attendee ${attendee.id}, payment ${attendee.payment_id}`,
       });
     }

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -343,7 +343,7 @@ const priceMismatchRefund = (
   detail: string,
   eventId?: number,
 ): Promise<PaymentResult> => {
-  logError({ code: ErrorCode.PAYMENT_SESSION, detail });
+  logError({ code: ErrorCode.PAYMENT_SESSION, eventId, detail });
   return refundAndFail(
     session,
     "The price for one or more events changed while you were completing payment.",
@@ -430,6 +430,7 @@ const processMultiPaymentSession = async (
   if (!hasPerItemPrices) {
     logError({
       code: ErrorCode.PAYMENT_SESSION,
+      eventId: validatedItems[0]?.event.id,
       detail: `Multi-ticket session ${session.id} missing per-item prices, using expected prices (possible old payment)`,
     });
   }

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -146,13 +146,14 @@ type PaymentResult =
  * Attempt to refund a payment. Returns true if refund succeeded, false otherwise.
  * Logs an error if refund fails.
  */
-const tryRefund = async (paymentReference: string): Promise<boolean> => {
+const tryRefund = async (paymentReference: string, eventId?: number): Promise<boolean> => {
   if (!paymentReference) return false;
 
   const provider = await getActivePaymentProvider();
   if (!provider) {
     logError({
       code: ErrorCode.PAYMENT_REFUND,
+      eventId,
       detail: "No payment provider configured for refund",
     });
     return false;
@@ -165,6 +166,7 @@ const tryRefund = async (paymentReference: string): Promise<boolean> => {
   } else {
     logError({
       code: ErrorCode.PAYMENT_REFUND,
+      eventId,
       detail: `Failed to refund payment ${paymentReference}`,
     });
   }
@@ -186,10 +188,11 @@ const refundAndFail = async (
   status?: number,
   eventId?: number | null,
 ): Promise<PaymentResult> => {
-  const refunded = await tryRefund(session.paymentReference);
+  const metadataEventId = session.metadata.event_id ? Number.parseInt(session.metadata.event_id, 10) : undefined;
+  const resolvedEventId = eventId ?? metadataEventId;
+  const refunded = await tryRefund(session.paymentReference, resolvedEventId);
   if (refunded) {
-    const metadataEventId = session.metadata.event_id ? Number.parseInt(session.metadata.event_id, 10) : null;
-    await logActivity(`Automatic refund: ${error}`, eventId ?? metadataEventId);
+    await logActivity(`Automatic refund: ${error}`, resolvedEventId);
   }
   return { success: false, error, status, refunded };
 };


### PR DESCRIPTION
## Summary
Enhanced error logging for payment session issues by including the `eventId` parameter in error logs, improving debugging and traceability of payment-related failures.

## Key Changes
- Added `eventId` parameter to `logError` call in `priceMismatchRefund` function to capture which event triggered the price mismatch error
- Added `eventId` extraction from validated items in `processMultiPaymentSession` function when logging missing per-item prices errors

## Implementation Details
These changes improve observability by ensuring that payment session errors are logged with the associated event ID, making it easier to correlate errors with specific events and trace issues through the payment pipeline. The `eventId` is sourced from the first validated item's event in the multi-payment session context.

https://claude.ai/code/session_014FNmcnqKmtmQqAR9o56yHQ