### PR TITLE
Fix refund count display to exclude already refunded attendees

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -464,7 +464,7 @@ const processRefundAll = async (
       event.id,
     );
     return htmlResponse(
-      adminRefundAllAttendeesPage(event, refundable.length, session, msg),
+      adminRefundAllAttendeesPage(event, refundable.length - refundedCount, session, msg),
       400,
     );
   }

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -549,12 +549,14 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
               await testCookie(),
             ),
           );
-          await expectHtmlResponse(
+          const html = await expectHtmlResponse(
             response,
             400,
             "1 refund(s) succeeded",
             "1 failed",
           );
+          expect(html).toContain("all 1 attendee(s)");
+          expect(html).not.toContain("all 2 attendee(s)");
         },
       );
     });


### PR DESCRIPTION
## Summary
Fixed a bug in the refund all attendees page where the count of remaining attendees to refund was incorrectly displaying the total refundable count instead of accounting for attendees that had already been refunded in the current operation.

## Changes
- **src/routes/admin/attendees.ts**: Updated the `processRefundAll` function to pass `refundable.length - refundedCount` instead of just `refundable.length` to the admin refund page, ensuring the displayed count reflects only the attendees still pending refund
- **test/lib/server-refunds.test.ts**: Added assertions to verify the correct attendee count is displayed in the response HTML, confirming that only the remaining attendees (not the total) are shown

## Details
When a partial refund operation occurs (some attendees succeed, some fail), the page was displaying the total number of refundable attendees rather than the count of attendees whose refunds actually failed. This change ensures the UI accurately reflects how many attendees still need to be refunded.

https://claude.ai/code/session_01MiJb4Um7SY6NXNGpW9gioG