### PR TITLE
Allow managers to access the admin log page

### DIFF
--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -35,7 +35,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
         navLink("/admin/site", "Site", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/settings", "Settings", active)}
-      {session.adminLevel === "owner" && navLink("/admin/log", "Log", active)}
+      {navLink("/admin/log", "Log", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/groups", "Groups", active)}
       {session.adminLevel === "owner" &&

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -17,6 +17,7 @@ import {
   createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
+  createTestManagerSession,
   deactivateTestEvent,
   expectAdminRedirect,
   expectHtmlResponse,
@@ -1609,6 +1610,14 @@ describe("server (admin events)", () => {
 
       const response = await awaitTestRequest("/admin/log", {
         cookie: await testCookie(),
+      });
+      await expectHtmlResponse(response, 200, "Log");
+    });
+
+    test("shows log page for manager", async () => {
+      const managerCookie = await createTestManagerSession();
+      const response = await awaitTestRequest("/admin/log", {
+        cookie: managerCookie,
       });
       await expectHtmlResponse(response, 200, "Log");
     });

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -689,6 +689,16 @@ describe("server (multi-user admin)", () => {
       expect(html).not.toContain("Sessions");
       expect(html).not.toContain("Users");
     });
+
+    test("manager sees log nav link", async () => {
+      const cookie = await createTestManagerSession(
+        "navmgr-log-session",
+        "navmanagerlog",
+      );
+      const dashboardResponse = await awaitTestRequest("/admin/", { cookie });
+      const html = await dashboardResponse.text();
+      expect(html).toContain("/admin/log");
+    });
   });
 
   describe("setup page", () => {


### PR DESCRIPTION
## Summary
This change grants manager-level users access to the admin log page, previously restricted to owners only.

## Key Changes
- **Navigation**: Updated `AdminNav` component to display the log link for all admin levels (not just owners)
- **Access Control**: Managers can now view the `/admin/log` page
- **Tests**: Added test coverage verifying:
  - Managers see the log navigation link on the dashboard
  - Managers can successfully access and view the log page

## Implementation Details
The log navigation link in the admin sidebar is now unconditionally rendered for all authenticated admin users, while other sensitive sections (Settings, Groups, Users, Sessions) remain owner-only. This allows managers to monitor system events and activity logs as part of their administrative responsibilities.

https://claude.ai/code/session_01RswH6S5GjQc9h4FSfg8Xxx