### PR TITLE
Allow managers to access group management features

### DIFF
--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -1,5 +1,5 @@
 /**
- * Admin group management routes - owner only
+ * Admin group management routes - accessible to owners and managers
  */
 
 import { compact, map } from "#fp";
@@ -27,7 +27,7 @@ import { defineNamedResource } from "#lib/rest/resource.ts";
 import { generateUniqueSlug, normalizeSlug } from "#lib/slug.ts";
 import { sortEvents } from "#lib/sort-events.ts";
 import { type Attendee, type Group, isPaidEvent } from "#lib/types.ts";
-import { createOwnerCrudHandlers } from "#routes/admin/owner-crud.ts";
+import { createCrudHandlers } from "#routes/admin/owner-crud.ts";
 import { requirePrivateKey } from "#routes/admin/utils.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { defineRoutes } from "#routes/router.ts";
@@ -36,8 +36,8 @@ import {
   htmlResponse,
   orNotFound,
   redirect,
-  requireOwnerOr,
-  withOwnerAuthForm,
+  requireSessionOr,
+  withAuthForm,
 } from "#routes/utils.ts";
 import {
   adminGroupDeletePage,
@@ -128,11 +128,11 @@ const groupsResource = defineNamedResource({
   onDelete: deleteGroup,
 });
 
-const crudCreate = createOwnerCrudHandlers({
+const crudCreate = createCrudHandlers({
   ...crudConfig,
   resource: wrapResourceForDemo(groupsCreateResource, GROUP_DEMO_FIELDS),
 });
-const crud = createOwnerCrudHandlers({
+const crud = createCrudHandlers({
   ...crudConfig,
   resource: wrapResourceForDemo(groupsResource, GROUP_DEMO_FIELDS),
 });
@@ -148,7 +148,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/group/:id"> = (
   request,
   { id },
 ) =>
-  requireOwnerOr(request, (session) =>
+  requireSessionOr(request, (session) =>
     withGroup(id, async (group) => {
       const [events, ungroupedEvents, holidays] = await Promise.all([
         getEventsByGroupId(id),
@@ -198,7 +198,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/group/:id"> = (
 const handleAddEventsToGroup: TypedRouteHandler<
   "POST /admin/group/:id/add-events"
 > = (request, { id }) =>
-  withOwnerAuthForm(request, (_session, form) =>
+  withAuthForm(request, (_session, form) =>
     withGroup(id, async (group) => {
       const eventIds = form
         .getAll("event_ids")

--- a/src/routes/admin/owner-crud.ts
+++ b/src/routes/admin/owner-crud.ts
@@ -8,10 +8,12 @@ import {
   orNotFound,
   redirect,
   requireOwnerOr,
+  requireSessionOr,
+  withAuthForm,
   withOwnerAuthForm,
 } from "#routes/utils.ts";
 
-type OwnerCrudConfig<Row, Input> = {
+type CrudConfig<Row, Input> = {
   singular: string;
   listPath: string;
   /** Redirect path after create/edit. Falls back to listPath when not provided. */
@@ -30,35 +32,59 @@ type OwnerCrudConfig<Row, Input> = {
   deleteConfirmError: string;
 };
 
+/** Create CRUD handlers that require owner role */
 export const createOwnerCrudHandlers = <Row, Input>(
-  cfg: OwnerCrudConfig<Row, Input>,
+  cfg: CrudConfig<Row, Input>,
+) => createCrudHandlersWithAuth(cfg, requireOwnerOr, withOwnerAuthForm);
+
+/** Create CRUD handlers accessible to any authenticated admin (owner or manager) */
+export const createCrudHandlers = <Row, Input>(cfg: CrudConfig<Row, Input>) =>
+  createCrudHandlersWithAuth(cfg, requireSessionOr, withAuthForm);
+
+type AuthGuard = (
+  request: Request,
+  handler: (session: AdminSession) => Response | Promise<Response>,
+) => Promise<Response>;
+
+type FormGuard = (
+  request: Request,
+  handler: (
+    session: AdminSession,
+    form: URLSearchParams,
+  ) => Response | Promise<Response>,
+) => Promise<Response>;
+
+const createCrudHandlersWithAuth = <Row, Input>(
+  cfg: CrudConfig<Row, Input>,
+  requireAuth: AuthGuard,
+  withFormAuth: FormGuard,
 ) => {
-  type OwnerFormHandler = (
+  type FormHandler = (
     session: AdminSession,
     form: URLSearchParams,
   ) => Response | Promise<Response>;
 
-  const ownerForm =
-    (handler: OwnerFormHandler) =>
+  const authForm =
+    (handler: FormHandler) =>
     (request: Request): Promise<Response> =>
-      withOwnerAuthForm(request, handler);
+      withFormAuth(request, handler);
 
-  const ownerFormForId =
-    (mkHandler: (id: number) => OwnerFormHandler) =>
+  const authFormForId =
+    (mkHandler: (id: number) => FormHandler) =>
     (request: Request, id: number): Promise<Response> =>
-      ownerForm(mkHandler(id))(request);
+      authForm(mkHandler(id))(request);
 
-  const ownerHtml =
+  const authHtml =
     (render: (session: AdminSession) => string | Promise<string>) =>
     (request: Request): Promise<Response> =>
-      requireOwnerOr(request, async (session) =>
+      requireAuth(request, async (session) =>
         htmlResponse(await render(session)),
       );
 
-  const ownerRowHtml =
+  const authRowHtml =
     (render: (row: Row, session: AdminSession) => string) =>
     (request: Request, id: number): Promise<Response> =>
-      requireOwnerOr(request, (session) =>
+      requireAuth(request, (session) =>
         orNotFound(cfg.resource.table.findById(id), (row) =>
           htmlResponse(render(row, session)),
         ),
@@ -74,15 +100,15 @@ export const createOwnerCrudHandlers = <Row, Input>(
   };
 
   const listGet = (request: Request): Promise<Response> =>
-    requireOwnerOr(request, async (session) => {
+    requireAuth(request, async (session) => {
       const rows = await cfg.getAll();
       const success = getSearchParam(request, "success") || undefined;
       return htmlResponse(cfg.renderList(rows, session, success));
     });
 
-  const newGet = ownerHtml(cfg.renderNew);
+  const newGet = authHtml(cfg.renderNew);
 
-  const createHandler: OwnerFormHandler = async (session, form) => {
+  const createHandler: FormHandler = async (session, form) => {
     const result = await cfg.resource.create(form);
     return result.ok
       ? await logAndRedirect(
@@ -93,9 +119,9 @@ export const createOwnerCrudHandlers = <Row, Input>(
       : htmlResponse(cfg.renderNew(session, result.error), 400);
   };
 
-  const createPost = ownerForm(createHandler);
+  const createPost = authForm(createHandler);
 
-  const editGet = ownerRowHtml(cfg.renderEdit);
+  const editGet = authRowHtml(cfg.renderEdit);
 
   const editHandler =
     (id: number) =>
@@ -114,9 +140,9 @@ export const createOwnerCrudHandlers = <Row, Input>(
       );
     };
 
-  const editPost = ownerFormForId(editHandler);
+  const editPost = authFormForId(editHandler);
 
-  const deleteGet = ownerRowHtml(cfg.renderDelete);
+  const deleteGet = authRowHtml(cfg.renderDelete);
 
   const deleteHandler =
     (id: number) =>
@@ -138,7 +164,7 @@ export const createOwnerCrudHandlers = <Row, Input>(
         return redirect(cfg.listPath, `${cfg.singular} deleted`, true);
       });
 
-  const deletePost = ownerFormForId(deleteHandler);
+  const deletePost = authFormForId(deleteHandler);
 
   return {
     listGet,

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -36,8 +36,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
       {session.adminLevel === "owner" &&
         navLink("/admin/settings", "Settings", active)}
       {navLink("/admin/log", "Log", active)}
-      {session.adminLevel === "owner" &&
-        navLink("/admin/groups", "Groups", active)}
+      {navLink("/admin/groups", "Groups", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/holidays", "Holidays", active)}
       {session.adminLevel === "owner" &&

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -46,11 +46,11 @@ describe("server (admin groups)", () => {
       expectAdminRedirect(response);
     });
 
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const response = await awaitTestRequest("/admin/groups", {
         cookie: await createTestManagerSession(),
       });
-      expectStatus(403)(response);
+      expectStatus(200)(response);
     });
 
     test("shows empty list when no groups exist", async () => {
@@ -83,11 +83,11 @@ describe("server (admin groups)", () => {
       expectAdminRedirect(response);
     });
 
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const response = await awaitTestRequest("/admin/group/new", {
         cookie: await createTestManagerSession(),
       });
-      expectStatus(403)(response);
+      expectStatus(200)(response);
     });
 
     test("shows create group form without slug field", async () => {
@@ -111,17 +111,24 @@ describe("server (admin groups)", () => {
       expectAdminRedirect(response);
     });
 
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const cookie = await createTestManagerSession("mgr-create-post");
       const csrfToken = await signCsrfToken();
       const response = await handleRequest(
         mockFormRequest(
           "/admin/group",
-          { name: "X", csrf_token: csrfToken },
+          {
+            name: "Manager Group",
+            terms_and_conditions: "",
+            csrf_token: csrfToken,
+          },
           cookie,
         ),
       );
-      expectStatus(403)(response);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toMatch(
+        /\/admin\/group\/\d+\?success=Group\+created$/,
+      );
     });
 
     test("creates group with auto-generated slug", async () => {
@@ -172,10 +179,10 @@ describe("server (admin groups)", () => {
   });
 
   describe("POST /admin/group/:id/edit", () => {
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const group = await createTestGroup({
-        name: "Edit Deny",
-        slug: "edit-deny",
+        name: "Edit Allow",
+        slug: "edit-allow",
       });
       const cookie = await createTestManagerSession("mgr-edit-post");
       const csrfToken = await signCsrfToken();
@@ -191,7 +198,10 @@ describe("server (admin groups)", () => {
           cookie,
         ),
       );
-      expectStatus(403)(response);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe(
+        `/admin/group/${group.id}?success=Group+updated`,
+      );
     });
 
     test("updates group", async () => {
@@ -251,10 +261,10 @@ describe("server (admin groups)", () => {
   });
 
   describe("POST /admin/group/:id/delete", () => {
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const group = await createTestGroup({
-        name: "Delete Deny",
-        slug: "delete-deny",
+        name: "Delete Allow",
+        slug: "delete-allow",
       });
       const cookie = await createTestManagerSession("mgr-delete-post");
       const csrfToken = await signCsrfToken();
@@ -262,13 +272,16 @@ describe("server (admin groups)", () => {
         mockFormRequest(
           `/admin/group/${group.id}/delete`,
           {
-            confirm_identifier: "Delete Deny",
+            confirm_identifier: "Delete Allow",
             csrf_token: csrfToken,
           },
           cookie,
         ),
       );
-      expectStatus(403)(response);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toMatch(
+        /\/admin\/groups\?success=Group\+deleted$/,
+      );
     });
 
     test("rejects deletion when name confirmation is wrong", async () => {
@@ -355,15 +368,15 @@ describe("server (admin groups)", () => {
       expectAdminRedirect(response);
     });
 
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const group = await createTestGroup({
-        name: "Detail Deny",
-        slug: "detail-deny",
+        name: "Detail Allow",
+        slug: "detail-allow",
       });
       const response = await awaitTestRequest(`/admin/group/${group.id}`, {
         cookie: await createTestManagerSession("mgr-detail"),
       });
-      expectStatus(403)(response);
+      expectStatus(200)(response);
     });
 
     test("returns 404 for non-existent group", async () => {
@@ -617,10 +630,10 @@ describe("server (admin groups)", () => {
       expectAdminRedirect(response);
     });
 
-    test("returns 403 for non-owner", async () => {
+    test("accessible to managers", async () => {
       const group = await createTestGroup({
-        name: "Add Deny",
-        slug: "add-deny",
+        name: "Add Allow",
+        slug: "add-allow",
       });
       const cookie = await createTestManagerSession("mgr-add-events");
       const csrfToken = await signCsrfToken();
@@ -628,13 +641,12 @@ describe("server (admin groups)", () => {
         mockFormRequest(
           `/admin/group/${group.id}/add-events`,
           {
-            event_ids: "1",
             csrf_token: csrfToken,
           },
           cookie,
         ),
       );
-      expectStatus(403)(response);
+      expect(response.status).toBe(302);
     });
 
     test("returns 404 for non-existent group", async () => {
@@ -862,13 +874,13 @@ describe("server (admin groups)", () => {
       expect(html).toContain("Groups");
     });
 
-    test("groups link not visible to managers", async () => {
+    test("groups link visible to managers", async () => {
       const response = await awaitTestRequest("/admin/", {
         cookie: await createTestManagerSession("mgr-groups-nav"),
       });
       expectStatus(200)(response);
       const html = await response.text();
-      expect(html).not.toContain("/admin/groups");
+      expect(html).toContain("/admin/groups");
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR extends group management functionality to allow managers (in addition to owners) to access and modify groups. Previously, these operations were restricted to owners only.

## Key Changes
- **Refactored CRUD handler creation**: Split `createOwnerCrudHandlers` into two functions:
  - `createOwnerCrudHandlers`: Maintains owner-only access using `requireOwnerOr` and `withOwnerAuthForm`
  - `createCrudHandlers`: New function for owner/manager access using `requireSessionOr` and `withAuthForm`
  - Extracted common logic into `createCrudHandlersWithAuth` to reduce duplication

- **Updated group management routes**: Changed from owner-only to manager-accessible:
  - Group CRUD operations (list, create, edit, delete) now use `createCrudHandlers`
  - Group detail view now uses `requireSessionOr` instead of `requireOwnerOr`
  - Add events to group endpoint now uses `withAuthForm` instead of `withOwnerAuthForm`

- **Updated navigation**: Groups link is now visible to managers in the admin navigation menu

- **Updated tests**: Modified test expectations to verify managers can now:
  - View group list and details
  - Create, edit, and delete groups
  - Add events to groups
  - Access the groups navigation link

## Implementation Details
- Introduced `AuthGuard` and `FormGuard` type aliases to abstract authentication/authorization logic
- Renamed internal helper functions (`ownerForm` → `authForm`, `ownerHtml` → `authHtml`, etc.) to reflect their broader applicability
- Updated documentation comments to reflect the new access levels

https://claude.ai/code/session_01MJbdMoa1eE1QGKfgLFcUXS