### PR TITLE
Improve API docs layout and add link to documentation

### DIFF
--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -73,6 +73,11 @@ export const adminApiKeysPage = (
         </div>
       )}
 
+      <p>
+        <a href="/admin/api-keys/docs">Click here</a> to read the API
+        documentation.
+      </p>
+
       <div class="table-scroll">
         <table>
           <thead>
@@ -200,26 +205,33 @@ export const adminApiDocsPage = (
       <AdminNav session={session} active="/admin/users" />
       <UsersSubNav />
 
-      <h3>Authentication</h3>
-      <p>
-        Admin API endpoints require authentication via API key or session
-        cookie:
-      </p>
-      <pre>
-        <code>Authorization: Bearer YOUR_API_KEY</code>
-      </pre>
-      <p>
-        Public API endpoints require no authentication. All responses are JSON.
-      </p>
+      <div class="stack-md column">
+        <h3>Authentication</h3>
+        <p>
+          Admin API endpoints require authentication via API key or session
+          cookie:
+        </p>
+        <pre>
+          <code>Authorization: Bearer YOUR_API_KEY</code>
+        </pre>
+        <p>
+          Public API endpoints require no authentication. All responses are
+          JSON.
+        </p>
+      </div>
 
-      <h3>Public API</h3>
-      <p>No API key required. All endpoints support CORS.</p>
-      <Raw html={EndpointList({ endpoints: publicEndpoints })} />
+      <div class="stack-md column">
+        <h3>Public API</h3>
+        <p>No API key required. All endpoints support CORS.</p>
+        <Raw html={EndpointList({ endpoints: publicEndpoints })} />
+      </div>
 
-      <h3>Admin API</h3>
-      <p>
-        Requires <code>Authorization: Bearer YOUR_API_KEY</code> header.
-      </p>
-      <Raw html={EndpointList({ endpoints: adminEndpoints })} />
+      <div class="stack-md column">
+        <h3>Admin API</h3>
+        <p>
+          Requires <code>Authorization: Bearer YOUR_API_KEY</code> header.
+        </p>
+        <Raw html={EndpointList({ endpoints: adminEndpoints })} />
+      </div>
     </Layout>,
   );

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -34,10 +34,10 @@ const Section = ({
   title: string;
   children?: Child;
 }): JSX.Element => (
-  <>
+  <div class="stack-md column">
     <h3 id={id}>{title}</h3>
     {children}
-  </>
+  </div>
 );
 
 const Q = ({ q, children }: { q: string; children?: Child }): JSX.Element => (


### PR DESCRIPTION
## Summary
This PR improves the layout and navigation of the API documentation pages by adding consistent spacing between sections and providing a direct link to the API docs from the API keys management page.

## Key Changes
- Added a link to API documentation on the admin API keys page for easier navigation
- Wrapped API documentation sections (Authentication, Public API, Admin API) in `stack-md column` divs for consistent spacing and improved visual hierarchy
- Updated the guide template's `Section` component to use `stack-md column` div instead of fragment for consistent styling with other documentation sections

## Implementation Details
- The new documentation link is placed prominently after the API keys list introduction
- All three main sections in the API docs page now use the same layout wrapper (`stack-md column`) for visual consistency
- The `Section` component change ensures guide pages follow the same spacing pattern as the API documentation

https://claude.ai/code/session_01CfQhoSUgcDhLQLtPNkaBrn