### PR TITLE
Improve API docs layout and add link to documentation

### DIFF
--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -73,6 +73,11 @@ export const adminApiKeysPage = (
         </div>
       )}
 
+      <p>
+        <a href="/admin/api-keys/docs">Click here</a> to read the API
+        documentation.
+      </p>
+
       <div class="table-scroll">
         <table>
           <thead>
@@ -200,26 +205,33 @@ export const adminApiDocsPage = (
       <AdminNav session={session} active="/admin/users" />
       <UsersSubNav />
 
-      <h3>Authentication</h3>
-      <p>
-        Admin API endpoints require authentication via API key or session
-        cookie:
-      </p>
-      <pre>
-        <code>Authorization: Bearer YOUR_API_KEY</code>
-      </pre>
-      <p>
-        Public API endpoints require no authentication. All responses are JSON.
-      </p>
+      <div class="stack-md column">
+        <h3>Authentication</h3>
+        <p>
+          Admin API endpoints require authentication via API key or session
+          cookie:
+        </p>
+        <pre>
+          <code>Authorization: Bearer YOUR_API_KEY</code>
+        </pre>
+        <p>
+          Public API endpoints require no authentication. All responses are
+          JSON.
+        </p>
+      </div>
 
-      <h3>Public API</h3>
-      <p>No API key required. All endpoints support CORS.</p>
-      <Raw html={EndpointList({ endpoints: publicEndpoints })} />
+      <div class="stack-md column">
+        <h3>Public API</h3>
+        <p>No API key required. All endpoints support CORS.</p>
+        <Raw html={EndpointList({ endpoints: publicEndpoints })} />
+      </div>
 
-      <h3>Admin API</h3>
-      <p>
-        Requires <code>Authorization: Bearer YOUR_API_KEY</code> header.
-      </p>
-      <Raw html={EndpointList({ endpoints: adminEndpoints })} />
+      <div class="stack-md column">
+        <h3>Admin API</h3>
+        <p>
+          Requires <code>Authorization: Bearer YOUR_API_KEY</code> header.
+        </p>
+        <Raw html={EndpointList({ endpoints: adminEndpoints })} />
+      </div>
     </Layout>,
   );

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -34,10 +34,10 @@ const Section = ({
   title: string;
   children?: Child;
 }): JSX.Element => (
-  <>
+  <div class="stack-md column">
     <h3 id={id}>{title}</h3>
     {children}
-  </>
+  </div>
 );
 
 const Q = ({ q, children }: { q: string; children?: Child }): JSX.Element => (


### PR DESCRIPTION
## Summary
This PR improves the layout and navigation of the API documentation pages by adding consistent spacing between sections and providing a direct link to the documentation from the API keys management page.

## Key Changes
- Added a link to API documentation on the admin API keys page for easier access
- Wrapped documentation sections in `stack-md column` divs for consistent vertical spacing and improved visual hierarchy in:
  - Authentication section
  - Public API section
  - Admin API section
- Updated the `Section` component in the guide template to use `stack-md column` wrapper instead of a fragment for consistent styling

## Implementation Details
- The new documentation link is placed prominently after the API keys list introduction
- All major sections in the API docs now use the same spacing utility class (`stack-md column`) for visual consistency
- This change maintains the existing functionality while improving the user experience through better visual organization

https://claude.ai/code/session_01CGDriMfnT3zyG4RhwAX7BN