### PR TITLE
Place "Select a date" between past and future dates in calendar dropdown

### DIFF
--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -3,9 +3,10 @@
  */
 
 import { filter, flatMap, map, pipe, reduce, sort, unique } from "#fp";
-import { getAllowedDomain } from "#lib/config.ts";
+import { getAllowedDomain, getTz } from "#lib/config.ts";
 import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
 import { eventDateToCalendarDate, formatDateLabel, getAvailableDates } from "#lib/dates.ts";
+import { todayInTz } from "#lib/timezone.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { decryptAttendees, decryptAttendeesForTable } from "#lib/db/attendees.ts";
 import { mergeEventFields } from "#lib/event-fields.ts";
@@ -185,6 +186,7 @@ const handleAdminCalendarGet = (request: Request) =>
         session,
         dateFilter,
         availableDates,
+        todayInTz(getTz()),
         phonePrefix,
       ),
     );

--- a/src/templates/admin/calendar.tsx
+++ b/src/templates/admin/calendar.tsx
@@ -26,17 +26,19 @@ export type CalendarAttendeeRow = Attendee & {
 };
 
 /** Build date selector dropdown for calendar view */
-const CalendarDateSelector = ({ dateFilter, dates }: { dateFilter: string | null; dates: CalendarDateOption[] }): string => {
-  const options = [
-    `<option value="/admin/calendar#attendees"${!dateFilter ? " selected" : ""}>Select a date</option>`,
-    ...dates.map(
-      (d) =>
-        d.hasBookings
-          ? `<option value="/admin/calendar?date=${d.value}#attendees"${dateFilter === d.value ? " selected" : ""}>${d.label}</option>`
-          : `<option disabled>${d.label}</option>`,
-    ),
-  ].join("");
-  return `<select data-nav-select>${options}</select>`;
+const CalendarDateSelector = ({ dateFilter, dates, today }: { dateFilter: string | null; dates: CalendarDateOption[]; today: string }): string => {
+  const selectOption = `<option value="/admin/calendar#attendees"${!dateFilter ? " selected" : ""}>Select a date</option>`;
+  const dateOptions = dates.map(
+    (d) =>
+      d.hasBookings
+        ? `<option value="/admin/calendar?date=${d.value}#attendees"${dateFilter === d.value ? " selected" : ""}>${d.label}</option>`
+        : `<option disabled>${d.label}</option>`,
+  );
+  // Insert "Select a date" before the first current/future date to split past from future
+  const splitIndex = dates.findIndex((d) => d.value >= today);
+  const insertAt = splitIndex === -1 ? dateOptions.length : splitIndex;
+  dateOptions.splice(insertAt, 0, selectOption);
+  return `<select data-nav-select>${dateOptions.join("")}</select>`;
 };
 
 /**
@@ -48,6 +50,7 @@ export const adminCalendarPage = (
   session: AdminSession,
   dateFilter: string | null,
   availableDates: CalendarDateOption[],
+  today: string,
   phonePrefix?: string,
 ): string => {
   const tableRows: AttendeeTableRow[] = pipe(
@@ -74,7 +77,7 @@ export const adminCalendarPage = (
 
         <article>
           <h2 id="attendees">Attendees by Date</h2>
-          <Raw html={CalendarDateSelector({ dateFilter, dates: availableDates })} />
+          <Raw html={CalendarDateSelector({ dateFilter, dates: availableDates, today })} />
           {dateFilter && (
             <p><strong>{formatDateLabel(dateFilter)}</strong></p>
           )}

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1840,7 +1840,7 @@ describe("html", () => {
     });
 
     test("renders Calendar title", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, [], "2026-03-10");
       expect(html).toContain("Calendar");
       expect(html).toContain("Attendees by Date");
     });
@@ -1850,7 +1850,7 @@ describe("html", () => {
         { value: "2026-03-15", label: "Sunday 15 March 2026", hasBookings: true },
         { value: "2026-03-16", label: "Monday 16 March 2026", hasBookings: false },
       ];
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
       expect(html).toContain("Sunday 15 March 2026");
       expect(html).toContain("Monday 16 March 2026");
       expect(html).toContain("Select a date");
@@ -1860,7 +1860,7 @@ describe("html", () => {
       const dates = [
         { value: "2026-03-15", label: "Sunday 15 March 2026", hasBookings: false },
       ];
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
       expect(html).toContain("<option disabled>");
     });
 
@@ -1868,70 +1868,122 @@ describe("html", () => {
       const dates = [
         { value: "2026-03-15", label: "Sunday 15 March 2026", hasBookings: true },
       ];
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
       expect(html).toContain('value="/admin/calendar?date=2026-03-15#attendees"');
     });
 
     test("shows prompt when no date selected", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, [], "2026-03-10");
       expect(html).toContain("Select a date above to view attendees");
     });
 
     test("shows no attendees message when date selected but empty", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).toContain("No attendees for this date");
     });
 
     test("shows formatted date label when date is selected", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).toContain("Sunday 15 March 2026");
     });
 
     test("renders attendee rows with event name and link", () => {
       const attendees = [calendarAttendee()];
-      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).toContain("Daily Event");
       expect(html).toContain('href="/admin/event/1"');
       expect(html).toContain("John Doe");
     });
 
     test("renders Event column header", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, [], "2026-03-10");
       expect(html).toContain("<th>Event</th>");
     });
 
     test("shows CSV export link when date has attendees", () => {
       const attendees = [calendarAttendee()];
-      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).toContain('href="/admin/calendar/export?date=2026-03-15"');
       expect(html).toContain("Export CSV");
     });
 
     test("does not show CSV export when date has no attendees", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).not.toContain("Export CSV");
     });
 
     test("does not show CSV export when no date selected", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, [], "2026-03-10");
       expect(html).not.toContain("Export CSV");
     });
 
     test("includes Calendar link in admin nav", () => {
-      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, []);
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, [], "2026-03-10");
       expect(html).toContain('href="/admin/calendar"');
     });
 
     test("renders empty string for attendee without email", () => {
       const attendees = [calendarAttendee({ email: "" })];
-      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).toContain("John Doe");
     });
 
     test("escapes attendee data", () => {
       const attendees = [calendarAttendee({ name: "<script>evil()</script>" })];
-      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", []);
+      const html = adminCalendarPage(attendees, "localhost", TEST_SESSION, "2026-03-15", [], "2026-03-10");
       expect(html).toContain("&lt;script&gt;");
+    });
+
+    test("places Select a date between past and future dates", () => {
+      const dates = [
+        { value: "2026-03-08", label: "Sunday 8 March 2026", hasBookings: true },
+        { value: "2026-03-09", label: "Monday 9 March 2026", hasBookings: true },
+        { value: "2026-03-15", label: "Sunday 15 March 2026", hasBookings: true },
+        { value: "2026-03-16", label: "Monday 16 March 2026", hasBookings: true },
+      ];
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
+      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/);
+      const options = selectMatch![1];
+      const optionTexts = [...options.matchAll(/>([^<]+)</g)].map((m) => m[1]);
+      expect(optionTexts).toEqual([
+        "Sunday 8 March 2026",
+        "Monday 9 March 2026",
+        "Select a date",
+        "Sunday 15 March 2026",
+        "Monday 16 March 2026",
+      ]);
+    });
+
+    test("places Select a date at end when all dates are past", () => {
+      const dates = [
+        { value: "2026-03-08", label: "Sunday 8 March 2026", hasBookings: true },
+        { value: "2026-03-09", label: "Monday 9 March 2026", hasBookings: true },
+      ];
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
+      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/);
+      const options = selectMatch![1];
+      const optionTexts = [...options.matchAll(/>([^<]+)</g)].map((m) => m[1]);
+      expect(optionTexts).toEqual([
+        "Sunday 8 March 2026",
+        "Monday 9 March 2026",
+        "Select a date",
+      ]);
+    });
+
+    test("places Select a date at start when all dates are future", () => {
+      const dates = [
+        { value: "2026-03-15", label: "Sunday 15 March 2026", hasBookings: true },
+        { value: "2026-03-16", label: "Monday 16 March 2026", hasBookings: true },
+      ];
+      const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
+      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/);
+      const options = selectMatch![1];
+      const optionTexts = [...options.matchAll(/>([^<]+)</g)].map((m) => m[1]);
+      expect(optionTexts).toEqual([
+        "Select a date",
+        "Sunday 15 March 2026",
+        "Monday 16 March 2026",
+      ]);
     });
   });
 

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1942,9 +1942,8 @@ describe("html", () => {
         { value: "2026-03-16", label: "Monday 16 March 2026", hasBookings: true },
       ];
       const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
-      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/);
-      const options = selectMatch![1];
-      const optionTexts = [...options.matchAll(/>([^<]+)</g)].map((m) => m[1]);
+      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/)!;
+      const optionTexts = [...selectMatch[1]!.matchAll(/>([^<]+)</g)].map((m) => m[1]);
       expect(optionTexts).toEqual([
         "Sunday 8 March 2026",
         "Monday 9 March 2026",
@@ -1960,9 +1959,8 @@ describe("html", () => {
         { value: "2026-03-09", label: "Monday 9 March 2026", hasBookings: true },
       ];
       const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
-      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/);
-      const options = selectMatch![1];
-      const optionTexts = [...options.matchAll(/>([^<]+)</g)].map((m) => m[1]);
+      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/)!;
+      const optionTexts = [...selectMatch[1]!.matchAll(/>([^<]+)</g)].map((m) => m[1]);
       expect(optionTexts).toEqual([
         "Sunday 8 March 2026",
         "Monday 9 March 2026",
@@ -1976,9 +1974,8 @@ describe("html", () => {
         { value: "2026-03-16", label: "Monday 16 March 2026", hasBookings: true },
       ];
       const html = adminCalendarPage([], "localhost", TEST_SESSION, null, dates, "2026-03-10");
-      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/);
-      const options = selectMatch![1];
-      const optionTexts = [...options.matchAll(/>([^<]+)</g)].map((m) => m[1]);
+      const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/)!;
+      const optionTexts = [...selectMatch[1]!.matchAll(/>([^<]+)</g)].map((m) => m[1]);
       expect(optionTexts).toEqual([
         "Select a date",
         "Sunday 15 March 2026",


### PR DESCRIPTION
The date selector now inserts the "Select a date" option before the first
current/future date, splitting past dates from upcoming ones. This makes
it easier to find upcoming dates in the dropdown.

https://claude.ai/code/session_01S5tuQowWW4RQ7FY73UwYuw