### PR TITLE
Fix documentation links in module table

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -22,17 +22,17 @@
  *
  * | Module | Description |
  * |--------|-------------|
- * | [Database](./docs/database.ts) | ORM, table abstractions, and entity CRUD |
- * | [Crypto](./docs/crypto.ts) | Encryption, hashing, and CSRF |
- * | [Payments](./docs/payments.ts) | Stripe and Square integration |
- * | [Email](./docs/email.ts) | Email sending and templates |
- * | [Tickets](./docs/tickets.ts) | QR codes, SVG tickets, Apple Wallet |
- * | [Events](./docs/events.ts) | Event fields, sorting, availability |
- * | [Config](./docs/config.ts) | Settings, environment, sessions |
- * | [Utilities](./docs/utilities.ts) | FP helpers, formatting, caching |
- * | [Embed](./docs/embed.ts) | Widget embedding and CDN |
- * | [Webhooks](./docs/webhooks.ts) | Webhook delivery and API examples |
- * | [Demo](./docs/demo.ts) | Demo mode and seed data |
+ * | [Database](../docs/database.ts) | ORM, table abstractions, and entity CRUD |
+ * | [Crypto](../docs/crypto.ts) | Encryption, hashing, and CSRF |
+ * | [Payments](../docs/payments.ts) | Stripe and Square integration |
+ * | [Email](../docs/email.ts) | Email sending and templates |
+ * | [Tickets](../docs/tickets.ts) | QR codes, SVG tickets, Apple Wallet |
+ * | [Events](../docs/events.ts) | Event fields, sorting, availability |
+ * | [Config](../docs/config.ts) | Settings, environment, sessions |
+ * | [Utilities](../docs/utilities.ts) | FP helpers, formatting, caching |
+ * | [Embed](../docs/embed.ts) | Widget embedding and CDN |
+ * | [Webhooks](../docs/webhooks.ts) | Webhook delivery and API examples |
+ * | [Demo](../docs/demo.ts) | Demo mode and seed data |
  *
  * ## Deployment Options
  *


### PR DESCRIPTION
## Summary
Updated the documentation module table links to use relative paths instead of absolute paths, ensuring proper navigation from the current file location.

## Changes
- Changed all module documentation links from `./docs/` to `../docs/` format
- Affected modules: Database, Crypto, Payments, Email, Tickets, Events, Config, Utilities, Embed, Webhooks, and Demo
- This corrects the relative path resolution for the documentation structure

## Details
The links were using `./docs/` which resolves relative to the current directory, but the correct relative path from `src/doc.ts` to the `docs/` directory requires `../docs/`. This ensures the documentation table properly links to the module documentation files.

https://claude.ai/code/session_01PZLsUh8PeeDZhRujajfK29