### PR TITLE
Fix ticket card QR code aspect ratio

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1104,6 +1104,7 @@ button.secondary:hover {
 .ticket-card-qr img {
   max-width: 100%;
   height: auto;
+  aspect-ratio: 1;
 }
 
 [data-theme="dark"] .ticket-card {


### PR DESCRIPTION
## Summary
Added `aspect-ratio: 1` CSS property to the `.ticket-card-qr img` selector to ensure QR codes display as perfect squares.

## Key Changes
- Added `aspect-ratio: 1` to `.ticket-card-qr img` styling in `src/static/mvp.css`

## Implementation Details
The QR code image now maintains a 1:1 aspect ratio, preventing distortion and ensuring consistent square display regardless of the container dimensions. This complements the existing `max-width: 100%` and `height: auto` properties to provide proper responsive sizing while maintaining the correct proportions.

https://claude.ai/code/session_01Eu6mRZNPVRBunRLRQHgtcn