### PR TITLE
Implement batched refunds with 30-per-request limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ const result = reduce((acc, item) => {
 | `unique(arr)` | Remove duplicates |
 | `uniqueBy(fn)` | Dedupe by key |
 | `compact(arr)` | Remove null/undefined |
+| `chunk(size)` | Split array into chunks |
 | `pick(keys)` | Extract object keys |
 
 | `groupBy(fn)` | Group array items |

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -318,6 +318,19 @@ export function pipeAsync(
 }
 
 /**
+ * Split an array into chunks of a given size
+ */
+export const chunk =
+  (size: number) =>
+  <T>(array: T[]): T[][] => {
+    const result: T[][] = [];
+    for (let i = 0; i < array.length; i += size) {
+      result.push(array.slice(i, i + size));
+    }
+    return result;
+  };
+
+/**
  * Map over a promise-returning function sequentially (one at a time)
  */
 export const mapSequential =

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -2,7 +2,7 @@
  * Admin attendee management routes
  */
 
-import { compact, filter, uniqueBy } from "#fp";
+import { chunk, compact, filter, uniqueBy } from "#fp";
 import { getCurrencyCode } from "#lib/config.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import {
@@ -420,22 +420,28 @@ const processRefundAll = async (
     );
   }
 
-  // TODO: Refunds are sequential to avoid overwhelming payment providers.
-  // For large events, consider batching with Promise.all in chunks.
+  const REFUND_CHUNK_SIZE = 5;
   let refundedCount = 0;
   let failedCount = 0;
-  for (const attendee of refundable) {
-    const refunded = await provider.refundPayment(attendee.payment_id);
-    if (refunded) {
-      await markRefunded(attendee.id);
-      refundedCount++;
-    } else {
-      failedCount++;
-      logError({
-        code: ErrorCode.PAYMENT_REFUND,
-        eventId: event.id,
-        detail: `Admin bulk refund failed for attendee ${attendee.id}, payment ${attendee.payment_id}`,
-      });
+  for (const batch of chunk(REFUND_CHUNK_SIZE)(refundable)) {
+    const results = await Promise.all(
+      batch.map(async (attendee) => {
+        const refunded = await provider.refundPayment(attendee.payment_id);
+        if (refunded) {
+          await markRefunded(attendee.id);
+          return true;
+        }
+        logError({
+          code: ErrorCode.PAYMENT_REFUND,
+          eventId: event.id,
+          detail: `Admin bulk refund failed for attendee ${attendee.id}, payment ${attendee.payment_id}`,
+        });
+        return false;
+      }),
+    );
+    for (const success of results) {
+      if (success) refundedCount++;
+      else failedCount++;
     }
   }
 

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -73,6 +73,9 @@ const REFUND_FAILED_ERROR =
   "Refund failed. The payment may have already been refunded.";
 const ALREADY_REFUNDED_ERROR = "This attendee has already been refunded.";
 
+/** Max refunds per request to stay within Bunny Edge fetch limits */
+const REFUND_BATCH_LIMIT = 30;
+
 /**
  * Load attendee ensuring it belongs to the specified event.
  * Uses batched query to fetch event + attendee in a single DB round-trip.
@@ -421,11 +424,14 @@ const processRefundAll = async (
   }
 
   const REFUND_CHUNK_SIZE = 5;
+  const batch = refundable.slice(0, REFUND_BATCH_LIMIT);
+  const remaining = refundable.length - batch.length;
+
   let refundedCount = 0;
   let failedCount = 0;
-  for (const batch of chunk(REFUND_CHUNK_SIZE)(refundable)) {
+  for (const group of chunk(REFUND_CHUNK_SIZE)(batch)) {
     const results = await Promise.all(
-      batch.map(async (attendee) => {
+      group.map(async (attendee) => {
         const refunded = await provider.refundPayment(attendee.payment_id);
         if (refunded) {
           await markRefunded(attendee.id);
@@ -446,18 +452,32 @@ const processRefundAll = async (
   }
 
   if (failedCount > 0) {
+    const msg =
+      remaining > 0
+        ? `${refundedCount} refund(s) succeeded, ${failedCount} failed. ${remaining} remaining — submit again to continue.`
+        : `${refundedCount} refund(s) succeeded, ${failedCount} failed. Some payments may have already been refunded.`;
     await logActivity(
       `Bulk refund: ${refundedCount} succeeded, ${failedCount} failed for '${event.name}'`,
       event.id,
     );
     return htmlResponse(
+      adminRefundAllAttendeesPage(event, refundable.length, session, msg),
+      400,
+    );
+  }
+
+  if (remaining > 0) {
+    await logActivity(
+      `Bulk refund: ${refundedCount} of ${refundable.length} refunded for '${event.name}'`,
+      event.id,
+    );
+    return htmlResponse(
       adminRefundAllAttendeesPage(
         event,
-        refundable.length,
+        remaining,
         session,
-        `${refundedCount} refund(s) succeeded, ${failedCount} failed. Some payments may have already been refunded.`,
+        `${refundedCount} attendee(s) refunded. ${remaining} remaining — submit again to continue.`,
       ),
-      400,
     );
   }
 

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   boundedLru,
   bracket,
+  chunk,
   collectionCache,
   compact,
   err,
@@ -286,6 +287,31 @@ describe("fp", () => {
     test("removes only null and undefined from mixed array", () => {
       const result = compact([null, undefined]);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("chunk", () => {
+    test("splits array into chunks of given size", () => {
+      expect(chunk(2)([1, 2, 3, 4, 5])).toEqual([[1, 2], [3, 4], [5]]);
+    });
+
+    test("returns single chunk when array fits", () => {
+      expect(chunk(5)([1, 2, 3])).toEqual([[1, 2, 3]]);
+    });
+
+    test("returns empty array for empty input", () => {
+      expect(chunk(3)([])).toEqual([]);
+    });
+
+    test("handles exact multiples", () => {
+      expect(chunk(2)([1, 2, 3, 4])).toEqual([
+        [1, 2],
+        [3, 4],
+      ]);
+    });
+
+    test("handles chunk size of 1", () => {
+      expect(chunk(1)([1, 2, 3])).toEqual([[1], [2], [3]]);
     });
   });
 

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -466,6 +466,63 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       });
     });
 
+    test("caps refunds at 30 per request and shows continuation message", async () => {
+      const event = await createPaidEvent({ maxAttendees: 500 });
+      for (let i = 0; i < 32; i++) {
+        await createPaidTestAttendee(
+          event.id,
+          `User ${i}`,
+          `user${i}@example.com`,
+          `pi_batch_${i}`,
+        );
+      }
+      await withRefundMock(true, async (mockRefund) => {
+        const response = await handleRequest(
+          mockFormRequest(
+            refundAllUrl(event.id),
+            { confirm_name: event.name, csrf_token: await testCsrfToken() },
+            await testCookie(),
+          ),
+        );
+        expect(mockRefund.calls.length).toBe(30);
+        await expectHtmlResponse(
+          response,
+          200,
+          "30 attendee(s) refunded",
+          "2 remaining",
+          "submit again to continue",
+        );
+      });
+    });
+
+    test("reports failures with remaining count when batch has errors", async () => {
+      const event = await createPaidEvent({ maxAttendees: 500 });
+      for (let i = 0; i < 32; i++) {
+        await createPaidTestAttendee(
+          event.id,
+          `User ${i}`,
+          `user${i}@example.com`,
+          `pi_batchfail_${i}`,
+        );
+      }
+      await withRefundMock(false, async () => {
+        const response = await handleRequest(
+          mockFormRequest(
+            refundAllUrl(event.id),
+            { confirm_name: event.name, csrf_token: await testCsrfToken() },
+            await testCookie(),
+          ),
+        );
+        await expectHtmlResponse(
+          response,
+          400,
+          "30 failed",
+          "2 remaining",
+          "submit again to continue",
+        );
+      });
+    });
+
     test("reports partial failure when some refunds fail", async () => {
       const event = await createPaidEvent();
       await createPaidTestAttendee(


### PR DESCRIPTION
## Summary
Refactors the bulk attendee refund process to batch refunds in chunks of 5 with a hard limit of 30 refunds per request. This prevents overwhelming payment providers and respects Bunny Edge fetch limits while allowing users to continue processing remaining refunds in subsequent requests.

## Key Changes
- **Added `chunk()` utility function** to `src/fp.ts` for splitting arrays into fixed-size chunks, with comprehensive test coverage
- **Implemented refund batching** in `processRefundAll()`:
  - Limits refunds to 30 per request (`REFUND_BATCH_LIMIT`)
  - Processes refunds in parallel groups of 5 using `Promise.all()` instead of sequential processing
  - Tracks remaining refunds and provides continuation messaging
- **Improved user feedback**:
  - Shows success count and remaining count when batch limit is reached
  - Displays appropriate error messages with remaining count when failures occur
  - Guides users to "submit again to continue" for large refund operations
- **Added test coverage** for the new batching behavior:
  - Verifies 30-refund cap with continuation message
  - Tests failure reporting with remaining count

## Implementation Details
- Refunds are now processed in parallel chunks (5 at a time) within each batch, improving throughput while maintaining safety limits
- The response status is 200 (success) when batch limit is reached with no failures, allowing seamless continuation
- Error responses (400) are returned only when actual refund failures occur, with remaining count included
- The `chunk()` function uses a curried, functional programming style consistent with the existing codebase patterns

https://claude.ai/code/session_01DwSgSWEBoh6ZZnkSBXh2KP