### PR TITLE
Fix email template render error code logging

### DIFF
--- a/src/lib/email-renderer.ts
+++ b/src/lib/email-renderer.ts
@@ -140,7 +140,7 @@ const safeRender = async (
     return await renderTemplate(template, data);
   } catch (error) {
     logError({
-      code: ErrorCode.EMAIL_SEND,
+      code: ErrorCode.EMAIL_TEMPLATE_RENDER,
       detail: `template render error (${type}/${format}): ${error instanceof Error ? error.message : String(error)}`,
     });
     // If the custom template failed and it differs from the default, try the default

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -88,6 +88,7 @@ const ERROR_DEFS = {
 
   // Email errors
   EMAIL_SEND: ["E_EMAIL_SEND", "Email send failed"],
+  EMAIL_TEMPLATE_RENDER: ["E_EMAIL_TEMPLATE_RENDER", "Email template render failed"],
 
   // Not found
   NOT_FOUND_EVENT: ["E_NOT_FOUND_EVENT", "Event not found"],

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -266,7 +266,7 @@ describe("email-renderer", () => {
         expect(result.subject).toContain("Test Event");
         // Should have logged the error
         const logs = map((c: { args: unknown[] }) => c.args[0] as string)(errorSpy.calls);
-        expect(logs.some((l) => l.includes("template render error"))).toBe(true);
+        expect(logs.some((l) => l.includes("E_EMAIL_TEMPLATE_RENDER") && l.includes("template render error"))).toBe(true);
       } finally {
         errorSpy.restore();
       }


### PR DESCRIPTION
## Summary
Corrected the error code logged when email template rendering fails. Previously, template render errors were incorrectly logged with the `EMAIL_SEND` error code, which is semantically inaccurate since the failure occurs during template rendering, not during the actual email send operation.

## Changes
- Added new `EMAIL_TEMPLATE_RENDER` error code definition in `logger.ts` with code `E_EMAIL_TEMPLATE_RENDER` and message "Email template render failed"
- Updated `email-renderer.ts` to use `ErrorCode.EMAIL_TEMPLATE_RENDER` instead of `ErrorCode.EMAIL_SEND` when logging template render errors
- Updated corresponding test assertion to verify the correct error code is logged alongside the error message

## Implementation Details
This change improves error tracking and debugging by ensuring that template rendering failures are properly categorized and logged with their own distinct error code, making it easier to distinguish between rendering issues and actual email delivery failures in logs and monitoring systems.

https://claude.ai/code/session_015atpV7gEZJqMtgMMLPHA1C