### PR TITLE
Force node-forge to use pure JavaScript mode

### DIFF
--- a/src/lib/apple-wallet.ts
+++ b/src/lib/apple-wallet.ts
@@ -13,6 +13,12 @@ import forge from "node-forge";
 import { zipSync } from "fflate";
 import { getDecimalPlaces } from "#lib/currency.ts";
 
+// Force pure-JS mode so node-forge never attempts require("crypto").
+// The Bunny Edge runtime sets process.versions.node (via the node:process
+// global), which makes node-forge think it's running in Node and try to
+// load native crypto — causing "Dynamic require of 'crypto' is not supported".
+forge.options.usePureJavaScript = true;
+
 /** Data needed to generate a pass — maps to existing ticket/event data */
 export type PassData = {
   /** Unique token identifying this ticket */


### PR DESCRIPTION
## Summary
Configure node-forge to use pure JavaScript implementation instead of attempting to load native crypto modules, ensuring compatibility with edge runtime environments.

## Key Changes
- Added configuration to set `forge.options.usePureJavaScript = true` at module initialization
- This prevents node-forge from attempting to dynamically require the native "crypto" module, which is not supported in Bunny Edge runtime
- Added explanatory comments documenting why this configuration is necessary

## Implementation Details
The Bunny Edge runtime sets `process.versions.node` (via the node:process global), which causes node-forge to incorrectly detect a Node.js environment and attempt to load native crypto modules. By explicitly enabling pure JavaScript mode, node-forge will use its built-in cryptographic implementations instead, avoiding the "Dynamic require of 'crypto' is not supported" error.

https://claude.ai/code/session_012Gvqiaqysk8KCqmqf2cY7D