### PR TITLE
Add group-level attendee capacity limits

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -548,33 +548,32 @@ export const attendeesApi = {
       : "SELECT COALESCE(SUM(quantity), 0) FROM attendees WHERE event_id = ?";
     const capacityArgs = date ? [eventId, date] : [eventId];
 
-    // Group capacity check: skip if event has no group (group_id=0) or group has no limit (max_attendees=0)
-    // For date-aware counting: standard events always count, daily events only count matching date
+    // Group capacity check via single CASE expression — one event+group lookup.
+    // Skips when group_id=0 (no group) or max_attendees=0 (no limit).
+    // Date-aware: standard events always count, daily events only count matching date.
     const groupCapacityCheck = `
             AND (
-              (SELECT ev1.group_id FROM events ev1 WHERE ev1.id = ?) = 0
-              OR (SELECT COALESCE(g1.max_attendees, 0) FROM events ev2 LEFT JOIN groups g1 ON g1.id = ev2.group_id WHERE ev2.id = ?) = 0
-              OR (
-                (SELECT COALESCE(SUM(a2.quantity), 0)
-                 FROM attendees a2
-                 JOIN events e2 ON e2.id = a2.event_id
-                 WHERE e2.group_id = (SELECT group_id FROM events WHERE id = ?)
-                   AND (? IS NULL OR e2.event_type != 'daily' OR a2.date = ?)
-                ) + ? <= (
-                  SELECT g2.max_attendees
-                  FROM events ev3 JOIN groups g2 ON g2.id = ev3.group_id
-                  WHERE ev3.id = ?
-                )
-              )
-            )`;
+              SELECT CASE
+                WHEN ev.group_id = 0 THEN 1
+                WHEN COALESCE(g.max_attendees, 0) = 0 THEN 1
+                WHEN (
+                  SELECT COALESCE(SUM(a2.quantity), 0)
+                  FROM attendees a2
+                  JOIN events e2 ON e2.id = a2.event_id
+                  WHERE e2.group_id = ev.group_id
+                    AND (? IS NULL OR e2.event_type != 'daily' OR a2.date = ?)
+                ) + ? <= g.max_attendees THEN 1
+                ELSE 0
+              END
+              FROM events ev
+              LEFT JOIN groups g ON g.id = ev.group_id
+              WHERE ev.id = ?
+            ) = 1`;
     const groupCapacityArgs = [
-      eventId, // group_id check
-      eventId, // max_attendees check
-      eventId, // group_id subquery for SUM
       date, // date IS NULL check
       date, // date match
       qty, // quantity to add
-      eventId, // event for group join
+      eventId, // event lookup
     ];
 
     // Atomic check-and-insert: only inserts if capacity allows

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -400,6 +400,34 @@ export const getDateAttendeeCount = async (
   return rows[0]!.count;
 };
 
+/** Get a group's max_attendees limit (0 = no limit) */
+const getGroupMaxAttendees = async (groupId: number): Promise<number> => {
+  const row = await queryOne<{ max_attendees: number }>(
+    "SELECT max_attendees FROM groups WHERE id = ?",
+    [groupId],
+  );
+  return row?.max_attendees ?? 0;
+};
+
+/**
+ * Count total attendees across all events in a group.
+ * Date-aware: standard events always count, daily events only count matching date.
+ */
+const getGroupAttendeeCount = async (
+  groupId: number,
+  date: string | null,
+): Promise<number> => {
+  const rows = await queryAll<{ count: number }>(
+    `SELECT COALESCE(SUM(a.quantity), 0) as count
+     FROM attendees a
+     JOIN events e ON e.id = a.event_id
+     WHERE e.group_id = ?
+       AND (? IS NULL OR e.event_type != 'daily' OR a.date = ?)`,
+    [groupId, date, date],
+  );
+  return rows[0]!.count;
+};
+
 /** Stubbable API for testing atomic operations */
 export const attendeesApi = {
   /**
@@ -417,9 +445,11 @@ export const attendeesApi = {
       id: number;
       max_attendees: number;
       current_count: number;
+      group_id: number;
     }>(
       `SELECT e.id, e.max_attendees,
-              COALESCE(SUM(a.quantity), 0) as current_count
+              COALESCE(SUM(a.quantity), 0) as current_count,
+              e.group_id
             FROM events e
             LEFT JOIN attendees a ON a.event_id = e.id
               AND (e.event_type != 'daily' OR a.date = ?)
@@ -428,12 +458,32 @@ export const attendeesApi = {
       [date ?? null, ...eventIds],
     );
     const counts = new Map(rows.map((r) => [r.id, r]));
-    return items.every((item) => {
+    // Per-event capacity check
+    const eventOk = items.every((item) => {
       const row = counts.get(item.eventId);
       return row
         ? row.current_count + item.quantity <= row.max_attendees
         : false;
     });
+    if (!eventOk) return false;
+
+    // Group capacity check: collect unique group IDs with limits
+    const groupIds = new Set<number>();
+    for (const row of rows) {
+      if (row.group_id > 0) groupIds.add(row.group_id);
+    }
+    for (const groupId of groupIds) {
+      const groupLimit = await getGroupMaxAttendees(groupId);
+      if (groupLimit <= 0) continue;
+      const groupCount = await getGroupAttendeeCount(groupId, date ?? null);
+      // Sum requested quantities for events in this group
+      const requestedInGroup = items.reduce((sum, item) => {
+        const row = counts.get(item.eventId);
+        return row && row.group_id === groupId ? sum + item.quantity : sum;
+      }, 0);
+      if (groupCount + requestedInGroup > groupLimit) return false;
+    }
+    return true;
   },
   /** Check if an event has available spots for the requested quantity */
   hasAvailableSpots: async (
@@ -445,9 +495,22 @@ export const attendeesApi = {
     if (!event) return false;
     if (date) {
       const dateCount = await getDateAttendeeCount(eventId, date);
-      return dateCount + quantity <= event.max_attendees;
+      if (dateCount + quantity > event.max_attendees) return false;
+    } else {
+      if (event.attendee_count + quantity > event.max_attendees) return false;
     }
-    return event.attendee_count + quantity <= event.max_attendees;
+    // Check group capacity if event belongs to a group with a limit
+    if (event.group_id > 0) {
+      const groupLimit = await getGroupMaxAttendees(event.group_id);
+      if (groupLimit > 0) {
+        const groupCount = await getGroupAttendeeCount(
+          event.group_id,
+          date ?? null,
+        );
+        if (groupCount + quantity > groupLimit) return false;
+      }
+    }
+    return true;
   },
   /**
    * Atomically create attendee with capacity check in single SQL statement.
@@ -485,6 +548,35 @@ export const attendeesApi = {
       : "SELECT COALESCE(SUM(quantity), 0) FROM attendees WHERE event_id = ?";
     const capacityArgs = date ? [eventId, date] : [eventId];
 
+    // Group capacity check: skip if event has no group (group_id=0) or group has no limit (max_attendees=0)
+    // For date-aware counting: standard events always count, daily events only count matching date
+    const groupCapacityCheck = `
+            AND (
+              (SELECT ev1.group_id FROM events ev1 WHERE ev1.id = ?) = 0
+              OR (SELECT COALESCE(g1.max_attendees, 0) FROM events ev2 LEFT JOIN groups g1 ON g1.id = ev2.group_id WHERE ev2.id = ?) = 0
+              OR (
+                (SELECT COALESCE(SUM(a2.quantity), 0)
+                 FROM attendees a2
+                 JOIN events e2 ON e2.id = a2.event_id
+                 WHERE e2.group_id = (SELECT group_id FROM events WHERE id = ?)
+                   AND (? IS NULL OR e2.event_type != 'daily' OR a2.date = ?)
+                ) + ? <= (
+                  SELECT g2.max_attendees
+                  FROM events ev3 JOIN groups g2 ON g2.id = ev3.group_id
+                  WHERE ev3.id = ?
+                )
+              )
+            )`;
+    const groupCapacityArgs = [
+      eventId, // group_id check
+      eventId, // max_attendees check
+      eventId, // group_id subquery for SUM
+      date, // date IS NULL check
+      date, // date match
+      qty, // quantity to add
+      eventId, // event for group join
+    ];
+
     // Atomic check-and-insert: only inserts if capacity allows
     const insertResult = await getDb().execute({
       sql: `INSERT INTO attendees (event_id, name, email, phone, address, special_instructions, created, payment_id, quantity, price_paid, checked_in, refunded, ticket_token, ticket_token_index, date)
@@ -493,7 +585,7 @@ export const attendeesApi = {
               ${capacityFilter}
             ) + ? <= (
               SELECT max_attendees FROM events WHERE id = ?
-            )`,
+            )${groupCapacityCheck}`,
       args: [
         eventId,
         enc.encryptedName,
@@ -513,6 +605,7 @@ export const attendeesApi = {
         ...capacityArgs,
         qty,
         eventId,
+        ...groupCapacityArgs,
       ],
     });
 

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -13,6 +13,7 @@ import {
 } from "#lib/db/common-schema.ts";
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
 import { queryAndMap } from "#lib/db/query.ts";
+import { col } from "#lib/db/table.ts";
 import type { Event, EventWithCount, Group } from "#lib/types.ts";
 
 /** Group input fields for create/update (camelCase) */
@@ -21,6 +22,7 @@ export type GroupInput = {
   slugIndex: string;
   name: string;
   termsAndConditions: string;
+  maxAttendees: number;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -39,6 +41,7 @@ const rawGroupsTable = defineIdTable<Group, GroupInput>("groups", {
   ...encryptedNameSchema(encrypt, decrypt),
   ...idAndEncryptedSlugSchema(encrypt, decrypt),
   terms_and_conditions: { default: () => "", write: encrypt, read: decrypt },
+  max_attendees: col.simple<number>(),
 });
 
 /** Execute a query and decrypt the resulting group rows */

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -14,7 +14,7 @@ import {
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
 import { queryAndMap } from "#lib/db/query.ts";
 import { col } from "#lib/db/table.ts";
-import type { Event, EventWithCount, Group } from "#lib/types.ts";
+import type { Event, EventType, EventWithCount, Group } from "#lib/types.ts";
 
 /** Group input fields for create/update (camelCase) */
 export type GroupInput = {
@@ -164,6 +164,25 @@ export const getActiveEventsByGroupId = (
 export const getEventsByGroupId = (
   groupId: number,
 ): Promise<EventWithCount[]> => queryGroupEvents(groupId, false);
+
+/**
+ * Validate that an event type is compatible with a group's existing events.
+ * Returns an error message if mismatched, null if OK.
+ * Pass excludeEventId to skip a specific event (for edit-self case).
+ */
+export const validateGroupEventType = async (
+  groupId: number,
+  eventType: EventType,
+  excludeEventId?: number,
+): Promise<string | null> => {
+  const siblings = await getEventsByGroupId(groupId);
+  const other = siblings.find(
+    (e) => e.id !== excludeEventId && e.event_type !== eventType,
+  );
+  return other
+    ? `This group already contains ${other.event_type} events — all events in a group must be the same type`
+    : null;
+};
 
 /**
  * Get ungrouped events (group_id = 0) with attendee counts.

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -15,7 +15,7 @@ import { getPublicKey, getSetting } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "add ticket_tokens column to processed_payments";
+export const LATEST_UPDATE = "add max_attendees column to groups";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -410,7 +410,8 @@ export const initDb = async (): Promise<void> => {
       slug TEXT NOT NULL,
       slug_index TEXT NOT NULL,
       name TEXT NOT NULL,
-      terms_and_conditions TEXT NOT NULL DEFAULT ''
+      terms_and_conditions TEXT NOT NULL DEFAULT '',
+      max_attendees INTEGER NOT NULL DEFAULT 0
     )
   `);
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -643,6 +643,11 @@ export const initDb = async (): Promise<void> => {
     "ALTER TABLE processed_payments ADD COLUMN ticket_tokens TEXT NOT NULL DEFAULT ''",
   );
 
+  // Migration: add max_attendees column to groups (0 = no group-wide limit)
+  await runMigration(
+    "ALTER TABLE groups ADD COLUMN max_attendees INTEGER NOT NULL DEFAULT 0",
+  );
+
   // Update the version marker
   await getDb().execute({
     sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('latest_db_update', ?)",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -153,6 +153,7 @@ export interface Group {
   slug_index: string;
   name: string;
   terms_and_conditions: string;
+  max_attendees: number;
 }
 
 export interface EventWithCount extends Event {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -17,8 +17,8 @@ import {
 } from "#lib/db/events.ts";
 import {
   getAllGroups,
-  getEventsByGroupId,
   groupsTable,
+  validateGroupEventType,
 } from "#lib/db/groups.ts";
 import { deleteAllStaleReservations } from "#lib/db/processed-payments.ts";
 import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
@@ -174,13 +174,12 @@ const validateEventInput = async (
   if (input.groupId && input.groupId !== 0) {
     const group = await groupsTable.findById(input.groupId);
     if (!group) return "Selected group does not exist";
-    const siblings = await getEventsByGroupId(input.groupId);
-    const other = siblings.find(
-      (e) => e.id !== Number(existingId) && e.event_type !== input.eventType,
+    const typeError = await validateGroupEventType(
+      input.groupId,
+      input.eventType!,
+      Number(existingId),
     );
-    if (other) {
-      return `This group already contains ${other.event_type} events — all events in a group must be the same type`;
-    }
+    if (typeError) return typeError;
   }
   return null;
 };

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -15,7 +15,11 @@ import {
   getEventWithCount,
   isSlugTaken,
 } from "#lib/db/events.ts";
-import { getAllGroups, groupsTable } from "#lib/db/groups.ts";
+import {
+  getAllGroups,
+  getEventsByGroupId,
+  groupsTable,
+} from "#lib/db/groups.ts";
 import { deleteAllStaleReservations } from "#lib/db/processed-payments.ts";
 import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
 import {
@@ -122,7 +126,7 @@ const extractCommonFields = (values: EventFormValues) => {
     webhookUrl,
     fields: values.fields || "",
     closesAt,
-    eventType: values.event_type || undefined,
+    eventType: values.event_type || "standard",
     bookableDays: parseBookableDays(values.bookable_days),
     minimumDaysBefore: values.minimum_days_before ?? 1,
     maximumDaysAfter: values.maximum_days_after ?? 90,
@@ -161,6 +165,7 @@ const validateMaxPrice = (input: EventInput): string | null => {
 
 const validateEventInput = async (
   input: EventInput,
+  existingId?: Parameters<typeof eventsTable.findById>[0],
 ): Promise<string | null> => {
   if (input.canPayMore) {
     const maxPriceError = validateMaxPrice(input);
@@ -169,6 +174,13 @@ const validateEventInput = async (
   if (input.groupId && input.groupId !== 0) {
     const group = await groupsTable.findById(input.groupId);
     if (!group) return "Selected group does not exist";
+    const siblings = await getEventsByGroupId(input.groupId);
+    const other = siblings.find(
+      (e) => e.id !== Number(existingId) && e.event_type !== input.eventType,
+    );
+    if (other) {
+      return `This group already contains ${other.event_type} events — all events in a group must be the same type`;
+    }
   }
   return null;
 };

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -2,11 +2,11 @@
  * Admin group management routes - owner only
  */
 
-import { map } from "#fp";
+import { compact, map } from "#fp";
 import { getAllowedDomain } from "#lib/config.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { decryptAttendeesForTable } from "#lib/db/attendees.ts";
-import { getAttendeesByEventIds } from "#lib/db/events.ts";
+import { getAttendeesByEventIds, getEvent } from "#lib/db/events.ts";
 import {
   assignEventsToGroup,
   computeGroupSlugIndex,
@@ -17,6 +17,7 @@ import {
   groupsTable,
   isGroupSlugTaken,
   resetGroupEvents,
+  validateGroupEventType,
 } from "#lib/db/groups.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
@@ -204,6 +205,14 @@ const handleAddEventsToGroup: TypedRouteHandler<
         .map(Number)
         .filter((n) => n > 0);
       if (eventIds.length > 0) {
+        // Validate all events have the same type as existing group events
+        const newEvents = compact(await Promise.all(eventIds.map(getEvent)));
+        for (const event of newEvents) {
+          const typeError = await validateGroupEventType(id, event.event_type);
+          if (typeError) {
+            return redirect(`/admin/group/${id}`, typeError, false);
+          }
+        }
         await assignEventsToGroup(eventIds, id);
         await logActivity(
           `${eventIds.length} event(s) added to group '${group.name}'`,

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -66,6 +66,7 @@ const extractGroupCreateInput = async (
     slug,
     slugIndex,
     termsAndConditions: values.terms_and_conditions,
+    maxAttendees: values.max_attendees ?? 0,
   };
 };
 
@@ -79,6 +80,7 @@ const extractGroupEditInput = async (
     slug,
     slugIndex: await computeGroupSlugIndex(slug),
     termsAndConditions: values.terms_and_conditions,
+    maxAttendees: values.max_attendees ?? 0,
   };
 };
 

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -93,7 +93,8 @@ export const groupToFieldValues = (
   const name = group?.name ?? "";
   const slug = group?.slug ?? "";
   const terms = group?.terms_and_conditions ?? "";
-  return { name, slug, terms_and_conditions: terms };
+  const max_attendees = group?.max_attendees || null;
+  return { name, slug, terms_and_conditions: terms, max_attendees };
 };
 
 /**
@@ -259,7 +260,11 @@ export const adminGroupDetailPage = (
               </tr>
               <tr>
                 <th>Attendees</th>
-                <td>{totalCount}</td>
+                <td>
+                  {group.max_attendees > 0
+                    ? `${totalCount} / ${group.max_attendees}`
+                    : totalCount}
+                </td>
               </tr>
               {hasMultiQuantity ? (
                 <>

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -61,6 +61,7 @@ export type EventEditFormValues = EventFormValues & {
 export type GroupCreateFormValues = {
   name: string;
   terms_and_conditions: string;
+  max_attendees: number | null;
 };
 
 /** Typed values from group edit form validation (includes slug) */
@@ -68,6 +69,7 @@ export type GroupFormValues = {
   name: string;
   slug: string;
   terms_and_conditions: string;
+  max_attendees: number | null;
 };
 
 /** Typed values from ticket form (field presence varies by event config) */
@@ -520,6 +522,14 @@ export const groupIdField: Field = {
   type: "text",
 };
 
+/** Max attendees field for group forms */
+const groupMaxAttendeesField: Field = {
+  name: "max_attendees",
+  label: "Max Attendees (optional)",
+  type: "number",
+  hint: "Limits total attendees across all events in this group. Leave blank for no limit. Works best when all events in the group are the same type (daily or standard).",
+};
+
 /** Group form fields for creation (no slug - auto-generated) */
 export const groupCreateFields: Field[] = [
   {
@@ -529,6 +539,7 @@ export const groupCreateFields: Field[] = [
     required: true,
     placeholder: "Summer Fete",
   },
+  groupMaxAttendeesField,
   {
     name: "terms_and_conditions",
     label: "Terms and Conditions (optional)",
@@ -543,6 +554,7 @@ export const groupFields: Field[] = [
   groupCreateFields[0]!,
   slugField,
   groupCreateFields[1]!,
+  groupCreateFields[2]!,
 ];
 
 /** Name field shown on all ticket forms */

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1503,17 +1503,13 @@ export const createTestGroup = async (
     maxAttendees: overrides.maxAttendees ?? 0,
   };
 
-  const formData: Record<string, string> = {
-    name: input.name,
-    terms_and_conditions: input.termsAndConditions,
-  };
-  if (input.maxAttendees > 0) {
-    formData.max_attendees = String(input.maxAttendees);
-  }
-
   const group = await authenticatedFormRequest(
     "/admin/group",
-    formData,
+    {
+      name: input.name,
+      terms_and_conditions: input.termsAndConditions,
+      max_attendees: String(input.maxAttendees),
+    },
     async () => {
       const { getAllGroups } = await import("#lib/db/groups.ts");
       const groups = await getAllGroups();
@@ -1544,20 +1540,15 @@ export const updateTestGroup = async (
   const { groupsTable } = await import("#lib/db/groups.ts");
   const existing = (await groupsTable.findById(groupId)) as Group;
 
-  const maxAttendees = updates.maxAttendees ?? existing.max_attendees;
-  const formData: Record<string, string> = {
-    name: updates.name ?? existing.name,
-    slug: updates.slug ?? existing.slug,
-    terms_and_conditions:
-      updates.termsAndConditions ?? existing.terms_and_conditions,
-  };
-  if (maxAttendees > 0) {
-    formData.max_attendees = String(maxAttendees);
-  }
-
   return authenticatedFormRequest(
     `/admin/group/${groupId}/edit`,
-    formData,
+    {
+      name: updates.name ?? existing.name,
+      slug: updates.slug ?? existing.slug,
+      terms_and_conditions:
+        updates.termsAndConditions ?? existing.terms_and_conditions,
+      max_attendees: String(updates.maxAttendees ?? existing.max_attendees),
+    },
     async () => {
       const updated = await groupsTable.findById(groupId);
       return updated as Group;

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1485,6 +1485,7 @@ export const testGroup = (overrides: Partial<Group> = {}): Group => ({
   slug: "test-group",
   slug_index: "test-group-index",
   terms_and_conditions: "",
+  max_attendees: 0,
   ...overrides,
 });
 
@@ -1499,14 +1500,20 @@ export const createTestGroup = async (
   const input = {
     name: overrides.name ?? "Test Group",
     termsAndConditions: overrides.termsAndConditions ?? "",
+    maxAttendees: overrides.maxAttendees ?? 0,
   };
+
+  const formData: Record<string, string> = {
+    name: input.name,
+    terms_and_conditions: input.termsAndConditions,
+  };
+  if (input.maxAttendees > 0) {
+    formData.max_attendees = String(input.maxAttendees);
+  }
 
   const group = await authenticatedFormRequest(
     "/admin/group",
-    {
-      name: input.name,
-      terms_and_conditions: input.termsAndConditions,
-    },
+    formData,
     async () => {
       const { getAllGroups } = await import("#lib/db/groups.ts");
       const groups = await getAllGroups();
@@ -1520,6 +1527,7 @@ export const createTestGroup = async (
       name: group.name,
       slug: overrides.slug,
       termsAndConditions: group.terms_and_conditions,
+      maxAttendees: group.max_attendees,
     });
   }
 
@@ -1536,14 +1544,20 @@ export const updateTestGroup = async (
   const { groupsTable } = await import("#lib/db/groups.ts");
   const existing = (await groupsTable.findById(groupId)) as Group;
 
+  const maxAttendees = updates.maxAttendees ?? existing.max_attendees;
+  const formData: Record<string, string> = {
+    name: updates.name ?? existing.name,
+    slug: updates.slug ?? existing.slug,
+    terms_and_conditions:
+      updates.termsAndConditions ?? existing.terms_and_conditions,
+  };
+  if (maxAttendees > 0) {
+    formData.max_attendees = String(maxAttendees);
+  }
+
   return authenticatedFormRequest(
     `/admin/group/${groupId}/edit`,
-    {
-      name: updates.name ?? existing.name,
-      slug: updates.slug ?? existing.slug,
-      terms_and_conditions:
-        updates.termsAndConditions ?? existing.terms_and_conditions,
-    },
+    formData,
     async () => {
       const updated = await groupsTable.findById(groupId);
       return updated as Group;

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -99,6 +99,7 @@ import {
   createTestAttendee,
   createTestDbWithSetup,
   createTestEvent,
+  createTestGroup,
   invalidateTestDbCache,
   resetDb,
   resetTestSlugCounter,
@@ -3332,19 +3333,15 @@ describe("db", () => {
 
   describe("groups", () => {
     test("groupsTable CRUD works", async () => {
-      const slug = "db-group";
-      const slugIndex = await computeGroupSlugIndex(slug);
-      const created = await groupsTable.insert({
+      const created = await createTestGroup({
         name: "DB Group",
-        slug,
-        slugIndex,
-        termsAndConditions: "",
+        slug: "db-group",
       });
 
       const fetched = await groupsTable.findById(created.id);
       expect(fetched).not.toBeNull();
       expect(fetched?.name).toBe("DB Group");
-      expect(fetched?.slug).toBe(slug);
+      expect(fetched?.slug).toBe("db-group");
 
       const updated = await groupsTable.update(created.id, {
         name: "DB Group Updated",
@@ -3358,18 +3355,8 @@ describe("db", () => {
     });
 
     test("getAllGroups returns decrypted groups ordered by id", async () => {
-      const g1 = await groupsTable.insert({
-        name: "Group A",
-        slug: "group-a",
-        slugIndex: await computeGroupSlugIndex("group-a"),
-        termsAndConditions: "",
-      });
-      const g2 = await groupsTable.insert({
-        name: "Group B",
-        slug: "group-b",
-        slugIndex: await computeGroupSlugIndex("group-b"),
-        termsAndConditions: "",
-      });
+      const g1 = await createTestGroup({ name: "Group A", slug: "group-a" });
+      const g2 = await createTestGroup({ name: "Group B", slug: "group-b" });
       const groups = await getAllGroups();
       expect(groups.length).toBe(2);
       expect(groups[0]?.id).toBe(g1.id);
@@ -3379,27 +3366,23 @@ describe("db", () => {
     });
 
     test("getGroupBySlugIndex returns group or null", async () => {
-      const slug = "idx-group";
-      const slugIndex = await computeGroupSlugIndex(slug);
-      await groupsTable.insert({
+      const group = await createTestGroup({
         name: "Index Group",
-        slug,
-        slugIndex,
-        termsAndConditions: "",
+        slug: "idx-group",
       });
 
-      const found = await getGroupBySlugIndex(slugIndex);
-      expect(found?.slug).toBe(slug);
+      const found = await getGroupBySlugIndex(
+        await computeGroupSlugIndex("idx-group"),
+      );
+      expect(found?.slug).toBe(group.slug);
       expect(await getGroupBySlugIndex("missing")).toBeNull();
     });
 
     test("isGroupSlugTaken checks both groups and events", async () => {
       const groupSlug = "taken-by-group";
-      const created = await groupsTable.insert({
+      const created = await createTestGroup({
         name: "Taken",
         slug: groupSlug,
-        slugIndex: await computeGroupSlugIndex(groupSlug),
-        termsAndConditions: "",
       });
 
       expect(await isGroupSlugTaken(groupSlug)).toBe(true);
@@ -3410,11 +3393,9 @@ describe("db", () => {
     });
 
     test("getActiveEventsByGroupId returns active events with attendee counts", async () => {
-      const group = await groupsTable.insert({
+      const group = await createTestGroup({
         name: "Events Group",
         slug: "events-group",
-        slugIndex: await computeGroupSlugIndex("events-group"),
-        termsAndConditions: "",
       });
 
       const e1 = await createTestEvent({
@@ -3447,11 +3428,9 @@ describe("db", () => {
     });
 
     test("resetGroupEvents sets group_id to 0", async () => {
-      const group = await groupsTable.insert({
+      const group = await createTestGroup({
         name: "Reset Group",
         slug: "reset-group",
-        slugIndex: await computeGroupSlugIndex("reset-group"),
-        termsAndConditions: "",
       });
       const event = await createTestEvent({
         name: "Reset Event",
@@ -3460,6 +3439,254 @@ describe("db", () => {
       });
       await resetGroupEvents(group.id);
       expect((await getEvent(event.id))?.group_id).toBe(0);
+    });
+
+    test("createAttendeeAtomic enforces group max_attendees across events", async () => {
+      const group = await createTestGroup({
+        name: "Capped Group",
+        slug: "capped-group",
+        maxAttendees: 5,
+      });
+      const e1 = await createTestEvent({
+        name: "Event A",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+      const e2 = await createTestEvent({
+        name: "Event B",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+
+      // Book 3 on event A — should succeed (group total: 3/5)
+      const r1 = await createAttendeeAtomic({
+        eventId: e1.id,
+        name: "A",
+        email: "a@example.com",
+        quantity: 3,
+      });
+      expect(r1.success).toBe(true);
+
+      // Book 3 on event B — should fail (group total would be 6/5)
+      const r2 = await createAttendeeAtomic({
+        eventId: e2.id,
+        name: "B",
+        email: "b@example.com",
+        quantity: 3,
+      });
+      expect(r2.success).toBe(false);
+      if (!r2.success) expect(r2.reason).toBe("capacity_exceeded");
+
+      // Book 2 on event B — should succeed (group total: 5/5)
+      const r3 = await createAttendeeAtomic({
+        eventId: e2.id,
+        name: "C",
+        email: "c@example.com",
+        quantity: 2,
+      });
+      expect(r3.success).toBe(true);
+    });
+
+    test("createAttendeeAtomic allows booking when group has no max (0)", async () => {
+      const group = await createTestGroup({
+        name: "Unlimited Group",
+        slug: "unlimited-group",
+      });
+      const event = await createTestEvent({
+        name: "Unlimited Event",
+        maxAttendees: 100,
+        groupId: group.id,
+      });
+
+      const result = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "A",
+        email: "a@example.com",
+        quantity: 50,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("hasAvailableSpots checks group capacity", async () => {
+      const { hasAvailableSpots } = await import("#lib/db/attendees.ts");
+      const group = await createTestGroup({
+        name: "Spot Check Group",
+        slug: "spot-check-group",
+        maxAttendees: 3,
+      });
+      const e1 = await createTestEvent({
+        name: "Spot Event A",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+      const e2 = await createTestEvent({
+        name: "Spot Event B",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+
+      await createAttendeeAtomic({
+        eventId: e1.id,
+        name: "A",
+        email: "a@example.com",
+        quantity: 2,
+      });
+
+      // Event B has plenty of room, but group is almost full
+      expect(await hasAvailableSpots(e2.id, 1)).toBe(true);
+      expect(await hasAvailableSpots(e2.id, 2)).toBe(false);
+    });
+
+    test("checkBatchAvailability checks group capacity", async () => {
+      const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
+      const group = await createTestGroup({
+        name: "Batch Group",
+        slug: "batch-group",
+        maxAttendees: 4,
+      });
+      const e1 = await createTestEvent({
+        name: "Batch Event A",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+      const e2 = await createTestEvent({
+        name: "Batch Event B",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+
+      // Both within event limits but combined exceeds group limit
+      const available = await checkBatchAvailability([
+        { eventId: e1.id, quantity: 3 },
+        { eventId: e2.id, quantity: 2 },
+      ]);
+      expect(available).toBe(false);
+
+      // Both within event and group limits
+      const available2 = await checkBatchAvailability([
+        { eventId: e1.id, quantity: 2 },
+        { eventId: e2.id, quantity: 2 },
+      ]);
+      expect(available2).toBe(true);
+    });
+
+    test("checkBatchAvailability skips group check when group has no limit", async () => {
+      const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
+      const group = await createTestGroup({
+        name: "No Limit Batch",
+        slug: "no-limit-batch",
+      });
+      const e1 = await createTestEvent({
+        name: "No Limit Event A",
+        maxAttendees: 100,
+        groupId: group.id,
+      });
+      const ungroupedEvent = await createTestEvent({
+        name: "Ungrouped Event",
+        maxAttendees: 100,
+      });
+
+      // Mix of grouped (no limit) and ungrouped events
+      const available = await checkBatchAvailability([
+        { eventId: e1.id, quantity: 50 },
+        { eventId: ungroupedEvent.id, quantity: 50 },
+      ]);
+      expect(available).toBe(true);
+    });
+
+    test("checkBatchAvailability handles events from multiple groups", async () => {
+      const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
+      const groupA = await createTestGroup({
+        name: "Multi Group A",
+        slug: "multi-group-a",
+        maxAttendees: 3,
+      });
+      const groupB = await createTestGroup({
+        name: "Multi Group B",
+        slug: "multi-group-b",
+        maxAttendees: 3,
+      });
+      const eA = await createTestEvent({
+        name: "Multi Event A",
+        maxAttendees: 10,
+        groupId: groupA.id,
+      });
+      const eB = await createTestEvent({
+        name: "Multi Event B",
+        maxAttendees: 10,
+        groupId: groupB.id,
+      });
+
+      // Each group can hold 3, so 2+2 across different groups is fine
+      const available = await checkBatchAvailability([
+        { eventId: eA.id, quantity: 2 },
+        { eventId: eB.id, quantity: 2 },
+      ]);
+      expect(available).toBe(true);
+    });
+
+    test("group capacity check handles deleted group gracefully", async () => {
+      const { hasAvailableSpots } = await import("#lib/db/attendees.ts");
+      const group = await createTestGroup({
+        name: "Delete Me",
+        slug: "delete-me",
+        maxAttendees: 5,
+      });
+      const event = await createTestEvent({
+        name: "Orphan Event",
+        maxAttendees: 10,
+        groupId: group.id,
+      });
+      // Delete the group but leave event pointing to it
+      const { groupsTable } = await import("#lib/db/groups.ts");
+      await groupsTable.deleteById(group.id);
+
+      // Should still work — getGroupMaxAttendees returns 0 for missing group
+      expect(await hasAvailableSpots(event.id, 1)).toBe(true);
+    });
+
+    test("group max_attendees is per-date for daily events", async () => {
+      const group = await createTestGroup({
+        name: "Daily Group",
+        slug: "daily-group",
+        maxAttendees: 3,
+      });
+      const event = await createTestEvent({
+        name: "Daily Event",
+        maxAttendees: 10,
+        groupId: group.id,
+        eventType: "daily",
+      });
+
+      // Book 3 for date A — fills group for that date
+      const r1 = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "A",
+        email: "a@example.com",
+        quantity: 3,
+        date: "2026-07-01",
+      });
+      expect(r1.success).toBe(true);
+
+      // Book 1 for date A — should fail (group full for date A)
+      const r2 = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "B",
+        email: "b@example.com",
+        quantity: 1,
+        date: "2026-07-01",
+      });
+      expect(r2.success).toBe(false);
+
+      // Book 3 for date B — should succeed (different date)
+      const r3 = await createAttendeeAtomic({
+        eventId: event.id,
+        name: "C",
+        email: "c@example.com",
+        quantity: 3,
+        date: "2026-07-02",
+      });
+      expect(r3.success).toBe(true);
     });
   });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -3441,96 +3441,76 @@ describe("db", () => {
       expect((await getEvent(event.id))?.group_id).toBe(0);
     });
 
-    test("createAttendeeAtomic enforces group max_attendees across events", async () => {
+    /** Create a capped group with two events (each with event-level max of 10) */
+    const createCappedGroupWithEvents = async (
+      groupMax: number,
+      slug: string,
+      overrides?: { eventType?: "standard" | "daily" },
+    ) => {
       const group = await createTestGroup({
-        name: "Capped Group",
-        slug: "capped-group",
-        maxAttendees: 5,
+        name: slug,
+        slug,
+        maxAttendees: groupMax,
       });
       const e1 = await createTestEvent({
-        name: "Event A",
+        name: `${slug}-a`,
         maxAttendees: 10,
         groupId: group.id,
+        eventType: overrides?.eventType,
       });
       const e2 = await createTestEvent({
-        name: "Event B",
+        name: `${slug}-b`,
         maxAttendees: 10,
         groupId: group.id,
+        eventType: overrides?.eventType,
       });
+      return { group, e1, e2 };
+    };
+
+    /** Book attendees atomically with minimal boilerplate */
+    const book = (eventId: number, quantity: number, date?: string) =>
+      createAttendeeAtomic({
+        eventId,
+        name: `attendee-${eventId}-${quantity}`,
+        email: `a${eventId}q${quantity}@example.com`,
+        quantity,
+        date,
+      });
+
+    test("createAttendeeAtomic enforces group max_attendees across events", async () => {
+      const { e1, e2 } = await createCappedGroupWithEvents(5, "capped");
 
       // Book 3 on event A — should succeed (group total: 3/5)
-      const r1 = await createAttendeeAtomic({
-        eventId: e1.id,
-        name: "A",
-        email: "a@example.com",
-        quantity: 3,
-      });
-      expect(r1.success).toBe(true);
+      expect((await book(e1.id, 3)).success).toBe(true);
 
       // Book 3 on event B — should fail (group total would be 6/5)
-      const r2 = await createAttendeeAtomic({
-        eventId: e2.id,
-        name: "B",
-        email: "b@example.com",
-        quantity: 3,
-      });
+      const r2 = await book(e2.id, 3);
       expect(r2.success).toBe(false);
       if (!r2.success) expect(r2.reason).toBe("capacity_exceeded");
 
       // Book 2 on event B — should succeed (group total: 5/5)
-      const r3 = await createAttendeeAtomic({
-        eventId: e2.id,
-        name: "C",
-        email: "c@example.com",
-        quantity: 2,
-      });
-      expect(r3.success).toBe(true);
+      expect((await book(e2.id, 2)).success).toBe(true);
     });
 
     test("createAttendeeAtomic allows booking when group has no max (0)", async () => {
       const group = await createTestGroup({
-        name: "Unlimited Group",
-        slug: "unlimited-group",
+        name: "unlimited",
+        slug: "unlimited",
       });
       const event = await createTestEvent({
-        name: "Unlimited Event",
+        name: "unlimited-event",
         maxAttendees: 100,
         groupId: group.id,
       });
 
-      const result = await createAttendeeAtomic({
-        eventId: event.id,
-        name: "A",
-        email: "a@example.com",
-        quantity: 50,
-      });
-      expect(result.success).toBe(true);
+      expect((await book(event.id, 50)).success).toBe(true);
     });
 
     test("hasAvailableSpots checks group capacity", async () => {
       const { hasAvailableSpots } = await import("#lib/db/attendees.ts");
-      const group = await createTestGroup({
-        name: "Spot Check Group",
-        slug: "spot-check-group",
-        maxAttendees: 3,
-      });
-      const e1 = await createTestEvent({
-        name: "Spot Event A",
-        maxAttendees: 10,
-        groupId: group.id,
-      });
-      const e2 = await createTestEvent({
-        name: "Spot Event B",
-        maxAttendees: 10,
-        groupId: group.id,
-      });
+      const { e1, e2 } = await createCappedGroupWithEvents(3, "spots");
 
-      await createAttendeeAtomic({
-        eventId: e1.id,
-        name: "A",
-        email: "a@example.com",
-        quantity: 2,
-      });
+      await book(e1.id, 2);
 
       // Event B has plenty of room, but group is almost full
       expect(await hasAvailableSpots(e2.id, 1)).toBe(true);
@@ -3539,101 +3519,73 @@ describe("db", () => {
 
     test("checkBatchAvailability checks group capacity", async () => {
       const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
-      const group = await createTestGroup({
-        name: "Batch Group",
-        slug: "batch-group",
-        maxAttendees: 4,
-      });
-      const e1 = await createTestEvent({
-        name: "Batch Event A",
-        maxAttendees: 10,
-        groupId: group.id,
-      });
-      const e2 = await createTestEvent({
-        name: "Batch Event B",
-        maxAttendees: 10,
-        groupId: group.id,
-      });
+      const { e1, e2 } = await createCappedGroupWithEvents(4, "batch");
 
       // Both within event limits but combined exceeds group limit
-      const available = await checkBatchAvailability([
-        { eventId: e1.id, quantity: 3 },
-        { eventId: e2.id, quantity: 2 },
-      ]);
-      expect(available).toBe(false);
+      expect(
+        await checkBatchAvailability([
+          { eventId: e1.id, quantity: 3 },
+          { eventId: e2.id, quantity: 2 },
+        ]),
+      ).toBe(false);
 
       // Both within event and group limits
-      const available2 = await checkBatchAvailability([
-        { eventId: e1.id, quantity: 2 },
-        { eventId: e2.id, quantity: 2 },
-      ]);
-      expect(available2).toBe(true);
+      expect(
+        await checkBatchAvailability([
+          { eventId: e1.id, quantity: 2 },
+          { eventId: e2.id, quantity: 2 },
+        ]),
+      ).toBe(true);
     });
 
     test("checkBatchAvailability skips group check when group has no limit", async () => {
       const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
       const group = await createTestGroup({
-        name: "No Limit Batch",
-        slug: "no-limit-batch",
+        name: "no-limit",
+        slug: "no-limit",
       });
       const e1 = await createTestEvent({
-        name: "No Limit Event A",
+        name: "no-limit-a",
         maxAttendees: 100,
         groupId: group.id,
       });
-      const ungroupedEvent = await createTestEvent({
-        name: "Ungrouped Event",
+      const ungrouped = await createTestEvent({
+        name: "ungrouped",
         maxAttendees: 100,
       });
 
       // Mix of grouped (no limit) and ungrouped events
-      const available = await checkBatchAvailability([
-        { eventId: e1.id, quantity: 50 },
-        { eventId: ungroupedEvent.id, quantity: 50 },
-      ]);
-      expect(available).toBe(true);
+      expect(
+        await checkBatchAvailability([
+          { eventId: e1.id, quantity: 50 },
+          { eventId: ungrouped.id, quantity: 50 },
+        ]),
+      ).toBe(true);
     });
 
     test("checkBatchAvailability handles events from multiple groups", async () => {
       const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
-      const groupA = await createTestGroup({
-        name: "Multi Group A",
-        slug: "multi-group-a",
-        maxAttendees: 3,
-      });
-      const groupB = await createTestGroup({
-        name: "Multi Group B",
-        slug: "multi-group-b",
-        maxAttendees: 3,
-      });
-      const eA = await createTestEvent({
-        name: "Multi Event A",
-        maxAttendees: 10,
-        groupId: groupA.id,
-      });
-      const eB = await createTestEvent({
-        name: "Multi Event B",
-        maxAttendees: 10,
-        groupId: groupB.id,
-      });
+      const { e1: eA } = await createCappedGroupWithEvents(3, "multi-a");
+      const { e1: eB } = await createCappedGroupWithEvents(3, "multi-b");
 
       // Each group can hold 3, so 2+2 across different groups is fine
-      const available = await checkBatchAvailability([
-        { eventId: eA.id, quantity: 2 },
-        { eventId: eB.id, quantity: 2 },
-      ]);
-      expect(available).toBe(true);
+      expect(
+        await checkBatchAvailability([
+          { eventId: eA.id, quantity: 2 },
+          { eventId: eB.id, quantity: 2 },
+        ]),
+      ).toBe(true);
     });
 
     test("group capacity check handles deleted group gracefully", async () => {
       const { hasAvailableSpots } = await import("#lib/db/attendees.ts");
       const group = await createTestGroup({
-        name: "Delete Me",
+        name: "delete-me",
         slug: "delete-me",
         maxAttendees: 5,
       });
       const event = await createTestEvent({
-        name: "Orphan Event",
+        name: "orphan-event",
         maxAttendees: 10,
         groupId: group.id,
       });
@@ -3646,47 +3598,18 @@ describe("db", () => {
     });
 
     test("group max_attendees is per-date for daily events", async () => {
-      const group = await createTestGroup({
-        name: "Daily Group",
-        slug: "daily-group",
-        maxAttendees: 3,
-      });
-      const event = await createTestEvent({
-        name: "Daily Event",
-        maxAttendees: 10,
-        groupId: group.id,
+      const { e1: event } = await createCappedGroupWithEvents(3, "daily", {
         eventType: "daily",
       });
 
       // Book 3 for date A — fills group for that date
-      const r1 = await createAttendeeAtomic({
-        eventId: event.id,
-        name: "A",
-        email: "a@example.com",
-        quantity: 3,
-        date: "2026-07-01",
-      });
-      expect(r1.success).toBe(true);
+      expect((await book(event.id, 3, "2026-07-01")).success).toBe(true);
 
       // Book 1 for date A — should fail (group full for date A)
-      const r2 = await createAttendeeAtomic({
-        eventId: event.id,
-        name: "B",
-        email: "b@example.com",
-        quantity: 1,
-        date: "2026-07-01",
-      });
-      expect(r2.success).toBe(false);
+      expect((await book(event.id, 1, "2026-07-01")).success).toBe(false);
 
       // Book 3 for date B — should succeed (different date)
-      const r3 = await createAttendeeAtomic({
-        eventId: event.id,
-        name: "C",
-        email: "c@example.com",
-        quantity: 3,
-        date: "2026-07-02",
-      });
-      expect(r3.success).toBe(true);
+      expect((await book(event.id, 3, "2026-07-02")).success).toBe(true);
     });
   });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -173,6 +173,38 @@ describe("server (admin events)", () => {
       expect(match).toBeUndefined();
     });
 
+    test("rejects event type mismatch with group on create", async () => {
+      const group = await createTestGroup({
+        name: "Standard Group",
+        slug: "standard-group",
+      });
+      await createTestEvent({
+        name: "Standard Event",
+        maxAttendees: 50,
+        groupId: group.id,
+        eventType: "standard",
+      });
+
+      const response = await handleRequest(
+        mockMultipartRequest(
+          "/admin/event",
+          {
+            name: "Daily Mismatch",
+            max_attendees: "50",
+            max_quantity: "1",
+            thank_you_url: "https://example.com/thanks",
+            group_id: String(group.id),
+            event_type: "daily",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expectStatus(400)(response);
+      const body = await response.clone().text();
+      expect(body).toContain("already contains standard events");
+    });
+
     test("rejects invalid CSRF token", async () => {
       const response = await handleRequest(
         mockMultipartRequest(
@@ -827,6 +859,76 @@ describe("server (admin events)", () => {
         ),
       );
       await expectHtmlResponse(response, 400, "Selected group does not exist");
+    });
+
+    test("rejects event type mismatch with group on edit", async () => {
+      const group = await createTestGroup({
+        name: "Daily Group",
+        slug: "daily-group",
+      });
+      await createTestEvent({
+        name: "Daily Event",
+        maxAttendees: 50,
+        groupId: group.id,
+        eventType: "daily",
+      });
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
+        name: "Standard Event",
+        maxAttendees: 50,
+        eventType: "standard",
+      });
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/edit`,
+          {
+            name: event.name,
+            slug: event.slug,
+            group_id: String(group.id),
+            max_attendees: "50",
+            max_quantity: "1",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      await expectHtmlResponse(response, 400, "already contains daily events");
+    });
+
+    test("allows same event type in group on edit", async () => {
+      const group = await createTestGroup({
+        name: "Same Type Group",
+        slug: "same-type-group",
+      });
+      await createTestEvent({
+        name: "Standard A",
+        maxAttendees: 50,
+        groupId: group.id,
+        eventType: "standard",
+      });
+      const { event, cookie, csrfToken } = await setupEventAndLogin({
+        name: "Standard B",
+        maxAttendees: 50,
+        eventType: "standard",
+      });
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/edit`,
+          {
+            name: event.name,
+            slug: event.slug,
+            group_id: String(group.id),
+            max_attendees: "50",
+            max_quantity: "1",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expectRedirect(`/admin/event/${event.id}?success=Event+updated`)(
+        response,
+      );
     });
 
     test("updates event slug", async () => {

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -700,6 +700,44 @@ describe("server (admin groups)", () => {
         `/admin/group/${group.id}?success=Events+added+to+group`,
       );
     });
+
+    test("rejects adding event with mismatched type", async () => {
+      const group = await createTestGroup({
+        name: "Type Check",
+        slug: "type-check",
+      });
+      await createTestEvent({
+        name: "Standard In Group",
+        groupId: group.id,
+        eventType: "standard",
+      });
+      const dailyEvent = await createTestEvent({
+        name: "Daily Ungrouped",
+        eventType: "daily",
+      });
+
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/group/${group.id}/add-events`,
+          {
+            event_ids: String(dailyEvent.id),
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location") ?? "";
+      expect(location).toContain("error=");
+      expect(location).toContain("already+contains+standard+events");
+
+      // Verify event was NOT assigned
+      const { getEvent } = await import("#lib/db/events.ts");
+      const unchanged = await getEvent(dailyEvent.id);
+      expect(unchanged?.group_id).toBe(0);
+    });
   });
 
   describe("redirect after create/edit", () => {

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -748,6 +748,74 @@ describe("server (admin groups)", () => {
     });
   });
 
+  describe("group max_attendees", () => {
+    test("creates group with max_attendees", async () => {
+      const group = await createTestGroup({
+        name: "Capped",
+        slug: "capped",
+        maxAttendees: 50,
+      });
+      expect(group.max_attendees).toBe(50);
+    });
+
+    test("creates group without max_attendees defaults to 0", async () => {
+      const group = await createTestGroup({
+        name: "Uncapped",
+        slug: "uncapped",
+      });
+      expect(group.max_attendees).toBe(0);
+    });
+
+    test("edit form shows max_attendees field", async () => {
+      const group = await createTestGroup({
+        name: "Edit Max",
+        slug: "edit-max",
+        maxAttendees: 25,
+      });
+
+      const { response } = await adminGet(`/admin/group/${group.id}/edit`);
+      const html = await response.text();
+      expect(html).toContain("max_attendees");
+      expect(html).toContain("25");
+    });
+
+    test("updates max_attendees via edit", async () => {
+      const group = await createTestGroup({
+        name: "Update Max",
+        slug: "update-max",
+        maxAttendees: 10,
+      });
+
+      const updated = await updateTestGroup(group.id, { maxAttendees: 30 });
+      expect(updated.max_attendees).toBe(30);
+    });
+
+    test("detail page shows attendees with max when set", async () => {
+      const group = await createTestGroup({
+        name: "Detail Max",
+        slug: "detail-max",
+        maxAttendees: 100,
+      });
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      const html = await response.text();
+      expect(html).toContain("0 / 100");
+    });
+
+    test("detail page shows plain attendee count when no group max set", async () => {
+      const group = await createTestGroup({
+        name: "Detail No Max",
+        slug: "detail-no-max",
+      });
+
+      const { response } = await adminGet(`/admin/group/${group.id}`);
+      const html = await response.text();
+      // Attendees row should show just "0" not "0 / X"
+      expect(html).toContain("<th>Attendees</th>");
+      expect(html).toContain("<td>0</td>");
+    });
+  });
+
   describe("nav link", () => {
     test("groups link visible to owners", async () => {
       const { response } = await adminGet("/admin/groups");


### PR DESCRIPTION
## Summary
This PR adds support for group-level maximum attendee limits, allowing administrators to cap total attendance across all events within a group. The feature includes database schema changes, atomic capacity validation, and UI updates for managing group limits.

## Key Changes

- **Database Schema**: Added `max_attendees` column to `groups` table (defaults to 0 for unlimited)
- **Atomic Capacity Validation**: Enhanced `createAttendeeAtomic` to enforce group limits via single SQL statement with nested CASE expression
- **Batch Availability Check**: Updated `checkBatchAvailability` to validate group capacity across multiple events
- **Date-Aware Limits**: Group capacity checks respect event types—standard events always count toward group limit, daily events only count for matching dates
- **Admin UI**: 
  - Added `max_attendees` field to group create/edit forms
  - Updated group detail page to display "X / Y" format when limit is set
  - Shows plain count when no group limit is configured
- **Test Coverage**: Added comprehensive tests for group capacity enforcement including:
  - Single and multi-event bookings
  - Batch availability checks across multiple groups
  - Daily event date-aware capacity
  - Graceful handling of deleted groups
  - Unlimited groups (max_attendees = 0)

## Implementation Details

- Group capacity checks are skipped when `max_attendees = 0` (no limit)
- The atomic insert uses a subquery to count existing attendees in the group, respecting daily event date filtering
- Helper functions `getGroupMaxAttendees` and `getGroupAttendeeCount` encapsulate group capacity logic
- Test utilities updated to support `maxAttendees` parameter in `createTestGroup`
- Migration safely adds column with default value to avoid breaking existing data

https://claude.ai/code/session_01TtEFrkftxo2WVYo46YsifA