### PR TITLE
Add SVG ticket attachments to registration confirmation emails

### DIFF
--- a/src/lib/email-renderer.ts
+++ b/src/lib/email-renderer.ts
@@ -12,7 +12,7 @@ import type { EmailTemplateFormat, EmailTemplateType } from "#lib/db/settings.ts
 import { getEmailTemplateSet } from "#lib/db/settings.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { isPaidEvent } from "#lib/types.ts";
-import type { RegistrationEntry } from "#lib/webhook.ts";
+import type { EmailEntry } from "#lib/email.ts";
 import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 import { eventNames } from "#templates/email/shared.ts";
 import type { EmailContent } from "#templates/email/shared.ts";
@@ -69,12 +69,12 @@ export type TemplateData = {
 
 /** Build the data object exposed to Liquid templates */
 export const buildTemplateData = (
-  entries: RegistrationEntry[],
+  entries: EmailEntry[],
   currency: string,
   ticketUrl: string,
 ): TemplateData => {
   const templateEntries: TemplateEntry[] = map(
-    ({ event, attendee }: RegistrationEntry): TemplateEntry => ({
+    ({ event, attendee }: EmailEntry): TemplateEntry => ({
       event: {
         name: event.name,
         slug: event.slug,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,7 +3,9 @@
  * Sends registration emails via HTTP email APIs (Resend, Postmark, SendGrid, Mailgun)
  */
 
+import { map } from "#fp";
 import { getBusinessEmailFromDb } from "#lib/business-email.ts";
+import { getAllowedDomain } from "#lib/config.ts";
 import {
   getEmailApiKeyFromDb,
   getEmailFromAddressFromDb,
@@ -12,8 +14,16 @@ import {
 import { buildTemplateData, renderEmailContent } from "#lib/email-renderer.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
+import { generateSvgTicket, type SvgTicketData } from "#lib/svg-ticket.ts";
 import { buildTicketUrl } from "#lib/ticket-url.ts";
 import type { RegistrationEntry } from "#lib/webhook.ts";
+
+/** A base64-encoded email attachment */
+export type EmailAttachment = {
+  filename: string;
+  content: string;
+  contentType: string;
+};
 
 export type EmailMessage = {
   to: string;
@@ -21,6 +31,7 @@ export type EmailMessage = {
   html: string;
   text: string;
   replyTo?: string;
+  attachments?: EmailAttachment[];
 };
 
 export type EmailConfig = {
@@ -58,6 +69,9 @@ export const getHostEmailConfig = (): EmailConfig | null => {
 /** Build provider-specific request: [url, extra-headers, body] */
 type ProviderRequest = (config: EmailConfig, msg: EmailMessage) => [string, Record<string, string>, unknown];
 
+const resendAttachments = (msg: EmailMessage) =>
+  msg.attachments?.map((a) => ({ filename: a.filename, content: a.content }));
+
 const resendRequest: ProviderRequest = (config, msg) => [
   "https://api.resend.com/emails",
   { "Authorization": `Bearer ${config.apiKey}` },
@@ -68,8 +82,16 @@ const resendRequest: ProviderRequest = (config, msg) => [
     subject: msg.subject,
     html: msg.html,
     text: msg.text,
+    attachments: resendAttachments(msg),
   },
 ];
+
+const postmarkAttachments = (msg: EmailMessage) =>
+  msg.attachments?.map((a) => ({
+    Name: a.filename,
+    Content: a.content,
+    ContentType: a.contentType,
+  }));
 
 const postmarkRequest: ProviderRequest = (config, msg) => [
   "https://api.postmarkapp.com/email",
@@ -81,8 +103,17 @@ const postmarkRequest: ProviderRequest = (config, msg) => [
     Subject: msg.subject,
     HtmlBody: msg.html,
     TextBody: msg.text,
+    Attachments: postmarkAttachments(msg),
   },
 ];
+
+const sendgridAttachments = (msg: EmailMessage) =>
+  msg.attachments?.map((a) => ({
+    content: a.content,
+    filename: a.filename,
+    type: a.contentType,
+    disposition: "attachment",
+  }));
 
 const sendgridRequest: ProviderRequest = (config, msg) => [
   "https://api.sendgrid.com/v3/mail/send",
@@ -96,6 +127,7 @@ const sendgridRequest: ProviderRequest = (config, msg) => [
       { type: "text/plain", value: msg.text },
       { type: "text/html", value: msg.html },
     ],
+    attachments: sendgridAttachments(msg),
   },
 ];
 
@@ -108,6 +140,10 @@ const mailgunRequest = (host: string): ProviderRequest => (config, msg) => {
   form.append("html", msg.html);
   form.append("text", msg.text);
   if (msg.replyTo) form.append("h:Reply-To", msg.replyTo);
+  for (const a of msg.attachments ?? []) {
+    const bytes = Uint8Array.from(atob(a.content), (c) => c.charCodeAt(0));
+    form.append("attachment", new Blob([bytes], { type: a.contentType }), a.filename);
+  }
   return [
     `https://${host}/v3/${domain}/messages`,
     { "Authorization": `Basic ${btoa("api:" + config.apiKey)}` },
@@ -172,10 +208,41 @@ export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise
   }
 };
 
+/** Build SVG ticket data from a registration entry (non-PII only) */
+export const buildSvgTicketData = (entry: RegistrationEntry, currency: string): SvgTicketData => ({
+  eventName: entry.event.name,
+  eventDate: "",
+  eventLocation: "",
+  attendeeDate: entry.attendee.date,
+  quantity: entry.attendee.quantity,
+  pricePaid: entry.attendee.price_paid,
+  currency,
+  checkinUrl: `https://${getAllowedDomain()}/checkin/${entry.attendee.ticket_token}`,
+});
+
+/** Generate SVG ticket attachments for all entries */
+export const buildTicketAttachments = async (
+  entries: RegistrationEntry[],
+  currency: string,
+): Promise<EmailAttachment[]> => {
+  const ticketDataList = map(
+    (entry: RegistrationEntry) => buildSvgTicketData(entry, currency),
+  )(entries);
+  const svgs = await Promise.all(
+    ticketDataList.map((data) => generateSvgTicket(data)),
+  );
+  return svgs.map((svg, i) => ({
+    filename: entries.length === 1 ? "ticket.svg" : `ticket-${i + 1}.svg`,
+    content: btoa(svg),
+    contentType: "image/svg+xml",
+  }));
+};
+
 /**
  * Send registration confirmation + admin notification emails.
  * Entries is an array because one registration can cover multiple events.
  * Silently skips if email is not configured.
+ * Attaches one SVG ticket per entry to the confirmation email.
  */
 export const sendRegistrationEmails = async (
   entries: RegistrationEntry[],
@@ -192,9 +259,12 @@ export const sendRegistrationEmails = async (
   const replyTo = businessEmail || undefined;
   const data = buildTemplateData(entries, currency, ticketUrl);
 
-  const confirmation = await renderEmailContent("confirmation", data);
+  const [confirmation, attachments] = await Promise.all([
+    renderEmailContent("confirmation", data),
+    buildTicketAttachments(entries, currency),
+  ]);
   const promises: Promise<number | undefined>[] = [
-    sendEmail(config, { to: attendeeEmail, ...confirmation, replyTo }),
+    sendEmail(config, { to: attendeeEmail, ...confirmation, replyTo, attachments }),
   ];
 
   if (businessEmail) {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -16,7 +16,19 @@ import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { generateSvgTicket, type SvgTicketData } from "#lib/svg-ticket.ts";
 import { buildTicketUrl } from "#lib/ticket-url.ts";
-import type { RegistrationEntry } from "#lib/webhook.ts";
+import type { WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
+
+/** Event data needed for email rendering (extends webhook event with display fields) */
+export type EmailEvent = WebhookEvent & {
+  date: string;
+  location: string;
+};
+
+/** Attendee + event pair for email rendering */
+export type EmailEntry = {
+  event: EmailEvent;
+  attendee: WebhookAttendee;
+};
 
 /** A base64-encoded email attachment */
 export type EmailAttachment = {
@@ -208,11 +220,11 @@ export const sendEmail = async (config: EmailConfig, msg: EmailMessage): Promise
   }
 };
 
-/** Build SVG ticket data from a registration entry (non-PII only) */
-export const buildSvgTicketData = (entry: RegistrationEntry, currency: string): SvgTicketData => ({
+/** Build SVG ticket data from an email entry (non-PII only) */
+export const buildSvgTicketData = (entry: EmailEntry, currency: string): SvgTicketData => ({
   eventName: entry.event.name,
-  eventDate: "",
-  eventLocation: "",
+  eventDate: entry.event.date,
+  eventLocation: entry.event.location,
   attendeeDate: entry.attendee.date,
   quantity: entry.attendee.quantity,
   pricePaid: entry.attendee.price_paid,
@@ -222,11 +234,11 @@ export const buildSvgTicketData = (entry: RegistrationEntry, currency: string): 
 
 /** Generate SVG ticket attachments for all entries */
 export const buildTicketAttachments = async (
-  entries: RegistrationEntry[],
+  entries: EmailEntry[],
   currency: string,
 ): Promise<EmailAttachment[]> => {
   const ticketDataList = map(
-    (entry: RegistrationEntry) => buildSvgTicketData(entry, currency),
+    (entry: EmailEntry) => buildSvgTicketData(entry, currency),
   )(entries);
   const svgs = await Promise.all(
     ticketDataList.map((data) => generateSvgTicket(data)),
@@ -245,7 +257,7 @@ export const buildTicketAttachments = async (
  * Attaches one SVG ticket per entry to the confirmation email.
  */
 export const sendRegistrationEmails = async (
-  entries: RegistrationEntry[],
+  entries: EmailEntry[],
   currency: string,
 ): Promise<void> => {
   const attendeeEmail = entries[0]!.attendee.email;

--- a/src/lib/svg-ticket.ts
+++ b/src/lib/svg-ticket.ts
@@ -1,0 +1,101 @@
+/**
+ * SVG ticket generator
+ * Composes a QR code SVG with event and booking data into a standalone SVG ticket
+ * suitable for email attachment. Contains no PII — only event details and booking metadata.
+ */
+
+import { formatCurrency } from "#lib/currency.ts";
+import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
+import { generateQrSvg } from "#lib/qr.ts";
+import { escapeHtml } from "#templates/layout.tsx";
+
+/** Non-PII ticket data for SVG rendering */
+export type SvgTicketData = {
+  eventName: string;
+  eventDate: string;
+  eventLocation: string;
+  attendeeDate: string | null;
+  quantity: number;
+  pricePaid: string;
+  currency: string;
+  checkinUrl: string;
+};
+
+/** SVG dimensions */
+const WIDTH = 400;
+const HEADER_Y = 40;
+const LINE_HEIGHT = 22;
+const QR_SIZE = 180;
+const MARGIN = 24;
+
+/** Extract the inner content of an SVG element (strip the outer <svg> wrapper) */
+export const extractSvgContent = (svg: string): string => {
+  const innerMatch = svg.match(/<svg[^>]*>([\s\S]*)<\/svg>/);
+  return innerMatch?.[1] ?? "";
+};
+
+/** Extract the viewBox from an SVG element to compute its coordinate space */
+export const extractViewBox = (svg: string): { width: number; height: number } => {
+  const match = svg.match(/viewBox="([^"]+)"/);
+  if (!match) return { width: QR_SIZE, height: QR_SIZE };
+  const parts = match[1]!.split(/\s+/).map(Number);
+  return { width: parts[2] ?? QR_SIZE, height: parts[3] ?? QR_SIZE };
+};
+
+/** Build info lines from ticket data (non-PII event and booking details) */
+export const buildInfoLines = (data: SvgTicketData): string[] => {
+  const lines: string[] = [];
+
+  if (data.eventDate) {
+    lines.push(formatDatetimeLabel(data.eventDate));
+  }
+
+  if (data.eventLocation) {
+    lines.push(data.eventLocation);
+  }
+
+  if (data.attendeeDate) {
+    lines.push(`Booking: ${formatDateLabel(data.attendeeDate)}`);
+  }
+
+  lines.push(`Qty: ${data.quantity}`);
+
+  const price = Number(data.pricePaid);
+  if (price > 0) {
+    lines.push(`Price: ${formatCurrency(price)}`);
+  }
+
+  return lines;
+};
+
+/**
+ * Generate a standalone SVG ticket with QR code and event/booking details.
+ * Returns a complete SVG document string.
+ */
+export const generateSvgTicket = async (data: SvgTicketData): Promise<string> => {
+  const qrSvg = await generateQrSvg(data.checkinUrl);
+  const qrViewBox = extractViewBox(qrSvg);
+  const qrContent = extractSvgContent(qrSvg);
+  const scale = QR_SIZE / qrViewBox.width;
+
+  const infoLines = buildInfoLines(data);
+  const infoHeight = infoLines.length * LINE_HEIGHT;
+
+  const qrY = HEADER_Y + infoHeight + 16;
+  const totalHeight = qrY + QR_SIZE + MARGIN;
+  const qrX = (WIDTH - QR_SIZE) / 2;
+
+  const escapedName = escapeHtml(data.eventName);
+  const linesSvg = infoLines.map((line, i) =>
+    `<text x="${MARGIN}" y="${HEADER_Y + (i + 1) * LINE_HEIGHT}" font-family="sans-serif" font-size="13" fill="#555">${escapeHtml(line)}</text>`
+  ).join("\n    ");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${totalHeight}" viewBox="0 0 ${WIDTH} ${totalHeight}">
+  <rect width="${WIDTH}" height="${totalHeight}" rx="8" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="${MARGIN}" y="${HEADER_Y}" font-family="sans-serif" font-size="18" font-weight="bold" fill="#333">${escapedName}</text>
+    ${linesSvg}
+  <g transform="translate(${qrX}, ${qrY}) scale(${scale})">
+    ${qrContent}
+  </g>
+</svg>`;
+};

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -5,7 +5,7 @@
 
 import { compact, unique } from "#fp";
 import { logActivity } from "#lib/db/activityLog.ts";
-import { sendRegistrationEmails } from "#lib/email.ts";
+import { type EmailEntry, sendRegistrationEmails } from "#lib/email.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { addPendingWork } from "#lib/pending-work.ts";
 import { buildTicketUrl } from "#lib/ticket-url.ts";
@@ -158,12 +158,12 @@ export const sendRegistrationWebhooks = async (
  * but complete before the edge runtime tears down the request context.
  */
 export const logAndNotifyRegistration = async (
-  event: WebhookEvent,
+  event: EmailEntry["event"],
   attendee: WebhookAttendee,
   currency: string,
 ): Promise<void> => {
   await logActivity(`Attendee registered for '${event.name}'`, event);
-  const entries = [{ event, attendee }];
+  const entries: EmailEntry[] = [{ event, attendee }];
   addPendingWork(sendRegistrationWebhooks(entries, currency));
   addPendingWork(sendRegistrationEmails(entries, currency));
 };
@@ -172,7 +172,7 @@ export const logAndNotifyRegistration = async (
  * Log and send consolidated webhook for multi-event registrations
  */
 export const logAndNotifyMultiRegistration = async (
-  entries: RegistrationEntry[],
+  entries: EmailEntry[],
   currency: string,
 ): Promise<void> => {
   for (const { event } of entries) {

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -887,6 +887,7 @@ const PREVIEW_BOOKINGS = [{
     id: 1, name: "Summer Concert", slug: "summer-concert",
     webhook_url: "", max_attendees: 100, attendee_count: 42,
     unit_price: 2500, can_pay_more: false,
+    date: "2026-07-15T19:00:00Z", location: "Town Hall",
   },
   attendee: {
     id: 1, name: "Jane Smith", email: "jane@example.com",
@@ -900,6 +901,7 @@ const PREVIEW_BOOKINGS = [{
     id: 2, name: "Workshop", slug: "workshop",
     webhook_url: "", max_attendees: 20, attendee_count: 8,
     unit_price: 0, can_pay_more: false,
+    date: "", location: "",
   },
   attendee: {
     id: 2, name: "Jane Smith", email: "jane@example.com",

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -33,10 +33,8 @@ import {
 } from "#lib/payments.ts";
 import type { ContactInfo, EventFields, EventWithCount, Group } from "#lib/types.ts";
 import { logDebug } from "#lib/logger.ts";
-import {
-  logAndNotifyMultiRegistration,
-  type RegistrationEntry,
-} from "#lib/webhook.ts";
+import type { EmailEntry } from "#lib/email.ts";
+import { logAndNotifyMultiRegistration } from "#lib/webhook.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import {
   formatCreationError,
@@ -690,7 +688,7 @@ const processMultiFreeReservation = async (
   contact: ContactInfo,
   date: string | null,
 ): Promise<{ success: true; tokens: string[] } | { success: false; error: string }> => {
-  const entries: RegistrationEntry[] = [];
+  const entries: EmailEntry[] = [];
   for (const { event, qty } of eventsWithQuantity(events, quantities)) {
     const eventDate = event.event_type === "daily" ? date : null;
     const result = await createAttendeeAtomic({ eventId: event.id, ...contact, quantity: qty, date: eventDate });

--- a/src/templates/email/shared.ts
+++ b/src/templates/email/shared.ts
@@ -3,12 +3,11 @@
  */
 
 import { map } from "#fp";
-import type { RegistrationEntry } from "#lib/webhook.ts";
-export type { RegistrationEntry };
+import type { EmailEntry } from "#lib/email.ts";
 
 export type EmailContent = { subject: string; html: string; text: string };
 
 const listFormat = new Intl.ListFormat("en", { type: "conjunction" });
 
-export const eventNames = (entries: RegistrationEntry[]): string =>
-  listFormat.format(map(({ event }: RegistrationEntry) => event.name)(entries));
+export const eventNames = (entries: EmailEntry[]): string =>
+  listFormat.format(map(({ event }: EmailEntry) => event.name)(entries));

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -8,7 +8,8 @@ import {
   validateTemplate,
 } from "#lib/email-renderer.ts";
 import type { TemplateData } from "#lib/email-renderer.ts";
-import type { RegistrationEntry, WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
+import type { EmailEntry, EmailEvent } from "#lib/email.ts";
+import type { WebhookAttendee } from "#lib/webhook.ts";
 import { createTestDbWithSetup, resetDb } from "#test-utils";
 import { setCurrencyCodeForTest, resetCurrencyCode } from "#lib/currency.ts";
 import {
@@ -19,7 +20,7 @@ import { spy, stub } from "@std/testing/mock";
 import { map } from "#fp";
 import { Liquid } from "liquidjs";
 
-const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+const makeEvent = (overrides: Partial<EmailEvent> = {}): EmailEvent => ({
   id: 1,
   name: "Test Event",
   slug: "test-event",
@@ -28,6 +29,8 @@ const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
   attendee_count: 10,
   unit_price: 0,
   can_pay_more: false,
+  date: "",
+  location: "",
   ...overrides,
 });
 
@@ -47,9 +50,9 @@ const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee
 });
 
 const makeEntry = (
-  eventOverrides?: Partial<WebhookEvent>,
+  eventOverrides?: Partial<EmailEvent>,
   attendeeOverrides?: Partial<WebhookAttendee>,
-): RegistrationEntry => ({
+): EmailEntry => ({
   event: makeEvent(eventOverrides),
   attendee: makeAttendee(attendeeOverrides),
 });

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { spy, stub } from "@std/testing/mock";
 import {
+  buildSvgTicketData,
+  buildTicketAttachments,
+  type EmailAttachment,
   type EmailConfig,
   type EmailMessage,
   getEmailConfig,
@@ -269,6 +272,111 @@ describe("email", () => {
     });
   });
 
+  describe("sendEmail with attachments", () => {
+    const attachment: EmailAttachment = {
+      filename: "ticket.svg",
+      content: btoa("<svg>test</svg>"),
+      contentType: "image/svg+xml",
+    };
+    const msgWithAttachment: EmailMessage = {
+      to: "user@test.com",
+      subject: "Tickets",
+      html: "<p>Hi</p>",
+      text: "Hi",
+      attachments: [attachment],
+    };
+
+    test("Resend includes attachments with filename and content", async () => {
+      await sendEmail(testConfig, msgWithAttachment);
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.attachments).toEqual([{ filename: "ticket.svg", content: attachment.content }]);
+    });
+
+    test("Postmark includes Attachments with Name, Content, ContentType", async () => {
+      await sendEmail({ ...testConfig, provider: "postmark" }, msgWithAttachment);
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.Attachments).toEqual([{
+        Name: "ticket.svg",
+        Content: attachment.content,
+        ContentType: "image/svg+xml",
+      }]);
+    });
+
+    test("SendGrid includes attachments with content, filename, type, disposition", async () => {
+      await sendEmail({ ...testConfig, provider: "sendgrid" }, msgWithAttachment);
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.attachments).toEqual([{
+        content: attachment.content,
+        filename: "ticket.svg",
+        type: "image/svg+xml",
+        disposition: "attachment",
+      }]);
+    });
+
+    test("Mailgun appends attachment as Blob to FormData", async () => {
+      await sendEmail({ ...testConfig, provider: "mailgun-us" }, msgWithAttachment);
+
+      const body = (fetchStub.calls[0].args as [string, RequestInit])[1].body as FormData;
+      const file = body.get("attachment") as File;
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toBe("ticket.svg");
+      expect(file.type).toBe("image/svg+xml");
+    });
+
+    test("omits attachments field when no attachments provided", async () => {
+      const msg: EmailMessage = { to: "user@test.com", subject: "Test", html: "h", text: "t" };
+      await sendEmail(testConfig, msg);
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.attachments).toBeUndefined();
+    });
+  });
+
+  describe("buildSvgTicketData", () => {
+    test("maps entry fields to SvgTicketData", () => {
+      const data = buildSvgTicketData(makeEntry({ name: "Concert" }, { quantity: 2, price_paid: "1500", ticket_token: "tok123" }), "GBP");
+      expect(data.eventName).toBe("Concert");
+      expect(data.quantity).toBe(2);
+      expect(data.pricePaid).toBe("1500");
+      expect(data.checkinUrl).toContain("/checkin/tok123");
+    });
+
+    test("includes attendee date for daily events", () => {
+      const data = buildSvgTicketData(makeEntry({}, { date: "2026-06-15" }), "GBP");
+      expect(data.attendeeDate).toBe("2026-06-15");
+    });
+  });
+
+  describe("buildTicketAttachments", () => {
+    test("generates one attachment per entry", async () => {
+      const entries = [makeEntry({}, { ticket_token: "tok1" }), makeEntry({}, { ticket_token: "tok2" })];
+      const attachments = await buildTicketAttachments(entries, "GBP");
+
+      expect(attachments.length).toBe(2);
+      expect(attachments[0]!.filename).toBe("ticket-1.svg");
+      expect(attachments[1]!.filename).toBe("ticket-2.svg");
+      expect(attachments[0]!.contentType).toBe("image/svg+xml");
+    });
+
+    test("uses 'ticket.svg' filename for single entry", async () => {
+      const attachments = await buildTicketAttachments([makeEntry()], "GBP");
+
+      expect(attachments.length).toBe(1);
+      expect(attachments[0]!.filename).toBe("ticket.svg");
+    });
+
+    test("attachment content is base64-encoded SVG", async () => {
+      const attachments = await buildTicketAttachments([makeEntry()], "GBP");
+
+      const decoded = atob(attachments[0]!.content);
+      expect(decoded).toContain("<svg");
+      expect(decoded).toContain("</svg>");
+    });
+  });
+
   describe("getEmailConfig", () => {
     test("returns null when no provider configured", async () => {
       invalidateSettingsCache();
@@ -493,6 +601,56 @@ describe("email", () => {
       });
       const body = JSON.parse((adminCall.args as [string, RequestInit])[1].body as string);
       expect(body.reply_to).toBe("jane@example.com");
+    });
+
+    test("attaches SVG ticket to confirmation email", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry()], "GBP");
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.attachments).toHaveLength(1);
+      expect(body.attachments[0].filename).toBe("ticket.svg");
+      const decoded = atob(body.attachments[0].content);
+      expect(decoded).toContain("<svg");
+    });
+
+    test("does not attach tickets to admin notification", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      await updateBusinessEmail("admin@business.com");
+      invalidateSettingsCache();
+
+      await sendRegistrationEmails([makeEntry()], "GBP");
+
+      const adminCall = fetchStub.calls.find((c: { args: unknown[] }) => {
+        const body = JSON.parse((c.args as [string, RequestInit])[1].body as string);
+        return body.to[0] === "admin@business.com";
+      });
+      const body = JSON.parse((adminCall.args as [string, RequestInit])[1].body as string);
+      expect(body.attachments).toBeUndefined();
+    });
+
+    test("attaches numbered tickets for multi-event registration", async () => {
+      await updateEmailProvider("resend");
+      await updateEmailApiKey("test-key");
+      await updateEmailFromAddress("from@test.com");
+      invalidateSettingsCache();
+
+      const entries = [
+        makeEntry({ name: "Event A" }, { ticket_token: "tok1" }),
+        makeEntry({ name: "Event B" }, { ticket_token: "tok2" }),
+      ];
+      await sendRegistrationEmails(entries, "GBP");
+
+      const body = JSON.parse((fetchStub.calls[0].args as [string, RequestInit])[1].body as string);
+      expect(body.attachments).toHaveLength(2);
+      expect(body.attachments[0].filename).toBe("ticket-1.svg");
+      expect(body.attachments[1].filename).toBe("ticket-2.svg");
     });
   });
 

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -14,7 +14,8 @@ import {
   sendRegistrationEmails,
   sendTestEmail,
 } from "#lib/email.ts";
-import type { RegistrationEntry, WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
+import type { EmailEntry, EmailEvent } from "#lib/email.ts";
+import type { WebhookAttendee } from "#lib/webhook.ts";
 import { createTestDbWithSetup, resetDb } from "#test-utils";
 import {
   invalidateSettingsCache,
@@ -25,7 +26,7 @@ import {
 import { updateBusinessEmail } from "#lib/business-email.ts";
 import { bracket, map } from "#fp";
 
-const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+const makeEvent = (overrides: Partial<EmailEvent> = {}): EmailEvent => ({
   id: 1,
   name: "Test Event",
   slug: "test-event",
@@ -34,6 +35,8 @@ const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
   attendee_count: 10,
   unit_price: 0,
   can_pay_more: false,
+  date: "",
+  location: "",
   ...overrides,
 });
 
@@ -53,9 +56,9 @@ const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee
 });
 
 const makeEntry = (
-  eventOverrides?: Partial<WebhookEvent>,
+  eventOverrides?: Partial<EmailEvent>,
   attendeeOverrides?: Partial<WebhookAttendee>,
-): RegistrationEntry => ({
+): EmailEntry => ({
   event: makeEvent(eventOverrides),
   attendee: makeAttendee(attendeeOverrides),
 });
@@ -347,6 +350,15 @@ describe("email", () => {
     test("includes attendee date for daily events", () => {
       const data = buildSvgTicketData(makeEntry({}, { date: "2026-06-15" }), "GBP");
       expect(data.attendeeDate).toBe("2026-06-15");
+    });
+
+    test("includes event date and location from event", () => {
+      const data = buildSvgTicketData(
+        makeEntry({ date: "2026-07-01T19:00:00Z", location: "Town Hall" }),
+        "GBP",
+      );
+      expect(data.eventDate).toBe("2026-07-01T19:00:00Z");
+      expect(data.eventLocation).toBe("Town Hall");
     });
   });
 

--- a/test/lib/svg-ticket.test.ts
+++ b/test/lib/svg-ticket.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  buildInfoLines,
+  extractSvgContent,
+  extractViewBox,
+  generateSvgTicket,
+  type SvgTicketData,
+} from "#lib/svg-ticket.ts";
+import { setCurrencyCodeForTest } from "#lib/currency.ts";
+import { createTestDbWithSetup, resetDb } from "#test-utils";
+
+const makeTicketData = (overrides: Partial<SvgTicketData> = {}): SvgTicketData => ({
+  eventName: "Summer Concert",
+  eventDate: "",
+  eventLocation: "",
+  attendeeDate: null,
+  quantity: 1,
+  pricePaid: "0",
+  currency: "GBP",
+  checkinUrl: "https://example.com/checkin/abc123",
+  ...overrides,
+});
+
+describe("svg-ticket", () => {
+  beforeEach(async () => {
+    setCurrencyCodeForTest("GBP");
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("extractSvgContent", () => {
+    test("extracts inner content from svg element", () => {
+      const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect/></svg>';
+      expect(extractSvgContent(svg)).toBe("<rect/>");
+    });
+
+    test("returns empty string when no svg element found", () => {
+      expect(extractSvgContent("<div>not svg</div>")).toBe("");
+    });
+  });
+
+  describe("extractViewBox", () => {
+    test("parses viewBox dimensions", () => {
+      const svg = '<svg viewBox="0 0 33 33"><rect/></svg>';
+      expect(extractViewBox(svg)).toEqual({ width: 33, height: 33 });
+    });
+
+    test("returns default size when no viewBox", () => {
+      const svg = '<svg><rect/></svg>';
+      expect(extractViewBox(svg)).toEqual({ width: 180, height: 180 });
+    });
+
+    test("falls back to defaults for incomplete viewBox", () => {
+      const svg = '<svg viewBox="0 0"><rect/></svg>';
+      expect(extractViewBox(svg)).toEqual({ width: 180, height: 180 });
+    });
+  });
+
+  describe("buildInfoLines", () => {
+    test("includes quantity for free event", () => {
+      const lines = buildInfoLines(makeTicketData());
+      expect(lines).toEqual(["Qty: 1"]);
+    });
+
+    test("includes price for paid event", () => {
+      const lines = buildInfoLines(makeTicketData({ pricePaid: "2500" }));
+      expect(lines).toContainEqual("Qty: 1");
+      expect(lines.some((l) => l.includes("Price:"))).toBe(true);
+    });
+
+    test("includes event date when provided", () => {
+      const lines = buildInfoLines(makeTicketData({ eventDate: "2026-06-15T18:00:00.000Z" }));
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines[0]).toContain("June");
+    });
+
+    test("includes location when provided", () => {
+      const lines = buildInfoLines(makeTicketData({ eventLocation: "The Venue" }));
+      expect(lines).toContain("The Venue");
+    });
+
+    test("includes booking date for daily events", () => {
+      const lines = buildInfoLines(makeTicketData({ attendeeDate: "2026-06-15" }));
+      expect(lines.some((l) => l.startsWith("Booking:"))).toBe(true);
+    });
+
+    test("omits price when zero", () => {
+      const lines = buildInfoLines(makeTicketData({ pricePaid: "0" }));
+      expect(lines.every((l) => !l.includes("Price:"))).toBe(true);
+    });
+  });
+
+  describe("generateSvgTicket", () => {
+    test("returns valid SVG document", async () => {
+      const svg = await generateSvgTicket(makeTicketData());
+      expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+      expect(svg).toContain("</svg>");
+    });
+
+    test("includes event name", async () => {
+      const svg = await generateSvgTicket(makeTicketData({ eventName: "Jazz Night" }));
+      expect(svg).toContain("Jazz Night");
+    });
+
+    test("escapes HTML in event name", async () => {
+      const svg = await generateSvgTicket(makeTicketData({ eventName: "A <B> & C" }));
+      expect(svg).toContain("A &lt;B&gt; &amp; C");
+      expect(svg).not.toContain("<B>");
+    });
+
+    test("includes QR code content", async () => {
+      const svg = await generateSvgTicket(makeTicketData());
+      // QR code generates path elements
+      expect(svg).toContain("<path");
+    });
+
+    test("different checkin URLs produce different SVGs", async () => {
+      const svg1 = await generateSvgTicket(makeTicketData({ checkinUrl: "https://example.com/checkin/aaa" }));
+      const svg2 = await generateSvgTicket(makeTicketData({ checkinUrl: "https://example.com/checkin/bbb" }));
+      expect(svg1).not.toBe(svg2);
+    });
+
+    test("includes quantity in output", async () => {
+      const svg = await generateSvgTicket(makeTicketData({ quantity: 3 }));
+      expect(svg).toContain("Qty: 3");
+    });
+
+    test("includes price for paid tickets", async () => {
+      const svg = await generateSvgTicket(makeTicketData({ pricePaid: "1500" }));
+      expect(svg).toContain("Price:");
+    });
+
+    test("includes location when provided", async () => {
+      const svg = await generateSvgTicket(makeTicketData({ eventLocation: "Main Hall" }));
+      expect(svg).toContain("Main Hall");
+    });
+
+    test("includes event date when provided", async () => {
+      const svg = await generateSvgTicket(makeTicketData({ eventDate: "2026-06-15T18:00:00.000Z" }));
+      expect(svg).toContain("June");
+    });
+  });
+});

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { spy, stub } from "@std/testing/mock";
+import type { EmailEntry, EmailEvent } from "#lib/email.ts";
 import {
   buildWebhookPayload,
   type RegistrationEntry,
@@ -14,8 +15,8 @@ import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { createTestDbWithSetup, createTestEvent, resetDb } from "#test-utils";
 import { bracket, map } from "#fp";
 
-/** Helper to build a WebhookEvent with sensible defaults */
-const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+/** Helper to build an EmailEvent with sensible defaults */
+const makeEvent = (overrides: Partial<EmailEvent> = {}): EmailEvent => ({
   id: 1,
   name: "Test Event",
   slug: "test-event",
@@ -24,6 +25,8 @@ const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
   attendee_count: 10,
   unit_price: 0,
   can_pay_more: false,
+  date: "",
+  location: "",
   ...overrides,
 });
 
@@ -43,17 +46,17 @@ const makeAttendee = (overrides: Partial<WebhookAttendee> = {}): WebhookAttendee
   ...overrides,
 });
 
-/** Build a RegistrationEntry from event/attendee overrides */
+/** Build an EmailEntry from event/attendee overrides */
 const makeEntry = (
-  eventOverrides?: Partial<WebhookEvent>,
+  eventOverrides?: Partial<EmailEvent>,
   attendeeOverrides?: Partial<WebhookAttendee>,
-): RegistrationEntry => ({
+): EmailEntry => ({
   event: makeEvent(eventOverrides),
   attendee: makeAttendee(attendeeOverrides),
 });
 
 /** Default single-entry registration (free event, default attendee) */
-const defaultEntries = (): RegistrationEntry[] => [makeEntry()];
+const defaultEntries = (): EmailEntry[] => [makeEntry()];
 
 /** Extract first arg (as string) from each spy call */
 const spyFirstArgs = map((c: { args: unknown[] }) => c.args[0] as string);


### PR DESCRIPTION
Generate one SVG ticket per entry containing the QR code and non-PII
event/booking data (name, date, location, quantity, price). Attach
to the attendee confirmation email via all five supported providers
(Resend, Postmark, SendGrid, Mailgun US/EU). Admin notification
emails do not receive attachments.

https://claude.ai/code/session_01TCrcHwipmbUfQhkTqCpDXG