### PR TITLE
Support multi-ticket payment cancellation flow

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -870,14 +870,15 @@ const handlePaymentCancel = withSessionId(async (sid) => {
     return paymentErrorResponse("Payment session not found");
   }
 
-  const intent = extractIntent(session);
+  // Multi-ticket sessions store event IDs in metadata.items, not event_id
+  const eventId = isMultiSession(session.metadata)
+    ? (extractMultiIntent(session)?.items[0]?.e ?? 0)
+    : extractIntent(session).eventId;
 
   // Use getEvent (not getEventWithCount) - we only need slug for redirect
-  const event = await getEvent(intent.eventId);
+  const event = await getEvent(eventId);
   if (!event) {
-    logCancelError(
-      `Event not found (session=${sid}, eventId=${intent.eventId})`,
-    );
+    logCancelError(`Event not found (session=${sid}, eventId=${eventId})`);
     return paymentErrorResponse("Event not found", 404);
   }
 

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -947,8 +947,8 @@ export const adminGuidePage = (
             <strong>Owners</strong> have full access: events, calendar, groups,
             users, settings, holidays, sessions, and the activity log.{" "}
             <strong>Managers</strong> can see events, the calendar, groups, and
-            the activity log. They cannot change settings, manage users, or
-            view sessions.
+            the activity log. They cannot change settings, manage users, or view
+            sessions.
           </p>
         </Q>
 

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -372,6 +372,89 @@ describe("server (payment flow)", () => {
         resetStripeClient,
       );
     });
+
+    test("shows cancel page for multi-ticket session", async () => {
+      const { stub } = await import("@std/testing/mock");
+      const { stripeApi } = await import("#lib/stripe.ts");
+      await setupStripe();
+
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+        unitPrice: 1000,
+      });
+      const event2 = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+        unitPrice: 2000,
+      });
+
+      await withMocks(
+        () =>
+          stub(stripeApi, "retrieveCheckoutSession", () =>
+            Promise.resolve({
+              id: "cs_test_cancel_multi",
+              payment_status: "unpaid",
+              metadata: {
+                multi: "1",
+                name: "John",
+                email: "john@example.com",
+                items: JSON.stringify([
+                  { e: event.id, q: 1, p: 1000 },
+                  { e: event2.id, q: 2, p: 4000 },
+                ]),
+              },
+            } as unknown as Awaited<
+              ReturnType<typeof stripeApi.retrieveCheckoutSession>
+            >),
+          ),
+        async () => {
+          const response = await handleRequest(
+            mockRequest("/payment/cancel?session_id=cs_test_cancel_multi"),
+          );
+          await expectHtmlResponse(
+            response,
+            200,
+            "Payment Cancelled",
+            `/ticket/${event.slug}`,
+          );
+        },
+        resetStripeClient,
+      );
+    });
+
+    test("returns 404 for multi-ticket session with invalid items", async () => {
+      const { stub } = await import("@std/testing/mock");
+      const { stripeApi } = await import("#lib/stripe.ts");
+      await setupStripe();
+
+      await withMocks(
+        () =>
+          stub(stripeApi, "retrieveCheckoutSession", () =>
+            Promise.resolve({
+              id: "cs_test_cancel_bad_multi",
+              payment_status: "unpaid",
+              metadata: {
+                multi: "1",
+                name: "John",
+                email: "john@example.com",
+                items: "[]", // Empty items array
+              },
+            } as unknown as Awaited<
+              ReturnType<typeof stripeApi.retrieveCheckoutSession>
+            >),
+          ),
+        async () => {
+          const response = await handleRequest(
+            mockRequest(
+              "/payment/cancel?session_id=cs_test_cancel_bad_multi",
+            ),
+          );
+          await expectHtmlResponse(response, 404, "Event not found");
+        },
+        resetStripeClient,
+      );
+    });
   });
 
   describe("payment routes", () => {


### PR DESCRIPTION
## Summary
This PR adds support for handling payment cancellations in multi-ticket checkout sessions, where customers purchase tickets for multiple events in a single transaction.

## Key Changes
- **Payment cancellation handler**: Updated `handlePaymentCancel` in `src/routes/webhooks.ts` to detect and properly handle multi-ticket sessions by extracting the event ID from the `metadata.items` array instead of the `event_id` field
- **Test coverage**: Added two new test cases in `test/lib/server-payments.test.ts`:
  - Test for successful cancellation page display for multi-ticket sessions
  - Test for proper 404 handling when multi-ticket session has invalid/empty items
- **Minor formatting**: Fixed line wrapping in admin guide documentation for consistency

## Implementation Details
- Multi-ticket sessions are identified by checking `metadata.multi` flag
- Event ID extraction uses `extractMultiIntent()` helper to parse the items array and retrieve the first event's ID
- Maintains backward compatibility with single-ticket sessions using the existing `extractIntent()` logic
- Error handling returns appropriate 404 response when event is not found for either session type

https://claude.ai/code/session_01AgdvRrdWCKPQaBf9AVfCwo