### PR TITLE
Add configurable booking fee feature for payment processing

### DIFF
--- a/src/lib/booking-fee.ts
+++ b/src/lib/booking-fee.ts
@@ -1,0 +1,26 @@
+/**
+ * Booking fee calculation utility.
+ * Used by Stripe, Square, and webhook validation.
+ */
+
+import { getBookingFee } from "#lib/config.ts";
+
+/** Calculate the booking fee amount in minor units from a subtotal and percentage. */
+export const calculateBookingFee = (
+  subtotalMinorUnits: number,
+  feePercent: number,
+): number => {
+  if (feePercent <= 0) return 0;
+  return Math.round((subtotalMinorUnits * feePercent) / 100);
+};
+
+/** Look up the configured booking fee percentage and calculate the fee for a subtotal. */
+export const getBookingFeeAmount = async (
+  subtotalMinorUnits: number,
+): Promise<number> =>
+  calculateBookingFee(subtotalMinorUnits, await getBookingFee());
+
+/** Calculate cart subtotal from items with unitPrice and quantity. */
+export const itemsSubtotal = (
+  items: ReadonlyArray<{ unitPrice: number; quantity: number }>,
+): number => items.reduce((sum, i) => sum + i.unitPrice * i.quantity, 0);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  getBookingFeeFromDb,
   getCurrencyCodeFromDb,
   getEmbedHostsFromDb,
   getPaymentProviderFromDb,
@@ -101,6 +102,17 @@ export const getSquareLocationId = (): Promise<string | null> =>
  */
 export const getSquareSandbox = (): Promise<boolean> =>
   getSquareSandboxFromDb();
+
+/**
+ * Get booking fee percentage from database.
+ * Returns 0 if not set or invalid. Valid range: 0-10.
+ */
+export const getBookingFee = async (): Promise<number> => {
+  const raw = await getBookingFeeFromDb();
+  if (!raw) return 0;
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) && value >= 0 && value <= 10 ? value : 0;
+};
 
 /**
  * Get currency code from database

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -105,13 +105,11 @@ export const getSquareSandbox = (): Promise<boolean> =>
 
 /**
  * Get booking fee percentage from database.
- * Returns 0 if not set or invalid. Valid range: 0-10.
+ * Returns 0 if not set.
  */
 export const getBookingFee = async (): Promise<number> => {
   const raw = await getBookingFeeFromDb();
-  if (!raw) return 0;
-  const value = Number.parseFloat(raw);
-  return Number.isFinite(value) && value >= 0 && value <= 10 ? value : 0;
+  return Number.parseFloat(raw) || 0;
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -107,10 +107,8 @@ export const getSquareSandbox = (): Promise<boolean> =>
  * Get booking fee percentage from database.
  * Returns 0 if not set.
  */
-export const getBookingFee = async (): Promise<number> => {
-  const raw = await getBookingFeeFromDb();
-  return Number.parseFloat(raw) || 0;
-};
+export const getBookingFee = async (): Promise<number> =>
+  Number.parseFloat((await getBookingFeeFromDb())!) || 0;
 
 /**
  * Get currency code from database

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -263,9 +263,12 @@ const encryptedSetting = (key: string) => ({
   update: (value: string): Promise<void> => updateEncryptedSetting(key, value),
 });
 
-/** Optional plaintext setting: get returns null if unset, update clears on empty. */
-const optionalTextSetting = (key: string) => ({
-  get: (): Promise<string | null> => getSetting(key),
+/** Optional plaintext setting: get returns defaultValue/null if unset, update clears on empty. */
+const optionalTextSetting = (key: string, defaultValue?: string) => ({
+  get: async (): Promise<string | null> => {
+    const value = await getSetting(key);
+    return value ?? defaultValue ?? null;
+  },
   update: (value: string): Promise<void> => setOrDeleteSetting(key, value),
 });
 
@@ -532,7 +535,7 @@ export const { get: getSquareSandboxFromDb, update: updateSquareSandbox } =
   booleanSetting(CONFIG_KEYS.SQUARE_SANDBOX);
 
 export const { get: getBookingFeeFromDb, update: updateBookingFee } =
-  optionalTextSetting(CONFIG_KEYS.BOOKING_FEE);
+  optionalTextSetting(CONFIG_KEYS.BOOKING_FEE, "0");
 
 /**
  * Get allowed embed hosts from database (decrypted)

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -265,10 +265,10 @@ const encryptedSetting = (key: string) => ({
 
 /** Plaintext setting: get returns defaultValue/null if unset, update clears on empty. */
 const textSetting = (key: string, defaultValue?: string) => ({
-  get: async (): Promise<string | null> => {
-    const value = await getSetting(key);
-    return value ?? defaultValue ?? null;
-  },
+  get: async (): Promise<string | null> =>
+    defaultValue !== undefined
+      ? (await getSetting(key)) ?? defaultValue
+      : getSetting(key),
   update: (value: string): Promise<void> => setOrDeleteSetting(key, value),
 });
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -85,6 +85,8 @@ export const CONFIG_KEYS = {
   CUSTOM_DOMAIN: "custom_domain",
   // Custom domain last validated timestamp (plaintext - ISO 8601 UTC)
   CUSTOM_DOMAIN_LAST_VALIDATED: "custom_domain_last_validated",
+  // Booking fee percentage (plaintext - "0" to "10", e.g. "1.5" for 1.5%)
+  BOOKING_FEE: "booking_fee",
   // Apple Wallet configuration
   APPLE_WALLET_PASS_TYPE_ID: "apple_wallet_pass_type_id",
   APPLE_WALLET_TEAM_ID: "apple_wallet_team_id",
@@ -529,6 +531,9 @@ export const updateSquareLocationId = async (
 export const { get: getSquareSandboxFromDb, update: updateSquareSandbox } =
   booleanSetting(CONFIG_KEYS.SQUARE_SANDBOX);
 
+export const { get: getBookingFeeFromDb, update: updateBookingFee } =
+  optionalTextSetting(CONFIG_KEYS.BOOKING_FEE);
+
 /**
  * Get allowed embed hosts from database (decrypted)
  * Returns null if not configured (embedding allowed from anywhere)
@@ -932,6 +937,8 @@ export const settingsApi = {
   updateSquareLocationId,
   getSquareSandboxFromDb,
   updateSquareSandbox,
+  getBookingFeeFromDb,
+  updateBookingFee,
   getEmbedHostsFromDb,
   updateEmbedHosts,
   getTermsAndConditionsFromDb,

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -263,8 +263,8 @@ const encryptedSetting = (key: string) => ({
   update: (value: string): Promise<void> => updateEncryptedSetting(key, value),
 });
 
-/** Optional plaintext setting: get returns defaultValue/null if unset, update clears on empty. */
-const optionalTextSetting = (key: string, defaultValue?: string) => ({
+/** Plaintext setting: get returns defaultValue/null if unset, update clears on empty. */
+const textSetting = (key: string, defaultValue?: string) => ({
   get: async (): Promise<string | null> => {
     const value = await getSetting(key);
     return value ?? defaultValue ?? null;
@@ -535,7 +535,7 @@ export const { get: getSquareSandboxFromDb, update: updateSquareSandbox } =
   booleanSetting(CONFIG_KEYS.SQUARE_SANDBOX);
 
 export const { get: getBookingFeeFromDb, update: updateBookingFee } =
-  optionalTextSetting(CONFIG_KEYS.BOOKING_FEE, "0");
+  textSetting(CONFIG_KEYS.BOOKING_FEE, "0");
 
 /**
  * Get allowed embed hosts from database (decrypted)
@@ -730,7 +730,7 @@ export const { get: getHeaderImageUrlFromDb, update: updateHeaderImageUrl } =
   encryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL);
 
 export const { get: getEmailProviderFromDb, update: updateEmailProvider } =
-  optionalTextSetting(CONFIG_KEYS.EMAIL_PROVIDER);
+  textSetting(CONFIG_KEYS.EMAIL_PROVIDER);
 
 /** Check if an email API key has been configured in the database */
 export const hasEmailApiKey = async (): Promise<boolean> => {
@@ -803,7 +803,7 @@ export const getEmailTemplateSet = async (
 };
 
 export const { get: getCustomDomainFromDb, update: updateCustomDomain } =
-  optionalTextSetting(CONFIG_KEYS.CUSTOM_DOMAIN);
+  textSetting(CONFIG_KEYS.CUSTOM_DOMAIN);
 
 /** Get the custom domain last validated timestamp. Returns null if never validated. */
 export const getCustomDomainLastValidatedFromDb = (): Promise<string | null> =>
@@ -863,12 +863,12 @@ export const hasAppleWalletConfig = async (): Promise<boolean> =>
 export const {
   get: getAppleWalletPassTypeIdFromDb,
   update: updateAppleWalletPassTypeId,
-} = optionalTextSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID);
+} = textSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID);
 
 export const {
   get: getAppleWalletTeamIdFromDb,
   update: updateAppleWalletTeamId,
-} = optionalTextSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID);
+} = textSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID);
 
 export const {
   get: getAppleWalletSigningCertFromDb,

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -267,7 +267,7 @@ const encryptedSetting = (key: string) => ({
 const textSetting = (key: string, defaultValue?: string) => ({
   get: async (): Promise<string | null> =>
     defaultValue !== undefined
-      ? (await getSetting(key)) ?? defaultValue
+      ? ((await getSetting(key)) ?? defaultValue)
       : getSetting(key),
   update: (value: string): Promise<void> => setOrDeleteSetting(key, value),
 });

--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -11,6 +11,7 @@
  */
 
 import { lazyRef, map } from "#fp";
+import { getBookingFeeAmount, itemsSubtotal } from "#lib/booking-fee.ts";
 import {
   getCurrencyCode,
   getSquareAccessToken,
@@ -511,6 +512,53 @@ const normalizeCheckoutPhone = async (
   return normalizePhone(phone, prefix);
 };
 
+/** Build a Square fee line item array (empty when fee is zero). */
+const squareFeeItems = async (
+  subtotal: number,
+  currency: string,
+): Promise<SquareLineItem[]> => {
+  const amt = await getBookingFeeAmount(subtotal);
+  return amt > 0
+    ? [
+        {
+          name: "Booking fee",
+          quantity: "1",
+          note: "Booking fee",
+          basePriceMoney: { amount: BigInt(amt), currency },
+        },
+      ]
+    : [];
+};
+
+type PreparedLink = {
+  config: NonNullable<Awaited<ReturnType<typeof getPaymentLinkConfig>>>;
+  metadata: Record<string, string>;
+};
+
+/** Append booking fee, submit the payment link, and log the result. */
+const submitPaymentLink = async (
+  prep: PreparedLink,
+  lineItems: SquareLineItem[],
+  feeSubtotal: number,
+  intent: { email: string; phone?: string },
+  baseUrl: string,
+  label: string,
+): Promise<PaymentLinkResult> => {
+  lineItems.push(...(await squareFeeItems(feeSubtotal, prep.config.currency)));
+  const result = await createPaymentLinkImpl({
+    ...prep.config,
+    lineItems,
+    ...(await buildCheckoutOptions(intent, prep.metadata, baseUrl, label)),
+  });
+  logDebug(
+    "Square",
+    result
+      ? `${label} created orderId=${result.orderId}`
+      : `${label} creation failed`,
+  );
+  return result;
+};
+
 /** Build common payment link options from intent */
 const buildCheckoutOptions = async (
   intent: { email: string; phone?: string },
@@ -529,10 +577,7 @@ const buildCheckoutOptions = async (
 const preparePaymentLink = async (
   rawMetadata: Record<string, string>,
   label: string,
-): Promise<{
-  config: NonNullable<Awaited<ReturnType<typeof getPaymentLinkConfig>>>;
-  metadata: Record<string, string>;
-} | null> => {
+): Promise<PreparedLink | null> => {
   const config = await getPaymentLinkConfig();
   if (!config) return null;
 
@@ -582,34 +627,27 @@ export const squareApi: {
     );
     if (!prep) return null;
 
-    const result = await createPaymentLinkImpl({
-      ...prep.config,
-      lineItems: [
-        {
-          name: `Ticket: ${event.name}`,
-          quantity: String(intent.quantity),
-          note: intent.quantity > 1 ? `${intent.quantity} Tickets` : "Ticket",
-          basePriceMoney: {
-            amount: BigInt(intent.customUnitPrice ?? event.unit_price),
-            currency: prep.config.currency,
-          },
+    const unitPrice = intent.customUnitPrice ?? event.unit_price;
+    const lineItems: SquareLineItem[] = [
+      {
+        name: `Ticket: ${event.name}`,
+        quantity: String(intent.quantity),
+        note: intent.quantity > 1 ? `${intent.quantity} Tickets` : "Ticket",
+        basePriceMoney: {
+          amount: BigInt(unitPrice),
+          currency: prep.config.currency,
         },
-      ],
-      ...(await buildCheckoutOptions(
-        intent,
-        prep.metadata,
-        baseUrl,
-        "Payment link",
-      )),
-    });
+      },
+    ];
 
-    logDebug(
-      "Square",
-      result
-        ? `Payment link created orderId=${result.orderId}`
-        : "Payment link creation failed",
+    return submitPaymentLink(
+      prep,
+      lineItems,
+      unitPrice * intent.quantity,
+      intent,
+      baseUrl,
+      "Payment link",
     );
-    return result;
   },
 
   /** Create a payment link for multi-event registration */
@@ -623,34 +661,26 @@ export const squareApi: {
     );
     if (!prep) return null;
 
-    const lineItems = map((item: MultiRegistrationIntent["items"][number]) => ({
-      name: `Ticket: ${item.name}`,
-      quantity: String(item.quantity),
-      note: item.quantity > 1 ? `${item.quantity} Tickets` : "Ticket",
-      basePriceMoney: {
-        amount: BigInt(item.unitPrice),
-        currency: prep.config.currency,
-      },
-    }))(intent.items);
+    const lineItems: SquareLineItem[] = map(
+      (item: MultiRegistrationIntent["items"][number]) => ({
+        name: `Ticket: ${item.name}`,
+        quantity: String(item.quantity),
+        note: item.quantity > 1 ? `${item.quantity} Tickets` : "Ticket",
+        basePriceMoney: {
+          amount: BigInt(item.unitPrice),
+          currency: prep.config.currency,
+        },
+      }),
+    )(intent.items);
 
-    const result = await createPaymentLinkImpl({
-      ...prep.config,
+    return submitPaymentLink(
+      prep,
       lineItems,
-      ...(await buildCheckoutOptions(
-        intent,
-        prep.metadata,
-        baseUrl,
-        "Multi payment link",
-      )),
-    });
-
-    logDebug(
-      "Square",
-      result
-        ? `Multi payment link created orderId=${result.orderId}`
-        : "Multi payment link creation failed",
+      itemsSubtotal(intent.items),
+      intent,
+      baseUrl,
+      "Multi payment link",
     );
-    return result;
   },
 
   /** Retrieve an order by ID */

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -5,6 +5,7 @@
 
 import type Stripe from "stripe";
 import { lazyRef, once } from "#fp";
+import { getBookingFeeAmount, itemsSubtotal } from "#lib/booking-fee.ts";
 import {
   getCurrencyCode,
   getStripeSecretKey,
@@ -136,27 +137,53 @@ type SessionConfig = {
   unitPriceOverride?: number;
 };
 
+/** Build a Stripe fee line item array (empty when fee is zero). */
+const stripeFeeItems = async (
+  subtotal: number,
+  currency: string,
+): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> => {
+  const amount = await getBookingFeeAmount(subtotal);
+  if (amount <= 0) return [];
+  return [
+    {
+      price_data: {
+        currency,
+        product_data: { name: "Booking fee" },
+        unit_amount: amount,
+      },
+      quantity: 1,
+    },
+  ];
+};
+
 const buildSessionParams = async (
   cfg: SessionConfig,
 ): Promise<Stripe.Checkout.SessionCreateParams> => {
   const unitAmount = cfg.unitPriceOverride ?? cfg.event.unit_price;
   const currency = (await getCurrencyCode()).toLowerCase();
   const label = cfg.quantity > 1 ? `${cfg.quantity} Tickets` : "Ticket";
+
+  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [
+    {
+      price_data: {
+        currency,
+        product_data: {
+          name: `Ticket: ${cfg.event.name}`,
+          description: label,
+        },
+        unit_amount: unitAmount,
+      },
+      quantity: cfg.quantity,
+    },
+  ];
+
+  lineItems.push(
+    ...(await stripeFeeItems(unitAmount * cfg.quantity, currency)),
+  );
+
   return {
     payment_method_types: ["card"],
-    line_items: [
-      {
-        price_data: {
-          currency,
-          product_data: {
-            name: `Ticket: ${cfg.event.name}`,
-            description: label,
-          },
-          unit_amount: unitAmount,
-        },
-        quantity: cfg.quantity,
-      },
-    ],
+    line_items: lineItems,
     mode: "payment",
     success_url: cfg.successUrl,
     cancel_url: cfg.cancelUrl,
@@ -345,6 +372,10 @@ export const stripeApi: {
         },
         quantity: item.quantity,
       }));
+
+    lineItems.push(
+      ...(await stripeFeeItems(itemsSubtotal(intent.items), currency)),
+    );
 
     const params: Stripe.Checkout.SessionCreateParams = {
       payment_method_types: ["card"],

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -181,7 +181,7 @@ const getSettingsPageState = async () => {
     squareSandbox,
     squareWebhookConfigured: squareWebhookKey !== null,
     webhookUrl: getWebhookUrl(),
-    bookingFee: bookingFeeRaw ?? "0",
+    bookingFee: bookingFeeRaw!,
     embedHosts: embedHosts ?? "",
     termsAndConditions: termsAndConditions ?? "",
     businessEmail,

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -27,6 +27,7 @@ import {
   type EmailTemplateType,
   getAppleWalletPassTypeIdFromDb,
   getAppleWalletTeamIdFromDb,
+  getBookingFeeFromDb,
   getCustomDomainFromDb,
   getCustomDomainLastValidatedFromDb,
   getEmailFromAddressFromDb,
@@ -58,6 +59,7 @@ import {
   updateAppleWalletSigningKey,
   updateAppleWalletTeamId,
   updateAppleWalletWwdrCert,
+  updateBookingFee,
   updateCustomDomain,
   updateCustomDomainLastValidated,
   updateEmailApiKey,
@@ -149,6 +151,7 @@ const getSettingsPageState = async () => {
     squareTokenConfigured,
     squareSandbox,
     squareWebhookKey,
+    bookingFeeRaw,
     embedHosts,
     termsAndConditions,
     businessEmail,
@@ -162,6 +165,7 @@ const getSettingsPageState = async () => {
     hasSquareToken(),
     getSquareSandboxFromDb(),
     getSquareWebhookSignatureKey(),
+    getBookingFeeFromDb(),
     getEmbedHostsFromDb(),
     getTermsAndConditionsFromDb(),
     getBusinessEmailFromDb(),
@@ -177,6 +181,7 @@ const getSettingsPageState = async () => {
     squareSandbox,
     squareWebhookConfigured: squareWebhookKey !== null,
     webhookUrl: getWebhookUrl(),
+    bookingFee: bookingFeeRaw ?? "0",
     embedHosts: embedHosts ?? "",
     termsAndConditions: termsAndConditions ?? "",
     businessEmail,
@@ -835,6 +840,29 @@ const processPhonePrefixForm: SettingsFormHandler = async (form, errorPage) => {
 /** Handle POST /admin/settings/phone-prefix - owner only */
 const handlePhonePrefixPost = settingsRoute(processPhonePrefixForm);
 
+/** Validate and save booking fee from form submission */
+const processBookingFeeForm: SettingsFormHandler = async (form, errorPage) => {
+  const raw = (form.get("booking_fee") ?? "").trim();
+  const value = Number.parseFloat(raw);
+
+  if (!Number.isFinite(value) || value < 0 || value > 10) {
+    return errorPage(
+      "Booking fee must be a number between 0 and 10",
+      400,
+      "settings-booking-fee",
+    );
+  }
+
+  await updateBookingFee(String(value));
+  await logActivity(`Booking fee set to ${value}%`);
+  return redirect("/admin/settings", `Booking fee updated to ${value}%`, true, {
+    formId: "settings-booking-fee",
+  });
+};
+
+/** Handle POST /admin/settings/booking-fee - owner only */
+const handleBookingFeePost = settingsRoute(processBookingFeeForm);
+
 /** Handle POST /admin/settings/header-image - owner only (multipart) */
 const handleHeaderImagePost = (request: Request): Promise<Response> =>
   withOwnerAuthMultipartForm(request, async (session, formData) => {
@@ -1361,6 +1389,7 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/show-public-site": handleShowPublicSitePost,
   "POST /admin/settings/show-public-api": handleShowPublicApiPost,
   "POST /admin/settings/phone-prefix": handlePhonePrefixPost,
+  "POST /admin/settings/booking-fee": handleBookingFeePost,
   "POST /admin/settings/header-image": handleHeaderImagePost,
   "POST /admin/settings/header-image/delete": handleHeaderImageDeletePost,
   "POST /admin/settings/email": handleEmailPost,

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -15,7 +15,12 @@
  */
 
 import { map, unique } from "#fp";
-import { getAllowedDomain, getCurrencyCode } from "#lib/config.ts";
+import { calculateBookingFee } from "#lib/booking-fee.ts";
+import {
+  getAllowedDomain,
+  getBookingFee,
+  getCurrencyCode,
+} from "#lib/config.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import {
   createAttendeeAtomic,
@@ -331,16 +336,25 @@ const validateAndPrice = async (
   return { ok: true, event, expectedPrice };
 };
 
-/** Check if the amount charged matches the current event price.
+/** Check if the amount charged matches the current event price (including booking fee).
  * For pay-more events, the amount must be >= the expected minimum price and <= the max cap. */
 const hasPriceMismatch = (
   amountTotal: number,
   expectedPrice: number,
   event: Pick<EventWithCount, "can_pay_more" | "max_price">,
-): boolean =>
-  event.can_pay_more
-    ? amountTotal < expectedPrice || amountTotal > event.max_price
-    : amountTotal !== expectedPrice;
+  bookingFeePercent = 0,
+): boolean => {
+  if (event.can_pay_more) {
+    const minWithFee =
+      expectedPrice + calculateBookingFee(expectedPrice, bookingFeePercent);
+    const maxWithFee =
+      event.max_price + calculateBookingFee(event.max_price, bookingFeePercent);
+    return amountTotal < minWithFee || amountTotal > maxWithFee;
+  }
+  const expectedWithFee =
+    expectedPrice + calculateBookingFee(expectedPrice, bookingFeePercent);
+  return amountTotal !== expectedWithFee;
+};
 
 /** Format error for post-payment attendee creation failure */
 const formatPostPaymentError = formatCreationError(
@@ -489,8 +503,10 @@ const processMultiPaymentSession = async (
 
   // When items have per-item prices, validate each against the event's rules
   const hasPerItemPrices = intent.items.some((item) => item.p > 0);
+  const bookingFeePercent = await getBookingFee();
 
   if (hasPerItemPrices) {
+    // Per-item prices are ticket-only (no fee), so validate without booking fee
     for (const { item, event, expectedPrice } of validatedItems) {
       if (hasPriceMismatch(item.p, expectedPrice, event)) {
         return priceMismatchRefund(
@@ -501,24 +517,28 @@ const processMultiPaymentSession = async (
       }
     }
 
-    // Cart total must equal the sum of per-item prices
+    // Cart total must equal the sum of per-item prices + booking fee
     const metadataTotal = validatedItems.reduce(
       (sum, { item }) => sum + item.p,
       0,
     );
-    if (session.amountTotal !== metadataTotal) {
+    const expectedCartTotal =
+      metadataTotal + calculateBookingFee(metadataTotal, bookingFeePercent);
+    if (session.amountTotal !== expectedCartTotal) {
       return priceMismatchRefund(
         session,
-        `Multi-ticket total mismatch: provider charged ${session.amountTotal} but sum(p) = ${metadataTotal}`,
+        `Multi-ticket total mismatch: provider charged ${session.amountTotal} but expected ${expectedCartTotal}`,
         validatedItems[0]?.event.id,
       );
     }
   } else {
-    // No per-item prices: validate that provider charged at least the expected total
-    if (session.amountTotal < expectedTotal) {
+    // No per-item prices: validate that provider charged at least the expected total + fee
+    const expectedWithFee =
+      expectedTotal + calculateBookingFee(expectedTotal, bookingFeePercent);
+    if (session.amountTotal < expectedWithFee) {
       return priceMismatchRefund(
         session,
-        `Multi-ticket total mismatch: provider charged ${session.amountTotal} but expected at least ${expectedTotal}`,
+        `Multi-ticket total mismatch: provider charged ${session.amountTotal} but expected at least ${expectedWithFee}`,
         validatedItems[0]?.event.id,
       );
     }
@@ -630,10 +650,18 @@ const processPaymentSession = async (
   if (!vp.ok) return validationFailure(session, vp);
 
   const { event, expectedPrice } = vp;
+  const bookingFeePercent = await getBookingFee();
 
   // Reject if event price changed since checkout was created
   // For pay-more events, the amount charged may be >= the minimum price
-  if (hasPriceMismatch(session.amountTotal, expectedPrice, event)) {
+  if (
+    hasPriceMismatch(
+      session.amountTotal,
+      expectedPrice,
+      event,
+      bookingFeePercent,
+    )
+  ) {
     return priceMismatchRefund(
       session,
       `Price mismatch: provider charged ${session.amountTotal} but current event price yields ${expectedPrice}`,
@@ -641,7 +669,7 @@ const processPaymentSession = async (
     );
   }
 
-  // Use the actual amount charged as price_paid (covers pay-more)
+  // Use the actual amount charged as price_paid (covers pay-more and booking fee)
   const pricePaid = event.can_pay_more ? session.amountTotal : expectedPrice;
 
   const result = await createAttendeeAtomic({

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -24,6 +24,7 @@ export type SettingsPageState = {
   squareSandbox: boolean;
   squareWebhookConfigured: boolean;
   webhookUrl: string;
+  bookingFee: string;
   embedHosts: string;
   termsAndConditions: string;
   businessEmail: string;
@@ -286,6 +287,32 @@ export const adminSettingsPage = (
             )}
           />
           <button type="submit">Update Webhook Key</button>
+        </CsrfForm>
+      )}
+
+      {s.paymentProvider && (
+        <CsrfForm
+          action="/admin/settings/booking-fee"
+          id="settings-booking-fee"
+        >
+          <h2>Booking Fee</h2>
+          <p>
+            Percentage fee added at checkout (e.g. 1.5 for 1.5%). Set to 0 to
+            disable. Max 10.
+          </p>
+          <label>
+            Booking Fee (%)
+            <input
+              type="number"
+              name="booking_fee"
+              step="0.1"
+              min="0"
+              max="10"
+              value={s.bookingFee}
+              required
+            />
+          </label>
+          <button type="submit">Save Booking Fee</button>
         </CsrfForm>
       )}
 

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -438,8 +438,7 @@ export const multiTicketPage = (
 
   const availableEvents = events.filter((e) => !e.isSoldOut && !e.isClosed);
   const hideQuantity =
-    availableEvents.length === 1 &&
-    availableEvents[0]?.maxPurchasable === 1;
+    availableEvents.length === 1 && availableEvents[0]?.maxPurchasable === 1;
 
   const eventRows = events
     .map((e) => renderMultiEventRow(e, hideQuantity))

--- a/test/lib/booking-fee.test.ts
+++ b/test/lib/booking-fee.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import {
+  calculateBookingFee,
+  getBookingFeeAmount,
+  itemsSubtotal,
+} from "#lib/booking-fee.ts";
+import { updateBookingFee } from "#lib/db/settings.ts";
+import { createTestDb, resetDb } from "#test-utils";
+
+describe("calculateBookingFee", () => {
+  test("returns 0 when fee percent is 0", () => {
+    expect(calculateBookingFee(1000, 0)).toBe(0);
+  });
+
+  test("returns 0 when fee percent is negative", () => {
+    expect(calculateBookingFee(1000, -1)).toBe(0);
+  });
+
+  test("returns 0 when subtotal is 0", () => {
+    expect(calculateBookingFee(0, 2.5)).toBe(0);
+  });
+
+  test("calculates 2.9% of 1000 correctly", () => {
+    // 1000 * 2.9 / 100 = 29
+    expect(calculateBookingFee(1000, 2.9)).toBe(29);
+  });
+
+  test("calculates 1.5% of 1000 correctly", () => {
+    // 1000 * 1.5 / 100 = 15
+    expect(calculateBookingFee(1000, 1.5)).toBe(15);
+  });
+
+  test("rounds to nearest integer", () => {
+    // 999 * 1.5 / 100 = 14.985 → 15
+    expect(calculateBookingFee(999, 1.5)).toBe(15);
+  });
+
+  test("rounds 0.5 up", () => {
+    // 100 * 2.5 / 100 = 2.5 → 3 (Math.round rounds 0.5 up)
+    expect(calculateBookingFee(100, 2.5)).toBe(3);
+  });
+
+  test("calculates 10% (maximum allowed) correctly", () => {
+    expect(calculateBookingFee(5000, 10)).toBe(500);
+  });
+
+  test("handles large subtotals", () => {
+    // 100000 (£1000) * 1.5 / 100 = 1500
+    expect(calculateBookingFee(100000, 1.5)).toBe(1500);
+  });
+});
+
+describe("getBookingFeeAmount", () => {
+  beforeEach(async () => {
+    await createTestDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  test("returns 0 when no booking fee configured", async () => {
+    expect(await getBookingFeeAmount(1000)).toBe(0);
+  });
+
+  test("returns calculated fee when booking fee is set", async () => {
+    await updateBookingFee("2.5");
+    // 1000 * 2.5 / 100 = 25
+    expect(await getBookingFeeAmount(1000)).toBe(25);
+  });
+});
+
+describe("itemsSubtotal", () => {
+  test("returns 0 for empty array", () => {
+    expect(itemsSubtotal([])).toBe(0);
+  });
+
+  test("calculates subtotal from items", () => {
+    const items = [
+      { unitPrice: 500, quantity: 2 },
+      { unitPrice: 1000, quantity: 1 },
+    ];
+    expect(itemsSubtotal(items)).toBe(2000);
+  });
+});

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -213,24 +213,9 @@ describe("config", () => {
       expect(await getBookingFee()).toBe(1.5);
     });
 
-    test("returns 0 for invalid value", async () => {
+    test("returns 0 for unparseable value", async () => {
       await updateBookingFee("abc");
       expect(await getBookingFee()).toBe(0);
-    });
-
-    test("returns 0 for negative value", async () => {
-      await updateBookingFee("-1");
-      expect(await getBookingFee()).toBe(0);
-    });
-
-    test("returns 0 for value exceeding 10", async () => {
-      await updateBookingFee("15");
-      expect(await getBookingFee()).toBe(0);
-    });
-
-    test("returns 10 for maximum valid value", async () => {
-      await updateBookingFee("10");
-      expect(await getBookingFee()).toBe(10);
     });
   });
 });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import {
   getAllowedDomain,
+  getBookingFee,
   getCurrencyCode,
   getPaymentProvider,
   getSquareAccessToken,
@@ -18,6 +19,7 @@ import {
   completeSetup,
   setPaymentProvider,
   setSetting,
+  updateBookingFee,
   updateSquareAccessToken,
   updateSquareLocationId,
   updateSquareWebhookSignatureKey,
@@ -198,6 +200,37 @@ describe("config", () => {
     test("returns null when key is whitespace only", () => {
       process.env.STRIPE_PUBLISHABLE_KEY = "   ";
       expect(getStripePublishableKey()).toBeNull();
+    });
+  });
+
+  describe("getBookingFee", () => {
+    test("returns 0 when not set", async () => {
+      expect(await getBookingFee()).toBe(0);
+    });
+
+    test("returns parsed value when set", async () => {
+      await updateBookingFee("1.5");
+      expect(await getBookingFee()).toBe(1.5);
+    });
+
+    test("returns 0 for invalid value", async () => {
+      await updateBookingFee("abc");
+      expect(await getBookingFee()).toBe(0);
+    });
+
+    test("returns 0 for negative value", async () => {
+      await updateBookingFee("-1");
+      expect(await getBookingFee()).toBe(0);
+    });
+
+    test("returns 0 for value exceeding 10", async () => {
+      await updateBookingFee("15");
+      expect(await getBookingFee()).toBe(0);
+    });
+
+    test("returns 10 for maximum valid value", async () => {
+      await updateBookingFee("10");
+      expect(await getBookingFee()).toBe(10);
     });
   });
 });

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -2557,6 +2557,7 @@ describe("html", () => {
         squareSandbox: false,
         squareWebhookConfigured: false,
         webhookUrl: "https://example.com/payment/webhook",
+        bookingFee: "0",
         embedHosts: "",
         termsAndConditions: "",
         businessEmail: "",

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -1736,6 +1736,147 @@ describe("server (admin settings)", () => {
       ).toBe(true);
     });
   });
+  describe("POST /admin/settings/booking-fee", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/settings/booking-fee", {
+          booking_fee: "1.5",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("saves valid booking fee", async () => {
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            booking_fee: "1.5",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
+        "Booking fee updated to 1.5%",
+      );
+
+      const { settingsApi } = await import("#lib/db/settings.ts");
+      expect(await settingsApi.getBookingFeeFromDb()).toBe("1.5");
+    });
+
+    test("saves zero booking fee", async () => {
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            booking_fee: "0",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
+        "Booking fee updated to 0%",
+      );
+    });
+
+    test("rejects value exceeding 10", async () => {
+      await setPaymentProvider("stripe");
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            booking_fee: "15",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      await expectHtmlResponse(
+        response,
+        400,
+        "Booking fee must be a number between 0 and 10",
+      );
+    });
+
+    test("rejects negative value", async () => {
+      await setPaymentProvider("stripe");
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            booking_fee: "-1",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      await expectHtmlResponse(
+        response,
+        400,
+        "Booking fee must be a number between 0 and 10",
+      );
+    });
+
+    test("rejects non-numeric value", async () => {
+      await setPaymentProvider("stripe");
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            booking_fee: "abc",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      await expectHtmlResponse(
+        response,
+        400,
+        "Booking fee must be a number between 0 and 10",
+      );
+    });
+
+    test("settings page displays booking fee form when payment provider is set", async () => {
+      await setPaymentProvider("stripe");
+      const response = await awaitTestRequest("/admin/settings", {
+        cookie: await testCookie(),
+      });
+      await expectHtmlResponse(response, 200, "Booking Fee", "booking_fee");
+    });
+
+    test("settings page hides booking fee form when no payment provider", async () => {
+      const response = await awaitTestRequest("/admin/settings", {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      expect(html).not.toContain('id="settings-booking-fee"');
+    });
+
+    test("logs activity when booking fee is changed", async () => {
+      await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            booking_fee: "2.5",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+
+      const logs = await getAllActivityLog();
+      expect(
+        logs.some((l) => l.message.includes("Booking fee set to 2.5%")),
+      ).toBe(true);
+    });
+  });
+
   describe("sensitive field masking", () => {
     test("shows mask sentinel for configured Stripe key", async () => {
       const { MASK_SENTINEL } = await import("#lib/db/settings.ts");

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -1858,6 +1858,24 @@ describe("server (admin settings)", () => {
       expect(html).not.toContain('id="settings-booking-fee"');
     });
 
+    test("rejects missing booking_fee field", async () => {
+      await setPaymentProvider("stripe");
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/booking-fee",
+          {
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      await expectHtmlResponse(
+        response,
+        400,
+        "Booking fee must be a number between 0 and 10",
+      );
+    });
+
     test("logs activity when booking fee is changed", async () => {
       await handleRequest(
         mockFormRequest(

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -402,6 +402,52 @@ describe("square", () => {
       );
     });
 
+    test("includes booking fee line item when fee is set", async () => {
+      const { updateBookingFee } = await import("#lib/db/settings.ts");
+      await updateBookingFee("2.5");
+      await updateSquareAccessToken("EAAAl_test_123");
+      await updateSquareLocationId("L_loc_456");
+      const { client, checkoutCreate } = createMockClient({
+        checkoutCreate: () =>
+          Promise.resolve({
+            paymentLink: {
+              orderId: "order_fee",
+              url: "https://square.link/fee",
+            },
+          }),
+      });
+
+      await withMocks(
+        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        async () => {
+          const event = testEvent({ unit_price: 1000 });
+          const intent = {
+            eventId: 1,
+            name: "Jane",
+            email: "jane@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            quantity: 2,
+          };
+
+          await squareApi.createPaymentLink(
+            event,
+            intent,
+            "https://tickets.example.com",
+          );
+
+          const args = checkoutCreate.calls[0]!
+            .args[0] as CreatePaymentLinkInput;
+          expect(args.order.lineItems).toHaveLength(2);
+          const feeItem = args.order.lineItems[1]!;
+          expect(feeItem.name).toBe("Booking fee");
+          // 2.5% of 2000 (2 × 1000) = 50
+          expect(feeItem.basePriceMoney.amount).toBe(BigInt(50));
+        },
+      );
+    });
+
     test("omits phone from pre-populated data when empty", async () => {
       await updateSquareAccessToken("EAAAl_test_123");
       await updateSquareLocationId("L_loc_456");

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -338,6 +338,54 @@ describe("stripe", () => {
       );
       expect(result).toBeNull();
     });
+
+    test("includes booking fee line item when fee is set", async () => {
+      const { updateBookingFee } = await import("#lib/db/settings.ts");
+      await updateBookingFee("5");
+      await updateStripeKey("sk_test_mock");
+      const client = await getStripeClient();
+      if (!client) throw new Error("Expected client");
+
+      const createSpy = stub(client.checkout.sessions, "create", () =>
+        Promise.resolve({
+          id: "cs_fee",
+          url: "https://checkout.stripe.com/fee",
+          object: "checkout.session",
+        } as never),
+      );
+
+      try {
+        const event = testEvent({ unit_price: 1000 });
+        const intent = {
+          eventId: 1,
+          name: "Jane",
+          email: "jane@example.com",
+          phone: "",
+          address: "",
+          special_instructions: "",
+          quantity: 1,
+        };
+
+        await createCheckoutSessionWithIntent(
+          event,
+          intent,
+          "http://localhost:3000",
+        );
+
+        const params = createSpy.calls[0]!.args[0]!;
+        const lineItems =
+          params.line_items as { price_data: { product_data: { name: string }; unit_amount: number }; quantity: number }[];
+        const feeItem = lineItems.find(
+          (li) => li.price_data.product_data.name === "Booking fee",
+        );
+        expect(feeItem).toBeDefined();
+        // 5% of 1000 = 50
+        expect(feeItem!.price_data.unit_amount).toBe(50);
+        expect(feeItem!.quantity).toBe(1);
+      } finally {
+        createSpy.restore();
+      }
+    });
   });
 
   describe("refundPayment", () => {

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -372,9 +372,13 @@ describe("stripe", () => {
           "http://localhost:3000",
         );
 
-        const params = createSpy.calls[0]!.args[0]!;
-        const lineItems =
-          params.line_items as { price_data: { product_data: { name: string }; unit_amount: number }; quantity: number }[];
+        const params = createSpy.calls[0]!.args[0] as unknown as {
+          line_items: {
+            price_data: { product_data: { name: string }; unit_amount: number };
+            quantity: number;
+          }[];
+        };
+        const lineItems = params.line_items;
         const feeItem = lineItems.find(
           (li) => li.price_data.product_data.name === "Booking fee",
         );


### PR DESCRIPTION
Adds a configurable booking fee that admins can set as a percentage (0–10%) applied at checkout on top of ticket prices.
Key Changes
	∙	Fee calculation module (src/lib/booking-fee.ts): calculateBookingFee, getBookingFeeAmount, and itemsSubtotal utilities shared by Stripe, Square, and webhook validation
	∙	Stripe integration: New stripeFeeItems helper appends a “Booking fee” line item to both single-event and multi-event checkout sessions when fee > 0
	∙	Square integration: New squareFeeItems helper and submitPaymentLink extracted to deduplicate single/multi payment link creation while appending booking fee line items
	∙	Webhook validation: hasPriceMismatch now factors in booking fee for both fixed-price and pay-more events; multi-ticket cart total validation includes fee in expected amount
	∙	Admin settings: New POST /admin/settings/booking-fee endpoint with 0–10 range validation; booking fee form shown only when a payment provider is configured
	∙	Database: New BOOKING_FEE config key stored as plaintext; optionalTextSetting generalized to textSetting with optional default value support
	∙	Tests: Full coverage for fee calculation, DB getter/setter, admin endpoint validation, and Stripe/Square line item generation