### PR TITLE
Fix ALLOWED_DOMAIN test flakiness with lazyRef cache pattern

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -123,21 +123,22 @@ export const getCurrencyCode = (): Promise<string> => {
  * Get allowed domain for security validation (runtime config via Bunny secrets)
  * This is a required configuration that hardens origin validation
  */
-const [getAllowedDomainCached, setAllowedDomainCached] = lazyRef(() =>
-  requireEnv("ALLOWED_DOMAIN"),
-);
+const [getAllowedDomainOverride, setAllowedDomainOverride] = lazyRef<
+  string | null
+>(() => null);
 
-export const getAllowedDomain = (): string => getAllowedDomainCached();
+export const getAllowedDomain = (): string =>
+  getAllowedDomainOverride() ?? requireEnv("ALLOWED_DOMAIN");
 
 /** Reset cached allowed domain value (for testing and cache invalidation) */
-export const resetAllowedDomain = (): void => setAllowedDomainCached(null);
+export const resetAllowedDomain = (): void => setAllowedDomainOverride(null);
 
 /**
  * Explicitly set allowed domain (for testing).
  * Bypasses Deno.env to avoid races between parallel test workers.
  */
 export const setAllowedDomainForTest = (domain: string): void =>
-  setAllowedDomainCached(domain);
+  setAllowedDomainOverride(domain);
 
 /**
  * Get allowed embed hosts from database (encrypted, parsed to array)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,6 +20,7 @@ import {
   hasStripeKey,
   isSetupComplete,
 } from "#lib/db/settings.ts";
+import { lazyRef } from "#fp";
 import { getEnv, requireEnv } from "#lib/env.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
 
@@ -122,9 +123,21 @@ export const getCurrencyCode = (): Promise<string> => {
  * Get allowed domain for security validation (runtime config via Bunny secrets)
  * This is a required configuration that hardens origin validation
  */
-export const getAllowedDomain = (): string => {
-  return requireEnv("ALLOWED_DOMAIN");
-};
+const [getAllowedDomainCached, setAllowedDomainCached] = lazyRef(
+  () => requireEnv("ALLOWED_DOMAIN"),
+);
+
+export const getAllowedDomain = (): string => getAllowedDomainCached();
+
+/** Reset cached allowed domain value (for testing and cache invalidation) */
+export const resetAllowedDomain = (): void => setAllowedDomainCached(null);
+
+/**
+ * Explicitly set allowed domain (for testing).
+ * Bypasses Deno.env to avoid races between parallel test workers.
+ */
+export const setAllowedDomainForTest = (domain: string): void =>
+  setAllowedDomainCached(domain);
 
 /**
  * Get allowed embed hosts from database (encrypted, parsed to array)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,7 @@
  * Payment provider and keys are configured via admin settings (stored encrypted in DB)
  */
 
+import { lazyRef } from "#fp";
 import {
   getBookingFeeFromDb,
   getCurrencyCodeFromDb,
@@ -20,7 +21,6 @@ import {
   hasStripeKey,
   isSetupComplete,
 } from "#lib/db/settings.ts";
-import { lazyRef } from "#fp";
 import { getEnv, requireEnv } from "#lib/env.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
 
@@ -123,8 +123,8 @@ export const getCurrencyCode = (): Promise<string> => {
  * Get allowed domain for security validation (runtime config via Bunny secrets)
  * This is a required configuration that hardens origin validation
  */
-const [getAllowedDomainCached, setAllowedDomainCached] = lazyRef(
-  () => requireEnv("ALLOWED_DOMAIN"),
+const [getAllowedDomainCached, setAllowedDomainCached] = lazyRef(() =>
+  requireEnv("ALLOWED_DOMAIN"),
 );
 
 export const getAllowedDomain = (): string => getAllowedDomainCached();

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -12,6 +12,7 @@ import { stub } from "@std/testing/mock";
 import forge from "node-forge";
 import { bracket } from "#fp";
 import type { SigningCredentials } from "#lib/apple-wallet.ts";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import {
   clearEncryptionKeyCache,
@@ -40,7 +41,6 @@ import {
   updateTimezone,
 } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
-import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
 

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -40,6 +40,7 @@ import {
   updateTimezone,
 } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
+import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
 
@@ -280,6 +281,7 @@ export const resetDb = (): void => {
   resetTestSession();
   resetCurrencyCode();
   setDemoModeForTest(false);
+  setAllowedDomainForTest("localhost");
 };
 
 /**

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -12,7 +12,7 @@ import { stub } from "@std/testing/mock";
 import forge from "node-forge";
 import { bracket } from "#fp";
 import type { SigningCredentials } from "#lib/apple-wallet.ts";
-import { setAllowedDomainForTest } from "#lib/config.ts";
+import { resetAllowedDomain } from "#lib/config.ts";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import {
   clearEncryptionKeyCache,
@@ -281,7 +281,7 @@ export const resetDb = (): void => {
   resetTestSession();
   resetCurrencyCode();
   setDemoModeForTest(false);
-  setAllowedDomainForTest("localhost");
+  resetAllowedDomain();
 };
 
 /**

--- a/test/lib/attachment-route.test.ts
+++ b/test/lib/attachment-route.test.ts
@@ -51,7 +51,6 @@ describe("getMimeType", () => {
 describe("GET /attachment/:id", () => {
   beforeEach(async () => {
     setupTestEncryptionKey();
-    Deno.env.set("ALLOWED_DOMAIN", "localhost");
     resetTestSlugCounter();
     await createTestDbWithSetup();
   });

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -6,6 +6,7 @@ import {
   getBunnyApiKey,
   getCdnHostname,
   isBunnyCdnEnabled,
+  setAllowedDomainForTest,
 } from "#lib/config.ts";
 import {
   getCustomDomainFromDb,
@@ -65,16 +66,15 @@ const stubFetchWithRecorder = (
 /** Set up BUNNY_API_KEY and ALLOWED_DOMAIN env vars for a describe block */
 const useBunnyEnv = () => {
   const envApiKey = withEnvVar("BUNNY_API_KEY");
-  const envDomain = withEnvVar("ALLOWED_DOMAIN");
 
   beforeEach(() => {
     Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
-    Deno.env.set("ALLOWED_DOMAIN", "mysite.bunny.run");
+    setAllowedDomainForTest("mysite.bunny.run");
   });
 
   afterEach(() => {
     envApiKey.restore();
-    envDomain.restore();
+    setAllowedDomainForTest("localhost");
   });
 };
 
@@ -108,17 +108,15 @@ describe("bunny-cdn", () => {
   });
 
   describe("getCdnHostname", () => {
-    const envDomain = withEnvVar("ALLOWED_DOMAIN");
-
-    afterEach(() => envDomain.restore());
+    afterEach(() => setAllowedDomainForTest("localhost"));
 
     test("replaces .bunny.run with .b-cdn.net", () => {
-      Deno.env.set("ALLOWED_DOMAIN", "mysite.bunny.run");
+      setAllowedDomainForTest("mysite.bunny.run");
       expect(getCdnHostname()).toBe("mysite.b-cdn.net");
     });
 
     test("returns domain unchanged when not .bunny.run", () => {
-      Deno.env.set("ALLOWED_DOMAIN", "example.com");
+      setAllowedDomainForTest("example.com");
       expect(getCdnHostname()).toBe("example.com");
     });
   });

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -6,6 +6,7 @@ import {
   getBunnyApiKey,
   getCdnHostname,
   isBunnyCdnEnabled,
+  resetAllowedDomain,
   setAllowedDomainForTest,
 } from "#lib/config.ts";
 import {
@@ -74,7 +75,7 @@ const useBunnyEnv = () => {
 
   afterEach(() => {
     envApiKey.restore();
-    setAllowedDomainForTest("localhost");
+    resetAllowedDomain();
   });
 };
 
@@ -108,7 +109,7 @@ describe("bunny-cdn", () => {
   });
 
   describe("getCdnHostname", () => {
-    afterEach(() => setAllowedDomainForTest("localhost"));
+    afterEach(() => resetAllowedDomain());
 
     test("replaces .bunny.run with .b-cdn.net", () => {
       setAllowedDomainForTest("mysite.bunny.run");

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -316,6 +316,9 @@ describe("code quality", () => {
       "routes/utils.ts:withCookie",
       // Reset cache registry between tests
       "lib/cache-registry.ts:resetCacheRegistry",
+      // Reset cached allowed domain between tests
+      "lib/config.ts:resetAllowedDomain",
+      "lib/config.ts:setAllowedDomainForTest",
       // Reset cached demo mode between tests
       "lib/demo.ts:resetDemoMode",
       "lib/demo.ts:setDemoModeForTest",

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -3,6 +3,8 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import {
   getAllowedDomain,
+  resetAllowedDomain,
+  setAllowedDomainForTest,
   getBookingFee,
   getCurrencyCode,
   getPaymentProvider,
@@ -175,13 +177,16 @@ describe("config", () => {
   });
 
   describe("getAllowedDomain", () => {
+    afterEach(() => setAllowedDomainForTest("localhost"));
+
     test("returns set value from environment", () => {
       Deno.env.set("ALLOWED_DOMAIN", "example.com");
+      resetAllowedDomain();
       expect(getAllowedDomain()).toBe("example.com");
     });
 
     test("returns localhost when set for testing", () => {
-      Deno.env.set("ALLOWED_DOMAIN", "localhost");
+      setAllowedDomainForTest("localhost");
       expect(getAllowedDomain()).toBe("localhost");
     });
   });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -177,7 +177,10 @@ describe("config", () => {
   });
 
   describe("getAllowedDomain", () => {
-    afterEach(() => setAllowedDomainForTest("localhost"));
+    afterEach(() => {
+      Deno.env.set("ALLOWED_DOMAIN", "localhost");
+      resetAllowedDomain();
+    });
 
     test("returns set value from environment", () => {
       Deno.env.set("ALLOWED_DOMAIN", "example.com");

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -3,8 +3,6 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import {
   getAllowedDomain,
-  resetAllowedDomain,
-  setAllowedDomainForTest,
   getBookingFee,
   getCurrencyCode,
   getPaymentProvider,
@@ -16,6 +14,8 @@ import {
   getTz,
   isPaymentsEnabled,
   isSetupComplete,
+  resetAllowedDomain,
+  setAllowedDomainForTest,
 } from "#lib/config.ts";
 import {
   completeSetup,

--- a/test/lib/cookies.test.ts
+++ b/test/lib/cookies.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import {
   buildSessionCookie,
   clearSessionCookie,
@@ -23,91 +24,76 @@ const expectSecureCookieAttributes = (cookie: string) => {
   expect(cookie).toContain("Path=/");
 };
 
-const withAllowedDomain = (domain: string, run: () => void): void => {
-  const original = Deno.env.get("ALLOWED_DOMAIN");
-  Deno.env.set("ALLOWED_DOMAIN", domain);
-  try {
-    run();
-  } finally {
-    if (original === undefined) {
-      Deno.env.delete("ALLOWED_DOMAIN");
-    } else {
-      Deno.env.set("ALLOWED_DOMAIN", original);
-    }
-  }
-};
-
 describe("isSecureMode", () => {
+  afterEach(() => setAllowedDomainForTest("localhost"));
+
   test("returns true for non-localhost domains", () => {
-    withAllowedDomain("example.com", () => {
-      expect(isSecureMode()).toBe(true);
-    });
+    setAllowedDomainForTest("example.com");
+    expect(isSecureMode()).toBe(true);
   });
 
   test("returns false for localhost", () => {
-    withAllowedDomain("localhost", () => {
-      expect(isSecureMode()).toBe(false);
-    });
+    setAllowedDomainForTest("localhost");
+    expect(isSecureMode()).toBe(false);
   });
 });
 
 describe("getSessionCookieName", () => {
+  afterEach(() => setAllowedDomainForTest("localhost"));
+
   test("returns __Host-session in secure mode", () => {
-    withAllowedDomain("example.com", () => {
-      expect(getSessionCookieName()).toBe("__Host-session");
-    });
+    setAllowedDomainForTest("example.com");
+    expect(getSessionCookieName()).toBe("__Host-session");
   });
 
   test("returns 'session' in dev mode", () => {
-    withAllowedDomain("localhost", () => {
-      expect(getSessionCookieName()).toBe("session");
-    });
+    setAllowedDomainForTest("localhost");
+    expect(getSessionCookieName()).toBe("session");
   });
 });
 
 describe("buildSessionCookie", () => {
+  afterEach(() => setAllowedDomainForTest("localhost"));
+
   test("includes __Host-session in secure mode with all required attributes", () => {
-    withAllowedDomain("example.com", () => {
-      const cookie = buildSessionCookie("test-token");
-      expect(cookie).toContain("__Host-session=test-token");
-      expectSecureCookieAttributes(cookie);
-      expect(cookie).toContain("Max-Age=86400");
-    });
+    setAllowedDomainForTest("example.com");
+    const cookie = buildSessionCookie("test-token");
+    expect(cookie).toContain("__Host-session=test-token");
+    expectSecureCookieAttributes(cookie);
+    expect(cookie).toContain("Max-Age=86400");
   });
 
   test("includes 'session' in dev mode without Secure flag", () => {
-    withAllowedDomain("localhost", () => {
-      const cookie = buildSessionCookie("test-token");
-      expect(cookie).toContain("session=test-token");
-      expectDevCookieAttributes(cookie);
-      expect(cookie).toContain("Max-Age=86400");
-    });
+    setAllowedDomainForTest("localhost");
+    const cookie = buildSessionCookie("test-token");
+    expect(cookie).toContain("session=test-token");
+    expectDevCookieAttributes(cookie);
+    expect(cookie).toContain("Max-Age=86400");
   });
 
   test("respects custom maxAge", () => {
-    withAllowedDomain("example.com", () => {
-      const cookie = buildSessionCookie("test-token", { maxAge: 3600 });
-      expect(cookie).toContain("Max-Age=3600");
-    });
+    setAllowedDomainForTest("example.com");
+    const cookie = buildSessionCookie("test-token", { maxAge: 3600 });
+    expect(cookie).toContain("Max-Age=3600");
   });
 });
 
 describe("clearSessionCookie", () => {
+  afterEach(() => setAllowedDomainForTest("localhost"));
+
   test("includes __Host-session in secure mode with Max-Age=0", () => {
-    withAllowedDomain("example.com", () => {
-      const cookie = clearSessionCookie();
-      expect(cookie).toContain("__Host-session=");
-      expectSecureCookieAttributes(cookie);
-      expect(cookie).toContain("Max-Age=0");
-    });
+    setAllowedDomainForTest("example.com");
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("__Host-session=");
+    expectSecureCookieAttributes(cookie);
+    expect(cookie).toContain("Max-Age=0");
   });
 
   test("includes 'session' in dev mode without Secure flag", () => {
-    withAllowedDomain("localhost", () => {
-      const cookie = clearSessionCookie();
-      expect(cookie).toContain("session=");
-      expectDevCookieAttributes(cookie);
-      expect(cookie).toContain("Max-Age=0");
-    });
+    setAllowedDomainForTest("localhost");
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("session=");
+    expectDevCookieAttributes(cookie);
+    expect(cookie).toContain("Max-Age=0");
   });
 });

--- a/test/lib/cookies.test.ts
+++ b/test/lib/cookies.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import { setAllowedDomainForTest } from "#lib/config.ts";
+import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import {
   buildSessionCookie,
   clearSessionCookie,
@@ -25,7 +25,7 @@ const expectSecureCookieAttributes = (cookie: string) => {
 };
 
 describe("isSecureMode", () => {
-  afterEach(() => setAllowedDomainForTest("localhost"));
+  afterEach(() => resetAllowedDomain());
 
   test("returns true for non-localhost domains", () => {
     setAllowedDomainForTest("example.com");
@@ -39,7 +39,7 @@ describe("isSecureMode", () => {
 });
 
 describe("getSessionCookieName", () => {
-  afterEach(() => setAllowedDomainForTest("localhost"));
+  afterEach(() => resetAllowedDomain());
 
   test("returns __Host-session in secure mode", () => {
     setAllowedDomainForTest("example.com");
@@ -53,7 +53,7 @@ describe("getSessionCookieName", () => {
 });
 
 describe("buildSessionCookie", () => {
-  afterEach(() => setAllowedDomainForTest("localhost"));
+  afterEach(() => resetAllowedDomain());
 
   test("includes __Host-session in secure mode with all required attributes", () => {
     setAllowedDomainForTest("example.com");
@@ -79,7 +79,7 @@ describe("buildSessionCookie", () => {
 });
 
 describe("clearSessionCookie", () => {
-  afterEach(() => setAllowedDomainForTest("localhost"));
+  afterEach(() => resetAllowedDomain());
 
   test("includes __Host-session in secure mode with Max-Age=0", () => {
     setAllowedDomainForTest("example.com");

--- a/test/lib/demo.test.ts
+++ b/test/lib/demo.test.ts
@@ -246,7 +246,6 @@ describe("demo", () => {
   describe("layout banner integration", () => {
     beforeAll(async () => {
       setupTestEncryptionKey();
-      Deno.env.set("ALLOWED_DOMAIN", "localhost");
       await createTestDbWithSetup();
     });
 

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
-import { setAllowedDomainForTest } from "#lib/config.ts";
+import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import {
   getCleanUrl,
@@ -521,7 +521,7 @@ describe("server (misc)", () => {
           "https://example.com/ticket/my-event",
         );
       } finally {
-        setAllowedDomainForTest("localhost");
+        resetAllowedDomain();
       }
     });
   });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import {
   getCleanUrl,
@@ -510,7 +511,7 @@ describe("server (misc)", () => {
     });
 
     test("uses https scheme when allowed domain is not localhost", async () => {
-      Deno.env.set("ALLOWED_DOMAIN", "example.com");
+      setAllowedDomainForTest("example.com");
       try {
         const response = await handleRequest(
           mockRequestWithHost("/ticket/my-event", "evil.com"),
@@ -520,7 +521,7 @@ describe("server (misc)", () => {
           "https://example.com/ticket/my-event",
         );
       } finally {
-        Deno.env.set("ALLOWED_DOMAIN", "localhost");
+        setAllowedDomainForTest("localhost");
       }
     });
   });

--- a/test/lib/square-provider.test.ts
+++ b/test/lib/square-provider.test.ts
@@ -1,10 +1,10 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import { PaymentUserError } from "#lib/payment-helpers.ts";
 import { squareApi } from "#lib/square.ts";
 import { squarePaymentProvider } from "#lib/square-provider.ts";
-import { setAllowedDomainForTest } from "#lib/config.ts";
 import { createTestDb, resetDb, testEvent, withMocks } from "#test-utils";
 
 describe("square-provider", () => {

--- a/test/lib/square-provider.test.ts
+++ b/test/lib/square-provider.test.ts
@@ -4,17 +4,17 @@ import { stub } from "@std/testing/mock";
 import { PaymentUserError } from "#lib/payment-helpers.ts";
 import { squareApi } from "#lib/square.ts";
 import { squarePaymentProvider } from "#lib/square-provider.ts";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import { createTestDb, resetDb, testEvent, withMocks } from "#test-utils";
 
 describe("square-provider", () => {
   beforeEach(async () => {
     await createTestDb();
-    Deno.env.set("ALLOWED_DOMAIN", "example.com");
+    setAllowedDomainForTest("example.com");
   });
 
   afterEach(() => {
     resetDb();
-    Deno.env.set("ALLOWED_DOMAIN", "localhost");
   });
 
   describe("retrieveSession", () => {

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -8,6 +8,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import { buildWebhookPayload, type RegistrationEntry } from "#lib/webhook.ts";
 import {
   EXAMPLE_ATTENDEE,
@@ -17,7 +18,6 @@ import {
   WEBHOOK_EXAMPLE_JSON,
   WEBHOOK_EXAMPLE_PAYLOAD,
 } from "#lib/webhook-example.ts";
-import { setAllowedDomainForTest } from "#lib/config.ts";
 import { createTestDbWithSetup, resetDb } from "#test-utils";
 
 /** Extract the domain from the example ticket_url (e.g. "https://x.com/t/..." → "x.com") */

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -17,6 +17,7 @@ import {
   WEBHOOK_EXAMPLE_JSON,
   WEBHOOK_EXAMPLE_PAYLOAD,
 } from "#lib/webhook-example.ts";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import { createTestDbWithSetup, resetDb } from "#test-utils";
 
 /** Extract the domain from the example ticket_url (e.g. "https://x.com/t/..." → "x.com") */
@@ -37,10 +38,10 @@ describe("webhook example", () => {
     const { updateBusinessEmail } = await import("#lib/business-email.ts");
     await updateBusinessEmail(EXAMPLE_BUSINESS_EMAIL);
 
-    // Stub ALLOWED_DOMAIN to match the example domain
-    Deno.env.set("ALLOWED_DOMAIN", exampleDomain);
+    // Set ALLOWED_DOMAIN to match the example domain
+    setAllowedDomainForTest(exampleDomain);
     domainStub = {
-      restore: () => Deno.env.set("ALLOWED_DOMAIN", "localhost"),
+      restore: () => setAllowedDomainForTest("localhost"),
     };
 
     // Fix time to match the example timestamp

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -8,7 +8,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import { setAllowedDomainForTest } from "#lib/config.ts";
+import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { buildWebhookPayload, type RegistrationEntry } from "#lib/webhook.ts";
 import {
   EXAMPLE_ATTENDEE,
@@ -41,7 +41,7 @@ describe("webhook example", () => {
     // Set ALLOWED_DOMAIN to match the example domain
     setAllowedDomainForTest(exampleDomain);
     domainStub = {
-      restore: () => setAllowedDomainForTest("localhost"),
+      restore: () => resetAllowedDomain(),
     };
 
     // Fix time to match the example timestamp

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,7 +4,6 @@
  * All testable logic is in stripe-mock.ts
  */
 
-import { setAllowedDomainForTest } from "#lib/config.ts";
 import { setupTestEncryptionKey } from "#test-utils";
 import {
   STRIPE_MOCK_PORT,
@@ -17,7 +16,9 @@ const manager = new StripeMockManager();
 setupTestEncryptionKey();
 
 // Configure allowed domain for tests (security middleware)
-setAllowedDomainForTest("localhost");
+// Set via env var (not override) so it's the default for all tests.
+// Tests that need a different domain use setAllowedDomainForTest().
+Deno.env.set("ALLOWED_DOMAIN", "localhost");
 
 // Configure stripe-mock env vars
 Deno.env.set("STRIPE_MOCK_HOST", "localhost");

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,6 +5,7 @@
  */
 
 import { setupTestEncryptionKey } from "#test-utils";
+import { setAllowedDomainForTest } from "#lib/config.ts";
 import {
   STRIPE_MOCK_PORT,
   StripeMockManager,
@@ -16,7 +17,7 @@ const manager = new StripeMockManager();
 setupTestEncryptionKey();
 
 // Configure allowed domain for tests (security middleware)
-Deno.env.set("ALLOWED_DOMAIN", "localhost");
+setAllowedDomainForTest("localhost");
 
 // Configure stripe-mock env vars
 Deno.env.set("STRIPE_MOCK_HOST", "localhost");

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,8 +4,8 @@
  * All testable logic is in stripe-mock.ts
  */
 
-import { setupTestEncryptionKey } from "#test-utils";
 import { setAllowedDomainForTest } from "#lib/config.ts";
+import { setupTestEncryptionKey } from "#test-utils";
 import {
   STRIPE_MOCK_PORT,
   StripeMockManager,


### PR DESCRIPTION
Use the same lazyRef + setForTest pattern as DEMO_MODE to avoid
Deno.env races between parallel test workers. All tests now use
setAllowedDomainForTest() instead of mutating Deno.env directly.

https://claude.ai/code/session_01PNDsumUGKTR7qRbyFzVLFn