### PR TITLE
Improve email provider type safety with EmailProvider union type

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -24,7 +24,7 @@ export type EmailMessage = {
 };
 
 export type EmailConfig = {
-  provider: string;
+  provider: EmailProvider;
   apiKey: string;
   fromAddress: string;
 };
@@ -39,7 +39,7 @@ export const getEmailConfig = async (): Promise<EmailConfig | null> => {
   ]);
   const from = fromAddress || businessEmail;
   if (!provider || !apiKey || !from) return null;
-  return { provider, apiKey, fromAddress: from };
+  return { provider: provider as EmailProvider, apiKey, fromAddress: from };
 };
 
 /** Read host-level email config from environment variables. Returns null if not fully configured. */
@@ -48,7 +48,7 @@ export const getHostEmailConfig = (): EmailConfig | null => {
   const apiKey = getEnv("HOST_EMAIL_API_KEY");
   const fromAddress = getEnv("HOST_EMAIL_FROM_ADDRESS");
   if (!provider || !apiKey || !fromAddress) return null;
-  return { provider, apiKey, fromAddress };
+  return { provider: provider as EmailProvider, apiKey, fromAddress };
 };
 
 /** Build provider-specific request: [url, extra-headers, body] */
@@ -111,19 +111,28 @@ const mailgunRequest = (host: string): ProviderRequest => (config, msg) => {
   ];
 };
 
-const PROVIDERS: Record<string, ProviderRequest> = {
+const PROVIDERS = {
   resend: resendRequest,
   postmark: postmarkRequest,
   sendgrid: sendgridRequest,
   "mailgun-us": mailgunRequest("api.mailgun.net"),
   "mailgun-eu": mailgunRequest("api.eu.mailgun.net"),
-};
+} as const satisfies Record<string, ProviderRequest>;
+
+/** Union of all supported email provider keys, derived from the PROVIDERS map */
+export type EmailProvider = keyof typeof PROVIDERS;
 
 /** Valid provider names, derived from the PROVIDERS map */
-export const VALID_EMAIL_PROVIDERS: ReadonlySet<string> = new Set(Object.keys(PROVIDERS));
+export const VALID_EMAIL_PROVIDERS: ReadonlySet<EmailProvider> = new Set(
+  Object.keys(PROVIDERS) as EmailProvider[],
+);
 
-/** Display labels for email providers */
-export const EMAIL_PROVIDER_LABELS: Record<string, string> = {
+/** Type guard: checks if a string is a valid EmailProvider */
+export const isEmailProvider = (value: string): value is EmailProvider =>
+  (VALID_EMAIL_PROVIDERS as ReadonlySet<string>).has(value);
+
+/** Display labels for email providers — keys must match EmailProvider */
+export const EMAIL_PROVIDER_LABELS: Record<EmailProvider, string> = {
   resend: "Resend",
   postmark: "Postmark",
   sendgrid: "SendGrid",

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -9,7 +9,7 @@ import {
   updateBusinessEmail,
 } from "#lib/business-email.ts";
 import { validateCustomDomain } from "#lib/bunny-cdn.ts";
-import { EMAIL_PROVIDER_LABELS, getEmailConfig, getHostEmailConfig, sendTestEmail, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
+import { EMAIL_PROVIDER_LABELS, getEmailConfig, getHostEmailConfig, isEmailProvider, sendTestEmail } from "#lib/email.ts";
 import { buildTemplateData, renderTemplate, validateTemplate } from "#lib/email-renderer.ts";
 import {
   getAllowedDomain,
@@ -799,7 +799,7 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
     return redirect("/admin/settings", "Email provider disabled", true, { formId: "settings-email" });
   }
 
-  if (!VALID_EMAIL_PROVIDERS.has(provider)) {
+  if (!isEmailProvider(provider)) {
     return errorPage("Invalid email provider", 400, "settings-email");
   }
 

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -6,6 +6,7 @@ import {
   type EmailMessage,
   getEmailConfig,
   getHostEmailConfig,
+  isEmailProvider,
   sendEmail,
   sendRegistrationEmails,
   sendTestEmail,
@@ -260,7 +261,7 @@ describe("email", () => {
 
     test("returns undefined for unknown provider", async () => {
       await withErrorSpy(async (errorSpy) => {
-        const status = await sendEmail({ ...testConfig, provider: "invalid" }, { to: "a@b.com", subject: "s", html: "h", text: "t" });
+        const status = await sendEmail({ ...testConfig, provider: "invalid" as never }, { to: "a@b.com", subject: "s", html: "h", text: "t" });
         expect(status).toBeUndefined();
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
         expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("unknown provider"))).toBe(true);
@@ -482,6 +483,21 @@ describe("email", () => {
       const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
       expect(body.to).toEqual(["admin@test.com"]);
       expect(body.subject).toContain("Test email");
+    });
+  });
+
+  describe("isEmailProvider", () => {
+    test("returns true for valid providers", () => {
+      expect(isEmailProvider("resend")).toBe(true);
+      expect(isEmailProvider("postmark")).toBe(true);
+      expect(isEmailProvider("sendgrid")).toBe(true);
+      expect(isEmailProvider("mailgun-us")).toBe(true);
+      expect(isEmailProvider("mailgun-eu")).toBe(true);
+    });
+
+    test("returns false for invalid providers", () => {
+      expect(isEmailProvider("invalid")).toBe(false);
+      expect(isEmailProvider("")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR enhances type safety for email provider handling by introducing a discriminated `EmailProvider` union type derived from the `PROVIDERS` map, replacing loose string types throughout the codebase.

## Key Changes
- **New `EmailProvider` type**: Created as a union of valid provider keys (`keyof typeof PROVIDERS`), ensuring only supported providers can be used at compile time
- **Type guard function**: Added `isEmailProvider()` function to safely narrow string values to the `EmailProvider` type at runtime
- **Updated type annotations**: Changed `EmailConfig.provider` from `string` to `EmailProvider`, and updated `EMAIL_PROVIDER_LABELS` to use `Record<EmailProvider, string>` for exhaustiveness checking
- **Improved PROVIDERS map**: Added `as const satisfies` to the `PROVIDERS` object for better type inference
- **Updated validation logic**: Replaced `VALID_EMAIL_PROVIDERS.has()` checks with the new `isEmailProvider()` type guard in admin settings
- **Enhanced test coverage**: Added comprehensive tests for the new `isEmailProvider()` function

## Implementation Details
- The `EmailProvider` type is automatically kept in sync with the `PROVIDERS` map through TypeScript's `keyof typeof` operator, eliminating manual maintenance
- The type guard enables safe runtime validation while maintaining type narrowing benefits
- All provider-related types now use the discriminated union, preventing invalid provider strings from being accepted by the type system

https://claude.ai/code/session_012WWtY9rwDUkCXSWBwzLigS