### PR TITLE
Refactor webhook testing to list all endpoints instead of retrieving one

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -284,7 +284,11 @@ setupTestButton(
     } else if (data.webhooks && data.webhooks.length > 0) {
       lines.push(`Webhooks: ${data.webhooks.length} endpoint(s)`);
       for (const wh of data.webhooks) {
-        lines.push(`  ${wh.status} - ${wh.url}`);
+        const ours =
+          data.ownEndpointId && wh.endpointId === data.ownEndpointId
+            ? " (tickets)"
+            : "";
+        lines.push(`  ${wh.status} - ${wh.url}${ours}`);
         lines.push(`  Events: ${wh.enabledEvents.join(", ")}`);
       }
     } else {

--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -279,14 +279,16 @@ setupTestButton(
         `API Key: Invalid${data.apiKey.error ? ` - ${data.apiKey.error}` : ""}`,
       );
     }
-    lines.push(
-      formatWebhookLine(data.webhook, data.webhook.status || "configured"),
-    );
-    if (data.webhook.configured) {
-      lines.push(`URL: ${data.webhook.url}`);
-      if (data.webhook.enabledEvents) {
-        lines.push(`Events: ${data.webhook.enabledEvents.join(", ")}`);
+    if (data.webhookError) {
+      lines.push(`Webhooks: Error - ${data.webhookError}`);
+    } else if (data.webhooks && data.webhooks.length > 0) {
+      lines.push(`Webhooks: ${data.webhooks.length} endpoint(s)`);
+      for (const wh of data.webhooks) {
+        lines.push(`  ${wh.status} - ${wh.url}`);
+        lines.push(`  Events: ${wh.enabledEvents.join(", ")}`);
       }
+    } else {
+      lines.push("Webhooks: None configured");
     }
     return lines;
   },

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -11,6 +11,7 @@ import {
   getStripeSecretKey,
   getStripeWebhookSecret,
 } from "#lib/config.ts";
+import { getStripeWebhookEndpointId } from "#lib/db/settings.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import { nowMs } from "#lib/now.ts";
@@ -436,6 +437,9 @@ export const stripeApi: {
     }
 
     // Step 2: List all webhook endpoints
+    const ownEndpointId = await getStripeWebhookEndpointId();
+    result.ownEndpointId = ownEndpointId;
+
     try {
       const endpoints = await client.webhookEndpoints.list({ limit: 100 });
       result.webhooks = endpoints.data.map((ep) => ({
@@ -563,6 +567,7 @@ export type StripeConnectionTestResult = {
   ok: boolean;
   apiKey: { valid: boolean; error?: string; mode?: string };
   webhooks: WebhookEndpointStatus[];
+  ownEndpointId?: string | null;
   webhookError?: string;
 };
 

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -11,7 +11,6 @@ import {
   getStripeSecretKey,
   getStripeWebhookSecret,
 } from "#lib/config.ts";
-import { getStripeWebhookEndpointId } from "#lib/db/settings.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import { nowMs } from "#lib/now.ts";
@@ -231,20 +230,7 @@ const setupWebhookEndpointImpl = async (
       }
     }
 
-    // Check if a webhook already exists for this exact URL
-    const existingEndpoints = await client.webhookEndpoints.list({
-      limit: 100,
-    });
-    const existingForUrl = existingEndpoints.data.find(
-      (ep) => ep.url === webhookUrl,
-    );
-
-    if (existingForUrl) {
-      // Delete existing endpoint to recreate with fresh secret
-      await client.webhookEndpoints.del(existingForUrl.id);
-    }
-
-    // Create new webhook endpoint
+    // Create new webhook endpoint (preserves any existing webhooks)
     const endpoint = await client.webhookEndpoints.create({
       url: webhookUrl,
       enabled_events: ["checkout.session.completed"],
@@ -421,12 +407,12 @@ export const stripeApi: {
     return session;
   },
 
-  /** Test Stripe connection: verify API key and webhook endpoint */
+  /** Test Stripe connection: verify API key and list all webhook endpoints */
   testStripeConnection: async (): Promise<StripeConnectionTestResult> => {
     const result: StripeConnectionTestResult = {
       ok: false,
       apiKey: { valid: false },
-      webhook: { configured: false },
+      webhooks: [],
     };
 
     // Step 1: Test API key by retrieving balance
@@ -449,32 +435,22 @@ export const stripeApi: {
       return result;
     }
 
-    // Step 2: Test webhook endpoint
-    const endpointId = await getStripeWebhookEndpointId();
-    if (!endpointId) {
-      result.webhook = {
-        configured: false,
-        error: "No webhook endpoint ID stored",
-      };
-      return result;
-    }
-
+    // Step 2: List all webhook endpoints
     try {
-      const endpoint = await client.webhookEndpoints.retrieve(endpointId);
-      result.webhook = {
-        configured: true,
-        endpointId: endpoint.id,
-        url: endpoint.url,
-        status: endpoint.status,
-        enabledEvents: endpoint.enabled_events,
-      };
+      const endpoints = await client.webhookEndpoints.list({ limit: 100 });
+      result.webhooks = endpoints.data.map((ep) => ({
+        endpointId: ep.id,
+        url: ep.url,
+        status: ep.status,
+        enabledEvents: ep.enabled_events,
+      }));
     } catch (err) {
       const message = errorMessage(err);
-      result.webhook = { configured: false, endpointId, error: message };
+      result.webhookError = message;
       return result;
     }
 
-    result.ok = result.apiKey.valid && result.webhook.configured;
+    result.ok = result.apiKey.valid && result.webhooks.length > 0;
     return result;
   },
 
@@ -574,18 +550,20 @@ const computeSignature = async (
 export type StripeWebhookEvent = WebhookEvent;
 export type { WebhookSetupResult, WebhookVerifyResult };
 
+/** A single webhook endpoint's status */
+export type WebhookEndpointStatus = {
+  endpointId: string;
+  url: string;
+  status: string;
+  enabledEvents: string[];
+};
+
 /** Result of testing the Stripe connection */
 export type StripeConnectionTestResult = {
   ok: boolean;
   apiKey: { valid: boolean; error?: string; mode?: string };
-  webhook: {
-    configured: boolean;
-    endpointId?: string;
-    url?: string;
-    status?: string;
-    enabledEvents?: string[];
-    error?: string;
-  };
+  webhooks: WebhookEndpointStatus[];
+  webhookError?: string;
 };
 
 /**

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -536,7 +536,7 @@ describe("server (admin settings)", () => {
                 valid: false,
                 error: "No Stripe secret key configured",
               },
-              webhook: { configured: false },
+              webhooks: [],
             }),
           ),
         async () => {
@@ -563,20 +563,21 @@ describe("server (admin settings)", () => {
       );
     });
 
-    test("returns success when API key and webhook are valid", async () => {
+    test("returns success when API key and webhooks are valid", async () => {
       await withMocks(
         () =>
           stub(stripeApi, "testStripeConnection", () =>
             Promise.resolve({
               ok: true,
               apiKey: { valid: true, mode: "test" },
-              webhook: {
-                configured: true,
-                endpointId: "we_test_123",
-                url: "https://example.com/payment/webhook",
-                status: "enabled",
-                enabledEvents: ["checkout.session.completed"],
-              },
+              webhooks: [
+                {
+                  endpointId: "we_test_123",
+                  url: "https://example.com/payment/webhook",
+                  status: "enabled",
+                  enabledEvents: ["checkout.session.completed"],
+                },
+              ],
             }),
           ),
         async () => {
@@ -594,27 +595,26 @@ describe("server (admin settings)", () => {
           expect(json.ok).toBe(true);
           expect(json.apiKey.valid).toBe(true);
           expect(json.apiKey.mode).toBe("test");
-          expect(json.webhook.configured).toBe(true);
-          expect(json.webhook.url).toBe("https://example.com/payment/webhook");
-          expect(json.webhook.status).toBe("enabled");
-          expect(json.webhook.enabledEvents).toContain(
+          expect(json.webhooks).toHaveLength(1);
+          expect(json.webhooks[0].url).toBe(
+            "https://example.com/payment/webhook",
+          );
+          expect(json.webhooks[0].status).toBe("enabled");
+          expect(json.webhooks[0].enabledEvents).toContain(
             "checkout.session.completed",
           );
         },
       );
     });
 
-    test("returns partial failure when API key valid but webhook missing", async () => {
+    test("returns partial failure when API key valid but no webhooks", async () => {
       await withMocks(
         () =>
           stub(stripeApi, "testStripeConnection", () =>
             Promise.resolve({
               ok: false,
               apiKey: { valid: true, mode: "test" },
-              webhook: {
-                configured: false,
-                error: "No webhook endpoint ID stored",
-              },
+              webhooks: [],
             }),
           ),
         async () => {
@@ -631,8 +631,7 @@ describe("server (admin settings)", () => {
           const json = await response.json();
           expect(json.ok).toBe(false);
           expect(json.apiKey.valid).toBe(true);
-          expect(json.webhook.configured).toBe(false);
-          expect(json.webhook.error).toContain("No webhook endpoint ID stored");
+          expect(json.webhooks).toHaveLength(0);
         },
       );
     });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -570,6 +570,7 @@ describe("server (admin settings)", () => {
             Promise.resolve({
               ok: true,
               apiKey: { valid: true, mode: "test" },
+              ownEndpointId: "we_test_123",
               webhooks: [
                 {
                   endpointId: "we_test_123",

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -743,6 +743,10 @@ describeWithEnv(
 
       test("returns full success when API key valid and webhooks exist", async () => {
         await updateStripeKey("sk_test_mock");
+        await setStripeWebhookConfig({
+          secret: "whsec_test",
+          endpointId: "we_test_valid",
+        });
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -781,6 +785,7 @@ describeWithEnv(
             expect(result.ok).toBe(true);
             expect(result.apiKey.valid).toBe(true);
             expect(result.apiKey.mode).toBe("test");
+            expect(result.ownEndpointId).toBe("we_test_valid");
             expect(result.webhooks).toHaveLength(2);
             const [first, second] = result.webhooks;
             expect(first!.endpointId).toBe("we_test_valid");

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -656,14 +656,14 @@ describeWithEnv(
         );
       });
 
-      test("returns test mode when API key is valid and webhook not configured", async () => {
+      test("returns test mode when API key is valid and no webhooks exist", async () => {
         await updateStripeKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
         await withMocks(
-          () =>
-            stub(client.balance, "retrieve", () =>
+          () => ({
+            balanceSpy: stub(client.balance, "retrieve", () =>
               Promise.resolve({
                 livemode: false,
                 available: [],
@@ -671,15 +671,15 @@ describeWithEnv(
                 object: "balance",
               } as never),
             ),
+            listSpy: stub(client.webhookEndpoints, "list", (() =>
+              Promise.resolve({ data: [] })) as never),
+          }),
           async () => {
             const result = await testStripeConnection();
             expect(result.ok).toBe(false);
             expect(result.apiKey.valid).toBe(true);
             expect(result.apiKey.mode).toBe("test");
-            expect(result.webhook.configured).toBe(false);
-            expect(result.webhook.error).toContain(
-              "No webhook endpoint ID stored",
-            );
+            expect(result.webhooks).toHaveLength(0);
           },
         );
       });
@@ -690,8 +690,8 @@ describeWithEnv(
         if (!client) throw new Error("Expected client to be defined");
 
         await withMocks(
-          () =>
-            stub(client.balance, "retrieve", () =>
+          () => ({
+            balanceSpy: stub(client.balance, "retrieve", () =>
               Promise.resolve({
                 livemode: true,
                 available: [],
@@ -699,6 +699,9 @@ describeWithEnv(
                 object: "balance",
               } as never),
             ),
+            listSpy: stub(client.webhookEndpoints, "list", (() =>
+              Promise.resolve({ data: [] })) as never),
+          }),
           async () => {
             const result = await testStripeConnection();
             expect(result.apiKey.valid).toBe(true);
@@ -707,12 +710,8 @@ describeWithEnv(
         );
       });
 
-      test("returns webhook error when endpoint retrieval fails", async () => {
+      test("returns webhook error when list fails", async () => {
         await updateStripeKey("sk_test_mock");
-        await setStripeWebhookConfig({
-          secret: "whsec_test",
-          endpointId: "we_test_missing",
-        });
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -726,28 +725,24 @@ describeWithEnv(
                 object: "balance",
               } as never),
             ),
-            webhookSpy: stub(client.webhookEndpoints, "retrieve", () =>
+            listSpy: stub(client.webhookEndpoints, "list", (() =>
               Promise.reject(
-                new Error("No such webhook endpoint: we_test_missing"),
-              ),
-            ),
+                new Error("Failed to list webhook endpoints"),
+              )) as never),
           }),
           async () => {
             const result = await testStripeConnection();
             expect(result.ok).toBe(false);
             expect(result.apiKey.valid).toBe(true);
-            expect(result.webhook.configured).toBe(false);
-            expect(result.webhook.error).toContain("No such webhook endpoint");
+            expect(result.webhookError).toContain(
+              "Failed to list webhook endpoints",
+            );
           },
         );
       });
 
-      test("returns full success when API key and webhook are both valid", async () => {
+      test("returns full success when API key valid and webhooks exist", async () => {
         await updateStripeKey("sk_test_mock");
-        await setStripeWebhookConfig({
-          secret: "whsec_test",
-          endpointId: "we_test_valid",
-        });
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -761,30 +756,41 @@ describeWithEnv(
                 object: "balance",
               } as never),
             ),
-            webhookSpy: stub(client.webhookEndpoints, "retrieve", () =>
+            listSpy: stub(client.webhookEndpoints, "list", (() =>
               Promise.resolve({
-                id: "we_test_valid",
-                url: "https://example.com/payment/webhook",
-                status: "enabled",
-                enabled_events: ["checkout.session.completed"],
-                object: "webhook_endpoint",
-              } as never),
-            ),
+                data: [
+                  {
+                    id: "we_test_valid",
+                    url: "https://example.com/payment/webhook",
+                    status: "enabled",
+                    enabled_events: ["checkout.session.completed"],
+                    object: "webhook_endpoint",
+                  },
+                  {
+                    id: "we_test_other",
+                    url: "https://other.com/webhook",
+                    status: "enabled",
+                    enabled_events: ["payment_intent.succeeded"],
+                    object: "webhook_endpoint",
+                  },
+                ],
+              })) as never),
           }),
           async () => {
             const result = await testStripeConnection();
             expect(result.ok).toBe(true);
             expect(result.apiKey.valid).toBe(true);
             expect(result.apiKey.mode).toBe("test");
-            expect(result.webhook.configured).toBe(true);
-            expect(result.webhook.endpointId).toBe("we_test_valid");
-            expect(result.webhook.url).toBe(
-              "https://example.com/payment/webhook",
-            );
-            expect(result.webhook.status).toBe("enabled");
-            expect(result.webhook.enabledEvents).toContain(
+            expect(result.webhooks).toHaveLength(2);
+            const [first, second] = result.webhooks;
+            expect(first!.endpointId).toBe("we_test_valid");
+            expect(first!.url).toBe("https://example.com/payment/webhook");
+            expect(first!.status).toBe("enabled");
+            expect(first!.enabledEvents).toContain(
               "checkout.session.completed",
             );
+            expect(second!.endpointId).toBe("we_test_other");
+            expect(second!.url).toBe("https://other.com/webhook");
           },
         );
       });
@@ -1107,12 +1113,8 @@ describeWithEnv(
         }
       });
 
-      test("handles non-Error thrown value in webhook retrieval", async () => {
+      test("handles non-Error thrown value in webhook list", async () => {
         await updateStripeKey("sk_test_mock");
-        await setStripeWebhookConfig({
-          secret: "whsec_test",
-          endpointId: "we_test_nonerror",
-        });
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1125,18 +1127,16 @@ describeWithEnv(
           } as never),
         );
 
-        const webhookSpy = stub(client.webhookEndpoints, "retrieve", () =>
-          Promise.reject("webhook string error"),
-        );
+        const listSpy = stub(client.webhookEndpoints, "list", (() =>
+          Promise.reject("webhook string error")) as never);
 
         try {
           const result = await testStripeConnection();
           expect(result.ok).toBe(false);
-          expect(result.webhook.configured).toBe(false);
-          expect(result.webhook.error).toBe("Unknown error");
+          expect(result.webhookError).toBe("Unknown error");
         } finally {
           balanceSpy.restore();
-          webhookSpy.restore();
+          listSpy.restore();
         }
       });
     });
@@ -1236,16 +1236,15 @@ describeWithEnv(
     });
 
     describe("setupWebhookEndpoint - stripe-mock paths", () => {
-      test("deletes existing endpoint for same URL before recreating", async () => {
+      test("creates new endpoint without deleting existing ones for same URL", async () => {
         // stripe-mock has a default endpoint at https://example.com/my/webhook/endpoint
-        // Calling setupWebhookEndpoint with that URL should find it via list and delete it
+        // Calling setupWebhookEndpoint with that URL should create a new one without deleting existing
         const result = await setupWebhookEndpoint(
           "sk_test_mock",
           "https://example.com/my/webhook/endpoint",
         );
 
         // stripe-mock doesn't return secret, so this hits the "no secret" error path
-        // but the important thing is it exercises the "delete existing for URL" code path (lines 368-371)
         expect(result).toBeDefined();
         expect(typeof result.success).toBe("boolean");
       });
@@ -1331,33 +1330,6 @@ describeWithEnv(
           // The function should continue past the failed delete and still attempt to create
           expect(result).toBeDefined();
           expect(typeof result.success).toBe("boolean");
-        });
-      });
-
-      test("returns error when list endpoints throws", async () => {
-        // Mock fetch so that the list call (GET) throws, exercising the outer catch
-        await withFetchMock(async (originalFetch) => {
-          installUrlHandler(originalFetch, (url, init) => {
-            if (
-              (init?.method ?? "GET") === "GET" &&
-              url.includes("/v1/webhook_endpoints")
-            ) {
-              throw new Error("List endpoints failed");
-            }
-            return null;
-          });
-
-          const result = await setupWebhookEndpoint(
-            "sk_test_mock",
-            "https://example.com/webhook/list-error-test",
-          );
-
-          expect(result.success).toBe(false);
-          if (!result.success) {
-            // Stripe SDK wraps connection errors with retry info
-            expect(typeof result.error).toBe("string");
-            expect(result.error!.length > 0).toBe(true);
-          }
         });
       });
 


### PR DESCRIPTION
## Summary
Changed the Stripe webhook connection testing logic from retrieving a single stored webhook endpoint to listing all webhook endpoints. This provides better visibility into the webhook configuration state and removes the dependency on storing a specific endpoint ID.

## Key Changes

- **testStripeConnection()**: Refactored to call `webhookEndpoints.list()` instead of `webhookEndpoints.retrieve()`, returning all configured webhooks rather than checking a single stored endpoint
- **StripeConnectionTestResult type**: Restructured the response object:
  - Replaced `webhook` object with `webhooks` array containing `WebhookEndpointStatus` items
  - Added `ownEndpointId` field to track which endpoint (if any) belongs to the application
  - Added `webhookError` field for webhook-related errors
  - Removed `webhook.configured` boolean in favor of checking `webhooks.length > 0`
- **setupWebhookEndpoint()**: Removed the logic that deleted existing endpoints with the same URL before creating a new one - now creates new endpoints without deleting existing ones
- **Admin UI (client/admin.ts)**: Updated webhook status display to show all configured endpoints with their details, marking the application's own endpoint with "(tickets)" label

## Implementation Details

- The `ok` result is now true when both API key is valid AND at least one webhook endpoint exists
- All webhook endpoints are returned in the response, providing complete visibility into the webhook configuration
- The stored `ownEndpointId` is still tracked separately to identify which endpoint belongs to the application
- Error handling now uses `webhookError` field instead of nested error in webhook object
- Tests updated to reflect the new list-based approach and verify multiple webhook endpoints can be returned

https://claude.ai/code/session_01F6PnMA21SGyPAD3UGo3zjE