### PR TITLE
Add type guard for EmailTemplateType validation

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -826,8 +826,11 @@ const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
   return redirect("/admin/settings", `Test email sent (status ${status})`, true, { formId: "settings-email-test" });
 });
 
-/** Valid template types for form submissions */
-const VALID_TEMPLATE_TYPES: ReadonlySet<string> = new Set(["confirmation", "admin"]);
+/** Valid template types for form submissions — derived from the EmailTemplateType union */
+const VALID_TEMPLATE_TYPES: ReadonlySet<EmailTemplateType> = new Set<EmailTemplateType>(["confirmation", "admin"]);
+
+/** Type guard: narrows a string to EmailTemplateType after Set membership check */
+const isEmailTemplateType = (v: string): v is EmailTemplateType => VALID_TEMPLATE_TYPES.has(v as EmailTemplateType);
 
 /** Handle POST /admin/settings/email-templates/:type - save custom email templates */
 const handleEmailTemplatePost = (type: EmailTemplateType) =>
@@ -876,7 +879,7 @@ const handleEmailTemplatePreviewPost = (request: Request): Promise<Response> =>
     const template = form.get("template") ?? "";
     const format = form.get("format") ?? "html";
 
-    if (!VALID_TEMPLATE_TYPES.has(type)) {
+    if (!isEmailTemplateType(type)) {
       return jsonResponse({ error: "Invalid template type" }, 400);
     }
 


### PR DESCRIPTION
## Summary
Improved type safety for email template type validation by introducing a dedicated type guard function and updating the `VALID_TEMPLATE_TYPES` constant to use the `EmailTemplateType` union type.

## Key Changes
- Updated `VALID_TEMPLATE_TYPES` to be explicitly typed as `ReadonlySet<EmailTemplateType>` instead of `ReadonlySet<string>`, making the valid types more explicit in the type system
- Added `isEmailTemplateType()` type guard function that narrows a string to `EmailTemplateType` after Set membership check
- Replaced direct `VALID_TEMPLATE_TYPES.has(type)` check with the new `isEmailTemplateType(type)` guard in the email template preview handler

## Implementation Details
The type guard uses a type assertion (`as EmailTemplateType`) internally to safely check Set membership while providing proper type narrowing to callers. This pattern allows TypeScript to understand that after the guard passes, the value is guaranteed to be a valid `EmailTemplateType`, improving type safety throughout the codebase.

https://claude.ai/code/session_016Myvpp2GrZpUT4SYvA1Rc5