### PR TITLE
Extend quantity select styling to support prefixed selectors

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -531,7 +531,8 @@ label > input[type="time"] {
   width: auto;
 }
 
-label > select[name="quantity"] {
+label > select[name="quantity"],
+label > select[name^="quantity_"] {
   width: 6ch;
   flex: 0 0 auto;
 }


### PR DESCRIPTION
## Summary
Updated the CSS selector for quantity dropdown styling to support both the exact `quantity` name and any select elements with names starting with `quantity_` prefix.

## Key Changes
- Modified the `label > select[name="quantity"]` selector to also match `label > select[name^="quantity_"]`
- This allows the 6-character width and flex properties to apply to quantity selectors with dynamic naming patterns (e.g., `quantity_1`, `quantity_item`, etc.)

## Implementation Details
- Used the CSS attribute substring matching selector `[name^="quantity_"]` to target any select element whose name attribute begins with "quantity_"
- Both selectors now share the same styling rules, maintaining consistent appearance across quantity-related dropdowns

https://claude.ai/code/session_01564nX5drRPx6qXkWCGHcax