### PR TITLE
Change pkpass Content-Disposition to inline for iOS compatibility

### DIFF
--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -59,7 +59,7 @@ const handleWalletGet = async (_request: Request, tokens: string[]): Promise<Res
   return new Response(pkpass as Uint8Array<ArrayBuffer>, {
     headers: {
       "Content-Type": PKPASS_CONTENT_TYPE,
-      "Content-Disposition": `attachment; filename="ticket.pkpass"`,
+      "Content-Disposition": `inline; filename="ticket.pkpass"`,
       "Cache-Control": CACHE_CONTROL,
     },
   });

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -89,12 +89,14 @@ describe("wallet route (/wallet/:token)", () => {
     expect(cacheControl).toContain("s-maxage=3600");
   });
 
-  test("returns pkpass with content-disposition header", async () => {
+  test("returns pkpass with inline content-disposition for iOS compatibility", async () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
 
     const response = await awaitTestRequest(`/wallet/${token}`);
-    expect(response.headers.get("Content-Disposition")).toContain("ticket.pkpass");
+    const disposition = response.headers.get("Content-Disposition")!;
+    expect(disposition).toContain("inline");
+    expect(disposition).toContain("ticket.pkpass");
   });
 
   test("pkpass is a valid ZIP containing pass.json, manifest.json, and signature", async () => {


### PR DESCRIPTION
## Summary
Updated the Content-Disposition header for pkpass wallet files from `attachment` to `inline` to improve compatibility with iOS devices.

## Changes
- Modified the `Content-Disposition` header in the wallet route from `attachment; filename="ticket.pkpass"` to `inline; filename="ticket.pkpass"`
- Updated the corresponding test to verify that the header contains both `inline` and the filename, rather than just checking for the filename

## Details
The `inline` disposition allows iOS to handle the pkpass file more gracefully by displaying it directly in the browser/wallet app rather than forcing a download. This provides a better user experience on Apple devices while maintaining the filename specification for clarity.

https://claude.ai/code/session_0183FGFLpJ5wGMqegc2Pskjh