### PR TITLE
Add advanced settings page and move nerdier settings out of main page

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -114,6 +114,7 @@ import {
   withOwnerAuthMultipartForm,
 } from "#routes/utils.ts";
 import { adminSettingsPage } from "#templates/admin/settings.tsx";
+import { adminAdvancedSettingsPage } from "#templates/admin/settings-advanced.tsx";
 import {
   type ChangePasswordFormValues,
   changePasswordFields,
@@ -130,7 +131,6 @@ const getWebhookUrl = (): string => {
  * to reduce sequential await overhead (especially for calls that decrypt).
  */
 const getSettingsPageState = async () => {
-  const bunnyCdnConfigured = isBunnyCdnEnabled();
   const [
     stripeKeyConfigured,
     paymentProvider,
@@ -139,23 +139,11 @@ const getSettingsPageState = async () => {
     squareWebhookKey,
     embedHosts,
     termsAndConditions,
-    timezone,
     businessEmail,
     theme,
     showPublicSite,
-    showPublicApi,
     phonePrefix,
     headerImageUrl,
-    emailProvider,
-    emailApiKeyConfigured,
-    emailFromAddress,
-    confirmationTemplates,
-    adminTemplates,
-    customDomain,
-    customDomainLastValidated,
-    appleWalletConfigured,
-    appleWalletPassTypeId,
-    appleWalletTeamId,
   ] = await Promise.all([
     hasStripeKey(),
     getPaymentProviderFromDb(),
@@ -164,23 +152,11 @@ const getSettingsPageState = async () => {
     getSquareWebhookSignatureKey(),
     getEmbedHostsFromDb(),
     getTermsAndConditionsFromDb(),
-    getTimezoneFromDb(),
     getBusinessEmailFromDb(),
     getThemeFromDb(),
     getShowPublicSiteFromDb(),
-    getShowPublicApiFromDb(),
     getPhonePrefixFromDb(),
     getHeaderImageUrlFromDb(),
-    getEmailProviderFromDb(),
-    hasEmailApiKey(),
-    getEmailFromAddressFromDb(),
-    getEmailTemplateSet("confirmation"),
-    getEmailTemplateSet("admin"),
-    bunnyCdnConfigured ? getCustomDomainFromDb() : Promise.resolve(null),
-    bunnyCdnConfigured ? getCustomDomainLastValidatedFromDb() : Promise.resolve(null),
-    hasAppleWalletDbConfig(),
-    getAppleWalletPassTypeIdFromDb(),
-    getAppleWalletTeamIdFromDb(),
   ]);
   return {
     stripeKeyConfigured,
@@ -191,14 +167,52 @@ const getSettingsPageState = async () => {
     webhookUrl: getWebhookUrl(),
     embedHosts: embedHosts ?? "",
     termsAndConditions: termsAndConditions ?? "",
-    timezone,
     businessEmail,
     theme,
     showPublicSite,
-    showPublicApi,
     phonePrefix,
     headerImageUrl: headerImageUrl ?? "",
     storageEnabled: isStorageEnabled(),
+  };
+};
+
+/** Gather state for the advanced settings page */
+const getAdvancedSettingsPageState = async () => {
+  const bunnyCdnConfigured = isBunnyCdnEnabled();
+  const [
+    timezone,
+    showPublicApi,
+    emailProvider,
+    emailApiKeyConfigured,
+    emailFromAddress,
+    businessEmail,
+    confirmationTemplates,
+    adminTemplates,
+    customDomain,
+    customDomainLastValidated,
+    appleWalletConfigured,
+    appleWalletPassTypeId,
+    appleWalletTeamId,
+    theme,
+  ] = await Promise.all([
+    getTimezoneFromDb(),
+    getShowPublicApiFromDb(),
+    getEmailProviderFromDb(),
+    hasEmailApiKey(),
+    getEmailFromAddressFromDb(),
+    getBusinessEmailFromDb(),
+    getEmailTemplateSet("confirmation"),
+    getEmailTemplateSet("admin"),
+    bunnyCdnConfigured ? getCustomDomainFromDb() : Promise.resolve(null),
+    bunnyCdnConfigured ? getCustomDomainLastValidatedFromDb() : Promise.resolve(null),
+    hasAppleWalletDbConfig(),
+    getAppleWalletPassTypeIdFromDb(),
+    getAppleWalletTeamIdFromDb(),
+    getThemeFromDb(),
+  ]);
+  return {
+    timezone,
+    showPublicApi,
     emailProvider: emailProvider ?? "",
     emailApiKeyConfigured,
     emailFromAddress: emailFromAddress ?? "",
@@ -208,6 +222,7 @@ const getSettingsPageState = async () => {
       const label = EMAIL_PROVIDER_LABELS[hostConfig.provider];
       return `Host ${label} (${hostConfig.fromAddress})`;
     })(),
+    businessEmail,
     confirmationTemplates: {
       subject: confirmationTemplates.subject ?? "",
       html: confirmationTemplates.html ?? "",
@@ -230,6 +245,7 @@ const getSettingsPageState = async () => {
       if (!hostConfig) return "";
       return `Host env (${hostConfig.passTypeId})`;
     })(),
+    theme,
   };
 };
 
@@ -239,12 +255,27 @@ const renderSettingsPage = async (session: AuthSession) => {
   return adminSettingsPage(session, state);
 };
 
+/** Render the advanced settings page with current state */
+const renderAdvancedSettingsPage = async (session: AuthSession) => {
+  const state = await getAdvancedSettingsPageState();
+  return adminAdvancedSettingsPage(session, state);
+};
+
 /** Render settings page with error on a specific form */
 const settingsPageWithError =
   (session: AuthSession) =>
   async (error: string, status: number, formId: string): Promise<Response> => {
     setFormError(formId, error);
     const html = await renderSettingsPage(session);
+    return htmlResponse(html, status);
+  };
+
+/** Render advanced settings page with error on a specific form */
+const advancedSettingsPageWithError =
+  (session: AuthSession) =>
+  async (error: string, status: number, formId: string): Promise<Response> => {
+    setFormError(formId, error);
+    const html = await renderAdvancedSettingsPage(session);
     return htmlResponse(html, status);
   };
 
@@ -288,6 +319,14 @@ const settingsRoute =
       handler(form, settingsPageWithError(session), session),
     );
 
+/** Owner auth form route for advanced settings - errors render the advanced page */
+const advancedSettingsRoute =
+  (handler: SettingsFormHandler) =>
+  (request: Request): Promise<Response> =>
+    withOwnerAuthForm(request, (session, form) =>
+      handler(form, advancedSettingsPageWithError(session), session),
+    );
+
 /**
  * Handle GET /admin/settings - owner only
  */
@@ -300,6 +339,20 @@ const handleAdminSettingsGet: TypedRouteHandler<"GET /admin/settings"> = (
       getSearchParam(request, "success"),
     );
     return htmlResponse(await renderSettingsPage(session));
+  });
+
+/**
+ * Handle GET /admin/settings-advanced - owner only
+ */
+const handleAdminSettingsAdvancedGet: TypedRouteHandler<"GET /admin/settings-advanced"> = (
+  request,
+) =>
+  requireOwnerOr(request, async (session) => {
+    setFormSuccess(
+      getSearchParam(request, "form"),
+      getSearchParam(request, "success"),
+    );
+    return htmlResponse(await renderAdvancedSettingsPage(session));
   });
 
 /**
@@ -651,13 +704,13 @@ const processTimezoneForm: SettingsFormHandler = async (form, errorPage) => {
   await updateTimezone(trimmed);
   await logActivity(`Timezone set to ${trimmed}`);
   return redirect(
-    "/admin/settings", "Timezone updated", true,
+    "/admin/settings-advanced", "Timezone updated", true,
     { formId: "settings-timezone" },
   );
 };
 
 /** Handle POST /admin/settings/timezone - owner only */
-const handleTimezonePost = settingsRoute(processTimezoneForm);
+const handleTimezonePost = advancedSettingsRoute(processTimezoneForm);
 
 /** Validate and save business email from form submission */
 const processBusinessEmailForm: SettingsFormHandler = async (
@@ -735,7 +788,7 @@ const processShowPublicApiForm: SettingsFormHandler = async (form) => {
   await updateShowPublicApi(value);
   await logActivity(`Public API ${value ? "enabled" : "disabled"}`);
   return redirect(
-    "/admin/settings",
+    "/admin/settings-advanced",
     value ? "Public API enabled" : "Public API disabled",
     true,
     { formId: "settings-show-public-api" },
@@ -743,7 +796,7 @@ const processShowPublicApiForm: SettingsFormHandler = async (form) => {
 };
 
 /** Handle POST /admin/settings/show-public-api - owner only */
-const handleShowPublicApiPost = settingsRoute(processShowPublicApiForm);
+const handleShowPublicApiPost = advancedSettingsRoute(processShowPublicApiForm);
 
 /** Validate and save phone prefix from form submission */
 const processPhonePrefixForm: SettingsFormHandler = async (form, errorPage) => {
@@ -828,7 +881,7 @@ const handleHeaderImageDeletePost = settingsRoute(async (_form, _errorPage) => {
 
 
 /** Handle POST /admin/settings/email - owner only */
-const handleEmailPost = settingsRoute(async (form, errorPage) => {
+const handleEmailPost = advancedSettingsRoute(async (form, errorPage) => {
   const provider = (form.get("email_provider") ?? "").trim();
   const apiKeyField = processSecretField(form, "email_api_key");
   const fromAddress = (form.get("email_from_address") ?? "").trim();
@@ -838,7 +891,7 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
     await updateEmailApiKey("");
     await updateEmailFromAddress("");
     await logActivity("Email provider disabled");
-    return redirect("/admin/settings", "Email provider disabled", true, { formId: "settings-email" });
+    return redirect("/admin/settings-advanced", "Email provider disabled", true, { formId: "settings-email" });
   }
 
   if (!isEmailProvider(provider)) {
@@ -857,11 +910,11 @@ const handleEmailPost = settingsRoute(async (form, errorPage) => {
   if (apiKeyField.action === "provided") await updateEmailApiKey(apiKeyField.value);
   if (fromAddress) await updateEmailFromAddress(fromAddress);
   await logActivity(`Email provider set to ${provider}`);
-  return redirect("/admin/settings", "Email settings updated", true, { formId: "settings-email" });
+  return redirect("/admin/settings-advanced", "Email settings updated", true, { formId: "settings-email" });
 });
 
 /** Handle POST /admin/settings/email/test - send test email to business email */
-const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
+const handleEmailTestPost = advancedSettingsRoute(async (_form, errorPage) => {
   const config = await getEmailConfig();
   if (!config) return errorPage("Email not configured", 400, "settings-email");
   const businessEmail = await getBusinessEmailFromDb();
@@ -873,7 +926,7 @@ const handleEmailTestPost = settingsRoute(async (_form, errorPage) => {
   if (status >= 300) {
     return errorPage(`Test email failed (status ${status})`, 502, "settings-email-test");
   }
-  return redirect("/admin/settings", `Test email sent (status ${status})`, true, { formId: "settings-email-test" });
+  return redirect("/admin/settings-advanced", `Test email sent (status ${status})`, true, { formId: "settings-email-test" });
 });
 
 /** Valid template types for form submissions — derived from the EmailTemplateType union */
@@ -884,7 +937,7 @@ const isEmailTemplateType = (v: string): v is EmailTemplateType => VALID_TEMPLAT
 
 /** Handle POST /admin/settings/email-templates/:type - save custom email templates */
 const handleEmailTemplatePost = (type: EmailTemplateType) =>
-  settingsRoute(async (form, errorPage) => {
+  advancedSettingsRoute(async (form, errorPage) => {
     const formId = `settings-email-tpl-${type}`;
     const subject = form.get("subject") ?? "";
     const html = form.get("html") ?? "";
@@ -919,7 +972,7 @@ const handleEmailTemplatePost = (type: EmailTemplateType) =>
 
     const label = type === "confirmation" ? "Confirmation" : "Admin notification";
     await logActivity(`${label} email template updated`);
-    return redirect("/admin/settings", `${label} email template updated`, true, { formId });
+    return redirect("/admin/settings-advanced", `${label} email template updated`, true, { formId });
   });
 
 /** Sample booking data used for email template previews */
@@ -987,7 +1040,7 @@ const handleEmailTemplatePreviewPost = (request: Request): Promise<Response> =>
   });
 
 /** Handle POST /admin/settings/custom-domain - save custom domain */
-const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
+const handleCustomDomainPost = advancedSettingsRoute(async (form, errorPage) => {
   if (!isBunnyCdnEnabled()) {
     return errorPage("Bunny CDN is not configured", 400, "settings-custom-domain");
   }
@@ -998,7 +1051,7 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
     await updateCustomDomain("");
     await logActivity("Custom domain cleared");
     return redirect(
-      "/admin/settings",
+      "/admin/settings-advanced",
       "Custom domain cleared",
       true,
       { formId: "settings-custom-domain" },
@@ -1019,7 +1072,7 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
     await updateCustomDomainLastValidated();
     await logActivity(`Custom domain validated: ${raw}`);
     return redirect(
-      "/admin/settings",
+      "/admin/settings-advanced",
       "Custom domain saved and validated",
       true,
       { formId: "settings-custom-domain" },
@@ -1027,7 +1080,7 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
   }
 
   return redirect(
-    "/admin/settings",
+    "/admin/settings-advanced",
     `Custom domain saved but validation failed: ${result.error}`,
     false,
     { formId: "settings-custom-domain" },
@@ -1035,7 +1088,7 @@ const handleCustomDomainPost = settingsRoute(async (form, errorPage) => {
 });
 
 /** Handle POST /admin/settings/custom-domain/validate - validate with Bunny CDN */
-const handleCustomDomainValidatePost = settingsRoute(async (_form, errorPage) => {
+const handleCustomDomainValidatePost = advancedSettingsRoute(async (_form, errorPage) => {
   if (!isBunnyCdnEnabled()) {
     return errorPage("Bunny CDN is not configured", 400, "settings-custom-domain-validate");
   }
@@ -1053,7 +1106,7 @@ const handleCustomDomainValidatePost = settingsRoute(async (_form, errorPage) =>
   await updateCustomDomainLastValidated();
   await logActivity(`Custom domain validated: ${customDomain}`);
   return redirect(
-    "/admin/settings",
+    "/admin/settings-advanced",
     "Custom domain validated successfully",
     true,
     { formId: "settings-custom-domain-validate" },
@@ -1063,7 +1116,7 @@ const handleCustomDomainValidatePost = settingsRoute(async (_form, errorPage) =>
 /**
  * Handle POST /admin/settings/apple-wallet - owner only
  */
-const handleAppleWalletPost = settingsRoute(async (form, errorPage) => {
+const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
   const passTypeId = `${form.get("apple_wallet_pass_type_id")}`.trim();
   const teamId = `${form.get("apple_wallet_team_id")}`.trim();
   const certField = processSecretField(form, "apple_wallet_signing_cert");
@@ -1080,7 +1133,7 @@ const handleAppleWalletPost = settingsRoute(async (form, errorPage) => {
       updateAppleWalletWwdrCert(""),
     ]);
     await logActivity("Apple Wallet configuration cleared");
-    return redirect("/admin/settings", "Apple Wallet configuration cleared", true, { formId: "settings-apple-wallet" });
+    return redirect("/admin/settings-advanced", "Apple Wallet configuration cleared", true, { formId: "settings-apple-wallet" });
   }
 
   if (!passTypeId) {
@@ -1123,13 +1176,13 @@ const handleAppleWalletPost = settingsRoute(async (form, errorPage) => {
   if (wwdrField.action === "provided") await updateAppleWalletWwdrCert(wwdrField.value);
 
   await logActivity("Apple Wallet configuration updated");
-  return redirect("/admin/settings", "Apple Wallet settings updated", true, { formId: "settings-apple-wallet" });
+  return redirect("/admin/settings-advanced", "Apple Wallet settings updated", true, { formId: "settings-apple-wallet" });
 });
 
 /**
  * Handle POST /admin/settings/reset-database - owner only
  */
-const handleResetDatabasePost = settingsRoute(async (form, errorPage) => {
+const handleResetDatabasePost = advancedSettingsRoute(async (form, errorPage) => {
   const phraseError = validateResetPhrase(form);
   if (phraseError)
     return errorPage(phraseError, 400, "settings-reset-database");
@@ -1144,6 +1197,7 @@ const handleResetDatabasePost = settingsRoute(async (form, errorPage) => {
 /** Settings routes */
 export const settingsRoutes = defineRoutes({
   "GET /admin/settings": handleAdminSettingsGet,
+  "GET /admin/settings-advanced": handleAdminSettingsAdvancedGet,
   "POST /admin/settings": handleAdminSettingsPost,
   "POST /admin/settings/payment-provider": handlePaymentProviderPost,
   "POST /admin/settings/stripe": handleAdminStripePost,

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -1,0 +1,338 @@
+/**
+ * Admin advanced settings page template
+ */
+
+import { MASK_SENTINEL } from "#lib/db/settings.ts";
+import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
+import { CsrfForm } from "#lib/forms.tsx";
+import type { AdminSession } from "#lib/types.ts";
+import { ResetDatabaseForm } from "#templates/admin/database-reset.tsx";
+import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
+import { Layout } from "#templates/layout.tsx";
+import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
+
+export type AdvancedSettingsPageState = {
+  timezone: string;
+  showPublicApi: boolean;
+  emailProvider: string;
+  emailApiKeyConfigured: boolean;
+  emailFromAddress: string;
+  hostEmailLabel: string;
+  businessEmail: string;
+  confirmationTemplates: {
+    subject: string;
+    html: string;
+    text: string;
+  };
+  adminTemplates: {
+    subject: string;
+    html: string;
+    text: string;
+  };
+  bunnyCdnEnabled: boolean;
+  customDomain: string;
+  customDomainLastValidated: string;
+  cdnHostname: string;
+  appleWalletConfigured: boolean;
+  appleWalletPassTypeId: string;
+  appleWalletTeamId: string;
+  hostAppleWalletLabel: string;
+  theme: string;
+};
+
+/**
+ * Admin advanced settings page
+ */
+export const adminAdvancedSettingsPage = (
+  session: AdminSession,
+  s: AdvancedSettingsPageState,
+): string =>
+  String(
+    <Layout title="Advanced Settings" theme={s.theme}>
+      <AdminNav session={session} active="/admin/settings" />
+      <Breadcrumb href="/admin/settings" label="Settings" />
+
+      <article>
+        <aside>
+          <p>Be careful changing settings on this page. You can break your site in ways that can be hard to diagnose. Test your booking process after making a change.</p>
+        </aside>
+      </article>
+
+      <CsrfForm action="/admin/settings/show-public-api" id="settings-show-public-api">
+        <h2>Enable public API?</h2>
+        <p>
+          Exposes a JSON API for listing events, checking availability, and creating bookings.
+          See the <a href="/admin/guide#api">API guide</a> for details.
+        </p>
+        <fieldset>
+          <label>
+            <input
+              type="radio"
+              name="show_public_api"
+              value="true"
+              checked={s.showPublicApi === true}
+            />
+            Yes
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="show_public_api"
+              value="false"
+              checked={s.showPublicApi !== true}
+            />
+            No
+          </label>
+        </fieldset>
+        <button type="submit">Save</button>
+      </CsrfForm>
+
+      <CsrfForm action="/admin/settings/apple-wallet" id="settings-apple-wallet">
+        <h2>Apple Wallet</h2>
+        <p>Configure Apple Wallet pass signing to show an &ldquo;Add to Apple Wallet&rdquo; button on ticket pages.{
+          s.hostAppleWalletLabel && !s.appleWalletConfigured
+            ? ` Currently using: ${s.hostAppleWalletLabel}. Override below or leave empty to keep using host config.`
+            : s.hostAppleWalletLabel && s.appleWalletConfigured
+              ? ` Overriding: ${s.hostAppleWalletLabel}.`
+              : ""
+        }</p>
+        <label>
+          Pass Type ID
+          <input
+            type="text"
+            name="apple_wallet_pass_type_id"
+            placeholder="pass.com.example.tickets"
+            value={s.appleWalletPassTypeId}
+            autocomplete="off"
+          />
+        </label>
+        <label>
+          Team ID
+          <input
+            type="text"
+            name="apple_wallet_team_id"
+            placeholder="ABC1234567"
+            value={s.appleWalletTeamId}
+            autocomplete="off"
+          />
+        </label>
+        <label>
+          Signing Certificate (PEM)
+          <textarea
+            name="apple_wallet_signing_cert"
+            rows={4}
+            placeholder="-----BEGIN CERTIFICATE-----"
+          >{s.appleWalletConfigured ? MASK_SENTINEL : ""}</textarea>
+        </label>
+        <label>
+          Signing Private Key (PEM)
+          <textarea
+            name="apple_wallet_signing_key"
+            rows={4}
+            placeholder="-----BEGIN PRIVATE KEY-----"
+          >{s.appleWalletConfigured ? MASK_SENTINEL : ""}</textarea>
+        </label>
+        <label>
+          WWDR Certificate (PEM)
+          <textarea
+            name="apple_wallet_wwdr_cert"
+            rows={4}
+            placeholder="-----BEGIN CERTIFICATE-----"
+          >{s.appleWalletConfigured ? MASK_SENTINEL : ""}</textarea>
+        </label>
+        <button type="submit">Save Apple Wallet Settings</button>
+      </CsrfForm>
+
+      <CsrfForm action="/admin/settings/email-templates/confirmation" id="settings-email-tpl-confirmation">
+        <h2>Confirmation Email Template</h2>
+        <p>Customise the registration confirmation email sent to attendees. Uses <a href="https://liquidjs.com/" target="_blank" rel="noopener">Liquid</a> template syntax. Leave blank to use the default template.</p>
+        <details>
+          <summary>Available variables</summary>
+          <table>
+            <tr><td><code>{`{{ event_names }}`}</code></td><td>All event names joined with "and"</td></tr>
+            <tr><td><code>{`{{ ticket_url }}`}</code></td><td>Link to view tickets</td></tr>
+            <tr><td><code>{`{{ attendee.name }}`}</code></td><td>Attendee name</td></tr>
+            <tr><td><code>{`{{ attendee.email }}`}</code></td><td>Attendee email</td></tr>
+            <tr><td><code>{`{{ attendee.phone }}`}</code></td><td>Attendee phone</td></tr>
+            <tr><td><code>{`{{ attendee.address }}`}</code></td><td>Attendee address</td></tr>
+            <tr><td><code>{`{{ attendee.special_instructions }}`}</code></td><td>Special instructions</td></tr>
+            <tr><td><code>{`{{ entries }}`}</code></td><td>Array of event+attendee pairs</td></tr>
+            <tr><td><code>{`{{ entry.event.name }}`}</code></td><td>Event name (in loop)</td></tr>
+            <tr><td><code>{`{{ entry.event.is_paid }}`}</code></td><td>Whether event has a price</td></tr>
+            <tr><td><code>{`{{ entry.attendee.quantity }}`}</code></td><td>Ticket quantity</td></tr>
+            <tr><td><code>{`{{ entry.attendee.price_paid | currency }}`}</code></td><td>Price formatted as currency</td></tr>
+            <tr><td><code>{`{{ entry.attendee.date }}`}</code></td><td>Selected date (if any)</td></tr>
+            <tr><td><code>{`{{ 2 | pluralize: "ticket", "tickets" }}`}</code></td><td>Pluralize based on count</td></tr>
+          </table>
+        </details>
+        <label>Subject
+          <input
+            type="text"
+            name="subject"
+            placeholder={DEFAULT_TEMPLATES.confirmation.subject}
+            value={s.confirmationTemplates.subject}
+            autocomplete="off"
+          />
+        </label>
+        <label>HTML Body
+          <textarea
+            id="confirmation_html"
+            name="html"
+            rows="8"
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.confirmation.html}
+          >{s.confirmationTemplates.html}</textarea>
+        </label>
+        <a href="#" data-fill-default="confirmation_html"><small>Edit default template</small></a>
+        <label>Plain Text Body
+          <textarea
+            id="confirmation_text"
+            name="text"
+            rows="6"
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.confirmation.text}
+          >{s.confirmationTemplates.text}</textarea>
+        </label>
+        <a href="#" data-fill-default="confirmation_text"><small>Edit default template</small></a>
+        <br />
+        <button type="submit">Save Confirmation Template</button>
+      </CsrfForm>
+
+      <CsrfForm action="/admin/settings/email-templates/admin" id="settings-email-tpl-admin">
+        <h2>Admin Notification Email Template</h2>
+        <p>Customise the notification email sent to the business email when a registration comes in. Leave blank to use the default template.</p>
+        <label>Subject
+          <input
+            type="text"
+            name="subject"
+            placeholder={DEFAULT_TEMPLATES.admin.subject}
+            value={s.adminTemplates.subject}
+            autocomplete="off"
+          />
+        </label>
+        <label>HTML Body
+          <textarea
+            id="admin_html"
+            name="html"
+            rows="8"
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.admin.html}
+          >{s.adminTemplates.html}</textarea>
+        </label>
+        <a href="#" data-fill-default="admin_html"><small>Edit default template</small></a>
+        <label>Plain Text Body
+          <textarea
+            id="admin_text"
+            name="text"
+            rows="6"
+            placeholder="Leave blank to use default template"
+            data-default-tpl={DEFAULT_TEMPLATES.admin.text}
+          >{s.adminTemplates.text}</textarea>
+        </label>
+        <a href="#" data-fill-default="admin_text"><small>Edit default template</small></a>
+        <br />
+        <button type="submit">Save Admin Notification Template</button>
+      </CsrfForm>
+
+      <CsrfForm action="/admin/settings/email" id="settings-email">
+        <h2>Email Notifications</h2>
+        <p>Send confirmation emails to attendees and admin notifications when registrations come in.</p>
+        <label>Email Provider
+          <select name="email_provider">
+            <option value="" selected={!s.emailProvider}>{s.hostEmailLabel || "None (disabled)"}</option>
+            {Array.from(VALID_EMAIL_PROVIDERS).map((p) => (
+              <option value={p} selected={s.emailProvider === p}>{EMAIL_PROVIDER_LABELS[p]}</option>
+            ))}
+          </select>
+        </label>
+        <label>API Key
+          <input
+            type="password"
+            name="email_api_key"
+            placeholder="Enter API key"
+            value={s.emailApiKeyConfigured ? MASK_SENTINEL : undefined}
+            autocomplete="off"
+          />
+        </label>
+        <label>From Address
+          <input
+            type="email"
+            name="email_from_address"
+            placeholder={s.businessEmail || "tickets@yourdomain.com"}
+            value={s.emailFromAddress}
+            autocomplete="off"
+          />
+        </label>
+        <button type="submit">Save Email Settings</button>
+      </CsrfForm>
+      {s.emailProvider && (
+      <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
+        <button type="submit" class="secondary">Send Test Email</button>
+      </CsrfForm>
+      )}
+
+      <CsrfForm action="/admin/settings/timezone" id="settings-timezone">
+        <h2>Timezone</h2>
+        <p>All dates and times will be interpreted and displayed in this timezone.</p>
+        <label>IANA Timezone
+          <select name="timezone" required>
+            {Intl.supportedValuesOf("timeZone").map((tz: string) => (
+              <option value={tz} selected={tz === s.timezone}>{tz}</option>
+            ))}
+          </select>
+        </label>
+        <button type="submit">Save Timezone</button>
+      </CsrfForm>
+
+      {s.bunnyCdnEnabled && (
+      <div>
+        <CsrfForm action="/admin/settings/custom-domain" id="settings-custom-domain">
+          <h2>Custom Domain</h2>
+          <p>Set a custom domain for your booking site.</p>
+          <label>Domain
+            <input
+              type="text"
+              name="custom_domain"
+              placeholder="tickets.yourdomain.com"
+              value={s.customDomain}
+              autocomplete="off"
+            />
+          </label>
+          <button type="submit">Save Custom Domain</button>
+        </CsrfForm>
+
+        {s.customDomain && (
+        <CsrfForm action="/admin/settings/custom-domain/validate" id="settings-custom-domain-validate">
+          {!s.customDomainLastValidated && (
+          <article>
+            <aside role="alert">
+              <p><strong>Your custom domain is not yet validated.</strong> It will not work until validation is complete.</p>
+            </aside>
+          </article>
+          )}
+          <article>
+            <aside>
+              <p>To use your custom domain, create a <strong>CNAME</strong> record:</p>
+              <table>
+                <thead>
+                  <tr><th>Type</th><th>Name</th><th>Value</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td>CNAME</td><td><code>{s.customDomain}</code></td><td><code>{s.cdnHostname}</code></td></tr>
+                </tbody>
+              </table>
+              <p>Once the DNS record is in place, click the button below to validate and enable SSL.</p>
+            </aside>
+          </article>
+          {s.customDomainLastValidated && (
+            <p><small>Last validated: {s.customDomainLastValidated}</small></p>
+          )}
+          <button type="submit">Validate Custom Domain</button>
+        </CsrfForm>
+        )}
+      </div>
+      )}
+
+      <ResetDatabaseForm action="/admin/settings/reset-database" id="settings-reset-database" />
+    </Layout>
+  );

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -3,12 +3,10 @@
  */
 
 import { MASK_SENTINEL } from "#lib/db/settings.ts";
-import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
 import { CsrfForm, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
 import type { AdminSession } from "#lib/types.ts";
-import { ResetDatabaseForm } from "#templates/admin/database-reset.tsx";
 import {
   changePasswordFields,
   FORMATTING_HINT,
@@ -16,15 +14,8 @@ import {
   squareWebhookFields,
   stripeKeyFields,
 } from "#templates/fields.ts";
-import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 import { Layout } from "#templates/layout.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
-
-export type EmailTemplateState = {
-  subject: string;
-  html: string;
-  text: string;
-};
 
 export type SettingsPageState = {
   stripeKeyConfigured: boolean;
@@ -35,28 +26,12 @@ export type SettingsPageState = {
   webhookUrl: string;
   embedHosts: string;
   termsAndConditions: string;
-  timezone: string;
   businessEmail: string;
   theme: string;
   showPublicSite: boolean;
-  showPublicApi: boolean;
   phonePrefix: string;
   headerImageUrl: string;
   storageEnabled: boolean;
-  emailProvider: string;
-  emailApiKeyConfigured: boolean;
-  emailFromAddress: string;
-  hostEmailLabel: string;
-  confirmationTemplates: EmailTemplateState;
-  adminTemplates: EmailTemplateState;
-  bunnyCdnEnabled: boolean;
-  customDomain: string;
-  customDomainLastValidated: string;
-  cdnHostname: string;
-  appleWalletConfigured: boolean;
-  appleWalletPassTypeId: string;
-  appleWalletTeamId: string;
-  hostAppleWalletLabel: string;
 };
 
 /**
@@ -70,18 +45,8 @@ export const adminSettingsPage = (
     <Layout title="Settings" theme={s.theme}>
       <AdminNav session={session} active="/admin/settings" />
 
-        <CsrfForm action="/admin/settings/timezone" id="settings-timezone">
-            <h2>Timezone</h2>
-          <p>All dates and times will be interpreted and displayed in this timezone.</p>
-          <label>IANA Timezone
-            <select name="timezone" required>
-              {Intl.supportedValuesOf("timeZone").map((tz: string) => (
-                <option value={tz} selected={tz === s.timezone}>{tz}</option>
-              ))}
-            </select>
-          </label>
-          <button type="submit">Save Timezone</button>
-        </CsrfForm>
+        <p>For advanced settings including public API, Apple Wallet, custom email templates, mail provider, timezone, custom domain, and database reset, <a href="/admin/settings-advanced">click here</a>.</p>
+
 
         {s.storageEnabled && (
         <div>
@@ -139,133 +104,6 @@ export const adminSettingsPage = (
           <button type="submit">Save Business Email</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/email" id="settings-email">
-            <h2>Email Notifications</h2>
-          <p>Send confirmation emails to attendees and admin notifications when registrations come in.</p>
-          <label>Email Provider
-            <select name="email_provider">
-              <option value="" selected={!s.emailProvider}>{s.hostEmailLabel || "None (disabled)"}</option>
-              {Array.from(VALID_EMAIL_PROVIDERS).map((p) => (
-                <option value={p} selected={s.emailProvider === p}>{EMAIL_PROVIDER_LABELS[p]}</option>
-              ))}
-            </select>
-          </label>
-          <label>API Key
-            <input
-              type="password"
-              name="email_api_key"
-              placeholder="Enter API key"
-              value={s.emailApiKeyConfigured ? MASK_SENTINEL : undefined}
-              autocomplete="off"
-            />
-          </label>
-          <label>From Address
-            <input
-              type="email"
-              name="email_from_address"
-              placeholder={s.businessEmail || "tickets@yourdomain.com"}
-              value={s.emailFromAddress}
-              autocomplete="off"
-            />
-          </label>
-          <button type="submit">Save Email Settings</button>
-        </CsrfForm>
-        {s.emailProvider && (
-        <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
-          <button type="submit" class="secondary">Send Test Email</button>
-        </CsrfForm>
-        )}
-
-        <CsrfForm action="/admin/settings/email-templates/confirmation" id="settings-email-tpl-confirmation">
-            <h2>Confirmation Email Template</h2>
-          <p>Customise the registration confirmation email sent to attendees. Uses <a href="https://liquidjs.com/" target="_blank" rel="noopener">Liquid</a> template syntax. Leave blank to use the default template.</p>
-          <details>
-            <summary>Available variables</summary>
-            <table>
-              <tr><td><code>{`{{ event_names }}`}</code></td><td>All event names joined with "and"</td></tr>
-              <tr><td><code>{`{{ ticket_url }}`}</code></td><td>Link to view tickets</td></tr>
-              <tr><td><code>{`{{ attendee.name }}`}</code></td><td>Attendee name</td></tr>
-              <tr><td><code>{`{{ attendee.email }}`}</code></td><td>Attendee email</td></tr>
-              <tr><td><code>{`{{ attendee.phone }}`}</code></td><td>Attendee phone</td></tr>
-              <tr><td><code>{`{{ attendee.address }}`}</code></td><td>Attendee address</td></tr>
-              <tr><td><code>{`{{ attendee.special_instructions }}`}</code></td><td>Special instructions</td></tr>
-              <tr><td><code>{`{{ entries }}`}</code></td><td>Array of event+attendee pairs</td></tr>
-              <tr><td><code>{`{{ entry.event.name }}`}</code></td><td>Event name (in loop)</td></tr>
-              <tr><td><code>{`{{ entry.event.is_paid }}`}</code></td><td>Whether event has a price</td></tr>
-              <tr><td><code>{`{{ entry.attendee.quantity }}`}</code></td><td>Ticket quantity</td></tr>
-              <tr><td><code>{`{{ entry.attendee.price_paid | currency }}`}</code></td><td>Price formatted as currency</td></tr>
-              <tr><td><code>{`{{ entry.attendee.date }}`}</code></td><td>Selected date (if any)</td></tr>
-              <tr><td><code>{`{{ 2 | pluralize: "ticket", "tickets" }}`}</code></td><td>Pluralize based on count</td></tr>
-            </table>
-          </details>
-          <label>Subject
-            <input
-              type="text"
-              name="subject"
-              placeholder={DEFAULT_TEMPLATES.confirmation.subject}
-              value={s.confirmationTemplates.subject}
-              autocomplete="off"
-            />
-          </label>
-          <label>HTML Body
-            <textarea
-              id="confirmation_html"
-              name="html"
-              rows="8"
-              placeholder="Leave blank to use default template"
-              data-default-tpl={DEFAULT_TEMPLATES.confirmation.html}
-            >{s.confirmationTemplates.html}</textarea>
-          </label>
-          <a href="#" data-fill-default="confirmation_html"><small>Edit default template</small></a>
-          <label>Plain Text Body
-            <textarea
-              id="confirmation_text"
-              name="text"
-              rows="6"
-              placeholder="Leave blank to use default template"
-              data-default-tpl={DEFAULT_TEMPLATES.confirmation.text}
-            >{s.confirmationTemplates.text}</textarea>
-          </label>
-          <a href="#" data-fill-default="confirmation_text"><small>Edit default template</small></a>
-          <br />
-          <button type="submit">Save Confirmation Template</button>
-        </CsrfForm>
-
-        <CsrfForm action="/admin/settings/email-templates/admin" id="settings-email-tpl-admin">
-            <h2>Admin Notification Email Template</h2>
-          <p>Customise the notification email sent to the business email when a registration comes in. Leave blank to use the default template.</p>
-          <label>Subject
-            <input
-              type="text"
-              name="subject"
-              placeholder={DEFAULT_TEMPLATES.admin.subject}
-              value={s.adminTemplates.subject}
-              autocomplete="off"
-            />
-          </label>
-          <label>HTML Body
-            <textarea
-              id="admin_html"
-              name="html"
-              rows="8"
-              placeholder="Leave blank to use default template"
-              data-default-tpl={DEFAULT_TEMPLATES.admin.html}
-            >{s.adminTemplates.html}</textarea>
-          </label>
-          <a href="#" data-fill-default="admin_html"><small>Edit default template</small></a>
-          <label>Plain Text Body
-            <textarea
-              id="admin_text"
-              name="text"
-              rows="6"
-              placeholder="Leave blank to use default template"
-              data-default-tpl={DEFAULT_TEMPLATES.admin.text}
-            >{s.adminTemplates.text}</textarea>
-          </label>
-          <a href="#" data-fill-default="admin_text"><small>Edit default template</small></a>
-          <br />
-          <button type="submit">Save Admin Notification Template</button>
-        </CsrfForm>
 
         <CsrfForm action="/admin/settings/payment-provider" id="settings-payment-provider">
             <h2>Payment Provider</h2>
@@ -435,34 +273,6 @@ export const adminSettingsPage = (
           <button type="submit">Save</button>
         </CsrfForm>
 
-        <CsrfForm action="/admin/settings/show-public-api" id="settings-show-public-api">
-            <h2>Enable public API?</h2>
-          <p>
-            Exposes a JSON API for listing events, checking availability, and creating bookings.
-            See the <a href="/admin/guide#api">API guide</a> for details.
-          </p>
-          <fieldset>
-            <label>
-              <input
-                type="radio"
-                name="show_public_api"
-                value="true"
-                checked={s.showPublicApi === true}
-              />
-              Yes
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="show_public_api"
-                value="false"
-                checked={s.showPublicApi !== true}
-              />
-              No
-            </label>
-          </fieldset>
-          <button type="submit">Save</button>
-        </CsrfForm>
 
         <CsrfForm action="/admin/settings/theme" id="settings-theme">
             <h2>Site Theme</h2>
@@ -490,111 +300,7 @@ export const adminSettingsPage = (
           <button type="submit">Save Theme</button>
         </CsrfForm>
 
-        {s.bunnyCdnEnabled && (
-        <div>
-          <CsrfForm action="/admin/settings/custom-domain" id="settings-custom-domain">
-            <h2>Custom Domain</h2>
-            <p>Set a custom domain for your booking site.</p>
-            <label>Domain
-              <input
-                type="text"
-                name="custom_domain"
-                placeholder="tickets.yourdomain.com"
-                value={s.customDomain}
-                autocomplete="off"
-              />
-            </label>
-            <button type="submit">Save Custom Domain</button>
-          </CsrfForm>
 
-          {s.customDomain && (
-          <CsrfForm action="/admin/settings/custom-domain/validate" id="settings-custom-domain-validate">
-            {!s.customDomainLastValidated && (
-            <article>
-              <aside role="alert">
-                <p><strong>Your custom domain is not yet validated.</strong> It will not work until validation is complete.</p>
-              </aside>
-            </article>
-            )}
-            <article>
-              <aside>
-                <p>To use your custom domain, create a <strong>CNAME</strong> record:</p>
-                <table>
-                  <thead>
-                    <tr><th>Type</th><th>Name</th><th>Value</th></tr>
-                  </thead>
-                  <tbody>
-                    <tr><td>CNAME</td><td><code>{s.customDomain}</code></td><td><code>{s.cdnHostname}</code></td></tr>
-                  </tbody>
-                </table>
-                <p>Once the DNS record is in place, click the button below to validate and enable SSL.</p>
-              </aside>
-            </article>
-            {s.customDomainLastValidated && (
-              <p><small>Last validated: {s.customDomainLastValidated}</small></p>
-            )}
-            <button type="submit">Validate Custom Domain</button>
-          </CsrfForm>
-          )}
-        </div>
-        )}
 
-        <CsrfForm action="/admin/settings/apple-wallet" id="settings-apple-wallet">
-            <h2>Apple Wallet</h2>
-          <p>Configure Apple Wallet pass signing to show an &ldquo;Add to Apple Wallet&rdquo; button on ticket pages.{
-            s.hostAppleWalletLabel && !s.appleWalletConfigured
-              ? ` Currently using: ${s.hostAppleWalletLabel}. Override below or leave empty to keep using host config.`
-              : s.hostAppleWalletLabel && s.appleWalletConfigured
-                ? ` Overriding: ${s.hostAppleWalletLabel}.`
-                : ""
-          }</p>
-          <label>
-            Pass Type ID
-            <input
-              type="text"
-              name="apple_wallet_pass_type_id"
-              placeholder="pass.com.example.tickets"
-              value={s.appleWalletPassTypeId}
-              autocomplete="off"
-            />
-          </label>
-          <label>
-            Team ID
-            <input
-              type="text"
-              name="apple_wallet_team_id"
-              placeholder="ABC1234567"
-              value={s.appleWalletTeamId}
-              autocomplete="off"
-            />
-          </label>
-          <label>
-            Signing Certificate (PEM)
-            <textarea
-              name="apple_wallet_signing_cert"
-              rows={4}
-              placeholder="-----BEGIN CERTIFICATE-----"
-            >{s.appleWalletConfigured ? MASK_SENTINEL : ""}</textarea>
-          </label>
-          <label>
-            Signing Private Key (PEM)
-            <textarea
-              name="apple_wallet_signing_key"
-              rows={4}
-              placeholder="-----BEGIN PRIVATE KEY-----"
-            >{s.appleWalletConfigured ? MASK_SENTINEL : ""}</textarea>
-          </label>
-          <label>
-            WWDR Certificate (PEM)
-            <textarea
-              name="apple_wallet_wwdr_cert"
-              rows={4}
-              placeholder="-----BEGIN CERTIFICATE-----"
-            >{s.appleWalletConfigured ? MASK_SENTINEL : ""}</textarea>
-          </label>
-          <button type="submit">Save Apple Wallet Settings</button>
-        </CsrfForm>
-
-        <ResetDatabaseForm action="/admin/settings/reset-database" id="settings-reset-database" />
     </Layout>
   );

--- a/test/lib/email-templates-admin.test.ts
+++ b/test/lib/email-templates-admin.test.ts
@@ -43,25 +43,25 @@ describe("admin email templates", () => {
 
   describe("settings page", () => {
     test("shows email template sections", async () => {
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       await expectHtmlResponse(response, 200, "Confirmation Email Template", "Admin Notification Email Template");
     });
 
     test("shows default templates as placeholders", async () => {
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       const html = await response.text();
       expect(html).toContain("Your tickets for");
       expect(html).toContain("New registration");
     });
 
     test("uses 'Leave blank' placeholder for html/text bodies", async () => {
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       const html = await response.text();
       expect(html).toContain('placeholder="Leave blank to use default template"');
     });
 
     test("shows edit default template links for html/text bodies", async () => {
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       const html = await response.text();
       expect(html).toContain('data-fill-default="confirmation_html"');
       expect(html).toContain('data-fill-default="confirmation_text"');
@@ -71,7 +71,7 @@ describe("admin email templates", () => {
     });
 
     test("includes default templates as data attributes", async () => {
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       const html = await response.text();
       expect(html).toContain("data-default-tpl=");
     });

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -9,6 +9,7 @@ import { adminEventActivityLogPage, adminGlobalActivityLogPage } from "#template
 import { Breadcrumb } from "#templates/admin/nav.tsx";
 import { adminSessionsPage } from "#templates/admin/sessions.tsx";
 import { adminSettingsPage } from "#templates/admin/settings.tsx";
+import { adminAdvancedSettingsPage } from "#templates/admin/settings-advanced.tsx";
 import { adminUserDeletePage, adminUsersPage, type DisplayUser } from "#templates/admin/users.tsx";
 import { type CsvEventInfo, generateAttendeesCsv, generateCalendarCsv } from "#templates/csv.ts";
 import { adminCalendarPage, type CalendarAttendeeRow } from "#templates/admin/calendar.tsx";
@@ -1756,28 +1757,12 @@ describe("html", () => {
       webhookUrl: "https://example.com/payment/webhook",
       embedHosts: "",
       termsAndConditions: "",
-      timezone: "Europe/London",
       businessEmail: "",
       theme: "light",
       showPublicSite: false,
       phonePrefix: "44",
       headerImageUrl: "",
       storageEnabled: false,
-      emailProvider: "",
-      emailApiKeyConfigured: false,
-      emailFromAddress: "",
-      showPublicApi: false,
-      hostEmailLabel: "",
-      confirmationTemplates: { subject: "", html: "", text: "" },
-      adminTemplates: { subject: "", html: "", text: "" },
-      bunnyCdnEnabled: false,
-      customDomain: "",
-      customDomainLastValidated: "",
-      cdnHostname: "",
-      appleWalletConfigured: false,
-      appleWalletPassTypeId: "",
-      appleWalletTeamId: "",
-      hostAppleWalletLabel: "",
     };
 
     test("shows square webhook configured message when key is set", () => {
@@ -1807,10 +1792,39 @@ describe("html", () => {
       expect(html).toContain('name="square_sandbox"');
     });
 
+    test("shows link to advanced settings", () => {
+      const html = adminSettingsPage(TEST_SESSION, defaultState);
+      expect(html).toContain('href="/admin/settings-advanced"');
+      expect(html).toContain("advanced settings");
+    });
+  });
+
+  describe("adminAdvancedSettingsPage", () => {
+    const advancedDefaultState: import("#templates/admin/settings-advanced.tsx").AdvancedSettingsPageState = {
+      timezone: "Europe/London",
+      showPublicApi: false,
+      emailProvider: "",
+      emailApiKeyConfigured: false,
+      emailFromAddress: "",
+      hostEmailLabel: "",
+      businessEmail: "",
+      confirmationTemplates: { subject: "", html: "", text: "" },
+      adminTemplates: { subject: "", html: "", text: "" },
+      bunnyCdnEnabled: false,
+      customDomain: "",
+      customDomainLastValidated: "",
+      cdnHostname: "",
+      appleWalletConfigured: false,
+      appleWalletPassTypeId: "",
+      appleWalletTeamId: "",
+      hostAppleWalletLabel: "",
+      theme: "light",
+    };
+
     test("shows email provider selection when configured", () => {
-      const html = adminSettingsPage(
+      const html = adminAdvancedSettingsPage(
         TEST_SESSION,
-        { ...defaultState, emailProvider: "resend", emailFromAddress: "from@test.com" },
+        { ...advancedDefaultState, emailProvider: "resend", emailFromAddress: "from@test.com" },
       );
       expect(html).toContain('value="resend"');
       expect(html).toContain("Send Test Email");
@@ -1818,34 +1832,44 @@ describe("html", () => {
     });
 
     test("hides test button when no email provider configured", () => {
-      const html = adminSettingsPage(TEST_SESSION, defaultState);
+      const html = adminAdvancedSettingsPage(TEST_SESSION, advancedDefaultState);
       expect(html).not.toContain("Send Test Email");
     });
 
     test("uses business email as from address placeholder", () => {
-      const html = adminSettingsPage(
+      const html = adminAdvancedSettingsPage(
         TEST_SESSION,
-        { ...defaultState, businessEmail: "biz@example.com" },
+        { ...advancedDefaultState, businessEmail: "biz@example.com" },
       );
       expect(html).toContain('placeholder="biz@example.com"');
     });
 
     test("uses default placeholder when no business email", () => {
-      const html = adminSettingsPage(TEST_SESSION, defaultState);
+      const html = adminAdvancedSettingsPage(TEST_SESSION, advancedDefaultState);
       expect(html).toContain('placeholder="tickets@yourdomain.com"');
     });
 
     test("shows host email label when hostEmailLabel is set", () => {
-      const html = adminSettingsPage(
+      const html = adminAdvancedSettingsPage(
         TEST_SESSION,
-        { ...defaultState, hostEmailLabel: "Host Resend (noreply@example.com)" },
+        { ...advancedDefaultState, hostEmailLabel: "Host Resend (noreply@example.com)" },
       );
       expect(html).toContain("Host Resend (noreply@example.com)");
     });
 
     test("shows None disabled when no hostEmailLabel set", () => {
-      const html = adminSettingsPage(TEST_SESSION, defaultState);
+      const html = adminAdvancedSettingsPage(TEST_SESSION, advancedDefaultState);
       expect(html).toContain("None (disabled)");
+    });
+
+    test("shows warning about careful changes", () => {
+      const html = adminAdvancedSettingsPage(TEST_SESSION, advancedDefaultState);
+      expect(html).toContain("Be careful changing settings on this page");
+    });
+
+    test("shows breadcrumb back to settings", () => {
+      const html = adminAdvancedSettingsPage(TEST_SESSION, advancedDefaultState);
+      expect(html).toContain('href="/admin/settings"');
     });
   });
 

--- a/test/lib/server-demo-reset.test.ts
+++ b/test/lib/server-demo-reset.test.ts
@@ -184,7 +184,7 @@ describe("server (demo reset)", () => {
   describe("shared form component", () => {
     test("admin settings page uses shared reset form", async () => {
       const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       const html = await expectHtmlResponse(response, 200, "Reset Database");
       expect(html).toContain(RESET_DATABASE_PHRASE);
       expect(html).toContain("confirm_phrase");

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -1,0 +1,1018 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
+import { getAllActivityLog } from "#lib/db/activityLog.ts";
+import {
+  getCustomDomainFromDb,
+  getCustomDomainLastValidatedFromDb,
+  getTimezoneFromDb,
+  updateCustomDomain,
+  updateCustomDomainLastValidated,
+} from "#lib/db/settings.ts";
+import { resetDemoMode } from "#lib/demo.ts";
+import { handleRequest } from "#routes";
+import {
+  awaitTestRequest,
+  createTestDbWithSetup,
+  expectAdminRedirect,
+  expectHtmlResponse,
+  expectRedirect,
+  loginAsAdmin,
+  mockFormRequest,
+  mockRequest,
+  resetDb,
+  resetTestSlugCounter,
+  setupEventAndLogin,
+  withMocks,
+} from "#test-utils";
+
+describe("server (admin settings-advanced)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    Deno.env.delete("DEMO_MODE");
+    resetDemoMode();
+    resetDb();
+  });
+
+  describe("GET /admin/settings-advanced", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(mockRequest("/admin/settings-advanced"));
+      expectAdminRedirect(response);
+    });
+
+    test("shows advanced settings page when authenticated", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      await expectHtmlResponse(response, 200, "Advanced Settings", "Enable public API?");
+    });
+
+    test("shows warning about careful changes", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain("Be careful changing settings on this page");
+    });
+
+    test("shows breadcrumb back to settings", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain('href="/admin/settings"');
+      expect(html).toContain("Settings");
+    });
+
+    test("each advanced settings form has an id attribute", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain('id="settings-show-public-api"');
+      expect(html).toContain('id="settings-apple-wallet"');
+      expect(html).toContain('id="settings-email-tpl-confirmation"');
+      expect(html).toContain('id="settings-email-tpl-admin"');
+      expect(html).toContain('id="settings-email"');
+      expect(html).toContain('id="settings-timezone"');
+      expect(html).toContain('id="settings-reset-database"');
+    });
+
+    test("shows host email label when host email is configured", async () => {
+      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+      try {
+        const { cookie } = await loginAsAdmin();
+        const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+        const html = await response.text();
+        expect(html).toContain("Host Resend (noreply@example.com)");
+        expect(html).not.toContain("None (disabled)");
+      } finally {
+        Deno.env.delete("HOST_EMAIL_PROVIDER");
+        Deno.env.delete("HOST_EMAIL_API_KEY");
+        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+      }
+    });
+
+    test("displays success message on the matching form when form param is provided", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest(
+        "/admin/settings-advanced?success=Timezone+updated&form=settings-timezone",
+        { cookie },
+      );
+      const html = await response.text();
+      expect(html).toContain('id="settings-timezone"');
+      expect(html).toContain("Timezone updated");
+    });
+  });
+
+  describe("POST /admin/settings/timezone", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/timezone", {
+          timezone: "America/New_York",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("rejects invalid CSRF token", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/timezone",
+          { timezone: "America/New_York", csrf_token: "invalid-csrf-token" },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    test("saves valid timezone", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/timezone",
+          { timezone: "America/New_York", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(location).toContain("/admin/settings-advanced");
+      expect(location).toContain("form=settings-timezone");
+      expect(location).toContain("#settings-timezone");
+      const saved = await getTimezoneFromDb();
+      expect(saved).toBe("America/New_York");
+    });
+
+    test("rejects empty timezone", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/timezone",
+          { timezone: "", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 400, "Timezone is required");
+    });
+
+    test("rejects invalid timezone string", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/timezone",
+          { timezone: "Not/A/Real/Timezone", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 400, "Invalid timezone");
+    });
+
+    test("trims whitespace from timezone value", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/timezone",
+          { timezone: "  Europe/London  ", csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+      const saved = await getTimezoneFromDb();
+      expect(saved).toBe("Europe/London");
+    });
+  });
+
+  describe("POST /admin/settings/show-public-api", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/show-public-api", {
+          show_public_api: "true",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("rejects invalid CSRF token", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/show-public-api",
+          {
+            show_public_api: "true",
+            csrf_token: "invalid-csrf-token",
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 403, "Invalid CSRF token");
+    });
+
+    test("enables public API", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/show-public-api",
+          {
+            show_public_api: "true",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Public API enabled");
+    });
+
+    test("disables public API", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/show-public-api",
+          {
+            show_public_api: "false",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Public API disabled");
+    });
+
+    test("setting persists in database", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      expect(await settingsApi.getShowPublicApiFromDb()).toBe(false);
+
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/show-public-api",
+          {
+            show_public_api: "true",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(await settingsApi.getShowPublicApiFromDb()).toBe(true);
+    });
+
+    test("advanced settings page displays enable public API section", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      await expectHtmlResponse(
+        response,
+        200,
+        "Enable public API?",
+        "show_public_api",
+      );
+    });
+  });
+
+  describe("POST /admin/settings/email", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/email", {
+          email_provider: "resend",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("saves email provider settings", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "resend",
+            email_api_key: "re_test_123",
+            email_from_address: "tickets@example.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Email settings updated");
+    });
+
+    test("disables email when provider is empty", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Email provider disabled");
+    });
+
+    test("rejects invalid email provider", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "invalid-provider",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "Invalid email provider");
+    });
+
+    test("rejects invalid from-address format", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "resend",
+            email_api_key: "re_test_123",
+            email_from_address: "not-an-email",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "Invalid from-address format");
+    });
+
+    test("disables email when provider field is missing", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(decodeURIComponent(response.headers.get("location")!.replaceAll("+", " "))).toContain("Email provider disabled");
+    });
+
+    test("saves provider without updating key when key is empty", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "postmark",
+            email_api_key: "",
+            email_from_address: "",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(decodeURIComponent(response.headers.get("location")!.replaceAll("+", " "))).toContain("Email settings updated");
+    });
+
+    test("logs activity when email provider is set", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email",
+          {
+            email_provider: "sendgrid",
+            email_api_key: "sg_key",
+            email_from_address: "from@test.com",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      const logs = await getAllActivityLog();
+      expect(logs.some((l) => l.message.includes("Email provider set to sendgrid"))).toBe(true);
+    });
+
+    test("advanced settings page displays email configuration section", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain('id="settings-email"');
+      expect(html).toContain("email_provider");
+      expect(html).toContain("Email Notifications");
+    });
+  });
+
+  describe("POST /admin/settings/email/test", () => {
+    test("shows error when email not configured", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email/test",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "Email not configured");
+    });
+
+    test("shows error when no business email set", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/email/test",
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+      );
+
+      await expectHtmlResponse(response, 400, "No business email set");
+    });
+
+    test("sends test email and redirects with success including status code", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+      await setBizEmail("admin@test.com");
+      settingsApi.invalidateSettingsCache();
+
+      await withMocks(
+        () => stub(globalThis, "fetch", () => Promise.resolve(new Response())),
+        async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/email/test",
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Test email sent (status 200)");
+        },
+      );
+    });
+
+    test("shows error when email API returns non-2xx status", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+      await setBizEmail("admin@test.com");
+      settingsApi.invalidateSettingsCache();
+
+      await withMocks(
+        () => stub(globalThis, "fetch", () => Promise.resolve(new Response("Forbidden", { status: 403 }))),
+        async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/email/test",
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          const html = await response.text();
+          expect(response.status).toBe(502);
+          expect(html).toContain("Test email failed (status 403)");
+        },
+      );
+    });
+
+    test("shows error when email send encounters network error", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailApiKey("re_test_key");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+      await setBizEmail("admin@test.com");
+      settingsApi.invalidateSettingsCache();
+
+      await withMocks(
+        () => stub(globalThis, "fetch", () => Promise.reject(new Error("Network error"))),
+        async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/email/test",
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+
+          const html = await response.text();
+          expect(response.status).toBe(502);
+          expect(html).toContain("Test email failed (no response)");
+        },
+      );
+    });
+  });
+
+  describe("settings-advanced page email provider display", () => {
+    test("shows email provider when configured", async () => {
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { cookie } = await loginAsAdmin();
+
+      await settingsApi.updateEmailProvider("resend");
+      await settingsApi.updateEmailFromAddress("from@test.com");
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain('value="resend"');
+      expect(html).toContain("Send Test Email");
+    });
+  });
+
+  describe("POST /admin/settings/reset-database", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/reset-database", {
+          confirm_phrase:
+            "The site will be fully reset and all data will be lost.",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("rejects invalid CSRF token", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/reset-database",
+          {
+            confirm_phrase:
+              "The site will be fully reset and all data will be lost.",
+            csrf_token: "invalid-csrf-token",
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 403, "Invalid CSRF token");
+    });
+
+    test("rejects wrong confirmation phrase", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/reset-database",
+          {
+            confirm_phrase: "wrong phrase",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(
+        response,
+        400,
+        "Confirmation phrase does not match",
+      );
+    });
+
+    test("resets database and redirects to setup on correct phrase", async () => {
+      // Create some data first
+      const { cookie, csrfToken } = await setupEventAndLogin({
+        name: "Test Event",
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com/thanks",
+      });
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/reset-database",
+          {
+            confirm_phrase:
+              "The site will be fully reset and all data will be lost.",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+
+      // Should redirect to setup page with session cleared
+      expectRedirect("/setup/?success=Database+reset")(response);
+      expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+    });
+
+    test("advanced settings page shows reset database section", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await expectHtmlResponse(response, 200, "Reset Database");
+      expect(html).toContain(
+        "The site will be fully reset and all data will be lost.",
+      );
+      expect(html).toContain("confirm_phrase");
+    });
+  });
+
+  describe("POST /admin/settings/reset-database (confirm phrase)", () => {
+    test("rejects empty confirm phrase", async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/reset-database",
+          {
+            confirm_phrase: "",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(
+        response,
+        400,
+        "Confirmation phrase does not match",
+      );
+    });
+  });
+
+  describe("custom domain", () => {
+    const setBunnyEnv = () => {
+      Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
+    };
+    const clearBunnyEnv = () => {
+      Deno.env.delete("BUNNY_API_KEY");
+    };
+
+    afterEach(() => {
+      clearBunnyEnv();
+    });
+
+    test("does not show custom domain form when Bunny CDN is not configured", async () => {
+      clearBunnyEnv();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).not.toContain('id="settings-custom-domain"');
+    });
+
+    test("shows custom domain form when Bunny CDN is configured", async () => {
+      setBunnyEnv();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain('id="settings-custom-domain"');
+      expect(html).toContain("Custom Domain");
+    });
+
+    test("does not show validate form when no custom domain is saved", async () => {
+      setBunnyEnv();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).not.toContain('id="settings-custom-domain-validate"');
+    });
+
+    test("shows validate form and CNAME instructions when custom domain is saved", async () => {
+      setBunnyEnv();
+      await updateCustomDomain("tickets.example.com");
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain('id="settings-custom-domain-validate"');
+      expect(html).toContain("CNAME");
+      expect(html).toContain("tickets.example.com");
+      // CDN hostname is derived from ALLOWED_DOMAIN (localhost in tests)
+      expect(html).toContain("localhost");
+    });
+
+    test("shows warning when custom domain is not validated", async () => {
+      setBunnyEnv();
+      await updateCustomDomain("tickets.example.com");
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain("not yet validated");
+      expect(html).toContain("will not work until validation is complete");
+    });
+
+    test("does not show warning when custom domain is validated", async () => {
+      setBunnyEnv();
+      await updateCustomDomain("tickets.example.com");
+      await updateCustomDomainLastValidated();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).not.toContain("not yet validated");
+    });
+
+    test("shows last validated timestamp when domain has been validated", async () => {
+      setBunnyEnv();
+      await updateCustomDomain("tickets.example.com");
+      await updateCustomDomainLastValidated();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
+      const html = await response.text();
+      expect(html).toContain("Last validated:");
+    });
+
+    describe("POST /admin/settings/custom-domain", () => {
+      test("rejects when Bunny CDN is not configured", async () => {
+        clearBunnyEnv();
+        const { cookie, csrfToken } = await loginAsAdmin();
+        const response = await handleRequest(
+          mockFormRequest("/admin/settings/custom-domain", {
+            custom_domain: "tickets.example.com",
+            csrf_token: csrfToken,
+          }, cookie),
+        );
+        expect(response.status).toBe(400);
+      });
+
+      test("saves and validates domain when validation succeeds", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          const response = await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain saved and validated");
+          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+          expect(await getCustomDomainLastValidatedFromDb()).not.toBeNull();
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("saves domain with error message when validation fails", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () =>
+          Promise.resolve({ ok: false as const, error: "DNS not configured" });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          const response = await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          const decoded = decodeURIComponent(location.replaceAll("+", " "));
+          expect(decoded).toContain("validation failed");
+          expect(decoded).toContain("DNS not configured");
+          expect(decoded).toContain("error=");
+          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+          expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("normalizes domain to lowercase", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "Tickets.Example.COM",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("clears custom domain when empty", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const { cookie, csrfToken } = await loginAsAdmin();
+        const response = await handleRequest(
+          mockFormRequest("/admin/settings/custom-domain", {
+            custom_domain: "",
+            csrf_token: csrfToken,
+          }, cookie),
+        );
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location")!;
+        expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain cleared");
+        expect(await getCustomDomainFromDb()).toBeNull();
+      });
+
+      test("clears domain when field is missing from form", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const { cookie, csrfToken } = await loginAsAdmin();
+        const response = await handleRequest(
+          mockFormRequest("/admin/settings/custom-domain", {
+            csrf_token: csrfToken,
+          }, cookie),
+        );
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location")!;
+        expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain cleared");
+        expect(await getCustomDomainFromDb()).toBeNull();
+      });
+
+      test("rejects invalid domain format", async () => {
+        setBunnyEnv();
+        const { cookie, csrfToken } = await loginAsAdmin();
+        const response = await handleRequest(
+          mockFormRequest("/admin/settings/custom-domain", {
+            custom_domain: "not a domain!",
+            csrf_token: csrfToken,
+          }, cookie),
+        );
+        await expectHtmlResponse(response, 400, "Invalid domain format");
+      });
+
+      test("logs activity when domain is set", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          const log = await getAllActivityLog();
+          expect(log.some((e) => e.message.includes("Custom domain set to tickets.example.com"))).toBe(true);
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("logs validation activity when save triggers successful validation", async () => {
+        setBunnyEnv();
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          const log = await getAllActivityLog();
+          expect(log.some((e) => e.message.includes("Custom domain validated"))).toBe(true);
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+    });
+
+    describe("POST /admin/settings/custom-domain/validate", () => {
+      test("rejects when Bunny CDN is not configured", async () => {
+        clearBunnyEnv();
+        const { cookie, csrfToken } = await loginAsAdmin();
+        const response = await handleRequest(
+          mockFormRequest("/admin/settings/custom-domain/validate", {
+            csrf_token: csrfToken,
+          }, cookie),
+        );
+        expect(response.status).toBe(400);
+      });
+
+      test("rejects when no custom domain is saved", async () => {
+        setBunnyEnv();
+        const { cookie, csrfToken } = await loginAsAdmin();
+        const response = await handleRequest(
+          mockFormRequest("/admin/settings/custom-domain/validate", {
+            csrf_token: csrfToken,
+          }, cookie),
+        );
+        expect(response.status).toBe(400);
+      });
+
+      test("calls Bunny API and saves timestamp on success", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          const response = await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain/validate", {
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location")!;
+          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain validated successfully");
+          const lastValidated = await getCustomDomainLastValidatedFromDb();
+          expect(lastValidated).not.toBeNull();
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("returns error when Bunny API fails", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () =>
+          Promise.resolve({ ok: false as const, error: "Add hostname failed (400): Hostname already exists" });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          const response = await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain/validate", {
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          await expectHtmlResponse(response, 502, "Add hostname failed");
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+
+      test("logs activity on successful validation", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const original = bunnyCdnApi.validateCustomDomain;
+        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
+        try {
+          const { cookie, csrfToken } = await loginAsAdmin();
+          await handleRequest(
+            mockFormRequest("/admin/settings/custom-domain/validate", {
+              csrf_token: csrfToken,
+            }, cookie),
+          );
+          const log = await getAllActivityLog();
+          expect(log.some((e) => e.message.includes("Custom domain validated"))).toBe(true);
+        } finally {
+          bunnyCdnApi.validateCustomDomain = original;
+        }
+      });
+    });
+  });
+});

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -1,16 +1,10 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import {
-  getCustomDomainFromDb,
-  getCustomDomainLastValidatedFromDb,
   getEmbedHostsFromDb,
-  getTimezoneFromDb,
   setPaymentProvider,
-  updateCustomDomain,
-  updateCustomDomainLastValidated,
   updateTermsAndConditions,
 } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
@@ -29,7 +23,6 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
-  setupEventAndLogin,
   TEST_ADMIN_PASSWORD,
   withMocks,
 } from "#test-utils";
@@ -74,18 +67,18 @@ describe("server (admin settings)", () => {
       const { cookie } = await loginAsAdmin();
 
       const response = await awaitTestRequest(
-        "/admin/settings?success=Timezone+updated&form=settings-timezone",
+        "/admin/settings?success=Phone+prefix+updated&form=settings-phone-prefix",
         { cookie },
       );
       const html = await response.text();
-      expect(html).toContain('id="settings-timezone"');
-      expect(html).toContain("Timezone updated");
-      // The success message should be inside the timezone form, not as a global banner
-      const timezoneFormMatch = html.match(
-        /id="settings-timezone"[\s\S]*?<\/form>/,
+      expect(html).toContain('id="settings-phone-prefix"');
+      expect(html).toContain("Phone prefix updated");
+      // The success message should be inside the form, not as a global banner
+      const formMatch = html.match(
+        /id="settings-phone-prefix"[\s\S]*?<\/form>/,
       );
-      expect(timezoneFormMatch).toBeDefined();
-      expect(timezoneFormMatch![0]).toContain("Timezone updated");
+      expect(formMatch).toBeDefined();
+      expect(formMatch![0]).toContain("Phone prefix updated");
     });
 
     test("does not show success on non-matching forms", async () => {
@@ -107,7 +100,6 @@ describe("server (admin settings)", () => {
 
       const response = await awaitTestRequest("/admin/settings", { cookie });
       const html = await response.text();
-      expect(html).toContain('id="settings-timezone"');
       expect(html).toContain('id="settings-phone-prefix"');
       expect(html).toContain('id="settings-business-email"');
       expect(html).toContain('id="settings-payment-provider"');
@@ -115,43 +107,18 @@ describe("server (admin settings)", () => {
       expect(html).toContain('id="settings-terms"');
       expect(html).toContain('id="settings-password"');
       expect(html).toContain('id="settings-show-public-site"');
-      expect(html).toContain('id="settings-show-public-api"');
       expect(html).toContain('id="settings-theme"');
-      expect(html).toContain('id="settings-reset-database"');
     });
 
-    test("shows host email label when host email is configured", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      try {
-        const { cookie } = await loginAsAdmin();
-        const response = await awaitTestRequest("/admin/settings", { cookie });
-        const html = await response.text();
-        expect(html).toContain("Host Resend (noreply@example.com)");
-        expect(html).not.toContain("None (disabled)");
-      } finally {
-        Deno.env.delete("HOST_EMAIL_PROVIDER");
-        Deno.env.delete("HOST_EMAIL_API_KEY");
-        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
-      }
+    test("shows link to advanced settings", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const html = await response.text();
+      expect(html).toContain('href="/admin/settings-advanced"');
+      expect(html).toContain("advanced settings");
     });
 
-    test("shows no host config when host email provider is invalid", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "custom-smtp");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-456");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "mail@example.com");
-      try {
-        const { cookie } = await loginAsAdmin();
-        const response = await awaitTestRequest("/admin/settings", { cookie });
-        const html = await response.text();
-        expect(html).not.toContain("Host custom-smtp");
-      } finally {
-        Deno.env.delete("HOST_EMAIL_PROVIDER");
-        Deno.env.delete("HOST_EMAIL_API_KEY");
-        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
-      }
-    });
   });
 
   describe("POST /admin/settings", () => {
@@ -838,90 +805,6 @@ describe("server (admin settings)", () => {
     });
   });
 
-  describe("POST /admin/settings/reset-database", () => {
-    test("redirects to login when not authenticated", async () => {
-      const response = await handleRequest(
-        mockFormRequest("/admin/settings/reset-database", {
-          confirm_phrase:
-            "The site will be fully reset and all data will be lost.",
-        }),
-      );
-      expectAdminRedirect(response);
-    });
-
-    test("rejects invalid CSRF token", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/reset-database",
-          {
-            confirm_phrase:
-              "The site will be fully reset and all data will be lost.",
-            csrf_token: "invalid-csrf-token",
-          },
-          cookie,
-        ),
-      );
-      await expectHtmlResponse(response, 403, "Invalid CSRF token");
-    });
-
-    test("rejects wrong confirmation phrase", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/reset-database",
-          {
-            confirm_phrase: "wrong phrase",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-      await expectHtmlResponse(
-        response,
-        400,
-        "Confirmation phrase does not match",
-      );
-    });
-
-    test("resets database and redirects to setup on correct phrase", async () => {
-      // Create some data first
-      const { cookie, csrfToken } = await setupEventAndLogin({
-        name: "Test Event",
-        maxAttendees: 100,
-        thankYouUrl: "https://example.com/thanks",
-      });
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/reset-database",
-          {
-            confirm_phrase:
-              "The site will be fully reset and all data will be lost.",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      // Should redirect to setup page with session cleared
-      expectRedirect("/setup/?success=Database+reset")(response);
-      expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
-    });
-
-    test("settings page shows reset database section", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await expectHtmlResponse(response, 200, "Reset Database");
-      expect(html).toContain(
-        "The site will be fully reset and all data will be lost.",
-      );
-      expect(html).toContain("confirm_phrase");
-    });
-  });
 
   describe("POST /admin/settings/payment-provider", () => {
     test("redirects to login when not authenticated", async () => {
@@ -1025,27 +908,6 @@ describe("server (admin settings)", () => {
     });
   });
 
-  describe("POST /admin/settings/reset-database (confirm phrase)", () => {
-    test("rejects empty confirm phrase", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/reset-database",
-          {
-            confirm_phrase: "",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-      await expectHtmlResponse(
-        response,
-        400,
-        "Confirmation phrase does not match",
-      );
-    });
-  });
 
   describe("admin/settings.ts (form.get fallbacks)", () => {
     test("payment provider POST without payment_provider field uses empty fallback", async () => {
@@ -1280,94 +1142,6 @@ describe("server (admin settings)", () => {
     });
   });
 
-  describe("POST /admin/settings/timezone", () => {
-    test("redirects to login when not authenticated", async () => {
-      const response = await handleRequest(
-        mockFormRequest("/admin/settings/timezone", {
-          timezone: "America/New_York",
-        }),
-      );
-      expectAdminRedirect(response);
-    });
-
-    test("rejects invalid CSRF token", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/timezone",
-          { timezone: "America/New_York", csrf_token: "invalid-csrf-token" },
-          cookie,
-        ),
-      );
-      expect(response.status).toBe(403);
-    });
-
-    test("saves valid timezone", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/timezone",
-          { timezone: "America/New_York", csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-      expect(response.status).toBe(302);
-      const location = response.headers.get("location")!;
-      expect(location).toContain("/admin/settings");
-      expect(location).toContain("form=settings-timezone");
-      expect(location).toContain("#settings-timezone");
-      const saved = await getTimezoneFromDb();
-      expect(saved).toBe("America/New_York");
-    });
-
-    test("rejects empty timezone", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/timezone",
-          { timezone: "", csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-      await expectHtmlResponse(response, 400, "Timezone is required");
-    });
-
-    test("rejects invalid timezone identifier", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/timezone",
-          { timezone: "Not/A_Timezone", csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-      await expectHtmlResponse(response, 400, "Invalid timezone");
-    });
-
-    test("shows error on the timezone form only", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/timezone",
-          { timezone: "", csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-      const html = await response.text();
-      const timezoneForm = html.match(/id="settings-timezone"[\s\S]*?<\/form>/);
-      expect(timezoneForm).toBeDefined();
-      expect(timezoneForm![0]).toContain("Timezone is required");
-      // Other forms should not have the error
-      const themeForm = html.match(/id="settings-theme"[\s\S]*?<\/form>/);
-      expect(themeForm).toBeDefined();
-      expect(themeForm![0]).not.toContain("Timezone is required");
-    });
-  });
 
   describe("POST /admin/settings/business-email", () => {
     test("redirects to login when not authenticated", async () => {
@@ -1937,102 +1711,6 @@ describe("server (admin settings)", () => {
     });
   });
 
-  describe("POST /admin/settings/show-public-api", () => {
-    test("redirects to login when not authenticated", async () => {
-      const response = await handleRequest(
-        mockFormRequest("/admin/settings/show-public-api", {
-          show_public_api: "true",
-        }),
-      );
-      expectAdminRedirect(response);
-    });
-
-    test("rejects invalid CSRF token", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/show-public-api",
-          {
-            show_public_api: "true",
-            csrf_token: "invalid-csrf-token",
-          },
-          cookie,
-        ),
-      );
-      await expectHtmlResponse(response, 403, "Invalid CSRF token");
-    });
-
-    test("enables public API", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/show-public-api",
-          {
-            show_public_api: "true",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get("location")!;
-      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Public API enabled");
-    });
-
-    test("disables public API", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/show-public-api",
-          {
-            show_public_api: "false",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get("location")!;
-      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Public API disabled");
-    });
-
-    test("setting persists in database", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      expect(await settingsApi.getShowPublicApiFromDb()).toBe(false);
-
-      await handleRequest(
-        mockFormRequest(
-          "/admin/settings/show-public-api",
-          {
-            show_public_api: "true",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      expect(await settingsApi.getShowPublicApiFromDb()).toBe(true);
-    });
-
-    test("settings page displays enable public API section", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      await expectHtmlResponse(
-        response,
-        200,
-        "Enable public API?",
-        "show_public_api",
-      );
-    });
-  });
 
   describe("POST /admin/settings/phone-prefix", () => {
     test("redirects to login when not authenticated", async () => {
@@ -2181,294 +1859,8 @@ describe("server (admin settings)", () => {
     });
   });
 
-  describe("POST /admin/settings/email", () => {
-    test("redirects to login when not authenticated", async () => {
-      const response = await handleRequest(
-        mockFormRequest("/admin/settings/email", {
-          email_provider: "resend",
-        }),
-      );
-      expectAdminRedirect(response);
-    });
 
-    test("saves email provider settings", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
 
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          {
-            email_provider: "resend",
-            email_api_key: "re_test_123",
-            email_from_address: "tickets@example.com",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get("location")!;
-      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Email settings updated");
-    });
-
-    test("disables email when provider is empty", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          {
-            email_provider: "",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get("location")!;
-      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Email provider disabled");
-    });
-
-    test("rejects invalid email provider", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          {
-            email_provider: "invalid-provider",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      await expectHtmlResponse(response, 400, "Invalid email provider");
-    });
-
-    test("rejects invalid from-address format", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          {
-            email_provider: "resend",
-            email_api_key: "re_test_123",
-            email_from_address: "not-an-email",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      await expectHtmlResponse(response, 400, "Invalid from-address format");
-    });
-
-    test("disables email when provider field is missing", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          { csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-
-      expect(response.status).toBe(302);
-      expect(decodeURIComponent(response.headers.get("location")!.replaceAll("+", " "))).toContain("Email provider disabled");
-    });
-
-    test("saves provider without updating key when key is empty", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          {
-            email_provider: "postmark",
-            email_api_key: "",
-            email_from_address: "",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      expect(response.status).toBe(302);
-      expect(decodeURIComponent(response.headers.get("location")!.replaceAll("+", " "))).toContain("Email settings updated");
-    });
-
-    test("logs activity when email provider is set", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email",
-          {
-            email_provider: "sendgrid",
-            email_api_key: "sg_key",
-            email_from_address: "from@test.com",
-            csrf_token: csrfToken,
-          },
-          cookie,
-        ),
-      );
-
-      const logs = await getAllActivityLog();
-      expect(logs.some((l) => l.message.includes("Email provider set to sendgrid"))).toBe(true);
-    });
-
-    test("settings page displays email configuration section", async () => {
-      const { cookie } = await loginAsAdmin();
-
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).toContain('id="settings-email"');
-      expect(html).toContain("email_provider");
-      expect(html).toContain("Email Notifications");
-    });
-  });
-
-  describe("POST /admin/settings/email/test", () => {
-    test("shows error when email not configured", async () => {
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email/test",
-          { csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-
-      await expectHtmlResponse(response, 400, "Email not configured");
-    });
-
-    test("shows error when no business email set", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/settings/email/test",
-          { csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-
-      await expectHtmlResponse(response, 400, "No business email set");
-    });
-
-    test("sends test email and redirects with success including status code", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
-      await setBizEmail("admin@test.com");
-      settingsApi.invalidateSettingsCache();
-
-      await withMocks(
-        () => stub(globalThis, "fetch", () => Promise.resolve(new Response())),
-        async () => {
-          const response = await handleRequest(
-            mockFormRequest(
-              "/admin/settings/email/test",
-              { csrf_token: csrfToken },
-              cookie,
-            ),
-          );
-
-          expect(response.status).toBe(302);
-          const location = response.headers.get("location")!;
-          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Test email sent (status 200)");
-        },
-      );
-    });
-
-    test("shows error when email API returns non-2xx status", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
-      await setBizEmail("admin@test.com");
-      settingsApi.invalidateSettingsCache();
-
-      await withMocks(
-        () => stub(globalThis, "fetch", () => Promise.resolve(new Response("Forbidden", { status: 403 }))),
-        async () => {
-          const response = await handleRequest(
-            mockFormRequest(
-              "/admin/settings/email/test",
-              { csrf_token: csrfToken },
-              cookie,
-            ),
-          );
-
-          const html = await response.text();
-          expect(response.status).toBe(502);
-          expect(html).toContain("Test email failed (status 403)");
-        },
-      );
-    });
-
-    test("shows error when email send encounters network error", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      const { updateBusinessEmail: setBizEmail } = await import("#lib/business-email.ts");
-      const { cookie, csrfToken } = await loginAsAdmin();
-
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
-      await setBizEmail("admin@test.com");
-      settingsApi.invalidateSettingsCache();
-
-      await withMocks(
-        () => stub(globalThis, "fetch", () => Promise.reject(new Error("Network error"))),
-        async () => {
-          const response = await handleRequest(
-            mockFormRequest(
-              "/admin/settings/email/test",
-              { csrf_token: csrfToken },
-              cookie,
-            ),
-          );
-
-          const html = await response.text();
-          expect(response.status).toBe(502);
-          expect(html).toContain("Test email failed (no response)");
-        },
-      );
-    });
-  });
-
-  describe("settings page email provider display", () => {
-    test("shows email provider when configured", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      const { cookie } = await loginAsAdmin();
-
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailFromAddress("from@test.com");
-
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).toContain('value="resend"');
-      expect(html).toContain("Send Test Email");
-    });
-  });
 
   describe("sensitive field masking", () => {
     test("shows mask sentinel for configured Stripe key", async () => {
@@ -2536,7 +1928,7 @@ describe("server (admin settings)", () => {
       await settingsApi.updateEmailProvider("resend");
       await settingsApi.updateEmailApiKey("re_real_secret_key");
 
-      const response = await awaitTestRequest("/admin/settings", { cookie });
+      const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
       const html = await response.text();
       expect(html).toContain(MASK_SENTINEL);
       expect(html).not.toContain("re_real_secret_key");
@@ -2866,329 +2258,4 @@ describe("server (admin settings)", () => {
     });
   });
 
-  describe("custom domain", () => {
-    const setBunnyEnv = () => {
-      Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
-    };
-    const clearBunnyEnv = () => {
-      Deno.env.delete("BUNNY_API_KEY");
-    };
-
-    afterEach(() => {
-      clearBunnyEnv();
-    });
-
-    test("does not show custom domain form when Bunny CDN is not configured", async () => {
-      clearBunnyEnv();
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).not.toContain('id="settings-custom-domain"');
-    });
-
-    test("shows custom domain form when Bunny CDN is configured", async () => {
-      setBunnyEnv();
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).toContain('id="settings-custom-domain"');
-      expect(html).toContain("Custom Domain");
-    });
-
-    test("does not show validate form when no custom domain is saved", async () => {
-      setBunnyEnv();
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).not.toContain('id="settings-custom-domain-validate"');
-    });
-
-    test("shows validate form and CNAME instructions when custom domain is saved", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).toContain('id="settings-custom-domain-validate"');
-      expect(html).toContain("CNAME");
-      expect(html).toContain("tickets.example.com");
-      // CDN hostname is derived from ALLOWED_DOMAIN (localhost in tests)
-      expect(html).toContain("localhost");
-    });
-
-    test("shows warning when custom domain is not validated", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).toContain("not yet validated");
-      expect(html).toContain("will not work until validation is complete");
-    });
-
-    test("does not show warning when custom domain is validated", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).not.toContain("not yet validated");
-    });
-
-    test("shows last validated timestamp when domain has been validated", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      const { cookie } = await loginAsAdmin();
-      const response = await awaitTestRequest("/admin/settings", { cookie });
-      const html = await response.text();
-      expect(html).toContain("Last validated:");
-    });
-
-    describe("POST /admin/settings/custom-domain", () => {
-      test("rejects when Bunny CDN is not configured", async () => {
-        clearBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            custom_domain: "tickets.example.com",
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(response.status).toBe(400);
-      });
-
-      test("saves and validates domain when validation succeeds", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          const response = await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain", {
-              custom_domain: "tickets.example.com",
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          expect(response.status).toBe(302);
-          const location = response.headers.get("location")!;
-          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain saved and validated");
-          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-          expect(await getCustomDomainLastValidatedFromDb()).not.toBeNull();
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("saves domain with error message when validation fails", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: false as const, error: "DNS not configured" });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          const response = await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain", {
-              custom_domain: "tickets.example.com",
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          expect(response.status).toBe(302);
-          const location = response.headers.get("location")!;
-          const decoded = decodeURIComponent(location.replaceAll("+", " "));
-          expect(decoded).toContain("validation failed");
-          expect(decoded).toContain("DNS not configured");
-          expect(decoded).toContain("error=");
-          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-          expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("normalizes domain to lowercase", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain", {
-              custom_domain: "Tickets.Example.COM",
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("clears custom domain when empty", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            custom_domain: "",
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location")!;
-        expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain cleared");
-        expect(await getCustomDomainFromDb()).toBeNull();
-      });
-
-      test("clears domain when field is missing from form", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location")!;
-        expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain cleared");
-        expect(await getCustomDomainFromDb()).toBeNull();
-      });
-
-      test("rejects invalid domain format", async () => {
-        setBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain", {
-            custom_domain: "not a domain!",
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        await expectHtmlResponse(response, 400, "Invalid domain format");
-      });
-
-      test("logs activity when domain is set", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain", {
-              custom_domain: "tickets.example.com",
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          const log = await getAllActivityLog();
-          expect(log.some((e) => e.message.includes("Custom domain set to tickets.example.com"))).toBe(true);
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("logs validation activity when save triggers successful validation", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain", {
-              custom_domain: "tickets.example.com",
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          const log = await getAllActivityLog();
-          expect(log.some((e) => e.message.includes("Custom domain validated"))).toBe(true);
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-    });
-
-    describe("POST /admin/settings/custom-domain/validate", () => {
-      test("rejects when Bunny CDN is not configured", async () => {
-        clearBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain/validate", {
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(response.status).toBe(400);
-      });
-
-      test("rejects when no custom domain is saved", async () => {
-        setBunnyEnv();
-        const { cookie, csrfToken } = await loginAsAdmin();
-        const response = await handleRequest(
-          mockFormRequest("/admin/settings/custom-domain/validate", {
-            csrf_token: csrfToken,
-          }, cookie),
-        );
-        expect(response.status).toBe(400);
-      });
-
-      test("calls Bunny API and saves timestamp on success", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          const response = await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain/validate", {
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          expect(response.status).toBe(302);
-          const location = response.headers.get("location")!;
-          expect(decodeURIComponent(location.replaceAll("+", " "))).toContain("Custom domain validated successfully");
-          const lastValidated = await getCustomDomainLastValidatedFromDb();
-          expect(lastValidated).not.toBeNull();
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("returns error when Bunny API fails", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: false as const, error: "Add hostname failed (400): Hostname already exists" });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          const response = await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain/validate", {
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          await expectHtmlResponse(response, 502, "Add hostname failed");
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("logs activity on successful validation", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () => Promise.resolve({ ok: true as const });
-        try {
-          const { cookie, csrfToken } = await loginAsAdmin();
-          await handleRequest(
-            mockFormRequest("/admin/settings/custom-domain/validate", {
-              csrf_token: csrfToken,
-            }, cookie),
-          );
-          const log = await getAllActivityLog();
-          expect(log.some((e) => e.message.includes("Custom domain validated"))).toBe(true);
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-    });
-  });
 });

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -370,7 +370,7 @@ describe("POST /admin/settings/apple-wallet", () => {
 
   test("shows Apple Wallet section on settings page", async () => {
     const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings", { cookie });
+    const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
     const body = await response.text();
     expect(body).toContain("Apple Wallet");
     expect(body).toContain("apple_wallet_pass_type_id");
@@ -379,7 +379,7 @@ describe("POST /admin/settings/apple-wallet", () => {
   test("shows masked values on settings page when configured", async () => {
     await configureAppleWallet();
     const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings", { cookie });
+    const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
     const body = await response.text();
     expect(body).toContain("pass.com.test.tickets");
     expect(body).toContain("TESTTEAM01");
@@ -499,7 +499,7 @@ describe("Apple Wallet env var fallback", () => {
   test("settings page shows host Apple Wallet label when env vars configured", async () => {
     setWalletEnvVars();
     const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings", { cookie });
+    const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
     const body = await response.text();
     expect(body).toContain("Host env (pass.com.env.tickets)");
     expect(body).toContain("Currently using");
@@ -509,7 +509,7 @@ describe("Apple Wallet env var fallback", () => {
     setWalletEnvVars();
     await configureAppleWallet();
     const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings", { cookie });
+    const response = await awaitTestRequest("/admin/settings-advanced", { cookie });
     const body = await response.text();
     expect(body).toContain("Host env (pass.com.env.tickets)");
     expect(body).toContain("Overriding");


### PR DESCRIPTION
Move public API, Apple Wallet, email templates, mail provider, timezone,
custom domain, and database reset to /admin/settings-advanced. Add link
on main settings page and warning message on advanced page. Split tests
into separate settings and settings-advanced test files.

https://claude.ai/code/session_0172FX3AAZoZTPrjo943HdM2