### PR TITLE
Add encryption key override for test isolation

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -124,11 +124,29 @@ const [getHmacKeyCache, setHmacKeyCache] = lazyRef<HmacKeyCache>(() => {
 });
 
 /**
+ * Module-level override for the encryption key string.
+ * Bypasses Deno.env to avoid races between parallel test workers.
+ * When set to a string, that value is used instead of reading Deno.env.
+ * Setting to null reverts to reading from the environment.
+ */
+const [getEncryptionKeyOverride, setEncryptionKeyOverride] = lazyRef<
+  string | null
+>(() => null);
+
+/**
+ * Explicitly set or clear the encryption key for testing.
+ * Bypasses Deno.env to avoid races between parallel test workers.
+ */
+export const setEncryptionKeyForTest = (key: string | null): void => {
+  setEncryptionKeyOverride(key);
+};
+
+/**
  * Get the encryption key bytes from environment variable (sync validation only)
  * Expects DB_ENCRYPTION_KEY to be a base64-encoded 256-bit (32 byte) key
  */
 const getEncryptionKeyString = (): string => {
-  const keyString = getEnv("DB_ENCRYPTION_KEY");
+  const keyString = getEncryptionKeyOverride() ?? getEnv("DB_ENCRYPTION_KEY");
 
   if (!keyString) {
     throw new Error(

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -438,8 +438,7 @@ export const multiTicketPage = (
 
   const availableEvents = events.filter((e) => !e.isSoldOut && !e.isClosed);
   const hideQuantity =
-    availableEvents.length === 1 &&
-    availableEvents[0]?.maxPurchasable === 1;
+    availableEvents.length === 1 && availableEvents[0]?.maxPurchasable === 1;
 
   const eventRows = events
     .map((e) => renderMultiEventRow(e, hideQuantity))

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -8,7 +8,10 @@ import forge from "node-forge";
 import { bracket } from "#fp";
 import type { SigningCredentials } from "#lib/apple-wallet.ts";
 import { getSessionCookieName } from "#lib/cookies.ts";
-import { clearEncryptionKeyCache } from "#lib/crypto.ts";
+import {
+  clearEncryptionKeyCache,
+  setEncryptionKeyForTest,
+} from "#lib/crypto.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import {
   resetCurrencyCode,
@@ -57,6 +60,7 @@ export const TEST_ENCRYPTION_KEY =
  * Also enables fast PBKDF2 hashing for tests
  */
 export const setupTestEncryptionKey = (): void => {
+  setEncryptionKeyForTest(TEST_ENCRYPTION_KEY);
   Deno.env.set("DB_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY);
   Deno.env.set("TEST_PBKDF2_ITERATIONS", "1"); // Enable fast password hashing for tests
   Deno.env.set("TEST_SKIP_LOGIN_DELAY", "1"); // Skip timing-attack delay in tests
@@ -69,6 +73,7 @@ export const setupTestEncryptionKey = (): void => {
  * Clear test encryption key from environment
  */
 export const clearTestEncryptionKey = (): void => {
+  setEncryptionKeyForTest(null);
   Deno.env.delete("DB_ENCRYPTION_KEY");
   Deno.env.delete("TEST_PBKDF2_ITERATIONS");
   Deno.env.delete("TEST_SKIP_LOGIN_DELAY");

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -273,6 +273,8 @@ describe("code quality", () => {
       "lib/db/client.ts:setDb",
       // Reset cached encryption key between tests
       "lib/crypto.ts:clearEncryptionKeyCache",
+      // Set encryption key directly to avoid env var races between parallel tests
+      "lib/crypto.ts:setEncryptionKeyForTest",
       // Reset cached Stripe client between tests
       "lib/stripe.ts:resetStripeClient",
       // Reset cached setup complete status between tests

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -19,6 +19,7 @@ import {
   hybridEncrypt,
   importPrivateKey,
   importPublicKey,
+  setEncryptionKeyForTest,
   unwrapKey,
   unwrapKeyWithToken,
   validateEncryptionKey,
@@ -137,7 +138,7 @@ describe("encryption", () => {
     });
 
     it("throws when key is wrong length", () => {
-      Deno.env.set("DB_ENCRYPTION_KEY", btoa("tooshort"));
+      setEncryptionKeyForTest(btoa("tooshort"));
       clearEncryptionKeyCache();
       expect(() => validateEncryptionKey()).toThrow(
         "DB_ENCRYPTION_KEY must be 32 bytes",
@@ -221,15 +222,14 @@ describe("encryption", () => {
 
       // Generate a different valid 32-byte key
       const newKey = btoa("abcdefghijklmnopqrstuvwxyz012345");
-      Deno.env.set("DB_ENCRYPTION_KEY", newKey);
+      setEncryptionKeyForTest(newKey);
       clearEncryptionKeyCache();
 
       // Decryption with new key should fail
       await expect(decrypt(encrypted)).rejects.toThrow();
 
       // Restore original key
-      Deno.env.set("DB_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY);
-      clearEncryptionKeyCache();
+      setupTestEncryptionKey();
 
       // Now decryption should work again
       const decrypted = await decrypt(encrypted);
@@ -351,18 +351,15 @@ describe("hmacHash", () => {
     const ip = "192.168.1.1";
     const hash1 = await hmacHash(ip);
 
-    // Change the encryption key
-    clearTestEncryptionKey();
-    Deno.env.set(
-      "DB_ENCRYPTION_KEY",
-      "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=",
-    );
+    // Change the encryption key via module override (avoids env var races)
+    const altKey = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=";
+    setEncryptionKeyForTest(altKey);
+    clearEncryptionKeyCache();
 
     const hash2 = await hmacHash(ip);
     expect(hash1).not.toBe(hash2);
 
     // Restore original key
-    clearTestEncryptionKey();
     setupTestEncryptionKey();
   });
 

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -30,7 +30,6 @@ import {
 import {
   clearTestEncryptionKey,
   setupTestEncryptionKey,
-  TEST_ENCRYPTION_KEY,
 } from "#test-utils";
 
 describe("constantTimeEqual", () => {


### PR DESCRIPTION
## Summary
Adds a module-level encryption key override mechanism to avoid race conditions between parallel test workers when setting the encryption key via environment variables.

## Key Changes
- Added `setEncryptionKeyForTest()` export to allow tests to set the encryption key directly without using `Deno.env`
- Added internal `getEncryptionKeyOverride` and `setEncryptionKeyOverride` lazy refs to store the override value
- Modified `getEncryptionKeyString()` to check the override first before falling back to `Deno.env`
- Updated `setupTestEncryptionKey()` and `clearTestEncryptionKey()` in test utilities to use the new override mechanism
- Updated test cases to use `setEncryptionKeyForTest()` instead of `Deno.env.set()` for encryption key changes
- Added `setEncryptionKeyForTest` to the code quality allowlist for test-only exports

## Implementation Details
The override mechanism uses a nullable string that defaults to `null`, which causes the system to fall back to reading from the environment. This approach:
- Eliminates race conditions from parallel test workers modifying shared environment variables
- Maintains backward compatibility by falling back to `Deno.env` when no override is set
- Provides explicit test setup/teardown through `setupTestEncryptionKey()` and `clearTestEncryptionKey()`
- Includes comprehensive JSDoc comments explaining the purpose and usage

Minor formatting fix also applied to `src/templates/public.tsx` for line length consistency.

https://claude.ai/code/session_01SoXzJR4jSicGNreohdeJbB