### PR TITLE
Fix attendee validation query to remove redundant pii_blob condition

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -531,7 +531,7 @@ export const initDb = async (): Promise<void> => {
       }>(
         `SELECT id, name, email, phone, address, special_instructions, checked_in
          FROM attendees
-         WHERE pii_blob = '' AND (name = '' OR email = '' OR phone = '' OR address = '' OR special_instructions = '' OR checked_in = '')`,
+         WHERE name = '' OR email = '' OR phone = '' OR address = '' OR special_instructions = '' OR checked_in = ''`,
       );
 
       for (const attendee of invalidAttendees) {


### PR DESCRIPTION
## Summary
Removed a redundant condition from the attendee validation query in the database migration that was filtering for empty `pii_blob` values alongside other field validations.

## Key Changes
- Removed `pii_blob = '' AND` condition from the WHERE clause in the attendee validation query
- The query now correctly identifies attendees with missing or empty required fields (name, email, phone, address, special_instructions, checked_in) without the unnecessary pii_blob check

## Implementation Details
The `pii_blob` field appears to be a separate concern from the validation of individual attendee fields. By removing this condition, the migration will now properly identify all attendees with incomplete data across the core fields, making the validation logic clearer and more maintainable.

https://claude.ai/code/session_014GZKifSZeAjEGtTmQZxQCR