### PR TITLE
Add biome linter and fixer to precommit pipeline

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,9 @@
     "fmt": "deno fmt src test scripts",
     "typecheck": "deno check src/**/*.ts src/**/*.tsx test/**/*.ts",
     "cpd": "deno run -A npm:jscpd src --config .jscpd.json",
-    "precommit": "deno task typecheck && deno task lint && deno task cpd && deno task build:edge && deno task test:coverage"
+    "biome:fix": "deno run -A npm:@biomejs/biome check --write src test scripts",
+    "biome:check": "deno run -A npm:@biomejs/biome check src test scripts",
+    "precommit": "deno task biome:fix && deno task biome:check && deno task typecheck && deno task lint && deno task cpd && deno task build:edge && deno task test:coverage"
   },
   "imports": {
     "#fp": "./src/fp.ts",


### PR DESCRIPTION
Adds biome:fix and biome:check tasks, and runs them at the start of
the precommit script so auto-fixable issues are resolved before the
remaining checks (typecheck, deno lint, cpd, build, tests) run.

https://claude.ai/code/session_019smcH6snbjYw5LaXHFX8m3