### PR TITLE
Simplify spacing by removing .stack-xl utility class

### DIFF
--- a/src/lib/admin-api-example.ts
+++ b/src/lib/admin-api-example.ts
@@ -6,11 +6,11 @@
  * output, so a shape change will break the test and force an update.
  */
 
-import type { AdminEvent, EventWithCount } from "#lib/types.ts";
 import {
   API_EXAMPLE_EVENT,
   API_EXAMPLE_PUBLIC_EVENT,
 } from "#lib/api-example.ts";
+import type { AdminEvent, EventWithCount } from "#lib/types.ts";
 import {
   type CreateEventBody,
   type DeleteEventBody,

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -2,6 +2,10 @@
  * Admin API key management routes
  */
 
+import {
+  ADMIN_API_ENDPOINTS,
+  PUBLIC_API_ENDPOINTS,
+} from "#lib/admin-api-example.ts";
 import { generateSecureToken, unwrapKeyWithToken } from "#lib/crypto.ts";
 import {
   createApiKey,
@@ -19,10 +23,6 @@ import {
   requireOwnerOr,
   withOwnerAuthForm,
 } from "#routes/utils.ts";
-import {
-  ADMIN_API_ENDPOINTS,
-  PUBLIC_API_ENDPOINTS,
-} from "#lib/admin-api-example.ts";
 import {
   adminApiDocsPage,
   adminApiKeysPage,

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -153,13 +153,12 @@ main {
 main {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: var(--space-xl);
 }
 
 /* Stack reset: gap controls spacing, not browser default margins */
 main > *,
-article > *,
-.stack-xl > * {
+article > * {
   margin-block: 0;
 }
 
@@ -168,13 +167,6 @@ article > *,
   display: flex;
   flex-direction: column;
   gap: var(--space-m);
-}
-
-/* Extra-large vertical stack for spacing between major page sections */
-.stack-xl {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xl);
 }
 
 hr {

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -181,11 +181,7 @@ const EndpointEntry = ({ endpoint }: { endpoint: EndpointDoc }): string =>
     </details>,
   );
 
-const EndpointList = ({
-  endpoints,
-}: {
-  endpoints: EndpointDoc[];
-}): string =>
+const EndpointList = ({ endpoints }: { endpoints: EndpointDoc[] }): string =>
   pipe(
     map((e: EndpointDoc) => EndpointEntry({ endpoint: e })),
     joinStrings,
@@ -217,9 +213,7 @@ export const adminApiDocsPage = (
       </p>
 
       <h3>Public API</h3>
-      <p>
-        No API key required. All endpoints support CORS.
-      </p>
+      <p>No API key required. All endpoints support CORS.</p>
       <Raw html={EndpointList({ endpoints: publicEndpoints })} />
 
       <h3>Admin API</h3>

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -182,7 +182,7 @@ export const adminDashboardPage = (
   const activeEvents = filter((e: EventWithCount) => e.active)(events);
 
   return String(
-    <Layout title="Events" mainClass="stack-xl">
+    <Layout title="Events">
       <AdminNav session={session} active="/admin/" />
 
       <Raw html={renderSuccess(successMessage)} />

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -75,7 +75,7 @@ export const adminDebugPage = (
   s: DebugPageState,
 ): string =>
   String(
-    <Layout title="Debug Info" theme={s.theme} mainClass="stack-xl">
+    <Layout title="Debug Info" theme={s.theme}>
       <AdminNav session={session} active="/admin/settings" />
       <Breadcrumb href="/admin/settings" label="Settings" />
 

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -287,7 +287,7 @@ export const adminEventPage = ({
       : "checkin-message-out";
 
   return String(
-    <Layout title={`Event: ${event.name}`} mainClass="stack-xl">
+    <Layout title={`Event: ${event.name}`}>
       <AdminNav session={session} active="/admin/" />
 
       <h1>{event.name}</h1>

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -237,7 +237,7 @@ export const adminGroupDetailPage = (
   });
 
   return String(
-    <Layout title={group.name} mainClass="stack-xl">
+    <Layout title={group.name}>
       <AdminNav session={session} active="/admin/groups" />
       <h1>{group.name}</h1>
       <Raw html={renderSuccess(successMessage)} />

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1611,8 +1611,7 @@ export const adminGuidePage = (
 
         <Q q="Where can I find the full API reference?">
           <p>
-            The{" "}
-            <a href="/admin/api-keys/docs">API documentation page</a> has a
+            The <a href="/admin/api-keys/docs">API documentation page</a> has a
             complete reference for both public and admin API endpoints, with
             example request and response payloads for each.
           </p>

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -51,7 +51,7 @@ export const adminAdvancedSettingsPage = (
   s: AdvancedSettingsPageState,
 ): string =>
   String(
-    <Layout title="Advanced Settings" theme={s.theme} mainClass="stack-xl">
+    <Layout title="Advanced Settings" theme={s.theme}>
       <AdminNav session={session} active="/admin/settings" />
       <Breadcrumb href="/admin/settings" label="Settings" />
 

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -46,7 +46,7 @@ export const adminSettingsPage = (
   s: SettingsPageState,
 ): string =>
   String(
-    <Layout title="Settings" theme={s.theme} mainClass="stack-xl">
+    <Layout title="Settings" theme={s.theme}>
       <AdminNav session={session} active="/admin/settings" />
 
       {s.storageEnabled && (

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -25,7 +25,6 @@ export const escapeHtml = (str: string): string =>
 interface LayoutProps {
   title: string;
   bodyClass?: string;
-  mainClass?: string;
   headExtra?: string;
   children?: Child;
   theme?: Theme;
@@ -37,7 +36,6 @@ interface LayoutProps {
 export const Layout = ({
   title,
   bodyClass,
-  mainClass,
   headExtra,
   children,
   theme,
@@ -61,7 +59,7 @@ export const Layout = ({
         </head>
         <body class={bodyClass || undefined}>
           {isDemoMode() && <Raw html={DEMO_BANNER} />}
-          <main class={mainClass || undefined}>
+          <main>
             {headerImage && (
               <img
                 src={getImageProxyUrl(headerImage)}


### PR DESCRIPTION
## Summary
This PR removes the `.stack-xl` CSS utility class and consolidates its spacing behavior into the default `main` element styling. The change simplifies the codebase by eliminating the need for an explicit class while maintaining consistent spacing across admin pages.

## Key Changes
- **CSS (mvp.css)**: 
  - Increased `main` element gap from `var(--space-lg)` to `var(--space-xl)` to match previous `.stack-xl` behavior
  - Removed `.stack-xl` utility class definition entirely
  - Updated margin-block reset selector to remove `.stack-xl > *`

- **Templates**: Removed `mainClass="stack-xl"` prop from 6 admin page layouts:
  - `adminDashboardPage`
  - `adminDebugPage`
  - `adminEventPage`
  - `adminGroupDetailPage`
  - `adminAdvancedSettingsPage`
  - `adminSettingsPage`

- **Layout Component**: Removed unused `mainClass` prop from `Layout` interface and implementation

- **Code Quality**: Minor formatting improvements:
  - Reorganized imports in `src/routes/admin/api-keys.ts` (moved admin-api-example imports before crypto imports)
  - Reorganized imports in `src/lib/admin-api-example.ts` (moved type imports after value imports)
  - Simplified multi-line JSX strings to single lines in templates

## Implementation Details
The spacing behavior is now handled uniformly by the `main` element's default styling, eliminating the need for conditional class application. All admin pages that previously used `mainClass="stack-xl"` now rely on the increased default gap value, resulting in cleaner template code and reduced CSS complexity.

https://claude.ai/code/session_0148j1GpAhuagDHkQv3FjFpz