### PR TITLE
Add custom question editing to admin attendee page

### DIFF
--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -272,7 +272,7 @@ const ATTENDEE_ANSWER_INSERT =
 
 /** Replace all answers for one or more attendees in a single atomic batch.
  * Deletes existing answers first, then inserts the new ones. */
-export const saveAttendeeAnswersBatch = async (
+export const saveAttendeeAnswers = async (
   attendeeIds: number[],
   answerIds: number[],
 ): Promise<void> => {
@@ -292,12 +292,6 @@ export const saveAttendeeAnswersBatch = async (
         );
   await executeBatch([...deletes, ...inserts]);
 };
-
-/** Replace attendee answers for a single attendee in a single atomic batch */
-export const saveAttendeeAnswers = (
-  attendeeId: number,
-  answerIds: number[],
-): Promise<void> => saveAttendeeAnswersBatch([attendeeId], answerIds);
 
 /** Get answers for multiple attendees in a single query */
 export const getAttendeeAnswersBatch = async (

--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -270,23 +270,30 @@ export const setEventQuestions = async (
 const ATTENDEE_ANSWER_INSERT =
   "INSERT INTO attendee_answers (attendee_id, answer_id) VALUES (?, ?)";
 
-/** Save the same answers for one or more attendees in a single batch */
+/** Replace all answers for one or more attendees in a single atomic batch.
+ * Deletes existing answers first, then inserts the new ones. */
 export const saveAttendeeAnswersBatch = async (
   attendeeIds: number[],
   answerIds: number[],
 ): Promise<void> => {
-  if (attendeeIds.length === 0 || answerIds.length === 0) return;
-  await executeBatch(
-    attendeeIds.flatMap((attendeeId) =>
-      answerIds.map((answerId) => ({
-        sql: ATTENDEE_ANSWER_INSERT,
-        args: [attendeeId, answerId],
-      })),
-    ),
-  );
+  if (attendeeIds.length === 0) return;
+  const deletes = attendeeIds.map((attendeeId) => ({
+    sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
+    args: [attendeeId],
+  }));
+  const inserts =
+    answerIds.length === 0
+      ? []
+      : attendeeIds.flatMap((attendeeId) =>
+          answerIds.map((answerId) => ({
+            sql: ATTENDEE_ANSWER_INSERT,
+            args: [attendeeId, answerId],
+          })),
+        );
+  await executeBatch([...deletes, ...inserts]);
 };
 
-/** Save attendee answers for a single attendee */
+/** Replace attendee answers for a single attendee in a single atomic batch */
 export const saveAttendeeAnswers = (
   attendeeId: number,
   answerIds: number[],
@@ -311,18 +318,6 @@ export const getAttendeeAnswersBatch = async (
     result.set(attendee_id, list);
   }
   return result;
-};
-
-/** Delete all answers for an attendee */
-export const deleteAttendeeAnswers = async (
-  attendeeId: number,
-): Promise<void> => {
-  await executeBatch([
-    {
-      sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
-      args: [attendeeId],
-    },
-  ]);
 };
 
 /** Delete a question and all related data in a single batch.

--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -313,6 +313,18 @@ export const getAttendeeAnswersBatch = async (
   return result;
 };
 
+/** Delete all answers for an attendee */
+export const deleteAttendeeAnswers = async (
+  attendeeId: number,
+): Promise<void> => {
+  await executeBatch([
+    {
+      sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
+      args: [attendeeId],
+    },
+  ]);
+};
+
 /** Delete a question and all related data in a single batch.
  * Uses a subquery for attendee_answers so the entire cascade is atomic. */
 export const deleteQuestion = async (questionId: number): Promise<void> => {

--- a/src/lib/payment-helpers.ts
+++ b/src/lib/payment-helpers.ts
@@ -91,9 +91,7 @@ const optionalFields = (
 });
 
 /** Serialize answer IDs for metadata (only if non-empty) */
-const answerIdsField = (
-  answerIds?: number[],
-): Record<string, string> =>
+const answerIdsField = (answerIds?: number[]): Record<string, string> =>
   answerIds && answerIds.length > 0
     ? { answer_ids: JSON.stringify(answerIds) }
     : {};

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -22,7 +22,6 @@ import {
 } from "#lib/db/events.ts";
 import type { QuestionWithAnswers } from "#lib/db/questions.ts";
 import {
-  deleteAttendeeAnswers,
   getAttendeeAnswersBatch,
   getQuestionsForEvent,
   saveAttendeeAnswers,
@@ -703,12 +702,9 @@ async function editAttendeeHandler(
     quantity,
   });
 
-  // Update answers: delete existing and save new selections
+  // Update answers (atomic delete + insert)
   if (data.questions.length > 0) {
-    await deleteAttendeeAnswers(attendeeId);
-    if (answerIds.length > 0) {
-      await saveAttendeeAnswers(attendeeId, answerIds);
-    }
+    await saveAttendeeAnswers(attendeeId, answerIds);
   }
 
   await logActivity(`Attendee '${name}' updated`, event_id);

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -704,7 +704,7 @@ async function editAttendeeHandler(
 
   // Update answers (atomic delete + insert)
   if (data.questions.length > 0) {
-    await saveAttendeeAnswers(attendeeId, answerIds);
+    await saveAttendeeAnswers([attendeeId], answerIds);
   }
 
   await logActivity(`Attendee '${name}' updated`, event_id);

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -20,6 +20,13 @@ import {
   getEventWithAttendeeRaw,
   getEventWithCount,
 } from "#lib/db/events.ts";
+import type { QuestionWithAnswers } from "#lib/db/questions.ts";
+import {
+  deleteAttendeeAnswers,
+  getAttendeeAnswersBatch,
+  getQuestionsForEvent,
+  saveAttendeeAnswers,
+} from "#lib/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import type { FormParams } from "#lib/form-data.ts";
 import { validateForm } from "#lib/forms.tsx";
@@ -551,6 +558,8 @@ const loadAttendeeForEdit = async (
   attendee: Attendee;
   event: EventWithCount;
   allEvents: EventWithCount[];
+  questions: QuestionWithAnswers[];
+  selectedAnswerIds: number[];
 } | null> => {
   const pk = await requirePrivateKey(session);
   const attendeeRaw = await queryOne<Attendee>(
@@ -560,9 +569,14 @@ const loadAttendeeForEdit = async (
   if (!attendeeRaw) return null;
   const attendee = (await decryptAttendeeOrNull(attendeeRaw, pk))!;
   const event = (await getEventWithCount(attendee.event_id))!;
-  const allEvents = await getEventsForSelector(event.id);
+  const [allEvents, questions, answersMap] = await Promise.all([
+    getEventsForSelector(event.id),
+    getQuestionsForEvent(event.id),
+    getAttendeeAnswersBatch([attendeeId]),
+  ]);
+  const selectedAnswerIds = answersMap.get(attendeeId) ?? [];
 
-  return { attendee, event, allEvents };
+  return { attendee, event, allEvents, questions, selectedAnswerIds };
 };
 
 type EditAttendeeData = NonNullable<
@@ -667,6 +681,18 @@ async function editAttendeeHandler(
     if (!available) return editError("Not enough spots available");
   }
 
+  // Parse question answers
+  const answerIds: number[] = [];
+  for (const q of data.questions) {
+    const raw = form.get(`question_${q.id}`);
+    if (raw) {
+      const answerId = Number.parseInt(raw, 10);
+      if (q.answers.some((a) => a.id === answerId)) {
+        answerIds.push(answerId);
+      }
+    }
+  }
+
   await updateAttendee(attendeeId, {
     name,
     email,
@@ -676,6 +702,15 @@ async function editAttendeeHandler(
     event_id,
     quantity,
   });
+
+  // Update answers: delete existing and save new selections
+  if (data.questions.length > 0) {
+    await deleteAttendeeAnswers(attendeeId);
+    if (answerIds.length > 0) {
+      await saveAttendeeAnswers(attendeeId, answerIds);
+    }
+  }
+
   await logActivity(`Attendee '${name}' updated`, event_id);
 
   return redirect(

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -33,7 +33,6 @@ import {
   type QuestionEventMap,
   type QuestionWithAnswers,
   saveAttendeeAnswers,
-  saveAttendeeAnswersBatch,
 } from "#lib/db/questions.ts";
 import {
   getContactPageTextFromDb,
@@ -229,7 +228,7 @@ const bookingResultToWebResponse = async (
   switch (result.type) {
     case "success": {
       if (answerIds.length > 0) {
-        await saveAttendeeAnswers(result.attendee.id, answerIds);
+        await saveAttendeeAnswers([result.attendee.id], answerIds);
       }
       if (event.thank_you_url) return redirectResponse(event.thank_you_url);
       return redirectResponse(
@@ -730,7 +729,7 @@ const submitMultiTicket = (
       // Save answers for all created attendees in a single batch
       if (answersResult.answerIds.length > 0) {
         const attendeeIds = result.entries.map((e) => e.attendee.id);
-        await saveAttendeeAnswersBatch(attendeeIds, answersResult.answerIds);
+        await saveAttendeeAnswers(attendeeIds, answersResult.answerIds);
       }
 
       const tokens = encodeURIComponent(result.tokens.join("+"));

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -28,7 +28,6 @@ import {
   getAttendeesByTokens,
 } from "#lib/db/attendees.ts";
 import { getEvent, getEventWithCount } from "#lib/db/events.ts";
-import { saveAttendeeAnswers, saveAttendeeAnswersBatch } from "#lib/db/questions.ts";
 import {
   clearSessionTokens,
   decryptSessionTokens,
@@ -36,6 +35,10 @@ import {
   type ProcessedPayment,
   reserveSession,
 } from "#lib/db/processed-payments.ts";
+import {
+  saveAttendeeAnswers,
+  saveAttendeeAnswersBatch,
+} from "#lib/db/questions.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import {
   getActivePaymentProvider,

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -35,10 +35,7 @@ import {
   type ProcessedPayment,
   reserveSession,
 } from "#lib/db/processed-payments.ts";
-import {
-  saveAttendeeAnswers,
-  saveAttendeeAnswersBatch,
-} from "#lib/db/questions.ts";
+import { saveAttendeeAnswers } from "#lib/db/questions.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import {
   getActivePaymentProvider,
@@ -609,7 +606,7 @@ const processMultiPaymentSession = async (
   // Save custom question answers for all created attendees
   if (intent.answerIds.length > 0) {
     const attendeeIds = createdAttendees.map(({ attendee }) => attendee.id);
-    await saveAttendeeAnswersBatch(attendeeIds, intent.answerIds);
+    await saveAttendeeAnswers(attendeeIds, intent.answerIds);
   }
 
   // Phase 3: Finalize with first attendee ID (for idempotency tracking)
@@ -715,7 +712,7 @@ const processPaymentSession = async (
 
   // Save custom question answers
   if (intent.answerIds && intent.answerIds.length > 0) {
-    await saveAttendeeAnswers(result.attendee.id, intent.answerIds);
+    await saveAttendeeAnswers([result.attendee.id], intent.answerIds);
   }
 
   // Phase 3: Finalize the session with the attendee ID and token

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -4,11 +4,12 @@
 
 import { map, pipe, unique } from "#fp";
 import { formatCurrency } from "#lib/currency.ts";
+import type { QuestionWithAnswers } from "#lib/db/questions.ts";
 import { CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { Layout } from "#templates/layout.tsx";
+import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /**
  * Admin delete attendee confirmation page
@@ -253,6 +254,25 @@ const PaymentDetails = ({ attendee }: { attendee: Attendee }): string => {
   );
 };
 
+/** Render custom question fields with pre-selected answers for admin edit */
+const renderEditQuestions = (
+  questions: QuestionWithAnswers[],
+  selectedAnswerIds: number[],
+): string => {
+  if (questions.length === 0) return "";
+  return questions
+    .map((q) => {
+      const options = q.answers
+        .map((a) => {
+          const checked = selectedAnswerIds.includes(a.id) ? " checked" : "";
+          return `<label><input type="radio" name="question_${q.id}" value="${a.id}"${checked}> ${escapeHtml(a.text)}</label>`;
+        })
+        .join("");
+      return `<fieldset class="custom-question"><legend>${escapeHtml(q.text)}</legend>${options}</fieldset>`;
+    })
+    .join("");
+};
+
 /**
  * Admin edit attendee page
  */
@@ -261,7 +281,15 @@ export const adminEditAttendeePage = (
     event,
     attendee,
     allEvents,
-  }: { event: EventWithCount; attendee: Attendee; allEvents: EventWithCount[] },
+    questions = [],
+    selectedAnswerIds = [],
+  }: {
+    event: EventWithCount;
+    attendee: Attendee;
+    allEvents: EventWithCount[];
+    questions?: QuestionWithAnswers[];
+    selectedAnswerIds?: number[];
+  },
   session: AdminSession,
   error?: string,
   returnUrl?: string,
@@ -346,6 +374,8 @@ export const adminEditAttendeePage = (
         </label>
 
         <Raw html={renderEventSelector(event.id, allEvents)} />
+
+        <Raw html={renderEditQuestions(questions, selectedAnswerIds)} />
 
         <button type="submit">Save Changes</button>
       </CsrfForm>

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -13,7 +13,6 @@ import {
   getQuestionWithAnswers,
   questionsTable,
   saveAttendeeAnswers,
-  saveAttendeeAnswersBatch,
   setEventQuestions,
 } from "#lib/db/questions.ts";
 import { createTestDbWithSetup, createTestEvent, resetDb } from "#test-utils";
@@ -68,7 +67,7 @@ describe("custom questions", () => {
       await setEventQuestions(event.id, [q.id]);
 
       const attendee = await createAttendee(event.id);
-      await saveAttendeeAnswers(attendee.id, [a.id]);
+      await saveAttendeeAnswers([attendee.id], [a.id]);
 
       await deleteQuestion(q.id);
 
@@ -259,7 +258,7 @@ describe("custom questions", () => {
       const event = await createTestEvent();
       const attendee = await createAttendee(event.id);
 
-      await saveAttendeeAnswers(attendee.id, [a1.id]);
+      await saveAttendeeAnswers([attendee.id], [a1.id]);
 
       const batch = await getAttendeeAnswersBatch([attendee.id]);
       expect(batch.get(attendee.id)).toEqual([a1.id]);
@@ -282,8 +281,8 @@ describe("custom questions", () => {
       const att1 = await createAttendee(event.id, "Alice");
       const att2 = await createAttendee(event.id, "Bob");
 
-      await saveAttendeeAnswers(att1.id, [a1.id]);
-      await saveAttendeeAnswers(att2.id, [a2.id]);
+      await saveAttendeeAnswers([att1.id], [a1.id]);
+      await saveAttendeeAnswers([att2.id], [a2.id]);
 
       const batch = await getAttendeeAnswersBatch([att1.id, att2.id]);
       expect(batch.get(att1.id)).toEqual([a1.id]);
@@ -295,13 +294,13 @@ describe("custom questions", () => {
       expect(batch.size).toBe(0);
     });
 
-    test("saveAttendeeAnswersBatch does nothing for empty attendeeIds", async () => {
-      await saveAttendeeAnswersBatch([], [1]);
+    test("saveAttendeeAnswers does nothing for empty attendeeIds", async () => {
+      await saveAttendeeAnswers([], [1]);
       // No error thrown, no rows inserted
     });
 
-    test("saveAttendeeAnswersBatch does nothing for empty answerIds", async () => {
-      await saveAttendeeAnswersBatch([1], []);
+    test("saveAttendeeAnswers does nothing for empty answerIds", async () => {
+      await saveAttendeeAnswers([1], []);
       // No error thrown, no rows inserted
     });
 
@@ -320,12 +319,12 @@ describe("custom questions", () => {
 
       const event = await createTestEvent();
       const att = await createAttendee(event.id);
-      await saveAttendeeAnswers(att.id, [a1.id]);
+      await saveAttendeeAnswers([att.id], [a1.id]);
 
       const before = await getAttendeeAnswersBatch([att.id]);
       expect(before.get(att.id)).toEqual([a1.id]);
 
-      await saveAttendeeAnswers(att.id, [a2.id]);
+      await saveAttendeeAnswers([att.id], [a2.id]);
 
       const after = await getAttendeeAnswersBatch([att.id]);
       expect(after.get(att.id)).toEqual([a2.id]);
@@ -341,9 +340,9 @@ describe("custom questions", () => {
 
       const event = await createTestEvent();
       const att = await createAttendee(event.id);
-      await saveAttendeeAnswers(att.id, [a1.id]);
+      await saveAttendeeAnswers([att.id], [a1.id]);
 
-      await saveAttendeeAnswers(att.id, []);
+      await saveAttendeeAnswers([att.id], []);
 
       const after = await getAttendeeAnswersBatch([att.id]);
       expect(after.get(att.id)).toBeUndefined();

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -4,6 +4,7 @@ import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import {
   answersTable,
   deleteAnswer,
+  deleteAttendeeAnswers,
   deleteQuestion,
   getAllQuestionsWithAnswers,
   getAttendeeAnswersBatch,
@@ -303,6 +304,32 @@ describe("custom questions", () => {
     test("saveAttendeeAnswersBatch does nothing for empty answerIds", async () => {
       await saveAttendeeAnswersBatch([1], []);
       // No error thrown, no rows inserted
+    });
+
+    test("deleteAttendeeAnswers removes all answers for an attendee", async () => {
+      const q = await questionsTable.insert({ text: "Colour?" });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        text: "Red",
+        sortOrder: 0,
+      });
+      const a2 = await answersTable.insert({
+        questionId: q.id,
+        text: "Blue",
+        sortOrder: 1,
+      });
+
+      const event = await createTestEvent();
+      const att = await createAttendee(event.id);
+      await saveAttendeeAnswers(att.id, [a1.id, a2.id]);
+
+      const before = await getAttendeeAnswersBatch([att.id]);
+      expect(before.get(att.id)!.length).toBe(2);
+
+      await deleteAttendeeAnswers(att.id);
+
+      const after = await getAttendeeAnswersBatch([att.id]);
+      expect(after.get(att.id)).toBeUndefined();
     });
   });
 

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -4,7 +4,6 @@ import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import {
   answersTable,
   deleteAnswer,
-  deleteAttendeeAnswers,
   deleteQuestion,
   getAllQuestionsWithAnswers,
   getAttendeeAnswersBatch,
@@ -306,7 +305,7 @@ describe("custom questions", () => {
       // No error thrown, no rows inserted
     });
 
-    test("deleteAttendeeAnswers removes all answers for an attendee", async () => {
+    test("saveAttendeeAnswers replaces existing answers atomically", async () => {
       const q = await questionsTable.insert({ text: "Colour?" });
       const a1 = await answersTable.insert({
         questionId: q.id,
@@ -321,12 +320,30 @@ describe("custom questions", () => {
 
       const event = await createTestEvent();
       const att = await createAttendee(event.id);
-      await saveAttendeeAnswers(att.id, [a1.id, a2.id]);
+      await saveAttendeeAnswers(att.id, [a1.id]);
 
       const before = await getAttendeeAnswersBatch([att.id]);
-      expect(before.get(att.id)!.length).toBe(2);
+      expect(before.get(att.id)).toEqual([a1.id]);
 
-      await deleteAttendeeAnswers(att.id);
+      await saveAttendeeAnswers(att.id, [a2.id]);
+
+      const after = await getAttendeeAnswersBatch([att.id]);
+      expect(after.get(att.id)).toEqual([a2.id]);
+    });
+
+    test("saveAttendeeAnswers with empty answerIds clears answers", async () => {
+      const q = await questionsTable.insert({ text: "Colour?" });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        text: "Red",
+        sortOrder: 0,
+      });
+
+      const event = await createTestEvent();
+      const att = await createAttendee(event.id);
+      await saveAttendeeAnswers(att.id, [a1.id]);
+
+      await saveAttendeeAnswers(att.id, []);
 
       const after = await getAttendeeAnswersBatch([att.id]);
       expect(after.get(att.id)).toBeUndefined();

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -2,6 +2,11 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { attendeesApi } from "#lib/db/attendees.ts";
+import {
+  answersTable,
+  questionsTable,
+  setEventQuestions,
+} from "#lib/db/questions.ts";
 import { paymentsApi } from "#lib/payments.ts";
 import { handleRequest } from "#routes";
 import {
@@ -2290,6 +2295,190 @@ describe("server (admin attendees)", () => {
           }
         },
       );
+    });
+  });
+
+  describe("edit attendee questions", () => {
+    const setupQuestionAndAttendee = async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      // Create attendee before assigning questions (public route requires answers)
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const q = await questionsTable.insert({ text: "T-shirt size?" });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        text: "Small",
+        sortOrder: 0,
+      });
+      const a2 = await answersTable.insert({
+        questionId: q.id,
+        text: "Large",
+        sortOrder: 1,
+      });
+      await setEventQuestions(event.id, [q.id]);
+      return { event, q, a1, a2, attendee };
+    };
+
+    test("shows questions on edit page", async () => {
+      const { attendee } = await setupQuestionAndAttendee();
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie: await testCookie() },
+      );
+      await expectHtmlResponse(
+        response,
+        200,
+        "T-shirt size?",
+        "Small",
+        "Large",
+      );
+    });
+
+    test("pre-selects existing answer on edit page", async () => {
+      const { attendee, a1 } = await setupQuestionAndAttendee();
+      const { saveAttendeeAnswers } = await import("#lib/db/questions.ts");
+      await saveAttendeeAnswers(attendee.id, [a1.id]);
+
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie: await testCookie() },
+      );
+      const html = await response.text();
+      expect(html).toContain(`value="${a1.id}" checked`);
+    });
+
+    test("does not show questions when event has none", async () => {
+      const event = await createTestEvent({ maxAttendees: 100 });
+      const attendee = await createTestAttendee(
+        event.id,
+        event.slug,
+        "Jane Doe",
+        "jane@example.com",
+      );
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie: await testCookie() },
+      );
+      const html = await response.text();
+      expect(html).not.toContain("custom-question");
+    });
+
+    test("saves selected answer on edit", async () => {
+      const { event, attendee, q, a2 } = await setupQuestionAndAttendee();
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "1",
+            [`question_${q.id}`]: String(a2.id),
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeAnswersBatch } = await import("#lib/db/questions.ts");
+      const answers = await getAttendeeAnswersBatch([attendee.id]);
+      expect(answers.get(attendee.id)).toEqual([a2.id]);
+    });
+
+    test("updates answer from one option to another", async () => {
+      const { event, attendee, q, a1, a2 } = await setupQuestionAndAttendee();
+      const { saveAttendeeAnswers, getAttendeeAnswersBatch } = await import(
+        "#lib/db/questions.ts"
+      );
+      await saveAttendeeAnswers(attendee.id, [a1.id]);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "1",
+            [`question_${q.id}`]: String(a2.id),
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const answers = await getAttendeeAnswersBatch([attendee.id]);
+      expect(answers.get(attendee.id)).toEqual([a2.id]);
+    });
+
+    test("clears answers when no question field submitted", async () => {
+      const { event, attendee, a1 } = await setupQuestionAndAttendee();
+      const { saveAttendeeAnswers, getAttendeeAnswersBatch } = await import(
+        "#lib/db/questions.ts"
+      );
+      await saveAttendeeAnswers(attendee.id, [a1.id]);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "1",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const answers = await getAttendeeAnswersBatch([attendee.id]);
+      const attendeeAnswers = answers.get(attendee.id) ?? [];
+      expect(attendeeAnswers.length).toBe(0);
+    });
+
+    test("ignores invalid answer ID for question", async () => {
+      const { event, attendee, q } = await setupQuestionAndAttendee();
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/attendees/${attendee.id}`,
+          {
+            name: "John Doe",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            event_id: String(event.id),
+            quantity: "1",
+            [`question_${q.id}`]: "99999",
+            csrf_token: await testCsrfToken(),
+          },
+          await testCookie(),
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      const { getAttendeeAnswersBatch } = await import("#lib/db/questions.ts");
+      const answers = await getAttendeeAnswersBatch([attendee.id]);
+      const attendeeAnswers = answers.get(attendee.id) ?? [];
+      expect(attendeeAnswers.length).toBe(0);
     });
   });
 });

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -2341,7 +2341,7 @@ describe("server (admin attendees)", () => {
     test("pre-selects existing answer on edit page", async () => {
       const { attendee, a1 } = await setupQuestionAndAttendee();
       const { saveAttendeeAnswers } = await import("#lib/db/questions.ts");
-      await saveAttendeeAnswers(attendee.id, [a1.id]);
+      await saveAttendeeAnswers([attendee.id], [a1.id]);
 
       const response = await awaitTestRequest(
         `/admin/attendees/${attendee.id}`,
@@ -2398,7 +2398,7 @@ describe("server (admin attendees)", () => {
       const { saveAttendeeAnswers, getAttendeeAnswersBatch } = await import(
         "#lib/db/questions.ts"
       );
-      await saveAttendeeAnswers(attendee.id, [a1.id]);
+      await saveAttendeeAnswers([attendee.id], [a1.id]);
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2428,7 +2428,7 @@ describe("server (admin attendees)", () => {
       const { saveAttendeeAnswers, getAttendeeAnswersBatch } = await import(
         "#lib/db/questions.ts"
       );
-      await saveAttendeeAnswers(attendee.id, [a1.id]);
+      await saveAttendeeAnswers([attendee.id], [a1.id]);
 
       const response = await handleRequest(
         mockFormRequest(

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -649,7 +649,7 @@ describe("server (admin events)", () => {
         sortOrder: 1,
       });
       await setEventQuestions(event.id, [q.id]);
-      await saveAttendeeAnswers(attendee.id, [a1.id]);
+      await saveAttendeeAnswers([attendee.id], [a1.id]);
 
       const response = await awaitTestRequest(
         `/admin/event/${event.id}/export`,

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -3954,10 +3954,7 @@ describe("server (webhooks)", () => {
         expect(att2.length).toBe(1);
 
         // Verify custom question answers were saved for all attendees
-        const batch = await getAttendeeAnswersBatch([
-          att1[0]!.id,
-          att2[0]!.id,
-        ]);
+        const batch = await getAttendeeAnswersBatch([att1[0]!.id, att2[0]!.id]);
         expect(batch.get(att1[0]!.id)).toEqual([a1.id]);
       } finally {
         mockVerify.restore();


### PR DESCRIPTION
## Summary
This PR adds the ability to view and edit custom question answers directly from the admin attendee edit page. Previously, custom questions were only available during the public booking flow. Now admins can see which questions are associated with an event and update attendee answers.

## Key Changes

- **Refactored `saveAttendeeAnswers` API**: Changed from single-attendee to batch operation that accepts arrays of attendee IDs. The function now atomically deletes existing answers before inserting new ones, enabling answer replacement.
  - Removed the separate `saveAttendeeAnswersBatch` function in favor of a unified `saveAttendeeAnswers` that handles both single and batch operations
  - Updated all call sites across webhooks, public routes, and tests to use the new signature

- **Enhanced admin attendee edit page**:
  - Added question loading and display in the edit form
  - Questions are fetched from the event and rendered as radio button groups
  - Pre-selects the attendee's existing answer if one exists
  - Parses submitted question answers and validates them against available options

- **Updated `loadAttendeeForEdit` function**: Now fetches event questions and the attendee's current answers alongside other attendee data

- **Added question rendering template**: New `renderEditQuestions` helper function in the admin attendees template that generates HTML for custom question fields with proper escaping and pre-selection

- **Comprehensive test coverage**: Added 7 new test cases covering:
  - Question display on edit page
  - Pre-selection of existing answers
  - Behavior when event has no questions
  - Saving new answers
  - Updating answers from one option to another
  - Clearing answers when no question field is submitted
  - Ignoring invalid answer IDs

## Implementation Details

- The atomic delete-then-insert pattern in `saveAttendeeAnswers` ensures data consistency when updating answers
- Answer validation occurs server-side by checking submitted answer IDs against the question's available answers
- The template uses radio buttons for single-answer questions with proper HTML escaping for security

https://claude.ai/code/session_018yfVvgB3sAUfwDAiFPRtvR