### PR TITLE
Refactor test setup with describeWithEnv helper

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -8,6 +8,7 @@ import {
   type InValue,
   type Row,
 } from "@libsql/client";
+import { afterEach, beforeEach, describe } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import forge from "node-forge";
 import { bracket } from "#fp";
@@ -473,6 +474,31 @@ export const setTestEnv = (
       else Deno.env.delete(key);
     }
   };
+};
+
+/**
+ * Describe block with automatic env var setup and restore.
+ * Sets env vars before each test and restores originals after each test.
+ * Additional beforeEach/afterEach hooks can be added inside the callback.
+ *
+ * @example
+ * describeWithEnv("storage", { STORAGE_ZONE_NAME: "z", STORAGE_ZONE_KEY: "k" }, () => {
+ *   test("uses storage", () => { ... });
+ * });
+ */
+export const describeWithEnv = (
+  name: string,
+  env: Record<string, string | undefined>,
+  fn: () => void,
+): void => {
+  describe(name, () => {
+    let restoreEnv: () => void;
+    beforeEach(() => {
+      restoreEnv = setTestEnv(env);
+    });
+    afterEach(() => restoreEnv());
+    fn();
+  });
 };
 
 /**

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -445,6 +445,37 @@ export const installUrlHandler = (
 };
 
 /**
+ * Set env vars for a test and return a restore function that puts them back.
+ * Saves originals so cleanup restores the exact prior state (or deletes if unset).
+ * Pass `undefined` as a value to delete the key (useful for ensuring a clean slate).
+ *
+ * @example
+ * let restoreEnv: () => void;
+ * beforeEach(() => { restoreEnv = setTestEnv({ STORAGE_ZONE_NAME: "z", STORAGE_ZONE_KEY: "k" }); });
+ * afterEach(() => restoreEnv());
+ *
+ * // Delete keys to start with a clean slate:
+ * restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
+ */
+export const setTestEnv = (
+  vars: Record<string, string | undefined>,
+): (() => void) => {
+  const saved: [string, string | undefined][] = [];
+  for (const key of Object.keys(vars)) {
+    saved.push([key, Deno.env.get(key)]);
+    const value = vars[key];
+    if (value !== undefined) Deno.env.set(key, value);
+    else Deno.env.delete(key);
+  }
+  return () => {
+    for (const [key, orig] of saved) {
+      if (orig !== undefined) Deno.env.set(key, orig);
+      else Deno.env.delete(key);
+    }
+  };
+};
+
+/**
  * Wait for a specified number of milliseconds
  */
 export const wait = (ms: number): Promise<void> =>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -476,27 +476,44 @@ export const setTestEnv = (
   };
 };
 
+/** Options for {@link describeWithEnv}. */
+interface DescribeEnvOptions {
+  /** Environment variables to set before each test and restore after. */
+  env?: Record<string, string | undefined>;
+  /** Reset slug counter, create test DB in beforeEach; resetDb in afterEach. */
+  db?: boolean;
+  /** Call setupTestEncryptionKey in beforeEach. */
+  encryptionKey?: boolean;
+}
+
 /**
- * Describe block with automatic env var setup and restore.
- * Sets env vars before each test and restores originals after each test.
+ * Describe block with automatic test infrastructure setup.
  * Additional beforeEach/afterEach hooks can be added inside the callback.
  *
  * @example
- * describeWithEnv("storage", { STORAGE_ZONE_NAME: "z", STORAGE_ZONE_KEY: "k" }, () => {
+ * describeWithEnv("storage", { env: { STORAGE_ZONE_NAME: "z" }, db: true }, () => {
  *   test("uses storage", () => { ... });
  * });
  */
 export const describeWithEnv = (
   name: string,
-  env: Record<string, string | undefined>,
+  options: DescribeEnvOptions,
   fn: () => void,
 ): void => {
   describe(name, () => {
     let restoreEnv: () => void;
-    beforeEach(() => {
-      restoreEnv = setTestEnv(env);
+    beforeEach(async () => {
+      if (options.encryptionKey) setupTestEncryptionKey();
+      if (options.env) restoreEnv = setTestEnv(options.env);
+      if (options.db) {
+        resetTestSlugCounter();
+        await createTestDbWithSetup();
+      }
     });
-    afterEach(() => restoreEnv());
+    afterEach(() => {
+      if (options.db) resetDb();
+      if (options.env) restoreEnv();
+    });
     fn();
   });
 };

--- a/test/lib/attachment-route.test.ts
+++ b/test/lib/attachment-route.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { signAttachmentUrl } from "#lib/attachment-url.ts";
 import { encryptBytes } from "#lib/crypto.ts";
 import { getAttendeeRaw } from "#lib/db/attendees.ts";
@@ -8,13 +8,9 @@ import { handleRequest } from "#routes";
 import { getMimeType } from "#routes/attachments.ts";
 import {
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
   describeWithEnv,
   installUrlHandler,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
-  setupTestEncryptionKey,
   withFetchMock,
 } from "#test-utils";
 
@@ -49,184 +45,182 @@ describe("getMimeType", () => {
   });
 });
 
-describeWithEnv("GET /attachment/:id", {
-  STORAGE_ZONE_NAME: undefined,
-  STORAGE_ZONE_KEY: undefined,
-}, () => {
-  beforeEach(async () => {
-    setupTestEncryptionKey();
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
+describeWithEnv(
+  "GET /attachment/:id",
+  {
+    env: {
+      STORAGE_ZONE_NAME: undefined,
+      STORAGE_ZONE_KEY: undefined,
+    },
+    db: true,
+    encryptionKey: true,
+  },
+  () => {
+    /** Enable storage by setting the required env vars */
+    const enableStorage = () => {
+      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
+      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+    };
 
-  afterEach(() => {
-    resetDb();
-  });
-
-  /** Enable storage by setting the required env vars */
-  const enableStorage = () => {
-    Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-    Deno.env.set("STORAGE_ZONE_KEY", "testkey");
-  };
-
-  /** Create an event+attendee with an attachment configured */
-  const setupAttachment = async () => {
-    const { event, attendee } = await createTestAttendeeWithToken(
-      "Test User",
-      "test@example.com",
-    );
-    await eventsTable.update(event.id, {
-      attachmentUrl: "file.pdf",
-      attachmentName: "guide.pdf",
-    });
-    return { eventId: event.id, attendeeId: attendee.id };
-  };
-
-  /** Sign a URL and return the full path with query params */
-  const signUrl = async (
-    eventId: number,
-    attendeeId: number,
-  ): Promise<string> => {
-    return await signAttachmentUrl(eventId, attendeeId);
-  };
-
-  /** Mock CDN fetch to return encrypted data */
-  const withCdnMock = (
-    data: Uint8Array,
-    fn: () => Promise<void>,
-  ): Promise<void> =>
-    withFetchMock(async (originalFetch) => {
-      const encrypted = await encryptBytes(data);
-      installUrlHandler(originalFetch, (url) => {
-        if (url.includes("storage.bunnycdn.com")) {
-          // deno-lint-ignore no-explicit-any
-          return Promise.resolve(new Response(encrypted as any));
-        }
-        return null;
-      });
-      await fn();
-    });
-
-  test("returns 404 when storage is not enabled", async () => {
-    const { eventId, attendeeId } = await setupAttachment();
-    const path = await signUrl(eventId, attendeeId);
-    const response = await handleRequest(mockRequest(path));
-    expect(response.status).toBe(404);
-  });
-
-  test("returns 403 when query params are missing", async () => {
-    enableStorage();
-    const response = await handleRequest(mockRequest("/attachment/1"));
-    expect(response.status).toBe(403);
-  });
-
-  test("returns 403 when attendee ID is not a number", async () => {
-    enableStorage();
-    const response = await handleRequest(
-      mockRequest("/attachment/1?a=abc&exp=123&sig=test"),
-    );
-    expect(response.status).toBe(403);
-  });
-
-  test("returns 403 when signature is invalid", async () => {
-    enableStorage();
-    const { eventId, attendeeId } = await setupAttachment();
-    const response = await handleRequest(
-      mockRequest(
-        `/attachment/${eventId}?a=${attendeeId}&exp=9999999999&sig=invalidsig`,
-      ),
-    );
-    expect(response.status).toBe(403);
-  });
-
-  test("returns 404 when event has no attachment", async () => {
-    enableStorage();
-    const { event, attendee } = await createTestAttendeeWithToken(
-      "No Attach",
-      "noattach@example.com",
-    );
-    const path = await signUrl(event.id, attendee.id);
-    const response = await handleRequest(mockRequest(path));
-    expect(response.status).toBe(404);
-  });
-
-  test("returns 403 when attendee does not belong to event", async () => {
-    enableStorage();
-    const { eventId } = await setupAttachment();
-    // Create a second attendee on a different event
-    const { attendee: otherAttendee } = await createTestAttendeeWithToken(
-      "Other User",
-      "other@example.com",
-    );
-    // Sign with the first event but the other attendee
-    const path = await signUrl(eventId, otherAttendee.id);
-    const response = await handleRequest(mockRequest(path));
-    expect(response.status).toBe(403);
-  });
-
-  test("serves decrypted file with correct Content-Type and Content-Disposition", async () => {
-    enableStorage();
-    const { eventId, attendeeId } = await setupAttachment();
-    const path = await signUrl(eventId, attendeeId);
-    const fileContent = new TextEncoder().encode("hello pdf content");
-
-    await withCdnMock(fileContent, async () => {
-      const response = await handleRequest(mockRequest(path));
-      expect(response.status).toBe(200);
-      expect(response.headers.get("content-type")).toBe("application/pdf");
-      expect(response.headers.get("content-disposition")).toBe(
-        'attachment; filename="guide.pdf"',
+    /** Create an event+attendee with an attachment configured */
+    const setupAttachment = async () => {
+      const { event, attendee } = await createTestAttendeeWithToken(
+        "Test User",
+        "test@example.com",
       );
-      const body = new Uint8Array(await response.arrayBuffer());
-      expect(body).toEqual(fileContent);
-    });
-  });
-
-  test("increments attachment_downloads counter", async () => {
-    enableStorage();
-    const { eventId, attendeeId } = await setupAttachment();
-    const path = await signUrl(eventId, attendeeId);
-    const fileContent = new TextEncoder().encode("data");
-
-    const before = await getAttendeeRaw(attendeeId);
-    expect(before!.attachment_downloads).toBe(0);
-
-    await withCdnMock(fileContent, async () => {
-      await handleRequest(mockRequest(path));
-    });
-
-    const after = await getAttendeeRaw(attendeeId);
-    expect(after!.attachment_downloads).toBe(1);
-  });
-
-  test("returns 404 when CDN download fails", async () => {
-    enableStorage();
-    const { eventId, attendeeId } = await setupAttachment();
-    const path = await signUrl(eventId, attendeeId);
-
-    await withFetchMock(async (originalFetch) => {
-      installUrlHandler(originalFetch, (url) => {
-        if (url.includes("storage.bunnycdn.com")) {
-          return Promise.resolve(new Response("Not Found", { status: 404 }));
-        }
-        return null;
+      await eventsTable.update(event.id, {
+        attachmentUrl: "file.pdf",
+        attachmentName: "guide.pdf",
       });
+      return { eventId: event.id, attendeeId: attendee.id };
+    };
+
+    /** Sign a URL and return the full path with query params */
+    const signUrl = async (
+      eventId: number,
+      attendeeId: number,
+    ): Promise<string> => {
+      return await signAttachmentUrl(eventId, attendeeId);
+    };
+
+    /** Mock CDN fetch to return encrypted data */
+    const withCdnMock = (
+      data: Uint8Array,
+      fn: () => Promise<void>,
+    ): Promise<void> =>
+      withFetchMock(async (originalFetch) => {
+        const encrypted = await encryptBytes(data);
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("storage.bunnycdn.com")) {
+            // deno-lint-ignore no-explicit-any
+            return Promise.resolve(new Response(encrypted as any));
+          }
+          return null;
+        });
+        await fn();
+      });
+
+    test("returns 404 when storage is not enabled", async () => {
+      const { eventId, attendeeId } = await setupAttachment();
+      const path = await signUrl(eventId, attendeeId);
       const response = await handleRequest(mockRequest(path));
       expect(response.status).toBe(404);
     });
-  });
 
-  test("returns public cache control for CDN caching", async () => {
-    enableStorage();
-    const { eventId, attendeeId } = await setupAttachment();
-    const path = await signUrl(eventId, attendeeId);
-    const fileContent = new TextEncoder().encode("data");
-
-    await withCdnMock(fileContent, async () => {
-      const response = await handleRequest(mockRequest(path));
-      expect(response.headers.get("cache-control")).toBe(
-        "public, max-age=3600",
-      );
+    test("returns 403 when query params are missing", async () => {
+      enableStorage();
+      const response = await handleRequest(mockRequest("/attachment/1"));
+      expect(response.status).toBe(403);
     });
-  });
-});
+
+    test("returns 403 when attendee ID is not a number", async () => {
+      enableStorage();
+      const response = await handleRequest(
+        mockRequest("/attachment/1?a=abc&exp=123&sig=test"),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    test("returns 403 when signature is invalid", async () => {
+      enableStorage();
+      const { eventId, attendeeId } = await setupAttachment();
+      const response = await handleRequest(
+        mockRequest(
+          `/attachment/${eventId}?a=${attendeeId}&exp=9999999999&sig=invalidsig`,
+        ),
+      );
+      expect(response.status).toBe(403);
+    });
+
+    test("returns 404 when event has no attachment", async () => {
+      enableStorage();
+      const { event, attendee } = await createTestAttendeeWithToken(
+        "No Attach",
+        "noattach@example.com",
+      );
+      const path = await signUrl(event.id, attendee.id);
+      const response = await handleRequest(mockRequest(path));
+      expect(response.status).toBe(404);
+    });
+
+    test("returns 403 when attendee does not belong to event", async () => {
+      enableStorage();
+      const { eventId } = await setupAttachment();
+      // Create a second attendee on a different event
+      const { attendee: otherAttendee } = await createTestAttendeeWithToken(
+        "Other User",
+        "other@example.com",
+      );
+      // Sign with the first event but the other attendee
+      const path = await signUrl(eventId, otherAttendee.id);
+      const response = await handleRequest(mockRequest(path));
+      expect(response.status).toBe(403);
+    });
+
+    test("serves decrypted file with correct Content-Type and Content-Disposition", async () => {
+      enableStorage();
+      const { eventId, attendeeId } = await setupAttachment();
+      const path = await signUrl(eventId, attendeeId);
+      const fileContent = new TextEncoder().encode("hello pdf content");
+
+      await withCdnMock(fileContent, async () => {
+        const response = await handleRequest(mockRequest(path));
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("application/pdf");
+        expect(response.headers.get("content-disposition")).toBe(
+          'attachment; filename="guide.pdf"',
+        );
+        const body = new Uint8Array(await response.arrayBuffer());
+        expect(body).toEqual(fileContent);
+      });
+    });
+
+    test("increments attachment_downloads counter", async () => {
+      enableStorage();
+      const { eventId, attendeeId } = await setupAttachment();
+      const path = await signUrl(eventId, attendeeId);
+      const fileContent = new TextEncoder().encode("data");
+
+      const before = await getAttendeeRaw(attendeeId);
+      expect(before!.attachment_downloads).toBe(0);
+
+      await withCdnMock(fileContent, async () => {
+        await handleRequest(mockRequest(path));
+      });
+
+      const after = await getAttendeeRaw(attendeeId);
+      expect(after!.attachment_downloads).toBe(1);
+    });
+
+    test("returns 404 when CDN download fails", async () => {
+      enableStorage();
+      const { eventId, attendeeId } = await setupAttachment();
+      const path = await signUrl(eventId, attendeeId);
+
+      await withFetchMock(async (originalFetch) => {
+        installUrlHandler(originalFetch, (url) => {
+          if (url.includes("storage.bunnycdn.com")) {
+            return Promise.resolve(new Response("Not Found", { status: 404 }));
+          }
+          return null;
+        });
+        const response = await handleRequest(mockRequest(path));
+        expect(response.status).toBe(404);
+      });
+    });
+
+    test("returns public cache control for CDN caching", async () => {
+      enableStorage();
+      const { eventId, attendeeId } = await setupAttachment();
+      const path = await signUrl(eventId, attendeeId);
+      const fileContent = new TextEncoder().encode("data");
+
+      await withCdnMock(fileContent, async () => {
+        const response = await handleRequest(mockRequest(path));
+        expect(response.headers.get("cache-control")).toBe(
+          "public, max-age=3600",
+        );
+      });
+    });
+  },
+);

--- a/test/lib/attachment-route.test.ts
+++ b/test/lib/attachment-route.test.ts
@@ -9,11 +9,11 @@ import { getMimeType } from "#routes/attachments.ts";
 import {
   createTestAttendeeWithToken,
   createTestDbWithSetup,
+  describeWithEnv,
   installUrlHandler,
   mockRequest,
   resetDb,
   resetTestSlugCounter,
-  setTestEnv,
   setupTestEncryptionKey,
   withFetchMock,
 } from "#test-utils";
@@ -49,21 +49,17 @@ describe("getMimeType", () => {
   });
 });
 
-describe("GET /attachment/:id", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("GET /attachment/:id", {
+  STORAGE_ZONE_NAME: undefined,
+  STORAGE_ZONE_KEY: undefined,
+}, () => {
   beforeEach(async () => {
-    restoreEnv = setTestEnv({
-      STORAGE_ZONE_NAME: undefined,
-      STORAGE_ZONE_KEY: undefined,
-    });
     setupTestEncryptionKey();
     resetTestSlugCounter();
     await createTestDbWithSetup();
   });
 
   afterEach(() => {
-    restoreEnv();
     resetDb();
   });
 

--- a/test/lib/attachment-route.test.ts
+++ b/test/lib/attachment-route.test.ts
@@ -13,6 +13,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   setupTestEncryptionKey,
   withFetchMock,
 } from "#test-utils";
@@ -49,15 +50,20 @@ describe("getMimeType", () => {
 });
 
 describe("GET /attachment/:id", () => {
+  let restoreEnv: () => void;
+
   beforeEach(async () => {
+    restoreEnv = setTestEnv({
+      STORAGE_ZONE_NAME: undefined,
+      STORAGE_ZONE_KEY: undefined,
+    });
     setupTestEncryptionKey();
     resetTestSlugCounter();
     await createTestDbWithSetup();
   });
 
   afterEach(() => {
-    Deno.env.delete("STORAGE_ZONE_NAME");
-    Deno.env.delete("STORAGE_ZONE_KEY");
+    restoreEnv();
     resetDb();
   });
 

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -87,17 +87,20 @@ const pullZoneResponse = (
 });
 
 describe("bunny-cdn", () => {
-  describeWithEnv("isBunnyCdnEnabled", { BUNNY_API_KEY: undefined }, () => {
+  describeWithEnv(
+    "isBunnyCdnEnabled",
+    { env: { BUNNY_API_KEY: undefined } },
+    () => {
+      test("returns false when BUNNY_API_KEY is not set", () => {
+        expect(isBunnyCdnEnabled()).toBe(false);
+      });
 
-    test("returns false when BUNNY_API_KEY is not set", () => {
-      expect(isBunnyCdnEnabled()).toBe(false);
-    });
-
-    test("returns true when BUNNY_API_KEY is set", () => {
-      Deno.env.set("BUNNY_API_KEY", "test-key");
-      expect(isBunnyCdnEnabled()).toBe(true);
-    });
-  });
+      test("returns true when BUNNY_API_KEY is set", () => {
+        Deno.env.set("BUNNY_API_KEY", "test-key");
+        expect(isBunnyCdnEnabled()).toBe(true);
+      });
+    },
+  );
 
   describe("getCdnHostname", () => {
     afterEach(() => resetAllowedDomain());
@@ -131,13 +134,16 @@ describe("bunny-cdn", () => {
     });
   });
 
-  describeWithEnv("getBunnyApiKey", { BUNNY_API_KEY: undefined }, () => {
-
-    test("getBunnyApiKey returns the env var value", () => {
-      Deno.env.set("BUNNY_API_KEY", "my-api-key");
-      expect(getBunnyApiKey()).toBe("my-api-key");
-    });
-  });
+  describeWithEnv(
+    "getBunnyApiKey",
+    { env: { BUNNY_API_KEY: undefined } },
+    () => {
+      test("getBunnyApiKey returns the env var value", () => {
+        Deno.env.set("BUNNY_API_KEY", "my-api-key");
+        expect(getBunnyApiKey()).toBe("my-api-key");
+      });
+    },
+  );
 
   describe("findPullZoneId", () => {
     useBunnyEnv();

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -15,18 +15,7 @@ import {
   updateCustomDomain,
   updateCustomDomainLastValidated,
 } from "#lib/db/settings.ts";
-import { createTestDb, resetDb, withMocks } from "#test-utils";
-
-/** Save and restore an env var around tests */
-const withEnvVar = (name: string) => {
-  const orig = Deno.env.get(name);
-  return {
-    restore() {
-      if (orig) Deno.env.set(name, orig);
-      else Deno.env.delete(name);
-    },
-  };
-};
+import { createTestDb, resetDb, setTestEnv, withMocks } from "#test-utils";
 
 /** Temporarily replace bunnyCdnApi.validateCustomDomain with a mock */
 const withMockValidate = async (
@@ -66,15 +55,15 @@ const stubFetchWithRecorder = (
 
 /** Set up BUNNY_API_KEY and ALLOWED_DOMAIN env vars for a describe block */
 const useBunnyEnv = () => {
-  const envApiKey = withEnvVar("BUNNY_API_KEY");
+  let restoreEnv: () => void;
 
   beforeEach(() => {
-    Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
+    restoreEnv = setTestEnv({ BUNNY_API_KEY: "test-bunny-key" });
     setAllowedDomainForTest("mysite.bunny.run");
   });
 
   afterEach(() => {
-    envApiKey.restore();
+    restoreEnv();
     resetAllowedDomain();
   });
 };
@@ -93,12 +82,15 @@ const pullZoneResponse = (
 
 describe("bunny-cdn", () => {
   describe("isBunnyCdnEnabled", () => {
-    const envApiKey = withEnvVar("BUNNY_API_KEY");
+    let restoreEnv: () => void;
 
-    afterEach(() => envApiKey.restore());
+    beforeEach(() => {
+      restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
+    });
+
+    afterEach(() => restoreEnv());
 
     test("returns false when BUNNY_API_KEY is not set", () => {
-      Deno.env.delete("BUNNY_API_KEY");
       expect(isBunnyCdnEnabled()).toBe(false);
     });
 
@@ -141,9 +133,13 @@ describe("bunny-cdn", () => {
   });
 
   describe("getBunnyApiKey", () => {
-    const envApiKey = withEnvVar("BUNNY_API_KEY");
+    let restoreEnv: () => void;
 
-    afterEach(() => envApiKey.restore());
+    beforeEach(() => {
+      restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
+    });
+
+    afterEach(() => restoreEnv());
 
     test("getBunnyApiKey returns the env var value", () => {
       Deno.env.set("BUNNY_API_KEY", "my-api-key");

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -15,7 +15,13 @@ import {
   updateCustomDomain,
   updateCustomDomainLastValidated,
 } from "#lib/db/settings.ts";
-import { createTestDb, resetDb, setTestEnv, withMocks } from "#test-utils";
+import {
+  createTestDb,
+  describeWithEnv,
+  resetDb,
+  setTestEnv,
+  withMocks,
+} from "#test-utils";
 
 /** Temporarily replace bunnyCdnApi.validateCustomDomain with a mock */
 const withMockValidate = async (
@@ -81,14 +87,7 @@ const pullZoneResponse = (
 });
 
 describe("bunny-cdn", () => {
-  describe("isBunnyCdnEnabled", () => {
-    let restoreEnv: () => void;
-
-    beforeEach(() => {
-      restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
-    });
-
-    afterEach(() => restoreEnv());
+  describeWithEnv("isBunnyCdnEnabled", { BUNNY_API_KEY: undefined }, () => {
 
     test("returns false when BUNNY_API_KEY is not set", () => {
       expect(isBunnyCdnEnabled()).toBe(false);
@@ -132,14 +131,7 @@ describe("bunny-cdn", () => {
     });
   });
 
-  describe("getBunnyApiKey", () => {
-    let restoreEnv: () => void;
-
-    beforeEach(() => {
-      restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
-    });
-
-    afterEach(() => restoreEnv());
+  describeWithEnv("getBunnyApiKey", { BUNNY_API_KEY: undefined }, () => {
 
     test("getBunnyApiKey returns the env var value", () => {
       Deno.env.set("BUNNY_API_KEY", "my-api-key");

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -19,7 +19,6 @@ import {
   createTestDb,
   describeWithEnv,
   resetDb,
-  setTestEnv,
   withMocks,
 } from "#test-utils";
 
@@ -59,21 +58,6 @@ const stubFetchWithRecorder = (
     },
   );
 
-/** Set up BUNNY_API_KEY and ALLOWED_DOMAIN env vars for a describe block */
-const useBunnyEnv = () => {
-  let restoreEnv: () => void;
-
-  beforeEach(() => {
-    restoreEnv = setTestEnv({ BUNNY_API_KEY: "test-bunny-key" });
-    setAllowedDomainForTest("mysite.bunny.run");
-  });
-
-  afterEach(() => {
-    restoreEnv();
-    resetAllowedDomain();
-  });
-};
-
 /** Build a pull zone Items response */
 const pullZoneResponse = (
   items: { Id: number; hostname: string }[],
@@ -86,67 +70,70 @@ const pullZoneResponse = (
   HasMoreItems: hasMore,
 });
 
-describe("bunny-cdn", () => {
-  describeWithEnv(
-    "isBunnyCdnEnabled",
-    { env: { BUNNY_API_KEY: undefined } },
-    () => {
-      test("returns false when BUNNY_API_KEY is not set", () => {
-        expect(isBunnyCdnEnabled()).toBe(false);
-      });
+describeWithEnv(
+  "isBunnyCdnEnabled",
+  { env: { BUNNY_API_KEY: undefined } },
+  () => {
+    test("returns false when BUNNY_API_KEY is not set", () => {
+      expect(isBunnyCdnEnabled()).toBe(false);
+    });
 
-      test("returns true when BUNNY_API_KEY is set", () => {
-        Deno.env.set("BUNNY_API_KEY", "test-key");
-        expect(isBunnyCdnEnabled()).toBe(true);
-      });
-    },
-  );
+    test("returns true when BUNNY_API_KEY is set", () => {
+      Deno.env.set("BUNNY_API_KEY", "test-key");
+      expect(isBunnyCdnEnabled()).toBe(true);
+    });
+  },
+);
 
-  describe("getCdnHostname", () => {
+describe("getCdnHostname", () => {
+  afterEach(() => resetAllowedDomain());
+
+  test("replaces .bunny.run with .b-cdn.net", () => {
+    setAllowedDomainForTest("mysite.bunny.run");
+    expect(getCdnHostname()).toBe("mysite.b-cdn.net");
+  });
+
+  test("returns domain unchanged when not .bunny.run", () => {
+    setAllowedDomainForTest("example.com");
+    expect(getCdnHostname()).toBe("example.com");
+  });
+});
+
+describe("validateCustomDomain", () => {
+  test("delegates to bunnyCdnApi.validateCustomDomain", async () => {
+    const mockResult = { ok: true as const };
+    await withMockValidate(mockResult, async () => {
+      const result = await validateCustomDomain("test.example.com");
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  test("returns error from bunnyCdnApi", async () => {
+    const mockResult = { ok: false as const, error: "test error" };
+    await withMockValidate(mockResult, async () => {
+      const result = await validateCustomDomain("test.example.com");
+      expect(result).toEqual(mockResult);
+    });
+  });
+});
+
+describeWithEnv(
+  "getBunnyApiKey",
+  { env: { BUNNY_API_KEY: undefined } },
+  () => {
+    test("getBunnyApiKey returns the env var value", () => {
+      Deno.env.set("BUNNY_API_KEY", "my-api-key");
+      expect(getBunnyApiKey()).toBe("my-api-key");
+    });
+  },
+);
+
+describeWithEnv(
+  "findPullZoneId",
+  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  () => {
+    beforeEach(() => setAllowedDomainForTest("mysite.bunny.run"));
     afterEach(() => resetAllowedDomain());
-
-    test("replaces .bunny.run with .b-cdn.net", () => {
-      setAllowedDomainForTest("mysite.bunny.run");
-      expect(getCdnHostname()).toBe("mysite.b-cdn.net");
-    });
-
-    test("returns domain unchanged when not .bunny.run", () => {
-      setAllowedDomainForTest("example.com");
-      expect(getCdnHostname()).toBe("example.com");
-    });
-  });
-
-  describe("validateCustomDomain", () => {
-    test("delegates to bunnyCdnApi.validateCustomDomain", async () => {
-      const mockResult = { ok: true as const };
-      await withMockValidate(mockResult, async () => {
-        const result = await validateCustomDomain("test.example.com");
-        expect(result).toEqual(mockResult);
-      });
-    });
-
-    test("returns error from bunnyCdnApi", async () => {
-      const mockResult = { ok: false as const, error: "test error" };
-      await withMockValidate(mockResult, async () => {
-        const result = await validateCustomDomain("test.example.com");
-        expect(result).toEqual(mockResult);
-      });
-    });
-  });
-
-  describeWithEnv(
-    "getBunnyApiKey",
-    { env: { BUNNY_API_KEY: undefined } },
-    () => {
-      test("getBunnyApiKey returns the env var value", () => {
-        Deno.env.set("BUNNY_API_KEY", "my-api-key");
-        expect(getBunnyApiKey()).toBe("my-api-key");
-      });
-    },
-  );
-
-  describe("findPullZoneId", () => {
-    useBunnyEnv();
 
     test("returns pull zone ID when matching hostname is found", async () => {
       await withMocks(
@@ -244,10 +231,15 @@ describe("bunny-cdn", () => {
         },
       );
     });
-  });
+  },
+);
 
-  describe("validateCustomDomain (real implementation)", () => {
-    useBunnyEnv();
+describeWithEnv(
+  "validateCustomDomain (real implementation)",
+  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  () => {
+    beforeEach(() => setAllowedDomainForTest("mysite.bunny.run"));
+    afterEach(() => resetAllowedDomain());
 
     /** Helper: stub findPullZoneId to return a fixed ID */
     const withFixedPullZoneId = (fn: () => Promise<void>): Promise<void> => {
@@ -501,42 +493,42 @@ describe("bunny-cdn", () => {
         );
       });
     });
+  },
+);
+
+describe("custom domain settings", () => {
+  beforeEach(async () => {
+    await createTestDb();
   });
 
-  describe("custom domain settings", () => {
-    beforeEach(async () => {
-      await createTestDb();
-    });
+  afterEach(() => {
+    resetDb();
+  });
 
-    afterEach(() => {
-      resetDb();
-    });
+  test("getCustomDomainFromDb returns null when not set", async () => {
+    expect(await getCustomDomainFromDb()).toBeNull();
+  });
 
-    test("getCustomDomainFromDb returns null when not set", async () => {
-      expect(await getCustomDomainFromDb()).toBeNull();
-    });
+  test("updateCustomDomain stores and retrieves domain", async () => {
+    await updateCustomDomain("tickets.example.com");
+    expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+  });
 
-    test("updateCustomDomain stores and retrieves domain", async () => {
-      await updateCustomDomain("tickets.example.com");
-      expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-    });
+  test("updateCustomDomain with empty string clears domain", async () => {
+    await updateCustomDomain("tickets.example.com");
+    await updateCustomDomain("");
+    expect(await getCustomDomainFromDb()).toBeNull();
+  });
 
-    test("updateCustomDomain with empty string clears domain", async () => {
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomain("");
-      expect(await getCustomDomainFromDb()).toBeNull();
-    });
+  test("getCustomDomainLastValidatedFromDb returns null when not set", async () => {
+    expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
+  });
 
-    test("getCustomDomainLastValidatedFromDb returns null when not set", async () => {
-      expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
-    });
-
-    test("updateCustomDomainLastValidated stores a timestamp", async () => {
-      await updateCustomDomainLastValidated();
-      const value = await getCustomDomainLastValidatedFromDb();
-      expect(value).not.toBeNull();
-      // Should be a valid ISO 8601 date
-      expect(new Date(value!).toISOString()).toBe(value);
-    });
+  test("updateCustomDomainLastValidated stores a timestamp", async () => {
+    await updateCustomDomainLastValidated();
+    const value = await getCustomDomainLastValidatedFromDb();
+    expect(value).not.toBeNull();
+    // Should be a valid ISO 8601 date
+    expect(new Date(value!).toISOString()).toBe(value);
   });
 });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -238,7 +238,6 @@ describe("payments", () => {
   afterEach(() => {
     resetDb();
   });
-
   test("getActivePaymentProvider returns null when no provider configured", async () => {
     const provider = await getActivePaymentProvider();
     expect(provider).toBeNull();

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -29,7 +29,7 @@ import {
 } from "#lib/db/settings.ts";
 import { getEnv } from "#lib/env.ts";
 import { getActivePaymentProvider } from "#lib/payments.ts";
-import { createTestDb, resetDb, setupStripe } from "#test-utils";
+import { createTestDb, resetDb, setTestEnv, setupStripe } from "#test-utils";
 
 describe("config", () => {
   beforeEach(async () => {
@@ -206,15 +206,11 @@ describe("env", () => {
     const uniqueKey = "TOTALLY_NONEXISTENT_VAR_XYZ_123";
     // Ensure it's not in process.env
     delete process.env[uniqueKey];
-    // Ensure it's not in Deno.env
-    try {
-      Deno.env.delete(uniqueKey);
-    } catch {
-      /* may not exist */
-    }
+    const restore = setTestEnv({ [uniqueKey]: undefined });
 
     const result = getEnv(uniqueKey);
     expect(result).toBeUndefined();
+    restore();
   });
 
   test("getEnv reads from process.env when available", () => {
@@ -227,10 +223,10 @@ describe("env", () => {
   test("getEnv falls back to Deno.env when not in process.env", () => {
     const key = "TEST_DENO_ONLY_VAR";
     delete process.env[key];
-    Deno.env.set(key, "from_deno");
+    const restore = setTestEnv({ [key]: "from_deno" });
     const result = getEnv(key);
     expect(result).toBe("from_deno");
-    Deno.env.delete(key);
+    restore();
   });
 });
 

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { beforeEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import {
   clearEncryptionKeyCache,
   constantTimeEqual,
@@ -29,6 +29,7 @@ import {
 } from "#lib/crypto.ts";
 import {
   clearTestEncryptionKey,
+  describeWithEnv,
   setTestEnv,
   setupTestEncryptionKey,
 } from "#test-utils";
@@ -120,11 +121,7 @@ describe("generateTicketToken", () => {
   });
 });
 
-describe("encryption", () => {
-  beforeEach(() => {
-    setupTestEncryptionKey();
-  });
-
+describeWithEnv("encryption", { encryptionKey: true }, () => {
   describe("validateEncryptionKey", () => {
     it("succeeds with valid 32-byte key", () => {
       expect(() => validateEncryptionKey()).not.toThrow();
@@ -321,11 +318,7 @@ describe("session token hashing", () => {
   });
 });
 
-describe("hmacHash", () => {
-  beforeEach(() => {
-    setupTestEncryptionKey();
-  });
-
+describeWithEnv("hmacHash", { encryptionKey: true }, () => {
   it("produces consistent hash for same IP", async () => {
     const ip = "192.168.1.1";
     const hash1 = await hmacHash(ip);
@@ -375,11 +368,7 @@ describe("hmacHash", () => {
   });
 });
 
-describe("KEK derivation", () => {
-  beforeEach(() => {
-    setupTestEncryptionKey();
-  });
-
+describeWithEnv("KEK derivation", { encryptionKey: true }, () => {
   it("derives a usable CryptoKey", async () => {
     const passwordHash = "pbkdf2:1000:c2FsdA==:aGFzaA==";
     const kek = await deriveKEK(passwordHash);
@@ -411,11 +400,7 @@ describe("KEK derivation", () => {
   });
 });
 
-describe("key wrapping", () => {
-  beforeEach(() => {
-    setupTestEncryptionKey();
-  });
-
+describeWithEnv("key wrapping", { encryptionKey: true }, () => {
   describe("wrapKey and unwrapKey", () => {
     it("round-trips a data key", async () => {
       const dataKey = await generateDataKey();

--- a/test/lib/crypto.test.ts
+++ b/test/lib/crypto.test.ts
@@ -27,7 +27,11 @@ import {
   wrapKey,
   wrapKeyWithToken,
 } from "#lib/crypto.ts";
-import { clearTestEncryptionKey, setupTestEncryptionKey } from "#test-utils";
+import {
+  clearTestEncryptionKey,
+  setTestEnv,
+  setupTestEncryptionKey,
+} from "#test-utils";
 
 describe("constantTimeEqual", () => {
   it("returns true for equal strings", () => {
@@ -243,14 +247,13 @@ describe("password hashing", () => {
     });
 
     it("uses production iterations when TEST_PBKDF2_ITERATIONS is unset", async () => {
-      const saved = Deno.env.get("TEST_PBKDF2_ITERATIONS");
-      Deno.env.delete("TEST_PBKDF2_ITERATIONS");
+      const restore = setTestEnv({ TEST_PBKDF2_ITERATIONS: undefined });
       try {
         const hash = await hashPassword("password");
         const iterations = Number(hash.split(":")[1]);
         expect(iterations).toBe(600000);
       } finally {
-        if (saved !== undefined) Deno.env.set("TEST_PBKDF2_ITERATIONS", saved);
+        restore();
       }
     });
   });
@@ -514,15 +517,14 @@ describe("RSA key pair and hybrid encryption", () => {
     });
 
     it("uses production key size when TEST_RSA_KEY_SIZE is unset", async () => {
-      const saved = Deno.env.get("TEST_RSA_KEY_SIZE");
-      Deno.env.delete("TEST_RSA_KEY_SIZE");
+      const restore = setTestEnv({ TEST_RSA_KEY_SIZE: undefined });
       try {
         const pair = await generateKeyPair();
         const jwk = JSON.parse(pair.publicKey);
         // 2048-bit RSA key: n (modulus) is 256 bytes = 344 base64url chars
         expect(jwk.n.length).toBeGreaterThan(300);
       } finally {
-        if (saved !== undefined) Deno.env.set("TEST_RSA_KEY_SIZE", saved);
+        restore();
       }
     });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -106,6 +106,7 @@ import {
   invalidateTestDbCache,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
 } from "#test-utils";
@@ -140,17 +141,13 @@ describe("db", () => {
   describe("getDb", () => {
     test("throws error when DB_URL is not set", () => {
       setDb(null);
-      const originalDbUrl = Deno.env.get("DB_URL");
-      Deno.env.delete("DB_URL");
-
+      const restore = setTestEnv({ DB_URL: undefined });
       try {
         expect(() => getDb()).toThrow(
           "DB_URL environment variable is required",
         );
       } finally {
-        if (originalDbUrl) {
-          Deno.env.set("DB_URL", originalDbUrl);
-        }
+        restore();
       }
     });
   });
@@ -1362,17 +1359,10 @@ describe("db", () => {
   describe("getDb", () => {
     test("creates client when db is null", () => {
       setDb(null);
-      const originalDbUrl = Deno.env.get("DB_URL");
-      Deno.env.set("DB_URL", ":memory:");
-
+      const restore = setTestEnv({ DB_URL: ":memory:" });
       const client = getDb();
       expect(client).toBeDefined();
-
-      if (originalDbUrl) {
-        Deno.env.set("DB_URL", originalDbUrl);
-      } else {
-        Deno.env.delete("DB_URL");
-      }
+      restore();
     });
 
     test("returns existing client when db is set", () => {

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
 import {
@@ -100,12 +100,10 @@ import { nowMs } from "#lib/now.ts";
 import {
   createPaidTestAttendee,
   createTestAttendee,
-  createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
+  describeWithEnv,
   invalidateTestDbCache,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
@@ -128,16 +126,7 @@ const getTestPrivateKey = async (): Promise<CryptoKey> => {
   return importPrivateKey(privateKeyJwk);
 };
 
-describe("db", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("db", { db: true }, () => {
   describe("getDb", () => {
     test("throws error when DB_URL is not set", () => {
       setDb(null);

--- a/test/lib/demo.test.ts
+++ b/test/lib/demo.test.ts
@@ -30,6 +30,7 @@ import {
   createTestDbWithSetup,
   mockRequest,
   resetDb,
+  setTestEnv,
   setupTestEncryptionKey,
 } from "#test-utils";
 
@@ -43,8 +44,12 @@ describe("demo", () => {
   });
 
   describe("isDemoMode", () => {
+    let restoreEnv: () => void;
+    beforeEach(() => {
+      restoreEnv = setTestEnv({ DEMO_MODE: undefined });
+    });
     afterEach(() => {
-      Deno.env.delete("DEMO_MODE");
+      restoreEnv();
     });
 
     test("returns false when DEMO_MODE is not set", () => {

--- a/test/lib/demo.test.ts
+++ b/test/lib/demo.test.ts
@@ -28,9 +28,9 @@ import { FormParams } from "#lib/form-data.ts";
 import { handleRequest } from "#routes";
 import {
   createTestDbWithSetup,
+  describeWithEnv,
   mockRequest,
   resetDb,
-  setTestEnv,
   setupTestEncryptionKey,
 } from "#test-utils";
 
@@ -43,14 +43,7 @@ describe("demo", () => {
     setDemoModeForTest(false);
   });
 
-  describe("isDemoMode", () => {
-    let restoreEnv: () => void;
-    beforeEach(() => {
-      restoreEnv = setTestEnv({ DEMO_MODE: undefined });
-    });
-    afterEach(() => {
-      restoreEnv();
-    });
+  describeWithEnv("isDemoMode", { DEMO_MODE: undefined }, () => {
 
     test("returns false when DEMO_MODE is not set", () => {
       expect(isDemoMode()).toBe(false);

--- a/test/lib/demo.test.ts
+++ b/test/lib/demo.test.ts
@@ -34,229 +34,229 @@ import {
   setupTestEncryptionKey,
 } from "#test-utils";
 
-describe("demo", () => {
-  beforeEach(() => {
-    setDemoModeForTest(false);
+describeWithEnv("isDemoMode", { env: { DEMO_MODE: undefined } }, () => {
+  beforeEach(() => setDemoModeForTest(false));
+  afterEach(() => setDemoModeForTest(false));
+
+  test("returns false when DEMO_MODE is not set", () => {
+    expect(isDemoMode()).toBe(false);
   });
 
-  afterEach(() => {
-    setDemoModeForTest(false);
+  test("returns true when DEMO_MODE is 'true'", () => {
+    Deno.env.set("DEMO_MODE", "true");
+    resetDemoMode();
+    expect(isDemoMode()).toBe(true);
   });
 
-  describeWithEnv("isDemoMode", { env: { DEMO_MODE: undefined } }, () => {
-    test("returns false when DEMO_MODE is not set", () => {
-      expect(isDemoMode()).toBe(false);
-    });
-
-    test("returns true when DEMO_MODE is 'true'", () => {
-      Deno.env.set("DEMO_MODE", "true");
-      resetDemoMode();
-      expect(isDemoMode()).toBe(true);
-    });
-
-    test("returns false when DEMO_MODE is any other value", () => {
-      Deno.env.set("DEMO_MODE", "false");
-      resetDemoMode();
-      expect(isDemoMode()).toBe(false);
-    });
-
-    test("caches the result across calls", () => {
-      Deno.env.set("DEMO_MODE", "true");
-      resetDemoMode();
-      expect(isDemoMode()).toBe(true);
-      // Change env after first call - should still return cached value
-      Deno.env.set("DEMO_MODE", "false");
-      expect(isDemoMode()).toBe(true);
-    });
-
-    test("resetDemoMode clears the cache", () => {
-      Deno.env.set("DEMO_MODE", "true");
-      resetDemoMode();
-      expect(isDemoMode()).toBe(true);
-      Deno.env.set("DEMO_MODE", "false");
-      resetDemoMode();
-      expect(isDemoMode()).toBe(false);
-    });
+  test("returns false when DEMO_MODE is any other value", () => {
+    Deno.env.set("DEMO_MODE", "false");
+    resetDemoMode();
+    expect(isDemoMode()).toBe(false);
   });
 
-  describe("applyDemoOverrides", () => {
-    test("returns form unchanged when demo mode is off", () => {
-      const form = new FormParams({
-        name: "Real Name",
-        email: "real@example.com",
-      });
-      const result = applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      expect(result.get("name")).toBe("Real Name");
-      expect(result.get("email")).toBe("real@example.com");
-    });
-
-    test("replaces fields that exist in the form when demo mode is on", () => {
-      setDemoModeForTest(true);
-      const form = new FormParams({
-        name: "Real Name",
-        email: "real@example.com",
-      });
-      applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      expect(form.get("name")).not.toBe("Real Name");
-      expect(DEMO_NAMES as readonly string[]).toContain(form.get("name"));
-      expect(form.get("email")).not.toBe("real@example.com");
-      expect(DEMO_EMAILS as readonly string[]).toContain(form.get("email"));
-    });
-
-    test("skips fields not present in the form", () => {
-      setDemoModeForTest(true);
-      const form = new FormParams({ name: "Real Name" });
-      applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      expect(form.has("email")).toBe(false);
-      expect(form.has("phone")).toBe(false);
-    });
-
-    test("skips empty-string fields", () => {
-      setDemoModeForTest(true);
-      const form = new FormParams({ name: "Real Name", email: "" });
-      applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      expect(form.get("email")).toBe("");
-      expect(DEMO_NAMES as readonly string[]).toContain(form.get("name"));
-    });
-
-    test("returns the same form instance", () => {
-      setDemoModeForTest(true);
-      const form = new FormParams({ name: "Test" });
-      const result = applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      expect(result).toBe(form);
-    });
-
-    test("does not modify fields not in the mapping", () => {
-      setDemoModeForTest(true);
-      const form = new FormParams({ name: "Real", csrf_token: "abc123" });
-      applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      expect(form.get("csrf_token")).toBe("abc123");
-    });
-
-    test("works with event demo fields", () => {
-      setDemoModeForTest(true);
-      const form = new FormParams({
-        name: "My Event",
-        description: "My description",
-        location: "My location",
-      });
-      applyDemoOverrides(form, EVENT_DEMO_FIELDS);
-      expect(DEMO_EVENT_NAMES as readonly string[]).toContain(form.get("name"));
-      expect(DEMO_EVENT_DESCRIPTIONS as readonly string[]).toContain(
-        form.get("description"),
-      );
-      expect(DEMO_EVENT_LOCATIONS as readonly string[]).toContain(
-        form.get("location"),
-      );
-    });
+  test("caches the result across calls", () => {
+    Deno.env.set("DEMO_MODE", "true");
+    resetDemoMode();
+    expect(isDemoMode()).toBe(true);
+    // Change env after first call - should still return cached value
+    Deno.env.set("DEMO_MODE", "false");
+    expect(isDemoMode()).toBe(true);
   });
 
-  describe("wrapResourceForDemo", () => {
-    const makeFakeResource = () => {
-      let lastCreateForm: URLSearchParams | null = null;
-      let lastUpdateForm: URLSearchParams | null = null;
+  test("resetDemoMode clears the cache", () => {
+    Deno.env.set("DEMO_MODE", "true");
+    resetDemoMode();
+    expect(isDemoMode()).toBe(true);
+    Deno.env.set("DEMO_MODE", "false");
+    resetDemoMode();
+    expect(isDemoMode()).toBe(false);
+  });
+});
 
-      const resource = {
-        table: {} as never,
-        fields: [],
-        parseInput: (_form: URLSearchParams) =>
-          Promise.resolve({ ok: true as const, input: {} }),
-        parsePartialInput: (_form: URLSearchParams) =>
-          Promise.resolve({ ok: true as const, input: {} }),
-        create: (form: URLSearchParams) => {
-          lastCreateForm = form;
-          return Promise.resolve({
-            ok: true as const,
-            row: { id: 1, name: "" },
-          });
-        },
-        update: (_id: unknown, form: URLSearchParams) => {
-          lastUpdateForm = form;
-          return Promise.resolve({
-            ok: true as const,
-            row: { id: 1, name: "" },
-          });
-        },
-        delete: () => Promise.resolve({ ok: true as const }),
-        verifyName: (_row: unknown, _name: string) => true,
-      };
-      return {
-        resource,
-        getLastCreateForm: () => lastCreateForm,
-        getLastUpdateForm: () => lastUpdateForm,
-      };
+describe("applyDemoOverrides", () => {
+  beforeEach(() => setDemoModeForTest(false));
+  afterEach(() => setDemoModeForTest(false));
+
+  test("returns form unchanged when demo mode is off", () => {
+    const form = new FormParams({
+      name: "Real Name",
+      email: "real@example.com",
+    });
+    const result = applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
+    expect(result.get("name")).toBe("Real Name");
+    expect(result.get("email")).toBe("real@example.com");
+  });
+
+  test("replaces fields that exist in the form when demo mode is on", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({
+      name: "Real Name",
+      email: "real@example.com",
+    });
+    applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
+    expect(form.get("name")).not.toBe("Real Name");
+    expect(DEMO_NAMES as readonly string[]).toContain(form.get("name"));
+    expect(form.get("email")).not.toBe("real@example.com");
+    expect(DEMO_EMAILS as readonly string[]).toContain(form.get("email"));
+  });
+
+  test("skips fields not present in the form", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({ name: "Real Name" });
+    applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
+    expect(form.has("email")).toBe(false);
+    expect(form.has("phone")).toBe(false);
+  });
+
+  test("skips empty-string fields", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({ name: "Real Name", email: "" });
+    applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
+    expect(form.get("email")).toBe("");
+    expect(DEMO_NAMES as readonly string[]).toContain(form.get("name"));
+  });
+
+  test("returns the same form instance", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({ name: "Test" });
+    const result = applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
+    expect(result).toBe(form);
+  });
+
+  test("does not modify fields not in the mapping", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({ name: "Real", csrf_token: "abc123" });
+    applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
+    expect(form.get("csrf_token")).toBe("abc123");
+  });
+
+  test("works with event demo fields", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({
+      name: "My Event",
+      description: "My description",
+      location: "My location",
+    });
+    applyDemoOverrides(form, EVENT_DEMO_FIELDS);
+    expect(DEMO_EVENT_NAMES as readonly string[]).toContain(form.get("name"));
+    expect(DEMO_EVENT_DESCRIPTIONS as readonly string[]).toContain(
+      form.get("description"),
+    );
+    expect(DEMO_EVENT_LOCATIONS as readonly string[]).toContain(
+      form.get("location"),
+    );
+  });
+});
+
+describe("wrapResourceForDemo", () => {
+  beforeEach(() => setDemoModeForTest(false));
+  afterEach(() => setDemoModeForTest(false));
+
+  const makeFakeResource = () => {
+    let lastCreateForm: URLSearchParams | null = null;
+    let lastUpdateForm: URLSearchParams | null = null;
+
+    const resource = {
+      table: {} as never,
+      fields: [],
+      parseInput: (_form: URLSearchParams) =>
+        Promise.resolve({ ok: true as const, input: {} }),
+      parsePartialInput: (_form: URLSearchParams) =>
+        Promise.resolve({ ok: true as const, input: {} }),
+      create: (form: URLSearchParams) => {
+        lastCreateForm = form;
+        return Promise.resolve({
+          ok: true as const,
+          row: { id: 1, name: "" },
+        });
+      },
+      update: (_id: unknown, form: URLSearchParams) => {
+        lastUpdateForm = form;
+        return Promise.resolve({
+          ok: true as const,
+          row: { id: 1, name: "" },
+        });
+      },
+      delete: () => Promise.resolve({ ok: true as const }),
+      verifyName: (_row: unknown, _name: string) => true,
     };
+    return {
+      resource,
+      getLastCreateForm: () => lastCreateForm,
+      getLastUpdateForm: () => lastUpdateForm,
+    };
+  };
 
-    test("delegates create with demo overrides applied", () => {
-      setDemoModeForTest(true);
+  test("delegates create with demo overrides applied", () => {
+    setDemoModeForTest(true);
 
-      const { resource, getLastCreateForm } = makeFakeResource();
-      const wrapped = wrapResourceForDemo(resource, {
-        name: DEMO_GROUP_NAMES,
-      } as DemoFieldMap);
+    const { resource, getLastCreateForm } = makeFakeResource();
+    const wrapped = wrapResourceForDemo(resource, {
+      name: DEMO_GROUP_NAMES,
+    } as DemoFieldMap);
 
-      const form = new FormParams({ name: "Real Group" });
-      wrapped.create(form);
+    const form = new FormParams({ name: "Real Group" });
+    wrapped.create(form);
 
-      // applyDemoOverrides mutates the form in place before passing to resource
-      expect(DEMO_GROUP_NAMES as readonly string[]).toContain(
-        getLastCreateForm()!.get("name"),
-      );
-    });
-
-    test("delegates update with demo overrides applied", () => {
-      setDemoModeForTest(true);
-
-      const { resource, getLastUpdateForm } = makeFakeResource();
-      const wrapped = wrapResourceForDemo(resource, {
-        name: DEMO_HOLIDAY_NAMES,
-      } as DemoFieldMap);
-
-      const form = new FormParams({ name: "Real Holiday" });
-      wrapped.update(42, form);
-
-      expect(DEMO_HOLIDAY_NAMES as readonly string[]).toContain(
-        getLastUpdateForm()!.get("name"),
-      );
-    });
-
-    test("preserves verifyName from original resource", () => {
-      const { resource } = makeFakeResource();
-      const wrapped = wrapResourceForDemo(resource, {
-        name: DEMO_NAMES,
-      } as DemoFieldMap);
-      expect(wrapped.verifyName).toBe(resource.verifyName);
-    });
-
-    test("does not apply overrides when demo mode is off", () => {
-      const { resource, getLastCreateForm } = makeFakeResource();
-      const wrapped = wrapResourceForDemo(resource, {
-        name: DEMO_NAMES,
-      } as DemoFieldMap);
-
-      const form = new FormParams({ name: "Unchanged" });
-      wrapped.create(form);
-
-      expect(getLastCreateForm()!.get("name")).toBe("Unchanged");
-    });
+    // applyDemoOverrides mutates the form in place before passing to resource
+    expect(DEMO_GROUP_NAMES as readonly string[]).toContain(
+      getLastCreateForm()!.get("name"),
+    );
   });
 
-  describe("layout banner integration", () => {
-    beforeAll(async () => {
-      setupTestEncryptionKey();
-      await createTestDbWithSetup();
-    });
+  test("delegates update with demo overrides applied", () => {
+    setDemoModeForTest(true);
 
-    afterAll(() => {
-      resetDb();
-    });
+    const { resource, getLastUpdateForm } = makeFakeResource();
+    const wrapped = wrapResourceForDemo(resource, {
+      name: DEMO_HOLIDAY_NAMES,
+    } as DemoFieldMap);
 
-    test("renders demo banner in page when demo mode is active", async () => {
-      setDemoModeForTest(true);
-      const response = await handleRequest(mockRequest("/admin/login"));
-      const html = await response.text();
-      expect(response.status).toBe(200);
-      expect(html).toContain("Demo Mode");
-    });
+    const form = new FormParams({ name: "Real Holiday" });
+    wrapped.update(42, form);
+
+    expect(DEMO_HOLIDAY_NAMES as readonly string[]).toContain(
+      getLastUpdateForm()!.get("name"),
+    );
+  });
+
+  test("preserves verifyName from original resource", () => {
+    const { resource } = makeFakeResource();
+    const wrapped = wrapResourceForDemo(resource, {
+      name: DEMO_NAMES,
+    } as DemoFieldMap);
+    expect(wrapped.verifyName).toBe(resource.verifyName);
+  });
+
+  test("does not apply overrides when demo mode is off", () => {
+    const { resource, getLastCreateForm } = makeFakeResource();
+    const wrapped = wrapResourceForDemo(resource, {
+      name: DEMO_NAMES,
+    } as DemoFieldMap);
+
+    const form = new FormParams({ name: "Unchanged" });
+    wrapped.create(form);
+
+    expect(getLastCreateForm()!.get("name")).toBe("Unchanged");
+  });
+});
+
+describe("layout banner integration", () => {
+  beforeAll(async () => {
+    setupTestEncryptionKey();
+    await createTestDbWithSetup();
+  });
+
+  afterAll(() => {
+    setDemoModeForTest(false);
+    resetDb();
+  });
+
+  test("renders demo banner in page when demo mode is active", async () => {
+    setDemoModeForTest(true);
+    const response = await handleRequest(mockRequest("/admin/login"));
+    const html = await response.text();
+    expect(response.status).toBe(200);
+    expect(html).toContain("Demo Mode");
   });
 });

--- a/test/lib/demo.test.ts
+++ b/test/lib/demo.test.ts
@@ -43,8 +43,7 @@ describe("demo", () => {
     setDemoModeForTest(false);
   });
 
-  describeWithEnv("isDemoMode", { DEMO_MODE: undefined }, () => {
-
+  describeWithEnv("isDemoMode", { env: { DEMO_MODE: undefined } }, () => {
     test("returns false when DEMO_MODE is not set", () => {
       expect(isDemoMode()).toBe(false);
     });

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -16,23 +16,17 @@ import {
   resetEngine,
   validateTemplate,
 } from "#lib/email-renderer.ts";
-import {
-  createTestDbWithSetup,
-  makeTestEntry as makeEntry,
-  resetDb,
-} from "#test-utils";
+import { describeWithEnv, makeTestEntry as makeEntry } from "#test-utils";
 
-describe("email-renderer", () => {
-  beforeEach(async () => {
+describeWithEnv("email-renderer", { db: true }, () => {
+  beforeEach(() => {
     setCurrencyCodeForTest("GBP");
     resetEngine();
-    await createTestDbWithSetup();
   });
 
   afterEach(() => {
     resetCurrencyCode();
     resetEngine();
-    resetDb();
   });
 
   describe("buildTemplateData", () => {

--- a/test/lib/email-templates-admin.test.ts
+++ b/test/lib/email-templates-admin.test.ts
@@ -12,28 +12,23 @@ import { resetEngine } from "#lib/email-renderer.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   mockFormRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
 
-describe("admin email templates", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
+describeWithEnv("admin email templates", { db: true }, () => {
+  beforeEach(() => {
     setCurrencyCodeForTest("GBP");
     resetEngine();
-    await createTestDbWithSetup();
   });
 
   afterEach(() => {
     resetCurrencyCode();
     resetEngine();
-    resetDb();
   });
 
   async function postTemplateForm(

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -26,6 +26,7 @@ import {
   createTestDbWithSetup,
   makeTestEntry as makeEntry,
   resetDb,
+  setTestEnv,
 } from "#test-utils";
 
 const testConfig: EmailConfig = {
@@ -528,11 +529,17 @@ describe("email", () => {
   });
 
   describe("getHostEmailConfig", () => {
-    afterEach(() => {
-      Deno.env.delete("HOST_EMAIL_PROVIDER");
-      Deno.env.delete("HOST_EMAIL_API_KEY");
-      Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+      restoreEnv = setTestEnv({
+        HOST_EMAIL_PROVIDER: undefined,
+        HOST_EMAIL_API_KEY: undefined,
+        HOST_EMAIL_FROM_ADDRESS: undefined,
+      });
     });
+
+    afterEach(() => restoreEnv());
 
     test("returns null when no env vars set", () => {
       expect(getHostEmailConfig()).toBeNull();
@@ -594,11 +601,17 @@ describe("email", () => {
   });
 
   describe("sendRegistrationEmails", () => {
-    afterEach(() => {
-      Deno.env.delete("HOST_EMAIL_PROVIDER");
-      Deno.env.delete("HOST_EMAIL_API_KEY");
-      Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+      restoreEnv = setTestEnv({
+        HOST_EMAIL_PROVIDER: undefined,
+        HOST_EMAIL_API_KEY: undefined,
+        HOST_EMAIL_FROM_ADDRESS: undefined,
+      });
     });
+
+    afterEach(() => restoreEnv());
 
     test("skips when attendee has no email address", async () => {
       await setupAndSendRegistration({}, [makeEntry({}, { email: "" })]);

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -528,177 +528,187 @@ describe("email", () => {
     });
   });
 
-  describeWithEnv("getHostEmailConfig", {
-    HOST_EMAIL_PROVIDER: undefined,
-    HOST_EMAIL_API_KEY: undefined,
-    HOST_EMAIL_FROM_ADDRESS: undefined,
-  }, () => {
-
-    test("returns null when no env vars set", () => {
-      expect(getHostEmailConfig()).toBeNull();
-    });
-
-    test("returns null when HOST_EMAIL_PROVIDER missing", () => {
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      expect(getHostEmailConfig()).toBeNull();
-    });
-
-    test("returns null when HOST_EMAIL_API_KEY missing", () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      expect(getHostEmailConfig()).toBeNull();
-    });
-
-    test("returns null when HOST_EMAIL_FROM_ADDRESS missing", () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      expect(getHostEmailConfig()).toBeNull();
-    });
-
-    test("returns config with specified provider", () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      expect(getHostEmailConfig()).toEqual({
-        provider: "resend",
-        apiKey: "key-123",
-        fromAddress: "noreply@example.com",
+  describeWithEnv(
+    "getHostEmailConfig",
+    {
+      env: {
+        HOST_EMAIL_PROVIDER: undefined,
+        HOST_EMAIL_API_KEY: undefined,
+        HOST_EMAIL_FROM_ADDRESS: undefined,
+      },
+    },
+    () => {
+      test("returns null when no env vars set", () => {
+        expect(getHostEmailConfig()).toBeNull();
       });
-    });
 
-    test("supports mailgun-eu provider", () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-eu");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      expect(getHostEmailConfig()).toEqual({
-        provider: "mailgun-eu",
-        apiKey: "key-123",
-        fromAddress: "noreply@example.com",
+      test("returns null when HOST_EMAIL_PROVIDER missing", () => {
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        expect(getHostEmailConfig()).toBeNull();
       });
-    });
 
-    test("returns null and logs error for invalid provider", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      await withErrorSpy((errorSpy) => {
-        const config = getHostEmailConfig();
-        expect(config).toBeNull();
-        expectEmailSendLog(
-          collectErrorLogs(errorSpy),
-          "invalid HOST_EMAIL_PROVIDER",
+      test("returns null when HOST_EMAIL_API_KEY missing", () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        expect(getHostEmailConfig()).toBeNull();
+      });
+
+      test("returns null when HOST_EMAIL_FROM_ADDRESS missing", () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        expect(getHostEmailConfig()).toBeNull();
+      });
+
+      test("returns config with specified provider", () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        expect(getHostEmailConfig()).toEqual({
+          provider: "resend",
+          apiKey: "key-123",
+          fromAddress: "noreply@example.com",
+        });
+      });
+
+      test("supports mailgun-eu provider", () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-eu");
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        expect(getHostEmailConfig()).toEqual({
+          provider: "mailgun-eu",
+          apiKey: "key-123",
+          fromAddress: "noreply@example.com",
+        });
+      });
+
+      test("returns null and logs error for invalid provider", async () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun");
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        await withErrorSpy((errorSpy) => {
+          const config = getHostEmailConfig();
+          expect(config).toBeNull();
+          expectEmailSendLog(
+            collectErrorLogs(errorSpy),
+            "invalid HOST_EMAIL_PROVIDER",
+          );
+        });
+      });
+    },
+  );
+
+  describeWithEnv(
+    "sendRegistrationEmails",
+    {
+      env: {
+        HOST_EMAIL_PROVIDER: undefined,
+        HOST_EMAIL_API_KEY: undefined,
+        HOST_EMAIL_FROM_ADDRESS: undefined,
+      },
+    },
+    () => {
+      test("skips when attendee has no email address", async () => {
+        await setupAndSendRegistration({}, [makeEntry({}, { email: "" })]);
+        expect(fetchStub.calls.length).toBe(0);
+      });
+
+      test("skips when email not configured", async () => {
+        await sendRegistrationEmails([makeEntry()], "GBP");
+        expect(fetchStub.calls.length).toBe(0);
+      });
+
+      test("falls back to host email config when no DB email provider", async () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-us");
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        invalidateSettingsCache();
+
+        await sendRegistrationEmails([makeEntry()], "GBP");
+
+        expect(fetchStub.calls.length).toBe(1);
+        const [url] = fetchStub.calls[0].args as [string, RequestInit];
+        expect(url).toBe("https://api.mailgun.net/v3/example.com/messages");
+      });
+
+      test("prefers DB email provider over host email config", async () => {
+        Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-us");
+        Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
+        Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+        await setupAndSendRegistration();
+
+        expect(fetchStub.calls.length).toBe(1);
+        const [url] = fetchStub.calls[0].args as [string, RequestInit];
+        expect(url).toBe("https://api.resend.com/emails");
+      });
+
+      test("sends confirmation email to attendee", async () => {
+        await setupAndSendRegistration();
+
+        expect(fetchStub.calls.length).toBe(1);
+        const body = getFetchJsonBody();
+        expect(body.to).toEqual(["jane@example.com"]);
+        expect(body.subject).toContain("Test Event");
+      });
+
+      test("sends both confirmation and admin notification when business email set", async () => {
+        await setupAndSendRegistration({ businessEmail: "admin@business.com" });
+
+        expect(fetchStub.calls.length).toBe(2);
+        const recipients = fetchStub.calls.map(
+          (c: { args: unknown[] }) => getCallJsonBody(c).to,
         );
+        expect(recipients).toContainEqual(["jane@example.com"]);
+        expect(recipients).toContainEqual(["admin@business.com"]);
       });
-    });
-  });
 
-  describeWithEnv("sendRegistrationEmails", {
-    HOST_EMAIL_PROVIDER: undefined,
-    HOST_EMAIL_API_KEY: undefined,
-    HOST_EMAIL_FROM_ADDRESS: undefined,
-  }, () => {
+      test("uses business email as reply-to on confirmation", async () => {
+        await setupAndSendRegistration({ businessEmail: "admin@business.com" });
 
-    test("skips when attendee has no email address", async () => {
-      await setupAndSendRegistration({}, [makeEntry({}, { email: "" })]);
-      expect(fetchStub.calls.length).toBe(0);
-    });
+        const body = findCallBodyByRecipient("jane@example.com");
+        expect(body.reply_to).toBe("admin@business.com");
+      });
 
-    test("skips when email not configured", async () => {
-      await sendRegistrationEmails([makeEntry()], "GBP");
-      expect(fetchStub.calls.length).toBe(0);
-    });
+      test("uses attendee email as reply-to on admin notification", async () => {
+        await setupAndSendRegistration({ businessEmail: "admin@business.com" });
 
-    test("falls back to host email config when no DB email provider", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-us");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      invalidateSettingsCache();
+        const body = findCallBodyByRecipient("admin@business.com");
+        expect(body.reply_to).toBe("jane@example.com");
+      });
 
-      await sendRegistrationEmails([makeEntry()], "GBP");
+      test("attaches SVG ticket to confirmation email", async () => {
+        await setupAndSendRegistration();
 
-      expect(fetchStub.calls.length).toBe(1);
-      const [url] = fetchStub.calls[0].args as [string, RequestInit];
-      expect(url).toBe("https://api.mailgun.net/v3/example.com/messages");
-    });
+        const body = getFetchJsonBody();
+        expect(body.attachments).toHaveLength(1);
+        expect(body.attachments[0].filename).toBe("ticket.svg");
+        const binary = atob(body.attachments[0].content);
+        const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+        const decoded = new TextDecoder().decode(bytes);
+        expect(decoded).toContain("<svg");
+      });
 
-    test("prefers DB email provider over host email config", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-us");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-      await setupAndSendRegistration();
+      test("does not attach tickets to admin notification", async () => {
+        await setupAndSendRegistration({ businessEmail: "admin@business.com" });
 
-      expect(fetchStub.calls.length).toBe(1);
-      const [url] = fetchStub.calls[0].args as [string, RequestInit];
-      expect(url).toBe("https://api.resend.com/emails");
-    });
+        const body = findCallBodyByRecipient("admin@business.com");
+        expect(body.attachments).toBeUndefined();
+      });
 
-    test("sends confirmation email to attendee", async () => {
-      await setupAndSendRegistration();
+      test("attaches numbered tickets for multi-event registration", async () => {
+        const entries = [
+          makeEntry({ name: "Event A" }, { ticket_token: "tok1" }),
+          makeEntry({ name: "Event B" }, { ticket_token: "tok2" }),
+        ];
+        await setupAndSendRegistration({}, entries);
 
-      expect(fetchStub.calls.length).toBe(1);
-      const body = getFetchJsonBody();
-      expect(body.to).toEqual(["jane@example.com"]);
-      expect(body.subject).toContain("Test Event");
-    });
-
-    test("sends both confirmation and admin notification when business email set", async () => {
-      await setupAndSendRegistration({ businessEmail: "admin@business.com" });
-
-      expect(fetchStub.calls.length).toBe(2);
-      const recipients = fetchStub.calls.map(
-        (c: { args: unknown[] }) => getCallJsonBody(c).to,
-      );
-      expect(recipients).toContainEqual(["jane@example.com"]);
-      expect(recipients).toContainEqual(["admin@business.com"]);
-    });
-
-    test("uses business email as reply-to on confirmation", async () => {
-      await setupAndSendRegistration({ businessEmail: "admin@business.com" });
-
-      const body = findCallBodyByRecipient("jane@example.com");
-      expect(body.reply_to).toBe("admin@business.com");
-    });
-
-    test("uses attendee email as reply-to on admin notification", async () => {
-      await setupAndSendRegistration({ businessEmail: "admin@business.com" });
-
-      const body = findCallBodyByRecipient("admin@business.com");
-      expect(body.reply_to).toBe("jane@example.com");
-    });
-
-    test("attaches SVG ticket to confirmation email", async () => {
-      await setupAndSendRegistration();
-
-      const body = getFetchJsonBody();
-      expect(body.attachments).toHaveLength(1);
-      expect(body.attachments[0].filename).toBe("ticket.svg");
-      const binary = atob(body.attachments[0].content);
-      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-      const decoded = new TextDecoder().decode(bytes);
-      expect(decoded).toContain("<svg");
-    });
-
-    test("does not attach tickets to admin notification", async () => {
-      await setupAndSendRegistration({ businessEmail: "admin@business.com" });
-
-      const body = findCallBodyByRecipient("admin@business.com");
-      expect(body.attachments).toBeUndefined();
-    });
-
-    test("attaches numbered tickets for multi-event registration", async () => {
-      const entries = [
-        makeEntry({ name: "Event A" }, { ticket_token: "tok1" }),
-        makeEntry({ name: "Event B" }, { ticket_token: "tok2" }),
-      ];
-      await setupAndSendRegistration({}, entries);
-
-      const body = getFetchJsonBody();
-      expect(body.attachments).toHaveLength(2);
-      expect(body.attachments[0].filename).toBe("ticket-1.svg");
-      expect(body.attachments[1].filename).toBe("ticket-2.svg");
-    });
-  });
+        const body = getFetchJsonBody();
+        expect(body.attachments).toHaveLength(2);
+        expect(body.attachments[0].filename).toBe("ticket-1.svg");
+        expect(body.attachments[1].filename).toBe("ticket-2.svg");
+      });
+    },
+  );
 
   describe("sendTestEmail", () => {
     test("sends test email and returns status code", async () => {

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -24,9 +24,9 @@ import {
 } from "#lib/email.ts";
 import {
   createTestDbWithSetup,
+  describeWithEnv,
   makeTestEntry as makeEntry,
   resetDb,
-  setTestEnv,
 } from "#test-utils";
 
 const testConfig: EmailConfig = {
@@ -528,18 +528,11 @@ describe("email", () => {
     });
   });
 
-  describe("getHostEmailConfig", () => {
-    let restoreEnv: () => void;
-
-    beforeEach(() => {
-      restoreEnv = setTestEnv({
-        HOST_EMAIL_PROVIDER: undefined,
-        HOST_EMAIL_API_KEY: undefined,
-        HOST_EMAIL_FROM_ADDRESS: undefined,
-      });
-    });
-
-    afterEach(() => restoreEnv());
+  describeWithEnv("getHostEmailConfig", {
+    HOST_EMAIL_PROVIDER: undefined,
+    HOST_EMAIL_API_KEY: undefined,
+    HOST_EMAIL_FROM_ADDRESS: undefined,
+  }, () => {
 
     test("returns null when no env vars set", () => {
       expect(getHostEmailConfig()).toBeNull();
@@ -600,18 +593,11 @@ describe("email", () => {
     });
   });
 
-  describe("sendRegistrationEmails", () => {
-    let restoreEnv: () => void;
-
-    beforeEach(() => {
-      restoreEnv = setTestEnv({
-        HOST_EMAIL_PROVIDER: undefined,
-        HOST_EMAIL_API_KEY: undefined,
-        HOST_EMAIL_FROM_ADDRESS: undefined,
-      });
-    });
-
-    afterEach(() => restoreEnv());
+  describeWithEnv("sendRegistrationEmails", {
+    HOST_EMAIL_PROVIDER: undefined,
+    HOST_EMAIL_API_KEY: undefined,
+    HOST_EMAIL_FROM_ADDRESS: undefined,
+  }, () => {
 
     test("skips when attendee has no email address", async () => {
       await setupAndSendRegistration({}, [makeEntry({}, { email: "" })]);

--- a/test/lib/env.test.ts
+++ b/test/lib/env.test.ts
@@ -2,20 +2,22 @@ import process from "node:process";
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getEnv, requireEnv } from "#lib/env.ts";
+import { setTestEnv } from "#test-utils";
 
 describe("env", () => {
   const originalEnv = { ...process.env };
+  let restoreEnv: () => void;
 
   beforeEach(() => {
     // Clear test env vars
     delete process.env.TEST_ENV_VAR;
-    Deno.env.delete("TEST_ENV_VAR");
+    restoreEnv = setTestEnv({ TEST_ENV_VAR: undefined });
   });
 
   afterEach(() => {
     // Restore original env
     process.env = { ...originalEnv };
-    Deno.env.delete("TEST_ENV_VAR");
+    restoreEnv();
   });
 
   describe("getEnv", () => {

--- a/test/lib/env.test.ts
+++ b/test/lib/env.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getEnv, requireEnv } from "#lib/env.ts";
 import { describeWithEnv } from "#test-utils";
 
-describeWithEnv("env", { TEST_ENV_VAR: undefined }, () => {
+describeWithEnv("env", { env: { TEST_ENV_VAR: undefined } }, () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {

--- a/test/lib/env.test.ts
+++ b/test/lib/env.test.ts
@@ -2,22 +2,19 @@ import process from "node:process";
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getEnv, requireEnv } from "#lib/env.ts";
-import { setTestEnv } from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
-describe("env", () => {
+describeWithEnv("env", { TEST_ENV_VAR: undefined }, () => {
   const originalEnv = { ...process.env };
-  let restoreEnv: () => void;
 
   beforeEach(() => {
     // Clear test env vars
     delete process.env.TEST_ENV_VAR;
-    restoreEnv = setTestEnv({ TEST_ENV_VAR: undefined });
   });
 
   afterEach(() => {
     // Restore original env
     process.env = { ...originalEnv };
-    restoreEnv();
   });
 
   describe("getEnv", () => {

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -16,13 +16,13 @@ import {
   adminGet,
   createTestDbWithSetup,
   createTestManagerSession,
+  describeWithEnv,
   expectHtmlResponse,
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
   resetDb,
   resetTestSlugCounter,
-  setTestEnv,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -210,23 +210,19 @@ describe("header image settings DB", () => {
   });
 });
 
-describe("server (header image settings)", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("server (header image settings)", {
+  STORAGE_ZONE_NAME: "testzone",
+  STORAGE_ZONE_KEY: "testkey",
+}, () => {
   beforeEach(async () => {
     resetTestSlugCounter();
     resetHeaderImage();
     await createTestDbWithSetup();
-    restoreEnv = setTestEnv({
-      STORAGE_ZONE_NAME: "testzone",
-      STORAGE_ZONE_KEY: "testkey",
-    });
   });
 
   afterEach(() => {
     resetDb();
     resetHeaderImage();
-    restoreEnv();
   });
 
   describe("GET /admin/settings (header image section)", () => {

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -22,6 +22,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -210,19 +211,22 @@ describe("header image settings DB", () => {
 });
 
 describe("server (header image settings)", () => {
+  let restoreEnv: () => void;
+
   beforeEach(async () => {
     resetTestSlugCounter();
     resetHeaderImage();
     await createTestDbWithSetup();
-    Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-    Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+    restoreEnv = setTestEnv({
+      STORAGE_ZONE_NAME: "testzone",
+      STORAGE_ZONE_KEY: "testkey",
+    });
   });
 
   afterEach(() => {
     resetDb();
     resetHeaderImage();
-    Deno.env.delete("STORAGE_ZONE_NAME");
-    Deno.env.delete("STORAGE_ZONE_KEY");
+    restoreEnv();
   });
 
   describe("GET /admin/settings (header image section)", () => {
@@ -352,8 +356,6 @@ describe("server (header image settings)", () => {
 
     test("reports error when upload fails", async () => {
       const originalFetch = globalThis.fetch;
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
       globalThis.fetch = (): Promise<Response> => {
         return Promise.reject(new Error("CDN unreachable"));
       };
@@ -368,8 +370,6 @@ describe("server (header image settings)", () => {
         );
       } finally {
         globalThis.fetch = originalFetch;
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
       }
     });
 

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -210,277 +210,283 @@ describe("header image settings DB", () => {
   });
 });
 
-describeWithEnv("server (header image settings)", {
-  STORAGE_ZONE_NAME: "testzone",
-  STORAGE_ZONE_KEY: "testkey",
-}, () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    resetHeaderImage();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-    resetHeaderImage();
-  });
-
-  describe("GET /admin/settings (header image section)", () => {
-    test("shows header image section when storage is enabled", async () => {
-      const { response } = await adminGet("/admin/settings");
-      await expectHtmlResponse(response, 200, "Header Image");
-    });
-
-    test("hides header image section when storage is disabled", async () => {
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
-      const { response } = await adminGet("/admin/settings");
-      const html = await response.text();
-      expect(html).not.toContain("Header Image");
-    });
-
-    test("shows remove button when header image is set", async () => {
-      await updateHeaderImageUrl("existing.jpg");
-      const { response } = await adminGet("/admin/settings");
-      await expectHtmlResponse(
-        response,
-        200,
-        "Remove Image",
-        "/image/existing.jpg",
-      );
-    });
-
-    test("shows upload button when no header image exists", async () => {
-      const { response } = await adminGet("/admin/settings");
-      await expectHtmlResponse(response, 200, "Upload Image");
-    });
-  });
-
-  describe("POST /admin/settings/header-image", () => {
-    test("uploads header image successfully", async () => {
-      await withStorageMock(async () => {
-        const response = await submitHeaderJpeg("logo.jpg");
-        expectSettingsRedirect(response);
-
-        const url = await getHeaderImageUrlFromDb();
-        expect(url).not.toBeNull();
-        expect(url).toMatch(/\.jpg$/);
-      });
-    });
-
-    test("rejects invalid image type", async () => {
-      await withStorageMock(async () => {
-        const response = await submitHeaderImage({
-          name: "doc.pdf",
-          data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
-          contentType: "application/pdf",
-        });
-        await expectHtmlResponse(response, 400, "JPEG, PNG, GIF, or WebP");
-      });
-    });
-
-    test("rejects oversized image", async () => {
-      const oversized = new Uint8Array(257 * 1024);
-      oversized[0] = 0xff;
-      oversized[1] = 0xd8;
-      oversized[2] = 0xff;
-
-      await withStorageMock(async () => {
-        const response = await submitHeaderImage({
-          name: "big.jpg",
-          data: oversized,
-          contentType: "image/jpeg",
-        });
-        await expectHtmlResponse(response, 400, "256KB");
-      });
-    });
-
-    test("returns 403 for non-owner admin", async () => {
-      const managerCookie = await createTestManagerSession(
-        "mgr-header-session",
-        "headerimgmgr",
-      );
-      const { signCsrfToken } = await import("#lib/csrf.ts");
-      const signedCsrf = await signCsrfToken();
-      const response = await submitHeaderJpeg(
-        "logo.jpg",
-        managerCookie,
-        signedCsrf,
-      );
-      expect(response.status).toBe(403);
-    });
-
-    test("rejects request with no file", async () => {
-      const request = mockMultipartRequest(
-        "/admin/settings/header-image",
-        { csrf_token: await testCsrfToken() },
-        await testCookie(),
-      );
-      const response = await handleRequest(request);
-      await expectHtmlResponse(response, 400, "No image file provided");
-    });
-
-    test("returns error when storage is not configured", async () => {
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
-
-      const response = await submitHeaderJpeg("logo.jpg");
-      await expectHtmlResponse(
-        response,
-        400,
-        "Image storage is not configured",
-      );
-    });
-
-    test("deletes old header image when uploading new one", async () => {
-      await updateHeaderImageUrl("old-header.jpg");
-
-      await withStorageMock(async (fetchCalls) => {
-        const response = await submitHeaderJpeg("new-logo.jpg");
-        expectSettingsRedirect(response);
-
-        const deleteCall = fetchCalls.find((url) =>
-          url.includes("old-header.jpg"),
-        );
-        expect(deleteCall).not.toBeUndefined();
-
-        const url = await getHeaderImageUrlFromDb();
-        expect(url).toMatch(/\.jpg$/);
-        expect(url).not.toBe("old-header.jpg");
-      });
-    });
-
-    test("reports error when upload fails", async () => {
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (): Promise<Response> => {
-        return Promise.reject(new Error("CDN unreachable"));
-      };
-
-      try {
-        const response = await submitHeaderJpeg("logo.jpg");
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("error=");
-        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
-          "upload failed",
-        );
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
-    });
-
-    test("rejects mismatched magic bytes", async () => {
-      await withStorageMock(async () => {
-        const response = await submitHeaderImage({
-          name: "fake.jpg",
-          data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
-          contentType: "image/jpeg",
-        });
-        await expectHtmlResponse(response, 400, "valid image");
-      });
-    });
-  });
-
-  describe("POST /admin/settings/header-image/delete", () => {
-    test("removes header image", async () => {
-      await updateHeaderImageUrl("to-delete.jpg");
-
-      await withStorageMock(async () => {
-        const response = await submitHeaderImageDelete();
-        expectSettingsRedirect(response);
-
-        const url = await getHeaderImageUrlFromDb();
-        expect(url).toBeNull();
-      });
-    });
-
-    test("returns error when no header image exists", async () => {
-      const response = await submitHeaderImageDelete();
-      await expectHtmlResponse(response, 400, "No header image to remove");
-    });
-
-    test("reports error when storage delete throws", async () => {
-      await updateHeaderImageUrl("failing.jpg");
-
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (): Promise<Response> => {
-        return Promise.reject(new Error("CDN unreachable"));
-      };
-
-      try {
-        const response = await submitHeaderImageDelete();
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("error=");
-        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
-          "removal failed",
-        );
-
-        // DB record should NOT be cleared when CDN delete fails
-        const url = await getHeaderImageUrlFromDb();
-        expect(url).toBe("failing.jpg");
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
-    });
-  });
-
-  describe("header image in layout", () => {
-    test("renders header image in page when set", async () => {
-      await updateHeaderImageUrl("my-header.jpg");
-      const { response } = await adminGet("/admin/settings");
-      await expectHtmlResponse(
-        response,
-        200,
-        'class="header-image"',
-        "/image/my-header.jpg",
-      );
-    });
-
-    test("does not render header image when not set", async () => {
+describeWithEnv(
+  "server (header image settings)",
+  {
+    env: {
+      STORAGE_ZONE_NAME: "testzone",
+      STORAGE_ZONE_KEY: "testkey",
+    },
+    db: true,
+  },
+  () => {
+    beforeEach(() => {
       resetHeaderImage();
-      const { response } = await adminGet("/admin/settings");
-      const html = await response.text();
-      expect(html).not.toContain('class="header-image"');
     });
-  });
 
-  describe("header image proxy", () => {
-    test("serves header image via proxy route", async () => {
-      const encrypted = await encryptBytes(JPEG_HEADER);
+    afterEach(() => {
+      resetHeaderImage();
+    });
 
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = (input: string | URL | Request): Promise<Response> => {
-        const url =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input.url;
-        if (url.includes("storage.bunnycdn.com")) {
-          return Promise.resolve(
-            // biome-ignore lint/suspicious/noExplicitAny: Uint8Array<ArrayBufferLike> not assignable to BodyInit in Deno's TS
-            // deno-lint-ignore no-explicit-any
-            new Response(encrypted as any, { status: 200 }),
+    describe("GET /admin/settings (header image section)", () => {
+      test("shows header image section when storage is enabled", async () => {
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(response, 200, "Header Image");
+      });
+
+      test("hides header image section when storage is disabled", async () => {
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
+        const { response } = await adminGet("/admin/settings");
+        const html = await response.text();
+        expect(html).not.toContain("Header Image");
+      });
+
+      test("shows remove button when header image is set", async () => {
+        await updateHeaderImageUrl("existing.jpg");
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(
+          response,
+          200,
+          "Remove Image",
+          "/image/existing.jpg",
+        );
+      });
+
+      test("shows upload button when no header image exists", async () => {
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(response, 200, "Upload Image");
+      });
+    });
+
+    describe("POST /admin/settings/header-image", () => {
+      test("uploads header image successfully", async () => {
+        await withStorageMock(async () => {
+          const response = await submitHeaderJpeg("logo.jpg");
+          expectSettingsRedirect(response);
+
+          const url = await getHeaderImageUrlFromDb();
+          expect(url).not.toBeNull();
+          expect(url).toMatch(/\.jpg$/);
+        });
+      });
+
+      test("rejects invalid image type", async () => {
+        await withStorageMock(async () => {
+          const response = await submitHeaderImage({
+            name: "doc.pdf",
+            data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+            contentType: "application/pdf",
+          });
+          await expectHtmlResponse(response, 400, "JPEG, PNG, GIF, or WebP");
+        });
+      });
+
+      test("rejects oversized image", async () => {
+        const oversized = new Uint8Array(257 * 1024);
+        oversized[0] = 0xff;
+        oversized[1] = 0xd8;
+        oversized[2] = 0xff;
+
+        await withStorageMock(async () => {
+          const response = await submitHeaderImage({
+            name: "big.jpg",
+            data: oversized,
+            contentType: "image/jpeg",
+          });
+          await expectHtmlResponse(response, 400, "256KB");
+        });
+      });
+
+      test("returns 403 for non-owner admin", async () => {
+        const managerCookie = await createTestManagerSession(
+          "mgr-header-session",
+          "headerimgmgr",
+        );
+        const { signCsrfToken } = await import("#lib/csrf.ts");
+        const signedCsrf = await signCsrfToken();
+        const response = await submitHeaderJpeg(
+          "logo.jpg",
+          managerCookie,
+          signedCsrf,
+        );
+        expect(response.status).toBe(403);
+      });
+
+      test("rejects request with no file", async () => {
+        const request = mockMultipartRequest(
+          "/admin/settings/header-image",
+          { csrf_token: await testCsrfToken() },
+          await testCookie(),
+        );
+        const response = await handleRequest(request);
+        await expectHtmlResponse(response, 400, "No image file provided");
+      });
+
+      test("returns error when storage is not configured", async () => {
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
+
+        const response = await submitHeaderJpeg("logo.jpg");
+        await expectHtmlResponse(
+          response,
+          400,
+          "Image storage is not configured",
+        );
+      });
+
+      test("deletes old header image when uploading new one", async () => {
+        await updateHeaderImageUrl("old-header.jpg");
+
+        await withStorageMock(async (fetchCalls) => {
+          const response = await submitHeaderJpeg("new-logo.jpg");
+          expectSettingsRedirect(response);
+
+          const deleteCall = fetchCalls.find((url) =>
+            url.includes("old-header.jpg"),
           );
-        }
-        return originalFetch(input);
-      };
+          expect(deleteCall).not.toBeUndefined();
 
-      try {
-        const response = await handleRequest(
-          mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-        );
-        expect(response.status).toBe(200);
-        const headers = response.headers;
-        expect(headers.get("content-type")).toBe("image/jpeg");
-        expect(headers.get("cache-control")).toContain("immutable");
-        expect(new Uint8Array(await response.arrayBuffer())).toEqual(
-          JPEG_HEADER,
-        );
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+          const url = await getHeaderImageUrlFromDb();
+          expect(url).toMatch(/\.jpg$/);
+          expect(url).not.toBe("old-header.jpg");
+        });
+      });
+
+      test("reports error when upload fails", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (): Promise<Response> => {
+          return Promise.reject(new Error("CDN unreachable"));
+        };
+
+        try {
+          const response = await submitHeaderJpeg("logo.jpg");
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location") ?? "";
+          expect(location).toContain("error=");
+          expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+            "upload failed",
+          );
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      test("rejects mismatched magic bytes", async () => {
+        await withStorageMock(async () => {
+          const response = await submitHeaderImage({
+            name: "fake.jpg",
+            data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            contentType: "image/jpeg",
+          });
+          await expectHtmlResponse(response, 400, "valid image");
+        });
+      });
     });
-  });
-});
+
+    describe("POST /admin/settings/header-image/delete", () => {
+      test("removes header image", async () => {
+        await updateHeaderImageUrl("to-delete.jpg");
+
+        await withStorageMock(async () => {
+          const response = await submitHeaderImageDelete();
+          expectSettingsRedirect(response);
+
+          const url = await getHeaderImageUrlFromDb();
+          expect(url).toBeNull();
+        });
+      });
+
+      test("returns error when no header image exists", async () => {
+        const response = await submitHeaderImageDelete();
+        await expectHtmlResponse(response, 400, "No header image to remove");
+      });
+
+      test("reports error when storage delete throws", async () => {
+        await updateHeaderImageUrl("failing.jpg");
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (): Promise<Response> => {
+          return Promise.reject(new Error("CDN unreachable"));
+        };
+
+        try {
+          const response = await submitHeaderImageDelete();
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location") ?? "";
+          expect(location).toContain("error=");
+          expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+            "removal failed",
+          );
+
+          // DB record should NOT be cleared when CDN delete fails
+          const url = await getHeaderImageUrlFromDb();
+          expect(url).toBe("failing.jpg");
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+    });
+
+    describe("header image in layout", () => {
+      test("renders header image in page when set", async () => {
+        await updateHeaderImageUrl("my-header.jpg");
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(
+          response,
+          200,
+          'class="header-image"',
+          "/image/my-header.jpg",
+        );
+      });
+
+      test("does not render header image when not set", async () => {
+        resetHeaderImage();
+        const { response } = await adminGet("/admin/settings");
+        const html = await response.text();
+        expect(html).not.toContain('class="header-image"');
+      });
+    });
+
+    describe("header image proxy", () => {
+      test("serves header image via proxy route", async () => {
+        const encrypted = await encryptBytes(JPEG_HEADER);
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (
+          input: string | URL | Request,
+        ): Promise<Response> => {
+          const url =
+            typeof input === "string"
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url;
+          if (url.includes("storage.bunnycdn.com")) {
+            return Promise.resolve(
+              // biome-ignore lint/suspicious/noExplicitAny: Uint8Array<ArrayBufferLike> not assignable to BodyInit in Deno's TS
+              // deno-lint-ignore no-explicit-any
+              new Response(encrypted as any, { status: 200 }),
+            );
+          }
+          return originalFetch(input);
+        };
+
+        try {
+          const response = await handleRequest(
+            mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
+          );
+          expect(response.status).toBe(200);
+          const headers = response.headers;
+          expect(headers.get("content-type")).toBe("image/jpeg");
+          expect(headers.get("cache-control")).toContain("immutable");
+          expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+            JPEG_HEADER,
+          );
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+    });
+  },
+);

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -67,6 +67,7 @@ import {
 } from "#templates/public.tsx";
 import { ticketViewPage } from "#templates/tickets.tsx";
 import {
+  setTestEnv,
   setupTestEncryptionKey,
   testAttendee,
   testEvent,
@@ -3515,14 +3516,12 @@ describe("html", () => {
   });
 
   describe("event images", () => {
+    let cleanupStorage: () => void;
     const setupStorage = () => {
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
-    };
-
-    const cleanupStorage = () => {
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
+      cleanupStorage = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
     };
 
     describe("renderEventImage", () => {

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   resetDb,
   setTestEnv,
 } from "#test-utils";
@@ -67,18 +68,15 @@ describe("logger", () => {
     });
   });
 
-  describe("logRequest", () => {
+  describeWithEnv("logRequest", { TEST_SUPPRESS_REQUEST_LOGS: undefined }, () => {
     let debugSpy: Spy<Console, [message?: unknown, ...args: unknown[]], void>;
-    let restoreEnv: () => void;
 
     beforeEach(() => {
-      restoreEnv = setTestEnv({ TEST_SUPPRESS_REQUEST_LOGS: undefined });
       debugSpy = spy(console, "debug");
     });
 
     afterEach(() => {
       debugSpy.restore();
-      restoreEnv();
     });
 
     test("logs request with redacted path", () => {
@@ -439,14 +437,7 @@ describe("logger", () => {
     });
   });
 
-  describe("runWithRequestId", () => {
-    let restoreEnv: () => void;
-
-    beforeEach(() => {
-      restoreEnv = setTestEnv({ TEST_SUPPRESS_REQUEST_LOGS: undefined });
-    });
-
-    afterEach(() => restoreEnv());
+  describeWithEnv("runWithRequestId", { TEST_SUPPRESS_REQUEST_LOGS: undefined }, () => {
 
     test("prefixes logRequest with 4-char hex ID", () => {
       const debugSpy = spy(console, "debug");

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -25,6 +25,8 @@ import {
   setTestEnv,
 } from "#test-utils";
 
+// Outer describe ensures sequential execution — logError's fire-and-forget
+// promises must settle before later blocks spy on the same console methods.
 describe("logger", () => {
   describe("redactPath", () => {
     test("redacts ticket slugs", () => {

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -17,7 +17,12 @@ import {
   redactPath,
   runWithRequestId,
 } from "#lib/logger.ts";
-import { createTestDbWithSetup, createTestEvent, resetDb } from "#test-utils";
+import {
+  createTestDbWithSetup,
+  createTestEvent,
+  resetDb,
+  setTestEnv,
+} from "#test-utils";
 
 describe("logger", () => {
   describe("redactPath", () => {
@@ -64,14 +69,16 @@ describe("logger", () => {
 
   describe("logRequest", () => {
     let debugSpy: Spy<Console, [message?: unknown, ...args: unknown[]], void>;
+    let restoreEnv: () => void;
 
     beforeEach(() => {
-      Deno.env.delete("TEST_SUPPRESS_REQUEST_LOGS");
+      restoreEnv = setTestEnv({ TEST_SUPPRESS_REQUEST_LOGS: undefined });
       debugSpy = spy(console, "debug");
     });
 
     afterEach(() => {
       debugSpy.restore();
+      restoreEnv();
     });
 
     test("logs request with redacted path", () => {
@@ -122,12 +129,9 @@ describe("logger", () => {
       });
 
       expect(debugSpy.calls.length).toBe(0);
-
-      Deno.env.delete("TEST_SUPPRESS_REQUEST_LOGS");
     });
 
     test("logs normally when TEST_SUPPRESS_REQUEST_LOGS is not set", () => {
-      Deno.env.delete("TEST_SUPPRESS_REQUEST_LOGS");
 
       logRequest({
         method: "POST",
@@ -205,7 +209,7 @@ describe("logger", () => {
     });
 
     test("sends ntfy notification when NTFY_URL is configured", () => {
-      Deno.env.set("NTFY_URL", "https://ntfy.sh/test-topic");
+      const restore = setTestEnv({ NTFY_URL: "https://ntfy.sh/test-topic" });
       const fetchStub = stub(globalThis, "fetch", () =>
         Promise.resolve(new Response()),
       );
@@ -218,7 +222,7 @@ describe("logger", () => {
       expect(options.body).toBe("E_DB_QUERY");
 
       fetchStub.restore();
-      Deno.env.delete("NTFY_URL");
+      restore();
     });
 
     describe("activity log persistence", () => {
@@ -303,7 +307,7 @@ describe("logger", () => {
     });
 
     test("does not send ntfy notification", () => {
-      Deno.env.set("NTFY_URL", "https://ntfy.sh/test-topic");
+      const restore = setTestEnv({ NTFY_URL: "https://ntfy.sh/test-topic" });
       const fetchStub = stub(globalThis, "fetch", () =>
         Promise.resolve(new Response()),
       );
@@ -313,7 +317,7 @@ describe("logger", () => {
       expect(fetchStub.calls.length).toBe(0);
 
       fetchStub.restore();
-      Deno.env.delete("NTFY_URL");
+      restore();
     });
   });
 
@@ -436,9 +440,13 @@ describe("logger", () => {
   });
 
   describe("runWithRequestId", () => {
+    let restoreEnv: () => void;
+
     beforeEach(() => {
-      Deno.env.delete("TEST_SUPPRESS_REQUEST_LOGS");
+      restoreEnv = setTestEnv({ TEST_SUPPRESS_REQUEST_LOGS: undefined });
     });
+
+    afterEach(() => restoreEnv());
 
     test("prefixes logRequest with 4-char hex ID", () => {
       const debugSpy = spy(console, "debug");

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -68,82 +68,87 @@ describe("logger", () => {
     });
   });
 
-  describeWithEnv("logRequest", { TEST_SUPPRESS_REQUEST_LOGS: undefined }, () => {
-    let debugSpy: Spy<Console, [message?: unknown, ...args: unknown[]], void>;
+  describeWithEnv(
+    "logRequest",
+    { env: { TEST_SUPPRESS_REQUEST_LOGS: undefined } },
+    () => {
+      let debugSpy: Spy<Console, [message?: unknown, ...args: unknown[]], void>;
 
-    beforeEach(() => {
-      debugSpy = spy(console, "debug");
-    });
-
-    afterEach(() => {
-      debugSpy.restore();
-    });
-
-    test("logs request with redacted path", () => {
-      logRequest({
-        method: "GET",
-        path: "/ticket/my-event",
-        status: 200,
-        durationMs: 42,
+      beforeEach(() => {
+        debugSpy = spy(console, "debug");
       });
 
-      expect(debugSpy.calls[0]!.args).toEqual([
-        "[Request] GET /ticket/[redacted] 200 42ms",
-      ]);
-    });
-
-    test("logs POST request", () => {
-      logRequest({
-        method: "POST",
-        path: "/admin/events/123",
-        status: 201,
-        durationMs: 100,
+      afterEach(() => {
+        debugSpy.restore();
       });
 
-      expect(debugSpy.calls[0]!.args).toEqual([
-        "[Request] POST /admin/events/[id] 201 100ms",
-      ]);
-    });
+      test("logs request with redacted path", () => {
+        logRequest({
+          method: "GET",
+          path: "/ticket/my-event",
+          status: 200,
+          durationMs: 42,
+        });
 
-    test("logs error status codes", () => {
-      logRequest({
-        method: "GET",
-        path: "/admin",
-        status: 403,
-        durationMs: 5,
+        expect(debugSpy.calls[0]!.args).toEqual([
+          "[Request] GET /ticket/[redacted] 200 42ms",
+        ]);
       });
 
-      expect(debugSpy.calls[0]!.args).toEqual(["[Request] GET /admin 403 5ms"]);
-    });
+      test("logs POST request", () => {
+        logRequest({
+          method: "POST",
+          path: "/admin/events/123",
+          status: 201,
+          durationMs: 100,
+        });
 
-    test("suppresses logs when TEST_SUPPRESS_REQUEST_LOGS is set", () => {
-      Deno.env.set("TEST_SUPPRESS_REQUEST_LOGS", "1");
-
-      logRequest({
-        method: "POST",
-        path: "/admin/login",
-        status: 302,
-        durationMs: 1,
+        expect(debugSpy.calls[0]!.args).toEqual([
+          "[Request] POST /admin/events/[id] 201 100ms",
+        ]);
       });
 
-      expect(debugSpy.calls.length).toBe(0);
-    });
+      test("logs error status codes", () => {
+        logRequest({
+          method: "GET",
+          path: "/admin",
+          status: 403,
+          durationMs: 5,
+        });
 
-    test("logs normally when TEST_SUPPRESS_REQUEST_LOGS is not set", () => {
-
-      logRequest({
-        method: "POST",
-        path: "/admin/login",
-        status: 302,
-        durationMs: 1,
+        expect(debugSpy.calls[0]!.args).toEqual([
+          "[Request] GET /admin 403 5ms",
+        ]);
       });
 
-      expect(debugSpy.calls.length).toBe(1);
-      expect(debugSpy.calls[0]!.args).toEqual([
-        "[Request] POST /admin/login 302 1ms",
-      ]);
-    });
-  });
+      test("suppresses logs when TEST_SUPPRESS_REQUEST_LOGS is set", () => {
+        Deno.env.set("TEST_SUPPRESS_REQUEST_LOGS", "1");
+
+        logRequest({
+          method: "POST",
+          path: "/admin/login",
+          status: 302,
+          durationMs: 1,
+        });
+
+        expect(debugSpy.calls.length).toBe(0);
+      });
+
+      test("logs normally when TEST_SUPPRESS_REQUEST_LOGS is not set", () => {
+        logRequest({
+          method: "POST",
+          path: "/admin/login",
+          status: 302,
+          durationMs: 1,
+        });
+
+        expect(debugSpy.calls.length).toBe(1);
+        expect(debugSpy.calls[0]!.args).toEqual([
+          "[Request] POST /admin/login 302 1ms",
+        ]);
+      });
+    },
+  );
 
   const setupErrorSpy = () => {
     let errorSpy: Spy<Console, [message?: unknown, ...args: unknown[]], void>;
@@ -437,93 +442,101 @@ describe("logger", () => {
     });
   });
 
-  describeWithEnv("runWithRequestId", { TEST_SUPPRESS_REQUEST_LOGS: undefined }, () => {
+  describeWithEnv(
+    "runWithRequestId",
+    { env: { TEST_SUPPRESS_REQUEST_LOGS: undefined } },
+    () => {
+      test("prefixes logRequest with 4-char hex ID", () => {
+        const debugSpy = spy(console, "debug");
 
-    test("prefixes logRequest with 4-char hex ID", () => {
-      const debugSpy = spy(console, "debug");
+        runWithRequestId(() => {
+          logRequest({
+            method: "GET",
+            path: "/admin",
+            status: 200,
+            durationMs: 10,
+          });
+        });
 
-      runWithRequestId(() => {
+        const message = debugSpy.calls[0]!.args[0] as string;
+        expect(message).toMatch(
+          /^\[[0-9a-f]{4}\] \[Request\] GET \/admin 200 10ms$/,
+        );
+        debugSpy.restore();
+      });
+
+      test("prefixes logError with same request ID", () => {
+        const debugSpy = spy(console, "debug");
+        const errorSpy = spy(console, "error");
+
+        runWithRequestId(() => {
+          logRequest({
+            method: "GET",
+            path: "/admin",
+            status: 200,
+            durationMs: 5,
+          });
+          logError({ code: ErrorCode.DB_CONNECTION });
+        });
+
+        const requestMsg = debugSpy.calls[0]!.args[0] as string;
+        const errorMsg = errorSpy.calls[0]!.args[0] as string;
+        const requestId = requestMsg.slice(1, 5);
+        expect(errorMsg).toBe(`[${requestId}] [Error] E_DB_CONNECTION`);
+
+        debugSpy.restore();
+        errorSpy.restore();
+      });
+
+      test("prefixes logDebug with request ID", () => {
+        const debugSpy = spy(console, "debug");
+
+        runWithRequestId(() => {
+          logDebug("Setup", "test message");
+        });
+
+        const message = debugSpy.calls[0]!.args[0] as string;
+        expect(message).toMatch(/^\[[0-9a-f]{4}\] \[Setup\] test message$/);
+        debugSpy.restore();
+      });
+
+      test("different requests get different IDs", () => {
+        const debugSpy = spy(console, "debug");
+
+        const ids: string[] = [];
+        for (let i = 0; i < 10; i++) {
+          runWithRequestId(() => {
+            logRequest({
+              method: "GET",
+              path: "/",
+              status: 200,
+              durationMs: 0,
+            });
+          });
+          ids.push((debugSpy.calls[i]!.args[0] as string).slice(1, 5));
+        }
+
+        // With 65536 possible values, 10 samples should not all be identical
+        const unique = new Set(ids);
+        expect(unique.size).toBeGreaterThan(1);
+        debugSpy.restore();
+      });
+
+      test("no prefix outside request context", () => {
+        const debugSpy = spy(console, "debug");
+
         logRequest({
           method: "GET",
           path: "/admin",
           status: 200,
           durationMs: 10,
         });
+
+        expect(debugSpy.calls[0]!.args).toEqual([
+          "[Request] GET /admin 200 10ms",
+        ]);
+        debugSpy.restore();
       });
-
-      const message = debugSpy.calls[0]!.args[0] as string;
-      expect(message).toMatch(
-        /^\[[0-9a-f]{4}\] \[Request\] GET \/admin 200 10ms$/,
-      );
-      debugSpy.restore();
-    });
-
-    test("prefixes logError with same request ID", () => {
-      const debugSpy = spy(console, "debug");
-      const errorSpy = spy(console, "error");
-
-      runWithRequestId(() => {
-        logRequest({
-          method: "GET",
-          path: "/admin",
-          status: 200,
-          durationMs: 5,
-        });
-        logError({ code: ErrorCode.DB_CONNECTION });
-      });
-
-      const requestMsg = debugSpy.calls[0]!.args[0] as string;
-      const errorMsg = errorSpy.calls[0]!.args[0] as string;
-      const requestId = requestMsg.slice(1, 5);
-      expect(errorMsg).toBe(`[${requestId}] [Error] E_DB_CONNECTION`);
-
-      debugSpy.restore();
-      errorSpy.restore();
-    });
-
-    test("prefixes logDebug with request ID", () => {
-      const debugSpy = spy(console, "debug");
-
-      runWithRequestId(() => {
-        logDebug("Setup", "test message");
-      });
-
-      const message = debugSpy.calls[0]!.args[0] as string;
-      expect(message).toMatch(/^\[[0-9a-f]{4}\] \[Setup\] test message$/);
-      debugSpy.restore();
-    });
-
-    test("different requests get different IDs", () => {
-      const debugSpy = spy(console, "debug");
-
-      const ids: string[] = [];
-      for (let i = 0; i < 10; i++) {
-        runWithRequestId(() => {
-          logRequest({ method: "GET", path: "/", status: 200, durationMs: 0 });
-        });
-        ids.push((debugSpy.calls[i]!.args[0] as string).slice(1, 5));
-      }
-
-      // With 65536 possible values, 10 samples should not all be identical
-      const unique = new Set(ids);
-      expect(unique.size).toBeGreaterThan(1);
-      debugSpy.restore();
-    });
-
-    test("no prefix outside request context", () => {
-      const debugSpy = spy(console, "debug");
-
-      logRequest({
-        method: "GET",
-        path: "/admin",
-        status: 200,
-        durationMs: 10,
-      });
-
-      expect(debugSpy.calls[0]!.args).toEqual([
-        "[Request] GET /admin 200 10ms",
-      ]);
-      debugSpy.restore();
-    });
-  });
+    },
+  );
 });

--- a/test/lib/ntfy.test.ts
+++ b/test/lib/ntfy.test.ts
@@ -3,14 +3,12 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { ErrorCode } from "#lib/logger.ts";
 import { sendNtfyError } from "#lib/ntfy.ts";
-import { setTestEnv } from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
-describe("ntfy", () => {
+describeWithEnv("ntfy", { NTFY_URL: undefined }, () => {
   let fetchStub: ReturnType<typeof stub<typeof globalThis, "fetch">>;
-  let restoreEnv: () => void;
 
   beforeEach(() => {
-    restoreEnv = setTestEnv({ NTFY_URL: undefined });
     fetchStub = stub(globalThis, "fetch", () =>
       Promise.resolve(new Response()),
     );
@@ -18,7 +16,6 @@ describe("ntfy", () => {
 
   afterEach(() => {
     fetchStub.restore();
-    restoreEnv();
   });
 
   describe("sendNtfyError", () => {

--- a/test/lib/ntfy.test.ts
+++ b/test/lib/ntfy.test.ts
@@ -3,11 +3,14 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { ErrorCode } from "#lib/logger.ts";
 import { sendNtfyError } from "#lib/ntfy.ts";
+import { setTestEnv } from "#test-utils";
 
 describe("ntfy", () => {
   let fetchStub: ReturnType<typeof stub<typeof globalThis, "fetch">>;
+  let restoreEnv: () => void;
 
   beforeEach(() => {
+    restoreEnv = setTestEnv({ NTFY_URL: undefined });
     fetchStub = stub(globalThis, "fetch", () =>
       Promise.resolve(new Response()),
     );
@@ -15,7 +18,7 @@ describe("ntfy", () => {
 
   afterEach(() => {
     fetchStub.restore();
-    Deno.env.delete("NTFY_URL");
+    restoreEnv();
   });
 
   describe("sendNtfyError", () => {

--- a/test/lib/ntfy.test.ts
+++ b/test/lib/ntfy.test.ts
@@ -5,7 +5,7 @@ import { ErrorCode } from "#lib/logger.ts";
 import { sendNtfyError } from "#lib/ntfy.ts";
 import { describeWithEnv } from "#test-utils";
 
-describeWithEnv("ntfy", { NTFY_URL: undefined }, () => {
+describeWithEnv("ntfy", { env: { NTFY_URL: undefined } }, () => {
   let fetchStub: ReturnType<typeof stub<typeof globalThis, "fetch">>;
 
   beforeEach(() => {

--- a/test/lib/page-cache.test.ts
+++ b/test/lib/page-cache.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
 import {
   CONFIG_KEYS,
@@ -20,19 +20,14 @@ const { PAGE_CACHE_TTL_MS } = settingsApi;
 
 import { encrypt } from "#lib/crypto.ts";
 import { getDb } from "#lib/db/client.ts";
-import { createTestDbWithSetup, resetDb } from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
-describe("page content cache", () => {
+describeWithEnv("page content cache", { db: true }, () => {
   let fakeTime: FakeTime | null = null;
-
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-  });
 
   afterEach(() => {
     fakeTime?.restore();
     fakeTime = null;
-    resetDb();
   });
 
   describe("getWebsiteTitleFromDb", () => {

--- a/test/lib/processed-payments.test.ts
+++ b/test/lib/processed-payments.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { getDb } from "#lib/db/client.ts";
 import {
@@ -16,10 +16,8 @@ import {
 } from "#lib/db/processed-payments.ts";
 import {
   createTestAttendee,
-  createTestDbWithSetup,
   createTestEvent,
-  resetDb,
-  resetTestSlugCounter,
+  describeWithEnv,
 } from "#test-utils";
 
 /** Helper to simulate the old markSessionProcessed behavior using two-phase locking */
@@ -35,14 +33,12 @@ const processSession = async (
   return true;
 };
 
-describe("processed-payments", () => {
+describeWithEnv("processed-payments", { db: true }, () => {
   let testAttendeeId: number;
   let testAttendeeId2: number;
   let testAttendeeId3: number;
 
   beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
     // Create test event and attendees to satisfy foreign key constraints
     const event = await createTestEvent();
     const attendee1 = await createTestAttendee(
@@ -66,10 +62,6 @@ describe("processed-payments", () => {
     testAttendeeId = attendee1.id;
     testAttendeeId2 = attendee2.id;
     testAttendeeId3 = attendee3.id;
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   describe("isSessionProcessed", () => {

--- a/test/lib/rest.test.ts
+++ b/test/lib/rest.test.ts
@@ -8,7 +8,7 @@ import { createHandler, deleteHandler } from "#lib/rest/handlers.ts";
 import { defineResource, type Resource } from "#lib/rest/resource.ts";
 import {
   createTestDb,
-  createTestDbWithSetup,
+  describeWithEnv,
   errorResponse,
   expectAdminRedirect,
   expectResultError,
@@ -330,14 +330,9 @@ describe("rest/resource", () => {
   });
 });
 
-describe("rest/handlers", () => {
+describeWithEnv("rest/handlers", { db: true }, () => {
   beforeEach(async () => {
-    await createTestDbWithSetup();
     await createTestItemsTable();
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   /** Create authenticated request with session and CSRF */
@@ -570,14 +565,9 @@ describe("rest/handlers", () => {
   });
 });
 
-describe("rest/resource - additional coverage", () => {
+describeWithEnv("rest/resource - additional coverage", { db: true }, () => {
   beforeEach(async () => {
-    await createTestDbWithSetup();
     await createTestItemsTable();
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   describe("custom onDelete handler", () => {

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { attendeesApi } from "#lib/db/attendees.ts";
 import { paymentsApi } from "#lib/payments.ts";
@@ -10,8 +10,8 @@ import {
   awaitTestRequest,
   createPaidTestAttendee,
   createTestAttendee,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirect,
@@ -19,24 +19,13 @@ import {
   mockFormRequest,
   mockProviderType,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
   withMocks,
 } from "#test-utils";
 
-describe("server (admin attendees)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin attendees)", { db: true }, () => {
   const deleteAction = adminAttendeeAction("delete");
   const checkinAction = adminAttendeeAction("checkin");
 

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -1,33 +1,22 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { handleRequest } from "#routes";
 import { setSkipLoginDelayForTest } from "#routes/admin/auth.ts";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   loginAsAdmin,
   mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   TEST_ADMIN_PASSWORD,
 } from "#test-utils";
 
-describe("server (admin auth)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin auth)", { db: true }, () => {
   describe("GET /admin/", () => {
     test("shows login page when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/"));

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -1,15 +1,13 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { addDays } from "#lib/dates.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import {
   awaitTestRequest,
   createDailyTestEvent,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
-  resetDb,
-  resetTestSlugCounter,
   submitTicketForm,
   testCookie,
 } from "#test-utils";
@@ -81,16 +79,7 @@ async function setupMixedBookings(
   return { dailyEvent, standardEvent, eventDate };
 }
 
-describe("admin calendar", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("admin calendar", { db: true }, () => {
   describe("GET /admin/calendar", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await awaitTestRequest("/admin/calendar");

--- a/test/lib/server-checkin.test.ts
+++ b/test/lib/server-checkin.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { formatDateLabel } from "#lib/dates.ts";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { handleRequest } from "#routes";
@@ -8,11 +8,9 @@ import {
   awaitTestRequest,
   createDailyTestAttendee,
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   mockFormRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -53,16 +51,7 @@ const postCheckin = (
     ),
   );
 
-describe("check-in (/checkin/:tokens)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("check-in (/checkin/:tokens)", { db: true }, () => {
   describe("GET /checkin/:tokens (unauthenticated)", () => {
     test("shows public check-in message for unauthenticated users", async () => {
       const { token } = await createTestAttendeeWithToken(

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -25,6 +25,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
 } from "#test-utils";
 
 describe("server (admin debug)", () => {
@@ -215,30 +216,19 @@ describe("server (admin debug)", () => {
   });
 
   describe("GET /admin/debug with Apple Wallet env vars", () => {
-    const envKeys = [
-      "APPLE_WALLET_PASS_TYPE_ID",
-      "APPLE_WALLET_TEAM_ID",
-      "APPLE_WALLET_SIGNING_CERT",
-      "APPLE_WALLET_SIGNING_KEY",
-      "APPLE_WALLET_WWDR_CERT",
-    ] as const;
+    let restoreEnv: () => void;
 
-    const origValues = envKeys.map((k) => [k, Deno.env.get(k)] as const);
-
-    afterEach(() => {
-      for (const [key, val] of origValues) {
-        if (val) Deno.env.set(key, val);
-        else Deno.env.delete(key);
-      }
-    });
+    afterEach(() => restoreEnv());
 
     test("shows Environment variables as source when env configured", async () => {
       const certs = generateTestCerts();
-      Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.env.test");
-      Deno.env.set("APPLE_WALLET_TEAM_ID", "ENVTEAM01");
-      Deno.env.set("APPLE_WALLET_SIGNING_CERT", certs.signingCert);
-      Deno.env.set("APPLE_WALLET_SIGNING_KEY", certs.signingKey);
-      Deno.env.set("APPLE_WALLET_WWDR_CERT", certs.wwdrCert);
+      restoreEnv = setTestEnv({
+        APPLE_WALLET_PASS_TYPE_ID: "pass.com.env.test",
+        APPLE_WALLET_TEAM_ID: "ENVTEAM01",
+        APPLE_WALLET_SIGNING_CERT: certs.signingCert,
+        APPLE_WALLET_SIGNING_KEY: certs.signingKey,
+        APPLE_WALLET_WWDR_CERT: certs.wwdrCert,
+      });
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("Environment variables");
@@ -247,25 +237,16 @@ describe("server (admin debug)", () => {
   });
 
   describe("GET /admin/debug with host email env vars", () => {
-    const envKeys = [
-      "HOST_EMAIL_PROVIDER",
-      "HOST_EMAIL_API_KEY",
-      "HOST_EMAIL_FROM_ADDRESS",
-    ] as const;
+    let restoreEnv: () => void;
 
-    const origValues = envKeys.map((k) => [k, Deno.env.get(k)] as const);
-
-    afterEach(() => {
-      for (const [key, val] of origValues) {
-        if (val) Deno.env.set(key, val);
-        else Deno.env.delete(key);
-      }
-    });
+    afterEach(() => restoreEnv());
 
     test("shows host email provider when env configured", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "re_test_key");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "test@example.com");
+      restoreEnv = setTestEnv({
+        HOST_EMAIL_PROVIDER: "resend",
+        HOST_EMAIL_API_KEY: "re_test_key",
+        HOST_EMAIL_FROM_ADDRESS: "test@example.com",
+      });
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("resend");
@@ -313,32 +294,18 @@ describe("server (admin debug)", () => {
   });
 
   describe("GET /admin/debug with Google Wallet env vars", () => {
-    const envKeys = [
-      "GOOGLE_WALLET_ISSUER_ID",
-      "GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL",
-      "GOOGLE_WALLET_SERVICE_ACCOUNT_KEY",
-    ] as const;
+    let restoreEnv: () => void;
 
-    const origValues = envKeys.map((k) => [k, Deno.env.get(k)] as const);
-
-    afterEach(() => {
-      for (const [key, val] of origValues) {
-        if (val) Deno.env.set(key, val);
-        else Deno.env.delete(key);
-      }
-    });
+    afterEach(() => restoreEnv());
 
     test("shows Environment variables as source when env configured", async () => {
       const creds = await generateGoogleTestCreds();
-      Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "9876543210");
-      Deno.env.set(
-        "GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL",
-        "env@test.iam.gserviceaccount.com",
-      );
-      Deno.env.set(
-        "GOOGLE_WALLET_SERVICE_ACCOUNT_KEY",
-        creds.serviceAccountKey,
-      );
+      restoreEnv = setTestEnv({
+        GOOGLE_WALLET_ISSUER_ID: "9876543210",
+        GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL:
+          "env@test.iam.gserviceaccount.com",
+        GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: creds.serviceAccountKey,
+      });
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("Environment variables");
@@ -347,15 +314,12 @@ describe("server (admin debug)", () => {
   });
 
   describe("GET /admin/debug with Bunny CDN enabled", () => {
-    const origApiKey = Deno.env.get("BUNNY_API_KEY");
+    let restoreEnv: () => void;
 
-    afterEach(() => {
-      if (origApiKey) Deno.env.set("BUNNY_API_KEY", origApiKey);
-      else Deno.env.delete("BUNNY_API_KEY");
-    });
+    afterEach(() => restoreEnv());
 
     test("shows CDN as configured when Bunny CDN is enabled", async () => {
-      Deno.env.set("BUNNY_API_KEY", "test-key");
+      restoreEnv = setTestEnv({ BUNNY_API_KEY: "test-key" });
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("badge-ok");

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import {
   setPaymentProvider,
   setStripeWebhookConfig,
@@ -17,27 +17,16 @@ import {
 import { handleRequest } from "#routes";
 import {
   adminGet,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   generateGoogleTestCreds,
   generateTestCerts,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
 } from "#test-utils";
 
-describe("server (admin debug)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin debug)", { db: true }, () => {
   describe("GET /admin/debug", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/debug"));
@@ -302,8 +291,7 @@ describe("server (admin debug)", () => {
       const creds = await generateGoogleTestCreds();
       restoreEnv = setTestEnv({
         GOOGLE_WALLET_ISSUER_ID: "9876543210",
-        GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL:
-          "env@test.iam.gserviceaccount.com",
+        GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: "env@test.iam.gserviceaccount.com",
         GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: creds.serviceAccountKey,
       });
       const { response } = await adminGet("/admin/debug");

--- a/test/lib/server-demo-reset.test.ts
+++ b/test/lib/server-demo-reset.test.ts
@@ -9,8 +9,8 @@ import {
 } from "#templates/admin/database-reset.tsx";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
   expectRedirect,
   extractCsrfToken,
@@ -18,24 +18,19 @@ import {
   invalidateTestDbCache,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   testCookie,
   testCsrfToken,
   withFetchMock,
 } from "#test-utils";
 
-describe("server (demo reset)", () => {
-  beforeEach(async () => {
+describeWithEnv("server (demo reset)", { db: true }, () => {
+  beforeEach(() => {
     setDemoModeForTest(false);
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
   });
 
   afterEach(() => {
     setDemoModeForTest(false);
-    resetDb();
   });
 
   describe("GET /demo/reset", () => {

--- a/test/lib/server-demo-reset.test.ts
+++ b/test/lib/server-demo-reset.test.ts
@@ -20,6 +20,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   testCookie,
   testCsrfToken,
   withFetchMock,
@@ -150,8 +151,10 @@ describe("server (demo reset)", () => {
 
     test("deletes storage files for all events during reset", async () => {
       setDemoModeForTest(true);
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+      const restore = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
 
       const event = await createTestEvent({ maxAttendees: 10 });
       await eventsTable.update(event.id, {
@@ -185,8 +188,7 @@ describe("server (demo reset)", () => {
         ).toBe(true);
       });
 
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
+      restore();
       invalidateTestDbCache();
     });
   });

--- a/test/lib/server-embed-hosts.test.ts
+++ b/test/lib/server-embed-hosts.test.ts
@@ -1,18 +1,16 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { updateEmbedHosts } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   adminFormPost,
   adminGet,
   awaitTestRequest,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectHtmlResponse,
   getEmbeddableTicketResponse,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
 } from "#test-utils";
 
 /** Decode redirect location from response, normalizing URL encoding */
@@ -55,16 +53,7 @@ async function getTicketCsp(setupEmbedHosts?: string): Promise<string> {
   return response.headers.get("content-security-policy")!;
 }
 
-describe("server (embed hosts)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (embed hosts)", { db: true }, () => {
   describe("GET /admin/settings (embed hosts section)", () => {
     test("shows embed hosts section on settings page", async () => {
       const { response } = await adminGet("/admin/settings");

--- a/test/lib/server-event-qr.test.ts
+++ b/test/lib/server-event-qr.test.ts
@@ -3,28 +3,17 @@
  */
 
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { handleTicketQrGet } from "#routes/public.ts";
 import {
-  createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
+  describeWithEnv,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
 } from "#test-utils";
 
-describe("ticket QR code", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("ticket QR code", { db: true }, () => {
   describe("GET /ticket/:slug/qr", () => {
     test("returns SVG content type for valid event", async () => {
       const event = await createTestEvent({ maxAttendees: 50 });

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -28,6 +28,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   setupEventAndLogin,
   submitTicketForm,
   testCookie,
@@ -3260,8 +3261,10 @@ describe("server (admin events)", () => {
         attachmentUrl: "uuid-guide.pdf",
         attachmentName: "Event Guide.pdf",
       });
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+      const restore = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
 
       const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
         cookie,
@@ -3271,14 +3274,15 @@ describe("server (admin events)", () => {
       expect(html).toContain("Event Guide.pdf");
       expect(html).toContain("Remove Attachment");
 
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
+      restore();
     });
 
     test("admin event edit page does not show attachment info when empty", async () => {
       const { event, cookie } = await setupEventAndLogin();
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+      const restore = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
 
       const response = await awaitTestRequest(`/admin/event/${event.id}/edit`, {
         cookie,
@@ -3287,8 +3291,7 @@ describe("server (admin events)", () => {
       expect(html).not.toContain("attachment-info");
       expect(html).not.toContain("Remove Attachment");
 
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
+      restore();
     });
   });
 });

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { addDays } from "#lib/dates.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
@@ -14,11 +14,11 @@ import {
   adminGet,
   awaitTestRequest,
   createTestAttendee,
-  createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
   createTestManagerSession,
   deactivateTestEvent,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirect,
@@ -26,8 +26,6 @@ import {
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   setupEventAndLogin,
   submitTicketForm,
@@ -36,15 +34,9 @@ import {
   updateTestEvent,
 } from "#test-utils";
 
-describe("server (admin events)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
+describeWithEnv("server (admin events)", { db: true }, () => {
   afterEach(() => {
     setDemoModeForTest(false);
-    resetDb();
   });
 
   describe("GET /admin/event/new", () => {

--- a/test/lib/server-feeds.test.ts
+++ b/test/lib/server-feeds.test.ts
@@ -3,17 +3,15 @@
  */
 
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { updateShowPublicSite, updateWebsiteTitle } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import { escapeIcs, escapeXml } from "#routes/feeds.ts";
 import {
-  createTestDbWithSetup,
   createTestEvent,
   deactivateTestEvent,
+  describeWithEnv,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
 } from "#test-utils";
 
 /** Fetch a feed URL and return the body text */
@@ -49,16 +47,7 @@ const expectExcludesClosedRegistration = async (
   expect(body).not.toContain(absentTag);
 };
 
-describe("feeds", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("feeds", { db: true }, () => {
   describe("GET /feeds/events.ics", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/feeds/events.ics"));

--- a/test/lib/server-google-wallet.test.ts
+++ b/test/lib/server-google-wallet.test.ts
@@ -17,6 +17,7 @@ import {
   awaitTestRequest,
   createTestAttendeeWithToken,
   createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   generateGoogleTestCreds,
@@ -364,15 +365,11 @@ const clearGoogleWalletEnvVars = () =>
     GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
   });
 
-describe("getHostGoogleWalletConfig", () => {
-  let restoreEnv: () => void;
-
-  beforeEach(() => {
-    restoreEnv = clearGoogleWalletEnvVars();
-  });
-
-  afterEach(() => restoreEnv());
-
+describeWithEnv("getHostGoogleWalletConfig", {
+  GOOGLE_WALLET_ISSUER_ID: undefined,
+  GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
+  GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
+}, () => {
   test("returns null when no env vars are set", () => {
     expect(getHostGoogleWalletConfig()).toBeNull();
   });
@@ -394,11 +391,12 @@ describe("getHostGoogleWalletConfig", () => {
   });
 });
 
-describe("Google Wallet env var fallback", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("Google Wallet env var fallback", {
+  GOOGLE_WALLET_ISSUER_ID: undefined,
+  GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
+  GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
+}, () => {
   beforeEach(async () => {
-    restoreEnv = clearGoogleWalletEnvVars();
     resetTestSlugCounter();
     await createTestDbWithSetup();
     await ensureCreds();
@@ -406,7 +404,6 @@ describe("Google Wallet env var fallback", () => {
 
   afterEach(() => {
     resetDb();
-    restoreEnv();
   });
 
   test("hasGoogleWalletConfig returns true with env vars when DB not configured", async () => {

--- a/test/lib/server-google-wallet.test.ts
+++ b/test/lib/server-google-wallet.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { beforeEach, it as test } from "@std/testing/bdd";
 import {
   getGoogleWalletConfig,
   getGoogleWalletIssuerIdFromDb,
@@ -16,15 +16,12 @@ import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
   describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   generateGoogleTestCreds,
   loginAsAdmin,
   mockFormRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
 } from "#test-utils";
 
@@ -45,15 +42,9 @@ const ensureCreds = async () => {
   if (!testCreds) testCreds = await generateGoogleTestCreds();
 };
 
-describe("google wallet route (/gwallet/:token)", () => {
+describeWithEnv("google wallet route (/gwallet/:token)", { db: true }, () => {
   beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
     await ensureCreds();
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   test("returns 404 when Google Wallet is not configured", async () => {
@@ -133,15 +124,9 @@ describe("google wallet route (/gwallet/:token)", () => {
   });
 });
 
-describe("ticket view google wallet link", () => {
+describeWithEnv("ticket view google wallet link", { db: true }, () => {
   beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
     await ensureCreds();
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   test("does not show google wallet link when not configured", async () => {
@@ -167,15 +152,9 @@ describe("ticket view google wallet link", () => {
   });
 });
 
-describe("POST /admin/settings/google-wallet", () => {
+describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
   beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
     await ensureCreds();
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   test("redirects to login when not authenticated", async () => {
@@ -357,120 +336,119 @@ const setGoogleWalletEnvVars = async () => {
   });
 };
 
-/** Clear all Google Wallet env vars and return restore function */
-const clearGoogleWalletEnvVars = () =>
-  setTestEnv({
-    GOOGLE_WALLET_ISSUER_ID: undefined,
-    GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
-    GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
-  });
-
-describeWithEnv("getHostGoogleWalletConfig", {
-  GOOGLE_WALLET_ISSUER_ID: undefined,
-  GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
-  GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
-}, () => {
-  test("returns null when no env vars are set", () => {
-    expect(getHostGoogleWalletConfig()).toBeNull();
-  });
-
-  test("returns null when only some env vars are set", () => {
-    Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "123");
-    expect(getHostGoogleWalletConfig()).toBeNull();
-  });
-
-  test("returns config when all env vars are set", async () => {
-    await setGoogleWalletEnvVars();
-    const config = getHostGoogleWalletConfig();
-    expect(config).not.toBeNull();
-    expect(config!.issuerId).toBe("9876543210");
-    expect(config!.serviceAccountEmail).toBe(
-      "env@env-project.iam.gserviceaccount.com",
-    );
-    expect(config!.serviceAccountKey).toContain("BEGIN PRIVATE KEY");
-  });
-});
-
-describeWithEnv("Google Wallet env var fallback", {
-  GOOGLE_WALLET_ISSUER_ID: undefined,
-  GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
-  GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
-}, () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-    await ensureCreds();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
-  test("hasGoogleWalletConfig returns true with env vars when DB not configured", async () => {
-    await setGoogleWalletEnvVars();
-    expect(await hasGoogleWalletDbConfig()).toBe(false);
-    expect(await hasGoogleWalletConfig()).toBe(true);
-  });
-
-  test("getGoogleWalletConfig falls back to env vars when DB not configured", async () => {
-    await setGoogleWalletEnvVars();
-    const config = await getGoogleWalletConfig();
-    expect(config).not.toBeNull();
-    expect(config!.issuerId).toBe("9876543210");
-  });
-
-  test("getGoogleWalletConfig prefers DB config over env vars", async () => {
-    await setGoogleWalletEnvVars();
-    await configureGoogleWallet();
-    const config = await getGoogleWalletConfig();
-    expect(config).not.toBeNull();
-    expect(config!.issuerId).toBe("1234567890");
-  });
-
-  test("gwallet route works with env var config", async () => {
-    await setGoogleWalletEnvVars();
-    const { token } = await createTestAttendeeWithToken(
-      "Alice",
-      "alice@test.com",
-    );
-    const response = await awaitTestRequest(`/gwallet/${token}`);
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toMatch(
-      /^https:\/\/pay\.google\.com\/gp\/v\/save\//,
-    );
-  });
-
-  test("ticket view shows google wallet link with env var config", async () => {
-    await setGoogleWalletEnvVars();
-    const { token } = await createTestAttendeeWithToken(
-      "Alice",
-      "alice@test.com",
-    );
-    const response = await awaitTestRequest(`/t/${token}`);
-    const body = await response.text();
-    expect(body).toContain("Google Wallet");
-  });
-
-  test("settings page shows host Google Wallet label when env vars configured", async () => {
-    await setGoogleWalletEnvVars();
-    const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings-advanced", {
-      cookie,
+describeWithEnv(
+  "getHostGoogleWalletConfig",
+  {
+    env: {
+      GOOGLE_WALLET_ISSUER_ID: undefined,
+      GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
+      GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
+    },
+  },
+  () => {
+    test("returns null when no env vars are set", () => {
+      expect(getHostGoogleWalletConfig()).toBeNull();
     });
-    const body = await response.text();
-    expect(body).toContain("Host env (9876543210)");
-    expect(body).toContain("Currently using");
-  });
 
-  test("settings page shows overriding label when both DB and env configured", async () => {
-    await setGoogleWalletEnvVars();
-    await configureGoogleWallet();
-    const { cookie } = await loginAsAdmin();
-    const response = await awaitTestRequest("/admin/settings-advanced", {
-      cookie,
+    test("returns null when only some env vars are set", () => {
+      Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "123");
+      expect(getHostGoogleWalletConfig()).toBeNull();
     });
-    const body = await response.text();
-    expect(body).toContain("Host env (9876543210)");
-    expect(body).toContain("Overriding");
-  });
-});
+
+    test("returns config when all env vars are set", async () => {
+      await setGoogleWalletEnvVars();
+      const config = getHostGoogleWalletConfig();
+      expect(config).not.toBeNull();
+      expect(config!.issuerId).toBe("9876543210");
+      expect(config!.serviceAccountEmail).toBe(
+        "env@env-project.iam.gserviceaccount.com",
+      );
+      expect(config!.serviceAccountKey).toContain("BEGIN PRIVATE KEY");
+    });
+  },
+);
+
+describeWithEnv(
+  "Google Wallet env var fallback",
+  {
+    env: {
+      GOOGLE_WALLET_ISSUER_ID: undefined,
+      GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
+      GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
+    },
+    db: true,
+  },
+  () => {
+    beforeEach(async () => {
+      await ensureCreds();
+    });
+
+    test("hasGoogleWalletConfig returns true with env vars when DB not configured", async () => {
+      await setGoogleWalletEnvVars();
+      expect(await hasGoogleWalletDbConfig()).toBe(false);
+      expect(await hasGoogleWalletConfig()).toBe(true);
+    });
+
+    test("getGoogleWalletConfig falls back to env vars when DB not configured", async () => {
+      await setGoogleWalletEnvVars();
+      const config = await getGoogleWalletConfig();
+      expect(config).not.toBeNull();
+      expect(config!.issuerId).toBe("9876543210");
+    });
+
+    test("getGoogleWalletConfig prefers DB config over env vars", async () => {
+      await setGoogleWalletEnvVars();
+      await configureGoogleWallet();
+      const config = await getGoogleWalletConfig();
+      expect(config).not.toBeNull();
+      expect(config!.issuerId).toBe("1234567890");
+    });
+
+    test("gwallet route works with env var config", async () => {
+      await setGoogleWalletEnvVars();
+      const { token } = await createTestAttendeeWithToken(
+        "Alice",
+        "alice@test.com",
+      );
+      const response = await awaitTestRequest(`/gwallet/${token}`);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toMatch(
+        /^https:\/\/pay\.google\.com\/gp\/v\/save\//,
+      );
+    });
+
+    test("ticket view shows google wallet link with env var config", async () => {
+      await setGoogleWalletEnvVars();
+      const { token } = await createTestAttendeeWithToken(
+        "Alice",
+        "alice@test.com",
+      );
+      const response = await awaitTestRequest(`/t/${token}`);
+      const body = await response.text();
+      expect(body).toContain("Google Wallet");
+    });
+
+    test("settings page shows host Google Wallet label when env vars configured", async () => {
+      await setGoogleWalletEnvVars();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", {
+        cookie,
+      });
+      const body = await response.text();
+      expect(body).toContain("Host env (9876543210)");
+      expect(body).toContain("Currently using");
+    });
+
+    test("settings page shows overriding label when both DB and env configured", async () => {
+      await setGoogleWalletEnvVars();
+      await configureGoogleWallet();
+      const { cookie } = await loginAsAdmin();
+      const response = await awaitTestRequest("/admin/settings-advanced", {
+        cookie,
+      });
+      const body = await response.text();
+      expect(body).toContain("Host env (9876543210)");
+      expect(body).toContain("Overriding");
+    });
+  },
+);

--- a/test/lib/server-google-wallet.test.ts
+++ b/test/lib/server-google-wallet.test.ts
@@ -24,6 +24,7 @@ import {
   mockFormRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
 } from "#test-utils";
 
 /** Reuse cached creds for all wallet configuration */
@@ -344,38 +345,35 @@ describe("POST /admin/settings/google-wallet", () => {
   });
 });
 
-const GOOGLE_WALLET_ENV_KEYS = [
-  "GOOGLE_WALLET_ISSUER_ID",
-  "GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL",
-  "GOOGLE_WALLET_SERVICE_ACCOUNT_KEY",
-] as const;
-
-/** Set all Google Wallet env vars */
+/** Set all Google Wallet env vars and return restore function */
 const setGoogleWalletEnvVars = async () => {
   await ensureCreds();
-  Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "9876543210");
-  Deno.env.set(
-    "GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL",
-    "env@env-project.iam.gserviceaccount.com",
-  );
-  Deno.env.set(
-    "GOOGLE_WALLET_SERVICE_ACCOUNT_KEY",
-    testCreds.serviceAccountKey,
-  );
+  return setTestEnv({
+    GOOGLE_WALLET_ISSUER_ID: "9876543210",
+    GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL:
+      "env@env-project.iam.gserviceaccount.com",
+    GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: testCreds.serviceAccountKey,
+  });
 };
 
-/** Clear all Google Wallet env vars */
-const clearGoogleWalletEnvVars = () => {
-  for (const key of GOOGLE_WALLET_ENV_KEYS) Deno.env.delete(key);
-};
-
-describe("getHostGoogleWalletConfig", () => {
-  afterEach(() => {
-    clearGoogleWalletEnvVars();
+/** Clear all Google Wallet env vars and return restore function */
+const clearGoogleWalletEnvVars = () =>
+  setTestEnv({
+    GOOGLE_WALLET_ISSUER_ID: undefined,
+    GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: undefined,
+    GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: undefined,
   });
 
+describe("getHostGoogleWalletConfig", () => {
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    restoreEnv = clearGoogleWalletEnvVars();
+  });
+
+  afterEach(() => restoreEnv());
+
   test("returns null when no env vars are set", () => {
-    clearGoogleWalletEnvVars();
     expect(getHostGoogleWalletConfig()).toBeNull();
   });
 
@@ -397,7 +395,10 @@ describe("getHostGoogleWalletConfig", () => {
 });
 
 describe("Google Wallet env var fallback", () => {
+  let restoreEnv: () => void;
+
   beforeEach(async () => {
+    restoreEnv = clearGoogleWalletEnvVars();
     resetTestSlugCounter();
     await createTestDbWithSetup();
     await ensureCreds();
@@ -405,7 +406,7 @@ describe("Google Wallet env var fallback", () => {
 
   afterEach(() => {
     resetDb();
-    clearGoogleWalletEnvVars();
+    restoreEnv();
   });
 
   test("hasGoogleWalletConfig returns true with env vars when DB not configured", async () => {

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -11,33 +11,28 @@ import {
   adminGet,
   awaitTestRequest,
   createTestAttendee,
-  createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
   createTestManagerSession,
   deleteTestGroup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   expectStatus,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
   updateTestGroup,
 } from "#test-utils";
 
-describe("server (admin groups)", () => {
-  beforeEach(async () => {
+describeWithEnv("server (admin groups)", { db: true }, () => {
+  beforeEach(() => {
     setDemoModeForTest(false);
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
   });
 
   afterEach(() => {
     setDemoModeForTest(false);
-    resetDb();
   });
 
   describe("GET /admin/groups", () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import {
   resetHostAppleWalletConfig,
   setHostAppleWalletConfigForTest,
@@ -8,24 +8,13 @@ import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { handleRequest } from "#routes";
 import {
   adminGet,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
 } from "#test-utils";
 
-describe("server (admin guide)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin guide)", { db: true }, () => {
   describe("GET /admin/guide", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/guide"));

--- a/test/lib/server-holidays.test.ts
+++ b/test/lib/server-holidays.test.ts
@@ -1,14 +1,14 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 
 import { handleRequest } from "#routes";
 import {
   adminFormPost,
   adminGet,
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestHoliday,
   deleteTestHoliday,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   expectStatus,
@@ -16,24 +16,13 @@ import {
   mockFormRequest,
   mockRequest,
   requireJoinCsrfToken,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
   testHoliday,
   updateTestHoliday,
 } from "#test-utils";
 
-describe("server (admin holidays)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin holidays)", { db: true }, () => {
   describe("GET /admin/holidays", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/holidays"));

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -7,6 +7,7 @@ import { handleRequest } from "#routes";
 import {
   createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
   installUrlHandler,
   mockFormRequest,
@@ -197,21 +198,17 @@ const submitCreateImage = (
 const proxyRequest = (ext = "jpg"): Promise<Response> =>
   handleRequest(mockRequest(`${PROXY_PATH}.${ext}`));
 
-describe("server (event images)", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("server (event images)", {
+  STORAGE_ZONE_NAME: "testzone",
+  STORAGE_ZONE_KEY: "testkey",
+}, () => {
   beforeEach(async () => {
     resetTestSlugCounter();
     await createTestDbWithSetup();
-    restoreEnv = setTestEnv({
-      STORAGE_ZONE_NAME: "testzone",
-      STORAGE_ZONE_KEY: "testkey",
-    });
   });
 
   afterEach(() => {
     resetDb();
-    restoreEnv();
   });
 
   describe("POST /admin/event/:id/edit (image upload via edit form)", () => {

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -1,11 +1,10 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { encryptBytes } from "#lib/crypto.ts";
 import { toMajorUnits } from "#lib/currency.ts";
 import { eventsTable, getEvent, getEventWithCount } from "#lib/db/events.ts";
 import { handleRequest } from "#routes";
 import {
-  createTestDbWithSetup,
   createTestEvent,
   describeWithEnv,
   expectHtmlResponse,
@@ -13,8 +12,6 @@ import {
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   setupEventAndLogin,
   testCookie,
@@ -198,513 +195,414 @@ const submitCreateImage = (
 const proxyRequest = (ext = "jpg"): Promise<Response> =>
   handleRequest(mockRequest(`${PROXY_PATH}.${ext}`));
 
-describeWithEnv("server (event images)", {
-  STORAGE_ZONE_NAME: "testzone",
-  STORAGE_ZONE_KEY: "testkey",
-}, () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
+describeWithEnv(
+  "server (event images)",
+  {
+    env: {
+      STORAGE_ZONE_NAME: "testzone",
+      STORAGE_ZONE_KEY: "testkey",
+    },
+    db: true,
+  },
+  () => {
+    describe("POST /admin/event/:id/edit (image upload via edit form)", () => {
+      test("ignores image when storage is not configured", async () => {
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-  afterEach(() => {
-    resetDb();
-  });
-
-  describe("POST /admin/event/:id/edit (image upload via edit form)", () => {
-    test("ignores image when storage is not configured", async () => {
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      const response = await submitEditJpeg(
-        event.id,
-        cookie,
-        csrfToken,
-        "test.jpg",
-      );
-      expect(response.status).toBe(302);
-      const updated = await getEventWithCount(event.id);
-      expect(updated?.image_url).toBe("");
-    });
-
-    test("updates event without image when no file is uploaded", async () => {
-      const event = await createTestEvent();
-      await updateTestEvent(event.id, { name: "Updated Name" });
-      const updated = await getEventWithCount(event.id);
-      expect(updated?.name).toBe("Updated Name");
-      expect(updated?.image_url).toBe("");
-    });
-
-    test("redirects with image error for invalid image type", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      await withStorageMock(async () => {
-        const response = await submitEditImage(event.id, cookie, csrfToken, {
-          name: "test.pdf",
-          data: PDF_BYTES,
-          contentType: "application/pdf",
-        });
-        await expectImageErrorRedirect(response, "JPEG, PNG, GIF, or WebP");
+        const response = await submitEditJpeg(
+          event.id,
+          cookie,
+          csrfToken,
+          "test.jpg",
+        );
+        expect(response.status).toBe(302);
         const updated = await getEventWithCount(event.id);
         expect(updated?.image_url).toBe("");
       });
-    });
 
-    test("redirects with image error for oversized image", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      test("updates event without image when no file is uploaded", async () => {
+        const event = await createTestEvent();
+        await updateTestEvent(event.id, { name: "Updated Name" });
+        const updated = await getEventWithCount(event.id);
+        expect(updated?.name).toBe("Updated Name");
+        expect(updated?.image_url).toBe("");
+      });
 
-      const oversized = new Uint8Array(257 * 1024);
-      oversized[0] = 0xff;
-      oversized[1] = 0xd8;
-      oversized[2] = 0xff;
+      test("redirects with image error for invalid image type", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      await withStorageMock(async () => {
-        const response = await submitEditImage(event.id, cookie, csrfToken, {
-          name: "big.jpg",
-          data: oversized,
-          contentType: "image/jpeg",
+        await withStorageMock(async () => {
+          const response = await submitEditImage(event.id, cookie, csrfToken, {
+            name: "test.pdf",
+            data: PDF_BYTES,
+            contentType: "application/pdf",
+          });
+          await expectImageErrorRedirect(response, "JPEG, PNG, GIF, or WebP");
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.image_url).toBe("");
         });
-        await expectImageErrorRedirect(response, "256KB");
+      });
+
+      test("redirects with image error for oversized image", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        const oversized = new Uint8Array(257 * 1024);
+        oversized[0] = 0xff;
+        oversized[1] = 0xd8;
+        oversized[2] = 0xff;
+
+        await withStorageMock(async () => {
+          const response = await submitEditImage(event.id, cookie, csrfToken, {
+            name: "big.jpg",
+            data: oversized,
+            contentType: "image/jpeg",
+          });
+          await expectImageErrorRedirect(response, "256KB");
+        });
+      });
+
+      test("redirects with image error for mismatched magic bytes", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        await withStorageMock(async () => {
+          const response = await submitEditImage(event.id, cookie, csrfToken, {
+            name: "fake.jpg",
+            data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+            contentType: "image/jpeg",
+          });
+          await expectImageErrorRedirect(response, "valid image");
+        });
+      });
+
+      test("uploads image and updates event via edit form", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        await withStorageMock(async () => {
+          const response = await submitEditJpeg(
+            event.id,
+            cookie,
+            csrfToken,
+            "photo.jpg",
+          );
+          expect(response.status).toBe(302);
+          expect(response.headers.get("location")).toBe(
+            `/admin/event/${event.id}?success=Event+updated`,
+          );
+
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.image_url).not.toBe("");
+          expect(updated?.image_url).toMatch(/\.jpg$/);
+        });
+      });
+
+      test("deletes old image when uploading new one via edit form", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, { imageUrl: "old-image.jpg" });
+
+        await withStorageMock(async (fetchCalls) => {
+          const response = await submitEditJpeg(
+            event.id,
+            cookie,
+            csrfToken,
+            "new-photo.jpg",
+          );
+          expect(response.status).toBe(302);
+
+          const deleteCall = fetchCalls.find((url) =>
+            url.includes("old-image.jpg"),
+          );
+          expect(deleteCall).not.toBeUndefined();
+        });
+      });
+
+      test("succeeds even when old image delete throws", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, { imageUrl: "old-failing.jpg" });
+
+        await withFetchMock(async (originalFetch) => {
+          installUrlHandler(originalFetch, (url) => {
+            if (url.includes("old-failing.jpg")) {
+              return Promise.reject(new Error("CDN delete failed"));
+            }
+            if (url.includes("storage.bunnycdn.com")) {
+              return Promise.resolve(cdnOkResponse());
+            }
+            return null;
+          });
+
+          const response = await submitEditJpeg(
+            event.id,
+            cookie,
+            csrfToken,
+            "new.jpg",
+          );
+          expect(response.status).toBe(302);
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.image_url).toMatch(/\.jpg$/);
+        });
       });
     });
 
-    test("redirects with image error for mismatched magic bytes", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
+    describe("POST /admin/event (image upload via create form)", () => {
+      test("uploads image when creating a new event", async () => {
+        const cookie = await testCookie();
+        const csrfToken = await testCsrfToken();
 
-      await withStorageMock(async () => {
-        const response = await submitEditImage(event.id, cookie, csrfToken, {
-          name: "fake.jpg",
-          data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
-          contentType: "image/jpeg",
+        await withStorageMock(async () => {
+          const response = await submitCreateImage(
+            cookie,
+            csrfToken,
+            "Image Test Event",
+            { name: "photo.jpg", data: JPEG_HEADER, contentType: "image/jpeg" },
+          );
+          expect(response.status).toBe(302);
+
+          const { getAllEvents } = await import("#lib/db/events.ts");
+          const events = await getAllEvents();
+          const created = events.find((e) => e.name === "Image Test Event");
+          expect(created).not.toBeUndefined();
+          expect(created?.image_url).toMatch(/\.jpg$/);
         });
-        await expectImageErrorRedirect(response, "valid image");
+      });
+
+      test("redirects with image error when creating event with invalid image", async () => {
+        const cookie = await testCookie();
+        const csrfToken = await testCsrfToken();
+
+        await withStorageMock(async () => {
+          const response = await submitCreateImage(
+            cookie,
+            csrfToken,
+            "Bad Image Event",
+            {
+              name: "test.pdf",
+              data: PDF_BYTES,
+              contentType: "application/pdf",
+            },
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location") ?? "";
+          expect(location).toContain("/admin?error=");
+          expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+            "JPEG, PNG, GIF, or WebP",
+          );
+
+          const { getAllEvents } = await import("#lib/db/events.ts");
+          const events = await getAllEvents();
+          const created = events.find((e) => e.name === "Bad Image Event");
+          expect(created).not.toBeUndefined();
+          expect(created?.image_url).toBe("");
+        });
       });
     });
 
-    test("uploads image and updates event via edit form", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      await withStorageMock(async () => {
-        const response = await submitEditJpeg(
-          event.id,
-          cookie,
-          csrfToken,
-          "photo.jpg",
+    describe("image error messages in rendered pages", () => {
+      test("displays image error on admin dashboard", async () => {
+        const response = await handleRequest(
+          mockRequest("/admin?error=Image+exceeds+the+256KB+size+limit", {
+            headers: { cookie: await testCookie() },
+          }),
         );
+        await expectHtmlResponse(
+          response,
+          200,
+          "Image exceeds the 256KB size limit",
+        );
+      });
+
+      test("displays image error on event detail page", async () => {
+        const { event, cookie } = await setupEventAndLogin();
+
+        const response = await handleRequest(
+          mockRequest(
+            `/admin/event/${event.id}?error=Image+must+be+a+JPEG%2C+PNG%2C+GIF%2C+or+WebP+file`,
+            { headers: { cookie } },
+          ),
+        );
+        await expectHtmlResponse(
+          response,
+          200,
+          "Image must be a JPEG, PNG, GIF, or WebP file",
+        );
+      });
+
+      test("does not display image error when query param is absent", async () => {
+        const { event, cookie } = await setupEventAndLogin();
+
+        const response = await handleRequest(
+          mockRequest(`/admin/event/${event.id}`, { headers: { cookie } }),
+        );
+        const html = await response.text();
+        expect(html).not.toContain("image was not uploaded");
+      });
+    });
+
+    describe("POST /admin/event/:id/image/delete", () => {
+      const expectImageDeleteRedirect = (
+        response: Response,
+        eventId: number,
+      ) => {
         expect(response.status).toBe(302);
         expect(response.headers.get("location")).toBe(
-          `/admin/event/${event.id}?success=Event+updated`,
+          `/admin/event/${eventId}?success=Image+removed`,
         );
+      };
 
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.image_url).not.toBe("");
-        expect(updated?.image_url).toMatch(/\.jpg$/);
-      });
-    });
+      test("removes image from event and storage", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, { imageUrl: "to-delete.jpg" });
 
-    test("deletes old image when uploading new one via edit form", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, { imageUrl: "old-image.jpg" });
+        await withStorageMock(async () => {
+          const response = await submitImageDelete(event.id, cookie, csrfToken);
+          expectImageDeleteRedirect(response, event.id);
 
-      await withStorageMock(async (fetchCalls) => {
-        const response = await submitEditJpeg(
-          event.id,
-          cookie,
-          csrfToken,
-          "new-photo.jpg",
-        );
-        expect(response.status).toBe(302);
-
-        const deleteCall = fetchCalls.find((url) =>
-          url.includes("old-image.jpg"),
-        );
-        expect(deleteCall).not.toBeUndefined();
-      });
-    });
-
-    test("succeeds even when old image delete throws", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, { imageUrl: "old-failing.jpg" });
-
-      await withFetchMock(async (originalFetch) => {
-        installUrlHandler(originalFetch, (url) => {
-          if (url.includes("old-failing.jpg")) {
-            return Promise.reject(new Error("CDN delete failed"));
-          }
-          if (url.includes("storage.bunnycdn.com")) {
-            return Promise.resolve(cdnOkResponse());
-          }
-          return null;
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.image_url).toBe("");
         });
-
-        const response = await submitEditJpeg(
-          event.id,
-          cookie,
-          csrfToken,
-          "new.jpg",
-        );
-        expect(response.status).toBe(302);
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.image_url).toMatch(/\.jpg$/);
       });
-    });
-  });
 
-  describe("POST /admin/event (image upload via create form)", () => {
-    test("uploads image when creating a new event", async () => {
-      const cookie = await testCookie();
-      const csrfToken = await testCsrfToken();
+      test("redirects when event has no image", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      await withStorageMock(async () => {
-        const response = await submitCreateImage(
-          cookie,
-          csrfToken,
-          "Image Test Event",
-          { name: "photo.jpg", data: JPEG_HEADER, contentType: "image/jpeg" },
-        );
-        expect(response.status).toBe(302);
-
-        const { getAllEvents } = await import("#lib/db/events.ts");
-        const events = await getAllEvents();
-        const created = events.find((e) => e.name === "Image Test Event");
-        expect(created).not.toBeUndefined();
-        expect(created?.image_url).toMatch(/\.jpg$/);
-      });
-    });
-
-    test("redirects with image error when creating event with invalid image", async () => {
-      const cookie = await testCookie();
-      const csrfToken = await testCsrfToken();
-
-      await withStorageMock(async () => {
-        const response = await submitCreateImage(
-          cookie,
-          csrfToken,
-          "Bad Image Event",
-          { name: "test.pdf", data: PDF_BYTES, contentType: "application/pdf" },
-        );
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("/admin?error=");
-        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
-          "JPEG, PNG, GIF, or WebP",
-        );
-
-        const { getAllEvents } = await import("#lib/db/events.ts");
-        const events = await getAllEvents();
-        const created = events.find((e) => e.name === "Bad Image Event");
-        expect(created).not.toBeUndefined();
-        expect(created?.image_url).toBe("");
-      });
-    });
-  });
-
-  describe("image error messages in rendered pages", () => {
-    test("displays image error on admin dashboard", async () => {
-      const response = await handleRequest(
-        mockRequest("/admin?error=Image+exceeds+the+256KB+size+limit", {
-          headers: { cookie: await testCookie() },
-        }),
-      );
-      await expectHtmlResponse(
-        response,
-        200,
-        "Image exceeds the 256KB size limit",
-      );
-    });
-
-    test("displays image error on event detail page", async () => {
-      const { event, cookie } = await setupEventAndLogin();
-
-      const response = await handleRequest(
-        mockRequest(
-          `/admin/event/${event.id}?error=Image+must+be+a+JPEG%2C+PNG%2C+GIF%2C+or+WebP+file`,
-          { headers: { cookie } },
-        ),
-      );
-      await expectHtmlResponse(
-        response,
-        200,
-        "Image must be a JPEG, PNG, GIF, or WebP file",
-      );
-    });
-
-    test("does not display image error when query param is absent", async () => {
-      const { event, cookie } = await setupEventAndLogin();
-
-      const response = await handleRequest(
-        mockRequest(`/admin/event/${event.id}`, { headers: { cookie } }),
-      );
-      const html = await response.text();
-      expect(html).not.toContain("image was not uploaded");
-    });
-  });
-
-  describe("POST /admin/event/:id/image/delete", () => {
-    const expectImageDeleteRedirect = (response: Response, eventId: number) => {
-      expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe(
-        `/admin/event/${eventId}?success=Image+removed`,
-      );
-    };
-
-    test("removes image from event and storage", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, { imageUrl: "to-delete.jpg" });
-
-      await withStorageMock(async () => {
         const response = await submitImageDelete(event.id, cookie, csrfToken);
         expectImageDeleteRedirect(response, event.id);
-
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.image_url).toBe("");
       });
-    });
 
-    test("redirects when event has no image", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      test("returns 404 for non-existent event", async () => {
+        const cookie = await testCookie();
+        const csrfToken = await testCsrfToken();
 
-      const response = await submitImageDelete(event.id, cookie, csrfToken);
-      expectImageDeleteRedirect(response, event.id);
-    });
-
-    test("returns 404 for non-existent event", async () => {
-      const cookie = await testCookie();
-      const csrfToken = await testCsrfToken();
-
-      const response = await submitImageDelete(9999, cookie, csrfToken);
-      expect(response.status).toBe(404);
-    });
-
-    test("reports error when storage delete throws", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, { imageUrl: "failing.jpg" });
-
-      await withFetchMock(async (originalFetch) => {
-        installUrlHandler(originalFetch, () =>
-          Promise.reject(new Error("CDN unreachable")),
-        );
-
-        const response = await submitImageDelete(event.id, cookie, csrfToken);
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("error=");
-        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
-          "removal failed",
-        );
-
-        // DB record should NOT be cleared when CDN delete fails
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.image_url).toBe("failing.jpg");
+        const response = await submitImageDelete(9999, cookie, csrfToken);
+        expect(response.status).toBe(404);
       });
-    });
-  });
 
-  describe("GET /image/:filename (proxy route)", () => {
-    test("serves decrypted image with correct content type", async () => {
-      const imageData = JPEG_HEADER;
-      const encrypted = await encryptBytes(imageData);
+      test("reports error when storage delete throws", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, { imageUrl: "failing.jpg" });
 
-      await withCdnProxy(
-        // biome-ignore lint/suspicious/noExplicitAny: Uint8Array<ArrayBufferLike> not assignable to BodyInit in Deno's TS
-        // deno-lint-ignore no-explicit-any
-        () => new Response(encrypted as any, { status: 200 }),
-        async () => {
-          const response = await proxyRequest();
-          expect(response.status).toBe(200);
-          expect(response.headers.get("content-type")).toBe("image/jpeg");
-          expect(response.headers.get("cache-control")).toContain("immutable");
-          const body = new Uint8Array(await response.arrayBuffer());
-          expect(body).toEqual(imageData);
-        },
-      );
-    });
-
-    test("returns 404 when file does not exist in storage", async () => {
-      await withCdnProxy(
-        () => new Response("Not Found", { status: 404 }),
-        async () => {
-          expect((await proxyRequest()).status).toBe(404);
-        },
-      );
-    });
-
-    test("propagates non-404 storage errors as 503", async () => {
-      await withCdnProxy(
-        () => new Response("Unauthorized", { status: 401 }),
-        async () => {
-          await expectHtmlResponse(
-            await proxyRequest(),
-            503,
-            "Temporary Error",
+        await withFetchMock(async (originalFetch) => {
+          installUrlHandler(originalFetch, () =>
+            Promise.reject(new Error("CDN unreachable")),
           );
-        },
-      );
-    });
 
-    test("returns 404 for unknown extension", async () => {
-      expect((await proxyRequest("bmp")).status).toBe(404);
-    });
+          const response = await submitImageDelete(event.id, cookie, csrfToken);
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location") ?? "";
+          expect(location).toContain("error=");
+          expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+            "removal failed",
+          );
 
-    test("returns 404 when storage is not enabled", async () => {
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
-      expect((await proxyRequest()).status).toBe(404);
-    });
-
-    test("returns 404 for non-GET method", async () => {
-      const request = new Request(`http://localhost${PROXY_PATH}.jpg`, {
-        method: "POST",
-        body: "test",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          host: "localhost",
-        },
+          // DB record should NOT be cleared when CDN delete fails
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.image_url).toBe("failing.jpg");
+        });
       });
-      expect((await handleRequest(request)).status).toBe(404);
     });
 
-    test("returns 404 for filename without extension", async () => {
-      const response = await handleRequest(mockRequest("/image/abcdef123456"));
-      expect(response.status).toBe(404);
-    });
-  });
+    describe("GET /image/:filename (proxy route)", () => {
+      test("serves decrypted image with correct content type", async () => {
+        const imageData = JPEG_HEADER;
+        const encrypted = await encryptBytes(imageData);
 
-  describe("POST /admin/event/:id/edit (attachment upload via edit form)", () => {
-    test("logs diagnostic when attachment field is not a File", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await withCdnProxy(
+          // biome-ignore lint/suspicious/noExplicitAny: Uint8Array<ArrayBufferLike> not assignable to BodyInit in Deno's TS
+          // deno-lint-ignore no-explicit-any
+          () => new Response(encrypted as any, { status: 200 }),
+          async () => {
+            const response = await proxyRequest();
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toBe("image/jpeg");
+            expect(response.headers.get("cache-control")).toContain(
+              "immutable",
+            );
+            const body = new Uint8Array(await response.arrayBuffer());
+            expect(body).toEqual(imageData);
+          },
+        );
+      });
 
-      await withStorageMock(async () => {
-        const fields = await editFormData(event.id, csrfToken);
-        // Add attachment as a text field instead of a file
-        fields.attachment = "not-a-file";
+      test("returns 404 when file does not exist in storage", async () => {
+        await withCdnProxy(
+          () => new Response("Not Found", { status: 404 }),
+          async () => {
+            expect((await proxyRequest()).status).toBe(404);
+          },
+        );
+      });
+
+      test("propagates non-404 storage errors as 503", async () => {
+        await withCdnProxy(
+          () => new Response("Unauthorized", { status: 401 }),
+          async () => {
+            await expectHtmlResponse(
+              await proxyRequest(),
+              503,
+              "Temporary Error",
+            );
+          },
+        );
+      });
+
+      test("returns 404 for unknown extension", async () => {
+        expect((await proxyRequest("bmp")).status).toBe(404);
+      });
+
+      test("returns 404 when storage is not enabled", async () => {
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
+        expect((await proxyRequest()).status).toBe(404);
+      });
+
+      test("returns 404 for non-GET method", async () => {
+        const request = new Request(`http://localhost${PROXY_PATH}.jpg`, {
+          method: "POST",
+          body: "test",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            host: "localhost",
+          },
+        });
+        expect((await handleRequest(request)).status).toBe(404);
+      });
+
+      test("returns 404 for filename without extension", async () => {
         const response = await handleRequest(
-          mockMultipartRequest(`/admin/event/${event.id}/edit`, fields, cookie),
+          mockRequest("/image/abcdef123456"),
         );
-        expect(response.status).toBe(302);
-        expect(response.headers.get("location")).toContain("success=");
-
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.attachment_url).toBe("");
+        expect(response.status).toBe(404);
       });
     });
 
-    test("ignores attachment when storage is not configured", async () => {
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
+    describe("POST /admin/event/:id/edit (attachment upload via edit form)", () => {
+      test("logs diagnostic when attachment field is not a File", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-      const fields = await editFormData(event.id, csrfToken);
-      const response = await handleRequest(
-        mockMultipartRequest(`/admin/event/${event.id}/edit`, fields, cookie, {
-          fieldName: "attachment",
-          name: "guide.pdf",
-          data: PDF_BYTES,
-          contentType: "application/pdf",
-        }),
-      );
-      expect(response.status).toBe(302);
-      const updated = await getEventWithCount(event.id);
-      expect(updated?.attachment_url).toBe("");
-    });
+        await withStorageMock(async () => {
+          const fields = await editFormData(event.id, csrfToken);
+          // Add attachment as a text field instead of a file
+          fields.attachment = "not-a-file";
+          const response = await handleRequest(
+            mockMultipartRequest(
+              `/admin/event/${event.id}/edit`,
+              fields,
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
+          expect(response.headers.get("location")).toContain("success=");
 
-    test("uploads attachment and updates event", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      await withStorageMock(async () => {
-        const fields = await editFormData(event.id, csrfToken);
-        const response = await handleRequest(
-          mockMultipartRequest(
-            `/admin/event/${event.id}/edit`,
-            fields,
-            cookie,
-            {
-              fieldName: "attachment",
-              name: "guide.pdf",
-              data: PDF_BYTES,
-              contentType: "application/pdf",
-            },
-          ),
-        );
-        expect(response.status).toBe(302);
-        expect(response.headers.get("location")).toBe(
-          `/admin/event/${event.id}?success=Event+updated`,
-        );
-
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.attachment_url).toMatch(/guide\.pdf$/);
-        expect(updated?.attachment_name).toBe("guide.pdf");
-      });
-    });
-
-    test("rejects oversized attachment", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      const oversized = new Uint8Array(25 * 1024 * 1024 + 1);
-      await withStorageMock(async () => {
-        const fields = await editFormData(event.id, csrfToken);
-        const response = await handleRequest(
-          mockMultipartRequest(
-            `/admin/event/${event.id}/edit`,
-            fields,
-            cookie,
-            {
-              fieldName: "attachment",
-              name: "huge.zip",
-              data: oversized,
-              contentType: "application/zip",
-            },
-          ),
-        );
-        expectImageErrorRedirect(response, "25MB");
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.attachment_url).toBe("");
-      });
-    });
-
-    test("deletes old attachment when uploading new one", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, {
-        attachmentUrl: "old-file.pdf",
-        attachmentName: "old.pdf",
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.attachment_url).toBe("");
+        });
       });
 
-      await withStorageMock(async (fetchCalls) => {
-        const fields = await editFormData(event.id, csrfToken);
-        const response = await handleRequest(
-          mockMultipartRequest(
-            `/admin/event/${event.id}/edit`,
-            fields,
-            cookie,
-            {
-              fieldName: "attachment",
-              name: "new.pdf",
-              data: PDF_BYTES,
-              contentType: "application/pdf",
-            },
-          ),
-        );
-        expect(response.status).toBe(302);
-
-        const deleteCall = fetchCalls.find((url) =>
-          url.includes("old-file.pdf"),
-        );
-        expect(deleteCall).not.toBeUndefined();
-      });
-    });
-
-    test("reports error when attachment upload fails", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      const restoreStorage = setTestEnv({
-        STORAGE_ZONE_NAME: "testzone",
-        STORAGE_ZONE_KEY: "testkey",
-      });
-      await withFetchMock(async (originalFetch) => {
-        installUrlHandler(originalFetch, () =>
-          Promise.reject(new Error("CDN unreachable")),
-        );
+      test("ignores attachment when storage is not configured", async () => {
+        Deno.env.delete("STORAGE_ZONE_NAME");
+        Deno.env.delete("STORAGE_ZONE_KEY");
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
 
         const fields = await editFormData(event.id, csrfToken);
         const response = await handleRequest(
@@ -721,59 +619,196 @@ describeWithEnv("server (event images)", {
           ),
         );
         expect(response.status).toBe(302);
-        const location = response.headers.get("location") ?? "";
-        expect(location).toContain("error=");
-        expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
-          "upload failed",
-        );
+        const updated = await getEventWithCount(event.id);
+        expect(updated?.attachment_url).toBe("");
       });
-      restoreStorage();
+
+      test("uploads attachment and updates event", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        await withStorageMock(async () => {
+          const fields = await editFormData(event.id, csrfToken);
+          const response = await handleRequest(
+            mockMultipartRequest(
+              `/admin/event/${event.id}/edit`,
+              fields,
+              cookie,
+              {
+                fieldName: "attachment",
+                name: "guide.pdf",
+                data: PDF_BYTES,
+                contentType: "application/pdf",
+              },
+            ),
+          );
+          expect(response.status).toBe(302);
+          expect(response.headers.get("location")).toBe(
+            `/admin/event/${event.id}?success=Event+updated`,
+          );
+
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.attachment_url).toMatch(/guide\.pdf$/);
+          expect(updated?.attachment_name).toBe("guide.pdf");
+        });
+      });
+
+      test("rejects oversized attachment", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        const oversized = new Uint8Array(25 * 1024 * 1024 + 1);
+        await withStorageMock(async () => {
+          const fields = await editFormData(event.id, csrfToken);
+          const response = await handleRequest(
+            mockMultipartRequest(
+              `/admin/event/${event.id}/edit`,
+              fields,
+              cookie,
+              {
+                fieldName: "attachment",
+                name: "huge.zip",
+                data: oversized,
+                contentType: "application/zip",
+              },
+            ),
+          );
+          expectImageErrorRedirect(response, "25MB");
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.attachment_url).toBe("");
+        });
+      });
+
+      test("deletes old attachment when uploading new one", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, {
+          attachmentUrl: "old-file.pdf",
+          attachmentName: "old.pdf",
+        });
+
+        await withStorageMock(async (fetchCalls) => {
+          const fields = await editFormData(event.id, csrfToken);
+          const response = await handleRequest(
+            mockMultipartRequest(
+              `/admin/event/${event.id}/edit`,
+              fields,
+              cookie,
+              {
+                fieldName: "attachment",
+                name: "new.pdf",
+                data: PDF_BYTES,
+                contentType: "application/pdf",
+              },
+            ),
+          );
+          expect(response.status).toBe(302);
+
+          const deleteCall = fetchCalls.find((url) =>
+            url.includes("old-file.pdf"),
+          );
+          expect(deleteCall).not.toBeUndefined();
+        });
+      });
+
+      test("reports error when attachment upload fails", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        const restoreStorage = setTestEnv({
+          STORAGE_ZONE_NAME: "testzone",
+          STORAGE_ZONE_KEY: "testkey",
+        });
+        await withFetchMock(async (originalFetch) => {
+          installUrlHandler(originalFetch, () =>
+            Promise.reject(new Error("CDN unreachable")),
+          );
+
+          const fields = await editFormData(event.id, csrfToken);
+          const response = await handleRequest(
+            mockMultipartRequest(
+              `/admin/event/${event.id}/edit`,
+              fields,
+              cookie,
+              {
+                fieldName: "attachment",
+                name: "guide.pdf",
+                data: PDF_BYTES,
+                contentType: "application/pdf",
+              },
+            ),
+          );
+          expect(response.status).toBe(302);
+          const location = response.headers.get("location") ?? "";
+          expect(location).toContain("error=");
+          expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
+            "upload failed",
+          );
+        });
+        restoreStorage();
+      });
     });
-  });
 
-  describe("POST /admin/event (attachment upload via create form)", () => {
-    test("uploads attachment when creating a new event", async () => {
-      const cookie = await testCookie();
-      const csrfToken = await testCsrfToken();
+    describe("POST /admin/event (attachment upload via create form)", () => {
+      test("uploads attachment when creating a new event", async () => {
+        const cookie = await testCookie();
+        const csrfToken = await testCsrfToken();
 
-      await withStorageMock(async () => {
-        const response = await handleRequest(
-          mockMultipartRequest(
-            "/admin/event",
-            newEventFormFields(csrfToken, "Attachment Event"),
-            cookie,
-            {
-              fieldName: "attachment",
-              name: "info.pdf",
-              data: PDF_BYTES,
-              contentType: "application/pdf",
-            },
-          ),
-        );
-        expect(response.status).toBe(302);
-        expect(response.headers.get("location")).toBe(
-          "/admin?success=Event+created",
-        );
+        await withStorageMock(async () => {
+          const response = await handleRequest(
+            mockMultipartRequest(
+              "/admin/event",
+              newEventFormFields(csrfToken, "Attachment Event"),
+              cookie,
+              {
+                fieldName: "attachment",
+                name: "info.pdf",
+                data: PDF_BYTES,
+                contentType: "application/pdf",
+              },
+            ),
+          );
+          expect(response.status).toBe(302);
+          expect(response.headers.get("location")).toBe(
+            "/admin?success=Event+created",
+          );
 
-        const events = await import("#lib/db/events.ts").then((m) =>
-          m.getAllEvents(),
-        );
-        const created = events.find((e) => e.name === "Attachment Event");
-        expect(created?.attachment_url).toMatch(/info\.pdf$/);
-        expect(created?.attachment_name).toBe("info.pdf");
+          const events = await import("#lib/db/events.ts").then((m) =>
+            m.getAllEvents(),
+          );
+          const created = events.find((e) => e.name === "Attachment Event");
+          expect(created?.attachment_url).toMatch(/info\.pdf$/);
+          expect(created?.attachment_name).toBe("info.pdf");
+        });
       });
     });
-  });
 
-  describe("POST /admin/event/:id/attachment/delete", () => {
-    test("removes attachment from event and storage", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, {
-        attachmentUrl: "to-delete.pdf",
-        attachmentName: "file.pdf",
+    describe("POST /admin/event/:id/attachment/delete", () => {
+      test("removes attachment from event and storage", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, {
+          attachmentUrl: "to-delete.pdf",
+          attachmentName: "file.pdf",
+        });
+
+        await withStorageMock(async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/event/${event.id}/attachment/delete`,
+              { csrf_token: csrfToken },
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
+          expect(response.headers.get("location")).toBe(
+            `/admin/event/${event.id}?success=Attachment+removed`,
+          );
+
+          const updated = await getEventWithCount(event.id);
+          expect(updated?.attachment_url).toBe("");
+          expect(updated?.attachment_name).toBe("");
+        });
       });
 
-      await withStorageMock(async () => {
+      test("redirects when event has no attachment", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
         const response = await handleRequest(
           mockFormRequest(
             `/admin/event/${event.id}/attachment/delete`,
@@ -785,169 +820,149 @@ describeWithEnv("server (event images)", {
         expect(response.headers.get("location")).toBe(
           `/admin/event/${event.id}?success=Attachment+removed`,
         );
-
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.attachment_url).toBe("");
-        expect(updated?.attachment_name).toBe("");
       });
-    });
 
-    test("redirects when event has no attachment", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
+      test("returns 404 for non-existent event", async () => {
+        const cookie = await testCookie();
+        const csrfToken = await testCsrfToken();
 
-      const response = await handleRequest(
-        mockFormRequest(
-          `/admin/event/${event.id}/attachment/delete`,
-          { csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-      expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe(
-        `/admin/event/${event.id}?success=Attachment+removed`,
-      );
-    });
-
-    test("returns 404 for non-existent event", async () => {
-      const cookie = await testCookie();
-      const csrfToken = await testCsrfToken();
-
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/event/9999/attachment/delete",
-          { csrf_token: csrfToken },
-          cookie,
-        ),
-      );
-      expect(response.status).toBe(404);
-    });
-  });
-
-  describe("event deletion cleans up storage files", () => {
-    test("deletes image from storage when event is deleted", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, { imageUrl: "event-image.jpg" });
-
-      await withStorageMock(async (fetchCalls) => {
         const response = await handleRequest(
           mockFormRequest(
-            `/admin/event/${event.id}/delete`,
-            { csrf_token: csrfToken, confirm_identifier: event.name },
+            "/admin/event/9999/attachment/delete",
+            { csrf_token: csrfToken },
             cookie,
           ),
         );
-        expect(response.status).toBe(302);
-
-        const deleteCall = fetchCalls.find((url) =>
-          url.includes("event-image.jpg"),
-        );
-        expect(deleteCall).not.toBeUndefined();
-
-        const deleted = await getEvent(event.id);
-        expect(deleted).toBeNull();
+        expect(response.status).toBe(404);
       });
     });
 
-    test("deletes attachment from storage when event is deleted", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, {
-        attachmentUrl: "event-attachment.pdf",
-        attachmentName: "doc.pdf",
+    describe("event deletion cleans up storage files", () => {
+      test("deletes image from storage when event is deleted", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, { imageUrl: "event-image.jpg" });
+
+        await withStorageMock(async (fetchCalls) => {
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/event/${event.id}/delete`,
+              { csrf_token: csrfToken, confirm_identifier: event.name },
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
+
+          const deleteCall = fetchCalls.find((url) =>
+            url.includes("event-image.jpg"),
+          );
+          expect(deleteCall).not.toBeUndefined();
+
+          const deleted = await getEvent(event.id);
+          expect(deleted).toBeNull();
+        });
       });
 
-      await withStorageMock(async (fetchCalls) => {
-        const response = await handleRequest(
-          mockFormRequest(
-            `/admin/event/${event.id}/delete`,
-            { csrf_token: csrfToken, confirm_identifier: event.name },
-            cookie,
-          ),
-        );
-        expect(response.status).toBe(302);
-
-        const deleteCall = fetchCalls.find((url) =>
-          url.includes("event-attachment.pdf"),
-        );
-        expect(deleteCall).not.toBeUndefined();
-      });
-    });
-
-    test("deletes both image and attachment from storage when event is deleted", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, {
-        imageUrl: "both-image.jpg",
-        attachmentUrl: "both-attachment.pdf",
-        attachmentName: "both.pdf",
-      });
-
-      await withStorageMock(async (fetchCalls) => {
-        const response = await handleRequest(
-          mockFormRequest(
-            `/admin/event/${event.id}/delete`,
-            { csrf_token: csrfToken, confirm_identifier: event.name },
-            cookie,
-          ),
-        );
-        expect(response.status).toBe(302);
-
-        const imageCall = fetchCalls.find((url) =>
-          url.includes("both-image.jpg"),
-        );
-        const attachmentCall = fetchCalls.find((url) =>
-          url.includes("both-attachment.pdf"),
-        );
-        expect(imageCall).not.toBeUndefined();
-        expect(attachmentCall).not.toBeUndefined();
-      });
-    });
-
-    test("succeeds even when storage delete fails during event deletion", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-      await eventsTable.update(event.id, { imageUrl: "failing-image.jpg" });
-
-      await withFetchMock(async (originalFetch) => {
-        installUrlHandler(originalFetch, (url) => {
-          if (url.includes("failing-image.jpg")) {
-            return Promise.reject(new Error("CDN delete failed"));
-          }
-          if (url.includes("storage.bunnycdn.com")) {
-            return Promise.resolve(cdnOkResponse());
-          }
-          return null;
+      test("deletes attachment from storage when event is deleted", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, {
+          attachmentUrl: "event-attachment.pdf",
+          attachmentName: "doc.pdf",
         });
 
-        const response = await handleRequest(
-          mockFormRequest(
-            `/admin/event/${event.id}/delete`,
-            { csrf_token: csrfToken, confirm_identifier: event.name },
-            cookie,
-          ),
-        );
-        expect(response.status).toBe(302);
+        await withStorageMock(async (fetchCalls) => {
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/event/${event.id}/delete`,
+              { csrf_token: csrfToken, confirm_identifier: event.name },
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
 
-        const deleted = await getEvent(event.id);
-        expect(deleted).toBeNull();
+          const deleteCall = fetchCalls.find((url) =>
+            url.includes("event-attachment.pdf"),
+          );
+          expect(deleteCall).not.toBeUndefined();
+        });
+      });
+
+      test("deletes both image and attachment from storage when event is deleted", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, {
+          imageUrl: "both-image.jpg",
+          attachmentUrl: "both-attachment.pdf",
+          attachmentName: "both.pdf",
+        });
+
+        await withStorageMock(async (fetchCalls) => {
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/event/${event.id}/delete`,
+              { csrf_token: csrfToken, confirm_identifier: event.name },
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
+
+          const imageCall = fetchCalls.find((url) =>
+            url.includes("both-image.jpg"),
+          );
+          const attachmentCall = fetchCalls.find((url) =>
+            url.includes("both-attachment.pdf"),
+          );
+          expect(imageCall).not.toBeUndefined();
+          expect(attachmentCall).not.toBeUndefined();
+        });
+      });
+
+      test("succeeds even when storage delete fails during event deletion", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+        await eventsTable.update(event.id, { imageUrl: "failing-image.jpg" });
+
+        await withFetchMock(async (originalFetch) => {
+          installUrlHandler(originalFetch, (url) => {
+            if (url.includes("failing-image.jpg")) {
+              return Promise.reject(new Error("CDN delete failed"));
+            }
+            if (url.includes("storage.bunnycdn.com")) {
+              return Promise.resolve(cdnOkResponse());
+            }
+            return null;
+          });
+
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/event/${event.id}/delete`,
+              { csrf_token: csrfToken, confirm_identifier: event.name },
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
+
+          const deleted = await getEvent(event.id);
+          expect(deleted).toBeNull();
+        });
+      });
+
+      test("skips storage cleanup when event has no image or attachment", async () => {
+        const { event, cookie, csrfToken } = await setupEventAndLogin();
+
+        await withStorageMock(async (fetchCalls) => {
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/event/${event.id}/delete`,
+              { csrf_token: csrfToken, confirm_identifier: event.name },
+              cookie,
+            ),
+          );
+          expect(response.status).toBe(302);
+
+          const storageCalls = fetchCalls.filter((url) =>
+            url.includes("storage.bunnycdn.com"),
+          );
+          expect(storageCalls).toHaveLength(0);
+        });
       });
     });
-
-    test("skips storage cleanup when event has no image or attachment", async () => {
-      const { event, cookie, csrfToken } = await setupEventAndLogin();
-
-      await withStorageMock(async (fetchCalls) => {
-        const response = await handleRequest(
-          mockFormRequest(
-            `/admin/event/${event.id}/delete`,
-            { csrf_token: csrfToken, confirm_identifier: event.name },
-            cookie,
-          ),
-        );
-        expect(response.status).toBe(302);
-
-        const storageCalls = fetchCalls.filter((url) =>
-          url.includes("storage.bunnycdn.com"),
-        );
-        expect(storageCalls).toHaveLength(0);
-      });
-    });
-  });
-});
+  },
+);

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -14,6 +14,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
@@ -197,17 +198,20 @@ const proxyRequest = (ext = "jpg"): Promise<Response> =>
   handleRequest(mockRequest(`${PROXY_PATH}.${ext}`));
 
 describe("server (event images)", () => {
+  let restoreEnv: () => void;
+
   beforeEach(async () => {
     resetTestSlugCounter();
     await createTestDbWithSetup();
-    Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-    Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+    restoreEnv = setTestEnv({
+      STORAGE_ZONE_NAME: "testzone",
+      STORAGE_ZONE_KEY: "testkey",
+    });
   });
 
   afterEach(() => {
     resetDb();
-    Deno.env.delete("STORAGE_ZONE_NAME");
-    Deno.env.delete("STORAGE_ZONE_KEY");
+    restoreEnv();
   });
 
   describe("POST /admin/event/:id/edit (image upload via edit form)", () => {

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -700,9 +700,11 @@ describe("server (event images)", () => {
     test("reports error when attachment upload fails", async () => {
       const { event, cookie, csrfToken } = await setupEventAndLogin();
 
+      const restoreStorage = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
       await withFetchMock(async (originalFetch) => {
-        Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-        Deno.env.set("STORAGE_ZONE_KEY", "testkey");
         installUrlHandler(originalFetch, () =>
           Promise.reject(new Error("CDN unreachable")),
         );
@@ -727,10 +729,8 @@ describe("server (event images)", () => {
         expect(decodeURIComponent(location.replaceAll("+", "%20"))).toContain(
           "upload failed",
         );
-
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
       });
+      restoreStorage();
     });
   });
 

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
@@ -17,28 +17,18 @@ import {
 } from "#routes/utils.ts";
 import {
   createTestDb,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
   getEmbeddableTicketResponse,
   mockFormRequest,
   mockRequest,
   mockRequestWithHost,
   resetDb,
-  resetTestSlugCounter,
   testCookie,
 } from "#test-utils";
 
-describe("server (misc)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (misc)", { db: true }, () => {
   /** Create an embeddable test event and return its ticket page response */
   const getTicketPageResponse = getEmbeddableTicketResponse;
 

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -16,6 +16,7 @@ import {
   resetDb,
   resetTestSlugCounter,
   setupStripe,
+  setTestEnv,
   submitTicketForm,
   withMocks,
 } from "#test-utils";
@@ -1493,9 +1494,11 @@ describe("server (payment flow)", () => {
       });
       if (!result.success) throw new Error("Failed to create attendee");
 
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "re_test123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@tickets.com");
+      const restore = setTestEnv({
+        HOST_EMAIL_PROVIDER: "resend",
+        HOST_EMAIL_API_KEY: "re_test123",
+        HOST_EMAIL_FROM_ADDRESS: "noreply@tickets.com",
+      });
 
       try {
         const response = await handleRequest(
@@ -1506,9 +1509,7 @@ describe("server (payment flow)", () => {
         const html = await expectHtmlResponse(response, 200, "Junk/Spam");
         expect(html).toContain("noreply@tickets.com");
       } finally {
-        Deno.env.delete("HOST_EMAIL_PROVIDER");
-        Deno.env.delete("HOST_EMAIL_API_KEY");
-        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+        restore();
       }
     });
   });

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -1,36 +1,25 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestEvent,
   deactivateTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
   expectRedirect,
   followRedirect,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
-  setupStripe,
   setTestEnv,
+  setupStripe,
   submitTicketForm,
   withMocks,
 } from "#test-utils";
 
-describe("server (payment flow)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (payment flow)", { db: true }, () => {
   describe("GET /payment/success", () => {
     test("returns error for missing session_id", async () => {
       const response = await handleRequest(mockRequest("/payment/success"));

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -32,6 +32,7 @@ import {
   setupStripe,
   submitMultiTicketForm,
   submitTicketForm,
+  setTestEnv,
   testCookie,
   updateTestEvent,
 } from "#test-utils";
@@ -1713,9 +1714,11 @@ describe("server (public routes)", () => {
     });
 
     test("shows email notice when email sending is configured", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "re_test123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "tickets@mysite.com");
+      const restore = setTestEnv({
+        HOST_EMAIL_PROVIDER: "resend",
+        HOST_EMAIL_API_KEY: "re_test123",
+        HOST_EMAIL_FROM_ADDRESS: "tickets@mysite.com",
+      });
       try {
         const response = await handleRequest(
           mockRequest("/ticket/reserved?tokens=abc123"),
@@ -1723,9 +1726,7 @@ describe("server (public routes)", () => {
         const html = await expectHtmlResponse(response, 200, "Junk/Spam");
         expect(html).toContain("tickets@mysite.com");
       } finally {
-        Deno.env.delete("HOST_EMAIL_PROVIDER");
-        Deno.env.delete("HOST_EMAIL_API_KEY");
-        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+        restore();
       }
     });
 

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { addDays } from "#lib/dates.ts";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
@@ -16,23 +16,21 @@ import { handleRequest } from "#routes";
 import { ICS_DISCOVERY_TAG, RSS_DISCOVERY_TAG } from "#templates/public.tsx";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
   createTestHoliday,
   deactivateTestEvent,
+  describeWithEnv,
   expectCheckoutRedirect,
   expectHtmlResponse,
   expectRedirect,
   getTicketCsrfToken,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
+  setTestEnv,
   setupStripe,
   submitMultiTicketForm,
   submitTicketForm,
-  setTestEnv,
   testCookie,
   updateTestEvent,
 } from "#test-utils";
@@ -43,16 +41,7 @@ const expectReservedRedirectWithTokens = (response: Response): void => {
   expect(location).toMatch(/^\/ticket\/reserved\?tokens=.+$/);
 };
 
-describe("server (public routes)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (public routes)", { db: true }, () => {
   describe("GET /", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/"));

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { type Stub, stub } from "@std/testing/mock";
 import type { EventInput } from "#lib/db/events.ts";
 import { paymentsApi } from "#lib/payments.ts";
@@ -9,15 +9,13 @@ import {
   awaitTestRequest,
   createPaidTestAttendee,
   createTestAttendee,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   mockFormRequest,
   mockProviderType,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
@@ -122,16 +120,7 @@ const withRefundMock = async (
 
 // -- Tests ---------------------------------------------------------------- //
 
-describe("server (admin refunds)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin refunds)", { db: true }, () => {
   describe("GET /admin/event/:eventId/attendee/:attendeeId/refund", () => {
     test("redirects to login when not authenticated", async () => {
       const event = await createPaidEvent();

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -5,18 +5,16 @@
  */
 
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { isJsonApiPath } from "#routes/middleware.ts";
 import {
   adminGet,
   awaitTestRequest,
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
-  resetDb,
-  resetTestSlugCounter,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
@@ -196,16 +194,7 @@ const orphanAttendee = async (token: string) => {
   return { getDb };
 };
 
-describe("QR Scanner", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("QR Scanner", { db: true }, () => {
   describe("isJsonApiPath", () => {
     test("matches scan endpoint with numeric event ID", () => {
       expect(isJsonApiPath("/admin/event/123/scan")).toBe(true);

--- a/test/lib/server-seeds.test.ts
+++ b/test/lib/server-seeds.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { getAttendeesRaw } from "#lib/db/attendees.ts";
 import { getDb } from "#lib/db/client.ts";
 import { getAllEvents } from "#lib/db/events.ts";
@@ -10,29 +10,18 @@ import { MAX_SEED_EVENTS } from "#routes/admin/seeds.ts";
 import {
   adminGet,
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestManagerSession,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   extractCsrfToken,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
 
-describe("server (admin seeds)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin seeds)", { db: true }, () => {
   describe("GET /admin/seeds", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/seeds"));

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -24,6 +24,7 @@ import {
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
+  setTestEnv,
   withMocks,
 } from "#test-utils";
 
@@ -89,9 +90,11 @@ describe("server (admin settings-advanced)", () => {
     });
 
     test("shows host email label when host email is configured", async () => {
-      Deno.env.set("HOST_EMAIL_PROVIDER", "resend");
-      Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
-      Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
+      const restore = setTestEnv({
+        HOST_EMAIL_PROVIDER: "resend",
+        HOST_EMAIL_API_KEY: "key-123",
+        HOST_EMAIL_FROM_ADDRESS: "noreply@example.com",
+      });
       try {
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
@@ -100,9 +103,7 @@ describe("server (admin settings-advanced)", () => {
         expect(html).toContain("Host Resend (noreply@example.com)");
         expect(html).not.toContain("None (disabled)");
       } finally {
-        Deno.env.delete("HOST_EMAIL_PROVIDER");
-        Deno.env.delete("HOST_EMAIL_API_KEY");
-        Deno.env.delete("HOST_EMAIL_FROM_ADDRESS");
+        restore();
       }
     });
 
@@ -611,19 +612,20 @@ describe("server (admin settings-advanced)", () => {
   });
 
   describe("custom domain", () => {
+    let restoreEnv: () => void;
+
     const setBunnyEnv = () => {
       Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
     };
-    const clearBunnyEnv = () => {
-      Deno.env.delete("BUNNY_API_KEY");
-    };
 
-    afterEach(() => {
-      clearBunnyEnv();
+    beforeEach(() => {
+      restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
     });
 
+    afterEach(() => restoreEnv());
+
     test("does not show custom domain form when Bunny CDN is not configured", async () => {
-      clearBunnyEnv();
+      Deno.env.delete("BUNNY_API_KEY");
       const response = await awaitTestRequest("/admin/settings-advanced", {
         cookie: await testCookie(),
       });
@@ -699,7 +701,7 @@ describe("server (admin settings-advanced)", () => {
 
     describe("POST /admin/settings/custom-domain", () => {
       test("rejects when Bunny CDN is not configured", async () => {
-        clearBunnyEnv();
+        Deno.env.delete("BUNNY_API_KEY");
         const response = await handleRequest(
           mockFormRequest(
             "/admin/settings/custom-domain",
@@ -903,7 +905,7 @@ describe("server (admin settings-advanced)", () => {
 
     describe("POST /admin/settings/custom-domain/validate", () => {
       test("rejects when Bunny CDN is not configured", async () => {
-        clearBunnyEnv();
+        Deno.env.delete("BUNNY_API_KEY");
         const response = await handleRequest(
           mockFormRequest(
             "/admin/settings/custom-domain/validate",

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -14,6 +14,7 @@ import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirect,
@@ -21,10 +22,10 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
-  setTestEnv,
   withMocks,
 } from "#test-utils";
 
@@ -611,18 +612,10 @@ describe("server (admin settings-advanced)", () => {
     });
   });
 
-  describe("custom domain", () => {
-    let restoreEnv: () => void;
-
+  describeWithEnv("custom domain", { BUNNY_API_KEY: undefined }, () => {
     const setBunnyEnv = () => {
       Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
     };
-
-    beforeEach(() => {
-      restoreEnv = setTestEnv({ BUNNY_API_KEY: undefined });
-    });
-
-    afterEach(() => restoreEnv());
 
     test("does not show custom domain form when Bunny CDN is not configured", async () => {
       Deno.env.delete("BUNNY_API_KEY");

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -612,113 +612,195 @@ describe("server (admin settings-advanced)", () => {
     });
   });
 
-  describeWithEnv("custom domain", { BUNNY_API_KEY: undefined }, () => {
-    const setBunnyEnv = () => {
-      Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
-    };
+  describeWithEnv(
+    "custom domain",
+    { env: { BUNNY_API_KEY: undefined } },
+    () => {
+      const setBunnyEnv = () => {
+        Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
+      };
 
-    test("does not show custom domain form when Bunny CDN is not configured", async () => {
-      Deno.env.delete("BUNNY_API_KEY");
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).not.toContain('id="settings-custom-domain"');
-    });
-
-    test("shows custom domain form when Bunny CDN is configured", async () => {
-      setBunnyEnv();
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).toContain('id="settings-custom-domain"');
-      expect(html).toContain("Custom Domain");
-    });
-
-    test("does not show validate form when no custom domain is saved", async () => {
-      setBunnyEnv();
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).not.toContain('id="settings-custom-domain-validate"');
-    });
-
-    test("shows validate form and CNAME instructions when custom domain is saved", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).toContain('id="settings-custom-domain-validate"');
-      expect(html).toContain("CNAME");
-      expect(html).toContain("tickets.example.com");
-      // CDN hostname is derived from ALLOWED_DOMAIN (localhost in tests)
-      expect(html).toContain("localhost");
-    });
-
-    test("shows warning when custom domain is not validated", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).toContain("not yet validated");
-      expect(html).toContain("will not work until validation is complete");
-    });
-
-    test("does not show warning when custom domain is validated", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).not.toContain("not yet validated");
-    });
-
-    test("shows last validated timestamp when domain has been validated", async () => {
-      setBunnyEnv();
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      const response = await awaitTestRequest("/admin/settings-advanced", {
-        cookie: await testCookie(),
-      });
-      const html = await response.text();
-      expect(html).toContain("Last validated:");
-    });
-
-    describe("POST /admin/settings/custom-domain", () => {
-      test("rejects when Bunny CDN is not configured", async () => {
+      test("does not show custom domain form when Bunny CDN is not configured", async () => {
         Deno.env.delete("BUNNY_API_KEY");
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/settings/custom-domain",
-            {
-              custom_domain: "tickets.example.com",
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        expect(response.status).toBe(400);
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).not.toContain('id="settings-custom-domain"');
       });
 
-      test("saves and validates domain when validation succeeds", async () => {
+      test("shows custom domain form when Bunny CDN is configured", async () => {
         setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: true as const });
-        try {
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).toContain('id="settings-custom-domain"');
+        expect(html).toContain("Custom Domain");
+      });
+
+      test("does not show validate form when no custom domain is saved", async () => {
+        setBunnyEnv();
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).not.toContain('id="settings-custom-domain-validate"');
+      });
+
+      test("shows validate form and CNAME instructions when custom domain is saved", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).toContain('id="settings-custom-domain-validate"');
+        expect(html).toContain("CNAME");
+        expect(html).toContain("tickets.example.com");
+        // CDN hostname is derived from ALLOWED_DOMAIN (localhost in tests)
+        expect(html).toContain("localhost");
+      });
+
+      test("shows warning when custom domain is not validated", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).toContain("not yet validated");
+        expect(html).toContain("will not work until validation is complete");
+      });
+
+      test("does not show warning when custom domain is validated", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        await updateCustomDomainLastValidated();
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).not.toContain("not yet validated");
+      });
+
+      test("shows last validated timestamp when domain has been validated", async () => {
+        setBunnyEnv();
+        await updateCustomDomain("tickets.example.com");
+        await updateCustomDomainLastValidated();
+        const response = await awaitTestRequest("/admin/settings-advanced", {
+          cookie: await testCookie(),
+        });
+        const html = await response.text();
+        expect(html).toContain("Last validated:");
+      });
+
+      describe("POST /admin/settings/custom-domain", () => {
+        test("rejects when Bunny CDN is not configured", async () => {
+          Deno.env.delete("BUNNY_API_KEY");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain",
               {
                 custom_domain: "tickets.example.com",
+                csrf_token: await testCsrfToken(),
+              },
+              await testCookie(),
+            ),
+          );
+          expect(response.status).toBe(400);
+        });
+
+        test("saves and validates domain when validation succeeds", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain",
+                {
+                  custom_domain: "tickets.example.com",
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            expect(response.status).toBe(302);
+            const location = response.headers.get("location")!;
+            expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
+              "Custom domain saved and validated",
+            );
+            expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+            expect(await getCustomDomainLastValidatedFromDb()).not.toBeNull();
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("saves domain with error message when validation fails", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "DNS not configured",
+            });
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain",
+                {
+                  custom_domain: "tickets.example.com",
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            expect(response.status).toBe(302);
+            const location = response.headers.get("location")!;
+            const decoded = decodeURIComponent(location.replaceAll("+", " "));
+            expect(decoded).toContain("validation failed");
+            expect(decoded).toContain("DNS not configured");
+            expect(decoded).toContain("error=");
+            expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+            expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("normalizes domain to lowercase", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain",
+                {
+                  custom_domain: "Tickets.Example.COM",
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("clears custom domain when empty", async () => {
+          setBunnyEnv();
+          await updateCustomDomain("tickets.example.com");
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/custom-domain",
+              {
+                custom_domain: "",
                 csrf_token: await testCsrfToken(),
               },
               await testCookie(),
@@ -727,214 +809,17 @@ describe("server (admin settings-advanced)", () => {
           expect(response.status).toBe(302);
           const location = response.headers.get("location")!;
           expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
-            "Custom domain saved and validated",
+            "Custom domain cleared",
           );
-          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-          expect(await getCustomDomainLastValidatedFromDb()).not.toBeNull();
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
+          expect(await getCustomDomainFromDb()).toBeNull();
+        });
 
-      test("saves domain with error message when validation fails", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: false as const, error: "DNS not configured" });
-        try {
+        test("clears domain when field is missing from form", async () => {
+          setBunnyEnv();
+          await updateCustomDomain("tickets.example.com");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain",
-              {
-                custom_domain: "tickets.example.com",
-                csrf_token: await testCsrfToken(),
-              },
-              await testCookie(),
-            ),
-          );
-          expect(response.status).toBe(302);
-          const location = response.headers.get("location")!;
-          const decoded = decodeURIComponent(location.replaceAll("+", " "));
-          expect(decoded).toContain("validation failed");
-          expect(decoded).toContain("DNS not configured");
-          expect(decoded).toContain("error=");
-          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-          expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("normalizes domain to lowercase", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: true as const });
-        try {
-          await handleRequest(
-            mockFormRequest(
-              "/admin/settings/custom-domain",
-              {
-                custom_domain: "Tickets.Example.COM",
-                csrf_token: await testCsrfToken(),
-              },
-              await testCookie(),
-            ),
-          );
-          expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("clears custom domain when empty", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/settings/custom-domain",
-            {
-              custom_domain: "",
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location")!;
-        expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
-          "Custom domain cleared",
-        );
-        expect(await getCustomDomainFromDb()).toBeNull();
-      });
-
-      test("clears domain when field is missing from form", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/settings/custom-domain",
-            {
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        expect(response.status).toBe(302);
-        const location = response.headers.get("location")!;
-        expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
-          "Custom domain cleared",
-        );
-        expect(await getCustomDomainFromDb()).toBeNull();
-      });
-
-      test("rejects invalid domain format", async () => {
-        setBunnyEnv();
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/settings/custom-domain",
-            {
-              custom_domain: "not a domain!",
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        await expectHtmlResponse(response, 400, "Invalid domain format");
-      });
-
-      test("logs activity when domain is set", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: true as const });
-        try {
-          await handleRequest(
-            mockFormRequest(
-              "/admin/settings/custom-domain",
-              {
-                custom_domain: "tickets.example.com",
-                csrf_token: await testCsrfToken(),
-              },
-              await testCookie(),
-            ),
-          );
-          const log = await getAllActivityLog();
-          expect(
-            log.some((e) =>
-              e.message.includes("Custom domain set to tickets.example.com"),
-            ),
-          ).toBe(true);
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-
-      test("logs validation activity when save triggers successful validation", async () => {
-        setBunnyEnv();
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: true as const });
-        try {
-          await handleRequest(
-            mockFormRequest(
-              "/admin/settings/custom-domain",
-              {
-                custom_domain: "tickets.example.com",
-                csrf_token: await testCsrfToken(),
-              },
-              await testCookie(),
-            ),
-          );
-          const log = await getAllActivityLog();
-          expect(
-            log.some((e) => e.message.includes("Custom domain validated")),
-          ).toBe(true);
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
-    });
-
-    describe("POST /admin/settings/custom-domain/validate", () => {
-      test("rejects when Bunny CDN is not configured", async () => {
-        Deno.env.delete("BUNNY_API_KEY");
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/settings/custom-domain/validate",
-            {
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        expect(response.status).toBe(400);
-      });
-
-      test("rejects when no custom domain is saved", async () => {
-        setBunnyEnv();
-        const response = await handleRequest(
-          mockFormRequest(
-            "/admin/settings/custom-domain/validate",
-            {
-              csrf_token: await testCsrfToken(),
-            },
-            await testCookie(),
-          ),
-        );
-        expect(response.status).toBe(400);
-      });
-
-      test("calls Bunny API and saves timestamp on success", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: true as const });
-        try {
-          const response = await handleRequest(
-            mockFormRequest(
-              "/admin/settings/custom-domain/validate",
               {
                 csrf_token: await testCsrfToken(),
               },
@@ -944,25 +829,82 @@ describe("server (admin settings-advanced)", () => {
           expect(response.status).toBe(302);
           const location = response.headers.get("location")!;
           expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
-            "Custom domain validated successfully",
+            "Custom domain cleared",
           );
-          const lastValidated = await getCustomDomainLastValidatedFromDb();
-          expect(lastValidated).not.toBeNull();
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
+          expect(await getCustomDomainFromDb()).toBeNull();
+        });
+
+        test("rejects invalid domain format", async () => {
+          setBunnyEnv();
+          const response = await handleRequest(
+            mockFormRequest(
+              "/admin/settings/custom-domain",
+              {
+                custom_domain: "not a domain!",
+                csrf_token: await testCsrfToken(),
+              },
+              await testCookie(),
+            ),
+          );
+          await expectHtmlResponse(response, 400, "Invalid domain format");
+        });
+
+        test("logs activity when domain is set", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain",
+                {
+                  custom_domain: "tickets.example.com",
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            const log = await getAllActivityLog();
+            expect(
+              log.some((e) =>
+                e.message.includes("Custom domain set to tickets.example.com"),
+              ),
+            ).toBe(true);
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("logs validation activity when save triggers successful validation", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain",
+                {
+                  custom_domain: "tickets.example.com",
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            const log = await getAllActivityLog();
+            expect(
+              log.some((e) => e.message.includes("Custom domain validated")),
+            ).toBe(true);
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
       });
 
-      test("returns error when Bunny API fails", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({
-            ok: false as const,
-            error: "Add hostname failed (400): Hostname already exists",
-          });
-        try {
+      describe("POST /admin/settings/custom-domain/validate", () => {
+        test("rejects when Bunny CDN is not configured", async () => {
+          Deno.env.delete("BUNNY_API_KEY");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain/validate",
@@ -972,20 +914,12 @@ describe("server (admin settings-advanced)", () => {
               await testCookie(),
             ),
           );
-          await expectHtmlResponse(response, 502, "Add hostname failed");
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
-      });
+          expect(response.status).toBe(400);
+        });
 
-      test("logs activity on successful validation", async () => {
-        setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        const original = bunnyCdnApi.validateCustomDomain;
-        bunnyCdnApi.validateCustomDomain = () =>
-          Promise.resolve({ ok: true as const });
-        try {
-          await handleRequest(
+        test("rejects when no custom domain is saved", async () => {
+          setBunnyEnv();
+          const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain/validate",
               {
@@ -994,14 +928,87 @@ describe("server (admin settings-advanced)", () => {
               await testCookie(),
             ),
           );
-          const log = await getAllActivityLog();
-          expect(
-            log.some((e) => e.message.includes("Custom domain validated")),
-          ).toBe(true);
-        } finally {
-          bunnyCdnApi.validateCustomDomain = original;
-        }
+          expect(response.status).toBe(400);
+        });
+
+        test("calls Bunny API and saves timestamp on success", async () => {
+          setBunnyEnv();
+          await updateCustomDomain("tickets.example.com");
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain/validate",
+                {
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            expect(response.status).toBe(302);
+            const location = response.headers.get("location")!;
+            expect(decodeURIComponent(location.replaceAll("+", " "))).toContain(
+              "Custom domain validated successfully",
+            );
+            const lastValidated = await getCustomDomainLastValidatedFromDb();
+            expect(lastValidated).not.toBeNull();
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("returns error when Bunny API fails", async () => {
+          setBunnyEnv();
+          await updateCustomDomain("tickets.example.com");
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "Add hostname failed (400): Hostname already exists",
+            });
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain/validate",
+                {
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            await expectHtmlResponse(response, 502, "Add hostname failed");
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("logs activity on successful validation", async () => {
+          setBunnyEnv();
+          await updateCustomDomain("tickets.example.com");
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            await handleRequest(
+              mockFormRequest(
+                "/admin/settings/custom-domain/validate",
+                {
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            const log = await getAllActivityLog();
+            expect(
+              log.some((e) => e.message.includes("Custom domain validated")),
+            ).toBe(true);
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
       });
-    });
-  });
+    },
+  );
 });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -27,6 +27,7 @@ import {
   mockRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   TEST_ADMIN_PASSWORD,
   testCookie,
   testCsrfToken,
@@ -1591,8 +1592,10 @@ describe("server (admin settings)", () => {
     });
 
     test("deletes storage files for all events during admin reset", async () => {
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+      const restore = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
 
       const event = await createTestEvent({ maxAttendees: 10 });
       await eventsTable.update(event.id, {
@@ -1634,8 +1637,7 @@ describe("server (admin settings)", () => {
         ).toBe(true);
       });
 
-      Deno.env.delete("STORAGE_ZONE_NAME");
-      Deno.env.delete("STORAGE_ZONE_KEY");
+      restore();
       invalidateTestDbCache();
     });
   });

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestDb,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectHtmlResponse,
   expectRedirect,
   getSetupCsrfToken,
@@ -13,20 +13,10 @@ import {
   mockRequest,
   mockSetupFormRequest,
   resetDb,
-  resetTestSlugCounter,
   withMocks,
 } from "#test-utils";
 
-describe("server (setup)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (setup)", { db: true }, () => {
   /** Get CSRF token from setup page and submit setup form with given fields */
   async function submitSetupForm(
     fields: Record<string, string>,

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import {
   getContactPageTextFromDb,
   getHomepageTextFromDb,
@@ -14,13 +14,11 @@ import {
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -34,16 +32,7 @@ const expectRedirectContaining = (response: Response, text: string) => {
   expect(decoded).toContain(text);
 };
 
-describe("server (admin site)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (admin site)", { db: true }, () => {
   describe("GET /admin/site", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/site"));

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { formatCurrency } from "#lib/currency.ts";
 import { formatDateLabel } from "#lib/dates.ts";
 import { eventsTable } from "#lib/db/events.ts";
@@ -9,12 +9,10 @@ import {
   createPaidTestAttendee,
   createTestAttendee,
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
   getAttendeesRaw,
-  resetDb,
-  resetTestSlugCounter,
 } from "#test-utils";
 
 /** Fetch a ticket page and return the response body text */
@@ -23,16 +21,7 @@ const fetchTicketBody = async (tokenPath: string): Promise<string> => {
   return response.text();
 };
 
-describe("ticket view (/t/:tokens)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("ticket view (/t/:tokens)", { db: true }, () => {
   test("displays ticket for a single valid token", async () => {
     const { event, token } = await createTestAttendeeWithToken(
       "Alice",

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { encrypt, hashPassword } from "#lib/crypto.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
@@ -20,17 +20,15 @@ import {
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestInvite,
   createTestManagerSession,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirect,
   mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   submitJoinForm,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
@@ -38,16 +36,7 @@ import {
   testCsrfToken,
 } from "#test-utils";
 
-describe("server (multi-user admin)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (multi-user admin)", { db: true }, () => {
   describe("users CRUD", () => {
     test("createTestDbWithSetup creates the owner user", async () => {
       const user = await getUserByUsername(TEST_ADMIN_USERNAME);

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { unzipSync } from "fflate";
 import {
   updateAppleWalletPassTypeId,
@@ -11,10 +11,8 @@ import {
 import { handleRequest } from "#routes";
 import {
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
+  describeWithEnv,
   generateTestCerts,
-  resetDb,
-  resetTestSlugCounter,
 } from "#test-utils";
 
 const testCerts = generateTestCerts();
@@ -52,16 +50,7 @@ const walletRequest = (
     }),
   );
 
-describe("Apple Wallet web service (/v1)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("Apple Wallet web service (/v1)", { db: true }, () => {
   describe("POST /v1/devices/:deviceId/registrations/:passTypeId/:serialNumber", () => {
     test("returns 201 for device registration", async () => {
       const response = await walletRequest(

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -25,6 +25,7 @@ import {
   mockFormRequest,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -417,35 +418,36 @@ describe("POST /admin/settings/apple-wallet", () => {
   });
 });
 
-const WALLET_ENV_KEYS = [
-  "APPLE_WALLET_PASS_TYPE_ID",
-  "APPLE_WALLET_TEAM_ID",
-  "APPLE_WALLET_SIGNING_CERT",
-  "APPLE_WALLET_SIGNING_KEY",
-  "APPLE_WALLET_WWDR_CERT",
-] as const;
-
-/** Set all Apple Wallet env vars using cached test certificates */
-const setWalletEnvVars = () => {
-  Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.env.tickets");
-  Deno.env.set("APPLE_WALLET_TEAM_ID", "ENVTEAM001");
-  Deno.env.set("APPLE_WALLET_SIGNING_CERT", testCerts.signingCert);
-  Deno.env.set("APPLE_WALLET_SIGNING_KEY", testCerts.signingKey);
-  Deno.env.set("APPLE_WALLET_WWDR_CERT", testCerts.wwdrCert);
-};
-
-/** Clear all Apple Wallet env vars */
-const clearWalletEnvVars = () => {
-  for (const key of WALLET_ENV_KEYS) Deno.env.delete(key);
-};
-
-describe("getHostAppleWalletConfig", () => {
-  afterEach(() => {
-    clearWalletEnvVars();
+/** Set all Apple Wallet env vars and return restore function */
+const setWalletEnvVars = () =>
+  setTestEnv({
+    APPLE_WALLET_PASS_TYPE_ID: "pass.com.env.tickets",
+    APPLE_WALLET_TEAM_ID: "ENVTEAM001",
+    APPLE_WALLET_SIGNING_CERT: testCerts.signingCert,
+    APPLE_WALLET_SIGNING_KEY: testCerts.signingKey,
+    APPLE_WALLET_WWDR_CERT: testCerts.wwdrCert,
   });
 
+/** Clear all Apple Wallet env vars and return restore function */
+const clearWalletEnvVars = () =>
+  setTestEnv({
+    APPLE_WALLET_PASS_TYPE_ID: undefined,
+    APPLE_WALLET_TEAM_ID: undefined,
+    APPLE_WALLET_SIGNING_CERT: undefined,
+    APPLE_WALLET_SIGNING_KEY: undefined,
+    APPLE_WALLET_WWDR_CERT: undefined,
+  });
+
+describe("getHostAppleWalletConfig", () => {
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    restoreEnv = clearWalletEnvVars();
+  });
+
+  afterEach(() => restoreEnv());
+
   test("returns null when no env vars are set", () => {
-    clearWalletEnvVars();
     expect(getHostAppleWalletConfig()).toBeNull();
   });
 
@@ -468,14 +470,17 @@ describe("getHostAppleWalletConfig", () => {
 });
 
 describe("Apple Wallet env var fallback", () => {
+  let restoreEnv: () => void;
+
   beforeEach(async () => {
+    restoreEnv = clearWalletEnvVars();
     resetTestSlugCounter();
     await createTestDbWithSetup();
   });
 
   afterEach(() => {
     resetDb();
-    clearWalletEnvVars();
+    restoreEnv();
   });
 
   test("hasAppleWalletConfig returns true with env vars when DB not configured", async () => {

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -19,6 +19,7 @@ import {
   awaitTestRequest,
   createTestAttendeeWithToken,
   createTestDbWithSetup,
+  describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   generateTestCerts,
@@ -438,15 +439,13 @@ const clearWalletEnvVars = () =>
     APPLE_WALLET_WWDR_CERT: undefined,
   });
 
-describe("getHostAppleWalletConfig", () => {
-  let restoreEnv: () => void;
-
-  beforeEach(() => {
-    restoreEnv = clearWalletEnvVars();
-  });
-
-  afterEach(() => restoreEnv());
-
+describeWithEnv("getHostAppleWalletConfig", {
+  APPLE_WALLET_PASS_TYPE_ID: undefined,
+  APPLE_WALLET_TEAM_ID: undefined,
+  APPLE_WALLET_SIGNING_CERT: undefined,
+  APPLE_WALLET_SIGNING_KEY: undefined,
+  APPLE_WALLET_WWDR_CERT: undefined,
+}, () => {
   test("returns null when no env vars are set", () => {
     expect(getHostAppleWalletConfig()).toBeNull();
   });
@@ -469,18 +468,20 @@ describe("getHostAppleWalletConfig", () => {
   });
 });
 
-describe("Apple Wallet env var fallback", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("Apple Wallet env var fallback", {
+  APPLE_WALLET_PASS_TYPE_ID: undefined,
+  APPLE_WALLET_TEAM_ID: undefined,
+  APPLE_WALLET_SIGNING_CERT: undefined,
+  APPLE_WALLET_SIGNING_KEY: undefined,
+  APPLE_WALLET_WWDR_CERT: undefined,
+}, () => {
   beforeEach(async () => {
-    restoreEnv = clearWalletEnvVars();
     resetTestSlugCounter();
     await createTestDbWithSetup();
   });
 
   afterEach(() => {
     resetDb();
-    restoreEnv();
   });
 
   test("hasAppleWalletConfig returns true with env vars when DB not configured", async () => {

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { unzipSync } from "fflate";
 import {
   getAppleWalletConfig,
@@ -18,14 +18,11 @@ import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestAttendeeWithToken,
-  createTestDbWithSetup,
   describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
   generateTestCerts,
   mockFormRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   testCookie,
   testCsrfToken,
@@ -100,16 +97,7 @@ const configureAppleWallet = async () => {
   ]);
 };
 
-describe("wallet route (/wallet/:token)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("wallet route (/wallet/:token)", { db: true }, () => {
   test("returns 404 when Apple Wallet is not configured", async () => {
     const { token } = await createTestAttendeeWithToken(
       "Alice",
@@ -244,16 +232,7 @@ describe("wallet route (/wallet/:token)", () => {
   });
 });
 
-describe("ticket view wallet link", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("ticket view wallet link", { db: true }, () => {
   test("does not show wallet link when Apple Wallet is not configured", async () => {
     const { token } = await createTestAttendeeWithToken(
       "Alice",
@@ -277,16 +256,7 @@ describe("ticket view wallet link", () => {
   });
 });
 
-describe("POST /admin/settings/apple-wallet", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
   test("redirects to login when not authenticated", async () => {
     const response = await handleRequest(
       mockFormRequest("/admin/settings/apple-wallet", {
@@ -429,122 +399,116 @@ const setWalletEnvVars = () =>
     APPLE_WALLET_WWDR_CERT: testCerts.wwdrCert,
   });
 
-/** Clear all Apple Wallet env vars and return restore function */
-const clearWalletEnvVars = () =>
-  setTestEnv({
-    APPLE_WALLET_PASS_TYPE_ID: undefined,
-    APPLE_WALLET_TEAM_ID: undefined,
-    APPLE_WALLET_SIGNING_CERT: undefined,
-    APPLE_WALLET_SIGNING_KEY: undefined,
-    APPLE_WALLET_WWDR_CERT: undefined,
-  });
-
-describeWithEnv("getHostAppleWalletConfig", {
-  APPLE_WALLET_PASS_TYPE_ID: undefined,
-  APPLE_WALLET_TEAM_ID: undefined,
-  APPLE_WALLET_SIGNING_CERT: undefined,
-  APPLE_WALLET_SIGNING_KEY: undefined,
-  APPLE_WALLET_WWDR_CERT: undefined,
-}, () => {
-  test("returns null when no env vars are set", () => {
-    expect(getHostAppleWalletConfig()).toBeNull();
-  });
-
-  test("returns null when only some env vars are set", () => {
-    Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.test");
-    Deno.env.set("APPLE_WALLET_TEAM_ID", "TEAM01");
-    expect(getHostAppleWalletConfig()).toBeNull();
-  });
-
-  test("returns config when all env vars are set", () => {
-    setWalletEnvVars();
-    const config = getHostAppleWalletConfig();
-    expect(config).not.toBeNull();
-    expect(config!.passTypeId).toBe("pass.com.env.tickets");
-    expect(config!.teamId).toBe("ENVTEAM001");
-    expect(config!.signingCert).toContain("BEGIN CERTIFICATE");
-    expect(config!.signingKey).toContain("BEGIN RSA PRIVATE KEY");
-    expect(config!.wwdrCert).toContain("BEGIN CERTIFICATE");
-  });
-});
-
-describeWithEnv("Apple Wallet env var fallback", {
-  APPLE_WALLET_PASS_TYPE_ID: undefined,
-  APPLE_WALLET_TEAM_ID: undefined,
-  APPLE_WALLET_SIGNING_CERT: undefined,
-  APPLE_WALLET_SIGNING_KEY: undefined,
-  APPLE_WALLET_WWDR_CERT: undefined,
-}, () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
-  test("hasAppleWalletConfig returns true with env vars when DB not configured", async () => {
-    setWalletEnvVars();
-    expect(await hasAppleWalletDbConfig()).toBe(false);
-    expect(await hasAppleWalletConfig()).toBe(true);
-  });
-
-  test("getAppleWalletConfig falls back to env vars when DB not configured", async () => {
-    setWalletEnvVars();
-    const config = await getAppleWalletConfig();
-    expect(config).not.toBeNull();
-    expect(config!.passTypeId).toBe("pass.com.env.tickets");
-    expect(config!.teamId).toBe("ENVTEAM001");
-  });
-
-  test("getAppleWalletConfig prefers DB config over env vars", async () => {
-    setWalletEnvVars();
-    await configureAppleWallet();
-    const config = await getAppleWalletConfig();
-    expect(config).not.toBeNull();
-    expect(config!.passTypeId).toBe("pass.com.test.tickets");
-    expect(config!.teamId).toBe("TESTTEAM01");
-  });
-
-  test("wallet route works with env var config", async () => {
-    setWalletEnvVars();
-    const { token } = await fetchValidPkpassForNewAttendee();
-
-    const passJson = await parsePkpassJson(token);
-    expect(passJson.passTypeIdentifier).toBe("pass.com.env.tickets");
-    expect(passJson.teamIdentifier).toBe("ENVTEAM001");
-  });
-
-  test("ticket view shows wallet link with env var config", async () => {
-    setWalletEnvVars();
-    const { token } = await createTestAttendeeWithToken(
-      "Alice",
-      "alice@test.com",
-    );
-    const body = await fetchWalletTicketBody(token);
-    expect(body).toContain("wallet-link");
-    expect(body).toContain("Apple Wallet");
-  });
-
-  test("settings page shows host Apple Wallet label when env vars configured", async () => {
-    setWalletEnvVars();
-    const response = await awaitTestRequest("/admin/settings-advanced", {
-      cookie: await testCookie(),
+describeWithEnv(
+  "getHostAppleWalletConfig",
+  {
+    env: {
+      APPLE_WALLET_PASS_TYPE_ID: undefined,
+      APPLE_WALLET_TEAM_ID: undefined,
+      APPLE_WALLET_SIGNING_CERT: undefined,
+      APPLE_WALLET_SIGNING_KEY: undefined,
+      APPLE_WALLET_WWDR_CERT: undefined,
+    },
+  },
+  () => {
+    test("returns null when no env vars are set", () => {
+      expect(getHostAppleWalletConfig()).toBeNull();
     });
-    const body = await response.text();
-    expect(body).toContain("Host env (pass.com.env.tickets)");
-    expect(body).toContain("Currently using");
-  });
 
-  test("settings page shows overriding label when both DB and env configured", async () => {
-    setWalletEnvVars();
-    await configureAppleWallet();
-    const response = await awaitTestRequest("/admin/settings-advanced", {
-      cookie: await testCookie(),
+    test("returns null when only some env vars are set", () => {
+      Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.test");
+      Deno.env.set("APPLE_WALLET_TEAM_ID", "TEAM01");
+      expect(getHostAppleWalletConfig()).toBeNull();
     });
-    const body = await response.text();
-    expect(body).toContain("Host env (pass.com.env.tickets)");
-    expect(body).toContain("Overriding");
-  });
-});
+
+    test("returns config when all env vars are set", () => {
+      setWalletEnvVars();
+      const config = getHostAppleWalletConfig();
+      expect(config).not.toBeNull();
+      expect(config!.passTypeId).toBe("pass.com.env.tickets");
+      expect(config!.teamId).toBe("ENVTEAM001");
+      expect(config!.signingCert).toContain("BEGIN CERTIFICATE");
+      expect(config!.signingKey).toContain("BEGIN RSA PRIVATE KEY");
+      expect(config!.wwdrCert).toContain("BEGIN CERTIFICATE");
+    });
+  },
+);
+
+describeWithEnv(
+  "Apple Wallet env var fallback",
+  {
+    env: {
+      APPLE_WALLET_PASS_TYPE_ID: undefined,
+      APPLE_WALLET_TEAM_ID: undefined,
+      APPLE_WALLET_SIGNING_CERT: undefined,
+      APPLE_WALLET_SIGNING_KEY: undefined,
+      APPLE_WALLET_WWDR_CERT: undefined,
+    },
+    db: true,
+  },
+  () => {
+    test("hasAppleWalletConfig returns true with env vars when DB not configured", async () => {
+      setWalletEnvVars();
+      expect(await hasAppleWalletDbConfig()).toBe(false);
+      expect(await hasAppleWalletConfig()).toBe(true);
+    });
+
+    test("getAppleWalletConfig falls back to env vars when DB not configured", async () => {
+      setWalletEnvVars();
+      const config = await getAppleWalletConfig();
+      expect(config).not.toBeNull();
+      expect(config!.passTypeId).toBe("pass.com.env.tickets");
+      expect(config!.teamId).toBe("ENVTEAM001");
+    });
+
+    test("getAppleWalletConfig prefers DB config over env vars", async () => {
+      setWalletEnvVars();
+      await configureAppleWallet();
+      const config = await getAppleWalletConfig();
+      expect(config).not.toBeNull();
+      expect(config!.passTypeId).toBe("pass.com.test.tickets");
+      expect(config!.teamId).toBe("TESTTEAM01");
+    });
+
+    test("wallet route works with env var config", async () => {
+      setWalletEnvVars();
+      const { token } = await fetchValidPkpassForNewAttendee();
+
+      const passJson = await parsePkpassJson(token);
+      expect(passJson.passTypeIdentifier).toBe("pass.com.env.tickets");
+      expect(passJson.teamIdentifier).toBe("ENVTEAM001");
+    });
+
+    test("ticket view shows wallet link with env var config", async () => {
+      setWalletEnvVars();
+      const { token } = await createTestAttendeeWithToken(
+        "Alice",
+        "alice@test.com",
+      );
+      const body = await fetchWalletTicketBody(token);
+      expect(body).toContain("wallet-link");
+      expect(body).toContain("Apple Wallet");
+    });
+
+    test("settings page shows host Apple Wallet label when env vars configured", async () => {
+      setWalletEnvVars();
+      const response = await awaitTestRequest("/admin/settings-advanced", {
+        cookie: await testCookie(),
+      });
+      const body = await response.text();
+      expect(body).toContain("Host env (pass.com.env.tickets)");
+      expect(body).toContain("Currently using");
+    });
+
+    test("settings page shows overriding label when both DB and env configured", async () => {
+      setWalletEnvVars();
+      await configureAppleWallet();
+      const response = await awaitTestRequest("/admin/settings-advanced", {
+        cookie: await testCookie(),
+      });
+      const body = await response.text();
+      expect(body).toContain("Host env (pass.com.env.tickets)");
+      expect(body).toContain("Overriding");
+    });
+  },
+);

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -1,35 +1,24 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { decrypt } from "#lib/crypto.ts";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
-  createTestDbWithSetup,
   createTestEvent,
   deactivateTestEvent,
+  describeWithEnv,
   expectHtmlResponse,
   followRedirect,
   mockRequest,
   mockWebhookRequest,
-  resetDb,
-  resetTestSlugCounter,
   setupStripe,
   stubWebhookVerify,
   webhookMeta,
 } from "#test-utils";
 
-describe("server (webhooks)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("server (webhooks)", { db: true }, () => {
   describe("POST /payment/webhook", () => {
     afterEach(() => {
       resetStripeClient();

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -16,420 +16,440 @@ import {
 } from "#lib/storage.ts";
 import { describeWithEnv, installUrlHandler, withFetchMock } from "#test-utils";
 
-describeWithEnv("storage", {
-  STORAGE_ZONE_NAME: undefined,
-  STORAGE_ZONE_KEY: undefined,
-}, () => {
+describeWithEnv(
+  "storage",
+  {
+    env: {
+      STORAGE_ZONE_NAME: undefined,
+      STORAGE_ZONE_KEY: undefined,
+    },
+  },
+  () => {
+    describe("isStorageEnabled", () => {
+      test("returns false when neither env var is set", () => {
+        expect(isStorageEnabled()).toBe(false);
+      });
 
-  describe("isStorageEnabled", () => {
-    test("returns false when neither env var is set", () => {
-      expect(isStorageEnabled()).toBe(false);
-    });
+      test("returns false when only STORAGE_ZONE_NAME is set", () => {
+        Deno.env.set("STORAGE_ZONE_NAME", "myzone");
+        expect(isStorageEnabled()).toBe(false);
+      });
 
-    test("returns false when only STORAGE_ZONE_NAME is set", () => {
-      Deno.env.set("STORAGE_ZONE_NAME", "myzone");
-      expect(isStorageEnabled()).toBe(false);
-    });
+      test("returns false when only STORAGE_ZONE_KEY is set", () => {
+        Deno.env.set("STORAGE_ZONE_KEY", "mykey");
+        expect(isStorageEnabled()).toBe(false);
+      });
 
-    test("returns false when only STORAGE_ZONE_KEY is set", () => {
-      Deno.env.set("STORAGE_ZONE_KEY", "mykey");
-      expect(isStorageEnabled()).toBe(false);
-    });
-
-    test("returns true when both env vars are set", () => {
-      Deno.env.set("STORAGE_ZONE_NAME", "myzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "mykey");
-      expect(isStorageEnabled()).toBe(true);
-    });
-  });
-
-  describe("getImageProxyUrl", () => {
-    test("returns proxy path for filename", () => {
-      expect(getImageProxyUrl("abc123.jpg")).toBe("/image/abc123.jpg");
-    });
-  });
-
-  describe("getMimeTypeFromFilename", () => {
-    test("returns MIME type for .jpg", () => {
-      expect(getMimeTypeFromFilename("abc.jpg")).toBe("image/jpeg");
-    });
-
-    test("returns MIME type for .png", () => {
-      expect(getMimeTypeFromFilename("abc.png")).toBe("image/png");
-    });
-
-    test("returns MIME type for .gif", () => {
-      expect(getMimeTypeFromFilename("abc.gif")).toBe("image/gif");
-    });
-
-    test("returns MIME type for .webp", () => {
-      expect(getMimeTypeFromFilename("abc.webp")).toBe("image/webp");
-    });
-
-    test("returns null for unknown extension", () => {
-      expect(getMimeTypeFromFilename("abc.bmp")).toBeNull();
-    });
-
-    test("returns null for no extension", () => {
-      expect(getMimeTypeFromFilename("abc")).toBeNull();
-    });
-  });
-
-  describe("detectImageType", () => {
-    test("detects JPEG from magic bytes", () => {
-      const data = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00]);
-      expect(detectImageType(data)).toBe("image/jpeg");
-    });
-
-    test("detects PNG from magic bytes", () => {
-      const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d]);
-      expect(detectImageType(data)).toBe("image/png");
-    });
-
-    test("detects GIF from magic bytes", () => {
-      const data = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39]);
-      expect(detectImageType(data)).toBe("image/gif");
-    });
-
-    test("detects WebP from magic bytes", () => {
-      const data = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00]);
-      expect(detectImageType(data)).toBe("image/webp");
-    });
-
-    test("returns null for unknown bytes", () => {
-      const data = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
-      expect(detectImageType(data)).toBeNull();
-    });
-
-    test("returns null for empty data", () => {
-      const data = new Uint8Array([]);
-      expect(detectImageType(data)).toBeNull();
-    });
-  });
-
-  describe("validateImage", () => {
-    const jpegHeader = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
-    const pngHeader = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
-
-    test("accepts valid JPEG image", () => {
-      const result = validateImage(jpegHeader, "image/jpeg");
-      expect(result.valid).toBe(true);
-      if (result.valid) {
-        expect(result.detectedType).toBe("image/jpeg");
-      }
-    });
-
-    test("accepts valid PNG image", () => {
-      const result = validateImage(pngHeader, "image/png");
-      expect(result.valid).toBe(true);
-      if (result.valid) {
-        expect(result.detectedType).toBe("image/png");
-      }
-    });
-
-    test("rejects image exceeding size limit", () => {
-      const largeData = new Uint8Array(256 * 1024 + 1);
-      largeData[0] = 0xff;
-      largeData[1] = 0xd8;
-      largeData[2] = 0xff;
-      const result = validateImage(largeData, "image/jpeg");
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("too_large");
-      }
-    });
-
-    test("rejects disallowed MIME type", () => {
-      const result = validateImage(jpegHeader, "application/pdf");
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("invalid_type");
-      }
-    });
-
-    test("rejects file with valid MIME but invalid magic bytes", () => {
-      const fakeData = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
-      const result = validateImage(fakeData, "image/jpeg");
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("invalid_content");
-      }
-    });
-
-    test("accepts image exactly at size limit", () => {
-      const data = new Uint8Array(256 * 1024);
-      data[0] = 0xff;
-      data[1] = 0xd8;
-      data[2] = 0xff;
-      const result = validateImage(data, "image/jpeg");
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe("generateImageFilename", () => {
-    test("generates filename with .jpg extension for JPEG", () => {
-      const filename = generateImageFilename("image/jpeg");
-      expect(filename).toMatch(/^[0-9a-f-]+\.jpg$/);
-    });
-
-    test("generates filename with .png extension for PNG", () => {
-      const filename = generateImageFilename("image/png");
-      expect(filename).toMatch(/^[0-9a-f-]+\.png$/);
-    });
-
-    test("generates filename with .gif extension for GIF", () => {
-      const filename = generateImageFilename("image/gif");
-      expect(filename).toMatch(/^[0-9a-f-]+\.gif$/);
-    });
-
-    test("generates filename with .webp extension for WebP", () => {
-      const filename = generateImageFilename("image/webp");
-      expect(filename).toMatch(/^[0-9a-f-]+\.webp$/);
-    });
-
-    test("generates unique filenames", () => {
-      const a = generateImageFilename("image/jpeg");
-      const b = generateImageFilename("image/jpeg");
-      expect(a).not.toBe(b);
-    });
-  });
-
-  describe("allowed image types", () => {
-    test("accepts the four supported types", () => {
-      expect(
-        validateImage(new Uint8Array([0xff, 0xd8, 0xff]), "image/jpeg").valid,
-      ).toBe(true);
-      expect(
-        validateImage(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), "image/png")
-          .valid,
-      ).toBe(true);
-      expect(
-        validateImage(new Uint8Array([0x47, 0x49, 0x46, 0x38]), "image/gif")
-          .valid,
-      ).toBe(true);
-      expect(
-        validateImage(new Uint8Array([0x52, 0x49, 0x46, 0x46]), "image/webp")
-          .valid,
-      ).toBe(true);
-    });
-
-    test("rejects unsupported types", () => {
-      const jpeg = new Uint8Array([0xff, 0xd8, 0xff]);
-      expect(validateImage(jpeg, "image/svg+xml").valid).toBe(false);
-      expect(validateImage(jpeg, "application/pdf").valid).toBe(false);
-    });
-  });
-
-  describe("validateAttachment", () => {
-    test("accepts file under 25MB", () => {
-      const data = new Uint8Array(1024);
-      const result = validateAttachment(data);
-      expect(result.valid).toBe(true);
-    });
-
-    test("accepts file exactly at 25MB limit", () => {
-      const data = new Uint8Array(MAX_ATTACHMENT_SIZE);
-      const result = validateAttachment(data);
-      expect(result.valid).toBe(true);
-    });
-
-    test("rejects file exceeding 25MB", () => {
-      const data = new Uint8Array(MAX_ATTACHMENT_SIZE + 1);
-      const result = validateAttachment(data);
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("too_large");
-      }
-    });
-
-    test("accepts any file type (not just images)", () => {
-      // PDF magic bytes - not a valid image, but attachments accept any type
-      const data = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
-      const result = validateAttachment(data);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe("ATTACHMENT_ERROR_MESSAGES", () => {
-    test("has message for too_large error", () => {
-      expect(ATTACHMENT_ERROR_MESSAGES.too_large).toBe(
-        "Attachment exceeds the 25MB size limit",
-      );
-    });
-  });
-
-  describe("generateAttachmentFilename", () => {
-    test("generates filename with UUID prefix and original name", () => {
-      const filename = generateAttachmentFilename("report.pdf");
-      expect(filename).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-report\.pdf$/,
-      );
-    });
-
-    test("sanitizes special characters in filename", () => {
-      const filename = generateAttachmentFilename("my file (1).pdf");
-      // Spaces and parens should be replaced with underscores
-      expect(filename).toMatch(/-my_file__1_\.pdf$/);
-    });
-
-    test("handles path separators in filename", () => {
-      const filename = generateAttachmentFilename("/path/to/file.txt");
-      // Only the basename should remain
-      expect(filename).toMatch(/-file\.txt$/);
-      expect(filename).not.toContain("/path");
-    });
-
-    test("handles backslash path separators", () => {
-      const filename = generateAttachmentFilename("C:\\Users\\docs\\file.txt");
-      expect(filename).toMatch(/-file\.txt$/);
-      expect(filename).not.toContain("Users");
-    });
-
-    test("falls back to 'file' when basename is empty", () => {
-      const filename = generateAttachmentFilename("/");
-      expect(filename).toMatch(/-file$/);
-    });
-
-    test("generates unique filenames for same input", () => {
-      const a = generateAttachmentFilename("doc.pdf");
-      const b = generateAttachmentFilename("doc.pdf");
-      expect(a).not.toBe(b);
-    });
-
-    test("preserves file extension", () => {
-      const filename = generateAttachmentFilename("archive.tar.gz");
-      expect(filename).toMatch(/\.tar\.gz$/);
-    });
-  });
-
-  describeWithEnv("deleteAllEventStorageFiles", {
-    STORAGE_ZONE_NAME: "testzone",
-    STORAGE_ZONE_KEY: "testkey",
-  }, () => {
-
-    test("deletes images and attachments for all events", async () => {
-      const events = [
-        { id: 1, image_url: "img1.jpg", attachment_url: "att1.pdf" },
-        { id: 2, image_url: "img2.png", attachment_url: "" },
-        { id: 3, image_url: "", attachment_url: "att3.pdf" },
-      ];
-
-      await withFetchMock(async (originalFetch) => {
-        const deletedUrls: string[] = [];
-        installUrlHandler(originalFetch, (url) => {
-          if (url.includes("storage.bunnycdn.com")) {
-            deletedUrls.push(url);
-            return Promise.resolve(
-              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
-            );
-          }
-          return null;
-        });
-
-        await deleteAllEventStorageFiles(events);
-
-        expect(deletedUrls.some((u) => u.includes("img1.jpg"))).toBe(true);
-        expect(deletedUrls.some((u) => u.includes("att1.pdf"))).toBe(true);
-        expect(deletedUrls.some((u) => u.includes("img2.png"))).toBe(true);
-        expect(deletedUrls.some((u) => u.includes("att3.pdf"))).toBe(true);
-        // Empty URLs should not trigger delete calls
-        expect(deletedUrls).toHaveLength(4);
+      test("returns true when both env vars are set", () => {
+        Deno.env.set("STORAGE_ZONE_NAME", "myzone");
+        Deno.env.set("STORAGE_ZONE_KEY", "mykey");
+        expect(isStorageEnabled()).toBe(true);
       });
     });
 
-    test("skips events with no image or attachment", async () => {
-      const events = [{ id: 1, image_url: "", attachment_url: "" }];
-
-      await withFetchMock(async (originalFetch) => {
-        const deletedUrls: string[] = [];
-        installUrlHandler(originalFetch, (url) => {
-          if (url.includes("storage.bunnycdn.com")) {
-            deletedUrls.push(url);
-            return Promise.resolve(
-              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
-            );
-          }
-          return null;
-        });
-
-        await deleteAllEventStorageFiles(events);
-
-        expect(deletedUrls).toHaveLength(0);
+    describe("getImageProxyUrl", () => {
+      test("returns proxy path for filename", () => {
+        expect(getImageProxyUrl("abc123.jpg")).toBe("/image/abc123.jpg");
       });
     });
 
-    test("handles empty events array", async () => {
-      await deleteAllEventStorageFiles([]);
-    });
+    describe("getMimeTypeFromFilename", () => {
+      test("returns MIME type for .jpg", () => {
+        expect(getMimeTypeFromFilename("abc.jpg")).toBe("image/jpeg");
+      });
 
-    test("continues deleting when individual file delete fails", async () => {
-      const events = [
-        { id: 1, image_url: "fail.jpg", attachment_url: "" },
-        { id: 2, image_url: "succeed.jpg", attachment_url: "" },
-      ];
+      test("returns MIME type for .png", () => {
+        expect(getMimeTypeFromFilename("abc.png")).toBe("image/png");
+      });
 
-      await withFetchMock(async (originalFetch) => {
-        const deletedUrls: string[] = [];
-        installUrlHandler(originalFetch, (url) => {
-          if (url.includes("fail.jpg")) {
-            return Promise.reject(new Error("CDN error"));
-          }
-          if (url.includes("storage.bunnycdn.com")) {
-            deletedUrls.push(url);
-            return Promise.resolve(
-              new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
-            );
-          }
-          return null;
-        });
+      test("returns MIME type for .gif", () => {
+        expect(getMimeTypeFromFilename("abc.gif")).toBe("image/gif");
+      });
 
-        await deleteAllEventStorageFiles(events);
+      test("returns MIME type for .webp", () => {
+        expect(getMimeTypeFromFilename("abc.webp")).toBe("image/webp");
+      });
 
-        expect(deletedUrls.some((u) => u.includes("succeed.jpg"))).toBe(true);
+      test("returns null for unknown extension", () => {
+        expect(getMimeTypeFromFilename("abc.bmp")).toBeNull();
+      });
+
+      test("returns null for no extension", () => {
+        expect(getMimeTypeFromFilename("abc")).toBeNull();
       });
     });
-  });
 
-  describe("encryptBytes / decryptBytes", () => {
-    test("round-trips binary data through encrypt then decrypt", async () => {
-      const original = new Uint8Array([
-        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46,
-      ]);
-      const encrypted = await encryptBytes(original);
-      // Encrypted data should be larger (12 byte IV + 16 byte auth tag)
-      expect(encrypted.byteLength).toBeGreaterThan(original.byteLength);
-      // Encrypted data should not start with original magic bytes
-      expect(encrypted[0]).not.toBe(0xff);
-      const decrypted = await decryptBytes(encrypted);
-      expect(decrypted).toEqual(original);
+    describe("detectImageType", () => {
+      test("detects JPEG from magic bytes", () => {
+        const data = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00]);
+        expect(detectImageType(data)).toBe("image/jpeg");
+      });
+
+      test("detects PNG from magic bytes", () => {
+        const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d]);
+        expect(detectImageType(data)).toBe("image/png");
+      });
+
+      test("detects GIF from magic bytes", () => {
+        const data = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39]);
+        expect(detectImageType(data)).toBe("image/gif");
+      });
+
+      test("detects WebP from magic bytes", () => {
+        const data = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00]);
+        expect(detectImageType(data)).toBe("image/webp");
+      });
+
+      test("returns null for unknown bytes", () => {
+        const data = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+        expect(detectImageType(data)).toBeNull();
+      });
+
+      test("returns null for empty data", () => {
+        const data = new Uint8Array([]);
+        expect(detectImageType(data)).toBeNull();
+      });
     });
 
-    test("produces different ciphertext for same input", async () => {
-      const data = new Uint8Array([1, 2, 3, 4, 5]);
-      const a = await encryptBytes(data);
-      const b = await encryptBytes(data);
-      // Different IVs mean different ciphertext
-      expect(a).not.toEqual(b);
-      // But both decrypt to the same value
-      expect(await decryptBytes(a)).toEqual(data);
-      expect(await decryptBytes(b)).toEqual(data);
+    describe("validateImage", () => {
+      const jpegHeader = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+      const pngHeader = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+      test("accepts valid JPEG image", () => {
+        const result = validateImage(jpegHeader, "image/jpeg");
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.detectedType).toBe("image/jpeg");
+        }
+      });
+
+      test("accepts valid PNG image", () => {
+        const result = validateImage(pngHeader, "image/png");
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.detectedType).toBe("image/png");
+        }
+      });
+
+      test("rejects image exceeding size limit", () => {
+        const largeData = new Uint8Array(256 * 1024 + 1);
+        largeData[0] = 0xff;
+        largeData[1] = 0xd8;
+        largeData[2] = 0xff;
+        const result = validateImage(largeData, "image/jpeg");
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("too_large");
+        }
+      });
+
+      test("rejects disallowed MIME type", () => {
+        const result = validateImage(jpegHeader, "application/pdf");
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("invalid_type");
+        }
+      });
+
+      test("rejects file with valid MIME but invalid magic bytes", () => {
+        const fakeData = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+        const result = validateImage(fakeData, "image/jpeg");
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("invalid_content");
+        }
+      });
+
+      test("accepts image exactly at size limit", () => {
+        const data = new Uint8Array(256 * 1024);
+        data[0] = 0xff;
+        data[1] = 0xd8;
+        data[2] = 0xff;
+        const result = validateImage(data, "image/jpeg");
+        expect(result.valid).toBe(true);
+      });
     });
 
-    test("throws on invalid binary format", async () => {
-      const invalidData = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x01]);
-      await expect(decryptBytes(invalidData)).rejects.toThrow(
-        "Invalid binary encryption format",
-      );
+    describe("generateImageFilename", () => {
+      test("generates filename with .jpg extension for JPEG", () => {
+        const filename = generateImageFilename("image/jpeg");
+        expect(filename).toMatch(/^[0-9a-f-]+\.jpg$/);
+      });
+
+      test("generates filename with .png extension for PNG", () => {
+        const filename = generateImageFilename("image/png");
+        expect(filename).toMatch(/^[0-9a-f-]+\.png$/);
+      });
+
+      test("generates filename with .gif extension for GIF", () => {
+        const filename = generateImageFilename("image/gif");
+        expect(filename).toMatch(/^[0-9a-f-]+\.gif$/);
+      });
+
+      test("generates filename with .webp extension for WebP", () => {
+        const filename = generateImageFilename("image/webp");
+        expect(filename).toMatch(/^[0-9a-f-]+\.webp$/);
+      });
+
+      test("generates unique filenames", () => {
+        const a = generateImageFilename("image/jpeg");
+        const b = generateImageFilename("image/jpeg");
+        expect(a).not.toBe(b);
+      });
     });
 
-    test("throws on unsupported binary version", async () => {
-      // Valid ENCB magic but wrong version (0xFF instead of 0x01)
-      const data = new Uint8Array(17); // BINARY_HEADER_SIZE = 17
-      data.set([0x45, 0x4e, 0x43, 0x42], 0); // "ENCB" magic
-      data[4] = 0xff; // Invalid version
-      await expect(decryptBytes(data)).rejects.toThrow(
-        "Unsupported binary encryption version: 255",
-      );
+    describe("allowed image types", () => {
+      test("accepts the four supported types", () => {
+        expect(
+          validateImage(new Uint8Array([0xff, 0xd8, 0xff]), "image/jpeg").valid,
+        ).toBe(true);
+        expect(
+          validateImage(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), "image/png")
+            .valid,
+        ).toBe(true);
+        expect(
+          validateImage(new Uint8Array([0x47, 0x49, 0x46, 0x38]), "image/gif")
+            .valid,
+        ).toBe(true);
+        expect(
+          validateImage(new Uint8Array([0x52, 0x49, 0x46, 0x46]), "image/webp")
+            .valid,
+        ).toBe(true);
+      });
+
+      test("rejects unsupported types", () => {
+        const jpeg = new Uint8Array([0xff, 0xd8, 0xff]);
+        expect(validateImage(jpeg, "image/svg+xml").valid).toBe(false);
+        expect(validateImage(jpeg, "application/pdf").valid).toBe(false);
+      });
     });
-  });
-});
+
+    describe("validateAttachment", () => {
+      test("accepts file under 25MB", () => {
+        const data = new Uint8Array(1024);
+        const result = validateAttachment(data);
+        expect(result.valid).toBe(true);
+      });
+
+      test("accepts file exactly at 25MB limit", () => {
+        const data = new Uint8Array(MAX_ATTACHMENT_SIZE);
+        const result = validateAttachment(data);
+        expect(result.valid).toBe(true);
+      });
+
+      test("rejects file exceeding 25MB", () => {
+        const data = new Uint8Array(MAX_ATTACHMENT_SIZE + 1);
+        const result = validateAttachment(data);
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("too_large");
+        }
+      });
+
+      test("accepts any file type (not just images)", () => {
+        // PDF magic bytes - not a valid image, but attachments accept any type
+        const data = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const result = validateAttachment(data);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe("ATTACHMENT_ERROR_MESSAGES", () => {
+      test("has message for too_large error", () => {
+        expect(ATTACHMENT_ERROR_MESSAGES.too_large).toBe(
+          "Attachment exceeds the 25MB size limit",
+        );
+      });
+    });
+
+    describe("generateAttachmentFilename", () => {
+      test("generates filename with UUID prefix and original name", () => {
+        const filename = generateAttachmentFilename("report.pdf");
+        expect(filename).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-report\.pdf$/,
+        );
+      });
+
+      test("sanitizes special characters in filename", () => {
+        const filename = generateAttachmentFilename("my file (1).pdf");
+        // Spaces and parens should be replaced with underscores
+        expect(filename).toMatch(/-my_file__1_\.pdf$/);
+      });
+
+      test("handles path separators in filename", () => {
+        const filename = generateAttachmentFilename("/path/to/file.txt");
+        // Only the basename should remain
+        expect(filename).toMatch(/-file\.txt$/);
+        expect(filename).not.toContain("/path");
+      });
+
+      test("handles backslash path separators", () => {
+        const filename = generateAttachmentFilename(
+          "C:\\Users\\docs\\file.txt",
+        );
+        expect(filename).toMatch(/-file\.txt$/);
+        expect(filename).not.toContain("Users");
+      });
+
+      test("falls back to 'file' when basename is empty", () => {
+        const filename = generateAttachmentFilename("/");
+        expect(filename).toMatch(/-file$/);
+      });
+
+      test("generates unique filenames for same input", () => {
+        const a = generateAttachmentFilename("doc.pdf");
+        const b = generateAttachmentFilename("doc.pdf");
+        expect(a).not.toBe(b);
+      });
+
+      test("preserves file extension", () => {
+        const filename = generateAttachmentFilename("archive.tar.gz");
+        expect(filename).toMatch(/\.tar\.gz$/);
+      });
+    });
+
+    describeWithEnv(
+      "deleteAllEventStorageFiles",
+      {
+        env: {
+          STORAGE_ZONE_NAME: "testzone",
+          STORAGE_ZONE_KEY: "testkey",
+        },
+      },
+      () => {
+        test("deletes images and attachments for all events", async () => {
+          const events = [
+            { id: 1, image_url: "img1.jpg", attachment_url: "att1.pdf" },
+            { id: 2, image_url: "img2.png", attachment_url: "" },
+            { id: 3, image_url: "", attachment_url: "att3.pdf" },
+          ];
+
+          await withFetchMock(async (originalFetch) => {
+            const deletedUrls: string[] = [];
+            installUrlHandler(originalFetch, (url) => {
+              if (url.includes("storage.bunnycdn.com")) {
+                deletedUrls.push(url);
+                return Promise.resolve(
+                  new Response(JSON.stringify({ HttpCode: 200 }), {
+                    status: 200,
+                  }),
+                );
+              }
+              return null;
+            });
+
+            await deleteAllEventStorageFiles(events);
+
+            expect(deletedUrls.some((u) => u.includes("img1.jpg"))).toBe(true);
+            expect(deletedUrls.some((u) => u.includes("att1.pdf"))).toBe(true);
+            expect(deletedUrls.some((u) => u.includes("img2.png"))).toBe(true);
+            expect(deletedUrls.some((u) => u.includes("att3.pdf"))).toBe(true);
+            // Empty URLs should not trigger delete calls
+            expect(deletedUrls).toHaveLength(4);
+          });
+        });
+
+        test("skips events with no image or attachment", async () => {
+          const events = [{ id: 1, image_url: "", attachment_url: "" }];
+
+          await withFetchMock(async (originalFetch) => {
+            const deletedUrls: string[] = [];
+            installUrlHandler(originalFetch, (url) => {
+              if (url.includes("storage.bunnycdn.com")) {
+                deletedUrls.push(url);
+                return Promise.resolve(
+                  new Response(JSON.stringify({ HttpCode: 200 }), {
+                    status: 200,
+                  }),
+                );
+              }
+              return null;
+            });
+
+            await deleteAllEventStorageFiles(events);
+
+            expect(deletedUrls).toHaveLength(0);
+          });
+        });
+
+        test("handles empty events array", async () => {
+          await deleteAllEventStorageFiles([]);
+        });
+
+        test("continues deleting when individual file delete fails", async () => {
+          const events = [
+            { id: 1, image_url: "fail.jpg", attachment_url: "" },
+            { id: 2, image_url: "succeed.jpg", attachment_url: "" },
+          ];
+
+          await withFetchMock(async (originalFetch) => {
+            const deletedUrls: string[] = [];
+            installUrlHandler(originalFetch, (url) => {
+              if (url.includes("fail.jpg")) {
+                return Promise.reject(new Error("CDN error"));
+              }
+              if (url.includes("storage.bunnycdn.com")) {
+                deletedUrls.push(url);
+                return Promise.resolve(
+                  new Response(JSON.stringify({ HttpCode: 200 }), {
+                    status: 200,
+                  }),
+                );
+              }
+              return null;
+            });
+
+            await deleteAllEventStorageFiles(events);
+
+            expect(deletedUrls.some((u) => u.includes("succeed.jpg"))).toBe(
+              true,
+            );
+          });
+        });
+      },
+    );
+
+    describe("encryptBytes / decryptBytes", () => {
+      test("round-trips binary data through encrypt then decrypt", async () => {
+        const original = new Uint8Array([
+          0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46,
+        ]);
+        const encrypted = await encryptBytes(original);
+        // Encrypted data should be larger (12 byte IV + 16 byte auth tag)
+        expect(encrypted.byteLength).toBeGreaterThan(original.byteLength);
+        // Encrypted data should not start with original magic bytes
+        expect(encrypted[0]).not.toBe(0xff);
+        const decrypted = await decryptBytes(encrypted);
+        expect(decrypted).toEqual(original);
+      });
+
+      test("produces different ciphertext for same input", async () => {
+        const data = new Uint8Array([1, 2, 3, 4, 5]);
+        const a = await encryptBytes(data);
+        const b = await encryptBytes(data);
+        // Different IVs mean different ciphertext
+        expect(a).not.toEqual(b);
+        // But both decrypt to the same value
+        expect(await decryptBytes(a)).toEqual(data);
+        expect(await decryptBytes(b)).toEqual(data);
+      });
+
+      test("throws on invalid binary format", async () => {
+        const invalidData = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x01]);
+        await expect(decryptBytes(invalidData)).rejects.toThrow(
+          "Invalid binary encryption format",
+        );
+      });
+
+      test("throws on unsupported binary version", async () => {
+        // Valid ENCB magic but wrong version (0xFF instead of 0x01)
+        const data = new Uint8Array(17); // BINARY_HEADER_SIZE = 17
+        data.set([0x45, 0x4e, 0x43, 0x42], 0); // "ENCB" magic
+        data[4] = 0xff; // Invalid version
+        await expect(decryptBytes(data)).rejects.toThrow(
+          "Unsupported binary encryption version: 255",
+        );
+      });
+    });
+  },
+);

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -14,18 +14,19 @@ import {
   validateAttachment,
   validateImage,
 } from "#lib/storage.ts";
-import { installUrlHandler, withFetchMock } from "#test-utils";
+import { installUrlHandler, setTestEnv, withFetchMock } from "#test-utils";
 
 describe("storage", () => {
+  let restoreEnv: () => void;
+
   beforeEach(() => {
-    Deno.env.delete("STORAGE_ZONE_NAME");
-    Deno.env.delete("STORAGE_ZONE_KEY");
+    restoreEnv = setTestEnv({
+      STORAGE_ZONE_NAME: undefined,
+      STORAGE_ZONE_KEY: undefined,
+    });
   });
 
-  afterEach(() => {
-    Deno.env.delete("STORAGE_ZONE_NAME");
-    Deno.env.delete("STORAGE_ZONE_KEY");
-  });
+  afterEach(() => restoreEnv());
 
   describe("isStorageEnabled", () => {
     test("returns false when neither env var is set", () => {

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { decryptBytes, encryptBytes } from "#lib/crypto.ts";
 import {
   ATTACHMENT_ERROR_MESSAGES,
@@ -14,19 +14,12 @@ import {
   validateAttachment,
   validateImage,
 } from "#lib/storage.ts";
-import { installUrlHandler, setTestEnv, withFetchMock } from "#test-utils";
+import { describeWithEnv, installUrlHandler, withFetchMock } from "#test-utils";
 
-describe("storage", () => {
-  let restoreEnv: () => void;
-
-  beforeEach(() => {
-    restoreEnv = setTestEnv({
-      STORAGE_ZONE_NAME: undefined,
-      STORAGE_ZONE_KEY: undefined,
-    });
-  });
-
-  afterEach(() => restoreEnv());
+describeWithEnv("storage", {
+  STORAGE_ZONE_NAME: undefined,
+  STORAGE_ZONE_KEY: undefined,
+}, () => {
 
   describe("isStorageEnabled", () => {
     test("returns false when neither env var is set", () => {
@@ -309,17 +302,10 @@ describe("storage", () => {
     });
   });
 
-  describe("deleteAllEventStorageFiles", () => {
-    let restoreStorageEnv: () => void;
-    beforeEach(() => {
-      restoreStorageEnv = setTestEnv({
-        STORAGE_ZONE_NAME: "testzone",
-        STORAGE_ZONE_KEY: "testkey",
-      });
-    });
-    afterEach(() => {
-      restoreStorageEnv();
-    });
+  describeWithEnv("deleteAllEventStorageFiles", {
+    STORAGE_ZONE_NAME: "testzone",
+    STORAGE_ZONE_KEY: "testkey",
+  }, () => {
 
     test("deletes images and attachments for all events", async () => {
       const events = [

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -310,9 +310,15 @@ describe("storage", () => {
   });
 
   describe("deleteAllEventStorageFiles", () => {
+    let restoreStorageEnv: () => void;
     beforeEach(() => {
-      Deno.env.set("STORAGE_ZONE_NAME", "testzone");
-      Deno.env.set("STORAGE_ZONE_KEY", "testkey");
+      restoreStorageEnv = setTestEnv({
+        STORAGE_ZONE_NAME: "testzone",
+        STORAGE_ZONE_KEY: "testkey",
+      });
+    });
+    afterEach(() => {
+      restoreStorageEnv();
     });
 
     test("deletes images and attachments for all events", async () => {

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -22,25 +22,20 @@ import {
 import { stripePaymentProvider } from "#lib/stripe-provider.ts";
 import {
   createTestDb,
+  describeWithEnv,
   installUrlHandler,
   resetDb,
   testEvent,
   urlFromFetchInput,
-  setTestEnv,
   withFetchMock,
   withMocks,
 } from "#test-utils";
 
-describe("stripe", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("stripe", {
+  STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
+  STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
+}, () => {
   beforeEach(async () => {
-    // Snapshot STRIPE_MOCK vars so tests can modify them freely;
-    // setTestEnv re-sets current values (no-op) but saves for restore.
-    restoreEnv = setTestEnv({
-      STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
-      STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
-    });
     resetStripeClient();
     // Create in-memory db for testing
     await createTestDb();
@@ -49,7 +44,6 @@ describe("stripe", () => {
   afterEach(() => {
     resetStripeClient();
     resetDb();
-    restoreEnv();
   });
 
   describe("getStripeClient", () => {
@@ -1582,14 +1576,11 @@ describe("stripe", () => {
   });
 });
 
-describe("stripe-provider", () => {
-  let restoreEnv: () => void;
-
+describeWithEnv("stripe-provider", {
+  STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
+  STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
+}, () => {
   beforeEach(async () => {
-    restoreEnv = setTestEnv({
-      STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
-      STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
-    });
     resetStripeClient();
     await createTestDb();
   });
@@ -1597,7 +1588,6 @@ describe("stripe-provider", () => {
   afterEach(() => {
     resetStripeClient();
     resetDb();
-    restoreEnv();
   });
 
   describe("toCheckoutResult - session with no URL", () => {

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -25,2156 +25,988 @@ import {
   describeWithEnv,
   installUrlHandler,
   resetDb,
+  resetTestSlugCounter,
   testEvent,
   urlFromFetchInput,
   withFetchMock,
   withMocks,
 } from "#test-utils";
 
-describeWithEnv("stripe", {
-  STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
-  STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
-}, () => {
-  beforeEach(async () => {
-    resetStripeClient();
-    // Create in-memory db for testing
-    await createTestDb();
-  });
-
-  afterEach(() => {
-    resetStripeClient();
-    resetDb();
-  });
-
-  describe("getStripeClient", () => {
-    test("returns null when stripe key not set", async () => {
-      const client = await getStripeClient();
-      expect(client).toBeNull();
-    });
-
-    test("returns client when stripe key is set in database", async () => {
-      await updateStripeKey("sk_test_123");
-      const client = await getStripeClient();
-      expect(client).not.toBeNull();
-    });
-
-    test("returns same client on subsequent calls", async () => {
-      await updateStripeKey("sk_test_123");
-      const client1 = await getStripeClient();
-      const client2 = await getStripeClient();
-      expect(client1).toBe(client2);
-    });
-  });
-
-  describe("resetStripeClient", () => {
-    test("resets client to null after key removed from db", async () => {
-      await updateStripeKey("sk_test_123");
-      const client1 = await getStripeClient();
-      expect(client1).not.toBeNull();
-
+describeWithEnv(
+  "stripe",
+  {
+    env: {
+      STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
+      STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
+    },
+  },
+  () => {
+    beforeEach(async () => {
       resetStripeClient();
-      // Reset DB to clear the stripe key
-      resetDb();
+      resetTestSlugCounter();
       await createTestDb();
-
-      const client2 = await getStripeClient();
-      expect(client2).toBeNull();
-    });
-  });
-
-  describe("retrieveCheckoutSession", () => {
-    test("returns null when stripe key not set", async () => {
-      const result = await retrieveCheckoutSession("cs_test_123");
-      expect(result).toBeNull();
     });
 
-    test("returns null when Stripe API throws error", async () => {
-      // Enable Stripe with mock
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      // Spy on the checkout.sessions.retrieve method and make it throw
-      await withMocks(
-        () =>
-          stub(client.checkout.sessions, "retrieve", () =>
-            Promise.reject(new Error("Network error")),
-          ),
-        async (retrieveSpy) => {
-          const result = await retrieveCheckoutSession("cs_test_123");
-          expect(result).toBeNull();
-          expect(retrieveSpy.calls[0]!.args).toEqual(["cs_test_123"]);
-        },
-      );
-    });
-  });
-
-  describe("mock configuration", () => {
-    test("creates client with mock config when STRIPE_MOCK_HOST is set", async () => {
-      // This test exercises the getMockConfig code path
-      await updateStripeKey("sk_test_123");
-      Deno.env.set("STRIPE_MOCK_HOST", "localhost");
-      Deno.env.set("STRIPE_MOCK_PORT", "12111");
-
-      // This will create a client with mock config, but won't make any API calls
-      const client = await getStripeClient();
-      expect(client).not.toBeNull();
+    afterEach(() => {
+      resetStripeClient();
+      resetDb();
     });
 
-    test("uses default port 12111 when STRIPE_MOCK_PORT not set", async () => {
-      await updateStripeKey("sk_test_123");
-      Deno.env.set("STRIPE_MOCK_HOST", "localhost");
-      Deno.env.delete("STRIPE_MOCK_PORT");
+    describe("getStripeClient", () => {
+      test("returns null when stripe key not set", async () => {
+        const client = await getStripeClient();
+        expect(client).toBeNull();
+      });
 
-      const client = await getStripeClient();
-      expect(client).not.toBeNull();
-    });
-  });
+      test("returns client when stripe key is set in database", async () => {
+        await updateStripeKey("sk_test_123");
+        const client = await getStripeClient();
+        expect(client).not.toBeNull();
+      });
 
-  describe("stripe-mock integration", () => {
-    // These tests require stripe-mock running on localhost:12111
-    // STRIPE_MOCK_HOST/PORT are set in test/setup.ts
-
-    test("retrieves checkout session with stripe-mock", async () => {
-      await updateStripeKey("sk_test_mock");
-
-      // First create a session using intent-based flow
-      const event = {
-        id: 1,
-        group_id: 0,
-        slug: "test-event",
-        slug_index: "test-event-index",
-        name: "Test Event",
-        description: "Test Description",
-        date: "",
-        location: "",
-        created: new Date().toISOString(),
-        max_attendees: 50,
-        thank_you_url: "https://example.com/thanks",
-        unit_price: 1000,
-        max_quantity: 1,
-        webhook_url: "",
-        active: true,
-        fields: "email" as const,
-        closes_at: null,
-        event_type: "standard" as const,
-        bookable_days: [
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-          "Sunday",
-        ],
-        minimum_days_before: 1,
-        maximum_days_after: 90,
-        image_url: "",
-        attachment_url: "",
-        attachment_name: "",
-        non_transferable: false,
-        can_pay_more: false,
-        max_price: 0,
-        hidden: false,
-      };
-      const intent = {
-        eventId: 1,
-        name: "John Doe",
-        email: "john@example.com",
-        phone: "",
-        address: "",
-        special_instructions: "",
-        quantity: 1,
-      };
-
-      const createdSession = await createCheckoutSessionWithIntent(
-        event,
-        intent,
-        "http://localhost:3000",
-      );
-      expect(createdSession).not.toBeNull();
-
-      // Then retrieve it
-      const retrievedSession = await retrieveCheckoutSession(
-        createdSession?.id || "",
-      );
-      expect(retrievedSession).not.toBeNull();
-      expect(retrievedSession?.id).toBe(createdSession?.id);
+      test("returns same client on subsequent calls", async () => {
+        await updateStripeKey("sk_test_123");
+        const client1 = await getStripeClient();
+        const client2 = await getStripeClient();
+        expect(client1).toBe(client2);
+      });
     });
 
-    test("creates checkout session with intent metadata", async () => {
-      await updateStripeKey("sk_test_mock");
+    describe("resetStripeClient", () => {
+      test("resets client to null after key removed from db", async () => {
+        await updateStripeKey("sk_test_123");
+        const client1 = await getStripeClient();
+        expect(client1).not.toBeNull();
 
-      const event = {
-        id: 1,
-        group_id: 0,
-        slug: "test-event",
-        slug_index: "test-event-index",
-        name: "Test Event",
-        description: "Test Description",
-        date: "",
-        location: "",
-        created: new Date().toISOString(),
-        max_attendees: 50,
-        thank_you_url: "https://example.com/thanks",
-        unit_price: 1000,
-        max_quantity: 5,
-        webhook_url: "",
-        active: true,
-        fields: "email" as const,
-        closes_at: null,
-        event_type: "standard" as const,
-        bookable_days: [
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-          "Sunday",
-        ],
-        minimum_days_before: 1,
-        maximum_days_after: 90,
-        image_url: "",
-        attachment_url: "",
-        attachment_name: "",
-        non_transferable: false,
-        can_pay_more: false,
-        max_price: 0,
-        hidden: false,
-      };
+        resetStripeClient();
+        // Reset DB to clear the stripe key
+        resetDb();
+        await createTestDb();
 
-      const intent = {
-        eventId: 1,
-        name: "John Doe",
-        email: "john@example.com",
-        phone: "",
-        address: "",
-        special_instructions: "",
-        quantity: 2,
-      };
-
-      const session = await createCheckoutSessionWithIntent(
-        event,
-        intent,
-        "http://localhost:3000",
-      );
-
-      // stripe-mock creates session successfully but may not return our custom metadata
-      expect(session).not.toBeNull();
-      expect(session?.id).toBeDefined();
-      expect(session?.url).toBeDefined();
+        const client2 = await getStripeClient();
+        expect(client2).toBeNull();
+      });
     });
 
-    test("refunds payment with stripe-mock", async () => {
-      await updateStripeKey("sk_test_mock");
+    describe("retrieveCheckoutSession", () => {
+      test("returns null when stripe key not set", async () => {
+        const result = await retrieveCheckoutSession("cs_test_123");
+        expect(result).toBeNull();
+      });
 
-      // stripe-mock accepts any payment_intent ID
-      const refund = await refundPayment("pi_test_123");
+      test("returns null when Stripe API throws error", async () => {
+        // Enable Stripe with mock
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
 
-      expect(refund).not.toBeNull();
-      expect(refund?.id).toBeDefined();
-    });
-  });
-
-  describe("createCheckoutSessionWithIntent", () => {
-    test("returns null when stripe key not set", async () => {
-      const event = {
-        id: 1,
-        group_id: 0,
-        slug: "test-event",
-        slug_index: "test-event-index",
-        name: "Test",
-        description: "Desc",
-        date: "",
-        location: "",
-        created: new Date().toISOString(),
-        max_attendees: 50,
-        thank_you_url: "https://example.com",
-        unit_price: 1000,
-        max_quantity: 1,
-        webhook_url: "",
-        active: true,
-        fields: "email" as const,
-        closes_at: null,
-        event_type: "standard" as const,
-        bookable_days: [
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-          "Sunday",
-        ],
-        minimum_days_before: 1,
-        maximum_days_after: 90,
-        image_url: "",
-        attachment_url: "",
-        attachment_name: "",
-        non_transferable: false,
-        can_pay_more: false,
-        max_price: 0,
-        hidden: false,
-      };
-      const intent = {
-        eventId: 1,
-        name: "John",
-        email: "john@example.com",
-        phone: "",
-        address: "",
-        special_instructions: "",
-        quantity: 1,
-      };
-      const result = await createCheckoutSessionWithIntent(
-        event,
-        intent,
-        "http://localhost",
-      );
-      expect(result).toBeNull();
+        // Spy on the checkout.sessions.retrieve method and make it throw
+        await withMocks(
+          () =>
+            stub(client.checkout.sessions, "retrieve", () =>
+              Promise.reject(new Error("Network error")),
+            ),
+          async (retrieveSpy) => {
+            const result = await retrieveCheckoutSession("cs_test_123");
+            expect(result).toBeNull();
+            expect(retrieveSpy.calls[0]!.args).toEqual(["cs_test_123"]);
+          },
+        );
+      });
     });
 
-    test("includes booking fee line item when fee is set", async () => {
-      const { updateBookingFee } = await import("#lib/db/settings.ts");
-      await updateBookingFee("5");
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
+    describe("mock configuration", () => {
+      test("creates client with mock config when STRIPE_MOCK_HOST is set", async () => {
+        // This test exercises the getMockConfig code path
+        await updateStripeKey("sk_test_123");
+        Deno.env.set("STRIPE_MOCK_HOST", "localhost");
+        Deno.env.set("STRIPE_MOCK_PORT", "12111");
 
-      const createSpy = stub(client.checkout.sessions, "create", () =>
-        Promise.resolve({
-          id: "cs_fee",
-          url: "https://checkout.stripe.com/fee",
-          object: "checkout.session",
-        } as never),
-      );
+        // This will create a client with mock config, but won't make any API calls
+        const client = await getStripeClient();
+        expect(client).not.toBeNull();
+      });
 
-      try {
-        const event = testEvent({ unit_price: 1000 });
+      test("uses default port 12111 when STRIPE_MOCK_PORT not set", async () => {
+        await updateStripeKey("sk_test_123");
+        Deno.env.set("STRIPE_MOCK_HOST", "localhost");
+        Deno.env.delete("STRIPE_MOCK_PORT");
+
+        const client = await getStripeClient();
+        expect(client).not.toBeNull();
+      });
+    });
+
+    describe("stripe-mock integration", () => {
+      // These tests require stripe-mock running on localhost:12111
+      // STRIPE_MOCK_HOST/PORT are set in test/setup.ts
+
+      test("retrieves checkout session with stripe-mock", async () => {
+        await updateStripeKey("sk_test_mock");
+
+        // First create a session using intent-based flow
+        const event = {
+          id: 1,
+          group_id: 0,
+          slug: "test-event",
+          slug_index: "test-event-index",
+          name: "Test Event",
+          description: "Test Description",
+          date: "",
+          location: "",
+          created: new Date().toISOString(),
+          max_attendees: 50,
+          thank_you_url: "https://example.com/thanks",
+          unit_price: 1000,
+          max_quantity: 1,
+          webhook_url: "",
+          active: true,
+          fields: "email" as const,
+          closes_at: null,
+          event_type: "standard" as const,
+          bookable_days: [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday",
+          ],
+          minimum_days_before: 1,
+          maximum_days_after: 90,
+          image_url: "",
+          attachment_url: "",
+          attachment_name: "",
+          non_transferable: false,
+          can_pay_more: false,
+          max_price: 0,
+          hidden: false,
+        };
         const intent = {
           eventId: 1,
-          name: "Jane",
-          email: "jane@example.com",
+          name: "John Doe",
+          email: "john@example.com",
           phone: "",
           address: "",
           special_instructions: "",
           quantity: 1,
         };
 
-        await createCheckoutSessionWithIntent(
+        const createdSession = await createCheckoutSessionWithIntent(
+          event,
+          intent,
+          "http://localhost:3000",
+        );
+        expect(createdSession).not.toBeNull();
+
+        // Then retrieve it
+        const retrievedSession = await retrieveCheckoutSession(
+          createdSession?.id || "",
+        );
+        expect(retrievedSession).not.toBeNull();
+        expect(retrievedSession?.id).toBe(createdSession?.id);
+      });
+
+      test("creates checkout session with intent metadata", async () => {
+        await updateStripeKey("sk_test_mock");
+
+        const event = {
+          id: 1,
+          group_id: 0,
+          slug: "test-event",
+          slug_index: "test-event-index",
+          name: "Test Event",
+          description: "Test Description",
+          date: "",
+          location: "",
+          created: new Date().toISOString(),
+          max_attendees: 50,
+          thank_you_url: "https://example.com/thanks",
+          unit_price: 1000,
+          max_quantity: 5,
+          webhook_url: "",
+          active: true,
+          fields: "email" as const,
+          closes_at: null,
+          event_type: "standard" as const,
+          bookable_days: [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday",
+          ],
+          minimum_days_before: 1,
+          maximum_days_after: 90,
+          image_url: "",
+          attachment_url: "",
+          attachment_name: "",
+          non_transferable: false,
+          can_pay_more: false,
+          max_price: 0,
+          hidden: false,
+        };
+
+        const intent = {
+          eventId: 1,
+          name: "John Doe",
+          email: "john@example.com",
+          phone: "",
+          address: "",
+          special_instructions: "",
+          quantity: 2,
+        };
+
+        const session = await createCheckoutSessionWithIntent(
           event,
           intent,
           "http://localhost:3000",
         );
 
-        const params = createSpy.calls[0]!.args[0] as unknown as {
-          line_items: {
-            price_data: { product_data: { name: string }; unit_amount: number };
-            quantity: number;
-          }[];
+        // stripe-mock creates session successfully but may not return our custom metadata
+        expect(session).not.toBeNull();
+        expect(session?.id).toBeDefined();
+        expect(session?.url).toBeDefined();
+      });
+
+      test("refunds payment with stripe-mock", async () => {
+        await updateStripeKey("sk_test_mock");
+
+        // stripe-mock accepts any payment_intent ID
+        const refund = await refundPayment("pi_test_123");
+
+        expect(refund).not.toBeNull();
+        expect(refund?.id).toBeDefined();
+      });
+    });
+
+    describe("createCheckoutSessionWithIntent", () => {
+      test("returns null when stripe key not set", async () => {
+        const event = {
+          id: 1,
+          group_id: 0,
+          slug: "test-event",
+          slug_index: "test-event-index",
+          name: "Test",
+          description: "Desc",
+          date: "",
+          location: "",
+          created: new Date().toISOString(),
+          max_attendees: 50,
+          thank_you_url: "https://example.com",
+          unit_price: 1000,
+          max_quantity: 1,
+          webhook_url: "",
+          active: true,
+          fields: "email" as const,
+          closes_at: null,
+          event_type: "standard" as const,
+          bookable_days: [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday",
+          ],
+          minimum_days_before: 1,
+          maximum_days_after: 90,
+          image_url: "",
+          attachment_url: "",
+          attachment_name: "",
+          non_transferable: false,
+          can_pay_more: false,
+          max_price: 0,
+          hidden: false,
         };
-        const lineItems = params.line_items;
-        const feeItem = lineItems.find(
-          (li) => li.price_data.product_data.name === "Booking fee",
+        const intent = {
+          eventId: 1,
+          name: "John",
+          email: "john@example.com",
+          phone: "",
+          address: "",
+          special_instructions: "",
+          quantity: 1,
+        };
+        const result = await createCheckoutSessionWithIntent(
+          event,
+          intent,
+          "http://localhost",
         );
-        expect(feeItem).toBeDefined();
-        // 5% of 1000 = 50
-        expect(feeItem!.price_data.unit_amount).toBe(50);
-        expect(feeItem!.quantity).toBe(1);
-      } finally {
-        createSpy.restore();
-      }
-    });
-  });
-
-  describe("refundPayment", () => {
-    test("returns null when stripe key not set", async () => {
-      const result = await refundPayment("pi_test_123");
-      expect(result).toBeNull();
-    });
-
-    test("returns null when Stripe API throws error", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () =>
-          stub(client.refunds, "create", () =>
-            Promise.reject(new Error("Network error")),
-          ),
-        async (refundSpy) => {
-          const result = await refundPayment("pi_test_123");
-          expect(result).toBeNull();
-          expect(refundSpy.calls.length).toBeGreaterThan(0);
-        },
-      );
-    });
-  });
-
-  describe("verifyWebhookSignature", () => {
-    const TEST_SECRET = "whsec_test_secret_key_for_webhook_verification";
-
-    beforeEach(async () => {
-      // Set webhook secret in database (encrypted)
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_test_endpoint",
+        expect(result).toBeNull();
       });
-    });
 
-    test("returns error when webhook secret not configured", async () => {
-      // Reset DB to have no webhook secret configured
-      await resetDb();
-      await createTestDb();
-      const result = await verifyWebhookSignature(
-        '{"test": true}',
-        "t=1234,v1=abc",
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Webhook secret not configured");
-      }
-    });
+      test("includes booking fee line item when fee is set", async () => {
+        const { updateBookingFee } = await import("#lib/db/settings.ts");
+        await updateBookingFee("5");
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
 
-    test("returns error for invalid signature header format", async () => {
-      const result = await verifyWebhookSignature(
-        '{"test": true}',
-        "invalid-header",
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Invalid signature header format");
-      }
-    });
+        const createSpy = stub(client.checkout.sessions, "create", () =>
+          Promise.resolve({
+            id: "cs_fee",
+            url: "https://checkout.stripe.com/fee",
+            object: "checkout.session",
+          } as never),
+        );
 
-    test("returns error for missing timestamp in header", async () => {
-      const result = await verifyWebhookSignature(
-        '{"test": true}',
-        "v1=abc123",
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Invalid signature header format");
-      }
-    });
-
-    test("returns error for missing signature in header", async () => {
-      const result = await verifyWebhookSignature('{"test": true}', "t=1234");
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Invalid signature header format");
-      }
-    });
-
-    test("returns error for timestamp outside tolerance window", async () => {
-      // Create a signature with old timestamp (more than 5 minutes ago)
-      const oldTimestamp = Math.floor(Date.now() / 1000) - 400; // 400 seconds ago
-      const payload = '{"test": true}';
-      const signedPayload = `${oldTimestamp}.${payload}`;
-
-      // Compute valid signature with old timestamp
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(TEST_SECRET),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"],
-      );
-      const signature = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(signedPayload),
-      );
-      const sigHex = Array.from(new Uint8Array(signature))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-      const result = await verifyWebhookSignature(
-        payload,
-        `t=${oldTimestamp},v1=${sigHex}`,
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Timestamp outside tolerance window");
-      }
-    });
-
-    test("returns error for invalid signature", async () => {
-      const timestamp = Math.floor(Date.now() / 1000);
-      const result = await verifyWebhookSignature(
-        '{"test": true}',
-        `t=${timestamp},v1=invalid_signature_that_wont_match`,
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Signature verification failed");
-      }
-    });
-
-    test("returns error for invalid JSON payload", async () => {
-      const payload = "not valid json {{{";
-      const timestamp = Math.floor(Date.now() / 1000);
-      const signedPayload = `${timestamp}.${payload}`;
-
-      // Compute valid signature
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(TEST_SECRET),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"],
-      );
-      const signature = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(signedPayload),
-      );
-      const sigHex = Array.from(new Uint8Array(signature))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-      const result = await verifyWebhookSignature(
-        payload,
-        `t=${timestamp},v1=${sigHex}`,
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Invalid JSON payload");
-      }
-    });
-
-    test("verifies valid signature successfully", async () => {
-      const event: StripeWebhookEvent = {
-        id: "evt_test_123",
-        type: "checkout.session.completed",
-        data: {
-          object: {
-            id: "cs_test_123",
-            payment_status: "paid",
-            metadata: {
-              event_id: "1",
-              name: "John Doe",
-              email: "john@example.com",
-              quantity: "1",
-            },
-          },
-        },
-      };
-
-      const { payload, signature } = await constructTestWebhookEvent(
-        event,
-        TEST_SECRET,
-      );
-
-      const result = await verifyWebhookSignature(payload, signature);
-      expect(result.valid).toBe(true);
-      if (result.valid) {
-        expect(result.event.id).toBe("evt_test_123");
-        expect(result.event.type).toBe("checkout.session.completed");
-      }
-    });
-
-    test("accepts custom tolerance window", async () => {
-      // Create signature with timestamp 100 seconds ago
-      const oldTimestamp = Math.floor(Date.now() / 1000) - 100;
-      const payload = '{"id": "evt_123", "type": "test"}';
-      const signedPayload = `${oldTimestamp}.${payload}`;
-
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(TEST_SECRET),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"],
-      );
-      const signature = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(signedPayload),
-      );
-      const sigHex = Array.from(new Uint8Array(signature))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-      // Should fail with default 300s tolerance but pass with 150s tolerance
-      const resultWithSmallTolerance = await verifyWebhookSignature(
-        payload,
-        `t=${oldTimestamp},v1=${sigHex}`,
-        50, // 50 second tolerance - should fail
-      );
-      expect(resultWithSmallTolerance.valid).toBe(false);
-
-      // Should pass with larger tolerance
-      const resultWithLargeTolerance = await verifyWebhookSignature(
-        payload,
-        `t=${oldTimestamp},v1=${sigHex}`,
-        200, // 200 second tolerance - should pass
-      );
-      expect(resultWithLargeTolerance.valid).toBe(true);
-    });
-  });
-
-  describe("testStripeConnection", () => {
-    test("returns error when no API key configured", async () => {
-      const result = await testStripeConnection();
-      expect(result.ok).toBe(false);
-      expect(result.apiKey.valid).toBe(false);
-      expect(result.apiKey.error).toContain("No Stripe secret key configured");
-    });
-
-    test("returns error when balance.retrieve fails", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () =>
-          stub(client.balance, "retrieve", () =>
-            Promise.reject(new Error("Invalid API Key provided")),
-          ),
-        async () => {
-          const result = await testStripeConnection();
-          expect(result.ok).toBe(false);
-          expect(result.apiKey.valid).toBe(false);
-          expect(result.apiKey.error).toContain("Invalid API Key provided");
-        },
-      );
-    });
-
-    test("returns test mode when API key is valid and webhook not configured", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () =>
-          stub(client.balance, "retrieve", () =>
-            Promise.resolve({
-              livemode: false,
-              available: [],
-              pending: [],
-              object: "balance",
-            } as never),
-          ),
-        async () => {
-          const result = await testStripeConnection();
-          expect(result.ok).toBe(false);
-          expect(result.apiKey.valid).toBe(true);
-          expect(result.apiKey.mode).toBe("test");
-          expect(result.webhook.configured).toBe(false);
-          expect(result.webhook.error).toContain(
-            "No webhook endpoint ID stored",
-          );
-        },
-      );
-    });
-
-    test("returns live mode for live key", async () => {
-      await updateStripeKey("sk_live_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () =>
-          stub(client.balance, "retrieve", () =>
-            Promise.resolve({
-              livemode: true,
-              available: [],
-              pending: [],
-              object: "balance",
-            } as never),
-          ),
-        async () => {
-          const result = await testStripeConnection();
-          expect(result.apiKey.valid).toBe(true);
-          expect(result.apiKey.mode).toBe("live");
-        },
-      );
-    });
-
-    test("returns webhook error when endpoint retrieval fails", async () => {
-      await updateStripeKey("sk_test_mock");
-      await setStripeWebhookConfig({
-        secret: "whsec_test",
-        endpointId: "we_test_missing",
-      });
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () => ({
-          balanceSpy: stub(client.balance, "retrieve", () =>
-            Promise.resolve({
-              livemode: false,
-              available: [],
-              pending: [],
-              object: "balance",
-            } as never),
-          ),
-          webhookSpy: stub(client.webhookEndpoints, "retrieve", () =>
-            Promise.reject(
-              new Error("No such webhook endpoint: we_test_missing"),
-            ),
-          ),
-        }),
-        async () => {
-          const result = await testStripeConnection();
-          expect(result.ok).toBe(false);
-          expect(result.apiKey.valid).toBe(true);
-          expect(result.webhook.configured).toBe(false);
-          expect(result.webhook.error).toContain("No such webhook endpoint");
-        },
-      );
-    });
-
-    test("returns full success when API key and webhook are both valid", async () => {
-      await updateStripeKey("sk_test_mock");
-      await setStripeWebhookConfig({
-        secret: "whsec_test",
-        endpointId: "we_test_valid",
-      });
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () => ({
-          balanceSpy: stub(client.balance, "retrieve", () =>
-            Promise.resolve({
-              livemode: false,
-              available: [],
-              pending: [],
-              object: "balance",
-            } as never),
-          ),
-          webhookSpy: stub(client.webhookEndpoints, "retrieve", () =>
-            Promise.resolve({
-              id: "we_test_valid",
-              url: "https://example.com/payment/webhook",
-              status: "enabled",
-              enabled_events: ["checkout.session.completed"],
-              object: "webhook_endpoint",
-            } as never),
-          ),
-        }),
-        async () => {
-          const result = await testStripeConnection();
-          expect(result.ok).toBe(true);
-          expect(result.apiKey.valid).toBe(true);
-          expect(result.apiKey.mode).toBe("test");
-          expect(result.webhook.configured).toBe(true);
-          expect(result.webhook.endpointId).toBe("we_test_valid");
-          expect(result.webhook.url).toBe(
-            "https://example.com/payment/webhook",
-          );
-          expect(result.webhook.status).toBe("enabled");
-          expect(result.webhook.enabledEvents).toContain(
-            "checkout.session.completed",
-          );
-        },
-      );
-    });
-  });
-
-  describe("constructTestWebhookEvent", () => {
-    test("creates valid payload and signature pair", async () => {
-      const secret = "whsec_test_construction";
-      const event: StripeWebhookEvent = {
-        id: "evt_constructed",
-        type: "payment_intent.succeeded",
-        data: {
-          object: {
-            amount: 1000,
-            currency: "gbp",
-          },
-        },
-      };
-
-      const { payload, signature } = await constructTestWebhookEvent(
-        event,
-        secret,
-      );
-
-      // Verify payload is valid JSON matching input
-      const parsed = JSON.parse(payload);
-      expect(parsed.id).toBe("evt_constructed");
-      expect(parsed.type).toBe("payment_intent.succeeded");
-
-      // Verify signature format
-      expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]+$/);
-
-      // Signature should be verifiable with the same secret (stored in DB)
-      await setStripeWebhookConfig({
-        secret,
-        endpointId: "we_test_construction",
-      });
-      const result = await verifyWebhookSignature(payload, signature);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe("sanitizeErrorDetail", () => {
-    test("returns 'unknown' for non-Error values", () => {
-      expect(sanitizeErrorDetail("string error")).toBe("unknown");
-      expect(sanitizeErrorDetail(null)).toBe("unknown");
-      expect(sanitizeErrorDetail(42)).toBe("unknown");
-      expect(sanitizeErrorDetail(undefined)).toBe("unknown");
-    });
-
-    test("returns error name for plain Error without Stripe fields", () => {
-      expect(sanitizeErrorDetail(new Error("sensitive message"))).toBe("Error");
-    });
-
-    test("returns error name for typed errors without Stripe fields", () => {
-      expect(sanitizeErrorDetail(new TypeError("bad type"))).toBe("TypeError");
-    });
-
-    test("extracts Stripe statusCode, code, and type", () => {
-      const err = new Error("Invalid API Key provided: sk_test_****1234");
-      Object.assign(err, {
-        statusCode: 401,
-        code: "api_key_invalid",
-        type: "StripeAuthenticationError",
-      });
-      expect(sanitizeErrorDetail(err)).toBe(
-        "status=401 code=api_key_invalid type=StripeAuthenticationError",
-      );
-    });
-
-    test("extracts partial Stripe fields", () => {
-      const err = new Error("Resource not found");
-      Object.assign(err, { statusCode: 404 });
-      expect(sanitizeErrorDetail(err)).toBe("status=404");
-    });
-
-    test("extracts code and type without statusCode", () => {
-      const err = new Error("Connection failed");
-      Object.assign(err, {
-        code: "ECONNREFUSED",
-        type: "StripeConnectionError",
-      });
-      expect(sanitizeErrorDetail(err)).toBe(
-        "code=ECONNREFUSED type=StripeConnectionError",
-      );
-    });
-
-    test("never includes the raw error message in output", () => {
-      const sensitiveMessage = "Invalid API Key provided: sk_live_realkey123";
-      const err = new Error(sensitiveMessage);
-      Object.assign(err, {
-        statusCode: 401,
-        type: "StripeAuthenticationError",
-      });
-      const detail = sanitizeErrorDetail(err);
-      expect(detail).not.toContain(sensitiveMessage);
-      expect(detail).not.toContain("sk_live");
-    });
-
-    test("falls back to err.name when no Stripe fields present", () => {
-      // Error with no statusCode/code/type but has a name
-      const err = new Error("something");
-      // Plain Error: err.name is "Error", parts is empty, so returns err.name || "Error"
-      expect(sanitizeErrorDetail(err)).toBe("Error");
-    });
-  });
-
-  describe("detectStripeKeyMode", () => {
-    test("returns 'test' for sk_test_ keys", () => {
-      expect(detectStripeKeyMode("sk_test_abc123")).toBe("test");
-    });
-
-    test("returns 'live' for sk_live_ keys", () => {
-      expect(detectStripeKeyMode("sk_live_abc123")).toBe("live");
-    });
-
-    test("returns null for invalid prefixes", () => {
-      expect(detectStripeKeyMode("sk_invalid_abc")).toBeNull();
-      expect(detectStripeKeyMode("rk_test_abc")).toBeNull();
-      expect(detectStripeKeyMode("")).toBeNull();
-      expect(detectStripeKeyMode("random_string")).toBeNull();
-    });
-  });
-
-  describe("createCheckoutSessionWithIntent - phone metadata", () => {
-    test("includes phone in metadata when provided", async () => {
-      await updateStripeKey("sk_test_mock");
-
-      const event = testEvent({ unit_price: 1000 });
-      const intent = {
-        eventId: 1,
-        name: "John Doe",
-        email: "john@example.com",
-        phone: "+44 7700 900000",
-        address: "",
-        special_instructions: "",
-        quantity: 1,
-      };
-
-      const session = await createCheckoutSessionWithIntent(
-        event,
-        intent,
-        "http://localhost:3000",
-      );
-
-      // stripe-mock creates session successfully
-      expect(session).not.toBeNull();
-      expect(session?.id).toBeDefined();
-    });
-  });
-
-  describe("createCheckoutSessionWithIntent - no email", () => {
-    test("creates checkout session without customer_email when email is empty", async () => {
-      await updateStripeKey("sk_test_mock");
-
-      const event = testEvent({ unit_price: 1000 });
-      const intent = {
-        eventId: 1,
-        name: "No Email User",
-        email: "",
-        phone: "+44 7700 900000",
-        address: "",
-        special_instructions: "",
-        quantity: 1,
-      };
-
-      const session = await createCheckoutSessionWithIntent(
-        event,
-        intent,
-        "http://localhost:3000",
-      );
-
-      // stripe-mock creates session successfully (email is empty, so customer_email is omitted)
-      expect(session).not.toBeNull();
-      expect(session?.id).toBeDefined();
-    });
-  });
-
-  describe("createMultiCheckoutSession", () => {
-    test("creates multi-checkout session with phone metadata", async () => {
-      await updateStripeKey("sk_test_mock");
-
-      const intent = {
-        name: "Jane Doe",
-        email: "jane@example.com",
-        phone: "+44 7700 900001",
-        address: "",
-        special_instructions: "",
-        items: [
-          {
+        try {
+          const event = testEvent({ unit_price: 1000 });
+          const intent = {
             eventId: 1,
-            quantity: 2,
-            unitPrice: 1000,
-            slug: "event-a",
-            name: "Event A",
-          },
-          {
-            eventId: 2,
+            name: "Jane",
+            email: "jane@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
             quantity: 1,
-            unitPrice: 2000,
-            slug: "event-b",
-            name: "Event B",
-          },
-        ],
-      };
+          };
 
-      const session = await createMultiCheckoutSession(
-        intent,
-        "http://localhost:3000",
-      );
+          await createCheckoutSessionWithIntent(
+            event,
+            intent,
+            "http://localhost:3000",
+          );
 
-      expect(session).not.toBeNull();
-      expect(session?.id).toBeDefined();
+          const params = createSpy.calls[0]!.args[0] as unknown as {
+            line_items: {
+              price_data: {
+                product_data: { name: string };
+                unit_amount: number;
+              };
+              quantity: number;
+            }[];
+          };
+          const lineItems = params.line_items;
+          const feeItem = lineItems.find(
+            (li) => li.price_data.product_data.name === "Booking fee",
+          );
+          expect(feeItem).toBeDefined();
+          // 5% of 1000 = 50
+          expect(feeItem!.price_data.unit_amount).toBe(50);
+          expect(feeItem!.quantity).toBe(1);
+        } finally {
+          createSpy.restore();
+        }
+      });
     });
 
-    test("returns null when stripe key not set", async () => {
-      const intent = {
-        name: "Jane Doe",
-        email: "jane@example.com",
-        phone: "",
-        address: "",
-        special_instructions: "",
-        items: [
-          {
-            eventId: 1,
-            quantity: 1,
-            unitPrice: 1000,
-            slug: "event-a",
-            name: "Event A",
-          },
-        ],
-      };
-
-      const result = await createMultiCheckoutSession(
-        intent,
-        "http://localhost:3000",
-      );
-      expect(result).toBeNull();
-    });
-
-    test("creates multi-checkout session without customer_email when email is empty", async () => {
-      await updateStripeKey("sk_test_mock");
-
-      const intent = {
-        name: "No Email Multi",
-        email: "",
-        phone: "+44 7700 900002",
-        address: "",
-        special_instructions: "",
-        items: [
-          {
-            eventId: 1,
-            quantity: 1,
-            unitPrice: 1000,
-            slug: "event-a",
-            name: "Event A",
-          },
-          {
-            eventId: 2,
-            quantity: 2,
-            unitPrice: 2000,
-            slug: "event-b",
-            name: "Event B",
-          },
-        ],
-      };
-
-      const session = await createMultiCheckoutSession(
-        intent,
-        "http://localhost:3000",
-      );
-
-      // stripe-mock creates session successfully (email is empty, so customer_email is omitted)
-      expect(session).not.toBeNull();
-      expect(session?.id).toBeDefined();
-    });
-  });
-
-  describe("refundPayment - non-Error exception", () => {
-    test("handles non-Error thrown value in refund", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      // Throw a non-Error value (string) to exercise the sanitizeErrorDetail "unknown" path
-      const refundSpy = stub(client.refunds, "create", () =>
-        Promise.reject("network failure string"),
-      );
-
-      try {
+    describe("refundPayment", () => {
+      test("returns null when stripe key not set", async () => {
         const result = await refundPayment("pi_test_123");
         expect(result).toBeNull();
-      } finally {
-        refundSpy.restore();
-      }
+      });
+
+      test("returns null when Stripe API throws error", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
+
+        await withMocks(
+          () =>
+            stub(client.refunds, "create", () =>
+              Promise.reject(new Error("Network error")),
+            ),
+          async (refundSpy) => {
+            const result = await refundPayment("pi_test_123");
+            expect(result).toBeNull();
+            expect(refundSpy.calls.length).toBeGreaterThan(0);
+          },
+        );
+      });
     });
-  });
 
-  describe("testStripeConnection - non-Error exception", () => {
-    test("handles non-Error thrown value in balance check", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
+    describe("verifyWebhookSignature", () => {
+      const TEST_SECRET = "whsec_test_secret_key_for_webhook_verification";
 
-      const balanceSpy = stub(client.balance, "retrieve", () =>
-        Promise.reject("string error"),
-      );
+      beforeEach(async () => {
+        // Set webhook secret in database (encrypted)
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_test_endpoint",
+        });
+      });
 
-      try {
+      test("returns error when webhook secret not configured", async () => {
+        // Reset DB to have no webhook secret configured
+        await resetDb();
+        await createTestDb();
+        const result = await verifyWebhookSignature(
+          '{"test": true}',
+          "t=1234,v1=abc",
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Webhook secret not configured");
+        }
+      });
+
+      test("returns error for invalid signature header format", async () => {
+        const result = await verifyWebhookSignature(
+          '{"test": true}',
+          "invalid-header",
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Invalid signature header format");
+        }
+      });
+
+      test("returns error for missing timestamp in header", async () => {
+        const result = await verifyWebhookSignature(
+          '{"test": true}',
+          "v1=abc123",
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Invalid signature header format");
+        }
+      });
+
+      test("returns error for missing signature in header", async () => {
+        const result = await verifyWebhookSignature('{"test": true}', "t=1234");
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Invalid signature header format");
+        }
+      });
+
+      test("returns error for timestamp outside tolerance window", async () => {
+        // Create a signature with old timestamp (more than 5 minutes ago)
+        const oldTimestamp = Math.floor(Date.now() / 1000) - 400; // 400 seconds ago
+        const payload = '{"test": true}';
+        const signedPayload = `${oldTimestamp}.${payload}`;
+
+        // Compute valid signature with old timestamp
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(TEST_SECRET),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"],
+        );
+        const signature = await crypto.subtle.sign(
+          "HMAC",
+          key,
+          encoder.encode(signedPayload),
+        );
+        const sigHex = Array.from(new Uint8Array(signature))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+
+        const result = await verifyWebhookSignature(
+          payload,
+          `t=${oldTimestamp},v1=${sigHex}`,
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Timestamp outside tolerance window");
+        }
+      });
+
+      test("returns error for invalid signature", async () => {
+        const timestamp = Math.floor(Date.now() / 1000);
+        const result = await verifyWebhookSignature(
+          '{"test": true}',
+          `t=${timestamp},v1=invalid_signature_that_wont_match`,
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Signature verification failed");
+        }
+      });
+
+      test("returns error for invalid JSON payload", async () => {
+        const payload = "not valid json {{{";
+        const timestamp = Math.floor(Date.now() / 1000);
+        const signedPayload = `${timestamp}.${payload}`;
+
+        // Compute valid signature
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(TEST_SECRET),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"],
+        );
+        const signature = await crypto.subtle.sign(
+          "HMAC",
+          key,
+          encoder.encode(signedPayload),
+        );
+        const sigHex = Array.from(new Uint8Array(signature))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+
+        const result = await verifyWebhookSignature(
+          payload,
+          `t=${timestamp},v1=${sigHex}`,
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Invalid JSON payload");
+        }
+      });
+
+      test("verifies valid signature successfully", async () => {
+        const event: StripeWebhookEvent = {
+          id: "evt_test_123",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_test_123",
+              payment_status: "paid",
+              metadata: {
+                event_id: "1",
+                name: "John Doe",
+                email: "john@example.com",
+                quantity: "1",
+              },
+            },
+          },
+        };
+
+        const { payload, signature } = await constructTestWebhookEvent(
+          event,
+          TEST_SECRET,
+        );
+
+        const result = await verifyWebhookSignature(payload, signature);
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.event.id).toBe("evt_test_123");
+          expect(result.event.type).toBe("checkout.session.completed");
+        }
+      });
+
+      test("accepts custom tolerance window", async () => {
+        // Create signature with timestamp 100 seconds ago
+        const oldTimestamp = Math.floor(Date.now() / 1000) - 100;
+        const payload = '{"id": "evt_123", "type": "test"}';
+        const signedPayload = `${oldTimestamp}.${payload}`;
+
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(TEST_SECRET),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"],
+        );
+        const signature = await crypto.subtle.sign(
+          "HMAC",
+          key,
+          encoder.encode(signedPayload),
+        );
+        const sigHex = Array.from(new Uint8Array(signature))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+
+        // Should fail with default 300s tolerance but pass with 150s tolerance
+        const resultWithSmallTolerance = await verifyWebhookSignature(
+          payload,
+          `t=${oldTimestamp},v1=${sigHex}`,
+          50, // 50 second tolerance - should fail
+        );
+        expect(resultWithSmallTolerance.valid).toBe(false);
+
+        // Should pass with larger tolerance
+        const resultWithLargeTolerance = await verifyWebhookSignature(
+          payload,
+          `t=${oldTimestamp},v1=${sigHex}`,
+          200, // 200 second tolerance - should pass
+        );
+        expect(resultWithLargeTolerance.valid).toBe(true);
+      });
+    });
+
+    describe("testStripeConnection", () => {
+      test("returns error when no API key configured", async () => {
         const result = await testStripeConnection();
         expect(result.ok).toBe(false);
         expect(result.apiKey.valid).toBe(false);
-        expect(result.apiKey.error).toBe("Unknown error");
-      } finally {
-        balanceSpy.restore();
-      }
-    });
-
-    test("handles non-Error thrown value in webhook retrieval", async () => {
-      await updateStripeKey("sk_test_mock");
-      await setStripeWebhookConfig({
-        secret: "whsec_test",
-        endpointId: "we_test_nonerror",
+        expect(result.apiKey.error).toContain(
+          "No Stripe secret key configured",
+        );
       });
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
 
-      const balanceSpy = stub(client.balance, "retrieve", () =>
-        Promise.resolve({
-          livemode: false,
-          available: [],
-          pending: [],
-          object: "balance",
-        } as never),
-      );
+      test("returns error when balance.retrieve fails", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
 
-      const webhookSpy = stub(client.webhookEndpoints, "retrieve", () =>
-        Promise.reject("webhook string error"),
-      );
+        await withMocks(
+          () =>
+            stub(client.balance, "retrieve", () =>
+              Promise.reject(new Error("Invalid API Key provided")),
+            ),
+          async () => {
+            const result = await testStripeConnection();
+            expect(result.ok).toBe(false);
+            expect(result.apiKey.valid).toBe(false);
+            expect(result.apiKey.error).toContain("Invalid API Key provided");
+          },
+        );
+      });
 
-      try {
-        const result = await testStripeConnection();
-        expect(result.ok).toBe(false);
-        expect(result.webhook.configured).toBe(false);
-        expect(result.webhook.error).toBe("Unknown error");
-      } finally {
-        balanceSpy.restore();
-        webhookSpy.restore();
-      }
-    });
-  });
+      test("returns test mode when API key is valid and webhook not configured", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
 
-  describe("setupWebhookEndpointImpl", () => {
-    // setupWebhookEndpointImpl creates its own client via createStripeClient(secretKey),
-    // so we mock at the stripeApi level to test the various code paths
+        await withMocks(
+          () =>
+            stub(client.balance, "retrieve", () =>
+              Promise.resolve({
+                livemode: false,
+                available: [],
+                pending: [],
+                object: "balance",
+              } as never),
+            ),
+          async () => {
+            const result = await testStripeConnection();
+            expect(result.ok).toBe(false);
+            expect(result.apiKey.valid).toBe(true);
+            expect(result.apiKey.mode).toBe("test");
+            expect(result.webhook.configured).toBe(false);
+            expect(result.webhook.error).toContain(
+              "No webhook endpoint ID stored",
+            );
+          },
+        );
+      });
 
-    test("creates webhook endpoint via stripe-mock (no secret returned)", async () => {
-      // stripe-mock doesn't return endpoint.secret, so this exercises the "no secret" error path
-      const result = await setupWebhookEndpoint(
-        "sk_test_mock",
-        "https://example.com/payment/webhook",
-      );
+      test("returns live mode for live key", async () => {
+        await updateStripeKey("sk_live_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
 
-      // stripe-mock likely doesn't return secret, testing the error path
-      if (!result.success) {
-        expect(result.error).toBe("Stripe did not return webhook secret");
-      }
-    });
+        await withMocks(
+          () =>
+            stub(client.balance, "retrieve", () =>
+              Promise.resolve({
+                livemode: true,
+                available: [],
+                pending: [],
+                object: "balance",
+              } as never),
+            ),
+          async () => {
+            const result = await testStripeConnection();
+            expect(result.apiKey.valid).toBe(true);
+            expect(result.apiKey.mode).toBe("live");
+          },
+        );
+      });
 
-    test("exercises delete-then-create path with existing endpoint ID", async () => {
-      // This exercises the existingEndpointId deletion path
-      const result = await setupWebhookEndpoint(
-        "sk_test_mock",
-        "https://example.com/payment/webhook",
-        "we_existing_123",
-      );
-
-      // The API call goes through - deletion of non-existent endpoint is caught
-      expect(result).toBeDefined();
-      expect(typeof result.success).toBe("boolean");
-    });
-
-    test("succeeds when mocked via stripeApi", async () => {
-      // Override stripeApi to test the full success path
-      const origSetup = stripeApi.setupWebhookEndpoint;
-      stripeApi.setupWebhookEndpoint = (_key, _url, _existing) =>
-        Promise.resolve({
-          success: true,
-          endpointId: "we_mocked",
-          secret: "whsec_mocked",
+      test("returns webhook error when endpoint retrieval fails", async () => {
+        await updateStripeKey("sk_test_mock");
+        await setStripeWebhookConfig({
+          secret: "whsec_test",
+          endpointId: "we_test_missing",
         });
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
 
-      try {
-        const result = await setupWebhookEndpoint(
-          "sk_test",
-          "https://example.com/webhook",
+        await withMocks(
+          () => ({
+            balanceSpy: stub(client.balance, "retrieve", () =>
+              Promise.resolve({
+                livemode: false,
+                available: [],
+                pending: [],
+                object: "balance",
+              } as never),
+            ),
+            webhookSpy: stub(client.webhookEndpoints, "retrieve", () =>
+              Promise.reject(
+                new Error("No such webhook endpoint: we_test_missing"),
+              ),
+            ),
+          }),
+          async () => {
+            const result = await testStripeConnection();
+            expect(result.ok).toBe(false);
+            expect(result.apiKey.valid).toBe(true);
+            expect(result.webhook.configured).toBe(false);
+            expect(result.webhook.error).toContain("No such webhook endpoint");
+          },
         );
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(result.endpointId).toBe("we_mocked");
-          expect(result.secret).toBe("whsec_mocked");
-        }
-      } finally {
-        stripeApi.setupWebhookEndpoint = origSetup;
-      }
-    });
+      });
 
-    test("returns error when API throws", async () => {
-      const origSetup = stripeApi.setupWebhookEndpoint;
-      stripeApi.setupWebhookEndpoint = (_key, _url) =>
-        Promise.resolve({ success: false as const, error: "API rate limited" });
+      test("returns full success when API key and webhook are both valid", async () => {
+        await updateStripeKey("sk_test_mock");
+        await setStripeWebhookConfig({
+          secret: "whsec_test",
+          endpointId: "we_test_valid",
+        });
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
 
-      try {
-        const result = await setupWebhookEndpoint(
-          "sk_test",
-          "https://example.com/webhook",
+        await withMocks(
+          () => ({
+            balanceSpy: stub(client.balance, "retrieve", () =>
+              Promise.resolve({
+                livemode: false,
+                available: [],
+                pending: [],
+                object: "balance",
+              } as never),
+            ),
+            webhookSpy: stub(client.webhookEndpoints, "retrieve", () =>
+              Promise.resolve({
+                id: "we_test_valid",
+                url: "https://example.com/payment/webhook",
+                status: "enabled",
+                enabled_events: ["checkout.session.completed"],
+                object: "webhook_endpoint",
+              } as never),
+            ),
+          }),
+          async () => {
+            const result = await testStripeConnection();
+            expect(result.ok).toBe(true);
+            expect(result.apiKey.valid).toBe(true);
+            expect(result.apiKey.mode).toBe("test");
+            expect(result.webhook.configured).toBe(true);
+            expect(result.webhook.endpointId).toBe("we_test_valid");
+            expect(result.webhook.url).toBe(
+              "https://example.com/payment/webhook",
+            );
+            expect(result.webhook.status).toBe("enabled");
+            expect(result.webhook.enabledEvents).toContain(
+              "checkout.session.completed",
+            );
+          },
         );
-        expect(result.success).toBe(false);
-        if (!result.success) {
-          expect(result.error).toBe("API rate limited");
-        }
-      } finally {
-        stripeApi.setupWebhookEndpoint = origSetup;
-      }
-    });
-  });
-
-  describe("getMockConfig", () => {
-    test("returns undefined when STRIPE_MOCK_HOST not set", async () => {
-      Deno.env.delete("STRIPE_MOCK_HOST");
-      Deno.env.delete("STRIPE_MOCK_PORT");
-      resetStripeClient();
-
-      // The getMockConfig is a once() function, so we can't easily re-test it.
-      // But getStripeClient exercises the createStripeClient path
-      await updateStripeKey("sk_test_123");
-      // Without mock config, a real Stripe client would be created
-      // We just verify no crash occurs
-      const client = await getStripeClient();
-      expect(client).not.toBeNull();
-    });
-  });
-
-  describe("setupWebhookEndpoint - stripe-mock paths", () => {
-    test("deletes existing endpoint for same URL before recreating", async () => {
-      // stripe-mock has a default endpoint at https://example.com/my/webhook/endpoint
-      // Calling setupWebhookEndpoint with that URL should find it via list and delete it
-      const result = await setupWebhookEndpoint(
-        "sk_test_mock",
-        "https://example.com/my/webhook/endpoint",
-      );
-
-      // stripe-mock doesn't return secret, so this hits the "no secret" error path
-      // but the important thing is it exercises the "delete existing for URL" code path (lines 368-371)
-      expect(result).toBeDefined();
-      expect(typeof result.success).toBe("boolean");
+      });
     });
 
-    test("returns success when endpoint.secret is present", async () => {
-      // Wrap fetch to intercept the webhook_endpoints create response and inject a secret
-      await withFetchMock(async (originalFetch) => {
-        globalThis.fetch = async (
-          input: RequestInfo | URL,
-          init?: RequestInit,
-        ): Promise<Response> => {
-          const response = await originalFetch(input, init);
-          const url = urlFromFetchInput(input as string | URL | Request);
-
-          // Intercept POST to webhook_endpoints (create) and add secret to response
-          if (
-            url.includes("/v1/webhook_endpoints") &&
-            init?.method === "POST"
-          ) {
-            const body = await response.json();
-            body.secret = "whsec_test_injected_secret";
-            return new Response(JSON.stringify(body), {
-              status: response.status,
-              headers: response.headers,
-            });
-          }
-          return response;
+    describe("constructTestWebhookEvent", () => {
+      test("creates valid payload and signature pair", async () => {
+        const secret = "whsec_test_construction";
+        const event: StripeWebhookEvent = {
+          id: "evt_constructed",
+          type: "payment_intent.succeeded",
+          data: {
+            object: {
+              amount: 1000,
+              currency: "gbp",
+            },
+          },
         };
 
-        const result = await setupWebhookEndpoint(
-          "sk_test_mock",
-          "https://example.com/webhook/success-test",
+        const { payload, signature } = await constructTestWebhookEvent(
+          event,
+          secret,
         );
 
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(result.endpointId).toBeDefined();
-          expect(result.secret).toBe("whsec_test_injected_secret");
-        }
-      });
-    });
+        // Verify payload is valid JSON matching input
+        const parsed = JSON.parse(payload);
+        expect(parsed.id).toBe("evt_constructed");
+        expect(parsed.type).toBe("payment_intent.succeeded");
 
-    test("returns error when createStripeClient or API call throws", async () => {
-      // Mock fetch to throw on all requests, exercising the outer catch block
-      await withFetchMock(async () => {
-        globalThis.fetch = () => {
-          throw new Error("Network unavailable");
-        };
+        // Verify signature format
+        expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]+$/);
 
-        const result = await setupWebhookEndpoint(
-          "sk_test_mock",
-          "https://example.com/webhook/error-test",
-        );
-
-        expect(result.success).toBe(false);
-        if (!result.success) {
-          // Stripe SDK wraps connection errors with retry info
-          expect(typeof result.error).toBe("string");
-          expect(result.error!.length > 0).toBe(true);
-        }
-      });
-    });
-
-    test("catches error when deleting existing endpoint ID fails", async () => {
-      // Mock fetch so that ALL DELETE requests throw (Stripe SDK retries, so we must fail all)
-      await withFetchMock(async (originalFetch) => {
-        installUrlHandler(originalFetch, (url, init) => {
-          if (
-            (init?.method ?? "GET") === "DELETE" &&
-            url.includes("we_should_fail_to_delete")
-          ) {
-            throw new Error("Delete failed");
-          }
-          return null;
+        // Signature should be verifiable with the same secret (stored in DB)
+        await setStripeWebhookConfig({
+          secret,
+          endpointId: "we_test_construction",
         });
-
-        const result = await setupWebhookEndpoint(
-          "sk_test_mock",
-          "https://example.com/webhook/delete-error-test-unique",
-          "we_should_fail_to_delete",
-        );
-
-        // The function should continue past the failed delete and still attempt to create
-        expect(result).toBeDefined();
-        expect(typeof result.success).toBe("boolean");
+        const result = await verifyWebhookSignature(payload, signature);
+        expect(result.valid).toBe(true);
       });
     });
 
-    test("returns error when list endpoints throws", async () => {
-      // Mock fetch so that the list call (GET) throws, exercising the outer catch
-      await withFetchMock(async (originalFetch) => {
-        installUrlHandler(originalFetch, (url, init) => {
-          if (
-            (init?.method ?? "GET") === "GET" &&
-            url.includes("/v1/webhook_endpoints")
-          ) {
-            throw new Error("List endpoints failed");
-          }
-          return null;
+    describe("sanitizeErrorDetail", () => {
+      test("returns 'unknown' for non-Error values", () => {
+        expect(sanitizeErrorDetail("string error")).toBe("unknown");
+        expect(sanitizeErrorDetail(null)).toBe("unknown");
+        expect(sanitizeErrorDetail(42)).toBe("unknown");
+        expect(sanitizeErrorDetail(undefined)).toBe("unknown");
+      });
+
+      test("returns error name for plain Error without Stripe fields", () => {
+        expect(sanitizeErrorDetail(new Error("sensitive message"))).toBe(
+          "Error",
+        );
+      });
+
+      test("returns error name for typed errors without Stripe fields", () => {
+        expect(sanitizeErrorDetail(new TypeError("bad type"))).toBe(
+          "TypeError",
+        );
+      });
+
+      test("extracts Stripe statusCode, code, and type", () => {
+        const err = new Error("Invalid API Key provided: sk_test_****1234");
+        Object.assign(err, {
+          statusCode: 401,
+          code: "api_key_invalid",
+          type: "StripeAuthenticationError",
         });
-
-        const result = await setupWebhookEndpoint(
-          "sk_test_mock",
-          "https://example.com/webhook/list-error-test",
+        expect(sanitizeErrorDetail(err)).toBe(
+          "status=401 code=api_key_invalid type=StripeAuthenticationError",
         );
-
-        expect(result.success).toBe(false);
-        if (!result.success) {
-          // Stripe SDK wraps connection errors with retry info
-          expect(typeof result.error).toBe("string");
-          expect(result.error!.length > 0).toBe(true);
-        }
       });
-    });
 
-    test("returns stringified error when non-Error is thrown", async () => {
-      // Mock fetch to throw a string (not an Error) to hit the String(err) path
-      await withFetchMock(async () => {
-        globalThis.fetch = () => {
-          throw "string_error";
-        }; // non-Error value
+      test("extracts partial Stripe fields", () => {
+        const err = new Error("Resource not found");
+        Object.assign(err, { statusCode: 404 });
+        expect(sanitizeErrorDetail(err)).toBe("status=404");
+      });
 
-        const result = await setupWebhookEndpoint(
-          "sk_test_mock",
-          "https://example.com/webhook/non-error-throw",
+      test("extracts code and type without statusCode", () => {
+        const err = new Error("Connection failed");
+        Object.assign(err, {
+          code: "ECONNREFUSED",
+          type: "StripeConnectionError",
+        });
+        expect(sanitizeErrorDetail(err)).toBe(
+          "code=ECONNREFUSED type=StripeConnectionError",
         );
-
-        expect(result.success).toBe(false);
-        if (!result.success) {
-          // Stripe SDK wraps thrown values, so error message comes from SDK wrapper
-          expect(typeof result.error).toBe("string");
-          expect(result.error!.length > 0).toBe(true);
-        }
-      });
-    });
-  });
-
-  describe("verifyWebhookSignature - timestamp parsing", () => {
-    const TEST_SECRET = "whsec_test_secret_key_for_timestamp_test";
-
-    test("handles timestamp value that needs parseInt", async () => {
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_test_ts",
       });
 
-      // Create event with proper signature
-      const event: StripeWebhookEvent = {
-        id: "evt_ts_test",
-        type: "checkout.session.completed",
-        data: { object: { id: "cs_test" } },
-      };
-
-      const { payload, signature } = await constructTestWebhookEvent(
-        event,
-        TEST_SECRET,
-      );
-
-      const result = await verifyWebhookSignature(payload, signature);
-      expect(result.valid).toBe(true);
-    });
-
-    test("parses timestamp with parseInt when t key has value", async () => {
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_test_parse",
+      test("never includes the raw error message in output", () => {
+        const sensitiveMessage = "Invalid API Key provided: sk_live_realkey123";
+        const err = new Error(sensitiveMessage);
+        Object.assign(err, {
+          statusCode: 401,
+          type: "StripeAuthenticationError",
+        });
+        const detail = sanitizeErrorDetail(err);
+        expect(detail).not.toContain(sensitiveMessage);
+        expect(detail).not.toContain("sk_live");
       });
 
-      // Use a timestamp that is a valid number string, exercising Number.parseInt
-      const timestamp = Math.floor(Date.now() / 1000);
-      const payload = '{"id": "evt_parse", "type": "test"}';
-      const signedPayload = `${timestamp}.${payload}`;
-
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(TEST_SECRET),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"],
-      );
-      const signature = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(signedPayload),
-      );
-      const sigHex = Array.from(new Uint8Array(signature))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-      const result = await verifyWebhookSignature(
-        payload,
-        `t=${timestamp},v1=${sigHex}`,
-      );
-      expect(result.valid).toBe(true);
-    });
-
-    test("treats t key without equals as zero timestamp via parseInt fallback", async () => {
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_test_nullish",
-      });
-
-      // Header "t,v1=abc123" - split("=") on "t" gives ["t"], so value is undefined
-      // value ?? "0" gives "0", parseInt("0", 10) gives 0
-      // timestamp === 0, so parseSignatureHeader returns null => "Invalid signature header format"
-      const result = await verifyWebhookSignature(
-        '{"test": true}',
-        "t,v1=abc123",
-      );
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Invalid signature header format");
-      }
-    });
-
-    test("secureCompare handles strings of different lengths", async () => {
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_test_len",
-      });
-
-      // Provide a signature that has different length than expected
-      const timestamp = Math.floor(Date.now() / 1000);
-      const result = await verifyWebhookSignature(
-        '{"test": true}',
-        `t=${timestamp},v1=short`,
-      );
-      // Signature won't match but should not crash - secureCompare handles length diff
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBe("Signature verification failed");
-      }
-    });
-  });
-
-  describe("verifyWebhookSignature - enhanced error details", () => {
-    const TEST_SECRET = "whsec_test_secret_key_for_detail_tests";
-
-    beforeEach(async () => {
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_test_details",
+      test("falls back to err.name when no Stripe fields present", () => {
+        // Error with no statusCode/code/type but has a name
+        const err = new Error("something");
+        // Plain Error: err.name is "Error", parts is empty, so returns err.name || "Error"
+        expect(sanitizeErrorDetail(err)).toBe("Error");
       });
     });
 
-    test("logs 'missing timestamp' when header has signature but no timestamp", async () => {
-      const errorSpy = spy(console, "error");
-      try {
-        await verifyWebhookSignature('{"test": true}', "v1=abc123");
-        const callArg = errorSpy.calls[0]!.args[0] as string;
-        expect(callArg).toContain('detail="invalid header: missing timestamp"');
-      } finally {
-        errorSpy.restore();
-      }
+    describe("detectStripeKeyMode", () => {
+      test("returns 'test' for sk_test_ keys", () => {
+        expect(detectStripeKeyMode("sk_test_abc123")).toBe("test");
+      });
+
+      test("returns 'live' for sk_live_ keys", () => {
+        expect(detectStripeKeyMode("sk_live_abc123")).toBe("live");
+      });
+
+      test("returns null for invalid prefixes", () => {
+        expect(detectStripeKeyMode("sk_invalid_abc")).toBeNull();
+        expect(detectStripeKeyMode("rk_test_abc")).toBeNull();
+        expect(detectStripeKeyMode("")).toBeNull();
+        expect(detectStripeKeyMode("random_string")).toBeNull();
+      });
     });
 
-    test("logs 'missing signature' when header has timestamp but no v1", async () => {
-      const errorSpy = spy(console, "error");
-      try {
-        await verifyWebhookSignature('{"test": true}', "t=1234");
-        const callArg = errorSpy.calls[0]!.args[0] as string;
-        expect(callArg).toContain('detail="invalid header: missing signature"');
-      } finally {
-        errorSpy.restore();
-      }
-    });
+    describe("createCheckoutSessionWithIntent - phone metadata", () => {
+      test("includes phone in metadata when provided", async () => {
+        await updateStripeKey("sk_test_mock");
 
-    test("logs 'missing timestamp and signature' for completely invalid header", async () => {
-      const errorSpy = spy(console, "error");
-      try {
-        await verifyWebhookSignature('{"test": true}', "invalid-header");
-        const callArg = errorSpy.calls[0]!.args[0] as string;
-        expect(callArg).toContain(
-          'detail="invalid header: missing timestamp and signature"',
-        );
-      } finally {
-        errorSpy.restore();
-      }
-    });
-
-    test("logs timestamp delta and tolerance when out of tolerance", async () => {
-      const errorSpy = spy(console, "error");
-      const oldTimestamp = Math.floor(Date.now() / 1000) - 400;
-      const payload = '{"test": true}';
-      const signedPayload = `${oldTimestamp}.${payload}`;
-
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(TEST_SECRET),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"],
-      );
-      const signature = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(signedPayload),
-      );
-      const sigHex = Array.from(new Uint8Array(signature))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-      try {
-        await verifyWebhookSignature(payload, `t=${oldTimestamp},v1=${sigHex}`);
-        const callArg = errorSpy.calls[0]!.args[0] as string;
-        expect(callArg).toContain("timestamp out of tolerance delta=");
-        expect(callArg).toContain("tolerance=300s");
-      } finally {
-        errorSpy.restore();
-      }
-    });
-
-    test("logs JSON parse error message for invalid payload", async () => {
-      const errorSpy = spy(console, "error");
-      const payload = "not valid json {{{";
-      const timestamp = Math.floor(Date.now() / 1000);
-      const signedPayload = `${timestamp}.${payload}`;
-
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(TEST_SECRET),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"],
-      );
-      const signature = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(signedPayload),
-      );
-      const sigHex = Array.from(new Uint8Array(signature))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-      try {
-        await verifyWebhookSignature(payload, `t=${timestamp},v1=${sigHex}`);
-        const callArg = errorSpy.calls[0]!.args[0] as string;
-        expect(callArg).toContain('detail="invalid JSON:');
-      } finally {
-        errorSpy.restore();
-      }
-    });
-  });
-});
-
-describeWithEnv("stripe-provider", {
-  STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
-  STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
-}, () => {
-  beforeEach(async () => {
-    resetStripeClient();
-    await createTestDb();
-  });
-
-  afterEach(() => {
-    resetStripeClient();
-    resetDb();
-  });
-
-  describe("toCheckoutResult - session with no URL", () => {
-    test("returns null when session has no URL", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      // Spy on stripe.checkout.sessions.create to return session without URL
-      const createSpy = stub(client.checkout.sessions, "create", () =>
-        Promise.resolve({
-          id: "cs_no_url",
-          url: null,
-          object: "checkout.session",
-        } as never),
-      );
-
-      try {
         const event = testEvent({ unit_price: 1000 });
         const intent = {
           eventId: 1,
-          name: "John",
+          name: "John Doe",
           email: "john@example.com",
-          phone: "",
+          phone: "+44 7700 900000",
           address: "",
           special_instructions: "",
           quantity: 1,
         };
 
-        // Use stripePaymentProvider which wraps via toCheckoutResult
-        const result = await stripePaymentProvider.createCheckoutSession(
+        const session = await createCheckoutSessionWithIntent(
           event,
           intent,
           "http://localhost:3000",
         );
 
-        expect(result).toBeNull();
-      } finally {
-        createSpy.restore();
-      }
+        // stripe-mock creates session successfully
+        expect(session).not.toBeNull();
+        expect(session?.id).toBeDefined();
+      });
     });
 
-    test("returns null when session is null", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
+    describe("createCheckoutSessionWithIntent - no email", () => {
+      test("creates checkout session without customer_email when email is empty", async () => {
+        await updateStripeKey("sk_test_mock");
 
-      const createSpy = stub(client.checkout.sessions, "create", () =>
-        Promise.reject(new Error("API error")),
-      );
-
-      try {
         const event = testEvent({ unit_price: 1000 });
         const intent = {
           eventId: 1,
-          name: "John",
-          email: "john@example.com",
-          phone: "",
+          name: "No Email User",
+          email: "",
+          phone: "+44 7700 900000",
           address: "",
           special_instructions: "",
           quantity: 1,
         };
 
-        const result = await stripePaymentProvider.createCheckoutSession(
+        const session = await createCheckoutSessionWithIntent(
           event,
           intent,
           "http://localhost:3000",
         );
 
-        expect(result).toBeNull();
-      } finally {
-        createSpy.restore();
-      }
-    });
-  });
-
-  describe("retrieveSession - edge cases", () => {
-    test("returns null for non-multi session without event_id", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_no_event",
-          payment_status: "paid",
-          payment_intent: "pi_test_123",
-          metadata: {
-            name: "Test User",
-            email: "test@example.com",
-            // No event_id, and not a multi session
-          },
-        } as never),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_no_event");
-        expect(result).toBeNull();
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("returns null when session is null from Stripe", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.reject(new Error("Not found")),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_notfound");
-        expect(result).toBeNull();
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("returns null when metadata is missing name or email", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_no_meta",
-          payment_status: "paid",
-          metadata: {
-            event_id: "1",
-            // Missing name and email
-          },
-        } as never),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_no_meta");
-        expect(result).toBeNull();
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("returns valid session for multi-ticket checkout", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_multi",
-          payment_status: "paid",
-          payment_intent: "pi_multi_123",
-          metadata: {
-            name: "Multi User",
-            email: "multi@example.com",
-            phone: "+44 7700 900000",
-            multi: "1",
-            items: '[{"e":1,"q":2}]',
-          },
-        } as never),
-      );
-
-      try {
-        const result = await stripePaymentProvider.retrieveSession("cs_multi");
-        expect(result).not.toBeNull();
-        expect(result?.id).toBe("cs_multi");
-        expect(result?.metadata.multi).toBe("1");
-        expect(result?.metadata.items).toBe('[{"e":1,"q":2}]');
-        expect(result?.metadata.phone).toBe("+44 7700 900000");
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("returns valid session for single-event checkout", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_single",
-          payment_status: "paid",
-          payment_intent: "pi_single_123",
-          metadata: {
-            name: "Single User",
-            email: "single@example.com",
-            event_id: "42",
-            quantity: "2",
-          },
-        } as never),
-      );
-
-      try {
-        const result = await stripePaymentProvider.retrieveSession("cs_single");
-        expect(result).not.toBeNull();
-        expect(result?.id).toBe("cs_single");
-        expect(result?.paymentStatus).toBe("paid");
-        expect(result?.paymentReference).toBe("pi_single_123");
-        expect(result?.metadata.event_id).toBe("42");
-        expect(result?.metadata.quantity).toBe("2");
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("returns amountTotal when session has numeric amount_total", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_with_amount",
-          payment_status: "paid",
-          payment_intent: "pi_amount_123",
-          amount_total: 4500,
-          metadata: {
-            name: "Amount User",
-            email: "amount@example.com",
-            event_id: "10",
-            quantity: "3",
-          },
-        } as never),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_with_amount");
-        expect(result).not.toBeNull();
-        expect(result?.amountTotal).toBe(4500);
-        expect(result?.paymentReference).toBe("pi_amount_123");
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("returns null when amount_total is null", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_null_amount",
-          payment_status: "paid",
-          payment_intent: "pi_null_amount",
-          amount_total: null,
-          metadata: {
-            name: "Null Amount User",
-            email: "nullamount@example.com",
-            event_id: "1",
-            quantity: "1",
-          },
-        } as never),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_null_amount");
-        expect(result).toBeNull();
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("falls back to unpaid for invalid payment_status", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_bad_status",
-          payment_status: "completed",
-          payment_intent: "pi_bad_status",
-          amount_total: 1000,
-          metadata: {
-            name: "Bad Status User",
-            email: "badstatus@example.com",
-            event_id: "1",
-            quantity: "1",
-          },
-        } as never),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_bad_status");
-        expect(result).not.toBeNull();
-        expect(result?.paymentStatus).toBe("unpaid");
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-
-    test("casts amount_total to number", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
-        Promise.resolve({
-          id: "cs_amount_cast",
-          payment_status: "paid",
-          payment_intent: "pi_amount_cast",
-          amount_total: 7500,
-          metadata: {
-            name: "Cast User",
-            email: "cast@example.com",
-            event_id: "11",
-            quantity: "1",
-          },
-        } as never),
-      );
-
-      try {
-        const result =
-          await stripePaymentProvider.retrieveSession("cs_amount_cast");
-        expect(result).not.toBeNull();
-        expect(result?.amountTotal).toBe(7500);
-      } finally {
-        retrieveSpy.restore();
-      }
-    });
-  });
-
-  describe("verifyWebhookSignature delegation", () => {
-    test("delegates to stripe.ts verifyWebhookSignature", async () => {
-      const TEST_SECRET = "whsec_provider_verify_test";
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_provider_test",
+        // stripe-mock creates session successfully (email is empty, so customer_email is omitted)
+        expect(session).not.toBeNull();
+        expect(session?.id).toBeDefined();
       });
-
-      const event: StripeWebhookEvent = {
-        id: "evt_provider",
-        type: "checkout.session.completed",
-        data: { object: { id: "cs_test" } },
-      };
-
-      const { payload, signature } = await constructTestWebhookEvent(
-        event,
-        TEST_SECRET,
-      );
-
-      const result = await stripePaymentProvider.verifyWebhookSignature(
-        payload,
-        signature,
-        "https://example.com/payment/webhook",
-        new TextEncoder().encode(payload),
-      );
-      expect(result.valid).toBe(true);
-      if (result.valid) {
-        expect(result.event.id).toBe("evt_provider");
-      }
     });
 
-    test("returns error for invalid signature", async () => {
-      const TEST_SECRET = "whsec_provider_invalid_test";
-      await setStripeWebhookConfig({
-        secret: TEST_SECRET,
-        endpointId: "we_provider_inv",
-      });
+    describe("createMultiCheckoutSession", () => {
+      test("creates multi-checkout session with phone metadata", async () => {
+        await updateStripeKey("sk_test_mock");
 
-      const timestamp = Math.floor(Date.now() / 1000);
-      const body = '{"test": true}';
-      const result = await stripePaymentProvider.verifyWebhookSignature(
-        body,
-        `t=${timestamp},v1=invalid_sig`,
-        "https://example.com/payment/webhook",
-        new TextEncoder().encode(body),
-      );
+        const intent = {
+          name: "Jane Doe",
+          email: "jane@example.com",
+          phone: "+44 7700 900001",
+          address: "",
+          special_instructions: "",
+          items: [
+            {
+              eventId: 1,
+              quantity: 2,
+              unitPrice: 1000,
+              slug: "event-a",
+              name: "Event A",
+            },
+            {
+              eventId: 2,
+              quantity: 1,
+              unitPrice: 2000,
+              slug: "event-b",
+              name: "Event B",
+            },
+          ],
+        };
 
-      expect(result.valid).toBe(false);
-      if (!result.valid) {
-        expect(result.error).toBeDefined();
-      }
-    });
-  });
-
-  describe("setupWebhookEndpoint delegation", () => {
-    test("delegates to stripe.ts setupWebhookEndpoint", async () => {
-      // Mock stripeApi since setupWebhookEndpointImpl creates its own client
-      const origSetup = stripeApi.setupWebhookEndpoint;
-      stripeApi.setupWebhookEndpoint = (_key, _url, _existing) =>
-        Promise.resolve({
-          success: true,
-          endpointId: "we_provider_created",
-          secret: "whsec_provider_secret",
-        });
-
-      try {
-        const result = await stripePaymentProvider.setupWebhookEndpoint(
-          "sk_test_mock",
-          "https://example.com/payment/webhook",
+        const session = await createMultiCheckoutSession(
+          intent,
+          "http://localhost:3000",
         );
 
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(result.endpointId).toBe("we_provider_created");
-          expect(result.secret).toBe("whsec_provider_secret");
-        }
-      } finally {
-        stripeApi.setupWebhookEndpoint = origSetup;
-      }
-    });
-  });
+        expect(session).not.toBeNull();
+        expect(session?.id).toBeDefined();
+      });
 
-  describe("refundPayment delegation", () => {
-    test("returns true when refund succeeds", async () => {
-      await updateStripeKey("sk_test_mock");
-      const result = await stripePaymentProvider.refundPayment("pi_test_123");
-      expect(result).toBe(true);
-    });
-
-    test("returns false when refund fails", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const refundSpy = stub(client.refunds, "create", () =>
-        Promise.reject(new Error("Refund failed")),
-      );
-
-      try {
-        const result = await stripePaymentProvider.refundPayment("pi_fail");
-        expect(result).toBe(false);
-      } finally {
-        refundSpy.restore();
-      }
-    });
-  });
-
-  describe("sanitizeErrorDetail edge cases", () => {
-    test("returns err.name when no statusCode/code/type and name is set", () => {
-      const err = new TypeError("something went wrong");
-      const detail = sanitizeErrorDetail(err);
-      expect(detail).toBe("TypeError");
-    });
-  });
-
-  describe("getMockConfig without STRIPE_MOCK_HOST", () => {
-    test("creates client without mock config when STRIPE_MOCK_HOST not set", async () => {
-      await updateStripeKey("sk_test_123");
-      Deno.env.delete("STRIPE_MOCK_HOST");
-      Deno.env.delete("STRIPE_MOCK_PORT");
-
-      // resetStripeClient now also resets getMockConfig (lazyRef)
-      resetStripeClient();
-
-      const client = await getStripeClient();
-      // Client is created using real Stripe (no mock) - returns non-null
-      expect(client !== undefined).toBe(true);
-    });
-  });
-
-  describe("retrievePaymentIntent", () => {
-    test("returns null when stripe key not set", async () => {
-      const result = await retrievePaymentIntent("pi_test_123");
-      expect(result).toBeNull();
-    });
-
-    test("returns null when Stripe API throws error", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client to be defined");
-
-      await withMocks(
-        () =>
-          stub(client.paymentIntents, "retrieve", () =>
-            Promise.reject(new Error("Network error")),
-          ),
-        async (retrieveSpy) => {
-          const result = await retrievePaymentIntent("pi_test_123");
-          expect(result).toBeNull();
-          expect(retrieveSpy.calls.length).toBeGreaterThan(0);
-        },
-      );
-    });
-  });
-
-  describe("isPaymentRefunded", () => {
-    test("returns true when latest_charge is refunded", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      await withMocks(
-        () =>
-          stub(client.paymentIntents, "retrieve", () =>
-            Promise.resolve({
-              id: "pi_refunded",
-              latest_charge: { id: "ch_1", refunded: true },
-            } as never),
-          ),
-        async () => {
-          const result =
-            await stripePaymentProvider.isPaymentRefunded("pi_refunded");
-          expect(result).toBe(true);
-        },
-      );
-    });
-
-    test("returns false when latest_charge is not refunded", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      await withMocks(
-        () =>
-          stub(client.paymentIntents, "retrieve", () =>
-            Promise.resolve({
-              id: "pi_not_refunded",
-              latest_charge: { id: "ch_2", refunded: false },
-            } as never),
-          ),
-        async () => {
-          const result =
-            await stripePaymentProvider.isPaymentRefunded("pi_not_refunded");
-          expect(result).toBe(false);
-        },
-      );
-    });
-
-    test("returns false when payment intent not found", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      await withMocks(
-        () =>
-          stub(client.paymentIntents, "retrieve", () =>
-            Promise.reject(new Error("Not found")),
-          ),
-        async () => {
-          const result =
-            await stripePaymentProvider.isPaymentRefunded("pi_missing");
-          expect(result).toBe(false);
-        },
-      );
-    });
-
-    test("returns false when latest_charge is a string ID", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      await withMocks(
-        () =>
-          stub(client.paymentIntents, "retrieve", () =>
-            Promise.resolve({
-              id: "pi_string_charge",
-              latest_charge: "ch_string_id",
-            } as never),
-          ),
-        async () => {
-          const result =
-            await stripePaymentProvider.isPaymentRefunded("pi_string_charge");
-          expect(result).toBe(false);
-        },
-      );
-    });
-  });
-
-  describe("createMultiCheckoutSession - via provider", () => {
-    test("returns null when session has no URL", async () => {
-      await updateStripeKey("sk_test_mock");
-      const client = await getStripeClient();
-      if (!client) throw new Error("Expected client");
-
-      const createSpy = stub(client.checkout.sessions, "create", () =>
-        Promise.resolve({
-          id: "cs_multi_nourl",
-          url: null,
-          object: "checkout.session",
-        } as never),
-      );
-
-      try {
+      test("returns null when stripe key not set", async () => {
         const intent = {
-          name: "Jane",
+          name: "Jane Doe",
           email: "jane@example.com",
           phone: "",
           address: "",
@@ -2184,87 +1016,1290 @@ describeWithEnv("stripe-provider", {
               eventId: 1,
               quantity: 1,
               unitPrice: 1000,
-              slug: "evt",
-              name: "Evt",
+              slug: "event-a",
+              name: "Event A",
             },
           ],
         };
-        const result = await stripePaymentProvider.createMultiCheckoutSession(
+
+        const result = await createMultiCheckoutSession(
           intent,
           "http://localhost:3000",
         );
         expect(result).toBeNull();
-      } finally {
-        createSpy.restore();
-      }
-    });
-  });
+      });
 
-  describe("resolveWebhookSession", () => {
-    test("extracts session directly from event with complete metadata", async () => {
-      const result = await stripePaymentProvider.resolveWebhookSession({
-        id: "evt_resolve_1",
-        type: "checkout.session.completed",
-        data: {
-          object: {
-            id: "cs_resolve_1",
+      test("creates multi-checkout session without customer_email when email is empty", async () => {
+        await updateStripeKey("sk_test_mock");
+
+        const intent = {
+          name: "No Email Multi",
+          email: "",
+          phone: "+44 7700 900002",
+          address: "",
+          special_instructions: "",
+          items: [
+            {
+              eventId: 1,
+              quantity: 1,
+              unitPrice: 1000,
+              slug: "event-a",
+              name: "Event A",
+            },
+            {
+              eventId: 2,
+              quantity: 2,
+              unitPrice: 2000,
+              slug: "event-b",
+              name: "Event B",
+            },
+          ],
+        };
+
+        const session = await createMultiCheckoutSession(
+          intent,
+          "http://localhost:3000",
+        );
+
+        // stripe-mock creates session successfully (email is empty, so customer_email is omitted)
+        expect(session).not.toBeNull();
+        expect(session?.id).toBeDefined();
+      });
+    });
+
+    describe("refundPayment - non-Error exception", () => {
+      test("handles non-Error thrown value in refund", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
+
+        // Throw a non-Error value (string) to exercise the sanitizeErrorDetail "unknown" path
+        const refundSpy = stub(client.refunds, "create", () =>
+          Promise.reject("network failure string"),
+        );
+
+        try {
+          const result = await refundPayment("pi_test_123");
+          expect(result).toBeNull();
+        } finally {
+          refundSpy.restore();
+        }
+      });
+    });
+
+    describe("testStripeConnection - non-Error exception", () => {
+      test("handles non-Error thrown value in balance check", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
+
+        const balanceSpy = stub(client.balance, "retrieve", () =>
+          Promise.reject("string error"),
+        );
+
+        try {
+          const result = await testStripeConnection();
+          expect(result.ok).toBe(false);
+          expect(result.apiKey.valid).toBe(false);
+          expect(result.apiKey.error).toBe("Unknown error");
+        } finally {
+          balanceSpy.restore();
+        }
+      });
+
+      test("handles non-Error thrown value in webhook retrieval", async () => {
+        await updateStripeKey("sk_test_mock");
+        await setStripeWebhookConfig({
+          secret: "whsec_test",
+          endpointId: "we_test_nonerror",
+        });
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
+
+        const balanceSpy = stub(client.balance, "retrieve", () =>
+          Promise.resolve({
+            livemode: false,
+            available: [],
+            pending: [],
+            object: "balance",
+          } as never),
+        );
+
+        const webhookSpy = stub(client.webhookEndpoints, "retrieve", () =>
+          Promise.reject("webhook string error"),
+        );
+
+        try {
+          const result = await testStripeConnection();
+          expect(result.ok).toBe(false);
+          expect(result.webhook.configured).toBe(false);
+          expect(result.webhook.error).toBe("Unknown error");
+        } finally {
+          balanceSpy.restore();
+          webhookSpy.restore();
+        }
+      });
+    });
+
+    describe("setupWebhookEndpointImpl", () => {
+      // setupWebhookEndpointImpl creates its own client via createStripeClient(secretKey),
+      // so we mock at the stripeApi level to test the various code paths
+
+      test("creates webhook endpoint via stripe-mock (no secret returned)", async () => {
+        // stripe-mock doesn't return endpoint.secret, so this exercises the "no secret" error path
+        const result = await setupWebhookEndpoint(
+          "sk_test_mock",
+          "https://example.com/payment/webhook",
+        );
+
+        // stripe-mock likely doesn't return secret, testing the error path
+        if (!result.success) {
+          expect(result.error).toBe("Stripe did not return webhook secret");
+        }
+      });
+
+      test("exercises delete-then-create path with existing endpoint ID", async () => {
+        // This exercises the existingEndpointId deletion path
+        const result = await setupWebhookEndpoint(
+          "sk_test_mock",
+          "https://example.com/payment/webhook",
+          "we_existing_123",
+        );
+
+        // The API call goes through - deletion of non-existent endpoint is caught
+        expect(result).toBeDefined();
+        expect(typeof result.success).toBe("boolean");
+      });
+
+      test("succeeds when mocked via stripeApi", async () => {
+        // Override stripeApi to test the full success path
+        const origSetup = stripeApi.setupWebhookEndpoint;
+        stripeApi.setupWebhookEndpoint = (_key, _url, _existing) =>
+          Promise.resolve({
+            success: true,
+            endpointId: "we_mocked",
+            secret: "whsec_mocked",
+          });
+
+        try {
+          const result = await setupWebhookEndpoint(
+            "sk_test",
+            "https://example.com/webhook",
+          );
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.endpointId).toBe("we_mocked");
+            expect(result.secret).toBe("whsec_mocked");
+          }
+        } finally {
+          stripeApi.setupWebhookEndpoint = origSetup;
+        }
+      });
+
+      test("returns error when API throws", async () => {
+        const origSetup = stripeApi.setupWebhookEndpoint;
+        stripeApi.setupWebhookEndpoint = (_key, _url) =>
+          Promise.resolve({
+            success: false as const,
+            error: "API rate limited",
+          });
+
+        try {
+          const result = await setupWebhookEndpoint(
+            "sk_test",
+            "https://example.com/webhook",
+          );
+          expect(result.success).toBe(false);
+          if (!result.success) {
+            expect(result.error).toBe("API rate limited");
+          }
+        } finally {
+          stripeApi.setupWebhookEndpoint = origSetup;
+        }
+      });
+    });
+
+    describe("getMockConfig", () => {
+      test("returns undefined when STRIPE_MOCK_HOST not set", async () => {
+        Deno.env.delete("STRIPE_MOCK_HOST");
+        Deno.env.delete("STRIPE_MOCK_PORT");
+        resetStripeClient();
+
+        // The getMockConfig is a once() function, so we can't easily re-test it.
+        // But getStripeClient exercises the createStripeClient path
+        await updateStripeKey("sk_test_123");
+        // Without mock config, a real Stripe client would be created
+        // We just verify no crash occurs
+        const client = await getStripeClient();
+        expect(client).not.toBeNull();
+      });
+    });
+
+    describe("setupWebhookEndpoint - stripe-mock paths", () => {
+      test("deletes existing endpoint for same URL before recreating", async () => {
+        // stripe-mock has a default endpoint at https://example.com/my/webhook/endpoint
+        // Calling setupWebhookEndpoint with that URL should find it via list and delete it
+        const result = await setupWebhookEndpoint(
+          "sk_test_mock",
+          "https://example.com/my/webhook/endpoint",
+        );
+
+        // stripe-mock doesn't return secret, so this hits the "no secret" error path
+        // but the important thing is it exercises the "delete existing for URL" code path (lines 368-371)
+        expect(result).toBeDefined();
+        expect(typeof result.success).toBe("boolean");
+      });
+
+      test("returns success when endpoint.secret is present", async () => {
+        // Wrap fetch to intercept the webhook_endpoints create response and inject a secret
+        await withFetchMock(async (originalFetch) => {
+          globalThis.fetch = async (
+            input: RequestInfo | URL,
+            init?: RequestInit,
+          ): Promise<Response> => {
+            const response = await originalFetch(input, init);
+            const url = urlFromFetchInput(input as string | URL | Request);
+
+            // Intercept POST to webhook_endpoints (create) and add secret to response
+            if (
+              url.includes("/v1/webhook_endpoints") &&
+              init?.method === "POST"
+            ) {
+              const body = await response.json();
+              body.secret = "whsec_test_injected_secret";
+              return new Response(JSON.stringify(body), {
+                status: response.status,
+                headers: response.headers,
+              });
+            }
+            return response;
+          };
+
+          const result = await setupWebhookEndpoint(
+            "sk_test_mock",
+            "https://example.com/webhook/success-test",
+          );
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.endpointId).toBeDefined();
+            expect(result.secret).toBe("whsec_test_injected_secret");
+          }
+        });
+      });
+
+      test("returns error when createStripeClient or API call throws", async () => {
+        // Mock fetch to throw on all requests, exercising the outer catch block
+        await withFetchMock(async () => {
+          globalThis.fetch = () => {
+            throw new Error("Network unavailable");
+          };
+
+          const result = await setupWebhookEndpoint(
+            "sk_test_mock",
+            "https://example.com/webhook/error-test",
+          );
+
+          expect(result.success).toBe(false);
+          if (!result.success) {
+            // Stripe SDK wraps connection errors with retry info
+            expect(typeof result.error).toBe("string");
+            expect(result.error!.length > 0).toBe(true);
+          }
+        });
+      });
+
+      test("catches error when deleting existing endpoint ID fails", async () => {
+        // Mock fetch so that ALL DELETE requests throw (Stripe SDK retries, so we must fail all)
+        await withFetchMock(async (originalFetch) => {
+          installUrlHandler(originalFetch, (url, init) => {
+            if (
+              (init?.method ?? "GET") === "DELETE" &&
+              url.includes("we_should_fail_to_delete")
+            ) {
+              throw new Error("Delete failed");
+            }
+            return null;
+          });
+
+          const result = await setupWebhookEndpoint(
+            "sk_test_mock",
+            "https://example.com/webhook/delete-error-test-unique",
+            "we_should_fail_to_delete",
+          );
+
+          // The function should continue past the failed delete and still attempt to create
+          expect(result).toBeDefined();
+          expect(typeof result.success).toBe("boolean");
+        });
+      });
+
+      test("returns error when list endpoints throws", async () => {
+        // Mock fetch so that the list call (GET) throws, exercising the outer catch
+        await withFetchMock(async (originalFetch) => {
+          installUrlHandler(originalFetch, (url, init) => {
+            if (
+              (init?.method ?? "GET") === "GET" &&
+              url.includes("/v1/webhook_endpoints")
+            ) {
+              throw new Error("List endpoints failed");
+            }
+            return null;
+          });
+
+          const result = await setupWebhookEndpoint(
+            "sk_test_mock",
+            "https://example.com/webhook/list-error-test",
+          );
+
+          expect(result.success).toBe(false);
+          if (!result.success) {
+            // Stripe SDK wraps connection errors with retry info
+            expect(typeof result.error).toBe("string");
+            expect(result.error!.length > 0).toBe(true);
+          }
+        });
+      });
+
+      test("returns stringified error when non-Error is thrown", async () => {
+        // Mock fetch to throw a string (not an Error) to hit the String(err) path
+        await withFetchMock(async () => {
+          globalThis.fetch = () => {
+            throw "string_error";
+          }; // non-Error value
+
+          const result = await setupWebhookEndpoint(
+            "sk_test_mock",
+            "https://example.com/webhook/non-error-throw",
+          );
+
+          expect(result.success).toBe(false);
+          if (!result.success) {
+            // Stripe SDK wraps thrown values, so error message comes from SDK wrapper
+            expect(typeof result.error).toBe("string");
+            expect(result.error!.length > 0).toBe(true);
+          }
+        });
+      });
+    });
+
+    describe("verifyWebhookSignature - timestamp parsing", () => {
+      const TEST_SECRET = "whsec_test_secret_key_for_timestamp_test";
+
+      test("handles timestamp value that needs parseInt", async () => {
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_test_ts",
+        });
+
+        // Create event with proper signature
+        const event: StripeWebhookEvent = {
+          id: "evt_ts_test",
+          type: "checkout.session.completed",
+          data: { object: { id: "cs_test" } },
+        };
+
+        const { payload, signature } = await constructTestWebhookEvent(
+          event,
+          TEST_SECRET,
+        );
+
+        const result = await verifyWebhookSignature(payload, signature);
+        expect(result.valid).toBe(true);
+      });
+
+      test("parses timestamp with parseInt when t key has value", async () => {
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_test_parse",
+        });
+
+        // Use a timestamp that is a valid number string, exercising Number.parseInt
+        const timestamp = Math.floor(Date.now() / 1000);
+        const payload = '{"id": "evt_parse", "type": "test"}';
+        const signedPayload = `${timestamp}.${payload}`;
+
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(TEST_SECRET),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"],
+        );
+        const signature = await crypto.subtle.sign(
+          "HMAC",
+          key,
+          encoder.encode(signedPayload),
+        );
+        const sigHex = Array.from(new Uint8Array(signature))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+
+        const result = await verifyWebhookSignature(
+          payload,
+          `t=${timestamp},v1=${sigHex}`,
+        );
+        expect(result.valid).toBe(true);
+      });
+
+      test("treats t key without equals as zero timestamp via parseInt fallback", async () => {
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_test_nullish",
+        });
+
+        // Header "t,v1=abc123" - split("=") on "t" gives ["t"], so value is undefined
+        // value ?? "0" gives "0", parseInt("0", 10) gives 0
+        // timestamp === 0, so parseSignatureHeader returns null => "Invalid signature header format"
+        const result = await verifyWebhookSignature(
+          '{"test": true}',
+          "t,v1=abc123",
+        );
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Invalid signature header format");
+        }
+      });
+
+      test("secureCompare handles strings of different lengths", async () => {
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_test_len",
+        });
+
+        // Provide a signature that has different length than expected
+        const timestamp = Math.floor(Date.now() / 1000);
+        const result = await verifyWebhookSignature(
+          '{"test": true}',
+          `t=${timestamp},v1=short`,
+        );
+        // Signature won't match but should not crash - secureCompare handles length diff
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBe("Signature verification failed");
+        }
+      });
+    });
+
+    describe("verifyWebhookSignature - enhanced error details", () => {
+      const TEST_SECRET = "whsec_test_secret_key_for_detail_tests";
+
+      beforeEach(async () => {
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_test_details",
+        });
+      });
+
+      test("logs 'missing timestamp' when header has signature but no timestamp", async () => {
+        const errorSpy = spy(console, "error");
+        try {
+          await verifyWebhookSignature('{"test": true}', "v1=abc123");
+          const callArg = errorSpy.calls[0]!.args[0] as string;
+          expect(callArg).toContain(
+            'detail="invalid header: missing timestamp"',
+          );
+        } finally {
+          errorSpy.restore();
+        }
+      });
+
+      test("logs 'missing signature' when header has timestamp but no v1", async () => {
+        const errorSpy = spy(console, "error");
+        try {
+          await verifyWebhookSignature('{"test": true}', "t=1234");
+          const callArg = errorSpy.calls[0]!.args[0] as string;
+          expect(callArg).toContain(
+            'detail="invalid header: missing signature"',
+          );
+        } finally {
+          errorSpy.restore();
+        }
+      });
+
+      test("logs 'missing timestamp and signature' for completely invalid header", async () => {
+        const errorSpy = spy(console, "error");
+        try {
+          await verifyWebhookSignature('{"test": true}', "invalid-header");
+          const callArg = errorSpy.calls[0]!.args[0] as string;
+          expect(callArg).toContain(
+            'detail="invalid header: missing timestamp and signature"',
+          );
+        } finally {
+          errorSpy.restore();
+        }
+      });
+
+      test("logs timestamp delta and tolerance when out of tolerance", async () => {
+        const errorSpy = spy(console, "error");
+        const oldTimestamp = Math.floor(Date.now() / 1000) - 400;
+        const payload = '{"test": true}';
+        const signedPayload = `${oldTimestamp}.${payload}`;
+
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(TEST_SECRET),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"],
+        );
+        const signature = await crypto.subtle.sign(
+          "HMAC",
+          key,
+          encoder.encode(signedPayload),
+        );
+        const sigHex = Array.from(new Uint8Array(signature))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+
+        try {
+          await verifyWebhookSignature(
+            payload,
+            `t=${oldTimestamp},v1=${sigHex}`,
+          );
+          const callArg = errorSpy.calls[0]!.args[0] as string;
+          expect(callArg).toContain("timestamp out of tolerance delta=");
+          expect(callArg).toContain("tolerance=300s");
+        } finally {
+          errorSpy.restore();
+        }
+      });
+
+      test("logs JSON parse error message for invalid payload", async () => {
+        const errorSpy = spy(console, "error");
+        const payload = "not valid json {{{";
+        const timestamp = Math.floor(Date.now() / 1000);
+        const signedPayload = `${timestamp}.${payload}`;
+
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(TEST_SECRET),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"],
+        );
+        const signature = await crypto.subtle.sign(
+          "HMAC",
+          key,
+          encoder.encode(signedPayload),
+        );
+        const sigHex = Array.from(new Uint8Array(signature))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+
+        try {
+          await verifyWebhookSignature(payload, `t=${timestamp},v1=${sigHex}`);
+          const callArg = errorSpy.calls[0]!.args[0] as string;
+          expect(callArg).toContain('detail="invalid JSON:');
+        } finally {
+          errorSpy.restore();
+        }
+      });
+    });
+  },
+);
+
+describeWithEnv(
+  "stripe-provider",
+  {
+    env: {
+      STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
+      STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
+    },
+  },
+  () => {
+    beforeEach(async () => {
+      resetStripeClient();
+      resetTestSlugCounter();
+      await createTestDb();
+    });
+
+    afterEach(() => {
+      resetStripeClient();
+      resetDb();
+    });
+
+    describe("toCheckoutResult - session with no URL", () => {
+      test("returns null when session has no URL", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        // Spy on stripe.checkout.sessions.create to return session without URL
+        const createSpy = stub(client.checkout.sessions, "create", () =>
+          Promise.resolve({
+            id: "cs_no_url",
+            url: null,
+            object: "checkout.session",
+          } as never),
+        );
+
+        try {
+          const event = testEvent({ unit_price: 1000 });
+          const intent = {
+            eventId: 1,
+            name: "John",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            quantity: 1,
+          };
+
+          // Use stripePaymentProvider which wraps via toCheckoutResult
+          const result = await stripePaymentProvider.createCheckoutSession(
+            event,
+            intent,
+            "http://localhost:3000",
+          );
+
+          expect(result).toBeNull();
+        } finally {
+          createSpy.restore();
+        }
+      });
+
+      test("returns null when session is null", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const createSpy = stub(client.checkout.sessions, "create", () =>
+          Promise.reject(new Error("API error")),
+        );
+
+        try {
+          const event = testEvent({ unit_price: 1000 });
+          const intent = {
+            eventId: 1,
+            name: "John",
+            email: "john@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            quantity: 1,
+          };
+
+          const result = await stripePaymentProvider.createCheckoutSession(
+            event,
+            intent,
+            "http://localhost:3000",
+          );
+
+          expect(result).toBeNull();
+        } finally {
+          createSpy.restore();
+        }
+      });
+    });
+
+    describe("retrieveSession - edge cases", () => {
+      test("returns null for non-multi session without event_id", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_no_event",
             payment_status: "paid",
-            payment_intent: "pi_resolve_1",
-            amount_total: 2000,
+            payment_intent: "pi_test_123",
             metadata: {
-              name: "Alice",
-              email: "alice@example.com",
+              name: "Test User",
+              email: "test@example.com",
+              // No event_id, and not a multi session
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_no_event");
+          expect(result).toBeNull();
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("returns null when session is null from Stripe", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.reject(new Error("Not found")),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_notfound");
+          expect(result).toBeNull();
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("returns null when metadata is missing name or email", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_no_meta",
+            payment_status: "paid",
+            metadata: {
+              event_id: "1",
+              // Missing name and email
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_no_meta");
+          expect(result).toBeNull();
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("returns valid session for multi-ticket checkout", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_multi",
+            payment_status: "paid",
+            payment_intent: "pi_multi_123",
+            metadata: {
+              name: "Multi User",
+              email: "multi@example.com",
+              phone: "+44 7700 900000",
+              multi: "1",
+              items: '[{"e":1,"q":2}]',
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_multi");
+          expect(result).not.toBeNull();
+          expect(result?.id).toBe("cs_multi");
+          expect(result?.metadata.multi).toBe("1");
+          expect(result?.metadata.items).toBe('[{"e":1,"q":2}]');
+          expect(result?.metadata.phone).toBe("+44 7700 900000");
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("returns valid session for single-event checkout", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_single",
+            payment_status: "paid",
+            payment_intent: "pi_single_123",
+            metadata: {
+              name: "Single User",
+              email: "single@example.com",
+              event_id: "42",
+              quantity: "2",
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_single");
+          expect(result).not.toBeNull();
+          expect(result?.id).toBe("cs_single");
+          expect(result?.paymentStatus).toBe("paid");
+          expect(result?.paymentReference).toBe("pi_single_123");
+          expect(result?.metadata.event_id).toBe("42");
+          expect(result?.metadata.quantity).toBe("2");
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("returns amountTotal when session has numeric amount_total", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_with_amount",
+            payment_status: "paid",
+            payment_intent: "pi_amount_123",
+            amount_total: 4500,
+            metadata: {
+              name: "Amount User",
+              email: "amount@example.com",
+              event_id: "10",
+              quantity: "3",
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_with_amount");
+          expect(result).not.toBeNull();
+          expect(result?.amountTotal).toBe(4500);
+          expect(result?.paymentReference).toBe("pi_amount_123");
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("returns null when amount_total is null", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_null_amount",
+            payment_status: "paid",
+            payment_intent: "pi_null_amount",
+            amount_total: null,
+            metadata: {
+              name: "Null Amount User",
+              email: "nullamount@example.com",
               event_id: "1",
               quantity: "1",
             },
-          },
-        },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_null_amount");
+          expect(result).toBeNull();
+        } finally {
+          retrieveSpy.restore();
+        }
       });
-      expect(result).not.toBe("skip");
-      expect(result).not.toBeNull();
-      if (result && result !== "skip") {
-        expect(result.id).toBe("cs_resolve_1");
-        expect(result.paymentStatus).toBe("paid");
-        expect(result.paymentReference).toBe("pi_resolve_1");
-        expect(result.amountTotal).toBe(2000);
-      }
+
+      test("falls back to unpaid for invalid payment_status", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_bad_status",
+            payment_status: "completed",
+            payment_intent: "pi_bad_status",
+            amount_total: 1000,
+            metadata: {
+              name: "Bad Status User",
+              email: "badstatus@example.com",
+              event_id: "1",
+              quantity: "1",
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_bad_status");
+          expect(result).not.toBeNull();
+          expect(result?.paymentStatus).toBe("unpaid");
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
+
+      test("casts amount_total to number", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const retrieveSpy = stub(client.checkout.sessions, "retrieve", () =>
+          Promise.resolve({
+            id: "cs_amount_cast",
+            payment_status: "paid",
+            payment_intent: "pi_amount_cast",
+            amount_total: 7500,
+            metadata: {
+              name: "Cast User",
+              email: "cast@example.com",
+              event_id: "11",
+              quantity: "1",
+            },
+          } as never),
+        );
+
+        try {
+          const result =
+            await stripePaymentProvider.retrieveSession("cs_amount_cast");
+          expect(result).not.toBeNull();
+          expect(result?.amountTotal).toBe(7500);
+        } finally {
+          retrieveSpy.restore();
+        }
+      });
     });
 
-    test("falls back to retrieveSession when event lacks metadata", async () => {
-      const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
-        Promise.resolve(null),
-      );
+    describe("verifyWebhookSignature delegation", () => {
+      test("delegates to stripe.ts verifyWebhookSignature", async () => {
+        const TEST_SECRET = "whsec_provider_verify_test";
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_provider_test",
+        });
 
-      try {
+        const event: StripeWebhookEvent = {
+          id: "evt_provider",
+          type: "checkout.session.completed",
+          data: { object: { id: "cs_test" } },
+        };
+
+        const { payload, signature } = await constructTestWebhookEvent(
+          event,
+          TEST_SECRET,
+        );
+
+        const result = await stripePaymentProvider.verifyWebhookSignature(
+          payload,
+          signature,
+          "https://example.com/payment/webhook",
+          new TextEncoder().encode(payload),
+        );
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.event.id).toBe("evt_provider");
+        }
+      });
+
+      test("returns error for invalid signature", async () => {
+        const TEST_SECRET = "whsec_provider_invalid_test";
+        await setStripeWebhookConfig({
+          secret: TEST_SECRET,
+          endpointId: "we_provider_inv",
+        });
+
+        const timestamp = Math.floor(Date.now() / 1000);
+        const body = '{"test": true}';
+        const result = await stripePaymentProvider.verifyWebhookSignature(
+          body,
+          `t=${timestamp},v1=invalid_sig`,
+          "https://example.com/payment/webhook",
+          new TextEncoder().encode(body),
+        );
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error).toBeDefined();
+        }
+      });
+    });
+
+    describe("setupWebhookEndpoint delegation", () => {
+      test("delegates to stripe.ts setupWebhookEndpoint", async () => {
+        // Mock stripeApi since setupWebhookEndpointImpl creates its own client
+        const origSetup = stripeApi.setupWebhookEndpoint;
+        stripeApi.setupWebhookEndpoint = (_key, _url, _existing) =>
+          Promise.resolve({
+            success: true,
+            endpointId: "we_provider_created",
+            secret: "whsec_provider_secret",
+          });
+
+        try {
+          const result = await stripePaymentProvider.setupWebhookEndpoint(
+            "sk_test_mock",
+            "https://example.com/payment/webhook",
+          );
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.endpointId).toBe("we_provider_created");
+            expect(result.secret).toBe("whsec_provider_secret");
+          }
+        } finally {
+          stripeApi.setupWebhookEndpoint = origSetup;
+        }
+      });
+    });
+
+    describe("refundPayment delegation", () => {
+      test("returns true when refund succeeds", async () => {
+        await updateStripeKey("sk_test_mock");
+        const result = await stripePaymentProvider.refundPayment("pi_test_123");
+        expect(result).toBe(true);
+      });
+
+      test("returns false when refund fails", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const refundSpy = stub(client.refunds, "create", () =>
+          Promise.reject(new Error("Refund failed")),
+        );
+
+        try {
+          const result = await stripePaymentProvider.refundPayment("pi_fail");
+          expect(result).toBe(false);
+        } finally {
+          refundSpy.restore();
+        }
+      });
+    });
+
+    describe("sanitizeErrorDetail edge cases", () => {
+      test("returns err.name when no statusCode/code/type and name is set", () => {
+        const err = new TypeError("something went wrong");
+        const detail = sanitizeErrorDetail(err);
+        expect(detail).toBe("TypeError");
+      });
+    });
+
+    describe("getMockConfig without STRIPE_MOCK_HOST", () => {
+      test("creates client without mock config when STRIPE_MOCK_HOST not set", async () => {
+        await updateStripeKey("sk_test_123");
+        Deno.env.delete("STRIPE_MOCK_HOST");
+        Deno.env.delete("STRIPE_MOCK_PORT");
+
+        // resetStripeClient now also resets getMockConfig (lazyRef)
+        resetStripeClient();
+
+        const client = await getStripeClient();
+        // Client is created using real Stripe (no mock) - returns non-null
+        expect(client !== undefined).toBe(true);
+      });
+    });
+
+    describe("retrievePaymentIntent", () => {
+      test("returns null when stripe key not set", async () => {
+        const result = await retrievePaymentIntent("pi_test_123");
+        expect(result).toBeNull();
+      });
+
+      test("returns null when Stripe API throws error", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client to be defined");
+
+        await withMocks(
+          () =>
+            stub(client.paymentIntents, "retrieve", () =>
+              Promise.reject(new Error("Network error")),
+            ),
+          async (retrieveSpy) => {
+            const result = await retrievePaymentIntent("pi_test_123");
+            expect(result).toBeNull();
+            expect(retrieveSpy.calls.length).toBeGreaterThan(0);
+          },
+        );
+      });
+    });
+
+    describe("isPaymentRefunded", () => {
+      test("returns true when latest_charge is refunded", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        await withMocks(
+          () =>
+            stub(client.paymentIntents, "retrieve", () =>
+              Promise.resolve({
+                id: "pi_refunded",
+                latest_charge: { id: "ch_1", refunded: true },
+              } as never),
+            ),
+          async () => {
+            const result =
+              await stripePaymentProvider.isPaymentRefunded("pi_refunded");
+            expect(result).toBe(true);
+          },
+        );
+      });
+
+      test("returns false when latest_charge is not refunded", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        await withMocks(
+          () =>
+            stub(client.paymentIntents, "retrieve", () =>
+              Promise.resolve({
+                id: "pi_not_refunded",
+                latest_charge: { id: "ch_2", refunded: false },
+              } as never),
+            ),
+          async () => {
+            const result =
+              await stripePaymentProvider.isPaymentRefunded("pi_not_refunded");
+            expect(result).toBe(false);
+          },
+        );
+      });
+
+      test("returns false when payment intent not found", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        await withMocks(
+          () =>
+            stub(client.paymentIntents, "retrieve", () =>
+              Promise.reject(new Error("Not found")),
+            ),
+          async () => {
+            const result =
+              await stripePaymentProvider.isPaymentRefunded("pi_missing");
+            expect(result).toBe(false);
+          },
+        );
+      });
+
+      test("returns false when latest_charge is a string ID", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        await withMocks(
+          () =>
+            stub(client.paymentIntents, "retrieve", () =>
+              Promise.resolve({
+                id: "pi_string_charge",
+                latest_charge: "ch_string_id",
+              } as never),
+            ),
+          async () => {
+            const result =
+              await stripePaymentProvider.isPaymentRefunded("pi_string_charge");
+            expect(result).toBe(false);
+          },
+        );
+      });
+    });
+
+    describe("createMultiCheckoutSession - via provider", () => {
+      test("returns null when session has no URL", async () => {
+        await updateStripeKey("sk_test_mock");
+        const client = await getStripeClient();
+        if (!client) throw new Error("Expected client");
+
+        const createSpy = stub(client.checkout.sessions, "create", () =>
+          Promise.resolve({
+            id: "cs_multi_nourl",
+            url: null,
+            object: "checkout.session",
+          } as never),
+        );
+
+        try {
+          const intent = {
+            name: "Jane",
+            email: "jane@example.com",
+            phone: "",
+            address: "",
+            special_instructions: "",
+            items: [
+              {
+                eventId: 1,
+                quantity: 1,
+                unitPrice: 1000,
+                slug: "evt",
+                name: "Evt",
+              },
+            ],
+          };
+          const result = await stripePaymentProvider.createMultiCheckoutSession(
+            intent,
+            "http://localhost:3000",
+          );
+          expect(result).toBeNull();
+        } finally {
+          createSpy.restore();
+        }
+      });
+    });
+
+    describe("resolveWebhookSession", () => {
+      test("extracts session directly from event with complete metadata", async () => {
         const result = await stripePaymentProvider.resolveWebhookSession({
-          id: "evt_no_meta",
+          id: "evt_resolve_1",
           type: "checkout.session.completed",
           data: {
             object: {
-              id: "cs_no_meta",
-              // No payment_status or metadata
+              id: "cs_resolve_1",
+              payment_status: "paid",
+              payment_intent: "pi_resolve_1",
+              amount_total: 2000,
+              metadata: {
+                name: "Alice",
+                email: "alice@example.com",
+                event_id: "1",
+                quantity: "1",
+              },
             },
           },
         });
-        // retrieveSession called with event object id
-        expect(mockRetrieve.calls[0]!.args[0]).toBe("cs_no_meta");
-        expect(result).toBeNull();
-      } finally {
-        mockRetrieve.restore();
-      }
-    });
-
-    test("returns null when event has no id", async () => {
-      const result = await stripePaymentProvider.resolveWebhookSession({
-        id: "evt_no_obj_id",
-        type: "checkout.session.completed",
-        data: {
-          object: {
-            some_field: "value",
-          },
-        },
+        expect(result).not.toBe("skip");
+        expect(result).not.toBeNull();
+        if (result && result !== "skip") {
+          expect(result.id).toBe("cs_resolve_1");
+          expect(result.paymentStatus).toBe("paid");
+          expect(result.paymentReference).toBe("pi_resolve_1");
+          expect(result.amountTotal).toBe(2000);
+        }
       });
-      expect(result).toBeNull();
+
+      test("falls back to retrieveSession when event lacks metadata", async () => {
+        const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
+          Promise.resolve(null),
+        );
+
+        try {
+          const result = await stripePaymentProvider.resolveWebhookSession({
+            id: "evt_no_meta",
+            type: "checkout.session.completed",
+            data: {
+              object: {
+                id: "cs_no_meta",
+                // No payment_status or metadata
+              },
+            },
+          });
+          // retrieveSession called with event object id
+          expect(mockRetrieve.calls[0]!.args[0]).toBe("cs_no_meta");
+          expect(result).toBeNull();
+        } finally {
+          mockRetrieve.restore();
+        }
+      });
+
+      test("returns null when event has no id", async () => {
+        const result = await stripePaymentProvider.resolveWebhookSession({
+          id: "evt_no_obj_id",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              some_field: "value",
+            },
+          },
+        });
+        expect(result).toBeNull();
+      });
     });
-  });
-});
+  },
+);

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -26,17 +26,21 @@ import {
   resetDb,
   testEvent,
   urlFromFetchInput,
+  setTestEnv,
   withFetchMock,
   withMocks,
 } from "#test-utils";
 
 describe("stripe", () => {
-  let originalMockHost: string | undefined;
-  let originalMockPort: string | undefined;
+  let restoreEnv: () => void;
 
   beforeEach(async () => {
-    originalMockHost = Deno.env.get("STRIPE_MOCK_HOST");
-    originalMockPort = Deno.env.get("STRIPE_MOCK_PORT");
+    // Snapshot STRIPE_MOCK vars so tests can modify them freely;
+    // setTestEnv re-sets current values (no-op) but saves for restore.
+    restoreEnv = setTestEnv({
+      STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
+      STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
+    });
     resetStripeClient();
     // Create in-memory db for testing
     await createTestDb();
@@ -45,17 +49,7 @@ describe("stripe", () => {
   afterEach(() => {
     resetStripeClient();
     resetDb();
-    // Restore original env values
-    if (originalMockHost !== undefined) {
-      Deno.env.set("STRIPE_MOCK_HOST", originalMockHost);
-    } else {
-      Deno.env.delete("STRIPE_MOCK_HOST");
-    }
-    if (originalMockPort !== undefined) {
-      Deno.env.set("STRIPE_MOCK_PORT", originalMockPort);
-    } else {
-      Deno.env.delete("STRIPE_MOCK_PORT");
-    }
+    restoreEnv();
   });
 
   describe("getStripeClient", () => {
@@ -1589,12 +1583,13 @@ describe("stripe", () => {
 });
 
 describe("stripe-provider", () => {
-  let originalMockHost: string | undefined;
-  let originalMockPort: string | undefined;
+  let restoreEnv: () => void;
 
   beforeEach(async () => {
-    originalMockHost = Deno.env.get("STRIPE_MOCK_HOST");
-    originalMockPort = Deno.env.get("STRIPE_MOCK_PORT");
+    restoreEnv = setTestEnv({
+      STRIPE_MOCK_HOST: Deno.env.get("STRIPE_MOCK_HOST"),
+      STRIPE_MOCK_PORT: Deno.env.get("STRIPE_MOCK_PORT"),
+    });
     resetStripeClient();
     await createTestDb();
   });
@@ -1602,16 +1597,7 @@ describe("stripe-provider", () => {
   afterEach(() => {
     resetStripeClient();
     resetDb();
-    if (originalMockHost !== undefined) {
-      Deno.env.set("STRIPE_MOCK_HOST", originalMockHost);
-    } else {
-      Deno.env.delete("STRIPE_MOCK_HOST");
-    }
-    if (originalMockPort !== undefined) {
-      Deno.env.set("STRIPE_MOCK_PORT", originalMockPort);
-    } else {
-      Deno.env.delete("STRIPE_MOCK_PORT");
-    }
+    restoreEnv();
   });
 
   describe("toCheckoutResult - session with no URL", () => {

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   type EmailEntry,
   makeTestAttendee as makeAttendee,
   makeTestEntry as makeEntry,
@@ -83,11 +84,9 @@ describe("webhook", () => {
       return spyFirstArgs(errorSpy.calls);
     });
 
-  describe("buildWebhookPayload", () => {
+  describeWithEnv("buildWebhookPayload", { db: true }, () => {
     beforeEach(async () => {
       const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
-      await resetDb();
-      await createTestDbWithSetup();
       invalidateSettingsCache();
     });
 
@@ -238,15 +237,7 @@ describe("webhook", () => {
     });
   });
 
-  describe("sendWebhook", () => {
-    beforeEach(async () => {
-      await createTestDbWithSetup();
-    });
-
-    afterEach(() => {
-      resetDb();
-    });
-
+  describeWithEnv("sendWebhook", { db: true }, () => {
     test("sends POST request with correct payload", async () => {
       const payload: WebhookPayload = await buildWebhookPayload(
         defaultEntries(),
@@ -396,15 +387,7 @@ describe("webhook", () => {
     });
   });
 
-  describe("sendRegistrationWebhooks", () => {
-    beforeEach(async () => {
-      await createTestDbWithSetup();
-    });
-
-    afterEach(() => {
-      resetDb();
-    });
-
+  describeWithEnv("sendRegistrationWebhooks", { db: true }, () => {
     test("sends to all unique webhook URLs", async () => {
       const entries = [
         makeEntry({ id: 1, webhook_url: "https://hook-a.com" }),
@@ -450,15 +433,7 @@ describe("webhook", () => {
     });
   });
 
-  describe("logAndNotifyRegistration", () => {
-    beforeEach(async () => {
-      await createTestDbWithSetup();
-    });
-
-    afterEach(() => {
-      resetDb();
-    });
-
+  describeWithEnv("logAndNotifyRegistration", { db: true }, () => {
     test("sends webhook when event has webhook_url", async () => {
       const { logAndNotifyRegistration } = await import("#lib/webhook.ts");
       const dbEvent = await createTestEvent({
@@ -489,15 +464,7 @@ describe("webhook", () => {
     });
   });
 
-  describe("logAndNotifyMultiRegistration", () => {
-    beforeEach(async () => {
-      await createTestDbWithSetup();
-    });
-
-    afterEach(() => {
-      resetDb();
-    });
-
+  describeWithEnv("logAndNotifyMultiRegistration", { db: true }, () => {
     test("sends webhooks for multi-event registration", async () => {
       const { logAndNotifyMultiRegistration } = await import("#lib/webhook.ts");
       const dbEventA = await createTestEvent({

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -1,16 +1,14 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { updateShowPublicApi } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   createDailyTestEvent,
   createTestAttendeeDirect,
-  createTestDbWithSetup,
   createTestEvent,
   deactivateTestEvent,
-  resetDb,
-  resetTestSlugCounter,
+  describeWithEnv,
   setupStripe,
 } from "#test-utils";
 
@@ -43,15 +41,9 @@ const expectCorsHeaders = (response: Response): void => {
   expect(response.headers.get("access-control-allow-origin")).toBe("*");
 };
 
-describe("Public API", () => {
+describeWithEnv("Public API", { db: true }, () => {
   beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
     await updateShowPublicApi(true);
-  });
-
-  afterEach(() => {
-    resetDb();
   });
 
   /** Fetch the events list and return parsed events array */


### PR DESCRIPTION
This PR introduces a new `describeWithEnv` test helper function to reduce boilerplate in test files and improve test isolation.

## Summary
Refactored test setup patterns across the test suite to use a new `describeWithEnv` helper that automatically manages environment variables and database setup/teardown. This eliminates repetitive `beforeEach`/`afterEach` blocks and provides a cleaner, more declarative way to configure test environments.

## Key Changes

- **New `describeWithEnv` helper** in `src/test-utils/index.ts`:
  - Accepts a test suite name, configuration object, and test function
  - Automatically sets up and tears down environment variables
  - Optionally initializes and resets the test database
  - Wraps the standard `describe` function with automatic lifecycle management

- **New `setTestEnv` helper** in `src/test-utils/index.ts`:
  - Returns a restore function to cleanly revert environment variable changes
  - Useful for tests that need temporary env var modifications within a test case

- **Updated test files** to use the new helpers:
  - `test/lib/server-images.test.ts`
  - `test/lib/storage.test.ts`
  - `test/lib/server-settings-advanced.test.ts`
  - `test/lib/header-image.test.ts`
  - `test/lib/attachment-route.test.ts`
  - `test/lib/email.test.ts`
  - `test/lib/logger.test.ts`
  - `test/lib/server-wallet.test.ts`
  - `test/lib/server-google-wallet.test.ts`
  - `test/lib/server-debug.test.ts`
  - `test/lib/bunny-cdn.test.ts`
  - `test/lib/webhook.test.ts`
  - And many others

## Implementation Details

- The `describeWithEnv` helper accepts a configuration object with:
  - `env`: Object mapping environment variable names to values (undefined values delete the var)
  - `db`: Boolean flag to enable automatic database setup/teardown
  
- Removed manual `beforeEach`/`afterEach` blocks that were setting/deleting environment variables
- Removed manual database initialization and reset calls where `db: true` is specified
- Tests that need dynamic env var changes within a test case use `setTestEnv()` with try/finally for cleanup
- Maintains backward compatibility - tests without special setup requirements are unchanged

https://claude.ai/code/session_01LnmuF9WmJERVdiLpeYS9a4