### PR TITLE
Fix form ID in email test error responses

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -824,13 +824,13 @@ const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
   const config = await getEmailConfig();
   if (!config) return errorPage("Email not configured", 400, "settings-email");
   const businessEmail = await getBusinessEmailFromDb();
-  if (!businessEmail) return errorPage("No business email set", 400, "settings-email");
+  if (!businessEmail) return errorPage("No business email set", 400, "settings-email-test");
   const status = await sendTestEmail(config, businessEmail);
   if (!status) {
-    return errorPage("Test email failed (no response)", 502, "settings-email");
+    return errorPage("Test email failed (no response)", 502, "settings-email-test");
   }
   if (status >= 300) {
-    return errorPage(`Test email failed (status ${status})`, 502, "settings-email");
+    return errorPage(`Test email failed (status ${status})`, 502, "settings-email-test");
   }
   return redirect("/admin/settings", `Test email sent (status ${status})`, true, { formId: "settings-email-test" });
 });


### PR DESCRIPTION
## Summary
Updated error response form IDs in the email test endpoint to use the correct form identifier for consistency with the success response.

## Changes
- Changed error page form ID from `"settings-email"` to `"settings-email-test"` in three error cases:
  - When no business email is configured
  - When test email fails with no response
  - When test email fails with HTTP error status

## Details
The success response already uses `formId: "settings-email-test"`, so these error responses now consistently use the same form identifier. This ensures proper form state management and error display on the client side when any of these error conditions occur during the email test operation.

https://claude.ai/code/session_015u19HZjjbhNMGK5VRvTgAf