### PR TITLE
Use Intl.ListFormat for proper event name formatting

### DIFF
--- a/src/templates/email/shared.ts
+++ b/src/templates/email/shared.ts
@@ -8,5 +8,7 @@ export type { RegistrationEntry };
 
 export type EmailContent = { subject: string; html: string; text: string };
 
+const listFormat = new Intl.ListFormat("en", { type: "conjunction" });
+
 export const eventNames = (entries: RegistrationEntry[]): string =>
-  map(({ event }: RegistrationEntry) => event.name)(entries).join(" and ");
+  listFormat.format(map(({ event }: RegistrationEntry) => event.name)(entries));

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -95,6 +95,17 @@ describe("email-renderer", () => {
       expect(data.attendee.name).toBe("Jane Doe");
     });
 
+    test("formats three or more event names with commas and 'and'", () => {
+      const entries = [
+        makeEntry({ name: "Event A" }),
+        makeEntry({ name: "Event B" }),
+        makeEntry({ name: "Event C" }),
+      ];
+      const data = buildTemplateData(entries, "GBP", "https://example.com/t/ABC+DEF+GHI");
+
+      expect(data.event_names).toBe("Event A, Event B, and Event C");
+    });
+
     test("marks paid events correctly", () => {
       const entries = [makeEntry({ unit_price: 1000 })];
       const data = buildTemplateData(entries, "GBP", "https://example.com/t/ABC");


### PR DESCRIPTION
## Summary
Updated event name formatting to use the native `Intl.ListFormat` API instead of manual string joining, which properly handles Oxford comma formatting for lists of three or more items.

## Key Changes
- Replaced manual `join(" and ")` with `Intl.ListFormat` using conjunction type
- Event names are now formatted as:
  - Two items: "Event A and Event B"
  - Three or more items: "Event A, Event B, and Event C" (with Oxford comma)
- Added test case to verify correct formatting of three or more event names

## Implementation Details
- Created a reusable `listFormat` instance using `new Intl.ListFormat("en", { type: "conjunction" })`
- The `Intl.ListFormat` API automatically handles proper punctuation and conjunction placement based on locale and list length
- This is more maintainable and follows internationalization best practices

https://claude.ai/code/session_01AduzAo9AHHy24GvdZv2t5K