### PR TITLE
Derive Stripe key mode from key prefix instead of storing separately

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -41,8 +41,6 @@ export const CONFIG_KEYS = {
   STRIPE_SECRET_KEY: "stripe_secret_key",
   STRIPE_WEBHOOK_SECRET: "stripe_webhook_secret",
   STRIPE_WEBHOOK_ENDPOINT_ID: "stripe_webhook_endpoint_id",
-  // Stripe key mode (plaintext - "test" or "live")
-  STRIPE_KEY_MODE: "stripe_key_mode",
   // Square configuration (encrypted)
   SQUARE_ACCESS_TOKEN: "square_access_token",
   SQUARE_WEBHOOK_SIGNATURE_KEY: "square_webhook_signature_key",
@@ -453,9 +451,15 @@ const { get: getStripeSecretKeyFromDb, update: updateStripeKey } =
 
 export { getStripeSecretKeyFromDb, updateStripeKey };
 
-/** Stripe key mode: "test" or "live". Returns null if not configured. */
-export const { get: getStripeKeyModeFromDb, update: updateStripeKeyMode } =
-  textSetting(CONFIG_KEYS.STRIPE_KEY_MODE);
+/** Derive Stripe key mode from the stored key prefix. */
+export const getStripeKeyMode = async (): Promise<"test" | "live" | null> => {
+  const key = await getStripeSecretKeyFromDb();
+  if (!key) return null;
+  // Inline prefix check to avoid circular import with stripe.ts
+  if (key.startsWith("sk_test_")) return "test";
+  if (key.startsWith("sk_live_")) return "live";
+  return null;
+};
 
 export const getStripeWebhookSecretFromDb = encryptedSetting(
   CONFIG_KEYS.STRIPE_WEBHOOK_SECRET,

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -46,8 +46,7 @@ import {
   getShowPublicApiFromDb,
   getShowPublicSiteFromDb,
   getSquareSandboxFromDb,
-  getStripeKeyModeFromDb,
-  getStripeSecretKeyFromDb,
+  getStripeKeyMode,
   getStripeWebhookEndpointId,
   getTermsAndConditionsFromDb,
   getThemeFromDb,
@@ -86,7 +85,6 @@ import {
   updateSquareSandbox,
   updateSquareWebhookSignatureKey,
   updateStripeKey,
-  updateStripeKeyMode,
   updateTermsAndConditions,
   updateTheme,
   updateUserPassword,
@@ -182,7 +180,7 @@ const getSettingsPageState = async () => {
     headerImageUrl,
   ] = await Promise.all([
     hasStripeKey(),
-    getStripeKeyModeFromDb(),
+    getStripeKeyMode(),
     getPaymentProviderFromDb(),
     hasSquareToken(),
     getSquareSandboxFromDb(),
@@ -197,22 +195,9 @@ const getSettingsPageState = async () => {
     getHeaderImageUrlFromDb(),
   ]);
 
-  // Backfill: if a Stripe key exists but mode was never stored (e.g. key
-  // was configured before mode tracking was added), derive it now and persist.
-  let resolvedStripeKeyMode = stripeKeyMode;
-  if (stripeKeyConfigured && !stripeKeyMode) {
-    const key = await getStripeSecretKeyFromDb();
-    if (key) {
-      resolvedStripeKeyMode = detectStripeKeyMode(key);
-      if (resolvedStripeKeyMode) {
-        await updateStripeKeyMode(resolvedStripeKeyMode);
-      }
-    }
-  }
-
   return {
     stripeKeyConfigured,
-    stripeKeyMode: resolvedStripeKeyMode,
+    stripeKeyMode,
     paymentProvider: paymentProvider ?? "",
     squareTokenConfigured,
     squareSandbox,
@@ -568,8 +553,7 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Validate key format — must start with sk_test_ or sk_live_
-  const keyMode = detectStripeKeyMode(field.value);
-  if (!keyMode) {
+  if (!detectStripeKeyMode(field.value)) {
     return errorPage(
       "Invalid Stripe key format. Keys must start with sk_test_ (test mode) or sk_live_ (live mode).",
       400,
@@ -595,10 +579,9 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  // Store the Stripe key, webhook config, and key mode
+  // Store the Stripe key and webhook config
   await updateStripeKey(field.value);
   await setStripeWebhookConfig(webhookResult);
-  await updateStripeKeyMode(keyMode);
 
   // Auto-set payment provider to stripe when key is configured
   await setPaymentProvider("stripe");

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -47,6 +47,7 @@ import {
   getShowPublicSiteFromDb,
   getSquareSandboxFromDb,
   getStripeKeyModeFromDb,
+  getStripeSecretKeyFromDb,
   getStripeWebhookEndpointId,
   getTermsAndConditionsFromDb,
   getThemeFromDb,
@@ -196,9 +197,22 @@ const getSettingsPageState = async () => {
     getHeaderImageUrlFromDb(),
   ]);
 
+  // Backfill: if a Stripe key exists but mode was never stored (e.g. key
+  // was configured before mode tracking was added), derive it now and persist.
+  let resolvedStripeKeyMode = stripeKeyMode;
+  if (stripeKeyConfigured && !stripeKeyMode) {
+    const key = await getStripeSecretKeyFromDb();
+    if (key) {
+      resolvedStripeKeyMode = detectStripeKeyMode(key);
+      if (resolvedStripeKeyMode) {
+        await updateStripeKeyMode(resolvedStripeKeyMode);
+      }
+    }
+  }
+
   return {
     stripeKeyConfigured,
-    stripeKeyMode,
+    stripeKeyMode: resolvedStripeKeyMode,
     paymentProvider: paymentProvider ?? "",
     squareTokenConfigured,
     squareSandbox,

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -81,6 +81,7 @@ import {
   getCurrencyCodeFromDb,
   getPublicKey,
   getSetting,
+  getStripeKeyMode,
   getStripeSecretKeyFromDb,
   getTimezoneCached,
   getTimezoneFromDb,
@@ -328,6 +329,25 @@ describeWithEnv("db", { db: true }, () => {
 
       await updateStripeKey("sk_test_second");
       expect(await getStripeSecretKeyFromDb()).toBe("sk_test_second");
+    });
+
+    test("getStripeKeyMode returns null when no key is set", async () => {
+      expect(await getStripeKeyMode()).toBeNull();
+    });
+
+    test("getStripeKeyMode returns test for sk_test_ key", async () => {
+      await updateStripeKey("sk_test_abc123");
+      expect(await getStripeKeyMode()).toBe("test");
+    });
+
+    test("getStripeKeyMode returns live for sk_live_ key", async () => {
+      await updateStripeKey("sk_live_abc123");
+      expect(await getStripeKeyMode()).toBe("live");
+    });
+
+    test("getStripeKeyMode returns null for unrecognised key prefix", async () => {
+      await updateStripeKey("rk_invalid_abc123");
+      expect(await getStripeKeyMode()).toBeNull();
     });
   });
 

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -7,6 +7,7 @@ import { eventsTable } from "#lib/db/events.ts";
 import {
   getEmbedHostsFromDb,
   setPaymentProvider,
+  updateStripeKey,
   updateTermsAndConditions,
 } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
@@ -503,6 +504,19 @@ describe("server (admin settings)", () => {
           expect(html).toContain("Payments will be charged for real");
         },
       );
+    });
+
+    test("backfills mode indicator when key exists but mode was never stored", async () => {
+      // Simulate pre-sentinel setup: key stored directly without mode
+      await updateStripeKey("sk_test_backfill");
+      await setPaymentProvider("stripe");
+
+      const response = await awaitTestRequest("/admin/settings", {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      expect(html).toContain("Test mode:");
+      expect(html).toContain("No real charges will be made");
     });
   });
 


### PR DESCRIPTION
## Summary
This PR refactors how the Stripe key mode ("test" or "live") is determined. Instead of storing it as a separate database setting, the mode is now derived directly from the Stripe secret key prefix at runtime.

## Key Changes
- **Removed separate storage**: Deleted `STRIPE_KEY_MODE` from `CONFIG_KEYS` and removed the `updateStripeKeyMode` function
- **Added derivation logic**: Implemented `getStripeKeyMode()` function that inspects the stored Stripe key prefix (`sk_test_` or `sk_live_`) to determine the mode
- **Updated imports**: Changed `getStripeKeyModeFromDb` to `getStripeKeyMode` in admin settings route
- **Removed redundant storage**: Eliminated the call to `updateStripeKeyMode()` when storing Stripe keys
- **Added test coverage**: Comprehensive tests for the new `getStripeKeyMode()` function covering null cases, test mode, live mode, and invalid prefixes
- **Backward compatibility**: Added integration test verifying that the system correctly backfills mode detection for keys stored before this change

## Implementation Details
The `getStripeKeyMode()` function is implemented as a simple async function that:
1. Retrieves the stored Stripe secret key
2. Returns `null` if no key is set
3. Checks the key prefix and returns `"test"` for `sk_test_` or `"live"` for `sk_live_`
4. Returns `null` for unrecognized prefixes

This approach eliminates redundant data storage and ensures the mode is always consistent with the actual key being used.

https://claude.ai/code/session_01V3CTyDXfZYkBcFyux9Ffm4