### PR TITLE
Implement keyed flash cookies for per-request message isolation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -40,7 +40,7 @@
     "esbuild": "npm:esbuild@^0.20.0",
     "@bunny.net/edgescript-sdk": "npm:@bunny.net/edgescript-sdk@^0.12.0",
     "@internationalized/date": "npm:@internationalized/date@^3.8.0",
-    "@bunny.net/storage-sdk": "npm:@bunny.net/storage-sdk@^0.2.0",
+    "@bunny.net/storage-sdk": "npm:@bunny.net/storage-sdk@^0.3.0",
     "jsqr": "npm:jsqr@^1.4.0",
     "qrcode": "npm:qrcode@^1.5.0",
     "@iframe-resizer/parent": "npm:@iframe-resizer/parent@^5",

--- a/deno.lock
+++ b/deno.lock
@@ -1,26 +1,24 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.17",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@^1.1.0": "1.2.0",
     "jsr:@std/data-structures@^1.0.10": "1.0.10",
     "jsr:@std/expect@1": "1.0.18",
-    "jsr:@std/fs@^1.0.22": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/testing@1": "1.0.17",
-    "npm:@biomejs/biome@*": "2.4.7",
-    "npm:@bunny.net/edgescript-sdk@0.12": "0.12.0_hono@4.11.5",
-    "npm:@bunny.net/storage-sdk@*": "0.2.2",
-    "npm:@bunny.net/storage-sdk@0.2": "0.2.2",
+    "npm:@biomejs/biome@*": "2.4.8",
+    "npm:@bunny.net/edgescript-sdk@0.12": "0.12.1",
+    "npm:@bunny.net/storage-sdk@0.3": "0.3.1",
     "npm:@iframe-resizer/child@5": "5.5.9",
     "npm:@iframe-resizer/core@5": "5.5.9",
     "npm:@iframe-resizer/parent@5": "5.5.9",
-    "npm:@internationalized/date@^3.8.0": "3.11.0",
-    "npm:@libsql/client@0.17": "0.17.0",
+    "npm:@internationalized/date@^3.8.0": "3.12.0",
+    "npm:@libsql/client@0.17": "0.17.2",
     "npm:auto-console-group@1": "1.3.0",
     "npm:esbuild@0.20": "0.20.2",
     "npm:fflate@0.8": "0.8.2",
@@ -33,12 +31,6 @@
     "npm:stripe@17": "17.7.0"
   },
   "jsr": {
-    "@std/assert@1.0.17": {
-      "integrity": "df5ebfffe77c03b3fa1401e11c762cc8f603d51021c56c4d15a8c7ab45e90dbe",
-      "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
@@ -59,12 +51,6 @@
         "jsr:@std/path@^1.1.4"
       ]
     },
-    "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
-      "dependencies": [
-        "jsr:@std/path@^1.1.4"
-      ]
-    },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
@@ -80,9 +66,7 @@
         "jsr:@std/assert@^1.0.17",
         "jsr:@std/async",
         "jsr:@std/data-structures",
-        "jsr:@std/fs",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.4"
+        "jsr:@std/internal"
       ]
     }
   },
@@ -93,8 +77,8 @@
     "@babel/helper-validator-identifier@7.28.5": {
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
     },
-    "@babel/parser@7.29.0": {
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+    "@babel/parser@7.29.2": {
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dependencies": [
         "@babel/types"
       ],
@@ -107,8 +91,8 @@
         "@babel/helper-validator-identifier"
       ]
     },
-    "@biomejs/biome@2.4.7": {
-      "integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+    "@biomejs/biome@2.4.8": {
+      "integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
       "optionalDependencies": [
         "@biomejs/cli-darwin-arm64",
         "@biomejs/cli-darwin-x64",
@@ -121,55 +105,55 @@
       ],
       "bin": true
     },
-    "@biomejs/cli-darwin-arm64@2.4.7": {
-      "integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+    "@biomejs/cli-darwin-arm64@2.4.8": {
+      "integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-darwin-x64@2.4.7": {
-      "integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+    "@biomejs/cli-darwin-x64@2.4.8": {
+      "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-linux-arm64-musl@2.4.7": {
-      "integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+    "@biomejs/cli-linux-arm64-musl@2.4.8": {
+      "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-linux-arm64@2.4.7": {
-      "integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+    "@biomejs/cli-linux-arm64@2.4.8": {
+      "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-linux-x64-musl@2.4.7": {
-      "integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+    "@biomejs/cli-linux-x64-musl@2.4.8": {
+      "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-linux-x64@2.4.7": {
-      "integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+    "@biomejs/cli-linux-x64@2.4.8": {
+      "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-win32-arm64@2.4.7": {
-      "integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+    "@biomejs/cli-win32-arm64@2.4.8": {
+      "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-win32-x64@2.4.7": {
-      "integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+    "@biomejs/cli-win32-x64@2.4.8": {
+      "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@bunny.net/edgescript-sdk@0.12.0_hono@4.11.5": {
-      "integrity": "sha512-SLXBnPjxj1zNchNaGT2n8j5JWHzzfEYvpv4k3o1Cg1u4tAsnqzdmV7jTajLgFPdaJBdgrzuWzYXgDNqR51Ad2Q==",
+    "@bunny.net/edgescript-sdk@0.12.1": {
+      "integrity": "sha512-+B+AUnfA+9y6PlyX6BNL2Uk8x3vExRIKKP+rH0r4UnEWRiJZsbuEnZg5Au6pglf67NumP8tOwbrqP9jS4e+jDQ==",
       "dependencies": [
         "@hono/node-server",
         "hono"
       ]
     },
-    "@bunny.net/storage-sdk@0.2.2": {
-      "integrity": "sha512-LhL9veq1np022kLdGilvvq5R3fBfFb/aeTT8J6doYQGInNwf3Innv/HpeRMz+FujpXlHCFLl0J9OefcS7+xRCQ==",
+    "@bunny.net/storage-sdk@0.3.1": {
+      "integrity": "sha512-nHD+e+CxYBcSoZERkxI/7Qir/kZaCfBTT+ULgZNUitNSyZ4mWD3DbTy+sHwVfRyc6wQ0XYD//6LImi2PU9JoWg==",
       "dependencies": [
         "dotenv",
         "zod"
@@ -293,8 +277,8 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@hono/node-server@1.19.9_hono@4.11.5": {
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+    "@hono/node-server@1.19.11_hono@4.12.8": {
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dependencies": [
         "hono"
       ]
@@ -318,8 +302,8 @@
         "auto-console-group"
       ]
     },
-    "@internationalized/date@3.11.0": {
-      "integrity": "sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==",
+    "@internationalized/date@3.12.0": {
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dependencies": [
         "@swc/helpers"
       ]
@@ -369,8 +353,8 @@
         "spark-md5"
       ]
     },
-    "@libsql/client@0.17.0": {
-      "integrity": "sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==",
+    "@libsql/client@0.17.2": {
+      "integrity": "sha512-0aw0S3iQMHvOxfRt5j1atoCCPMT3gjsB2PS8/uxSM1DcDn39xqz6RlgSMxtP8I3JsxIXAFuw7S41baLEw0Zi+Q==",
       "dependencies": [
         "@libsql/core",
         "@libsql/hrana-client",
@@ -379,19 +363,19 @@
         "promise-limit"
       ]
     },
-    "@libsql/core@0.17.0": {
-      "integrity": "sha512-hnZRnJHiS+nrhHKLGYPoJbc78FE903MSDrFJTbftxo+e52X+E0Y0fHOCVYsKWcg6XgB7BbJYUrz/xEkVTSaipw==",
+    "@libsql/core@0.17.2": {
+      "integrity": "sha512-L8qv12HZ/jRBcETVR3rscP0uHNxh+K3EABSde6scCw7zfOdiLqO3MAkJaeE1WovPsjXzsN/JBoZED4+7EZVT3g==",
       "dependencies": [
         "js-base64"
       ]
     },
-    "@libsql/darwin-arm64@0.5.22": {
-      "integrity": "sha512-4B8ZlX3nIDPndfct7GNe0nI3Yw6ibocEicWdC4fvQbSs/jdq/RC2oCsoJxJ4NzXkvktX70C1J4FcmmoBy069UA==",
+    "@libsql/darwin-arm64@0.5.28": {
+      "integrity": "sha512-Lc/b8JXO2W2+H+5UXfw7PCHZCim1jlrB0CmLPsjfVmihMluBpdYafFImhjAHxHlWGfuZ32WzjVPUap5fGmkthw==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@libsql/darwin-x64@0.5.22": {
-      "integrity": "sha512-ny2HYWt6lFSIdNFzUFIJ04uiW6finXfMNJ7wypkAD8Pqdm6nAByO+Fdqu8t7sD0sqJGeUCiOg480icjyQ2/8VA==",
+    "@libsql/darwin-x64@0.5.28": {
+      "integrity": "sha512-m1hGkQm8A+CjZmR9D5G3zi36na7GXGJomsMbHwOFiCUYPjqRReD5KZ2HZ/qEAV6U/66xPdDDCuqDB8MzNhiwxA==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
@@ -411,38 +395,38 @@
         "ws"
       ]
     },
-    "@libsql/linux-arm-gnueabihf@0.5.22": {
-      "integrity": "sha512-3Uo3SoDPJe/zBnyZKosziRGtszXaEtv57raWrZIahtQDsjxBVjuzYQinCm9LRCJCUT5t2r5Z5nLDPJi2CwZVoA==",
+    "@libsql/linux-arm-gnueabihf@0.5.28": {
+      "integrity": "sha512-D22yQotJkLcYxrwYP9ukoqbpA5hK7pHmho9jagCM/ij7UwjWJPAY2d2SmEndpJs/SueaGy1xuiUQFec4R7VebQ==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@libsql/linux-arm-musleabihf@0.5.22": {
-      "integrity": "sha512-LCsXh07jvSojTNJptT9CowOzwITznD+YFGGW+1XxUr7fS+7/ydUrpDfsMX7UqTqjm7xG17eq86VkWJgHJfvpNg==",
+    "@libsql/linux-arm-musleabihf@0.5.28": {
+      "integrity": "sha512-Z/aSb2WzZm7TYn/FEqefoN2sJoDhMtCjV8aHw55ibck6mdLLPGMYXxTyWn5U/OZbqD+wiM7eUgdsG20uEzxEoQ==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@libsql/linux-arm64-gnu@0.5.22": {
-      "integrity": "sha512-KSdnOMy88c9mpOFKUEzPskSaF3VLflfSUCBwas/pn1/sV3pEhtMF6H8VUCd2rsedwoukeeCSEONqX7LLnQwRMA==",
+    "@libsql/linux-arm64-gnu@0.5.28": {
+      "integrity": "sha512-gQGJgmUBdk3qm8rDwvFujzTWipLE4ZNP9fgcdVabVBFmD38wLOU5aZ4F3BHrL1ZWdvsrC8mrtnCTKEGuYHDZIw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@libsql/linux-arm64-musl@0.5.22": {
-      "integrity": "sha512-mCHSMAsDTLK5YH//lcV3eFEgiR23Ym0U9oEvgZA0667gqRZg/2px+7LshDvErEKv2XZ8ixzw3p1IrBzLQHGSsw==",
+    "@libsql/linux-arm64-musl@0.5.28": {
+      "integrity": "sha512-zLlgKyG96DKJ4skFtubHbWuWRUW8YpcjHVyKyJJDIp2USPQKLXfB+rT06OSQIS90Bm3dbfU+9rAlNX0ua0cSvw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@libsql/linux-x64-gnu@0.5.22": {
-      "integrity": "sha512-kNBHaIkSg78Y4BqAdgjcR2mBilZXs4HYkAmi58J+4GRwDQZh5fIUWbnQvB9f95DkWUIGVeenqLRFY2pcTmlsew==",
+    "@libsql/linux-x64-gnu@0.5.28": {
+      "integrity": "sha512-ra+fk6FmTl8ma4opxcTJ8JIt3KrSr+TrFCJtgccfg+7HDdGiE5Ys6jIJMqYuYG61Mv40z3lPZxRivBK5sP9o/w==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@libsql/linux-x64-musl@0.5.22": {
-      "integrity": "sha512-UZ4Xdxm4pu3pQXjvfJiyCzZop/9j/eA2JjmhMaAhe3EVLH2g11Fy4fwyUp9sT1QJYR1kpc2JLuybPM0kuXv/Tg==",
+    "@libsql/linux-x64-musl@0.5.28": {
+      "integrity": "sha512-XXl7lHsZEY8szhfMWoe0tFzKXv52nlDt0kckMmtYb97AkKB0bIcxbgx5zTHGyoXLMMhLvEo33OR7NHvjdDyvjw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@libsql/win32-x64-msvc@0.5.22": {
-      "integrity": "sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==",
+    "@libsql/win32-x64-msvc@0.5.28": {
+      "integrity": "sha512-KLB4TQKkRdki9Ugbz+X986a1F7IaZUZbPuTfPNFi7slTT+biSw0b/LPJ0tCk7EHyo5QmN8tZ1XLZwI7GgUBsfA==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -466,14 +450,17 @@
         "fastq"
       ]
     },
-    "@swc/helpers@0.5.18": {
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+    "@swc/helpers@0.5.19": {
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@types/node@14.18.63": {
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+    "@types/node@25.5.0": {
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dependencies": [
+        "undici-types"
+      ]
     },
     "@types/sarif@2.1.7": {
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="
@@ -749,8 +736,8 @@
         "fetch-blob"
       ]
     },
-    "fs-extra@11.3.3": {
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+    "fs-extra@11.3.4": {
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dependencies": [
         "graceful-fs",
         "jsonfile",
@@ -821,8 +808,8 @@
         "function-bind"
       ]
     },
-    "hono@4.11.5": {
-      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g=="
+    "hono@4.12.8": {
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="
     },
     "human-signals@1.1.1": {
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
@@ -922,8 +909,8 @@
         "promise"
       ]
     },
-    "libsql@0.5.22": {
-      "integrity": "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==",
+    "libsql@0.5.28": {
+      "integrity": "sha512-wKqx9FgtPcKHdPfR/Kfm0gejsnbuf8zV+ESPmltFvsq5uXwdeN9fsWn611DmqrdXj1e94NkARcMA2f1syiAqOg==",
       "dependencies": [
         "@neon-rs/load",
         "detect-libc"
@@ -1083,8 +1070,8 @@
         "pug-runtime"
       ]
     },
-    "pug-code-gen@3.0.3": {
-      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
+    "pug-code-gen@3.0.4": {
+      "integrity": "sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==",
       "dependencies": [
         "constantinople",
         "doctypes",
@@ -1150,8 +1137,8 @@
     "pug-walk@2.0.0": {
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
     },
-    "pug@3.0.3": {
-      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
+    "pug@3.0.4": {
+      "integrity": "sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==",
       "dependencies": [
         "pug-code-gen",
         "pug-filters",
@@ -1163,8 +1150,8 @@
         "pug-strip-comments"
       ]
     },
-    "pump@3.0.3": {
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+    "pump@3.0.4": {
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dependencies": [
         "end-of-stream",
         "once"
@@ -1179,8 +1166,8 @@
       ],
       "bin": true
     },
-    "qs@6.14.1": {
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+    "qs@6.15.0": {
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dependencies": [
         "side-channel"
       ]
@@ -1314,6 +1301,9 @@
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "undici-types@7.18.2": {
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+    },
     "universalify@2.0.1": {
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
@@ -1363,8 +1353,8 @@
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "ws@8.19.0": {
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "y18n@4.0.3": {
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
@@ -1403,7 +1393,7 @@
       "jsr:@std/path@1",
       "jsr:@std/testing@1",
       "npm:@bunny.net/edgescript-sdk@0.12",
-      "npm:@bunny.net/storage-sdk@0.2",
+      "npm:@bunny.net/storage-sdk@0.3",
       "npm:@iframe-resizer/child@5",
       "npm:@iframe-resizer/core@5",
       "npm:@iframe-resizer/parent@5",

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -25,8 +25,7 @@ export const clearSessionCookie = (): string =>
 const FLASH_COOKIE_PREFIX = "flash_";
 
 /** Build the cookie name for a keyed flash message */
-const flashCookieName = (id: string): string =>
-  `${FLASH_COOKIE_PREFIX}${id}`;
+const flashCookieName = (id: string): string => `${FLASH_COOKIE_PREFIX}${id}`;
 
 /** Build a flash cookie containing a success or error message, keyed by ID */
 export const buildFlashCookie = (

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -21,22 +21,34 @@ export const buildSessionCookie = (
 export const clearSessionCookie = (): string =>
   `${sessionCookieName()}=; HttpOnly${secureAttribute()}; SameSite=Strict; Path=/; Max-Age=0`;
 
-/** Cookie name for flash messages (success/error after redirects) */
-const FLASH_COOKIE_NAME = "flash";
+/** Cookie name prefix for flash messages (keyed by per-request ID) */
+const FLASH_COOKIE_PREFIX = "flash_";
 
-/** Build a flash cookie containing a success or error message */
+/** Build the cookie name for a keyed flash message */
+const flashCookieName = (id: string): string =>
+  `${FLASH_COOKIE_PREFIX}${id}`;
+
+/** Generate a short random hex ID for keying flash cookies */
+export const generateFlashId = (): string => {
+  const bytes = new Uint8Array(3);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+};
+
+/** Build a flash cookie containing a success or error message, keyed by ID */
 export const buildFlashCookie = (
+  id: string,
   message: string,
   succeeded: boolean,
 ): string => {
   const type = succeeded ? "s" : "e";
   const value = encodeURIComponent(`${type}:${message}`);
-  return `${FLASH_COOKIE_NAME}=${value}; HttpOnly${secureAttribute()}; SameSite=Strict; Path=/; Max-Age=10`;
+  return `${flashCookieName(id)}=${value}; HttpOnly${secureAttribute()}; SameSite=Strict; Path=/; Max-Age=10`;
 };
 
-/** Clear the flash cookie (set after reading) */
-export const clearFlashCookie = (): string =>
-  `${FLASH_COOKIE_NAME}=; HttpOnly${secureAttribute()}; SameSite=Strict; Path=/; Max-Age=0`;
+/** Clear a keyed flash cookie (set after reading) */
+export const clearFlashCookie = (id: string): string =>
+  `${flashCookieName(id)}=; HttpOnly${secureAttribute()}; SameSite=Strict; Path=/; Max-Age=0`;
 
 /** Parse a flash cookie value into type and message, or null if invalid */
 export const parseFlashValue = (

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -28,13 +28,6 @@ const FLASH_COOKIE_PREFIX = "flash_";
 const flashCookieName = (id: string): string =>
   `${FLASH_COOKIE_PREFIX}${id}`;
 
-/** Generate a short random hex ID for keying flash cookies */
-export const generateFlashId = (): string => {
-  const bytes = new Uint8Array(3);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-};
-
 /** Build a flash cookie containing a success or error message, keyed by ID */
 export const buildFlashCookie = (
   id: string,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -27,6 +27,9 @@ const getLogPrefix = (): string => {
   return id ? `[${id}] ` : "";
 };
 
+/** Get the current request ID, or empty string if outside request context */
+export const getRequestId = (): string => requestIdStorage.getStore() ?? "";
+
 /** Run a function with a request-scoped random ID for log correlation */
 export const runWithRequestId = <T>(fn: () => T): T =>
   requestIdStorage.run(generateRequestId(), () => runWithPendingWork(fn));

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -167,7 +167,7 @@ const encryptAndUpload = async (
       controller.close();
     },
   });
-  await BunnyStorageSDK.file.upload(sz, `/${filename}`, stream, {
+  await BunnyStorageSDK.file.upload(sz, `/${filename}`, stream as never, {
     contentType: "application/octet-stream",
   });
   return filename;

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -34,12 +34,10 @@ const handleApiKeysGet: TypedRouteHandler<"GET /admin/api-keys"> = (request) =>
     const flash = getFlash();
     // The API key is embedded in the flash success message after a newline
     const newLineIdx = flash.success?.indexOf("\n") ?? -1;
-    const success = newLineIdx >= 0
-      ? flash.success!.slice(0, newLineIdx)
-      : flash.success;
-    const newKey = newLineIdx >= 0
-      ? flash.success!.slice(newLineIdx + 1)
-      : undefined;
+    const success =
+      newLineIdx >= 0 ? flash.success!.slice(0, newLineIdx) : flash.success;
+    const newKey =
+      newLineIdx >= 0 ? flash.success!.slice(newLineIdx + 1) : undefined;
     return htmlResponse(
       adminApiKeysPage(keys, session, {
         success,
@@ -86,11 +84,7 @@ const handleApiKeysPost: TypedRouteHandler<"POST /admin/api-keys"> = (
     );
 
     // Embed the key in the flash message (after a newline) so it's not exposed in the URL
-    return redirect(
-      "/admin/api-keys",
-      `API key created\n${apiKey}`,
-      true,
-    );
+    return redirect("/admin/api-keys", `API key created\n${apiKey}`, true);
   });
 
 /**

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -464,7 +464,12 @@ const processRefundAll = async (
       event.id,
     );
     return htmlResponse(
-      adminRefundAllAttendeesPage(event, refundable.length - refundedCount, session, msg),
+      adminRefundAllAttendeesPage(
+        event,
+        refundable.length - refundedCount,
+        session,
+        msg,
+      ),
       400,
     );
   }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -393,8 +393,13 @@ export const handleRequest = async (
           }
 
           try {
-            // Populate flash context from cookie before handling
-            const flashRaw = parseCookies(effectiveRequest).get("flash");
+            // Populate flash context from keyed cookie (flash ID in URL)
+            const flashId = new URL(effectiveRequest.url).searchParams.get(
+              "flash",
+            );
+            const flashRaw = flashId
+              ? parseCookies(effectiveRequest).get(`flash_${flashId}`)
+              : null;
             const flash = flashRaw ? parseFlashValue(flashRaw) : null;
             if (flash) setFlashContext(flash);
 
@@ -405,9 +410,9 @@ export const handleRequest = async (
               server,
             );
 
-            // Clear flash cookie if one was consumed
-            if (flash && hasFlash()) {
-              withCookie(response, clearFlashCookie());
+            // Clear keyed flash cookie if one was consumed
+            if (flashId && flash && hasFlash()) {
+              withCookie(response, clearFlashCookie(flashId));
             }
             resetFlashContext();
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -3,7 +3,11 @@
  */
 
 import { compact, map, pipe, reduce } from "#fp";
-import { buildFlashCookie, getSessionCookieName } from "#lib/cookies.ts";
+import {
+  buildFlashCookie,
+  generateFlashId,
+  getSessionCookieName,
+} from "#lib/cookies.ts";
 import {
   generateSecureToken,
   getPrivateKeyFromSession,
@@ -323,11 +327,13 @@ export const redirect = (
 ): Response => {
   const target = opts?.form?.get("return_url") || url;
   const u = new URL(target, "http://localhost");
+  const flashId = generateFlashId();
+  u.searchParams.set("flash", flashId);
   if (opts?.formId) {
     u.searchParams.set("form", opts.formId);
     u.hash = opts.formId;
   }
-  const flash = buildFlashCookie(message, succeeded);
+  const flash = buildFlashCookie(flashId, message, succeeded);
   const response = redirectResponse(u.pathname + u.search + u.hash, flash);
   if (opts?.cookie) withCookie(response, opts.cookie);
   return response;

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -3,11 +3,7 @@
  */
 
 import { compact, map, pipe, reduce } from "#fp";
-import {
-  buildFlashCookie,
-  generateFlashId,
-  getSessionCookieName,
-} from "#lib/cookies.ts";
+import { buildFlashCookie, getSessionCookieName } from "#lib/cookies.ts";
 import {
   generateSecureToken,
   getPrivateKeyFromSession,
@@ -26,7 +22,7 @@ import { decryptAdminLevel, getUserById } from "#lib/db/users.ts";
 import { FormParams } from "#lib/form-data.ts";
 import { clearSavedFormData, setSavedFormData } from "#lib/forms.tsx";
 import { appendIframeParam, getIframeMode } from "#lib/iframe.ts";
-import { ErrorCode, logError } from "#lib/logger.ts";
+import { ErrorCode, getRequestId, logError } from "#lib/logger.ts";
 import { nowMs } from "#lib/now.ts";
 import { getCachedSession, setCachedSession } from "#lib/session-context.ts";
 import type { AdminLevel, AdminSession, EventWithCount } from "#lib/types.ts";
@@ -327,7 +323,7 @@ export const redirect = (
 ): Response => {
   const target = opts?.form?.get("return_url") || url;
   const u = new URL(target, "http://localhost");
-  const flashId = generateFlashId();
+  const flashId = getRequestId();
   u.searchParams.set("flash", flashId);
   if (opts?.formId) {
     u.searchParams.set("form", opts.formId);

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1236,7 +1236,7 @@ export const expectAdminRedirect: (response: Response) => Response =
   expectRedirect("/admin");
 
 /** Fixed flash ID used in tests for deterministic keyed cookies */
-export const FLASH_TEST_ID = "test01";
+export const FLASH_TEST_ID = "t001";
 
 /**
  * Assert the response carries a keyed flash cookie with the given message.

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1268,7 +1268,8 @@ export const expectFlash = (
  * Compares the location without the flash param for clean assertions.
  */
 export const expectRedirectWithFlash =
-  (location: string, message: string, succeeded = true) =>
+  // deno-lint-ignore no-explicit-any
+  (location: string, message: string | any, succeeded = true) =>
   (response: Response): Response => {
     expect(response.status).toBe(302);
     const actualLocation = response.headers.get("location")!;

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1258,7 +1258,7 @@ export const expectFlash = (
   const parsed = parseFlashValue(value);
   expect(parsed).not.toBeNull();
   const actual = succeeded ? parsed!.success : parsed!.error;
-  expect(actual).toEqual(message);
+  if (message !== undefined) expect(actual).toEqual(message);
   return response;
 };
 
@@ -1268,8 +1268,7 @@ export const expectFlash = (
  * Compares the location without the flash param for clean assertions.
  */
 export const expectRedirectWithFlash =
-  // deno-lint-ignore no-explicit-any
-  (location: string, message: string | any, succeeded = true) =>
+  (location: string, message?: string, succeeded = true) =>
   (response: Response): Response => {
     expect(response.status).toBe(302);
     const actualLocation = response.headers.get("location")!;

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1235,8 +1235,12 @@ export const expectRedirect =
 export const expectAdminRedirect: (response: Response) => Response =
   expectRedirect("/admin");
 
+/** Fixed flash ID used in tests for deterministic keyed cookies */
+export const FLASH_TEST_ID = "test01";
+
 /**
- * Assert the response carries a flash cookie with the given message.
+ * Assert the response carries a keyed flash cookie with the given message.
+ * Finds any cookie starting with "flash_" prefix.
  * Works on both redirect (302) and rendered (200) responses.
  */
 export const expectFlash = (
@@ -1246,9 +1250,10 @@ export const expectFlash = (
   succeeded = true,
 ): Response => {
   const cookies = response.headers.getSetCookie();
-  const flash = cookies.find((c) => c.startsWith("flash="));
+  const flash = cookies.find((c) => c.startsWith("flash_"));
   expect(flash).toBeDefined();
   const cookiePart = flash!.split(";")[0]!;
+  // Cookie is "flash_{id}={value}", extract value after first "="
   const value = cookiePart.split("=").slice(1).join("=");
   const parsed = parseFlashValue(value);
   expect(parsed).not.toBeNull();
@@ -1259,26 +1264,36 @@ export const expectFlash = (
 
 /**
  * Assert a redirect (302) to the given location with a flash message.
- * Combines expectRedirect + expectFlash in one step.
+ * Extracts the flash ID from the redirect URL and verifies the keyed cookie.
+ * Compares the location without the flash param for clean assertions.
  */
 export const expectRedirectWithFlash =
   (location: string, message: string, succeeded = true) =>
   (response: Response): Response => {
-    expectRedirect(location)(response);
+    expect(response.status).toBe(302);
+    const actualLocation = response.headers.get("location")!;
+    const url = new URL(actualLocation, "http://localhost");
+    const flashId = url.searchParams.get("flash");
+    expect(flashId).toBeDefined();
+    // Compare location without flash param
+    url.searchParams.delete("flash");
+    const clean = url.pathname + url.search + url.hash;
+    expect(clean).toBe(location);
     expectFlash(response, message, succeeded);
     return response;
   };
 
 /**
- * Build a cookie header string containing a flash message.
+ * Build a cookie header string containing a keyed flash message.
  * Use in mockRequest to simulate a flash cookie from a previous redirect.
+ * Uses FLASH_TEST_ID as the key — pair with ?flash=test01 in the URL.
  */
 export const flashCookieHeader = (
   message: string,
   succeeded = true,
 ): string => {
   const type = succeeded ? "s" : "e";
-  return `flash=${encodeURIComponent(`${type}:${message}`)}`;
+  return `flash_${FLASH_TEST_ID}=${encodeURIComponent(`${type}:${message}`)}`;
 };
 
 /** Assert response is a checkout redirect (302 to an external HTTPS URL) */

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -261,7 +261,7 @@ describe("API Keys", () => {
       // Follow the redirect and verify the key is shown
       const flashCookie = response.headers
         .getSetCookie()
-        .find((c) => c.startsWith("flash="))!;
+        .find((c) => c.startsWith("flash_"))!;
       const redirectResponse = await handleRequest(
         mockRequest(location, {
           headers: { cookie: `${cookie}; ${flashCookie.split(";")[0]}` },

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -26,6 +26,7 @@ import {
   createTestEvent,
   expectFlash,
   extractCsrfToken,
+  FLASH_TEST_ID,
   flashCookieHeader,
   mockRequest,
   resetDb,
@@ -386,7 +387,7 @@ describe("API Keys", () => {
     test("GET /admin/api-keys shows success message from flash cookie", async () => {
       const cookie = await testCookie();
       const response = await handleRequest(
-        mockRequest("/admin/api-keys", {
+        mockRequest(`/admin/api-keys?flash=${FLASH_TEST_ID}`, {
           headers: { cookie: `${cookie}; ${flashCookieHeader("done")}` },
         }),
       );
@@ -398,7 +399,7 @@ describe("API Keys", () => {
     test("GET /admin/api-keys shows error message from flash cookie", async () => {
       const cookie = await testCookie();
       const response = await handleRequest(
-        mockRequest("/admin/api-keys", {
+        mockRequest(`/admin/api-keys?flash=${FLASH_TEST_ID}`, {
           headers: {
             cookie: `${cookie}; ${flashCookieHeader("key failed", false)}`,
           },

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -255,7 +255,9 @@ describe("API Keys", () => {
 
       expect(response.status).toBe(302);
       const location = response.headers.get("location")!;
-      expect(location).toBe("/admin/api-keys");
+      const locationUrl = new URL(location, "http://localhost");
+      locationUrl.searchParams.delete("flash");
+      expect(locationUrl.pathname).toBe("/admin/api-keys");
       expectFlash(response, expect.stringContaining("API key created\n"));
 
       // Follow the redirect and verify the key is shown

--- a/test/lib/cookies.test.ts
+++ b/test/lib/cookies.test.ts
@@ -6,7 +6,6 @@ import {
   buildSessionCookie,
   clearFlashCookie,
   clearSessionCookie,
-  generateFlashId,
   getSessionCookieName,
   isSecureMode,
   parseFlashValue,
@@ -99,18 +98,6 @@ describe("clearSessionCookie", () => {
     expect(cookie).toContain("session=");
     expectDevCookieAttributes(cookie);
     expect(cookie).toContain("Max-Age=0");
-  });
-});
-
-describe("generateFlashId", () => {
-  test("returns a 6-character hex string", () => {
-    const id = generateFlashId();
-    expect(id).toMatch(/^[0-9a-f]{6}$/);
-  });
-
-  test("generates unique IDs", () => {
-    const ids = new Set(Array.from({ length: 100 }, () => generateFlashId()));
-    expect(ids.size).toBe(100);
   });
 });
 

--- a/test/lib/cookies.test.ts
+++ b/test/lib/cookies.test.ts
@@ -2,8 +2,11 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import {
+  buildFlashCookie,
   buildSessionCookie,
+  clearFlashCookie,
   clearSessionCookie,
+  generateFlashId,
   getSessionCookieName,
   isSecureMode,
   parseFlashValue,
@@ -95,6 +98,57 @@ describe("clearSessionCookie", () => {
     const cookie = clearSessionCookie();
     expect(cookie).toContain("session=");
     expectDevCookieAttributes(cookie);
+    expect(cookie).toContain("Max-Age=0");
+  });
+});
+
+describe("generateFlashId", () => {
+  test("returns a 6-character hex string", () => {
+    const id = generateFlashId();
+    expect(id).toMatch(/^[0-9a-f]{6}$/);
+  });
+
+  test("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateFlashId()));
+    expect(ids.size).toBe(100);
+  });
+});
+
+describe("buildFlashCookie", () => {
+  afterEach(() => resetAllowedDomain());
+
+  test("keys cookie name by flash ID", () => {
+    setAllowedDomainForTest("localhost");
+    const cookie = buildFlashCookie("abc123", "Saved", true);
+    expect(cookie).toMatch(/^flash_abc123=/);
+  });
+
+  test("encodes success message", () => {
+    setAllowedDomainForTest("localhost");
+    const cookie = buildFlashCookie("abc123", "Saved", true);
+    expect(cookie).toContain(encodeURIComponent("s:Saved"));
+  });
+
+  test("encodes error message", () => {
+    setAllowedDomainForTest("localhost");
+    const cookie = buildFlashCookie("abc123", "Failed", false);
+    expect(cookie).toContain(encodeURIComponent("e:Failed"));
+  });
+
+  test("sets short Max-Age", () => {
+    setAllowedDomainForTest("localhost");
+    const cookie = buildFlashCookie("abc123", "Saved", true);
+    expect(cookie).toContain("Max-Age=10");
+  });
+});
+
+describe("clearFlashCookie", () => {
+  afterEach(() => resetAllowedDomain());
+
+  test("clears the keyed cookie with Max-Age=0", () => {
+    setAllowedDomainForTest("localhost");
+    const cookie = clearFlashCookie("abc123");
+    expect(cookie).toMatch(/^flash_abc123=/);
     expect(cookie).toContain("Max-Age=0");
   });
 });

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -293,7 +293,12 @@ describe("logger", () => {
         const logActivityStub = stub(activityLogMod, "logActivity", () => {
           // Simulate logActivity triggering another logError (recursion)
           logError({ code: ErrorCode.DB_QUERY });
-          return Promise.resolve();
+          return Promise.resolve({
+            id: 1,
+            created: "",
+            event_id: null,
+            message: "",
+          });
         });
 
         logError({ code: ErrorCode.DB_CONNECTION });

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -290,15 +290,11 @@ describe("logger", () => {
       });
 
       test("guards against recursive logError during persistence", async () => {
-        const logActivityStub = stub(
-          activityLogMod,
-          "logActivity",
-          () => {
-            // Simulate logActivity triggering another logError (recursion)
-            logError({ code: ErrorCode.DB_QUERY });
-            return Promise.resolve();
-          },
-        );
+        const logActivityStub = stub(activityLogMod, "logActivity", () => {
+          // Simulate logActivity triggering another logError (recursion)
+          logError({ code: ErrorCode.DB_QUERY });
+          return Promise.resolve();
+        });
 
         logError({ code: ErrorCode.DB_CONNECTION });
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { type Spy, spy, stub } from "@std/testing/mock";
+import * as activityLogMod from "#lib/db/activityLog.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import {
   createRequestTimer,
@@ -286,6 +287,26 @@ describe("logger", () => {
           (e) => e.message === "Error: Database connection failed",
         );
         expect(match).toBeDefined();
+      });
+
+      test("guards against recursive logError during persistence", async () => {
+        const logActivityStub = stub(
+          activityLogMod,
+          "logActivity",
+          () => {
+            // Simulate logActivity triggering another logError (recursion)
+            logError({ code: ErrorCode.DB_QUERY });
+            return Promise.resolve();
+          },
+        );
+
+        logError({ code: ErrorCode.DB_CONNECTION });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // The outer logError triggers logActivity, which triggers a nested logError.
+        // The nested logError should be guarded — only one logActivity call.
+        expect(logActivityStub.calls.length).toBe(1);
+        logActivityStub.restore();
       });
     });
   });

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { type Spy, spy, stub } from "@std/testing/mock";
-import * as activityLogMod from "#lib/db/activityLog.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import {
   createRequestTimer,
@@ -11,6 +10,7 @@ import {
   errorCodeLabel,
   formatErrorMessage,
   formatRequestError,
+  getRequestId,
   logDebug,
   logError,
   logErrorLocal,
@@ -290,24 +290,22 @@ describe("logger", () => {
       });
 
       test("guards against recursive logError during persistence", async () => {
-        const logActivityStub = stub(activityLogMod, "logActivity", () => {
-          // Simulate logActivity triggering another logError (recursion)
-          logError({ code: ErrorCode.DB_QUERY });
-          return Promise.resolve({
-            id: 1,
-            created: "",
-            event_id: null,
-            message: "",
-          });
-        });
-
+        // Call logError twice rapidly — the guard prevents the second from
+        // persisting to the activity log while the first is still writing
         logError({ code: ErrorCode.DB_CONNECTION });
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        logError({ code: ErrorCode.DB_QUERY });
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
-        // The outer logError triggers logActivity, which triggers a nested logError.
-        // The nested logError should be guarded — only one logActivity call.
-        expect(logActivityStub.calls.length).toBe(1);
-        logActivityStub.restore();
+        const entries = await getAllActivityLog();
+        const connError = entries.find(
+          (e) => e.message === "Error: Database connection failed",
+        );
+        const queryError = entries.find(
+          (e) => e.message === "Error: Database query failed",
+        );
+        // First error persists; second is guarded (skipped) since first is still active
+        expect(connError).toBeDefined();
+        expect(queryError).toBeUndefined();
       });
     });
   });
@@ -470,6 +468,17 @@ describe("logger", () => {
     "runWithRequestId",
     { env: { TEST_SUPPRESS_REQUEST_LOGS: undefined } },
     () => {
+      test("getRequestId returns ID inside request context", () => {
+        runWithRequestId(() => {
+          const id = getRequestId();
+          expect(id).toMatch(/^[0-9a-f]{4}$/);
+        });
+      });
+
+      test("getRequestId returns empty string outside request context", () => {
+        expect(getRequestId()).toBe("");
+      });
+
       test("prefixes logRequest with 4-char hex ID", () => {
         const debugSpy = spy(console, "debug");
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -405,7 +405,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       expectRedirectWithFlash(
         `/admin/event/${event.id}`,
-        expect.stringContaining(""),
+        undefined,
         false,
       )(response);
 
@@ -436,7 +436,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       expectRedirectWithFlash(
         `/admin/event/${event.id}`,
-        expect.stringContaining(""),
+        undefined,
         false,
       )(response);
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -17,6 +17,7 @@ import {
   expectHtmlResponse,
   expectRedirect,
   expectRedirectWithFlash,
+  FLASH_TEST_ID,
   flashCookieHeader,
   getAttendeesRaw,
   mockFormRequest,
@@ -940,7 +941,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     test("event page shows success message when flash cookie present", async () => {
       const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
-      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+      const response = await awaitTestRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("Added Jane Doe")}`,
       });
       await expectHtmlResponse(response, 200, "Added Jane Doe");
@@ -949,7 +950,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     test("event page shows error message when flash cookie present", async () => {
       const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
-      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+      const response = await awaitTestRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("Not enough spots", false)}`,
       });
       await expectHtmlResponse(response, 200, "Not enough spots");
@@ -1379,7 +1380,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     test("event page shows edit success message", async () => {
       const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
-      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+      const response = await awaitTestRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("Updated Jane Doe")}`,
       });
       await expectHtmlResponse(response, 200, "Updated Jane Doe");
@@ -2119,7 +2120,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       const cookie = await testCookie();
       const response = await awaitTestRequest(
-        `/admin/attendees/${attendee.id}`,
+        `/admin/attendees/${attendee.id}?flash=${FLASH_TEST_ID}`,
         {
           cookie: `${cookie}; ${flashCookieHeader("Payment status is up to date")}`,
         },

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -15,7 +15,6 @@ import {
   expectAdminRedirect,
   expectFlash,
   expectHtmlResponse,
-  expectRedirect,
   expectRedirectWithFlash,
   FLASH_TEST_ID,
   flashCookieHeader,
@@ -404,9 +403,11 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           cookie,
         ),
       );
-      expect(response.status).toBe(302);
-      expectRedirect(`/admin/event/${event.id}`)(response);
-      expectFlash(response, expect.stringContaining(""), false);
+      expectRedirectWithFlash(
+        `/admin/event/${event.id}`,
+        expect.stringContaining(""),
+        false,
+      )(response);
 
       // Verify attendee was NOT deleted (still exists)
       const rows = await getAttendeesRaw(event.id);
@@ -433,9 +434,11 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           cookie,
         ),
       );
-      expect(response.status).toBe(302);
-      expectRedirect(`/admin/event/${event.id}`)(response);
-      expectFlash(response, expect.stringContaining(""), false);
+      expectRedirectWithFlash(
+        `/admin/event/${event.id}`,
+        expect.stringContaining(""),
+        false,
+      )(response);
 
       // Verify attendee was NOT deleted
       const rows = await getAttendeesRaw(event.id);

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -944,18 +944,24 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     test("event page shows success message when flash cookie present", async () => {
       const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
-      const response = await awaitTestRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("Added Jane Doe")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Added Jane Doe")}`,
+        },
+      );
       await expectHtmlResponse(response, 200, "Added Jane Doe");
     });
 
     test("event page shows error message when flash cookie present", async () => {
       const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
-      const response = await awaitTestRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("Not enough spots", false)}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Not enough spots", false)}`,
+        },
+      );
       await expectHtmlResponse(response, 200, "Not enough spots");
     });
   });
@@ -1383,9 +1389,12 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     test("event page shows edit success message", async () => {
       const { event, cookie } = await setupEventAndLogin({ maxAttendees: 100 });
 
-      const response = await awaitTestRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("Updated Jane Doe")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/event/${event.id}?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Updated Jane Doe")}`,
+        },
+      );
       await expectHtmlResponse(response, 200, "Updated Jane Doe");
     });
 

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -287,9 +287,12 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
     test("displays success message from flash cookie on sessions page", async () => {
       const { cookie } = await loginAsAdmin();
 
-      const response = await awaitTestRequest(`/admin/sessions?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("Logged out of all other sessions")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/sessions?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Logged out of all other sessions")}`,
+        },
+      );
       await expectHtmlResponse(
         response,
         200,

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -10,6 +10,7 @@ import {
   expectAdminRedirect,
   expectHtmlResponse,
   expectRedirectWithFlash,
+  FLASH_TEST_ID,
   flashCookieHeader,
   loginAsAdmin,
   mockAdminLoginRequest,
@@ -286,7 +287,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
     test("displays success message from flash cookie on sessions page", async () => {
       const { cookie } = await loginAsAdmin();
 
-      const response = await awaitTestRequest("/admin/sessions", {
+      const response = await awaitTestRequest(`/admin/sessions?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("Logged out of all other sessions")}`,
       });
       await expectHtmlResponse(

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -123,7 +123,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toMatch(/\/admin\/group\/\d+$/);
+      expect(response.headers.get("location")).toMatch(/\/admin\/group\/\d+(\?|$)/);
       expectFlash(response, "Group created");
     });
 
@@ -276,7 +276,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toMatch(/\/admin\/groups$/);
+      expect(response.headers.get("location")).toMatch(/\/admin\/groups(\?|$)/);
       expectFlash(response, "Group deleted");
     });
 
@@ -771,7 +771,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
       );
       expect(response.status).toBe(302);
       const location = response.headers.get("location") ?? "";
-      expect(location).toMatch(/\/admin\/group\/\d+$/);
+      expect(location).toMatch(/\/admin\/group\/\d+(\?|$)/);
       expectFlash(response, "Group created");
     });
 

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -123,7 +123,9 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toMatch(/\/admin\/group\/\d+(\?|$)/);
+      expect(response.headers.get("location")).toMatch(
+        /\/admin\/group\/\d+(\?|$)/,
+      );
       expectFlash(response, "Group created");
     });
 

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -10,6 +10,7 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirectWithFlash,
+  FLASH_TEST_ID,
   flashCookieHeader,
   installUrlHandler,
   mockFormRequest,
@@ -401,7 +402,7 @@ describeWithEnv(
       test("displays image error on admin dashboard", async () => {
         const cookie = await testCookie();
         const response = await handleRequest(
-          mockRequest("/admin", {
+          mockRequest(`/admin?flash=${FLASH_TEST_ID}`, {
             headers: {
               cookie: `${cookie}; ${flashCookieHeader("Image exceeds the 256KB size limit", false)}`,
             },
@@ -418,7 +419,7 @@ describeWithEnv(
         const { event, cookie } = await setupEventAndLogin();
 
         const response = await handleRequest(
-          mockRequest(`/admin/event/${event.id}`, {
+          mockRequest(`/admin/event/${event.id}?flash=${FLASH_TEST_ID}`, {
             headers: {
               cookie: `${cookie}; ${flashCookieHeader("Image must be a JPEG, PNG, GIF, or WebP file", false)}`,
             },

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -148,9 +148,10 @@ const expectImageErrorRedirect = (
 ): void => {
   expect(response.status).toBe(302);
   const cookies = response.headers.getSetCookie();
-  const flash = cookies.find((c) => c.startsWith("flash="));
+  const flash = cookies.find((c) => c.startsWith("flash_"));
   expect(flash).toBeDefined();
   const cookiePart = flash!.split(";")[0] ?? "";
+  // Cookie is "flash_{id}={value}", extract value after first "="
   const decoded = decodeURIComponent(cookiePart.split("=").slice(1).join("="));
   expect(decoded).toContain(errorSubstring);
 };

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -463,7 +463,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
       const url = new URL(location, "http://localhost");
       const flashId = url.searchParams.get("flash");
       expect(flashId).toBeDefined();
-      expect(flashId!.length).toBe(6);
+      expect(flashId!.length).toBe(4);
     });
 
     test("keys flash cookie by the flash ID in the URL", () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
+import { runWithRequestId } from "#lib/logger.ts";
 import {
   buildCspHeader,
   getCleanUrl,
@@ -393,97 +394,119 @@ describeWithEnv("server (misc)", { db: true }, () => {
       return url.pathname + url.search + url.hash;
     };
 
-    test("creates success redirect without form ID", () => {
-      const response = redirect("/admin/settings", "Saved", true);
-      expect(response.status).toBe(302);
-      expect(parseRedirectLocation(response)).toBe("/admin/settings");
-      expectFlash(response, "Saved");
-    });
+    /** Run callback inside a request context so getRequestId() returns a value */
+    const withRequestContext = <T>(fn: () => T): T => runWithRequestId(fn);
 
-    test("creates success redirect with form ID and anchor", () => {
-      const response = redirect("/admin/settings", "Timezone updated", true, {
-        formId: "settings-timezone",
-      });
-      expect(response.status).toBe(302);
-      expect(parseRedirectLocation(response)).toBe(
-        "/admin/settings?form=settings-timezone#settings-timezone",
-      );
-      expectFlash(response, "Timezone updated");
-    });
+    test("creates success redirect without form ID", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin/settings", "Saved", true);
+        expect(response.status).toBe(302);
+        expect(parseRedirectLocation(response)).toBe("/admin/settings");
+        expectFlash(response, "Saved");
+      }));
 
-    test("encodes special characters in message and form ID", () => {
-      const response = redirect("/admin/settings", "A & B", true, {
-        formId: "form&id",
-      });
-      const location = response.headers.get("location")!;
-      expect(location).not.toContain("success=");
-      expect(location).toContain("form=form%26id");
-      expect(location).toContain("#form&id");
-      expectFlash(response, "A & B");
-    });
+    test("creates success redirect with form ID and anchor", () =>
+      withRequestContext(() => {
+        const response = redirect(
+          "/admin/settings",
+          "Timezone updated",
+          true,
+          { formId: "settings-timezone" },
+        );
+        expect(response.status).toBe(302);
+        expect(parseRedirectLocation(response)).toBe(
+          "/admin/settings?form=settings-timezone#settings-timezone",
+        );
+        expectFlash(response, "Timezone updated");
+      }));
 
-    test("creates error redirect", () => {
-      const response = redirect("/admin/settings", "Something failed", false);
-      expect(response.status).toBe(302);
-      expect(parseRedirectLocation(response)).toBe("/admin/settings");
-      expectFlash(response, "Something failed", false);
-    });
+    test("encodes special characters in message and form ID", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin/settings", "A & B", true, {
+          formId: "form&id",
+        });
+        const location = response.headers.get("location")!;
+        expect(location).not.toContain("success=");
+        expect(location).toContain("form=form%26id");
+        expect(location).toContain("#form&id");
+        expectFlash(response, "A & B");
+      }));
 
-    test("preserves existing query params without adding message", () => {
-      const response = redirect(
-        "/admin/event/1?tab=attendees",
-        "Updated",
-        true,
-      );
-      expect(response.status).toBe(302);
-      expect(parseRedirectLocation(response)).toBe(
-        "/admin/event/1?tab=attendees",
-      );
-      expectFlash(response, "Updated");
-    });
+    test("creates error redirect", () =>
+      withRequestContext(() => {
+        const response = redirect(
+          "/admin/settings",
+          "Something failed",
+          false,
+        );
+        expect(response.status).toBe(302);
+        expect(parseRedirectLocation(response)).toBe("/admin/settings");
+        expectFlash(response, "Something failed", false);
+      }));
 
-    test("preserves hash fragment", () => {
-      const response = redirect("/admin/calendar#attendees", "Done", true);
-      expect(response.status).toBe(302);
-      expect(parseRedirectLocation(response)).toBe(
-        "/admin/calendar#attendees",
-      );
-      expectFlash(response, "Done");
-    });
+    test("preserves existing query params without adding message", () =>
+      withRequestContext(() => {
+        const response = redirect(
+          "/admin/event/1?tab=attendees",
+          "Updated",
+          true,
+        );
+        expect(response.status).toBe(302);
+        expect(parseRedirectLocation(response)).toBe(
+          "/admin/event/1?tab=attendees",
+        );
+        expectFlash(response, "Updated");
+      }));
 
-    test("encodes special characters in flash cookie", () => {
-      const response = redirect("/admin/event/1", "A & B", true);
-      expect(parseRedirectLocation(response)).toBe("/admin/event/1");
-      expectFlash(response, "A & B");
-    });
+    test("preserves hash fragment", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin/calendar#attendees", "Done", true);
+        expect(response.status).toBe(302);
+        expect(parseRedirectLocation(response)).toBe(
+          "/admin/calendar#attendees",
+        );
+        expectFlash(response, "Done");
+      }));
 
-    test("includes flash ID in redirect URL", () => {
-      const response = redirect("/admin/settings", "Saved", true);
-      const location = response.headers.get("location")!;
-      const url = new URL(location, "http://localhost");
-      const flashId = url.searchParams.get("flash");
-      expect(flashId).toBeDefined();
-      expect(flashId!.length).toBe(4);
-    });
+    test("encodes special characters in flash cookie", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin/event/1", "A & B", true);
+        expect(parseRedirectLocation(response)).toBe("/admin/event/1");
+        expectFlash(response, "A & B");
+      }));
 
-    test("keys flash cookie by the flash ID in the URL", () => {
-      const response = redirect("/admin/settings", "Saved", true);
-      const location = response.headers.get("location")!;
-      const url = new URL(location, "http://localhost");
-      const flashId = url.searchParams.get("flash")!;
-      const cookies = response.headers.getSetCookie();
-      const flashCookie = cookies.find((c) => c.startsWith(`flash_${flashId}=`));
-      expect(flashCookie).toBeDefined();
-    });
+    test("uses request ID as flash key in redirect URL", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin/settings", "Saved", true);
+        const location = response.headers.get("location")!;
+        const url = new URL(location, "http://localhost");
+        const flashId = url.searchParams.get("flash");
+        expect(flashId).toBeDefined();
+        expect(flashId!.length).toBe(4);
+      }));
 
-    test("passes cookie through to response alongside flash cookie", () => {
-      const response = redirect("/admin", "Done", true, {
-        cookie: "session=abc; Path=/",
-      });
-      const cookies = response.headers.getSetCookie();
-      expect(cookies.some((c) => c === "session=abc; Path=/")).toBe(true);
-      expectFlash(response, "Done");
-    });
+    test("keys flash cookie by the flash ID in the URL", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin/settings", "Saved", true);
+        const location = response.headers.get("location")!;
+        const url = new URL(location, "http://localhost");
+        const flashId = url.searchParams.get("flash")!;
+        const cookies = response.headers.getSetCookie();
+        const flashCookie = cookies.find((c) =>
+          c.startsWith(`flash_${flashId}=`)
+        );
+        expect(flashCookie).toBeDefined();
+      }));
+
+    test("passes cookie through to response alongside flash cookie", () =>
+      withRequestContext(() => {
+        const response = redirect("/admin", "Done", true, {
+          cookie: "session=abc; Path=/",
+        });
+        const cookies = response.headers.getSetCookie();
+        expect(cookies.some((c) => c === "session=abc; Path=/")).toBe(true);
+        expectFlash(response, "Done");
+      }));
   });
 
   describe("routes/utils.ts (redirectResponse)", () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -384,10 +384,19 @@ describeWithEnv("server (misc)", { db: true }, () => {
   });
 
   describe("routes/utils.ts (redirect)", () => {
+    /** Parse the redirect location, stripping the flash param for comparison */
+    const parseRedirectLocation = (response: Response) => {
+      const location = response.headers.get("location")!;
+      const url = new URL(location, "http://localhost");
+      expect(url.searchParams.has("flash")).toBe(true);
+      url.searchParams.delete("flash");
+      return url.pathname + url.search + url.hash;
+    };
+
     test("creates success redirect without form ID", () => {
       const response = redirect("/admin/settings", "Saved", true);
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/settings");
+      expect(parseRedirectLocation(response)).toBe("/admin/settings");
       expectFlash(response, "Saved");
     });
 
@@ -396,8 +405,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
         formId: "settings-timezone",
       });
       expect(response.status).toBe(302);
-      const location = response.headers.get("location")!;
-      expect(location).toBe(
+      expect(parseRedirectLocation(response)).toBe(
         "/admin/settings?form=settings-timezone#settings-timezone",
       );
       expectFlash(response, "Timezone updated");
@@ -417,7 +425,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
     test("creates error redirect", () => {
       const response = redirect("/admin/settings", "Something failed", false);
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/settings");
+      expect(parseRedirectLocation(response)).toBe("/admin/settings");
       expectFlash(response, "Something failed", false);
     });
 
@@ -428,7 +436,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
         true,
       );
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe(
+      expect(parseRedirectLocation(response)).toBe(
         "/admin/event/1?tab=attendees",
       );
       expectFlash(response, "Updated");
@@ -437,7 +445,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
     test("preserves hash fragment", () => {
       const response = redirect("/admin/calendar#attendees", "Done", true);
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe(
+      expect(parseRedirectLocation(response)).toBe(
         "/admin/calendar#attendees",
       );
       expectFlash(response, "Done");
@@ -445,8 +453,27 @@ describeWithEnv("server (misc)", { db: true }, () => {
 
     test("encodes special characters in flash cookie", () => {
       const response = redirect("/admin/event/1", "A & B", true);
-      expect(response.headers.get("location")).toBe("/admin/event/1");
+      expect(parseRedirectLocation(response)).toBe("/admin/event/1");
       expectFlash(response, "A & B");
+    });
+
+    test("includes flash ID in redirect URL", () => {
+      const response = redirect("/admin/settings", "Saved", true);
+      const location = response.headers.get("location")!;
+      const url = new URL(location, "http://localhost");
+      const flashId = url.searchParams.get("flash");
+      expect(flashId).toBeDefined();
+      expect(flashId!.length).toBe(6);
+    });
+
+    test("keys flash cookie by the flash ID in the URL", () => {
+      const response = redirect("/admin/settings", "Saved", true);
+      const location = response.headers.get("location")!;
+      const url = new URL(location, "http://localhost");
+      const flashId = url.searchParams.get("flash")!;
+      const cookies = response.headers.getSetCookie();
+      const flashCookie = cookies.find((c) => c.startsWith(`flash_${flashId}=`));
+      expect(flashCookie).toBeDefined();
     });
 
     test("passes cookie through to response alongside flash cookie", () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -407,12 +407,9 @@ describeWithEnv("server (misc)", { db: true }, () => {
 
     test("creates success redirect with form ID and anchor", () =>
       withRequestContext(() => {
-        const response = redirect(
-          "/admin/settings",
-          "Timezone updated",
-          true,
-          { formId: "settings-timezone" },
-        );
+        const response = redirect("/admin/settings", "Timezone updated", true, {
+          formId: "settings-timezone",
+        });
         expect(response.status).toBe(302);
         expect(parseRedirectLocation(response)).toBe(
           "/admin/settings?form=settings-timezone#settings-timezone",
@@ -434,11 +431,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
 
     test("creates error redirect", () =>
       withRequestContext(() => {
-        const response = redirect(
-          "/admin/settings",
-          "Something failed",
-          false,
-        );
+        const response = redirect("/admin/settings", "Something failed", false);
         expect(response.status).toBe(302);
         expect(parseRedirectLocation(response)).toBe("/admin/settings");
         expectFlash(response, "Something failed", false);
@@ -493,7 +486,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
         const flashId = url.searchParams.get("flash")!;
         const cookies = response.headers.getSetCookie();
         const flashCookie = cookies.find((c) =>
-          c.startsWith(`flash_${flashId}=`)
+          c.startsWith(`flash_${flashId}=`),
         );
         expect(flashCookie).toBeDefined();
       }));

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -20,6 +20,7 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirectWithFlash,
+  FLASH_TEST_ID,
   flashCookieHeader,
   mockFormRequest,
   mockRequest,
@@ -113,7 +114,7 @@ describe("server (admin settings-advanced)", () => {
 
     test("displays success message on the matching form when form param is provided", async () => {
       const response = await awaitTestRequest(
-        "/admin/settings-advanced?form=settings-show-public-api",
+        `/admin/settings-advanced?form=settings-show-public-api&flash=${FLASH_TEST_ID}`,
         {
           cookie: `${await testCookie()}; ${flashCookieHeader("API enabled")}`,
         },

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -64,9 +64,12 @@ describe("server (admin settings)", () => {
     });
 
     test("does not display success when form param is missing", async () => {
-      const response = await awaitTestRequest(`/admin/settings?flash=${FLASH_TEST_ID}`, {
-        cookie: `${await testCookie()}; ${flashCookieHeader("Test success message")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/settings?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${await testCookie()}; ${flashCookieHeader("Test success message")}`,
+        },
+      );
       const html = await response.text();
       expect(html).not.toContain('class="success"');
     });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -22,6 +22,7 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirectWithFlash,
+  FLASH_TEST_ID,
   flashCookieHeader,
   installUrlHandler,
   invalidateTestDbCache,
@@ -63,7 +64,7 @@ describe("server (admin settings)", () => {
     });
 
     test("does not display success when form param is missing", async () => {
-      const response = await awaitTestRequest("/admin/settings", {
+      const response = await awaitTestRequest(`/admin/settings?flash=${FLASH_TEST_ID}`, {
         cookie: `${await testCookie()}; ${flashCookieHeader("Test success message")}`,
       });
       const html = await response.text();
@@ -72,7 +73,7 @@ describe("server (admin settings)", () => {
 
     test("displays success message on the matching form when form param is provided", async () => {
       const response = await awaitTestRequest(
-        "/admin/settings?form=settings-country",
+        `/admin/settings?form=settings-country&flash=${FLASH_TEST_ID}`,
         {
           cookie: `${await testCookie()}; ${flashCookieHeader("Country updated")}`,
         },
@@ -88,7 +89,7 @@ describe("server (admin settings)", () => {
 
     test("does not show success on non-matching forms", async () => {
       const response = await awaitTestRequest(
-        "/admin/settings?form=settings-country",
+        `/admin/settings?form=settings-country&flash=${FLASH_TEST_ID}`,
         {
           cookie: `${await testCookie()}; ${flashCookieHeader("Country updated")}`,
         },

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -66,9 +66,12 @@ describeWithEnv("server (admin site)", { db: true }, () => {
 
     test("displays success message from flash cookie", async () => {
       const cookie = await testCookie();
-      const response = await awaitTestRequest(`/admin/site?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("Homepage updated")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/site?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Homepage updated")}`,
+        },
+      );
       const html = await response.text();
       expect(html).toContain("Homepage updated");
     });
@@ -213,9 +216,12 @@ describeWithEnv("server (admin site)", { db: true }, () => {
 
     test("displays success message from flash cookie", async () => {
       const cookie = await testCookie();
-      const response = await awaitTestRequest(`/admin/site/contact?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("Contact page updated")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/site/contact?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Contact page updated")}`,
+        },
+      );
       const html = await response.text();
       expect(html).toContain("Contact page updated");
     });

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -18,6 +18,7 @@ import {
   expectAdminRedirect,
   expectFlash,
   expectHtmlResponse,
+  FLASH_TEST_ID,
   flashCookieHeader,
   mockFormRequest,
   mockRequest,
@@ -65,7 +66,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
 
     test("displays success message from flash cookie", async () => {
       const cookie = await testCookie();
-      const response = await awaitTestRequest("/admin/site", {
+      const response = await awaitTestRequest(`/admin/site?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("Homepage updated")}`,
       });
       const html = await response.text();
@@ -212,7 +213,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
 
     test("displays success message from flash cookie", async () => {
       const cookie = await testCookie();
-      const response = await awaitTestRequest("/admin/site/contact", {
+      const response = await awaitTestRequest(`/admin/site/contact?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("Contact page updated")}`,
       });
       const html = await response.text();

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -273,9 +273,12 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
 
     test("displays success message from flash cookie", async () => {
       const cookie = await testCookie();
-      const response = await awaitTestRequest(`/admin/users?flash=${FLASH_TEST_ID}`, {
-        cookie: `${cookie}; ${flashCookieHeader("User deleted successfully")}`,
-      });
+      const response = await awaitTestRequest(
+        `/admin/users?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("User deleted successfully")}`,
+        },
+      );
       await expectHtmlResponse(
         response,
         200,

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -27,6 +27,7 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirectWithFlash,
+  FLASH_TEST_ID,
   flashCookieHeader,
   mockAdminLoginRequest,
   mockFormRequest,
@@ -272,7 +273,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
 
     test("displays success message from flash cookie", async () => {
       const cookie = await testCookie();
-      const response = await awaitTestRequest("/admin/users", {
+      const response = await awaitTestRequest(`/admin/users?flash=${FLASH_TEST_ID}`, {
         cookie: `${cookie}; ${flashCookieHeader("User deleted successfully")}`,
       });
       await expectHtmlResponse(


### PR DESCRIPTION
## Summary
This change refactors the flash cookie system to use per-request IDs as keys, enabling proper isolation of flash messages across concurrent requests and preventing message leakage between different redirects.

## Key Changes

- **Flash cookie keying**: Changed from a single `flash` cookie to `flash_{id}` cookies, where the ID is a per-request identifier
  - Updated `buildFlashCookie()` to accept an `id` parameter and use it in the cookie name
  - Updated `clearFlashCookie()` to accept an `id` parameter for clearing the correct keyed cookie
  - Added `flashCookieName()` helper to construct keyed cookie names

- **Request ID integration**: 
  - Exported `getRequestId()` from logger module to retrieve the current request's ID
  - Used in `redirect()` function to generate and include flash ID in redirect URLs as a query parameter

- **Flash message retrieval**: 
  - Updated request handler to extract flash ID from URL query parameter (`?flash=...`)
  - Looks up the keyed cookie (`flash_{id}`) instead of a global `flash` cookie
  - Clears the specific keyed cookie after consuming the message

- **Test utilities**:
  - Added `FLASH_TEST_ID` constant (`"t001"`) for deterministic test assertions
  - Updated `flashCookieHeader()` to use keyed cookies with the test ID
  - Updated `expectFlash()` to find cookies with `flash_` prefix
  - Updated `expectRedirectWithFlash()` to extract and verify flash ID from redirect URL
  - Updated test assertions to include `?flash={FLASH_TEST_ID}` in request URLs

## Implementation Details

- Flash IDs are 4-character strings generated per-request (existing `generateRequestId()` mechanism)
- Flash cookies have a short 10-second Max-Age, suitable for post-redirect display
- The flash ID is passed through the redirect URL as a query parameter, allowing the client to retrieve the correct keyed cookie
- All existing flash message functionality is preserved; this is purely an internal refactoring for better isolation

https://claude.ai/code/session_014BvnJYWu1T7DwsieBWKiXG