### PR TITLE
Extract domain validation pattern to shared constant

### DIFF
--- a/src/lib/embed-hosts.ts
+++ b/src/lib/embed-hosts.ts
@@ -4,21 +4,14 @@
 
 import { filter, map, pipe } from "#fp";
 
-/**
- * Valid host pattern: a hostname with optional wildcard prefix.
- * Allowed forms:
- *   - "example.com"
- *   - "sub.example.com"
- *   - "*.example.com"
- * Rejects:
- *   - Ports, paths, protocols, spaces
- *   - Bare "*" (too broad)
- *   - "**.example.com" or "*example.com"
- */
 /** Matches a valid hostname like "example.com" or "sub.example.com" */
 export const DOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/;
 
-const HOST_PATTERN = /^(?:\*\.)?[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/;
+/**
+ * Matches a hostname with optional wildcard prefix ("*.example.com").
+ * Rejects ports, paths, protocols, spaces, bare "*", "**.", "*example.com".
+ */
+const HOST_PATTERN = new RegExp(`^(?:\\*\\.)?${DOMAIN_PATTERN.source.slice(1)}`);
 
 /**
  * Validate a single host pattern

--- a/src/lib/embed-hosts.ts
+++ b/src/lib/embed-hosts.ts
@@ -15,6 +15,9 @@ import { filter, map, pipe } from "#fp";
  *   - Bare "*" (too broad)
  *   - "**.example.com" or "*example.com"
  */
+/** Matches a valid hostname like "example.com" or "sub.example.com" */
+export const DOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/;
+
 const HOST_PATTERN = /^(?:\*\.)?[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/;
 
 /**

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -9,6 +9,7 @@ import {
   updateBusinessEmail,
 } from "#lib/business-email.ts";
 import { validateCustomDomain } from "#lib/bunny-cdn.ts";
+import { DOMAIN_PATTERN } from "#lib/embed-hosts.ts";
 import { EMAIL_PROVIDER_LABELS, getEmailConfig, getHostEmailConfig, isEmailProvider, sendTestEmail } from "#lib/email.ts";
 import { buildTemplateData, renderTemplate, validateTemplate } from "#lib/email-renderer.ts";
 import {
@@ -946,7 +947,7 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
   }
 
   // Basic domain validation: must look like a hostname
-  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(raw)) {
+  if (!DOMAIN_PATTERN.test(raw)) {
     return errorPage("Invalid domain format", 400, "settings-custom-domain");
   }
 

--- a/test/lib/embed-hosts.test.ts
+++ b/test/lib/embed-hosts.test.ts
@@ -2,6 +2,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   buildFrameAncestors,
+  DOMAIN_PATTERN,
   parseEmbedHosts,
   validateEmbedHosts,
   validateHostPattern,
@@ -76,6 +77,40 @@ describe("embed-hosts", () => {
     test("rejects uppercase characters", () => {
       const result = validateHostPattern("Example.com");
       expect(result).toContain("Invalid host pattern");
+    });
+  });
+
+  describe("DOMAIN_PATTERN", () => {
+    test("matches simple hostname", () => {
+      expect(DOMAIN_PATTERN.test("example.com")).toBe(true);
+    });
+
+    test("matches subdomain hostname", () => {
+      expect(DOMAIN_PATTERN.test("sub.example.com")).toBe(true);
+    });
+
+    test("matches hostname with hyphens", () => {
+      expect(DOMAIN_PATTERN.test("my-site.example.com")).toBe(true);
+    });
+
+    test("rejects single label", () => {
+      expect(DOMAIN_PATTERN.test("localhost")).toBe(false);
+    });
+
+    test("rejects wildcard prefix", () => {
+      expect(DOMAIN_PATTERN.test("*.example.com")).toBe(false);
+    });
+
+    test("rejects hostname with port", () => {
+      expect(DOMAIN_PATTERN.test("example.com:8080")).toBe(false);
+    });
+
+    test("rejects hostname with path", () => {
+      expect(DOMAIN_PATTERN.test("example.com/path")).toBe(false);
+    });
+
+    test("rejects uppercase characters", () => {
+      expect(DOMAIN_PATTERN.test("Example.com")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
Extracted the domain hostname validation regex pattern into a reusable constant `DOMAIN_PATTERN` in the embed-hosts module, eliminating code duplication and improving maintainability.

## Key Changes
- **Added `DOMAIN_PATTERN` export** in `src/lib/embed-hosts.ts`: A regex that matches valid hostnames (e.g., "example.com", "sub.example.com") while rejecting invalid formats like single labels, wildcards, ports, paths, and uppercase characters
- **Updated domain validation** in `src/routes/admin/settings.ts`: Replaced inline regex with the new `DOMAIN_PATTERN` constant for custom domain validation
- **Added comprehensive test coverage** in `test/lib/embed-hosts.test.ts`: 8 test cases covering valid hostnames, subdomains, hyphens, and various rejection cases (single labels, wildcards, ports, paths, uppercase)

## Implementation Details
The `DOMAIN_PATTERN` regex enforces:
- Lowercase alphanumeric characters and hyphens only
- Must contain at least one dot (no single-label domains)
- Labels cannot start or end with hyphens
- No wildcard prefixes, ports, or paths allowed

https://claude.ai/code/session_018KyVTfmoSNQbPvcnVfve8y