### PR TITLE
Use describeWithEnv in more test files for consistency and speed

### DIFF
--- a/test/admin-api-events.test.ts
+++ b/test/admin-api-events.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { generateSecureToken, unwrapKeyWithToken } from "#lib/crypto.ts";
 import { createApiKey } from "#lib/db/api-keys.ts";
@@ -13,11 +13,10 @@ import type { EventWithCount } from "#lib/types.ts";
 import { handleRequest } from "#routes";
 import { bodyToCreateInput, bodyToUpdateInput } from "#routes/admin/api.ts";
 import {
-  createTestDbWithSetup,
   createTestEvent,
   createTestGroup,
+  describeWithEnv,
   mockRequest,
-  resetDb,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -70,14 +69,7 @@ const apiRequest = async (
   return handleRequest(mockRequest(path, init));
 };
 
-describe("Admin API - Events", () => {
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("Admin API - Events", { db: true }, () => {
 
   describe("GET /api/admin/events/:eventId", () => {
     test("returns single event by ID", async () => {

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { buildSessionCookie, getSessionCookieName } from "#lib/cookies.ts";
 import {
   generateSecureToken,
@@ -22,8 +22,8 @@ import { getDb } from "#lib/db/client.ts";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { handleRequest } from "#routes";
 import {
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectFlash,
   expectRedirect,
   extractCsrfToken,
@@ -31,7 +31,6 @@ import {
   flashCookieHeader,
   matchGroup,
   mockRequest,
-  resetDb,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -47,14 +46,7 @@ const getTestDataKey = async (): Promise<CryptoKey> => {
   return unwrapKeyWithToken(session!.wrapped_data_key!, token);
 };
 
-describe("API Keys", () => {
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("API Keys", { db: true }, () => {
 
   describe("database operations", () => {
     test("creates and retrieves an API key", async () => {

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -15,7 +15,7 @@ import {
   updateCustomDomain,
   updateCustomDomainLastValidated,
 } from "#lib/db/settings.ts";
-import { createTestDb, describeWithEnv, resetDb, withMocks } from "#test-utils";
+import { describeWithEnv, withMocks } from "#test-utils";
 
 /** Temporarily replace bunnyCdnApi.validateCustomDomain with a mock */
 const withMockValidate = async (
@@ -487,15 +487,7 @@ describeWithEnv(
   },
 );
 
-describe("custom domain settings", () => {
-  beforeEach(async () => {
-    await createTestDb();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("custom domain settings", { db: true }, () => {
   test("getCustomDomainFromDb returns null when not set", async () => {
     expect(await getCustomDomainFromDb()).toBeNull();
   });

--- a/test/lib/business-email.test.ts
+++ b/test/lib/business-email.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import {
   getBusinessEmailFromDb,
   isValidBusinessEmail,
@@ -7,16 +7,9 @@ import {
   updateBusinessEmail,
 } from "#lib/business-email.ts";
 import { invalidateSettingsCache } from "#lib/db/settings.ts";
-import { createTestDbWithSetup, resetDb } from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
-describe("business-email", () => {
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-  });
-
-  afterEach(async () => {
-    await resetDb();
-  });
+describeWithEnv("business-email", { db: true }, () => {
 
   describe("isValidBusinessEmail", () => {
     test("accepts valid email", () => {

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -314,6 +314,7 @@ describe("payments", () => {
   afterEach(() => {
     resetDb();
   });
+
   test("getActivePaymentProvider returns null when no provider configured", async () => {
     const provider = await getActivePaymentProvider();
     expect(provider).toBeNull();

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import {
   addDays,
   DAY_NAMES,
@@ -12,7 +12,7 @@ import {
 } from "#lib/dates.ts";
 import { setTimezoneForTest } from "#lib/db/settings.ts";
 import { todayInTz } from "#lib/timezone.ts";
-import { createTestDbWithSetup, resetDb, testEvent } from "#test-utils";
+import { describeWithEnv, testEvent } from "#test-utils";
 
 const today = () => todayInTz("UTC");
 
@@ -27,15 +27,7 @@ const ALL_DAYS = [
   "Sunday",
 ] as const;
 
-describe("dates", () => {
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-    setTimezoneForTest("UTC");
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("dates", { db: true }, () => {
 
   describe("addDays", () => {
     test("adds positive days to a date", () => {

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -22,12 +22,7 @@ import {
   sendRegistrationEmails,
   sendTestEmail,
 } from "#lib/email.ts";
-import {
-  createTestDbWithSetup,
-  describeWithEnv,
-  makeTestEntry as makeEntry,
-  resetDb,
-} from "#test-utils";
+import { describeWithEnv, makeTestEntry as makeEntry } from "#test-utils";
 
 const testConfig: EmailConfig = {
   provider: "resend",
@@ -40,24 +35,22 @@ const withErrorSpy = bracket(
   (s: { restore: () => void }) => s.restore(),
 );
 
-describe("email", () => {
+describeWithEnv("email", { db: true }, () => {
   // biome-ignore lint/suspicious/noExplicitAny: Deno's fetch stub type is incompatible with Stub generics
   // deno-lint-ignore no-explicit-any
   let fetchStub: any;
   let originalFetch: typeof fetch;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     originalFetch = globalThis.fetch;
     fetchStub = stub(globalThis, "fetch", () =>
       Promise.resolve(new Response()),
     );
-    await createTestDbWithSetup();
   });
 
   afterEach(() => {
     fetchStub.restore();
     globalThis.fetch = originalFetch;
-    resetDb();
   });
 
   const restubFetch = (impl: () => Promise<Response>): void => {

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -14,7 +14,6 @@ import {
 import { handleRequest } from "#routes";
 import {
   adminGet,
-  createTestDbWithSetup,
   createTestManagerSession,
   describeWithEnv,
   expectFlash,
@@ -22,8 +21,6 @@ import {
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -145,15 +142,9 @@ describe("header image", () => {
     });
   });
 
-  describe("loadHeaderImage", () => {
-    beforeEach(async () => {
-      resetTestSlugCounter();
-      await createTestDbWithSetup();
+  describeWithEnv("loadHeaderImage", { db: true }, () => {
+    beforeEach(() => {
       resetHeaderImage();
-    });
-
-    afterEach(() => {
-      resetDb();
     });
 
     test("returns null when no header image is set", async () => {
@@ -182,16 +173,7 @@ describe("header image", () => {
   });
 });
 
-describe("header image settings DB", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
+describeWithEnv("header image settings DB", { db: true }, () => {
   test("getHeaderImageUrlFromDb returns null when not set", async () => {
     const url = await getHeaderImageUrlFromDb();
     expect(url).toBeNull();

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -3615,260 +3615,273 @@ describe("html", () => {
     });
   });
 
-  describeWithEnv("event images", { env: { STORAGE_ZONE_NAME: "testzone", STORAGE_ZONE_KEY: "testkey" } }, () => {
-    describe("renderEventImage", () => {
-      test("returns empty string when image_url is null", () => {
-        const html = renderEventImage({ image_url: "", name: "Test" });
-        expect(html).toBe("");
-      });
-
-      test("renders img tag with proxy URL when image_url is set", () => {
-        const html = renderEventImage({
-          image_url: "abc123.jpg",
-          name: "Test Event",
+  describeWithEnv(
+    "event images",
+    { env: { STORAGE_ZONE_NAME: "testzone", STORAGE_ZONE_KEY: "testkey" } },
+    () => {
+      describe("renderEventImage", () => {
+        test("returns empty string when image_url is null", () => {
+          const html = renderEventImage({ image_url: "", name: "Test" });
+          expect(html).toBe("");
         });
-        expect(html).toContain("/image/abc123.jpg");
-        expect(html).toContain('alt="Test Event"');
-        expect(html).toContain('class="event-image"');
-      });
 
-      test("escapes HTML in event name for alt attribute", () => {
-        const html = renderEventImage({
-          image_url: "img.jpg",
-          name: '<script>alert("xss")</script>',
+        test("renders img tag with proxy URL when image_url is set", () => {
+          const html = renderEventImage({
+            image_url: "abc123.jpg",
+            name: "Test Event",
+          });
+          expect(html).toContain("/image/abc123.jpg");
+          expect(html).toContain('alt="Test Event"');
+          expect(html).toContain('class="event-image"');
         });
-        expect(html).not.toContain("<script>");
-        expect(html).toContain("&lt;script&gt;");
-      });
-    });
 
-    describe("ticketPage with image", () => {
-      test("shows event image when image_url is set", () => {
-        const event = testEventWithCount({ image_url: "event-img.jpg" });
-        const html = ticketPage(event, undefined, false, undefined, null);
-        expect(html).toContain("/image/event-img.jpg");
-        expect(html).toContain('class="event-image"');
-      });
-
-      test("does not show image when image_url is null", () => {
-        const event = testEventWithCount({ image_url: "" });
-        const html = ticketPage(event, undefined, false, undefined, null);
-        expect(html).not.toContain("/image/");
-      });
-
-      test("does not show image in iframe mode", () => {
-        detectIframeMode("https://example.com/?iframe=true");
-        const event = testEventWithCount({ image_url: "event-img.jpg" });
-        const html = ticketPage(event, undefined, false, undefined, null);
-        expect(html).not.toContain("event-img.jpg");
-        detectIframeMode("https://example.com/");
-      });
-    });
-
-    describe("multiTicketPage with images", () => {
-      test("shows image before each event with image_url", () => {
-        const events = [
-          buildMultiTicketEvent(
-            testEventWithCount({
-              id: 1,
-              name: "Event A",
-              image_url: "img-a.jpg",
-            }),
-          ),
-          buildMultiTicketEvent(
-            testEventWithCount({
-              id: 2,
-              name: "Event B",
-              image_url: "img-b.jpg",
-            }),
-          ),
-        ];
-        const html = multiTicketPage({ events, slugs: ["slug-a", "slug-b"] });
-        expect(html).toContain("/image/img-a.jpg");
-        expect(html).toContain("/image/img-b.jpg");
-      });
-
-      test("does not show images when image_url is null", () => {
-        const events = [
-          buildMultiTicketEvent(
-            testEventWithCount({ id: 1, name: "Event A", image_url: "" }),
-          ),
-        ];
-        const html = multiTicketPage({ events, slugs: ["slug-a"] });
-        expect(html).not.toContain("/image/");
-      });
-    });
-
-    describe("ticketViewPage ticket count", () => {
-      const token = "AABB0011CCDDEEFF";
-
-      test("shows '1 Ticket' for single ticket", () => {
-        const cards = [
-          {
-            entry: {
-              event: testEventWithCount({ id: 1 }),
-              attendee: testAttendee({ id: 1 }),
-            },
-            token,
-          },
-        ];
-        const html = ticketViewPage(cards);
-        expect(html).toContain("1 Ticket");
-      });
-
-      test("shows '2 Tickets' for multiple tickets", () => {
-        const cards = [
-          {
-            entry: {
-              event: testEventWithCount({ id: 1 }),
-              attendee: testAttendee({ id: 1 }),
-            },
-            token: "AABB0011CCDDEEF1",
-          },
-          {
-            entry: {
-              event: testEventWithCount({ id: 2 }),
-              attendee: testAttendee({ id: 2 }),
-            },
-            token: "AABB0011CCDDEEF2",
-          },
-        ];
-        const html = ticketViewPage(cards);
-        expect(html).toContain("2 Tickets");
-      });
-    });
-
-    describe("ticketViewPage with image", () => {
-      const token = "AABB0011CCDDEEFF";
-
-      test("shows image when event has image_url", () => {
-        const cards = [
-          {
-            entry: {
-              event: testEventWithCount({ image_url: "ticket-img.jpg" }),
-              attendee: testAttendee(),
-            },
-            token,
-          },
-        ];
-        const html = ticketViewPage(cards);
-        expect(html).toContain("/image/ticket-img.jpg");
-        expect(html).toContain('class="ticket-card-image"');
-      });
-
-      test("does not show image when image_url is empty", () => {
-        const cards = [
-          {
-            entry: {
-              event: testEventWithCount({ image_url: "" }),
-              attendee: testAttendee(),
-            },
-            token,
-          },
-        ];
-        const html = ticketViewPage(cards);
-        expect(html).not.toContain("ticket-card-image");
-      });
-    });
-
-    describe("adminDashboardPage with images", () => {
-      test("shows thumbnail when event has image_url", () => {
-        const events = [testEventWithCount({ image_url: "thumb.jpg" })];
-        const html = adminDashboardPage(events, TEST_SESSION);
-        expect(html).toContain("/image/thumb.jpg");
-        expect(html).toContain('class="event-thumbnail"');
-      });
-
-      test("does not show thumbnail when event has no image_url", () => {
-        const events = [testEventWithCount({ image_url: "" })];
-        const html = adminDashboardPage(events, TEST_SESSION);
-        expect(html).not.toContain('src="/image/');
-      });
-    });
-
-    describe("adminEventPage image section", () => {
-      test("does not show image upload on detail page", () => {
-        const event = testEventWithCount({ image_url: "" });
-        const html = adminEventPage({
-          event,
-          attendees: [],
-          allowedDomain: "localhost",
-          session: TEST_SESSION,
+        test("escapes HTML in event name for alt attribute", () => {
+          const html = renderEventImage({
+            image_url: "img.jpg",
+            name: '<script>alert("xss")</script>',
+          });
+          expect(html).not.toContain("<script>");
+          expect(html).toContain("&lt;script&gt;");
         });
-        expect(html).not.toContain('type="file"');
-        expect(html).not.toContain('name="image"');
-      });
-    });
-
-    describe("adminEventEditPage image section", () => {
-      test("shows image upload field when storage enabled", () => {
-        const event = testEventWithCount({ image_url: "" });
-        const html = adminEventEditPage(event, [], TEST_SESSION);
-        expect(html).toContain('type="file"');
-        expect(html).toContain('name="image"');
-        expect(html).toContain("multipart/form-data");
       });
 
-      test("shows current image and remove button when image is set", () => {
-        const event = testEventWithCount({ image_url: "current.jpg" });
-        const html = adminEventEditPage(event, [], TEST_SESSION);
-        expect(html).toContain("/image/current.jpg");
-        expect(html).toContain("Remove Image");
-        expect(html).toContain("/image/delete");
+      describe("ticketPage with image", () => {
+        test("shows event image when image_url is set", () => {
+          const event = testEventWithCount({ image_url: "event-img.jpg" });
+          const html = ticketPage(event, undefined, false, undefined, null);
+          expect(html).toContain("/image/event-img.jpg");
+          expect(html).toContain('class="event-image"');
+        });
+
+        test("does not show image when image_url is null", () => {
+          const event = testEventWithCount({ image_url: "" });
+          const html = ticketPage(event, undefined, false, undefined, null);
+          expect(html).not.toContain("/image/");
+        });
+
+        test("does not show image in iframe mode", () => {
+          detectIframeMode("https://example.com/?iframe=true");
+          const event = testEventWithCount({ image_url: "event-img.jpg" });
+          const html = ticketPage(event, undefined, false, undefined, null);
+          expect(html).not.toContain("event-img.jpg");
+          detectIframeMode("https://example.com/");
+        });
       });
 
-      test("does not show image field when storage is not enabled", () => {
-        const restore = setTestEnv({ STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined });
-        const event = testEventWithCount({ image_url: "" });
-        const html = adminEventEditPage(event, [], TEST_SESSION);
-        expect(html).not.toContain('type="file"');
-        expect(html).not.toContain('name="image"');
-        restore();
+      describe("multiTicketPage with images", () => {
+        test("shows image before each event with image_url", () => {
+          const events = [
+            buildMultiTicketEvent(
+              testEventWithCount({
+                id: 1,
+                name: "Event A",
+                image_url: "img-a.jpg",
+              }),
+            ),
+            buildMultiTicketEvent(
+              testEventWithCount({
+                id: 2,
+                name: "Event B",
+                image_url: "img-b.jpg",
+              }),
+            ),
+          ];
+          const html = multiTicketPage({ events, slugs: ["slug-a", "slug-b"] });
+          expect(html).toContain("/image/img-a.jpg");
+          expect(html).toContain("/image/img-b.jpg");
+        });
+
+        test("does not show images when image_url is null", () => {
+          const events = [
+            buildMultiTicketEvent(
+              testEventWithCount({ id: 1, name: "Event A", image_url: "" }),
+            ),
+          ];
+          const html = multiTicketPage({ events, slugs: ["slug-a"] });
+          expect(html).not.toContain("/image/");
+        });
       });
 
-      test("shows full-width image preview when event has image", () => {
-        const event = testEventWithCount({ image_url: "preview.jpg" });
-        const html = adminEventEditPage(event, [], TEST_SESSION);
-        expect(html).toContain("event-image-full");
-        expect(html).toContain("/image/preview.jpg");
-      });
-    });
+      describe("ticketViewPage ticket count", () => {
+        const token = "AABB0011CCDDEEFF";
 
-    describe("adminDuplicateEventPage image section", () => {
-      test("does not show image upload field even when storage enabled", () => {
-        const event = testEventWithCount({ image_url: "" });
-        const html = adminDuplicateEventPage(event, [], TEST_SESSION);
-        expect(html).not.toContain('type="file"');
-        expect(html).not.toContain('name="image"');
-        expect(html).toContain("multipart/form-data");
+        test("shows '1 Ticket' for single ticket", () => {
+          const cards = [
+            {
+              entry: {
+                event: testEventWithCount({ id: 1 }),
+                attendee: testAttendee({ id: 1 }),
+              },
+              token,
+            },
+          ];
+          const html = ticketViewPage(cards);
+          expect(html).toContain("1 Ticket");
+        });
+
+        test("shows '2 Tickets' for multiple tickets", () => {
+          const cards = [
+            {
+              entry: {
+                event: testEventWithCount({ id: 1 }),
+                attendee: testAttendee({ id: 1 }),
+              },
+              token: "AABB0011CCDDEEF1",
+            },
+            {
+              entry: {
+                event: testEventWithCount({ id: 2 }),
+                attendee: testAttendee({ id: 2 }),
+              },
+              token: "AABB0011CCDDEEF2",
+            },
+          ];
+          const html = ticketViewPage(cards);
+          expect(html).toContain("2 Tickets");
+        });
       });
 
-      test("does not show image field when storage is not enabled", () => {
-        const restore = setTestEnv({ STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined });
-        const event = testEventWithCount({ image_url: "" });
-        const html = adminDuplicateEventPage(event, [], TEST_SESSION);
-        expect(html).not.toContain('type="file"');
-        expect(html).not.toContain('name="image"');
-        restore();
-      });
-    });
+      describe("ticketViewPage with image", () => {
+        const token = "AABB0011CCDDEEFF";
 
-    describe("adminEventNewPage image section", () => {
-      test("shows image upload field on create form when storage enabled", () => {
-        const html = adminEventNewPage([], TEST_SESSION);
-        expect(html).toContain('type="file"');
-        expect(html).toContain('name="image"');
-        expect(html).toContain("multipart/form-data");
+        test("shows image when event has image_url", () => {
+          const cards = [
+            {
+              entry: {
+                event: testEventWithCount({ image_url: "ticket-img.jpg" }),
+                attendee: testAttendee(),
+              },
+              token,
+            },
+          ];
+          const html = ticketViewPage(cards);
+          expect(html).toContain("/image/ticket-img.jpg");
+          expect(html).toContain('class="ticket-card-image"');
+        });
+
+        test("does not show image when image_url is empty", () => {
+          const cards = [
+            {
+              entry: {
+                event: testEventWithCount({ image_url: "" }),
+                attendee: testAttendee(),
+              },
+              token,
+            },
+          ];
+          const html = ticketViewPage(cards);
+          expect(html).not.toContain("ticket-card-image");
+        });
       });
 
-      test("does not show image field on create form when storage is not enabled", () => {
-        const restore = setTestEnv({ STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined });
-        const html = adminEventNewPage([], TEST_SESSION);
-        expect(html).not.toContain('type="file"');
-        restore();
+      describe("adminDashboardPage with images", () => {
+        test("shows thumbnail when event has image_url", () => {
+          const events = [testEventWithCount({ image_url: "thumb.jpg" })];
+          const html = adminDashboardPage(events, TEST_SESSION);
+          expect(html).toContain("/image/thumb.jpg");
+          expect(html).toContain('class="event-thumbnail"');
+        });
+
+        test("does not show thumbnail when event has no image_url", () => {
+          const events = [testEventWithCount({ image_url: "" })];
+          const html = adminDashboardPage(events, TEST_SESSION);
+          expect(html).not.toContain('src="/image/');
+        });
       });
-    });
-  });
+
+      describe("adminEventPage image section", () => {
+        test("does not show image upload on detail page", () => {
+          const event = testEventWithCount({ image_url: "" });
+          const html = adminEventPage({
+            event,
+            attendees: [],
+            allowedDomain: "localhost",
+            session: TEST_SESSION,
+          });
+          expect(html).not.toContain('type="file"');
+          expect(html).not.toContain('name="image"');
+        });
+      });
+
+      describe("adminEventEditPage image section", () => {
+        test("shows image upload field when storage enabled", () => {
+          const event = testEventWithCount({ image_url: "" });
+          const html = adminEventEditPage(event, [], TEST_SESSION);
+          expect(html).toContain('type="file"');
+          expect(html).toContain('name="image"');
+          expect(html).toContain("multipart/form-data");
+        });
+
+        test("shows current image and remove button when image is set", () => {
+          const event = testEventWithCount({ image_url: "current.jpg" });
+          const html = adminEventEditPage(event, [], TEST_SESSION);
+          expect(html).toContain("/image/current.jpg");
+          expect(html).toContain("Remove Image");
+          expect(html).toContain("/image/delete");
+        });
+
+        test("does not show image field when storage is not enabled", () => {
+          const restore = setTestEnv({
+            STORAGE_ZONE_NAME: undefined,
+            STORAGE_ZONE_KEY: undefined,
+          });
+          const event = testEventWithCount({ image_url: "" });
+          const html = adminEventEditPage(event, [], TEST_SESSION);
+          expect(html).not.toContain('type="file"');
+          expect(html).not.toContain('name="image"');
+          restore();
+        });
+
+        test("shows full-width image preview when event has image", () => {
+          const event = testEventWithCount({ image_url: "preview.jpg" });
+          const html = adminEventEditPage(event, [], TEST_SESSION);
+          expect(html).toContain("event-image-full");
+          expect(html).toContain("/image/preview.jpg");
+        });
+      });
+
+      describe("adminDuplicateEventPage image section", () => {
+        test("does not show image upload field even when storage enabled", () => {
+          const event = testEventWithCount({ image_url: "" });
+          const html = adminDuplicateEventPage(event, [], TEST_SESSION);
+          expect(html).not.toContain('type="file"');
+          expect(html).not.toContain('name="image"');
+          expect(html).toContain("multipart/form-data");
+        });
+
+        test("does not show image field when storage is not enabled", () => {
+          const restore = setTestEnv({
+            STORAGE_ZONE_NAME: undefined,
+            STORAGE_ZONE_KEY: undefined,
+          });
+          const event = testEventWithCount({ image_url: "" });
+          const html = adminDuplicateEventPage(event, [], TEST_SESSION);
+          expect(html).not.toContain('type="file"');
+          expect(html).not.toContain('name="image"');
+          restore();
+        });
+      });
+
+      describe("adminEventNewPage image section", () => {
+        test("shows image upload field on create form when storage enabled", () => {
+          const html = adminEventNewPage([], TEST_SESSION);
+          expect(html).toContain('type="file"');
+          expect(html).toContain('name="image"');
+          expect(html).toContain("multipart/form-data");
+        });
+
+        test("does not show image field on create form when storage is not enabled", () => {
+          const restore = setTestEnv({
+            STORAGE_ZONE_NAME: undefined,
+            STORAGE_ZONE_KEY: undefined,
+          });
+          const html = adminEventNewPage([], TEST_SESSION);
+          expect(html).not.toContain('type="file"');
+          restore();
+        });
+      });
+    },
+  );
 
   describe("adminQuestionsPage", () => {
     test("renders empty state when no questions", () => {

--- a/test/lib/owner-footer.test.ts
+++ b/test/lib/owner-footer.test.ts
@@ -1,29 +1,19 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import {
   adminGet,
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestEvent,
   createTestManagerSession,
+  describeWithEnv,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
 
-describe("admin debug footer", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("admin debug footer", { db: true }, () => {
 
   test("owner sees footer on admin dashboard", async () => {
     const { response } = await adminGet("/admin/");

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import {
   answersTable,
@@ -19,7 +19,7 @@ import {
   setEventQuestions,
   swapAnswerOrder,
 } from "#lib/db/questions.ts";
-import { createTestDbWithSetup, createTestEvent, resetDb } from "#test-utils";
+import { createTestEvent, describeWithEnv } from "#test-utils";
 
 /** Create a test attendee directly via the DB (bypasses routes) */
 const createAttendee = async (eventId: number, name = "Alice") => {
@@ -33,14 +33,7 @@ const createAttendee = async (eventId: number, name = "Alice") => {
   return result.attendee;
 };
 
-describe("custom questions", () => {
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("custom questions", { db: true }, () => {
 
   describe("questions CRUD", () => {
     test("creates and retrieves a question", async () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
 import { setPaymentProvider, updateSquareSandbox } from "#lib/db/settings.ts";
@@ -18,8 +18,8 @@ import {
 } from "#routes/utils.ts";
 import {
   createTestDb,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectFlash,
   expectHtmlResponse,
   expectRedirect,
@@ -29,20 +29,11 @@ import {
   mockRequest,
   mockRequestWithHost,
   resetDb,
-  resetTestSlugCounter,
   testCookie,
   withExpectedError,
 } from "#test-utils";
 
-describe("server (misc)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("server (misc)", { db: true }, () => {
 
   /** Create an embeddable test event and return its ticket page response */
   const getTicketPageResponse = getEmbeddableTicketResponse;

--- a/test/lib/server-questions.test.ts
+++ b/test/lib/server-questions.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 
 import { handleRequest } from "#routes";
@@ -7,9 +7,9 @@ import {
   adminFormPost,
   adminGet,
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestEvent,
   createTestManagerSession,
+  describeWithEnv,
   expectAdminRedirect,
   expectFlash,
   expectHtmlResponse,
@@ -17,8 +17,6 @@ import {
   expectStatus,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -52,15 +50,7 @@ const addAnswer = async (questionId: number, text: string): Promise<number> => {
   return found!.id;
 };
 
-describe("server (admin questions)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("server (admin questions)", { db: true }, () => {
 
   describe("GET /admin/questions", () => {
     test("redirects to login when not authenticated", async () => {

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { getSessionCookieName } from "#lib/cookies.ts";
@@ -14,7 +14,6 @@ import { setDemoModeForTest } from "#lib/demo.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
   describeWithEnv,
   expectAdminRedirect,
   expectFlash,
@@ -25,8 +24,6 @@ import {
   mockFormRequest,
   mockRequest,
   mockRequestWithHost,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   setupEventAndLogin,
   testCookie,
@@ -34,15 +31,9 @@ import {
   withMocks,
 } from "#test-utils";
 
-describe("server (admin settings-advanced)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
+describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
   afterEach(() => {
     setDemoModeForTest(false);
-    resetDb();
   });
 
   describe("GET /admin/settings-advanced", () => {

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -17,8 +17,8 @@ import { stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
-  createTestDbWithSetup,
   createTestEvent,
+  describeWithEnv,
   expectAdminRedirect,
   expectFlash,
   expectHtmlResponse,
@@ -31,8 +31,6 @@ import {
   mockAdminLoginRequest,
   mockFormRequest,
   mockRequest,
-  resetDb,
-  resetTestSlugCounter,
   setTestEnv,
   TEST_ADMIN_PASSWORD,
   testCookie,
@@ -41,15 +39,9 @@ import {
   withMocks,
 } from "#test-utils";
 
-describe("server (admin settings)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
+describeWithEnv("server (admin settings)", { db: true }, () => {
   afterEach(() => {
     setDemoModeForTest(false);
-    resetDb();
   });
 
   describe("GET /admin/settings", () => {

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
   createTestDb,
-  createTestDbWithSetup,
+  describeWithEnv,
   expectHtmlResponse,
   expectRedirect,
   getSetupCsrfToken,
@@ -13,20 +13,11 @@ import {
   mockRequest,
   mockSetupFormRequest,
   resetDb,
-  resetTestSlugCounter,
   withExpectedError,
   withMocks,
 } from "#test-utils";
 
-describe("server (setup)", () => {
-  beforeEach(async () => {
-    resetTestSlugCounter();
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("server (setup)", { db: true }, () => {
 
   /** Get CSRF token from setup page and submit setup form with given fields */
   async function submitSetupForm(

--- a/test/lib/sort-events.test.ts
+++ b/test/lib/sort-events.test.ts
@@ -1,16 +1,10 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { addDays } from "#lib/dates.ts";
-import { setTimezoneForTest } from "#lib/db/settings.ts";
 import { sortEvents } from "#lib/sort-events.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import type { EventWithCount, Holiday } from "#lib/types.ts";
-import {
-  createTestDbWithSetup,
-  resetDb,
-  testEvent,
-  testEventWithCount,
-} from "#test-utils";
+import { describeWithEnv, testEvent, testEventWithCount } from "#test-utils";
 
 const today = () => todayInTz("UTC");
 
@@ -25,15 +19,7 @@ const expectAlphaBeforeBravo = (
   expect(sorted[1]!.name).toBe("Bravo");
 };
 
-describe("sortEvents", () => {
-  beforeEach(async () => {
-    await createTestDbWithSetup();
-    setTimezoneForTest("UTC");
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("sortEvents", { db: true }, () => {
 
   test("returns empty array for empty input", () => {
     expect(sortEvents([], [])).toEqual([]);

--- a/test/lib/svg-ticket.test.ts
+++ b/test/lib/svg-ticket.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { setCurrencyCodeForTest } from "#lib/currency.ts";
+import { describe, it as test } from "@std/testing/bdd";
 import {
   buildInfoLines,
   extractSvgContent,
@@ -8,7 +7,7 @@ import {
   generateSvgTicket,
   type SvgTicketData,
 } from "#lib/svg-ticket.ts";
-import { createTestDbWithSetup, resetDb } from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
 const makeTicketData = (
   overrides: Partial<SvgTicketData> = {},
@@ -24,15 +23,7 @@ const makeTicketData = (
   ...overrides,
 });
 
-describe("svg-ticket", () => {
-  beforeEach(async () => {
-    setCurrencyCodeForTest("GBP");
-    await createTestDbWithSetup();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
+describeWithEnv("svg-ticket", { db: true }, () => {
 
   describe("extractSvgContent", () => {
     test("extracts inner content from svg element", () => {

--- a/test/lib/theme.test.ts
+++ b/test/lib/theme.test.ts
@@ -7,11 +7,7 @@ import {
   resetTheme,
   setThemeForTest,
 } from "#lib/theme.ts";
-import {
-  createTestDbWithSetup,
-  resetDb,
-  setupTestEncryptionKey,
-} from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
 describe("theme", () => {
   afterEach(() => {
@@ -37,15 +33,9 @@ describe("theme", () => {
     });
   });
 
-  describe("loadTheme", () => {
-    beforeEach(async () => {
-      setupTestEncryptionKey();
-      await createTestDbWithSetup();
+  describeWithEnv("loadTheme", { db: true }, () => {
+    beforeEach(() => {
       resetTheme();
-    });
-
-    afterEach(() => {
-      resetDb();
     });
 
     test("loads light theme from database by default", async () => {


### PR DESCRIPTION
## Summary

- Replaces manual `describe` + `beforeEach(createTestDbWithSetup)` + `afterEach(resetDb)` patterns with `describeWithEnv({ db: true })` across 18 test files
- Prevents `TEST_RSA_KEY_SIZE` env var leaks — `describeWithEnv({ db: true })` consistently calls `setupTestEncryptionKey()` which sets `TEST_RSA_KEY_SIZE=1024`, `TEST_PBKDF2_ITERATIONS=1`, and `TEST_SKIP_LOGIN_DELAY=1`
- Removes redundant setup calls (`resetTestSlugCounter`, `setTimezoneForTest("UTC")`, `setCurrencyCodeForTest("GBP")`, `setupTestEncryptionKey`) that `createTestDbWithSetup` already handles
- Cleans up unused imports (`beforeEach`, `afterEach`, `resetDb`, `createTestDbWithSetup`, etc.)
- Net reduction: -145 lines (274 added, 419 removed)

## Files changed

`server-settings-advanced`, `server-settings`, `server-setup`, `server-misc`, `server-questions`, `email`, `header-image`, `bunny-cdn`, `business-email`, `questions`, `api-keys`, `admin-api-events`, `owner-footer`, `sort-events`, `dates`, `svg-ticket`, `theme`, `config` (formatting only), `html` (auto-formatted by linter)

## Test plan

- [x] All 154 tests pass (5199 steps)
- [x] Lint passes clean
- [ ] Verify no `TEST_RSA_KEY_SIZE` leaks in CI

https://claude.ai/code/session_01SAvwa73ibQBEHF3PA9LVhf