### PR TITLE
Require validation before using custom domains

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,6 +9,7 @@ import {
   getBookingFeeFromDb,
   getCurrencyCodeFromDb,
   getCustomDomainFromDb,
+  getCustomDomainLastValidatedFromDb,
   getEmbedHostsFromDb,
   getPaymentProviderFromDb,
   getSquareAccessTokenFromDb,
@@ -143,7 +144,11 @@ const effectiveDomainState = { domain: null as string | null };
 export const loadEffectiveDomain = async (): Promise<string> => {
   try {
     const custom = await getCustomDomainFromDb();
-    effectiveDomainState.domain = custom || getAllowedDomain();
+    const validated = custom
+      ? await getCustomDomainLastValidatedFromDb()
+      : null;
+    effectiveDomainState.domain =
+      custom && validated ? custom : getAllowedDomain();
   } catch {
     effectiveDomainState.domain = getAllowedDomain();
   }

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -317,6 +317,9 @@ describe("code quality", () => {
       // Reset cached allowed domain between tests
       "lib/config.ts:resetAllowedDomain",
       "lib/config.ts:setAllowedDomainForTest",
+      // Reset cached effective domain between tests
+      "lib/config.ts:resetEffectiveDomain",
+      "lib/config.ts:setEffectiveDomainForTest",
       // Reset cached demo mode between tests
       "lib/demo.ts:resetDemoMode",
       "lib/demo.ts:setDemoModeForTest",

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -27,6 +27,7 @@ import {
   setSetting,
   updateBookingFee,
   updateCustomDomain,
+  updateCustomDomainLastValidated,
   updateSquareAccessToken,
   updateSquareLocationId,
   updateSquareWebhookSignatureKey,
@@ -192,18 +193,29 @@ describe("config", () => {
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
     });
 
-    test("returns custom domain when set in DB", async () => {
+    test("returns custom domain when set and validated in DB", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
       await updateCustomDomain("tickets.example.com");
+      await updateCustomDomainLastValidated();
       invalidateSettingsCache();
       const result = await loadEffectiveDomain();
       expect(result).toBe("tickets.example.com");
       expect(getEffectiveDomain()).toBe("tickets.example.com");
     });
 
+    test("falls back to ALLOWED_DOMAIN when custom domain is set but not validated", async () => {
+      setAllowedDomainForTest("mysite.bunny.run");
+      await updateCustomDomain("tickets.example.com");
+      invalidateSettingsCache();
+      const result = await loadEffectiveDomain();
+      expect(result).toBe("mysite.bunny.run");
+      expect(getEffectiveDomain()).toBe("mysite.bunny.run");
+    });
+
     test("falls back to ALLOWED_DOMAIN after custom domain is cleared", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
       await updateCustomDomain("tickets.example.com");
+      await updateCustomDomainLastValidated();
       invalidateSettingsCache();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("tickets.example.com");
@@ -228,6 +240,7 @@ describe("config", () => {
     test("resetEffectiveDomain clears the cached value", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
       await updateCustomDomain("tickets.example.com");
+      await updateCustomDomainLastValidated();
       invalidateSettingsCache();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("tickets.example.com");

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -24,6 +24,7 @@ import {
   flashCookieHeader,
   mockFormRequest,
   mockRequest,
+  mockRequestWithHost,
   resetDb,
   resetTestSlugCounter,
   setTestEnv,
@@ -675,11 +676,21 @@ describe("server (admin settings-advanced)", () => {
 
       test("shows last validated timestamp when domain has been validated", async () => {
         setBunnyEnv();
+        // Get session token before setting the validated custom domain,
+        // then re-format the cookie for the secure domain cookie name.
+        const cookie = await testCookie();
+        const token = cookie.split("=").slice(1).join("=");
         await updateCustomDomain("tickets.example.com");
         await updateCustomDomainLastValidated();
-        const response = await awaitTestRequest("/admin/settings-advanced", {
-          cookie: await testCookie(),
-        });
+        const response = await handleRequest(
+          mockRequestWithHost(
+            "/admin/settings-advanced",
+            "tickets.example.com",
+            {
+              headers: { cookie: `__Host-session=${token}` },
+            },
+          ),
+        );
         const html = await response.text();
         expect(html).toContain("Last validated:");
       });

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -8,7 +8,12 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
+import {
+  resetAllowedDomain,
+  resetEffectiveDomain,
+  setAllowedDomainForTest,
+  setEffectiveDomainForTest,
+} from "#lib/config.ts";
 import { buildWebhookPayload, type RegistrationEntry } from "#lib/webhook.ts";
 import {
   EXAMPLE_ATTENDEE,
@@ -38,10 +43,14 @@ describe("webhook example", () => {
     const { updateBusinessEmail } = await import("#lib/business-email.ts");
     await updateBusinessEmail(EXAMPLE_BUSINESS_EMAIL);
 
-    // Set ALLOWED_DOMAIN to match the example domain
+    // Set ALLOWED_DOMAIN and effective domain to match the example domain
     setAllowedDomainForTest(exampleDomain);
+    setEffectiveDomainForTest(exampleDomain);
     domainStub = {
-      restore: () => resetAllowedDomain(),
+      restore: () => {
+        resetAllowedDomain();
+        resetEffectiveDomain();
+      },
     };
 
     // Fix time to match the example timestamp


### PR DESCRIPTION
## Summary
This change adds validation requirement for custom domains. Custom domains are now only used as the effective domain if they have been explicitly validated, otherwise the system falls back to the allowed domain.

## Key Changes
- **Domain validation check**: Modified `loadEffectiveDomain()` to check if a custom domain has been validated via `getCustomDomainLastValidatedFromDb()` before using it. Unvalidated custom domains are ignored and the allowed domain is used instead.
- **Test updates**: 
  - Updated existing test to call `updateCustomDomainLastValidated()` when testing with custom domains
  - Added new test case to verify fallback behavior when custom domain is set but not validated
  - Updated server settings test to use `mockRequestWithHost` with proper `__Host-session` cookie format for secure domain testing
  - Added new test helper imports (`mockRequestWithHost`, `updateCustomDomainLastValidated`)
- **Config module exports**: Added `resetEffectiveDomain` and `setEffectiveDomainForTest` to the config module's public API for proper test isolation
- **Code quality checks**: Updated allowed test utilities list to include the new effective domain reset functions

## Implementation Details
The validation check is performed at domain load time, ensuring that only validated custom domains are used throughout the application. This prevents accidental use of unvalidated domains while still allowing the domain to be stored in the database before validation is complete.

https://claude.ai/code/session_01N15ASYKNaVWzHstevyJSBZ