### PR TITLE
Handle missing price field in legacy multi-ticket webhook data

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -53,7 +53,10 @@ import {
 } from "#routes/utils.ts";
 import { paymentCancelPage, paymentSuccessPage } from "#templates/payment.tsx";
 
-/** Parsed multi-ticket item from metadata */
+/** Raw multi-ticket item from metadata (p may be absent in old webhooks) */
+type RawMultiItem = { e: number; q: number; p?: number };
+
+/** Multi-ticket item with p defaulted to 0 */
 type MultiItem = { e: number; q: number; p: number };
 
 /** Check if session is a multi-ticket session */
@@ -289,8 +292,8 @@ const alreadyProcessedResult = async (
   return { success: true, attendee: { id: attendeeId }, event, ticketTokens: [] };
 };
 
-/** Validate that a parsed value has the shape of a valid MultiItem */
-const isMultiItem = (v: unknown): v is MultiItem => {
+/** Validate that a parsed value has the shape of a valid RawMultiItem */
+const isMultiItem = (v: unknown): v is RawMultiItem => {
   if (typeof v !== "object" || v === null) return false;
   const { e, q, p } = v as Record<string, unknown>;
   return typeof e === "number" && Number.isInteger(e) && e > 0 &&
@@ -303,8 +306,8 @@ const parseMultiItems = (itemsJson: string): MultiItem[] | null => {
   try {
     const parsed: unknown = JSON.parse(itemsJson);
     if (!Array.isArray(parsed) || !parsed.every(isMultiItem)) return null;
-    // Default p to 0 when absent — backfilled in processMultiPaymentSession
-    return map((item: MultiItem) => ({ ...item, p: item.p ?? 0 }))(parsed);
+    // Default p to 0 when absent — old webhooks may lack per-item prices
+    return map((item: RawMultiItem): MultiItem => ({ ...item, p: item.p ?? 0 }))(parsed);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
Updated webhook handling to properly support legacy multi-ticket webhook payloads that may lack the per-item price field (`p`). This ensures backward compatibility with older webhook data while maintaining type safety.

## Key Changes
- Introduced `RawMultiItem` type to represent multi-ticket items as they appear in webhook metadata, where the price field (`p`) is optional
- Updated `MultiItem` type to represent the normalized form with `p` always present (defaulted to 0)
- Modified `isMultiItem` validator to check for `RawMultiItem` shape instead of `MultiItem`
- Updated `parseMultiItems` to explicitly cast and transform `RawMultiItem` objects to `MultiItem` by defaulting missing `p` values to 0
- Improved comments to clarify that old webhooks may not include per-item prices

## Implementation Details
The changes maintain backward compatibility by allowing the `p` field to be absent during parsing, then normalizing it to 0 during the transformation step. This approach keeps the type system accurate while gracefully handling legacy data formats.

https://claude.ai/code/session_01AN2mrPmtuWpocwAje46HyJ