### PR TITLE
Surface storage upload/delete errors to users instead of silently swallowing them

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -100,6 +100,7 @@ const ERROR_DEFS = {
 
   // Storage errors
   STORAGE_DELETE: ["E_STORAGE_DELETE", "Storage delete failed"],
+  STORAGE_UPLOAD: ["E_STORAGE_UPLOAD", "Storage upload failed"],
 
   // Webhook errors
   WEBHOOK_SEND: ["E_WEBHOOK_SEND", "Webhook send failed"],
@@ -269,7 +270,8 @@ export type LogCategory =
   | "Stripe"
   | "Square"
   | "Domain"
-  | "Email";
+  | "Email"
+  | "Storage";
 
 /**
  * Log a debug message with category prefix

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -119,7 +119,11 @@ export const tryDeleteImage = async (
 
 /** Delete all storage files (images and attachments) for a list of events */
 export const deleteAllEventStorageFiles = async (
-  events: ReadonlyArray<{ id: number; image_url: string; attachment_url: string }>,
+  events: ReadonlyArray<{
+    id: number;
+    image_url: string;
+    attachment_url: string;
+  }>,
 ): Promise<void> => {
   for (const event of events) {
     if (event.image_url) {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -23,10 +23,12 @@ import {
   EVENT_DEMO_FIELDS,
   isDemoMode,
 } from "#lib/demo.ts";
+import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import { defineResource } from "#lib/rest/resource.ts";
 import { generateUniqueSlug, normalizeSlug } from "#lib/slug.ts";
 import {
   ATTACHMENT_ERROR_MESSAGES,
+  deleteImage,
   generateAttachmentFilename,
   IMAGE_ERROR_MESSAGES,
   isStorageEnabled,
@@ -192,7 +194,15 @@ const processFormFile = async (opts: {
 }): Promise<string | null> => {
   if (!isStorageEnabled()) return null;
   const entry = opts.formData.get(opts.fieldName);
-  if (!(entry instanceof File) || entry.size === 0) return null;
+  if (!(entry instanceof File) || entry.size === 0) {
+    if (entry !== null && !(entry instanceof File)) {
+      logDebug(
+        "Storage",
+        `${opts.label} field "${opts.fieldName}" is ${typeof entry}, not File`,
+      );
+    }
+    return null;
+  }
 
   const data = new Uint8Array(await entry.arrayBuffer());
   const error = opts.validate(data, entry);
@@ -206,10 +216,15 @@ const processFormFile = async (opts: {
     );
   }
 
-  const fields = await opts.upload(data, entry);
-  await eventsTable.update(opts.eventId, fields);
-  await logActivity(`${opts.label} uploaded for event`, opts.eventId);
-  return null;
+  const [uploadResult] = await Promise.allSettled([opts.upload(data, entry)]);
+  if (uploadResult.status === "fulfilled") {
+    await eventsTable.update(opts.eventId, uploadResult.value);
+    await logActivity(`${opts.label} uploaded for event`, opts.eventId);
+    return null;
+  }
+  const detail = `${opts.label} upload failed: ${String(uploadResult.reason)}`;
+  logError({ code: ErrorCode.STORAGE_UPLOAD, detail, eventId: opts.eventId });
+  return detail;
 };
 
 /** Process image from multipart form and attach to event. Returns error message if validation fails. */
@@ -687,9 +702,23 @@ const handleFileDelete =
       orNotFound(getEventWithCount(id), async (event) => {
         const url = getUrl(event);
         if (url) {
-          await tryDeleteImage(url, event.id, `${label} removal`);
-          await eventsTable.update(id, clearFields);
-          await logActivity(`${label} removed for '${event.name}'`, event);
+          const [deleteResult] = await Promise.allSettled([deleteImage(url)]);
+          if (deleteResult.status === "fulfilled") {
+            await eventsTable.update(id, clearFields);
+            await logActivity(`${label} removed for '${event.name}'`, event);
+            return redirect(`/admin/event/${id}`, `${label} removed`, true);
+          }
+          const detail = `${label} removal failed: ${String(deleteResult.reason)}`;
+          logError({
+            code: ErrorCode.STORAGE_DELETE,
+            detail,
+            eventId: event.id,
+          });
+          return redirect(
+            `/admin/event/${id}`,
+            `${label} removal failed`,
+            false,
+          );
         }
         return redirect(`/admin/event/${id}`, `${label} removed`, true);
       }),

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -106,9 +106,11 @@ import {
   validateEmbedHosts,
 } from "#lib/embed-hosts.ts";
 import { setFormError, setFormSuccess, validateForm } from "#lib/forms.tsx";
+import { ErrorCode, logError } from "#lib/logger.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
 import {
   deleteAllEventStorageFiles,
+  deleteImage,
   IMAGE_ERROR_MESSAGES,
   isStorageEnabled,
   tryDeleteImage,
@@ -886,7 +888,7 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
       return htmlResponse(await renderSettingsPage(session), 400);
     }
 
-    // Delete old header image if one exists
+    // Delete old header image if one exists (best-effort, don't block new upload)
     const existingUrl = await getHeaderImageUrlFromDb();
     if (existingUrl) {
       await tryDeleteImage(
@@ -896,10 +898,19 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
       );
     }
 
-    const filename = await uploadImage(data, validation.detectedType);
-    await updateHeaderImageUrl(filename);
-    await logActivity("Header image uploaded");
-    return redirect("/admin/settings", "Header image uploaded", true, {
+    const [uploadResult] = await Promise.allSettled([
+      uploadImage(data, validation.detectedType),
+    ]);
+    if (uploadResult.status === "fulfilled") {
+      await updateHeaderImageUrl(uploadResult.value);
+      await logActivity("Header image uploaded");
+      return redirect("/admin/settings", "Header image uploaded", true, {
+        formId: "settings-header-image",
+      });
+    }
+    const uploadDetail = `Header image upload failed: ${String(uploadResult.reason)}`;
+    logError({ code: ErrorCode.STORAGE_UPLOAD, detail: uploadDetail });
+    return redirect("/admin/settings", "Header image upload failed", false, {
       formId: "settings-header-image",
     });
   });
@@ -911,10 +922,17 @@ const handleHeaderImageDeletePost = settingsRoute(async (_form, _errorPage) => {
     return htmlResponse("No header image to remove", 400);
   }
 
-  await tryDeleteImage(existingUrl, undefined, `header image: ${existingUrl}`);
-  await updateHeaderImageUrl("");
-  await logActivity("Header image removed");
-  return redirect("/admin/settings", "Header image removed", true, {
+  const [deleteResult] = await Promise.allSettled([deleteImage(existingUrl)]);
+  if (deleteResult.status === "fulfilled") {
+    await updateHeaderImageUrl("");
+    await logActivity("Header image removed");
+    return redirect("/admin/settings", "Header image removed", true, {
+      formId: "settings-header-image-delete",
+    });
+  }
+  const deleteDetail = `Header image removal failed: ${String(deleteResult.reason)}`;
+  logError({ code: ErrorCode.STORAGE_DELETE, detail: deleteDetail });
+  return redirect("/admin/settings", "Header image removal failed", false, {
     formId: "settings-header-image-delete",
   });
 });

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -224,8 +224,8 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
 
         <Q q="How do I add a file attachment to an event?">
           <p>
-            When creating or editing an event, use the attachment upload field to
-            attach a file. This can be any type of file &mdash; PDFs, Word
+            When creating or editing an event, use the attachment upload field
+            to attach a file. This can be any type of file &mdash; PDFs, Word
             documents, spreadsheets, images, audio, video, zip archives, you
             name it. The maximum file size is 25&nbsp;MB.
           </p>

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -350,6 +350,29 @@ describe("server (header image settings)", () => {
       });
     });
 
+    test("reports error when upload fails", async () => {
+      const originalFetch = globalThis.fetch;
+      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+      globalThis.fetch = (): Promise<Response> => {
+        return Promise.reject(new Error("CDN unreachable"));
+      };
+
+      try {
+        const response = await submitHeaderJpeg("logo.jpg");
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location") ?? "";
+        expect(location).toContain("error=");
+        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+          "upload failed",
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
+      }
+    });
+
     test("rejects mismatched magic bytes", async () => {
       await withStorageMock(async () => {
         const response = await submitHeaderImage({
@@ -380,7 +403,7 @@ describe("server (header image settings)", () => {
       await expectHtmlResponse(response, 400, "No header image to remove");
     });
 
-    test("succeeds even when storage delete throws", async () => {
+    test("reports error when storage delete throws", async () => {
       await updateHeaderImageUrl("failing.jpg");
 
       const originalFetch = globalThis.fetch;
@@ -390,10 +413,16 @@ describe("server (header image settings)", () => {
 
       try {
         const response = await submitHeaderImageDelete();
-        expectSettingsRedirect(response);
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location") ?? "";
+        expect(location).toContain("error=");
+        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+          "removal failed",
+        );
 
+        // DB record should NOT be cleared when CDN delete fails
         const url = await getHeaderImageUrlFromDb();
-        expect(url).toBeNull();
+        expect(url).toBe("failing.jpg");
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -476,7 +476,7 @@ describe("server (event images)", () => {
       expect(response.status).toBe(404);
     });
 
-    test("succeeds even when storage delete throws", async () => {
+    test("reports error when storage delete throws", async () => {
       const { event, cookie, csrfToken } = await setupEventAndLogin();
       await eventsTable.update(event.id, { imageUrl: "failing.jpg" });
 
@@ -487,8 +487,15 @@ describe("server (event images)", () => {
 
         const response = await submitImageDelete(event.id, cookie, csrfToken);
         expect(response.status).toBe(302);
+        const location = response.headers.get("location") ?? "";
+        expect(location).toContain("error=");
+        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+          "removal failed",
+        );
+
+        // DB record should NOT be cleared when CDN delete fails
         const updated = await getEventWithCount(event.id);
-        expect(updated?.image_url).toBe("");
+        expect(updated?.image_url).toBe("failing.jpg");
       });
     });
   });
@@ -564,6 +571,24 @@ describe("server (event images)", () => {
   });
 
   describe("POST /admin/event/:id/edit (attachment upload via edit form)", () => {
+    test("logs diagnostic when attachment field is not a File", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+      await withStorageMock(async () => {
+        const fields = await editFormData(event.id, csrfToken);
+        // Add attachment as a text field instead of a file
+        fields.attachment = "not-a-file";
+        const response = await handleRequest(
+          mockMultipartRequest(`/admin/event/${event.id}/edit`, fields, cookie),
+        );
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toContain("success=");
+
+        const updated = await getEventWithCount(event.id);
+        expect(updated?.attachment_url).toBe("");
+      });
+    });
+
     test("ignores attachment when storage is not configured", async () => {
       Deno.env.delete("STORAGE_ZONE_NAME");
       Deno.env.delete("STORAGE_ZONE_KEY");
@@ -665,6 +690,42 @@ describe("server (event images)", () => {
           url.includes("old-file.pdf"),
         );
         expect(deleteCall).not.toBeUndefined();
+      });
+    });
+
+    test("reports error when attachment upload fails", async () => {
+      const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+      await withFetchMock(async (originalFetch) => {
+        Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+        Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+        installUrlHandler(originalFetch, () =>
+          Promise.reject(new Error("CDN unreachable")),
+        );
+
+        const fields = await editFormData(event.id, csrfToken);
+        const response = await handleRequest(
+          mockMultipartRequest(
+            `/admin/event/${event.id}/edit`,
+            fields,
+            cookie,
+            {
+              fieldName: "attachment",
+              name: "guide.pdf",
+              data: PDF_BYTES,
+              contentType: "application/pdf",
+            },
+          ),
+        );
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location") ?? "";
+        expect(location).toContain("error=");
+        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+          "upload failed",
+        );
+
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
       });
     });
   });

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -345,9 +345,7 @@ describe("storage", () => {
     });
 
     test("skips events with no image or attachment", async () => {
-      const events = [
-        { id: 1, image_url: "", attachment_url: "" },
-      ];
+      const events = [{ id: 1, image_url: "", attachment_url: "" }];
 
       await withFetchMock(async (originalFetch) => {
         const deletedUrls: string[] = [];


### PR DESCRIPTION
Storage operations (image uploads, attachment uploads, header image
management) previously swallowed errors silently via tryDeleteImage,
showing success messages even when CDN operations failed. This change
uses Promise.allSettled to handle errors and surfaces them as
user-visible error messages in redirects.

- processFormFile: report upload failures with error redirect
- handleFileDelete: report CDN delete failures instead of silent success
- Header image upload/delete: surface errors via redirect with error param
- Add STORAGE_UPLOAD error code to logger
- Add "Storage" log category

https://claude.ai/code/session_01Avxuivj9DpaYLeo4UUj4F6