### PR TITLE
Use non-null assertion in getQuestionWithAnswers

### DIFF
--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -349,7 +349,8 @@ export const getQuestionWithAnswers = async (
     [id],
   );
   if (rows.length === 0) return null;
-  return (await groupJoinedRows(rows))[0] ?? null;
+  // rows is non-empty so groupJoinedRows always returns at least one entry
+  return (await groupJoinedRows(rows))[0]!;
 };
 
 /** Get the next sort_order for a new answer in a question */


### PR DESCRIPTION
## Summary
Updated the `getQuestionWithAnswers` function to use a non-null assertion operator instead of the nullish coalescing operator when accessing the first element of the grouped rows.

## Changes
- Replaced `?? null` with `!` non-null assertion on the result of `groupJoinedRows(rows)[0]`
- Added clarifying comment explaining that `rows` is guaranteed to be non-empty at this point, so `groupJoinedRows` will always return at least one entry

## Details
Since the function already checks that `rows.length === 0` and returns early if true, the code path that reaches the return statement is guaranteed to have at least one row. The non-null assertion (`!`) more accurately reflects this logic guarantee compared to the previous nullish coalescing operator (`?? null`), which suggested the array access could return `undefined`.

https://claude.ai/code/session_01QuyswuXUrfamBNvCnJxJX7