### PR TITLE
Add email notice to payment and reservation success pages

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -49,6 +49,7 @@ import {
   withCsrfForm,
   withActiveEventBySlug,
 } from "#routes/utils.ts";
+import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
 import { extractContact, mergeEventFields, tryValidateTicketFields } from "#templates/fields.ts";
 import { checkoutPopupPage, reservationSuccessPage } from "#templates/payment.tsx";
 import {
@@ -730,15 +731,24 @@ const handleGroupTicketBySlug = (request: Request, slug: string): Promise<Respon
   withActiveGroupEventsBySlug(slug, (group, activeEvents) =>
     handleMultiTicket(request, [slug], activeEvents, getGroupMultiTicketContext(group)));
 
+/** Get the email from-address if email is configured. Returns empty string if not. */
+export const getFromEmailIfConfigured = async (): Promise<string> => {
+  const config = await getEmailConfig() ?? getHostEmailConfig();
+  return config?.fromAddress ?? "";
+};
+
 /** Handle GET /ticket/reserved - reservation success page */
-const handleReservedGet = (request: Request): Response => {
+const handleReservedGet = async (request: Request): Promise<Response> => {
   const url = new URL(request.url);
   const tokensParam = url.searchParams.get("tokens");
   const normalizedTokens = tokensParam?.replaceAll(" ", "+") ?? "";
   const tokens = normalizedTokens.split("+").filter((t) => t.length > 0);
   const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
   const inIframe = isIframeRequest(request.url);
-  return htmlResponse(reservationSuccessPage(ticketUrl, inIframe));
+
+  const fromEmail = tokens.length > 0 ? await getFromEmailIfConfigured() : "";
+
+  return htmlResponse(reservationSuccessPage(ticketUrl, inIframe, fromEmail));
 };
 
 /** Create a slug route that dispatches single vs multi-ticket requests */

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -51,6 +51,7 @@ import {
   plainResponse,
   redirectResponse,
 } from "#routes/utils.ts";
+import { getFromEmailIfConfigured } from "#routes/public.ts";
 import { paymentCancelPage, paymentSuccessPage } from "#templates/payment.tsx";
 
 /** Parsed multi-ticket item from metadata */
@@ -634,7 +635,9 @@ const renderSuccessFromTokens = async (tokensParam: string): Promise<Response> =
     if (event) thankYouUrl = event.thank_you_url;
   }
 
-  return htmlResponse(paymentSuccessPage(thankYouUrl, ticketUrl));
+  const fromEmail = await getFromEmailIfConfigured();
+
+  return htmlResponse(paymentSuccessPage(thankYouUrl, ticketUrl, fromEmail));
 };
 
 /**

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -32,7 +32,7 @@ export const paymentPage = (
 /**
  * Payment success page - with optional redirect and ticket link
  */
-export const paymentSuccessPage = (thankYouUrl: string, ticketUrl: string | null): string =>
+export const paymentSuccessPage = (thankYouUrl: string, ticketUrl: string | null, fromEmail = ""): string =>
   String(
     <Layout title="Payment Successful" headExtra={thankYouUrl ? `<meta http-equiv="refresh" content="3;url=${escapeHtml(thankYouUrl)}">` : undefined}>
         <div data-payment-result="success">
@@ -40,6 +40,9 @@ export const paymentSuccessPage = (thankYouUrl: string, ticketUrl: string | null
           <div class="success">
             <p>Thank you for your payment. Your ticket has been confirmed.</p>
           </div>
+          {fromEmail ? (
+            <p><small><i>Your ticket will be sent from {fromEmail} &mdash; please check your Junk/Spam folder.</i></small></p>
+          ) : null}
           {ticketUrl ? (
             <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>
           ) : null}
@@ -56,10 +59,13 @@ export const paymentSuccessPage = (thankYouUrl: string, ticketUrl: string | null
 /**
  * Simple reservation success page (for free events with no thank_you_url)
  */
-export const reservationSuccessPage = (ticketUrl: string | null, inIframe = false): string =>
+export const reservationSuccessPage = (ticketUrl: string | null, inIframe = false, fromEmail = ""): string =>
   String(
     <Layout title="Ticket Reserved" bodyClass={inIframe ? "iframe" : undefined}>
         <h1 data-scroll-into-view={inIframe || undefined}>Ticket reserved successfully.</h1>
+        {fromEmail ? (
+          <p><small><i>Your ticket will be sent from {fromEmail} &mdash; please check your Junk/Spam folder.</i></small></p>
+        ) : null}
         {ticketUrl ? (
           <p><a href={ticketUrl} target="_blank">Click here to view your tickets</a></p>
         ) : null}

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -721,6 +721,17 @@ describe("html", () => {
       const html = paymentSuccessPage("", null);
       expect(html).not.toContain("view your tickets");
     });
+
+    test("shows email notice when fromEmail is provided", () => {
+      const html = paymentSuccessPage("", "/t/abc123", "tickets@example.com");
+      expect(html).toContain("tickets@example.com");
+      expect(html).toContain("Junk/Spam");
+    });
+
+    test("does not show email notice when fromEmail is empty", () => {
+      const html = paymentSuccessPage("", "/t/abc123");
+      expect(html).not.toContain("Junk/Spam");
+    });
   });
 
   describe("paymentCancelPage", () => {
@@ -800,6 +811,17 @@ describe("html", () => {
     test("excludes scroll-into-view marker when not in iframe mode", () => {
       const html = reservationSuccessPage("/t/abc123");
       expect(html).not.toContain("data-scroll-into-view");
+    });
+
+    test("shows email notice when fromEmail is provided", () => {
+      const html = reservationSuccessPage("/t/abc123", false, "tickets@example.com");
+      expect(html).toContain("tickets@example.com");
+      expect(html).toContain("Junk/Spam");
+    });
+
+    test("does not show email notice when fromEmail is empty", () => {
+      const html = reservationSuccessPage("/t/abc123");
+      expect(html).not.toContain("Junk/Spam");
     });
   });
 

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -1316,5 +1316,38 @@ describe("server (payment flow)", () => {
         mockRetrieve.restore();
       }
     });
+
+    test("shows email notice on payment success when email configured", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+
+      // Create attendee directly (simulates post-payment state)
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "Email Test",
+        email: "buyer@example.com",
+        paymentId: "pi_email_notice",
+        pricePaid: 500,
+      });
+      if (!result.success) throw new Error("Failed to create attendee");
+
+      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+      Deno.env.set("HOST_EMAIL_API_KEY", "re_test123");
+      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@tickets.com");
+
+      try {
+        const response = await handleRequest(
+          mockRequest(`/payment/success?tokens=${encodeURIComponent(result.attendee.ticket_token)}`),
+        );
+        const html = await expectHtmlResponse(response, 200, "Junk/Spam");
+        expect(html).toContain("noreply@tickets.com");
+      } finally {
+        Deno.env.delete("HOST_EMAIL_PROVIDER");
+        Deno.env.delete("HOST_EMAIL_API_KEY");
+        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+      }
+    });
   });
 });

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1622,6 +1622,31 @@ describe("server (public routes)", () => {
       const html = await response.text();
       expect(html).not.toContain("iframe-resizer-child.js");
     });
+
+    test("shows email notice when email sending is configured", async () => {
+      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+      Deno.env.set("HOST_EMAIL_API_KEY", "re_test123");
+      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "tickets@mysite.com");
+      try {
+        const response = await handleRequest(
+          mockRequest("/ticket/reserved?tokens=abc123"),
+        );
+        const html = await expectHtmlResponse(response, 200, "Junk/Spam");
+        expect(html).toContain("tickets@mysite.com");
+      } finally {
+        Deno.env.delete("HOST_EMAIL_PROVIDER");
+        Deno.env.delete("HOST_EMAIL_API_KEY");
+        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+      }
+    });
+
+    test("does not show email notice when email is not configured", async () => {
+      const response = await handleRequest(
+        mockRequest("/ticket/reserved?tokens=abc123"),
+      );
+      const html = await expectHtmlResponse(response, 200, "success");
+      expect(html).not.toContain("Junk/Spam");
+    });
   });
 
   describe("POST /ticket/:slug (free event without thank_you_url)", () => {


### PR DESCRIPTION
## Summary
This PR adds a user-facing notice on payment and reservation success pages when email notifications are configured, informing users that their ticket will be sent via email and to check their spam folder.

## Key Changes
- **Email configuration detection**: Added `getFromEmailIfConfigured()` helper function in `public.ts` that retrieves the configured email sender address from either custom email config or host email config
- **Success page updates**: Modified `paymentSuccessPage()` and `reservationSuccessPage()` template functions to accept an optional `fromEmail` parameter and display a notice when provided
- **Route handlers**: Updated `handleReservedGet()` in public routes and `renderSuccessFromTokens()` in webhooks to fetch the email configuration and pass it to the success page templates
- **Comprehensive test coverage**: Added tests across three test files:
  - `html.test.ts`: Unit tests for the template functions with and without email configuration
  - `server-public.test.ts`: Integration tests for the reservation success page showing/hiding the notice based on configuration
  - `server-payments.test.ts`: Integration test for the payment success page with email configuration

## Implementation Details
- The email notice displays as: "Your ticket will be sent from [email] — please check your Junk/Spam folder."
- The notice only appears when email is actually configured (non-empty `fromEmail`)
- The implementation gracefully handles both configured and unconfigured states
- Email configuration is checked at request time, allowing dynamic configuration changes

https://claude.ai/code/session_01BFCdFCMFHYNDqiCENUKkZR