### PR TITLE
Skip registration emails when attendee has no email address

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -181,6 +181,9 @@ export const sendRegistrationEmails = async (
   entries: RegistrationEntry[],
   currency: string,
 ): Promise<void> => {
+  const attendeeEmail = entries[0]!.attendee.email;
+  if (!attendeeEmail) return;
+
   const config = await getEmailConfig() ?? getHostEmailConfig();
   if (!config) return;
 
@@ -191,13 +194,13 @@ export const sendRegistrationEmails = async (
 
   const confirmation = await renderEmailContent("confirmation", data);
   const promises: Promise<number | undefined>[] = [
-    sendEmail(config, { to: entries[0]!.attendee.email, ...confirmation, replyTo }),
+    sendEmail(config, { to: attendeeEmail, ...confirmation, replyTo }),
   ];
 
   if (businessEmail) {
     const notification = await renderEmailContent("admin", data);
     promises.push(
-      sendEmail(config, { to: businessEmail, ...notification, replyTo: entries[0]!.attendee.email }),
+      sendEmail(config, { to: businessEmail, ...notification, replyTo: attendeeEmail }),
     );
   }
 

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -386,6 +386,16 @@ describe("email", () => {
       Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
     });
 
+    test("skips when attendee has no email address", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry({}, { email: "" })], "GBP");
+      expect(fetchStub.calls.length).toBe(0);
+    });
+
     test("skips when email not configured", async () => {
       await sendRegistrationEmails([makeEntry()], "GBP");
       expect(fetchStub.calls.length).toBe(0);


### PR DESCRIPTION
## Summary
Added validation to skip sending registration emails when an attendee has no email address, preventing potential errors and unnecessary email send attempts.

## Key Changes
- Added early return in `sendRegistrationEmails()` to check if the attendee email is empty before proceeding with email configuration and sending
- Extracted attendee email to a variable for reuse and cleaner code
- Added test case to verify emails are not sent when attendee email is empty

## Implementation Details
The validation is performed at the start of the `sendRegistrationEmails()` function, before any email configuration is loaded or email sending is attempted. This ensures we fail fast and avoid unnecessary processing when there's no valid recipient email address.

https://claude.ai/code/session_016GvAcMCViDHtpPGVhE3tKN