### PR TITLE
Add active event statistics dashboard section

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -6,7 +6,7 @@
  * - Decryption requires the private key (only available to authenticated sessions)
  */
 
-import { map } from "#fp";
+import { filter, map, reduce } from "#fp";
 import {
   computeTicketTokenIndex,
   decrypt,
@@ -31,6 +31,7 @@ import type {
   ContactField,
   ContactFields,
   ContactInfo,
+  EventWithCount,
 } from "#lib/types.ts";
 
 /** Encrypt all contact fields in parallel, returning a keyed record */
@@ -149,6 +150,45 @@ export const getNewestAttendeesRaw = (limit: number): Promise<Attendee[]> =>
   queryAll<Attendee>("SELECT * FROM attendees ORDER BY created DESC LIMIT ?", [
     limit,
   ]);
+
+/** Aggregated statistics for active events */
+export type ActiveEventStats = {
+  income: number;
+  tickets: number;
+  attendees: number;
+};
+
+/**
+ * Get aggregated statistics for active events.
+ * Filters active events from the provided list, computes attendees
+ * (sum of quantities) from cached EventWithCount data, and queries
+ * ticket count (rows) and income (sum of decrypted price_paid).
+ */
+export const getActiveEventStats = async (
+  events: EventWithCount[],
+): Promise<ActiveEventStats> => {
+  const active = filter((e: EventWithCount) => e.active)(events);
+  if (active.length === 0) {
+    return { income: 0, tickets: 0, attendees: 0 };
+  }
+  const activeIds = map((e: EventWithCount) => e.id)(active);
+  const attendees = reduce(
+    (sum: number, e: EventWithCount) => sum + e.attendee_count,
+    0,
+  )(active);
+  const rows = await queryAll<{ price_paid: string }>(
+    `SELECT price_paid FROM attendees WHERE event_id IN (${inPlaceholders(activeIds)})`,
+    activeIds,
+  );
+  const decrypted = await Promise.all(
+    map((r: { price_paid: string }) => decrypt(r.price_paid))(rows),
+  );
+  const income = reduce(
+    (sum: number, v: string) => sum + Number.parseInt(v, 10),
+    0,
+  )(decrypted);
+  return { income, tickets: rows.length, attendees };
+};
 
 /**
  * Decrypt a list of raw attendees (all fields).

--- a/src/routes/admin/dashboard.ts
+++ b/src/routes/admin/dashboard.ts
@@ -4,7 +4,11 @@
 
 import { signCsrfToken } from "#lib/csrf.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
-import { decryptAttendees, getNewestAttendeesRaw } from "#lib/db/attendees.ts";
+import {
+  decryptAttendees,
+  getActiveEventStats,
+  getNewestAttendeesRaw,
+} from "#lib/db/attendees.ts";
 import { getAllEvents } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { sortEvents } from "#lib/sort-events.ts";
@@ -45,6 +49,7 @@ const handleAdminGet = (request: Request): Promise<Response> =>
       ]);
       const newestAttendees = await decryptAttendees(newestRaw, privateKey);
       const sortedEvents = sortEvents(events, holidays);
+      const stats = await getActiveEventStats(sortedEvents);
       return htmlResponse(
         adminDashboardPage(
           sortedEvents,
@@ -52,6 +57,7 @@ const handleAdminGet = (request: Request): Promise<Response> =>
           imageError,
           newestAttendees,
           successMessage,
+          stats,
         ),
       );
     },

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -63,9 +63,7 @@ const validateAppleWalletCerts = (
     signingKey: isValidPemPrivateKey(config.signingKey)
       ? "Valid"
       : "Invalid PEM",
-    wwdrCert: isValidPemCertificate(config.wwdrCert)
-      ? "Valid"
-      : "Invalid PEM",
+    wwdrCert: isValidPemCertificate(config.wwdrCert) ? "Valid" : "Invalid PEM",
   };
 };
 

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -4,6 +4,8 @@
 
 import { filter, map, pipe, reduce } from "#fp";
 import { getAllowedDomain } from "#lib/config.ts";
+import { formatCurrency } from "#lib/currency.ts";
+import type { ActiveEventStats } from "#lib/db/attendees.ts";
 import { renderSuccess } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
@@ -96,6 +98,25 @@ const multiBookingSection = (activeEvents: EventWithCount[]): string => {
   );
 };
 
+/** Active event statistics section */
+export const activeEventStatsSection = (stats: ActiveEventStats): string =>
+  String(
+    <details>
+      <summary>Active Event Statistics</summary>
+      <ul>
+        <li>
+          <strong>Income:</strong> {formatCurrency(stats.income)}
+        </li>
+        <li>
+          <strong>Tickets:</strong> {stats.tickets}
+        </li>
+        <li>
+          <strong>Attendees:</strong> {stats.attendees}
+        </li>
+      </ul>
+    </details>,
+  );
+
 /** Build the newest attendees section with a details/summary wrapper */
 const newestAttendeesSection = (
   attendees: Attendee[],
@@ -148,6 +169,7 @@ export const adminDashboardPage = (
   imageError?: string | null,
   newestAttendees: Attendee[] = [],
   successMessage?: string | null,
+  stats?: ActiveEventStats | null,
 ): string => {
   const eventRows =
     events.length > 0
@@ -187,6 +209,8 @@ export const adminDashboardPage = (
           </tbody>
         </table>
       </div>
+
+      {stats && <Raw html={activeEventStatsSection(stats)} />}
 
       {activeEvents.length >= 2 && (
         <Raw html={multiBookingSection(activeEvents)} />

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -20,6 +20,7 @@ import {
   decryptAttendees,
   decryptAttendeesForTable,
   deleteAttendee,
+  getActiveEventStats,
   getAttendee,
   getAttendeesByTokens,
   getAttendeesRaw,
@@ -94,6 +95,7 @@ import {
 import { getUserByUsername, verifyUserPassword } from "#lib/db/users.ts";
 import { nowMs } from "#lib/now.ts";
 import {
+  createPaidTestAttendee,
   createTestAttendee,
   createTestDbWithSetup,
   createTestEvent,
@@ -904,6 +906,88 @@ describe("db", () => {
     test("getNewestAttendeesRaw returns empty array when no attendees", async () => {
       const raw = await getNewestAttendeesRaw(10);
       expect(raw).toEqual([]);
+    });
+
+    test("getActiveEventStats returns zeros for empty events", async () => {
+      const stats = await getActiveEventStats([]);
+      expect(stats).toEqual({ income: 0, tickets: 0, attendees: 0 });
+    });
+
+    test("getActiveEventStats returns zeros when all events inactive", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      await createPaidTestAttendee(
+        event.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      const events = await getAllEvents();
+      const inactive = events.map((e) => ({ ...e, active: false }));
+      const stats = await getActiveEventStats(inactive);
+      expect(stats).toEqual({ income: 0, tickets: 0, attendees: 0 });
+    });
+
+    test("getActiveEventStats counts tickets and sums income for active events", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      await createPaidTestAttendee(
+        event.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      await createPaidTestAttendee(
+        event.id,
+        "Bob",
+        "bob@example.com",
+        "pay_2",
+        2000,
+      );
+      const events = await getAllEvents();
+      const stats = await getActiveEventStats(events);
+      expect(stats.tickets).toBe(2);
+      expect(stats.income).toBe(3000);
+      expect(stats.attendees).toBe(2);
+    });
+
+    test("getActiveEventStats excludes inactive events", async () => {
+      const event1 = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      const event2 = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      await createPaidTestAttendee(
+        event1.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      await createPaidTestAttendee(
+        event2.id,
+        "Bob",
+        "bob@example.com",
+        "pay_2",
+        2000,
+      );
+      const events = await getAllEvents();
+      const mixed = events.map((e) =>
+        e.id === event2.id ? { ...e, active: false } : e,
+      );
+      const stats = await getActiveEventStats(mixed);
+      expect(stats.tickets).toBe(1);
+      expect(stats.income).toBe(1000);
+      expect(stats.attendees).toBe(1);
     });
 
     test("attendee count reflects in getEventWithCount", async () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -17,7 +17,10 @@ import {
   adminCalendarPage,
   type CalendarAttendeeRow,
 } from "#templates/admin/calendar.tsx";
-import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
+import {
+  activeEventStatsSection,
+  adminDashboardPage,
+} from "#templates/admin/dashboard.tsx";
 import {
   adminDuplicateEventPage,
   adminEventEditPage,
@@ -1590,6 +1593,63 @@ describe("html", () => {
       const html = adminDashboardPage(events, TEST_SESSION);
       expect(html).toContain("inactive-row");
       expect(html).toContain("Inactive");
+    });
+  });
+
+  describe("activeEventStatsSection", () => {
+    test("renders income, tickets, and attendees", () => {
+      const html = activeEventStatsSection({
+        income: 5000,
+        tickets: 30,
+        attendees: 52,
+      });
+      expect(html).toContain("Active Event Statistics");
+      expect(html).toContain("<strong>Income:</strong>");
+      expect(html).toContain("<strong>Tickets:</strong>");
+      expect(html).toContain("<strong>Attendees:</strong>");
+      expect(html).toContain("30");
+      expect(html).toContain("52");
+    });
+
+    test("renders zero values", () => {
+      const html = activeEventStatsSection({
+        income: 0,
+        tickets: 0,
+        attendees: 0,
+      });
+      expect(html).toContain("<strong>Tickets:</strong> 0");
+      expect(html).toContain("<strong>Attendees:</strong> 0");
+    });
+
+    test("renders as closed details element", () => {
+      const html = activeEventStatsSection({
+        income: 0,
+        tickets: 0,
+        attendees: 0,
+      });
+      expect(html).toContain("<details>");
+      expect(html).not.toContain("<details open");
+    });
+  });
+
+  describe("adminDashboardPage active event statistics", () => {
+    test("shows stats section when stats provided", () => {
+      const html = adminDashboardPage([], TEST_SESSION, null, [], null, {
+        income: 1000,
+        tickets: 5,
+        attendees: 10,
+      });
+      expect(html).toContain("Active Event Statistics");
+    });
+
+    test("does not show stats section when stats is null", () => {
+      const html = adminDashboardPage([], TEST_SESSION, null, [], null, null);
+      expect(html).not.toContain("Active Event Statistics");
+    });
+
+    test("does not show stats section when stats not provided", () => {
+      const html = adminDashboardPage([], TEST_SESSION);
+      expect(html).not.toContain("Active Event Statistics");
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds a new "Active Event Statistics" section to the admin dashboard that displays aggregated metrics for all active events, including total income, ticket count, and attendee count.

## Key Changes
- **New database function** (`getActiveEventStats`): Aggregates statistics across active events by:
  - Filtering events marked as active
  - Summing attendee counts from cached `EventWithCount` data
  - Querying and decrypting `price_paid` values to calculate total income
  - Returning ticket count (number of attendee rows)

- **New template component** (`activeEventStatsSection`): Renders a collapsible details element displaying:
  - Total income (formatted as currency)
  - Total ticket count
  - Total attendee count

- **Dashboard integration**: Updated `adminDashboardPage` to accept optional `ActiveEventStats` and conditionally render the statistics section when provided

- **Route handler update**: Modified the admin dashboard route to fetch active event statistics and pass them to the page template

## Implementation Details
- Statistics are only calculated for events with `active: true` flag
- Income is computed by decrypting individual `price_paid` values from attendees and summing them
- Attendee count uses pre-cached `attendee_count` from `EventWithCount` objects for efficiency
- The statistics section is rendered as a closed `<details>` element for a clean dashboard layout
- Gracefully handles empty event lists by returning zero values

https://claude.ai/code/session_014RCYU1LbZzGHVJRoykjtV4