### PR TITLE
Force remove box-shadow from bulk-checkout button

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -931,7 +931,7 @@ button.bulk-checkout:hover {
   padding: 0;
   border: none;
   margin: 0;
-  box-shadow: none;
+  box-shadow: none !important;
 }
 
 button.link-button {


### PR DESCRIPTION
## Summary
Added `!important` flag to the `box-shadow: none` rule for the bulk-checkout button to ensure the shadow is properly removed and not overridden by other CSS rules.

## Key Changes
- Modified the `button.bulk-checkout` CSS rule to use `box-shadow: none !important` instead of `box-shadow: none`

## Details
This change ensures that the box-shadow removal for the bulk-checkout button takes precedence over any other CSS rules that might attempt to apply a shadow. This is a common pattern when dealing with CSS specificity issues where inherited or cascading styles need to be explicitly overridden.

https://claude.ai/code/session_0195nHXxnXQi1bNgLVtQtyf2