### PR TITLE
Add security headers and event booking validation tests

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -14,6 +14,7 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
   "x-content-type-options": "nosniff",
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-robots-tag": "noindex, nofollow",
+  "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
 };
 
 /**

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -14,7 +14,6 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
   "x-content-type-options": "nosniff",
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-robots-tag": "noindex, nofollow",
-  "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
 };
 
 /**
@@ -46,6 +45,9 @@ export const getSecurityHeaders = (
   ...BASE_SECURITY_HEADERS,
   ...(!embeddable && { "x-frame-options": "DENY" }),
   ...(embeddable && { "x-robots-tag": "index, follow" }),
+  ...(getAllowedDomain() !== "localhost" && {
+    "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
+  }),
   "content-security-policy": buildCspHeader(embeddable),
 });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -3649,11 +3649,9 @@ describe("db", () => {
 
     test("checkBatchAvailability checks group capacity with date for daily events", async () => {
       const { checkBatchAvailability } = await import("#lib/db/attendees.ts");
-      const { e1, e2 } = await createCappedGroupWithEvents(
-        5,
-        "daily-batch",
-        { eventType: "daily" },
-      );
+      const { e1, e2 } = await createCappedGroupWithEvents(5, "daily-batch", {
+        eventType: "daily",
+      });
 
       // Both events in same group — combined quantity exceeds group cap for this date
       expect(

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -139,6 +139,13 @@ describe("server (misc)", () => {
         expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
       });
 
+      test("responses have Strict-Transport-Security header", async () => {
+        const response = await handleRequest(mockRequest("/"));
+        expect(response.headers.get("strict-transport-security")).toBe(
+          "max-age=63072000; includeSubDomains; preload",
+        );
+      });
+
       test("ticket pages also have base security headers", async () => {
         const response = await getTicketPageResponse();
         expect(response.headers.get("x-content-type-options")).toBe("nosniff");
@@ -146,6 +153,9 @@ describe("server (misc)", () => {
           "strict-origin-when-cross-origin",
         );
         expect(response.headers.get("x-robots-tag")).toBe("index, follow");
+        expect(response.headers.get("strict-transport-security")).toBe(
+          "max-age=63072000; includeSubDomains; preload",
+        );
       });
     });
   });
@@ -480,6 +490,9 @@ describe("server (misc)", () => {
       expect(response.headers.get("x-frame-options")).toBe("DENY");
       expect(response.headers.get("x-content-type-options")).toBe("nosniff");
       expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+      expect(response.headers.get("strict-transport-security")).toBe(
+        "max-age=63072000; includeSubDomains; preload",
+      );
     });
 
     test("logs debug message with host details on domain redirect", async () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -139,11 +139,21 @@ describe("server (misc)", () => {
         expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
       });
 
-      test("responses have Strict-Transport-Security header", async () => {
+      test("omits Strict-Transport-Security on localhost", async () => {
         const response = await handleRequest(mockRequest("/"));
-        expect(response.headers.get("strict-transport-security")).toBe(
-          "max-age=63072000; includeSubDomains; preload",
-        );
+        expect(response.headers.has("strict-transport-security")).toBe(false);
+      });
+
+      test("includes Strict-Transport-Security on non-localhost domains", async () => {
+        setAllowedDomainForTest("example.com");
+        try {
+          const response = await handleRequest(mockRequest("/"));
+          expect(response.headers.get("strict-transport-security")).toBe(
+            "max-age=63072000; includeSubDomains; preload",
+          );
+        } finally {
+          resetAllowedDomain();
+        }
       });
 
       test("ticket pages also have base security headers", async () => {
@@ -153,9 +163,6 @@ describe("server (misc)", () => {
           "strict-origin-when-cross-origin",
         );
         expect(response.headers.get("x-robots-tag")).toBe("index, follow");
-        expect(response.headers.get("strict-transport-security")).toBe(
-          "max-age=63072000; includeSubDomains; preload",
-        );
       });
     });
   });
@@ -490,9 +497,6 @@ describe("server (misc)", () => {
       expect(response.headers.get("x-frame-options")).toBe("DENY");
       expect(response.headers.get("x-content-type-options")).toBe("nosniff");
       expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
-      expect(response.headers.get("strict-transport-security")).toBe(
-        "max-age=63072000; includeSubDomains; preload",
-      );
     });
 
     test("logs debug message with host details on domain redirect", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4023,4 +4023,101 @@ describe("server (public routes)", () => {
       expectCheckoutRedirect(response);
     });
   });
+
+  describe("booking form event_id manipulation", () => {
+    test("single-ticket form ignores injected event_id field", async () => {
+      const target = await createTestEvent({
+        name: "Target Event",
+        maxAttendees: 50,
+      });
+      const other = await createTestEvent({
+        name: "Other Event",
+        maxAttendees: 50,
+      });
+
+      // Submit form to target event but inject other event's id
+      const response = await submitTicketForm(target.slug, {
+        name: "Mallory",
+        email: "mallory@example.com",
+        event_id: String(other.id),
+      });
+      // Booking succeeds (302 redirect to thank-you URL)
+      expect(response.status).toBe(302);
+
+      // Verify booking went to the URL's event, not the injected one
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const targetAttendees = await getAttendeesRaw(target.id);
+      const otherAttendees = await getAttendeesRaw(other.id);
+      expect(targetAttendees.length).toBe(1);
+      expect(otherAttendees.length).toBe(0);
+    });
+
+    test("multi-ticket form ignores quantity fields for events not in URL", async () => {
+      const event1 = await createTestEvent({
+        name: "Legit Event 1",
+        maxAttendees: 50,
+        maxQuantity: 5,
+      });
+      const event2 = await createTestEvent({
+        name: "Legit Event 2",
+        maxAttendees: 50,
+        maxQuantity: 5,
+      });
+      const secret = await createTestEvent({
+        name: "Secret Event",
+        maxAttendees: 50,
+        maxQuantity: 5,
+      });
+
+      // Submit multi-ticket form with only event1+event2 in URL
+      // but inject quantity for the secret event
+      const path = `/ticket/${event1.slug}+${event2.slug}`;
+      const getResponse = await handleRequest(mockRequest(path));
+      const csrfToken = getTicketCsrfToken(await getResponse.text());
+      if (!csrfToken) throw new Error("Failed to get CSRF token");
+
+      const response = await handleRequest(
+        mockFormRequest(path, {
+          name: "Mallory",
+          email: "mallory@example.com",
+          [`quantity_${event1.id}`]: "1",
+          [`quantity_${event2.id}`]: "0",
+          [`quantity_${secret.id}`]: "3",
+          csrf_token: csrfToken,
+        }),
+      );
+      expectReservedRedirectWithTokens(response);
+
+      // Verify only event1 was booked; secret event was not
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const attendees1 = await getAttendeesRaw(event1.id);
+      const attendees2 = await getAttendeesRaw(event2.id);
+      const secretAttendees = await getAttendeesRaw(secret.id);
+      expect(attendees1.length).toBe(1);
+      expect(attendees2.length).toBe(0);
+      expect(secretAttendees.length).toBe(0);
+    });
+
+    test("multi-ticket URL cannot book inactive events", async () => {
+      const active = await createTestEvent({
+        name: "Active Event",
+        maxAttendees: 50,
+      });
+      const inactive = await createTestEvent({
+        name: "Inactive Event",
+        maxAttendees: 50,
+      });
+      await deactivateTestEvent(inactive.id);
+
+      // Try to load multi-ticket page with inactive event in URL
+      const path = `/ticket/${active.slug}+${inactive.slug}`;
+      const getResponse = await handleRequest(mockRequest(path));
+      const html = await getResponse.text();
+
+      // Page should load but only show the active event
+      expect(html).toContain("Active Event");
+      expect(html).not.toContain("Inactive Event");
+    });
+
+  });
 });

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4118,6 +4118,5 @@ describe("server (public routes)", () => {
       expect(html).toContain("Active Event");
       expect(html).not.toContain("Inactive Event");
     });
-
   });
 });

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -682,4 +682,60 @@ describe("Public API", () => {
       expect(response.status).toBe(404);
     });
   });
+
+  describe("booking event_id manipulation", () => {
+    test("ignores event_id in JSON body", async () => {
+      const target = await createTestEvent({ maxAttendees: 50 });
+      const other = await createTestEvent({ maxAttendees: 50 });
+
+      const { response } = await bookEvent(target.slug, {
+        name: "Mallory",
+        email: "mallory@example.com",
+        event_id: other.id,
+      });
+      expect(response.status).toBe(200);
+
+      // Verify booking went to target (URL slug), not other (injected id)
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const targetAttendees = await getAttendeesRaw(target.id);
+      const otherAttendees = await getAttendeesRaw(other.id);
+      expect(targetAttendees.length).toBe(1);
+      expect(otherAttendees.length).toBe(0);
+    });
+
+    test("returns 404 for non-existent slug even with valid event_id in body", async () => {
+      const event = await createTestEvent({ maxAttendees: 50 });
+
+      const { response } = await bookEvent("nonexistent", {
+        name: "Mallory",
+        email: "mallory@example.com",
+        event_id: event.id,
+      });
+      expect(response.status).toBe(404);
+
+      // Verify no booking was created
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const attendees = await getAttendeesRaw(event.id);
+      expect(attendees.length).toBe(0);
+    });
+
+    test("ignores slug field in JSON body", async () => {
+      const target = await createTestEvent({ maxAttendees: 50 });
+      const other = await createTestEvent({ maxAttendees: 50 });
+
+      const { response } = await bookEvent(target.slug, {
+        name: "Mallory",
+        email: "mallory@example.com",
+        slug: other.slug,
+      });
+      expect(response.status).toBe(200);
+
+      // Booking goes to URL slug, body slug is ignored
+      const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+      const targetAttendees = await getAttendeesRaw(target.id);
+      const otherAttendees = await getAttendeesRaw(other.id);
+      expect(targetAttendees.length).toBe(1);
+      expect(otherAttendees.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds comprehensive security tests and implements Strict-Transport-Security (HSTS) headers for non-localhost domains. It also adds test coverage for event booking parameter validation to prevent event_id and slug injection attacks.

## Key Changes

### Security Headers
- Added HSTS header (`strict-transport-security: max-age=63072000; includeSubDomains; preload`) for non-localhost domains
- Header is omitted on localhost to avoid issues during local development
- Tests verify correct header presence/absence based on domain

### Event Booking Validation Tests
- **Single-ticket form**: Verifies that injected `event_id` fields are ignored and bookings use the URL slug
- **Multi-ticket form**: Ensures quantity fields for events not in the URL are ignored, preventing unauthorized bookings
- **Multi-ticket URL filtering**: Confirms inactive events in URLs are filtered out and not displayed
- **API endpoint tests**: Validates that `event_id` and `slug` fields in JSON request bodies are ignored in favor of URL parameters
- **404 handling**: Confirms proper 404 responses for non-existent slugs even when valid event IDs are provided in request bodies

## Implementation Details
- HSTS header implementation uses the existing `getAllowedDomain()` utility to determine if the domain is localhost
- All new tests follow existing patterns and use the test helper functions (`createTestEvent`, `deactivateTestEvent`, etc.)
- Tests verify both the HTTP response and database state to ensure bookings are created for the correct events

https://claude.ai/code/session_01MLfnJJqkiymwieDooDYANN