### PR TITLE
Fix custom domain validation error messaging

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -968,8 +968,8 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
 
   return redirect(
     "/admin/settings",
-    "Custom domain saved (validation pending — see instructions below)",
-    true,
+    `Custom domain saved but validation failed: ${result.error}`,
+    false,
     { formId: "settings-custom-domain" },
   );
 });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2962,7 +2962,7 @@ describe("server (admin settings)", () => {
         }
       });
 
-      test("saves domain with pending message when validation fails", async () => {
+      test("saves domain with error message when validation fails", async () => {
         setBunnyEnv();
         const original = bunnyCdnApi.validateCustomDomain;
         bunnyCdnApi.validateCustomDomain = () =>
@@ -2977,7 +2977,10 @@ describe("server (admin settings)", () => {
           );
           expect(response.status).toBe(302);
           const location = response.headers.get("location")!;
-          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("validation pending");
+          const decoded = decodeURIComponent(location.replaceAll("+", " "));
+          expect(decoded).toContain("validation failed");
+          expect(decoded).toContain("DNS not configured");
+          expect(decoded).toContain("error=");
           expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
           expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
         } finally {


### PR DESCRIPTION
## Summary
Updated custom domain validation error handling to properly display validation failure messages instead of misleading "pending" status messages.

## Key Changes
- Changed error message from "validation pending" to display the actual validation error returned by the API
- Updated the redirect flag from `true` to `false` to properly indicate an error state rather than a success state
- Modified test expectations to verify the error message contains "validation failed", the specific error reason (e.g., "DNS not configured"), and the error parameter in the URL
- Updated test name from "saves domain with pending message" to "saves domain with error message" to accurately reflect the test's purpose

## Implementation Details
- The custom domain validation now surfaces the actual error details from the BunnyCDN API (`result.error`) to the user
- The redirect flag change ensures the UI properly treats this as an error condition rather than a pending/success state
- The `getCustomDomainLastValidatedFromDb()` remains null when validation fails, preventing false positives about successful validation

https://claude.ai/code/session_01NJC9YwzZMm6JpnCFQaXmnf