### PR TITLE
Fix noExcessiveCognitiveComplexity violations in build scripts

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -175,16 +175,57 @@ const exists = (path: string): boolean => {
 const resolveFile = (path: string): string =>
   [path, `${path}.js`, `${path}.json`, `${path}/index.js`].find(exists) ?? path;
 
-/** Resolve a bare npm specifier (e.g. "@libsql/client" or "@libsql/core/api") */
-const resolveNpmSpecifier = (specifier: string): string | null => {
-  // Split into package name and subpath (scoped packages have 2 segments)
+/** Split a bare specifier into package name and subpath */
+const parseSpecifier = (
+  specifier: string,
+): { pkgName: string; subpath: string } => {
   const nameSegments = specifier.startsWith("@") ? 2 : 1;
   const idx = specifier.split("/", nameSegments).join("/").length;
-  const pkgName = specifier.slice(
-    0,
-    idx === specifier.length ? undefined : idx,
-  );
-  const subpath = idx < specifier.length ? specifier.slice(idx + 1) : "";
+  return {
+    pkgName: specifier.slice(0, idx === specifier.length ? undefined : idx),
+    subpath: idx < specifier.length ? specifier.slice(idx + 1) : "",
+  };
+};
+
+/** Try to resolve via the package.json exports map */
+const resolveViaExports = (
+  pkgDir: string,
+  pkgJson: Record<string, unknown>,
+  subpath: string,
+): string | null => {
+  if (!pkgJson.exports) return null;
+  const key = subpath ? `./${subpath}` : ".";
+  // Handle both subpath exports ({ ".": { ... } }) and top-level condition
+  // exports ({ "browser": { ... }, "default": { ... } }) used by packages like stripe
+  const exportEntry =
+    pkgJson.exports[key] ??
+    (!subpath && !("." in pkgJson.exports) ? pkgJson.exports : undefined);
+  if (!exportEntry) return null;
+  const resolved = resolveExport(exportEntry);
+  return resolved ? resolveFile(`${pkgDir}/${resolved}`) : null;
+};
+
+/** Fallback resolution: browser → module → main → index.js */
+const resolveViaFallback = (
+  pkgDir: string,
+  pkgJson: Record<string, unknown>,
+): string => {
+  if (typeof pkgJson.browser === "string") {
+    return resolveFile(`${pkgDir}/${pkgJson.browser}`);
+  }
+  const entry = pkgJson.module ?? pkgJson.main;
+  if (!entry) return resolveFile(`${pkgDir}/index`);
+  // When browser is an object it's a module replacement map
+  if (typeof pkgJson.browser === "object" && pkgJson.browser !== null) {
+    const mapped = pkgJson.browser[entry];
+    if (typeof mapped === "string") return resolveFile(`${pkgDir}/${mapped}`);
+  }
+  return resolveFile(`${pkgDir}/${entry}`);
+};
+
+/** Resolve a bare npm specifier (e.g. "@libsql/client" or "@libsql/core/api") */
+const resolveNpmSpecifier = (specifier: string): string | null => {
+  const { pkgName, subpath } = parseSpecifier(specifier);
 
   let pkgDir: string;
   try {
@@ -195,40 +236,10 @@ const resolveNpmSpecifier = (specifier: string): string | null => {
 
   const pkgJson = JSON.parse(Deno.readTextFileSync(`${pkgDir}/package.json`));
 
-  // Try exports map first
-  if (pkgJson.exports) {
-    const key = subpath ? `./${subpath}` : ".";
-    // Handle both subpath exports ({ ".": { ... } }) and top-level condition
-    // exports ({ "browser": { ... }, "default": { ... } }) used by packages like stripe
-    const exportEntry =
-      pkgJson.exports[key] ??
-      (!subpath && !("." in pkgJson.exports) ? pkgJson.exports : undefined);
-    if (exportEntry) {
-      const resolved = resolveExport(exportEntry);
-      if (resolved) return resolveFile(`${pkgDir}/${resolved}`);
-    }
-  }
+  const fromExports = resolveViaExports(pkgDir, pkgJson, subpath);
+  if (fromExports) return fromExports;
 
-  // Fallback: browser → module → main → index.js
-  if (!subpath) {
-    if (typeof pkgJson.browser === "string") {
-      return resolveFile(`${pkgDir}/${pkgJson.browser}`);
-    }
-    const entry = pkgJson.module ?? pkgJson.main;
-    if (entry) {
-      // When browser is an object it's a module replacement map
-      // e.g. { "./lib/index.js": "./lib/browser.js", "fs": false }
-      if (typeof pkgJson.browser === "object" && pkgJson.browser !== null) {
-        const mapped = pkgJson.browser[entry];
-        if (typeof mapped === "string")
-          return resolveFile(`${pkgDir}/${mapped}`);
-      }
-      return resolveFile(`${pkgDir}/${entry}`);
-    }
-    return resolveFile(`${pkgDir}/index`);
-  }
-
-  return null;
+  return subpath ? null : resolveViaFallback(pkgDir, pkgJson);
 };
 
 /** Plugin to resolve npm packages from Deno's npm cache */

--- a/scripts/build-static-assets.ts
+++ b/scripts/build-static-assets.ts
@@ -40,23 +40,36 @@ const denoNpmResolvePlugin: Plugin = {
   },
 };
 
+/** Match a single import map entry against a specifier */
+const matchImportEntry = (
+  specifier: string,
+  key: string,
+  value: unknown,
+): string | undefined => {
+  if (typeof value !== "string" || !value.startsWith("./")) return undefined;
+  if (key.endsWith("/") && specifier.startsWith(key)) {
+    return projectRoot + value.slice(2) + specifier.slice(key.length);
+  }
+  if (specifier === key) return projectRoot + value.slice(2);
+  return undefined;
+};
+
+/** Resolve a #-prefixed specifier using the deno.json import map */
+const resolveImportMap = (specifier: string): string | undefined => {
+  for (const [key, value] of Object.entries(denoImports)) {
+    const resolved = matchImportEntry(specifier, key, value);
+    if (resolved) return resolved;
+  }
+  return undefined;
+};
+
 /** Resolve #-prefixed imports using the deno.json import map */
 const denoImportMapPlugin: Plugin = {
   name: "deno-import-map",
   setup(build) {
     build.onResolve({ filter: /^#/ }, (args) => {
-      for (const [key, value] of Object.entries(denoImports)) {
-        if (typeof value !== "string" || !value.startsWith("./")) continue;
-        if (key.endsWith("/") && args.path.startsWith(key)) {
-          return {
-            path: projectRoot + value.slice(2) + args.path.slice(key.length),
-          };
-        }
-        if (args.path === key) {
-          return { path: projectRoot + value.slice(2) };
-        }
-      }
-      return undefined;
+      const resolved = resolveImportMap(args.path);
+      return resolved ? { path: resolved } : undefined;
     });
   },
 };

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -93,21 +93,9 @@ const startStripeMock = async (): Promise<Deno.ChildProcess | null> => {
   throw new Error("stripe-mock failed to start");
 };
 
-/** Main: start stripe-mock, run tests, cleanup */
-const main = async (): Promise<void> => {
-  await buildStaticAssets({ stop: true });
-  const stripeMockProcess = await startStripeMock();
-
-  // Set environment for tests
-  Deno.env.set("STRIPE_MOCK_HOST", "localhost");
-  Deno.env.set("STRIPE_MOCK_PORT", String(STRIPE_MOCK_PORT));
-  Deno.env.set("ALLOWED_DOMAIN", "localhost");
-
-  // Get test args (pass through any CLI args after --)
-  const testArgs = Deno.args;
-  const useCoverage = testArgs.includes("--coverage");
-
-  const denoTestArgs = [
+/** Build the deno test CLI args */
+const buildDenoTestArgs = (useCoverage: boolean): string[] => {
+  const args = [
     "test",
     "--no-check",
     "--allow-net",
@@ -119,16 +107,16 @@ const main = async (): Promise<void> => {
     "--allow-ffi",
     "--parallel",
   ];
+  if (useCoverage) args.push("--coverage=coverage");
+  args.push("test/");
+  return args;
+};
 
-  if (useCoverage) {
-    denoTestArgs.push("--coverage=coverage");
-  }
-
-  denoTestArgs.push("test/");
-
+/** Run deno test and return the exit code */
+const runTests = async (useCoverage: boolean): Promise<number> => {
   console.log("Running tests...");
   const testCmd = new Deno.Command(Deno.execPath(), {
-    args: denoTestArgs,
+    args: buildDenoTestArgs(useCoverage),
     cwd: projectRoot,
     stdin: "inherit",
     stdout: "inherit",
@@ -138,118 +126,143 @@ const main = async (): Promise<void> => {
       STRIPE_MOCK_HOST: "localhost",
       STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
       ALLOWED_DOMAIN: "localhost",
-      // Limit parallel workers to avoid env var races between test files
       DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "3",
     },
   });
-
   const result = await testCmd.output();
+  return result.code;
+};
 
-  // Cleanup
+/** Check a coverage metric (lines or branches) in an lcov record */
+const checkMetric = (
+  record: string,
+  hitKey: string,
+  foundKey: string,
+  file: string,
+  label: string,
+): string | undefined => {
+  const hitMatch = record.match(new RegExp(`${hitKey}:(\\d+)`));
+  const foundMatch = record.match(new RegExp(`${foundKey}:(\\d+)`));
+  if (!hitMatch || !foundMatch) return undefined;
+  const hit = parseInt(hitMatch[1], 10);
+  const found = parseInt(foundMatch[1], 10);
+  return hit < found ? `${file}: ${hit}/${found} ${label} covered` : undefined;
+};
+
+// Files excluded from coverage enforcement
+const COVERAGE_EXCLUSIONS = ["src/lib/db/migrations.ts"];
+
+/** Extract the relative file path from an lcov record, or null if excluded */
+const extractRecordFile = (record: string): string | null => {
+  const sfMatch = record.match(/SF:(.*)/);
+  if (!sfMatch) return null;
+  const file = sfMatch[1].replace(`${projectRoot}/`, "");
+  if (COVERAGE_EXCLUSIONS.some((exclusion) => file.includes(exclusion))) return null;
+  return file;
+};
+
+/** Check both line and branch coverage for a single lcov record */
+const checkRecord = (
+  record: string,
+  file: string,
+  lineFailures: string[],
+  branchFailures: string[],
+): void => {
+  const lineFail = checkMetric(record, "LH", "LF", file, "lines");
+  if (lineFail) lineFailures.push(lineFail);
+  const branchFail = checkMetric(record, "BRH", "BRF", file, "branches");
+  if (branchFail) branchFailures.push(branchFail);
+};
+
+/** Parse lcov records and return coverage failures */
+const findCoverageFailures = (
+  lcov: string,
+): { lineFailures: string[]; branchFailures: string[] } => {
+  const records = lcov.split("end_of_record").filter((r) => r.includes("SF:"));
+  if (records.length === 0) return { lineFailures: ["No coverage data found"], branchFailures: [] };
+
+  const lineFailures: string[] = [];
+  const branchFailures: string[] = [];
+  for (const record of records) {
+    const file = extractRecordFile(record);
+    if (file) checkRecord(record, file, lineFailures, branchFailures);
+  }
+  return { lineFailures, branchFailures };
+};
+
+/** Print a labeled list of failures */
+const printFailureCategory = (label: string, failures: string[]): void => {
+  if (failures.length === 0) return;
+  console.error(`\n${label}:`);
+  for (const f of failures) console.error(`  ${f}`);
+};
+
+/** Report coverage failures and exit if any */
+const reportCoverageFailures = (
+  lineFailures: string[],
+  branchFailures: string[],
+): void => {
+  if (lineFailures.length === 0 && branchFailures.length === 0) {
+    console.log("\nAll files have 100% line and branch coverage");
+    return;
+  }
+  printFailureCategory("Line coverage is not 100%", lineFailures);
+  printFailureCategory("Branch coverage is not 100%", branchFailures);
+  console.error("\nTest quality rules:");
+  console.error("  - 100% line coverage is required");
+  console.error("  - 100% branch coverage is required");
+  console.error("  - Test outcomes not implementations");
+  console.error("  - Test-only exports are forbidden");
+  console.error("  - Tautological tests are forbidden");
+  Deno.exit(1);
+};
+
+/** Run coverage check: print table, parse lcov, enforce 100% */
+const checkCoverage = async (): Promise<void> => {
+  console.log("\nChecking coverage...");
+  const coverageDir = join(projectRoot, "coverage");
+
+  const tableCmd = new Deno.Command(Deno.execPath(), {
+    args: ["coverage", coverageDir],
+    cwd: projectRoot,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  await tableCmd.output();
+
+  const lcovCmd = new Deno.Command(Deno.execPath(), {
+    args: ["coverage", coverageDir, "--lcov"],
+    cwd: projectRoot,
+    stdout: "piped",
+    stderr: "inherit",
+  });
+  const lcovResult = await lcovCmd.output();
+  const lcov = new TextDecoder().decode(lcovResult.stdout);
+
+  const { lineFailures, branchFailures } = findCoverageFailures(lcov);
+  reportCoverageFailures(lineFailures, branchFailures);
+};
+
+/** Main: start stripe-mock, run tests, cleanup */
+const main = async (): Promise<void> => {
+  await buildStaticAssets({ stop: true });
+  const stripeMockProcess = await startStripeMock();
+
+  Deno.env.set("STRIPE_MOCK_HOST", "localhost");
+  Deno.env.set("STRIPE_MOCK_PORT", String(STRIPE_MOCK_PORT));
+  Deno.env.set("ALLOWED_DOMAIN", "localhost");
+
+  const useCoverage = Deno.args.includes("--coverage");
+  const exitCode = await runTests(useCoverage);
+
   if (stripeMockProcess) {
     console.log("Stopping stripe-mock...");
     stripeMockProcess.kill();
   }
 
-  if (result.code !== 0) {
-    Deno.exit(result.code);
-  }
-
-  if (useCoverage) {
-    console.log("\nChecking coverage...");
-    const coverageDir = join(projectRoot, "coverage");
-
-    // Print human-readable table
-    const tableCmd = new Deno.Command(Deno.execPath(), {
-      args: ["coverage", coverageDir],
-      cwd: projectRoot,
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    await tableCmd.output();
-
-    // Parse stable lcov format for enforcement
-    const lcovCmd = new Deno.Command(Deno.execPath(), {
-      args: ["coverage", coverageDir, "--lcov"],
-      cwd: projectRoot,
-      stdout: "piped",
-      stderr: "inherit",
-    });
-    const lcovResult = await lcovCmd.output();
-    const lcov = new TextDecoder().decode(lcovResult.stdout);
-
-    // Parse lcov records: enforce 100% line coverage, report branch coverage
-    const records = lcov
-      .split("end_of_record")
-      .filter((r) => r.includes("SF:"));
-    if (records.length === 0) {
-      console.error("No coverage data found");
-      Deno.exit(1);
-    }
-
-    const lineFailures: string[] = [];
-    const branchFailures: string[] = [];
-
-    // Files excluded from coverage enforcement
-    const coverageExclusions = ["src/lib/db/migrations.ts"];
-
-    for (const record of records) {
-      const sfMatch = record.match(/SF:(.*)/);
-      if (!sfMatch) continue;
-      const file = sfMatch[1].replace(`${projectRoot}/`, "");
-
-      // Skip excluded files
-      if (coverageExclusions.some((exclusion) => file.includes(exclusion))) {
-        continue;
-      }
-
-      // Line coverage: LH (lines hit) / LF (lines found)
-      const lhMatch = record.match(/LH:(\d+)/);
-      const lfMatch = record.match(/LF:(\d+)/);
-      if (lhMatch && lfMatch) {
-        const hit = parseInt(lhMatch[1], 10);
-        const found = parseInt(lfMatch[1], 10);
-        if (hit < found) {
-          lineFailures.push(`${file}: ${hit}/${found} lines covered`);
-        }
-      }
-
-      // Branch coverage: BRH (branches hit) / BRF (branches found)
-      const brhMatch = record.match(/BRH:(\d+)/);
-      const brfMatch = record.match(/BRF:(\d+)/);
-      if (brhMatch && brfMatch) {
-        const hit = parseInt(brhMatch[1], 10);
-        const found = parseInt(brfMatch[1], 10);
-        if (hit < found) {
-          branchFailures.push(`${file}: ${hit}/${found} branches covered`);
-        }
-      }
-    }
-
-    const failures = [...lineFailures, ...branchFailures];
-
-    if (failures.length > 0) {
-      if (lineFailures.length > 0) {
-        console.error("\nLine coverage is not 100%:");
-        for (const f of lineFailures) console.error(`  ${f}`);
-      }
-      if (branchFailures.length > 0) {
-        console.error("\nBranch coverage is not 100%:");
-        for (const f of branchFailures) console.error(`  ${f}`);
-      }
-      console.error("\nTest quality rules:");
-      console.error("  - 100% line coverage is required");
-      console.error("  - 100% branch coverage is required");
-      console.error("  - Test outcomes not implementations");
-      console.error("  - Test-only exports are forbidden");
-      console.error("  - Tautological tests are forbidden");
-      Deno.exit(1);
-    }
-
-    console.log("\nAll files have 100% line and branch coverage");
-  }
-
+  if (exitCode !== 0) Deno.exit(exitCode);
+  if (useCoverage) await checkCoverage();
   Deno.exit(0);
 };
 


### PR DESCRIPTION
Extract helper functions to reduce cognitive complexity below the max
of 7 in three files:
- build-edge.ts: split resolveNpmSpecifier (30→small helpers) into
  parseSpecifier, resolveViaExports, resolveViaFallback
- build-static-assets.ts: extract matchImportEntry and resolveImportMap
  from the onResolve callback (13→trivial)
- run-tests.ts: decompose main (47→small helpers) into buildDenoTestArgs,
  runTests, checkMetric, extractRecordFile, checkRecord,
  findCoverageFailures, printFailureCategory, reportCoverageFailures,
  checkCoverage

https://claude.ai/code/session_016qxLxdT7UaPTU8EN7HxkC5