### PR TITLE
Replace TTL-based collection caches with per-request caching

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -143,9 +143,7 @@ const effectiveDomainState = { domain: null as string | null };
 /** Load the effective domain from DB (call early in request pipeline). */
 export const loadEffectiveDomain = async (): Promise<string> => {
   const custom = await getCustomDomainFromDb();
-  const validated = custom
-    ? await getCustomDomainLastValidatedFromDb()
-    : null;
+  const validated = custom ? await getCustomDomainLastValidatedFromDb() : null;
   effectiveDomainState.domain =
     custom && validated ? custom : getAllowedDomain();
   return effectiveDomainState.domain;

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ResultSet } from "@libsql/client";
-import { collectionCache, filter as fpFilter } from "#fp";
+import { filter as fpFilter } from "#fp";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import {
   executeBatch,
@@ -21,7 +21,8 @@ import {
 } from "#lib/db/common-schema.ts";
 import { col } from "#lib/db/table.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
-import { nowIso, nowMs } from "#lib/now.ts";
+import { nowIso } from "#lib/now.ts";
+import { requestCache } from "#lib/request-cache.ts";
 import type {
   Attendee,
   Event,
@@ -120,13 +121,6 @@ const readClosesAt = async (v: string | null): Promise<string | null> => {
 /** Encrypt event date for DB storage */
 export const writeEventDate = (v: string): Promise<string> =>
   encryptDatetime(v, "date");
-
-/**
- * In-memory events cache. Loads all events with attendee counts
- * in a single query and serves subsequent reads from memory until
- * the TTL expires or a write invalidates the cache.
- */
-export const EVENTS_CACHE_TTL_MS = 60_000;
 
 /**
  * Events table definition
@@ -279,11 +273,7 @@ const queryEventsWithCounts = async (
   );
 };
 
-const eventsCache = collectionCache(
-  () => queryEventsWithCounts(),
-  EVENTS_CACHE_TTL_MS,
-  nowMs,
-);
+const eventsCache = requestCache(() => queryEventsWithCounts());
 
 registerCache(() => ({ name: "events", entries: eventsCache.size() }));
 

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -2,7 +2,7 @@
  * Groups table operations
  */
 
-import { collectionCache, mapParallel } from "#fp";
+import { mapParallel } from "#fp";
 import { decrypt, encrypt, hmacHash } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
 import {
@@ -14,6 +14,7 @@ import {
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
 import { queryAndMap } from "#lib/db/query.ts";
 import { col } from "#lib/db/table.ts";
+import { requestCache } from "#lib/request-cache.ts";
 import type { Event, EventType, EventWithCount, Group } from "#lib/types.ts";
 
 /** Group input fields for create/update (camelCase) */
@@ -29,13 +30,6 @@ export type GroupInput = {
 export const computeGroupSlugIndex = (slug: string): Promise<string> =>
   hmacHash(slug);
 
-/**
- * In-memory groups cache. Loads all groups in a single query and
- * serves subsequent reads from memory until the TTL expires or a
- * write invalidates the cache.
- */
-export const GROUPS_CACHE_TTL_MS = 60_000;
-
 /** Raw groups table with CRUD operations */
 const rawGroupsTable = defineIdTable<Group, GroupInput>("groups", {
   ...encryptedNameSchema(encrypt, decrypt),
@@ -49,9 +43,8 @@ const queryGroups = queryAndMap<Group, Group>((row) =>
   rawGroupsTable.fromDb(row),
 );
 
-const groupsCache = collectionCache(
-  () => queryGroups("SELECT * FROM groups ORDER BY id ASC"),
-  GROUPS_CACHE_TTL_MS,
+const groupsCache = requestCache(() =>
+  queryGroups("SELECT * FROM groups ORDER BY id ASC"),
 );
 
 registerCache(() => ({ name: "groups", entries: groupsCache.size() }));

--- a/src/lib/db/holidays.ts
+++ b/src/lib/db/holidays.ts
@@ -2,12 +2,13 @@
  * Holidays table operations
  */
 
-import { collectionCache, filter } from "#fp";
+import { filter } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
 import { getTz } from "#lib/config.ts";
 import { decrypt, encrypt } from "#lib/crypto.ts";
 import { queryAndMap } from "#lib/db/query.ts";
 import { col, defineTable } from "#lib/db/table.ts";
+import { requestCache } from "#lib/request-cache.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import type { Holiday } from "#lib/types.ts";
 
@@ -17,13 +18,6 @@ export type HolidayInput = {
   startDate: string;
   endDate: string;
 };
-
-/**
- * In-memory holidays cache. Loads all holidays in a single query and
- * serves subsequent reads from memory until the TTL expires or a
- * write invalidates the cache.
- */
-export const HOLIDAYS_CACHE_TTL_MS = 60_000;
 
 /** Raw holidays table with CRUD operations — name is encrypted, dates are plaintext */
 const rawHolidaysTable = defineTable<Holiday, HolidayInput>({
@@ -42,9 +36,8 @@ const queryHolidays = queryAndMap<Holiday, Holiday>((row) =>
   rawHolidaysTable.fromDb(row),
 );
 
-const holidaysCache = collectionCache(
-  () => queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC"),
-  HOLIDAYS_CACHE_TTL_MS,
+const holidaysCache = requestCache(() =>
+  queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC"),
 );
 
 registerCache(() => ({ name: "holidays", entries: holidaysCache.size() }));

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -2,7 +2,6 @@
  * Users table operations
  */
 
-import { collectionCache } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
 import {
   decrypt,
@@ -16,22 +15,13 @@ import {
 } from "#lib/crypto.ts";
 import { deleteByFieldBatch, getDb, queryAll } from "#lib/db/client.ts";
 import { now } from "#lib/now.ts";
+import { requestCache } from "#lib/request-cache.ts";
 import { type AdminLevel, isAdminLevel, type User } from "#lib/types.ts";
-
-/**
- * In-memory users cache. Loads all rows in a single query and
- * serves subsequent reads from memory until the TTL expires or a
- * write invalidates the cache.
- */
-export const USERS_CACHE_TTL_MS = 60_000;
 
 const USER_SELECT =
   "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users ORDER BY id ASC";
 
-const usersCache = collectionCache(
-  () => queryAll<User>(USER_SELECT),
-  USERS_CACHE_TTL_MS,
-);
+const usersCache = requestCache(() => queryAll<User>(USER_SELECT));
 
 const loadAllUsers = (): Promise<User[]> => usersCache.getAll();
 

--- a/src/lib/request-cache.ts
+++ b/src/lib/request-cache.ts
@@ -1,0 +1,67 @@
+/**
+ * Per-request collection cache using AsyncLocalStorage.
+ *
+ * Each incoming request gets a fresh cache scope. The first call to
+ * getAll() fetches from the database; subsequent calls within the same
+ * request return the cached result. Writes call invalidate() to clear
+ * the cached data so the next read re-fetches.
+ *
+ * Outside a request context (e.g. tests), every getAll() call fetches
+ * directly — no caching is applied.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { CollectionCache } from "#fp";
+
+/** Per-request store: maps each cache's unique key to its cached data */
+type RequestStore = Map<symbol, unknown[] | Promise<unknown[]>>;
+
+const storage = new AsyncLocalStorage<RequestStore>();
+
+/** Run a function within a per-request cache scope */
+export const runWithRequestCache = <T>(fn: () => T): T =>
+  storage.run(new Map(), fn);
+
+/**
+ * Create a per-request collection cache.
+ *
+ * Same CollectionCache interface as collectionCache(), but scoped to the
+ * current request instead of using a global TTL. This eliminates stale
+ * reads across edge isolates — every request starts fresh.
+ */
+export const requestCache = <T>(
+  fetchAll: () => Promise<T[]>,
+): CollectionCache<T> => {
+  const key = Symbol();
+
+  return {
+    getAll: async (): Promise<T[]> => {
+      const store = storage.getStore();
+      if (!store) return fetchAll();
+
+      const cached = store.get(key);
+      if (cached) return cached as T[] | Promise<T[]>;
+
+      let resolve!: (items: T[]) => void;
+      const promise: Promise<T[]> = new Promise((r) => {
+        resolve = r;
+      });
+      store.set(key, promise);
+      const items = await fetchAll();
+      // Replace the promise with the resolved array so future
+      // reads within this request get the array directly.
+      if (store.get(key) === promise) store.set(key, items);
+      resolve(items);
+      return items;
+    },
+
+    invalidate: (): void => {
+      storage.getStore()?.delete(key);
+    },
+
+    size: (): number => {
+      const cached = storage.getStore()?.get(key);
+      return Array.isArray(cached) ? cached.length : 0;
+    },
+  };
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -31,6 +31,7 @@ import {
   runWithRequestId,
 } from "#lib/logger.ts";
 import { flushPendingWork } from "#lib/pending-work.ts";
+import { runWithRequestCache } from "#lib/request-cache.ts";
 import { runWithSessionContext } from "#lib/session-context.ts";
 import { loadTheme } from "#lib/theme.ts";
 import {
@@ -346,125 +347,127 @@ export const handleRequest = async (
     : request;
 
   return runWithRequestId(() =>
-    runWithQueryLogContext(() =>
-      runWithSessionContext(async () => {
-        const { url, path, method } = parseRequest(effectiveRequest);
-        const getElapsed = createRequestTimer();
-        detectIframeMode(effectiveRequest.url);
-        clearSavedFormData();
-
-        try {
-          // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues
-          if (method === "GET") {
-            const cleanUrl = getCleanUrl(url);
-            if (cleanUrl) {
-              return logAndReturn(
-                new Response(null, {
-                  status: 301,
-                  headers: { location: cleanUrl },
-                }),
-                method,
-                path,
-                getElapsed,
-              );
-            }
-          }
-
-          // Load effective domain (custom_domain from DB if set, else ALLOWED_DOMAIN)
-          // before domain validation so redirects go to the right host.
-          await loadEffectiveDomain();
-
-          // Domain validation: redirect requests from unauthorized domains to the effective domain
-          if (!isValidDomain(effectiveRequest)) {
-            const redirectUrl = buildDomainRedirectUrl(effectiveRequest);
-            logDebug(
-              "Domain",
-              `Redirecting to ${redirectUrl} (${getDomainRejectionReason(effectiveRequest)})`,
-            );
-            return logAndReturn(
-              domainRedirectResponse(redirectUrl),
-              method,
-              path,
-              getElapsed,
-            );
-          }
-
-          const embeddable = isEmbeddablePath(path);
-
-          // Content-Type validation: reject POST requests without proper Content-Type
-          // (webhook endpoints accept JSON, all others require form-urlencoded)
-          if (!isValidContentType(effectiveRequest, path)) {
-            return logAndReturn(
-              contentTypeRejectionResponse(),
-              method,
-              path,
-              getElapsed,
-            );
-          }
+    runWithRequestCache(() =>
+      runWithQueryLogContext(() =>
+        runWithSessionContext(async () => {
+          const { url, path, method } = parseRequest(effectiveRequest);
+          const getElapsed = createRequestTimer();
+          detectIframeMode(effectiveRequest.url);
+          clearSavedFormData();
 
           try {
-            // Populate flash context from keyed cookie (flash ID in URL)
-            const flashId = new URL(effectiveRequest.url).searchParams.get(
-              "flash",
-            );
-            const flashRaw = flashId
-              ? parseCookies(effectiveRequest).get(`flash_${flashId}`)
-              : null;
-            const flash = flashRaw ? parseFlashValue(flashRaw) : null;
-            if (flash) setFlashContext(flash);
-
-            const response = await handleRequestInternal(
-              effectiveRequest,
-              path,
-              method,
-              server,
-            );
-
-            // Clear keyed flash cookie if one was consumed
-            if (flashId && flash && hasFlash()) {
-              withCookie(response, clearFlashCookie(flashId));
+            // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues
+            if (method === "GET") {
+              const cleanUrl = getCleanUrl(url);
+              if (cleanUrl) {
+                return logAndReturn(
+                  new Response(null, {
+                    status: 301,
+                    headers: { location: cleanUrl },
+                  }),
+                  method,
+                  path,
+                  getElapsed,
+                );
+              }
             }
-            resetFlashContext();
 
-            return logAndReturn(
-              await applySecurityHeaders(response, embeddable),
-              method,
-              path,
-              getElapsed,
-            );
-          } catch (error) {
-            logError({
-              code: ErrorCode.CDN_REQUEST,
-              detail: formatRequestError(method, path, error),
-            });
-            // In tests, surface the real error instead of swallowing it
-            // behind a generic "Temporary Error" page
-            if (
-              Deno.env.get("TEST_RETHROW_ERRORS") &&
-              !(error instanceof SessionKeyError) &&
-              !Deno.env.get("TEST_EXPECT_ERROR")
-            ) {
-              throw error;
-            }
-            if (error instanceof SessionKeyError) {
+            // Load effective domain (custom_domain from DB if set, else ALLOWED_DOMAIN)
+            // before domain validation so redirects go to the right host.
+            await loadEffectiveDomain();
+
+            // Domain validation: redirect requests from unauthorized domains to the effective domain
+            if (!isValidDomain(effectiveRequest)) {
+              const redirectUrl = buildDomainRedirectUrl(effectiveRequest);
+              logDebug(
+                "Domain",
+                `Redirecting to ${redirectUrl} (${getDomainRejectionReason(effectiveRequest)})`,
+              );
               return logAndReturn(
-                redirectResponse("/admin", clearSessionCookie()),
+                domainRedirectResponse(redirectUrl),
                 method,
                 path,
                 getElapsed,
               );
             }
-            return logAndReturn(
-              temporaryErrorResponse(),
-              method,
-              path,
-              getElapsed,
-            );
+
+            const embeddable = isEmbeddablePath(path);
+
+            // Content-Type validation: reject POST requests without proper Content-Type
+            // (webhook endpoints accept JSON, all others require form-urlencoded)
+            if (!isValidContentType(effectiveRequest, path)) {
+              return logAndReturn(
+                contentTypeRejectionResponse(),
+                method,
+                path,
+                getElapsed,
+              );
+            }
+
+            try {
+              // Populate flash context from keyed cookie (flash ID in URL)
+              const flashId = new URL(effectiveRequest.url).searchParams.get(
+                "flash",
+              );
+              const flashRaw = flashId
+                ? parseCookies(effectiveRequest).get(`flash_${flashId}`)
+                : null;
+              const flash = flashRaw ? parseFlashValue(flashRaw) : null;
+              if (flash) setFlashContext(flash);
+
+              const response = await handleRequestInternal(
+                effectiveRequest,
+                path,
+                method,
+                server,
+              );
+
+              // Clear keyed flash cookie if one was consumed
+              if (flashId && flash && hasFlash()) {
+                withCookie(response, clearFlashCookie(flashId));
+              }
+              resetFlashContext();
+
+              return logAndReturn(
+                await applySecurityHeaders(response, embeddable),
+                method,
+                path,
+                getElapsed,
+              );
+            } catch (error) {
+              logError({
+                code: ErrorCode.CDN_REQUEST,
+                detail: formatRequestError(method, path, error),
+              });
+              // In tests, surface the real error instead of swallowing it
+              // behind a generic "Temporary Error" page
+              if (
+                Deno.env.get("TEST_RETHROW_ERRORS") &&
+                !(error instanceof SessionKeyError) &&
+                !Deno.env.get("TEST_EXPECT_ERROR")
+              ) {
+                throw error;
+              }
+              if (error instanceof SessionKeyError) {
+                return logAndReturn(
+                  redirectResponse("/admin", clearSessionCookie()),
+                  method,
+                  path,
+                  getElapsed,
+                );
+              }
+              return logAndReturn(
+                temporaryErrorResponse(),
+                method,
+                path,
+                getElapsed,
+              );
+            }
+          } finally {
+            await flushPendingWork();
           }
-        } finally {
-          await flushPendingWork();
-        }
-      }),
+        }),
+      ),
     ),
   );
 };

--- a/test/lib/request-cache.test.ts
+++ b/test/lib/request-cache.test.ts
@@ -1,0 +1,115 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { requestCache, runWithRequestCache } from "#lib/request-cache.ts";
+
+/** Create a tracked fetcher that counts calls */
+const trackedFetcher = <T>(items: () => T[]) => {
+  let calls = 0;
+  const fetcher = () => {
+    calls++;
+    return Promise.resolve(items());
+  };
+  return { fetcher, getCalls: () => calls };
+};
+
+describe("requestCache", () => {
+  test("fetches on first call and caches within request", async () => {
+    const { fetcher, getCalls } = trackedFetcher(() => [1, 2, 3]);
+    const cache = requestCache(fetcher);
+
+    await runWithRequestCache(async () => {
+      const first = await cache.getAll();
+      expect(first).toEqual([1, 2, 3]);
+      const second = await cache.getAll();
+      expect(second).toBe(first); // same reference
+      expect(getCalls()).toBe(1);
+    });
+  });
+
+  test("each request gets a fresh cache", async () => {
+    let counter = 0;
+    const fetcher = () => Promise.resolve([++counter]);
+    const cache = requestCache(fetcher);
+
+    const first = await runWithRequestCache(() => cache.getAll());
+    const second = await runWithRequestCache(() => cache.getAll());
+    expect(first).toEqual([1]);
+    expect(second).toEqual([2]);
+  });
+
+  test("invalidate clears cache within request", async () => {
+    let counter = 0;
+    const fetcher = () => Promise.resolve([++counter]);
+    const cache = requestCache(fetcher);
+
+    await runWithRequestCache(async () => {
+      expect(await cache.getAll()).toEqual([1]);
+      cache.invalidate();
+      expect(await cache.getAll()).toEqual([2]);
+    });
+  });
+
+  test("fetches directly without request context", async () => {
+    const { fetcher, getCalls } = trackedFetcher(() => [1, 2, 3]);
+    const cache = requestCache(fetcher);
+
+    await cache.getAll();
+    await cache.getAll();
+    expect(getCalls()).toBe(2); // no caching
+  });
+
+  test("concurrent reads within request share one fetch", async () => {
+    const { fetcher, getCalls } = trackedFetcher(() => [1, 2, 3]);
+    const cache = requestCache(fetcher);
+
+    await runWithRequestCache(async () => {
+      const [a, b] = await Promise.all([cache.getAll(), cache.getAll()]);
+      expect(a).toBe(b); // same reference
+      expect(getCalls()).toBe(1);
+    });
+  });
+
+  test("size returns 0 before fetch and count after", async () => {
+    const cache = requestCache(() => Promise.resolve([1, 2, 3]));
+
+    await runWithRequestCache(async () => {
+      expect(cache.size()).toBe(0);
+      await cache.getAll();
+      expect(cache.size()).toBe(3);
+    });
+  });
+
+  test("size returns 0 after invalidate", async () => {
+    const cache = requestCache(() => Promise.resolve([1, 2, 3]));
+
+    await runWithRequestCache(async () => {
+      await cache.getAll();
+      expect(cache.size()).toBe(3);
+      cache.invalidate();
+      expect(cache.size()).toBe(0);
+    });
+  });
+
+  test("size returns 0 without request context", () => {
+    const cache = requestCache(() => Promise.resolve([1, 2, 3]));
+    expect(cache.size()).toBe(0);
+  });
+
+  test("invalidate is safe without request context", () => {
+    const cache = requestCache(() => Promise.resolve([1, 2, 3]));
+    cache.invalidate(); // should not throw
+  });
+
+  test("multiple caches are independent", async () => {
+    const cacheA = requestCache(() => Promise.resolve(["a"]));
+    const cacheB = requestCache(() => Promise.resolve(["b"]));
+
+    await runWithRequestCache(async () => {
+      expect(await cacheA.getAll()).toEqual(["a"]);
+      expect(await cacheB.getAll()).toEqual(["b"]);
+      cacheA.invalidate();
+      expect(cacheB.size()).toBe(1); // B unaffected
+      expect(cacheA.size()).toBe(0); // A cleared
+    });
+  });
+});


### PR DESCRIPTION
The 60-second TTL cache caused stale data on Bunny Edge where multiple
isolates each maintain their own in-memory cache. Deactivating an event
would show stale status on the dashboard until the TTL expired on the
serving isolate.

Per-request caching (via AsyncLocalStorage) fetches from DB once per
request and serves subsequent reads from memory within that request.
Every new request starts fresh, eliminating cross-isolate staleness.

https://claude.ai/code/session_014aJnUhmWsmZUywgfA5iMWe