### PR TITLE
Remove default outline on dark theme form focus states

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -81,6 +81,7 @@ html[data-theme="dark"] {
 [data-theme="dark"] select:focus,
 [data-theme="dark"] textarea:focus {
   border-color: #ffffff;
+  outline: none;
 }
 [data-theme="dark"] table {
   border-width: 2px;


### PR DESCRIPTION
## Summary
This change removes the default browser outline from focused form elements (input, select, textarea) in dark theme mode, providing a cleaner visual appearance when the custom border-color is applied.

## Key Changes
- Added `outline: none;` to the dark theme focus styles for form inputs, selects, and textareas
- This prevents the default browser outline from appearing alongside the custom white border color, eliminating visual redundancy

## Implementation Details
The change applies to the existing dark theme focus selector `[data-theme="dark"] input:focus, [data-theme="dark"] select:focus, [data-theme="dark"] textarea:focus`, which already sets a white border color. By removing the outline, the focus state now relies solely on the border-color change for visual feedback, creating a more cohesive design.

https://claude.ai/code/session_01Ne1aeuV2gRLVBn4D6Zd4tX