### PR TITLE
Move QR codes to separate CDN-cacheable endpoint

### DIFF
--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -1,12 +1,14 @@
 /**
- * Public ticket view routes - /t/:tokens
- * Displays ticket information for attendees using their ticket tokens
- * Includes an inline SVG QR code for each ticket encoding the /checkin/:token URL
+ * Public ticket view routes - /t/:tokens and /t/:token/svg
+ * Displays ticket information for attendees using their ticket tokens.
+ * The SVG endpoint serves individual QR codes for CDN caching.
  */
 
+import { compact } from "#fp";
 import { signAttachmentUrl } from "#lib/attachment-url.ts";
 import { getAllowedDomain } from "#lib/config.ts";
 import { decrypt } from "#lib/crypto.ts";
+import { getAttendeesByTokens } from "#lib/db/attendees.ts";
 import { hasAppleWalletConfig } from "#lib/db/settings.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import {
@@ -15,14 +17,14 @@ import {
   resolveEntries,
   type TokenEntry,
 } from "#routes/token-utils.ts";
-import { htmlResponse } from "#routes/utils.ts";
+import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { type TicketCard, ticketViewPage } from "#templates/tickets.tsx";
 
 /** Build the check-in URL for a single token */
-const buildCheckinUrl = (token: string): string =>
+export const buildCheckinUrl = (token: string): string =>
   `https://${getAllowedDomain()}/checkin/${token}`;
 
-/** Build a ticket card with QR code for a single token/entry pair */
+/** Build a ticket card for a single token/entry pair */
 const buildTicketCard = async (
   entry: TokenEntry,
   token: string,
@@ -33,7 +35,6 @@ const buildTicketCard = async (
     : undefined;
   return {
     entry,
-    qrSvg: await generateQrSvg(buildCheckinUrl(token)),
     token,
     attachmentUrl,
   };
@@ -60,5 +61,42 @@ const handleTicketView = async (
   return htmlResponse(ticketViewPage(cards, walletEnabled));
 };
 
-/** Route ticket view requests */
-export const routeTicketView = createTokenRoute("t", { GET: handleTicketView });
+/** One year in seconds — SVG tickets never change so cache aggressively */
+const ONE_YEAR = 365 * 24 * 60 * 60;
+
+/** Handle GET /t/:token/svg — serve QR code SVG for CDN caching */
+const handleTicketSvg = async (token: string): Promise<Response> => {
+  const attendees = await getAttendeesByTokens([token]);
+  const valid = compact(attendees);
+  if (valid.length === 0) return notFoundResponse();
+
+  const svg = await generateQrSvg(buildCheckinUrl(token));
+  return new Response(svg, {
+    headers: {
+      "content-type": "image/svg+xml",
+      "cache-control": `public, max-age=${ONE_YEAR}, immutable`,
+    },
+  });
+};
+
+/** Match /t/:token/svg path, returning the token if matched */
+const matchSvgPath = (path: string): string | null => {
+  const match = path.match(/^\/t\/([^/+]+)\/svg$/);
+  return match?.[1] ?? null;
+};
+
+/** Token-based route for the regular ticket view */
+const tokenRoute = createTokenRoute("t", { GET: handleTicketView });
+
+/** Route ticket view and SVG requests */
+export const routeTicketView = (
+  request: Request,
+  path: string,
+  method: string,
+): Promise<Response | null> => {
+  if (method === "GET") {
+    const svgToken = matchSvgPath(path);
+    if (svgToken) return Promise.resolve(handleTicketSvg(svgToken));
+  }
+  return tokenRoute(request, path, method);
+};

--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -16,6 +16,7 @@ import {
   lookupAttendees,
   resolveEntries,
   type TokenEntry,
+  type TokenRouteFn,
 } from "#routes/token-utils.ts";
 import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { type TicketCard, ticketViewPage } from "#templates/tickets.tsx";
@@ -89,11 +90,7 @@ const matchSvgPath = (path: string): string | null => {
 const tokenRoute = createTokenRoute("t", { GET: handleTicketView });
 
 /** Route ticket view and SVG requests */
-export const routeTicketView = (
-  request: Request,
-  path: string,
-  method: string,
-): Promise<Response | null> => {
+export const routeTicketView: TokenRouteFn = (request, path, method) => {
   if (method === "GET") {
     const svgToken = matchSvgPath(path);
     if (svgToken) return Promise.resolve(handleTicketSvg(svgToken));

--- a/src/routes/token-utils.ts
+++ b/src/routes/token-utils.ts
@@ -14,6 +14,13 @@ export type TokenEntry = {
   event: EventWithCount;
 };
 
+/** Route function signature for token-based routes */
+export type TokenRouteFn = (
+  request: Request,
+  path: string,
+  method: string,
+) => Promise<Response | null>;
+
 /** Handler type for token-based route methods */
 type TokenMethodHandler = (
   request: Request,
@@ -68,12 +75,8 @@ export const lookupAttendees = async (
  * Extracts tokens from the path, dispatches to method handlers.
  */
 export const createTokenRoute =
-  (prefix: string, methods: TokenMethodMap) =>
-  (
-    request: Request,
-    path: string,
-    method: string,
-  ): Promise<Response | null> => {
+  (prefix: string, methods: TokenMethodMap): TokenRouteFn =>
+  (request, path, method) => {
     const tokensStr = extractTokenSegment(prefix, path);
     if (!tokensStr) return Promise.resolve(null);
 

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1101,7 +1101,7 @@ button.secondary:hover {
   text-align: center;
 }
 
-.ticket-card-qr svg {
+.ticket-card-qr img {
   max-width: 100%;
   height: auto;
 }
@@ -1337,7 +1337,7 @@ button.secondary:hover {
     color: #666;
   }
 
-  .ticket-card-qr svg {
+  .ticket-card-qr img {
     max-width: 8rem;
   }
 

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -13,10 +13,9 @@ import { renderEventImage } from "#templates/public.tsx";
 /** Re-export for backwards compatibility */
 export type { TokenEntry as TicketEntry };
 
-/** Ticket card with individual QR code */
+/** Ticket card data for rendering */
 export type TicketCard = {
   entry: TokenEntry;
-  qrSvg: string;
   token: string;
   attachmentUrl?: string;
 };
@@ -31,7 +30,7 @@ const renderWalletLink = (token: string): string =>
 
 /** Render a single ticket card */
 const renderTicketCard = (card: TicketCard, walletEnabled: boolean): string => {
-  const { entry, qrSvg, token, attachmentUrl } = card;
+  const { entry, token, attachmentUrl } = card;
   const { event, attendee } = entry;
   const imageHtml = renderEventImage(event, "ticket-card-image");
   const eventDateHtml = event.date
@@ -78,7 +77,7 @@ const renderTicketCard = (card: TicketCard, walletEnabled: boolean): string => {
       <div class="ticket-card-quantity">Quantity: ${attendee.quantity}</div>
       ${priceHtml}
       ${attachmentHtml}
-      <div class="ticket-card-qr">${qrSvg}</div>
+      <div class="ticket-card-qr"><img src="/t/${escapeHtml(token)}/svg" alt="QR code" /></div>
       <div class="ticket-card-token">${escapeHtml(token)}</div>
       ${walletHtml}
     </div>

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -27,10 +27,7 @@ import {
   wrapKey,
   wrapKeyWithToken,
 } from "#lib/crypto.ts";
-import {
-  clearTestEncryptionKey,
-  setupTestEncryptionKey,
-} from "#test-utils";
+import { clearTestEncryptionKey, setupTestEncryptionKey } from "#test-utils";
 
 describe("constantTimeEqual", () => {
   it("returns true for equal strings", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -3399,7 +3399,6 @@ describe("html", () => {
   });
 
   describe("ticketViewPage event date and location", () => {
-    const qrSvg = "<svg>test</svg>";
     const token = "AABB0011CCDDEEFF";
 
     test("shows event date when entry has non-empty event date", () => {
@@ -3409,7 +3408,6 @@ describe("html", () => {
             event: testEventWithCount({ date: "2026-06-15T14:00:00.000Z" }),
             attendee: testAttendee(),
           },
-          qrSvg,
           token,
         },
       ];
@@ -3424,7 +3422,6 @@ describe("html", () => {
             event: testEventWithCount({ date: "" }),
             attendee: testAttendee(),
           },
-          qrSvg,
           token,
         },
       ];
@@ -3439,7 +3436,6 @@ describe("html", () => {
             event: testEventWithCount({ location: "Village Hall" }),
             attendee: testAttendee(),
           },
-          qrSvg,
           token,
         },
       ];
@@ -3454,7 +3450,6 @@ describe("html", () => {
             event: testEventWithCount({ location: "" }),
             attendee: testAttendee(),
           },
-          qrSvg,
           token,
         },
       ];
@@ -3472,7 +3467,6 @@ describe("html", () => {
             }),
             attendee: testAttendee(),
           },
-          qrSvg,
           token,
         },
       ];
@@ -3481,7 +3475,7 @@ describe("html", () => {
       expect(html).toContain("Town Centre");
     });
 
-    test("shows each ticket as separate card with individual QR code", () => {
+    test("shows each ticket as separate card with SVG endpoint reference", () => {
       const cards = [
         {
           entry: {
@@ -3491,7 +3485,6 @@ describe("html", () => {
             }),
             attendee: testAttendee({ id: 1 }),
           },
-          qrSvg: "<svg>qr1</svg>",
           token: "AABB0011CCDDEEF1",
         },
         {
@@ -3499,13 +3492,12 @@ describe("html", () => {
             event: testEventWithCount({ id: 2, date: "" }),
             attendee: testAttendee({ id: 2 }),
           },
-          qrSvg: "<svg>qr2</svg>",
           token: "AABB0011CCDDEEF2",
         },
       ];
       const html = ticketViewPage(cards);
-      expect(html).toContain("<svg>qr1</svg>");
-      expect(html).toContain("<svg>qr2</svg>");
+      expect(html).toContain("/t/AABB0011CCDDEEF1/svg");
+      expect(html).toContain("/t/AABB0011CCDDEEF2/svg");
       expect(html).toContain("2 Tickets");
     });
   });
@@ -3621,7 +3613,6 @@ describe("html", () => {
     });
 
     describe("ticketViewPage ticket count", () => {
-      const qrSvg = '<svg class="qr"><rect/></svg>';
       const token = "AABB0011CCDDEEFF";
 
       test("shows '1 Ticket' for single ticket", () => {
@@ -3632,7 +3623,6 @@ describe("html", () => {
               event: testEventWithCount({ id: 1 }),
               attendee: testAttendee({ id: 1 }),
             },
-            qrSvg,
             token,
           },
         ];
@@ -3649,7 +3639,6 @@ describe("html", () => {
               event: testEventWithCount({ id: 1 }),
               attendee: testAttendee({ id: 1 }),
             },
-            qrSvg,
             token: "AABB0011CCDDEEF1",
           },
           {
@@ -3657,7 +3646,6 @@ describe("html", () => {
               event: testEventWithCount({ id: 2 }),
               attendee: testAttendee({ id: 2 }),
             },
-            qrSvg,
             token: "AABB0011CCDDEEF2",
           },
         ];
@@ -3668,7 +3656,6 @@ describe("html", () => {
     });
 
     describe("ticketViewPage with image", () => {
-      const qrSvg = '<svg class="qr"><rect/></svg>';
       const token = "AABB0011CCDDEEFF";
 
       test("shows image when event has image_url", () => {
@@ -3679,7 +3666,6 @@ describe("html", () => {
               event: testEventWithCount({ image_url: "ticket-img.jpg" }),
               attendee: testAttendee(),
             },
-            qrSvg,
             token,
           },
         ];
@@ -3697,7 +3683,6 @@ describe("html", () => {
               event: testEventWithCount({ image_url: "" }),
               attendee: testAttendee(),
             },
-            qrSvg,
             token,
           },
         ];

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -131,13 +131,32 @@ describe("ticket view (/t/:tokens)", () => {
     expect(attendees[0]!.ticket_token).not.toBe(attendees[1]!.ticket_token);
   });
 
-  test("includes inline SVG QR code in ticket view", async () => {
+  test("references SVG endpoint for QR code instead of inline SVG", async () => {
     const { token } = await createTestAttendeeWithToken("Eve", "eve@test.com");
 
     const response = await awaitTestRequest(`/t/${token}`);
     const body = await response.text();
+    expect(body).toContain(`/t/${token}/svg`);
+    expect(body).toContain("<img");
+  });
+
+  test("serves QR code SVG at /t/:token/svg with cache headers", async () => {
+    const { token } = await createTestAttendeeWithToken("Eve", "eve@test.com");
+
+    const response = await awaitTestRequest(`/t/${token}/svg`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/svg+xml");
+    expect(response.headers.get("cache-control")).toContain("immutable");
+    expect(response.headers.get("cache-control")).toContain("public");
+
+    const body = await response.text();
     expect(body).toContain("<svg");
     expect(body).toContain("</svg>");
+  });
+
+  test("returns 404 for /t/:token/svg with invalid token", async () => {
+    const response = await awaitTestRequest("/t/nonexistent-token/svg");
+    expect(response.status).toBe(404);
   });
 
   test("displays booked date for daily event tickets", async () => {


### PR DESCRIPTION
## Summary
Refactored the ticket view system to serve QR codes from a dedicated endpoint (`/t/:token/svg`) instead of embedding them inline in the HTML. This enables aggressive CDN caching of QR codes while keeping the main ticket view page dynamic.

## Key Changes
- **New SVG endpoint**: Added `/t/:token/svg` route that serves individual QR code SVGs with aggressive cache headers (`max-age=1 year, immutable`)
- **Removed inline QR generation**: Removed `qrSvg` field from `TicketCard` type and stopped generating QR codes during ticket card building
- **Updated routing**: Modified `routeTicketView` to handle both the main ticket view and the new SVG endpoint by matching the `/svg` path suffix
- **Template updates**: Changed ticket card rendering to use `<img src="/t/:token/svg">` instead of embedding SVG directly
- **Validation**: Added token validation for the SVG endpoint using `getAttendeesByTokens` to return 404 for invalid tokens
- **CSS updates**: Updated stylesheet selectors from `.ticket-card-qr svg` to `.ticket-card-qr img` to match new image-based rendering
- **Test updates**: Updated tests to verify SVG endpoint behavior, cache headers, and 404 handling for invalid tokens

## Implementation Details
- The `buildCheckinUrl` function was exported to support the new SVG endpoint handler
- Path matching uses regex to extract tokens from `/t/:token/svg` format while avoiding conflicts with token-based routes
- SVG endpoint returns proper `content-type: image/svg+xml` header for correct browser handling
- One-year cache duration (31,536,000 seconds) is used since QR codes are immutable per token

https://claude.ai/code/session_01D2orZaq2T6fYLXHP9neMVw