### PR TITLE
Validate email provider configuration and reject invalid providers

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -48,7 +48,11 @@ export const getHostEmailConfig = (): EmailConfig | null => {
   const apiKey = getEnv("HOST_EMAIL_API_KEY");
   const fromAddress = getEnv("HOST_EMAIL_FROM_ADDRESS");
   if (!provider || !apiKey || !fromAddress) return null;
-  return { provider: provider as EmailProvider, apiKey, fromAddress };
+  if (!isEmailProvider(provider)) {
+    logError({ code: ErrorCode.EMAIL_SEND, detail: `invalid HOST_EMAIL_PROVIDER: "${provider}"` });
+    return null;
+  }
+  return { provider, apiKey, fromAddress };
 };
 
 /** Build provider-specific request: [url, extra-headers, body] */

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -188,7 +188,7 @@ const getSettingsPageState = async () => {
     hostEmailLabel: (() => {
       const hostConfig = getHostEmailConfig();
       if (!hostConfig) return "";
-      const label = EMAIL_PROVIDER_LABELS[hostConfig.provider] ?? hostConfig.provider;
+      const label = EMAIL_PROVIDER_LABELS[hostConfig.provider];
       return `Host ${label} (${hostConfig.fromAddress})`;
     })(),
     confirmationTemplates: {

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -365,6 +365,18 @@ describe("email", () => {
         fromAddress: "noreply@example.com",
       });
     });
+
+    test("returns null and logs error for invalid provider", async () => {
+      Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun");
+      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+      await withErrorSpy((errorSpy) => {
+        const config = getHostEmailConfig();
+        expect(config).toBeNull();
+        const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
+        expect(logs.some((l) => l.includes("E_EMAIL_SEND") && l.includes("invalid HOST_EMAIL_PROVIDER"))).toBe(true);
+      });
+    });
   });
 
   describe("sendRegistrationEmails", () => {

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -137,7 +137,7 @@ describe("server (admin settings)", () => {
       }
     });
 
-    test("shows raw provider name when host email provider is unknown", async () => {
+    test("shows no host config when host email provider is invalid", async () => {
       Deno.env.set("HOST_EMAIL_PROVIDER", "custom-smtp");
       Deno.env.set("HOST_EMAIL_API_KEY", "key-456");
       Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "mail@example.com");
@@ -145,7 +145,7 @@ describe("server (admin settings)", () => {
         const { cookie } = await loginAsAdmin();
         const response = await awaitTestRequest("/admin/settings", { cookie });
         const html = await response.text();
-        expect(html).toContain("Host custom-smtp (mail@example.com)");
+        expect(html).not.toContain("Host custom-smtp");
       } finally {
         Deno.env.delete("HOST_EMAIL_PROVIDER");
         Deno.env.delete("HOST_EMAIL_API_KEY");


### PR DESCRIPTION
## Summary
This PR adds validation for the `HOST_EMAIL_PROVIDER` configuration to ensure only supported email providers are accepted. Invalid providers are now rejected with an error log, and the admin settings page no longer displays email configuration when the provider is invalid.

## Key Changes
- Added validation in `getHostEmailConfig()` to check if the provider is in the `VALID_EMAIL_PROVIDERS` set
- Invalid providers now log an error with code `E_EMAIL_SEND` and return `null` instead of silently accepting unknown providers
- Updated admin settings page to only display the host email label when a valid configuration exists (removed fallback to raw provider name)
- Added test case to verify error logging for invalid providers
- Updated existing test to reflect the new behavior of rejecting invalid providers

## Implementation Details
- The validation uses `VALID_EMAIL_PROVIDERS.has(provider)` to check against allowed providers
- Invalid providers trigger an error log with descriptive messaging about the invalid `HOST_EMAIL_PROVIDER` value
- The admin settings UI now cleanly omits email configuration display rather than showing unsupported provider names

https://claude.ai/code/session_015Et6RFs6FAyCUyS4aAUV6J