### PR TITLE
Remove unused pullZoneId parameter from loadFreeCertificate

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -103,7 +103,6 @@ const pullZonePost = async (
 
 /** Request a free Let's Encrypt certificate for a hostname on a pull zone. */
 const loadFreeCertificate = async (
-  _pullZoneId: number,
   hostname: string,
 ): Promise<BunnyApiResult> => {
   const url =
@@ -147,7 +146,7 @@ const validateCustomDomainImpl = async (
     return hostnameResult;
   }
 
-  const certResult = await loadFreeCertificate(pullZoneId, hostname);
+  const certResult = await loadFreeCertificate(hostname);
   if (!certResult.ok) {
     logError({ code: ErrorCode.CDN_REQUEST, detail: certResult.error });
     return certResult;


### PR DESCRIPTION
## Summary
Removed an unused `_pullZoneId` parameter from the `loadFreeCertificate` function and updated the corresponding function call to match the new signature.

## Key Changes
- Removed the `_pullZoneId: number` parameter from the `loadFreeCertificate` function definition
- Updated the call to `loadFreeCertificate` in `validateCustomDomainImpl` to pass only the `hostname` argument

## Details
The `_pullZoneId` parameter was not being used within the `loadFreeCertificate` function (indicated by the underscore prefix convention), so it has been removed to clean up the API and reduce unnecessary parameter passing.

https://claude.ai/code/session_01NkTNu9ng6ywU3FjtdACn8e