### PR TITLE
Delete images and attachments from Bunny storage on event/database deletion

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -117,6 +117,20 @@ export const tryDeleteImage = async (
   }
 };
 
+/** Delete all storage files (images and attachments) for a list of events */
+export const deleteAllEventStorageFiles = async (
+  events: ReadonlyArray<{ id: number; image_url: string; attachment_url: string }>,
+): Promise<void> => {
+  for (const event of events) {
+    if (event.image_url) {
+      await tryDeleteImage(event.image_url, event.id, "database reset");
+    }
+    if (event.attachment_url) {
+      await tryDeleteImage(event.attachment_url, event.id, "database reset");
+    }
+  }
+};
+
 /** Generate a random filename with the correct extension */
 export const generateImageFilename = (detectedType: string): string => {
   const ext = MIME_TO_EXT[detectedType];

--- a/src/routes/admin/database-reset.ts
+++ b/src/routes/admin/database-reset.ts
@@ -5,8 +5,10 @@
 
 import { clearSessionCookie } from "#lib/cookies.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
+import { getAllEvents } from "#lib/db/events.ts";
 import { resetDatabase } from "#lib/db/migrations.ts";
 import { isDemoMode } from "#lib/demo.ts";
+import { deleteAllEventStorageFiles, isStorageEnabled } from "#lib/storage.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import {
   htmlResponse,
@@ -55,6 +57,9 @@ const handleDemoResetPost = (request: Request): Response | Promise<Response> =>
       const phraseError = validateResetPhrase(form);
       if (phraseError) return resetPageError(phraseError, 400);
 
+      if (isStorageEnabled()) {
+        await deleteAllEventStorageFiles(await getAllEvents());
+      }
       await resetDatabase();
       return redirect("/setup/", "Database reset", true, {
         cookie: clearSessionCookie(),

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -646,6 +646,12 @@ const handleAdminEventLog: TypedRouteHandler<"GET /admin/event/:id/log"> = (
 /** Perform event deletion */
 const performDelete = async (event: EventWithCount): Promise<Response> => {
   const attendeeCount = event.attendee_count;
+  if (event.image_url) {
+    await tryDeleteImage(event.image_url, event.id, "event deletion");
+  }
+  if (event.attachment_url) {
+    await tryDeleteImage(event.attachment_url, event.id, "event deletion");
+  }
   await deleteEvent(event.id);
   await logActivity(
     `Event '${event.name}' deleted (${attendeeCount} attendee(s) removed)`,

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -21,6 +21,7 @@ import {
 } from "#lib/config.ts";
 import { clearSessionCookie } from "#lib/cookies.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
+import { getAllEvents } from "#lib/db/events.ts";
 import { resetDatabase } from "#lib/db/migrations.ts";
 import {
   clearPaymentProvider,
@@ -105,6 +106,7 @@ import {
 import { setFormError, setFormSuccess, validateForm } from "#lib/forms.tsx";
 import type { PaymentProviderType } from "#lib/payments.ts";
 import {
+  deleteAllEventStorageFiles,
   IMAGE_ERROR_MESSAGES,
   isStorageEnabled,
   tryDeleteImage,
@@ -1332,6 +1334,9 @@ const handleResetDatabasePost = advancedSettingsRoute(
       return errorPage(phraseError, 400, "settings-reset-database");
 
     await logActivity("Database reset initiated");
+    if (isStorageEnabled()) {
+      await deleteAllEventStorageFiles(await getAllEvents());
+    }
     await resetDatabase();
 
     // Redirect to setup page since the database is now empty

--- a/test/lib/server-demo-reset.test.ts
+++ b/test/lib/server-demo-reset.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { eventsTable } from "#lib/db/events.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { handleRequest } from "#routes";
 import {
@@ -9,9 +10,11 @@ import {
 import {
   awaitTestRequest,
   createTestDbWithSetup,
+  createTestEvent,
   expectHtmlResponse,
   expectRedirect,
   extractCsrfToken,
+  installUrlHandler,
   invalidateTestDbCache,
   mockFormRequest,
   mockRequest,
@@ -19,6 +22,7 @@ import {
   resetTestSlugCounter,
   testCookie,
   testCsrfToken,
+  withFetchMock,
 } from "#test-utils";
 
 describe("server (demo reset)", () => {
@@ -141,6 +145,48 @@ describe("server (demo reset)", () => {
 
       expectRedirect("/setup/?success=Database+reset")(response);
       expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+      invalidateTestDbCache();
+    });
+
+    test("deletes storage files for all events during reset", async () => {
+      setDemoModeForTest(true);
+      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await eventsTable.update(event.id, {
+        imageUrl: "reset-image.jpg",
+        attachmentUrl: "reset-attachment.pdf",
+        attachmentName: "doc.pdf",
+      });
+
+      await withFetchMock(async (originalFetch) => {
+        const deletedUrls: string[] = [];
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("storage.bunnycdn.com")) {
+            deletedUrls.push(url);
+            return Promise.resolve(
+              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
+            );
+          }
+          return null;
+        });
+
+        const response = await submitDemoResetForm({
+          confirm_phrase: RESET_DATABASE_PHRASE,
+        });
+
+        expectRedirect("/setup/?success=Database+reset")(response);
+        expect(deletedUrls.some((u) => u.includes("reset-image.jpg"))).toBe(
+          true,
+        );
+        expect(
+          deletedUrls.some((u) => u.includes("reset-attachment.pdf")),
+        ).toBe(true);
+      });
+
+      Deno.env.delete("STORAGE_ZONE_NAME");
+      Deno.env.delete("STORAGE_ZONE_KEY");
       invalidateTestDbCache();
     });
   });

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { encryptBytes } from "#lib/crypto.ts";
 import { toMajorUnits } from "#lib/currency.ts";
-import { eventsTable, getEventWithCount } from "#lib/db/events.ts";
+import { eventsTable, getEvent, getEventWithCount } from "#lib/db/events.ts";
 import { handleRequest } from "#routes";
 import {
   createTestDbWithSetup,
@@ -758,6 +758,134 @@ describe("server (event images)", () => {
         ),
       );
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe("event deletion cleans up storage files", () => {
+    test("deletes image from storage when event is deleted", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      await eventsTable.update(event.id, { imageUrl: "event-image.jpg" });
+
+      await withStorageMock(async (fetchCalls) => {
+        const response = await handleRequest(
+          mockFormRequest(
+            `/admin/event/${event.id}/delete`,
+            { csrf_token: csrfToken, confirm_identifier: event.name },
+            cookie,
+          ),
+        );
+        expect(response.status).toBe(302);
+
+        const deleteCall = fetchCalls.find((url) =>
+          url.includes("event-image.jpg"),
+        );
+        expect(deleteCall).not.toBeUndefined();
+
+        const deleted = await getEvent(event.id);
+        expect(deleted).toBeNull();
+      });
+    });
+
+    test("deletes attachment from storage when event is deleted", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      await eventsTable.update(event.id, {
+        attachmentUrl: "event-attachment.pdf",
+        attachmentName: "doc.pdf",
+      });
+
+      await withStorageMock(async (fetchCalls) => {
+        const response = await handleRequest(
+          mockFormRequest(
+            `/admin/event/${event.id}/delete`,
+            { csrf_token: csrfToken, confirm_identifier: event.name },
+            cookie,
+          ),
+        );
+        expect(response.status).toBe(302);
+
+        const deleteCall = fetchCalls.find((url) =>
+          url.includes("event-attachment.pdf"),
+        );
+        expect(deleteCall).not.toBeUndefined();
+      });
+    });
+
+    test("deletes both image and attachment from storage when event is deleted", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      await eventsTable.update(event.id, {
+        imageUrl: "both-image.jpg",
+        attachmentUrl: "both-attachment.pdf",
+        attachmentName: "both.pdf",
+      });
+
+      await withStorageMock(async (fetchCalls) => {
+        const response = await handleRequest(
+          mockFormRequest(
+            `/admin/event/${event.id}/delete`,
+            { csrf_token: csrfToken, confirm_identifier: event.name },
+            cookie,
+          ),
+        );
+        expect(response.status).toBe(302);
+
+        const imageCall = fetchCalls.find((url) =>
+          url.includes("both-image.jpg"),
+        );
+        const attachmentCall = fetchCalls.find((url) =>
+          url.includes("both-attachment.pdf"),
+        );
+        expect(imageCall).not.toBeUndefined();
+        expect(attachmentCall).not.toBeUndefined();
+      });
+    });
+
+    test("succeeds even when storage delete fails during event deletion", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      await eventsTable.update(event.id, { imageUrl: "failing-image.jpg" });
+
+      await withFetchMock(async (originalFetch) => {
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("failing-image.jpg")) {
+            return Promise.reject(new Error("CDN delete failed"));
+          }
+          if (url.includes("storage.bunnycdn.com")) {
+            return Promise.resolve(cdnOkResponse());
+          }
+          return null;
+        });
+
+        const response = await handleRequest(
+          mockFormRequest(
+            `/admin/event/${event.id}/delete`,
+            { csrf_token: csrfToken, confirm_identifier: event.name },
+            cookie,
+          ),
+        );
+        expect(response.status).toBe(302);
+
+        const deleted = await getEvent(event.id);
+        expect(deleted).toBeNull();
+      });
+    });
+
+    test("skips storage cleanup when event has no image or attachment", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+      await withStorageMock(async (fetchCalls) => {
+        const response = await handleRequest(
+          mockFormRequest(
+            `/admin/event/${event.id}/delete`,
+            { csrf_token: csrfToken, confirm_identifier: event.name },
+            cookie,
+          ),
+        );
+        expect(response.status).toBe(302);
+
+        const storageCalls = fetchCalls.filter((url) =>
+          url.includes("storage.bunnycdn.com"),
+        );
+        expect(storageCalls).toHaveLength(0);
+      });
     });
   });
 });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
+import { eventsTable } from "#lib/db/events.ts";
 import {
   getEmbedHostsFromDb,
   setPaymentProvider,
@@ -14,9 +15,12 @@ import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestDbWithSetup,
+  createTestEvent,
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirect,
+  installUrlHandler,
+  invalidateTestDbCache,
   mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
@@ -25,6 +29,7 @@ import {
   TEST_ADMIN_PASSWORD,
   testCookie,
   testCsrfToken,
+  withFetchMock,
   withMocks,
 } from "#test-utils";
 
@@ -1377,6 +1382,55 @@ describe("server (admin settings)", () => {
       // Instead, verify the reset succeeded (redirects to /setup/)
       // The logActivity call happens before resetDatabase() so it was logged
       // but the table is then dropped. This test verifies no error is thrown.
+    });
+
+    test("deletes storage files for all events during admin reset", async () => {
+      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+
+      const event = await createTestEvent({ maxAttendees: 10 });
+      await eventsTable.update(event.id, {
+        imageUrl: "admin-reset-image.jpg",
+        attachmentUrl: "admin-reset-attachment.pdf",
+        attachmentName: "doc.pdf",
+      });
+
+      await withFetchMock(async (originalFetch) => {
+        const deletedUrls: string[] = [];
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("storage.bunnycdn.com")) {
+            deletedUrls.push(url);
+            return Promise.resolve(
+              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
+            );
+          }
+          return null;
+        });
+
+        const response = await handleRequest(
+          mockFormRequest(
+            "/admin/settings/reset-database",
+            {
+              confirm_phrase:
+                "The site will be fully reset and all data will be lost.",
+              csrf_token: await testCsrfToken(),
+            },
+            await testCookie(),
+          ),
+        );
+
+        expectRedirect("/setup/?success=Database+reset")(response);
+        expect(
+          deletedUrls.some((u) => u.includes("admin-reset-image.jpg")),
+        ).toBe(true);
+        expect(
+          deletedUrls.some((u) => u.includes("admin-reset-attachment.pdf")),
+        ).toBe(true);
+      });
+
+      Deno.env.delete("STORAGE_ZONE_NAME");
+      Deno.env.delete("STORAGE_ZONE_KEY");
+      invalidateTestDbCache();
     });
   });
 

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { decryptBytes, encryptBytes } from "#lib/crypto.ts";
 import {
   ATTACHMENT_ERROR_MESSAGES,
+  deleteAllEventStorageFiles,
   detectImageType,
   generateAttachmentFilename,
   generateImageFilename,
@@ -13,6 +14,7 @@ import {
   validateAttachment,
   validateImage,
 } from "#lib/storage.ts";
+import { installUrlHandler, withFetchMock } from "#test-utils";
 
 describe("storage", () => {
   beforeEach(() => {
@@ -303,6 +305,97 @@ describe("storage", () => {
     test("preserves file extension", () => {
       const filename = generateAttachmentFilename("archive.tar.gz");
       expect(filename).toMatch(/\.tar\.gz$/);
+    });
+  });
+
+  describe("deleteAllEventStorageFiles", () => {
+    beforeEach(() => {
+      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+    });
+
+    test("deletes images and attachments for all events", async () => {
+      const events = [
+        { id: 1, image_url: "img1.jpg", attachment_url: "att1.pdf" },
+        { id: 2, image_url: "img2.png", attachment_url: "" },
+        { id: 3, image_url: "", attachment_url: "att3.pdf" },
+      ];
+
+      await withFetchMock(async (originalFetch) => {
+        const deletedUrls: string[] = [];
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("storage.bunnycdn.com")) {
+            deletedUrls.push(url);
+            return Promise.resolve(
+              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
+            );
+          }
+          return null;
+        });
+
+        await deleteAllEventStorageFiles(events);
+
+        expect(deletedUrls.some((u) => u.includes("img1.jpg"))).toBe(true);
+        expect(deletedUrls.some((u) => u.includes("att1.pdf"))).toBe(true);
+        expect(deletedUrls.some((u) => u.includes("img2.png"))).toBe(true);
+        expect(deletedUrls.some((u) => u.includes("att3.pdf"))).toBe(true);
+        // Empty URLs should not trigger delete calls
+        expect(deletedUrls).toHaveLength(4);
+      });
+    });
+
+    test("skips events with no image or attachment", async () => {
+      const events = [
+        { id: 1, image_url: "", attachment_url: "" },
+      ];
+
+      await withFetchMock(async (originalFetch) => {
+        const deletedUrls: string[] = [];
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("storage.bunnycdn.com")) {
+            deletedUrls.push(url);
+            return Promise.resolve(
+              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
+            );
+          }
+          return null;
+        });
+
+        await deleteAllEventStorageFiles(events);
+
+        expect(deletedUrls).toHaveLength(0);
+      });
+    });
+
+    test("handles empty events array", async () => {
+      await deleteAllEventStorageFiles([]);
+    });
+
+    test("continues deleting when individual file delete fails", async () => {
+      const events = [
+        { id: 1, image_url: "fail.jpg", attachment_url: "" },
+        { id: 2, image_url: "succeed.jpg", attachment_url: "" },
+      ];
+
+      await withFetchMock(async (originalFetch) => {
+        const deletedUrls: string[] = [];
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("fail.jpg")) {
+            return Promise.reject(new Error("CDN error"));
+          }
+          if (url.includes("storage.bunnycdn.com")) {
+            deletedUrls.push(url);
+            return Promise.resolve(
+              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
+            );
+          }
+          return null;
+        });
+
+        await deleteAllEventStorageFiles(events);
+
+        expect(deletedUrls.some((u) => u.includes("succeed.jpg"))).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
- Event deletion now cleans up associated image and attachment files from
  Bunny CDN storage before removing the database records
- Database reset (both admin settings and demo reset) now deletes all
  event storage files before dropping tables, preventing orphaned files
- Added deleteAllEventStorageFiles helper to storage module
- Added tests for all cleanup paths including error resilience

https://claude.ai/code/session_012eC3zwPkcfARCEPLPn8tL6