### PR TITLE
Fix webhook body buffering for trailing slash URLs

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -329,10 +329,12 @@ export const handleRequest = async (
   // Buffer webhook body BEFORE entering async context wrappers. The Bunny Edge
   // runtime can garbage-collect the underlying request body resource during
   // awaits, so we must capture it while the resource is still alive.
+  // Use normalizePath on the raw pathname so trailing-slash variants like
+  // /payment/webhook/ are correctly detected (the router normalizes later,
+  // but by then the body resource may already be garbage-collected).
   const { pathname } = new URL(request.url);
-  const normalizedPathname = normalizePath(pathname);
   const webhookBody =
-    request.method === "POST" && isWebhookPath(normalizedPathname)
+    request.method === "POST" && isWebhookPath(normalizePath(pathname))
       ? new Uint8Array(await request.arrayBuffer())
       : undefined;
   const effectiveRequest = webhookBody

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -18,8 +18,8 @@ import {
   resetFlashContext,
   setFlashContext,
 } from "#lib/flash-context.ts";
-import { loadHeaderImage } from "#lib/header-image.ts";
 import { clearSavedFormData } from "#lib/forms.tsx";
+import { loadHeaderImage } from "#lib/header-image.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import {
   createRequestTimer,
@@ -49,6 +49,7 @@ import { createRouter } from "#routes/router.ts";
 import { routeStatic } from "#routes/static.ts";
 import type { ServerContext } from "#routes/types.ts";
 import {
+  normalizePath,
   notFoundResponse,
   parseCookies,
   parseRequest,
@@ -329,8 +330,9 @@ export const handleRequest = async (
   // runtime can garbage-collect the underlying request body resource during
   // awaits, so we must capture it while the resource is still alive.
   const { pathname } = new URL(request.url);
+  const normalizedPathname = normalizePath(pathname);
   const webhookBody =
-    request.method === "POST" && isWebhookPath(pathname)
+    request.method === "POST" && isWebhookPath(normalizedPathname)
       ? new Uint8Array(await request.arrayBuffer())
       : undefined;
   const effectiveRequest = webhookBody

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -54,6 +54,33 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
       await expectHtmlResponse(response, 400, "Missing signature");
     });
 
+    test("handles trailing slash on webhook URL (body buffered correctly)", async () => {
+      await setupStripe();
+
+      // Trailing slash: /payment/webhook/ should still buffer body before
+      // async context wrappers, avoiding "Cannot read body as underlying
+      // resource unavailable" on the Bunny Edge runtime.
+      const request = new Request("http://localhost/payment/webhook/", {
+        method: "POST",
+        headers: {
+          host: "localhost",
+          "content-type": "application/json",
+          "stripe-signature": "sig_test",
+        },
+        body: JSON.stringify({ type: "checkout.session.completed" }),
+      });
+
+      const response = await handleRequest(request);
+      // Should reach the handler and process the body (not fail on body read)
+      expect(response.status).toBe(400);
+      const text = await response.text();
+      // Any handler-level rejection proves the body was read successfully
+      expect(
+        text.includes("Invalid signature") ||
+          text.includes("Webhook secret not configured"),
+      ).toBe(true);
+    });
+
     test("returns 400 when signature verification fails", async () => {
       await setupStripe();
 


### PR DESCRIPTION
## Summary
Fixed an issue where webhook URLs with trailing slashes (e.g., `/payment/webhook/`) were not having their request bodies buffered correctly before async context wrappers, causing "Cannot read body as underlying resource unavailable" errors on the Bunny Edge runtime.

## Key Changes
- **Path normalization for webhook detection**: Updated the webhook body buffering logic to normalize the pathname before checking `isWebhookPath()`, ensuring trailing-slash variants are correctly identified as webhook endpoints
- **Import reordering**: Alphabetically reordered imports in `src/routes/index.ts` for consistency
- **Test coverage**: Added a new test case that verifies webhook body buffering works correctly with trailing slashes on the webhook URL

## Implementation Details
The fix addresses a timing issue specific to the Bunny Edge runtime where the underlying request body resource can be garbage-collected during async operations. By normalizing the pathname early (before entering async context wrappers), the code now correctly identifies webhook requests regardless of trailing slashes and buffers their bodies while the resource is still available.

The `normalizePath()` function is applied to the raw pathname from the URL before the router processes it, ensuring the body is captured at the right time in the request lifecycle.

https://claude.ai/code/session_01GkJHYomuWFiuPnF4z34ie2