### PR TITLE
Add margin spacing for multi-ticket row elements

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -982,6 +982,10 @@ body.iframe form {
   padding-left: 0;
 }
 
+.multi-ticket-row {
+  margin-bottom: 2rem;
+}
+
 fieldset {
   border: 0;
 }


### PR DESCRIPTION
## Summary
Added CSS styling to improve visual spacing for multi-ticket row components.

## Changes
- Added `.multi-ticket-row` CSS class with `margin-bottom: 2rem` to provide consistent bottom margin spacing between multi-ticket row elements

## Implementation Details
The new style rule is inserted in the mvp.css stylesheet before the `fieldset` rule, ensuring proper spacing between rows of multiple tickets in the UI layout.

https://claude.ai/code/session_01E4847pjKHvr5ZxZsgzfFa4