### PR TITLE
Allow events to collect only name with no other contact fields

### DIFF
--- a/src/lib/event-fields.ts
+++ b/src/lib/event-fields.ts
@@ -24,7 +24,7 @@ export const parseEventFields = (fields: EventFields): ContactField[] =>
  * Returns the union of all field settings, sorted by canonical CONTACT_FIELDS order.
  */
 export const mergeEventFields = (fieldSettings: EventFields[]): EventFields => {
-  if (fieldSettings.length === 0) return "email";
+  if (fieldSettings.length === 0) return "";
   const allFields = new Set<string>();
   for (const setting of fieldSettings) {
     for (const f of parseEventFields(setting)) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -119,7 +119,11 @@ export const tryDeleteImage = async (
 
 /** Delete all storage files (images and attachments) for a list of events */
 export const deleteAllEventStorageFiles = async (
-  events: ReadonlyArray<{ id: number; image_url: string; attachment_url: string }>,
+  events: ReadonlyArray<{
+    id: number;
+    image_url: string;
+    attachment_url: string;
+  }>,
 ): Promise<void> => {
   for (const event of events) {
     if (event.image_url) {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -118,7 +118,7 @@ const extractCommonFields = (values: EventFormValues) => {
     unitPrice,
     maxQuantity: values.max_quantity,
     webhookUrl,
-    fields: values.fields || "email",
+    fields: values.fields || "",
     closesAt,
     eventType: values.event_type || undefined,
     bookableDays: parseBookableDays(values.bookable_days),

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -224,8 +224,8 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
 
         <Q q="How do I add a file attachment to an event?">
           <p>
-            When creating or editing an event, use the attachment upload field to
-            attach a file. This can be any type of file &mdash; PDFs, Word
+            When creating or editing an event, use the attachment upload field
+            to attach a file. This can be any type of file &mdash; PDFs, Word
             documents, spreadsheets, images, audio, video, zip archives, you
             name it. The maximum file size is 25&nbsp;MB.
           </p>

--- a/test/lib/event-fields.test.ts
+++ b/test/lib/event-fields.test.ts
@@ -32,8 +32,12 @@ describe("event-fields", () => {
   });
 
   describe("mergeEventFields", () => {
-    test("returns email for empty array", () => {
-      expect(mergeEventFields([])).toBe("email");
+    test("returns empty string for empty array", () => {
+      expect(mergeEventFields([])).toBe("");
+    });
+
+    test("returns empty string when all events have empty fields", () => {
+      expect(mergeEventFields(["", ""])).toBe("");
     });
 
     test("returns union of fields in canonical order", () => {

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -696,8 +696,12 @@ describe("forms", () => {
   });
 
   describe("mergeEventFields", () => {
-    test("returns email for empty array", () => {
-      expect(mergeEventFields([])).toBe("email");
+    test("returns empty string for empty array", () => {
+      expect(mergeEventFields([])).toBe("");
+    });
+
+    test("returns empty string when all events have empty fields", () => {
+      expect(mergeEventFields(["", ""])).toBe("");
     });
 
     test("returns email when all events use email", () => {

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -345,9 +345,7 @@ describe("storage", () => {
     });
 
     test("skips events with no image or attachment", async () => {
-      const events = [
-        { id: 1, image_url: "", attachment_url: "" },
-      ];
+      const events = [{ id: 1, image_url: "", attachment_url: "" }];
 
       await withFetchMock(async (originalFetch) => {
         const deletedUrls: string[] = [];


### PR DESCRIPTION
Previously, unchecking all contact field checkboxes when creating/editing
an event would force email to be collected as a fallback. Now empty fields
are stored as-is, allowing name-only registration.

https://claude.ai/code/session_01APDaofqD5UYpFhH1A9syNj