### PR TITLE
Add email from-address format validation

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -803,6 +803,14 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
     return errorPage("Invalid email provider", 400, "settings-email");
   }
 
+  if (fromAddress && !isValidBusinessEmail(fromAddress)) {
+    return errorPage(
+      "Invalid from-address format. Please use format: name@domain.com",
+      400,
+      "settings-email",
+    );
+  }
+
   await updateEmailProvider(provider);
   if (apiKey && !isMaskSentinel(apiKey)) await updateEmailApiKey(apiKey);
   if (fromAddress) await updateEmailFromAddress(fromAddress);

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2248,6 +2248,25 @@ describe("server (admin settings)", () => {
       await expectHtmlResponse(response, 400, "Invalid email provider");
     });
 
+    test("rejects invalid from-address format", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "resend",
+            email_api_key: "re_test_123",
+            email_from_address: "not-an-email",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "Invalid from-address format");
+    });
+
     test("disables email when provider field is missing", async () => {
       const { cookie, csrfToken } = await loginAsAdmin();
 


### PR DESCRIPTION
## Summary
Added validation for the email from-address field in the admin settings to ensure it follows a valid email format before being saved.

## Key Changes
- Added `isValidBusinessEmail()` validation check in the email settings POST handler
- Returns a 400 error with message "Invalid from-address format. Please use format: name@domain.com" when an invalid email format is provided
- Added corresponding test case to verify the validation rejects improperly formatted email addresses

## Implementation Details
The validation is performed in the `handleEmailPost` function after the email provider validation, ensuring that if a from-address is provided, it must be in a valid email format (e.g., name@domain.com). The error is returned before any database updates occur, preventing invalid data from being persisted.

https://claude.ai/code/session_01Qt79XdBzgD5CaUYcVYteQk