### PR TITLE
Extract email template preview data to constants

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -869,6 +869,38 @@ const handleEmailTemplatePost = (type: EmailTemplateType) =>
     return redirect("/admin/settings", `${label} email template updated`, true, { formId });
   });
 
+/** Sample booking data used for email template previews */
+const PREVIEW_BOOKINGS = [{
+  event: {
+    id: 1, name: "Summer Concert", slug: "summer-concert",
+    webhook_url: "", max_attendees: 100, attendee_count: 42,
+    unit_price: 2500, can_pay_more: false,
+  },
+  attendee: {
+    id: 1, name: "Jane Smith", email: "jane@example.com",
+    phone: "+44 7700 900000", address: "123 High Street, London",
+    special_instructions: "Wheelchair access please",
+    quantity: 2, payment_id: "pi_sample", price_paid: "5000",
+    ticket_token: "SAMPLE123", date: null,
+  },
+}, {
+  event: {
+    id: 2, name: "Workshop", slug: "workshop",
+    webhook_url: "", max_attendees: 20, attendee_count: 8,
+    unit_price: 0, can_pay_more: false,
+  },
+  attendee: {
+    id: 2, name: "Jane Smith", email: "jane@example.com",
+    phone: "+44 7700 900000", address: "123 High Street, London",
+    special_instructions: "Wheelchair access please",
+    quantity: 1, payment_id: "", price_paid: "0",
+    ticket_token: "SAMPLE456", date: "2026-04-15",
+  },
+}];
+
+const PREVIEW_CURRENCY = "GBP";
+const PREVIEW_TICKET_URL = "https://example.com/t/SAMPLE123+SAMPLE456";
+
 /** Handle POST /admin/settings/email-templates/preview - render template with sample data */
 const handleEmailTemplatePreviewPost = (request: Request): Promise<Response> =>
   withOwnerAuthForm(request, async (_session, form) => {
@@ -885,37 +917,10 @@ const handleEmailTemplatePreviewPost = (request: Request): Promise<Response> =>
       return jsonResponse({ error: `Template syntax error: ${error}` }, 400);
     }
 
-    // Sample data for preview
     const sampleData = buildTemplateData(
-      [{
-        event: {
-          id: 1, name: "Summer Concert", slug: "summer-concert",
-          webhook_url: "", max_attendees: 100, attendee_count: 42,
-          unit_price: 2500, can_pay_more: false,
-        },
-        attendee: {
-          id: 1, name: "Jane Smith", email: "jane@example.com",
-          phone: "+44 7700 900000", address: "123 High Street, London",
-          special_instructions: "Wheelchair access please",
-          quantity: 2, payment_id: "pi_sample", price_paid: "5000",
-          ticket_token: "SAMPLE123", date: null,
-        },
-      }, {
-        event: {
-          id: 2, name: "Workshop", slug: "workshop",
-          webhook_url: "", max_attendees: 20, attendee_count: 8,
-          unit_price: 0, can_pay_more: false,
-        },
-        attendee: {
-          id: 2, name: "Jane Smith", email: "jane@example.com",
-          phone: "+44 7700 900000", address: "123 High Street, London",
-          special_instructions: "Wheelchair access please",
-          quantity: 1, payment_id: "", price_paid: "0",
-          ticket_token: "SAMPLE456", date: "2026-04-15",
-        },
-      }],
-      "GBP",
-      "https://example.com/t/SAMPLE123+SAMPLE456",
+      PREVIEW_BOOKINGS,
+      PREVIEW_CURRENCY,
+      PREVIEW_TICKET_URL,
     );
 
     try {


### PR DESCRIPTION
## Summary
Refactored the email template preview functionality by extracting hardcoded sample data into module-level constants for improved maintainability and reusability.

## Key Changes
- Extracted sample booking data into `PREVIEW_BOOKINGS` constant containing two booking examples (paid event and free workshop)
- Extracted preview currency into `PREVIEW_CURRENCY` constant ("GBP")
- Extracted preview ticket URL into `PREVIEW_TICKET_URL` constant
- Updated `handleEmailTemplatePreviewPost` to use these constants instead of inline data

## Benefits
- Reduces code duplication and improves readability
- Makes sample data easier to maintain and update in one place
- Allows potential reuse of preview data in other parts of the codebase
- Maintains the same functionality with cleaner code organization

https://claude.ai/code/session_01PkogsHVzU49F478PGZvLud