### PR TITLE
Handle non-numeric price_paid values in event stats calculation

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -184,7 +184,7 @@ export const getActiveEventStats = async (
     map((r: { price_paid: string }) => decrypt(r.price_paid))(rows),
   );
   const income = reduce(
-    (sum: number, v: string) => sum + Number.parseInt(v, 10),
+    (sum: number, v: string) => sum + (Number.parseInt(v, 10) || 0),
     0,
   )(decrypted);
   return { income, tickets: rows.length, attendees };

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -990,6 +990,25 @@ describe("db", () => {
       expect(stats.attendees).toBe(1);
     });
 
+    test("getActiveEventStats treats non-numeric price_paid as zero", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 0,
+      });
+      await createPaidTestAttendee(
+        event.id,
+        "Free Alice",
+        "free@example.com",
+        "",
+        0,
+      );
+      const events = await getAllEvents();
+      const stats = await getActiveEventStats(events);
+      expect(stats.tickets).toBe(1);
+      expect(stats.income).toBe(0);
+      expect(stats.attendees).toBe(1);
+    });
+
     test("attendee count reflects in getEventWithCount", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,


### PR DESCRIPTION
## Summary
Fixed a bug in the `getActiveEventStats` function where non-numeric `price_paid` values would result in `NaN` when calculating total income. The function now treats invalid numeric conversions as zero.

## Changes
- Updated the income calculation in `getActiveEventStats` to use the nullish coalescing operator (`||`) to default to 0 when `Number.parseInt()` returns `NaN`
- Added test case to verify that non-numeric price_paid values are handled correctly and don't break income calculations

## Implementation Details
The fix changes the reduce function from:
```typescript
(sum: number, v: string) => sum + Number.parseInt(v, 10)
```
to:
```typescript
(sum: number, v: string) => sum + (Number.parseInt(v, 10) || 0)
```

This ensures that when `Number.parseInt()` returns `NaN` (for non-numeric strings), it defaults to 0 instead of propagating the `NaN` value through the sum calculation.

https://claude.ai/code/session_01VygP8MP8UagerHUL6JiTSd