### PR TITLE
Add API key authentication and admin API endpoints

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -5,6 +5,56 @@ Extract business logic from route handlers into reusable functions, then expose 
 
 ---
 
+## Completed: API Key Infrastructure
+
+### What's built
+- **API key CRUD** — create, list, delete with encrypted names at rest
+- **Bearer token auth** — HMAC-indexed lookup, DATA_KEY wrapped per-token
+- **Scoped auth** — Bearer tokens only work on `/api/admin/*` (via `withAdminApi`). Cookie-based session helpers (`withSession`, `requireSessionOr`, `requireOwnerOr`) are cookie-only; API keys cannot authenticate admin HTML pages.
+- **Admin JSON API** — `GET /api/admin/events` returns events via `withAdminApi`
+- **Delete confirmation** — "Type the name" flow matching events/attendees pattern
+- **Cascade cleanup** — user deletion removes API keys via `deleteByFieldBatch`
+- **Error logging** — invalid Bearer attempts, orphaned keys, corrupted wrapped data all logged
+
+### Key files
+| File | Purpose |
+|------|---------|
+| `src/lib/db/api-keys.ts` | DB operations: create, lookup, list, delete, count |
+| `src/routes/admin/api-keys.ts` | Admin UI routes: key management pages |
+| `src/routes/admin/api.ts` | JSON API routes (currently just events list) |
+| `src/routes/utils.ts` | `getAuthenticatedApiKey`, `withAdminApi` |
+| `src/templates/admin/api-keys.tsx` | Key list page + delete confirmation page |
+| `test/api-keys.test.ts` | 54 tests covering DB, UI, auth scope, JSON API |
+
+### Auth flow
+```
+/api/admin/* request
+  → withAdminApi()
+    → getAuthenticatedApiKey(request)
+      → getBearerToken() extracts token
+      → getApiKeyByToken() HMAC lookup
+      → getUserById() loads user
+      → unwrapKeyWithToken() validates token can decrypt wrapped key
+      → decryptAdminLevel() gets role
+      → returns AuthSession
+    → if valid: handle request
+    → if Bearer present but invalid: 401
+    → if no Bearer: fall through to cookie+CSRF via withAuthJson()
+```
+
+### Design decisions
+- **No key rotation** — keys are immutable; delete and recreate instead
+- **No scope restrictions** — keys inherit full admin_level from parent user
+- **No rate limiting on auth** — relies on external rate limiting (edge CDN)
+- **Nav link hidden** — API Keys page exists but isn't linked from admin nav yet (waiting for feature completion)
+- **`apiKeysApi` stub exported** — follows existing codebase pattern for test mocking (matches `usersApi` etc.)
+
+### What's NOT built yet
+- Admin nav link to `/admin/api-keys` (hidden until feature complete)
+- Remaining API endpoints beyond `GET /api/admin/events`
+
+---
+
 ## Phase 1: Extract business logic from tangled handlers
 
 ### 1a. `src/lib/attendees-actions.ts` (new file)
@@ -51,16 +101,12 @@ Extract from `src/routes/admin/settings.ts`:
 
 ## Phase 2: Admin API routes
 
-### New file: `src/routes/admin/api.ts`
-
-Uses existing infrastructure: `withAuthJson`, `defineRoutes`, `createRouter`, `jsonResponse`.
-
-Auth: same session cookie auth as admin UI. CSRF via `x-csrf-token` header (already supported by `withAuthJson`).
+Extends `src/routes/admin/api.ts`. All endpoints use `withAdminApi` for dual auth (Bearer token or cookie+CSRF).
 
 ### Priority endpoints (highest value for external tooling):
 
 **Events CRUD:**
-- `GET /api/admin/events` → list all events with counts
+- `GET /api/admin/events` → list all events with counts *(done)*
 - `GET /api/admin/events/:eventId` → single event detail
 - `POST /api/admin/events` → create event (JSON body)
 - `PUT /api/admin/events/:eventId` → update event
@@ -95,9 +141,6 @@ Auth: same session cookie auth as admin UI. CSRF via `x-csrf-token` header (alre
 - Calendar data endpoint
 - CSV export as JSON
 
-### Registration in router
-Add `"api/admin"` prefix to `src/routes/index.ts` lazy loader, pointing to `src/routes/admin/api.ts`.
-
 ---
 
 ## Phase 3: Tests
@@ -111,7 +154,7 @@ Add `"api/admin"` prefix to `src/routes/index.ts` lazy loader, pointing to `src/
 ## What this enables
 
 After Phase 2, users can:
-- Build CLI tools for event management (`curl -X POST /api/admin/events`)
+- Build CLI tools for event management (`curl -H "Authorization: Bearer KEY" /api/admin/events`)
 - Script bulk operations (import attendees from CSV via API)
 - Build custom dashboards pulling from the API
 - Wire up Zapier/n8n to admin operations

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,120 @@
+# API-First Refactor Plan
+
+## Principle
+Extract business logic from route handlers into reusable functions, then expose those functions via admin API endpoints. Each phase is independently shippable. No existing behavior changes.
+
+---
+
+## Phase 1: Extract business logic from tangled handlers
+
+### 1a. `src/lib/attendees-actions.ts` (new file)
+Extract from `src/routes/admin/attendees.ts`:
+
+- **`isIncompleteAttendee(attendee, event)`** → boolean
+  - Currently inline in `handleDeleteIncomplete` (~3 lines of logic)
+
+- **`refundAttendeesBatch(attendees, provider)`** → `{ refunded: number, failed: number }`
+  - Currently a loop inside `processRefundAll` with counter tracking
+
+- **`calculateSpotsNeeded(oldQty, newQty, oldEventId, newEventId)`** → number
+  - Currently inline in `editAttendeeHandler` with conditional logic
+
+### 1b. `src/lib/settings-actions.ts` (new file)
+Extract from `src/routes/admin/settings.ts`:
+
+- **`configureStripe(secretKey, existingKey, domain)`** → `{ ok: true } | { ok: false, error: string }`
+  - Currently ~60 lines inline: key format detection, webhook setup, multi-field storage
+
+- **`configureSquare(token, locationId, sandbox, existingToken)`** → same result type
+  - Currently ~40 lines inline
+
+- **`configureAppleWallet(input)`** → same result type
+  - Currently ~60 lines inline: all-clear detection, required field checks, PEM validation
+
+- **`configureGoogleWallet(input)`** → same result type
+  - Currently ~70 lines inline
+
+- **`validateEmailTemplates(subject, html, text)`** → `string | null`
+  - Currently two inline loops doing length + syntax validation
+
+### 1c. Minor extraction in `src/routes/admin/events.ts`
+- **`validateEventSlug(slug, excludeId?)`** → `string | null`
+  - Currently a lambda inside the route handler
+
+### After Phase 1
+- All route handlers become: parse input → call extracted function → format response
+- All existing behavior unchanged
+- Extracted functions are independently testable
+- Tests updated to cover extracted functions directly
+
+---
+
+## Phase 2: Admin API routes
+
+### New file: `src/routes/admin/api.ts`
+
+Uses existing infrastructure: `withAuthJson`, `defineRoutes`, `createRouter`, `jsonResponse`.
+
+Auth: same session cookie auth as admin UI. CSRF via `x-csrf-token` header (already supported by `withAuthJson`).
+
+### Priority endpoints (highest value for external tooling):
+
+**Events CRUD:**
+- `GET /api/admin/events` → list all events with counts
+- `GET /api/admin/events/:eventId` → single event detail
+- `POST /api/admin/events` → create event (JSON body)
+- `PUT /api/admin/events/:eventId` → update event
+- `DELETE /api/admin/events/:eventId` → delete event (requires `{ confirmName }`)
+- `POST /api/admin/events/:eventId/deactivate` → deactivate
+- `POST /api/admin/events/:eventId/reactivate` → reactivate
+
+**Attendees:**
+- `GET /api/admin/events/:eventId/attendees` → list attendees (decrypted)
+- `POST /api/admin/events/:eventId/attendees` → add attendee manually
+- `PUT /api/admin/attendees/:attendeeId` → edit attendee
+- `DELETE /api/admin/attendees/:attendeeId` → delete attendee
+- `POST /api/admin/attendees/:attendeeId/checkin` → toggle check-in
+- `POST /api/admin/attendees/:attendeeId/refund` → refund single
+- `POST /api/admin/events/:eventId/refund-all` → batch refund
+
+**Groups:**
+- `GET /api/admin/groups` → list groups
+- `POST /api/admin/groups` → create group
+- `PUT /api/admin/groups/:groupId` → update group
+- `DELETE /api/admin/groups/:groupId` → delete group
+
+**Dashboard/Read-only:**
+- `GET /api/admin/dashboard` → dashboard summary data
+- `GET /api/admin/events/:eventId/activity` → activity log
+- `GET /api/admin/activity` → global activity log
+
+### Lower priority (Phase 2b):
+- Settings endpoints (payment provider config, email templates, branding)
+- User management endpoints
+- Holiday management endpoints
+- Calendar data endpoint
+- CSV export as JSON
+
+### Registration in router
+Add `"api/admin"` prefix to `src/routes/index.ts` lazy loader, pointing to `src/routes/admin/api.ts`.
+
+---
+
+## Phase 3: Tests
+
+- Unit tests for all extracted functions in Phase 1 (test the business logic directly)
+- Integration tests for Phase 2 API endpoints (mock DB, verify JSON responses)
+- Maintain 100% coverage requirement
+
+---
+
+## What this enables
+
+After Phase 2, users can:
+- Build CLI tools for event management (`curl -X POST /api/admin/events`)
+- Script bulk operations (import attendees from CSV via API)
+- Build custom dashboards pulling from the API
+- Wire up Zapier/n8n to admin operations
+- Build a mobile admin app against the same backend
+
+The web admin UI continues working exactly as before — it just shares business logic with the API.

--- a/src/lib/db/api-keys.ts
+++ b/src/lib/db/api-keys.ts
@@ -1,0 +1,157 @@
+/**
+ * API keys table operations
+ *
+ * API keys allow programmatic access to admin endpoints without
+ * password-based login. Each key wraps the shared DATA_KEY with
+ * a token-derived key (same crypto as session tokens), so the
+ * plaintext API key is needed to decrypt attendee PII.
+ *
+ * Keys inherit admin_level from their parent user.
+ */
+
+import {
+  decrypt,
+  encrypt,
+  hmacHash,
+  unwrapKeyWithToken,
+  wrapKeyWithToken,
+} from "#lib/crypto.ts";
+import { executeByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
+import { nowIso } from "#lib/now.ts";
+import type { ApiKey } from "#lib/types.ts";
+
+/** Maximum number of API keys per user */
+export const MAX_KEYS_PER_USER = 10;
+
+/**
+ * Create a new API key for a user.
+ * Requires the plaintext DATA_KEY (available during an authenticated session).
+ * Returns the plaintext API key token — shown once, never stored.
+ */
+export const createApiKey = async (
+  userId: number,
+  name: string,
+  dataKey: CryptoKey,
+  generateToken: () => string,
+): Promise<{ apiKey: string; id: number }> => {
+  const apiKey = generateToken();
+  const keyIndex = await hmacHash(apiKey);
+  const wrappedDataKey = await wrapKeyWithToken(dataKey, apiKey);
+  const encryptedName = await encrypt(name);
+
+  const result = await getDb().execute({
+    sql: `INSERT INTO api_keys (user_id, key_index, wrapped_data_key, name, created, last_used)
+          VALUES (?, ?, ?, ?, ?, '')`,
+    args: [userId, keyIndex, wrappedDataKey, encryptedName, nowIso()],
+  });
+
+  return { apiKey, id: Number(result.lastInsertRowid) };
+};
+
+/**
+ * Look up an API key by its plaintext token.
+ * Returns the row if found (for auth), null otherwise.
+ */
+export const getApiKeyByToken = async (
+  token: string,
+): Promise<ApiKey | null> => {
+  const keyIndex = await hmacHash(token);
+  return queryOne<ApiKey>(
+    "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE key_index = ?",
+    [keyIndex],
+  );
+};
+
+/**
+ * Unwrap the DATA_KEY from an API key row using the plaintext token.
+ * Returns null if unwrapping fails (e.g. corrupted or rotated key).
+ */
+export const unwrapApiKeyDataKey = async (
+  wrappedDataKey: string,
+  token: string,
+): Promise<CryptoKey | null> => {
+  try {
+    return await unwrapKeyWithToken(wrappedDataKey, token);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * List all API keys for a user (decrypts names for display).
+ */
+export const getApiKeysForUser = async (
+  userId: number,
+): Promise<
+  Array<{ id: number; name: string; created: string; lastUsed: string }>
+> => {
+  const rows = await queryAll<ApiKey>(
+    "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE user_id = ? ORDER BY id ASC",
+    [userId],
+  );
+
+  const results = [];
+  for (const row of rows) {
+    results.push({
+      id: row.id,
+      name: await decrypt(row.name),
+      created: row.created,
+      lastUsed: row.last_used,
+    });
+  }
+  return results;
+};
+
+/**
+ * Count API keys for a user (for enforcing MAX_KEYS_PER_USER).
+ */
+export const countApiKeysForUser = async (userId: number): Promise<number> => {
+  const result = await queryOne<{ count: number }>(
+    "SELECT COUNT(*) as count FROM api_keys WHERE user_id = ?",
+    [userId],
+  );
+  return result!.count;
+};
+
+/**
+ * Delete an API key by ID (must belong to the given user).
+ */
+export const deleteApiKey = async (
+  id: number,
+  userId: number,
+): Promise<boolean> => {
+  const result = await getDb().execute({
+    sql: "DELETE FROM api_keys WHERE id = ? AND user_id = ?",
+    args: [id, userId],
+  });
+  return result.rowsAffected > 0;
+};
+
+/**
+ * Delete all API keys for a user.
+ */
+export const deleteAllApiKeysForUser = (userId: number): Promise<void> =>
+  executeByField("api_keys", "user_id", userId);
+
+/**
+ * Update last_used timestamp for an API key.
+ * Uses fire-and-forget pattern to avoid slowing down requests.
+ */
+export const touchApiKeyLastUsed = async (id: number): Promise<void> => {
+  await getDb().execute({
+    sql: "UPDATE api_keys SET last_used = ? WHERE id = ?",
+    args: [nowIso(), id],
+  });
+};
+
+export const apiKeysApi = {
+  createApiKey,
+  getApiKeyByToken,
+  unwrapApiKeyDataKey,
+  getApiKeysForUser,
+  countApiKeysForUser,
+  deleteApiKey,
+  deleteAllApiKeysForUser,
+  touchApiKeyLastUsed,
+  MAX_KEYS_PER_USER,
+};

--- a/src/lib/db/api-keys.ts
+++ b/src/lib/db/api-keys.ts
@@ -16,12 +16,9 @@ import {
   unwrapKeyWithToken,
   wrapKeyWithToken,
 } from "#lib/crypto.ts";
-import { executeByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
+import { deleteByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
 import { nowIso } from "#lib/now.ts";
 import type { ApiKey } from "#lib/types.ts";
-
-/** Maximum number of API keys per user */
-export const MAX_KEYS_PER_USER = 10;
 
 /**
  * Create a new API key for a user.
@@ -64,18 +61,12 @@ export const getApiKeyByToken = async (
 
 /**
  * Unwrap the DATA_KEY from an API key row using the plaintext token.
- * Returns null if unwrapping fails (e.g. corrupted or rotated key).
+ * Throws if unwrapping fails (e.g. corrupted or rotated key).
  */
-export const unwrapApiKeyDataKey = async (
+export const unwrapApiKeyDataKey = (
   wrappedDataKey: string,
   token: string,
-): Promise<CryptoKey | null> => {
-  try {
-    return await unwrapKeyWithToken(wrappedDataKey, token);
-  } catch {
-    return null;
-  }
-};
+): Promise<CryptoKey> => unwrapKeyWithToken(wrappedDataKey, token);
 
 /**
  * List all API keys for a user (decrypts names for display).
@@ -90,20 +81,33 @@ export const getApiKeysForUser = async (
     [userId],
   );
 
-  const results = [];
-  for (const row of rows) {
-    results.push({
+  return Promise.all(
+    rows.map(async (row) => ({
       id: row.id,
       name: await decrypt(row.name),
       created: row.created,
       lastUsed: row.last_used,
-    });
-  }
-  return results;
+    })),
+  );
 };
 
 /**
- * Count API keys for a user (for enforcing MAX_KEYS_PER_USER).
+ * Get a single API key by ID and user, with decrypted name.
+ */
+export const getApiKeyForUser = async (
+  id: number,
+  userId: number,
+): Promise<{ id: number; name: string } | null> => {
+  const row = await queryOne<ApiKey>(
+    "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE id = ? AND user_id = ?",
+    [id, userId],
+  );
+  if (!row) return null;
+  return { id: row.id, name: await decrypt(row.name) };
+};
+
+/**
+ * Count API keys for a user.
  */
 export const countApiKeysForUser = async (userId: number): Promise<number> => {
   const result = await queryOne<{ count: number }>(
@@ -131,7 +135,7 @@ export const deleteApiKey = async (
  * Delete all API keys for a user.
  */
 export const deleteAllApiKeysForUser = (userId: number): Promise<void> =>
-  executeByField("api_keys", "user_id", userId);
+  deleteByField("api_keys", "user_id", userId);
 
 /**
  * Update last_used timestamp for an API key.
@@ -149,9 +153,9 @@ export const apiKeysApi = {
   getApiKeyByToken,
   unwrapApiKeyDataKey,
   getApiKeysForUser,
+  getApiKeyForUser,
   countApiKeysForUser,
   deleteApiKey,
   deleteAllApiKeysForUser,
   touchApiKeyLastUsed,
-  MAX_KEYS_PER_USER,
 };

--- a/src/lib/db/api-keys.ts
+++ b/src/lib/db/api-keys.ts
@@ -9,13 +9,7 @@
  * Keys inherit admin_level from their parent user.
  */
 
-import {
-  decrypt,
-  encrypt,
-  hmacHash,
-  unwrapKeyWithToken,
-  wrapKeyWithToken,
-} from "#lib/crypto.ts";
+import { decrypt, encrypt, hmacHash, wrapKeyWithToken } from "#lib/crypto.ts";
 import { deleteByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
 import { nowIso } from "#lib/now.ts";
 import type { ApiKey } from "#lib/types.ts";
@@ -60,15 +54,6 @@ export const getApiKeyByToken = async (
 };
 
 /**
- * Unwrap the DATA_KEY from an API key row using the plaintext token.
- * Throws if unwrapping fails (e.g. corrupted or rotated key).
- */
-export const unwrapApiKeyDataKey = (
-  wrappedDataKey: string,
-  token: string,
-): Promise<CryptoKey> => unwrapKeyWithToken(wrappedDataKey, token);
-
-/**
  * List all API keys for a user (decrypts names for display).
  */
 export const getApiKeysForUser = async (
@@ -97,12 +82,12 @@ export const getApiKeysForUser = async (
 export const getApiKeyForUser = async (
   id: number,
   userId: number,
-): Promise<{ id: number; name: string } | null> => {
+): Promise<{ id: number; name: string }> => {
   const row = await queryOne<ApiKey>(
     "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE id = ? AND user_id = ?",
     [id, userId],
   );
-  if (!row) return null;
+  if (!row) throw new Error(`API key ${id} not found for user ${userId}`);
   return { id: row.id, name: await decrypt(row.name) };
 };
 
@@ -151,7 +136,6 @@ export const touchApiKeyLastUsed = async (id: number): Promise<void> => {
 export const apiKeysApi = {
   createApiKey,
   getApiKeyByToken,
-  unwrapApiKeyDataKey,
   getApiKeysForUser,
   getApiKeyForUser,
   countApiKeysForUser,

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -2,7 +2,7 @@
  * Database client setup and core utilities
  *
  * When query logging is enabled (admin debug footer), the core query
- * functions (queryOne, queryAll, queryBatch, executeByField) time each
+ * functions (queryOne, queryAll, queryBatch, deleteByField) time each
  * call and record the SQL via the query-log module.
  */
 
@@ -69,8 +69,8 @@ export const queryAll = async <T>(
   return resultRows<T>(result);
 };
 
-/** Execute delete by field */
-export const executeByField = async (
+/** Delete rows matching a field value */
+export const deleteByField = async (
   table: string,
   field: string,
   value: InValue,
@@ -78,6 +78,17 @@ export const executeByField = async (
   const sql = `DELETE FROM ${table} WHERE ${field} = ?`;
   await trackQuery(sql, () => getDb().execute({ sql, args: [value] }));
 };
+
+/** Delete rows from multiple tables in a single batch transaction */
+export const deleteByFieldBatch = (
+  deletes: Array<{ table: string; field: string; value: InValue }>,
+): Promise<void> =>
+  executeBatch(
+    deletes.map(({ table, field, value }) => ({
+      sql: `DELETE FROM ${table} WHERE ${field} = ?`,
+      args: [value],
+    })),
+  );
 
 /** Execute a batch with optional query logging and timing */
 const trackedBatch = async (

--- a/src/lib/db/login-attempts.ts
+++ b/src/lib/db/login-attempts.ts
@@ -3,7 +3,7 @@
  */
 
 import { hmacHash } from "#lib/crypto.ts";
-import { executeByField, getDb, queryOne } from "#lib/db/client.ts";
+import { deleteByField, getDb, queryOne } from "#lib/db/client.ts";
 import { nowMs } from "#lib/now.ts";
 
 /**
@@ -43,7 +43,7 @@ const checkLockout = async (
 
   // If lockout expired, reset
   if (row.locked_until && row.locked_until <= currentMs) {
-    await executeByField("login_attempts", "ip", hashedIp);
+    await deleteByField("login_attempts", "ip", hashedIp);
   }
 
   return false;
@@ -90,5 +90,5 @@ export const recordFailedLogin = (ip: string): Promise<boolean> =>
  */
 export const clearLoginAttempts = async (ip: string): Promise<void> => {
   const hashedIp = await hmacHash(ip);
-  await executeByField("login_attempts", "ip", hashedIp);
+  await deleteByField("login_attempts", "ip", hashedIp);
 };

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -15,7 +15,7 @@ import { getPublicKey, getSetting } from "#lib/db/settings.ts";
 /**
  * The latest database update identifier - update this when changing schema
  */
-export const LATEST_UPDATE = "recreate processed_payments table";
+export const LATEST_UPDATE = "add api_keys table";
 
 /**
  * Run a migration that may fail if already applied (e.g., adding a column that exists)
@@ -665,6 +665,25 @@ export const initDb = async (): Promise<void> => {
     "ALTER TABLE groups ADD COLUMN max_attendees INTEGER NOT NULL DEFAULT 0",
   );
 
+  // Create api_keys table for programmatic admin access
+  await runMigration(`
+    CREATE TABLE IF NOT EXISTS api_keys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      key_index TEXT NOT NULL,
+      wrapped_data_key TEXT NOT NULL,
+      name TEXT NOT NULL,
+      created TEXT NOT NULL,
+      last_used TEXT NOT NULL DEFAULT '',
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    )
+  `);
+
+  // Create unique index on key_index for fast lookups
+  await runMigration(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key_index ON api_keys(key_index)",
+  );
+
   // Update the version marker
   await getDb().execute({
     sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('latest_db_update', ?)",
@@ -676,6 +695,7 @@ export const initDb = async (): Promise<void> => {
  * All database tables in order for safe dropping (respects foreign key constraints)
  */
 const ALL_TABLES = [
+  "api_keys",
   "groups",
   "holidays",
   "activity_log",

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -4,7 +4,7 @@
 
 import { registerCache } from "#lib/cache-registry.ts";
 import { hashSessionToken } from "#lib/crypto.ts";
-import { executeByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
+import { deleteByField, getDb, queryAll, queryOne } from "#lib/db/client.ts";
 
 import type { Session } from "#lib/types.ts";
 
@@ -121,7 +121,7 @@ export const getSession = async (token: string): Promise<Session | null> => {
 export const deleteSession = async (token: string): Promise<void> => {
   const tokenHash = await hashSessionToken(token);
   invalidateSessionCache(tokenHash);
-  await executeByField("sessions", "token", tokenHash);
+  await deleteByField("sessions", "token", tokenHash);
 };
 
 /**

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -14,7 +14,7 @@ import {
   verifyPassword,
   wrapKey,
 } from "#lib/crypto.ts";
-import { executeByField, getDb, queryAll } from "#lib/db/client.ts";
+import { deleteByFieldBatch, getDb, queryAll } from "#lib/db/client.ts";
 import { now } from "#lib/now.ts";
 import { type AdminLevel, isAdminLevel, type User } from "#lib/types.ts";
 
@@ -233,9 +233,11 @@ export const activateUser = async (
  * Delete a user and all their sessions and API keys
  */
 export const deleteUser = async (userId: number): Promise<void> => {
-  await executeByField("api_keys", "user_id", userId);
-  await executeByField("sessions", "user_id", userId);
-  await executeByField("users", "id", userId);
+  await deleteByFieldBatch([
+    { table: "api_keys", field: "user_id", value: userId },
+    { table: "sessions", field: "user_id", value: userId },
+    { table: "users", field: "id", value: userId },
+  ]);
   invalidateUsersCache();
 };
 

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -14,7 +14,7 @@ import {
   verifyPassword,
   wrapKey,
 } from "#lib/crypto.ts";
-import { getDb, queryAll } from "#lib/db/client.ts";
+import { executeByField, getDb, queryAll } from "#lib/db/client.ts";
 import { now } from "#lib/now.ts";
 import { type AdminLevel, isAdminLevel, type User } from "#lib/types.ts";
 
@@ -230,17 +230,12 @@ export const activateUser = async (
 };
 
 /**
- * Delete a user and all their sessions
+ * Delete a user and all their sessions and API keys
  */
 export const deleteUser = async (userId: number): Promise<void> => {
-  await getDb().execute({
-    sql: "DELETE FROM sessions WHERE user_id = ?",
-    args: [userId],
-  });
-  await getDb().execute({
-    sql: "DELETE FROM users WHERE id = ?",
-    args: [userId],
-  });
+  await executeByField("api_keys", "user_id", userId);
+  await executeByField("sessions", "user_id", userId);
+  await executeByField("users", "id", userId);
   invalidateUsersCache();
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -140,6 +140,16 @@ export interface User {
   invite_expiry: string | null; // encrypted ISO 8601, null after password set
 }
 
+export interface ApiKey {
+  id: number;
+  user_id: number;
+  key_index: string; // HMAC hash for lookup
+  wrapped_data_key: string; // DATA_KEY wrapped with the API key token
+  name: string; // encrypted label
+  created: string;
+  last_used: string; // ISO 8601 or empty string
+}
+
 export interface Holiday {
   id: number;
   name: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -169,3 +169,10 @@ export interface Group {
 export interface EventWithCount extends Event {
   attendee_count: number;
 }
+
+/**
+ * Admin API event shape — all event fields except internal indices.
+ * Used by both admin JSON API and admin templates to ensure consistent
+ * field exposure. Snake_case keys match the DB schema.
+ */
+export type AdminEvent = Omit<EventWithCount, "slug_index">;

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -4,22 +4,26 @@
 
 import { generateSecureToken, unwrapKeyWithToken } from "#lib/crypto.ts";
 import {
-  countApiKeysForUser,
   createApiKey,
   deleteApiKey,
+  getApiKeyForUser,
   getApiKeysForUser,
-  MAX_KEYS_PER_USER,
 } from "#lib/db/api-keys.ts";
+import { verifyIdentifier } from "#routes/admin/utils.ts";
 import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import {
   getSearchParam,
   htmlResponse,
   jsonResponse,
+  notFoundResponse,
   redirect,
   requireOwnerOr,
   withOwnerAuthForm,
 } from "#routes/utils.ts";
-import { adminApiKeysPage } from "#templates/admin/api-keys.tsx";
+import {
+  adminApiKeysPage,
+  adminDeleteApiKeyPage,
+} from "#templates/admin/api-keys.tsx";
 
 /**
  * Handle GET /admin/api-keys
@@ -45,15 +49,6 @@ const handleApiKeysPost = (request: Request): Promise<Response> =>
       return redirect(
         "/admin/api-keys",
         "Name must be under 100 characters",
-        false,
-      );
-    }
-
-    const count = await countApiKeysForUser(session.userId);
-    if (count >= MAX_KEYS_PER_USER) {
-      return redirect(
-        "/admin/api-keys",
-        `Maximum of ${MAX_KEYS_PER_USER} API keys reached`,
         false,
       );
     }
@@ -86,16 +81,42 @@ const handleApiKeysPost = (request: Request): Promise<Response> =>
   });
 
 /**
+ * Handle GET /admin/api-keys/:apiKeyId/delete — confirmation page
+ */
+const handleApiKeyDeleteGet: TypedRouteHandler<
+  "GET /admin/api-keys/:apiKeyId/delete"
+> = (request, { apiKeyId }) =>
+  requireOwnerOr(request, async (session) => {
+    const apiKey = await getApiKeyForUser(apiKeyId, session.userId);
+    if (!apiKey) return notFoundResponse();
+    return htmlResponse(adminDeleteApiKeyPage(apiKey, session));
+  });
+
+/**
  * Handle POST /admin/api-keys/:apiKeyId/delete
  */
 const handleApiKeyDelete: TypedRouteHandler<
   "POST /admin/api-keys/:apiKeyId/delete"
 > = (request, { apiKeyId }) =>
-  withOwnerAuthForm(request, async (session) => {
-    const deleted = await deleteApiKey(apiKeyId, session.userId);
-    if (!deleted) {
+  withOwnerAuthForm(request, async (session, form) => {
+    const apiKey = await getApiKeyForUser(apiKeyId, session.userId);
+    if (!apiKey) {
       return redirect("/admin/api-keys", "API key not found", false);
     }
+
+    const confirmIdentifier = form.getString("confirm_identifier");
+    if (!verifyIdentifier(apiKey.name, confirmIdentifier)) {
+      return htmlResponse(
+        adminDeleteApiKeyPage(
+          apiKey,
+          session,
+          "API key name does not match. Please type the exact name to confirm deletion.",
+        ),
+        400,
+      );
+    }
+
+    await deleteApiKey(apiKeyId, session.userId);
     return redirect("/admin/api-keys", "API key deleted", true);
   });
 
@@ -121,6 +142,7 @@ const handleApiDocsGet: TypedRouteHandler<"GET /admin/api-keys/docs"> = (
 export const apiKeysRoutes = defineRoutes({
   "GET /admin/api-keys": handleApiKeysGet,
   "POST /admin/api-keys": handleApiKeysPost,
+  "GET /admin/api-keys/:apiKeyId/delete": handleApiKeyDeleteGet,
   "POST /admin/api-keys/:apiKeyId/delete": handleApiKeyDelete,
   "GET /admin/api-keys/docs": handleApiDocsGet,
 });

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -15,7 +15,7 @@ import {
   getSearchParam,
   htmlResponse,
   jsonResponse,
-  notFoundResponse,
+  orNotFound,
   redirect,
   requireOwnerOr,
   withOwnerAuthForm,
@@ -86,11 +86,12 @@ const handleApiKeysPost = (request: Request): Promise<Response> =>
 const handleApiKeyDeleteGet: TypedRouteHandler<
   "GET /admin/api-keys/:apiKeyId/delete"
 > = (request, { apiKeyId }) =>
-  requireOwnerOr(request, async (session) => {
-    const apiKey = await getApiKeyForUser(apiKeyId, session.userId);
-    if (!apiKey) return notFoundResponse();
-    return htmlResponse(adminDeleteApiKeyPage(apiKey, session));
-  });
+  requireOwnerOr(request, (session) =>
+    orNotFound(
+      getApiKeyForUser(apiKeyId, session.userId).catch(() => null),
+      (apiKey) => htmlResponse(adminDeleteApiKeyPage(apiKey, session)),
+    ),
+  );
 
 /**
  * Handle POST /admin/api-keys/:apiKeyId/delete
@@ -99,8 +100,10 @@ const handleApiKeyDelete: TypedRouteHandler<
   "POST /admin/api-keys/:apiKeyId/delete"
 > = (request, { apiKeyId }) =>
   withOwnerAuthForm(request, async (session, form) => {
-    const apiKey = await getApiKeyForUser(apiKeyId, session.userId);
-    if (!apiKey) {
+    let apiKey;
+    try {
+      apiKey = await getApiKeyForUser(apiKeyId, session.userId);
+    } catch {
       return redirect("/admin/api-keys", "API key not found", false);
     }
 

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -1,0 +1,126 @@
+/**
+ * Admin API key management routes
+ */
+
+import { generateSecureToken, unwrapKeyWithToken } from "#lib/crypto.ts";
+import {
+  countApiKeysForUser,
+  createApiKey,
+  deleteApiKey,
+  getApiKeysForUser,
+  MAX_KEYS_PER_USER,
+} from "#lib/db/api-keys.ts";
+import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
+import {
+  getSearchParam,
+  htmlResponse,
+  jsonResponse,
+  redirect,
+  requireOwnerOr,
+  withOwnerAuthForm,
+} from "#routes/utils.ts";
+import { adminApiKeysPage } from "#templates/admin/api-keys.tsx";
+
+/**
+ * Handle GET /admin/api-keys
+ */
+const handleApiKeysGet: TypedRouteHandler<"GET /admin/api-keys"> = (request) =>
+  requireOwnerOr(request, async (session) => {
+    const keys = await getApiKeysForUser(session.userId);
+    const success = getSearchParam(request, "success");
+    const error = getSearchParam(request, "error");
+    return htmlResponse(adminApiKeysPage(keys, session, { success, error }));
+  });
+
+/**
+ * Handle POST /admin/api-keys (create new API key)
+ */
+const handleApiKeysPost = (request: Request): Promise<Response> =>
+  withOwnerAuthForm(request, async (session, form) => {
+    const name = (form.get("name") ?? "").trim();
+    if (!name) {
+      return redirect("/admin/api-keys", "Name is required", false);
+    }
+    if (name.length > 100) {
+      return redirect(
+        "/admin/api-keys",
+        "Name must be under 100 characters",
+        false,
+      );
+    }
+
+    const count = await countApiKeysForUser(session.userId);
+    if (count >= MAX_KEYS_PER_USER) {
+      return redirect(
+        "/admin/api-keys",
+        `Maximum of ${MAX_KEYS_PER_USER} API keys reached`,
+        false,
+      );
+    }
+
+    if (!session.wrappedDataKey) {
+      return redirect("/admin/api-keys", "Session key unavailable", false);
+    }
+
+    // Unwrap the DATA_KEY from the current session
+    const dataKey = await unwrapKeyWithToken(
+      session.wrappedDataKey,
+      session.token,
+    );
+
+    const { apiKey } = await createApiKey(
+      session.userId,
+      name,
+      dataKey,
+      generateSecureToken,
+    );
+
+    // Return the plaintext key in the response (shown once)
+    const keys = await getApiKeysForUser(session.userId);
+    return htmlResponse(
+      adminApiKeysPage(keys, session, {
+        success: "API key created",
+        newKey: apiKey,
+      }),
+    );
+  });
+
+/**
+ * Handle POST /admin/api-keys/:apiKeyId/delete
+ */
+const handleApiKeyDelete: TypedRouteHandler<
+  "POST /admin/api-keys/:apiKeyId/delete"
+> = (request, { apiKeyId }) =>
+  withOwnerAuthForm(request, async (session) => {
+    const deleted = await deleteApiKey(apiKeyId, session.userId);
+    if (!deleted) {
+      return redirect("/admin/api-keys", "API key not found", false);
+    }
+    return redirect("/admin/api-keys", "API key deleted", true);
+  });
+
+/**
+ * Handle GET /admin/api-keys/docs — simple API docs page
+ */
+const handleApiDocsGet: TypedRouteHandler<"GET /admin/api-keys/docs"> = (
+  request,
+) =>
+  requireOwnerOr(request, (_session) => {
+    return jsonResponse({
+      message: "Admin API documentation",
+      authentication:
+        "Add 'Authorization: Bearer YOUR_API_KEY' header to requests",
+      endpoints: {
+        "GET /api/admin/events": "List all events",
+        "GET /api/admin/events/:id": "Get event details",
+        "GET /api/admin/events/:id/attendees": "List attendees for event",
+      },
+    });
+  });
+
+export const apiKeysRoutes = defineRoutes({
+  "GET /admin/api-keys": handleApiKeysGet,
+  "POST /admin/api-keys": handleApiKeysPost,
+  "POST /admin/api-keys/:apiKeyId/delete": handleApiKeyDelete,
+  "GET /admin/api-keys/docs": handleApiDocsGet,
+});

--- a/src/routes/admin/api.ts
+++ b/src/routes/admin/api.ts
@@ -1,0 +1,36 @@
+/**
+ * Admin JSON API routes — accessible via API key or cookie+CSRF.
+ *
+ * These endpoints expose admin operations as JSON for programmatic access.
+ * Authentication is handled by withAdminApi which accepts either:
+ *   - Bearer token (API key) — no CSRF needed
+ *   - Session cookie + x-csrf-token header
+ */
+
+import { getAllEvents } from "#lib/db/events.ts";
+import { defineRoutes } from "#routes/router.ts";
+import { jsonResponse, withAdminApi } from "#routes/utils.ts";
+
+/** GET /api/admin/events — list all events with counts */
+const handleListEvents = (request: Request): Promise<Response> =>
+  withAdminApi(request, async (session) => {
+    const events = await getAllEvents();
+    return jsonResponse({
+      events: events.map((e) => ({
+        id: e.id,
+        name: e.name,
+        slug: e.slug,
+        active: e.active,
+        maxAttendees: e.max_attendees,
+        attendeeCount: e.attendee_count,
+        unitPrice: e.unit_price,
+        eventType: e.event_type,
+        hidden: e.hidden,
+      })),
+      adminLevel: session.adminLevel,
+    });
+  });
+
+export const adminApiRoutes = defineRoutes({
+  "GET /api/admin/events": handleListEvents,
+});

--- a/src/routes/admin/api.ts
+++ b/src/routes/admin/api.ts
@@ -7,27 +7,25 @@
  *   - Session cookie + x-csrf-token header
  */
 
+import { map } from "#fp";
 import { getAllEvents } from "#lib/db/events.ts";
+import type { AdminEvent, EventWithCount } from "#lib/types.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { jsonResponse, withAdminApi } from "#routes/utils.ts";
+
+/** Strip internal fields from an event, returning the admin API shape */
+export const toAdminEvent = ({
+  slug_index: _,
+  ...event
+}: EventWithCount): AdminEvent => event;
 
 /** GET /api/admin/events — list all events with counts */
 const handleListEvents = (request: Request): Promise<Response> =>
   withAdminApi(request, async (session) => {
     const events = await getAllEvents();
     return jsonResponse({
-      events: events.map((e) => ({
-        id: e.id,
-        name: e.name,
-        slug: e.slug,
-        active: e.active,
-        maxAttendees: e.max_attendees,
-        attendeeCount: e.attendee_count,
-        unitPrice: e.unit_price,
-        eventType: e.event_type,
-        hidden: e.hidden,
-      })),
-      adminLevel: session.adminLevel,
+      events: map(toAdminEvent)(events),
+      admin_level: session.adminLevel,
     });
   });
 

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -9,6 +9,7 @@
 
 import { enableQueryLog } from "#lib/db/query-log.ts";
 import { loadAllSettings } from "#lib/db/settings.ts";
+import { apiKeysRoutes } from "#routes/admin/api-keys.ts";
 import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
@@ -31,6 +32,7 @@ import { getAuthenticatedSession } from "#routes/utils.ts";
 const adminRoutes = {
   ...dashboardRoutes,
   ...authRoutes,
+  ...apiKeysRoutes,
   ...settingsRoutes,
   ...debugRoutes,
   ...siteRoutes,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -158,6 +158,12 @@ const loadApiRoutes = once(async () => {
   return routeApi;
 });
 
+/** Lazy-load admin API routes */
+const loadAdminApiRoutes = once(async () => {
+  const { adminApiRoutes } = await import("#routes/admin/api.ts");
+  return createRouter(adminApiRoutes);
+});
+
 export type { PaymentCspConfig } from "#routes/middleware.ts";
 // Re-export middleware functions for testing
 export {
@@ -222,10 +228,20 @@ const prefixHandlers: Record<string, RouterFn> = {
   gwallet: lazyRoute(loadGoogleWalletRoutes),
   v1: lazyRoute(loadWalletWebserviceRoutes),
   demo: lazyRoute(loadDemoResetRoutes),
-  api: async (request, path, method, server) =>
-    (await getShowPublicApiFromDb())
+  api: async (request, path, method, server) => {
+    // Admin API is always available (auth-protected)
+    const adminResult = await (await loadAdminApiRoutes())(
+      request,
+      path,
+      method,
+      server,
+    );
+    if (adminResult) return adminResult;
+    // Public API requires feature flag
+    return (await getShowPublicApiFromDb())
       ? (await loadApiRoutes())(request, path, method, server)
-      : null,
+      : null;
+  },
 };
 
 /**

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -172,7 +172,13 @@ export const getAuthenticatedApiKey = async (
   if (!token) return null;
 
   const apiKeyRow = await getApiKeyByToken(token);
-  if (!apiKeyRow) return null;
+  if (!apiKeyRow) {
+    logError({
+      code: ErrorCode.AUTH_INVALID_SESSION,
+      detail: "Bearer token does not match any API key",
+    });
+    return null;
+  }
 
   const user = await getUserById(apiKeyRow.user_id);
   if (!user) {
@@ -186,6 +192,10 @@ export const getAuthenticatedApiKey = async (
   try {
     await unwrapApiKeyDataKey(apiKeyRow.wrapped_data_key, token);
   } catch {
+    logError({
+      code: ErrorCode.AUTH_INVALID_SESSION,
+      detail: "API key wrapped data key corrupted",
+    });
     return null;
   }
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -209,18 +209,6 @@ export const getAuthenticatedApiKey = async (
 };
 
 /**
- * Get authenticated session from either cookie or API key.
- * Cookie auth is checked first (for browser requests), then Bearer token.
- */
-export const getAuth = async (
-  request: Request,
-): Promise<AuthSession | null> => {
-  const session = await getAuthenticatedSession(request);
-  if (session) return session;
-  return getAuthenticatedApiKey(request);
-};
-
-/**
  * Whether the current request is authenticated via API key (not cookie session).
  */
 export const isApiKeyAuth = (request: Request): boolean =>
@@ -500,14 +488,16 @@ export type AuthSession = {
 };
 
 /**
- * Handle request with authenticated session
+ * Handle request with authenticated cookie session.
+ * Only checks cookie-based auth. API key auth is intentionally excluded —
+ * Bearer tokens should only authenticate /api/* endpoints via withAdminApi.
  */
 export const withSession = async (
   request: Request,
   handler: (session: AuthSession) => Response | Promise<Response>,
   onNoSession: () => Response | Promise<Response>,
 ): Promise<Response> => {
-  const session = await getAuth(request);
+  const session = await getAuthenticatedSession(request);
   return session ? handler(session) : onNoSession();
 };
 
@@ -768,11 +758,13 @@ export async function withAdminApi(
   request: Request,
   handler: JsonHandler,
 ): Promise<Response> {
+  // Try API key auth first — getAuthenticatedApiKey returns null for
+  // non-Bearer requests (falling through to cookie+CSRF auth below)
+  // or when the key is invalid (returning 401).
+  const apiKeySession = await getAuthenticatedApiKey(request);
+  if (apiKeySession) return runJsonHandler(request, apiKeySession, handler);
   if (isApiKeyAuth(request)) {
-    const session = await getAuthenticatedApiKey(request);
-    if (!session)
-      return jsonResponse({ status: "error", message: "Invalid API key" }, 401);
-    return runJsonHandler(request, session, handler);
+    return jsonResponse({ status: "error", message: "Invalid API key" }, 401);
   }
   return withAuthJson(request, handler);
 }

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -4,17 +4,17 @@
 
 import { compact, map, pipe, reduce } from "#fp";
 import { getSessionCookieName } from "#lib/cookies.ts";
-import { generateSecureToken, getPrivateKeyFromSession } from "#lib/crypto.ts";
+import {
+  generateSecureToken,
+  getPrivateKeyFromSession,
+  unwrapKeyWithToken,
+} from "#lib/crypto.ts";
 import {
   CSRF_INVALID_FORM_MESSAGE,
   signCsrfToken,
   verifySignedCsrfToken,
 } from "#lib/csrf.ts";
-import {
-  getApiKeyByToken,
-  touchApiKeyLastUsed,
-  unwrapApiKeyDataKey,
-} from "#lib/db/api-keys.ts";
+import { getApiKeyByToken, touchApiKeyLastUsed } from "#lib/db/api-keys.ts";
 import { getEventWithCount, getEventWithCountBySlug } from "#lib/db/events.ts";
 import { deleteSession, getSession } from "#lib/db/sessions.ts";
 import { getWrappedPrivateKey } from "#lib/db/settings.ts";
@@ -190,7 +190,7 @@ export const getAuthenticatedApiKey = async (
   }
 
   try {
-    await unwrapApiKeyDataKey(apiKeyRow.wrapped_data_key, token);
+    await unwrapKeyWithToken(apiKeyRow.wrapped_data_key, token);
   } catch {
     logError({
       code: ErrorCode.AUTH_INVALID_SESSION,
@@ -217,12 +217,6 @@ export const getAuthenticatedApiKey = async (
   setCachedSession(result);
   return result;
 };
-
-/**
- * Whether the current request is authenticated via API key (not cookie session).
- */
-export const isApiKeyAuth = (request: Request): boolean =>
-  getBearerToken(request) !== null;
 
 /**
  * Get private key for decrypting attendee PII from an authenticated session
@@ -773,7 +767,7 @@ export async function withAdminApi(
   // or when the key is invalid (returning 401).
   const apiKeySession = await getAuthenticatedApiKey(request);
   if (apiKeySession) return runJsonHandler(request, apiKeySession, handler);
-  if (isApiKeyAuth(request)) {
+  if (getBearerToken(request)) {
     return jsonResponse({ status: "error", message: "Invalid API key" }, 401);
   }
   return withAuthJson(request, handler);

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -175,10 +175,19 @@ export const getAuthenticatedApiKey = async (
   if (!apiKeyRow) return null;
 
   const user = await getUserById(apiKeyRow.user_id);
-  if (!user) return null;
+  if (!user) {
+    logError({
+      code: ErrorCode.AUTH_INVALID_SESSION,
+      detail: "API key references non-existent user",
+    });
+    return null;
+  }
 
-  const dataKey = await unwrapApiKeyDataKey(apiKeyRow.wrapped_data_key, token);
-  if (!dataKey) return null;
+  try {
+    await unwrapApiKeyDataKey(apiKeyRow.wrapped_data_key, token);
+  } catch {
+    return null;
+  }
 
   // Re-wrap DATA_KEY with the token so getPrivateKey() works
   // (it expects token + wrappedDataKey in the same format as sessions)

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -10,6 +10,11 @@ import {
   signCsrfToken,
   verifySignedCsrfToken,
 } from "#lib/csrf.ts";
+import {
+  getApiKeyByToken,
+  touchApiKeyLastUsed,
+  unwrapApiKeyDataKey,
+} from "#lib/db/api-keys.ts";
 import { getEventWithCount, getEventWithCountBySlug } from "#lib/db/events.ts";
 import { deleteSession, getSession } from "#lib/db/sessions.ts";
 import { getWrappedPrivateKey } from "#lib/db/settings.ts";
@@ -145,6 +150,72 @@ export const getAuthenticatedSession = async (
   setCachedSession(result);
   return result;
 };
+
+/**
+ * Extract Bearer token from Authorization header.
+ */
+const getBearerToken = (request: Request): string | null => {
+  const auth = request.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+  return auth.slice(7);
+};
+
+/**
+ * Authenticate via API key (Bearer token).
+ * Returns an AuthSession (compatible with session-based auth) or null.
+ * API key auth bypasses CSRF since the key itself is the secret.
+ */
+export const getAuthenticatedApiKey = async (
+  request: Request,
+): Promise<AuthSession | null> => {
+  const token = getBearerToken(request);
+  if (!token) return null;
+
+  const apiKeyRow = await getApiKeyByToken(token);
+  if (!apiKeyRow) return null;
+
+  const user = await getUserById(apiKeyRow.user_id);
+  if (!user) return null;
+
+  const dataKey = await unwrapApiKeyDataKey(apiKeyRow.wrapped_data_key, token);
+  if (!dataKey) return null;
+
+  // Re-wrap DATA_KEY with the token so getPrivateKey() works
+  // (it expects token + wrappedDataKey in the same format as sessions)
+  const wrappedDataKey = apiKeyRow.wrapped_data_key;
+
+  const adminLevel = await decryptAdminLevel(user);
+
+  // Fire-and-forget last_used update
+  touchApiKeyLastUsed(apiKeyRow.id).catch(() => {});
+
+  const result: AuthSession = {
+    token,
+    wrappedDataKey,
+    userId: apiKeyRow.user_id,
+    adminLevel,
+  };
+  setCachedSession(result);
+  return result;
+};
+
+/**
+ * Get authenticated session from either cookie or API key.
+ * Cookie auth is checked first (for browser requests), then Bearer token.
+ */
+export const getAuth = async (
+  request: Request,
+): Promise<AuthSession | null> => {
+  const session = await getAuthenticatedSession(request);
+  if (session) return session;
+  return getAuthenticatedApiKey(request);
+};
+
+/**
+ * Whether the current request is authenticated via API key (not cookie session).
+ */
+export const isApiKeyAuth = (request: Request): boolean =>
+  getBearerToken(request) !== null;
 
 /**
  * Get private key for decrypting attendee PII from an authenticated session
@@ -427,7 +498,7 @@ export const withSession = async (
   handler: (session: AuthSession) => Response | Promise<Response>,
   onNoSession: () => Response | Promise<Response>,
 ): Promise<Response> => {
-  const session = await getAuthenticatedSession(request);
+  const session = await getAuth(request);
   return session ? handler(session) : onNoSession();
 };
 
@@ -621,6 +692,42 @@ type JsonHandler = (
   body: Record<string, unknown>,
 ) => Response | Promise<Response>;
 
+/** Parse JSON body from request, returning empty object for non-JSON or GET requests */
+const parseJsonBody = async (
+  request: Request,
+): Promise<
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: Response }
+> => {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) return { ok: true, body: {} };
+  try {
+    return { ok: true, body: await request.json() };
+  } catch {
+    logError({
+      code: ErrorCode.VALIDATION_FORM,
+      detail: "Malformed JSON body",
+    });
+    return {
+      ok: false,
+      response: jsonResponse(
+        { status: "error", message: "Invalid request body" },
+        400,
+      ),
+    };
+  }
+};
+
+/** Parse JSON body and invoke handler with session */
+const runJsonHandler = async (
+  request: Request,
+  session: AuthSession,
+  handler: JsonHandler,
+): Promise<Response> => {
+  const parsed = await parseJsonBody(request);
+  return parsed.ok ? handler(session, parsed.body) : parsed.response;
+};
+
 /**
  * Handle JSON API request with auth + CSRF validation (from x-csrf-token header).
  * Mirrors withAuthForm but for JSON endpoints.
@@ -640,19 +747,23 @@ export async function withAuthJson(
     return jsonResponse({ status: "error", message: "Forbidden" }, 403);
   }
 
-  let body: Record<string, unknown>;
-  try {
-    body = await request.json();
-  } catch {
-    logError({
-      code: ErrorCode.VALIDATION_FORM,
-      detail: "Malformed JSON body",
-    });
-    return jsonResponse(
-      { status: "error", message: "Invalid request body" },
-      400,
-    );
-  }
+  return runJsonHandler(request, session, handler);
+}
 
-  return handler(session, body);
+/**
+ * Handle admin API request with either cookie+CSRF or API key auth.
+ * Cookie-based requests require x-csrf-token header.
+ * API key requests (Bearer token) skip CSRF since the key is the secret.
+ */
+export async function withAdminApi(
+  request: Request,
+  handler: JsonHandler,
+): Promise<Response> {
+  if (isApiKeyAuth(request)) {
+    const session = await getAuthenticatedApiKey(request);
+    if (!session)
+      return jsonResponse({ status: "error", message: "Invalid API key" }, 401);
+    return runJsonHandler(request, session, handler);
+  }
+  return withAuthJson(request, handler);
 }

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -1,0 +1,115 @@
+/**
+ * Admin API keys page template
+ */
+
+import { map, pipe, reduce } from "#fp";
+import { CsrfForm } from "#lib/forms.tsx";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import type { AdminSession } from "#lib/types.ts";
+import { AdminNav } from "#templates/admin/nav.tsx";
+import { Layout } from "#templates/layout.tsx";
+
+const joinStrings = reduce((acc: string, s: string) => acc + s, "");
+
+type ApiKeyDisplay = {
+  id: number;
+  name: string;
+  created: string;
+  lastUsed: string;
+};
+
+const ApiKeyRow = ({ apiKey }: { apiKey: ApiKeyDisplay }): string =>
+  String(
+    <tr>
+      <td>{apiKey.name}</td>
+      <td>{new Date(apiKey.created).toLocaleDateString()}</td>
+      <td>
+        {apiKey.lastUsed
+          ? new Date(apiKey.lastUsed).toLocaleDateString()
+          : "Never"}
+      </td>
+      <td>
+        <CsrfForm
+          action={`/admin/api-keys/${apiKey.id}/delete`}
+          class="one-button"
+        >
+          <button type="submit" class="danger small">
+            Delete
+          </button>
+        </CsrfForm>
+      </td>
+    </tr>,
+  );
+
+/**
+ * Admin API keys page
+ */
+export const adminApiKeysPage = (
+  keys: ApiKeyDisplay[],
+  adminSession: AdminSession,
+  opts: { success?: string; error?: string; newKey?: string },
+): string => {
+  const keyRows =
+    keys.length > 0
+      ? pipe(
+          map((k: ApiKeyDisplay) => ApiKeyRow({ apiKey: k })),
+          joinStrings,
+        )(keys)
+      : '<tr><td colspan="4">No API keys</td></tr>';
+
+  return String(
+    <Layout title="API Keys">
+      <AdminNav session={adminSession} active="/admin/api-keys" />
+
+      {opts.error && <div class="error">{opts.error}</div>}
+      {opts.success && <div class="success">{opts.success}</div>}
+
+      {opts.newKey && (
+        <div class="warning">
+          <strong>Copy your API key now — it won't be shown again:</strong>
+          <pre>
+            <code>{opts.newKey}</code>
+          </pre>
+          <p>
+            Use it with: <code>Authorization: Bearer YOUR_KEY</code>
+          </p>
+        </div>
+      )}
+
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Created</th>
+              <th>Last used</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <Raw html={keyRows} />
+          </tbody>
+        </table>
+      </div>
+
+      <br />
+
+      <CsrfForm action="/admin/api-keys">
+        <fieldset>
+          <legend>Create API key</legend>
+          <label>
+            Name
+            <input
+              type="text"
+              name="name"
+              placeholder="e.g. CI Pipeline"
+              required
+              maxLength={100}
+            />
+          </label>
+          <button type="submit">Create key</button>
+        </fieldset>
+      </CsrfForm>
+    </Layout>,
+  );
+};

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -29,14 +29,9 @@ const ApiKeyRow = ({ apiKey }: { apiKey: ApiKeyDisplay }): string =>
           : "Never"}
       </td>
       <td>
-        <CsrfForm
-          action={`/admin/api-keys/${apiKey.id}/delete`}
-          class="one-button"
-        >
-          <button type="submit" class="danger small">
-            Delete
-          </button>
-        </CsrfForm>
+        <a href={`/admin/api-keys/${apiKey.id}/delete`} class="danger small">
+          Delete
+        </a>
       </td>
     </tr>,
   );
@@ -113,3 +108,47 @@ export const adminApiKeysPage = (
     </Layout>,
   );
 };
+
+/**
+ * Admin API key delete confirmation page
+ */
+export const adminDeleteApiKeyPage = (
+  apiKey: { id: number; name: string },
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title={`Delete: ${apiKey.name}`}>
+      <AdminNav session={session} active="/admin/api-keys" />
+      {error && <div class="error">{error}</div>}
+
+      <article>
+        <aside>
+          <p>
+            <strong>Warning:</strong> This will permanently delete this API key.
+            Any integrations using it will stop working immediately.
+          </p>
+        </aside>
+      </article>
+
+      <p>
+        To delete this API key, type its name &quot;{apiKey.name}&quot; into the
+        box below:
+      </p>
+
+      <CsrfForm action={`/admin/api-keys/${apiKey.id}/delete`}>
+        <label for="confirm_identifier">API key name</label>
+        <input
+          type="text"
+          id="confirm_identifier"
+          name="confirm_identifier"
+          placeholder={apiKey.name}
+          autocomplete="off"
+          required
+        />
+        <button type="submit" class="danger">
+          Delete API Key
+        </button>
+      </CsrfForm>
+    </Layout>,
+  );

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -6,7 +6,7 @@ import { map, pipe, reduce } from "#fp";
 import { CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#lib/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
@@ -54,7 +54,8 @@ export const adminApiKeysPage = (
 
   return String(
     <Layout title="API Keys">
-      <AdminNav session={adminSession} active="/admin/api-keys" />
+      <AdminNav session={adminSession} active="/admin/users" />
+      <UsersSubNav />
 
       {opts.error && <div class="error">{opts.error}</div>}
       {opts.success && <div class="success">{opts.success}</div>}
@@ -119,7 +120,7 @@ export const adminDeleteApiKeyPage = (
 ): string =>
   String(
     <Layout title={`Delete: ${apiKey.name}`}>
-      <AdminNav session={session} active="/admin/api-keys" />
+      <AdminNav session={session} active="/admin/users" />
       {error && <div class="error">{error}</div>}
 
       <article>

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -49,6 +49,23 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
   </nav>
 );
 
+/** Sub-navigation for user-related pages */
+export const UsersSubNav = (): JSX.Element => (
+  <nav>
+    <ul>
+      <li>
+        <a href="/admin/users">Users</a>
+      </li>
+      <li>
+        <a href="/admin/sessions">Sessions</a>
+      </li>
+      <li>
+        <a href="/admin/api-keys">API Keys</a>
+      </li>
+    </ul>
+  </nav>
+);
+
 interface BreadcrumbProps {
   href: string;
   label: string;

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -39,6 +39,8 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
       {navLink("/admin/groups", "Groups", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/holidays", "Holidays", active)}
+      {session.adminLevel === "owner" &&
+        navLink("/admin/api-keys", "API Keys", active)}
       {navLink("/admin/guide", "Guide", active)}
       <li>
         <CsrfForm action="/admin/logout" class="inline">

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -39,8 +39,6 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
       {navLink("/admin/groups", "Groups", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/holidays", "Holidays", active)}
-      {session.adminLevel === "owner" &&
-        navLink("/admin/api-keys", "API Keys", active)}
       {navLink("/admin/guide", "Guide", active)}
       <li>
         <CsrfForm action="/admin/logout" class="inline">

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -6,7 +6,7 @@ import { map, pipe, reduce } from "#fp";
 import { CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, Session } from "#lib/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const joinStrings = reduce((acc: string, s: string) => acc + s, "");
@@ -51,7 +51,8 @@ export const adminSessionsPage = (
 
   return String(
     <Layout title="Sessions">
-      <AdminNav session={adminSession} active="/admin/sessions" />
+      <AdminNav session={adminSession} active="/admin/users" />
+      <UsersSubNav />
 
       {success && <div class="success">{success}</div>}
 

--- a/src/templates/admin/users.tsx
+++ b/src/templates/admin/users.tsx
@@ -5,7 +5,7 @@
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminLevel, AdminSession } from "#lib/types.ts";
-import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
+import { AdminNav, Breadcrumb, UsersSubNav } from "#templates/admin/nav.tsx";
 import { inviteUserFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -45,11 +45,8 @@ export const adminUsersPage = (
   String(
     <Layout title="Users">
       <AdminNav session={session} active="/admin/users" />
+      <UsersSubNav />
       <h1>Users</h1>
-      <p>
-        <a href="/admin/sessions">Click here</a> to view your currently logged
-        in sessions.
-      </p>
       <p>
         <a href="/admin/guide#user-classes">User roles and permissions</a>
       </p>

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -1,0 +1,632 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { buildSessionCookie, getSessionCookieName } from "#lib/cookies.ts";
+import {
+  generateSecureToken,
+  hmacHash,
+  unwrapKeyWithToken,
+} from "#lib/crypto.ts";
+import { signCsrfToken } from "#lib/csrf.ts";
+import {
+  countApiKeysForUser,
+  createApiKey,
+  deleteAllApiKeysForUser,
+  deleteApiKey,
+  getApiKeyByToken,
+  getApiKeysForUser,
+  MAX_KEYS_PER_USER,
+  touchApiKeyLastUsed,
+  unwrapApiKeyDataKey,
+} from "#lib/db/api-keys.ts";
+import { getDb } from "#lib/db/client.ts";
+import { createSession, getSession } from "#lib/db/sessions.ts";
+import { handleRequest } from "#routes";
+import {
+  createTestDbWithSetup,
+  createTestEvent,
+  extractCsrfToken,
+  mockRequest,
+  resetDb,
+  testCookie,
+  testCsrfToken,
+} from "#test-utils";
+
+/** Helper to get the DATA_KEY from the test session */
+const getTestDataKey = async (): Promise<CryptoKey> => {
+  const cookie = await testCookie();
+  const sessionMatch = cookie.match(
+    new RegExp(`${getSessionCookieName()}=([^;]+)`),
+  );
+  const token = sessionMatch![1]!;
+  const session = await getSession(token);
+  return unwrapKeyWithToken(session!.wrapped_data_key!, token);
+};
+
+describe("API Keys", () => {
+  beforeEach(async () => {
+    await createTestDbWithSetup();
+  });
+
+  afterEach(() => {
+    resetDb();
+  });
+
+  describe("database operations", () => {
+    test("creates and retrieves an API key", async () => {
+      const dataKey = await getTestDataKey();
+      const { apiKey, id } = await createApiKey(
+        1,
+        "Test Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      expect(id).toBeGreaterThan(0);
+      expect(apiKey).toBeTruthy();
+
+      const found = await getApiKeyByToken(apiKey);
+      expect(found).not.toBeNull();
+      expect(found!.user_id).toBe(1);
+      expect(found!.id).toBe(id);
+    });
+
+    test("unwraps DATA_KEY from API key", async () => {
+      const dataKey = await getTestDataKey();
+      const { apiKey } = await createApiKey(
+        1,
+        "Test Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const found = await getApiKeyByToken(apiKey);
+      const unwrapped = await unwrapApiKeyDataKey(
+        found!.wrapped_data_key,
+        apiKey,
+      );
+      expect(unwrapped).not.toBeNull();
+    });
+
+    test("returns null for unknown token", async () => {
+      const found = await getApiKeyByToken("nonexistent-token");
+      expect(found).toBeNull();
+    });
+
+    test("returns null for wrong token unwrap", async () => {
+      const dataKey = await getTestDataKey();
+      const { apiKey } = await createApiKey(
+        1,
+        "Test Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const found = await getApiKeyByToken(apiKey);
+      const unwrapped = await unwrapApiKeyDataKey(
+        found!.wrapped_data_key,
+        "wrong-token",
+      );
+      expect(unwrapped).toBeNull();
+    });
+
+    test("lists API keys for a user", async () => {
+      const dataKey = await getTestDataKey();
+      await createApiKey(1, "Key A", dataKey, generateSecureToken);
+      await createApiKey(1, "Key B", dataKey, generateSecureToken);
+
+      const keys = await getApiKeysForUser(1);
+      expect(keys).toHaveLength(2);
+      expect(keys[0]!.name).toBe("Key A");
+      expect(keys[1]!.name).toBe("Key B");
+    });
+
+    test("counts API keys for a user", async () => {
+      const dataKey = await getTestDataKey();
+      await createApiKey(1, "Key A", dataKey, generateSecureToken);
+      await createApiKey(1, "Key B", dataKey, generateSecureToken);
+
+      expect(await countApiKeysForUser(1)).toBe(2);
+      expect(await countApiKeysForUser(999)).toBe(0);
+    });
+
+    test("deletes an API key", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Test Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const deleted = await deleteApiKey(id, 1);
+      expect(deleted).toBe(true);
+      expect(await countApiKeysForUser(1)).toBe(0);
+    });
+
+    test("delete fails for wrong user", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Test Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const deleted = await deleteApiKey(id, 999);
+      expect(deleted).toBe(false);
+      expect(await countApiKeysForUser(1)).toBe(1);
+    });
+
+    test("deletes all API keys for a user", async () => {
+      const dataKey = await getTestDataKey();
+      await createApiKey(1, "Key A", dataKey, generateSecureToken);
+      await createApiKey(1, "Key B", dataKey, generateSecureToken);
+
+      await deleteAllApiKeysForUser(1);
+      expect(await countApiKeysForUser(1)).toBe(0);
+    });
+
+    test("updates last_used timestamp", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Touch Test",
+        dataKey,
+        generateSecureToken,
+      );
+
+      await touchApiKeyLastUsed(id);
+      const keys = await getApiKeysForUser(1);
+      expect(keys[0]!.lastUsed).toBeTruthy();
+    });
+
+    test("lists empty array for user with no keys", async () => {
+      const keys = await getApiKeysForUser(999);
+      expect(keys).toHaveLength(0);
+    });
+  });
+
+  describe("admin UI", () => {
+    test("GET /admin/api-keys shows the page", async () => {
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          headers: { cookie },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("API Keys");
+      expect(html).toContain("Create API key");
+    });
+
+    test("POST /admin/api-keys creates a key and shows it", async () => {
+      const cookie = await testCookie();
+
+      // GET the page to get CSRF token
+      const getResponse = await handleRequest(
+        mockRequest("/admin/api-keys", { headers: { cookie } }),
+      );
+      const pageHtml = await getResponse.text();
+      const csrfToken = extractCsrfToken(pageHtml);
+
+      const body = new URLSearchParams({
+        name: "My Test Key",
+        csrf_token: csrfToken!,
+      });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("API key created");
+      // The key should be shown in the response
+      expect(html).toContain("Copy your API key now");
+    });
+
+    test("POST /admin/api-keys rejects empty name", async () => {
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({
+        name: "",
+        csrf_token: csrfToken,
+      });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      // Should redirect with error
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain("error=");
+    });
+
+    test("POST /admin/api-keys rejects missing name field", async () => {
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({
+        csrf_token: csrfToken,
+      });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain("error=");
+    });
+
+    test("POST /admin/api-keys rejects name over 100 characters", async () => {
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({
+        name: "x".repeat(101),
+        csrf_token: csrfToken,
+      });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain("error=");
+    });
+
+    test("POST /admin/api-keys enforces max keys limit", async () => {
+      const dataKey = await getTestDataKey();
+      for (let i = 0; i < MAX_KEYS_PER_USER; i++) {
+        await createApiKey(1, `Key ${i}`, dataKey, generateSecureToken);
+      }
+
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({
+        name: "One Too Many",
+        csrf_token: csrfToken,
+      });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain("error=");
+    });
+
+    test("POST /admin/api-keys/:id/delete returns error for nonexistent key", async () => {
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({ csrf_token: csrfToken });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys/99999/delete", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain("error=");
+    });
+
+    test("GET /admin/api-keys shows existing keys with last used date", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Visible Key",
+        dataKey,
+        generateSecureToken,
+      );
+      await touchApiKeyLastUsed(id);
+
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", { headers: { cookie } }),
+      );
+
+      const html = await response.text();
+      expect(html).toContain("Visible Key");
+      expect(html).not.toContain("Never");
+    });
+
+    test("GET /admin/api-keys shows success and error messages", async () => {
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys?success=done&error=oops", {
+          headers: { cookie },
+        }),
+      );
+
+      const html = await response.text();
+      expect(html).toContain("done");
+      expect(html).toContain("oops");
+    });
+
+    test("POST /admin/api-keys/:id/delete removes a key", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Doomed Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({ csrf_token: csrfToken });
+      const response = await handleRequest(
+        mockRequest(`/admin/api-keys/${id}/delete`, {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(await countApiKeysForUser(1)).toBe(0);
+    });
+  });
+
+  describe("Bearer token authentication", () => {
+    test("authenticates admin API request with Bearer token", async () => {
+      const dataKey = await getTestDataKey();
+      const { apiKey } = await createApiKey(
+        1,
+        "Auth Test",
+        dataKey,
+        generateSecureToken,
+      );
+
+      // Use the API key to access an admin-only page
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys/docs", {
+          headers: {
+            authorization: `Bearer ${apiKey}`,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.message).toBe("Admin API documentation");
+    });
+
+    test("rejects invalid Bearer token", async () => {
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys/docs", {
+          headers: {
+            authorization: "Bearer invalid-token",
+          },
+        }),
+      );
+
+      // Should redirect to login (requireOwnerOr behavior)
+      expect(response.status).toBe(302);
+    });
+
+    test("rejects request without auth", async () => {
+      const response = await handleRequest(mockRequest("/admin/api-keys/docs"));
+
+      expect(response.status).toBe(302);
+    });
+  });
+
+  describe("admin UI edge cases", () => {
+    test("GET /admin/api-keys without success or error params shows no messages", async () => {
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", { headers: { cookie } }),
+      );
+
+      const html = await response.text();
+      expect(html).not.toContain('class="success"');
+      expect(html).not.toContain('class="error"');
+    });
+
+    test("POST /admin/api-keys redirects when session has no wrapped data key", async () => {
+      // Create a session without wrapped_data_key
+      const token = generateSecureToken();
+      const csrfToken = await signCsrfToken();
+      const expires = Date.now() + 86400000;
+      await createSession(token, csrfToken, expires, null, 1);
+      const cookie = buildSessionCookie(token);
+
+      const body = new URLSearchParams({
+        name: "No Key Session",
+        csrf_token: csrfToken,
+      });
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain(
+        "Session+key+unavailable",
+      );
+    });
+
+    test("GET /admin/api-keys/docs returns JSON via cookie auth", async () => {
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys/docs", { headers: { cookie } }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.authentication).toContain("Bearer");
+    });
+  });
+
+  describe("admin JSON API", () => {
+    test("GET /api/admin/events returns events via API key", async () => {
+      await createTestEvent({ name: "Test Event" });
+
+      const dataKey = await getTestDataKey();
+      const { apiKey } = await createApiKey(
+        1,
+        "Events API",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const response = await handleRequest(
+        mockRequest("/api/admin/events", {
+          headers: { authorization: `Bearer ${apiKey}` },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.events).toBeDefined();
+      expect(body.events.length).toBeGreaterThan(0);
+      expect(body.adminLevel).toBe("owner");
+    });
+
+    test("GET /api/admin/events returns events via cookie+CSRF", async () => {
+      await createTestEvent({ name: "Cookie Event" });
+
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const response = await handleRequest(
+        mockRequest("/api/admin/events", {
+          headers: {
+            cookie,
+            "x-csrf-token": csrfToken,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.events).toBeDefined();
+    });
+
+    test("GET /api/admin/events returns 401 for invalid API key", async () => {
+      const response = await handleRequest(
+        mockRequest("/api/admin/events", {
+          headers: { authorization: "Bearer bad-key" },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    test("GET /api/admin/events returns 401 without auth", async () => {
+      const response = await handleRequest(mockRequest("/api/admin/events"));
+
+      expect(response.status).toBe(401);
+    });
+
+    test("returns 401 when API key user no longer exists", async () => {
+      const token = generateSecureToken();
+      const keyIndex = await hmacHash(token);
+
+      // Disable FK checks to insert an orphaned API key row
+      await getDb().execute({ sql: "PRAGMA foreign_keys = OFF", args: [] });
+      await getDb().execute({
+        sql: `INSERT INTO api_keys (user_id, key_index, wrapped_data_key, name, created, last_used)
+              VALUES (?, ?, ?, ?, ?, '')`,
+        args: [9999, keyIndex, "dummy", "Ghost", new Date().toISOString()],
+      });
+      await getDb().execute({ sql: "PRAGMA foreign_keys = ON", args: [] });
+
+      const response = await handleRequest(
+        mockRequest("/api/admin/events", {
+          headers: { authorization: `Bearer ${token}` },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    test("returns 401 when API key wrapped data key is corrupted", async () => {
+      const dataKey = await getTestDataKey();
+      const { apiKey, id } = await createApiKey(
+        1,
+        "Corrupt Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      // Corrupt the wrapped_data_key in the DB
+      await getDb().execute({
+        sql: "UPDATE api_keys SET wrapped_data_key = ? WHERE id = ?",
+        args: ["corrupted-data", id],
+      });
+
+      const response = await handleRequest(
+        mockRequest("/api/admin/events", {
+          headers: { authorization: `Bearer ${apiKey}` },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    test("GET /api/admin/events returns 401 for cookie without CSRF header", async () => {
+      await createTestEvent({ name: "CSRF Event" });
+      const cookie = await testCookie();
+
+      const response = await handleRequest(
+        mockRequest("/api/admin/events", {
+          headers: { cookie },
+        }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -13,8 +13,8 @@ import {
   deleteAllApiKeysForUser,
   deleteApiKey,
   getApiKeyByToken,
+  getApiKeyForUser,
   getApiKeysForUser,
-  MAX_KEYS_PER_USER,
   touchApiKeyLastUsed,
   unwrapApiKeyDataKey,
 } from "#lib/db/api-keys.ts";
@@ -92,7 +92,7 @@ describe("API Keys", () => {
       expect(found).toBeNull();
     });
 
-    test("returns null for wrong token unwrap", async () => {
+    test("throws for wrong token unwrap", async () => {
       const dataKey = await getTestDataKey();
       const { apiKey } = await createApiKey(
         1,
@@ -102,11 +102,9 @@ describe("API Keys", () => {
       );
 
       const found = await getApiKeyByToken(apiKey);
-      const unwrapped = await unwrapApiKeyDataKey(
-        found!.wrapped_data_key,
-        "wrong-token",
-      );
-      expect(unwrapped).toBeNull();
+      await expect(
+        unwrapApiKeyDataKey(found!.wrapped_data_key, "wrong-token"),
+      ).rejects.toThrow();
     });
 
     test("lists API keys for a user", async () => {
@@ -178,6 +176,32 @@ describe("API Keys", () => {
       await touchApiKeyLastUsed(id);
       const keys = await getApiKeysForUser(1);
       expect(keys[0]!.lastUsed).toBeTruthy();
+    });
+
+    test("gets a single API key by ID and user", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Lookup Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const found = await getApiKeyForUser(id, 1);
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe("Lookup Key");
+    });
+
+    test("getApiKeyForUser returns null for wrong user", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Wrong User",
+        dataKey,
+        generateSecureToken,
+      );
+
+      expect(await getApiKeyForUser(id, 999)).toBeNull();
     });
 
     test("lists empty array for user with no keys", async () => {
@@ -302,39 +326,14 @@ describe("API Keys", () => {
       expect(response.headers.get("location")).toContain("error=");
     });
 
-    test("POST /admin/api-keys enforces max keys limit", async () => {
-      const dataKey = await getTestDataKey();
-      for (let i = 0; i < MAX_KEYS_PER_USER; i++) {
-        await createApiKey(1, `Key ${i}`, dataKey, generateSecureToken);
-      }
-
-      const cookie = await testCookie();
-      const csrfToken = await testCsrfToken();
-
-      const body = new URLSearchParams({
-        name: "One Too Many",
-        csrf_token: csrfToken,
-      });
-      const response = await handleRequest(
-        mockRequest("/admin/api-keys", {
-          method: "POST",
-          headers: {
-            cookie,
-            "content-type": "application/x-www-form-urlencoded",
-          },
-          body: body.toString(),
-        }),
-      );
-
-      expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toContain("error=");
-    });
-
     test("POST /admin/api-keys/:id/delete returns error for nonexistent key", async () => {
       const cookie = await testCookie();
       const csrfToken = await testCsrfToken();
 
-      const body = new URLSearchParams({ csrf_token: csrfToken });
+      const body = new URLSearchParams({
+        csrf_token: csrfToken,
+        confirm_identifier: "anything",
+      });
       const response = await handleRequest(
         mockRequest("/admin/api-keys/99999/delete", {
           method: "POST",
@@ -383,7 +382,7 @@ describe("API Keys", () => {
       expect(html).toContain("oops");
     });
 
-    test("POST /admin/api-keys/:id/delete removes a key", async () => {
+    test("POST /admin/api-keys/:id/delete removes a key with name confirmation", async () => {
       const dataKey = await getTestDataKey();
       const { id } = await createApiKey(
         1,
@@ -395,7 +394,10 @@ describe("API Keys", () => {
       const cookie = await testCookie();
       const csrfToken = await testCsrfToken();
 
-      const body = new URLSearchParams({ csrf_token: csrfToken });
+      const body = new URLSearchParams({
+        csrf_token: csrfToken,
+        confirm_identifier: "Doomed Key",
+      });
       const response = await handleRequest(
         mockRequest(`/admin/api-keys/${id}/delete`, {
           method: "POST",
@@ -409,6 +411,72 @@ describe("API Keys", () => {
 
       expect(response.status).toBe(302);
       expect(await countApiKeysForUser(1)).toBe(0);
+    });
+
+    test("POST /admin/api-keys/:id/delete rejects wrong name", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "My Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const cookie = await testCookie();
+      const csrfToken = await testCsrfToken();
+
+      const body = new URLSearchParams({
+        csrf_token: csrfToken,
+        confirm_identifier: "Wrong Name",
+      });
+      const response = await handleRequest(
+        mockRequest(`/admin/api-keys/${id}/delete`, {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      const html = await response.text();
+      expect(html).toContain("does not match");
+      expect(await countApiKeysForUser(1)).toBe(1);
+    });
+
+    test("GET /admin/api-keys/:id/delete shows confirmation page", async () => {
+      const dataKey = await getTestDataKey();
+      const { id } = await createApiKey(
+        1,
+        "Confirm Key",
+        dataKey,
+        generateSecureToken,
+      );
+
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest(`/admin/api-keys/${id}/delete`, {
+          headers: { cookie },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Confirm Key");
+      expect(html).toContain("confirm_identifier");
+    });
+
+    test("GET /admin/api-keys/:id/delete returns 404 for nonexistent key", async () => {
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys/99999/delete", {
+          headers: { cookie },
+        }),
+      );
+
+      expect(response.status).toBe(404);
     });
   });
 

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -6,6 +6,7 @@ import {
   hmacHash,
   unwrapKeyWithToken,
 } from "#lib/crypto.ts";
+
 import { signCsrfToken } from "#lib/csrf.ts";
 import {
   countApiKeysForUser,
@@ -16,7 +17,6 @@ import {
   getApiKeyForUser,
   getApiKeysForUser,
   touchApiKeyLastUsed,
-  unwrapApiKeyDataKey,
 } from "#lib/db/api-keys.ts";
 import { getDb } from "#lib/db/client.ts";
 import { createSession, getSession } from "#lib/db/sessions.ts";
@@ -80,7 +80,7 @@ describe("API Keys", () => {
       );
 
       const found = await getApiKeyByToken(apiKey);
-      const unwrapped = await unwrapApiKeyDataKey(
+      const unwrapped = await unwrapKeyWithToken(
         found!.wrapped_data_key,
         apiKey,
       );
@@ -103,7 +103,7 @@ describe("API Keys", () => {
 
       const found = await getApiKeyByToken(apiKey);
       await expect(
-        unwrapApiKeyDataKey(found!.wrapped_data_key, "wrong-token"),
+        unwrapKeyWithToken(found!.wrapped_data_key, "wrong-token"),
       ).rejects.toThrow();
     });
 
@@ -192,7 +192,7 @@ describe("API Keys", () => {
       expect(found!.name).toBe("Lookup Key");
     });
 
-    test("getApiKeyForUser returns null for wrong user", async () => {
+    test("getApiKeyForUser throws for wrong user", async () => {
       const dataKey = await getTestDataKey();
       const { id } = await createApiKey(
         1,
@@ -201,7 +201,7 @@ describe("API Keys", () => {
         generateSecureToken,
       );
 
-      expect(await getApiKeyForUser(id, 999)).toBeNull();
+      await expect(getApiKeyForUser(id, 999)).rejects.toThrow();
     });
 
     test("lists empty array for user with no keys", async () => {

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -481,7 +481,9 @@ describe("API Keys", () => {
   });
 
   describe("Bearer token authentication", () => {
-    test("authenticates admin API request with Bearer token", async () => {
+    test("authenticates /api/admin/* request with Bearer token", async () => {
+      await createTestEvent({ name: "Bearer Test" });
+
       const dataKey = await getTestDataKey();
       const { apiKey } = await createApiKey(
         1,
@@ -490,31 +492,57 @@ describe("API Keys", () => {
         generateSecureToken,
       );
 
-      // Use the API key to access an admin-only page
       const response = await handleRequest(
-        mockRequest("/admin/api-keys/docs", {
-          headers: {
-            authorization: `Bearer ${apiKey}`,
-          },
+        mockRequest("/api/admin/events", {
+          headers: { authorization: `Bearer ${apiKey}` },
         }),
       );
 
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body.message).toBe("Admin API documentation");
+      expect(body.events).toBeDefined();
+    });
+
+    test("rejects Bearer token on admin HTML pages", async () => {
+      const dataKey = await getTestDataKey();
+      const { apiKey } = await createApiKey(
+        1,
+        "Scope Test",
+        dataKey,
+        generateSecureToken,
+      );
+
+      // Bearer should NOT authenticate admin UI routes
+      const dashboardResponse = await handleRequest(
+        mockRequest("/admin/api-keys/docs", {
+          headers: { authorization: `Bearer ${apiKey}` },
+        }),
+      );
+      expect(dashboardResponse.status).toBe(302);
+
+      const settingsResponse = await handleRequest(
+        mockRequest("/admin/settings", {
+          headers: { authorization: `Bearer ${apiKey}` },
+        }),
+      );
+      expect(settingsResponse.status).toBe(302);
+
+      const keysResponse = await handleRequest(
+        mockRequest("/admin/api-keys", {
+          headers: { authorization: `Bearer ${apiKey}` },
+        }),
+      );
+      expect(keysResponse.status).toBe(302);
     });
 
     test("rejects invalid Bearer token", async () => {
       const response = await handleRequest(
-        mockRequest("/admin/api-keys/docs", {
-          headers: {
-            authorization: "Bearer invalid-token",
-          },
+        mockRequest("/api/admin/events", {
+          headers: { authorization: "Bearer invalid-token" },
         }),
       );
 
-      // Should redirect to login (requireOwnerOr behavior)
-      expect(response.status).toBe(302);
+      expect(response.status).toBe(401);
     });
 
     test("rejects request without auth", async () => {

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -627,7 +627,15 @@ describe("API Keys", () => {
       const body = await response.json();
       expect(body.events).toBeDefined();
       expect(body.events.length).toBeGreaterThan(0);
-      expect(body.adminLevel).toBe("owner");
+      expect(body.admin_level).toBe("owner");
+
+      // Verify snake_case keys and no internal fields
+      const event = body.events[0];
+      expect(event.name).toBe("Test Event");
+      expect(event.max_attendees).toBeDefined();
+      expect(event.attendee_count).toBeDefined();
+      expect(event.event_type).toBeDefined();
+      expect(event.slug_index).toBeUndefined();
     });
 
     test("GET /api/admin/events returns events via cookie+CSRF", async () => {


### PR DESCRIPTION
## Summary
Implement API key-based authentication for programmatic access to admin endpoints, enabling external tools and integrations to interact with the system via Bearer token authentication.

## Key Changes

### API Key Management
- **New database table** (`api_keys`) to store API keys with encrypted names and wrapped DATA_KEY
- **New module** `src/lib/db/api-keys.ts` with operations: create, lookup by token, list/count for user, delete, and update last-used timestamp
- **Admin UI** at `/admin/api-keys` to create, view, and delete API keys with confirmation workflow
- **Template** `src/templates/admin/api-keys.tsx` for key management interface

### Authentication Infrastructure
- **New function** `getAuthenticatedApiKey()` in `src/routes/utils.ts` to authenticate Bearer token requests
- **New function** `withAdminApi()` to handle requests authenticated via either API key (Bearer token) or session cookie + CSRF header
- API keys inherit admin level from their parent user
- Fire-and-forget `last_used` timestamp updates on API key usage

### Admin API Endpoints
- **New routes** in `src/routes/admin/api.ts` for JSON API access
- **GET /api/admin/events** — list all events with counts (accessible via API key or cookie+CSRF)
- **GET /admin/api-keys/docs** — API documentation endpoint
- Bearer token authentication bypasses CSRF requirement (token itself is the secret)
- Session cookie auth still requires `x-csrf-token` header for API endpoints

### Security & Design
- API keys wrap the shared DATA_KEY with token-derived encryption (same crypto as session tokens)
- Plaintext API key shown only once at creation time, never stored or retrievable
- Key lookup uses HMAC hash of token for constant-time comparison
- API key auth intentionally excluded from HTML admin UI routes (only `/api/*` endpoints)
- Corrupted or missing wrapped keys result in 401 authentication failure

### Database & Cleanup
- New migration to create `api_keys` table with foreign key to users
- User deletion cascades to delete all associated API keys
- Renamed `executeByField` to `deleteByField` for clarity in `src/lib/db/client.ts`

### Testing
- Comprehensive test suite (728 lines) covering:
  - Database operations (CRUD, encryption, lookups)
  - Admin UI workflows (create, delete with confirmation)
  - Bearer token authentication
  - Error cases (invalid tokens, corrupted keys, wrong user)
  - Edge cases (session without wrapped key, missing user)

## Implementation Details
- API keys use the same token generation and wrapping infrastructure as session tokens
- `getAuthenticatedApiKey()` returns an `AuthSession` object compatible with existing auth handlers
- Admin API routes use `withAdminApi()` which tries API key auth first, then falls back to session+CSRF
- Key names are encrypted at rest; decryption happens only when displaying to authenticated user
- Last-used tracking is non-blocking (fire-and-forget) to avoid slowing down API requests

https://claude.ai/code/session_01GE9RjG6UFXNacQ9j8wrEyS