### PR TITLE
Change attendee migration endpoint to redirect instead of returning JSON

### DIFF
--- a/src/routes/admin/migrate.ts
+++ b/src/routes/admin/migrate.ts
@@ -18,7 +18,7 @@ import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import type { AuthSession } from "#routes/utils.ts";
 import {
   htmlResponse,
-  jsonResponse,
+  redirectResponse,
   requireOwnerOr,
   withOwnerAuthForm,
 } from "#routes/utils.ts";
@@ -61,15 +61,14 @@ const handleMigrateGet: TypedRouteHandler<"GET /admin/migrate"> = (request) =>
 const handleMigratePost = (request: Request): Promise<Response> =>
   withOwnerAuthForm(
     request,
-    whenNotMigrated(() =>
-      jsonResponse({ done: true, migrated: 0, remaining: 0 }),
-    )(async (session) => {
-      const privateKey = await requirePrivateKey(session);
-      const result = await migrateAttendeeBatch(privateKey);
-      const done = result.remaining === 0;
-      if (done) await setAttendeeBlobMigrated();
-      return jsonResponse({ done, ...result });
-    }),
+    whenNotMigrated(() => redirectResponse("/admin/migrate"))(
+      async (session) => {
+        const privateKey = await requirePrivateKey(session);
+        const result = await migrateAttendeeBatch(privateKey);
+        if (result.remaining === 0) await setAttendeeBlobMigrated();
+        return redirectResponse("/admin/migrate");
+      },
+    ),
   );
 
 /** Migration routes */

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -364,7 +364,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
   });
 
   describe("POST /admin/migrate", () => {
-    test("processes a batch and returns progress", async () => {
+    test("processes a batch and redirects back", async () => {
       const event = await createTestEventForMigration({ maxAttendees: 10 });
       await createTestAttendee(event.id, event.slug, "Mig", "mig@test.com");
       // Simulate pre-migration
@@ -373,19 +373,19 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
       );
 
       const { response } = await adminFormPost("/admin/migrate");
-      expect(response.status).toBe(200);
-      const body = await response.json();
-      expect(body.migrated).toBe(1);
-      expect(body.remaining).toBe(0);
-      expect(body.done).toBe(true);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/migrate");
+
+      // Verify the batch was actually processed
+      const progress = await getMigrationProgress();
+      expect(progress.remaining).toBe(0);
     });
 
-    test("returns done when already migrated", async () => {
+    test("redirects when already migrated", async () => {
       await setAttendeeBlobMigrated();
       const { response } = await adminFormPost("/admin/migrate");
-      expect(response.status).toBe(200);
-      const body = await response.json();
-      expect(body.done).toBe(true);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/migrate");
     });
   });
 


### PR DESCRIPTION
## Summary
Modified the POST /admin/migrate endpoint to return a redirect response instead of JSON, improving the user experience by automatically redirecting back to the migration status page after processing a batch.

## Key Changes
- Changed `handleMigratePost` response from `jsonResponse()` to `redirectResponse("/admin/migrate")`
- Updated the endpoint to redirect to `/admin/migrate` both when migration is already complete and after successfully processing a batch
- Replaced `jsonResponse` import with `redirectResponse` in the routes utility imports
- Updated corresponding tests to verify redirect behavior (302 status code and location header) instead of JSON response body validation
- Tests now verify batch processing by checking migration progress state rather than response body

## Implementation Details
- The migration logic itself remains unchanged - batches are still processed via `migrateAttendeeBatch()`
- The `setAttendeeBlobMigrated()` call is still invoked when all remaining items are processed
- The redirect approach allows the client to fetch updated progress information by navigating to the migration status page, rather than receiving it in the POST response

https://claude.ai/code/session_01WTMkHYZ4PYExxf4t1qTBmj