### PR TITLE
Warm settings cache before stubbing DB in error handling test

### DIFF
--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -788,8 +788,13 @@ describe("server (misc)", () => {
     test("rethrows unhandled errors in test mode", async () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
       const { invalidateEventsCache } = await import("#lib/db/events.ts");
+      const { loadAllSettings } = await import("#lib/db/settings.ts");
       const db = getDbFn();
       invalidateEventsCache();
+      // Warm the settings cache so loadEffectiveDomain/isSetupComplete/etc.
+      // resolve from cache; the stub then only affects route-handler queries
+      // inside the inner try/catch.
+      await loadAllSettings();
       const executeStub = stub(db, "execute", () => {
         throw new Error("synthetic db failure");
       });


### PR DESCRIPTION
## Summary
Updated the error handling test to pre-populate the settings cache before stubbing the database, ensuring that settings-dependent operations resolve from cache rather than triggering additional database queries during the test.

## Key Changes
- Added import of `loadAllSettings` from the settings module
- Call `loadAllSettings()` before stubbing the database to warm the settings cache
- Added explanatory comment clarifying that this ensures `loadEffectiveDomain`, `isSetupComplete`, and similar functions resolve from cache, allowing the stub to only affect route-handler queries within the test's inner try/catch block

## Implementation Details
This change improves test isolation by separating cache initialization from the actual error scenario being tested. The settings cache is now warmed before the database stub is applied, preventing unintended side effects from the stub on cache-loading operations and making the test more focused on the specific error handling behavior being validated.

https://claude.ai/code/session_01EVZW1npu5Wf5K38KwUxETL