### PR TITLE
Fix form data leakage between requests

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -19,6 +19,7 @@ import {
   setFlashContext,
 } from "#lib/flash-context.ts";
 import { loadHeaderImage } from "#lib/header-image.ts";
+import { clearSavedFormData } from "#lib/forms.tsx";
 import { detectIframeMode } from "#lib/iframe.ts";
 import {
   createRequestTimer,
@@ -346,6 +347,7 @@ export const handleRequest = async (
         const { url, path, method } = parseRequest(effectiveRequest);
         const getElapsed = createRequestTimer();
         detectIframeMode(effectiveRequest.url);
+        clearSavedFormData();
 
         try {
           // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -541,13 +541,16 @@ export const requireCsrfForm = async (
   const form = await parseFormData(request);
   const formCsrf = form.getString("csrf_token");
 
+  // Always save form data so validation errors can restore user input.
+  // This clears any stale data from a prior request and makes the current
+  // submission available to renderFields/getSavedValue during re-rendering.
+  setSavedFormData(form);
+
   if (formCsrf && (await verifySignedCsrfToken(formCsrf))) {
-    setSavedFormData(form);
     return { ok: true, form };
   }
 
   await signCsrfToken();
-  setSavedFormData(form);
   return { ok: false, response: onInvalid() };
 };
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -20,7 +20,7 @@ import { deleteSession, getSession } from "#lib/db/sessions.ts";
 import { getWrappedPrivateKey } from "#lib/db/settings.ts";
 import { decryptAdminLevel, getUserById } from "#lib/db/users.ts";
 import { FormParams } from "#lib/form-data.ts";
-import { clearSavedFormData, setSavedFormData } from "#lib/forms.tsx";
+import { setSavedFormData } from "#lib/forms.tsx";
 import { appendIframeParam, getIframeMode } from "#lib/iframe.ts";
 import { ErrorCode, getRequestId, logError } from "#lib/logger.ts";
 import { nowMs } from "#lib/now.ts";
@@ -542,7 +542,7 @@ export const requireCsrfForm = async (
   const formCsrf = form.getString("csrf_token");
 
   if (formCsrf && (await verifySignedCsrfToken(formCsrf))) {
-    clearSavedFormData();
+    setSavedFormData(form);
     return { ok: true, form };
   }
 

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -362,9 +362,9 @@ export const adminGuidePage = (
         <Q q="Where do I see the answers?">
           <p>
             Answers appear in the attendee table on event and group pages, so
-            you can see at a glance what each attendee chose. They're also
-            shown on the individual attendee detail page, included in the CSV
-            export, and sent in webhook payloads.
+            you can see at a glance what each attendee chose. They're also shown
+            on the individual attendee detail page, included in the CSV export,
+            and sent in webhook payloads.
           </p>
         </Q>
       </Section>

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1213,6 +1213,47 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(html).toContain('value="john@example.com"');
     });
 
+    test("does not leak saved form data into subsequent GET request", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      // First: POST with invalid CSRF to save form data
+      await handleRequest(
+        mockFormRequest(`/ticket/${event.slug}`, {
+          name: "Stale Name",
+          email: "stale@example.com",
+        }),
+      );
+      // Second: GET the same page — stale values must not appear
+      const getResponse = await handleRequest(
+        mockRequest(`/ticket/${event.slug}`),
+      );
+      const html = await getResponse.text();
+      expect(html).not.toContain("Stale Name");
+      expect(html).not.toContain("stale@example.com");
+    });
+
+    test("does not leak saved form data from validation error into next POST", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+      // First: POST with missing name to trigger validation error
+      await submitTicketForm(event.slug, {
+        name: "",
+        email: "first@example.com",
+      });
+      // Second: POST with different data and its own validation error
+      const response = await submitTicketForm(event.slug, {
+        name: "",
+        email: "second@example.com",
+      });
+      const html = await response.text();
+      expect(html).not.toContain("first@example.com");
+      expect(html).toContain('value="second@example.com"');
+    });
+
     test("validates required fields", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3761,6 +3761,20 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(html).toContain("maximum");
     });
 
+    test("POST preserves form values when price exceeds maximum", async () => {
+      const event = await payMoreEvent();
+      const response = await submitTicketForm(event.slug, {
+        name: "Preserved Name",
+        email: "preserved@example.com",
+        quantity: "1",
+        custom_price: "150.00",
+      });
+      const html = await response.text();
+      expect(html).toContain("maximum");
+      expect(html).toContain('value="Preserved Name"');
+      expect(html).toContain('value="preserved@example.com"');
+    });
+
     test("POST accepts price at maximum", async () => {
       await setupStripe();
       const event = await payMoreEvent();


### PR DESCRIPTION
## Summary
Fixed a security issue where form data from failed submissions was persisting across subsequent requests, potentially leaking user input between different form submissions or GET requests.

## Key Changes
- **Form data lifecycle management**: Moved `setSavedFormData()` to always execute before CSRF validation in `requireCsrfForm()`, ensuring each request starts with fresh form data
- **Request-level cleanup**: Added `clearSavedFormData()` call at the start of request handling in `handleRequest()` to clear any stale data from prior requests
- **Removed redundant logic**: Eliminated the conditional clearing of saved form data that only occurred on successful CSRF validation
- **Added comprehensive tests**: 
  - Test verifying form data doesn't leak from POST into subsequent GET requests
  - Test verifying form data doesn't leak between consecutive POST requests with validation errors
  - Test verifying form values are preserved when validation fails (e.g., price exceeds maximum)

## Implementation Details
The fix ensures that:
1. At the start of each HTTP request, any previously saved form data is cleared
2. During form processing, the current request's form data is saved immediately (before validation)
3. If validation fails, the current request's data is available for re-rendering
4. The next request starts fresh with no stale data from prior submissions

This prevents scenarios where a user's input from one form submission could appear in another user's form or in a subsequent request.

https://claude.ai/code/session_01Trs2F9NZCKWjVVJh8qzRLF