### PR TITLE
Add host-level configuration display to admin guide

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -830,7 +830,7 @@ const toCredentials = (
     : null;
 
 /** Read Apple Wallet config from environment variables. Returns null if not fully configured. */
-export const getHostAppleWalletConfig = (): SigningCredentials | null =>
+const getHostAppleWalletConfigFromEnv = (): SigningCredentials | null =>
   toCredentials(
     getEnv("APPLE_WALLET_PASS_TYPE_ID"),
     getEnv("APPLE_WALLET_TEAM_ID"),
@@ -838,6 +838,25 @@ export const getHostAppleWalletConfig = (): SigningCredentials | null =>
     getEnv("APPLE_WALLET_SIGNING_KEY"),
     getEnv("APPLE_WALLET_WWDR_CERT"),
   );
+
+const [getHostWalletOverride, setHostWalletOverride] = lazyRef<
+  SigningCredentials | null | undefined
+>(() => undefined);
+
+/** Get host-level Apple Wallet config. Uses test override if set, otherwise reads env vars. */
+export const getHostAppleWalletConfig = (): SigningCredentials | null => {
+  const override = getHostWalletOverride();
+  return override !== undefined ? override : getHostAppleWalletConfigFromEnv();
+};
+
+/** For testing: set host Apple Wallet config directly. Bypasses env vars to avoid races. */
+export const setHostAppleWalletConfigForTest = (
+  config: SigningCredentials | null,
+): void => setHostWalletOverride(config);
+
+/** For testing: reset host Apple Wallet config to read from env vars. */
+export const resetHostAppleWalletConfig = (): void =>
+  setHostWalletOverride(undefined);
 
 /** Check if Apple Wallet DB settings are fully configured (all 5 settings present). */
 export const hasAppleWalletDbConfig = async (): Promise<boolean> => {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,7 +3,7 @@
  * Sends registration emails via HTTP email APIs (Resend, Postmark, SendGrid, Mailgun)
  */
 
-import { map } from "#fp";
+import { lazyRef, map } from "#fp";
 import { getBusinessEmailFromDb } from "#lib/business-email.ts";
 import { getAllowedDomain } from "#lib/config.ts";
 import {
@@ -66,7 +66,7 @@ export const getEmailConfig = async (): Promise<EmailConfig | null> => {
 };
 
 /** Read host-level email config from environment variables. Returns null if not fully configured. */
-export const getHostEmailConfig = (): EmailConfig | null => {
+const getHostEmailConfigFromEnv = (): EmailConfig | null => {
   const provider = getEnv("HOST_EMAIL_PROVIDER");
   const apiKey = getEnv("HOST_EMAIL_API_KEY");
   const fromAddress = getEnv("HOST_EMAIL_FROM_ADDRESS");
@@ -80,6 +80,23 @@ export const getHostEmailConfig = (): EmailConfig | null => {
   }
   return { provider, apiKey, fromAddress };
 };
+
+const [getHostEmailOverride, setHostEmailOverride] = lazyRef<
+  EmailConfig | null | undefined
+>(() => undefined);
+
+/** Get host-level email config. Uses test override if set, otherwise reads env vars. */
+export const getHostEmailConfig = (): EmailConfig | null => {
+  const override = getHostEmailOverride();
+  return override !== undefined ? override : getHostEmailConfigFromEnv();
+};
+
+/** For testing: set host email config directly. Bypasses env vars to avoid races. */
+export const setHostEmailConfigForTest = (config: EmailConfig | null): void =>
+  setHostEmailOverride(config);
+
+/** For testing: reset host email config to read from env vars. */
+export const resetHostEmailConfig = (): void => setHostEmailOverride(undefined);
 
 type Headers = Record<string, string>;
 type ProviderRequest = (

--- a/src/routes/admin/guide.ts
+++ b/src/routes/admin/guide.ts
@@ -2,6 +2,8 @@
  * Admin guide route
  */
 
+import { getHostAppleWalletConfig } from "#lib/db/settings.ts";
+import { EMAIL_PROVIDER_LABELS, getHostEmailConfig } from "#lib/email.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { htmlResponse, requireSessionOr } from "#routes/utils.ts";
 import { adminGuidePage } from "#templates/admin/guide.tsx";
@@ -10,7 +12,19 @@ import { adminGuidePage } from "#templates/admin/guide.tsx";
  * Handle GET /admin/guide
  */
 const handleAdminGuideGet = (request: Request): Promise<Response> =>
-  requireSessionOr(request, (session) => htmlResponse(adminGuidePage(session)));
+  requireSessionOr(request, (session) => {
+    const hostEmail = getHostEmailConfig();
+    const hostWallet = getHostAppleWalletConfig();
+    return htmlResponse(
+      adminGuidePage(session, {
+        hostEmailProvider: hostEmail
+          ? EMAIL_PROVIDER_LABELS[hostEmail.provider]
+          : null,
+        hostEmailFromAddress: hostEmail?.fromAddress ?? null,
+        hostAppleWalletPassTypeId: hostWallet?.passTypeId ?? null,
+      }),
+    );
+  });
 
 /** Guide routes */
 export const guideRoutes = defineRoutes({

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -18,6 +18,13 @@ import { WEBHOOK_EXAMPLE_JSON } from "#lib/webhook-example.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
 
+/** Host-level configuration info passed from the route */
+export type GuideHostConfig = {
+  hostEmailProvider: string | null;
+  hostEmailFromAddress: string | null;
+  hostAppleWalletPassTypeId: string | null;
+};
+
 const Section = ({
   id,
   title,
@@ -43,7 +50,10 @@ const Q = ({ q, children }: { q: string; children?: Child }): JSX.Element => (
 /**
  * Admin guide page
  */
-export const adminGuidePage = (adminSession: AdminSession): string =>
+export const adminGuidePage = (
+  adminSession: AdminSession,
+  hostConfig?: GuideHostConfig,
+): string =>
   String(
     <Layout title="Guide" bodyClass="guide">
       <AdminNav session={adminSession} active="/admin/guide" />
@@ -841,38 +851,51 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
 
         <Q q="How do I set up Apple Wallet?">
-          <p>
-            Go to <a href="/admin/settings">Settings</a>, click{" "}
-            <strong>Advanced Settings</strong>, and find the{" "}
-            <strong>Apple Wallet</strong> section. You need five values from
-            your Apple Developer account:
-          </p>
-          <ol>
-            <li>
-              <strong>Pass Type ID</strong> &mdash; e.g.{" "}
-              <code>pass.com.example.tickets</code>
-            </li>
-            <li>
-              <strong>Team ID</strong> &mdash; your Apple Developer Team ID
-            </li>
-            <li>
-              <strong>Signing Certificate</strong> &mdash; PEM-encoded
-              certificate for your Pass Type ID
-            </li>
-            <li>
-              <strong>Signing Key</strong> &mdash; PEM-encoded private key for
-              the certificate
-            </li>
-            <li>
-              <strong>WWDR Certificate</strong> &mdash; Apple's intermediate
-              certificate (download from the Apple Developer portal)
-            </li>
-          </ol>
-          <p>
-            All five fields are required. Once saved, the Add to Apple Wallet
-            button appears automatically on all ticket pages. If none are
-            configured, the feature is simply hidden.
-          </p>
+          {hostConfig?.hostAppleWalletPassTypeId ? (
+            <p>
+              Apple Wallet is already configured by your server administrator
+              using pass type{" "}
+              <code>{hostConfig.hostAppleWalletPassTypeId}</code>. The Add to
+              Apple Wallet button should appear automatically on all ticket
+              pages. You can override this by entering your own credentials in{" "}
+              <a href="/admin/settings">Settings</a>.
+            </p>
+          ) : (
+            <>
+              <p>
+                Go to <a href="/admin/settings">Settings</a>, click{" "}
+                <strong>Advanced Settings</strong>, and find the{" "}
+                <strong>Apple Wallet</strong> section. You need five values from
+                your Apple Developer account:
+              </p>
+              <ol>
+                <li>
+                  <strong>Pass Type ID</strong> &mdash; e.g.{" "}
+                  <code>pass.com.example.tickets</code>
+                </li>
+                <li>
+                  <strong>Team ID</strong> &mdash; your Apple Developer Team ID
+                </li>
+                <li>
+                  <strong>Signing Certificate</strong> &mdash; PEM-encoded
+                  certificate for your Pass Type ID
+                </li>
+                <li>
+                  <strong>Signing Key</strong> &mdash; PEM-encoded private key
+                  for the certificate
+                </li>
+                <li>
+                  <strong>WWDR Certificate</strong> &mdash; Apple's intermediate
+                  certificate (download from the Apple Developer portal)
+                </li>
+              </ol>
+              <p>
+                All five fields are required. Once saved, the Add to Apple
+                Wallet button appears automatically on all ticket pages. If none
+                are configured, the feature is simply hidden.
+              </p>
+            </>
+          )}
         </Q>
 
         <Q q="Do wallet passes update automatically?">
@@ -1077,28 +1100,47 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
 
         <Q q="How do I set up email?">
-          <ol>
-            <li>
-              Go to <a href="/admin/settings">Settings</a> and find the{" "}
-              <strong>Email</strong> section
-            </li>
-            <li>Choose your email provider from the dropdown</li>
-            <li>
-              Paste your provider's API key into the <strong>API Key</strong>{" "}
-              field
-            </li>
-            <li>
-              Enter a <strong>From Address</strong> &mdash; this is the sender
-              address that appears on outgoing emails. If left blank, the
-              business email address is used instead
-            </li>
-            <li>Save the settings</li>
-          </ol>
-          <p>
-            The from address must be a verified sender in your email provider's
-            account, otherwise emails will be rejected. Check your provider's
-            documentation for how to verify a sender domain or address.
-          </p>
+          {hostConfig?.hostEmailProvider ? (
+            <>
+              <p>
+                Email is already configured by your server administrator using{" "}
+                <strong>{hostConfig.hostEmailProvider}</strong> with from
+                address <code>{hostConfig.hostEmailFromAddress}</code>. You can
+                override this by entering your own provider and API key in{" "}
+                <a href="/admin/settings">Settings</a>.
+              </p>
+              <p>
+                If you provide your own settings, they take priority over the
+                server configuration.
+              </p>
+            </>
+          ) : (
+            <>
+              <ol>
+                <li>
+                  Go to <a href="/admin/settings">Settings</a> and find the{" "}
+                  <strong>Email</strong> section
+                </li>
+                <li>Choose your email provider from the dropdown</li>
+                <li>
+                  Paste your provider's API key into the{" "}
+                  <strong>API Key</strong> field
+                </li>
+                <li>
+                  Enter a <strong>From Address</strong> &mdash; this is the
+                  sender address that appears on outgoing emails. If left blank,
+                  the business email address is used instead
+                </li>
+                <li>Save the settings</li>
+              </ol>
+              <p>
+                The from address must be a verified sender in your email
+                provider's account, otherwise emails will be rejected. Check
+                your provider's documentation for how to verify a sender domain
+                or address.
+              </p>
+            </>
+          )}
         </Q>
 
         <Q q="How do I test that email is working?">

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -56,9 +56,9 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             From the <strong>Events</strong> page, fill in the form at the
             bottom. Give your event a name, set the capacity, and choose which
             contact details to collect (any combination of email, phone, postal
-            address, and special instructions). You can leave the price blank
-            for free events. Once created, share the booking link with your
-            attendees.
+            address, and special instructions &mdash; or none at all for
+            name-only registration). You can leave the price blank for free
+            events. Once created, share the booking link with your attendees.
           </p>
         </Q>
 
@@ -68,6 +68,19 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
             payment provider. Paste in your API key and save. For Stripe, the
             webhook is configured automatically. For Square, you'll need to copy
             the webhook URL shown and add it in your Square Developer Dashboard.
+          </p>
+        </Q>
+      </Section>
+
+      <Section title="Dashboard">
+        <Q q="What is the dashboard?">
+          <p>
+            The <strong>Events</strong> page is your dashboard. It lists all
+            your events with attendee counts, booking links, and quick actions.
+            At the top, the <strong>Active Event Statistics</strong> section
+            shows totals across all active events: total income, number of
+            ticket rows, and total attendee quantity. Click the heading to
+            expand or collapse it.
           </p>
         </Q>
       </Section>
@@ -426,6 +439,22 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           <p>
             See the <strong>Refunds</strong> section below for full details on
             automatic refunds, admin-issued refunds, and bulk refunds.
+          </p>
+        </Q>
+
+        <Q q="What is the booking fee?">
+          <p>
+            The booking fee is an optional percentage-based charge added to
+            ticket prices at checkout. For example, if you set a 2% booking fee
+            on a {formatCurrency(1000)} ticket, the attendee pays{" "}
+            {formatCurrency(1020)} in total.
+          </p>
+          <p>
+            Configure it in <a href="/admin/settings">Settings</a> under{" "}
+            <strong>Booking Fee</strong> (only visible when a payment provider
+            is set up). Enter a percentage between 0 and 10. Set it to 0 or
+            leave it blank to disable. The fee is calculated on the subtotal and
+            added automatically during checkout.
           </p>
         </Q>
       </Section>
@@ -799,13 +828,72 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
         </Q>
       </Section>
 
+      <Section title="Apple Wallet">
+        <Q q="What is Apple Wallet integration?">
+          <p>
+            When configured, attendees see an{" "}
+            <strong>Add to Apple Wallet</strong> button on their ticket page.
+            Tapping it downloads a <code>.pkpass</code> file that adds the
+            ticket to their iPhone Wallet and Apple Watch. The pass shows the
+            event name, date, location, ticket quantity, price paid, and a QR
+            code for check-in.
+          </p>
+        </Q>
+
+        <Q q="How do I set up Apple Wallet?">
+          <p>
+            Go to <a href="/admin/settings">Settings</a>, click{" "}
+            <strong>Advanced Settings</strong>, and find the{" "}
+            <strong>Apple Wallet</strong> section. You need five values from
+            your Apple Developer account:
+          </p>
+          <ol>
+            <li>
+              <strong>Pass Type ID</strong> &mdash; e.g.{" "}
+              <code>pass.com.example.tickets</code>
+            </li>
+            <li>
+              <strong>Team ID</strong> &mdash; your Apple Developer Team ID
+            </li>
+            <li>
+              <strong>Signing Certificate</strong> &mdash; PEM-encoded
+              certificate for your Pass Type ID
+            </li>
+            <li>
+              <strong>Signing Key</strong> &mdash; PEM-encoded private key for
+              the certificate
+            </li>
+            <li>
+              <strong>WWDR Certificate</strong> &mdash; Apple's intermediate
+              certificate (download from the Apple Developer portal)
+            </li>
+          </ol>
+          <p>
+            All five fields are required. Once saved, the Add to Apple Wallet
+            button appears automatically on all ticket pages. If none are
+            configured, the feature is simply hidden.
+          </p>
+        </Q>
+
+        <Q q="Do wallet passes update automatically?">
+          <p>
+            Yes. If an attendee's details change (e.g. they are moved to a
+            different event or their check-in status changes), Apple Wallet
+            automatically fetches the updated pass. This uses the Apple Wallet
+            web service API built into the system &mdash; no extra setup is
+            needed beyond the initial configuration.
+          </p>
+        </Q>
+      </Section>
+
       <Section id="user-classes" title="Users &amp; Permissions">
         <Q q="What's the difference between an owner and a manager?">
           <p>
             <strong>Owners</strong> have full access: events, calendar, users,
             settings, holidays, sessions, and the activity log.{" "}
-            <strong>Managers</strong> can only see events and the calendar. They
-            cannot change settings, manage users, or view the activity log.
+            <strong>Managers</strong> can see events, the calendar, and the
+            activity log. They cannot change settings, manage users, or view
+            sessions.
           </p>
         </Q>
 
@@ -937,10 +1025,11 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
       <Section title="Activity Log">
         <Q q="What is the activity log?">
           <p>
-            The <strong>Log</strong> page (owners only) shows a chronological
-            list of admin actions such as event creation, attendee changes, and
-            settings updates. Each event also has its own log, accessible from
-            the event page, showing only actions related to that event.
+            The <strong>Log</strong> page shows a chronological list of admin
+            actions such as event creation, attendee changes, and settings
+            updates. Both owners and managers can view the log. Each event also
+            has its own log, accessible from the event page, showing only
+            actions related to that event.
           </p>
         </Q>
       </Section>
@@ -1150,10 +1239,6 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
           </p>
           <ul>
             <li>
-              <strong>Timezone</strong> &mdash; all dates and times use this
-              timezone
-            </li>
-            <li>
               <strong>Phone prefix</strong> &mdash; country calling code (e.g.
               44 for UK, 1 for US) used to normalise phone numbers
             </li>
@@ -1165,16 +1250,8 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
               <strong>Payment provider</strong> &mdash; Stripe, Square, or none
             </li>
             <li>
-              <strong>Email provider</strong> &mdash; Resend, Postmark,
-              SendGrid, or Mailgun for automatic registration emails
-            </li>
-            <li>
-              <strong>Email templates</strong> &mdash; customise confirmation
-              and admin notification emails using Liquid syntax
-            </li>
-            <li>
-              <strong>Custom domain</strong> &mdash; set up a custom domain for
-              your site (Bunny CDN only)
+              <strong>Booking fee</strong> &mdash; percentage-based fee added to
+              ticket prices (requires a payment provider)
             </li>
             <li>
               <strong>Embed hosts</strong> &mdash; restrict which websites can
@@ -1185,13 +1262,64 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
               before booking
             </li>
             <li>
+              <strong>Site theme</strong> &mdash; light or dark
+            </li>
+            <li>
+              <strong>Admin password</strong> &mdash; change your login password
+            </li>
+          </ul>
+        </Q>
+
+        <Q q="What are Advanced Settings?">
+          <p>
+            The main Settings page has a link to{" "}
+            <strong>Advanced Settings</strong> for less common configuration.
+            Advanced settings include:
+          </p>
+          <ul>
+            <li>
+              <strong>Public API</strong> &mdash; enable the JSON API for
+              external integrations
+            </li>
+            <li>
+              <strong>Apple Wallet</strong> &mdash; configure pass signing
+              certificates for Add to Apple Wallet
+            </li>
+            <li>
+              <strong>Email provider</strong> &mdash; choose and configure your
+              email sending service
+            </li>
+            <li>
+              <strong>Email templates</strong> &mdash; customise confirmation
+              and admin notification emails using Liquid syntax
+            </li>
+            <li>
+              <strong>Timezone</strong> &mdash; all dates and times use this
+              timezone
+            </li>
+            <li>
+              <strong>Custom domain</strong> &mdash; set up a custom domain for
+              your site (Bunny CDN only)
+            </li>
+            <li>
               <strong>Public site</strong> &mdash; enable or disable the public
               website
             </li>
             <li>
-              <strong>Site theme</strong> &mdash; light or dark
+              <strong>Database reset</strong> &mdash; permanently delete all
+              data
             </li>
           </ul>
+        </Q>
+
+        <Q q="What is the debug page?">
+          <p>
+            The debug page at <code>/admin/debug</code> shows the configuration
+            status of all integrated services (payments, email, Apple Wallet,
+            storage, CDN, notifications) without revealing any secrets or API
+            keys. It's useful for troubleshooting setup issues &mdash; you can
+            quickly see which services are configured and which are missing.
+          </p>
         </Q>
       </Section>
 

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -851,7 +851,7 @@ export const adminGuidePage = (
         </Q>
 
         <Q q="How do I set up Apple Wallet?">
-          {hostConfig?.hostAppleWalletPassTypeId ? (
+          {hostConfig?.hostAppleWalletPassTypeId && (
             <p>
               Apple Wallet is already configured by your server administrator
               using pass type{" "}
@@ -860,42 +860,39 @@ export const adminGuidePage = (
               pages. You can override this by entering your own credentials in{" "}
               <a href="/admin/settings">Settings</a>.
             </p>
-          ) : (
-            <>
-              <p>
-                Go to <a href="/admin/settings">Settings</a>, click{" "}
-                <strong>Advanced Settings</strong>, and find the{" "}
-                <strong>Apple Wallet</strong> section. You need five values from
-                your Apple Developer account:
-              </p>
-              <ol>
-                <li>
-                  <strong>Pass Type ID</strong> &mdash; e.g.{" "}
-                  <code>pass.com.example.tickets</code>
-                </li>
-                <li>
-                  <strong>Team ID</strong> &mdash; your Apple Developer Team ID
-                </li>
-                <li>
-                  <strong>Signing Certificate</strong> &mdash; PEM-encoded
-                  certificate for your Pass Type ID
-                </li>
-                <li>
-                  <strong>Signing Key</strong> &mdash; PEM-encoded private key
-                  for the certificate
-                </li>
-                <li>
-                  <strong>WWDR Certificate</strong> &mdash; Apple's intermediate
-                  certificate (download from the Apple Developer portal)
-                </li>
-              </ol>
-              <p>
-                All five fields are required. Once saved, the Add to Apple
-                Wallet button appears automatically on all ticket pages. If none
-                are configured, the feature is simply hidden.
-              </p>
-            </>
           )}
+          <p>
+            Go to <a href="/admin/settings">Settings</a>, click{" "}
+            <strong>Advanced Settings</strong>, and find the{" "}
+            <strong>Apple Wallet</strong> section. You need five values from
+            your Apple Developer account:
+          </p>
+          <ol>
+            <li>
+              <strong>Pass Type ID</strong> &mdash; e.g.{" "}
+              <code>pass.com.example.tickets</code>
+            </li>
+            <li>
+              <strong>Team ID</strong> &mdash; your Apple Developer Team ID
+            </li>
+            <li>
+              <strong>Signing Certificate</strong> &mdash; PEM-encoded
+              certificate for your Pass Type ID
+            </li>
+            <li>
+              <strong>Signing Key</strong> &mdash; PEM-encoded private key for
+              the certificate
+            </li>
+            <li>
+              <strong>WWDR Certificate</strong> &mdash; Apple's intermediate
+              certificate (download from the Apple Developer portal)
+            </li>
+          </ol>
+          <p>
+            All five fields are required. Once saved, the Add to Apple Wallet
+            button appears automatically on all ticket pages. If none are
+            configured, the feature is simply hidden.
+          </p>
         </Q>
 
         <Q q="Do wallet passes update automatically?">
@@ -1100,47 +1097,38 @@ export const adminGuidePage = (
         </Q>
 
         <Q q="How do I set up email?">
-          {hostConfig?.hostEmailProvider ? (
-            <>
-              <p>
-                Email is already configured by your server administrator using{" "}
-                <strong>{hostConfig.hostEmailProvider}</strong> with from
-                address <code>{hostConfig.hostEmailFromAddress}</code>. You can
-                override this by entering your own provider and API key in{" "}
-                <a href="/admin/settings">Settings</a>.
-              </p>
-              <p>
-                If you provide your own settings, they take priority over the
-                server configuration.
-              </p>
-            </>
-          ) : (
-            <>
-              <ol>
-                <li>
-                  Go to <a href="/admin/settings">Settings</a> and find the{" "}
-                  <strong>Email</strong> section
-                </li>
-                <li>Choose your email provider from the dropdown</li>
-                <li>
-                  Paste your provider's API key into the{" "}
-                  <strong>API Key</strong> field
-                </li>
-                <li>
-                  Enter a <strong>From Address</strong> &mdash; this is the
-                  sender address that appears on outgoing emails. If left blank,
-                  the business email address is used instead
-                </li>
-                <li>Save the settings</li>
-              </ol>
-              <p>
-                The from address must be a verified sender in your email
-                provider's account, otherwise emails will be rejected. Check
-                your provider's documentation for how to verify a sender domain
-                or address.
-              </p>
-            </>
+          {hostConfig?.hostEmailProvider && (
+            <p>
+              Email is already configured by your server administrator using{" "}
+              <strong>{hostConfig.hostEmailProvider}</strong> with from address{" "}
+              <code>{hostConfig.hostEmailFromAddress}</code>. You can override
+              this by entering your own provider and API key in{" "}
+              <a href="/admin/settings">Settings</a>. If you provide your own
+              settings, they take priority over the server configuration.
+            </p>
           )}
+          <ol>
+            <li>
+              Go to <a href="/admin/settings">Settings</a> and find the{" "}
+              <strong>Email</strong> section
+            </li>
+            <li>Choose your email provider from the dropdown</li>
+            <li>
+              Paste your provider's API key into the <strong>API Key</strong>{" "}
+              field
+            </li>
+            <li>
+              Enter a <strong>From Address</strong> &mdash; this is the sender
+              address that appears on outgoing emails. If left blank, the
+              business email address is used instead
+            </li>
+            <li>Save the settings</li>
+          </ol>
+          <p>
+            The from address must be a verified sender in your email provider's
+            account, otherwise emails will be rejected. Check your provider's
+            documentation for how to verify a sender domain or address.
+          </p>
         </Q>
 
         <Q q="How do I test that email is working?">

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -877,11 +877,11 @@ export const adminGuidePage = (adminSession: AdminSession): string =>
 
         <Q q="Do wallet passes update automatically?">
           <p>
-            Yes. If an attendee's details change (e.g. they are moved to a
-            different event or their check-in status changes), Apple Wallet
-            automatically fetches the updated pass. This uses the Apple Wallet
-            web service API built into the system &mdash; no extra setup is
-            needed beyond the initial configuration.
+            Yes. Apple Wallet periodically polls the server (roughly once a day)
+            and re-downloads the pass with the latest details. There are no push
+            notifications &mdash; updates arrive on Apple's polling schedule.
+            Attendees can also pull down on the pass in Wallet to force an
+            immediate refresh.
           </p>
         </Q>
       </Section>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -38,10 +38,12 @@ import {
   clearSetupCompleteCache,
   completeSetup,
   invalidateSettingsCache,
+  resetHostAppleWalletConfig,
   updateTimezone,
 } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
+import { resetHostEmailConfig } from "#lib/email.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
 
 /**
@@ -282,6 +284,8 @@ export const resetDb = (): void => {
   resetCurrencyCode();
   setDemoModeForTest(false);
   resetAllowedDomain();
+  resetHostEmailConfig();
+  resetHostAppleWalletConfig();
 };
 
 /**

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -326,6 +326,12 @@ describe("code quality", () => {
       "lib/email-renderer.ts:resetEngine",
       // Skip login delay in tests without env var races
       "routes/admin/auth.ts:setSkipLoginDelayForTest",
+      // Reset/set host email config between tests without env var races
+      "lib/email.ts:setHostEmailConfigForTest",
+      "lib/email.ts:resetHostEmailConfig",
+      // Reset/set host Apple Wallet config between tests without env var races
+      "lib/db/settings.ts:setHostAppleWalletConfigForTest",
+      "lib/db/settings.ts:resetHostAppleWalletConfig",
       // Attachment size constant used in production (validateAttachment) but test pattern doesn't detect same-file usage
       "lib/storage.ts:MAX_ATTACHMENT_SIZE",
     ];

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -194,7 +194,7 @@ describe("server (admin guide)", () => {
       );
     });
 
-    test("shows host email config when configured", async () => {
+    test("shows host email config and setup instructions when configured", async () => {
       setHostEmailConfigForTest({
         provider: "resend",
         apiKey: "re_test_key",
@@ -208,9 +208,7 @@ describe("server (admin guide)", () => {
         );
         expect(html).toContain("Resend");
         expect(html).toContain("tickets@example.com");
-        expect(html).not.toContain(
-          "Choose your email provider from the dropdown",
-        );
+        expect(html).toContain("Choose your email provider from the dropdown");
       } finally {
         resetHostEmailConfig();
       }
@@ -225,7 +223,7 @@ describe("server (admin guide)", () => {
       );
     });
 
-    test("shows host wallet config when configured", async () => {
+    test("shows host wallet config and setup instructions when configured", async () => {
       setHostAppleWalletConfigForTest({
         passTypeId: "pass.com.host.tickets",
         teamId: "HOSTTEAM01",
@@ -240,7 +238,7 @@ describe("server (admin guide)", () => {
           "already configured by your server administrator using pass type",
         );
         expect(html).toContain("pass.com.host.tickets");
-        expect(html).not.toContain("You need five values from");
+        expect(html).toContain("You need five values from");
       } finally {
         resetHostAppleWalletConfig();
       }

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -1,5 +1,10 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import {
+  resetHostAppleWalletConfig,
+  setHostAppleWalletConfigForTest,
+} from "#lib/db/settings.ts";
+import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { handleRequest } from "#routes";
 import {
   adminGet,
@@ -178,6 +183,67 @@ describe("server (admin guide)", () => {
       expect(html).toContain("/admin/guide");
       expect(html).toContain("Events");
       expect(html).toContain("Logout");
+    });
+
+    test("shows default email setup instructions when no host email configured", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Choose your email provider from the dropdown");
+      expect(html).not.toContain(
+        "already configured by your server administrator",
+      );
+    });
+
+    test("shows host email config when configured", async () => {
+      setHostEmailConfigForTest({
+        provider: "resend",
+        apiKey: "re_test_key",
+        fromAddress: "tickets@example.com",
+      });
+      try {
+        const { response } = await adminGet("/admin/guide");
+        const html = await response.text();
+        expect(html).toContain(
+          "already configured by your server administrator",
+        );
+        expect(html).toContain("Resend");
+        expect(html).toContain("tickets@example.com");
+        expect(html).not.toContain(
+          "Choose your email provider from the dropdown",
+        );
+      } finally {
+        resetHostEmailConfig();
+      }
+    });
+
+    test("shows default wallet setup instructions when no host wallet configured", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("You need five values from");
+      expect(html).not.toContain(
+        "already configured by your server administrator using pass type",
+      );
+    });
+
+    test("shows host wallet config when configured", async () => {
+      setHostAppleWalletConfigForTest({
+        passTypeId: "pass.com.host.tickets",
+        teamId: "HOSTTEAM01",
+        signingCert: "cert-data",
+        signingKey: "key-data",
+        wwdrCert: "wwdr-data",
+      });
+      try {
+        const { response } = await adminGet("/admin/guide");
+        const html = await response.text();
+        expect(html).toContain(
+          "already configured by your server administrator using pass type",
+        );
+        expect(html).toContain("pass.com.host.tickets");
+        expect(html).not.toContain("You need five values from");
+      } finally {
+        resetHostAppleWalletConfig();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR enhances the admin guide page to display host-level configuration information for email and Apple Wallet when available, allowing users to see what's been pre-configured by their server administrator while still providing setup instructions for custom configuration.

## Key Changes

- **New `GuideHostConfig` type**: Added a TypeScript type to pass host-level configuration data to the guide template, including email provider, from address, and Apple Wallet pass type ID.

- **Host configuration display in guide**: 
  - Email section now shows when host email is configured, displaying the provider name and from address
  - Apple Wallet section now shows when host wallet is configured, displaying the pass type ID
  - Both sections still include full setup instructions for users who want to override with their own credentials

- **Route handler enhancement**: Updated `/admin/guide` route to fetch host email and Apple Wallet configs and pass them to the template with proper label formatting.

- **Test infrastructure for host configs**: 
  - Added `setHostEmailConfigForTest()` and `resetHostEmailConfig()` functions to `lib/email.ts` for test isolation
  - Added `setHostAppleWalletConfigForTest()` and `resetHostAppleWalletConfig()` functions to `lib/db/settings.ts` for test isolation
  - Both use a `lazyRef` pattern to avoid environment variable race conditions in tests

- **Comprehensive test coverage**: Added tests verifying the guide displays default instructions when no host config exists, and shows host config information when configured.

- **Documentation updates**: 
  - Clarified that managers can now view the activity log (previously owners-only)
  - Added new "Dashboard" section explaining the Events page statistics
  - Added new "Booking Fee" Q&A section
  - Reorganized Settings into main and Advanced Settings sections
  - Added "Debug Page" Q&A section
  - Updated various permission descriptions

## Implementation Details

The host configuration is read at request time (not cached) to ensure the guide always reflects current configuration. The test helper functions use `lazyRef` to maintain test isolation without relying on environment variables, preventing race conditions in concurrent test execution.

https://claude.ai/code/session_01K7NPwZVehdTqEDxK6acc9d