### PR TITLE
Add Apple Wallet web service API for automatic pass updates

### DIFF
--- a/src/lib/apple-wallet.ts
+++ b/src/lib/apple-wallet.ts
@@ -80,15 +80,14 @@ export const generatePassJson = (
         messageEncoding: "iso-8859-1",
       },
     ],
+    webServiceURL: data.webServiceURL,
+    authenticationToken: data.serialNumber,
     eventTicket: buildEventTicketFields(data),
   };
 
   if (data.eventDate) {
     pass.relevantDate = data.eventDate;
   }
-
-  pass.webServiceURL = data.webServiceURL;
-  pass.authenticationToken = data.serialNumber;
 
   return pass;
 };

--- a/src/lib/apple-wallet.ts
+++ b/src/lib/apple-wallet.ts
@@ -41,6 +41,8 @@ export type PassData = {
   currencyCode: string;
   /** Full URL encoded in the QR barcode */
   checkinUrl: string;
+  /** Base URL for Apple Wallet web service (e.g. https://example.com) */
+  webServiceURL?: string;
   /** Optional pass colors (CSS rgb() format) */
   foregroundColor?: string;
   backgroundColor?: string;
@@ -83,6 +85,11 @@ export const generatePassJson = (
 
   if (data.eventDate) {
     pass.relevantDate = data.eventDate;
+  }
+
+  if (data.webServiceURL) {
+    pass.webServiceURL = data.webServiceURL;
+    pass.authenticationToken = data.serialNumber;
   }
 
   return pass;

--- a/src/lib/apple-wallet.ts
+++ b/src/lib/apple-wallet.ts
@@ -42,7 +42,7 @@ export type PassData = {
   /** Full URL encoded in the QR barcode */
   checkinUrl: string;
   /** Base URL for Apple Wallet web service (e.g. https://example.com) */
-  webServiceURL?: string;
+  webServiceURL: string;
   /** Optional pass colors (CSS rgb() format) */
   foregroundColor?: string;
   backgroundColor?: string;
@@ -87,10 +87,8 @@ export const generatePassJson = (
     pass.relevantDate = data.eventDate;
   }
 
-  if (data.webServiceURL) {
-    pass.webServiceURL = data.webServiceURL;
-    pass.authenticationToken = data.serialNumber;
-  }
+  pass.webServiceURL = data.webServiceURL;
+  pass.authenticationToken = data.serialNumber;
 
   return pass;
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -131,6 +131,14 @@ const loadWalletRoutes = once(async () => {
   return routeWallet;
 });
 
+/** Lazy-load Apple Wallet web service routes (v1 API for pass updates) */
+const loadWalletWebserviceRoutes = once(async () => {
+  const { routeWalletWebservice } = await import(
+    "#routes/wallet-webservice.ts"
+  );
+  return routeWalletWebservice;
+});
+
 /** Lazy-load public API routes */
 const loadApiRoutes = once(async () => {
   const { routeApi } = await import("#routes/api.ts");
@@ -195,6 +203,7 @@ const prefixHandlers: Record<string, RouterFn> = {
   join: lazyRoute(loadJoinRoutes),
   feeds: lazyRoute(loadFeedRoutes),
   wallet: lazyRoute(loadWalletRoutes),
+  v1: lazyRoute(loadWalletWebserviceRoutes),
   demo: lazyRoute(loadDemoResetRoutes),
   api: async (request, path, method, server) =>
     (await getShowPublicApiFromDb())

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -129,12 +129,17 @@ export const isWebhookPath = (path: string): boolean =>
 /** Pattern for public API paths */
 const API_PATH_PATTERN = /^\/api\//;
 
+/** Pattern for Apple Wallet web service paths (PassKit protocol) */
+const WALLET_WEBSERVICE_PATTERN = /^\/v1\//;
+
 /**
  * Check if path is a JSON API endpoint.
  * Patterns are exported from their respective route modules.
  */
 export const isJsonApiPath = (path: string): boolean =>
-  SCAN_API_PATTERN.test(path) || API_PATH_PATTERN.test(path);
+  SCAN_API_PATTERN.test(path) ||
+  API_PATH_PATTERN.test(path) ||
+  WALLET_WEBSERVICE_PATTERN.test(path);
 
 /**
  * Validate Content-Type for POST requests

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -12,11 +12,20 @@
  * so devices re-download the pass on every manual refresh.
  */
 
+import type { SigningCredentials } from "#lib/apple-wallet.ts";
 import { getAppleWalletConfig } from "#lib/db/settings.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import { buildPkpassForToken } from "#routes/wallet.ts";
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+/** Load config and verify the passType matches. Returns null on mismatch. */
+const verifyPassType = async (
+  passType: string,
+): Promise<SigningCredentials | null> => {
+  const config = await getAppleWalletConfig();
+  return config && passType === config.passTypeId ? config : null;
+};
 
 /** Stub: accept device registration */
 const handleRegister = () => new Response(null, { status: 201 });
@@ -29,10 +38,8 @@ const handleGetTokens = async (
   request: Request,
   params: { _device: string; passType: string },
 ) => {
-  const config = await getAppleWalletConfig();
-  if (!config || params.passType !== config.passTypeId) {
-    return new Response(null, { status: 204 });
-  }
+  const config = await verifyPassType(params.passType);
+  if (!config) return new Response(null, { status: 204 });
 
   const authHeader = request.headers.get("Authorization") ?? "";
   const token = authHeader.replace(/^ApplePass\s+/i, "");
@@ -53,10 +60,8 @@ const handleGetPass = async (
   _request: Request,
   params: { passType: string; token: string },
 ) => {
-  const config = await getAppleWalletConfig();
-  if (!config || params.passType !== config.passTypeId) {
-    return new Response(null, { status: 404 });
-  }
+  const config = await verifyPassType(params.passType);
+  if (!config) return new Response(null, { status: 404 });
 
   return buildPkpassForToken(params.token, config);
 };

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -1,0 +1,77 @@
+/**
+ * Apple Wallet web service endpoints for automatic pass updates.
+ *
+ * Implements the minimal subset of Apple's PassKit web service protocol:
+ * - POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber → 201 (stub)
+ * - DELETE /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber → 200 (stub)
+ * - GET /v1/devices/:deviceId/registrations/:passTypeId → always returns all serials
+ * - GET /v1/passes/:passTypeId/:serialNumber → serves fresh .pkpass
+ * - POST /v1/log → 200 (stub)
+ *
+ * No device tracking or update timestamps — always says "everything is updated"
+ * so devices re-download the pass on every manual refresh.
+ */
+
+import { getAppleWalletConfig } from "#lib/db/settings.ts";
+import { createRouter, defineRoutes } from "#routes/router.ts";
+import { buildPkpassForToken } from "#routes/wallet.ts";
+
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+/** Stub: accept device registration */
+const handleRegister = () => new Response(null, { status: 201 });
+
+/** Stub: accept device unregistration */
+const handleUnregister = () => new Response(null, { status: 200 });
+
+/** Return all serials for this pass type — always says "updated" */
+const handleGetSerials = async (
+  request: Request,
+  params: { passTypeId: string },
+) => {
+  const config = await getAppleWalletConfig();
+  if (!config || params.passTypeId !== config.passTypeId) {
+    return new Response(null, { status: 204 });
+  }
+
+  const authHeader = request.headers.get("Authorization") ?? "";
+  const token = authHeader.replace(/^ApplePass\s+/i, "");
+  if (!token) return new Response(null, { status: 401 });
+
+  // Ignore passesUpdatedSince — always return the token as updated
+  return new Response(
+    JSON.stringify({
+      serialNumbers: [token],
+      lastUpdated: String(Date.now()),
+    }),
+    { status: 200, headers: JSON_HEADERS },
+  );
+};
+
+/** Serve a fresh .pkpass for the given serial number */
+const handleGetPass = async (
+  _request: Request,
+  params: { passTypeId: string; serialNumber: string },
+) => {
+  const config = await getAppleWalletConfig();
+  if (!config || params.passTypeId !== config.passTypeId) {
+    return new Response(null, { status: 404 });
+  }
+
+  return buildPkpassForToken(params.serialNumber, config);
+};
+
+/** Stub: accept log messages from devices */
+const handleLog = () => new Response(null, { status: 200 });
+
+export const routeWalletWebservice = createRouter(
+  defineRoutes({
+    "POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber":
+      handleRegister,
+    "DELETE /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber":
+      handleUnregister,
+    "GET /v1/devices/:deviceId/registrations/:passTypeId": handleGetSerials,
+    "GET /v1/passes/:passTypeId/:serialNumber": handleGetPass,
+    "POST /v1/log": handleLog,
+  }),
+);

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -2,10 +2,10 @@
  * Apple Wallet web service endpoints for automatic pass updates.
  *
  * Implements the minimal subset of Apple's PassKit web service protocol:
- * - POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber → 201 (stub)
- * - DELETE /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber → 200 (stub)
- * - GET /v1/devices/:deviceId/registrations/:passTypeId → always returns all serials
- * - GET /v1/passes/:passTypeId/:serialNumber → serves fresh .pkpass
+ * - POST /v1/devices/:device/registrations/:passTypeId/:token → 201 (stub)
+ * - DELETE /v1/devices/:device/registrations/:passTypeId/:token → 200 (stub)
+ * - GET /v1/devices/:device/registrations/:passTypeId → always returns all tokens
+ * - GET /v1/passes/:passTypeId/:token → serves fresh .pkpass
  * - POST /v1/log → 200 (stub)
  *
  * No device tracking or update timestamps — always says "everything is updated"
@@ -24,10 +24,10 @@ const handleRegister = () => new Response(null, { status: 201 });
 /** Stub: accept device unregistration */
 const handleUnregister = () => new Response(null, { status: 200 });
 
-/** Return all serials for this pass type — always says "updated" */
-const handleGetSerials = async (
+/** Return all tokens for this pass type — always says "updated" */
+const handleGetTokens = async (
   request: Request,
-  params: { passTypeId: string },
+  params: { _device: string; passTypeId: string },
 ) => {
   const config = await getAppleWalletConfig();
   if (!config || params.passTypeId !== config.passTypeId) {
@@ -48,17 +48,17 @@ const handleGetSerials = async (
   );
 };
 
-/** Serve a fresh .pkpass for the given serial number */
+/** Serve a fresh .pkpass for the given token */
 const handleGetPass = async (
   _request: Request,
-  params: { passTypeId: string; serialNumber: string },
+  params: { passTypeId: string; token: string },
 ) => {
   const config = await getAppleWalletConfig();
   if (!config || params.passTypeId !== config.passTypeId) {
     return new Response(null, { status: 404 });
   }
 
-  return buildPkpassForToken(params.serialNumber, config);
+  return buildPkpassForToken(params.token, config);
 };
 
 /** Stub: accept log messages from devices */
@@ -66,12 +66,12 @@ const handleLog = () => new Response(null, { status: 200 });
 
 export const routeWalletWebservice = createRouter(
   defineRoutes({
-    "POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber":
+    "POST /v1/devices/:_device/registrations/:_passTypeId/:_token":
       handleRegister,
-    "DELETE /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber":
+    "DELETE /v1/devices/:_device/registrations/:_passTypeId/:_token":
       handleUnregister,
-    "GET /v1/devices/:deviceId/registrations/:passTypeId": handleGetSerials,
-    "GET /v1/passes/:passTypeId/:serialNumber": handleGetPass,
+    "GET /v1/devices/:_device/registrations/:passTypeId": handleGetTokens,
+    "GET /v1/passes/:passTypeId/:token": handleGetPass,
     "POST /v1/log": handleLog,
   }),
 );

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -2,10 +2,10 @@
  * Apple Wallet web service endpoints for automatic pass updates.
  *
  * Implements the minimal subset of Apple's PassKit web service protocol:
- * - POST /v1/devices/:device/registrations/:passTypeId/:token → 201 (stub)
- * - DELETE /v1/devices/:device/registrations/:passTypeId/:token → 200 (stub)
- * - GET /v1/devices/:device/registrations/:passTypeId → always returns all tokens
- * - GET /v1/passes/:passTypeId/:token → serves fresh .pkpass
+ * - POST /v1/devices/:device/registrations/:passType/:token → 201 (stub)
+ * - DELETE /v1/devices/:device/registrations/:passType/:token → 200 (stub)
+ * - GET /v1/devices/:device/registrations/:passType → always returns all tokens
+ * - GET /v1/passes/:passType/:token → serves fresh .pkpass
  * - POST /v1/log → 200 (stub)
  *
  * No device tracking or update timestamps — always says "everything is updated"
@@ -27,10 +27,10 @@ const handleUnregister = () => new Response(null, { status: 200 });
 /** Return all tokens for this pass type — always says "updated" */
 const handleGetTokens = async (
   request: Request,
-  params: { _device: string; passTypeId: string },
+  params: { _device: string; passType: string },
 ) => {
   const config = await getAppleWalletConfig();
-  if (!config || params.passTypeId !== config.passTypeId) {
+  if (!config || params.passType !== config.passTypeId) {
     return new Response(null, { status: 204 });
   }
 
@@ -51,10 +51,10 @@ const handleGetTokens = async (
 /** Serve a fresh .pkpass for the given token */
 const handleGetPass = async (
   _request: Request,
-  params: { passTypeId: string; token: string },
+  params: { passType: string; token: string },
 ) => {
   const config = await getAppleWalletConfig();
-  if (!config || params.passTypeId !== config.passTypeId) {
+  if (!config || params.passType !== config.passTypeId) {
     return new Response(null, { status: 404 });
   }
 
@@ -66,12 +66,12 @@ const handleLog = () => new Response(null, { status: 200 });
 
 export const routeWalletWebservice = createRouter(
   defineRoutes({
-    "POST /v1/devices/:_device/registrations/:_passTypeId/:_token":
+    "POST /v1/devices/:_device/registrations/:_passType/:_token":
       handleRegister,
-    "DELETE /v1/devices/:_device/registrations/:_passTypeId/:_token":
+    "DELETE /v1/devices/:_device/registrations/:_passType/:_token":
       handleUnregister,
-    "GET /v1/devices/:_device/registrations/:passTypeId": handleGetTokens,
-    "GET /v1/passes/:passTypeId/:token": handleGetPass,
+    "GET /v1/devices/:_device/registrations/:passType": handleGetTokens,
+    "GET /v1/passes/:passType/:token": handleGetPass,
     "POST /v1/log": handleLog,
   }),
 );

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -37,7 +37,7 @@ const handleRegister = () => new Response(null, { status: 201 });
 const handleUnregister = () => new Response(null, { status: 200 });
 
 /** Return all tokens for this pass type — always says "updated" */
-const handleGetTokens = async (
+const handleGetTokens = (
   request: Request,
   params: { _device: string; passType: string },
 ) =>
@@ -57,7 +57,7 @@ const handleGetTokens = async (
   })(params.passType);
 
 /** Serve a fresh .pkpass for the given token */
-const handleGetPass = async (
+const handleGetPass = (
   _request: Request,
   params: { passType: string; token: string },
 ) =>

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -19,13 +19,16 @@ import { buildPkpassForToken } from "#routes/wallet.ts";
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 
-/** Load config and verify the passType matches. Returns null on mismatch. */
-const verifyPassType = async (
-  passType: string,
-): Promise<SigningCredentials | null> => {
-  const config = await getAppleWalletConfig();
-  return config && passType === config.passTypeId ? config : null;
-};
+/** Verify passType matches config, then run handler. Returns failure status on mismatch. */
+const withVerifiedPass =
+  (failStatus: number) =>
+  (handler: (config: SigningCredentials) => Response | Promise<Response>) =>
+  async (passType: string): Promise<Response> => {
+    const config = await getAppleWalletConfig();
+    return config && passType === config.passTypeId
+      ? handler(config)
+      : new Response(null, { status: failStatus });
+  };
 
 /** Stub: accept device registration */
 const handleRegister = () => new Response(null, { status: 201 });
@@ -37,34 +40,30 @@ const handleUnregister = () => new Response(null, { status: 200 });
 const handleGetTokens = async (
   request: Request,
   params: { _device: string; passType: string },
-) => {
-  const config = await verifyPassType(params.passType);
-  if (!config) return new Response(null, { status: 204 });
+) =>
+  withVerifiedPass(204)((_config) => {
+    const authHeader = request.headers.get("Authorization") ?? "";
+    const token = authHeader.replace(/^ApplePass\s+/i, "");
+    if (!token) return new Response(null, { status: 401 });
 
-  const authHeader = request.headers.get("Authorization") ?? "";
-  const token = authHeader.replace(/^ApplePass\s+/i, "");
-  if (!token) return new Response(null, { status: 401 });
-
-  // Ignore passesUpdatedSince — always return the token as updated
-  return new Response(
-    JSON.stringify({
-      serialNumbers: [token],
-      lastUpdated: String(Date.now()),
-    }),
-    { status: 200, headers: JSON_HEADERS },
-  );
-};
+    // Ignore passesUpdatedSince — always return the token as updated
+    return new Response(
+      JSON.stringify({
+        serialNumbers: [token],
+        lastUpdated: String(Date.now()),
+      }),
+      { status: 200, headers: JSON_HEADERS },
+    );
+  })(params.passType);
 
 /** Serve a fresh .pkpass for the given token */
 const handleGetPass = async (
   _request: Request,
   params: { passType: string; token: string },
-) => {
-  const config = await verifyPassType(params.passType);
-  if (!config) return new Response(null, { status: 404 });
-
-  return buildPkpassForToken(params.token, config);
-};
+) =>
+  withVerifiedPass(404)((config) => buildPkpassForToken(params.token, config))(
+    params.passType,
+  );
 
 /** Stub: accept log messages from devices */
 const handleLog = () => new Response(null, { status: 200 });

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -4,7 +4,11 @@
  * CDN-cacheable — passes are deterministic for a given token + settings.
  */
 
-import { buildPkpass, type PassData } from "#lib/apple-wallet.ts";
+import {
+  buildPkpass,
+  type PassData,
+  type SigningCredentials,
+} from "#lib/apple-wallet.ts";
 import { getAllowedDomain } from "#lib/config.ts";
 import { decrypt } from "#lib/crypto.ts";
 import {
@@ -47,6 +51,7 @@ const buildPassData = async (
     pricePaid,
     currencyCode,
     checkinUrl: `https://${domain}/checkin/${token}`,
+    webServiceURL: `https://${domain}`,
   };
 };
 
@@ -69,8 +74,19 @@ const handleWalletGet = async (
   const config = await getAppleWalletConfig();
   if (!config) return notFoundResponse();
 
+  return buildPkpassForToken(token, config);
+};
+
+/**
+ * Build and return a .pkpass Response for a token.
+ * Shared by the download route and the web service "get latest pass" endpoint.
+ */
+export const buildPkpassForToken = async (
+  token: string,
+  config: SigningCredentials,
+): Promise<Response> => {
   const result = await lookupAttendees([token]);
-  if (!result.ok) return result.response;
+  if (!result.ok) return notFoundResponse();
 
   const entries = await resolveEntries(result.attendees);
   const passData = await buildPassData(entries[0]!, token);

--- a/test/lib/apple-wallet.test.ts
+++ b/test/lib/apple-wallet.test.ts
@@ -36,6 +36,7 @@ const makePassData = (overrides: Partial<PassData> = {}): PassData => ({
   pricePaid: 0,
   currencyCode: "GBP",
   checkinUrl: "https://example.com/checkin/ABC123",
+  webServiceURL: "https://example.com",
   ...overrides,
 });
 
@@ -179,19 +180,10 @@ describe("apple-wallet", () => {
       expect(pass.labelColor).toBe("rgb(0, 255, 0)");
     });
 
-    test("includes webServiceURL and authenticationToken when webServiceURL is set", () => {
-      const pass = generatePassJson(
-        makePassData({ webServiceURL: "https://example.com" }),
-        creds,
-      );
+    test("includes webServiceURL and authenticationToken for auto-updates", () => {
+      const pass = generatePassJson(makePassData(), creds);
       expect(pass.webServiceURL).toBe("https://example.com");
       expect(pass.authenticationToken).toBe("ABC123");
-    });
-
-    test("omits webServiceURL and authenticationToken when webServiceURL is not set", () => {
-      const pass = generatePassJson(makePassData(), creds);
-      expect(pass.webServiceURL).toBeUndefined();
-      expect(pass.authenticationToken).toBeUndefined();
     });
   });
 

--- a/test/lib/apple-wallet.test.ts
+++ b/test/lib/apple-wallet.test.ts
@@ -178,6 +178,21 @@ describe("apple-wallet", () => {
       expect(pass.backgroundColor).toBe("rgb(0, 0, 255)");
       expect(pass.labelColor).toBe("rgb(0, 255, 0)");
     });
+
+    test("includes webServiceURL and authenticationToken when webServiceURL is set", () => {
+      const pass = generatePassJson(
+        makePassData({ webServiceURL: "https://example.com" }),
+        creds,
+      );
+      expect(pass.webServiceURL).toBe("https://example.com");
+      expect(pass.authenticationToken).toBe("ABC123");
+    });
+
+    test("omits webServiceURL and authenticationToken when webServiceURL is not set", () => {
+      const pass = generatePassJson(makePassData(), creds);
+      expect(pass.webServiceURL).toBeUndefined();
+      expect(pass.authenticationToken).toBeUndefined();
+    });
   });
 
   describe("sha1Hex", () => {

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -40,7 +40,14 @@ const walletRequest = (
       method: options.method ?? "GET",
       headers: { host: "localhost", ...options.headers },
       ...(options.method === "POST"
-        ? { body: "{}", headers: { host: "localhost", "content-type": "application/json", ...options.headers } }
+        ? {
+            body: "{}",
+            headers: {
+              host: "localhost",
+              "content-type": "application/json",
+              ...options.headers,
+            },
+          }
         : {}),
     }),
   );

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -1,0 +1,184 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { unzipSync } from "fflate";
+import {
+  updateAppleWalletPassTypeId,
+  updateAppleWalletSigningCert,
+  updateAppleWalletSigningKey,
+  updateAppleWalletTeamId,
+  updateAppleWalletWwdrCert,
+} from "#lib/db/settings.ts";
+import { handleRequest } from "#routes";
+import {
+  createTestAttendeeWithToken,
+  createTestDbWithSetup,
+  generateTestCerts,
+  resetDb,
+  resetTestSlugCounter,
+} from "#test-utils";
+
+const testCerts = generateTestCerts();
+
+/** Configure all Apple Wallet settings in the database */
+const configureAppleWallet = async () => {
+  await Promise.all([
+    updateAppleWalletPassTypeId("pass.com.test.tickets"),
+    updateAppleWalletTeamId("TESTTEAM01"),
+    updateAppleWalletSigningCert(testCerts.signingCert),
+    updateAppleWalletSigningKey(testCerts.signingKey),
+    updateAppleWalletWwdrCert(testCerts.wwdrCert),
+  ]);
+};
+
+/** Make a request through the full handler pipeline */
+const walletRequest = (
+  path: string,
+  options: { method?: string; headers?: Record<string, string> } = {},
+) =>
+  handleRequest(
+    new Request(`http://localhost${path}`, {
+      method: options.method ?? "GET",
+      headers: { host: "localhost", ...options.headers },
+      ...(options.method === "POST"
+        ? { body: "{}", headers: { host: "localhost", "content-type": "application/json", ...options.headers } }
+        : {}),
+    }),
+  );
+
+describe("Apple Wallet web service (/v1)", () => {
+  beforeEach(async () => {
+    resetTestSlugCounter();
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber", () => {
+    test("returns 201 for device registration", async () => {
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.test/serial-1",
+        { method: "POST" },
+      );
+      expect(response.status).toBe(201);
+    });
+  });
+
+  describe("DELETE /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber", () => {
+    test("returns 200 for device unregistration", async () => {
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.test/serial-1",
+        { method: "DELETE" },
+      );
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("GET /v1/devices/:deviceId/registrations/:passTypeId", () => {
+    test("returns 401 without Authorization header", async () => {
+      await configureAppleWallet();
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.test.tickets",
+      );
+      expect(response.status).toBe(401);
+    });
+
+    test("returns 204 when passTypeId does not match config", async () => {
+      await configureAppleWallet();
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.wrong",
+        { headers: { Authorization: "ApplePass some-token" } },
+      );
+      expect(response.status).toBe(204);
+    });
+
+    test("returns 204 when wallet is not configured", async () => {
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.test.tickets",
+        { headers: { Authorization: "ApplePass some-token" } },
+      );
+      expect(response.status).toBe(204);
+    });
+
+    test("returns serial numbers and lastUpdated for valid request", async () => {
+      await configureAppleWallet();
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.test.tickets",
+        { headers: { Authorization: "ApplePass my-serial-token" } },
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.serialNumbers).toEqual(["my-serial-token"]);
+      expect(body.lastUpdated).toBeDefined();
+    });
+
+    test("ignores passesUpdatedSince parameter", async () => {
+      await configureAppleWallet();
+      const response = await walletRequest(
+        "/v1/devices/abc123/registrations/pass.com.test.tickets?passesUpdatedSince=12345",
+        { headers: { Authorization: "ApplePass my-serial-token" } },
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.serialNumbers).toEqual(["my-serial-token"]);
+    });
+  });
+
+  describe("GET /v1/passes/:passTypeId/:serialNumber", () => {
+    test("returns 404 when wallet is not configured", async () => {
+      const response = await walletRequest(
+        "/v1/passes/pass.com.test.tickets/some-token",
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 404 when passTypeId does not match", async () => {
+      await configureAppleWallet();
+      const response = await walletRequest(
+        "/v1/passes/pass.com.wrong/some-token",
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 404 for invalid serial number", async () => {
+      await configureAppleWallet();
+      const response = await walletRequest(
+        "/v1/passes/pass.com.test.tickets/nonexistent-token",
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("returns valid pkpass for existing attendee token", async () => {
+      await configureAppleWallet();
+      const { token } = await createTestAttendeeWithToken(
+        "Alice",
+        "alice@test.com",
+      );
+      const response = await walletRequest(
+        `/v1/passes/pass.com.test.tickets/${token}`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe(
+        "application/vnd.apple.pkpass",
+      );
+
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      const files = unzipSync(bytes);
+      expect(files["pass.json"]).toBeDefined();
+
+      const passJson = JSON.parse(
+        new TextDecoder().decode(files["pass.json"]!),
+      );
+      expect(passJson.serialNumber).toBe(token);
+      expect(passJson.passTypeIdentifier).toBe("pass.com.test.tickets");
+    });
+  });
+
+  describe("POST /v1/log", () => {
+    test("returns 200 for log submission", async () => {
+      const response = await walletRequest("/v1/log", { method: "POST" });
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -220,6 +220,17 @@ describe("wallet route (/wallet/:token)", () => {
     expect(passJson.eventTicket.primaryFields[0].value).toBe(event.name);
   });
 
+  test("pass.json includes webServiceURL and authenticationToken for auto-updates", async () => {
+    await configureAppleWallet();
+    const { token } = await createTestAttendeeWithToken(
+      "Alice",
+      "alice@test.com",
+    );
+    const passJson = await parsePkpassJson(token);
+    expect(passJson.webServiceURL).toBe("https://localhost");
+    expect(passJson.authenticationToken).toBe(token);
+  });
+
   test("returns null for non-GET methods", async () => {
     const { routeWallet } = await import("#routes/wallet.ts");
     const request = new Request("http://localhost/wallet/some-token", {


### PR DESCRIPTION
## Summary
Implements the Apple PassKit web service protocol to enable automatic pass updates on devices. This allows Apple Wallet to periodically check for updated passes without requiring manual re-downloads.

## Key Changes

- **New web service endpoints** (`/v1/` routes):
  - `POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber` — Accept device registrations (stub)
  - `DELETE /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber` — Accept device unregistrations (stub)
  - `GET /v1/devices/:deviceId/registrations/:passTypeId` — Return registered tokens with auth validation
  - `GET /v1/passes/:passTypeId/:serialNumber` — Serve fresh `.pkpass` files
  - `POST /v1/log` — Accept device log messages (stub)

- **Pass data enhancements**:
  - Added `webServiceURL` field to `PassData` type
  - Passes now include `webServiceURL` and `authenticationToken` in generated pass.json
  - Extracted `buildPkpassForToken()` as a shared utility for both download and web service endpoints

- **Routing and middleware**:
  - Registered `/v1/` prefix handler with lazy-loaded web service routes
  - Updated `isJsonApiPath()` to recognize web service endpoints as JSON APIs

- **Comprehensive test coverage**:
  - Tests for all five web service endpoints
  - Validation of authentication, pass type matching, and pass generation
  - Verification of `.pkpass` structure and pass.json contents

## Implementation Details

The web service uses a simplified approach: it doesn't track device state or update timestamps. Instead, it always reports passes as updated, causing devices to re-download on manual refresh. This ensures users always get the latest pass without complex state management.

The `buildPkpassForToken()` function is now shared between the existing `/wallet/:token` download route and the new `/v1/passes/:passTypeId/:serialNumber` web service endpoint, ensuring consistent pass generation.

https://claude.ai/code/session_01RaJY4JPoCfb9w51ZwYWwKi