### PR TITLE
Centralize iframe detection into shared helpers

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -5,6 +5,7 @@
 import { map, pipe, reduce } from "#fp";
 import { getCurrentCsrfToken } from "#lib/csrf.ts";
 import { appendIframeParam } from "#lib/iframe.ts";
+
 import { type Child, Raw } from "#jsx/jsx-runtime.ts";
 
 const escapeHtml = (str: string): string =>
@@ -308,16 +309,15 @@ export const setFormError = (formId: string, message: string): void => {
  * Shows a success or error message when the form's id matches the current state.
  */
 export const CsrfForm = (
-  { action, inIframe, children, ...rest }: {
+  { action, children, ...rest }: {
     action: string;
-    inIframe?: boolean;
     children?: Child;
     id?: string;
     class?: string;
     enctype?: string;
   },
 ): JSX.Element => (
-  <form method="POST" action={appendIframeParam(action, inIframe ?? false)} {...rest}>
+  <form method="POST" action={appendIframeParam(action)} {...rest}>
     <input type="hidden" name="csrf_token" value={getCurrentCsrfToken()} />
     {rest.id && rest.id === _successStore.formId && <Raw html={renderSuccess(_successStore.message)} />}
     {rest.id && rest.id === _errorStore.formId && <Raw html={renderError(_errorStore.message)} />}

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -4,6 +4,7 @@
 
 import { map, pipe, reduce } from "#fp";
 import { getCurrentCsrfToken } from "#lib/csrf.ts";
+import { appendIframeParam } from "#lib/iframe.ts";
 import { type Child, Raw } from "#jsx/jsx-runtime.ts";
 
 const escapeHtml = (str: string): string =>
@@ -307,15 +308,16 @@ export const setFormError = (formId: string, message: string): void => {
  * Shows a success or error message when the form's id matches the current state.
  */
 export const CsrfForm = (
-  { action, children, ...rest }: {
+  { action, inIframe, children, ...rest }: {
     action: string;
+    inIframe?: boolean;
     children?: Child;
     id?: string;
     class?: string;
     enctype?: string;
   },
 ): JSX.Element => (
-  <form method="POST" action={action} {...rest}>
+  <form method="POST" action={appendIframeParam(action, inIframe ?? false)} {...rest}>
     <input type="hidden" name="csrf_token" value={getCurrentCsrfToken()} />
     {rest.id && rest.id === _successStore.formId && <Raw html={renderSuccess(_successStore.message)} />}
     {rest.id && rest.id === _errorStore.formId && <Raw html={renderError(_errorStore.message)} />}

--- a/src/lib/iframe.ts
+++ b/src/lib/iframe.ts
@@ -3,15 +3,25 @@
  * Iframe mode (?iframe=true) is used when ticket pages are embedded via
  * <iframe> or the embed script. It affects response strategy (popup vs redirect
  * for Stripe checkout) and template rendering (hide header, include resizer).
+ *
+ * The iframe mode is stored per-request (like the CSRF token store) and read
+ * synchronously by CsrfForm, redirectResponse, checkoutResponse, and templates.
  */
 
-/** Check if request URL has ?iframe=true */
-export const isIframeRequest = (url: string): boolean =>
-  new URL(url).searchParams.get("iframe") === "true";
+/** Per-request iframe mode, readable synchronously by consumers */
+const _iframeStore = { value: false };
+
+/** Detect iframe mode from a request URL and store it for the current request */
+export const detectIframeMode = (url: string): void => {
+  _iframeStore.value = new URL(url).searchParams.get("iframe") === "true";
+};
+
+/** Get the current request's iframe mode */
+export const getIframeMode = (): boolean => _iframeStore.value;
 
 /** Append iframe=true query param to a URL when in iframe mode */
-export const appendIframeParam = (url: string, inIframe: boolean): string => {
-  if (!inIframe) return url;
+export const appendIframeParam = (url: string): string => {
+  if (!_iframeStore.value) return url;
   const separator = url.includes("?") ? "&" : "?";
   return `${url}${separator}iframe=true`;
 };

--- a/src/lib/iframe.ts
+++ b/src/lib/iframe.ts
@@ -1,0 +1,17 @@
+/**
+ * Centralized iframe detection and URL helpers.
+ * Iframe mode (?iframe=true) is used when ticket pages are embedded via
+ * <iframe> or the embed script. It affects response strategy (popup vs redirect
+ * for Stripe checkout) and template rendering (hide header, include resizer).
+ */
+
+/** Check if request URL has ?iframe=true */
+export const isIframeRequest = (url: string): boolean =>
+  new URL(url).searchParams.get("iframe") === "true";
+
+/** Append iframe=true query param to a URL when in iframe mode */
+export const appendIframeParam = (url: string, inIframe: boolean): string => {
+  if (!inIframe) return url;
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}iframe=true`;
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -271,7 +271,7 @@ export const handleRequest = (
   } catch (error) {
     logError({ code: ErrorCode.CDN_REQUEST, detail: String(error) });
     if (error instanceof SessionKeyError) {
-      return logAndReturn(redirectResponse("/admin", clearSessionCookie()), method, path, getElapsed);
+      return logAndReturn(redirectResponse("/admin", { cookie: clearSessionCookie() }), method, path, getElapsed);
     }
     return logAndReturn(temporaryErrorResponse(), method, path, getElapsed);
   }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import { once } from "#fp";
 import { isSetupComplete } from "#lib/config.ts";
 import { loadCurrencyCode } from "#lib/currency.ts";
 import { loadHeaderImage } from "#lib/header-image.ts";
+import { detectIframeMode } from "#lib/iframe.ts";
 import { loadTheme } from "#lib/theme.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { createRequestTimer, ErrorCode, logDebug, logError, logRequest, runWithRequestId } from "#lib/logger.ts";
@@ -237,6 +238,7 @@ export const handleRequest = (
   return runWithRequestId(() => runWithQueryLogContext(() => runWithSessionContext(async () => {
   const { url, path, method } = parseRequest(request);
   const getElapsed = createRequestTimer();
+  detectIframeMode(request.url);
 
   try {
   // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues
@@ -271,7 +273,7 @@ export const handleRequest = (
   } catch (error) {
     logError({ code: ErrorCode.CDN_REQUEST, detail: String(error) });
     if (error instanceof SessionKeyError) {
-      return logAndReturn(redirectResponse("/admin", { cookie: clearSessionCookie() }), method, path, getElapsed);
+      return logAndReturn(redirectResponse("/admin", clearSessionCookie()), method, path, getElapsed);
     }
     return logAndReturn(temporaryErrorResponse(), method, path, getElapsed);
   }

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -39,9 +39,12 @@ import {
 } from "#lib/webhook.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import {
+  checkoutResponse,
   formatCreationError,
   getBaseUrl,
   htmlResponse,
+  iframeAwareRedirect,
+  isIframeRequest,
   isRegistrationClosed,
   notFoundResponse,
   redirectResponse,
@@ -50,7 +53,7 @@ import {
 } from "#routes/utils.ts";
 import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
 import { extractContact, mergeEventFields, tryValidateTicketFields } from "#templates/fields.ts";
-import { checkoutPopupPage, successPage } from "#templates/payment.tsx";
+import { successPage } from "#templates/payment.tsx";
 import {
   buildMultiTicketEvent,
   homepagePage,
@@ -129,10 +132,6 @@ const ticketResponse = validationErrorResponder(
     ticketPage(event, error, false, inIframe, dates, terms),
 );
 
-/** Check if request URL has ?iframe=true */
-const isIframeRequest = (url: string): boolean =>
-  new URL(url).searchParams.get("iframe") === "true";
-
 /** Compute available dates for a daily event, or undefined for standard */
 const computeDatesForEvent = async (event: EventWithCount): Promise<string[] | undefined> => {
   if (event.event_type !== "daily") return undefined;
@@ -169,11 +168,10 @@ const bookingResultToWebResponse = (
   switch (result.type) {
     case "success": {
       if (event.thank_you_url) return redirectResponse(event.thank_you_url);
-      const iframeParam = ctx.inIframe ? "&iframe=true" : "";
-      return redirectResponse(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}${iframeParam}`);
+      return iframeAwareRedirect(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`, ctx.inIframe);
     }
     case "checkout":
-      return ctx.inIframe ? htmlResponse(checkoutPopupPage(result.checkoutUrl)) : redirectResponse(result.checkoutUrl);
+      return checkoutResponse(result.checkoutUrl, ctx.inIframe);
     case "sold_out":
       return ticketResponse(event, ctx.inIframe, ctx.dates, ctx.terms)("Sorry, not enough spots available");
     case "checkout_failed":
@@ -195,7 +193,7 @@ const tryCheckoutRedirect = <T>(
   errorHandler: () => T,
 ): Response | T => {
   if (!sessionUrl) return errorHandler();
-  return inIframe ? htmlResponse(checkoutPopupPage(sessionUrl)) : redirectResponse(sessionUrl);
+  return checkoutResponse(sessionUrl, inIframe);
 };
 
 /** Get active payment provider or return an error response */
@@ -554,9 +552,8 @@ const submitMultiTicket = (
         return multiTicketFormErrorResponse(ctx)(result.error);
       }
 
-      const iframeParam = inIframe ? "&iframe=true" : "";
       const tokens = encodeURIComponent(result.tokens.join("+"));
-      return redirectResponse(`/ticket/reserved?tokens=${tokens}${iframeParam}`);
+      return iframeAwareRedirect(`/ticket/reserved?tokens=${tokens}`, inIframe);
     },
   );
 

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -43,7 +43,6 @@ import {
   formatCreationError,
   getBaseUrl,
   htmlResponse,
-  iframeAwareRedirect,
   isIframeRequest,
   isRegistrationClosed,
   notFoundResponse,
@@ -168,7 +167,7 @@ const bookingResultToWebResponse = (
   switch (result.type) {
     case "success": {
       if (event.thank_you_url) return redirectResponse(event.thank_you_url);
-      return iframeAwareRedirect(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`, ctx.inIframe);
+      return redirectResponse(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`, { inIframe: ctx.inIframe });
     }
     case "checkout":
       return checkoutResponse(result.checkoutUrl, ctx.inIframe);
@@ -553,7 +552,7 @@ const submitMultiTicket = (
       }
 
       const tokens = encodeURIComponent(result.tokens.join("+"));
-      return iframeAwareRedirect(`/ticket/reserved?tokens=${tokens}`, inIframe);
+      return redirectResponse(`/ticket/reserved?tokens=${tokens}`, { inIframe });
     },
   );
 

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -43,7 +43,6 @@ import {
   formatCreationError,
   getBaseUrl,
   htmlResponse,
-  isIframeRequest,
   isRegistrationClosed,
   notFoundResponse,
   redirectResponse,
@@ -108,9 +107,9 @@ export const handlePublicContact = (): Promise<Response> =>
 
 /** Ticket response builder (CSRF token auto-embedded by CsrfForm) */
 const ticketResponseWithToken =
-  (event: EventWithCount, isClosed: boolean, inIframe: boolean, dates: string[] | undefined, terms: string | null | undefined, baseUrl?: string) =>
+  (event: EventWithCount, isClosed: boolean, dates: string[] | undefined, terms: string | null | undefined, baseUrl?: string) =>
   (error?: string, status = 200) =>
-    htmlResponse(ticketPage(event, error, isClosed, inIframe, dates, terms, baseUrl), status);
+    htmlResponse(ticketPage(event, error, isClosed, dates, terms, baseUrl), status);
 
 /** Curried error response: render(error) → (error, status) → Response */
 const errorResponse =
@@ -127,8 +126,8 @@ const validationErrorResponder = <Args extends unknown[]>(
 
 /** Ticket error response - for validation errors after CSRF passed */
 const ticketResponse = validationErrorResponder(
-  (error: string, event: EventWithCount, inIframe: boolean, dates: string[] | undefined, terms: string | null | undefined) =>
-    ticketPage(event, error, false, inIframe, dates, terms),
+  (error: string, event: EventWithCount, dates: string[] | undefined, terms: string | null | undefined) =>
+    ticketPage(event, error, false, dates, terms),
 );
 
 /** Compute available dates for a daily event, or undefined for standard */
@@ -147,13 +146,12 @@ const applyHiddenNoindex = (response: Response, hidden: boolean): Response => {
 const handleSingleTicketGet = (slug: string, request: Request): Promise<Response> =>
   withActiveEventBySlug(slug, async (event) => {
     const closed = isRegistrationClosed(event);
-    const inIframe = isIframeRequest(request.url);
     await signCsrfToken();
     const dates = await computeDatesForEvent(event);
     const terms = await getTermsAndConditionsFromDb();
     const baseUrl = getBaseUrl(request);
     return applyHiddenNoindex(
-      ticketResponseWithToken(event, closed, inIframe, dates, terms, baseUrl)(),
+      ticketResponseWithToken(event, closed, dates, terms, baseUrl)(),
       event.hidden,
     );
   });
@@ -167,32 +165,31 @@ const bookingResultToWebResponse = (
   switch (result.type) {
     case "success": {
       if (event.thank_you_url) return redirectResponse(event.thank_you_url);
-      return redirectResponse(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`, { inIframe: ctx.inIframe });
+      return redirectResponse(`/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`);
     }
     case "checkout":
-      return checkoutResponse(result.checkoutUrl, ctx.inIframe);
+      return checkoutResponse(result.checkoutUrl);
     case "sold_out":
-      return ticketResponse(event, ctx.inIframe, ctx.dates, ctx.terms)("Sorry, not enough spots available");
+      return ticketResponse(event, ctx.dates, ctx.terms)("Sorry, not enough spots available");
     case "checkout_failed":
       return result.error
-        ? ticketResponse(event, ctx.inIframe, ctx.dates, ctx.terms)(result.error, 400)
-        : ticketResponse(event, ctx.inIframe, ctx.dates, ctx.terms)("Failed to create payment session. Please try again.", 500);
+        ? ticketResponse(event, ctx.dates, ctx.terms)(result.error, 400)
+        : ticketResponse(event, ctx.dates, ctx.terms)("Failed to create payment session. Please try again.", 500);
     case "creation_failed":
-      return ticketResponse(event, ctx.inIframe, ctx.dates, ctx.terms)(
+      return ticketResponse(event, ctx.dates, ctx.terms)(
         formatAtomicError(result.reason),
       );
   }
 };
 
 /** Try to redirect to checkout, or return error using provided handler.
- * When iframe=true, returns a popup page instead of redirect since Stripe cannot run in iframes. */
+ * When in iframe mode, returns a popup page instead of redirect since Stripe cannot run in iframes. */
 const tryCheckoutRedirect = <T>(
   sessionUrl: string | undefined | null,
-  inIframe: boolean,
   errorHandler: () => T,
 ): Response | T => {
   if (!sessionUrl) return errorHandler();
-  return checkoutResponse(sessionUrl, inIframe);
+  return checkoutResponse(sessionUrl);
 };
 
 /** Get active payment provider or return an error response */
@@ -205,11 +202,10 @@ const withPaymentProvider = async (
 };
 
 /** Generic checkout flow: resolve provider, create session, redirect or show error.
- * When iframe=true, opens checkout in a popup window instead of redirect. */
+ * When in iframe mode, opens checkout in a popup window instead of redirect. */
 const runCheckoutFlow = (
   label: string,
   request: Request,
-  inIframe: boolean,
   createSession: (
     provider: Awaited<ReturnType<typeof getActivePaymentProvider>> & object,
     baseUrl: string,
@@ -232,7 +228,7 @@ const runCheckoutFlow = (
         return onError(result.error, 400);
       }
       logDebug("Payment", `Checkout result for ${label}: ${result ? `url=${result.checkoutUrl}` : "null"}`);
-      return tryCheckoutRedirect(result?.checkoutUrl, inIframe, () => {
+      return tryCheckoutRedirect(result?.checkoutUrl, () => {
         logDebug("Payment", `Checkout redirect failed for ${label}: no session URL`);
         return onError("Failed to create payment session. Please try again.", 500);
       });
@@ -241,7 +237,7 @@ const runCheckoutFlow = (
 };
 
 /** Shared context for ticket page rendering */
-type TicketContext = { dates: string[] | undefined; terms: string | null | undefined; inIframe: boolean };
+type TicketContext = { dates: string[] | undefined; terms: string | null | undefined };
 
 /** Parse and validate a quantity value from a raw string, capping at max */
 const parseQuantityValue = (raw: string, max: number, minDefault = 1): number => {
@@ -285,19 +281,18 @@ const processTicketReservation = async (
   event: EventWithCount,
 ): Promise<Response> => {
   const terms = await getTermsAndConditionsFromDb();
-  const inIframe = isIframeRequest(request.url);
 
   return withCsrfForm(
     request,
     (message, status) =>
-      ticketResponseWithToken(event, false, inIframe, undefined, terms)(
+      ticketResponseWithToken(event, false, undefined, terms)(
         message,
         status,
       ),
     async (form) => {
       // Check if registration has closed since the form was loaded
       if (isRegistrationClosed(event)) {
-        return ticketResponse(event, inIframe, undefined, terms)(
+        return ticketResponse(event, undefined, terms)(
           REGISTRATION_CLOSED_SUBMIT_MESSAGE,
         );
       }
@@ -305,14 +300,14 @@ const processTicketReservation = async (
       applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
       const valResult = tryValidateTicketFields(
         form, event.fields,
-        (msg) => ticketResponse(event, inIframe, undefined, terms)(msg),
+        (msg) => ticketResponse(event, undefined, terms)(msg),
       );
       if (valResult instanceof Response) return valResult;
       const values = valResult;
 
       // Validate terms and conditions acceptance if configured
       if (terms && form.get("agree_terms") !== "1") {
-        return ticketResponse(event, inIframe, undefined, terms)(
+        return ticketResponse(event, undefined, terms)(
           "You must agree to the terms and conditions",
         );
       }
@@ -324,7 +319,7 @@ const processTicketReservation = async (
         dates = getAvailableDates(event, await getActiveHolidays());
         date = validateSubmittedDate(form, dates);
         if (!date) {
-          return ticketResponse(event, inIframe, dates, terms)(
+          return ticketResponse(event, dates, terms)(
             "Please select a valid date",
           );
         }
@@ -337,12 +332,12 @@ const processTicketReservation = async (
       if (event.can_pay_more) {
         const priceResult = parseCustomPrice(form, "custom_price", event.unit_price, event.max_price);
         if (!priceResult.ok) {
-          return ticketResponse(event, inIframe, dates, terms)(priceResult.error);
+          return ticketResponse(event, dates, terms)(priceResult.error);
         }
         customUnitPrice = priceResult.price;
       }
 
-      const ctx: TicketContext = { dates, terms, inIframe };
+      const ctx: TicketContext = { dates, terms };
       const contact = extractContact(values);
       const bookingResult = await processBooking(event, contact, quantity, date, getBaseUrl(request), customUnitPrice);
       return bookingResultToWebResponse(bookingResult, event, ctx);
@@ -383,7 +378,6 @@ const renderMultiTicketPage = (ctx: MultiTicketCtx, error?: string) =>
     error,
     ctx.dates,
     ctx.terms,
-    ctx.inIframe,
   );
 
 /** Multi-ticket response builder */
@@ -396,7 +390,6 @@ type MultiTicketCtx = {
   events: MultiTicketEvent[];
   dates: string[];
   terms: string;
-  inIframe: boolean;
 };
 
 /** Multi-ticket form error response (after CSRF passed) */
@@ -438,15 +431,11 @@ const getMultiTicketContext = async (activeEvents: MultiTicketEvent[]): Promise<
 type MultiTicketContextProvider = (events: MultiTicketEvent[]) => Promise<{ dates: string[]; terms: string }>;
 
 /** Load shared meta for multi-ticket pages */
-const loadMultiTicketMeta = async (
-  request: Request,
+const loadMultiTicketMeta = (
   activeEvents: MultiTicketEvent[],
   getContext: MultiTicketContextProvider,
-): Promise<{ inIframe: boolean; dates: string[]; terms: string }> => {
-  const inIframe = isIframeRequest(request.url);
-  const { dates, terms } = await getContext(activeEvents);
-  return { inIframe, dates, terms };
-};
+): Promise<{ dates: string[]; terms: string }> =>
+  getContext(activeEvents);
 
 /** Handle POST for multi-ticket registration */
 const submitMultiTicket = (
@@ -458,7 +447,7 @@ const submitMultiTicket = (
     (message, status) =>
       multiTicketResponse(ctx)(message, status),
     async (form) => {
-      const { inIframe, dates, terms } = ctx;
+      const { dates, terms } = ctx;
 
       applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
 
@@ -552,7 +541,7 @@ const submitMultiTicket = (
       }
 
       const tokens = encodeURIComponent(result.tokens.join("+"));
-      return redirectResponse(`/ticket/reserved?tokens=${tokens}`, { inIframe });
+      return redirectResponse(`/ticket/reserved?tokens=${tokens}`);
     },
   );
 
@@ -562,8 +551,8 @@ const handleMultiTicket = async (
   activeEvents: MultiTicketEvent[],
   getContext: MultiTicketContextProvider,
 ): Promise<Response> => {
-  const [{ inIframe, dates, terms }] = await Promise.all([
-    loadMultiTicketMeta(request, activeEvents, getContext),
+  const [{ dates, terms }] = await Promise.all([
+    loadMultiTicketMeta(activeEvents, getContext),
     signCsrfToken(),
   ]);
   const ctx: MultiTicketCtx = {
@@ -571,7 +560,6 @@ const handleMultiTicket = async (
     events: activeEvents,
     dates,
     terms,
-    inIframe,
   };
   const response = request.method === "GET"
     ? multiTicketResponse(ctx)()
@@ -670,7 +658,6 @@ const handleMultiPaymentFlow = (
   runCheckoutFlow(
     `multi-ticket items=${intent.items.length}`,
     request,
-    ctx.inIframe,
     (provider, baseUrl) => provider.createMultiCheckoutSession(intent, baseUrl),
     (msg, status) => multiTicketResponse(ctx)(msg, status),
   );
@@ -739,10 +726,9 @@ const handleReservedGet = async (request: Request): Promise<Response> => {
   const normalizedTokens = tokensParam?.replaceAll(" ", "+") ?? "";
   const tokens = normalizedTokens.split("+").filter((t) => t.length > 0);
   const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
-  const inIframe = isIframeRequest(request.url);
   const fromEmail = tokens.length > 0 ? await getFromEmailIfConfigured() : "";
 
-  return htmlResponse(successPage({ ticketUrl, inIframe, fromEmail }));
+  return htmlResponse(successPage({ ticketUrl, fromEmail }));
 };
 
 /** Create a slug route that dispatches single vs multi-ticket requests */

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -23,7 +23,7 @@ import { checkoutPopupPage, paymentErrorPage } from "#templates/payment.tsx";
 import { notFoundPage, temporaryErrorPage } from "#templates/public.tsx";
 
 // Re-export for use by other modules
-export { isIframeRequest, appendIframeParam };
+export { isIframeRequest };
 
 // Re-export for use by other route modules
 export { generateSecureToken };
@@ -195,13 +195,6 @@ export const temporaryErrorResponse = (): Response =>
   htmlResponse(temporaryErrorPage(), 503);
 
 /**
- * Redirect response that preserves iframe mode by appending ?iframe=true to the target URL.
- * Use instead of manually building iframe query params on redirect URLs.
- */
-export const iframeAwareRedirect = (url: string, inIframe: boolean): Response =>
-  redirectResponse(appendIframeParam(url, inIframe));
-
-/**
  * Respond with checkout: popup page in iframe mode, 302 redirect otherwise.
  * Stripe Checkout cannot run inside iframes, so we show a page that opens
  * the checkout URL in a popup window instead.
@@ -209,19 +202,24 @@ export const iframeAwareRedirect = (url: string, inIframe: boolean): Response =>
 export const checkoutResponse = (checkoutUrl: string, inIframe: boolean): Response =>
   inIframe ? htmlResponse(checkoutPopupPage(checkoutUrl)) : redirectResponse(checkoutUrl);
 
+/** Options for redirectResponse */
+type RedirectResponseOpts = { cookie?: string; inIframe?: boolean };
+
 /**
  * Create bare 302 redirect response (no message).
  * Use for external URLs, setup flow, public pages, and other cases
  * where the target page doesn't render success/error banners.
  * For admin redirects that should show a message, use `redirect` instead.
+ * When inIframe is true, appends ?iframe=true to the target URL.
  */
-export const redirectResponse = (url: string, cookie?: string): Response => {
+export const redirectResponse = (url: string, opts?: RedirectResponseOpts): Response => {
+  const location = appendIframeParam(url, opts?.inIframe ?? false);
   const headers: HeadersInit = {
-    location: url,
+    location,
     "content-type": "text/html; charset=utf-8",
   };
-  if (cookie) {
-    headers["set-cookie"] = cookie;
+  if (opts?.cookie) {
+    headers["set-cookie"] = opts.cookie;
   }
   return new Response(null, { status: 302, headers });
 };
@@ -245,7 +243,7 @@ export const redirect = (
     u.searchParams.set("form", opts.formId);
     u.hash = opts.formId;
   }
-  return redirectResponse(u.pathname + u.search + u.hash, opts?.cookie);
+  return redirectResponse(u.pathname + u.search + u.hash, { cookie: opts?.cookie });
 };
 
 /**

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -18,8 +18,12 @@ import { getCachedSession, setCachedSession } from "#lib/session-context.ts";
 import { nowMs } from "#lib/now.ts";
 import type { AdminLevel, AdminSession, EventWithCount } from "#lib/types.ts";
 import type { ServerContext } from "#routes/types.ts";
-import { paymentErrorPage } from "#templates/payment.tsx";
+import { isIframeRequest, appendIframeParam } from "#lib/iframe.ts";
+import { checkoutPopupPage, paymentErrorPage } from "#templates/payment.tsx";
 import { notFoundPage, temporaryErrorPage } from "#templates/public.tsx";
+
+// Re-export for use by other modules
+export { isIframeRequest, appendIframeParam };
 
 // Re-export for use by other route modules
 export { generateSecureToken };
@@ -189,6 +193,21 @@ export const paymentErrorResponse = (message: string, status = 400): Response =>
  */
 export const temporaryErrorResponse = (): Response =>
   htmlResponse(temporaryErrorPage(), 503);
+
+/**
+ * Redirect response that preserves iframe mode by appending ?iframe=true to the target URL.
+ * Use instead of manually building iframe query params on redirect URLs.
+ */
+export const iframeAwareRedirect = (url: string, inIframe: boolean): Response =>
+  redirectResponse(appendIframeParam(url, inIframe));
+
+/**
+ * Respond with checkout: popup page in iframe mode, 302 redirect otherwise.
+ * Stripe Checkout cannot run inside iframes, so we show a page that opens
+ * the checkout URL in a popup window instead.
+ */
+export const checkoutResponse = (checkoutUrl: string, inIframe: boolean): Response =>
+  inIframe ? htmlResponse(checkoutPopupPage(checkoutUrl)) : redirectResponse(checkoutUrl);
 
 /**
  * Create bare 302 redirect response (no message).

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -18,12 +18,9 @@ import { getCachedSession, setCachedSession } from "#lib/session-context.ts";
 import { nowMs } from "#lib/now.ts";
 import type { AdminLevel, AdminSession, EventWithCount } from "#lib/types.ts";
 import type { ServerContext } from "#routes/types.ts";
-import { isIframeRequest, appendIframeParam } from "#lib/iframe.ts";
+import { appendIframeParam, getIframeMode } from "#lib/iframe.ts";
 import { checkoutPopupPage, paymentErrorPage } from "#templates/payment.tsx";
 import { notFoundPage, temporaryErrorPage } from "#templates/public.tsx";
-
-// Re-export for use by other modules
-export { isIframeRequest };
 
 // Re-export for use by other route modules
 export { generateSecureToken };
@@ -198,28 +195,25 @@ export const temporaryErrorResponse = (): Response =>
  * Respond with checkout: popup page in iframe mode, 302 redirect otherwise.
  * Stripe Checkout cannot run inside iframes, so we show a page that opens
  * the checkout URL in a popup window instead.
+ * Reads iframe mode from the per-request store (set by detectIframeMode).
  */
-export const checkoutResponse = (checkoutUrl: string, inIframe: boolean): Response =>
-  inIframe ? htmlResponse(checkoutPopupPage(checkoutUrl)) : redirectResponse(checkoutUrl);
-
-/** Options for redirectResponse */
-type RedirectResponseOpts = { cookie?: string; inIframe?: boolean };
+export const checkoutResponse = (checkoutUrl: string): Response =>
+  getIframeMode() ? htmlResponse(checkoutPopupPage(checkoutUrl)) : redirectResponse(checkoutUrl);
 
 /**
  * Create bare 302 redirect response (no message).
  * Use for external URLs, setup flow, public pages, and other cases
  * where the target page doesn't render success/error banners.
  * For admin redirects that should show a message, use `redirect` instead.
- * When inIframe is true, appends ?iframe=true to the target URL.
+ * Automatically appends ?iframe=true when the current request is in iframe mode.
  */
-export const redirectResponse = (url: string, opts?: RedirectResponseOpts): Response => {
-  const location = appendIframeParam(url, opts?.inIframe ?? false);
+export const redirectResponse = (url: string, cookie?: string): Response => {
   const headers: HeadersInit = {
-    location,
+    location: appendIframeParam(url),
     "content-type": "text/html; charset=utf-8",
   };
-  if (opts?.cookie) {
-    headers["set-cookie"] = opts.cookie;
+  if (cookie) {
+    headers["set-cookie"] = cookie;
   }
   return new Response(null, { status: 302, headers });
 };
@@ -243,7 +237,7 @@ export const redirect = (
     u.searchParams.set("form", opts.formId);
     u.hash = opts.formId;
   }
-  return redirectResponse(u.pathname + u.search + u.hash, { cookie: opts?.cookie });
+  return redirectResponse(u.pathname + u.search + u.hash, opts?.cookie);
 };
 
 /**

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -2,6 +2,7 @@
  * Payment page templates - success, cancel, error pages
  */
 
+import { getIframeMode } from "#lib/iframe.ts";
 import type { Attendee, Event } from "#lib/types.ts";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
 
@@ -35,16 +36,15 @@ export const paymentPage = (
 export const successPage = ({
   ticketUrl,
   thankYouUrl = "",
-  inIframe = false,
   paid = false,
   fromEmail = "",
 }: {
   ticketUrl: string | null;
   thankYouUrl?: string;
-  inIframe?: boolean;
   paid?: boolean;
   fromEmail?: string;
 }): string => {
+  const inIframe = getIframeMode();
   const title = paid ? "Payment Successful" : "Ticket Reserved";
   const heading = paid ? "Payment Successful!" : "Ticket reserved successfully.";
   return String(

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -7,6 +7,7 @@ import { formatCurrency, toMajorUnits } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
 import type { Field } from "#lib/forms.tsx";
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
+import { getIframeMode } from "#lib/iframe.ts";
 import { renderMarkdown, renderMarkdownInline } from "#lib/markdown.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
 import type { EventFields, EventWithCount } from "#lib/types.ts";
@@ -198,11 +199,11 @@ export const ticketPage = (
   event: EventWithCount,
   error: string | undefined,
   isClosed: boolean,
-  inIframe: boolean,
   availableDates: string[] | undefined,
   termsAndConditions: string | null | undefined,
   baseUrl?: string,
 ): string => {
+  const inIframe = getIframeMode();
   const spotsRemaining = event.max_attendees - event.attendee_count;
   const isFull = spotsRemaining <= 0;
   const maxPurchasable = Math.min(event.max_quantity, spotsRemaining);
@@ -238,7 +239,7 @@ export const ticketPage = (
       ) : isFull ? (
           <div class="error">Sorry, this event is full.</div>
       ) : (
-          <CsrfForm action={`/ticket/${event.slug}`} inIframe={inIframe}>
+          <CsrfForm action={`/ticket/${event.slug}`}>
             <Raw html={renderFields(fields)} />
             {isDaily && availableDates && (
               <Raw html={renderDateSelector(availableDates)} />
@@ -376,8 +377,8 @@ export const multiTicketPage = (
   error?: string,
   availableDates?: string[],
   termsAndConditions?: string | null,
-  inIframe = false,
 ): string => {
+  const inIframe = getIframeMode();
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
   const allClosed = events.every((e) => e.isClosed);
   const fieldsSetting = getMultiTicketFieldsSetting(events);
@@ -396,7 +397,7 @@ export const multiTicketPage = (
       {allUnavailable ? (
         <div class="error">{allClosed ? "Registration closed." : "Sorry, all events are sold out."}</div>
       ) : (
-        <CsrfForm action={`/ticket/${slugs.join("+")}`} inIframe={inIframe}>
+        <CsrfForm action={`/ticket/${slugs.join("+")}`}>
           <Raw html={renderFields(fields)} />
           {hasDaily && availableDates && (
             <Raw html={renderDateSelector(availableDates)} />

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -7,6 +7,7 @@ import { formatCurrency, toMajorUnits } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
 import type { Field } from "#lib/forms.tsx";
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
+import { appendIframeParam } from "#lib/iframe.ts";
 import { renderMarkdown, renderMarkdownInline } from "#lib/markdown.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
 import type { EventFields, EventWithCount } from "#lib/types.ts";
@@ -238,7 +239,7 @@ export const ticketPage = (
       ) : isFull ? (
           <div class="error">Sorry, this event is full.</div>
       ) : (
-          <CsrfForm action={`/ticket/${event.slug}${inIframe ? "?iframe=true" : ""}`}>
+          <CsrfForm action={appendIframeParam(`/ticket/${event.slug}`, inIframe)}>
             <Raw html={renderFields(fields)} />
             {isDaily && availableDates && (
               <Raw html={renderDateSelector(availableDates)} />
@@ -380,7 +381,7 @@ export const multiTicketPage = (
 ): string => {
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
   const allClosed = events.every((e) => e.isClosed);
-  const formAction = `/ticket/${slugs.join("+")}${inIframe ? "?iframe=true" : ""}`;
+  const formAction = appendIframeParam(`/ticket/${slugs.join("+")}`, inIframe);
   const fieldsSetting = getMultiTicketFieldsSetting(events);
   const fields: Field[] = getTicketFields(fieldsSetting);
   const hasDaily = events.some((e) => e.event.event_type === "daily");

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -7,7 +7,6 @@ import { formatCurrency, toMajorUnits } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
 import type { Field } from "#lib/forms.tsx";
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
-import { appendIframeParam } from "#lib/iframe.ts";
 import { renderMarkdown, renderMarkdownInline } from "#lib/markdown.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
 import type { EventFields, EventWithCount } from "#lib/types.ts";
@@ -239,7 +238,7 @@ export const ticketPage = (
       ) : isFull ? (
           <div class="error">Sorry, this event is full.</div>
       ) : (
-          <CsrfForm action={appendIframeParam(`/ticket/${event.slug}`, inIframe)}>
+          <CsrfForm action={`/ticket/${event.slug}`} inIframe={inIframe}>
             <Raw html={renderFields(fields)} />
             {isDaily && availableDates && (
               <Raw html={renderDateSelector(availableDates)} />
@@ -381,7 +380,6 @@ export const multiTicketPage = (
 ): string => {
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
   const allClosed = events.every((e) => e.isClosed);
-  const formAction = appendIframeParam(`/ticket/${slugs.join("+")}`, inIframe);
   const fieldsSetting = getMultiTicketFieldsSetting(events);
   const fields: Field[] = getTicketFields(fieldsSetting);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
@@ -398,7 +396,7 @@ export const multiTicketPage = (
       {allUnavailable ? (
         <div class="error">{allClosed ? "Registration closed." : "Sorry, all events are sold out."}</div>
       ) : (
-        <CsrfForm action={formAction}>
+        <CsrfForm action={`/ticket/${slugs.join("+")}`} inIframe={inIframe}>
           <Raw html={renderFields(fields)} />
           {hasDaily && availableDates && (
             <Raw html={renderDateSelector(availableDates)} />

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -1183,6 +1183,23 @@ describe("forms", () => {
       expect(html).not.toContain('class="error"');
       setFormError("", "");
     });
+
+    test("appends ?iframe=true to action when inIframe is true", () => {
+      const html = String(CsrfForm({ action: "/ticket/test", inIframe: true }));
+      expect(html).toContain('action="/ticket/test?iframe=true"');
+    });
+
+    test("does not append iframe param when inIframe is false", () => {
+      const html = String(CsrfForm({ action: "/ticket/test", inIframe: false }));
+      expect(html).toContain('action="/ticket/test"');
+      expect(html).not.toContain("iframe");
+    });
+
+    test("does not append iframe param when inIframe is omitted", () => {
+      const html = String(CsrfForm({ action: "/ticket/test" }));
+      expect(html).toContain('action="/ticket/test"');
+      expect(html).not.toContain("iframe");
+    });
   });
 
   describe("renderSuccess", () => {

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, it as test } from "@std/testing/bdd";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { getCurrentCsrfToken, signCsrfToken } from "#lib/csrf.ts";
 import { detectIframeMode } from "#lib/iframe.ts";

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { afterEach, beforeAll, describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { getCurrentCsrfToken, signCsrfToken } from "#lib/csrf.ts";
+import { detectIframeMode } from "#lib/iframe.ts";
 import {
   CsrfForm,
   type Field,
@@ -1184,18 +1185,15 @@ describe("forms", () => {
       setFormError("", "");
     });
 
-    test("appends ?iframe=true to action when inIframe is true", () => {
-      const html = String(CsrfForm({ action: "/ticket/test", inIframe: true }));
+    test("appends ?iframe=true to action when iframe mode is active", () => {
+      detectIframeMode("https://example.com/?iframe=true");
+      const html = String(CsrfForm({ action: "/ticket/test" }));
       expect(html).toContain('action="/ticket/test?iframe=true"');
+      detectIframeMode("https://example.com/");
     });
 
-    test("does not append iframe param when inIframe is false", () => {
-      const html = String(CsrfForm({ action: "/ticket/test", inIframe: false }));
-      expect(html).toContain('action="/ticket/test"');
-      expect(html).not.toContain("iframe");
-    });
-
-    test("does not append iframe param when inIframe is omitted", () => {
+    test("does not append iframe param when iframe mode is inactive", () => {
+      detectIframeMode("https://example.com/");
       const html = String(CsrfForm({ action: "/ticket/test" }));
       expect(html).toContain('action="/ticket/test"');
       expect(html).not.toContain("iframe");

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { afterEach, beforeAll, describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { CSS_PATH, EMBED_JS_PATH, IFRAME_RESIZER_CHILD_JS_PATH, IFRAME_RESIZER_PARENT_JS_PATH, JS_PATH } from "#lib/asset-paths.ts";
+import { detectIframeMode } from "#lib/iframe.ts";
 import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
 import { adminDuplicateEventPage, adminEventEditPage, adminEventNewPage, adminEventPage, calculateTotalRevenue, countCheckedIn, countCheckedInRows, formatAddressInline, isIncompletePayment, nearCapacity } from "#templates/admin/events.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
@@ -70,6 +71,10 @@ describe("asset-paths", () => {
 });
 
 describe("html", () => {
+  afterEach(() => {
+    detectIframeMode("https://example.com/");
+  });
+
   describe("adminLoginPage", () => {
     test("renders login form", () => {
       const html = adminLoginPage();
@@ -413,7 +418,11 @@ describe("html", () => {
     const renderTicket = (
       ev: Parameters<typeof ticketPage>[0],
       opts?: { error?: string; isClosed?: boolean; iframe?: boolean; dates?: string[]; terms?: string | null },
-    ) => ticketPage(ev, opts?.error, opts?.isClosed ?? false, opts?.iframe ?? false, opts?.dates, opts?.terms);
+    ) => {
+      if (opts?.iframe) detectIframeMode("https://example.com/?iframe=true");
+      else detectIframeMode("https://example.com/");
+      return ticketPage(ev, opts?.error, opts?.isClosed ?? false, opts?.dates, opts?.terms);
+    };
 
     test("renders page title", () => {
       const html = renderTicket(event);
@@ -533,28 +542,28 @@ describe("html", () => {
     });
 
     test("renders terms and conditions with checkbox", () => {
-      const html = ticketPage(event, undefined, false, false, undefined, "No refunds allowed");
+      const html = ticketPage(event, undefined, false, undefined, "No refunds allowed");
       expect(html).toContain("No refunds allowed");
       expect(html).toContain('class="terms"');
       expect(html).toContain('name="agree_terms"');
     });
 
     test("renders markdown paragraphs in terms and conditions", () => {
-      const html = ticketPage(event, undefined, false, false, undefined, "Line one\n\nLine two\n\nLine three");
+      const html = ticketPage(event, undefined, false, undefined, "Line one\n\nLine two\n\nLine three");
       expect(html).toContain("<p>Line one</p>");
       expect(html).toContain("<p>Line two</p>");
       expect(html).toContain("<p>Line three</p>");
     });
 
     test("does not render terms when not provided", () => {
-      const html = ticketPage(event, undefined, false, false, undefined, undefined);
+      const html = ticketPage(event, undefined, false, undefined, undefined);
       expect(html).not.toContain('class="terms"');
       expect(html).not.toContain('name="agree_terms"');
     });
 
     test("includes OpenGraph tags when baseUrl is provided", () => {
       const ev = testEventWithCount({ name: "Birthday Party", slug: "birthday-party", description: "A fun party" });
-      const html = ticketPage(ev, undefined, false, false, undefined, undefined, "https://tix.example.com");
+      const html = ticketPage(ev, undefined, false, undefined, undefined, "https://tix.example.com");
       expect(html).toContain('<meta property="og:title" content="Birthday Party">');
       expect(html).toContain('<meta property="og:type" content="website">');
       expect(html).toContain('<meta property="og:url" content="https://tix.example.com/ticket/birthday-party">');
@@ -562,7 +571,7 @@ describe("html", () => {
     });
 
     test("does not include OpenGraph tags when baseUrl is not provided", () => {
-      const html = ticketPage(event, undefined, false, false, undefined, undefined);
+      const html = ticketPage(event, undefined, false, undefined, undefined);
       expect(html).not.toContain('og:title');
     });
   });
@@ -734,9 +743,11 @@ describe("html", () => {
     });
 
     test("includes iframe-resizer child script in iframe mode", () => {
-      const html = successPage({ ticketUrl: "/t/abc123", inIframe: true });
+      detectIframeMode("https://example.com/?iframe=true");
+      const html = successPage({ ticketUrl: "/t/abc123" });
       expect(html).toContain("iframe-resizer-child.js");
       expect(html).toContain('class="iframe"');
+      detectIframeMode("https://example.com/");
     });
 
     test("excludes iframe-resizer child script when not in iframe mode", () => {
@@ -746,8 +757,10 @@ describe("html", () => {
     });
 
     test("includes scroll-into-view marker in iframe mode", () => {
-      const html = successPage({ ticketUrl: "/t/abc123", inIframe: true });
+      detectIframeMode("https://example.com/?iframe=true");
+      const html = successPage({ ticketUrl: "/t/abc123" });
       expect(html).toContain("data-scroll-into-view");
+      detectIframeMode("https://example.com/");
     });
 
     test("excludes scroll-into-view marker when not in iframe mode", () => {
@@ -1694,20 +1707,24 @@ describe("html", () => {
     });
 
     test("appends ?iframe=true to form action in iframe mode", () => {
+      detectIframeMode("https://example.com/?iframe=true");
       const events = [
         buildMultiTicketEvent(testEventWithCount({ id: 1, slug: "ab12c", name: "Event A", attendee_count: 0 })),
       ];
-      const html = multiTicketPage(events, ["ab12c"], undefined, undefined, undefined, true);
+      const html = multiTicketPage(events, ["ab12c"]);
       expect(html).toContain('action="/ticket/ab12c?iframe=true"');
       expect(html).toContain('class="iframe"');
+      detectIframeMode("https://example.com/");
     });
 
     test("includes iframe-resizer child script in iframe mode", () => {
+      detectIframeMode("https://example.com/?iframe=true");
       const events = [
         buildMultiTicketEvent(testEventWithCount({ id: 1, slug: "ab12c", name: "Event A", attendee_count: 0 })),
       ];
-      const html = multiTicketPage(events, ["ab12c"], undefined, undefined, undefined, true);
+      const html = multiTicketPage(events, ["ab12c"]);
       expect(html).toContain("iframe-resizer-child.js");
+      detectIframeMode("https://example.com/");
     });
 
     test("excludes iframe-resizer child script without iframe mode", () => {
@@ -2224,7 +2241,11 @@ describe("html", () => {
     const renderTicket = (
       ev: Parameters<typeof ticketPage>[0],
       opts?: { iframe?: boolean },
-    ) => ticketPage(ev, undefined, false, opts?.iframe ?? false, undefined, undefined);
+    ) => {
+      if (opts?.iframe) detectIframeMode("https://example.com/?iframe=true");
+      else detectIframeMode("https://example.com/");
+      return ticketPage(ev, undefined, false, undefined, undefined);
+    };
 
     test("shows date on public ticket page when event has date", () => {
       const event = testEventWithCount({
@@ -2417,7 +2438,7 @@ describe("html", () => {
       test("shows event image when image_url is set", () => {
         setupStorage();
         const event = testEventWithCount({ image_url: "event-img.jpg" });
-        const html = ticketPage(event, undefined, false, false, undefined, null);
+        const html = ticketPage(event, undefined, false, undefined, null);
         expect(html).toContain("/image/event-img.jpg");
         expect(html).toContain('class="event-image"');
         cleanupStorage();
@@ -2426,16 +2447,18 @@ describe("html", () => {
       test("does not show image when image_url is null", () => {
         setupStorage();
         const event = testEventWithCount({ image_url: "" });
-        const html = ticketPage(event, undefined, false, false, undefined, null);
+        const html = ticketPage(event, undefined, false, undefined, null);
         expect(html).not.toContain("/image/");
         cleanupStorage();
       });
 
       test("does not show image in iframe mode", () => {
         setupStorage();
+        detectIframeMode("https://example.com/?iframe=true");
         const event = testEventWithCount({ image_url: "event-img.jpg" });
-        const html = ticketPage(event, undefined, false, true, undefined, null);
+        const html = ticketPage(event, undefined, false, undefined, null);
         expect(html).not.toContain("event-img.jpg");
+        detectIframeMode("https://example.com/");
         cleanupStorage();
       });
     });

--- a/test/lib/iframe.test.ts
+++ b/test/lib/iframe.test.ts
@@ -1,0 +1,45 @@
+import { describe, it as test } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { appendIframeParam, isIframeRequest } from "#lib/iframe.ts";
+
+describe("iframe", () => {
+  describe("isIframeRequest", () => {
+    test("returns true when iframe=true is present", () => {
+      expect(isIframeRequest("https://example.com/ticket/test?iframe=true")).toBe(true);
+    });
+
+    test("returns false when iframe param is absent", () => {
+      expect(isIframeRequest("https://example.com/ticket/test")).toBe(false);
+    });
+
+    test("returns false when iframe param has a different value", () => {
+      expect(isIframeRequest("https://example.com/ticket/test?iframe=false")).toBe(false);
+    });
+
+    test("returns true with additional query params", () => {
+      expect(isIframeRequest("https://example.com/ticket/test?foo=bar&iframe=true")).toBe(true);
+    });
+  });
+
+  describe("appendIframeParam", () => {
+    test("appends ?iframe=true when inIframe is true and no existing query", () => {
+      expect(appendIframeParam("/ticket/test", true)).toBe("/ticket/test?iframe=true");
+    });
+
+    test("appends &iframe=true when inIframe is true and query exists", () => {
+      expect(appendIframeParam("/ticket/reserved?tokens=abc", true)).toBe(
+        "/ticket/reserved?tokens=abc&iframe=true",
+      );
+    });
+
+    test("returns url unchanged when inIframe is false", () => {
+      expect(appendIframeParam("/ticket/test", false)).toBe("/ticket/test");
+    });
+
+    test("returns url with existing query unchanged when inIframe is false", () => {
+      expect(appendIframeParam("/ticket/reserved?tokens=abc", false)).toBe(
+        "/ticket/reserved?tokens=abc",
+      );
+    });
+  });
+});

--- a/test/lib/iframe.test.ts
+++ b/test/lib/iframe.test.ts
@@ -1,43 +1,55 @@
-import { describe, it as test } from "@std/testing/bdd";
+import { describe, it as test, afterEach } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { appendIframeParam, isIframeRequest } from "#lib/iframe.ts";
+import { appendIframeParam, detectIframeMode, getIframeMode } from "#lib/iframe.ts";
 
 describe("iframe", () => {
-  describe("isIframeRequest", () => {
-    test("returns true when iframe=true is present", () => {
-      expect(isIframeRequest("https://example.com/ticket/test?iframe=true")).toBe(true);
+  afterEach(() => {
+    detectIframeMode("https://example.com/");
+  });
+
+  describe("detectIframeMode", () => {
+    test("sets iframe mode to true when iframe=true is present", () => {
+      detectIframeMode("https://example.com/ticket/test?iframe=true");
+      expect(getIframeMode()).toBe(true);
     });
 
-    test("returns false when iframe param is absent", () => {
-      expect(isIframeRequest("https://example.com/ticket/test")).toBe(false);
+    test("sets iframe mode to false when iframe param is absent", () => {
+      detectIframeMode("https://example.com/ticket/test");
+      expect(getIframeMode()).toBe(false);
     });
 
-    test("returns false when iframe param has a different value", () => {
-      expect(isIframeRequest("https://example.com/ticket/test?iframe=false")).toBe(false);
+    test("sets iframe mode to false when iframe param has a different value", () => {
+      detectIframeMode("https://example.com/ticket/test?iframe=false");
+      expect(getIframeMode()).toBe(false);
     });
 
-    test("returns true with additional query params", () => {
-      expect(isIframeRequest("https://example.com/ticket/test?foo=bar&iframe=true")).toBe(true);
+    test("sets iframe mode to true with additional query params", () => {
+      detectIframeMode("https://example.com/ticket/test?foo=bar&iframe=true");
+      expect(getIframeMode()).toBe(true);
     });
   });
 
   describe("appendIframeParam", () => {
-    test("appends ?iframe=true when inIframe is true and no existing query", () => {
-      expect(appendIframeParam("/ticket/test", true)).toBe("/ticket/test?iframe=true");
+    test("appends ?iframe=true when in iframe mode and no existing query", () => {
+      detectIframeMode("https://example.com/?iframe=true");
+      expect(appendIframeParam("/ticket/test")).toBe("/ticket/test?iframe=true");
     });
 
-    test("appends &iframe=true when inIframe is true and query exists", () => {
-      expect(appendIframeParam("/ticket/reserved?tokens=abc", true)).toBe(
+    test("appends &iframe=true when in iframe mode and query exists", () => {
+      detectIframeMode("https://example.com/?iframe=true");
+      expect(appendIframeParam("/ticket/reserved?tokens=abc")).toBe(
         "/ticket/reserved?tokens=abc&iframe=true",
       );
     });
 
-    test("returns url unchanged when inIframe is false", () => {
-      expect(appendIframeParam("/ticket/test", false)).toBe("/ticket/test");
+    test("returns url unchanged when not in iframe mode", () => {
+      detectIframeMode("https://example.com/");
+      expect(appendIframeParam("/ticket/test")).toBe("/ticket/test");
     });
 
-    test("returns url with existing query unchanged when inIframe is false", () => {
-      expect(appendIframeParam("/ticket/reserved?tokens=abc", false)).toBe(
+    test("returns url with existing query unchanged when not in iframe mode", () => {
+      detectIframeMode("https://example.com/");
+      expect(appendIframeParam("/ticket/reserved?tokens=abc")).toBe(
         "/ticket/reserved?tokens=abc",
       );
     });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -7,7 +7,7 @@ import {
   isValidContentType,
   normalizeHostname,
 } from "#routes";
-import { redirect, temporaryErrorResponse } from "#routes/utils.ts";
+import { redirect, redirectResponse, temporaryErrorResponse } from "#routes/utils.ts";
 import {
   createTestDb,
   createTestDbWithSetup,
@@ -313,6 +313,29 @@ describe("server (misc)", () => {
 
     test("passes cookie through to response", () => {
       const response = redirect("/admin", "Done", true, { cookie: "session=abc; Path=/" });
+      expect(response.headers.get("set-cookie")).toBe("session=abc; Path=/");
+    });
+  });
+
+  describe("routes/utils.ts (redirectResponse)", () => {
+    test("creates 302 redirect with location header", () => {
+      const response = redirectResponse("/ticket/test");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/ticket/test");
+    });
+
+    test("appends iframe=true when inIframe is true", () => {
+      const response = redirectResponse("/ticket/reserved?tokens=abc", { inIframe: true });
+      expect(response.headers.get("location")).toBe("/ticket/reserved?tokens=abc&iframe=true");
+    });
+
+    test("does not append iframe param when inIframe is false", () => {
+      const response = redirectResponse("/ticket/test", { inIframe: false });
+      expect(response.headers.get("location")).toBe("/ticket/test");
+    });
+
+    test("sets cookie header when cookie option is provided", () => {
+      const response = redirectResponse("/admin", { cookie: "session=abc; Path=/" });
       expect(response.headers.get("set-cookie")).toBe("session=abc; Path=/");
     });
   });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -7,6 +7,7 @@ import {
   isValidContentType,
   normalizeHostname,
 } from "#routes";
+import { detectIframeMode } from "#lib/iframe.ts";
 import { redirect, redirectResponse, temporaryErrorResponse } from "#routes/utils.ts";
 import {
   createTestDb,
@@ -324,18 +325,21 @@ describe("server (misc)", () => {
       expect(response.headers.get("location")).toBe("/ticket/test");
     });
 
-    test("appends iframe=true when inIframe is true", () => {
-      const response = redirectResponse("/ticket/reserved?tokens=abc", { inIframe: true });
+    test("appends iframe=true when iframe mode is active", () => {
+      detectIframeMode("https://example.com/?iframe=true");
+      const response = redirectResponse("/ticket/reserved?tokens=abc");
       expect(response.headers.get("location")).toBe("/ticket/reserved?tokens=abc&iframe=true");
+      detectIframeMode("https://example.com/");
     });
 
-    test("does not append iframe param when inIframe is false", () => {
-      const response = redirectResponse("/ticket/test", { inIframe: false });
+    test("does not append iframe param when iframe mode is inactive", () => {
+      detectIframeMode("https://example.com/");
+      const response = redirectResponse("/ticket/test");
       expect(response.headers.get("location")).toBe("/ticket/test");
     });
 
-    test("sets cookie header when cookie option is provided", () => {
-      const response = redirectResponse("/admin", { cookie: "session=abc; Path=/" });
+    test("sets cookie header when cookie is provided", () => {
+      const response = redirectResponse("/admin", "session=abc; Path=/");
       expect(response.headers.get("set-cookie")).toBe("session=abc; Path=/");
     });
   });


### PR DESCRIPTION
Extract scattered iframe-awareness logic (detection, URL param appending,
checkout vs redirect response branching) into a single module (lib/iframe.ts)
with response helpers in routes/utils.ts. This eliminates duplicated
conditional branches across public.ts, templates/public.tsx, and payment
helpers, making it easier to maintain as more payment flows are added.

https://claude.ai/code/session_017iEVN4fUhuLPBUkhAubAD6