### PR TITLE
Add Square payment domain to CSP form-action directive

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -28,7 +28,7 @@ const buildCspHeader = (embeddable: boolean): string => {
     "style-src 'self'",
     "script-src 'self' https://*.squarecdn.com https://js.squareup.com https://js.squareupsandbox.com",
     "connect-src 'self' https://pci-connect.squareup.com https://pci-connect.squareupsandbox.com",
-    "form-action 'self' https://checkout.stripe.com",
+    "form-action 'self' https://checkout.stripe.com https://square.link",
   ];
   if (!embeddable) {
     directives.unshift("frame-ancestors 'none'");

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -101,7 +101,7 @@ describe("server (misc)", () => {
 
     describe("Content-Security-Policy", () => {
       const baseCsp =
-        "default-src 'self'; style-src 'self'; script-src 'self' https://*.squarecdn.com https://js.squareup.com https://js.squareupsandbox.com; connect-src 'self' https://pci-connect.squareup.com https://pci-connect.squareupsandbox.com; form-action 'self' https://checkout.stripe.com";
+        "default-src 'self'; style-src 'self'; script-src 'self' https://*.squarecdn.com https://js.squareup.com https://js.squareupsandbox.com; connect-src 'self' https://pci-connect.squareup.com https://pci-connect.squareupsandbox.com; form-action 'self' https://checkout.stripe.com https://square.link";
 
       test("non-embeddable pages have frame-ancestors 'none' and security restrictions", async () => {
         const response = await handleRequest(mockRequest("/"));


### PR DESCRIPTION
## Summary
Updated the Content Security Policy (CSP) header to allow form submissions to Square's payment domain in addition to the existing Stripe domain.

## Changes
- Added `https://square.link` to the `form-action` directive in the CSP header configuration
- Updated the corresponding test case to reflect the new CSP policy

## Details
The `form-action` directive now permits form submissions to both `https://checkout.stripe.com` and `https://square.link`, enabling support for Square payment processing alongside the existing Stripe integration. This change was made in both the middleware configuration and its test assertions to maintain consistency.

https://claude.ai/code/session_01LmKkjgy2xFRoQxYgUntLhe