### PR TITLE
Simplify safeRender by removing unnecessary nested try-catch fallback

### DIFF
--- a/src/lib/email-renderer.ts
+++ b/src/lib/email-renderer.ts
@@ -143,16 +143,7 @@ const safeRender = async (
       code: ErrorCode.EMAIL_TEMPLATE_RENDER,
       detail: `template render error (${type}/${format}): ${error instanceof Error ? error.message : String(error)}`,
     });
-    // If the custom template failed and it differs from the default, try the default
-    if (template !== fallbackTemplate) {
-      try {
-        return await renderTemplate(fallbackTemplate, data);
-      } catch {
-        // Even default failed — return a minimal fallback
-        return format === "subject" ? "Registration confirmation" : "";
-      }
-    }
-    return format === "subject" ? "Registration confirmation" : "";
+    return await renderTemplate(fallbackTemplate, data);
   }
 };
 

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -356,65 +356,20 @@ describe("email-renderer", () => {
       expect(result.text).toContain("Thanks for registering!");
     });
 
-    test("returns minimal fallback when both custom and default templates fail", async () => {
-      // Set a custom template so template !== fallbackTemplate
-      await updateEmailTemplate("confirmation", "subject", "Custom {{ event_names }}");
-      await updateEmailTemplate("confirmation", "html", "<p>Custom {{ event_names }}</p>");
-      await updateEmailTemplate("confirmation", "text", "Custom {{ event_names }}");
-      invalidateSettingsCache();
-
-      // Stub parseAndRender to always throw, so both custom and default fail
-      const parseAndRenderStub = stub(
-        Liquid.prototype,
-        "parseAndRender",
-        () => { throw new Error("engine broken"); },
-      );
-      const errorSpy = spy(console, "error");
-      try {
-        const entries = [makeEntry()];
-        const data = buildTemplateData(entries, "GBP", "https://example.com/t/ABC");
-        const result = await renderEmailContent("confirmation", data);
-
-        expect(result.subject).toBe("Registration confirmation");
-        expect(result.html).toBe("");
-        expect(result.text).toBe("");
-      } finally {
-        parseAndRenderStub.restore();
-        errorSpy.restore();
-      }
-    });
-
-    test("returns minimal fallback when default template fails (no custom set)", async () => {
-      // No custom template set, so template === fallbackTemplate
-      const parseAndRenderStub = stub(
-        Liquid.prototype,
-        "parseAndRender",
-        () => { throw new Error("engine broken"); },
-      );
-      const errorSpy = spy(console, "error");
-      try {
-        const entries = [makeEntry()];
-        const data = buildTemplateData(entries, "GBP", "https://example.com/t/ABC");
-        const result = await renderEmailContent("confirmation", data);
-
-        expect(result.subject).toBe("Registration confirmation");
-        expect(result.html).toBe("");
-        expect(result.text).toBe("");
-      } finally {
-        parseAndRenderStub.restore();
-        errorSpy.restore();
-      }
-    });
-
     test("logs non-Error thrown values as strings", async () => {
       await updateEmailTemplate("confirmation", "subject", "Custom {{ event_names }}");
       invalidateSettingsCache();
 
-      // Stub parseAndRender to throw a non-Error value
+      // Stub parseAndRender to throw a non-Error value on first call, then succeed
+      let callCount = 0;
+      const original = Liquid.prototype.parseAndRender;
       const parseAndRenderStub = stub(
         Liquid.prototype,
         "parseAndRender",
-        () => { throw "string error value"; },
+        function (this: InstanceType<typeof Liquid>, ...args: Parameters<typeof original>) {
+          if (callCount++ === 0) throw "string error value";
+          return original.apply(this, args);
+        },
       );
       const errorSpy = spy(console, "error");
       try {


### PR DESCRIPTION
The default templates are hardcoded constants that always render successfully,
so the inner try-catch with minimal string fallback was unreachable dead code.
Simplified to a single try-catch that falls back directly to the default template.

https://claude.ai/code/session_011yKnYDNKHTN8ZuTzird14V