### PR TITLE
Hide quantity selector for single event with max quantity 1

### DIFF
--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -438,7 +438,8 @@ export const multiTicketPage = (
 
   const availableEvents = events.filter((e) => !e.isSoldOut && !e.isClosed);
   const hideQuantity =
-    availableEvents.length === 1 && availableEvents[0].maxPurchasable === 1;
+    availableEvents.length === 1 &&
+    availableEvents[0]?.maxPurchasable === 1;
 
   const eventRows = events
     .map((e) => renderMultiEventRow(e, hideQuantity))

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -361,7 +361,10 @@ const renderMultiEventDescription = (description: string): string =>
     : "";
 
 /** Render quantity selector for a single event in multi-ticket form */
-const renderMultiEventRow = (info: MultiTicketEvent): string => {
+const renderMultiEventRow = (
+  info: MultiTicketEvent,
+  hideQuantity = false,
+): string => {
   const { event, isSoldOut, isClosed, maxPurchasable } = info;
   const fieldName = `quantity_${event.id}`;
   const imageHtml = renderEventImage(event);
@@ -387,9 +390,14 @@ const renderMultiEventRow = (info: MultiTicketEvent): string => {
     `;
   }
 
-  const options = Array.from({ length: maxPurchasable + 1 }, (_, i) => i)
-    .map((n) => `<option value="${n}">${n}</option>`)
-    .join("");
+  const quantityHtml = hideQuantity
+    ? `<input type="hidden" name="${fieldName}" value="1" />`
+    : (() => {
+        const options = Array.from({ length: maxPurchasable + 1 }, (_, i) => i)
+          .map((n) => `<option value="${n}">${n}</option>`)
+          .join("");
+        return `<select name="${fieldName}" id="${fieldName}">${options}</select>`;
+      })();
 
   const showPayMore = event.can_pay_more;
   const priceFieldName = `custom_price_${event.id}`;
@@ -399,9 +407,7 @@ const renderMultiEventRow = (info: MultiTicketEvent): string => {
       ${imageHtml}
       <label for="${fieldName}">${escapeHtml(event.name)}</label>
       ${renderMultiEventDescription(event.description)}
-      <select name="${fieldName}" id="${fieldName}">
-        ${options}
-      </select>
+      ${quantityHtml}
       ${showPayMore ? renderPayMoreInput(event, priceFieldName) : ""}
     </div>
   `;
@@ -430,9 +436,15 @@ export const multiTicketPage = (
   const fields: Field[] = getTicketFields(fieldsSetting);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
 
-  const eventRows = pipe(map(renderMultiEventRow), (rows: string[]) =>
-    rows.join(""),
-  )(events);
+  const availableEvents = events.filter(
+    (e) => !e.isSoldOut && !e.isClosed,
+  );
+  const hideQuantity =
+    availableEvents.length === 1 && availableEvents[0].maxPurchasable === 1;
+
+  const eventRows = events
+    .map((e) => renderMultiEventRow(e, hideQuantity))
+    .join("");
 
   return String(
     <Layout title="Reserve Tickets" bodyClass={inIframe ? "iframe" : undefined}>
@@ -451,10 +463,14 @@ export const multiTicketPage = (
             <Raw html={renderDateSelector(availableDates)} />
           )}
 
-          <fieldset class="multi-ticket-events">
-            <legend>Select Tickets</legend>
+          {hideQuantity ? (
             <Raw html={eventRows} />
-          </fieldset>
+          ) : (
+            <fieldset class="multi-ticket-events">
+              <legend>Select Tickets</legend>
+              <Raw html={eventRows} />
+            </fieldset>
+          )}
 
           {termsAndConditions && (
             <Raw html={renderTermsAndCheckbox(termsAndConditions)} />

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -436,9 +436,7 @@ export const multiTicketPage = (
   const fields: Field[] = getTicketFields(fieldsSetting);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
 
-  const availableEvents = events.filter(
-    (e) => !e.isSoldOut && !e.isClosed,
-  );
+  const availableEvents = events.filter((e) => !e.isSoldOut && !e.isClosed);
   const hideQuantity =
     availableEvents.length === 1 && availableEvents[0].maxPurchasable === 1;
 

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -2457,6 +2457,99 @@ describe("html", () => {
       expect(html).not.toContain("?iframe=true");
       expect(html).not.toContain('class="iframe"');
     });
+
+    test("hides quantity selector for single event with max quantity 1", () => {
+      const events = [
+        buildMultiTicketEvent(
+          testEventWithCount({
+            id: 1,
+            slug: "ab12c",
+            name: "Event A",
+            attendee_count: 0,
+            max_quantity: 1,
+          }),
+        ),
+      ];
+      const html = multiTicketPage(events, ["ab12c"]);
+      expect(html).toContain('type="hidden"');
+      expect(html).toContain('name="quantity_1"');
+      expect(html).toContain('value="1"');
+      expect(html).not.toContain("<select");
+      expect(html).not.toContain("Select Tickets");
+    });
+
+    test("shows quantity selector for single event with max quantity above 1", () => {
+      const events = [
+        buildMultiTicketEvent(
+          testEventWithCount({
+            id: 1,
+            slug: "ab12c",
+            name: "Event A",
+            attendee_count: 0,
+            max_quantity: 3,
+          }),
+        ),
+      ];
+      const html = multiTicketPage(events, ["ab12c"]);
+      expect(html).toContain("<select");
+      expect(html).toContain('name="quantity_1"');
+      expect(html).toContain("Select Tickets");
+      expect(html).not.toContain('type="hidden"');
+    });
+
+    test("shows quantity selector for multiple events even with max quantity 1", () => {
+      const events = [
+        buildMultiTicketEvent(
+          testEventWithCount({
+            id: 1,
+            slug: "ab12c",
+            name: "Event A",
+            attendee_count: 0,
+            max_quantity: 1,
+          }),
+        ),
+        buildMultiTicketEvent(
+          testEventWithCount({
+            id: 2,
+            slug: "cd34e",
+            name: "Event B",
+            attendee_count: 0,
+            max_quantity: 1,
+          }),
+        ),
+      ];
+      const html = multiTicketPage(events, ["ab12c", "cd34e"]);
+      expect(html).toContain("<select");
+      expect(html).toContain("Select Tickets");
+    });
+
+    test("hides quantity selector when one event available and one sold out", () => {
+      const events = [
+        buildMultiTicketEvent(
+          testEventWithCount({
+            id: 1,
+            slug: "ab12c",
+            name: "Event A",
+            attendee_count: 0,
+            max_quantity: 1,
+          }),
+        ),
+        buildMultiTicketEvent(
+          testEventWithCount({
+            id: 2,
+            slug: "cd34e",
+            name: "Event B",
+            attendee_count: 50,
+            max_attendees: 50,
+          }),
+        ),
+      ];
+      const html = multiTicketPage(events, ["ab12c", "cd34e"]);
+      expect(html).toContain('type="hidden"');
+      expect(html).toContain('name="quantity_1"');
+      expect(html).toContain('value="1"');
+      expect(html).not.toContain("Select Tickets");
+    });
   });
 
   describe("adminSettingsPage", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -2471,9 +2471,7 @@ describe("html", () => {
         ),
       ];
       const html = multiTicketPage(events, ["ab12c"]);
-      expect(html).toContain('type="hidden"');
-      expect(html).toContain('name="quantity_1"');
-      expect(html).toContain('value="1"');
+      expect(html).toContain('name="quantity_1" value="1"');
       expect(html).not.toContain("<select");
       expect(html).not.toContain("Select Tickets");
     });
@@ -2494,7 +2492,7 @@ describe("html", () => {
       expect(html).toContain("<select");
       expect(html).toContain('name="quantity_1"');
       expect(html).toContain("Select Tickets");
-      expect(html).not.toContain('type="hidden"');
+      expect(html).not.toContain('name="quantity_1" value="1"');
     });
 
     test("shows quantity selector for multiple events even with max quantity 1", () => {
@@ -2545,9 +2543,7 @@ describe("html", () => {
         ),
       ];
       const html = multiTicketPage(events, ["ab12c", "cd34e"]);
-      expect(html).toContain('type="hidden"');
-      expect(html).toContain('name="quantity_1"');
-      expect(html).toContain('value="1"');
+      expect(html).toContain('name="quantity_1" value="1"');
       expect(html).not.toContain("Select Tickets");
     });
   });


### PR DESCRIPTION
When the registration page has only one available event and its max
purchasable quantity is 1, hide the dropdown selector and submit
quantity=1 automatically via a hidden input. This removes the confusing
step of changing 0 to 1 for single-ticket registrations.

https://claude.ai/code/session_01Q4qpQMauZxsoyWd3ZWUyG6