### PR TITLE
Replace crypto shim with Web Crypto API adapter for node-forge

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -232,12 +232,13 @@ const nodeExternals = [
 ];
 
 /**
- * Plugin to shim bare "crypto" imports with an empty module.
- * node-forge uses `require("crypto")` internally and falls back to its own
- * pure-JS implementation when it's unavailable. By returning an empty module
- * we let the fallback kick in, avoiding the "Dynamic require of 'crypto' is
- * not supported" error in the Bunny Edge ESM runtime. The node:-prefixed
- * "node:crypto" stays external for code that needs it.
+ * Plugin to shim bare "crypto" imports with a Web Crypto API adapter.
+ * node-forge's prng.js calls `require("crypto")` at module load time (before
+ * `forge.options.usePureJavaScript` can be set) and uses `randomBytes()` for
+ * seeding its Fortuna PRNG. We provide a shim that delegates to the Web Crypto
+ * API (`globalThis.crypto.getRandomValues`), which is available in both Deno
+ * and Bunny Edge runtimes. The node:-prefixed "node:crypto" stays external for
+ * code that needs the full Node.js crypto API.
  */
 const shimBareNodeCryptoPlugin: Plugin = {
   name: "shim-bare-node-crypto",
@@ -247,7 +248,15 @@ const shimBareNodeCryptoPlugin: Plugin = {
       namespace: "shim-bare-crypto",
     }));
     build.onLoad({ filter: /.*/, namespace: "shim-bare-crypto" }, () => ({
-      contents: "export default {};",
+      contents: `
+        export function randomBytes(size, cb) {
+          var b = Buffer.alloc(size);
+          globalThis.crypto.getRandomValues(b);
+          if (cb) { cb(null, b); return; }
+          return b;
+        }
+        export default { randomBytes };
+      `,
       loader: "js",
     }));
   },


### PR DESCRIPTION
## Summary
Updated the bare "crypto" import shim to provide a functional `randomBytes()` implementation using the Web Crypto API instead of returning an empty module. This ensures node-forge's PRNG initialization works correctly in edge runtimes.

## Changes
- **Replaced empty module shim** with a Web Crypto API adapter that implements the `randomBytes(size, cb)` function signature
- **Implementation details:**
  - Allocates a Buffer of the requested size
  - Populates it using `globalThis.crypto.getRandomValues()` (available in Deno and Bunny Edge)
  - Supports both callback and synchronous return patterns
  - Maintains external resolution of `node:crypto` for code requiring the full Node.js crypto API

## Rationale
node-forge's `prng.js` calls `require("crypto")` at module load time before `forge.options.usePureJavaScript` can be set, and immediately uses `randomBytes()` for PRNG seeding. The previous empty module approach failed to provide this critical function. The new adapter delegates to the Web Crypto API, which is universally available in modern edge runtimes.

https://claude.ai/code/session_0194rxA632gZ7t3RAjxcgqCz