### PR TITLE
Add booking questions section to admin guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -361,9 +361,10 @@ export const adminGuidePage = (
 
         <Q q="Where do I see the answers?">
           <p>
-            Each attendee's selected answer is shown on their detail page in the
-            admin area. Answers are also included in the CSV export and in
-            webhook payloads, so you can use them in external tools.
+            Answers appear in the attendee table on event and group pages, so
+            you can see at a glance what each attendee chose. They're also
+            shown on the individual attendee detail page, included in the CSV
+            export, and sent in webhook payloads.
           </p>
         </Q>
       </Section>

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -321,6 +321,53 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
+      <Section title="Booking Questions">
+        <Q q="What are custom booking questions?">
+          <p>
+            Custom booking questions let you ask attendees a multiple-choice
+            question during the booking process. Each question has a set of
+            answers you define, and the attendee must select one before they can
+            complete their booking.
+          </p>
+        </Q>
+
+        <Q q="How do I create a question?">
+          <p>
+            Go to <strong>Questions</strong> in the admin menu, type your
+            question text, and click <strong>Add Question</strong>. Then open
+            the question and add your answer options. You can reorder answers
+            using the move-up and move-down buttons.
+          </p>
+        </Q>
+
+        <Q q="How do I add a question to an event?">
+          <p>
+            Open the event in the admin area and click{" "}
+            <strong>Questions</strong>. Tick the questions you want to appear on
+            that event's booking form and save. The same question can be shared
+            across multiple events &mdash; create it once and assign it wherever
+            you need it.
+          </p>
+        </Q>
+
+        <Q q="Can I share questions between events?">
+          <p>
+            Yes. Questions are created independently and then assigned to
+            events, so a single question can appear on as many events as you
+            like. Updating the question text or answers updates it everywhere
+            it's used.
+          </p>
+        </Q>
+
+        <Q q="Where do I see the answers?">
+          <p>
+            Each attendee's selected answer is shown on their detail page in the
+            admin area. Answers are also included in the CSV export and in
+            webhook payloads, so you can use them in external tools.
+          </p>
+        </Q>
+      </Section>
+
       <Section title="Public Links">
         <Q q="Why do I get a 403 error when sharing my link on Facebook?">
           <p>

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -42,6 +42,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       expect(html).toContain("multiple-choice");
       expect(html).toContain("must select one");
       expect(html).toContain("shared across multiple events");
+      expect(html).toContain("attendee table on event and group pages");
     });
 
     test("contains public links section", async () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -35,6 +35,15 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       expect(html).toContain("Check-in");
     });
 
+    test("contains booking questions section", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).toContain("Booking Questions");
+      expect(html).toContain("multiple-choice");
+      expect(html).toContain("must select one");
+      expect(html).toContain("shared across multiple events");
+    });
+
     test("contains public links section", async () => {
       const { response } = await adminGet("/admin/guide");
       const html = await response.text();


### PR DESCRIPTION
## Summary
Added a new "Booking Questions" section to the admin guide documentation that explains how to create, manage, and use custom booking questions in the system.

## Changes
- **Documentation**: Added comprehensive FAQ section covering:
  - What custom booking questions are and how they work
  - Step-by-step instructions for creating questions
  - How to assign questions to events
  - Question sharing capabilities across multiple events
  - Where attendee answers appear (attendee tables, detail pages, CSV exports, webhooks)

- **Tests**: Added test coverage to verify the new section is properly rendered and contains expected content about booking questions functionality

## Implementation Details
The new section follows the existing documentation pattern with Q&A format using the `<Section>` and `<Q>` components. It's positioned logically between the "Check-in" and "Public Links" sections in the guide.

https://claude.ai/code/session_01H5vHkbAwYWiouqrZpvgCGj