### PR TITLE
Fix encryption key cleanup to prevent race conditions in tests

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -81,7 +81,9 @@ export const setupTestEncryptionKey = (): void => {
  * Clear test encryption key from environment
  */
 export const clearTestEncryptionKey = (): void => {
-  setEncryptionKeyForTest(null);
+  // Use empty string (not null) so the override stays active and doesn't
+  // fall through to Deno.env, avoiding races with parallel test workers.
+  setEncryptionKeyForTest("");
   Deno.env.delete("DB_ENCRYPTION_KEY");
   Deno.env.delete("TEST_PBKDF2_ITERATIONS");
   Deno.env.delete("TEST_SKIP_LOGIN_DELAY");


### PR DESCRIPTION
## Summary
Changed the test encryption key cleanup logic to use an empty string instead of `null` when clearing the test encryption key, preventing race conditions in parallel test execution.

## Key Changes
- Modified `clearTestEncryptionKey()` to call `setEncryptionKeyForTest("")` instead of `setEncryptionKeyForTest(null)`
- This ensures the override remains active rather than falling through to `Deno.env`, which could cause races with parallel test workers

## Implementation Details
The change addresses a concurrency issue where setting the encryption key to `null` would cause the system to fall back to reading from `Deno.env`. In parallel test execution, this could lead to race conditions where one test worker's environment variable state interferes with another's. By using an empty string, the override stays active and prevents this fallback behavior, ensuring test isolation.

https://claude.ai/code/session_01MmNoj8xTX2T9Bzxs44P7X8