### PR TITLE
Refactor webhook test stubs into reusable test utilities

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { type Client, createClient } from "@libsql/client";
+import { stub } from "@std/testing/mock";
 import { bracket } from "#fp";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { clearEncryptionKeyCache } from "#lib/crypto.ts";
@@ -1891,4 +1892,35 @@ export const createTestManagerSession = async (
   );
 
   return `${getSessionCookieName()}=${token}`;
+};
+
+/**
+ * Stub `stripePaymentProvider.verifyWebhookSignature` to return a valid event.
+ * Returns the stub (call `.restore()` in a `finally` block).
+ */
+export const stubWebhookVerify = async (
+  eventData: Record<string, unknown>,
+) => {
+  const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+  return stub(
+    stripePaymentProvider,
+    "verifyWebhookSignature",
+    () => Promise.resolve({ valid: true as const, event: eventData }),
+  );
+};
+
+/**
+ * Stub `stripeApi.refundPayment` to return a successful refund.
+ * Returns the stub (call `.restore()` in a `finally` block).
+ */
+export const stubRefundPayment = async () => {
+  const { stripeApi } = await import("#lib/stripe.ts");
+  return stub(
+    stripeApi,
+    "refundPayment",
+    () =>
+      Promise.resolve({ id: "re_stub" } as unknown as Awaited<
+        ReturnType<typeof stripeApi.refundPayment>
+      >),
+  );
 };

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1899,7 +1899,7 @@ export const createTestManagerSession = async (
  * Returns the stub (call `.restore()` in a `finally` block).
  */
 export const stubWebhookVerify = async (
-  eventData: Record<string, unknown>,
+  eventData: { id: string; type: string; data: { object: Record<string, unknown> } },
 ) => {
   const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
   return stub(

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -16,6 +16,8 @@ import {
   resetDb,
   resetTestSlugCounter,
   setupStripe,
+  stubRefundPayment,
+  stubWebhookVerify,
   webhookMeta,
 } from "#test-utils";
 
@@ -322,32 +324,28 @@ describe("server (webhooks)", () => {
         unitPrice: 1000,
       });
 
-      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
       // Items without p field — legacy sessions created before per-item price tracking
-      const mockVerify = stub(stripePaymentProvider, "verifyWebhookSignature", () => Promise.resolve({
-        valid: true,
-        event: {
-          id: "evt_legacy_multi",
-          type: "checkout.session.completed",
-          data: {
-            object: {
-              id: "cs_legacy_multi",
-              payment_status: "paid",
-              payment_intent: "pi_legacy_multi",
-              amount_total: 2000,
-              metadata: webhookMeta({
-                name: "Legacy User",
-                email: "legacy@example.com",
-                multi: "1",
-                items: JSON.stringify([
-                  { e: event1.id, q: 2 },
-                  { e: event2.id, q: 1 },
-                ]),
-              }),
-            },
+      const mockVerify = await stubWebhookVerify({
+        id: "evt_legacy_multi",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_legacy_multi",
+            payment_status: "paid",
+            payment_intent: "pi_legacy_multi",
+            amount_total: 2000,
+            metadata: webhookMeta({
+              name: "Legacy User",
+              email: "legacy@example.com",
+              multi: "1",
+              items: JSON.stringify([
+                { e: event1.id, q: 2 },
+                { e: event2.id, q: 1 },
+              ]),
+            }),
           },
         },
-      }));
+      });
 
       try {
         const response = await handleRequest(
@@ -361,14 +359,67 @@ describe("server (webhooks)", () => {
         expect(json.received).toBe(true);
         expect(json.processed).toBe(true);
 
-        // Verify attendees were created for both events
+        // Verify attendees were created with correct pricePaid (unit_price * quantity)
         const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
         const attendees1 = await getAttendeesRaw(event1.id);
         const attendees2 = await getAttendeesRaw(event2.id);
         expect(attendees1.length).toBe(1);
         expect(attendees1[0]?.quantity).toBe(2);
+        expect(await decrypt(attendees1[0]!.price_paid)).toBe("1000"); // 500 * 2
         expect(attendees2.length).toBe(1);
         expect(attendees2[0]?.quantity).toBe(1);
+        expect(await decrypt(attendees2[0]!.price_paid)).toBe("1000"); // 1000 * 1
+      } finally {
+        mockVerify.restore();
+      }
+    });
+
+    test("multi-ticket webhook without per-item prices accepts overpayment", async () => {
+      await setupStripe();
+
+      const event1 = await createTestEvent({
+        name: "Overpaid Multi",
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+
+      // amountTotal (1200) > expectedTotal (500 * 1 = 500) — overpayment accepted in legacy path
+      const mockVerify = await stubWebhookVerify({
+        id: "evt_overpaid_legacy",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_overpaid_legacy",
+            payment_status: "paid",
+            payment_intent: "pi_overpaid_legacy",
+            amount_total: 1200,
+            metadata: webhookMeta({
+              name: "Overpaid User",
+              email: "overpaid@example.com",
+              multi: "1",
+              items: JSON.stringify([{ e: event1.id, q: 1 }]),
+            }),
+          },
+        },
+      });
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest(
+            {},
+            { "stripe-signature": "sig_valid" },
+          ),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.received).toBe(true);
+        expect(json.processed).toBe(true);
+
+        // pricePaid falls back to expectedPrice (unit_price * quantity), not the overpaid amount
+        const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+        const attendees = await getAttendeesRaw(event1.id);
+        expect(attendees.length).toBe(1);
+        expect(await decrypt(attendees[0]!.price_paid)).toBe("500"); // 500 * 1, not 1200
       } finally {
         mockVerify.restore();
       }
@@ -383,32 +434,26 @@ describe("server (webhooks)", () => {
         unitPrice: 500,
       });
 
-      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
-      const mockVerify = stub(stripePaymentProvider, "verifyWebhookSignature", () => Promise.resolve({
-        valid: true,
-        event: {
-          id: "evt_underpaid",
-          type: "checkout.session.completed",
-          data: {
-            object: {
-              id: "cs_underpaid",
-              payment_status: "paid",
-              payment_intent: "pi_underpaid",
-              amount_total: 100, // Far less than expected 500
-              metadata: webhookMeta({
-                name: "Underpaid User",
-                email: "underpaid@example.com",
-                multi: "1",
-                items: JSON.stringify([{ e: event1.id, q: 1 }]),
-              }),
-            },
+      const mockVerify = await stubWebhookVerify({
+        id: "evt_underpaid",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_underpaid",
+            payment_status: "paid",
+            payment_intent: "pi_underpaid",
+            amount_total: 100, // Far less than expected 500
+            metadata: webhookMeta({
+              name: "Underpaid User",
+              email: "underpaid@example.com",
+              multi: "1",
+              items: JSON.stringify([{ e: event1.id, q: 1 }]),
+            }),
           },
         },
-      }));
+      });
 
-      const mockRefund = stub(stripeApi, "refundPayment", () => Promise.resolve({ id: "re_test" } as unknown as Awaited<
-        ReturnType<typeof stripeApi.refundPayment>
-      >));
+      const mockRefund = await stubRefundPayment();
 
       try {
         const response = await handleRequest(
@@ -421,6 +466,10 @@ describe("server (webhooks)", () => {
         const json = await response.json();
         expect(json.processed).toBe(false);
         expect(json.error).toContain("price");
+
+        // Verify refund was actually attempted
+        expect(mockRefund.calls.length).toBe(1);
+        expect(mockRefund.calls[0]!.args).toEqual(["pi_underpaid"]);
       } finally {
         mockVerify.restore();
         mockRefund.restore();


### PR DESCRIPTION
## Summary
Extracted webhook mocking logic from individual tests into reusable helper functions in the test utilities, reducing code duplication and improving test maintainability.

## Key Changes
- **New test utilities** (`src/test-utils/index.ts`):
  - Added `stubWebhookVerify()` helper to stub `stripePaymentProvider.verifyWebhookSignature` with configurable event data
  - Added `stubRefundPayment()` helper to stub `stripeApi.refundPayment` with a successful response

- **Test refactoring** (`test/lib/server-webhooks.test.ts`):
  - Replaced inline stub creation with `stubWebhookVerify()` calls in three webhook tests
  - Replaced inline `stripeApi.refundPayment` stub with `stubRefundPayment()` call
  - Added new test case "multi-ticket webhook without per-item prices accepts overpayment" to verify overpayment handling in legacy webhook paths
  - Enhanced existing test assertions to verify `price_paid` values are correctly calculated from unit prices and quantities
  - Added verification that refund was actually attempted when underpayment is detected

## Notable Implementation Details
- The new helpers return the stub object directly, allowing callers to invoke `.restore()` in finally blocks
- Event data is passed as a plain object to `stubWebhookVerify()`, simplifying the API compared to inline stub creation
- Test coverage improved with explicit assertions on refund invocation and price calculation logic

https://claude.ai/code/session_01DMhKehxC8qZigr8j8b4R8T