### PR TITLE
Fix docs 404 errors by disabling Jekyll processing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,9 @@ jobs:
           src/docs/webhooks.ts
           src/docs/demo.ts
 
+      - name: Disable Jekyll processing
+        run: touch docs-output/.nojekyll
+
       - name: Add root redirect to overview page
         run: |
           cat > docs-output/index.html << 'HTMLEOF'


### PR DESCRIPTION
GitHub Pages uses Jekyll by default, which ignores files/directories
with dots in their names. Since deno doc generates directories like
utilities.ts/ and database.ts/, Jekyll was skipping them. Adding
.nojekyll to the output disables Jekyll and serves files as-is.

https://claude.ai/code/session_01HzmPx41WHaJBqbMZ7pcokf