### PR TITLE
Extract error key from Bunny CDN JSON error responses

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -35,7 +35,7 @@ interface BunnyPullZoneListResponse {
  * (ALLOWED_DOMAIN with .bunny.run replaced by .b-cdn.net).
  */
 const findPullZoneIdImpl = async (): Promise<
-  { ok: true; id: number } | { ok: false; error: string }
+  { ok: true; id: number } | { ok: false; error: string; errorKey?: string }
 > => {
   const cdnHostname = getCdnHostname();
   const response = await fetch(
@@ -44,11 +44,7 @@ const findPullZoneIdImpl = async (): Promise<
   );
 
   if (!response.ok) {
-    const text = await response.text();
-    return {
-      ok: false,
-      error: `List pull zones failed (${response.status}): ${text}`,
-    };
+    return parseBunnyError(response, "List pull zones");
   }
 
   const data: BunnyPullZoneListResponse = await response.json();

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -205,6 +205,28 @@ describe("bunny-cdn", () => {
         },
       );
     });
+
+    test("returns errorKey from JSON error response", async () => {
+      const jsonBody = JSON.stringify({
+        ErrorKey: "pullzone.rate_limited",
+        Message: "Too many requests.",
+      });
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response(jsonBody, { status: 429 }),
+            )),
+        async () => {
+          const result = await bunnyCdnApi.findPullZoneId();
+          expect(result).toEqual({
+            ok: false,
+            error: "List pull zones failed (429): Too many requests.",
+            errorKey: "pullzone.rate_limited",
+          });
+        },
+      );
+    });
   });
 
   describe("validateCustomDomain (real implementation)", () => {


### PR DESCRIPTION
## Summary
This PR enhances error handling for Bunny CDN API responses by extracting and returning the `ErrorKey` field from JSON error responses, providing more granular error information to callers.

## Key Changes
- Updated `findPullZoneIdImpl` return type to include an optional `errorKey` field in error responses
- Refactored error handling to use a new `parseBunnyError` helper function instead of manually parsing response text
- Added test case verifying that `ErrorKey` from JSON error responses is properly extracted and returned

## Implementation Details
- The `parseBunnyError` function (called but not shown in diff) handles parsing both the error message and the `ErrorKey` field from Bunny CDN's JSON error responses
- This allows consumers of the API to distinguish between different error types (e.g., `pullzone.rate_limited`) for more targeted error handling
- The change is backward compatible as `errorKey` is optional in the error response object

https://claude.ai/code/session_01NKHEN7Hfro61tEZczp5D34