### PR TITLE
Improve type safety for email template key lookup

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -822,7 +822,7 @@ export type EmailTemplateFormat = "subject" | "html" | "text";
 
 /** Config key for a given template type+format */
 const emailTemplateKey = (type: EmailTemplateType, format: EmailTemplateFormat): string => {
-  const keys: Record<string, string> = {
+  const keys: Record<`${EmailTemplateType}:${EmailTemplateFormat}`, string> = {
     "confirmation:subject": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_SUBJECT,
     "confirmation:html": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML,
     "confirmation:text": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT,
@@ -830,7 +830,7 @@ const emailTemplateKey = (type: EmailTemplateType, format: EmailTemplateFormat):
     "admin:html": CONFIG_KEYS.EMAIL_TPL_ADMIN_HTML,
     "admin:text": CONFIG_KEYS.EMAIL_TPL_ADMIN_TEXT,
   };
-  return keys[`${type}:${format}`]!;
+  return keys[`${type}:${format}`];
 };
 
 /** Max length for email templates */


### PR DESCRIPTION
## Summary
Improved type safety in the email template configuration key lookup function by using a more specific TypeScript type for the keys object.

## Key Changes
- Updated the `keys` object type annotation from `Record<string, string>` to `Record<`${EmailTemplateType}:${EmailTemplateFormat}`, string>` to enforce that only valid template type and format combinations are used as keys
- Removed the non-null assertion operator (`!`) from the return statement, as the stricter type now guarantees the key exists at compile time

## Implementation Details
This change leverages TypeScript's template literal types to create a more precise type that represents the exact format of valid keys (`"confirmation:subject"`, `"confirmation:html"`, etc.). This provides better compile-time safety and eliminates the need for runtime assertions, making the code more maintainable and reducing the risk of invalid key lookups.

https://claude.ai/code/session_01K44F1b8uW5U3eoVzCwJCF2