### PR TITLE
Make CSP header dynamic based on payment provider configuration

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -158,8 +158,10 @@ const loadApiRoutes = once(async () => {
   return routeApi;
 });
 
+export type { PaymentCspConfig } from "#routes/middleware.ts";
 // Re-export middleware functions for testing
 export {
+  buildCspHeader,
   getCleanUrl,
   getSecurityHeaders,
   isEmbeddablePath,

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -6,7 +6,6 @@ import {
   getAllowedDomain,
   getEmbedHosts,
   getPaymentProvider,
-  getSquareSandbox,
 } from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
@@ -21,26 +20,9 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
   "x-robots-tag": "noindex, nofollow",
 };
 
-/** Square CDN domain for sandbox vs production */
-const SQUARE_CDN = {
-  sandbox: "https://sandbox.web.squarecdn.com",
-  production: "https://web.squarecdn.com",
-} as const;
-
-/** Square PCI connect domain for sandbox vs production */
-const SQUARE_PCI = {
-  sandbox: "https://pci-connect.squareupsandbox.com",
-  production: "https://pci-connect.squareup.com",
-} as const;
-
-/** Square font domains (same for sandbox and production) */
-const SQUARE_FONT_DOMAINS =
-  "https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net";
-
 /** Payment config for CSP header construction */
 export type PaymentCspConfig = {
   provider: "stripe" | "square" | null;
-  squareSandbox?: boolean;
 };
 
 /**
@@ -49,6 +31,8 @@ export type PaymentCspConfig = {
  * Embeddable pages omit frame-ancestors here; it's added by applySecurityHeaders
  * if embed host restrictions are configured.
  * Payment-specific directives are included only when a provider is configured.
+ * Both Stripe and Square use server-side redirect flows (not embedded SDKs),
+ * so only form-action needs provider-specific domains.
  */
 export const buildCspHeader = (
   embeddable: boolean,
@@ -57,18 +41,7 @@ export const buildCspHeader = (
   const directives = ["default-src 'self'"];
 
   if (payment?.provider === "square") {
-    const cdn = payment.squareSandbox
-      ? SQUARE_CDN.sandbox
-      : SQUARE_CDN.production;
-    const pci = payment.squareSandbox
-      ? SQUARE_PCI.sandbox
-      : SQUARE_PCI.production;
     directives.push(
-      `style-src 'self' ${cdn}`,
-      `script-src 'self' ${cdn}`,
-      `frame-src 'self' ${cdn}`,
-      `connect-src 'self' ${pci} https://o160250.ingest.sentry.io`,
-      `font-src ${SQUARE_FONT_DOMAINS}`,
       "form-action 'self' https://square.link https://checkout.square.site",
     );
   } else if (payment?.provider === "stripe") {
@@ -301,11 +274,9 @@ export const applySecurityHeaders = async (
 
   // Rebuild CSP with payment-provider-specific directives
   const provider = await getPaymentProvider();
-  const squareSandbox =
-    provider === "square" ? await getSquareSandbox() : undefined;
   response.headers.set(
     "content-security-policy",
-    buildCspHeader(embeddable, { provider, squareSandbox }),
+    buildCspHeader(embeddable, { provider }),
   );
 
   // Override x-robots-tag for hidden events (signal header set by route handlers)

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -2,7 +2,12 @@
  * Middleware functions for request processing
  */
 
-import { getAllowedDomain, getEmbedHosts } from "#lib/config.ts";
+import {
+  getAllowedDomain,
+  getEmbedHosts,
+  getPaymentProvider,
+  getSquareSandbox,
+} from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
 import { encodeBody } from "#routes/utils.ts";
@@ -16,20 +21,62 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
   "x-robots-tag": "noindex, nofollow",
 };
 
+/** Square CDN domain for sandbox vs production */
+const SQUARE_CDN = {
+  sandbox: "https://sandbox.web.squarecdn.com",
+  production: "https://web.squarecdn.com",
+} as const;
+
+/** Square PCI connect domain for sandbox vs production */
+const SQUARE_PCI = {
+  sandbox: "https://pci-connect.squareupsandbox.com",
+  production: "https://pci-connect.squareup.com",
+} as const;
+
+/** Square font domains (same for sandbox and production) */
+const SQUARE_FONT_DOMAINS =
+  "https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net";
+
+/** Payment config for CSP header construction */
+export type PaymentCspConfig = {
+  provider: "stripe" | "square" | null;
+  squareSandbox?: boolean;
+};
+
 /**
  * Build CSP header value
  * Non-embeddable pages get frame-ancestors 'none' to prevent clickjacking.
  * Embeddable pages omit frame-ancestors here; it's added by applySecurityHeaders
  * if embed host restrictions are configured.
+ * Payment-specific directives are included only when a provider is configured.
  */
-const buildCspHeader = (embeddable: boolean): string => {
-  const directives = [
-    "default-src 'self'",
-    "style-src 'self'",
-    "script-src 'self' https://*.squarecdn.com https://js.squareup.com https://js.squareupsandbox.com",
-    "connect-src 'self' https://pci-connect.squareup.com https://pci-connect.squareupsandbox.com",
-    "form-action 'self' https://checkout.stripe.com https://square.link https://checkout.square.site",
-  ];
+export const buildCspHeader = (
+  embeddable: boolean,
+  payment?: PaymentCspConfig,
+): string => {
+  const directives = ["default-src 'self'"];
+
+  if (payment?.provider === "square") {
+    const cdn = payment.squareSandbox
+      ? SQUARE_CDN.sandbox
+      : SQUARE_CDN.production;
+    const pci = payment.squareSandbox
+      ? SQUARE_PCI.sandbox
+      : SQUARE_PCI.production;
+    directives.push(
+      `style-src 'self' ${cdn}`,
+      `script-src 'self' ${cdn}`,
+      `frame-src 'self' ${cdn}`,
+      `connect-src 'self' ${pci} https://o160250.ingest.sentry.io`,
+      `font-src ${SQUARE_FONT_DOMAINS}`,
+      "form-action 'self' https://square.link https://checkout.square.site",
+    );
+  } else if (payment?.provider === "stripe") {
+    directives.push("form-action 'self' https://checkout.stripe.com");
+  } else {
+    directives.push("form-action 'self'");
+  }
+
   if (!embeddable) {
     directives.unshift("frame-ancestors 'none'");
   }
@@ -251,6 +298,15 @@ export const applySecurityHeaders = async (
   for (const [key, value] of Object.entries(securityHeaders)) {
     response.headers.set(key, value);
   }
+
+  // Rebuild CSP with payment-provider-specific directives
+  const provider = await getPaymentProvider();
+  const squareSandbox =
+    provider === "square" ? await getSquareSandbox() : undefined;
+  response.headers.set(
+    "content-security-policy",
+    buildCspHeader(embeddable, { provider, squareSandbox }),
+  );
 
   // Override x-robots-tag for hidden events (signal header set by route handlers)
   if (response.headers.has("x-robots-noindex")) {

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -6,6 +6,7 @@ import {
   getAllowedDomain,
   getEmbedHosts,
   getPaymentProvider,
+  getSquareSandbox,
 } from "#lib/config.ts";
 import { buildFrameAncestors } from "#lib/embed-hosts.ts";
 import { SCAN_API_PATTERN } from "#routes/admin/scanner.ts";
@@ -23,6 +24,7 @@ const BASE_SECURITY_HEADERS: Record<string, string> = {
 /** Payment config for CSP header construction */
 export type PaymentCspConfig = {
   provider: "stripe" | "square" | null;
+  sandbox?: boolean;
 };
 
 /**
@@ -41,8 +43,11 @@ export const buildCspHeader = (
   const directives = ["default-src 'self'"];
 
   if (payment?.provider === "square") {
+    const sq = payment.sandbox
+      ? "https://connect.squareupsandbox.com https://pci-connect.squareupsandbox.com https://api.squareupsandbox.com"
+      : "https://connect.squareup.com https://pci-connect.squareup.com https://api.squareup.com";
     directives.push(
-      "form-action 'self' https://square.link https://checkout.square.site",
+      `form-action 'self' https://square.link https://checkout.square.site https://*.squarecdn.com https://geoissuer.cardinalcommerce.com ${sq}`,
     );
   } else if (payment?.provider === "stripe") {
     directives.push("form-action 'self' https://checkout.stripe.com");
@@ -274,9 +279,10 @@ export const applySecurityHeaders = async (
 
   // Rebuild CSP with payment-provider-specific directives
   const provider = await getPaymentProvider();
+  const sandbox = provider === "square" ? await getSquareSandbox() : undefined;
   response.headers.set(
     "content-security-policy",
-    buildCspHeader(embeddable, { provider }),
+    buildCspHeader(embeddable, { provider, sandbox }),
   );
 
   // Override x-robots-tag for hidden events (signal header set by route handlers)

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -138,20 +138,45 @@ describe("server (misc)", () => {
         }
       });
 
-      test("includes Square CSP directives when Square is configured", async () => {
-        const { setPaymentProvider, invalidateSettingsCache } = await import(
-          "#lib/db/settings.ts"
-        );
+      test("includes Square production CSP directives when Square is configured", async () => {
+        const {
+          setPaymentProvider,
+          invalidateSettingsCache,
+          updateSquareSandbox,
+        } = await import("#lib/db/settings.ts");
         await setPaymentProvider("square");
+        await updateSquareSandbox(false);
         invalidateSettingsCache();
         try {
           const response = await handleRequest(mockRequest("/"));
           expect(response.headers.get("content-security-policy")).toBe(
-            "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site",
+            "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site https://*.squarecdn.com https://geoissuer.cardinalcommerce.com https://connect.squareup.com https://pci-connect.squareup.com https://api.squareup.com",
           );
         } finally {
           const { clearPaymentProvider } = await import("#lib/db/settings.ts");
           await clearPaymentProvider();
+          invalidateSettingsCache();
+        }
+      });
+
+      test("includes Square sandbox CSP directives when sandbox mode is enabled", async () => {
+        const {
+          setPaymentProvider,
+          invalidateSettingsCache,
+          updateSquareSandbox,
+        } = await import("#lib/db/settings.ts");
+        await setPaymentProvider("square");
+        await updateSquareSandbox(true);
+        invalidateSettingsCache();
+        try {
+          const response = await handleRequest(mockRequest("/"));
+          expect(response.headers.get("content-security-policy")).toBe(
+            "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site https://*.squarecdn.com https://geoissuer.cardinalcommerce.com https://connect.squareupsandbox.com https://pci-connect.squareupsandbox.com https://api.squareupsandbox.com",
+          );
+        } finally {
+          const { clearPaymentProvider } = await import("#lib/db/settings.ts");
+          await clearPaymentProvider();
+          await updateSquareSandbox(false);
           invalidateSettingsCache();
         }
       });
@@ -223,15 +248,28 @@ describe("server (misc)", () => {
       );
     });
 
-    test("includes Square redirect domains when Square is configured", () => {
-      const csp = buildCspHeader(false, { provider: "square" });
+    test("includes Square production domains when sandbox is false", () => {
+      const csp = buildCspHeader(false, { provider: "square", sandbox: false });
       expect(csp).toBe(
-        "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site",
+        "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site https://*.squarecdn.com https://geoissuer.cardinalcommerce.com https://connect.squareup.com https://pci-connect.squareup.com https://api.squareup.com",
       );
     });
 
+    test("includes Square sandbox domains when sandbox is true", () => {
+      const csp = buildCspHeader(false, { provider: "square", sandbox: true });
+      expect(csp).toBe(
+        "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site https://*.squarecdn.com https://geoissuer.cardinalcommerce.com https://connect.squareupsandbox.com https://pci-connect.squareupsandbox.com https://api.squareupsandbox.com",
+      );
+    });
+
+    test("Square defaults to production domains when sandbox is undefined", () => {
+      const csp = buildCspHeader(false, { provider: "square" });
+      expect(csp).toContain("https://connect.squareup.com");
+      expect(csp).not.toContain("squareupsandbox");
+    });
+
     test("Square embeddable page omits frame-ancestors", () => {
-      const csp = buildCspHeader(true, { provider: "square" });
+      const csp = buildCspHeader(true, { provider: "square", sandbox: false });
       expect(csp).not.toContain("frame-ancestors");
       expect(csp).toContain("form-action 'self' https://square.link");
     });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -4,6 +4,7 @@ import { spy } from "@std/testing/mock";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import {
+  buildCspHeader,
   getCleanUrl,
   handleRequest,
   isValidContentType,
@@ -100,8 +101,7 @@ describe("server (misc)", () => {
     });
 
     describe("Content-Security-Policy", () => {
-      const baseCsp =
-        "default-src 'self'; style-src 'self'; script-src 'self' https://*.squarecdn.com https://js.squareup.com https://js.squareupsandbox.com; connect-src 'self' https://pci-connect.squareup.com https://pci-connect.squareupsandbox.com; form-action 'self' https://checkout.stripe.com https://square.link https://checkout.square.site";
+      const baseCsp = "default-src 'self'; form-action 'self'";
 
       test("non-embeddable pages have frame-ancestors 'none' and security restrictions", async () => {
         const response = await handleRequest(mockRequest("/"));
@@ -118,6 +118,89 @@ describe("server (misc)", () => {
       test("multi-slug ticket page allows embedding (no frame-ancestors)", async () => {
         const response = await getMultiSlugTicketPageResponse();
         expect(response.headers.get("content-security-policy")).toBe(baseCsp);
+      });
+
+      test("includes Stripe CSP directives when Stripe is configured", async () => {
+        const { setPaymentProvider, invalidateSettingsCache } = await import(
+          "#lib/db/settings.ts"
+        );
+        await setPaymentProvider("stripe");
+        invalidateSettingsCache();
+        try {
+          const response = await handleRequest(mockRequest("/"));
+          expect(response.headers.get("content-security-policy")).toBe(
+            "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://checkout.stripe.com",
+          );
+        } finally {
+          const { clearPaymentProvider } = await import("#lib/db/settings.ts");
+          await clearPaymentProvider();
+          invalidateSettingsCache();
+        }
+      });
+
+      test("includes Square production CSP directives when Square is configured", async () => {
+        const {
+          setPaymentProvider,
+          updateSquareSandbox,
+          invalidateSettingsCache,
+        } = await import("#lib/db/settings.ts");
+        await setPaymentProvider("square");
+        await updateSquareSandbox(false);
+        invalidateSettingsCache();
+        try {
+          const response = await handleRequest(mockRequest("/"));
+          const csp = response.headers.get("content-security-policy")!;
+          expect(csp).toContain("script-src 'self' https://web.squarecdn.com");
+          expect(csp).toContain("frame-src 'self' https://web.squarecdn.com");
+          expect(csp).toContain("style-src 'self' https://web.squarecdn.com");
+          expect(csp).toContain(
+            "connect-src 'self' https://pci-connect.squareup.com",
+          );
+          expect(csp).toContain(
+            "font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net",
+          );
+          expect(csp).toContain(
+            "form-action 'self' https://square.link https://checkout.square.site",
+          );
+        } finally {
+          const { clearPaymentProvider } = await import("#lib/db/settings.ts");
+          await clearPaymentProvider();
+          invalidateSettingsCache();
+        }
+      });
+
+      test("includes Square sandbox CSP directives when Square sandbox is enabled", async () => {
+        const {
+          setPaymentProvider,
+          updateSquareSandbox,
+          invalidateSettingsCache,
+        } = await import("#lib/db/settings.ts");
+        await setPaymentProvider("square");
+        await updateSquareSandbox(true);
+        invalidateSettingsCache();
+        try {
+          const response = await handleRequest(mockRequest("/"));
+          const csp = response.headers.get("content-security-policy")!;
+          expect(csp).toContain(
+            "script-src 'self' https://sandbox.web.squarecdn.com",
+          );
+          expect(csp).toContain(
+            "frame-src 'self' https://sandbox.web.squarecdn.com",
+          );
+          expect(csp).toContain(
+            "style-src 'self' https://sandbox.web.squarecdn.com",
+          );
+          expect(csp).toContain(
+            "connect-src 'self' https://pci-connect.squareupsandbox.com",
+          );
+          expect(csp).toContain(
+            "font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net",
+          );
+        } finally {
+          const { clearPaymentProvider } = await import("#lib/db/settings.ts");
+          await clearPaymentProvider();
+          invalidateSettingsCache();
+        }
       });
     });
 
@@ -164,6 +247,63 @@ describe("server (misc)", () => {
         );
         expect(response.headers.get("x-robots-tag")).toBe("index, follow");
       });
+    });
+  });
+
+  describe("buildCspHeader", () => {
+    test("returns base CSP with no payment provider", () => {
+      const csp = buildCspHeader(false);
+      expect(csp).toBe(
+        "frame-ancestors 'none'; default-src 'self'; form-action 'self'",
+      );
+    });
+
+    test("omits frame-ancestors for embeddable pages", () => {
+      const csp = buildCspHeader(true);
+      expect(csp).toBe("default-src 'self'; form-action 'self'");
+    });
+
+    test("includes Stripe checkout domain when Stripe is configured", () => {
+      const csp = buildCspHeader(false, { provider: "stripe" });
+      expect(csp).toBe(
+        "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://checkout.stripe.com",
+      );
+    });
+
+    test("includes Square production domains when Square is configured without sandbox", () => {
+      const csp = buildCspHeader(false, {
+        provider: "square",
+        squareSandbox: false,
+      });
+      expect(csp).toBe(
+        "frame-ancestors 'none'; default-src 'self'; style-src 'self' https://web.squarecdn.com; script-src 'self' https://web.squarecdn.com; frame-src 'self' https://web.squarecdn.com; connect-src 'self' https://pci-connect.squareup.com https://o160250.ingest.sentry.io; font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net; form-action 'self' https://square.link https://checkout.square.site",
+      );
+    });
+
+    test("includes Square sandbox domains when Square sandbox is enabled", () => {
+      const csp = buildCspHeader(false, {
+        provider: "square",
+        squareSandbox: true,
+      });
+      expect(csp).toBe(
+        "frame-ancestors 'none'; default-src 'self'; style-src 'self' https://sandbox.web.squarecdn.com; script-src 'self' https://sandbox.web.squarecdn.com; frame-src 'self' https://sandbox.web.squarecdn.com; connect-src 'self' https://pci-connect.squareupsandbox.com https://o160250.ingest.sentry.io; font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net; form-action 'self' https://square.link https://checkout.square.site",
+      );
+    });
+
+    test("Square embeddable page omits frame-ancestors", () => {
+      const csp = buildCspHeader(true, {
+        provider: "square",
+        squareSandbox: false,
+      });
+      expect(csp).not.toContain("frame-ancestors");
+      expect(csp).toContain("script-src 'self' https://web.squarecdn.com");
+    });
+
+    test("null provider returns base CSP", () => {
+      const csp = buildCspHeader(false, { provider: null });
+      expect(csp).toBe(
+        "frame-ancestors 'none'; default-src 'self'; form-action 'self'",
+      );
     });
   });
 

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -138,63 +138,16 @@ describe("server (misc)", () => {
         }
       });
 
-      test("includes Square production CSP directives when Square is configured", async () => {
-        const {
-          setPaymentProvider,
-          updateSquareSandbox,
-          invalidateSettingsCache,
-        } = await import("#lib/db/settings.ts");
+      test("includes Square CSP directives when Square is configured", async () => {
+        const { setPaymentProvider, invalidateSettingsCache } = await import(
+          "#lib/db/settings.ts"
+        );
         await setPaymentProvider("square");
-        await updateSquareSandbox(false);
         invalidateSettingsCache();
         try {
           const response = await handleRequest(mockRequest("/"));
-          const csp = response.headers.get("content-security-policy")!;
-          expect(csp).toContain("script-src 'self' https://web.squarecdn.com");
-          expect(csp).toContain("frame-src 'self' https://web.squarecdn.com");
-          expect(csp).toContain("style-src 'self' https://web.squarecdn.com");
-          expect(csp).toContain(
-            "connect-src 'self' https://pci-connect.squareup.com",
-          );
-          expect(csp).toContain(
-            "font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net",
-          );
-          expect(csp).toContain(
-            "form-action 'self' https://square.link https://checkout.square.site",
-          );
-        } finally {
-          const { clearPaymentProvider } = await import("#lib/db/settings.ts");
-          await clearPaymentProvider();
-          invalidateSettingsCache();
-        }
-      });
-
-      test("includes Square sandbox CSP directives when Square sandbox is enabled", async () => {
-        const {
-          setPaymentProvider,
-          updateSquareSandbox,
-          invalidateSettingsCache,
-        } = await import("#lib/db/settings.ts");
-        await setPaymentProvider("square");
-        await updateSquareSandbox(true);
-        invalidateSettingsCache();
-        try {
-          const response = await handleRequest(mockRequest("/"));
-          const csp = response.headers.get("content-security-policy")!;
-          expect(csp).toContain(
-            "script-src 'self' https://sandbox.web.squarecdn.com",
-          );
-          expect(csp).toContain(
-            "frame-src 'self' https://sandbox.web.squarecdn.com",
-          );
-          expect(csp).toContain(
-            "style-src 'self' https://sandbox.web.squarecdn.com",
-          );
-          expect(csp).toContain(
-            "connect-src 'self' https://pci-connect.squareupsandbox.com",
-          );
-          expect(csp).toContain(
-            "font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net",
+          expect(response.headers.get("content-security-policy")).toBe(
+            "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site",
           );
         } finally {
           const { clearPaymentProvider } = await import("#lib/db/settings.ts");
@@ -270,33 +223,17 @@ describe("server (misc)", () => {
       );
     });
 
-    test("includes Square production domains when Square is configured without sandbox", () => {
-      const csp = buildCspHeader(false, {
-        provider: "square",
-        squareSandbox: false,
-      });
+    test("includes Square redirect domains when Square is configured", () => {
+      const csp = buildCspHeader(false, { provider: "square" });
       expect(csp).toBe(
-        "frame-ancestors 'none'; default-src 'self'; style-src 'self' https://web.squarecdn.com; script-src 'self' https://web.squarecdn.com; frame-src 'self' https://web.squarecdn.com; connect-src 'self' https://pci-connect.squareup.com https://o160250.ingest.sentry.io; font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net; form-action 'self' https://square.link https://checkout.square.site",
-      );
-    });
-
-    test("includes Square sandbox domains when Square sandbox is enabled", () => {
-      const csp = buildCspHeader(false, {
-        provider: "square",
-        squareSandbox: true,
-      });
-      expect(csp).toBe(
-        "frame-ancestors 'none'; default-src 'self'; style-src 'self' https://sandbox.web.squarecdn.com; script-src 'self' https://sandbox.web.squarecdn.com; frame-src 'self' https://sandbox.web.squarecdn.com; connect-src 'self' https://pci-connect.squareupsandbox.com https://o160250.ingest.sentry.io; font-src https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net; form-action 'self' https://square.link https://checkout.square.site",
+        "frame-ancestors 'none'; default-src 'self'; form-action 'self' https://square.link https://checkout.square.site",
       );
     });
 
     test("Square embeddable page omits frame-ancestors", () => {
-      const csp = buildCspHeader(true, {
-        provider: "square",
-        squareSandbox: false,
-      });
+      const csp = buildCspHeader(true, { provider: "square" });
       expect(csp).not.toContain("frame-ancestors");
-      expect(csp).toContain("script-src 'self' https://web.squarecdn.com");
+      expect(csp).toContain("form-action 'self' https://square.link");
     });
 
     test("null provider returns base CSP", () => {


### PR DESCRIPTION
## Summary
Refactored the Content-Security-Policy (CSP) header generation to be dynamic based on the configured payment provider (Stripe, Square, or none) instead of including all payment domains statically. This reduces the CSP surface area when payment providers aren't configured and properly handles Square sandbox vs. production environments.

## Key Changes
- **Extracted `buildCspHeader` function**: Made it a reusable, testable function that accepts embeddable flag and optional payment configuration
- **Dynamic payment directives**: CSP now only includes form-action domains for the configured payment provider:
  - Stripe: adds `https://checkout.stripe.com`
  - Square production: adds Square production domains (connect.squareup.com, pci-connect.squareup.com, api.squareup.com)
  - Square sandbox: adds Square sandbox domains (connect.squareupsandbox.com, pci-connect.squareupsandbox.com, api.squareupsandbox.com)
  - None: only includes base directives
- **Removed unnecessary directives**: Eliminated `style-src`, `script-src`, and `connect-src` directives that were overly permissive and not needed for the server-side redirect payment flows
- **Updated middleware**: Modified `applySecurityHeaders` to fetch payment provider configuration at request time and rebuild CSP accordingly
- **Added comprehensive tests**: Created unit tests for `buildCspHeader` covering all payment provider scenarios and integration tests verifying CSP headers in actual responses

## Implementation Details
- Payment configuration is fetched from the database during request processing, allowing CSP to adapt to runtime configuration changes
- The function is exported for testing purposes and maintains backward compatibility
- Both Stripe and Square use server-side redirect flows (not embedded SDKs), so only `form-action` directive needs provider-specific domains
- Embeddable pages omit `frame-ancestors 'none'` to allow embedding when configured

https://claude.ai/code/session_01GtY2ZqNAJVm1HFbn4BhRBd