### PR TITLE
Reorganize README with Bunny Edge as primary deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,46 @@
 # Chobble Tickets
 
-A self-hosted ticket reservation system built by [Chobble CIC](https://chobble.com), a community interest company. Runs on any Deno environment (or Bunny Edge Scripting) with libsql (Turso). Encrypts all PII at rest. Handles free and paid events with Stripe or Square.
+A self-hosted ticket reservation system built by [Chobble CIC](https://chobble.com), a community interest company. Runs on Bunny Edge Scripting (or any Deno environment) with libsql. Encrypts all PII at rest. Handles free and paid events with Stripe or Square.
 
 **Website**: [tickets.chobble.com](https://tickets.chobble.com)
 
 This is not "open core" — every feature is available under **AGPLv3** with no proprietary add-ons. Hosted instances available at [tix.chobble.com](https://tix.chobble.com/ticket/register) for £50/year, no tiers.
 
-## Deploy
+---
 
-Deploy to: **[DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main)**, **[Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main)**, **[Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/)**, or **[Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)**
+## Deploy on Bunny Edge Scripting
 
-Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
+The recommended deployment. Fork the repo, connect it to Bunny, and deploy via GitHub Actions. You can pull in upstream changes and push your own customisations on your own schedule.
+
+1. **Fork or clone** this repository
+2. **Create a Bunny Database** in the [Bunny dashboard](https://dash.bunny.net) — note the database URL and token
+3. **Create a Bunny Edge Script** using your repository as the linked source
+4. **Add secrets** to the script in the Bunny dashboard:
+
+   | Secret | Description |
+   |--------|-------------|
+   | `DB_URL` | Your Bunny database URL |
+   | `DB_TOKEN` | Your Bunny database auth token |
+   | `DB_ENCRYPTION_KEY` | 32-byte base64-encoded AES-256 key |
+   | `ALLOWED_DOMAIN` | Your domain (e.g. `tickets.example.com`) |
+
+5. **Add GitHub Actions secrets** to your repository: `BUNNY_SCRIPT_ID` and `BUNNY_ACCESS_KEY`
+
+Pushes to `main` trigger the deploy workflow automatically. The database schema auto-migrates on first request. Visit `/setup/` to set your admin password and currency.
+
+For image uploads, also add `STORAGE_ZONE_NAME` and `STORAGE_ZONE_KEY` as Bunny secrets. See the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html) for all optional variables.
+
+---
 
 ## Features
 
 ### Events
+
 - Standard events (fixed capacity) and daily events (per-date capacity with calendar picker)
+- Event groups for organising related events together
 - Optional event date and location fields, displayed on the ticket page
 - Configurable contact fields: email, phone, postal address (any combination)
+- Special instructions field for attendee notes
 - Terms and conditions — set globally in settings, attendees must agree before booking
 - Capacity limits, max tickets per purchase, registration deadlines
 - Multi-event booking — combine events in one URL (`/ticket/event1+event2`), one form, one checkout
@@ -26,16 +49,21 @@ Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 - Embeddable via iframe with configurable CSP frame-ancestors
 - Custom thank-you URL or default confirmation page
 - Non-transferable tickets — per-event toggle requiring ID verification at check-in
+- Event image and file attachment uploads (encrypted, stored on Bunny CDN)
 - Manual attendee creation from the admin event page (walk-ins, comps)
 
 ### Payments
+
 - Stripe and Square with a pluggable provider interface
 - Enter your API key in admin settings — webhook endpoint auto-configures
 - Checkout sessions with metadata, webhook-driven attendee creation
+- Configurable booking fee added to each transaction
+- "Pay what you want" pricing with optional minimum and maximum
 - Automatic refund if capacity exceeded after payment or event price changes during checkout
 - Admin-issued full refunds for individual attendees or all attendees in bulk
 
 ### Check-in
+
 - Each ticket gets a unique URL (`/t/:token`) with a QR code
 - Staff scan QR to reach check-in page, toggle check-in/out
 - Built-in QR scanner — open from an event page, uses device camera, check-in-only (no accidental check-outs)
@@ -43,44 +71,35 @@ Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 - Cross-event detection: scanner warns if a ticket belongs to a different event
 - Multi-ticket view for multi-event bookings (`/t/token1+token2`)
 
+### Apple Wallet
+
+- Generates `.pkpass` files for Apple Wallet with event details and barcode
+- Standards-compliant web service API for automatic pass updates
+- Configurable via admin settings or environment variables
+
 ### Admin
+
 - Event CRUD, duplicate, deactivate/reactivate, delete (requires typing event name)
+- Calendar view for daily events with per-date attendee counts
 - Attendee list with date filtering (daily events), check-in status filtering
 - Attendee editing — update name, contact details, quantity, or reassign to a different event
-- CSV export (respects filters)
-- Per-event activity log (creation, updates, check-ins, exports, deletions)
+- CSV export (respects active filters)
+- Per-event and global activity log (creation, updates, check-ins, exports, refunds, deletions)
 - Holiday/blackout date management for daily events
 - Multi-user: owners invite managers via time-limited links (7-day expiry)
 - Session management: view active sessions, kill all others
-- Settings: payment provider config, email templates, custom domain, embed host restrictions, terms and conditions, password change, database reset
+- Settings: payment provider config, email templates, custom domain, embed host restrictions, terms and conditions, password change
+- Branding: custom header image, website title, theme colours
 - Built-in admin guide (`/admin/guide`) with FAQ for all features
 - Ntfy error notifications for production monitoring (optional)
 
-### Encryption
-- **Hybrid RSA-OAEP + AES-256-GCM** for attendee PII (name, email, phone, postal address)
-  - Public key encrypts on submission (no auth needed)
-  - Private key only available to authenticated admin sessions
-  - A database dump alone is not sufficient to recover PII — an attacker would also need the encryption key from the environment
-- **AES-256-GCM** for payment IDs, prices, check-in status, API keys, holiday names, usernames
-- **PBKDF2** (600k iterations, SHA-256) for password hashing
-- Three-layer key hierarchy: env var root key → RSA key pair → per-user wrapped data keys
-- Lost password = permanently unreadable data. No backdoor.
+### Feeds
 
-### Concurrency
-- Capacity check + insert in a single SQL statement to reduce the window for overbooking
-- Payment webhook idempotency via two-phase locking on `processed_payments` table
-- Stale reservation auto-cleanup after 5 minutes
-
-### Security
-- CSRF: double-submit cookie with 256-bit random tokens, path-scoped
-- Rate limiting: 5 failed logins → 15-minute IP lockout (IPs HMAC-hashed before storage)
-- Constant-time password comparison with random delay
-- Session tokens hashed before database storage, 24-hour expiry, HttpOnly cookies
-- Content-Type validation on all POST endpoints
-
-These measures aim to raise the cost of common attacks. They do not guarantee security against all scenarios — proper operational practices (key management, access control, monitoring) are equally important.
+- ICS calendar feed (`/feeds/events.ics`) for calendar apps
+- RSS feed (`/feeds/events.rss`) for feed readers
 
 ### Email Notifications
+
 - Automatic confirmation email to attendees and notification email to admins on each registration
 - Five HTTP API providers: Resend, Postmark, SendGrid, Mailgun (US/EU)
 - Customisable email templates using Liquid syntax (subject, HTML body, text body)
@@ -88,11 +107,13 @@ These measures aim to raise the cost of common attacks. They do not guarantee se
 - Configured in admin settings — optional, system works without it
 
 ### Public JSON API
+
 - RESTful API for event listing and booking (`/api/events`, `/api/events/:slug`, `/api/events/:slug/availability`, `/api/events/:slug/book`)
 - No API key required — same data as public booking pages
 - CORS-enabled for cross-origin requests
 
 ### Webhooks
+
 - Outbound POST on every registration (free or paid) to per-event and/or global webhook URLs
 - Payload: name, email, phone, address, amount, currency, payment ID, ticket URL, per-ticket details
 - Multi-event bookings send one consolidated webhook
@@ -133,7 +154,60 @@ Prices are in the smallest currency unit (e.g. pence, cents). For multi-event bo
 
 </details>
 
-## Quick Start
+### Encryption
+
+- **Hybrid RSA-OAEP + AES-256-GCM** for attendee PII (name, email, phone, postal address)
+  - Public key encrypts on submission (no auth needed)
+  - Private key only available to authenticated admin sessions
+  - A database dump alone is not sufficient to recover PII — an attacker would also need the encryption key from the environment
+- **AES-256-GCM** for payment IDs, prices, check-in status, API keys, holiday names, usernames
+- **PBKDF2** (600k iterations, SHA-256) for password hashing
+- Three-layer key hierarchy: env var root key → RSA key pair → per-user wrapped data keys
+- Lost password = permanently unreadable data. No backdoor.
+
+### Concurrency
+
+- Capacity check + insert in a single SQL statement to reduce the window for overbooking
+- Payment webhook idempotency via two-phase locking on `processed_payments` table
+- Stale reservation auto-cleanup after 5 minutes
+
+### Security
+
+- CSRF: double-submit cookie with 256-bit random tokens, path-scoped
+- Rate limiting: 5 failed logins → 15-minute IP lockout (IPs HMAC-hashed before storage)
+- Constant-time password comparison with random delay
+- Session tokens hashed before database storage, 24-hour expiry, HttpOnly cookies
+- Content-Type validation on all POST endpoints
+
+These measures aim to raise the cost of common attacks. They do not guarantee security against all scenarios — proper operational practices (key management, access control, monitoring) are equally important.
+
+---
+
+## Alternative Deployment
+
+### Docker
+
+```bash
+docker build -t chobble-tickets .
+docker run -p 3000:3000 \
+  -v tickets-data:/data \
+  -e DB_URL="file:/data/tickets.db" \
+  -e DB_ENCRYPTION_KEY="your-base64-key" \
+  -e ALLOWED_DOMAIN="your-domain.com" \
+  chobble-tickets
+```
+
+The Dockerfile uses a local SQLite file by default. Set `DB_URL` and `DB_TOKEN` to point at a remote Turso database instead if preferred.
+
+### One-click platforms
+
+Deploy to: [DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/chobbledotcom/tickets/tree/main) | [Heroku](https://heroku.com/deploy?template=https://github.com/chobbledotcom/tickets/tree/main) | [Koyeb](https://app.koyeb.com/deploy?type=git&repository=github.com/chobbledotcom/tickets&branch=main&name=chobble-tickets&builder=dockerfile&ports=3000;http;/) | [Render](https://render.com/deploy?repo=https://github.com/chobbledotcom/tickets)
+
+Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
+
+---
+
+## Development
 
 ```bash
 # Install Deno, cache dependencies, run all checks
@@ -150,7 +224,20 @@ deno task test
 
 On first launch, visit `/setup/` to set admin credentials and currency. Payment providers are configured at `/admin/settings`.
 
-## Environment Variables
+### Available tasks
+
+```
+deno task start          # Run server
+deno task test           # Run tests
+deno task test:coverage  # Tests with coverage report
+deno task lint           # Lint
+deno task fmt            # Format
+deno task typecheck      # Type check
+deno task build:edge     # Build for Bunny Edge
+deno task precommit      # All checks (typecheck, lint, cpd, build:edge, test:coverage)
+```
+
+### Environment variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -159,47 +246,9 @@ On first launch, visit `/setup/` to set admin credentials and currency. Payment 
 | `DB_ENCRYPTION_KEY` | Yes | 32-byte base64-encoded AES-256 key |
 | `ALLOWED_DOMAIN` | Yes | Domain for security validation |
 
-There are additional optional variables covering emails, Apple Wallet, image uploads, and more — see the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html) for the full list.
+See the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html) for all optional variables (email providers, Apple Wallet, image uploads, and more).
 
-## Deployment
-
-### Docker
-
-```bash
-docker build -t chobble-tickets .
-docker run -p 3000:3000 \
-  -v tickets-data:/data \
-  -e DB_URL="file:/data/tickets.db" \
-  -e DB_ENCRYPTION_KEY="your-base64-key" \
-  -e ALLOWED_DOMAIN="your-domain.com" \
-  chobble-tickets
-```
-
-The Dockerfile uses a local SQLite file by default. Set `DB_URL` and `DB_TOKEN` to point at a remote Turso database instead if preferred.
-
-### Bunny Edge Scripting
-
-Builds to a single JavaScript file for Bunny Edge Scripting:
-
-```bash
-deno task build:edge
-```
-
-Configure `DB_URL`, `DB_TOKEN`, `DB_ENCRYPTION_KEY`, and `ALLOWED_DOMAIN` as Bunny native secrets. For image uploads, also configure `STORAGE_ZONE_NAME` and `STORAGE_ZONE_KEY`. GitHub Actions secrets: `BUNNY_SCRIPT_ID`, `BUNNY_ACCESS_KEY`.
-
-Database schema auto-migrates on first request.
-
-## Development
-
-```bash
-deno task start          # Run server
-deno task test           # Run tests
-deno task test:coverage  # Tests with coverage report
-deno task lint           # Lint
-deno task fmt            # Format
-deno task typecheck      # Type check
-deno task precommit      # All checks (typecheck, lint, cpd, build:edge, test:coverage)
-```
+---
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

Restructured the README to prioritize Bunny Edge Scripting as the recommended deployment method, while reorganizing other sections for better clarity and discoverability.

## Key Changes

- **Reordered deployment section**: Moved Bunny Edge Scripting to a dedicated primary section with detailed step-by-step instructions, replacing the previous brief mention
- **Reorganized features**: Added section headers and better grouping for Events, Payments, Check-in, Apple Wallet, Admin, Feeds, Email, API, and Webhooks
- **Moved Quick Start to Development**: Relocated local development instructions to a new "Development" section with subsections for setup, tasks, and environment variables
- **Renamed and reorganized**: Changed "Deploy" to "Alternative Deployment" and moved one-click platforms (DigitalOcean, Heroku, etc.) and Docker instructions there
- **Improved structure**: Added horizontal dividers (`---`) to separate major sections and improve visual hierarchy
- **Enhanced feature descriptions**: Added new features like event groups, special instructions field, event image uploads, Apple Wallet support, calendar view, and global activity logs
- **Clarified Bunny setup**: Added detailed secrets table and GitHub Actions configuration instructions for Bunny deployment
- **Reorganized technical details**: Moved Encryption, Concurrency, and Security sections after features for better flow

## Notable Details

- The README now emphasizes Bunny Edge Scripting as the "recommended deployment" with comprehensive setup instructions
- Development section now clearly separates local setup from available deno tasks
- All deployment options remain documented but are now secondary to the Bunny Edge approach
- Feature list expanded to reflect recent additions (Apple Wallet, image uploads, calendar view, etc.)

https://claude.ai/code/session_01A2FVhEmDTuKtauhMftwW3u