### PR TITLE
Optimize Apple Wallet tests: cache RSA keygen, remove redundant DB setup, combine tests

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1939,14 +1939,10 @@ export const stubRefundPayment = async () => {
   );
 };
 
-/** Cached test certs — RSA-2048 keygen in pure JS is very slow (~5s per keypair) */
-let _cachedCerts: SigningCredentials | null = null;
-
-/** Generate self-signed test certificates for Apple Wallet PKCS#7 signing.
- *  Results are cached since RSA key generation in pure JS is expensive. */
-export const generateTestCerts = (): SigningCredentials => {
-  if (_cachedCerts) return _cachedCerts;
-
+/** Pre-built test certificates for Apple Wallet PKCS#7 signing.
+ *  Generated once at module load since RSA-2048 keygen in pure JS is slow (~5s per keypair).
+ *  Safe because #test-utils is only imported by test files, and Deno loads it once per process. */
+const _testCerts: SigningCredentials = (() => {
   const keys = forge.pki.rsa.generateKeyPair(2048);
 
   // Create a CA cert (WWDR stand-in)
@@ -1974,12 +1970,14 @@ export const generateTestCerts = (): SigningCredentials => {
   signingCert.setIssuer(caAttrs);
   signingCert.sign(keys.privateKey, forge.md.sha256.create());
 
-  _cachedCerts = {
+  return {
     passTypeId: "pass.com.test.tickets",
     teamId: "TESTTEAM01",
     signingCert: forge.pki.certificateToPem(signingCert),
     signingKey: forge.pki.privateKeyToPem(signingKeys.privateKey),
     wwdrCert: forge.pki.certificateToPem(caCert),
   };
-  return _cachedCerts;
-};
+})();
+
+/** Return pre-built test certificates for Apple Wallet signing */
+export const generateTestCerts = (): SigningCredentials => _testCerts;

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1939,8 +1939,14 @@ export const stubRefundPayment = async () => {
   );
 };
 
-/** Generate self-signed test certificates for Apple Wallet PKCS#7 signing */
+/** Cached test certs — RSA-2048 keygen in pure JS is very slow (~5s per keypair) */
+let _cachedCerts: SigningCredentials | null = null;
+
+/** Generate self-signed test certificates for Apple Wallet PKCS#7 signing.
+ *  Results are cached since RSA key generation in pure JS is expensive. */
 export const generateTestCerts = (): SigningCredentials => {
+  if (_cachedCerts) return _cachedCerts;
+
   const keys = forge.pki.rsa.generateKeyPair(2048);
 
   // Create a CA cert (WWDR stand-in)
@@ -1968,11 +1974,12 @@ export const generateTestCerts = (): SigningCredentials => {
   signingCert.setIssuer(caAttrs);
   signingCert.sign(keys.privateKey, forge.md.sha256.create());
 
-  return {
+  _cachedCerts = {
     passTypeId: "pass.com.test.tickets",
     teamId: "TESTTEAM01",
     signingCert: forge.pki.certificateToPem(signingCert),
     signingKey: forge.pki.privateKeyToPem(signingKeys.privateKey),
     wwdrCert: forge.pki.certificateToPem(caCert),
   };
+  return _cachedCerts;
 };

--- a/test/lib/apple-wallet.test.ts
+++ b/test/lib/apple-wallet.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   buildPkpass,
@@ -11,7 +11,7 @@ import {
   signManifest,
   type SigningCredentials,
 } from "#lib/apple-wallet.ts";
-import { createTestDbWithSetup, generateTestCerts, resetDb } from "#test-utils";
+import { generateTestCerts } from "#test-utils";
 import { unzipSync } from "fflate";
 import forge from "node-forge";
 
@@ -39,16 +39,8 @@ const makePassData = (overrides: Partial<PassData> = {}): PassData => ({
 });
 
 describe("apple-wallet", () => {
-  let creds: SigningCredentials;
-
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-    creds = generateTestCerts();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+  // Certs are cached in generateTestCerts — no per-test RSA keygen
+  const creds: SigningCredentials = generateTestCerts();
 
   describe("generatePassJson", () => {
     test("includes required top-level fields", () => {
@@ -203,65 +195,49 @@ describe("apple-wallet", () => {
   });
 
   describe("signManifest", () => {
-    test("produces a non-empty PKCS#7 signature", () => {
-      const manifest = '{"pass.json":"abc123"}';
-      const sig = signManifest(manifest, creds.signingCert, creds.signingKey, creds.wwdrCert);
-      expect(sig).toBeInstanceOf(Uint8Array);
-      expect(sig.length).toBeGreaterThan(0);
-    });
+    test("produces valid DER-encoded PKCS#7 signatures", () => {
+      const manifest1 = '{"pass.json":"abc123"}';
+      const manifest2 = '{"pass.json":"def456"}';
+      const sig1 = signManifest(manifest1, creds.signingCert, creds.signingKey, creds.wwdrCert);
+      const sig2 = signManifest(manifest2, creds.signingCert, creds.signingKey, creds.wwdrCert);
 
-    test("produces valid DER-encoded ASN.1", () => {
-      const manifest = '{"pass.json":"abc123"}';
-      const sig = signManifest(manifest, creds.signingCert, creds.signingKey, creds.wwdrCert);
-      // Should be parseable as ASN.1
-      const der = forge.util.binary.raw.encode(sig);
-      const asn1 = forge.asn1.fromDer(der);
-      expect(asn1).toBeDefined();
-    });
-
-    test("different manifests produce different signatures", () => {
-      const sig1 = signManifest('{"a":"1"}', creds.signingCert, creds.signingKey, creds.wwdrCert);
-      const sig2 = signManifest('{"b":"2"}', creds.signingCert, creds.signingKey, creds.wwdrCert);
-      // Binary comparison — signatures contain timestamps so they always differ
+      // Non-empty Uint8Array
+      expect(sig1).toBeInstanceOf(Uint8Array);
       expect(sig1.length).toBeGreaterThan(0);
       expect(sig2.length).toBeGreaterThan(0);
+
+      // Parseable as ASN.1
+      const der = forge.util.binary.raw.encode(sig1);
+      const asn1 = forge.asn1.fromDer(der);
+      expect(asn1).toBeDefined();
     });
   });
 
   describe("buildPkpass", () => {
-    test("produces a valid ZIP archive", () => {
-      const pkpass = buildPkpass(makePassData(), creds);
+    test("produces a valid ZIP with correct pass.json and manifest hashes", () => {
+      const data = makePassData();
+      const pkpass = buildPkpass(data, creds);
       expect(pkpass).toBeInstanceOf(Uint8Array);
       expect(pkpass.length).toBeGreaterThan(0);
 
-      // Should be unzippable
       const files = unzipSync(pkpass);
       expect(files["pass.json"]).toBeDefined();
       expect(files["manifest.json"]).toBeDefined();
       expect(files["signature"]).toBeDefined();
-    });
 
-    test("pass.json in archive matches generatePassJson output", () => {
-      const data = makePassData();
-      const pkpass = buildPkpass(data, creds);
-      const files = unzipSync(pkpass);
+      // pass.json matches generatePassJson
       const passJson = JSON.parse(new TextDecoder().decode(files["pass.json"]!));
       const expected = generatePassJson(data, creds);
       expect(passJson).toEqual(expected);
-    });
 
-    test("manifest.json contains correct SHA-1 of pass.json", () => {
-      const pkpass = buildPkpass(makePassData(), creds);
-      const files = unzipSync(pkpass);
+      // manifest SHA-1 is correct
       const manifest = JSON.parse(new TextDecoder().decode(files["manifest.json"]!));
-      const passJsonHash = sha1Hex(files["pass.json"]!);
-      expect(manifest["pass.json"]).toBe(passJsonHash);
+      expect(manifest["pass.json"]).toBe(sha1Hex(files["pass.json"]!));
     });
 
     test("produces different pkpass for different serial numbers", () => {
       const a = buildPkpass(makePassData({ serialNumber: "AAA" }), creds);
       const b = buildPkpass(makePassData({ serialNumber: "BBB" }), creds);
-      // Different serial numbers → different pass.json → different archive
       const aJson = JSON.parse(new TextDecoder().decode(unzipSync(a)["pass.json"]!));
       const bJson = JSON.parse(new TextDecoder().decode(unzipSync(b)["pass.json"]!));
       expect(aJson.serialNumber).toBe("AAA");

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -28,15 +28,17 @@ import {
   updateAppleWalletWwdrCert,
 } from "#lib/db/settings.ts";
 
+/** Reuse cached certs for all wallet configuration */
+const testCerts = generateTestCerts();
+
 /** Configure all Apple Wallet settings in the database */
 const configureAppleWallet = async () => {
-  const certs = generateTestCerts();
   await Promise.all([
     updateAppleWalletPassTypeId("pass.com.test.tickets"),
     updateAppleWalletTeamId("TESTTEAM01"),
-    updateAppleWalletSigningCert(certs.signingCert),
-    updateAppleWalletSigningKey(certs.signingKey),
-    updateAppleWalletWwdrCert(certs.wwdrCert),
+    updateAppleWalletSigningCert(testCerts.signingCert),
+    updateAppleWalletSigningKey(testCerts.signingKey),
+    updateAppleWalletWwdrCert(testCerts.wwdrCert),
   ]);
 };
 
@@ -70,47 +72,7 @@ describe("wallet route (/wallet/:token)", () => {
     expect(response.status).toBe(404);
   });
 
-  test("returns pkpass with correct content type", async () => {
-    await configureAppleWallet();
-    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-
-    const response = await awaitTestRequest(`/wallet/${token}`);
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("application/vnd.apple.pkpass");
-  });
-
-  test("returns pkpass with cache-control headers", async () => {
-    await configureAppleWallet();
-    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-
-    const response = await awaitTestRequest(`/wallet/${token}`);
-    const cacheControl = response.headers.get("Cache-Control");
-    expect(cacheControl).toContain("public");
-    expect(cacheControl).toContain("s-maxage=3600");
-  });
-
-  test("returns pkpass with content-disposition header", async () => {
-    await configureAppleWallet();
-    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-
-    const response = await awaitTestRequest(`/wallet/${token}`);
-    expect(response.headers.get("Content-Disposition")).toContain("ticket.pkpass");
-  });
-
-  test("pkpass is a valid ZIP containing pass.json, manifest.json, and signature", async () => {
-    await configureAppleWallet();
-    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-
-    const response = await awaitTestRequest(`/wallet/${token}`);
-    const body = new Uint8Array(await response.arrayBuffer());
-    const files = unzipSync(body);
-
-    expect(files["pass.json"]).toBeDefined();
-    expect(files["manifest.json"]).toBeDefined();
-    expect(files["signature"]).toBeDefined();
-  });
-
-  test("pass.json contains correct event data", async () => {
+  test("returns pkpass with correct headers and valid ZIP content", async () => {
     await configureAppleWallet();
     const { event, token } = await createTestAttendeeWithToken("Alice", "alice@test.com", {
       date: "2026-06-15T19:00",
@@ -118,10 +80,28 @@ describe("wallet route (/wallet/:token)", () => {
     });
 
     const response = await awaitTestRequest(`/wallet/${token}`);
+    expect(response.status).toBe(200);
+
+    // Content type
+    expect(response.headers.get("Content-Type")).toBe("application/vnd.apple.pkpass");
+
+    // Cache headers
+    const cacheControl = response.headers.get("Cache-Control");
+    expect(cacheControl).toContain("public");
+    expect(cacheControl).toContain("s-maxage=3600");
+
+    // Content disposition
+    expect(response.headers.get("Content-Disposition")).toContain("ticket.pkpass");
+
+    // Valid ZIP with required files
     const body = new Uint8Array(await response.arrayBuffer());
     const files = unzipSync(body);
-    const passJson = JSON.parse(new TextDecoder().decode(files["pass.json"]!));
+    expect(files["pass.json"]).toBeDefined();
+    expect(files["manifest.json"]).toBeDefined();
+    expect(files["signature"]).toBeDefined();
 
+    // Correct event data in pass.json
+    const passJson = JSON.parse(new TextDecoder().decode(files["pass.json"]!));
     expect(passJson.passTypeIdentifier).toBe("pass.com.test.tickets");
     expect(passJson.teamIdentifier).toBe("TESTTEAM01");
     expect(passJson.serialNumber).toBe(token);
@@ -187,16 +167,15 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("requires Pass Type ID", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "",
         apple_wallet_team_id: "TESTTEAM01",
-        apple_wallet_signing_cert: certs.signingCert,
-        apple_wallet_signing_key: certs.signingKey,
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_signing_cert: testCerts.signingCert,
+        apple_wallet_signing_key: testCerts.signingKey,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -204,16 +183,15 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("requires Team ID", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "",
-        apple_wallet_signing_cert: certs.signingCert,
-        apple_wallet_signing_key: certs.signingKey,
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_signing_cert: testCerts.signingCert,
+        apple_wallet_signing_key: testCerts.signingKey,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -221,7 +199,6 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("requires signing certificate on initial setup", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
@@ -229,8 +206,8 @@ describe("POST /admin/settings/apple-wallet", () => {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "TESTTEAM01",
         apple_wallet_signing_cert: "",
-        apple_wallet_signing_key: certs.signingKey,
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_signing_key: testCerts.signingKey,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -238,16 +215,15 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("requires signing key on initial setup", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "TESTTEAM01",
-        apple_wallet_signing_cert: certs.signingCert,
+        apple_wallet_signing_cert: testCerts.signingCert,
         apple_wallet_signing_key: "",
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -255,15 +231,14 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("requires WWDR certificate on initial setup", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "TESTTEAM01",
-        apple_wallet_signing_cert: certs.signingCert,
-        apple_wallet_signing_key: certs.signingKey,
+        apple_wallet_signing_cert: testCerts.signingCert,
+        apple_wallet_signing_key: testCerts.signingKey,
         apple_wallet_wwdr_cert: "",
         csrf_token: csrfToken,
       }, cookie),
@@ -272,7 +247,6 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("rejects invalid PEM signing certificate", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
@@ -280,8 +254,8 @@ describe("POST /admin/settings/apple-wallet", () => {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "TESTTEAM01",
         apple_wallet_signing_cert: "not a valid cert",
-        apple_wallet_signing_key: certs.signingKey,
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_signing_key: testCerts.signingKey,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -289,16 +263,15 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("rejects invalid PEM signing key", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "TESTTEAM01",
-        apple_wallet_signing_cert: certs.signingCert,
+        apple_wallet_signing_cert: testCerts.signingCert,
         apple_wallet_signing_key: "not a valid key",
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -306,15 +279,14 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("rejects invalid PEM WWDR certificate", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "pass.com.test",
         apple_wallet_team_id: "TESTTEAM01",
-        apple_wallet_signing_cert: certs.signingCert,
-        apple_wallet_signing_key: certs.signingKey,
+        apple_wallet_signing_cert: testCerts.signingCert,
+        apple_wallet_signing_key: testCerts.signingKey,
         apple_wallet_wwdr_cert: "not a valid cert",
         csrf_token: csrfToken,
       }, cookie),
@@ -323,16 +295,15 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 
   test("saves all settings successfully", async () => {
-    const certs = generateTestCerts();
     const { cookie, csrfToken } = await loginAsAdmin();
 
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
         apple_wallet_pass_type_id: "pass.com.test.tickets",
         apple_wallet_team_id: "TESTTEAM01",
-        apple_wallet_signing_cert: certs.signingCert,
-        apple_wallet_signing_key: certs.signingKey,
-        apple_wallet_wwdr_cert: certs.wwdrCert,
+        apple_wallet_signing_cert: testCerts.signingCert,
+        apple_wallet_signing_key: testCerts.signingKey,
+        apple_wallet_wwdr_cert: testCerts.wwdrCert,
         csrf_token: csrfToken,
       }, cookie),
     );
@@ -368,22 +339,18 @@ describe("POST /admin/settings/apple-wallet", () => {
     expect(await hasAppleWalletConfig()).toBe(false);
   });
 
-  test("shows Apple Wallet section on settings page", async () => {
-    const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings", { cookie });
-    const body = await response.text();
-    expect(body).toContain("Apple Wallet");
-    expect(body).toContain("apple_wallet_pass_type_id");
-  });
-
-  test("shows masked values on settings page when configured", async () => {
+  test("shows Apple Wallet section with masked values when configured", async () => {
     await configureAppleWallet();
     const { cookie } = await loginAsAdmin();
     const response = await awaitTestRequest("/admin/settings", { cookie });
     const body = await response.text();
+    // Section exists
+    expect(body).toContain("Apple Wallet");
+    expect(body).toContain("apple_wallet_pass_type_id");
+    // Configured values shown
     expect(body).toContain("pass.com.test.tickets");
     expect(body).toContain("TESTTEAM01");
-    // Configured secrets should show mask sentinel
+    // Secrets are masked
     expect(body).toContain("••••••••");
   });
 });
@@ -396,14 +363,13 @@ const WALLET_ENV_KEYS = [
   "APPLE_WALLET_WWDR_CERT",
 ] as const;
 
-/** Set all Apple Wallet env vars using real test certificates */
+/** Set all Apple Wallet env vars using cached test certificates */
 const setWalletEnvVars = () => {
-  const certs = generateTestCerts();
   Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.env.tickets");
   Deno.env.set("APPLE_WALLET_TEAM_ID", "ENVTEAM001");
-  Deno.env.set("APPLE_WALLET_SIGNING_CERT", certs.signingCert);
-  Deno.env.set("APPLE_WALLET_SIGNING_KEY", certs.signingKey);
-  Deno.env.set("APPLE_WALLET_WWDR_CERT", certs.wwdrCert);
+  Deno.env.set("APPLE_WALLET_SIGNING_CERT", testCerts.signingCert);
+  Deno.env.set("APPLE_WALLET_SIGNING_KEY", testCerts.signingKey);
+  Deno.env.set("APPLE_WALLET_WWDR_CERT", testCerts.wwdrCert);
 };
 
 /** Clear all Apple Wallet env vars */


### PR DESCRIPTION
The wallet tests were taking ~10min because generateTestCerts() created 2x
RSA-2048 keypairs in pure JS on every beforeEach (~5s per call, 30+ calls).

Key changes:
- Cache generateTestCerts result (biggest win: 30+ RSA keygens → 1)
- Remove unnecessary createTestDbWithSetup from apple-wallet.test.ts (no
  functions in that file touch the database)
- Combine signManifest tests (3→1) to reduce signing operations
- Combine buildPkpass tests (4→2) to reduce signing operations
- Combine wallet route header/content tests (5→1) to reduce pkpass generations
- Merge settings page section/masked-values tests (2→1)
- Reuse cached testCerts instead of calling generateTestCerts per test

100% line and branch coverage maintained on all wallet files.

https://claude.ai/code/session_01NJ9PXBUbrivVtgwdAGgM5e