### PR TITLE
Fix Apple Wallet pass download on iOS Safari and Orion

### DIFF
--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -40,11 +40,17 @@ const buildPassData = async (entry: TokenEntry, token: string): Promise<PassData
   };
 };
 
-/** Handle GET /wallet/:token — generate and return .pkpass */
+/** Strip .pkpass extension from token for iOS URL compatibility */
+const stripPkpassExtension = (token: string): string =>
+  token.endsWith(".pkpass") ? token.slice(0, -7) : token;
+
+/** Handle GET /wallet/:token[.pkpass] — generate and return .pkpass */
 const handleWalletGet = async (_request: Request, tokens: string[]): Promise<Response> => {
   // Only support single-token downloads
-  const token = tokens[0];
-  if (!token || tokens.length > 1) return notFoundResponse();
+  const raw = tokens[0];
+  if (!raw || tokens.length > 1) return notFoundResponse();
+
+  const token = stripPkpassExtension(raw);
 
   const config = await getAppleWalletConfig();
   if (!config) return notFoundResponse();
@@ -55,11 +61,13 @@ const handleWalletGet = async (_request: Request, tokens: string[]): Promise<Res
   const entries = await resolveEntries(result.attendees);
   const passData = await buildPassData(entries[0]!, token);
   const pkpass = buildPkpass(passData, config);
+  const body = pkpass as Uint8Array<ArrayBuffer>;
 
-  return new Response(pkpass as Uint8Array<ArrayBuffer>, {
+  return new Response(body, {
     headers: {
       "Content-Type": PKPASS_CONTENT_TYPE,
       "Content-Disposition": `inline; filename="ticket.pkpass"`,
+      "Content-Length": String(body.byteLength),
       "Cache-Control": CACHE_CONTROL,
     },
   });

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -40,17 +40,18 @@ const buildPassData = async (entry: TokenEntry, token: string): Promise<PassData
   };
 };
 
-/** Strip .pkpass extension from token for iOS URL compatibility */
-const stripPkpassExtension = (token: string): string =>
-  token.endsWith(".pkpass") ? token.slice(0, -7) : token;
+/** .pkpass suffix required on all wallet URLs for iOS compatibility */
+const PKPASS_EXT = ".pkpass";
 
-/** Handle GET /wallet/:token[.pkpass] — generate and return .pkpass */
+/** Handle GET /wallet/:token.pkpass — generate and return .pkpass */
 const handleWalletGet = async (_request: Request, tokens: string[]): Promise<Response> => {
   // Only support single-token downloads
   const raw = tokens[0];
   if (!raw || tokens.length > 1) return notFoundResponse();
 
-  const token = stripPkpassExtension(raw);
+  // Require .pkpass extension
+  if (!raw.endsWith(PKPASS_EXT)) return notFoundResponse();
+  const token = raw.slice(0, -PKPASS_EXT.length);
 
   const config = await getAppleWalletConfig();
   if (!config) return notFoundResponse();

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -24,9 +24,9 @@ export type TicketCard = {
 const ticketCount = (count: number): string =>
   count === 1 ? "1 Ticket" : `${count} Tickets`;
 
-/** Render an "Add to Apple Wallet" link for a token */
+/** Render an "Add to Apple Wallet" link for a token (.pkpass extension aids iOS detection) */
 const renderWalletLink = (token: string): string =>
-  `<a href="/wallet/${escapeHtml(token)}" class="wallet-link">Add to Apple Wallet</a>`;
+  `<a href="/wallet/${escapeHtml(token)}.pkpass" class="wallet-link">Add to Apple Wallet</a>`;
 
 /** Render a single ticket card */
 const renderTicketCard = (card: TicketCard, walletEnabled: boolean): string => {

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -101,6 +101,31 @@ describe("wallet route (/wallet/:token)", () => {
     expect(disposition).toContain("ticket.pkpass");
   });
 
+  test("returns pkpass with Content-Length header for iOS compatibility", async () => {
+    await configureAppleWallet();
+    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
+
+    const response = await awaitTestRequest(`/wallet/${token}`);
+    const contentLength = response.headers.get("Content-Length");
+    expect(contentLength).not.toBeNull();
+    const body = new Uint8Array(await response.arrayBuffer());
+    expect(Number(contentLength)).toBe(body.byteLength);
+  });
+
+  test("serves pkpass when URL has .pkpass extension", async () => {
+    await configureAppleWallet();
+    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
+
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/vnd.apple.pkpass");
+
+    const body = new Uint8Array(await response.arrayBuffer());
+    const files = unzipSync(body);
+    const passJson = JSON.parse(new TextDecoder().decode(files["pass.json"]!));
+    expect(passJson.serialNumber).toBe(token);
+  });
+
   test("pkpass is a valid ZIP containing pass.json, manifest.json, and signature", async () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
@@ -167,7 +192,7 @@ describe("ticket view wallet link", () => {
     const body = await response.text();
     expect(body).toContain("wallet-link");
     expect(body).toContain("Add to Apple Wallet");
-    expect(body).toContain(`/wallet/${token}`);
+    expect(body).toContain(`/wallet/${token}.pkpass`);
   });
 });
 

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -54,13 +54,13 @@ describe("wallet route (/wallet/:token)", () => {
 
   test("returns 404 when Apple Wallet is not configured", async () => {
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     expect(response.status).toBe(404);
   });
 
   test("returns 404 for invalid token", async () => {
     await configureAppleWallet();
-    const response = await awaitTestRequest("/wallet/nonexistent-token");
+    const response = await awaitTestRequest("/wallet/nonexistent-token.pkpass");
     expect(response.status).toBe(404);
   });
 
@@ -68,7 +68,14 @@ describe("wallet route (/wallet/:token)", () => {
     await configureAppleWallet();
     const { token: a } = await createTestAttendeeWithToken("A", "a@test.com");
     const { token: b } = await createTestAttendeeWithToken("B", "b@test.com");
-    const response = await awaitTestRequest(`/wallet/${a}+${b}`);
+    const response = await awaitTestRequest(`/wallet/${a}+${b}.pkpass`);
+    expect(response.status).toBe(404);
+  });
+
+  test("returns 404 without .pkpass extension", async () => {
+    await configureAppleWallet();
+    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
+    const response = await awaitTestRequest(`/wallet/${token}`);
     expect(response.status).toBe(404);
   });
 
@@ -76,7 +83,7 @@ describe("wallet route (/wallet/:token)", () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
 
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/vnd.apple.pkpass");
   });
@@ -85,7 +92,7 @@ describe("wallet route (/wallet/:token)", () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
 
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     const cacheControl = response.headers.get("Cache-Control");
     expect(cacheControl).toContain("public");
     expect(cacheControl).toContain("s-maxage=3600");
@@ -95,7 +102,7 @@ describe("wallet route (/wallet/:token)", () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
 
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     const disposition = response.headers.get("Content-Disposition")!;
     expect(disposition).toContain("inline");
     expect(disposition).toContain("ticket.pkpass");
@@ -105,32 +112,18 @@ describe("wallet route (/wallet/:token)", () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
 
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     const contentLength = response.headers.get("Content-Length");
     expect(contentLength).not.toBeNull();
     const body = new Uint8Array(await response.arrayBuffer());
     expect(Number(contentLength)).toBe(body.byteLength);
   });
 
-  test("serves pkpass when URL has .pkpass extension", async () => {
-    await configureAppleWallet();
-    const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-
-    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("application/vnd.apple.pkpass");
-
-    const body = new Uint8Array(await response.arrayBuffer());
-    const files = unzipSync(body);
-    const passJson = JSON.parse(new TextDecoder().decode(files["pass.json"]!));
-    expect(passJson.serialNumber).toBe(token);
-  });
-
   test("pkpass is a valid ZIP containing pass.json, manifest.json, and signature", async () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
 
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     const body = new Uint8Array(await response.arrayBuffer());
     const files = unzipSync(body);
 
@@ -146,7 +139,7 @@ describe("wallet route (/wallet/:token)", () => {
       location: "Town Hall",
     });
 
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     const body = new Uint8Array(await response.arrayBuffer());
     const files = unzipSync(body);
     const passJson = JSON.parse(new TextDecoder().decode(files["pass.json"]!));
@@ -491,7 +484,7 @@ describe("Apple Wallet env var fallback", () => {
   test("wallet route works with env var config", async () => {
     setWalletEnvVars();
     const { token } = await createTestAttendeeWithToken("Alice", "alice@test.com");
-    const response = await awaitTestRequest(`/wallet/${token}`);
+    const response = await awaitTestRequest(`/wallet/${token}.pkpass`);
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/vnd.apple.pkpass");
 


### PR DESCRIPTION
iOS Safari fails to handle .pkpass files served without a Content-Length
header (uses chunked transfer encoding instead) and without a file
extension in the URL. Two fixes:

1. Add explicit Content-Length header so iOS Safari can determine file
   size upfront instead of relying on chunked transfer encoding
2. Add .pkpass extension to wallet URLs (/wallet/TOKEN.pkpass) so iOS
   browsers can use the URL extension as a file type hint for handoff
   to the Wallet app

The route now strips the .pkpass extension before token lookup, and the
ticket template links to the .pkpass-suffixed URL.

https://claude.ai/code/session_01A8giVP4VzAT3SdtBbHwqNF