### PR TITLE
Allow manual override of Bunny script ID in deploy workflow

### DIFF
--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      script_id:
+        description: "Override Bunny script ID (defaults to BUNNY_SCRIPT_ID secret)"
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -33,6 +38,6 @@ jobs:
       - name: Deploy Script to Bunny Edge Scripting
         uses: BunnyWay/actions/deploy-script@main
         with:
-          script_id: ${{ secrets.BUNNY_SCRIPT_ID }}
+          script_id: ${{ inputs.script_id || secrets.BUNNY_SCRIPT_ID }}
           file: "bunny-script.ts"
           api_key: ${{ secrets.BUNNY_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
This PR adds the ability to manually override the Bunny script ID when manually triggering the deployment workflow, while maintaining the default behavior of using the `BUNNY_SCRIPT_ID` secret.

## Key Changes
- Added `workflow_dispatch` input parameter `script_id` to allow users to optionally specify a script ID when manually running the workflow
- Updated the deploy step to use the provided input if available, otherwise fall back to the `BUNNY_SCRIPT_ID` secret
- The input is optional and does not require a value to trigger the workflow

## Implementation Details
- The `script_id` input is defined as a string type with `required: false`
- Uses conditional expression `${{ inputs.script_id || secrets.BUNNY_SCRIPT_ID }}` to prioritize the manual input over the secret
- This maintains backward compatibility - existing automated pushes to main will continue to use the secret, while manual workflow runs can optionally override it

https://claude.ai/code/session_01P4Qtg1G3KSvJ5EaPX7XT2Q