### PR TITLE
Add admin debug page for configuration status overview

### DIFF
--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -44,28 +44,28 @@ type CertValidation = {
   wwdrCert: string;
 };
 
-/** Validate Apple Wallet PEM certs/key, returning "Valid", "Invalid", or "Not set" for each */
+/** Validate Apple Wallet PEM certs/key, returning "Valid", "Invalid PEM", or "Not set" for each */
 const validateAppleWalletCerts = (
   config: Awaited<ReturnType<typeof getAppleWalletConfig>>,
 ): CertValidation => {
-  if (!config) return { signingCert: "Not set", signingKey: "Not set", wwdrCert: "Not set" };
-
-  const check = (
-    value: string | undefined,
-    validator: (pem: string) => boolean,
-  ): string => {
-    if (!value) return "Not set";
-    try {
-      return validator(value) ? "Valid" : "Invalid PEM";
-    } catch {
-      return "Invalid PEM";
-    }
-  };
+  if (!config) {
+    return {
+      signingCert: "Not set",
+      signingKey: "Not set",
+      wwdrCert: "Not set",
+    };
+  }
 
   return {
-    signingCert: check(config.signingCert, isValidPemCertificate),
-    signingKey: check(config.signingKey, isValidPemPrivateKey),
-    wwdrCert: check(config.wwdrCert, isValidPemCertificate),
+    signingCert: isValidPemCertificate(config.signingCert)
+      ? "Valid"
+      : "Invalid PEM",
+    signingKey: isValidPemPrivateKey(config.signingKey)
+      ? "Valid"
+      : "Invalid PEM",
+    wwdrCert: isValidPemCertificate(config.wwdrCert)
+      ? "Valid"
+      : "Invalid PEM",
   };
 };
 
@@ -120,17 +120,18 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
         ? squareWebhookKey !== null
         : false;
 
-  const appleWalletSource = appleWalletDbConfigured
-    ? "Database"
-    : appleWalletEnvConfigured
-      ? "Environment variables"
-      : "";
-
-  const appleWalletPassTypeIdDisplay = appleWalletDbConfigured
-    ? (appleWalletPassTypeId ?? "")
-    : appleWalletEnvConfigured
-      ? (getHostAppleWalletConfig()?.passTypeId ?? "")
-      : "";
+  const resolveWalletPassTypeId = (): string => {
+    if (appleWalletDbConfigured) return appleWalletPassTypeId as string;
+    if (appleWalletEnvConfigured) return getHostAppleWalletConfig()!.passTypeId;
+    return "";
+  };
+  const resolveWalletSource = (): string => {
+    if (appleWalletDbConfigured) return "Database";
+    if (appleWalletEnvConfigured) return "Environment variables";
+    return "";
+  };
+  const walletPassTypeId = resolveWalletPassTypeId();
+  const walletSource = resolveWalletSource();
 
   const certValidation = validateAppleWalletCerts(appleWalletConfig);
 
@@ -138,8 +139,8 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     appleWallet: {
       dbConfigured: appleWalletDbConfigured,
       envConfigured: appleWalletEnvConfigured,
-      passTypeId: appleWalletPassTypeIdDisplay,
-      source: appleWalletSource,
+      passTypeId: walletPassTypeId,
+      source: walletSource,
       certValidation,
     },
     payment: {

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -4,11 +4,16 @@
  */
 
 import {
+  isValidPemCertificate,
+  isValidPemPrivateKey,
+} from "#lib/apple-wallet.ts";
+import {
   getAllowedDomain,
   getCdnHostname,
   isBunnyCdnEnabled,
 } from "#lib/config.ts";
 import {
+  getAppleWalletConfig,
   getAppleWalletPassTypeIdFromDb,
   getCustomDomainFromDb,
   getEmailFromAddressFromDb,
@@ -33,6 +38,37 @@ import {
   type DebugPageState,
 } from "#templates/admin/debug.tsx";
 
+type CertValidation = {
+  signingCert: string;
+  signingKey: string;
+  wwdrCert: string;
+};
+
+/** Validate Apple Wallet PEM certs/key, returning "Valid", "Invalid", or "Not set" for each */
+const validateAppleWalletCerts = (
+  config: Awaited<ReturnType<typeof getAppleWalletConfig>>,
+): CertValidation => {
+  if (!config) return { signingCert: "Not set", signingKey: "Not set", wwdrCert: "Not set" };
+
+  const check = (
+    value: string | undefined,
+    validator: (pem: string) => boolean,
+  ): string => {
+    if (!value) return "Not set";
+    try {
+      return validator(value) ? "Valid" : "Invalid PEM";
+    } catch {
+      return "Invalid PEM";
+    }
+  };
+
+  return {
+    signingCert: check(config.signingCert, isValidPemCertificate),
+    signingKey: check(config.signingKey, isValidPemPrivateKey),
+    wwdrCert: check(config.wwdrCert, isValidPemCertificate),
+  };
+};
+
 /** Gather debug state concurrently */
 const getDebugPageState = async (): Promise<DebugPageState> => {
   const bunnyCdnEnabled = isBunnyCdnEnabled();
@@ -40,6 +76,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
   const [
     appleWalletDbConfigured,
     appleWalletPassTypeId,
+    appleWalletConfig,
     paymentProvider,
     stripeKeyConfigured,
     squareTokenConfigured,
@@ -53,6 +90,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
   ] = await Promise.all([
     hasAppleWalletDbConfig(),
     getAppleWalletPassTypeIdFromDb(),
+    getAppleWalletConfig(),
     getPaymentProviderFromDb(),
     hasStripeKey(),
     hasSquareToken(),
@@ -94,12 +132,15 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
       ? (getHostAppleWalletConfig()?.passTypeId ?? "")
       : "";
 
+  const certValidation = validateAppleWalletCerts(appleWalletConfig);
+
   return {
     appleWallet: {
       dbConfigured: appleWalletDbConfigured,
       envConfigured: appleWalletEnvConfigured,
       passTypeId: appleWalletPassTypeIdDisplay,
       source: appleWalletSource,
+      certValidation,
     },
     payment: {
       provider: paymentProvider ?? "",

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -1,0 +1,146 @@
+/**
+ * Admin debug route - shows configuration status for troubleshooting
+ * Owner-only access enforced via requireOwnerOr
+ */
+
+import {
+  getAllowedDomain,
+  getCdnHostname,
+  isBunnyCdnEnabled,
+} from "#lib/config.ts";
+import {
+  getAppleWalletPassTypeIdFromDb,
+  getCustomDomainFromDb,
+  getEmailFromAddressFromDb,
+  getEmailProviderFromDb,
+  getHostAppleWalletConfig,
+  getPaymentProviderFromDb,
+  getSquareWebhookSignatureKeyFromDb,
+  getStripeWebhookEndpointId,
+  getThemeFromDb,
+  hasAppleWalletDbConfig,
+  hasEmailApiKey,
+  hasSquareToken,
+  hasStripeKey,
+} from "#lib/db/settings.ts";
+import { getHostEmailConfig } from "#lib/email.ts";
+import { getEnv } from "#lib/env.ts";
+import { isStorageEnabled } from "#lib/storage.ts";
+import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
+import { htmlResponse, requireOwnerOr } from "#routes/utils.ts";
+import {
+  adminDebugPage,
+  type DebugPageState,
+} from "#templates/admin/debug.tsx";
+
+/** Gather debug state concurrently */
+const getDebugPageState = async (): Promise<DebugPageState> => {
+  const bunnyCdnEnabled = isBunnyCdnEnabled();
+
+  const [
+    appleWalletDbConfigured,
+    appleWalletPassTypeId,
+    paymentProvider,
+    stripeKeyConfigured,
+    squareTokenConfigured,
+    stripeWebhookEndpointId,
+    squareWebhookKey,
+    emailProvider,
+    emailApiKeyConfigured,
+    emailFromAddress,
+    customDomain,
+    theme,
+  ] = await Promise.all([
+    hasAppleWalletDbConfig(),
+    getAppleWalletPassTypeIdFromDb(),
+    getPaymentProviderFromDb(),
+    hasStripeKey(),
+    hasSquareToken(),
+    getStripeWebhookEndpointId(),
+    getSquareWebhookSignatureKeyFromDb(),
+    getEmailProviderFromDb(),
+    hasEmailApiKey(),
+    getEmailFromAddressFromDb(),
+    bunnyCdnEnabled ? getCustomDomainFromDb() : Promise.resolve(null),
+    getThemeFromDb(),
+  ]);
+
+  const appleWalletEnvConfigured = getHostAppleWalletConfig() !== null;
+  const hostEmailConfig = getHostEmailConfig();
+
+  const keyConfigured =
+    paymentProvider === "stripe"
+      ? stripeKeyConfigured
+      : paymentProvider === "square"
+        ? squareTokenConfigured
+        : false;
+
+  const webhookConfigured =
+    paymentProvider === "stripe"
+      ? stripeWebhookEndpointId !== null
+      : paymentProvider === "square"
+        ? squareWebhookKey !== null
+        : false;
+
+  const appleWalletSource = appleWalletDbConfigured
+    ? "Database"
+    : appleWalletEnvConfigured
+      ? "Environment variables"
+      : "";
+
+  const appleWalletPassTypeIdDisplay = appleWalletDbConfigured
+    ? (appleWalletPassTypeId ?? "")
+    : appleWalletEnvConfigured
+      ? (getHostAppleWalletConfig()?.passTypeId ?? "")
+      : "";
+
+  return {
+    appleWallet: {
+      dbConfigured: appleWalletDbConfigured,
+      envConfigured: appleWalletEnvConfigured,
+      passTypeId: appleWalletPassTypeIdDisplay,
+      source: appleWalletSource,
+    },
+    payment: {
+      provider: paymentProvider ?? "",
+      keyConfigured,
+      webhookConfigured,
+    },
+    email: {
+      provider: emailProvider ?? "",
+      apiKeyConfigured: emailApiKeyConfigured,
+      fromAddress: emailFromAddress ?? "",
+      hostProvider: hostEmailConfig?.provider ?? "",
+    },
+    ntfy: {
+      configured: !!getEnv("NTFY_URL"),
+    },
+    storage: {
+      enabled: isStorageEnabled(),
+    },
+    bunnyCdn: {
+      enabled: bunnyCdnEnabled,
+      cdnHostname: bunnyCdnEnabled ? getCdnHostname() : "",
+      customDomain: customDomain ?? "",
+    },
+    database: {
+      hostConfigured: !!getEnv("DB_URL"),
+    },
+    domain: getAllowedDomain(),
+    theme,
+  };
+};
+
+/**
+ * Handle GET /admin/debug - owner only
+ */
+const handleAdminDebugGet: TypedRouteHandler<"GET /admin/debug"> = (request) =>
+  requireOwnerOr(request, async (session) => {
+    const state = await getDebugPageState();
+    return htmlResponse(adminDebugPage(session, state));
+  });
+
+/** Debug routes */
+export const debugRoutes = defineRoutes({
+  "GET /admin/debug": handleAdminDebugGet,
+});

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -13,6 +13,7 @@ import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
 import { dashboardRoutes } from "#routes/admin/dashboard.ts";
+import { debugRoutes } from "#routes/admin/debug.ts";
 import { eventsRoutes } from "#routes/admin/events.ts";
 import { groupsRoutes } from "#routes/admin/groups.ts";
 import { guideRoutes } from "#routes/admin/guide.ts";
@@ -31,6 +32,7 @@ const adminRoutes = {
   ...dashboardRoutes,
   ...authRoutes,
   ...settingsRoutes,
+  ...debugRoutes,
   ...siteRoutes,
   ...sessionsRoutes,
   ...calendarRoutes,

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -1,0 +1,224 @@
+/**
+ * Admin debug page template - shows configuration status for troubleshooting
+ */
+
+import type { AdminSession } from "#lib/types.ts";
+import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
+import { Layout } from "#templates/layout.tsx";
+
+export type DebugPageState = {
+  appleWallet: {
+    dbConfigured: boolean;
+    envConfigured: boolean;
+    passTypeId: string;
+    source: string;
+  };
+  payment: {
+    provider: string;
+    keyConfigured: boolean;
+    webhookConfigured: boolean;
+  };
+  email: {
+    provider: string;
+    apiKeyConfigured: boolean;
+    fromAddress: string;
+    hostProvider: string;
+  };
+  ntfy: {
+    configured: boolean;
+  };
+  storage: {
+    enabled: boolean;
+  };
+  bunnyCdn: {
+    enabled: boolean;
+    cdnHostname: string;
+    customDomain: string;
+  };
+  database: {
+    hostConfigured: boolean;
+  };
+  domain: string;
+  theme: string;
+};
+
+const StatusBadge = ({ ok }: { ok: boolean }): JSX.Element =>
+  ok ? (
+    <span class="badge-ok">Configured</span>
+  ) : (
+    <span class="badge-missing">Not configured</span>
+  );
+
+/**
+ * Admin debug page
+ */
+export const adminDebugPage = (
+  session: AdminSession,
+  s: DebugPageState,
+): string =>
+  String(
+    <Layout title="Debug Info" theme={s.theme}>
+      <AdminNav session={session} active="/admin/settings" />
+      <Breadcrumb href="/admin/settings" label="Settings" />
+
+      <h1>Debug Info</h1>
+      <p>
+        Configuration status overview for troubleshooting. No secrets or keys
+        are shown.
+      </p>
+
+      <article>
+        <h2>Apple Wallet</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>DB config</td>
+              <td>
+                <StatusBadge ok={s.appleWallet.dbConfigured} />
+              </td>
+            </tr>
+            <tr>
+              <td>Env var config</td>
+              <td>
+                <StatusBadge ok={s.appleWallet.envConfigured} />
+              </td>
+            </tr>
+            <tr>
+              <td>Active source</td>
+              <td>{s.appleWallet.source || "None"}</td>
+            </tr>
+            <tr>
+              <td>Pass Type ID</td>
+              <td>{s.appleWallet.passTypeId || "—"}</td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Payments</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>Provider</td>
+              <td>{s.payment.provider || "None"}</td>
+            </tr>
+            <tr>
+              <td>API key</td>
+              <td>
+                <StatusBadge ok={s.payment.keyConfigured} />
+              </td>
+            </tr>
+            <tr>
+              <td>Webhook</td>
+              <td>
+                <StatusBadge ok={s.payment.webhookConfigured} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Email</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>Provider (DB)</td>
+              <td>{s.email.provider || "None"}</td>
+            </tr>
+            <tr>
+              <td>API key</td>
+              <td>
+                <StatusBadge ok={s.email.apiKeyConfigured} />
+              </td>
+            </tr>
+            <tr>
+              <td>From address</td>
+              <td>{s.email.fromAddress || "—"}</td>
+            </tr>
+            <tr>
+              <td>Host provider (env)</td>
+              <td>{s.email.hostProvider || "None"}</td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Notifications (ntfy)</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>NTFY URL</td>
+              <td>
+                <StatusBadge ok={s.ntfy.configured} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Bunny Storage (images)</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>Storage zone</td>
+              <td>
+                <StatusBadge ok={s.storage.enabled} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Bunny CDN</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>CDN management</td>
+              <td>
+                <StatusBadge ok={s.bunnyCdn.enabled} />
+              </td>
+            </tr>
+            <tr>
+              <td>CDN hostname</td>
+              <td>{s.bunnyCdn.cdnHostname || "—"}</td>
+            </tr>
+            <tr>
+              <td>Custom domain</td>
+              <td>{s.bunnyCdn.customDomain || "—"}</td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Database</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>DB_URL</td>
+              <td>
+                <StatusBadge ok={s.database.hostConfigured} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article>
+        <h2>Domain</h2>
+        <table>
+          <tbody>
+            <tr>
+              <td>ALLOWED_DOMAIN</td>
+              <td>{s.domain}</td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+    </Layout>,
+  );

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -12,6 +12,11 @@ export type DebugPageState = {
     envConfigured: boolean;
     passTypeId: string;
     source: string;
+    certValidation: {
+      signingCert: string;
+      signingKey: string;
+      wwdrCert: string;
+    };
   };
   payment: {
     provider: string;
@@ -90,6 +95,18 @@ export const adminDebugPage = (
             <tr>
               <td>Pass Type ID</td>
               <td>{s.appleWallet.passTypeId || "—"}</td>
+            </tr>
+            <tr>
+              <td>Signing certificate</td>
+              <td>{s.appleWallet.certValidation.signingCert}</td>
+            </tr>
+            <tr>
+              <td>Signing key</td>
+              <td>{s.appleWallet.certValidation.signingKey}</td>
+            </tr>
+            <tr>
+              <td>WWDR certificate</td>
+              <td>{s.appleWallet.certValidation.wwdrCert}</td>
             </tr>
           </tbody>
         </table>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -405,5 +405,9 @@ export const adminSettingsPage = (
         templates, mail provider, timezone, custom domain, and database reset,{" "}
         <a href="/admin/settings-advanced">click here</a>.
       </p>
+
+      <p>
+        For nerdy debug info <a href="/admin/debug">click here</a>.
+      </p>
     </Layout>,
   );

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -1,11 +1,23 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import {
+  setPaymentProvider,
+  setStripeWebhookConfig,
+  updateAppleWalletPassTypeId,
+  updateAppleWalletSigningCert,
+  updateAppleWalletSigningKey,
+  updateAppleWalletTeamId,
+  updateAppleWalletWwdrCert,
+  updateSquareWebhookSignatureKey,
+  updateStripeKey,
+} from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   adminGet,
   createTestDbWithSetup,
   expectAdminRedirect,
   expectHtmlResponse,
+  generateTestCerts,
   mockRequest,
   resetDb,
   resetTestSlugCounter,
@@ -49,7 +61,7 @@ describe("server (admin debug)", () => {
       expect(html).toContain("Pass Type ID");
     });
 
-    test("shows Apple Wallet cert validation status", async () => {
+    test("shows Apple Wallet cert validation as Not set when unconfigured", async () => {
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("Signing certificate");
@@ -131,6 +143,137 @@ describe("server (admin debug)", () => {
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("No secrets or keys are shown");
+    });
+  });
+
+  describe("GET /admin/debug with Stripe configured", () => {
+    test("shows stripe as provider with key and webhook status", async () => {
+      await setPaymentProvider("stripe");
+      await updateStripeKey("sk_test_fake");
+      await setStripeWebhookConfig({
+        secret: "whsec_fake",
+        endpointId: "we_fake",
+      });
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("stripe");
+      expect(html).toContain("Configured");
+    });
+  });
+
+  describe("GET /admin/debug with Square configured", () => {
+    test("shows square as provider with webhook status", async () => {
+      await setPaymentProvider("square");
+      await updateSquareWebhookSignatureKey("sig_fake");
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("square");
+    });
+  });
+
+  describe("GET /admin/debug with Apple Wallet DB config", () => {
+    test("shows Database as source with valid cert status", async () => {
+      const certs = generateTestCerts();
+      await Promise.all([
+        updateAppleWalletPassTypeId("pass.com.test.tickets"),
+        updateAppleWalletTeamId("TESTTEAM01"),
+        updateAppleWalletSigningCert(certs.signingCert),
+        updateAppleWalletSigningKey(certs.signingKey),
+        updateAppleWalletWwdrCert(certs.wwdrCert),
+      ]);
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Database");
+      expect(html).toContain("pass.com.test.tickets");
+      expect(html).toContain("Valid");
+    });
+
+    test("shows Invalid PEM for bad certificate data", async () => {
+      await Promise.all([
+        updateAppleWalletPassTypeId("pass.com.test.tickets"),
+        updateAppleWalletTeamId("TESTTEAM01"),
+        updateAppleWalletSigningCert("not-a-valid-pem"),
+        updateAppleWalletSigningKey("not-a-valid-pem"),
+        updateAppleWalletWwdrCert("not-a-valid-pem"),
+      ]);
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Invalid PEM");
+    });
+  });
+
+  describe("GET /admin/debug with Apple Wallet env vars", () => {
+    const envKeys = [
+      "APPLE_WALLET_PASS_TYPE_ID",
+      "APPLE_WALLET_TEAM_ID",
+      "APPLE_WALLET_SIGNING_CERT",
+      "APPLE_WALLET_SIGNING_KEY",
+      "APPLE_WALLET_WWDR_CERT",
+    ] as const;
+
+    const origValues = envKeys.map((k) => [k, Deno.env.get(k)] as const);
+
+    afterEach(() => {
+      for (const [key, val] of origValues) {
+        if (val) Deno.env.set(key, val);
+        else Deno.env.delete(key);
+      }
+    });
+
+    test("shows Environment variables as source when env configured", async () => {
+      const certs = generateTestCerts();
+      Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.env.test");
+      Deno.env.set("APPLE_WALLET_TEAM_ID", "ENVTEAM01");
+      Deno.env.set("APPLE_WALLET_SIGNING_CERT", certs.signingCert);
+      Deno.env.set("APPLE_WALLET_SIGNING_KEY", certs.signingKey);
+      Deno.env.set("APPLE_WALLET_WWDR_CERT", certs.wwdrCert);
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Environment variables");
+      expect(html).toContain("pass.com.env.test");
+    });
+  });
+
+  describe("GET /admin/debug with host email env vars", () => {
+    const envKeys = [
+      "HOST_EMAIL_PROVIDER",
+      "HOST_EMAIL_API_KEY",
+      "HOST_EMAIL_FROM_ADDRESS",
+    ] as const;
+
+    const origValues = envKeys.map((k) => [k, Deno.env.get(k)] as const);
+
+    afterEach(() => {
+      for (const [key, val] of origValues) {
+        if (val) Deno.env.set(key, val);
+        else Deno.env.delete(key);
+      }
+    });
+
+    test("shows host email provider when env configured", async () => {
+      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+      Deno.env.set("HOST_EMAIL_API_KEY", "re_test_key");
+      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "test@example.com");
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("resend");
+    });
+  });
+
+  describe("GET /admin/debug with Bunny CDN enabled", () => {
+    const origApiKey = Deno.env.get("BUNNY_API_KEY");
+
+    afterEach(() => {
+      if (origApiKey) Deno.env.set("BUNNY_API_KEY", origApiKey);
+      else Deno.env.delete("BUNNY_API_KEY");
+    });
+
+    test("shows CDN as configured when Bunny CDN is enabled", async () => {
+      Deno.env.set("BUNNY_API_KEY", "test-key");
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("badge-ok");
+      expect(html).toContain("CDN management");
     });
   });
 });

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -1,0 +1,127 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { handleRequest } from "#routes";
+import {
+  adminGet,
+  createTestDbWithSetup,
+  expectAdminRedirect,
+  expectHtmlResponse,
+  mockRequest,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+describe("server (admin debug)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("GET /admin/debug", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(mockRequest("/admin/debug"));
+      expectAdminRedirect(response);
+    });
+
+    test("renders debug page when authenticated", async () => {
+      const { response } = await adminGet("/admin/debug");
+      await expectHtmlResponse(response, 200, "Debug Info");
+    });
+
+    test("shows breadcrumb back to settings", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain('href="/admin/settings"');
+      expect(html).toContain("Settings");
+    });
+
+    test("shows Apple Wallet section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Apple Wallet");
+      expect(html).toContain("DB config");
+      expect(html).toContain("Env var config");
+      expect(html).toContain("Active source");
+      expect(html).toContain("Pass Type ID");
+    });
+
+    test("shows Payments section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Payments");
+      expect(html).toContain("Provider");
+      expect(html).toContain("API key");
+      expect(html).toContain("Webhook");
+    });
+
+    test("shows Email section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Email");
+      expect(html).toContain("Provider (DB)");
+      expect(html).toContain("From address");
+      expect(html).toContain("Host provider (env)");
+    });
+
+    test("shows Notifications section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Notifications (ntfy)");
+      expect(html).toContain("NTFY URL");
+    });
+
+    test("shows Bunny Storage section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Bunny Storage (images)");
+      expect(html).toContain("Storage zone");
+    });
+
+    test("shows Bunny CDN section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Bunny CDN");
+      expect(html).toContain("CDN management");
+      expect(html).toContain("CDN hostname");
+      expect(html).toContain("Custom domain");
+    });
+
+    test("shows Database section", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Database");
+      expect(html).toContain("DB_URL");
+    });
+
+    test("shows Domain section with ALLOWED_DOMAIN", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Domain");
+      expect(html).toContain("ALLOWED_DOMAIN");
+    });
+
+    test("does not expose secret keys or full URLs", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).not.toContain("sk_test_");
+      expect(html).not.toContain("sk_live_");
+      expect(html).not.toContain("ntfy.sh");
+    });
+
+    test("shows Configured/Not configured badges", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Not configured");
+    });
+
+    test("shows no secrets disclaimer", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("No secrets or keys are shown");
+    });
+  });
+});

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -49,6 +49,15 @@ describe("server (admin debug)", () => {
       expect(html).toContain("Pass Type ID");
     });
 
+    test("shows Apple Wallet cert validation status", async () => {
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("Signing certificate");
+      expect(html).toContain("Signing key");
+      expect(html).toContain("WWDR certificate");
+      expect(html).toContain("Not set");
+    });
+
     test("shows Payments section", async () => {
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();


### PR DESCRIPTION
Adds /admin/debug (owner-only) showing configuration status for
Apple Wallet, payments, email, ntfy, Bunny Storage/CDN, database,
and domain. Shows whether each service is configured and its source
without exposing any secrets or full URLs. Links from settings page
with "For nerdy debug info click here".

https://claude.ai/code/session_012KqFT3kuj64XC6DeakdN9o