### PR TITLE
Move API key from URL parameter to flash message

### DIFF
--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -13,7 +13,6 @@ import { getFlash } from "#lib/flash-context.ts";
 import { verifyIdentifier } from "#routes/admin/utils.ts";
 import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import {
-  getSearchParam,
   htmlResponse,
   jsonResponse,
   orNotFound,
@@ -33,10 +32,17 @@ const handleApiKeysGet: TypedRouteHandler<"GET /admin/api-keys"> = (request) =>
   requireOwnerOr(request, async (session) => {
     const keys = await getApiKeysForUser(session.userId);
     const flash = getFlash();
-    const newKey = getSearchParam(request, "key") || undefined;
+    // The API key is embedded in the flash success message after a newline
+    const newLineIdx = flash.success?.indexOf("\n") ?? -1;
+    const success = newLineIdx >= 0
+      ? flash.success!.slice(0, newLineIdx)
+      : flash.success;
+    const newKey = newLineIdx >= 0
+      ? flash.success!.slice(newLineIdx + 1)
+      : undefined;
     return htmlResponse(
       adminApiKeysPage(keys, session, {
-        success: flash.success,
+        success,
         error: flash.error,
         newKey,
       }),
@@ -79,10 +85,10 @@ const handleApiKeysPost: TypedRouteHandler<"POST /admin/api-keys"> = (
       generateSecureToken,
     );
 
-    // Redirect back with the key in the URL (shown once on the GET page)
+    // Embed the key in the flash message (after a newline) so it's not exposed in the URL
     return redirect(
-      `/admin/api-keys?key=${encodeURIComponent(apiKey)}`,
-      "API key created",
+      "/admin/api-keys",
+      `API key created\n${apiKey}`,
       true,
     );
   });

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -62,7 +62,7 @@ export const adminApiKeysPage = (
 
       {opts.newKey && (
         <div class="warning">
-          <strong>Copy your API key now — it won't be shown again.</strong>
+          <strong>Copy your API key now — it won't be shown again:</strong>
           <pre>
             <code>{opts.newKey}</code>
           </pre>

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -62,7 +62,7 @@ export const adminApiKeysPage = (
 
       {opts.newKey && (
         <div class="warning">
-          <strong>Copy your API key now — it won't be shown again:</strong>
+          <strong>Copy your API key now — it won't be shown again.</strong>
           <pre>
             <code>{opts.newKey}</code>
           </pre>

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -254,8 +254,8 @@ describe("API Keys", () => {
 
       expect(response.status).toBe(302);
       const location = response.headers.get("location")!;
-      expect(location).toContain("key=");
-      expectFlash(response, "API key created");
+      expect(location).toBe("/admin/api-keys");
+      expectFlash(response, expect.stringContaining("API key created\n"));
 
       // Follow the redirect and verify the key is shown
       const flashCookie = response.headers


### PR DESCRIPTION
## Summary
This change improves security by removing the API key from the redirect URL and instead embedding it in the flash message. This prevents the key from being exposed in browser history, server logs, or referrer headers.

## Key Changes
- **Removed URL parameter approach**: Previously, the newly created API key was passed via the `key` query parameter in the redirect URL
- **Implemented flash message embedding**: The API key is now embedded in the flash success message after a newline separator
- **Updated flash message parsing**: The GET handler now extracts the API key from the flash message by splitting on the newline character, separating the success message from the key
- **Removed unused import**: Removed the `getSearchParam` import that is no longer needed
- **Updated tests**: Modified test expectations to verify the redirect goes to `/admin/api-keys` without query parameters and that the flash message contains the key

## Implementation Details
- The flash message format is now: `"API key created\n{apiKey}"` where the newline acts as a delimiter
- The GET handler parses this by finding the newline index and slicing the message accordingly
- The success message shown to the user is everything before the newline, while the key is extracted from after the newline
- This approach keeps the sensitive key out of URLs while still making it available for display on the page after redirect

https://claude.ai/code/session_01MrReGBVsyyXPVYgAv5qXGT