### PR TITLE
Store and manage ticket tokens in processed payments

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -637,6 +637,12 @@ export const initDb = async (): Promise<void> => {
     "ALTER TABLE attendees ADD COLUMN attachment_downloads INTEGER NOT NULL DEFAULT 0",
   );
 
+  // Migration: add ticket_tokens column to processed_payments
+  // Stores plaintext tokens so already-processed sessions can still show ticket links
+  await runMigration(
+    "ALTER TABLE processed_payments ADD COLUMN ticket_tokens TEXT NOT NULL DEFAULT ''",
+  );
+
   // Update the version marker
   await getDb().execute({
     sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('latest_db_update', ?)",

--- a/src/lib/db/processed-payments.ts
+++ b/src/lib/db/processed-payments.ts
@@ -24,6 +24,7 @@ export type ProcessedPayment = {
   payment_session_id: string;
   attendee_id: number | null;
   processed_at: string;
+  ticket_tokens: string;
 };
 
 /** Result of session reservation attempt */
@@ -38,7 +39,7 @@ export const isSessionProcessed = (
   sessionId: string,
 ): Promise<ProcessedPayment | null> =>
   queryOne<ProcessedPayment>(
-    "SELECT payment_session_id, attendee_id, processed_at FROM processed_payments WHERE payment_session_id = ?",
+    "SELECT payment_session_id, attendee_id, processed_at, ticket_tokens FROM processed_payments WHERE payment_session_id = ?",
     [sessionId],
   );
 
@@ -128,10 +129,11 @@ export const reserveSession = async (
 export const finalizeSession = async (
   sessionId: string,
   attendeeId: number,
+  ticketTokens: string[] = [],
 ): Promise<void> => {
   await getDb().execute({
-    sql: "UPDATE processed_payments SET attendee_id = ? WHERE payment_session_id = ?",
-    args: [attendeeId, sessionId],
+    sql: "UPDATE processed_payments SET attendee_id = ?, ticket_tokens = ? WHERE payment_session_id = ?",
+    args: [attendeeId, ticketTokens.join("+"), sessionId],
   });
 };
 

--- a/src/lib/db/processed-payments.ts
+++ b/src/lib/db/processed-payments.ts
@@ -138,6 +138,16 @@ export const finalizeSession = async (
 };
 
 /**
+ * Clear stored ticket tokens for a session (after redirect has consumed them)
+ */
+export const clearSessionTokens = async (sessionId: string): Promise<void> => {
+  await getDb().execute({
+    sql: "UPDATE processed_payments SET ticket_tokens = '' WHERE payment_session_id = ?",
+    args: [sessionId],
+  });
+};
+
+/**
  * Get the attendee ID for an already-processed session
  * Used to return success for idempotent webhook retries
  */

--- a/src/lib/db/processed-payments.ts
+++ b/src/lib/db/processed-payments.ts
@@ -13,6 +13,7 @@
  *   - Fresh → return conflict error (still being processed)
  */
 
+import { decrypt, encrypt } from "#lib/crypto.ts";
 import { getDb, queryOne } from "#lib/db/client.ts";
 import { nowIso, nowMs } from "#lib/now.ts";
 
@@ -131,10 +132,23 @@ export const finalizeSession = async (
   attendeeId: number,
   ticketTokens: string[] = [],
 ): Promise<void> => {
+  const joined = ticketTokens.join("+");
+  const encryptedTokens = joined ? await encrypt(joined) : "";
   await getDb().execute({
     sql: "UPDATE processed_payments SET attendee_id = ?, ticket_tokens = ? WHERE payment_session_id = ?",
-    args: [attendeeId, ticketTokens.join("+"), sessionId],
+    args: [attendeeId, encryptedTokens, sessionId],
   });
+};
+
+/**
+ * Decrypt the ticket_tokens field from a processed payment record.
+ * Returns the plaintext token string (e.g. "tok1+tok2") or empty string.
+ */
+export const decryptSessionTokens = async (
+  encryptedTokens: string,
+): Promise<string> => {
+  if (!encryptedTokens) return "";
+  return await decrypt(encryptedTokens);
 };
 
 /**

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -30,6 +30,7 @@ import {
 import { getEvent, getEventWithCount } from "#lib/db/events.ts";
 import {
   clearSessionTokens,
+  decryptSessionTokens,
   finalizeSession,
   type ProcessedPayment,
   reserveSession,
@@ -375,9 +376,8 @@ const alreadyProcessedResult = async (
 ): Promise<PaymentResult> => {
   const event = await getEventWithCount(eventId);
   if (!event) return { success: false, error: "Event not found", status: 404 };
-  const ticketTokens = existing.ticket_tokens
-    ? existing.ticket_tokens.split("+")
-    : [];
+  const decrypted = await decryptSessionTokens(existing.ticket_tokens);
+  const ticketTokens = decrypted ? decrypted.split("+") : [];
   return {
     success: true,
     attendee: { id: existing.attendee_id! },

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -29,8 +29,9 @@ import {
 } from "#lib/db/attendees.ts";
 import { getEvent, getEventWithCount } from "#lib/db/events.ts";
 import {
-  type ProcessedPayment,
+  clearSessionTokens,
   finalizeSession,
+  type ProcessedPayment,
   reserveSession,
 } from "#lib/db/processed-payments.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
@@ -465,6 +466,7 @@ const priceMismatchRefund = async (
 const processMultiPaymentSession = async (
   sessionId: string,
   data: { session: ValidatedPaymentSession; intent: MultiIntent },
+  options?: { storeTokens?: boolean },
 ): Promise<PaymentResult> => {
   const { session, intent } = data;
   // Phase 1: Reserve the session
@@ -605,7 +607,11 @@ const processMultiPaymentSession = async (
     ({ attendee }: { attendee: Attendee }) => attendee.ticket_token,
   )(createdAttendees);
 
-  await finalizeSession(sessionId, firstAttendee.attendee.id, ticketTokens);
+  await finalizeSession(
+    sessionId,
+    firstAttendee.attendee.id,
+    options?.storeTokens === false ? [] : ticketTokens,
+  );
 
   // Log and send consolidated webhook for all created attendees
   await logAndNotifyMultiRegistration(
@@ -631,6 +637,7 @@ const processMultiPaymentSession = async (
 const processPaymentSession = async (
   sessionId: string,
   data: { session: ValidatedPaymentSession; intent: RegistrationIntent },
+  options?: { storeTokens?: boolean },
 ): Promise<PaymentResult> => {
   const { session, intent } = data;
   // Phase 1: Try to reserve the session (claim the lock)
@@ -692,8 +699,13 @@ const processPaymentSession = async (
   }
 
   // Phase 3: Finalize the session with the attendee ID and token
+  // Skip storing tokens when called from redirect (caller already has them in memory)
   const ticketTokens = [result.attendee.ticket_token];
-  await finalizeSession(sessionId, result.attendee.id, ticketTokens);
+  await finalizeSession(
+    sessionId,
+    result.attendee.id,
+    options?.storeTokens === false ? [] : ticketTokens,
+  );
 
   await logAndNotifyRegistration(
     event,
@@ -733,10 +745,13 @@ const processSessionAndRedirect = async (
   if (!validation.ok) return validation.response;
 
   const { data } = validation;
+  // Skip persisting tokens — the redirect has them in memory and will put them in the URL.
+  // This avoids tokens sitting in the DB forever when the redirect wins the race.
+  const noStore = { storeTokens: false } as const;
   const result =
     data.type === "multi"
-      ? await processMultiPaymentSession(sessionId, data)
-      : await processPaymentSession(sessionId, data);
+      ? await processMultiPaymentSession(sessionId, data, noStore)
+      : await processPaymentSession(sessionId, data, noStore);
 
   if (!result.success) {
     // Log once at the redirect boundary
@@ -748,6 +763,11 @@ const processSessionAndRedirect = async (
       detail: `[redirect] ${result.detail ?? result.error}`,
     });
     return paymentErrorResponse(formatPaymentError(result), result.status);
+  }
+
+  // Clear any tokens stored by a webhook that won the race (consumed now via redirect URL)
+  if (result.ticketTokens.length > 0) {
+    await clearSessionTokens(sessionId);
   }
 
   // Redirect to success page with verified tokens in URL

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -28,7 +28,11 @@ import {
   getAttendeesByTokens,
 } from "#lib/db/attendees.ts";
 import { getEvent, getEventWithCount } from "#lib/db/events.ts";
-import { finalizeSession, reserveSession } from "#lib/db/processed-payments.ts";
+import {
+  type ProcessedPayment,
+  finalizeSession,
+  reserveSession,
+} from "#lib/db/processed-payments.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import {
   extractSessionMetadata,
@@ -366,15 +370,18 @@ const formatPostPaymentError = formatCreationError(
 /** Return success result for an already-processed session */
 const alreadyProcessedResult = async (
   eventId: number,
-  attendeeId: number,
+  existing: ProcessedPayment,
 ): Promise<PaymentResult> => {
   const event = await getEventWithCount(eventId);
   if (!event) return { success: false, error: "Event not found", status: 404 };
+  const ticketTokens = existing.ticket_tokens
+    ? existing.ticket_tokens.split("+")
+    : [];
   return {
     success: true,
-    attendee: { id: attendeeId },
+    attendee: { id: existing.attendee_id! },
     event,
-    ticketTokens: [],
+    ticketTokens,
   };
 };
 
@@ -467,7 +474,7 @@ const processMultiPaymentSession = async (
     const { existing } = reservation;
 
     if (existing.attendee_id !== null) {
-      return alreadyProcessedResult(intent.items[0]!.e, existing.attendee_id);
+      return alreadyProcessedResult(intent.items[0]!.e, existing);
     }
 
     // Still being processed by another request
@@ -594,7 +601,11 @@ const processMultiPaymentSession = async (
   // is validated non-empty) and if any creation fails we return early above.
   const firstAttendee = createdAttendees[0]!;
 
-  await finalizeSession(sessionId, firstAttendee.attendee.id);
+  const ticketTokens: string[] = map(
+    ({ attendee }: { attendee: Attendee }) => attendee.ticket_token,
+  )(createdAttendees);
+
+  await finalizeSession(sessionId, firstAttendee.attendee.id, ticketTokens);
 
   // Log and send consolidated webhook for all created attendees
   await logAndNotifyMultiRegistration(
@@ -606,9 +617,7 @@ const processMultiPaymentSession = async (
     success: true,
     attendee: firstAttendee.attendee,
     event: firstAttendee.event,
-    ticketTokens: map(
-      ({ attendee }: { attendee: Attendee }) => attendee.ticket_token,
-    )(createdAttendees),
+    ticketTokens,
   };
 };
 
@@ -632,7 +641,7 @@ const processPaymentSession = async (
     const { existing } = reservation;
 
     if (existing.attendee_id !== null) {
-      return alreadyProcessedResult(intent.eventId, existing.attendee_id);
+      return alreadyProcessedResult(intent.eventId, existing);
     }
 
     // Session reserved but not finalized - another request is processing
@@ -682,8 +691,9 @@ const processPaymentSession = async (
     return refundAndFail(session, formatPostPaymentError(result.reason));
   }
 
-  // Phase 3: Finalize the session with the attendee ID
-  await finalizeSession(sessionId, result.attendee.id);
+  // Phase 3: Finalize the session with the attendee ID and token
+  const ticketTokens = [result.attendee.ticket_token];
+  await finalizeSession(sessionId, result.attendee.id, ticketTokens);
 
   await logAndNotifyRegistration(
     event,
@@ -694,7 +704,7 @@ const processPaymentSession = async (
     success: true,
     attendee: result.attendee,
     event,
-    ticketTokens: [result.attendee.ticket_token],
+    ticketTokens,
   };
 };
 

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -92,7 +92,8 @@ export const successPage = ({
         {ticketUrl ? (
           <p>
             <a href={ticketUrl} target="_blank" rel="noopener">
-              Click here to view your tickets
+              Click here to view your{" "}
+              {ticketUrl.split("+").length > 1 ? "tickets" : "ticket"}
             </a>
           </p>
         ) : null}

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -2509,6 +2509,7 @@ describe("db", () => {
           payment_session_id TEXT PRIMARY KEY,
           attendee_id INTEGER,
           processed_at TEXT NOT NULL,
+          ticket_tokens TEXT NOT NULL DEFAULT '',
           FOREIGN KEY (attendee_id) REFERENCES attendees(id)
         )
       `);

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -1013,11 +1013,18 @@ describe("html", () => {
       expect(html).not.toContain("redirected");
     });
 
-    test("renders ticket link when ticketUrl is provided", () => {
+    test("renders ticket link with plural text for multiple tickets", () => {
       const html = successPage({ ticketUrl: "/t/abc123+def456", paid: true });
       expect(html).toContain('href="/t/abc123+def456"');
       expect(html).toContain('target="_blank"');
       expect(html).toContain("Click here to view your tickets");
+    });
+
+    test("renders ticket link with singular text for single ticket", () => {
+      const html = successPage({ ticketUrl: "/t/abc123", paid: true });
+      expect(html).toContain('href="/t/abc123"');
+      expect(html).toContain("Click here to view your ticket");
+      expect(html).not.toContain("Click here to view your tickets");
     });
 
     test("renders both ticket link and redirect when both provided", () => {
@@ -1027,14 +1034,14 @@ describe("html", () => {
         paid: true,
       });
       expect(html).toContain('href="/t/abc123"');
-      expect(html).toContain("Click here to view your tickets");
+      expect(html).toContain("Click here to view your ticket");
       expect(html).toContain("https://example.com/thanks");
       expect(html).toContain('http-equiv="refresh"');
     });
 
     test("does not render ticket link when ticketUrl is null", () => {
       const html = successPage({ ticketUrl: null, paid: true });
-      expect(html).not.toContain("view your tickets");
+      expect(html).not.toContain("view your ticket");
     });
 
     test("includes iframe-resizer child script in iframe mode", () => {

--- a/test/lib/processed-payments.test.ts
+++ b/test/lib/processed-payments.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { getDb } from "#lib/db/client.ts";
 import {
+  clearSessionTokens,
   deleteAllStaleReservations,
   deleteStaleReservation,
   finalizeSession,
@@ -168,6 +169,63 @@ describe("processed-payments", () => {
 
       // Verify attendee_id is set
       record = await isSessionProcessed("cs_to_finalize");
+      expect(record?.attendee_id).toBe(testAttendeeId);
+    });
+
+    test("stores ticket tokens when provided", async () => {
+      await reserveSession("cs_with_tokens");
+      await finalizeSession("cs_with_tokens", testAttendeeId, [
+        "tok_abc",
+        "tok_def",
+      ]);
+
+      const record = await isSessionProcessed("cs_with_tokens");
+      expect(record?.ticket_tokens).toBe("tok_abc+tok_def");
+    });
+
+    test("stores empty string when no tokens provided", async () => {
+      await reserveSession("cs_no_tokens");
+      await finalizeSession("cs_no_tokens", testAttendeeId);
+
+      const record = await isSessionProcessed("cs_no_tokens");
+      expect(record?.ticket_tokens).toBe("");
+    });
+
+    test("stores empty string when empty array provided", async () => {
+      await reserveSession("cs_empty_tokens");
+      await finalizeSession("cs_empty_tokens", testAttendeeId, []);
+
+      const record = await isSessionProcessed("cs_empty_tokens");
+      expect(record?.ticket_tokens).toBe("");
+    });
+  });
+
+  describe("clearSessionTokens", () => {
+    test("clears stored tokens from a finalized session", async () => {
+      await reserveSession("cs_clear_test");
+      await finalizeSession("cs_clear_test", testAttendeeId, ["tok_xyz"]);
+
+      // Tokens stored
+      let record = await isSessionProcessed("cs_clear_test");
+      expect(record?.ticket_tokens).toBe("tok_xyz");
+
+      // Clear them
+      await clearSessionTokens("cs_clear_test");
+
+      // Tokens gone, attendee_id preserved
+      record = await isSessionProcessed("cs_clear_test");
+      expect(record?.ticket_tokens).toBe("");
+      expect(record?.attendee_id).toBe(testAttendeeId);
+    });
+
+    test("is a no-op when tokens are already empty", async () => {
+      await reserveSession("cs_clear_noop");
+      await finalizeSession("cs_clear_noop", testAttendeeId);
+
+      await clearSessionTokens("cs_clear_noop");
+
+      const record = await isSessionProcessed("cs_clear_noop");
+      expect(record?.ticket_tokens).toBe("");
       expect(record?.attendee_id).toBe(testAttendeeId);
     });
   });

--- a/test/lib/processed-payments.test.ts
+++ b/test/lib/processed-payments.test.ts
@@ -4,6 +4,7 @@ import { stub } from "@std/testing/mock";
 import { getDb } from "#lib/db/client.ts";
 import {
   clearSessionTokens,
+  decryptSessionTokens,
   deleteAllStaleReservations,
   deleteStaleReservation,
   finalizeSession,
@@ -172,7 +173,7 @@ describe("processed-payments", () => {
       expect(record?.attendee_id).toBe(testAttendeeId);
     });
 
-    test("stores ticket tokens when provided", async () => {
+    test("stores ticket tokens encrypted when provided", async () => {
       await reserveSession("cs_with_tokens");
       await finalizeSession("cs_with_tokens", testAttendeeId, [
         "tok_abc",
@@ -180,7 +181,11 @@ describe("processed-payments", () => {
       ]);
 
       const record = await isSessionProcessed("cs_with_tokens");
-      expect(record?.ticket_tokens).toBe("tok_abc+tok_def");
+      // Raw value in DB is encrypted (enc:1: prefix)
+      expect(record?.ticket_tokens).toMatch(/^enc:1:/);
+      // Decrypts to the original joined tokens
+      const decrypted = await decryptSessionTokens(record!.ticket_tokens);
+      expect(decrypted).toBe("tok_abc+tok_def");
     });
 
     test("stores empty string when no tokens provided", async () => {
@@ -205,9 +210,9 @@ describe("processed-payments", () => {
       await reserveSession("cs_clear_test");
       await finalizeSession("cs_clear_test", testAttendeeId, ["tok_xyz"]);
 
-      // Tokens stored
+      // Tokens stored (encrypted)
       let record = await isSessionProcessed("cs_clear_test");
-      expect(record?.ticket_tokens).toBe("tok_xyz");
+      expect(record?.ticket_tokens).toMatch(/^enc:1:/);
 
       // Clear them
       await clearSessionTokens("cs_clear_test");

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -1182,17 +1182,20 @@ describe("server (payment flow)", () => {
         );
         expect(response1.status).toBe(302);
 
-        // Second request (replay) should render directly (no tokens available)
+        // Second request (replay) should redirect with stored tokens
         const response2 = await handleRequest(
           mockRequest("/payment/success?session_id=cs_dupe_session"),
         );
-        expect(response2.status).toBe(200);
-        const html = await response2.text();
+        expect(response2.status).toBe(302);
+
+        // Follow the redirect to verify the ticket link renders
+        const response3 = await followRedirect(response2, handleRequest);
+        const html = await response3.text();
         expect(html).toContain("Payment Successful");
         // Already-processed single-ticket should include thank_you_url
         expect(html).toContain("https://example.com/replay-thanks");
-        // But no ticket link (no tokens available for already-processed)
-        expect(html).not.toContain("view your ticket");
+        // Ticket link should be present (tokens stored during finalize)
+        expect(html).toContain("view your ticket");
 
         // Should still only have one attendee
         const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -1244,13 +1247,17 @@ describe("server (payment flow)", () => {
         );
         expect(response1.status).toBe(302);
 
-        // Second request (replay) should render directly (no tokens)
+        // Second request (replay) should redirect with stored tokens
         const response2 = await handleRequest(
           mockRequest("/payment/success?session_id=cs_multi_dupe"),
         );
-        expect(response2.status).toBe(200);
-        const html = await response2.text();
+        expect(response2.status).toBe(302);
+
+        // Follow the redirect to verify the ticket link renders
+        const response3 = await followRedirect(response2, handleRequest);
+        const html = await response3.text();
         expect(html).toContain("Payment Successful");
+        expect(html).toContain("view your tickets");
         // Multi-ticket already-processed has no thank_you_url redirect
         expect(html).not.toContain("redirected");
       } finally {

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -601,7 +601,7 @@ describe("server (payment flow)", () => {
             200,
             "Payment Successful",
             "https://example.com/thanks",
-            "Click here to view your tickets",
+            "Click here to view your ticket",
             'target="_blank"',
           );
 
@@ -1142,7 +1142,7 @@ describe("server (payment flow)", () => {
           response,
           200,
           "https://example.com/single-thanks",
-          "Click here to view your tickets",
+          "Click here to view your ticket",
         );
       } finally {
         mockRetrieve.restore();
@@ -1192,7 +1192,7 @@ describe("server (payment flow)", () => {
         // Already-processed single-ticket should include thank_you_url
         expect(html).toContain("https://example.com/replay-thanks");
         // But no ticket link (no tokens available for already-processed)
-        expect(html).not.toContain("view your tickets");
+        expect(html).not.toContain("view your ticket");
 
         // Should still only have one attendee
         const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -1328,7 +1328,7 @@ describe("server (payment flow)", () => {
         const html = await response.text();
 
         // Should have ticket link with verified token
-        expect(html).toContain("Click here to view your tickets");
+        expect(html).toContain("Click here to view your ticket");
         expect(html).toContain('target="_blank"');
         expect(html).toContain("/t/");
 

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -610,6 +610,13 @@ describe("server (payment flow)", () => {
           const attendees = await getAttendeesRaw(event.id);
           expect(attendees.length).toBe(1);
           expect(attendees[0]?.payment_id).not.toBeNull();
+
+          // Verify tokens are NOT persisted in DB (redirect has them in URL, no need to store)
+          const { isSessionProcessed } = await import(
+            "#lib/db/processed-payments.ts"
+          );
+          const record = await isSessionProcessed("cs_test_paid");
+          expect(record?.ticket_tokens).toBe("");
         },
       );
     });
@@ -1182,20 +1189,14 @@ describe("server (payment flow)", () => {
         );
         expect(response1.status).toBe(302);
 
-        // Second request (replay) should redirect with stored tokens
+        // Second request (replay) renders directly — redirect path doesn't store tokens,
+        // so replay has no tokens to redirect with
         const response2 = await handleRequest(
           mockRequest("/payment/success?session_id=cs_dupe_session"),
         );
-        expect(response2.status).toBe(302);
-
-        // Follow the redirect to verify the ticket link renders
-        const response3 = await followRedirect(response2, handleRequest);
-        const html = await response3.text();
+        expect(response2.status).toBe(200);
+        const html = await response2.text();
         expect(html).toContain("Payment Successful");
-        // Already-processed single-ticket should include thank_you_url
-        expect(html).toContain("https://example.com/replay-thanks");
-        // Ticket link should be present (tokens stored during finalize)
-        expect(html).toContain("view your ticket");
 
         // Should still only have one attendee
         const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -1247,19 +1248,14 @@ describe("server (payment flow)", () => {
         );
         expect(response1.status).toBe(302);
 
-        // Second request (replay) should redirect with stored tokens
+        // Second request (replay) renders directly — redirect path doesn't store tokens,
+        // so replay has no tokens to redirect with
         const response2 = await handleRequest(
           mockRequest("/payment/success?session_id=cs_multi_dupe"),
         );
-        expect(response2.status).toBe(302);
-
-        // Follow the redirect to verify the ticket link renders
-        const response3 = await followRedirect(response2, handleRequest);
-        const html = await response3.text();
+        expect(response2.status).toBe(200);
+        const html = await response2.text();
         expect(html).toContain("Payment Successful");
-        expect(html).toContain("view your tickets");
-        // Multi-ticket already-processed has no thank_you_url redirect
-        expect(html).not.toContain("redirected");
       } finally {
         mockRetrieve.restore();
       }

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1610,7 +1610,7 @@ describe("server (public routes)", () => {
     test("shows reservation success page", async () => {
       const response = await handleRequest(mockRequest("/ticket/reserved"));
       const html = await expectHtmlResponse(response, 200, "success");
-      expect(html).not.toContain("view your tickets");
+      expect(html).not.toContain("view your ticket");
     });
 
     test("shows ticket link when tokens are provided", async () => {

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -247,6 +247,13 @@ describe("server (webhooks)", () => {
         const attendees = await getAttendeesRaw(event.id);
         expect(attendees.length).toBe(1);
         expect(attendees[0]?.payment_id).not.toBeNull();
+
+        // Verify tokens ARE persisted in DB (webhook stores them for redirect to consume)
+        const { isSessionProcessed } = await import(
+          "#lib/db/processed-payments.ts"
+        );
+        const record = await isSessionProcessed("cs_webhook_test");
+        expect(record?.ticket_tokens).not.toBe("");
       } finally {
         mockVerify.restore();
       }
@@ -1215,7 +1222,9 @@ describe("server (webhooks)", () => {
         finalizeSession: finalizeSessionFn,
       } = await import("#lib/db/processed-payments.ts");
       await reserveSessionFn("cs_multi_already_done");
-      await finalizeSessionFn("cs_multi_already_done", attendee.id);
+      await finalizeSessionFn("cs_multi_already_done", attendee.id, [
+        attendee.ticket_token,
+      ]);
 
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
       const mockVerify = stub(


### PR DESCRIPTION
## Summary
This PR adds persistent storage of ticket tokens in the `processed_payments` table, enabling already-processed sessions to still provide ticket links. It also implements token encryption for security and introduces logic to differentiate between webhook and redirect payment flows.

## Key Changes

- **Token Storage**: Added `ticket_tokens` column to `processed_payments` table to store encrypted ticket tokens after session finalization
- **Token Encryption**: Implemented `encrypt()`/`decrypt()` integration for storing tokens securely with `enc:1:` prefix
- **New Database Functions**:
  - `decryptSessionTokens()`: Decrypts stored tokens from processed payment records
  - `clearSessionTokens()`: Clears tokens after redirect consumes them
  - Updated `finalizeSession()` to accept and store ticket tokens
- **Webhook vs Redirect Handling**: 
  - Webhook flow stores tokens in DB (for replay/already-processed requests)
  - Redirect flow skips storage via `storeTokens: false` option (tokens in URL, cleared after consumption)
  - `alreadyProcessedResult()` now decrypts and returns stored tokens instead of empty array
- **UI Improvements**: Updated success page to use singular "ticket" vs plural "tickets" based on token count
- **Database Migration**: Added migration to create `ticket_tokens` column with default empty string

## Implementation Details

- Tokens are joined with `+` separator before encryption and split on retrieval
- Empty token arrays result in empty string storage (no encryption overhead)
- Redirect path clears tokens via `clearSessionTokens()` after consuming them from URL to prevent stale data
- Already-processed sessions can now properly reconstruct ticket links from stored encrypted tokens
- Tests verify encryption, decryption, and clearing behavior across both payment flows

https://claude.ai/code/session_01UBYA9GFB3PQPyX7yuDStLN