### PR TITLE
Fix 24 low-risk biome lint errors across 4 rules

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -197,7 +197,7 @@ const main = async (): Promise<void> => {
     for (const record of records) {
       const sfMatch = record.match(/SF:(.*)/);
       if (!sfMatch) continue;
-      const file = sfMatch[1].replace(projectRoot + "/", "");
+      const file = sfMatch[1].replace(`${projectRoot}/`, "");
 
       // Skip excluded files
       if (coverageExclusions.some((exclusion) => file.includes(exclusion))) {
@@ -208,8 +208,8 @@ const main = async (): Promise<void> => {
       const lhMatch = record.match(/LH:(\d+)/);
       const lfMatch = record.match(/LF:(\d+)/);
       if (lhMatch && lfMatch) {
-        const hit = parseInt(lhMatch[1]);
-        const found = parseInt(lfMatch[1]);
+        const hit = parseInt(lhMatch[1], 10);
+        const found = parseInt(lfMatch[1], 10);
         if (hit < found) {
           lineFailures.push(`${file}: ${hit}/${found} lines covered`);
         }
@@ -219,8 +219,8 @@ const main = async (): Promise<void> => {
       const brhMatch = record.match(/BRH:(\d+)/);
       const brfMatch = record.match(/BRF:(\d+)/);
       if (brhMatch && brfMatch) {
-        const hit = parseInt(brhMatch[1]);
-        const found = parseInt(brfMatch[1]);
+        const hit = parseInt(brhMatch[1], 10);
+        const found = parseInt(brfMatch[1], 10);
         if (hit < found) {
           branchFailures.push(`${file}: ${hit}/${found} branches covered`);
         }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -126,7 +126,7 @@ const mailgun = (host: string) =>
   provider(
     (config) =>
       `https://${host}/v3/${config.fromAddress.split("@")[1]}/messages`,
-    (apiKey) => ({ Authorization: `Basic ${btoa("api:" + apiKey)}` }),
+    (apiKey) => ({ Authorization: `Basic ${btoa(`api:${apiKey}`)}` }),
     mailgunBody,
   );
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -19,7 +19,7 @@ declare const process: { env: Record<string, string | undefined> } | undefined;
  */
 export function getEnv(key: string): string | undefined {
   // Try process.env first (available in Bunny Edge via node:process)
-  if (typeof process !== "undefined" && process?.env && key in process.env) {
+  if (process?.env && key in process.env) {
     return process.env[key];
   }
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -6,5 +6,5 @@
 export const normalizePhone = (phone: string, prefix: string): string => {
   const digits = phone.replace(/\D/g, "");
   if (!digits) return "";
-  return digits.startsWith("0") ? "+" + prefix + digits.slice(1) : "+" + digits;
+  return digits.startsWith("0") ? `+${prefix}${digits.slice(1)}` : `+${digits}`;
 };

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -116,7 +116,7 @@ const findActiveEvent = async (
   slug: string,
 ): Promise<EventWithCount | Response> => {
   const event = await getEventWithCountBySlug(slug);
-  return event && event.active ? event : apiResponse(EVENT_NOT_FOUND, 404);
+  return event?.active ? event : apiResponse(EVENT_NOT_FOUND, 404);
 };
 
 /** Parse a JSON request body, returning a 400 response on failure */

--- a/test/lib/apple-wallet.test.ts
+++ b/test/lib/apple-wallet.test.ts
@@ -255,7 +255,7 @@ describe("apple-wallet", () => {
       expect(files["icon@2x.png"]).toBeDefined();
       expect(files["icon@3x.png"]).toBeDefined();
       expect(files["manifest.json"]).toBeDefined();
-      expect(files["signature"]).toBeDefined();
+      expect(files.signature).toBeDefined();
 
       // pass.json matches generatePassJson
       const passJson = JSON.parse(

--- a/test/lib/csrf.test.ts
+++ b/test/lib/csrf.test.ts
@@ -67,7 +67,7 @@ describe("verifySignedCsrfToken", () => {
 
   test("rejects a token with tampered HMAC", async () => {
     const token = await signCsrfToken();
-    const tampered = token.slice(0, -4) + "XXXX";
+    const tampered = `${token.slice(0, -4)}XXXX`;
     expect(await verifySignedCsrfToken(tampered)).toBe(false);
   });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -2554,8 +2554,8 @@ describe("db", () => {
       // Single-word columns like "name" should map to themselves
       // This exercises the ?? dbCol fallback since toCamelCase("name") === "name"
       const map = buildInputKeyMap(["name", "max_attendees"]);
-      expect(map["name"]).toBe("name");
-      expect(map["max_attendees"]).toBe("maxAttendees");
+      expect(map.name).toBe("name");
+      expect(map.max_attendees).toBe("maxAttendees");
     });
 
     test("getProvidedColumns uses inputKeyMap fallback for single-word keys", async () => {

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -116,7 +116,7 @@ describe("email", () => {
       expect(fetchStub.calls.length).toBe(1);
       const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
       expect(url).toBe("https://api.resend.com/emails");
-      expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
+      expect((opts.headers as Record<string, string>).Authorization).toBe(
         "Bearer re_test_key",
       );
       const body = JSON.parse(opts.body as string);
@@ -166,7 +166,7 @@ describe("email", () => {
 
       const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
       expect(url).toBe("https://api.sendgrid.com/v3/mail/send");
-      expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
+      expect((opts.headers as Record<string, string>).Authorization).toBe(
         "Bearer re_test_key",
       );
       const body = JSON.parse(opts.body as string);
@@ -214,7 +214,7 @@ describe("email", () => {
       expect(fetchStub.calls.length).toBe(1);
       const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
       expect(url).toBe("https://api.mailgun.net/v3/example.com/messages");
-      expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
+      expect((opts.headers as Record<string, string>).Authorization).toBe(
         `Basic ${btoa("api:re_test_key")}`,
       );
       expect(opts.headers as Record<string, string>).not.toHaveProperty(
@@ -243,7 +243,7 @@ describe("email", () => {
       expect(fetchStub.calls.length).toBe(1);
       const [url, opts] = fetchStub.calls[0].args as [string, RequestInit];
       expect(url).toBe("https://api.eu.mailgun.net/v3/example.com/messages");
-      expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
+      expect((opts.headers as Record<string, string>).Authorization).toBe(
         `Basic ${btoa("api:re_test_key")}`,
       );
       const body = opts.body as FormData;

--- a/test/lib/ntfy.test.ts
+++ b/test/lib/ntfy.test.ts
@@ -44,7 +44,7 @@ describe("ntfy", () => {
 
       const [, options] = fetchStub.calls[0]!.args as [string, RequestInit];
       const headers = options.headers as Record<string, string>;
-      expect(headers["Title"]).toBe("localhost error");
+      expect(headers.Title).toBe("localhost error");
     });
 
     test("includes warning tag in headers", () => {
@@ -54,7 +54,7 @@ describe("ntfy", () => {
 
       const [, options] = fetchStub.calls[0]!.args as [string, RequestInit];
       const headers = options.headers as Record<string, string>;
-      expect(headers["Tags"]).toBe("warning");
+      expect(headers.Tags).toBe("warning");
     });
 
     test("logs error when fetch fails", async () => {

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -153,7 +153,7 @@ describe("wallet route (/wallet/:token)", () => {
 
     expect(files["pass.json"]).toBeDefined();
     expect(files["manifest.json"]).toBeDefined();
-    expect(files["signature"]).toBeDefined();
+    expect(files.signature).toBeDefined();
   });
 
   test("pass.json contains correct event data", async () => {

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -151,7 +151,7 @@ describe("square", () => {
     });
 
     test("returns null when non-truncatable value exceeds limit", () => {
-      const longItems = "[" + "{e:1,q:1},".repeat(50) + "]";
+      const longItems = `[${"{e:1,q:1},".repeat(50)}]`;
       const metadata = {
         multi: "1",
         name: "John",
@@ -162,7 +162,7 @@ describe("square", () => {
     });
 
     test("returns null when email exceeds limit", () => {
-      const longEmail = "a".repeat(300) + "@example.com";
+      const longEmail = `${"a".repeat(300)}@example.com`;
       const metadata = {
         event_id: "1",
         name: "John",
@@ -636,7 +636,7 @@ describe("square", () => {
           const intent = {
             eventId: 1,
             name: "John",
-            email: "a".repeat(300) + "@example.com",
+            email: `${"a".repeat(300)}@example.com`,
             phone: "",
             address: "",
             special_instructions: "",


### PR DESCRIPTION
- useTemplate: string concatenation → template literals
- useParseIntRadix: add explicit radix 10 to parseInt calls
- useLiteralKeys: bracket notation → dot notation for literal keys
- useOptionalChain: simplify to optional chaining

https://claude.ai/code/session_018SDB5WMAtn5QpEsAmMec7b