### PR TITLE
Enforce 3-digit maximum for phone prefix validation

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -832,6 +832,14 @@ const processPhonePrefixForm: SettingsFormHandler = async (form, errorPage) => {
     );
   }
 
+  if (raw.length > 3) {
+    return errorPage(
+      "Phone prefix must be 1-3 digits",
+      400,
+      "settings-phone-prefix",
+    );
+  }
+
   await updatePhonePrefix(raw);
   await logActivity(`Phone prefix set to ${raw}`);
   return redirect("/admin/settings", `Phone prefix updated to ${raw}`, true, {

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -102,6 +102,7 @@ export const adminSettingsPage = (
             name="phone_prefix"
             step="1"
             min="1"
+            max="999"
             value={s.phonePrefix}
             required
           />

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -1730,6 +1730,44 @@ describe("server (admin settings)", () => {
       await expectHtmlResponse(response, 400, "Phone prefix must be a number");
     });
 
+    test("rejects prefix longer than 3 digits", async () => {
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/phone-prefix",
+          {
+            phone_prefix: "1234",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+
+      await expectHtmlResponse(
+        response,
+        400,
+        "Phone prefix must be 1-3 digits",
+      );
+    });
+
+    test("accepts 3-digit prefix", async () => {
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/phone-prefix",
+          {
+            phone_prefix: "886",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location")!;
+      expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
+        "Phone prefix updated to 886",
+      );
+    });
+
     test("rejects when phone_prefix field is missing", async () => {
       const response = await handleRequest(
         mockFormRequest(


### PR DESCRIPTION
## Summary
Added validation to enforce that phone prefixes cannot exceed 3 digits, with corresponding UI and test updates.

## Key Changes
- **Backend validation**: Added length check in `processPhonePrefixForm` to reject prefixes longer than 3 digits with error message "Phone prefix must be 1-3 digits"
- **Frontend constraint**: Added `max="999"` attribute to the phone prefix input field to prevent users from entering values exceeding 3 digits
- **Test coverage**: Added two new test cases:
  - Test that rejects 4-digit prefix (1234)
  - Test that accepts valid 3-digit prefix (886)

## Implementation Details
The validation is applied server-side after the existing numeric validation, ensuring that only numeric values between 1 and 999 are accepted as phone prefixes. The HTML input constraint provides immediate client-side feedback while the server-side validation ensures data integrity.

https://claude.ai/code/session_0114cxJd9ZT6aV4N74bXzx8a