### PR TITLE
Remove duplicate event ID check in question event mapping

### DIFF
--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -235,7 +235,7 @@ export const getQuestionsWithEventIds = async (
   for (const { question_id, event_id } of links) {
     const existing = questionEventMap.get(question_id);
     if (existing) {
-      if (!existing.includes(event_id)) existing.push(event_id);
+      existing.push(event_id);
     } else {
       questionEventMap.set(question_id, [event_id]);
     }


### PR DESCRIPTION
## Summary
Simplified the event ID assignment logic in `getQuestionsWithEventIds` by removing an unnecessary duplicate check before pushing event IDs to the existing array.

## Key Changes
- Removed the `!existing.includes(event_id)` condition before pushing event IDs to the question-event map
- Event IDs are now always added to the existing array without checking for duplicates first

## Implementation Details
The change assumes that duplicate event IDs for the same question should either:
1. Not occur in the source data, or
2. Be allowed to exist in the mapping

This simplification reduces the O(n) lookup cost of the `includes()` check on each iteration, improving performance when processing large numbers of question-event links.

https://claude.ai/code/session_01MoAxBdftcmY2Anpt8ddyo1