### PR TITLE
Update documentation links and environment variable references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A self-hosted ticket reservation system built by [Chobble CIC](https://chobble.com), a community interest company. Runs on any Deno environment (or Bunny Edge Scripting) with libsql (Turso). Encrypts all PII at rest. Handles free and paid events with Stripe or Square.
 
+**Website**: [tickets.chobble.com](https://tickets.chobble.com)
+
 This is not "open core" — every feature is available under **AGPLv3** with no proprietary add-ons. Hosted instances available at [tix.chobble.com](https://tix.chobble.com/ticket/register) for £50/year, no tiers.
 
 ## Deploy
@@ -150,20 +152,7 @@ On first launch, visit `/setup/` to set admin credentials and currency. Payment 
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DB_URL` | Yes | libsql database URL |
-| `DB_TOKEN` | Yes* | Database auth token (*remote databases) |
-| `DB_ENCRYPTION_KEY` | Yes | 32-byte base64-encoded AES-256 key |
-| `ALLOWED_DOMAIN` | Yes | Domain for security validation |
-| `PORT` | No | Local dev server port (default: 3000) |
-| `STORAGE_ZONE_NAME` | No | Bunny CDN storage zone name (required for image uploads) |
-| `STORAGE_ZONE_KEY` | No | Bunny CDN storage zone access key (required for image uploads) |
-| `BUNNY_API_KEY` | No | Bunny CDN API key (required for custom domain settings) |
-| `HOST_EMAIL_PROVIDER` | No | Host-level email provider (resend, postmark, sendgrid, mailgun-us, mailgun-eu) |
-| `HOST_EMAIL_API_KEY` | No | Host-level email API key |
-| `HOST_EMAIL_FROM_ADDRESS` | No | Host-level email sender address |
-| `NTFY_URL` | No | Ntfy endpoint for error notifications (sends domain + error code only) |
+See the full list of configuration keys in the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html).
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,14 @@ On first launch, visit `/setup/` to set admin credentials and currency. Payment 
 
 ## Environment Variables
 
-See the full list of configuration keys in the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html).
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DB_URL` | Yes | libsql database URL |
+| `DB_TOKEN` | Yes* | Database auth token (*remote databases) |
+| `DB_ENCRYPTION_KEY` | Yes | 32-byte base64-encoded AES-256 key |
+| `ALLOWED_DOMAIN` | Yes | Domain for security validation |
+
+There are additional optional variables covering emails, Apple Wallet, image uploads, and more — see the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html) for the full list.
 
 ## Deployment
 

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1350,7 +1350,7 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           <p>
             Absolutely. This is open-source software, so you have full control.
             You can{" "}
-            <a href="https://github.com/chobble-mirror/tickets">
+            <a href="https://github.com/chobbledotcom/tickets">
               grab the code from GitHub
             </a>{" "}
             and host it yourself on Bunny Edge Scripting or any compatible


### PR DESCRIPTION
## Summary
This PR updates documentation and links to improve clarity and maintainability of the project's setup and deployment information.

## Key Changes
- Added website link to README header for easier access to the live instance
- Simplified environment variables table in README by moving optional variables to a reference link instead of listing them inline
- Updated GitHub repository link from `chobble-mirror/tickets` to `chobbledotcom/tickets` in the admin guide

## Details
- The README now directs users to the [CONFIG_KEYS reference documentation](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html) for the complete list of optional environment variables (emails, Apple Wallet, image uploads, etc.) rather than maintaining a potentially outdated list in the table
- This reduces maintenance burden and ensures the single source of truth for configuration is the generated API documentation
- The GitHub link correction ensures users are directed to the correct repository for self-hosting

https://claude.ai/code/session_01LiU8AgAjM4d5j9e3vMsq3i