### PR TITLE
Pad authentication tokens to meet Apple's 16-character minimum

### DIFF
--- a/src/lib/apple-wallet.ts
+++ b/src/lib/apple-wallet.ts
@@ -59,6 +59,20 @@ export type SigningCredentials = {
   wwdrCert: string;
 };
 
+/** Apple requires authenticationToken to be at least 16 characters */
+const MIN_AUTH_TOKEN_LENGTH = 16;
+
+/**
+ * Pad a serial number to meet Apple's minimum authenticationToken length.
+ * Uses "-" (not in uppercase hex charset) so padding is cleanly reversible.
+ */
+export const padAuthToken = (serial: string): string =>
+  serial.padEnd(MIN_AUTH_TOKEN_LENGTH, "-");
+
+/** Strip padding added by padAuthToken to recover the original serial number */
+export const trimAuthToken = (authToken: string): string =>
+  authToken.replace(/-+$/, "");
+
 /** Build the pass.json content from pass data and signing credentials */
 export const generatePassJson = (
   data: PassData,
@@ -82,7 +96,7 @@ export const generatePassJson = (
       },
     ],
     webServiceURL: data.webServiceURL,
-    authenticationToken: data.serialNumber,
+    authenticationToken: padAuthToken(data.serialNumber),
     eventTicket: buildEventTicketFields(data),
   };
 

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -12,7 +12,7 @@
  * so devices re-download the pass on every manual refresh.
  */
 
-import type { SigningCredentials } from "#lib/apple-wallet.ts";
+import { trimAuthToken, type SigningCredentials } from "#lib/apple-wallet.ts";
 import { getAppleWalletConfig } from "#lib/db/settings.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import { buildPkpassForToken } from "#routes/wallet.ts";
@@ -43,8 +43,9 @@ const handleGetTokens = (
 ) =>
   withVerifiedPass(204)((_config) => {
     const authHeader = request.headers.get("Authorization") ?? "";
-    const token = authHeader.replace(/^ApplePass\s+/i, "");
-    if (!token) return new Response(null, { status: 401 });
+    const rawToken = authHeader.replace(/^ApplePass\s+/i, "");
+    if (!rawToken) return new Response(null, { status: 401 });
+    const token = trimAuthToken(rawToken);
 
     // Ignore passesUpdatedSince — always return the token as updated
     return new Response(

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -62,7 +62,6 @@ export const buildPkpassForToken = async (
     headers: {
       "Content-Type": PKPASS_CONTENT_TYPE,
       "Content-Disposition": `inline; filename="ticket.pkpass"`,
-      "Content-Length": String(body.byteLength),
       "Cache-Control": WALLET_CACHE_CONTROL,
     },
   });

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -62,6 +62,7 @@ export const buildPkpassForToken = async (
     headers: {
       "Content-Type": PKPASS_CONTENT_TYPE,
       "Content-Disposition": `inline; filename="ticket.pkpass"`,
+      "Content-Length": String(body.byteLength),
       "Cache-Control": WALLET_CACHE_CONTROL,
     },
   });

--- a/test/lib/apple-wallet.test.ts
+++ b/test/lib/apple-wallet.test.ts
@@ -8,6 +8,8 @@ import {
   generatePassJson,
   isValidPemCertificate,
   isValidPemPrivateKey,
+  padAuthToken,
+  trimAuthToken,
   type PassData,
   type SigningCredentials,
   sha1Hex,
@@ -183,7 +185,36 @@ describe("apple-wallet", () => {
     test("includes webServiceURL and authenticationToken for auto-updates", () => {
       const pass = generatePassJson(makePassData(), creds);
       expect(pass.webServiceURL).toBe("https://example.com");
-      expect(pass.authenticationToken).toBe("ABC123");
+      expect(pass.authenticationToken).toBe("ABC123----------");
+      expect((pass.authenticationToken as string).length).toBeGreaterThanOrEqual(
+        16,
+      );
+    });
+  });
+
+  describe("padAuthToken / trimAuthToken", () => {
+    test("pads short tokens to 16 characters", () => {
+      expect(padAuthToken("ABC123")).toBe("ABC123----------");
+      expect(padAuthToken("ABC123")).toHaveLength(16);
+    });
+
+    test("pads 10-char ticket tokens to 16 characters", () => {
+      expect(padAuthToken("803357EE59")).toBe("803357EE59------");
+      expect(padAuthToken("803357EE59")).toHaveLength(16);
+    });
+
+    test("does not pad tokens already at 16 characters", () => {
+      const long = "ABCDEF1234567890";
+      expect(padAuthToken(long)).toBe(long);
+    });
+
+    test("trimAuthToken reverses padAuthToken", () => {
+      expect(trimAuthToken(padAuthToken("ABC123"))).toBe("ABC123");
+      expect(trimAuthToken(padAuthToken("803357EE59"))).toBe("803357EE59");
+    });
+
+    test("trimAuthToken handles unpadded tokens", () => {
+      expect(trimAuthToken("ABCDEF1234567890")).toBe("ABCDEF1234567890");
     });
   });
 

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -101,11 +101,11 @@ describeWithEnv("Apple Wallet web service (/v1)", { db: true }, () => {
       await configureAppleWallet();
       const response = await walletRequest(
         "/v1/devices/abc123/registrations/pass.com.test.tickets",
-        { headers: { Authorization: "ApplePass my-serial-token" } },
+        { headers: { Authorization: "ApplePass my-serial------" } },
       );
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body.serialNumbers).toEqual(["my-serial-token"]);
+      expect(body.serialNumbers).toEqual(["my-serial"]);
       expect(body.lastUpdated).toBeDefined();
     });
 
@@ -113,11 +113,11 @@ describeWithEnv("Apple Wallet web service (/v1)", { db: true }, () => {
       await configureAppleWallet();
       const response = await walletRequest(
         "/v1/devices/abc123/registrations/pass.com.test.tickets?passesUpdatedSince=12345",
-        { headers: { Authorization: "ApplePass my-serial-token" } },
+        { headers: { Authorization: "ApplePass my-serial------" } },
       );
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body.serialNumbers).toEqual(["my-serial-token"]);
+      expect(body.serialNumbers).toEqual(["my-serial"]);
     });
   });
 

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -164,7 +164,7 @@ describeWithEnv("wallet route (/wallet/:token)", { db: true }, () => {
     expect(disposition).toContain("ticket.pkpass");
   });
 
-  test("does not set explicit Content-Length to avoid CDN content-encoding mismatch", async () => {
+  test("returns pkpass with Content-Length header for iOS compatibility", async () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken(
       "Alice",
@@ -172,7 +172,10 @@ describeWithEnv("wallet route (/wallet/:token)", { db: true }, () => {
     );
 
     const response = await fetchPkpassResponse(token);
-    expect(response.headers.get("Content-Length")).toBeNull();
+    const contentLength = response.headers.get("Content-Length");
+    expect(contentLength).not.toBeNull();
+    const body = new Uint8Array(await response.arrayBuffer());
+    expect(Number(contentLength)).toBe(body.byteLength);
   });
 
   test("pkpass is a valid ZIP containing pass.json, manifest.json, and signature", async () => {

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -221,7 +221,8 @@ describeWithEnv("wallet route (/wallet/:token)", { db: true }, () => {
     );
     const passJson = await parsePkpassJson(token);
     expect(passJson.webServiceURL).toBe("https://localhost");
-    expect(passJson.authenticationToken).toBe(token);
+    expect(passJson.authenticationToken).toBe(token.padEnd(16, "-"));
+    expect(passJson.authenticationToken.length).toBeGreaterThanOrEqual(16);
   });
 
   test("returns null for non-GET methods", async () => {

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -164,7 +164,7 @@ describeWithEnv("wallet route (/wallet/:token)", { db: true }, () => {
     expect(disposition).toContain("ticket.pkpass");
   });
 
-  test("returns pkpass with Content-Length header for iOS compatibility", async () => {
+  test("does not set explicit Content-Length to avoid CDN content-encoding mismatch", async () => {
     await configureAppleWallet();
     const { token } = await createTestAttendeeWithToken(
       "Alice",
@@ -172,10 +172,7 @@ describeWithEnv("wallet route (/wallet/:token)", { db: true }, () => {
     );
 
     const response = await fetchPkpassResponse(token);
-    const contentLength = response.headers.get("Content-Length");
-    expect(contentLength).not.toBeNull();
-    const body = new Uint8Array(await response.arrayBuffer());
-    expect(Number(contentLength)).toBe(body.byteLength);
+    expect(response.headers.get("Content-Length")).toBeNull();
   });
 
   test("pkpass is a valid ZIP containing pass.json, manifest.json, and signature", async () => {


### PR DESCRIPTION
## Summary
Apple Wallet requires authentication tokens to be at least 16 characters long. This PR adds padding logic to meet that requirement while preserving the ability to recover the original serial number.

## Key Changes
- Added `padAuthToken()` function that pads short tokens to 16 characters using "-" as padding character
- Added `trimAuthToken()` function that removes the padding to recover the original serial number
- Updated `generatePassJson()` to pad the authentication token before including it in the pass.json
- Updated wallet web service to trim the padded token when extracting the serial number from the Authorization header
- Updated tests to verify padding behavior and that the round-trip (pad → trim) preserves the original value

## Implementation Details
- Padding uses "-" characters (not in the uppercase hex charset) to ensure padding is cleanly reversible via regex
- The minimum token length constant (`MIN_AUTH_TOKEN_LENGTH = 16`) is defined for consistency
- `trimAuthToken()` uses a regex to strip trailing dashes, making it safe for both padded and unpadded tokens
- All existing functionality is preserved; this is purely an additive change to meet Apple's requirements

https://claude.ai/code/session_01JaVPeURq29GAXqhaKnLNve