### PR TITLE
Handle spurious zero after country code in phone normalization

### DIFF
--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -2,9 +2,18 @@
  * Phone number normalization utilities
  */
 
-/** Strip non-numeric characters from a phone number, then prefix if it starts with 0 */
+/** Strip non-numeric characters from a phone number and normalize to +{prefix}{local} */
 export const normalizePhone = (phone: string, prefix: string): string => {
   const digits = phone.replace(/\D/g, "");
   if (!digits) return "";
-  return digits.startsWith("0") ? `+${prefix}${digits.slice(1)}` : `+${digits}`;
+
+  // Local number with leading zero: 0161... → +44161...
+  if (digits.startsWith("0")) return `+${prefix}${digits.slice(1)}`;
+
+  // Country code followed by spurious zero: 440161... → +44161...
+  if (digits.startsWith(`${prefix}0`))
+    return `+${prefix}${digits.slice(prefix.length + 1)}`;
+
+  // Already has country code without leading zero: 44161... → +44161...
+  return `+${digits}`;
 };

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -3649,11 +3649,9 @@ describe("db", () => {
 
     test("checkBatchAvailability checks group capacity with date for daily events", async () => {
       const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
-      const { e1, e2 } = await createCappedGroupWithEvents(
-        5,
-        "daily-batch",
-        { eventType: "daily" },
-      );
+      const { e1, e2 } = await createCappedGroupWithEvents(5, "daily-batch", {
+        eventType: "daily",
+      });
 
       // Both events in same group — combined quantity exceeds group cap for this date
       expect(

--- a/test/lib/phone.test.ts
+++ b/test/lib/phone.test.ts
@@ -42,4 +42,28 @@ describe("normalizePhone", () => {
   test("handles number with spaces and leading zero", () => {
     expect(normalizePhone("0 20 1234 5678", "44")).toBe("+442012345678");
   });
+
+  test("strips spurious zero after country code: 44 0161 1234567", () => {
+    expect(normalizePhone("44 0161 1234567", "44")).toBe("+441611234567");
+  });
+
+  test("strips spurious zero after +country code: +44 0161 1234567", () => {
+    expect(normalizePhone("+44 0161 1234567", "44")).toBe("+441611234567");
+  });
+
+  test("strips spurious zero with parenthesized country code: (44) 0161 1234567", () => {
+    expect(normalizePhone("(44) 0161 1234567", "44")).toBe("+441611234567");
+  });
+
+  test("normalizes +44 161 1234567", () => {
+    expect(normalizePhone("+44 161 1234567", "44")).toBe("+441611234567");
+  });
+
+  test("normalizes 44 161 1234567", () => {
+    expect(normalizePhone("44 161 1234567", "44")).toBe("+441611234567");
+  });
+
+  test("normalizes 0161 1234567", () => {
+    expect(normalizePhone("0161 1234567", "44")).toBe("+441611234567");
+  });
 });


### PR DESCRIPTION
Fixes cases like "44 0161 1234567", "+44 0161 1234567", and
"(44) 0161 1234567" where users include both the country code and
the leading zero from the local number format.

https://claude.ai/code/session_01Mi1d7HgZeyANTf3WhCM9r9