### PR TITLE
Remove image and attachment upload from event duplication

### DIFF
--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -768,10 +768,6 @@ export const adminDuplicateEventPage = (
   groups: Group[],
   session: AdminSession,
 ): string => {
-  const storageEnabled = isStorageEnabled();
-  const fields = storageEnabled
-    ? [...eventFieldsWithAutofocus, imageField, attachmentField]
-    : eventFieldsWithAutofocus;
   const values = eventToFieldValues(event);
   values.name = "";
 
@@ -783,7 +779,7 @@ export const adminDuplicateEventPage = (
         Creating a new event based on <strong>{event.name}</strong>.
       </p>
       <CsrfForm action="/admin/event" enctype="multipart/form-data">
-        <Raw html={renderFields(fields, values)} />
+        <Raw html={renderFields(eventFieldsWithAutofocus, values)} />
         <EventGroupSelect groups={groups} selectedGroupId={event.group_id} />
         <button type="submit">Create Event</button>
       </CsrfForm>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -3775,12 +3775,12 @@ describe("html", () => {
     });
 
     describe("adminDuplicateEventPage image section", () => {
-      test("shows image upload field when storage enabled", () => {
+      test("does not show image upload field even when storage enabled", () => {
         setupStorage();
         const event = testEventWithCount({ image_url: "" });
         const html = adminDuplicateEventPage(event, [], TEST_SESSION);
-        expect(html).toContain('type="file"');
-        expect(html).toContain('name="image"');
+        expect(html).not.toContain('type="file"');
+        expect(html).not.toContain('name="image"');
         expect(html).toContain("multipart/form-data");
         cleanupStorage();
       });


### PR DESCRIPTION
## Summary
Removed the ability to upload images and attachments when duplicating events in the admin panel. The duplication form now only includes basic event fields, regardless of storage configuration.

## Changes
- Removed conditional logic that added image and attachment fields to the event duplication form when storage is enabled
- Simplified the form to always use only `eventFieldsWithAutofocus` instead of conditionally including `imageField` and `attachmentField`
- Updated corresponding test to reflect that image upload fields are no longer shown during event duplication

## Implementation Details
- The `adminDuplicateEventPage` function previously checked `isStorageEnabled()` to conditionally include file upload fields
- This check and the conditional field selection have been removed, streamlining the duplication workflow
- The form still maintains `multipart/form-data` encoding for consistency, though file uploads are no longer available

https://claude.ai/code/session_01JgzmunxBvXDUHeULBEspg6