### PR TITLE
Improve test error handling and fix SQL query

### DIFF
--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -197,7 +197,8 @@ export const getQuestionsForEvent = async (
     await queryAll<JoinedRow>(
       `SELECT ${QA_COLS}
        FROM event_questions eq
-       JOIN ${QA_JOIN} ON q.id = eq.question_id
+       JOIN questions q ON q.id = eq.question_id
+       LEFT JOIN answers a ON a.question_id = q.id
        WHERE eq.event_id = ?
        ORDER BY eq.sort_order, a.sort_order`,
       [eventId],

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -377,6 +377,15 @@ export const handleRequest = async (
             );
           } catch (error) {
             logError({ code: ErrorCode.CDN_REQUEST, detail: String(error) });
+            // In tests, surface the real error instead of swallowing it
+            // behind a generic "Temporary Error" page
+            if (
+              Deno.env.get("TEST_RETHROW_ERRORS") &&
+              !(error instanceof SessionKeyError) &&
+              !Deno.env.get("TEST_EXPECT_ERROR")
+            ) {
+              throw error;
+            }
             if (error instanceof SessionKeyError) {
               return logAndReturn(
                 redirectResponse("/admin", clearSessionCookie()),

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -78,6 +78,7 @@ export const setupTestEncryptionKey = (): void => {
   Deno.env.set("TEST_SKIP_LOGIN_DELAY", "1"); // Skip timing-attack delay in tests
   Deno.env.set("TEST_RSA_KEY_SIZE", "1024"); // Use smaller RSA keys for faster test setup
   Deno.env.set("TEST_SUPPRESS_REQUEST_LOGS", "1"); // Reduce test output noise
+  Deno.env.set("TEST_RETHROW_ERRORS", "1"); // Surface real errors instead of "Temporary Error" page
   clearEncryptionKeyCache();
 };
 
@@ -402,6 +403,20 @@ export const urlFromFetchInput = (input: string | URL | Request): string =>
     : input instanceof URL
       ? input.toString()
       : input.url;
+
+/**
+ * Run a callback that intentionally triggers an error caught by handleRequest.
+ * Temporarily sets TEST_EXPECT_ERROR so the error is returned as a response
+ * instead of being rethrown by the TEST_RETHROW_ERRORS guard.
+ */
+export const withExpectedError = bracket(
+  () => {
+    Deno.env.set("TEST_EXPECT_ERROR", "1");
+  },
+  () => {
+    Deno.env.delete("TEST_EXPECT_ERROR");
+  },
+);
 
 /**
  * Swap globalThis.fetch for the duration of a callback, using bracket for safe restore.

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -32,6 +32,7 @@ import {
   submitTicketForm,
   testCookie,
   testCsrfToken,
+  withExpectedError,
   updateTestEvent,
 } from "#test-utils";
 
@@ -2180,20 +2181,22 @@ describe("server (admin events)", () => {
       });
 
       try {
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/event",
-            {
-              name: "Collision Event",
-              max_attendees: "50",
-              max_quantity: "1",
-              thank_you_url: "https://example.com",
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        await expectHtmlResponse(response, 503, "Temporary Error");
+        await withExpectedError(async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/event",
+              {
+                name: "Collision Event",
+                max_attendees: "50",
+                max_quantity: "1",
+                thank_you_url: "https://example.com",
+                csrf_token: await testCsrfToken(),
+              },
+              await testCookie(),
+            ),
+          );
+          await expectHtmlResponse(response, 503, "Temporary Error");
+        });
       } finally {
         executeStub.restore();
       }

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -18,6 +18,7 @@ import {
   testCookie,
   testCsrfToken,
   updateTestEvent,
+  withExpectedError,
   withFetchMock,
 } from "#test-utils";
 
@@ -530,16 +531,18 @@ describe("server (event images)", () => {
     });
 
     test("propagates non-404 storage errors as 503", async () => {
-      await withCdnProxy(
-        () => new Response("Unauthorized", { status: 401 }),
-        async () => {
-          await expectHtmlResponse(
-            await proxyRequest(),
-            503,
-            "Temporary Error",
-          );
-        },
-      );
+      await withExpectedError(async () => {
+        await withCdnProxy(
+          () => new Response("Unauthorized", { status: 401 }),
+          async () => {
+            await expectHtmlResponse(
+              await proxyRequest(),
+              503,
+              "Temporary Error",
+            );
+          },
+        );
+      });
     });
 
     test("returns 404 for unknown extension", async () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { spy } from "@std/testing/mock";
+import { spy, stub } from "@std/testing/mock";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import {
@@ -727,6 +727,23 @@ describe("server (misc)", () => {
       expect(response.headers.get("content-type")).toBe(
         "text/html; charset=utf-8",
       );
+    });
+
+    test("rethrows unhandled errors in test mode", async () => {
+      const { getDb: getDbFn } = await import("#lib/db/client.ts");
+      const { invalidateEventsCache } = await import("#lib/db/events.ts");
+      const db = getDbFn();
+      invalidateEventsCache();
+      const executeStub = stub(db, "execute", () => {
+        throw new Error("synthetic db failure");
+      });
+      try {
+        await expect(
+          handleRequest(mockRequest("/ticket/nonexistent")),
+        ).rejects.toThrow("synthetic db failure");
+      } finally {
+        executeStub.restore();
+      }
     });
 
     test("SessionKeyError clears cookie and redirects to /admin", async () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -26,6 +26,7 @@ import {
   resetDb,
   resetTestSlugCounter,
   testCookie,
+  withExpectedError,
 } from "#test-utils";
 
 describe("server (misc)", () => {
@@ -739,16 +740,18 @@ describe("server (misc)", () => {
       });
       invalidateSettingsCache();
 
-      // Hit admin dashboard (GET /admin with session) which calls requirePrivateKey
-      const response = await handleRequest(
-        mockRequest("/admin", { headers: { cookie: await testCookie() } }),
-      );
+      await withExpectedError(async () => {
+        // Hit admin dashboard (GET /admin with session) which calls requirePrivateKey
+        const response = await handleRequest(
+          mockRequest("/admin", { headers: { cookie: await testCookie() } }),
+        );
 
-      expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin");
-      const setCookie = response.headers.get("set-cookie")!;
-      expect(setCookie).toContain("session=");
-      expect(setCookie).toContain("Max-Age=0");
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe("/admin");
+        const setCookie = response.headers.get("set-cookie")!;
+        expect(setCookie).toContain("session=");
+        expect(setCookie).toContain("Max-Age=0");
+      });
     });
   });
 });

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -14,6 +14,7 @@ import {
   mockSetupFormRequest,
   resetDb,
   resetTestSlugCounter,
+  withExpectedError,
   withMocks,
 } from "#test-utils";
 
@@ -181,28 +182,30 @@ describe("server (setup)", () => {
         const getResponse = await handleRequest(mockRequest("/setup/"));
         const csrfToken = getSetupCsrfToken(await getResponse.text());
 
-        await withMocks(
-          () => ({
-            mockCompleteSetup: stub(settingsApi, "completeSetup", () =>
-              Promise.reject(new Error("Database error")),
-            ),
-            mockConsoleError: stub(console, "error", () => {}),
-          }),
-          async () => {
-            const response = await handleRequest(
-              mockSetupFormRequest(
-                {
-                  admin_username: "testadmin",
-                  admin_password: "mypassword123",
-                  admin_password_confirm: "mypassword123",
-                  country: "GB",
-                },
-                csrfToken as string,
+        await withExpectedError(async () => {
+          await withMocks(
+            () => ({
+              mockCompleteSetup: stub(settingsApi, "completeSetup", () =>
+                Promise.reject(new Error("Database error")),
               ),
-            );
-            await expectHtmlResponse(response, 503, "Temporary Error");
-          },
-        );
+              mockConsoleError: stub(console, "error", () => {}),
+            }),
+            async () => {
+              const response = await handleRequest(
+                mockSetupFormRequest(
+                  {
+                    admin_username: "testadmin",
+                    admin_password: "mypassword123",
+                    admin_password_confirm: "mypassword123",
+                    country: "GB",
+                  },
+                  csrfToken as string,
+                ),
+              );
+              await expectHtmlResponse(response, 503, "Temporary Error");
+            },
+          );
+        });
       });
 
       test("PUT /setup/ redirects to /setup/ (unsupported method)", async () => {


### PR DESCRIPTION
## Summary
This PR improves test error handling by introducing a new `withExpectedError` utility and fixes a SQL query bug in the questions module.

## Key Changes

- **Test Error Handling**: Added `withExpectedError` utility function that temporarily sets `TEST_EXPECT_ERROR` environment variable to allow intentional errors in tests to be caught and returned as responses instead of being rethrown by the `TEST_RETHROW_ERRORS` guard.

- **Error Rethrow Logic**: Updated `handleRequest` in `src/routes/index.ts` to check for `TEST_RETHROW_ERRORS` and `TEST_EXPECT_ERROR` flags, allowing tests to surface real errors instead of generic "Temporary Error" pages when appropriate.

- **Test Updates**: Wrapped multiple test cases that intentionally trigger errors with `withExpectedError()` in:
  - `server-setup.test.ts` (setup form error handling)
  - `server-events.test.ts` (event creation error handling)
  - `server-images.test.ts` (CDN proxy error handling)
  - `server-misc.test.ts` (private key requirement error handling)

- **SQL Query Fix**: Fixed malformed SQL query in `src/lib/db/questions.ts` by replacing the incomplete `JOIN ${QA_JOIN}` with explicit `JOIN questions q` and `LEFT JOIN answers a` clauses.

- **Test Setup**: Added `TEST_RETHROW_ERRORS` environment variable to `setupTestEncryptionKey()` to enable error rethrowing by default in tests.

## Implementation Details

The `withExpectedError` utility uses a bracket pattern (setup/teardown) to manage the `TEST_EXPECT_ERROR` flag lifecycle, ensuring clean state even if the callback throws. This allows tests to verify error handling behavior while maintaining the ability to surface real errors for debugging when needed.

https://claude.ai/code/session_01EKd8gTmoTxNpBKRep7HXPw