### PR TITLE
Refactor getAllowedDomain test to use dedicated test helper

### DIFF
--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -161,14 +161,10 @@ describe("config", () => {
   });
 
   describe("getAllowedDomain", () => {
-    afterEach(() => {
-      Deno.env.set("ALLOWED_DOMAIN", "localhost");
-      resetAllowedDomain();
-    });
+    afterEach(() => resetAllowedDomain());
 
-    test("returns set value from environment", () => {
-      Deno.env.set("ALLOWED_DOMAIN", "example.com");
-      resetAllowedDomain();
+    test("returns set value via test override", () => {
+      setAllowedDomainForTest("example.com");
       expect(getAllowedDomain()).toBe("example.com");
     });
 


### PR DESCRIPTION
## Summary
Updated the `getAllowedDomain` test suite to use a dedicated test helper function instead of directly manipulating environment variables and calling internal reset functions.

## Key Changes
- Replaced `Deno.env.set()` and `resetAllowedDomain()` calls with `setAllowedDomainForTest()` helper function
- Simplified `afterEach` cleanup to only call `resetAllowedDomain()`, removing redundant environment variable reset
- Updated test description from "returns set value from environment" to "returns set value via test override" to better reflect the new testing approach

## Implementation Details
This change improves test maintainability by:
- Providing a clearer, more explicit API for test setup (`setAllowedDomainForTest`)
- Reducing direct coupling to environment variables in tests
- Making the test intent more obvious through the helper function name

https://claude.ai/code/session_013etzUGk5vtf1UyXgkQMn8o