### PR TITLE
Add type safety to email renderer template parameters

### DIFF
--- a/src/lib/email-renderer.ts
+++ b/src/lib/email-renderer.ts
@@ -8,7 +8,7 @@
 
 import { lazyRef, map } from "#fp";
 import { formatCurrency } from "#lib/currency.ts";
-import type { EmailTemplateType } from "#lib/db/settings.ts";
+import type { EmailTemplateFormat, EmailTemplateType } from "#lib/db/settings.ts";
 import { getEmailTemplateSet } from "#lib/db/settings.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { isPaidEvent } from "#lib/types.ts";
@@ -133,8 +133,8 @@ const safeRender = async (
   template: string,
   data: TemplateData,
   fallbackTemplate: string,
-  type: string,
-  format: string,
+  type: EmailTemplateType,
+  format: EmailTemplateFormat,
 ): Promise<string> => {
   try {
     return await renderTemplate(template, data);


### PR DESCRIPTION
## Summary
Improved type safety in the email renderer by replacing generic string types with specific type definitions for email template parameters.

## Key Changes
- Imported `EmailTemplateFormat` type from settings module alongside existing `EmailTemplateType`
- Updated `safeRender` function signature to use `EmailTemplateType` instead of generic `string` for the `type` parameter
- Updated `safeRender` function signature to use `EmailTemplateFormat` instead of generic `string` for the `format` parameter

## Implementation Details
These changes enforce compile-time type checking for email template types and formats, preventing invalid values from being passed to the `safeRender` function. This reduces the risk of runtime errors and improves code maintainability by making the expected parameter types explicit.

https://claude.ai/code/session_01Vor4ME1V3agSjN8G81B9U4