### PR TITLE
Save custom question answers for multi-ticket checkouts

### DIFF
--- a/src/lib/booking.ts
+++ b/src/lib/booking.ts
@@ -38,6 +38,7 @@ export const processBooking = async (
   date: string | null,
   baseUrl: string,
   customUnitPrice?: number,
+  answerIds?: number[],
 ): Promise<BookingResult> => {
   const paymentsEnabled = await isPaymentsEnabled();
   const needsPayment =
@@ -57,6 +58,7 @@ export const processBooking = async (
       quantity,
       date,
       customUnitPrice,
+      answerIds,
     };
 
     const result = await provider.createCheckoutSession(event, intent, baseUrl);

--- a/src/lib/payment-helpers.ts
+++ b/src/lib/payment-helpers.ts
@@ -90,10 +90,19 @@ const optionalFields = (
   ...(intent.date ? { date: intent.date } : {}),
 });
 
+/** Serialize answer IDs for metadata (only if non-empty) */
+const answerIdsField = (
+  answerIds?: number[],
+): Record<string, string> =>
+  answerIds && answerIds.length > 0
+    ? { answer_ids: JSON.stringify(answerIds) }
+    : {};
+
 /** Single-event checkout intent for metadata building */
 type SingleIntentMetadata = ContactFields & {
   quantity: number;
   date?: string | null;
+  answerIds?: number[];
 };
 
 /**
@@ -110,6 +119,7 @@ export const buildSingleIntentMetadata = (
   email: intent.email,
   quantity: String(intent.quantity),
   ...optionalFields(intent),
+  ...answerIdsField(intent.answerIds),
 });
 
 /**
@@ -125,6 +135,7 @@ export const buildMultiIntentMetadata = (
   email: intent.email,
   items: serializeMultiItems(intent.items),
   ...optionalFields(intent),
+  ...answerIdsField(intent.answerIds),
 });
 
 /**
@@ -177,4 +188,5 @@ export const extractSessionMetadata = (
   multi: metadata.multi || "",
   date: metadata.date || "",
   items: metadata.items || "",
+  answer_ids: metadata.answer_ids || "",
 });

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -28,6 +28,8 @@ export type RegistrationIntent = ContactInfo & {
   date?: string | null;
   /** Custom unit price (minor units) when can_pay_more is enabled; overrides event.unit_price */
   customUnitPrice?: number;
+  /** Custom question answer IDs selected during checkout */
+  answerIds?: number[];
 };
 
 /** Single item within a multi-event checkout */
@@ -43,6 +45,8 @@ export type MultiRegistrationItem = {
 export type MultiRegistrationIntent = ContactInfo & {
   date?: string | null;
   items: MultiRegistrationItem[];
+  /** Custom question answer IDs selected during checkout */
+  answerIds?: number[];
 };
 
 /** Result of creating a checkout session.
@@ -81,6 +85,7 @@ export type SessionMetadata = {
   multi: string;
   items: string;
   date: string;
+  answer_ids: string;
 };
 
 /** Valid payment status values */

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -459,6 +459,7 @@ const processTicketReservation = async (
         date,
         getBaseUrl(request),
         customUnitPrice,
+        answersResult.answerIds,
       );
       return bookingResultToWebResponse(
         bookingResult,
@@ -705,7 +706,12 @@ const submitMultiTicket = (
           );
         }
 
-        const intent: MultiRegistrationIntent = { ...contact, date, items };
+        const intent: MultiRegistrationIntent = {
+          ...contact,
+          date,
+          items,
+          answerIds: answersResult.answerIds,
+        };
         return handleMultiPaymentFlow(request, intent, ctx);
       }
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -28,7 +28,7 @@ import {
   getAttendeesByTokens,
 } from "#lib/db/attendees.ts";
 import { getEvent, getEventWithCount } from "#lib/db/events.ts";
-import { saveAttendeeAnswersBatch } from "#lib/db/questions.ts";
+import { saveAttendeeAnswers, saveAttendeeAnswersBatch } from "#lib/db/questions.ts";
 import {
   clearSessionTokens,
   decryptSessionTokens,
@@ -77,19 +77,9 @@ const PRICE_CHANGED_MESSAGE =
 const isMultiSession = (metadata: SessionMetadata): boolean =>
   metadata.multi === "1" && metadata.items !== "";
 
-/** Parse answer_ids from metadata JSON string; returns empty array on missing/invalid */
-const parseAnswerIds = (json: string): number[] => {
-  if (!json) return [];
-  try {
-    const parsed: unknown = JSON.parse(json);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (v): v is number => typeof v === "number" && Number.isInteger(v) && v > 0,
-    );
-  } catch {
-    return [];
-  }
-};
+/** Parse answer_ids from metadata JSON string */
+const parseAnswerIds = (json: string): number[] =>
+  json ? JSON.parse(json) : [];
 
 /**
  * Extract registration intent from validated session metadata (single-ticket only).
@@ -615,9 +605,7 @@ const processMultiPaymentSession = async (
 
   // Save custom question answers for all created attendees
   if (intent.answerIds.length > 0) {
-    const attendeeIds = map(
-      ({ attendee }: { attendee: Attendee }) => attendee.id,
-    )(createdAttendees);
+    const attendeeIds = createdAttendees.map(({ attendee }) => attendee.id);
     await saveAttendeeAnswersBatch(attendeeIds, intent.answerIds);
   }
 
@@ -724,7 +712,7 @@ const processPaymentSession = async (
 
   // Save custom question answers
   if (intent.answerIds && intent.answerIds.length > 0) {
-    await saveAttendeeAnswersBatch([result.attendee.id], intent.answerIds);
+    await saveAttendeeAnswers(result.attendee.id, intent.answerIds);
   }
 
   // Phase 3: Finalize the session with the attendee ID and token

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -28,6 +28,7 @@ import {
   getAttendeesByTokens,
 } from "#lib/db/attendees.ts";
 import { getEvent, getEventWithCount } from "#lib/db/events.ts";
+import { saveAttendeeAnswersBatch } from "#lib/db/questions.ts";
 import {
   clearSessionTokens,
   decryptSessionTokens,
@@ -76,6 +77,20 @@ const PRICE_CHANGED_MESSAGE =
 const isMultiSession = (metadata: SessionMetadata): boolean =>
   metadata.multi === "1" && metadata.items !== "";
 
+/** Parse answer_ids from metadata JSON string; returns empty array on missing/invalid */
+const parseAnswerIds = (json: string): number[] => {
+  if (!json) return [];
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (v): v is number => typeof v === "number" && Number.isInteger(v) && v > 0,
+    );
+  } catch {
+    return [];
+  }
+};
+
 /**
  * Extract registration intent from validated session metadata (single-ticket only).
  *
@@ -94,6 +109,7 @@ const extractIntent = (
   special_instructions: session.metadata.special_instructions,
   quantity: Number.parseInt(session.metadata.quantity || "1", 10),
   date: session.metadata.date || null,
+  answerIds: parseAnswerIds(session.metadata.answer_ids),
 });
 
 /** Wrap handler with session ID extraction */
@@ -417,6 +433,7 @@ const parseMultiItems = (itemsJson: string): MultiItem[] | null => {
 type MultiIntent = ContactInfo & {
   date: string | null;
   items: MultiItem[];
+  answerIds: number[];
 };
 
 /**
@@ -439,6 +456,7 @@ const extractMultiIntent = (
     special_instructions: metadata.special_instructions,
     date: metadata.date || null,
     items,
+    answerIds: parseAnswerIds(metadata.answer_ids),
   };
 };
 
@@ -595,6 +613,14 @@ const processMultiPaymentSession = async (
     );
   }
 
+  // Save custom question answers for all created attendees
+  if (intent.answerIds.length > 0) {
+    const attendeeIds = map(
+      ({ attendee }: { attendee: Attendee }) => attendee.id,
+    )(createdAttendees);
+    await saveAttendeeAnswersBatch(attendeeIds, intent.answerIds);
+  }
+
   // Phase 3: Finalize with first attendee ID (for idempotency tracking)
   // createdAttendees is guaranteed non-empty: the loop always runs (intent.items
   // is validated non-empty) and if any creation fails we return early above.
@@ -694,6 +720,11 @@ const processPaymentSession = async (
 
   if (!result.success) {
     return refundAndFail(session, formatPostPaymentError(result.reason));
+  }
+
+  // Save custom question answers
+  if (intent.answerIds && intent.answerIds.length > 0) {
+    await saveAttendeeAnswersBatch([result.attendee.id], intent.answerIds);
   }
 
   // Phase 3: Finalize the session with the attendee ID and token

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1475,6 +1475,7 @@ export const webhookMeta = (
   multi: "",
   items: "",
   date: "",
+  answer_ids: "",
   ...metadata,
 });
 

--- a/test/lib/payment-helpers.test.ts
+++ b/test/lib/payment-helpers.test.ts
@@ -581,6 +581,7 @@ describe("payment-helpers", () => {
         multi: "",
         date: "",
         items: "",
+        answer_ids: "",
       });
     });
 
@@ -604,6 +605,7 @@ describe("payment-helpers", () => {
         multi: "1",
         date: "",
         items: '[{"e":1,"q":2}]',
+        answer_ids: "",
       });
     });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -32,8 +32,8 @@ import {
   submitTicketForm,
   testCookie,
   testCsrfToken,
-  withExpectedError,
   updateTestEvent,
+  withExpectedError,
 } from "#test-utils";
 
 describe("server (admin events)", () => {

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -446,9 +446,7 @@ describe("server (payment flow)", () => {
           ),
         async () => {
           const response = await handleRequest(
-            mockRequest(
-              "/payment/cancel?session_id=cs_test_cancel_bad_multi",
-            ),
+            mockRequest("/payment/cancel?session_id=cs_test_cancel_bad_multi"),
           );
           await expectHtmlResponse(response, 404, "Event not found");
         },

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -3913,8 +3913,7 @@ describe("server (webhooks)", () => {
       expectCheckoutRedirect(checkoutResponse);
 
       // Now simulate the webhook callback from the payment provider.
-      // The metadata is what the checkout session stored — answer_ids
-      // cannot currently be included because SessionMetadata has no such field.
+      // The metadata includes answer_ids serialized during checkout.
       const mockVerify = await stubWebhookVerify({
         id: "evt_multi_q",
         type: "checkout.session.completed",
@@ -3932,6 +3931,7 @@ describe("server (webhooks)", () => {
                 { e: event1.id, q: 1, p: 1000 },
                 { e: event2.id, q: 1, p: 0 },
               ]),
+              answer_ids: JSON.stringify([a1.id]),
             }),
           },
         },
@@ -3953,10 +3953,7 @@ describe("server (webhooks)", () => {
         expect(att1.length).toBe(1);
         expect(att2.length).toBe(1);
 
-        // BUG: Custom question answers should be saved for the attendee of
-        // event1 (which had the question), but they are lost because
-        // answer_ids are not included in SessionMetadata / MultiRegistrationIntent
-        // and the webhook handler never saves them.
+        // Verify custom question answers were saved for all attendees
         const batch = await getAttendeeAnswersBatch([
           att1[0]!.id,
           att2[0]!.id,

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -3,6 +3,12 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { decrypt } from "#lib/crypto.ts";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
+import {
+  answersTable,
+  getAttendeeAnswersBatch,
+  questionsTable,
+  setEventQuestions,
+} from "#lib/db/questions.ts";
 import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
@@ -3854,6 +3860,110 @@ describe("server (webhooks)", () => {
       } finally {
         mockVerify.restore();
         mockRefund.restore();
+      }
+    });
+  });
+
+  describe("multi-ticket webhook with custom questions", () => {
+    afterEach(() => {
+      resetStripeClient();
+    });
+
+    test("saves custom question answers for paid multi-ticket checkout", async () => {
+      await setupStripe();
+
+      // Event with questions (paid) and event without questions (free)
+      const event1 = await createTestEvent({
+        name: "Multi Q Paid",
+        maxAttendees: 50,
+        unitPrice: 1000,
+      });
+      const event2 = await createTestEvent({
+        name: "Multi No Q Free",
+        maxAttendees: 50,
+      });
+
+      // Add a custom question only to event1
+      const q = await questionsTable.insert({ text: "Dietary needs?" });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        text: "None",
+        sortOrder: 0,
+      });
+      await answersTable.insert({
+        questionId: q.id,
+        text: "Vegetarian",
+        sortOrder: 1,
+      });
+      await setEventQuestions(event1.id, [q.id]);
+
+      // Submit multi-ticket form with a question answer selected.
+      // One event is paid, so this triggers the payment flow.
+      const { submitMultiTicketForm, expectCheckoutRedirect } = await import(
+        "#test-utils"
+      );
+      const slug = `${event1.slug}+${event2.slug}`;
+      const checkoutResponse = await submitMultiTicketForm(slug, {
+        name: "Q Buyer",
+        email: "qbuyer@example.com",
+        [`quantity_${event1.id}`]: "1",
+        [`quantity_${event2.id}`]: "1",
+        [`question_${q.id}`]: String(a1.id),
+      });
+      expectCheckoutRedirect(checkoutResponse);
+
+      // Now simulate the webhook callback from the payment provider.
+      // The metadata is what the checkout session stored — answer_ids
+      // cannot currently be included because SessionMetadata has no such field.
+      const mockVerify = await stubWebhookVerify({
+        id: "evt_multi_q",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_multi_q",
+            payment_status: "paid",
+            payment_intent: "pi_multi_q",
+            amount_total: 1000,
+            metadata: webhookMeta({
+              name: "Q Buyer",
+              email: "qbuyer@example.com",
+              multi: "1",
+              items: JSON.stringify([
+                { e: event1.id, q: 1, p: 1000 },
+                { e: event2.id, q: 1, p: 0 },
+              ]),
+            }),
+          },
+        },
+      });
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest({}, { "stripe-signature": "sig_valid" }),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.received).toBe(true);
+        expect(json.processed).toBe(true);
+
+        // Verify attendees were created
+        const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+        const att1 = await getAttendeesRaw(event1.id);
+        const att2 = await getAttendeesRaw(event2.id);
+        expect(att1.length).toBe(1);
+        expect(att2.length).toBe(1);
+
+        // BUG: Custom question answers should be saved for the attendee of
+        // event1 (which had the question), but they are lost because
+        // answer_ids are not included in SessionMetadata / MultiRegistrationIntent
+        // and the webhook handler never saves them.
+        const batch = await getAttendeeAnswersBatch([
+          att1[0]!.id,
+          att2[0]!.id,
+        ]);
+        expect(batch.get(att1[0]!.id)).toEqual([a1.id]);
+      } finally {
+        mockVerify.restore();
       }
     });
   });

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -3963,5 +3963,63 @@ describe("server (webhooks)", () => {
         mockVerify.restore();
       }
     });
+
+    test("saves custom question answers for paid single-ticket checkout", async () => {
+      await setupStripe();
+
+      const event = await createTestEvent({
+        name: "Single Q Paid",
+        maxAttendees: 50,
+        unitPrice: 1000,
+      });
+
+      const q = await questionsTable.insert({ text: "Dietary needs?" });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        text: "Vegan",
+        sortOrder: 1,
+      });
+      await setEventQuestions(event.id, [q.id]);
+
+      const mockVerify = await stubWebhookVerify({
+        id: "evt_single_q",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_single_q",
+            payment_status: "paid",
+            payment_intent: "pi_single_q",
+            amount_total: 1000,
+            metadata: webhookMeta({
+              event_id: String(event.id),
+              name: "Q Single Buyer",
+              email: "qsingle@example.com",
+              quantity: "1",
+              answer_ids: JSON.stringify([a1.id]),
+            }),
+          },
+        },
+      });
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest({}, { "stripe-signature": "sig_valid" }),
+        );
+        expect(response.status).toBe(200);
+        const json = await response.json();
+        expect(json.received).toBe(true);
+        expect(json.processed).toBe(true);
+
+        const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
+        const attendees = await getAttendeesRaw(event.id);
+        expect(attendees.length).toBe(1);
+
+        // Verify custom question answers were saved
+        const batch = await getAttendeeAnswersBatch([attendees[0]!.id]);
+        expect(batch.get(attendees[0]!.id)).toEqual([a1.id]);
+      } finally {
+        mockVerify.restore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds support for saving custom question answers when processing multi-ticket checkouts with payment. Previously, custom question answers were only handled for single-ticket checkouts.

## Key Changes
- **Question answer persistence**: Added `saveAttendeeAnswersBatch()` call in `processMultiPaymentSession()` to save answers for all attendees created during multi-ticket checkout
- **Metadata serialization**: Extended `SessionMetadata` type and metadata building functions to include `answer_ids` field, serialized as JSON during checkout and deserialized during webhook processing
- **Intent types**: Updated `RegistrationIntent` and `MultiRegistrationIntent` types to include optional `answerIds` field
- **Webhook handling**: Modified webhook processors to extract and pass `answerIds` from session metadata to both single and multi-ticket payment handlers
- **Public API**: Updated `processTicketReservation()` and `submitMultiTicket()` to pass answer IDs through the payment flow
- **Test coverage**: Added comprehensive test case `"saves custom question answers for paid multi-ticket checkout"` verifying end-to-end answer persistence

## Implementation Details
- Answer IDs are serialized to JSON in metadata only when non-empty (via `answerIdsField()` helper)
- The `parseAnswerIds()` utility safely handles missing or empty answer_ids metadata
- Both single and multi-ticket flows now consistently handle custom question answers
- Test utilities updated to include `answer_ids` in webhook metadata defaults

https://claude.ai/code/session_01KnqWPQ9TGQoqnPa2M1RH1Q