### PR TITLE
Refactor settings API: namespace object replaces individual exports

### DIFF
--- a/src/lib/booking-fee.ts
+++ b/src/lib/booking-fee.ts
@@ -15,10 +15,8 @@ export const calculateBookingFee = (
 };
 
 /** Look up the configured booking fee percentage and calculate the fee for a subtotal. */
-export const getBookingFeeAmount = async (
-  subtotalMinorUnits: number,
-): Promise<number> =>
-  calculateBookingFee(subtotalMinorUnits, await getBookingFee());
+export const getBookingFeeAmount = (subtotalMinorUnits: number): number =>
+  calculateBookingFee(subtotalMinorUnits, getBookingFee());
 
 /** Calculate cart subtotal from items with unitPrice and quantity. */
 export const itemsSubtotal = (

--- a/src/lib/booking.ts
+++ b/src/lib/booking.ts
@@ -40,7 +40,7 @@ export const processBooking = async (
   customUnitPrice?: number,
   answerIds?: number[],
 ): Promise<BookingResult> => {
-  const paymentsEnabled = await isPaymentsEnabled();
+  const paymentsEnabled = isPaymentsEnabled();
   const needsPayment =
     (paymentsEnabled && event.unit_price > 0) ||
     (customUnitPrice !== undefined && customUnitPrice > 0 && paymentsEnabled);
@@ -80,10 +80,6 @@ export const processBooking = async (
   if (!result.success)
     return { type: "creation_failed", reason: result.reason };
 
-  await logAndNotifyRegistration(
-    event,
-    result.attendee,
-    await getCurrencyCode(),
-  );
+  await logAndNotifyRegistration(event, result.attendee, getCurrencyCode());
   return { type: "success", attendee: result.attendee };
 };

--- a/src/lib/business-email.ts
+++ b/src/lib/business-email.ts
@@ -1,11 +1,6 @@
 import { decrypt, encrypt } from "#lib/crypto.ts";
 import { getDb } from "#lib/db/client.ts";
-import {
-  CONFIG_KEYS,
-  getSetting,
-  invalidateSettingsCache,
-  setSetting,
-} from "#lib/db/settings.ts";
+import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
 
 /**
  * Validates a basic email format: something@something.something
@@ -31,7 +26,7 @@ export function normalizeBusinessEmail(email: string): string {
  * Returns decrypted email or empty string if not set.
  */
 export async function getBusinessEmailFromDb(): Promise<string> {
-  const value = await getSetting(CONFIG_KEYS.BUSINESS_EMAIL);
+  const value = await settings.get(CONFIG_KEYS.BUSINESS_EMAIL);
   if (!value) return "";
   return decrypt(value);
 }
@@ -48,7 +43,7 @@ export async function updateBusinessEmail(email: string): Promise<void> {
       sql: "DELETE FROM settings WHERE key = ?",
       args: [CONFIG_KEYS.BUSINESS_EMAIL],
     });
-    invalidateSettingsCache();
+    settings.invalidateCache();
     return;
   }
 
@@ -59,5 +54,5 @@ export async function updateBusinessEmail(email: string): Promise<void> {
   }
 
   const encrypted = await encrypt(normalized);
-  await setSetting(CONFIG_KEYS.BUSINESS_EMAIL, encrypted);
+  await settings.set(CONFIG_KEYS.BUSINESS_EMAIL, encrypted);
 }

--- a/src/lib/business-email.ts
+++ b/src/lib/business-email.ts
@@ -1,6 +1,4 @@
-import { decrypt, encrypt } from "#lib/crypto.ts";
-import { getDb } from "#lib/db/client.ts";
-import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 
 /**
  * Validates a basic email format: something@something.something
@@ -22,28 +20,21 @@ export function normalizeBusinessEmail(email: string): string {
 }
 
 /**
- * Gets the business email from the database (uses settings cache).
+ * Gets the business email from the snapshot (sync after loadAll).
  * Returns decrypted email or empty string if not set.
  */
-export async function getBusinessEmailFromDb(): Promise<string> {
-  const value = await settings.get(CONFIG_KEYS.BUSINESS_EMAIL);
-  if (!value) return "";
-  return decrypt(value);
+export function getBusinessEmailFromDb(): string {
+  return settings.businessEmail ?? "";
 }
 
 /**
- * Updates the business email in the database and invalidates the settings cache.
+ * Updates the business email in the database.
  * Pass empty string to clear the business email.
  * Email is encrypted at rest.
  */
 export async function updateBusinessEmail(email: string): Promise<void> {
-  // Empty string = clear the setting
   if (email.trim() === "") {
-    await getDb().execute({
-      sql: "DELETE FROM settings WHERE key = ?",
-      args: [CONFIG_KEYS.BUSINESS_EMAIL],
-    });
-    settings.invalidateCache();
+    await settings.update.businessEmail("");
     return;
   }
 
@@ -53,6 +44,5 @@ export async function updateBusinessEmail(email: string): Promise<void> {
     throw new Error("Invalid business email format");
   }
 
-  const encrypted = await encrypt(normalized);
-  await settings.set(CONFIG_KEYS.BUSINESS_EMAIL, encrypted);
+  await settings.update.businessEmail(normalized);
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,28 +13,27 @@ import type { PaymentProviderType } from "#lib/payments.ts";
  * Get the configured payment provider type
  * Returns null if no provider is configured
  */
-export const getPaymentProvider =
-  async (): Promise<PaymentProviderType | null> => {
-    const provider = await settings.paymentProvider.get();
-    if (provider === "stripe") return "stripe";
-    if (provider === "square") return "square";
-    return null;
-  };
+export const getPaymentProvider = (): PaymentProviderType | null => {
+  const provider = settings.paymentProvider;
+  if (provider === "stripe") return "stripe";
+  if (provider === "square") return "square";
+  return null;
+};
 
 /**
  * Get Stripe secret key from database (encrypted)
  * Returns null if not configured (payments disabled)
  */
-export const getStripeSecretKey = (): Promise<string | null> => {
-  return settings.stripe.secretKey.get();
+export const getStripeSecretKey = (): string | null => {
+  return settings.stripe.secretKey;
 };
 
 /**
  * Get Stripe webhook signing secret from database (encrypted)
  * Automatically configured when Stripe secret key is saved
  */
-export const getStripeWebhookSecret = (): Promise<string | null> => {
-  return settings.stripe.webhookSecret.get();
+export const getStripeWebhookSecret = (): string | null => {
+  return settings.stripe.webhookSecret;
 };
 
 /** Stubbable API for internal calls (testable via spyOn, like stripeApi/squareApi) */
@@ -45,10 +44,10 @@ export const configApi = {
 /**
  * Check if payments are enabled (any provider configured with valid keys)
  */
-export const isPaymentsEnabled = async (): Promise<boolean> => {
-  const provider = await configApi.getPaymentProvider();
-  if (provider === "stripe") return settings.stripe.secretKey.has();
-  if (provider === "square") return settings.square.accessToken.has();
+export const isPaymentsEnabled = (): boolean => {
+  const provider = configApi.getPaymentProvider();
+  if (provider === "stripe") return settings.stripe.hasKey;
+  if (provider === "square") return settings.square.hasToken;
   return false;
 };
 
@@ -56,43 +55,42 @@ export const isPaymentsEnabled = async (): Promise<boolean> => {
  * Get Square access token from database (encrypted)
  * Returns null if not configured
  */
-export const getSquareAccessToken = (): Promise<string | null> =>
-  settings.square.accessToken.get();
+export const getSquareAccessToken = (): string | null =>
+  settings.square.accessToken;
 
 /**
  * Get Square webhook signature key from database (encrypted)
  * Returns null if not configured
  */
-export const getSquareWebhookSignatureKey = (): Promise<string | null> =>
-  settings.square.webhookSignatureKey.get();
+export const getSquareWebhookSignatureKey = (): string | null =>
+  settings.square.webhookSignatureKey;
 
 /**
  * Get Square location ID from database
  * Returns null if not configured
  */
-export const getSquareLocationId = (): Promise<string | null> =>
-  settings.square.locationId.get();
+export const getSquareLocationId = (): string | null =>
+  settings.square.locationId;
 
 /**
  * Get Square sandbox mode setting from database
  * Returns true if sandbox mode is enabled
  */
-export const getSquareSandbox = (): Promise<boolean> =>
-  settings.square.sandbox.get();
+export const getSquareSandbox = (): boolean => settings.square.sandbox;
 
 /**
  * Get booking fee percentage from database.
  * Returns 0 if not set.
  */
-export const getBookingFee = async (): Promise<number> =>
-  Number.parseFloat((await settings.bookingFee.get())!) || 0;
+export const getBookingFee = (): number =>
+  Number.parseFloat(settings.bookingFee!) || 0;
 
 /**
  * Get currency code from database
  * Defaults to GBP if not set
  */
-export const getCurrencyCode = (): Promise<string> => {
-  return settings.currency.get();
+export const getCurrencyCode = (): string => {
+  return settings.currency;
 };
 
 /**
@@ -124,11 +122,9 @@ export const setAllowedDomainForTest = (domain: string): void =>
 const effectiveDomainState = { domain: null as string | null };
 
 /** Load the effective domain from DB (call early in request pipeline). */
-export const loadEffectiveDomain = async (): Promise<string> => {
-  const custom = await settings.customDomain.get();
-  const validated = custom
-    ? await settings.customDomain.lastValidated.get()
-    : null;
+export const loadEffectiveDomain = (): string => {
+  const custom = settings.customDomain;
+  const validated = custom ? settings.customDomainLastValidated : null;
   effectiveDomainState.domain =
     custom && validated ? custom : getAllowedDomain();
   return effectiveDomainState.domain;
@@ -153,7 +149,7 @@ export const setEffectiveDomainForTest = (domain: string): void => {
  * Returns empty array if not configured (embedding allowed from anywhere)
  */
 export const getEmbedHosts = async (): Promise<string[]> => {
-  const raw = await settings.embedHosts.get();
+  const raw = settings.embedHosts;
   if (!raw) return [];
   const { parseEmbedHosts } = await import("#lib/embed-hosts.ts");
   return parseEmbedHosts(raw);
@@ -164,7 +160,7 @@ export const getEmbedHosts = async (): Promise<string[]> => {
  * Safe to call from synchronous code (templates, helpers) because
  * the settings cache is populated by middleware on every request.
  */
-export const getTz = (): string => settings.timezone.getCached();
+export const getTz = (): string => settings.timezone;
 
 /**
  * Check if initial setup has been completed

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,24 +5,7 @@
  */
 
 import { lazyRef } from "#fp";
-import {
-  getBookingFeeFromDb,
-  getCurrencyCodeFromDb,
-  getCustomDomainFromDb,
-  getCustomDomainLastValidatedFromDb,
-  getEmbedHostsFromDb,
-  getPaymentProviderFromDb,
-  getSquareAccessTokenFromDb,
-  getSquareLocationIdFromDb,
-  getSquareSandboxFromDb,
-  getSquareWebhookSignatureKeyFromDb,
-  getStripeSecretKeyFromDb,
-  getStripeWebhookSecretFromDb,
-  getTimezoneCached,
-  hasSquareToken,
-  hasStripeKey,
-  isSetupComplete,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { getEnv, requireEnv } from "#lib/env.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
 
@@ -32,7 +15,7 @@ import type { PaymentProviderType } from "#lib/payments.ts";
  */
 export const getPaymentProvider =
   async (): Promise<PaymentProviderType | null> => {
-    const provider = await getPaymentProviderFromDb();
+    const provider = await settings.paymentProvider.get();
     if (provider === "stripe") return "stripe";
     if (provider === "square") return "square";
     return null;
@@ -43,7 +26,7 @@ export const getPaymentProvider =
  * Returns null if not configured (payments disabled)
  */
 export const getStripeSecretKey = (): Promise<string | null> => {
-  return getStripeSecretKeyFromDb();
+  return settings.stripe.secretKey.get();
 };
 
 /**
@@ -51,7 +34,7 @@ export const getStripeSecretKey = (): Promise<string | null> => {
  * Automatically configured when Stripe secret key is saved
  */
 export const getStripeWebhookSecret = (): Promise<string | null> => {
-  return getStripeWebhookSecretFromDb();
+  return settings.stripe.webhookSecret.get();
 };
 
 /** Stubbable API for internal calls (testable via spyOn, like stripeApi/squareApi) */
@@ -64,8 +47,8 @@ export const configApi = {
  */
 export const isPaymentsEnabled = async (): Promise<boolean> => {
   const provider = await configApi.getPaymentProvider();
-  if (provider === "stripe") return hasStripeKey();
-  if (provider === "square") return hasSquareToken();
+  if (provider === "stripe") return settings.stripe.secretKey.has();
+  if (provider === "square") return settings.square.accessToken.has();
   return false;
 };
 
@@ -74,42 +57,42 @@ export const isPaymentsEnabled = async (): Promise<boolean> => {
  * Returns null if not configured
  */
 export const getSquareAccessToken = (): Promise<string | null> =>
-  getSquareAccessTokenFromDb();
+  settings.square.accessToken.get();
 
 /**
  * Get Square webhook signature key from database (encrypted)
  * Returns null if not configured
  */
 export const getSquareWebhookSignatureKey = (): Promise<string | null> =>
-  getSquareWebhookSignatureKeyFromDb();
+  settings.square.webhookSignatureKey.get();
 
 /**
  * Get Square location ID from database
  * Returns null if not configured
  */
 export const getSquareLocationId = (): Promise<string | null> =>
-  getSquareLocationIdFromDb();
+  settings.square.locationId.get();
 
 /**
  * Get Square sandbox mode setting from database
  * Returns true if sandbox mode is enabled
  */
 export const getSquareSandbox = (): Promise<boolean> =>
-  getSquareSandboxFromDb();
+  settings.square.sandbox.get();
 
 /**
  * Get booking fee percentage from database.
  * Returns 0 if not set.
  */
 export const getBookingFee = async (): Promise<number> =>
-  Number.parseFloat((await getBookingFeeFromDb())!) || 0;
+  Number.parseFloat((await settings.bookingFee.get())!) || 0;
 
 /**
  * Get currency code from database
  * Defaults to GBP if not set
  */
 export const getCurrencyCode = (): Promise<string> => {
-  return getCurrencyCodeFromDb();
+  return settings.currency.get();
 };
 
 /**
@@ -142,8 +125,10 @@ const effectiveDomainState = { domain: null as string | null };
 
 /** Load the effective domain from DB (call early in request pipeline). */
 export const loadEffectiveDomain = async (): Promise<string> => {
-  const custom = await getCustomDomainFromDb();
-  const validated = custom ? await getCustomDomainLastValidatedFromDb() : null;
+  const custom = await settings.customDomain.get();
+  const validated = custom
+    ? await settings.customDomain.lastValidated.get()
+    : null;
   effectiveDomainState.domain =
     custom && validated ? custom : getAllowedDomain();
   return effectiveDomainState.domain;
@@ -168,7 +153,7 @@ export const setEffectiveDomainForTest = (domain: string): void => {
  * Returns empty array if not configured (embedding allowed from anywhere)
  */
 export const getEmbedHosts = async (): Promise<string[]> => {
-  const raw = await getEmbedHostsFromDb();
+  const raw = await settings.embedHosts.get();
   if (!raw) return [];
   const { parseEmbedHosts } = await import("#lib/embed-hosts.ts");
   return parseEmbedHosts(raw);
@@ -179,12 +164,12 @@ export const getEmbedHosts = async (): Promise<string[]> => {
  * Safe to call from synchronous code (templates, helpers) because
  * the settings cache is populated by middleware on every request.
  */
-export const getTz = (): string => getTimezoneCached();
+export const getTz = (): string => settings.timezone.getCached();
 
 /**
  * Check if initial setup has been completed
  */
-export { isSetupComplete };
+export const isSetupComplete = settings.setup.isComplete;
 
 /**
  * Check if Bunny CDN pull zone management is enabled

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -17,8 +17,8 @@ const state = { code: "GBP" };
  * Called once per request in routes/index.ts before templates render.
  * Settings are already cached so this is cheap on repeat calls.
  */
-export const loadCurrencyCode = async (): Promise<string> => {
-  state.code = await getCurrencyCode();
+export const loadCurrencyCode = (): string => {
+  state.code = getCurrencyCode();
   return state.code;
 };
 

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -224,7 +224,7 @@ const contactFields = ({
 const encryptAttendeeFields = async (
   input: EncryptInput,
 ): Promise<EncryptedAttendeeData | null> => {
-  const publicKeyJwk = await settings.publicKey.get();
+  const publicKeyJwk = settings.publicKey;
   if (!publicKeyJwk) return null;
 
   const ticketToken = generateTicketToken();
@@ -683,7 +683,7 @@ export const updateAttendee = async (
   attendeeId: number,
   input: UpdateAttendeeInput,
 ): Promise<void> => {
-  const publicKeyJwk = (await settings.publicKey.get())!;
+  const publicKeyJwk = settings.publicKey!;
   const encryptedPiiBlob = await encryptPiiBlob(
     buildPiiBlob({
       ...input,
@@ -734,7 +734,7 @@ export const migrateAttendeeBatch = async (
     return { migrated: 0, remaining: remaining[0]!.count };
   }
 
-  const publicKeyJwk = (await settings.publicKey.get())!;
+  const publicKeyJwk = settings.publicKey!;
 
   // Process each row: decrypt old fields, build blob, prepare update
   for (const row of rows) {

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -22,7 +22,7 @@ import {
   queryOne,
 } from "#lib/db/client.ts";
 import { getEventWithCount, invalidateEventsCache } from "#lib/db/events.ts";
-import { getPublicKey } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { nowIso } from "#lib/now.ts";
 import type {
   Attendee,
@@ -224,7 +224,7 @@ const contactFields = ({
 const encryptAttendeeFields = async (
   input: EncryptInput,
 ): Promise<EncryptedAttendeeData | null> => {
-  const publicKeyJwk = await getPublicKey();
+  const publicKeyJwk = await settings.publicKey.get();
   if (!publicKeyJwk) return null;
 
   const ticketToken = generateTicketToken();
@@ -683,7 +683,7 @@ export const updateAttendee = async (
   attendeeId: number,
   input: UpdateAttendeeInput,
 ): Promise<void> => {
-  const publicKeyJwk = (await getPublicKey())!;
+  const publicKeyJwk = (await settings.publicKey.get())!;
   const encryptedPiiBlob = await encryptPiiBlob(
     buildPiiBlob({
       ...input,
@@ -730,7 +730,7 @@ export const migrateAttendeeBatch = async (
     return { migrated: 0, remaining: remaining[0]!.count };
   }
 
-  const publicKeyJwk = (await getPublicKey())!;
+  const publicKeyJwk = (await settings.publicKey.get())!;
 
   // Process each row: decrypt old fields, build blob, prepare update
   for (const row of rows) {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -74,7 +74,7 @@ const backfillHybridEncryptedColumn = async (
   column: string,
   whereClause: string,
 ): Promise<void> => {
-  const publicKey = await settings.publicKey.get();
+  const publicKey = settings.publicKey;
   if (!publicKey) return;
   await backfillColumn(
     table,
@@ -306,7 +306,7 @@ export const initDb = async (): Promise<void> => {
     `ALTER TABLE attendees ADD COLUMN checked_in TEXT NOT NULL DEFAULT ''`,
   );
   // Backfill existing attendees with encrypted "false" if public key is available
-  const publicKey = await settings.publicKey.get();
+  const publicKey = settings.publicKey;
   if (publicKey) {
     const encryptedFalse = await encryptAttendeePII("false", publicKey);
     await getDb().execute({
@@ -343,8 +343,8 @@ export const initDb = async (): Promise<void> => {
   // Migration: migrate existing single-admin credentials to users table
   // For pre-multi-user installations, admin_password and wrapped_data_key are in settings
   {
-    const existingPasswordHash = await settings.get("admin_password");
-    const existingWrappedDataKey = await settings.get("wrapped_data_key");
+    const existingPasswordHash = settings.getCachedRaw("admin_password");
+    const existingWrappedDataKey = settings.getCachedRaw("wrapped_data_key");
     const userCountRows = await queryAll<{ count: number }>(
       "SELECT COUNT(*) as count FROM users",
     );
@@ -492,7 +492,7 @@ export const initDb = async (): Promise<void> => {
 
   // Backfill: encrypt existing plaintext ticket_token values and generate HMAC indexes
   {
-    const pubKey = await settings.publicKey.get();
+    const pubKey = settings.publicKey;
     if (pubKey) {
       // Get all attendees that need migration (those with plaintext tokens or missing index)
       const attendees = await queryAll<{ id: number; ticket_token: string }>(

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -10,7 +10,7 @@ import {
   hmacHash,
 } from "#lib/crypto.ts";
 import { getDb, queryAll } from "#lib/db/client.ts";
-import { getPublicKey, getSetting } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 
 /**
  * The latest database update identifier - update this when changing schema
@@ -74,7 +74,7 @@ const backfillHybridEncryptedColumn = async (
   column: string,
   whereClause: string,
 ): Promise<void> => {
-  const publicKey = await getPublicKey();
+  const publicKey = await settings.publicKey.get();
   if (!publicKey) return;
   await backfillColumn(
     table,
@@ -306,7 +306,7 @@ export const initDb = async (): Promise<void> => {
     `ALTER TABLE attendees ADD COLUMN checked_in TEXT NOT NULL DEFAULT ''`,
   );
   // Backfill existing attendees with encrypted "false" if public key is available
-  const publicKey = await getPublicKey();
+  const publicKey = await settings.publicKey.get();
   if (publicKey) {
     const encryptedFalse = await encryptAttendeePII("false", publicKey);
     await getDb().execute({
@@ -343,8 +343,8 @@ export const initDb = async (): Promise<void> => {
   // Migration: migrate existing single-admin credentials to users table
   // For pre-multi-user installations, admin_password and wrapped_data_key are in settings
   {
-    const existingPasswordHash = await getSetting("admin_password");
-    const existingWrappedDataKey = await getSetting("wrapped_data_key");
+    const existingPasswordHash = await settings.get("admin_password");
+    const existingWrappedDataKey = await settings.get("wrapped_data_key");
     const userCountRows = await queryAll<{ count: number }>(
       "SELECT COUNT(*) as count FROM users",
     );
@@ -492,7 +492,7 @@ export const initDb = async (): Promise<void> => {
 
   // Backfill: encrypt existing plaintext ticket_token values and generate HMAC indexes
   {
-    const pubKey = await getPublicKey();
+    const pubKey = await settings.publicKey.get();
     if (pubKey) {
       // Get all attendees that need migration (those with plaintext tokens or missing index)
       const attendees = await queryAll<{ id: number; ticket_token: string }>(

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -1,5 +1,17 @@
 /**
- * Settings table operations
+ * Settings — sync reads, async writes.
+ *
+ * Call `settings.loadAll()` once per request to populate the snapshot.
+ * After that, every setting is a plain sync property:
+ *
+ *   settings.theme            // "light"
+ *   settings.headerImageUrl   // string | null
+ *   settings.stripe.secretKey // string | null
+ *
+ * Writes go through `settings.update.*`:
+ *
+ *   await settings.update.theme("dark");
+ *   await settings.update.headerImageUrl(url);
  */
 
 import { lazyRef } from "#fp";
@@ -26,735 +38,85 @@ import { nowMs } from "#lib/now.ts";
 import { DEFAULT_TIMEZONE } from "#lib/timezone.ts";
 import type { PaymentProviderType, Settings, Theme } from "#lib/types.ts";
 
-/**
- * Setting keys for configuration
- */
+// ---------------------------------------------------------------------------
+// Setting keys
+// ---------------------------------------------------------------------------
+
 export const CONFIG_KEYS = {
   COUNTRY: "country",
   SETUP_COMPLETE: "setup_complete",
-  // Encryption key hierarchy
   WRAPPED_PRIVATE_KEY: "wrapped_private_key",
   PUBLIC_KEY: "public_key",
-  // Payment provider selection
   PAYMENT_PROVIDER: "payment_provider",
-  // Stripe configuration (encrypted)
   STRIPE_SECRET_KEY: "stripe_secret_key",
   STRIPE_WEBHOOK_SECRET: "stripe_webhook_secret",
   STRIPE_WEBHOOK_ENDPOINT_ID: "stripe_webhook_endpoint_id",
-  // Square configuration (encrypted)
   SQUARE_ACCESS_TOKEN: "square_access_token",
   SQUARE_WEBHOOK_SIGNATURE_KEY: "square_webhook_signature_key",
   SQUARE_LOCATION_ID: "square_location_id",
   SQUARE_SANDBOX: "square_sandbox",
-  // Embed host restrictions (encrypted)
   EMBED_HOSTS: "embed_hosts",
-  // Terms and conditions (plaintext - displayed publicly)
   TERMS_AND_CONDITIONS: "terms_and_conditions",
-  // Business email (encrypted)
   BUSINESS_EMAIL: "business_email",
-  // Theme setting (plaintext - light or dark)
   THEME: "theme",
-  // Show public site (plaintext - "true" or "false")
   SHOW_PUBLIC_SITE: "show_public_site",
-  // Website title (encrypted - shown on public site)
   WEBSITE_TITLE: "website_title",
-  // Homepage text (encrypted - shown on public site homepage)
   HOMEPAGE_TEXT: "homepage_text",
-  // Contact page text (encrypted - shown on public site contact page)
   CONTACT_PAGE_TEXT: "contact_page_text",
-  // Header image (encrypted - Bunny CDN filename)
   HEADER_IMAGE_URL: "header_image_url",
-  // Show public API (plaintext - "true" or "false")
   SHOW_PUBLIC_API: "show_public_api",
-  // Email provider (plaintext - "resend" | "postmark" | "sendgrid" | "")
   EMAIL_PROVIDER: "email_provider",
-  // Email API key (encrypted)
   EMAIL_API_KEY: "email_api_key",
-  // Email from address (encrypted - verified sender address)
   EMAIL_FROM_ADDRESS: "email_from_address",
-  // Custom email templates (encrypted - may contain PII in Liquid syntax)
   EMAIL_TPL_CONFIRMATION_SUBJECT: "email_tpl_confirmation_subject",
   EMAIL_TPL_CONFIRMATION_HTML: "email_tpl_confirmation_html",
   EMAIL_TPL_CONFIRMATION_TEXT: "email_tpl_confirmation_text",
   EMAIL_TPL_ADMIN_SUBJECT: "email_tpl_admin_subject",
   EMAIL_TPL_ADMIN_HTML: "email_tpl_admin_html",
   EMAIL_TPL_ADMIN_TEXT: "email_tpl_admin_text",
-  // Custom domain (plaintext - user-configured custom domain for Bunny CDN pull zone)
   CUSTOM_DOMAIN: "custom_domain",
-  // Custom domain last validated timestamp (plaintext - ISO 8601 UTC)
   CUSTOM_DOMAIN_LAST_VALIDATED: "custom_domain_last_validated",
-  // Booking fee percentage (plaintext - "0" to "10", e.g. "1.5" for 1.5%)
   BOOKING_FEE: "booking_fee",
-  // Apple Wallet configuration
   APPLE_WALLET_PASS_TYPE_ID: "apple_wallet_pass_type_id",
   APPLE_WALLET_TEAM_ID: "apple_wallet_team_id",
   APPLE_WALLET_SIGNING_CERT: "apple_wallet_signing_cert",
   APPLE_WALLET_SIGNING_KEY: "apple_wallet_signing_key",
   APPLE_WALLET_WWDR_CERT: "apple_wallet_wwdr_cert",
-  // Google Wallet configuration
   GOOGLE_WALLET_ISSUER_ID: "google_wallet_issuer_id",
   GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: "google_wallet_service_account_email",
   GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: "google_wallet_service_account_key",
-  // Attendee blob migration (plaintext ISO timestamp when complete, empty = not migrated)
   ATTENDEE_BLOB_MIGRATED: "attendee_blob_migrated",
 } as const;
 
-/**
- * Sentinel value rendered in password fields for configured secrets.
- * The actual secret is never sent to the browser — only this placeholder.
- * On form submission, if the value equals the sentinel, the update is skipped.
- */
 export const MASK_SENTINEL = "••••••••";
-
-/** Check whether a submitted form value is the mask sentinel (i.e. unchanged) */
 export const isMaskSentinel = (value: string): boolean =>
   value === MASK_SENTINEL;
 
-/**
- * In-memory settings cache. Loads all rows in a single query and
- * serves subsequent reads from memory until the TTL expires or a
- * write invalidates the cache.
- */
+// ---------------------------------------------------------------------------
+// Raw cache — stores DB rows in memory (60 s TTL)
+// ---------------------------------------------------------------------------
+
 export const SETTINGS_CACHE_TTL_MS = 60_000;
 
-/**
- * Decrypted page content cache. Pages like homepage, contact, terms
- * and website title change very rarely, so we cache the decrypted
- * values for 30 minutes per edge instance, avoiding repeated
- * AES-GCM decryption and DB round-trips on every public page view.
- * Invalidated immediately when content is saved via admin routes.
- */
-const PAGE_CACHE_TTL_MS = 30 * 60 * 1_000;
-
-type PageCacheEntry = { value: string | null; time: number };
-
-const [getPageCacheMap, setPageCacheMap] = lazyRef<Map<string, PageCacheEntry>>(
-  () => new Map(),
-);
-
-const getPageCacheEntry = (key: string): string | null | undefined => {
-  const entry = getPageCacheMap().get(key);
-  if (!entry) return undefined;
-  if (nowMs() - entry.time >= PAGE_CACHE_TTL_MS) {
-    getPageCacheMap().delete(key);
-    return undefined;
-  }
-  return entry.value;
-};
-
-const setPageCacheEntry = (key: string, value: string | null): void => {
-  getPageCacheMap().set(key, { value, time: nowMs() });
-};
-
-const invalidatePageCacheEntry = (key: string): void => {
-  getPageCacheMap().delete(key);
-};
-
-/** Clear the entire page content cache (for testing or after bulk changes). */
-const invalidatePageCache = (): void => {
-  setPageCacheMap(null);
-};
-
-type SettingsCacheState = {
-  entries: Map<string, string> | null;
-  time: number;
-};
-
-const [getSettingsCacheState, setSettingsCacheState] =
-  lazyRef<SettingsCacheState>(() => ({ entries: null, time: 0 }));
-
-const isCacheValid = (): boolean => {
-  const state = getSettingsCacheState();
-  return state.entries !== null && nowMs() - state.time < SETTINGS_CACHE_TTL_MS;
-};
-
-const settingsCacheSize = (): number => {
-  const { entries } = getSettingsCacheState();
-  return entries ? entries.size : 0;
-};
-
-registerCache(() => ({ name: "settings", entries: settingsCacheSize() }));
-
-registerCache(() => ({
-  name: "pageContent",
-  entries: getPageCacheMap().size,
+type CacheState = { entries: Map<string, string> | null; time: number };
+const [getCacheState, setCacheState] = lazyRef<CacheState>(() => ({
+  entries: null,
+  time: 0,
 }));
 
-/**
- * Load every setting row into the in-memory cache with a single query.
- */
-const loadAllSettings = async (): Promise<Map<string, string>> => {
-  const rows = await queryAll<Settings>("SELECT key, value FROM settings");
-  const cache = new Map<string, string>();
-  for (const row of rows) {
-    cache.set(row.key, row.value);
-  }
-  setSettingsCacheState({ entries: cache, time: nowMs() });
-  return cache;
+const isCacheValid = (): boolean => {
+  const s = getCacheState();
+  return s.entries !== null && nowMs() - s.time < SETTINGS_CACHE_TTL_MS;
 };
 
-/**
- * Invalidate the settings cache (for testing or after writes).
- * Also clears the permanent timezone cache since it derives from settings,
- * and the page content cache since it derives from encrypted settings.
- */
-const invalidateSettingsCache = (): void => {
-  setSettingsCacheState(null);
-  invalidateTimezoneCache();
-  invalidatePageCache();
-};
-
-/**
- * Get a setting value synchronously from the in-memory cache.
- * Returns null if the cache is not populated or the key is absent.
- * Safe to call from synchronous code because the settings cache is populated by middleware.
- */
-const getSettingCached = (key: string): string | null => {
-  const state = getSettingsCacheState();
-  return state.entries?.get(key) ?? null;
-};
-
-/**
- * Get a setting value. Reads from the in-memory cache, loading all
- * settings in one query on first access or after TTL expiry.
- */
-const getSetting = async (key: string): Promise<string | null> => {
-  const cache = isCacheValid()
-    ? getSettingsCacheState().entries!
-    : await loadAllSettings();
-  return cache.get(key) ?? null;
-};
-
-/**
- * Set a setting value. Invalidates the cache so the next read
- * will pick up the new value.
- */
-const setSetting = async (key: string, value: string): Promise<void> => {
-  await getDb().execute({
-    sql: "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
-    args: [key, value],
-  });
-  invalidateSettingsCache();
-};
-
-/** Get a boolean setting (stored as "true"/"false" string in DB). */
-const getBoolSetting = async (key: string): Promise<boolean> => {
-  const value = await getSetting(key);
-  return value === "true";
-};
-
-/** Set a boolean setting (stored as "true"/"false" string in DB). */
-const setBoolSetting = async (key: string, value: boolean): Promise<void> => {
-  await setSetting(key, value ? "true" : "false");
-};
-
-/**
- * Set a setting value, or delete it if value is empty.
- * Common pattern for optional text settings.
- */
-const setOrDeleteSetting = async (
-  key: string,
-  value: string,
-): Promise<void> => {
-  if (value === "") {
-    await getDb().execute({
-      sql: "DELETE FROM settings WHERE key = ?",
-      args: [key],
-    });
-    invalidateSettingsCache();
-    return;
-  }
-  await setSetting(key, value);
-};
+registerCache(() => ({
+  name: "settings",
+  entries: getCacheState().entries?.size ?? 0,
+}));
 
 // ---------------------------------------------------------------------------
-// Setting factories — generate typed get/update pairs from a config key
+// Snapshot — pre-resolved settings for sync access
 // ---------------------------------------------------------------------------
-
-/** Encrypted setting: get decrypts, update encrypts (empty string clears). */
-const encryptedSetting = (key: string) => ({
-  get: (): Promise<string | null> => getEncryptedSetting(key),
-  update: (value: string): Promise<void> => updateEncryptedSetting(key, value),
-});
-
-/** Plaintext setting: get returns defaultValue/null if unset, update clears on empty. */
-const textSetting = (key: string, defaultValue?: string) => ({
-  get: async (): Promise<string | null> =>
-    defaultValue !== undefined
-      ? ((await getSetting(key)) ?? defaultValue)
-      : getSetting(key),
-  update: (value: string): Promise<void> => setOrDeleteSetting(key, value),
-});
-
-/** Boolean setting stored as "true"/"false" string. */
-const booleanSetting = (key: string) => ({
-  get: (): Promise<boolean> => getBoolSetting(key),
-  update: (value: boolean): Promise<void> => setBoolSetting(key, value),
-});
-
-/** Encrypted setting with 30-minute page content cache. */
-const cachedEncryptedSetting = (key: string) => ({
-  get: (): Promise<string | null> => getCachedPageSetting(key),
-  update: async (text: string): Promise<void> => {
-    await updateEncryptedSetting(key, text);
-    invalidatePageCacheEntry(key);
-  },
-});
-
-/**
- * Cached setup complete status using lazyRef pattern.
- * Once setup is complete (true), it can never go back to false,
- * so we cache it permanently to avoid per-request DB queries.
- */
-const [getSetupCompleteCache, setSetupCompleteCache] = lazyRef<boolean>(
-  () => false,
-);
-
-/**
- * Track whether we've confirmed setup is complete
- */
-const [getSetupConfirmed, setSetupConfirmed] = lazyRef<boolean>(() => false);
-
-/**
- * Check if initial setup has been completed
- * Result is cached in memory - once true, we never query again.
- */
-const isSetupComplete = async (): Promise<boolean> => {
-  // Check both caches (avoid short-circuit to ensure consistent initialization)
-  const confirmed = getSetupConfirmed();
-  const cached = getSetupCompleteCache();
-  if (confirmed && cached) return true;
-
-  const isComplete = await getBoolSetting(CONFIG_KEYS.SETUP_COMPLETE);
-
-  // Only cache positive result (setup complete is permanent)
-  if (isComplete) {
-    setSetupCompleteCache(true);
-    setSetupConfirmed(true);
-  }
-
-  return isComplete;
-};
-
-/**
- * Clear setup complete cache (for testing)
- */
-const clearSetupCompleteCache = (): void => {
-  setSetupCompleteCache(null);
-  setSetupConfirmed(null);
-};
-
-/**
- * Complete initial setup by storing all configuration
- * Generates the encryption key hierarchy:
- * - DATA_KEY: random symmetric key for encrypting private key
- * - RSA key pair: public key encrypts attendee PII, private key decrypts
- * - KEK: derived from password hash + DB_ENCRYPTION_KEY, wraps DATA_KEY
- * Creates the first owner user row instead of storing credentials in settings.
- */
-const completeSetup = async (
-  username: string,
-  adminPassword: string,
-  country: string,
-): Promise<void> => {
-  // Hash the password
-  const hashedPassword = await hashPassword(adminPassword);
-
-  // Generate DATA_KEY (random symmetric key)
-  const dataKey = await generateDataKey();
-
-  // Generate RSA key pair for asymmetric encryption
-  const { publicKey, privateKey } = await generateKeyPair();
-
-  // Derive KEK from password hash + DB_ENCRYPTION_KEY
-  const kek = await deriveKEK(hashedPassword);
-
-  // Wrap DATA_KEY with KEK
-  const wrappedDataKey = await wrapKey(dataKey, kek);
-
-  // Create the owner user row with wrapped data key
-  await createUser(username, hashedPassword, wrappedDataKey, "owner");
-
-  // Encrypt private key with DATA_KEY
-  const encryptedPrivateKey = await encryptWithKey(privateKey, dataKey);
-  await setSetting(CONFIG_KEYS.WRAPPED_PRIVATE_KEY, encryptedPrivateKey);
-
-  // Store public key (plaintext - it's meant to be public)
-  await setSetting(CONFIG_KEYS.PUBLIC_KEY, publicKey);
-
-  await setSetting(CONFIG_KEYS.COUNTRY, country);
-  await setSetting(CONFIG_KEYS.SETUP_COMPLETE, "true");
-};
-
-/**
- * Get the configured country code from database.
- * Returns ISO 3166-1 alpha-2 code, defaulting to "GB".
- */
-const getCountryFromDb = async (): Promise<string> => {
-  const value = await getSetting(CONFIG_KEYS.COUNTRY);
-  return value || DEFAULT_COUNTRY;
-};
-
-/**
- * Update the configured country.
- */
-const updateCountry = async (country: string): Promise<void> => {
-  await setSetting(CONFIG_KEYS.COUNTRY, country);
-  // Also update timezone cache since it derives from country
-  const tz = getCountry(country).timezone;
-  setTzCache(tz);
-};
-
-/**
- * Get currency code derived from country setting.
- */
-const getCurrencyCodeFromDb = async (): Promise<string> => {
-  const country = await getCountryFromDb();
-  return getCountry(country).currency;
-};
-
-/**
- * Get the configured payment provider type
- * Returns null if no provider is configured
- */
-const getPaymentProviderFromDb = (): Promise<string | null> =>
-  getSetting(CONFIG_KEYS.PAYMENT_PROVIDER);
-
-/**
- * Set the active payment provider type
- */
-const setPaymentProvider = async (
-  provider: PaymentProviderType,
-): Promise<void> => {
-  await setSetting(CONFIG_KEYS.PAYMENT_PROVIDER, provider);
-};
-
-/**
- * Clear the active payment provider (disables payments)
- */
-const clearPaymentProvider = async (): Promise<void> => {
-  await getDb().execute({
-    sql: "DELETE FROM settings WHERE key = ?",
-    args: [CONFIG_KEYS.PAYMENT_PROVIDER],
-  });
-  invalidateSettingsCache();
-};
-
-/**
- * Check if a Stripe key has been configured in the database
- */
-const hasStripeKey = async (): Promise<boolean> => {
-  const value = await getSetting(CONFIG_KEYS.STRIPE_SECRET_KEY);
-  return value !== null;
-};
-
-const { get: getStripeSecretKeyFromDb } = encryptedSetting(
-  CONFIG_KEYS.STRIPE_SECRET_KEY,
-);
-
-/** Derive Stripe key mode from the stored key prefix. */
-const getStripeKeyMode = async (): Promise<"test" | "live" | null> => {
-  const key = await getStripeSecretKeyFromDb();
-  if (!key) return null;
-  // Inline prefix check to avoid circular import with stripe.ts
-  if (key.startsWith("sk_test_")) return "test";
-  if (key.startsWith("sk_live_")) return "live";
-  return null;
-};
-
-const getStripeWebhookSecretFromDb = encryptedSetting(
-  CONFIG_KEYS.STRIPE_WEBHOOK_SECRET,
-).get;
-
-/**
- * Get Stripe webhook endpoint ID from database
- * Returns null if not configured
- */
-const getStripeWebhookEndpointId = (): Promise<string | null> => {
-  return getSetting(CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID);
-};
-
-/**
- * Store Stripe webhook configuration (secret encrypted, endpoint ID plaintext)
- */
-const setStripeWebhookConfig = async (config: {
-  secret: string;
-  endpointId: string;
-}): Promise<void> => {
-  const encryptedSecret = await encrypt(config.secret);
-  await setSetting(CONFIG_KEYS.STRIPE_WEBHOOK_SECRET, encryptedSecret);
-  await setSetting(CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID, config.endpointId);
-};
-
-/**
- * Get the public key for encrypting attendee PII
- * Always available (it's meant to be public)
- */
-const getPublicKey = (): Promise<string | null> => {
-  return getSetting(CONFIG_KEYS.PUBLIC_KEY);
-};
-
-/**
- * Get the wrapped private key (needs DATA_KEY to decrypt)
- */
-const getWrappedPrivateKey = (): Promise<string | null> => {
-  return getSetting(CONFIG_KEYS.WRAPPED_PRIVATE_KEY);
-};
-
-/** Check whether the attendee blob migration has been completed */
-const isAttendeeBlobMigrated = async (): Promise<boolean> => {
-  const value = await getSetting(CONFIG_KEYS.ATTENDEE_BLOB_MIGRATED);
-  return value !== null && value !== "";
-};
-
-/** Mark the attendee blob migration as complete */
-const setAttendeeBlobMigrated = (): Promise<void> =>
-  setSetting(CONFIG_KEYS.ATTENDEE_BLOB_MIGRATED, new Date().toISOString());
-
-/**
- * Update a user's password and re-wrap DATA_KEY with new KEK
- * Requires the user's old password hash (decrypted) and their user row
- */
-const updateUserPassword = async (
-  userId: number,
-  oldPasswordHash: string,
-  oldWrappedDataKey: string,
-  newPassword: string,
-): Promise<boolean> => {
-  // Unwrap DATA_KEY with old KEK
-  const oldKek = await deriveKEK(oldPasswordHash);
-  let dataKey: CryptoKey;
-  try {
-    dataKey = await unwrapKey(oldWrappedDataKey, oldKek);
-  } catch {
-    return false;
-  }
-
-  // Hash the new password
-  const newHash = await hashPassword(newPassword);
-  const encryptedNewHash = await encrypt(newHash);
-
-  // Derive new KEK and re-wrap DATA_KEY
-  const newKek = await deriveKEK(newHash);
-  const newWrappedDataKey = await wrapKey(dataKey, newKek);
-
-  // Update user row
-  await getDb().execute({
-    sql: "UPDATE users SET password_hash = ?, wrapped_data_key = ? WHERE id = ?",
-    args: [encryptedNewHash, newWrappedDataKey, userId],
-  });
-  invalidateUsersCache();
-
-  // Invalidate all sessions (force re-login with new password)
-  await deleteAllSessions();
-
-  return true;
-};
-
-/**
- * Check if a Square access token has been configured in the database
- */
-const hasSquareToken = async (): Promise<boolean> => {
-  const value = await getSetting(CONFIG_KEYS.SQUARE_ACCESS_TOKEN);
-  return value !== null;
-};
-
-/**
- * Get Square location ID from database
- * Returns null if not configured
- */
-const getSquareLocationIdFromDb = (): Promise<string | null> =>
-  getSetting(CONFIG_KEYS.SQUARE_LOCATION_ID);
-
-/**
- * Store Square location ID (plaintext - not sensitive)
- */
-const updateSquareLocationId = async (locationId: string): Promise<void> => {
-  await setSetting(CONFIG_KEYS.SQUARE_LOCATION_ID, locationId);
-};
-
-/**
- * Get allowed embed hosts from database (decrypted)
- * Returns null if not configured (embedding allowed from anywhere)
- */
-const getEmbedHostsFromDb = async (): Promise<string | null> => {
-  const value = await getSetting(CONFIG_KEYS.EMBED_HOSTS);
-  if (!value) return null;
-  return decrypt(value);
-};
-
-/**
- * Update allowed embed hosts (encrypted at rest)
- * Pass empty string to clear the restriction
- */
-const updateEmbedHosts = async (hosts: string): Promise<void> => {
-  if (hosts === "") {
-    return setOrDeleteSetting(CONFIG_KEYS.EMBED_HOSTS, "");
-  }
-  const encrypted = await encrypt(hosts);
-  await setSetting(CONFIG_KEYS.EMBED_HOSTS, encrypted);
-};
-
-/** Max length for terms and conditions text */
-export const MAX_TERMS_LENGTH = 10_240;
-
-/**
- * Get terms and conditions text from database (30m cached).
- * Returns null if not configured.
- */
-const getTermsAndConditionsFromDb = async (): Promise<string | null> => {
-  const cached = getPageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS);
-  if (cached !== undefined) return cached;
-  const value = await getSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS);
-  setPageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS, value);
-  return value;
-};
-
-/**
- * Update terms and conditions text
- * Pass empty string to clear
- */
-const updateTermsAndConditions = async (text: string): Promise<void> => {
-  await setOrDeleteSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS, text);
-  invalidatePageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS);
-};
-
-/**
- * Permanent timezone cache. Timezone changes very rarely, so we cache it
- * indefinitely and update on explicit changes via updateCountry().
- */
-const [getTzCache, setTzCache] = lazyRef<string | null>(() => null);
-
-/**
- * Test-only timezone override. Survives cache invalidation so tests
- * can pin the timezone to UTC without it being cleared.
- */
-const [getTzTestOverride, setTzTestOverride] = lazyRef<string | null>(
-  () => null,
-);
-
-/**
- * Get the configured timezone derived from country setting.
- * Also populates the permanent timezone cache for sync access via getTimezoneCached().
- */
-const getTimezoneFromDb = async (): Promise<string> => {
-  const testOverride = getTzTestOverride();
-  if (testOverride !== null) return testOverride;
-  const cached = getTzCache();
-  if (cached !== null) return cached;
-  const country = await getCountryFromDb();
-  const tz = getCountry(country).timezone;
-  setTzCache(tz);
-  return tz;
-};
-
-/**
- * Get the configured timezone synchronously.
- * Derives from country setting. Safe to call from synchronous template code
- * because the middleware populates the settings cache on every request.
- */
-const getTimezoneCached = (): string => {
-  const testOverride = getTzTestOverride();
-  if (testOverride !== null) return testOverride;
-  const cached = getTzCache();
-  if (cached !== null) return cached;
-  const state = getSettingsCacheState();
-  if (state.entries !== null) {
-    const country = state.entries.get(CONFIG_KEYS.COUNTRY) || DEFAULT_COUNTRY;
-    const value = getCountry(country).timezone;
-    setTzCache(value);
-    return value;
-  }
-  return DEFAULT_TIMEZONE;
-};
-
-/** Clear the permanent timezone cache (called by invalidateSettingsCache) */
-const invalidateTimezoneCache = (): void => {
-  setTzCache(null);
-};
-
-/**
- * Explicitly set timezone for testing.
- * Uses a separate override that survives cache invalidation.
- */
-const setTimezoneForTest = (tz: string): void => setTzTestOverride(tz);
-
-/** Clear the test timezone override (call in test teardown). */
-const resetTimezoneTestOverride = (): void => setTzTestOverride(null);
-
-/**
- * Get the configured theme from database.
- * Returns "light" or "dark", defaulting to "light".
- */
-const getThemeFromDb = async (): Promise<Theme> => {
-  const value = await getSetting(CONFIG_KEYS.THEME);
-  return value === "dark" ? "dark" : "light";
-};
-
-/**
- * Update the configured theme.
- */
-const updateTheme = async (theme: Theme): Promise<void> => {
-  await setSetting(CONFIG_KEYS.THEME, theme);
-};
-
-/**
- * Get the "show public site" setting synchronously from cache.
- * Returns false if the cache is not populated or the setting is not "true".
- * Safe to call from synchronous template code after the settings cache is warmed.
- */
-const getShowPublicSiteCached = (): boolean => {
-  const state = getSettingsCacheState();
-  if (state.entries !== null) {
-    return state.entries.get(CONFIG_KEYS.SHOW_PUBLIC_SITE) === "true";
-  }
-  return false;
-};
-
-/** Get an encrypted optional setting (decrypted). Returns null if not set. */
-const getEncryptedSetting = async (key: string): Promise<string | null> => {
-  const value = await getSetting(key);
-  if (!value) return null;
-  return decrypt(value);
-};
-
-/** Update an encrypted optional setting. Pass empty string to clear. */
-const updateEncryptedSetting = async (
-  key: string,
-  text: string,
-): Promise<void> => {
-  if (text === "") return setOrDeleteSetting(key, "");
-  await setSetting(key, await encrypt(text));
-};
-
-/** Max length for website title */
-export const MAX_WEBSITE_TITLE_LENGTH = 128;
-
-/** Max length for page text content */
-export const MAX_PAGE_TEXT_LENGTH = 2048;
-
-/** Get a page setting with 30m decrypted content cache. */
-const getCachedPageSetting = async (key: string): Promise<string | null> => {
-  const cached = getPageCacheEntry(key);
-  if (cached !== undefined) return cached;
-  const value = await getEncryptedSetting(key);
-  setPageCacheEntry(key, value);
-  return value;
-};
-
-/**
- * Get the configured phone prefix derived from country setting.
- */
-const getPhonePrefixFromDb = async (): Promise<string> => {
-  const country = await getCountryFromDb();
-  return getCountry(country).phonePrefix;
-};
-
-/** Check if an email API key has been configured in the database */
-const hasEmailApiKey = async (): Promise<boolean> => {
-  const value = await getSetting(CONFIG_KEYS.EMAIL_API_KEY);
-  return value !== null;
-};
 
 /** Valid email template types */
 export type EmailTemplateType = "confirmation" | "admin";
@@ -762,68 +124,333 @@ export type EmailTemplateType = "confirmation" | "admin";
 /** Valid email template formats */
 export type EmailTemplateFormat = "subject" | "html" | "text";
 
-/** Config key for a given template type+format */
-const emailTemplateKey = (
-  type: EmailTemplateType,
-  format: EmailTemplateFormat,
-): string => {
-  const keys: Record<`${EmailTemplateType}:${EmailTemplateFormat}`, string> = {
-    "confirmation:subject": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_SUBJECT,
-    "confirmation:html": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML,
-    "confirmation:text": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT,
-    "admin:subject": CONFIG_KEYS.EMAIL_TPL_ADMIN_SUBJECT,
-    "admin:html": CONFIG_KEYS.EMAIL_TPL_ADMIN_HTML,
-    "admin:text": CONFIG_KEYS.EMAIL_TPL_ADMIN_TEXT,
-  };
-  return keys[`${type}:${format}`];
+const TEMPLATE_SNAPSHOT_KEYS: Record<string, keyof typeof data> = {
+  "confirmation:subject": "emailTplConfirmationSubject",
+  "confirmation:html": "emailTplConfirmationHtml",
+  "confirmation:text": "emailTplConfirmationText",
+  "admin:subject": "emailTplAdminSubject",
+  "admin:html": "emailTplAdminHtml",
+  "admin:text": "emailTplAdminText",
 };
 
-/** Max length for email templates */
-export const MAX_EMAIL_TEMPLATE_LENGTH = 51_200;
-
-/** Get a custom email template (decrypted). Returns null if not customised (use default). */
-const getEmailTemplate = (
-  type: EmailTemplateType,
-  format: EmailTemplateFormat,
-): Promise<string | null> =>
-  getEncryptedSetting(emailTemplateKey(type, format));
-
-/** Update a custom email template (encrypted at rest). Pass empty string to clear (revert to default). */
-const updateEmailTemplate = (
-  type: EmailTemplateType,
-  format: EmailTemplateFormat,
-  content: string,
-): Promise<void> =>
-  updateEncryptedSetting(emailTemplateKey(type, format), content);
-
-/** Get all 3 parts of a custom email template (subject, html, text). Nulls mean "use default". */
-const getEmailTemplateSet = async (
-  type: EmailTemplateType,
-): Promise<{
-  subject: string | null;
-  html: string | null;
-  text: string | null;
-}> => {
-  const [subject, html, text] = await Promise.all([
-    getEmailTemplate(type, "subject"),
-    getEmailTemplate(type, "html"),
-    getEmailTemplate(type, "text"),
-  ]);
-  return { subject, html, text };
+const TEMPLATE_CONFIG_KEYS: Record<string, string> = {
+  "confirmation:subject": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_SUBJECT,
+  "confirmation:html": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML,
+  "confirmation:text": CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT,
+  "admin:subject": CONFIG_KEYS.EMAIL_TPL_ADMIN_SUBJECT,
+  "admin:html": CONFIG_KEYS.EMAIL_TPL_ADMIN_HTML,
+  "admin:text": CONFIG_KEYS.EMAIL_TPL_ADMIN_TEXT,
 };
 
-/** Get the custom domain last validated timestamp. Returns null if never validated. */
-const getCustomDomainLastValidatedFromDb = (): Promise<string | null> =>
-  getSetting(CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED);
+/** Mutable snapshot of all settings. Populated by loadAll(). */
+const data = {
+  // --- Plaintext ---
+  country: DEFAULT_COUNTRY,
+  theme: "light" as Theme,
+  showPublicSite: false,
+  showPublicApi: false,
+  paymentProvider: null as PaymentProviderType | null,
+  terms: null as string | null,
+  emailProvider: null as string | null,
+  bookingFee: "0",
+  customDomain: null as string | null,
+  customDomainLastValidated: null as string | null,
+  publicKey: null as string | null,
+  wrappedPrivateKey: null as string | null,
+  squareLocationId: null as string | null,
+  squareSandbox: false,
+  stripeWebhookEndpointId: null as string | null,
+  appleWalletPassTypeId: null as string | null,
+  appleWalletTeamId: null as string | null,
+  googleWalletIssuerId: null as string | null,
+  googleWalletServiceAccountEmail: null as string | null,
+  attendeeBlobMigrated: false,
 
-/** Update the custom domain last validated timestamp to now (UTC ISO 8601). */
-const updateCustomDomainLastValidated = (): Promise<void> =>
-  setSetting(
-    CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED,
-    new Date().toISOString(),
+  // --- Derived from country ---
+  currency: "GBP",
+  timezone: DEFAULT_TIMEZONE,
+  phonePrefix: "+44",
+
+  // --- Encrypted (pre-decrypted by loadAll) ---
+  businessEmail: null as string | null,
+  headerImageUrl: null as string | null,
+  websiteTitle: null as string | null,
+  homepageText: null as string | null,
+  contactPageText: null as string | null,
+  stripeSecretKey: null as string | null,
+  stripeWebhookSecret: null as string | null,
+  squareAccessToken: null as string | null,
+  squareWebhookSignatureKey: null as string | null,
+  embedHosts: null as string | null,
+  emailApiKey: null as string | null,
+  emailFromAddress: null as string | null,
+  emailTplConfirmationSubject: null as string | null,
+  emailTplConfirmationHtml: null as string | null,
+  emailTplConfirmationText: null as string | null,
+  emailTplAdminSubject: null as string | null,
+  emailTplAdminHtml: null as string | null,
+  emailTplAdminText: null as string | null,
+  appleWalletSigningCert: null as string | null,
+  appleWalletSigningKey: null as string | null,
+  appleWalletWwdrCert: null as string | null,
+  googleWalletServiceAccountKey: null as string | null,
+};
+
+type SettingsData = typeof data;
+
+const defaults: Readonly<SettingsData> = { ...data };
+
+/** Test overrides — survive invalidateCache(), cleared by clearTestOverrides(). */
+const [getTestOverrides, setTestOverrides] = lazyRef<Record<string, unknown>>(
+  () => ({}),
+);
+
+/** Read a snapshot value, checking test overrides first. */
+const snap = <K extends keyof SettingsData>(key: K): SettingsData[K] => {
+  const overrides = getTestOverrides();
+  return key in overrides ? (overrides[key] as SettingsData[K]) : data[key];
+};
+
+// ---------------------------------------------------------------------------
+// Raw DB operations (internal)
+// ---------------------------------------------------------------------------
+
+/** Read a raw string from the cache. Returns null if missing or cache not loaded. */
+const getRawCached = (key: string): string | null =>
+  getCacheState().entries?.get(key) ?? null;
+
+/** Write a setting to the DB and update the raw cache in-place. */
+const writeRaw = async (key: string, value: string): Promise<void> => {
+  await getDb().execute({
+    sql: "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    args: [key, value],
+  });
+  const state = getCacheState();
+  if (state.entries) state.entries.set(key, value);
+};
+
+/** Delete a setting from the DB and remove it from the raw cache. */
+const deleteRaw = async (key: string): Promise<void> => {
+  await getDb().execute({
+    sql: "DELETE FROM settings WHERE key = ?",
+    args: [key],
+  });
+  const state = getCacheState();
+  if (state.entries) state.entries.delete(key);
+};
+
+/** Write a setting or delete it if value is empty. */
+const writeOrDelete = (key: string, value: string): Promise<void> => {
+  if (value === "") return deleteRaw(key);
+  return writeRaw(key, value);
+};
+
+/** Encrypt then write (empty string deletes the key). */
+const writeEncrypted = async (key: string, value: string): Promise<void> => {
+  if (!value) return deleteRaw(key);
+  await writeRaw(key, await encrypt(value));
+};
+
+// ---------------------------------------------------------------------------
+// Snapshot builder — called by loadAll()
+// ---------------------------------------------------------------------------
+
+/** Mapping: CONFIG_KEY → snapshot field for encrypted values. */
+const ENCRYPTED_FIELDS: [string, keyof SettingsData][] = [
+  [CONFIG_KEYS.BUSINESS_EMAIL, "businessEmail"],
+  [CONFIG_KEYS.HEADER_IMAGE_URL, "headerImageUrl"],
+  [CONFIG_KEYS.WEBSITE_TITLE, "websiteTitle"],
+  [CONFIG_KEYS.HOMEPAGE_TEXT, "homepageText"],
+  [CONFIG_KEYS.CONTACT_PAGE_TEXT, "contactPageText"],
+  [CONFIG_KEYS.STRIPE_SECRET_KEY, "stripeSecretKey"],
+  [CONFIG_KEYS.STRIPE_WEBHOOK_SECRET, "stripeWebhookSecret"],
+  [CONFIG_KEYS.SQUARE_ACCESS_TOKEN, "squareAccessToken"],
+  [CONFIG_KEYS.SQUARE_WEBHOOK_SIGNATURE_KEY, "squareWebhookSignatureKey"],
+  [CONFIG_KEYS.EMBED_HOSTS, "embedHosts"],
+  [CONFIG_KEYS.EMAIL_API_KEY, "emailApiKey"],
+  [CONFIG_KEYS.EMAIL_FROM_ADDRESS, "emailFromAddress"],
+  [CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_SUBJECT, "emailTplConfirmationSubject"],
+  [CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML, "emailTplConfirmationHtml"],
+  [CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT, "emailTplConfirmationText"],
+  [CONFIG_KEYS.EMAIL_TPL_ADMIN_SUBJECT, "emailTplAdminSubject"],
+  [CONFIG_KEYS.EMAIL_TPL_ADMIN_HTML, "emailTplAdminHtml"],
+  [CONFIG_KEYS.EMAIL_TPL_ADMIN_TEXT, "emailTplAdminText"],
+  [CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT, "appleWalletSigningCert"],
+  [CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY, "appleWalletSigningKey"],
+  [CONFIG_KEYS.APPLE_WALLET_WWDR_CERT, "appleWalletWwdrCert"],
+  [
+    CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY,
+    "googleWalletServiceAccountKey",
+  ],
+];
+
+type CountryInfo = ReturnType<typeof getCountry>;
+const applyCountryDerived = (info: CountryInfo): void => {
+  data.currency = info.currency;
+  data.timezone = info.timezone;
+  data.phonePrefix = info.phonePrefix;
+};
+
+const buildSnapshot = async (raw: Map<string, string>): Promise<void> => {
+  // Plaintext fields
+  const country = raw.get(CONFIG_KEYS.COUNTRY) || DEFAULT_COUNTRY;
+  const info = getCountry(country);
+
+  data.country = country;
+  data.theme = raw.get(CONFIG_KEYS.THEME) === "dark" ? "dark" : "light";
+  data.showPublicSite = raw.get(CONFIG_KEYS.SHOW_PUBLIC_SITE) === "true";
+  data.showPublicApi = raw.get(CONFIG_KEYS.SHOW_PUBLIC_API) === "true";
+  data.paymentProvider =
+    (raw.get(CONFIG_KEYS.PAYMENT_PROVIDER) as PaymentProviderType) ?? null;
+  data.terms = raw.get(CONFIG_KEYS.TERMS_AND_CONDITIONS) ?? null;
+  data.emailProvider = raw.get(CONFIG_KEYS.EMAIL_PROVIDER) ?? null;
+  data.bookingFee = raw.get(CONFIG_KEYS.BOOKING_FEE) ?? "0";
+  data.customDomain = raw.get(CONFIG_KEYS.CUSTOM_DOMAIN) ?? null;
+  data.customDomainLastValidated =
+    raw.get(CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED) ?? null;
+  data.publicKey = raw.get(CONFIG_KEYS.PUBLIC_KEY) ?? null;
+  data.wrappedPrivateKey = raw.get(CONFIG_KEYS.WRAPPED_PRIVATE_KEY) ?? null;
+  data.squareLocationId = raw.get(CONFIG_KEYS.SQUARE_LOCATION_ID) ?? null;
+  data.squareSandbox = raw.get(CONFIG_KEYS.SQUARE_SANDBOX) === "true";
+  data.stripeWebhookEndpointId =
+    raw.get(CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID) ?? null;
+  data.appleWalletPassTypeId =
+    raw.get(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID) ?? null;
+  data.appleWalletTeamId = raw.get(CONFIG_KEYS.APPLE_WALLET_TEAM_ID) ?? null;
+  data.googleWalletIssuerId =
+    raw.get(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID) ?? null;
+  data.googleWalletServiceAccountEmail =
+    raw.get(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL) ?? null;
+  const m = raw.get(CONFIG_KEYS.ATTENDEE_BLOB_MIGRATED);
+  data.attendeeBlobMigrated = m !== undefined && m !== "" && m !== null;
+
+  // Derived
+  applyCountryDerived(info);
+
+  // Encrypted — parallel decrypt
+  const values = await Promise.all(
+    ENCRYPTED_FIELDS.map(([key]) => {
+      const v = raw.get(key);
+      return v ? decrypt(v) : null;
+    }),
   );
+  for (let i = 0; i < ENCRYPTED_FIELDS.length; i++) {
+    const field = ENCRYPTED_FIELDS[i]!;
+    (data as Record<string, unknown>)[field[1]] = values[i] ?? null;
+  }
+};
 
-/** Return SigningCredentials if all 5 fields are present, null otherwise. */
+// ---------------------------------------------------------------------------
+// loadAll / invalidateCache
+// ---------------------------------------------------------------------------
+
+/**
+ * Load all settings from the DB and pre-decrypt encrypted values.
+ * No-op when the raw cache is still valid.
+ */
+const loadAll = async (): Promise<void> => {
+  if (isCacheValid()) return;
+  const rows = await queryAll<Settings>("SELECT key, value FROM settings");
+  const raw = new Map<string, string>();
+  for (const row of rows) raw.set(row.key, row.value);
+  setCacheState({ entries: raw, time: nowMs() });
+  await buildSnapshot(raw);
+};
+
+/** Full invalidation — clears raw cache AND resets snapshot to defaults. */
+const invalidateCache = (): void => {
+  setCacheState(null);
+  for (const key of Object.keys(defaults)) {
+    (data as Record<string, unknown>)[key] = (
+      defaults as Record<string, unknown>
+    )[key];
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Setup-complete permanent cache
+// ---------------------------------------------------------------------------
+
+const [getSetupCompleteCache, setSetupCompleteCache] = lazyRef<boolean>(
+  () => false,
+);
+const [getSetupConfirmed, setSetupConfirmed] = lazyRef<boolean>(() => false);
+
+const isSetupComplete = async (): Promise<boolean> => {
+  const confirmed = getSetupConfirmed();
+  const cached = getSetupCompleteCache();
+  if (confirmed && cached) return true;
+  // Need the raw cache for this check
+  if (!isCacheValid()) await loadAll();
+  const isComplete = getRawCached(CONFIG_KEYS.SETUP_COMPLETE) === "true";
+  if (isComplete) {
+    setSetupCompleteCache(true);
+    setSetupConfirmed(true);
+  }
+  return isComplete;
+};
+
+const clearSetupCompleteCache = (): void => {
+  setSetupCompleteCache(null);
+  setSetupConfirmed(null);
+};
+
+// ---------------------------------------------------------------------------
+// Initial setup
+// ---------------------------------------------------------------------------
+
+const completeSetup = async (
+  username: string,
+  adminPassword: string,
+  country: string,
+): Promise<void> => {
+  const hashedPassword = await hashPassword(adminPassword);
+  const dataKey = await generateDataKey();
+  const { publicKey, privateKey } = await generateKeyPair();
+  const kek = await deriveKEK(hashedPassword);
+  const wrappedDataKey = await wrapKey(dataKey, kek);
+  await createUser(username, hashedPassword, wrappedDataKey, "owner");
+  const encryptedPrivateKey = await encryptWithKey(privateKey, dataKey);
+  await writeRaw(CONFIG_KEYS.WRAPPED_PRIVATE_KEY, encryptedPrivateKey);
+  await writeRaw(CONFIG_KEYS.PUBLIC_KEY, publicKey);
+  await writeRaw(CONFIG_KEYS.COUNTRY, country);
+  await writeRaw(CONFIG_KEYS.SETUP_COMPLETE, "true");
+};
+
+// ---------------------------------------------------------------------------
+// Password update
+// ---------------------------------------------------------------------------
+
+const updateUserPassword = async (
+  userId: number,
+  oldPasswordHash: string,
+  oldWrappedDataKey: string,
+  newPassword: string,
+): Promise<boolean> => {
+  const oldKek = await deriveKEK(oldPasswordHash);
+  let dk: CryptoKey;
+  try {
+    dk = await unwrapKey(oldWrappedDataKey, oldKek);
+  } catch {
+    return false;
+  }
+  const newHash = await hashPassword(newPassword);
+  const encryptedNewHash = await encrypt(newHash);
+  const newKek = await deriveKEK(newHash);
+  const newWrappedDataKey = await wrapKey(dk, newKek);
+  await getDb().execute({
+    sql: "UPDATE users SET password_hash = ?, wrapped_data_key = ? WHERE id = ?",
+    args: [encryptedNewHash, newWrappedDataKey, userId],
+  });
+  invalidateUsersCache();
+  await deleteAllSessions();
+  return true;
+};
+
+// ---------------------------------------------------------------------------
+// Apple Wallet host config (env-var based, separate from DB settings)
+// ---------------------------------------------------------------------------
+
 const toCredentials = (
   passTypeId: string | null | undefined,
   teamId: string | null | undefined,
@@ -835,7 +462,6 @@ const toCredentials = (
     ? { passTypeId, teamId, signingCert, signingKey, wwdrCert }
     : null;
 
-/** Read Apple Wallet config from environment variables. Returns null if not fully configured. */
 const getHostAppleWalletConfigFromEnv = (): SigningCredentials | null =>
   toCredentials(
     getEnv("APPLE_WALLET_PASS_TYPE_ID"),
@@ -849,84 +475,15 @@ const [getHostWalletOverride, setHostWalletOverride] = lazyRef<
   SigningCredentials | null | undefined
 >(() => undefined);
 
-/** Get host-level Apple Wallet config. Uses test override if set, otherwise reads env vars. */
 const getHostAppleWalletConfig = (): SigningCredentials | null => {
   const override = getHostWalletOverride();
   return override !== undefined ? override : getHostAppleWalletConfigFromEnv();
 };
 
-/** For testing: set host Apple Wallet config directly. Bypasses env vars to avoid races. */
-const setHostAppleWalletConfigForTest = (
-  config: SigningCredentials | null,
-): void => setHostWalletOverride(config);
-
-/** For testing: reset host Apple Wallet config to read from env vars. */
-const resetHostAppleWalletConfig = (): void => setHostWalletOverride(undefined);
-
-/** Check if Apple Wallet DB settings are fully configured (all 5 settings present). */
-const hasAppleWalletDbConfig = async (): Promise<boolean> => {
-  const [passTypeId, teamId, cert, key, wwdr] = await Promise.all([
-    getSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID),
-    getSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID),
-    getSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT),
-    getSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY),
-    getSetting(CONFIG_KEYS.APPLE_WALLET_WWDR_CERT),
-  ]);
-  return (
-    passTypeId !== null &&
-    teamId !== null &&
-    cert !== null &&
-    key !== null &&
-    wwdr !== null
-  );
-};
-
-/** Check if Apple Wallet is configured (DB settings or env vars). */
-const hasAppleWalletConfig = async (): Promise<boolean> =>
-  (await hasAppleWalletDbConfig()) || getHostAppleWalletConfig() !== null;
-
-const { get: getAppleWalletPassTypeIdFromDb } = textSetting(
-  CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID,
-);
-
-const { get: getAppleWalletTeamIdFromDb } = textSetting(
-  CONFIG_KEYS.APPLE_WALLET_TEAM_ID,
-);
-
-const { get: getAppleWalletSigningCertFromDb } = encryptedSetting(
-  CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT,
-);
-
-const { get: getAppleWalletSigningKeyFromDb } = encryptedSetting(
-  CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY,
-);
-
-const { get: getAppleWalletWwdrCertFromDb } = encryptedSetting(
-  CONFIG_KEYS.APPLE_WALLET_WWDR_CERT,
-);
-
-/** Get Apple Wallet config from DB (decrypted). Returns null if incomplete. */
-const getAppleWalletDbConfig = async (): Promise<SigningCredentials | null> => {
-  const [passTypeId, teamId, signingCert, signingKey, wwdrCert] =
-    await Promise.all([
-      getAppleWalletPassTypeIdFromDb(),
-      getAppleWalletTeamIdFromDb(),
-      getAppleWalletSigningCertFromDb(),
-      getAppleWalletSigningKeyFromDb(),
-      getAppleWalletWwdrCertFromDb(),
-    ]);
-  return toCredentials(passTypeId, teamId, signingCert, signingKey, wwdrCert);
-};
-
-/** Get Apple Wallet config for pass generation. DB settings take priority, falls back to env vars. */
-const getAppleWalletConfig = async (): Promise<SigningCredentials | null> =>
-  (await getAppleWalletDbConfig()) ?? getHostAppleWalletConfig();
-
 // ---------------------------------------------------------------------------
-// Google Wallet configuration
+// Google Wallet host config
 // ---------------------------------------------------------------------------
 
-/** Return GoogleWalletCredentials if all 3 fields are present, null otherwise. */
 const toGoogleCredentials = (
   issuerId: string | null | undefined,
   serviceAccountEmail: string | null | undefined,
@@ -936,7 +493,6 @@ const toGoogleCredentials = (
     ? { issuerId, serviceAccountEmail, serviceAccountKey }
     : null;
 
-/** Read Google Wallet config from environment variables. Returns null if not fully configured. */
 const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
   toGoogleCredentials(
     getEnv("GOOGLE_WALLET_ISSUER_ID"),
@@ -944,217 +500,474 @@ const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
     getEnv("GOOGLE_WALLET_SERVICE_ACCOUNT_KEY"),
   );
 
-/** Check if Google Wallet DB settings are fully configured (all 3 settings present). */
-const hasGoogleWalletDbConfig = async (): Promise<boolean> => {
-  const [issuerId, email, key] = await Promise.all([
-    getSetting(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID),
-    getSetting(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL),
-    getSetting(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY),
-  ]);
-  return issuerId !== null && email !== null && key !== null;
-};
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
-/** Check if Google Wallet is configured (DB settings or env vars). */
-const hasGoogleWalletConfig = async (): Promise<boolean> =>
-  (await hasGoogleWalletDbConfig()) || getHostGoogleWalletConfig() !== null;
+export const MAX_TERMS_LENGTH = 10_240;
+export const MAX_WEBSITE_TITLE_LENGTH = 128;
+export const MAX_PAGE_TEXT_LENGTH = 2048;
+export const MAX_EMAIL_TEMPLATE_LENGTH = 51_200;
 
-const { get: getGoogleWalletIssuerIdFromDb } = textSetting(
-  CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID,
-);
+// ---------------------------------------------------------------------------
+// The settings namespace
+// ---------------------------------------------------------------------------
 
-const { get: getGoogleWalletServiceAccountEmailFromDb } = textSetting(
-  CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL,
-);
-
-const { get: getGoogleWalletServiceAccountKeyFromDb } = encryptedSetting(
-  CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY,
-);
-
-/** Get Google Wallet config from DB (decrypted). Returns null if incomplete. */
-const getGoogleWalletDbConfig =
-  async (): Promise<GoogleWalletCredentials | null> => {
-    const [issuerId, serviceAccountEmail, serviceAccountKey] =
-      await Promise.all([
-        getGoogleWalletIssuerIdFromDb(),
-        getGoogleWalletServiceAccountEmailFromDb(),
-        getGoogleWalletServiceAccountKeyFromDb(),
-      ]);
-    return toGoogleCredentials(
-      issuerId,
-      serviceAccountEmail,
-      serviceAccountKey,
-    );
-  };
-
-/** Get Google Wallet config for pass generation. DB settings take priority, falls back to env vars. */
-const getGoogleWalletConfig =
-  async (): Promise<GoogleWalletCredentials | null> =>
-    (await getGoogleWalletDbConfig()) ?? getHostGoogleWalletConfig();
-
-/**
- * Unified settings namespace. Replaces individual function exports and settingsApi.
- *
- * Usage:
- *   import { settings } from "#lib/db/settings.ts";
- *   const key = await settings.stripe.secretKey.get();
- *   await settings.stripe.secretKey.update(newKey);
- *
- * Stubbable for testing: stub(settings.stripe.secretKey, "get", ...)
- */
 export const settings = {
-  // --- Core cache operations ---
-  get: getSetting,
-  set: setSetting,
-  getCached: getSettingCached,
-  loadAll: loadAllSettings,
-  invalidateCache: invalidateSettingsCache,
-  invalidatePageCache,
+  // --- Core ---
+  loadAll,
+  invalidateCache,
 
-  // --- Setup & auth ---
-  setup: {
-    isComplete: isSetupComplete,
-    clearCache: clearSetupCompleteCache,
-    complete: completeSetup,
-  },
-  updateUserPassword,
+  /** Read a raw (possibly encrypted) value from the cache. */
+  getCachedRaw: getRawCached,
 
-  // --- Encryption keys ---
-  publicKey: { get: getPublicKey },
-  wrappedPrivateKey: { get: getWrappedPrivateKey },
+  /** Write a raw value to the DB (low-level, prefer update.*). */
+  setRaw: writeRaw,
 
-  // --- Country / locale ---
-  country: { get: getCountryFromDb, update: updateCountry },
-  currency: { get: getCurrencyCodeFromDb },
-  phonePrefix: { get: getPhonePrefixFromDb },
-
-  // --- Timezone ---
-  timezone: {
-    get: getTimezoneFromDb,
-    getCached: getTimezoneCached,
-    setForTest: setTimezoneForTest,
-    resetTestOverride: resetTimezoneTestOverride,
+  /** Set test overrides (survive invalidateCache, cleared by clearTestOverrides). */
+  setForTest(overrides: Partial<SettingsData>): void {
+    const current = getTestOverrides();
+    for (const [k, v] of Object.entries(overrides)) {
+      current[k] = v;
+    }
   },
 
-  // --- Payment provider ---
-  paymentProvider: {
-    get: getPaymentProviderFromDb,
-    set: setPaymentProvider,
-    clear: clearPaymentProvider,
+  /** Clear all test overrides. */
+  clearTestOverrides(): void {
+    setTestOverrides(null);
+  },
+
+  // -----------------------------------------------------------------------
+  // Sync reads — all populated by loadAll()
+  // -----------------------------------------------------------------------
+
+  get country(): string {
+    return snap("country");
+  },
+  get theme(): Theme {
+    return snap("theme");
+  },
+  get showPublicSite(): boolean {
+    return snap("showPublicSite");
+  },
+  get showPublicApi(): boolean {
+    return snap("showPublicApi");
+  },
+  get paymentProvider(): PaymentProviderType | null {
+    return snap("paymentProvider");
+  },
+  get terms(): string | null {
+    return snap("terms");
+  },
+  get bookingFee(): string {
+    return snap("bookingFee");
+  },
+  get customDomain(): string | null {
+    return snap("customDomain");
+  },
+  get customDomainLastValidated(): string | null {
+    return snap("customDomainLastValidated");
+  },
+  get publicKey(): string | null {
+    return snap("publicKey");
+  },
+  get wrappedPrivateKey(): string | null {
+    return snap("wrappedPrivateKey");
+  },
+  get headerImageUrl(): string | null {
+    return snap("headerImageUrl");
+  },
+  get websiteTitle(): string | null {
+    return snap("websiteTitle");
+  },
+  get homepageText(): string | null {
+    return snap("homepageText");
+  },
+  get contactPageText(): string | null {
+    return snap("contactPageText");
+  },
+  get businessEmail(): string | null {
+    return snap("businessEmail");
+  },
+  get embedHosts(): string | null {
+    return snap("embedHosts");
+  },
+  get attendeeBlobMigrated(): boolean {
+    return snap("attendeeBlobMigrated");
+  },
+
+  // Derived from country
+  get currency(): string {
+    return snap("currency");
+  },
+  get timezone(): string {
+    return snap("timezone");
+  },
+  get phonePrefix(): string {
+    return snap("phonePrefix");
   },
 
   // --- Stripe ---
   stripe: {
-    secretKey: {
-      ...encryptedSetting(CONFIG_KEYS.STRIPE_SECRET_KEY),
-      has: hasStripeKey,
-      mode: getStripeKeyMode,
+    get secretKey(): string | null {
+      return snap("stripeSecretKey");
     },
-    webhookSecret: { get: getStripeWebhookSecretFromDb },
-    webhookEndpointId: { get: getStripeWebhookEndpointId },
-    setWebhookConfig: setStripeWebhookConfig,
+    get hasKey(): boolean {
+      return snap("stripeSecretKey") !== null;
+    },
+    get keyMode(): "test" | "live" | null {
+      const k = snap("stripeSecretKey");
+      if (!k) return null;
+      if (k.startsWith("sk_test_")) return "test";
+      if (k.startsWith("sk_live_")) return "live";
+      return null;
+    },
+    get webhookSecret(): string | null {
+      return snap("stripeWebhookSecret");
+    },
+    get webhookEndpointId(): string | null {
+      return snap("stripeWebhookEndpointId");
+    },
   },
 
   // --- Square ---
   square: {
-    accessToken: {
-      ...encryptedSetting(CONFIG_KEYS.SQUARE_ACCESS_TOKEN),
-      has: hasSquareToken,
+    get accessToken(): string | null {
+      return snap("squareAccessToken");
     },
-    webhookSignatureKey: encryptedSetting(
-      CONFIG_KEYS.SQUARE_WEBHOOK_SIGNATURE_KEY,
-    ),
-    locationId: {
-      get: getSquareLocationIdFromDb,
-      update: updateSquareLocationId,
+    get hasToken(): boolean {
+      return snap("squareAccessToken") !== null;
     },
-    sandbox: booleanSetting(CONFIG_KEYS.SQUARE_SANDBOX),
+    get webhookSignatureKey(): string | null {
+      return snap("squareWebhookSignatureKey");
+    },
+    get locationId(): string | null {
+      return snap("squareLocationId");
+    },
+    get sandbox(): boolean {
+      return snap("squareSandbox");
+    },
   },
-
-  // --- Fees ---
-  bookingFee: textSetting(CONFIG_KEYS.BOOKING_FEE, "0"),
-
-  // --- Embed ---
-  embedHosts: { get: getEmbedHostsFromDb, update: updateEmbedHosts },
-
-  // --- Terms ---
-  terms: { get: getTermsAndConditionsFromDb, update: updateTermsAndConditions },
-
-  // --- Theme / display ---
-  theme: { get: getThemeFromDb, update: updateTheme },
-  showPublicSite: {
-    ...booleanSetting(CONFIG_KEYS.SHOW_PUBLIC_SITE),
-    getCached: getShowPublicSiteCached,
-  },
-  showPublicApi: booleanSetting(CONFIG_KEYS.SHOW_PUBLIC_API),
-
-  // --- Page content ---
-  websiteTitle: cachedEncryptedSetting(CONFIG_KEYS.WEBSITE_TITLE),
-  homepageText: cachedEncryptedSetting(CONFIG_KEYS.HOMEPAGE_TEXT),
-  contactPageText: cachedEncryptedSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT),
-  headerImageUrl: encryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL),
 
   // --- Email ---
   email: {
-    provider: textSetting(CONFIG_KEYS.EMAIL_PROVIDER),
-    apiKey: {
-      ...encryptedSetting(CONFIG_KEYS.EMAIL_API_KEY),
-      has: hasEmailApiKey,
+    get provider(): string | null {
+      return snap("emailProvider");
     },
-    fromAddress: encryptedSetting(CONFIG_KEYS.EMAIL_FROM_ADDRESS),
-    template: {
-      get: getEmailTemplate,
-      update: updateEmailTemplate,
-      getSet: getEmailTemplateSet,
+    get apiKey(): string | null {
+      return snap("emailApiKey");
     },
-  },
-
-  // --- Custom domain ---
-  customDomain: {
-    ...textSetting(CONFIG_KEYS.CUSTOM_DOMAIN),
-    lastValidated: {
-      get: getCustomDomainLastValidatedFromDb,
-      update: updateCustomDomainLastValidated,
+    get hasApiKey(): boolean {
+      return snap("emailApiKey") !== null;
+    },
+    get fromAddress(): string | null {
+      return snap("emailFromAddress");
+    },
+    template(
+      type: EmailTemplateType,
+      format: EmailTemplateFormat,
+    ): string | null {
+      return snap(
+        TEMPLATE_SNAPSHOT_KEYS[`${type}:${format}`] as keyof SettingsData,
+      ) as string | null;
+    },
+    templateSet(type: EmailTemplateType): {
+      subject: string | null;
+      html: string | null;
+      text: string | null;
+    } {
+      return {
+        subject: this.template(type, "subject"),
+        html: this.template(type, "html"),
+        text: this.template(type, "text"),
+      };
     },
   },
 
   // --- Apple Wallet ---
   appleWallet: {
-    passTypeId: textSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID),
-    teamId: textSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID),
-    signingCert: encryptedSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT),
-    signingKey: encryptedSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY),
-    wwdrCert: encryptedSetting(CONFIG_KEYS.APPLE_WALLET_WWDR_CERT),
-    hasDbConfig: hasAppleWalletDbConfig,
-    hasConfig: hasAppleWalletConfig,
-    getDbConfig: getAppleWalletDbConfig,
-    getConfig: getAppleWalletConfig,
-    getHostConfig: getHostAppleWalletConfig,
-    setHostConfigForTest: setHostAppleWalletConfigForTest,
-    resetHostConfig: resetHostAppleWalletConfig,
+    get passTypeId(): string | null {
+      return snap("appleWalletPassTypeId");
+    },
+    get teamId(): string | null {
+      return snap("appleWalletTeamId");
+    },
+    get signingCert(): string | null {
+      return snap("appleWalletSigningCert");
+    },
+    get signingKey(): string | null {
+      return snap("appleWalletSigningKey");
+    },
+    get wwdrCert(): string | null {
+      return snap("appleWalletWwdrCert");
+    },
+    get hasDbConfig(): boolean {
+      return (
+        this.passTypeId !== null &&
+        this.teamId !== null &&
+        this.signingCert !== null &&
+        this.signingKey !== null &&
+        this.wwdrCert !== null
+      );
+    },
+    get dbConfig(): SigningCredentials | null {
+      return toCredentials(
+        this.passTypeId,
+        this.teamId,
+        this.signingCert,
+        this.signingKey,
+        this.wwdrCert,
+      );
+    },
+    get hostConfig(): SigningCredentials | null {
+      return getHostAppleWalletConfig();
+    },
+    get config(): SigningCredentials | null {
+      return this.dbConfig ?? this.hostConfig;
+    },
+    get hasConfig(): boolean {
+      return this.config !== null;
+    },
+    setHostConfigForTest: (c: SigningCredentials | null): void =>
+      setHostWalletOverride(c),
+    resetHostConfig: (): void => setHostWalletOverride(undefined),
   },
 
   // --- Google Wallet ---
   googleWallet: {
-    issuerId: textSetting(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID),
-    serviceAccountEmail: textSetting(
-      CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL,
-    ),
-    serviceAccountKey: encryptedSetting(
-      CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY,
-    ),
-    hasDbConfig: hasGoogleWalletDbConfig,
-    hasConfig: hasGoogleWalletConfig,
-    getDbConfig: getGoogleWalletDbConfig,
-    getConfig: getGoogleWalletConfig,
-    getHostConfig: getHostGoogleWalletConfig,
+    get issuerId(): string | null {
+      return snap("googleWalletIssuerId");
+    },
+    get serviceAccountEmail(): string | null {
+      return snap("googleWalletServiceAccountEmail");
+    },
+    get serviceAccountKey(): string | null {
+      return snap("googleWalletServiceAccountKey");
+    },
+    get hasDbConfig(): boolean {
+      const { issuerId, serviceAccountEmail, serviceAccountKey } = this;
+      return (
+        issuerId !== null &&
+        serviceAccountEmail !== null &&
+        serviceAccountKey !== null
+      );
+    },
+    get dbConfig(): GoogleWalletCredentials | null {
+      return toGoogleCredentials(
+        this.issuerId,
+        this.serviceAccountEmail,
+        this.serviceAccountKey,
+      );
+    },
+    get hostConfig(): GoogleWalletCredentials | null {
+      return getHostGoogleWalletConfig();
+    },
+    get config(): GoogleWalletCredentials | null {
+      return this.dbConfig ?? getHostGoogleWalletConfig();
+    },
+    get hasConfig(): boolean {
+      return this.config !== null;
+    },
   },
 
-  // --- Migration ---
-  attendeeBlobMigrated: {
-    is: isAttendeeBlobMigrated,
-    set: setAttendeeBlobMigrated,
+  // --- Setup & auth ---
+  setup: {
+    isComplete: isSetupComplete,
+    complete: completeSetup,
+    clearCache: clearSetupCompleteCache,
   },
+  updateUserPassword,
 
-  // --- Constants ---
-  PAGE_CACHE_TTL_MS,
+  // -----------------------------------------------------------------------
+  // Async writes — settings.update.*
+  // -----------------------------------------------------------------------
+  update: {
+    country: async (v: string): Promise<void> => {
+      await writeRaw(CONFIG_KEYS.COUNTRY, v);
+      data.country = v;
+      applyCountryDerived(getCountry(v));
+    },
+    theme: async (v: Theme): Promise<void> => {
+      await writeRaw(CONFIG_KEYS.THEME, v);
+      data.theme = v;
+    },
+    showPublicSite: async (v: boolean): Promise<void> => {
+      await writeRaw(CONFIG_KEYS.SHOW_PUBLIC_SITE, v ? "true" : "false");
+      data.showPublicSite = v;
+    },
+    showPublicApi: async (v: boolean): Promise<void> => {
+      await writeRaw(CONFIG_KEYS.SHOW_PUBLIC_API, v ? "true" : "false");
+      data.showPublicApi = v;
+    },
+    paymentProvider: async (v: PaymentProviderType): Promise<void> => {
+      await writeRaw(CONFIG_KEYS.PAYMENT_PROVIDER, v);
+      data.paymentProvider = v;
+    },
+    clearPaymentProvider: async (): Promise<void> => {
+      await deleteRaw(CONFIG_KEYS.PAYMENT_PROVIDER);
+      data.paymentProvider = null;
+    },
+    terms: async (v: string): Promise<void> => {
+      await writeOrDelete(CONFIG_KEYS.TERMS_AND_CONDITIONS, v);
+      data.terms = v || null;
+    },
+    bookingFee: async (v: string): Promise<void> => {
+      await writeOrDelete(CONFIG_KEYS.BOOKING_FEE, v);
+      data.bookingFee = v || "0";
+    },
+    customDomain: async (v: string): Promise<void> => {
+      await writeOrDelete(CONFIG_KEYS.CUSTOM_DOMAIN, v);
+      data.customDomain = v || null;
+    },
+    customDomainLastValidated: async (): Promise<void> => {
+      const ts = new Date().toISOString();
+      await writeRaw(CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED, ts);
+      data.customDomainLastValidated = ts;
+    },
+    headerImageUrl: async (v: string): Promise<void> => {
+      await writeEncrypted(CONFIG_KEYS.HEADER_IMAGE_URL, v);
+      data.headerImageUrl = v || null;
+    },
+    websiteTitle: async (v: string): Promise<void> => {
+      await writeEncrypted(CONFIG_KEYS.WEBSITE_TITLE, v);
+      data.websiteTitle = v || null;
+    },
+    homepageText: async (v: string): Promise<void> => {
+      await writeEncrypted(CONFIG_KEYS.HOMEPAGE_TEXT, v);
+      data.homepageText = v || null;
+    },
+    contactPageText: async (v: string): Promise<void> => {
+      await writeEncrypted(CONFIG_KEYS.CONTACT_PAGE_TEXT, v);
+      data.contactPageText = v || null;
+    },
+    businessEmail: async (v: string): Promise<void> => {
+      await writeEncrypted(CONFIG_KEYS.BUSINESS_EMAIL, v);
+      data.businessEmail = v || null;
+    },
+    embedHosts: async (v: string): Promise<void> => {
+      if (v === "") {
+        await writeOrDelete(CONFIG_KEYS.EMBED_HOSTS, "");
+        data.embedHosts = null;
+        return;
+      }
+      await writeRaw(CONFIG_KEYS.EMBED_HOSTS, await encrypt(v));
+      data.embedHosts = v;
+    },
+    attendeeBlobMigrated: async (): Promise<void> => {
+      await writeRaw(
+        CONFIG_KEYS.ATTENDEE_BLOB_MIGRATED,
+        new Date().toISOString(),
+      );
+      data.attendeeBlobMigrated = true;
+    },
+
+    // --- Stripe writes ---
+    stripe: {
+      secretKey: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.STRIPE_SECRET_KEY, v);
+        data.stripeSecretKey = v || null;
+      },
+      webhookConfig: async (config: {
+        secret: string;
+        endpointId: string;
+      }): Promise<void> => {
+        await writeRaw(
+          CONFIG_KEYS.STRIPE_WEBHOOK_SECRET,
+          await encrypt(config.secret),
+        );
+        await writeRaw(
+          CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID,
+          config.endpointId,
+        );
+        data.stripeWebhookSecret = config.secret;
+        data.stripeWebhookEndpointId = config.endpointId;
+      },
+    },
+
+    // --- Square writes ---
+    square: {
+      accessToken: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.SQUARE_ACCESS_TOKEN, v);
+        data.squareAccessToken = v || null;
+      },
+      webhookSignatureKey: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.SQUARE_WEBHOOK_SIGNATURE_KEY, v);
+        data.squareWebhookSignatureKey = v || null;
+      },
+      locationId: async (v: string): Promise<void> => {
+        await writeRaw(CONFIG_KEYS.SQUARE_LOCATION_ID, v);
+        data.squareLocationId = v || null;
+      },
+      sandbox: async (v: boolean): Promise<void> => {
+        await writeRaw(CONFIG_KEYS.SQUARE_SANDBOX, v ? "true" : "false");
+        data.squareSandbox = v;
+      },
+    },
+
+    // --- Email writes ---
+    email: {
+      provider: async (v: string): Promise<void> => {
+        await writeOrDelete(CONFIG_KEYS.EMAIL_PROVIDER, v);
+        data.emailProvider = v || null;
+      },
+      apiKey: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.EMAIL_API_KEY, v);
+        data.emailApiKey = v || null;
+      },
+      fromAddress: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.EMAIL_FROM_ADDRESS, v);
+        data.emailFromAddress = v || null;
+      },
+      template: async (
+        type: EmailTemplateType,
+        format: EmailTemplateFormat,
+        content: string,
+      ): Promise<void> => {
+        const k = `${type}:${format}`;
+        await writeEncrypted(TEMPLATE_CONFIG_KEYS[k]!, content);
+        (data as Record<string, unknown>)[TEMPLATE_SNAPSHOT_KEYS[k]!] =
+          content || null;
+      },
+    },
+
+    // --- Apple Wallet writes ---
+    appleWallet: {
+      passTypeId: async (v: string): Promise<void> => {
+        await writeOrDelete(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID, v);
+        data.appleWalletPassTypeId = v || null;
+      },
+      teamId: async (v: string): Promise<void> => {
+        await writeOrDelete(CONFIG_KEYS.APPLE_WALLET_TEAM_ID, v);
+        data.appleWalletTeamId = v || null;
+      },
+      signingCert: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT, v);
+        data.appleWalletSigningCert = v || null;
+      },
+      signingKey: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY, v);
+        data.appleWalletSigningKey = v || null;
+      },
+      wwdrCert: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.APPLE_WALLET_WWDR_CERT, v);
+        data.appleWalletWwdrCert = v || null;
+      },
+    },
+
+    // --- Google Wallet writes ---
+    googleWallet: {
+      issuerId: async (v: string): Promise<void> => {
+        await writeOrDelete(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID, v);
+        data.googleWalletIssuerId = v || null;
+      },
+      serviceAccountEmail: async (v: string): Promise<void> => {
+        await writeOrDelete(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL, v);
+        data.googleWalletServiceAccountEmail = v || null;
+      },
+      serviceAccountKey: async (v: string): Promise<void> => {
+        await writeEncrypted(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY, v);
+        data.googleWalletServiceAccountKey = v || null;
+      },
+    },
+  },
 };

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -151,7 +151,7 @@ const invalidatePageCacheEntry = (key: string): void => {
 };
 
 /** Clear the entire page content cache (for testing or after bulk changes). */
-export const invalidatePageCache = (): void => {
+const invalidatePageCache = (): void => {
   setPageCacheMap(null);
 };
 
@@ -183,7 +183,7 @@ registerCache(() => ({
 /**
  * Load every setting row into the in-memory cache with a single query.
  */
-export const loadAllSettings = async (): Promise<Map<string, string>> => {
+const loadAllSettings = async (): Promise<Map<string, string>> => {
   const rows = await queryAll<Settings>("SELECT key, value FROM settings");
   const cache = new Map<string, string>();
   for (const row of rows) {
@@ -198,7 +198,7 @@ export const loadAllSettings = async (): Promise<Map<string, string>> => {
  * Also clears the permanent timezone cache since it derives from settings,
  * and the page content cache since it derives from encrypted settings.
  */
-export const invalidateSettingsCache = (): void => {
+const invalidateSettingsCache = (): void => {
   setSettingsCacheState(null);
   invalidateTimezoneCache();
   invalidatePageCache();
@@ -209,7 +209,7 @@ export const invalidateSettingsCache = (): void => {
  * Returns null if the cache is not populated or the key is absent.
  * Safe to call from synchronous code because the settings cache is populated by middleware.
  */
-export const getSettingCached = (key: string): string | null => {
+const getSettingCached = (key: string): string | null => {
   const state = getSettingsCacheState();
   return state.entries?.get(key) ?? null;
 };
@@ -218,7 +218,7 @@ export const getSettingCached = (key: string): string | null => {
  * Get a setting value. Reads from the in-memory cache, loading all
  * settings in one query on first access or after TTL expiry.
  */
-export const getSetting = async (key: string): Promise<string | null> => {
+const getSetting = async (key: string): Promise<string | null> => {
   const cache = isCacheValid()
     ? getSettingsCacheState().entries!
     : await loadAllSettings();
@@ -229,7 +229,7 @@ export const getSetting = async (key: string): Promise<string | null> => {
  * Set a setting value. Invalidates the cache so the next read
  * will pick up the new value.
  */
-export const setSetting = async (key: string, value: string): Promise<void> => {
+const setSetting = async (key: string, value: string): Promise<void> => {
   await getDb().execute({
     sql: "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
     args: [key, value],
@@ -319,7 +319,7 @@ const [getSetupConfirmed, setSetupConfirmed] = lazyRef<boolean>(() => false);
  * Check if initial setup has been completed
  * Result is cached in memory - once true, we never query again.
  */
-export const isSetupComplete = async (): Promise<boolean> => {
+const isSetupComplete = async (): Promise<boolean> => {
   // Check both caches (avoid short-circuit to ensure consistent initialization)
   const confirmed = getSetupConfirmed();
   const cached = getSetupCompleteCache();
@@ -339,7 +339,7 @@ export const isSetupComplete = async (): Promise<boolean> => {
 /**
  * Clear setup complete cache (for testing)
  */
-export const clearSetupCompleteCache = (): void => {
+const clearSetupCompleteCache = (): void => {
   setSetupCompleteCache(null);
   setSetupConfirmed(null);
 };
@@ -352,7 +352,7 @@ export const clearSetupCompleteCache = (): void => {
  * - KEK: derived from password hash + DB_ENCRYPTION_KEY, wraps DATA_KEY
  * Creates the first owner user row instead of storing credentials in settings.
  */
-export const completeSetup = async (
+const completeSetup = async (
   username: string,
   adminPassword: string,
   country: string,
@@ -390,7 +390,7 @@ export const completeSetup = async (
  * Get the configured country code from database.
  * Returns ISO 3166-1 alpha-2 code, defaulting to "GB".
  */
-export const getCountryFromDb = async (): Promise<string> => {
+const getCountryFromDb = async (): Promise<string> => {
   const value = await getSetting(CONFIG_KEYS.COUNTRY);
   return value || DEFAULT_COUNTRY;
 };
@@ -398,7 +398,7 @@ export const getCountryFromDb = async (): Promise<string> => {
 /**
  * Update the configured country.
  */
-export const updateCountry = async (country: string): Promise<void> => {
+const updateCountry = async (country: string): Promise<void> => {
   await setSetting(CONFIG_KEYS.COUNTRY, country);
   // Also update timezone cache since it derives from country
   const tz = getCountry(country).timezone;
@@ -408,7 +408,7 @@ export const updateCountry = async (country: string): Promise<void> => {
 /**
  * Get currency code derived from country setting.
  */
-export const getCurrencyCodeFromDb = async (): Promise<string> => {
+const getCurrencyCodeFromDb = async (): Promise<string> => {
   const country = await getCountryFromDb();
   return getCountry(country).currency;
 };
@@ -417,13 +417,13 @@ export const getCurrencyCodeFromDb = async (): Promise<string> => {
  * Get the configured payment provider type
  * Returns null if no provider is configured
  */
-export const getPaymentProviderFromDb = (): Promise<string | null> =>
+const getPaymentProviderFromDb = (): Promise<string | null> =>
   getSetting(CONFIG_KEYS.PAYMENT_PROVIDER);
 
 /**
  * Set the active payment provider type
  */
-export const setPaymentProvider = async (
+const setPaymentProvider = async (
   provider: PaymentProviderType,
 ): Promise<void> => {
   await setSetting(CONFIG_KEYS.PAYMENT_PROVIDER, provider);
@@ -432,7 +432,7 @@ export const setPaymentProvider = async (
 /**
  * Clear the active payment provider (disables payments)
  */
-export const clearPaymentProvider = async (): Promise<void> => {
+const clearPaymentProvider = async (): Promise<void> => {
   await getDb().execute({
     sql: "DELETE FROM settings WHERE key = ?",
     args: [CONFIG_KEYS.PAYMENT_PROVIDER],
@@ -443,18 +443,17 @@ export const clearPaymentProvider = async (): Promise<void> => {
 /**
  * Check if a Stripe key has been configured in the database
  */
-export const hasStripeKey = async (): Promise<boolean> => {
+const hasStripeKey = async (): Promise<boolean> => {
   const value = await getSetting(CONFIG_KEYS.STRIPE_SECRET_KEY);
   return value !== null;
 };
 
-const { get: getStripeSecretKeyFromDb, update: updateStripeKey } =
-  encryptedSetting(CONFIG_KEYS.STRIPE_SECRET_KEY);
-
-export { getStripeSecretKeyFromDb, updateStripeKey };
+const { get: getStripeSecretKeyFromDb } = encryptedSetting(
+  CONFIG_KEYS.STRIPE_SECRET_KEY,
+);
 
 /** Derive Stripe key mode from the stored key prefix. */
-export const getStripeKeyMode = async (): Promise<"test" | "live" | null> => {
+const getStripeKeyMode = async (): Promise<"test" | "live" | null> => {
   const key = await getStripeSecretKeyFromDb();
   if (!key) return null;
   // Inline prefix check to avoid circular import with stripe.ts
@@ -463,7 +462,7 @@ export const getStripeKeyMode = async (): Promise<"test" | "live" | null> => {
   return null;
 };
 
-export const getStripeWebhookSecretFromDb = encryptedSetting(
+const getStripeWebhookSecretFromDb = encryptedSetting(
   CONFIG_KEYS.STRIPE_WEBHOOK_SECRET,
 ).get;
 
@@ -471,14 +470,14 @@ export const getStripeWebhookSecretFromDb = encryptedSetting(
  * Get Stripe webhook endpoint ID from database
  * Returns null if not configured
  */
-export const getStripeWebhookEndpointId = (): Promise<string | null> => {
+const getStripeWebhookEndpointId = (): Promise<string | null> => {
   return getSetting(CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID);
 };
 
 /**
  * Store Stripe webhook configuration (secret encrypted, endpoint ID plaintext)
  */
-export const setStripeWebhookConfig = async (config: {
+const setStripeWebhookConfig = async (config: {
   secret: string;
   endpointId: string;
 }): Promise<void> => {
@@ -491,32 +490,32 @@ export const setStripeWebhookConfig = async (config: {
  * Get the public key for encrypting attendee PII
  * Always available (it's meant to be public)
  */
-export const getPublicKey = (): Promise<string | null> => {
+const getPublicKey = (): Promise<string | null> => {
   return getSetting(CONFIG_KEYS.PUBLIC_KEY);
 };
 
 /**
  * Get the wrapped private key (needs DATA_KEY to decrypt)
  */
-export const getWrappedPrivateKey = (): Promise<string | null> => {
+const getWrappedPrivateKey = (): Promise<string | null> => {
   return getSetting(CONFIG_KEYS.WRAPPED_PRIVATE_KEY);
 };
 
 /** Check whether the attendee blob migration has been completed */
-export const isAttendeeBlobMigrated = async (): Promise<boolean> => {
+const isAttendeeBlobMigrated = async (): Promise<boolean> => {
   const value = await getSetting(CONFIG_KEYS.ATTENDEE_BLOB_MIGRATED);
   return value !== null && value !== "";
 };
 
 /** Mark the attendee blob migration as complete */
-export const setAttendeeBlobMigrated = (): Promise<void> =>
+const setAttendeeBlobMigrated = (): Promise<void> =>
   setSetting(CONFIG_KEYS.ATTENDEE_BLOB_MIGRATED, new Date().toISOString());
 
 /**
  * Update a user's password and re-wrap DATA_KEY with new KEK
  * Requires the user's old password hash (decrypted) and their user row
  */
-export const updateUserPassword = async (
+const updateUserPassword = async (
   userId: number,
   oldPasswordHash: string,
   oldWrappedDataKey: string,
@@ -555,48 +554,30 @@ export const updateUserPassword = async (
 /**
  * Check if a Square access token has been configured in the database
  */
-export const hasSquareToken = async (): Promise<boolean> => {
+const hasSquareToken = async (): Promise<boolean> => {
   const value = await getSetting(CONFIG_KEYS.SQUARE_ACCESS_TOKEN);
   return value !== null;
 };
-
-export const {
-  get: getSquareAccessTokenFromDb,
-  update: updateSquareAccessToken,
-} = encryptedSetting(CONFIG_KEYS.SQUARE_ACCESS_TOKEN);
-
-export const {
-  get: getSquareWebhookSignatureKeyFromDb,
-  update: updateSquareWebhookSignatureKey,
-} = encryptedSetting(CONFIG_KEYS.SQUARE_WEBHOOK_SIGNATURE_KEY);
 
 /**
  * Get Square location ID from database
  * Returns null if not configured
  */
-export const getSquareLocationIdFromDb = (): Promise<string | null> =>
+const getSquareLocationIdFromDb = (): Promise<string | null> =>
   getSetting(CONFIG_KEYS.SQUARE_LOCATION_ID);
 
 /**
  * Store Square location ID (plaintext - not sensitive)
  */
-export const updateSquareLocationId = async (
-  locationId: string,
-): Promise<void> => {
+const updateSquareLocationId = async (locationId: string): Promise<void> => {
   await setSetting(CONFIG_KEYS.SQUARE_LOCATION_ID, locationId);
 };
-
-export const { get: getSquareSandboxFromDb, update: updateSquareSandbox } =
-  booleanSetting(CONFIG_KEYS.SQUARE_SANDBOX);
-
-export const { get: getBookingFeeFromDb, update: updateBookingFee } =
-  textSetting(CONFIG_KEYS.BOOKING_FEE, "0");
 
 /**
  * Get allowed embed hosts from database (decrypted)
  * Returns null if not configured (embedding allowed from anywhere)
  */
-export const getEmbedHostsFromDb = async (): Promise<string | null> => {
+const getEmbedHostsFromDb = async (): Promise<string | null> => {
   const value = await getSetting(CONFIG_KEYS.EMBED_HOSTS);
   if (!value) return null;
   return decrypt(value);
@@ -606,7 +587,7 @@ export const getEmbedHostsFromDb = async (): Promise<string | null> => {
  * Update allowed embed hosts (encrypted at rest)
  * Pass empty string to clear the restriction
  */
-export const updateEmbedHosts = async (hosts: string): Promise<void> => {
+const updateEmbedHosts = async (hosts: string): Promise<void> => {
   if (hosts === "") {
     return setOrDeleteSetting(CONFIG_KEYS.EMBED_HOSTS, "");
   }
@@ -621,7 +602,7 @@ export const MAX_TERMS_LENGTH = 10_240;
  * Get terms and conditions text from database (30m cached).
  * Returns null if not configured.
  */
-export const getTermsAndConditionsFromDb = async (): Promise<string | null> => {
+const getTermsAndConditionsFromDb = async (): Promise<string | null> => {
   const cached = getPageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS);
   if (cached !== undefined) return cached;
   const value = await getSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS);
@@ -633,7 +614,7 @@ export const getTermsAndConditionsFromDb = async (): Promise<string | null> => {
  * Update terms and conditions text
  * Pass empty string to clear
  */
-export const updateTermsAndConditions = async (text: string): Promise<void> => {
+const updateTermsAndConditions = async (text: string): Promise<void> => {
   await setOrDeleteSetting(CONFIG_KEYS.TERMS_AND_CONDITIONS, text);
   invalidatePageCacheEntry(CONFIG_KEYS.TERMS_AND_CONDITIONS);
 };
@@ -656,7 +637,7 @@ const [getTzTestOverride, setTzTestOverride] = lazyRef<string | null>(
  * Get the configured timezone derived from country setting.
  * Also populates the permanent timezone cache for sync access via getTimezoneCached().
  */
-export const getTimezoneFromDb = async (): Promise<string> => {
+const getTimezoneFromDb = async (): Promise<string> => {
   const testOverride = getTzTestOverride();
   if (testOverride !== null) return testOverride;
   const cached = getTzCache();
@@ -672,7 +653,7 @@ export const getTimezoneFromDb = async (): Promise<string> => {
  * Derives from country setting. Safe to call from synchronous template code
  * because the middleware populates the settings cache on every request.
  */
-export const getTimezoneCached = (): string => {
+const getTimezoneCached = (): string => {
   const testOverride = getTzTestOverride();
   if (testOverride !== null) return testOverride;
   const cached = getTzCache();
@@ -696,16 +677,16 @@ const invalidateTimezoneCache = (): void => {
  * Explicitly set timezone for testing.
  * Uses a separate override that survives cache invalidation.
  */
-export const setTimezoneForTest = (tz: string): void => setTzTestOverride(tz);
+const setTimezoneForTest = (tz: string): void => setTzTestOverride(tz);
 
 /** Clear the test timezone override (call in test teardown). */
-export const resetTimezoneTestOverride = (): void => setTzTestOverride(null);
+const resetTimezoneTestOverride = (): void => setTzTestOverride(null);
 
 /**
  * Get the configured theme from database.
  * Returns "light" or "dark", defaulting to "light".
  */
-export const getThemeFromDb = async (): Promise<Theme> => {
+const getThemeFromDb = async (): Promise<Theme> => {
   const value = await getSetting(CONFIG_KEYS.THEME);
   return value === "dark" ? "dark" : "light";
 };
@@ -713,28 +694,22 @@ export const getThemeFromDb = async (): Promise<Theme> => {
 /**
  * Update the configured theme.
  */
-export const updateTheme = async (theme: Theme): Promise<void> => {
+const updateTheme = async (theme: Theme): Promise<void> => {
   await setSetting(CONFIG_KEYS.THEME, theme);
 };
-
-export const { get: getShowPublicSiteFromDb, update: updateShowPublicSite } =
-  booleanSetting(CONFIG_KEYS.SHOW_PUBLIC_SITE);
 
 /**
  * Get the "show public site" setting synchronously from cache.
  * Returns false if the cache is not populated or the setting is not "true".
  * Safe to call from synchronous template code after the settings cache is warmed.
  */
-export const getShowPublicSiteCached = (): boolean => {
+const getShowPublicSiteCached = (): boolean => {
   const state = getSettingsCacheState();
   if (state.entries !== null) {
     return state.entries.get(CONFIG_KEYS.SHOW_PUBLIC_SITE) === "true";
   }
   return false;
 };
-
-export const { get: getShowPublicApiFromDb, update: updateShowPublicApi } =
-  booleanSetting(CONFIG_KEYS.SHOW_PUBLIC_API);
 
 /** Get an encrypted optional setting (decrypted). Returns null if not set. */
 const getEncryptedSetting = async (key: string): Promise<string | null> => {
@@ -767,42 +742,19 @@ const getCachedPageSetting = async (key: string): Promise<string | null> => {
   return value;
 };
 
-export const { get: getWebsiteTitleFromDb, update: updateWebsiteTitle } =
-  cachedEncryptedSetting(CONFIG_KEYS.WEBSITE_TITLE);
-
-export const { get: getHomepageTextFromDb, update: updateHomepageText } =
-  cachedEncryptedSetting(CONFIG_KEYS.HOMEPAGE_TEXT);
-
-export const { get: getContactPageTextFromDb, update: updateContactPageText } =
-  cachedEncryptedSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT);
-
 /**
  * Get the configured phone prefix derived from country setting.
  */
-export const getPhonePrefixFromDb = async (): Promise<string> => {
+const getPhonePrefixFromDb = async (): Promise<string> => {
   const country = await getCountryFromDb();
   return getCountry(country).phonePrefix;
 };
 
-export const { get: getHeaderImageUrlFromDb, update: updateHeaderImageUrl } =
-  encryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL);
-
-export const { get: getEmailProviderFromDb, update: updateEmailProvider } =
-  textSetting(CONFIG_KEYS.EMAIL_PROVIDER);
-
 /** Check if an email API key has been configured in the database */
-export const hasEmailApiKey = async (): Promise<boolean> => {
+const hasEmailApiKey = async (): Promise<boolean> => {
   const value = await getSetting(CONFIG_KEYS.EMAIL_API_KEY);
   return value !== null;
 };
-
-export const { get: getEmailApiKeyFromDb, update: updateEmailApiKey } =
-  encryptedSetting(CONFIG_KEYS.EMAIL_API_KEY);
-
-export const {
-  get: getEmailFromAddressFromDb,
-  update: updateEmailFromAddress,
-} = encryptedSetting(CONFIG_KEYS.EMAIL_FROM_ADDRESS);
 
 /** Valid email template types */
 export type EmailTemplateType = "confirmation" | "admin";
@@ -830,14 +782,14 @@ const emailTemplateKey = (
 export const MAX_EMAIL_TEMPLATE_LENGTH = 51_200;
 
 /** Get a custom email template (decrypted). Returns null if not customised (use default). */
-export const getEmailTemplate = (
+const getEmailTemplate = (
   type: EmailTemplateType,
   format: EmailTemplateFormat,
 ): Promise<string | null> =>
   getEncryptedSetting(emailTemplateKey(type, format));
 
 /** Update a custom email template (encrypted at rest). Pass empty string to clear (revert to default). */
-export const updateEmailTemplate = (
+const updateEmailTemplate = (
   type: EmailTemplateType,
   format: EmailTemplateFormat,
   content: string,
@@ -845,7 +797,7 @@ export const updateEmailTemplate = (
   updateEncryptedSetting(emailTemplateKey(type, format), content);
 
 /** Get all 3 parts of a custom email template (subject, html, text). Nulls mean "use default". */
-export const getEmailTemplateSet = async (
+const getEmailTemplateSet = async (
   type: EmailTemplateType,
 ): Promise<{
   subject: string | null;
@@ -860,15 +812,12 @@ export const getEmailTemplateSet = async (
   return { subject, html, text };
 };
 
-export const { get: getCustomDomainFromDb, update: updateCustomDomain } =
-  textSetting(CONFIG_KEYS.CUSTOM_DOMAIN);
-
 /** Get the custom domain last validated timestamp. Returns null if never validated. */
-export const getCustomDomainLastValidatedFromDb = (): Promise<string | null> =>
+const getCustomDomainLastValidatedFromDb = (): Promise<string | null> =>
   getSetting(CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED);
 
 /** Update the custom domain last validated timestamp to now (UTC ISO 8601). */
-export const updateCustomDomainLastValidated = (): Promise<void> =>
+const updateCustomDomainLastValidated = (): Promise<void> =>
   setSetting(
     CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED,
     new Date().toISOString(),
@@ -901,22 +850,21 @@ const [getHostWalletOverride, setHostWalletOverride] = lazyRef<
 >(() => undefined);
 
 /** Get host-level Apple Wallet config. Uses test override if set, otherwise reads env vars. */
-export const getHostAppleWalletConfig = (): SigningCredentials | null => {
+const getHostAppleWalletConfig = (): SigningCredentials | null => {
   const override = getHostWalletOverride();
   return override !== undefined ? override : getHostAppleWalletConfigFromEnv();
 };
 
 /** For testing: set host Apple Wallet config directly. Bypasses env vars to avoid races. */
-export const setHostAppleWalletConfigForTest = (
+const setHostAppleWalletConfigForTest = (
   config: SigningCredentials | null,
 ): void => setHostWalletOverride(config);
 
 /** For testing: reset host Apple Wallet config to read from env vars. */
-export const resetHostAppleWalletConfig = (): void =>
-  setHostWalletOverride(undefined);
+const resetHostAppleWalletConfig = (): void => setHostWalletOverride(undefined);
 
 /** Check if Apple Wallet DB settings are fully configured (all 5 settings present). */
-export const hasAppleWalletDbConfig = async (): Promise<boolean> => {
+const hasAppleWalletDbConfig = async (): Promise<boolean> => {
   const [passTypeId, teamId, cert, key, wwdr] = await Promise.all([
     getSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID),
     getSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID),
@@ -934,52 +882,45 @@ export const hasAppleWalletDbConfig = async (): Promise<boolean> => {
 };
 
 /** Check if Apple Wallet is configured (DB settings or env vars). */
-export const hasAppleWalletConfig = async (): Promise<boolean> =>
+const hasAppleWalletConfig = async (): Promise<boolean> =>
   (await hasAppleWalletDbConfig()) || getHostAppleWalletConfig() !== null;
 
-export const {
-  get: getAppleWalletPassTypeIdFromDb,
-  update: updateAppleWalletPassTypeId,
-} = textSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID);
+const { get: getAppleWalletPassTypeIdFromDb } = textSetting(
+  CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID,
+);
 
-export const {
-  get: getAppleWalletTeamIdFromDb,
-  update: updateAppleWalletTeamId,
-} = textSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID);
+const { get: getAppleWalletTeamIdFromDb } = textSetting(
+  CONFIG_KEYS.APPLE_WALLET_TEAM_ID,
+);
 
-export const {
-  get: getAppleWalletSigningCertFromDb,
-  update: updateAppleWalletSigningCert,
-} = encryptedSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT);
+const { get: getAppleWalletSigningCertFromDb } = encryptedSetting(
+  CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT,
+);
 
-export const {
-  get: getAppleWalletSigningKeyFromDb,
-  update: updateAppleWalletSigningKey,
-} = encryptedSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY);
+const { get: getAppleWalletSigningKeyFromDb } = encryptedSetting(
+  CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY,
+);
 
-export const {
-  get: getAppleWalletWwdrCertFromDb,
-  update: updateAppleWalletWwdrCert,
-} = encryptedSetting(CONFIG_KEYS.APPLE_WALLET_WWDR_CERT);
+const { get: getAppleWalletWwdrCertFromDb } = encryptedSetting(
+  CONFIG_KEYS.APPLE_WALLET_WWDR_CERT,
+);
 
 /** Get Apple Wallet config from DB (decrypted). Returns null if incomplete. */
-export const getAppleWalletDbConfig =
-  async (): Promise<SigningCredentials | null> => {
-    const [passTypeId, teamId, signingCert, signingKey, wwdrCert] =
-      await Promise.all([
-        getAppleWalletPassTypeIdFromDb(),
-        getAppleWalletTeamIdFromDb(),
-        getAppleWalletSigningCertFromDb(),
-        getAppleWalletSigningKeyFromDb(),
-        getAppleWalletWwdrCertFromDb(),
-      ]);
-    return toCredentials(passTypeId, teamId, signingCert, signingKey, wwdrCert);
-  };
+const getAppleWalletDbConfig = async (): Promise<SigningCredentials | null> => {
+  const [passTypeId, teamId, signingCert, signingKey, wwdrCert] =
+    await Promise.all([
+      getAppleWalletPassTypeIdFromDb(),
+      getAppleWalletTeamIdFromDb(),
+      getAppleWalletSigningCertFromDb(),
+      getAppleWalletSigningKeyFromDb(),
+      getAppleWalletWwdrCertFromDb(),
+    ]);
+  return toCredentials(passTypeId, teamId, signingCert, signingKey, wwdrCert);
+};
 
 /** Get Apple Wallet config for pass generation. DB settings take priority, falls back to env vars. */
-export const getAppleWalletConfig =
-  async (): Promise<SigningCredentials | null> =>
-    (await getAppleWalletDbConfig()) ?? getHostAppleWalletConfig();
+const getAppleWalletConfig = async (): Promise<SigningCredentials | null> =>
+  (await getAppleWalletDbConfig()) ?? getHostAppleWalletConfig();
 
 // ---------------------------------------------------------------------------
 // Google Wallet configuration
@@ -996,7 +937,7 @@ const toGoogleCredentials = (
     : null;
 
 /** Read Google Wallet config from environment variables. Returns null if not fully configured. */
-export const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
+const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
   toGoogleCredentials(
     getEnv("GOOGLE_WALLET_ISSUER_ID"),
     getEnv("GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL"),
@@ -1004,7 +945,7 @@ export const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
   );
 
 /** Check if Google Wallet DB settings are fully configured (all 3 settings present). */
-export const hasGoogleWalletDbConfig = async (): Promise<boolean> => {
+const hasGoogleWalletDbConfig = async (): Promise<boolean> => {
   const [issuerId, email, key] = await Promise.all([
     getSetting(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID),
     getSetting(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL),
@@ -1014,26 +955,23 @@ export const hasGoogleWalletDbConfig = async (): Promise<boolean> => {
 };
 
 /** Check if Google Wallet is configured (DB settings or env vars). */
-export const hasGoogleWalletConfig = async (): Promise<boolean> =>
+const hasGoogleWalletConfig = async (): Promise<boolean> =>
   (await hasGoogleWalletDbConfig()) || getHostGoogleWalletConfig() !== null;
 
-export const {
-  get: getGoogleWalletIssuerIdFromDb,
-  update: updateGoogleWalletIssuerId,
-} = textSetting(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID);
+const { get: getGoogleWalletIssuerIdFromDb } = textSetting(
+  CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID,
+);
 
-export const {
-  get: getGoogleWalletServiceAccountEmailFromDb,
-  update: updateGoogleWalletServiceAccountEmail,
-} = textSetting(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL);
+const { get: getGoogleWalletServiceAccountEmailFromDb } = textSetting(
+  CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL,
+);
 
-export const {
-  get: getGoogleWalletServiceAccountKeyFromDb,
-  update: updateGoogleWalletServiceAccountKey,
-} = encryptedSetting(CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY);
+const { get: getGoogleWalletServiceAccountKeyFromDb } = encryptedSetting(
+  CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY,
+);
 
 /** Get Google Wallet config from DB (decrypted). Returns null if incomplete. */
-export const getGoogleWalletDbConfig =
+const getGoogleWalletDbConfig =
   async (): Promise<GoogleWalletCredentials | null> => {
     const [issuerId, serviceAccountEmail, serviceAccountKey] =
       await Promise.all([
@@ -1049,111 +987,174 @@ export const getGoogleWalletDbConfig =
   };
 
 /** Get Google Wallet config for pass generation. DB settings take priority, falls back to env vars. */
-export const getGoogleWalletConfig =
+const getGoogleWalletConfig =
   async (): Promise<GoogleWalletCredentials | null> =>
     (await getGoogleWalletDbConfig()) ?? getHostGoogleWalletConfig();
 
 /**
- * Stubbable API for testing - allows mocking in ES modules
- * Use spyOn(settingsApi, "method") instead of spyOn(settingsModule, "method")
+ * Unified settings namespace. Replaces individual function exports and settingsApi.
+ *
+ * Usage:
+ *   import { settings } from "#lib/db/settings.ts";
+ *   const key = await settings.stripe.secretKey.get();
+ *   await settings.stripe.secretKey.update(newKey);
+ *
+ * Stubbable for testing: stub(settings.stripe.secretKey, "get", ...)
  */
-export const settingsApi = {
-  PAGE_CACHE_TTL_MS,
-  completeSetup,
-  getSetting,
-  setSetting,
-  loadAllSettings,
-  invalidateSettingsCache,
+export const settings = {
+  // --- Core cache operations ---
+  get: getSetting,
+  set: setSetting,
+  getCached: getSettingCached,
+  loadAll: loadAllSettings,
+  invalidateCache: invalidateSettingsCache,
   invalidatePageCache,
-  isSetupComplete,
-  clearSetupCompleteCache,
-  getPublicKey,
-  getWrappedPrivateKey,
+
+  // --- Setup & auth ---
+  setup: {
+    isComplete: isSetupComplete,
+    clearCache: clearSetupCompleteCache,
+    complete: completeSetup,
+  },
   updateUserPassword,
-  getCountryFromDb,
-  updateCountry,
-  getCurrencyCodeFromDb,
-  getPaymentProviderFromDb,
-  setPaymentProvider,
-  clearPaymentProvider,
-  hasStripeKey,
-  getStripeSecretKeyFromDb,
-  updateStripeKey,
-  getStripeWebhookSecretFromDb,
-  getStripeWebhookEndpointId,
-  setStripeWebhookConfig,
-  hasSquareToken,
-  getSquareAccessTokenFromDb,
-  updateSquareAccessToken,
-  getSquareWebhookSignatureKeyFromDb,
-  updateSquareWebhookSignatureKey,
-  getSquareLocationIdFromDb,
-  updateSquareLocationId,
-  getSquareSandboxFromDb,
-  updateSquareSandbox,
-  getBookingFeeFromDb,
-  updateBookingFee,
-  getEmbedHostsFromDb,
-  updateEmbedHosts,
-  getTermsAndConditionsFromDb,
-  updateTermsAndConditions,
-  getTimezoneFromDb,
-  setTimezoneForTest,
-  resetTimezoneTestOverride,
-  getThemeFromDb,
-  updateTheme,
-  getShowPublicSiteFromDb,
-  getShowPublicSiteCached,
-  updateShowPublicSite,
-  getWebsiteTitleFromDb,
-  updateWebsiteTitle,
-  getHomepageTextFromDb,
-  updateHomepageText,
-  getContactPageTextFromDb,
-  updateContactPageText,
-  getPhonePrefixFromDb,
-  getHeaderImageUrlFromDb,
-  updateHeaderImageUrl,
-  getShowPublicApiFromDb,
-  updateShowPublicApi,
-  getEmailProviderFromDb,
-  updateEmailProvider,
-  hasEmailApiKey,
-  getEmailApiKeyFromDb,
-  updateEmailApiKey,
-  getEmailFromAddressFromDb,
-  updateEmailFromAddress,
-  getEmailTemplate,
-  updateEmailTemplate,
-  getEmailTemplateSet,
-  getCustomDomainFromDb,
-  updateCustomDomain,
-  getCustomDomainLastValidatedFromDb,
-  updateCustomDomainLastValidated,
-  hasAppleWalletConfig,
-  hasAppleWalletDbConfig,
-  getHostAppleWalletConfig,
-  getAppleWalletPassTypeIdFromDb,
-  updateAppleWalletPassTypeId,
-  getAppleWalletTeamIdFromDb,
-  updateAppleWalletTeamId,
-  getAppleWalletSigningCertFromDb,
-  updateAppleWalletSigningCert,
-  getAppleWalletSigningKeyFromDb,
-  updateAppleWalletSigningKey,
-  getAppleWalletWwdrCertFromDb,
-  updateAppleWalletWwdrCert,
-  getAppleWalletConfig,
-  getAppleWalletDbConfig,
-  hasGoogleWalletConfig,
-  hasGoogleWalletDbConfig,
-  getHostGoogleWalletConfig,
-  getGoogleWalletIssuerIdFromDb,
-  updateGoogleWalletIssuerId,
-  getGoogleWalletServiceAccountEmailFromDb,
-  updateGoogleWalletServiceAccountEmail,
-  getGoogleWalletServiceAccountKeyFromDb,
-  updateGoogleWalletServiceAccountKey,
-  getGoogleWalletConfig,
-  getGoogleWalletDbConfig,
+
+  // --- Encryption keys ---
+  publicKey: { get: getPublicKey },
+  wrappedPrivateKey: { get: getWrappedPrivateKey },
+
+  // --- Country / locale ---
+  country: { get: getCountryFromDb, update: updateCountry },
+  currency: { get: getCurrencyCodeFromDb },
+  phonePrefix: { get: getPhonePrefixFromDb },
+
+  // --- Timezone ---
+  timezone: {
+    get: getTimezoneFromDb,
+    getCached: getTimezoneCached,
+    setForTest: setTimezoneForTest,
+    resetTestOverride: resetTimezoneTestOverride,
+  },
+
+  // --- Payment provider ---
+  paymentProvider: {
+    get: getPaymentProviderFromDb,
+    set: setPaymentProvider,
+    clear: clearPaymentProvider,
+  },
+
+  // --- Stripe ---
+  stripe: {
+    secretKey: {
+      ...encryptedSetting(CONFIG_KEYS.STRIPE_SECRET_KEY),
+      has: hasStripeKey,
+      mode: getStripeKeyMode,
+    },
+    webhookSecret: { get: getStripeWebhookSecretFromDb },
+    webhookEndpointId: { get: getStripeWebhookEndpointId },
+    setWebhookConfig: setStripeWebhookConfig,
+  },
+
+  // --- Square ---
+  square: {
+    accessToken: {
+      ...encryptedSetting(CONFIG_KEYS.SQUARE_ACCESS_TOKEN),
+      has: hasSquareToken,
+    },
+    webhookSignatureKey: encryptedSetting(
+      CONFIG_KEYS.SQUARE_WEBHOOK_SIGNATURE_KEY,
+    ),
+    locationId: {
+      get: getSquareLocationIdFromDb,
+      update: updateSquareLocationId,
+    },
+    sandbox: booleanSetting(CONFIG_KEYS.SQUARE_SANDBOX),
+  },
+
+  // --- Fees ---
+  bookingFee: textSetting(CONFIG_KEYS.BOOKING_FEE, "0"),
+
+  // --- Embed ---
+  embedHosts: { get: getEmbedHostsFromDb, update: updateEmbedHosts },
+
+  // --- Terms ---
+  terms: { get: getTermsAndConditionsFromDb, update: updateTermsAndConditions },
+
+  // --- Theme / display ---
+  theme: { get: getThemeFromDb, update: updateTheme },
+  showPublicSite: {
+    ...booleanSetting(CONFIG_KEYS.SHOW_PUBLIC_SITE),
+    getCached: getShowPublicSiteCached,
+  },
+  showPublicApi: booleanSetting(CONFIG_KEYS.SHOW_PUBLIC_API),
+
+  // --- Page content ---
+  websiteTitle: cachedEncryptedSetting(CONFIG_KEYS.WEBSITE_TITLE),
+  homepageText: cachedEncryptedSetting(CONFIG_KEYS.HOMEPAGE_TEXT),
+  contactPageText: cachedEncryptedSetting(CONFIG_KEYS.CONTACT_PAGE_TEXT),
+  headerImageUrl: encryptedSetting(CONFIG_KEYS.HEADER_IMAGE_URL),
+
+  // --- Email ---
+  email: {
+    provider: textSetting(CONFIG_KEYS.EMAIL_PROVIDER),
+    apiKey: {
+      ...encryptedSetting(CONFIG_KEYS.EMAIL_API_KEY),
+      has: hasEmailApiKey,
+    },
+    fromAddress: encryptedSetting(CONFIG_KEYS.EMAIL_FROM_ADDRESS),
+    template: {
+      get: getEmailTemplate,
+      update: updateEmailTemplate,
+      getSet: getEmailTemplateSet,
+    },
+  },
+
+  // --- Custom domain ---
+  customDomain: {
+    ...textSetting(CONFIG_KEYS.CUSTOM_DOMAIN),
+    lastValidated: {
+      get: getCustomDomainLastValidatedFromDb,
+      update: updateCustomDomainLastValidated,
+    },
+  },
+
+  // --- Apple Wallet ---
+  appleWallet: {
+    passTypeId: textSetting(CONFIG_KEYS.APPLE_WALLET_PASS_TYPE_ID),
+    teamId: textSetting(CONFIG_KEYS.APPLE_WALLET_TEAM_ID),
+    signingCert: encryptedSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_CERT),
+    signingKey: encryptedSetting(CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY),
+    wwdrCert: encryptedSetting(CONFIG_KEYS.APPLE_WALLET_WWDR_CERT),
+    hasDbConfig: hasAppleWalletDbConfig,
+    hasConfig: hasAppleWalletConfig,
+    getDbConfig: getAppleWalletDbConfig,
+    getConfig: getAppleWalletConfig,
+    getHostConfig: getHostAppleWalletConfig,
+    setHostConfigForTest: setHostAppleWalletConfigForTest,
+    resetHostConfig: resetHostAppleWalletConfig,
+  },
+
+  // --- Google Wallet ---
+  googleWallet: {
+    issuerId: textSetting(CONFIG_KEYS.GOOGLE_WALLET_ISSUER_ID),
+    serviceAccountEmail: textSetting(
+      CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL,
+    ),
+    serviceAccountKey: encryptedSetting(
+      CONFIG_KEYS.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY,
+    ),
+    hasDbConfig: hasGoogleWalletDbConfig,
+    hasConfig: hasGoogleWalletConfig,
+    getDbConfig: getGoogleWalletDbConfig,
+    getConfig: getGoogleWalletConfig,
+    getHostConfig: getHostGoogleWalletConfig,
+  },
+
+  // --- Migration ---
+  attendeeBlobMigrated: {
+    is: isAttendeeBlobMigrated,
+    set: setAttendeeBlobMigrated,
+  },
+
+  // --- Constants ---
+  PAGE_CACHE_TTL_MS,
 };

--- a/src/lib/email-renderer.ts
+++ b/src/lib/email-renderer.ts
@@ -122,7 +122,7 @@ export const renderEmailContent = async (
   data: TemplateData,
 ): Promise<EmailContent> => {
   const defaults = DEFAULT_TEMPLATES[type];
-  const custom = await settings.email.template.getSet(type);
+  const custom = settings.email.templateSet(type);
 
   const [subject, html, text] = await Promise.all([
     safeRender(

--- a/src/lib/email-renderer.ts
+++ b/src/lib/email-renderer.ts
@@ -13,7 +13,7 @@ import type {
   EmailTemplateFormat,
   EmailTemplateType,
 } from "#lib/db/settings.ts";
-import { getEmailTemplateSet } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { EmailEntry } from "#lib/email.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { isPaidEvent } from "#lib/types.ts";
@@ -122,7 +122,7 @@ export const renderEmailContent = async (
   data: TemplateData,
 ): Promise<EmailContent> => {
   const defaults = DEFAULT_TEMPLATES[type];
-  const custom = await getEmailTemplateSet(type);
+  const custom = await settings.email.template.getSet(type);
 
   const [subject, html, text] = await Promise.all([
     safeRender(

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -51,12 +51,10 @@ export type EmailConfig = {
 
 /** Read email config from DB settings. Falls back to business email for fromAddress. Returns null if not configured. */
 export const getEmailConfig = async (): Promise<EmailConfig | null> => {
-  const [provider, apiKey, fromAddress, businessEmail] = await Promise.all([
-    settings.email.provider.get(),
-    settings.email.apiKey.get(),
-    settings.email.fromAddress.get(),
-    getBusinessEmailFromDb(),
-  ]);
+  const provider = settings.email.provider;
+  const apiKey = settings.email.apiKey;
+  const fromAddress = settings.email.fromAddress;
+  const businessEmail = await getBusinessEmailFromDb();
   const from = fromAddress || businessEmail;
   if (!provider || !apiKey || !from) return null;
   return { provider: provider as EmailProvider, apiKey, fromAddress: from };

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -7,11 +7,7 @@ import { lazyRef, map } from "#fp";
 import { getBusinessEmailFromDb } from "#lib/business-email.ts";
 import { getEffectiveDomain } from "#lib/config.ts";
 import { toBase64 } from "#lib/crypto.ts";
-import {
-  getEmailApiKeyFromDb,
-  getEmailFromAddressFromDb,
-  getEmailProviderFromDb,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { buildTemplateData, renderEmailContent } from "#lib/email-renderer.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
@@ -56,9 +52,9 @@ export type EmailConfig = {
 /** Read email config from DB settings. Falls back to business email for fromAddress. Returns null if not configured. */
 export const getEmailConfig = async (): Promise<EmailConfig | null> => {
   const [provider, apiKey, fromAddress, businessEmail] = await Promise.all([
-    getEmailProviderFromDb(),
-    getEmailApiKeyFromDb(),
-    getEmailFromAddressFromDb(),
+    settings.email.provider.get(),
+    settings.email.apiKey.get(),
+    settings.email.fromAddress.get(),
     getBusinessEmailFromDb(),
   ]);
   const from = fromAddress || businessEmail;

--- a/src/lib/header-image.ts
+++ b/src/lib/header-image.ts
@@ -16,8 +16,8 @@ const state = { url: null as string | null };
  * Called once per request in routes/index.ts before templates render.
  * Settings are already cached so this is cheap on repeat calls.
  */
-export const loadHeaderImage = async (): Promise<string | null> => {
-  state.url = await settings.headerImageUrl.get();
+export const loadHeaderImage = (): string | null => {
+  state.url = settings.headerImageUrl;
   return state.url;
 };
 

--- a/src/lib/header-image.ts
+++ b/src/lib/header-image.ts
@@ -6,7 +6,7 @@
  * before templates render.
  */
 
-import { getHeaderImageUrlFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 
 /** Sync-accessible header image URL, populated by loadHeaderImage() */
 const state = { url: null as string | null };
@@ -17,7 +17,7 @@ const state = { url: null as string | null };
  * Settings are already cached so this is cheap on repeat calls.
  */
 export const loadHeaderImage = async (): Promise<string | null> => {
-  state.url = await getHeaderImageUrlFromDb();
+  state.url = await settings.headerImageUrl.get();
   return state.url;
 };
 

--- a/src/lib/payment-helpers.ts
+++ b/src/lib/payment-helpers.ts
@@ -50,7 +50,7 @@ export const safeAsync = async <T>(
  * Returns null if the client is not available or the operation fails.
  */
 export const createWithClient =
-  <Client>(getClient: () => Promise<Client | null>) =>
+  <Client>(getClient: () => Client | null | Promise<Client | null>) =>
   async <T>(
     op: (client: Client) => Promise<T>,
     errorCode: ErrorCodeType,

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -222,7 +222,7 @@ export interface PaymentProvider {
  */
 export const getActivePaymentProvider =
   async (): Promise<PaymentProvider | null> => {
-    const providerType = await paymentsApi.getConfiguredProvider();
+    const providerType = paymentsApi.getConfiguredProvider();
     if (!providerType) {
       logDebug("Payment", "No payment provider configured in settings");
       return null;

--- a/src/lib/seeds.ts
+++ b/src/lib/seeds.ts
@@ -13,7 +13,7 @@ import {
 } from "#lib/crypto.ts";
 import { executeBatch, queryAll } from "#lib/db/client.ts";
 import { invalidateEventsCache } from "#lib/db/events.ts";
-import { getPublicKey } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   DEMO_ADDRESSES,
   DEMO_EMAILS,
@@ -208,7 +208,7 @@ export const createSeeds = async (
   eventCount: number,
   attendeesPerEvent: number,
 ): Promise<SeedResult> => {
-  const publicKeyJwk = await getPublicKey();
+  const publicKeyJwk = await settings.publicKey.get();
   if (!publicKeyJwk) throw new Error("Public key not configured");
 
   // Build structured event data: quantities, capacity, price, and slug per event

--- a/src/lib/seeds.ts
+++ b/src/lib/seeds.ts
@@ -208,7 +208,7 @@ export const createSeeds = async (
   eventCount: number,
   attendeesPerEvent: number,
 ): Promise<SeedResult> => {
-  const publicKeyJwk = await settings.publicKey.get();
+  const publicKeyJwk = settings.publicKey;
   if (!publicKeyJwk) throw new Error("Public key not configured");
 
   // Build structured event data: quantities, capacity, price, and slug per event

--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -387,14 +387,14 @@ const [getCache, setCache] = lazyRef<SquareCache>(() => {
 });
 
 /** Internal getSquareClient implementation */
-const getClientImpl = async () => {
-  const accessToken = await getSquareAccessToken();
+const getClientImpl = () => {
+  const accessToken = getSquareAccessToken();
   if (!accessToken) {
     logDebug("Square", "No access token configured, cannot create client");
     return null;
   }
 
-  const sandbox = await getSquareSandbox();
+  const sandbox = getSquareSandbox();
 
   try {
     const cached = getCache();
@@ -418,8 +418,8 @@ const getClientImpl = async () => {
 const withClient = createWithClient(() => squareApi.getSquareClient());
 
 /** Get the configured location ID */
-const getLocationId = async (): Promise<string | null> => {
-  const locationId = await getSquareLocationId();
+const getLocationId = (): string | null => {
+  const locationId = getSquareLocationId();
   if (!locationId) {
     logDebug("Square", "No location ID configured");
     return null;
@@ -431,10 +431,10 @@ const getLocationId = async (): Promise<string | null> => {
 type PaymentLinkConfig = { locationId: string; currency: string };
 
 /** Get location ID and currency, returning null if location is not configured */
-const getPaymentLinkConfig = async (): Promise<PaymentLinkConfig | null> => {
-  const locationId = await getLocationId();
+const getPaymentLinkConfig = (): PaymentLinkConfig | null => {
+  const locationId = getLocationId();
   if (!locationId) return null;
-  const currency = (await getCurrencyCode()).toUpperCase();
+  const currency = getCurrencyCode().toUpperCase();
   return { locationId, currency };
 };
 
@@ -519,20 +519,20 @@ const createPaymentLinkImpl = (
   }, ErrorCode.SQUARE_CHECKOUT);
 
 /** Normalize a phone number for Square pre-populated checkout data */
-const normalizeCheckoutPhone = async (
+const normalizeCheckoutPhone = (
   phone: string | undefined,
-): Promise<string | undefined> => {
+): string | undefined => {
   if (!phone) return undefined;
-  const prefix = await settings.phonePrefix.get();
+  const prefix = settings.phonePrefix;
   return normalizePhone(phone, prefix);
 };
 
 /** Build a Square fee line item array (empty when fee is zero). */
-const squareFeeItems = async (
+const squareFeeItems = (
   subtotal: number,
   currency: string,
-): Promise<SquareLineItem[]> => {
-  const amt = await getBookingFeeAmount(subtotal);
+): SquareLineItem[] => {
+  const amt = getBookingFeeAmount(subtotal);
   return amt > 0
     ? [
         {
@@ -559,11 +559,11 @@ const submitPaymentLink = async (
   baseUrl: string,
   label: string,
 ): Promise<PaymentLinkResult> => {
-  lineItems.push(...(await squareFeeItems(feeSubtotal, prep.config.currency)));
+  lineItems.push(...squareFeeItems(feeSubtotal, prep.config.currency));
   const result = await createPaymentLinkImpl({
     ...prep.config,
     lineItems,
-    ...(await buildCheckoutOptions(intent, prep.metadata, baseUrl, label)),
+    ...buildCheckoutOptions(intent, prep.metadata, baseUrl, label),
   });
   logDebug(
     "Square",
@@ -575,7 +575,7 @@ const submitPaymentLink = async (
 };
 
 /** Build common payment link options from intent */
-const buildCheckoutOptions = async (
+const buildCheckoutOptions = (
   intent: { email: string; phone?: string },
   metadata: Record<string, string>,
   baseUrl: string,
@@ -584,16 +584,16 @@ const buildCheckoutOptions = async (
   metadata,
   baseUrl,
   email: intent.email,
-  phone: await normalizeCheckoutPhone(intent.phone),
+  phone: normalizeCheckoutPhone(intent.phone),
   label,
 });
 
 /** Shared setup for payment link creation: validates config and metadata */
-const preparePaymentLink = async (
+const preparePaymentLink = (
   rawMetadata: Record<string, string>,
   label: string,
-): Promise<PreparedLink | null> => {
-  const config = await getPaymentLinkConfig();
+): PreparedLink | null => {
+  const config = getPaymentLinkConfig();
   if (!config) return null;
 
   logDebug("Square", `Creating ${label}`);
@@ -651,7 +651,7 @@ export const squareApi: {
     try {
       const response = await client.locations.list();
       locations = response.locations ?? [];
-      const sandbox = await getSquareSandbox();
+      const sandbox = getSquareSandbox();
       result.accessToken = {
         valid: true,
         mode: sandbox ? "sandbox" : "production",
@@ -662,7 +662,7 @@ export const squareApi: {
     }
 
     // Step 2: Verify location ID
-    const locationId = await getSquareLocationId();
+    const locationId = getSquareLocationId();
     if (!locationId) {
       result.location = {
         configured: false,
@@ -687,7 +687,7 @@ export const squareApi: {
     }
 
     // Step 3: Check webhook signature key
-    const webhookKey = await getSquareWebhookSignatureKey();
+    const webhookKey = getSquareWebhookSignatureKey();
     result.webhook = { configured: webhookKey !== null };
     if (!webhookKey) {
       result.webhook.error = "No webhook signature key configured";
@@ -915,7 +915,7 @@ export const verifyWebhookSignature = async (
   notificationUrl: string,
   payloadBytes: Uint8Array,
 ): Promise<WebhookVerifyResult> => {
-  const secret = await getSquareWebhookSignatureKey();
+  const secret = getSquareWebhookSignatureKey();
   if (!secret) {
     logError({
       code: ErrorCode.CONFIG_MISSING,

--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -19,7 +19,7 @@ import {
   getSquareSandbox,
   getSquareWebhookSignatureKey,
 } from "#lib/config.ts";
-import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import {
   computeHmacSha256,
@@ -523,7 +523,7 @@ const normalizeCheckoutPhone = async (
   phone: string | undefined,
 ): Promise<string | undefined> => {
   if (!phone) return undefined;
-  const prefix = await getPhonePrefixFromDb();
+  const prefix = await settings.phonePrefix.get();
   return normalizePhone(phone, prefix);
 };
 

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -11,7 +11,7 @@ import {
   getStripeSecretKey,
   getStripeWebhookSecret,
 } from "#lib/config.ts";
-import { getStripeWebhookEndpointId } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { getEnv } from "#lib/env.ts";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 import { nowMs } from "#lib/now.ts";
@@ -437,7 +437,7 @@ export const stripeApi: {
     }
 
     // Step 2: List all webhook endpoints
-    const ownEndpointId = await getStripeWebhookEndpointId();
+    const ownEndpointId = await settings.stripe.webhookEndpointId.get();
     result.ownEndpointId = ownEndpointId;
 
     try {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -117,7 +117,7 @@ const [getCache, setCache] = lazyRef<StripeCache>(() => {
 
 /** Internal getStripeClient implementation */
 const getClientImpl = async (): Promise<Stripe | null> => {
-  const secretKey = await getStripeSecretKey();
+  const secretKey = getStripeSecretKey();
   if (!secretKey) {
     logDebug("Stripe", "No secret key configured, cannot create client");
     return null;
@@ -155,11 +155,11 @@ type SessionConfig = {
 };
 
 /** Build a Stripe fee line item array (empty when fee is zero). */
-const stripeFeeItems = async (
+const stripeFeeItems = (
   subtotal: number,
   currency: string,
-): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> => {
-  const amount = await getBookingFeeAmount(subtotal);
+): Stripe.Checkout.SessionCreateParams.LineItem[] => {
+  const amount = getBookingFeeAmount(subtotal);
   if (amount <= 0) return [];
   return [
     {
@@ -173,11 +173,11 @@ const stripeFeeItems = async (
   ];
 };
 
-const buildSessionParams = async (
+const buildSessionParams = (
   cfg: SessionConfig,
-): Promise<Stripe.Checkout.SessionCreateParams> => {
+): Stripe.Checkout.SessionCreateParams => {
   const unitAmount = cfg.unitPriceOverride ?? cfg.event.unit_price;
-  const currency = (await getCurrencyCode()).toLowerCase();
+  const currency = getCurrencyCode().toLowerCase();
   const label = cfg.quantity > 1 ? `${cfg.quantity} Tickets` : "Ticket";
 
   const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [
@@ -194,9 +194,7 @@ const buildSessionParams = async (
     },
   ];
 
-  lineItems.push(
-    ...(await stripeFeeItems(unitAmount * cfg.quantity, currency)),
-  );
+  lineItems.push(...stripeFeeItems(unitAmount * cfg.quantity, currency));
 
   return {
     payment_method_types: ["card"],
@@ -325,7 +323,7 @@ export const stripeApi: {
       "Stripe",
       `Creating checkout session for event=${event.id} qty=${intent.quantity}`,
     );
-    const config = await buildSessionParams({
+    const config = buildSessionParams({
       event,
       quantity: intent.quantity,
       email: intent.email,
@@ -360,7 +358,7 @@ export const stripeApi: {
       "Stripe",
       `Creating multi-checkout session for ${intent.items.length} events`,
     );
-    const currency = (await getCurrencyCode()).toLowerCase();
+    const currency = getCurrencyCode().toLowerCase();
 
     // Build line items for each event
     const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] =
@@ -377,9 +375,7 @@ export const stripeApi: {
         quantity: item.quantity,
       }));
 
-    lineItems.push(
-      ...(await stripeFeeItems(itemsSubtotal(intent.items), currency)),
-    );
+    lineItems.push(...stripeFeeItems(itemsSubtotal(intent.items), currency));
 
     const params: Stripe.Checkout.SessionCreateParams = {
       payment_method_types: ["card"],
@@ -437,7 +433,7 @@ export const stripeApi: {
     }
 
     // Step 2: List all webhook endpoints
-    const ownEndpointId = await settings.stripe.webhookEndpointId.get();
+    const ownEndpointId = settings.stripe.webhookEndpointId;
     result.ownEndpointId = ownEndpointId;
 
     try {
@@ -584,7 +580,7 @@ export const verifyWebhookSignature = async (
   signature: string,
   toleranceSeconds = DEFAULT_TOLERANCE_SECONDS,
 ): Promise<WebhookVerifyResult> => {
-  const secret = await getStripeWebhookSecret();
+  const secret = getStripeWebhookSecret();
   if (!secret) {
     logError({ code: ErrorCode.CONFIG_MISSING, detail: "webhook secret" });
     return { valid: false, error: "Webhook secret not configured" };

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -17,8 +17,8 @@ const state: { theme: Theme } = { theme: "light" };
  * Called once per request in routes/index.ts before templates render.
  * Settings are already cached so this is cheap on repeat calls.
  */
-export const loadTheme = async (): Promise<Theme> => {
-  state.theme = await settings.theme.get();
+export const loadTheme = (): Theme => {
+  state.theme = settings.theme;
   return state.theme;
 };
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -6,7 +6,7 @@
  * before templates render.
  */
 
-import { getThemeFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { Theme } from "#lib/types.ts";
 
 /** Sync-accessible theme, populated by loadTheme() */
@@ -18,7 +18,7 @@ const state: { theme: Theme } = { theme: "light" };
  * Settings are already cached so this is cheap on repeat calls.
  */
 export const loadTheme = async (): Promise<Theme> => {
-  state.theme = await getThemeFromDb();
+  state.theme = await settings.theme.get();
   return state.theme;
 };
 

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -780,7 +780,7 @@ const handleResendNotification = attendeeFormAction(
     );
     if (error) return error;
 
-    const currency = await getCurrencyCode();
+    const currency = getCurrencyCode();
     await Promise.all([
       logAndNotifyRegistration(data.event, data.attendee, currency),
       logActivity(

--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -215,7 +215,7 @@ const handleAdminCalendarGet = (request: Request) =>
       standardCtx.standardEvents,
       holidays,
     );
-    const phonePrefix = await settings.phonePrefix.get();
+    const phonePrefix = settings.phonePrefix;
 
     const questionData = await loadQuestionData(
       attendees.map((a) => a.eventId),

--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -19,7 +19,7 @@ import {
   getDailyEventAttendeesByDate,
 } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
-import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import { type Attendee, type EventWithCount, isPaidEvent } from "#lib/types.ts";
 import {
@@ -215,7 +215,7 @@ const handleAdminCalendarGet = (request: Request) =>
       standardCtx.standardEvents,
       holidays,
     );
-    const phonePrefix = await getPhonePrefixFromDb();
+    const phonePrefix = await settings.phonePrefix.get();
 
     const questionData = await loadQuestionData(
       attendees.map((a) => a.eventId),

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -34,7 +34,7 @@ type CertValidation = {
 
 /** Validate Apple Wallet PEM certs/key, returning "Valid", "Invalid PEM", or "Not set" for each */
 const validateAppleWalletCerts = (
-  config: Awaited<ReturnType<typeof settings.appleWallet.getConfig>>,
+  config: typeof settings.appleWallet.config,
 ): CertValidation => {
   if (!config) {
     return {
@@ -59,46 +59,25 @@ const validateAppleWalletCerts = (
 const getDebugPageState = async (): Promise<DebugPageState> => {
   const bunnyCdnEnabled = isBunnyCdnEnabled();
 
-  const [
-    appleWalletDbConfigured,
-    appleWalletPassTypeId,
-    appleWalletConfig,
-    googleWalletDbConfigured,
-    googleWalletIssuerId,
-    googleWalletConfig,
-    paymentProvider,
-    stripeKeyConfigured,
-    squareTokenConfigured,
-    stripeWebhookEndpointId,
-    squareWebhookKey,
-    emailProvider,
-    emailApiKeyConfigured,
-    emailFromAddress,
-    customDomain,
-    theme,
-  ] = await Promise.all([
-    settings.appleWallet.hasDbConfig(),
-    settings.appleWallet.passTypeId.get(),
-    settings.appleWallet.getConfig(),
-    settings.googleWallet.hasDbConfig(),
-    settings.googleWallet.issuerId.get(),
-    settings.googleWallet.getConfig(),
-    settings.paymentProvider.get(),
-    settings.stripe.secretKey.has(),
-    settings.square.accessToken.has(),
-    settings.stripe.webhookEndpointId.get(),
-    settings.square.webhookSignatureKey.get(),
-    settings.email.provider.get(),
-    settings.email.apiKey.has(),
-    settings.email.fromAddress.get(),
-    bunnyCdnEnabled ? settings.customDomain.get() : Promise.resolve(null),
-    settings.theme.get(),
-  ]);
+  const appleWalletDbConfigured = settings.appleWallet.hasDbConfig;
+  const appleWalletPassTypeId = settings.appleWallet.passTypeId;
+  const appleWalletConfig = settings.appleWallet.config;
+  const googleWalletDbConfigured = settings.googleWallet.hasDbConfig;
+  const googleWalletIssuerId = settings.googleWallet.issuerId;
+  const googleWalletConfig = settings.googleWallet.config;
+  const paymentProvider = settings.paymentProvider;
+  const stripeKeyConfigured = settings.stripe.hasKey;
+  const squareTokenConfigured = settings.square.hasToken;
+  const stripeWebhookEndpointId = settings.stripe.webhookEndpointId;
+  const squareWebhookKey = settings.square.webhookSignatureKey;
+  const emailProvider = settings.email.provider;
+  const emailApiKeyConfigured = settings.email.hasApiKey;
+  const emailFromAddress = settings.email.fromAddress;
+  const customDomain = bunnyCdnEnabled ? settings.customDomain : null;
+  const theme = settings.theme;
 
-  const appleWalletEnvConfigured =
-    settings.appleWallet.getHostConfig() !== null;
-  const googleWalletEnvConfigured =
-    settings.googleWallet.getHostConfig() !== null;
+  const appleWalletEnvConfigured = settings.appleWallet.hostConfig !== null;
+  const googleWalletEnvConfigured = settings.googleWallet.hostConfig !== null;
   const hostEmailConfig = getHostEmailConfig();
 
   const keyConfigured =
@@ -118,7 +97,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
   const resolveWalletPassTypeId = (): string => {
     if (appleWalletDbConfigured) return appleWalletPassTypeId as string;
     if (appleWalletEnvConfigured)
-      return settings.appleWallet.getHostConfig()!.passTypeId;
+      return settings.appleWallet.hostConfig!.passTypeId;
     return "";
   };
   const resolveWalletSource = (): string => {
@@ -134,7 +113,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
   const resolveGoogleWalletIssuerId = (): string => {
     if (googleWalletDbConfigured) return googleWalletIssuerId as string;
     if (googleWalletEnvConfigured)
-      return settings.googleWallet.getHostConfig()!.issuerId;
+      return settings.googleWallet.hostConfig!.issuerId;
     return "";
   };
   const resolveGoogleWalletSource = (): string => {

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -13,26 +13,7 @@ import {
   getEffectiveDomain,
   isBunnyCdnEnabled,
 } from "#lib/config.ts";
-import {
-  getAppleWalletConfig,
-  getAppleWalletPassTypeIdFromDb,
-  getCustomDomainFromDb,
-  getEmailFromAddressFromDb,
-  getEmailProviderFromDb,
-  getGoogleWalletConfig,
-  getGoogleWalletIssuerIdFromDb,
-  getHostAppleWalletConfig,
-  getHostGoogleWalletConfig,
-  getPaymentProviderFromDb,
-  getSquareWebhookSignatureKeyFromDb,
-  getStripeWebhookEndpointId,
-  getThemeFromDb,
-  hasAppleWalletDbConfig,
-  hasEmailApiKey,
-  hasGoogleWalletDbConfig,
-  hasSquareToken,
-  hasStripeKey,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { getHostEmailConfig } from "#lib/email.ts";
 import { getEnv } from "#lib/env.ts";
 import { isValidGooglePrivateKey } from "#lib/google-wallet.ts";
@@ -53,7 +34,7 @@ type CertValidation = {
 
 /** Validate Apple Wallet PEM certs/key, returning "Valid", "Invalid PEM", or "Not set" for each */
 const validateAppleWalletCerts = (
-  config: Awaited<ReturnType<typeof getAppleWalletConfig>>,
+  config: Awaited<ReturnType<typeof settings.appleWallet.getConfig>>,
 ): CertValidation => {
   if (!config) {
     return {
@@ -96,26 +77,28 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     customDomain,
     theme,
   ] = await Promise.all([
-    hasAppleWalletDbConfig(),
-    getAppleWalletPassTypeIdFromDb(),
-    getAppleWalletConfig(),
-    hasGoogleWalletDbConfig(),
-    getGoogleWalletIssuerIdFromDb(),
-    getGoogleWalletConfig(),
-    getPaymentProviderFromDb(),
-    hasStripeKey(),
-    hasSquareToken(),
-    getStripeWebhookEndpointId(),
-    getSquareWebhookSignatureKeyFromDb(),
-    getEmailProviderFromDb(),
-    hasEmailApiKey(),
-    getEmailFromAddressFromDb(),
-    bunnyCdnEnabled ? getCustomDomainFromDb() : Promise.resolve(null),
-    getThemeFromDb(),
+    settings.appleWallet.hasDbConfig(),
+    settings.appleWallet.passTypeId.get(),
+    settings.appleWallet.getConfig(),
+    settings.googleWallet.hasDbConfig(),
+    settings.googleWallet.issuerId.get(),
+    settings.googleWallet.getConfig(),
+    settings.paymentProvider.get(),
+    settings.stripe.secretKey.has(),
+    settings.square.accessToken.has(),
+    settings.stripe.webhookEndpointId.get(),
+    settings.square.webhookSignatureKey.get(),
+    settings.email.provider.get(),
+    settings.email.apiKey.has(),
+    settings.email.fromAddress.get(),
+    bunnyCdnEnabled ? settings.customDomain.get() : Promise.resolve(null),
+    settings.theme.get(),
   ]);
 
-  const appleWalletEnvConfigured = getHostAppleWalletConfig() !== null;
-  const googleWalletEnvConfigured = getHostGoogleWalletConfig() !== null;
+  const appleWalletEnvConfigured =
+    settings.appleWallet.getHostConfig() !== null;
+  const googleWalletEnvConfigured =
+    settings.googleWallet.getHostConfig() !== null;
   const hostEmailConfig = getHostEmailConfig();
 
   const keyConfigured =
@@ -134,7 +117,8 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
 
   const resolveWalletPassTypeId = (): string => {
     if (appleWalletDbConfigured) return appleWalletPassTypeId as string;
-    if (appleWalletEnvConfigured) return getHostAppleWalletConfig()!.passTypeId;
+    if (appleWalletEnvConfigured)
+      return settings.appleWallet.getHostConfig()!.passTypeId;
     return "";
   };
   const resolveWalletSource = (): string => {
@@ -149,7 +133,8 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
 
   const resolveGoogleWalletIssuerId = (): string => {
     if (googleWalletDbConfigured) return googleWalletIssuerId as string;
-    if (googleWalletEnvConfigured) return getHostGoogleWalletConfig()!.issuerId;
+    if (googleWalletEnvConfigured)
+      return settings.googleWallet.getHostConfig()!.issuerId;
     return "";
   };
   const resolveGoogleWalletSource = (): string => {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -404,7 +404,7 @@ const renderEventPage = async (
       const [flash, phonePrefix, questions, attendeeAnswerMap] =
         await Promise.all([
           Promise.resolve(getFlash()),
-          settings.phonePrefix.get(),
+          Promise.resolve(settings.phonePrefix),
           getQuestionsForEvent(event.id),
           getAttendeeAnswersBatch(attendeeIds),
         ]);

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -20,7 +20,7 @@ import {
   getAttendeeAnswersBatch,
   getQuestionsForEvent,
 } from "#lib/db/questions.ts";
-import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   applyDemoOverrides,
   EVENT_DEMO_FIELDS,
@@ -404,7 +404,7 @@ const renderEventPage = async (
       const [flash, phonePrefix, questions, attendeeAnswerMap] =
         await Promise.all([
           Promise.resolve(getFlash()),
-          getPhonePrefixFromDb(),
+          settings.phonePrefix.get(),
           getQuestionsForEvent(event.id),
           getAttendeeAnswersBatch(attendeeIds),
         ]);

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -20,7 +20,7 @@ import {
   validateGroupEventType,
 } from "#lib/db/groups.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
-import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { GROUP_DEMO_FIELDS, wrapResourceForDemo } from "#lib/demo.ts";
 import { getFlash } from "#lib/flash-context.ts";
 import { defineNamedResource } from "#lib/rest/resource.ts";
@@ -162,7 +162,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/group/:id"> = (
         const hasPaidEvent = sortedEvents.some(isPaidEvent);
         const [rawAttendees, prefix] = await Promise.all([
           getAttendeesByEventIds(eventIds),
-          getPhonePrefixFromDb(),
+          settings.phonePrefix.get(),
         ]);
         attendees = await decryptAttendees(
           rawAttendees,

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -162,7 +162,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/group/:id"> = (
         const hasPaidEvent = sortedEvents.some(isPaidEvent);
         const [rawAttendees, prefix] = await Promise.all([
           getAttendeesByEventIds(eventIds),
-          settings.phonePrefix.get(),
+          Promise.resolve(settings.phonePrefix),
         ]);
         attendees = await decryptAttendees(
           rawAttendees,

--- a/src/routes/admin/guide.ts
+++ b/src/routes/admin/guide.ts
@@ -2,7 +2,7 @@
  * Admin guide route
  */
 
-import { getHostAppleWalletConfig } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { EMAIL_PROVIDER_LABELS, getHostEmailConfig } from "#lib/email.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { htmlResponse, requireSessionOr } from "#routes/utils.ts";
@@ -14,7 +14,7 @@ import { adminGuidePage } from "#templates/admin/guide.tsx";
 const handleAdminGuideGet = (request: Request): Promise<Response> =>
   requireSessionOr(request, (session) => {
     const hostEmail = getHostEmailConfig();
-    const hostWallet = getHostAppleWalletConfig();
+    const hostWallet = settings.appleWallet.getHostConfig();
     return htmlResponse(
       adminGuidePage(session, {
         hostEmailProvider: hostEmail

--- a/src/routes/admin/guide.ts
+++ b/src/routes/admin/guide.ts
@@ -14,7 +14,7 @@ import { adminGuidePage } from "#templates/admin/guide.tsx";
 const handleAdminGuideGet = (request: Request): Promise<Response> =>
   requireSessionOr(request, (session) => {
     const hostEmail = getHostEmailConfig();
-    const hostWallet = settings.appleWallet.getHostConfig();
+    const hostWallet = settings.appleWallet.hostConfig;
     return htmlResponse(
       adminGuidePage(session, {
         hostEmailProvider: hostEmail

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -85,7 +85,7 @@ export const routeAdmin: RouterFn = async (request, path, method, server) => {
 
   // Gate non-auth routes behind migration completion
   if (session && !isUngatedRoute(path)) {
-    const migrated = await settings.attendeeBlobMigrated.is();
+    const migrated = settings.attendeeBlobMigrated;
     if (!migrated) return redirectResponse("/admin/migrate");
   }
 

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { enableQueryLog } from "#lib/db/query-log.ts";
-import { isAttendeeBlobMigrated, loadAllSettings } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { apiKeysRoutes } from "#routes/admin/api-keys.ts";
 import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
@@ -78,13 +78,13 @@ export const routeAdmin: RouterFn = async (request, path, method, server) => {
 
   // Gate non-auth routes behind migration completion
   if (session && !isUngatedRoute(path)) {
-    const migrated = await isAttendeeBlobMigrated();
+    const migrated = await settings.attendeeBlobMigrated.is();
     if (!migrated) return redirectResponse("/admin/migrate");
   }
 
   if (method === "GET" && session) {
     enableQueryLog();
-    await loadAllSettings();
+    await settings.loadAll();
   }
 
   return innerRouter(request, path, method, server);

--- a/src/routes/admin/migrate.ts
+++ b/src/routes/admin/migrate.ts
@@ -9,10 +9,7 @@ import {
   MIGRATE_BATCH_SIZE,
   migrateAttendeeBatch,
 } from "#lib/db/attendees.ts";
-import {
-  isAttendeeBlobMigrated,
-  setAttendeeBlobMigrated,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { requirePrivateKey } from "#routes/admin/utils.ts";
 import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import type { AuthSession } from "#routes/utils.ts";
@@ -29,7 +26,7 @@ const whenNotMigrated =
   (doneResponse: (session: AuthSession) => Response | Promise<Response>) =>
   (handler: (session: AuthSession) => Promise<Response>) =>
   async (session: AuthSession): Promise<Response> => {
-    const migrated = await isAttendeeBlobMigrated();
+    const migrated = await settings.attendeeBlobMigrated.is();
     if (migrated) return doneResponse(session);
     return handler(session);
   };
@@ -46,7 +43,7 @@ const handleMigrateGet: TypedRouteHandler<"GET /admin/migrate"> = (request) =>
       const progress = await getMigrationProgress();
       // Auto-complete: fresh DBs and fully-migrated DBs have 0 remaining
       if (progress.remaining === 0) {
-        await setAttendeeBlobMigrated();
+        await settings.attendeeBlobMigrated.set();
         return htmlResponse(adminMigratePage(session, { done: true }));
       }
       return htmlResponse(
@@ -70,7 +67,7 @@ const handleMigratePost = (request: Request): Promise<Response> =>
       async (session) => {
         const privateKey = await requirePrivateKey(session);
         const result = await migrateAttendeeBatch(privateKey);
-        if (result.remaining === 0) await setAttendeeBlobMigrated();
+        if (result.remaining === 0) await settings.attendeeBlobMigrated.set();
         return redirectResponse("/admin/migrate");
       },
     ),

--- a/src/routes/admin/migrate.ts
+++ b/src/routes/admin/migrate.ts
@@ -25,8 +25,8 @@ import { adminMigratePage } from "#templates/admin/migrate.tsx";
 const whenNotMigrated =
   (doneResponse: (session: AuthSession) => Response | Promise<Response>) =>
   (handler: (session: AuthSession) => Promise<Response>) =>
-  async (session: AuthSession): Promise<Response> => {
-    const migrated = await settings.attendeeBlobMigrated.is();
+  (session: AuthSession): Response | Promise<Response> => {
+    const migrated = settings.attendeeBlobMigrated;
     if (migrated) return doneResponse(session);
     return handler(session);
   };
@@ -43,7 +43,7 @@ const handleMigrateGet: TypedRouteHandler<"GET /admin/migrate"> = (request) =>
       const progress = await getMigrationProgress();
       // Auto-complete: fresh DBs and fully-migrated DBs have 0 remaining
       if (progress.remaining === 0) {
-        await settings.attendeeBlobMigrated.set();
+        await settings.update.attendeeBlobMigrated();
         return htmlResponse(adminMigratePage(session, { done: true }));
       }
       return htmlResponse(
@@ -68,7 +68,7 @@ const handleMigratePost = (request: Request): Promise<Response> =>
         const privateKey = await requirePrivateKey(session);
         const result = await migrateAttendeeBatch(privateKey);
         if (result.remaining === 0) {
-          await settings.attendeeBlobMigrated.set();
+          await settings.update.attendeeBlobMigrated();
           return redirectResponse("/admin/");
         }
         return redirectResponse("/admin/migrate");

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -105,54 +105,24 @@ const getWebhookUrl = (): string => {
  * to reduce sequential await overhead (especially for calls that decrypt).
  */
 const getSettingsPageState = async () => {
-  const [
-    stripeKeyConfigured,
-    stripeKeyMode,
-    paymentProvider,
-    squareTokenConfigured,
-    squareSandbox,
-    squareWebhookKey,
-    bookingFeeRaw,
-    embedHosts,
-    termsAndConditions,
-    businessEmail,
-    theme,
-    showPublicSite,
-    country,
-    headerImageUrl,
-  ] = await Promise.all([
-    settings.stripe.secretKey.has(),
-    settings.stripe.secretKey.mode(),
-    settings.paymentProvider.get(),
-    settings.square.accessToken.has(),
-    settings.square.sandbox.get(),
-    getSquareWebhookSignatureKey(),
-    settings.bookingFee.get(),
-    settings.embedHosts.get(),
-    settings.terms.get(),
-    getBusinessEmailFromDb(),
-    settings.theme.get(),
-    settings.showPublicSite.get(),
-    settings.country.get(),
-    settings.headerImageUrl.get(),
-  ]);
+  const businessEmail = await getBusinessEmailFromDb();
 
   return {
-    stripeKeyConfigured,
-    stripeKeyMode,
-    paymentProvider: paymentProvider ?? "",
-    squareTokenConfigured,
-    squareSandbox,
-    squareWebhookConfigured: squareWebhookKey !== null,
+    stripeKeyConfigured: settings.stripe.hasKey,
+    stripeKeyMode: settings.stripe.keyMode,
+    paymentProvider: settings.paymentProvider ?? "",
+    squareTokenConfigured: settings.square.hasToken,
+    squareSandbox: settings.square.sandbox,
+    squareWebhookConfigured: getSquareWebhookSignatureKey() !== null,
     webhookUrl: getWebhookUrl(),
-    bookingFee: bookingFeeRaw!,
-    embedHosts: embedHosts ?? "",
-    termsAndConditions: termsAndConditions ?? "",
+    bookingFee: settings.bookingFee!,
+    embedHosts: settings.embedHosts ?? "",
+    termsAndConditions: settings.terms ?? "",
     businessEmail,
-    theme,
-    showPublicSite,
-    country,
-    headerImageUrl: headerImageUrl ?? "",
+    theme: settings.theme,
+    showPublicSite: settings.showPublicSite,
+    country: settings.country,
+    headerImageUrl: settings.headerImageUrl ?? "",
     storageEnabled: isStorageEnabled(),
   };
 };
@@ -160,43 +130,25 @@ const getSettingsPageState = async () => {
 /** Gather state for the advanced settings page */
 const getAdvancedSettingsPageState = async () => {
   const bunnyCdnConfigured = isBunnyCdnEnabled();
-  const [
-    showPublicApi,
-    emailProvider,
-    emailApiKeyConfigured,
-    emailFromAddress,
-    businessEmail,
-    confirmationTemplates,
-    adminTemplates,
-    customDomain,
-    customDomainLastValidated,
-    appleWalletConfigured,
-    appleWalletPassTypeId,
-    appleWalletTeamId,
-    googleWalletConfigured,
-    googleWalletIssuerId,
-    googleWalletServiceAccountEmail,
-    theme,
-  ] = await Promise.all([
-    settings.showPublicApi.get(),
-    settings.email.provider.get(),
-    settings.email.apiKey.has(),
-    settings.email.fromAddress.get(),
-    getBusinessEmailFromDb(),
-    settings.email.template.getSet("confirmation"),
-    settings.email.template.getSet("admin"),
-    bunnyCdnConfigured ? settings.customDomain.get() : Promise.resolve(null),
-    bunnyCdnConfigured
-      ? settings.customDomain.lastValidated.get()
-      : Promise.resolve(null),
-    settings.appleWallet.hasDbConfig(),
-    settings.appleWallet.passTypeId.get(),
-    settings.appleWallet.teamId.get(),
-    settings.googleWallet.hasDbConfig(),
-    settings.googleWallet.issuerId.get(),
-    settings.googleWallet.serviceAccountEmail.get(),
-    settings.theme.get(),
-  ]);
+  const showPublicApi = settings.showPublicApi;
+  const emailProvider = settings.email.provider;
+  const emailApiKeyConfigured = settings.email.hasApiKey;
+  const emailFromAddress = settings.email.fromAddress;
+  const businessEmail = await getBusinessEmailFromDb();
+  const confirmationTemplates = settings.email.templateSet("confirmation");
+  const adminTemplates = settings.email.templateSet("admin");
+  const customDomain = bunnyCdnConfigured ? settings.customDomain : null;
+  const customDomainLastValidated = bunnyCdnConfigured
+    ? settings.customDomainLastValidated
+    : null;
+  const appleWalletConfigured = settings.appleWallet.hasDbConfig;
+  const appleWalletPassTypeId = settings.appleWallet.passTypeId;
+  const appleWalletTeamId = settings.appleWallet.teamId;
+  const googleWalletConfigured = settings.googleWallet.hasDbConfig;
+  const googleWalletIssuerId = settings.googleWallet.issuerId;
+  const googleWalletServiceAccountEmail =
+    settings.googleWallet.serviceAccountEmail;
+  const theme = settings.theme;
   return {
     showPublicApi,
     emailProvider: emailProvider ?? "",
@@ -227,7 +179,7 @@ const getAdvancedSettingsPageState = async () => {
     appleWalletPassTypeId: appleWalletPassTypeId ?? "",
     appleWalletTeamId: appleWalletTeamId ?? "",
     hostAppleWalletLabel: (() => {
-      const hostConfig = settings.appleWallet.getHostConfig();
+      const hostConfig = settings.appleWallet.hostConfig;
       if (!hostConfig) return "";
       return `Host env (${hostConfig.passTypeId})`;
     })(),
@@ -235,7 +187,7 @@ const getAdvancedSettingsPageState = async () => {
     googleWalletIssuerId: googleWalletIssuerId ?? "",
     googleWalletServiceAccountEmail: googleWalletServiceAccountEmail ?? "",
     hostGoogleWalletLabel: (() => {
-      const hostConfig = settings.googleWallet.getHostConfig();
+      const hostConfig = settings.googleWallet.hostConfig;
       if (!hostConfig) return "";
       return `Host env (${hostConfig.issuerId})`;
     })(),
@@ -437,7 +389,7 @@ const handlePaymentProviderPost = settingsRoute(async (form, errorPage) => {
   const provider = form.getString("payment_provider");
 
   if (provider === "none") {
-    await settings.paymentProvider.clear();
+    await settings.update.clearPaymentProvider();
     await logActivity("Payment provider disabled");
     return redirect("/admin/settings", "Payment provider disabled", true, {
       formId: "settings-payment-provider",
@@ -452,7 +404,7 @@ const handlePaymentProviderPost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  await settings.paymentProvider.set(provider);
+  await settings.update.paymentProvider(provider);
   await logActivity(`Payment provider set to ${provider}`);
 
   return redirect(
@@ -485,7 +437,7 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
 
   if (field.action === "cleared") {
     // Require a key when none is configured
-    if (!(await settings.stripe.secretKey.has())) {
+    if (!settings.stripe.hasKey) {
       return errorPage("Stripe Secret Key is required", 400, "settings-stripe");
     }
     // Empty with existing key = no change
@@ -505,7 +457,7 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
 
   // Set up webhook endpoint automatically
   const webhookUrl = getWebhookUrl();
-  const existingEndpointId = await settings.stripe.webhookEndpointId.get();
+  const existingEndpointId = settings.stripe.webhookEndpointId;
 
   const webhookResult = await setupWebhookEndpoint(
     field.value,
@@ -522,11 +474,11 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Store the Stripe key and webhook config
-  await settings.stripe.secretKey.update(field.value);
-  await settings.stripe.setWebhookConfig(webhookResult);
+  await settings.update.stripe.secretKey(field.value);
+  await settings.update.stripe.webhookConfig(webhookResult);
 
   // Auto-set payment provider to stripe when key is configured
-  await settings.paymentProvider.set("stripe");
+  await settings.update.paymentProvider("stripe");
 
   await logActivity("Stripe key configured");
   return redirect(
@@ -558,24 +510,21 @@ const handleAdminSquarePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Require a token when none is configured
-  if (
-    tokenField.action === "cleared" &&
-    !(await settings.square.accessToken.has())
-  ) {
+  if (tokenField.action === "cleared" && !settings.square.hasToken) {
     return errorPage("Square Access Token is required", 400, "settings-square");
   }
 
   // Only update the token when a new value is provided
   if (tokenField.action === "provided") {
-    await settings.square.accessToken.update(tokenField.value);
+    await settings.update.square.accessToken(tokenField.value);
   }
 
   // Always allow updating non-secret fields
-  await settings.square.locationId.update(locationId);
-  await settings.square.sandbox.update(sandbox);
+  await settings.update.square.locationId(locationId);
+  await settings.update.square.sandbox(sandbox);
 
   // Auto-set payment provider to square when credentials are configured
-  await settings.paymentProvider.set("square");
+  await settings.update.paymentProvider("square");
 
   await logActivity("Square credentials configured");
   return redirect(
@@ -609,7 +558,7 @@ const handleAdminSquareWebhookPost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  await settings.square.webhookSignatureKey.update(field.value);
+  await settings.update.square.webhookSignatureKey(field.value);
 
   await logActivity("Square webhook signature key configured");
   return redirect(
@@ -646,7 +595,7 @@ const handleEmbedHostsPost = settingsRoute(async (form, errorPage) => {
 
   // Empty = clear restriction
   if (trimmed === "") {
-    await settings.embedHosts.update("");
+    await settings.update.embedHosts("");
     return redirect(
       "/admin/settings",
       "Embed host restrictions removed",
@@ -662,7 +611,7 @@ const handleEmbedHostsPost = settingsRoute(async (form, errorPage) => {
 
   // Normalize: trim, lowercase, rejoin
   const normalized = parseEmbedHosts(trimmed).join(", ");
-  await settings.embedHosts.update(normalized);
+  await settings.update.embedHosts(normalized);
   return redirect("/admin/settings", "Allowed embed hosts updated", true, {
     formId: "settings-embed-hosts",
   });
@@ -683,7 +632,7 @@ const handleTermsPost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  await settings.terms.update(trimmed);
+  await settings.update.terms(trimmed);
 
   if (trimmed === "") {
     await logActivity("Terms and conditions removed");
@@ -709,7 +658,7 @@ const processCountryForm: SettingsFormHandler = async (form, errorPage) => {
     return errorPage("Please select a valid country", 400, "settings-country");
   }
 
-  await settings.country.update(trimmed);
+  await settings.update.country(trimmed);
   await logActivity(`Country set to ${trimmed}`);
   return redirect("/admin/settings", "Country updated", true, {
     formId: "settings-country",
@@ -761,7 +710,7 @@ const processThemeForm: SettingsFormHandler = async (form, errorPage) => {
     return errorPage("Invalid theme selection", 400, "settings-theme");
   }
 
-  await settings.theme.update(theme);
+  await settings.update.theme(theme);
   await logActivity(`Theme set to ${theme}`);
   return redirect("/admin/settings", `Theme updated to ${theme}`, true, {
     formId: "settings-theme",
@@ -774,7 +723,7 @@ const handleThemePost = settingsRoute(processThemeForm);
 /** Validate and save show-public-site from form submission */
 const processShowPublicSiteForm: SettingsFormHandler = async (form) => {
   const value = form.get("show_public_site") === "true";
-  await settings.showPublicSite.update(value);
+  await settings.update.showPublicSite(value);
   await logActivity(`Public site ${value ? "enabled" : "disabled"}`);
   return redirect(
     "/admin/settings",
@@ -790,7 +739,7 @@ const handleShowPublicSitePost = settingsRoute(processShowPublicSiteForm);
 /** Validate and save show-public-api from form submission */
 const processShowPublicApiForm: SettingsFormHandler = async (form) => {
   const value = form.get("show_public_api") === "true";
-  await settings.showPublicApi.update(value);
+  await settings.update.showPublicApi(value);
   await logActivity(`Public API ${value ? "enabled" : "disabled"}`);
   return redirect(
     "/admin/settings-advanced",
@@ -816,7 +765,7 @@ const processBookingFeeForm: SettingsFormHandler = async (form, errorPage) => {
     );
   }
 
-  await settings.bookingFee.update(String(value));
+  await settings.update.bookingFee(String(value));
   await logActivity(`Booking fee set to ${value}%`);
   return redirect("/admin/settings", `Booking fee updated to ${value}%`, true, {
     formId: "settings-booking-fee",
@@ -850,7 +799,7 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
     }
 
     // Delete old header image if one exists (best-effort, don't block new upload)
-    const existingUrl = await settings.headerImageUrl.get();
+    const existingUrl = settings.headerImageUrl;
     if (existingUrl) {
       await tryDeleteImage(
         existingUrl,
@@ -863,7 +812,7 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
       uploadImage(data, validation.detectedType),
     ]);
     if (uploadResult.status === "fulfilled") {
-      await settings.headerImageUrl.update(uploadResult.value);
+      await settings.update.headerImageUrl(uploadResult.value);
       await logActivity("Header image uploaded");
       return redirect("/admin/settings", "Header image uploaded", true, {
         formId: "settings-header-image",
@@ -878,14 +827,14 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
 
 /** Handle POST /admin/settings/header-image/delete - owner only */
 const handleHeaderImageDeletePost = settingsRoute(async (_form, _errorPage) => {
-  const existingUrl = await settings.headerImageUrl.get();
+  const existingUrl = settings.headerImageUrl;
   if (!existingUrl) {
     return htmlResponse("No header image to remove", 400);
   }
 
   const [deleteResult] = await Promise.allSettled([deleteImage(existingUrl)]);
   if (deleteResult.status === "fulfilled") {
-    await settings.headerImageUrl.update("");
+    await settings.update.headerImageUrl("");
     await logActivity("Header image removed");
     return redirect("/admin/settings", "Header image removed", true, {
       formId: "settings-header-image-delete",
@@ -905,9 +854,9 @@ const handleEmailPost = advancedSettingsRoute(async (form, errorPage) => {
   const fromAddress = form.getString("email_from_address");
 
   if (provider === "") {
-    await settings.email.provider.update("");
-    await settings.email.apiKey.update("");
-    await settings.email.fromAddress.update("");
+    await settings.update.email.provider("");
+    await settings.update.email.apiKey("");
+    await settings.update.email.fromAddress("");
     await logActivity("Email provider disabled");
     return redirect(
       "/admin/settings-advanced",
@@ -929,10 +878,10 @@ const handleEmailPost = advancedSettingsRoute(async (form, errorPage) => {
     );
   }
 
-  await settings.email.provider.update(provider);
+  await settings.update.email.provider(provider);
   if (apiKeyField.action === "provided")
-    await settings.email.apiKey.update(apiKeyField.value);
-  if (fromAddress) await settings.email.fromAddress.update(fromAddress);
+    await settings.update.email.apiKey(apiKeyField.value);
+  if (fromAddress) await settings.update.email.fromAddress(fromAddress);
   await logActivity(`Email provider set to ${provider}`);
   return redirect("/admin/settings-advanced", "Email settings updated", true, {
     formId: "settings-email",
@@ -1019,9 +968,9 @@ const handleEmailTemplatePost = (type: EmailTemplateType) =>
     }
 
     await Promise.all([
-      settings.email.template.update(type, "subject", subject.trim()),
-      settings.email.template.update(type, "html", html.trim()),
-      settings.email.template.update(type, "text", text.trim()),
+      settings.update.email.template(type, "subject", subject.trim()),
+      settings.update.email.template(type, "html", html.trim()),
+      settings.update.email.template(type, "text", text.trim()),
     ]);
 
     const label =
@@ -1140,7 +1089,7 @@ const handleCustomDomainPost = advancedSettingsRoute(
     const raw = form.getString("custom_domain").toLowerCase();
 
     if (raw === "") {
-      await settings.customDomain.update("");
+      await settings.update.customDomain("");
       await logActivity("Custom domain cleared");
       return redirect(
         "/admin/settings-advanced",
@@ -1155,13 +1104,13 @@ const handleCustomDomainPost = advancedSettingsRoute(
       return errorPage("Invalid domain format", 400, "settings-custom-domain");
     }
 
-    await settings.customDomain.update(raw);
+    await settings.update.customDomain(raw);
     await logActivity(`Custom domain set to ${raw}`);
 
     // Attempt validation immediately after saving
     const result = await validateCustomDomain(raw);
     if (result.ok) {
-      await settings.customDomain.lastValidated.update();
+      await settings.update.customDomainLastValidated();
       await logActivity(`Custom domain validated: ${raw}`);
       return redirect(
         "/admin/settings-advanced",
@@ -1191,7 +1140,7 @@ const handleCustomDomainValidatePost = advancedSettingsRoute(
       );
     }
 
-    const customDomain = await settings.customDomain.get();
+    const customDomain = settings.customDomain;
     if (!customDomain) {
       return errorPage(
         "No custom domain is configured",
@@ -1205,7 +1154,7 @@ const handleCustomDomainValidatePost = advancedSettingsRoute(
       return errorPage(result.error, 502, "settings-custom-domain-validate");
     }
 
-    await settings.customDomain.lastValidated.update();
+    await settings.update.customDomainLastValidated();
     await logActivity(`Custom domain validated: ${customDomain}`);
     return redirect(
       "/admin/settings-advanced",
@@ -1235,11 +1184,11 @@ const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
     wwdrField.action === "cleared"
   ) {
     await Promise.all([
-      settings.appleWallet.passTypeId.update(""),
-      settings.appleWallet.teamId.update(""),
-      settings.appleWallet.signingCert.update(""),
-      settings.appleWallet.signingKey.update(""),
-      settings.appleWallet.wwdrCert.update(""),
+      settings.update.appleWallet.passTypeId(""),
+      settings.update.appleWallet.teamId(""),
+      settings.update.appleWallet.signingCert(""),
+      settings.update.appleWallet.signingKey(""),
+      settings.update.appleWallet.wwdrCert(""),
     ]);
     await logActivity("Apple Wallet configuration cleared");
     return redirect(
@@ -1259,7 +1208,7 @@ const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
   }
 
   // For initial setup, require all three PEM fields
-  const isConfigured = await settings.appleWallet.hasDbConfig();
+  const isConfigured = settings.appleWallet.hasDbConfig;
   if (!isConfigured) {
     if (certField.action !== "provided") {
       return errorPage(
@@ -1313,14 +1262,14 @@ const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
     );
   }
 
-  await settings.appleWallet.passTypeId.update(passTypeId);
-  await settings.appleWallet.teamId.update(teamId);
+  await settings.update.appleWallet.passTypeId(passTypeId);
+  await settings.update.appleWallet.teamId(teamId);
   if (certField.action === "provided")
-    await settings.appleWallet.signingCert.update(certField.value);
+    await settings.update.appleWallet.signingCert(certField.value);
   if (keyField.action === "provided")
-    await settings.appleWallet.signingKey.update(keyField.value);
+    await settings.update.appleWallet.signingKey(keyField.value);
   if (wwdrField.action === "provided")
-    await settings.appleWallet.wwdrCert.update(wwdrField.value);
+    await settings.update.appleWallet.wwdrCert(wwdrField.value);
 
   await logActivity("Apple Wallet configuration updated");
   return redirect(
@@ -1348,9 +1297,9 @@ const handleGoogleWalletPost = advancedSettingsRoute(
     // If everything is cleared, remove all settings
     if (!issuerId && !email && keyField.action === "cleared") {
       await Promise.all([
-        settings.googleWallet.issuerId.update(""),
-        settings.googleWallet.serviceAccountEmail.update(""),
-        settings.googleWallet.serviceAccountKey.update(""),
+        settings.update.googleWallet.issuerId(""),
+        settings.update.googleWallet.serviceAccountEmail(""),
+        settings.update.googleWallet.serviceAccountKey(""),
       ]);
       await logActivity("Google Wallet configuration cleared");
       return redirect(
@@ -1374,7 +1323,7 @@ const handleGoogleWalletPost = advancedSettingsRoute(
     }
 
     // For initial setup, require the private key
-    const isConfigured = await settings.googleWallet.hasDbConfig();
+    const isConfigured = settings.googleWallet.hasDbConfig;
     if (!isConfigured && keyField.action !== "provided") {
       return errorPage(
         "Service account private key is required",
@@ -1395,10 +1344,10 @@ const handleGoogleWalletPost = advancedSettingsRoute(
       );
     }
 
-    await settings.googleWallet.issuerId.update(issuerId);
-    await settings.googleWallet.serviceAccountEmail.update(email);
+    await settings.update.googleWallet.issuerId(issuerId);
+    await settings.update.googleWallet.serviceAccountEmail(email);
     if (keyField.action === "provided")
-      await settings.googleWallet.serviceAccountKey.update(keyField.value);
+      await settings.update.googleWallet.serviceAccountKey(keyField.value);
 
     await logActivity("Google Wallet configuration updated");
     return redirect(

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -25,69 +25,11 @@ import { logActivity } from "#lib/db/activityLog.ts";
 import { getAllEvents } from "#lib/db/events.ts";
 import { resetDatabase } from "#lib/db/migrations.ts";
 import {
-  clearPaymentProvider,
   type EmailTemplateType,
-  getAppleWalletPassTypeIdFromDb,
-  getAppleWalletTeamIdFromDb,
-  getBookingFeeFromDb,
-  getCountryFromDb,
-  getCustomDomainFromDb,
-  getCustomDomainLastValidatedFromDb,
-  getEmailFromAddressFromDb,
-  getEmailProviderFromDb,
-  getEmailTemplateSet,
-  getEmbedHostsFromDb,
-  getGoogleWalletIssuerIdFromDb,
-  getGoogleWalletServiceAccountEmailFromDb,
-  getHeaderImageUrlFromDb,
-  getHostAppleWalletConfig,
-  getHostGoogleWalletConfig,
-  getPaymentProviderFromDb,
-  getShowPublicApiFromDb,
-  getShowPublicSiteFromDb,
-  getSquareSandboxFromDb,
-  getStripeKeyMode,
-  getStripeWebhookEndpointId,
-  getTermsAndConditionsFromDb,
-  getThemeFromDb,
-  hasAppleWalletDbConfig,
-  hasEmailApiKey,
-  hasGoogleWalletDbConfig,
-  hasSquareToken,
-  hasStripeKey,
   isMaskSentinel,
   MAX_EMAIL_TEMPLATE_LENGTH,
   MAX_TERMS_LENGTH,
-  setPaymentProvider,
-  setStripeWebhookConfig,
-  updateAppleWalletPassTypeId,
-  updateAppleWalletSigningCert,
-  updateAppleWalletSigningKey,
-  updateAppleWalletTeamId,
-  updateAppleWalletWwdrCert,
-  updateBookingFee,
-  updateCountry,
-  updateCustomDomain,
-  updateCustomDomainLastValidated,
-  updateEmailApiKey,
-  updateEmailFromAddress,
-  updateEmailProvider,
-  updateEmailTemplate,
-  updateEmbedHosts,
-  updateGoogleWalletIssuerId,
-  updateGoogleWalletServiceAccountEmail,
-  updateGoogleWalletServiceAccountKey,
-  updateHeaderImageUrl,
-  updateShowPublicApi,
-  updateShowPublicSite,
-  updateSquareAccessToken,
-  updateSquareLocationId,
-  updateSquareSandbox,
-  updateSquareWebhookSignatureKey,
-  updateStripeKey,
-  updateTermsAndConditions,
-  updateTheme,
-  updateUserPassword,
+  settings,
 } from "#lib/db/settings.ts";
 import { getUserById, verifyUserPassword } from "#lib/db/users.ts";
 import {
@@ -179,20 +121,20 @@ const getSettingsPageState = async () => {
     country,
     headerImageUrl,
   ] = await Promise.all([
-    hasStripeKey(),
-    getStripeKeyMode(),
-    getPaymentProviderFromDb(),
-    hasSquareToken(),
-    getSquareSandboxFromDb(),
+    settings.stripe.secretKey.has(),
+    settings.stripe.secretKey.mode(),
+    settings.paymentProvider.get(),
+    settings.square.accessToken.has(),
+    settings.square.sandbox.get(),
     getSquareWebhookSignatureKey(),
-    getBookingFeeFromDb(),
-    getEmbedHostsFromDb(),
-    getTermsAndConditionsFromDb(),
+    settings.bookingFee.get(),
+    settings.embedHosts.get(),
+    settings.terms.get(),
     getBusinessEmailFromDb(),
-    getThemeFromDb(),
-    getShowPublicSiteFromDb(),
-    getCountryFromDb(),
-    getHeaderImageUrlFromDb(),
+    settings.theme.get(),
+    settings.showPublicSite.get(),
+    settings.country.get(),
+    settings.headerImageUrl.get(),
   ]);
 
   return {
@@ -236,24 +178,24 @@ const getAdvancedSettingsPageState = async () => {
     googleWalletServiceAccountEmail,
     theme,
   ] = await Promise.all([
-    getShowPublicApiFromDb(),
-    getEmailProviderFromDb(),
-    hasEmailApiKey(),
-    getEmailFromAddressFromDb(),
+    settings.showPublicApi.get(),
+    settings.email.provider.get(),
+    settings.email.apiKey.has(),
+    settings.email.fromAddress.get(),
     getBusinessEmailFromDb(),
-    getEmailTemplateSet("confirmation"),
-    getEmailTemplateSet("admin"),
-    bunnyCdnConfigured ? getCustomDomainFromDb() : Promise.resolve(null),
+    settings.email.template.getSet("confirmation"),
+    settings.email.template.getSet("admin"),
+    bunnyCdnConfigured ? settings.customDomain.get() : Promise.resolve(null),
     bunnyCdnConfigured
-      ? getCustomDomainLastValidatedFromDb()
+      ? settings.customDomain.lastValidated.get()
       : Promise.resolve(null),
-    hasAppleWalletDbConfig(),
-    getAppleWalletPassTypeIdFromDb(),
-    getAppleWalletTeamIdFromDb(),
-    hasGoogleWalletDbConfig(),
-    getGoogleWalletIssuerIdFromDb(),
-    getGoogleWalletServiceAccountEmailFromDb(),
-    getThemeFromDb(),
+    settings.appleWallet.hasDbConfig(),
+    settings.appleWallet.passTypeId.get(),
+    settings.appleWallet.teamId.get(),
+    settings.googleWallet.hasDbConfig(),
+    settings.googleWallet.issuerId.get(),
+    settings.googleWallet.serviceAccountEmail.get(),
+    settings.theme.get(),
   ]);
   return {
     showPublicApi,
@@ -285,7 +227,7 @@ const getAdvancedSettingsPageState = async () => {
     appleWalletPassTypeId: appleWalletPassTypeId ?? "",
     appleWalletTeamId: appleWalletTeamId ?? "",
     hostAppleWalletLabel: (() => {
-      const hostConfig = getHostAppleWalletConfig();
+      const hostConfig = settings.appleWallet.getHostConfig();
       if (!hostConfig) return "";
       return `Host env (${hostConfig.passTypeId})`;
     })(),
@@ -293,7 +235,7 @@ const getAdvancedSettingsPageState = async () => {
     googleWalletIssuerId: googleWalletIssuerId ?? "",
     googleWalletServiceAccountEmail: googleWalletServiceAccountEmail ?? "",
     hostGoogleWalletLabel: (() => {
-      const hostConfig = getHostGoogleWalletConfig();
+      const hostConfig = settings.googleWallet.getHostConfig();
       if (!hostConfig) return "";
       return `Host env (${hostConfig.issuerId})`;
     })(),
@@ -467,7 +409,7 @@ const handleAdminSettingsPost = settingsRoute(
       );
     }
 
-    const success = await updateUserPassword(
+    const success = await settings.updateUserPassword(
       session.userId,
       passwordHash,
       user.wrapped_data_key!,
@@ -495,7 +437,7 @@ const handlePaymentProviderPost = settingsRoute(async (form, errorPage) => {
   const provider = form.getString("payment_provider");
 
   if (provider === "none") {
-    await clearPaymentProvider();
+    await settings.paymentProvider.clear();
     await logActivity("Payment provider disabled");
     return redirect("/admin/settings", "Payment provider disabled", true, {
       formId: "settings-payment-provider",
@@ -510,7 +452,7 @@ const handlePaymentProviderPost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  await setPaymentProvider(provider);
+  await settings.paymentProvider.set(provider);
   await logActivity(`Payment provider set to ${provider}`);
 
   return redirect(
@@ -543,7 +485,7 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
 
   if (field.action === "cleared") {
     // Require a key when none is configured
-    if (!(await hasStripeKey())) {
+    if (!(await settings.stripe.secretKey.has())) {
       return errorPage("Stripe Secret Key is required", 400, "settings-stripe");
     }
     // Empty with existing key = no change
@@ -563,7 +505,7 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
 
   // Set up webhook endpoint automatically
   const webhookUrl = getWebhookUrl();
-  const existingEndpointId = await getStripeWebhookEndpointId();
+  const existingEndpointId = await settings.stripe.webhookEndpointId.get();
 
   const webhookResult = await setupWebhookEndpoint(
     field.value,
@@ -580,11 +522,11 @@ const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Store the Stripe key and webhook config
-  await updateStripeKey(field.value);
-  await setStripeWebhookConfig(webhookResult);
+  await settings.stripe.secretKey.update(field.value);
+  await settings.stripe.setWebhookConfig(webhookResult);
 
   // Auto-set payment provider to stripe when key is configured
-  await setPaymentProvider("stripe");
+  await settings.paymentProvider.set("stripe");
 
   await logActivity("Stripe key configured");
   return redirect(
@@ -616,21 +558,24 @@ const handleAdminSquarePost = settingsRoute(async (form, errorPage) => {
   }
 
   // Require a token when none is configured
-  if (tokenField.action === "cleared" && !(await hasSquareToken())) {
+  if (
+    tokenField.action === "cleared" &&
+    !(await settings.square.accessToken.has())
+  ) {
     return errorPage("Square Access Token is required", 400, "settings-square");
   }
 
   // Only update the token when a new value is provided
   if (tokenField.action === "provided") {
-    await updateSquareAccessToken(tokenField.value);
+    await settings.square.accessToken.update(tokenField.value);
   }
 
   // Always allow updating non-secret fields
-  await updateSquareLocationId(locationId);
-  await updateSquareSandbox(sandbox);
+  await settings.square.locationId.update(locationId);
+  await settings.square.sandbox.update(sandbox);
 
   // Auto-set payment provider to square when credentials are configured
-  await setPaymentProvider("square");
+  await settings.paymentProvider.set("square");
 
   await logActivity("Square credentials configured");
   return redirect(
@@ -664,7 +609,7 @@ const handleAdminSquareWebhookPost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  await updateSquareWebhookSignatureKey(field.value);
+  await settings.square.webhookSignatureKey.update(field.value);
 
   await logActivity("Square webhook signature key configured");
   return redirect(
@@ -701,7 +646,7 @@ const handleEmbedHostsPost = settingsRoute(async (form, errorPage) => {
 
   // Empty = clear restriction
   if (trimmed === "") {
-    await updateEmbedHosts("");
+    await settings.embedHosts.update("");
     return redirect(
       "/admin/settings",
       "Embed host restrictions removed",
@@ -717,7 +662,7 @@ const handleEmbedHostsPost = settingsRoute(async (form, errorPage) => {
 
   // Normalize: trim, lowercase, rejoin
   const normalized = parseEmbedHosts(trimmed).join(", ");
-  await updateEmbedHosts(normalized);
+  await settings.embedHosts.update(normalized);
   return redirect("/admin/settings", "Allowed embed hosts updated", true, {
     formId: "settings-embed-hosts",
   });
@@ -738,7 +683,7 @@ const handleTermsPost = settingsRoute(async (form, errorPage) => {
     );
   }
 
-  await updateTermsAndConditions(trimmed);
+  await settings.terms.update(trimmed);
 
   if (trimmed === "") {
     await logActivity("Terms and conditions removed");
@@ -764,7 +709,7 @@ const processCountryForm: SettingsFormHandler = async (form, errorPage) => {
     return errorPage("Please select a valid country", 400, "settings-country");
   }
 
-  await updateCountry(trimmed);
+  await settings.country.update(trimmed);
   await logActivity(`Country set to ${trimmed}`);
   return redirect("/admin/settings", "Country updated", true, {
     formId: "settings-country",
@@ -816,7 +761,7 @@ const processThemeForm: SettingsFormHandler = async (form, errorPage) => {
     return errorPage("Invalid theme selection", 400, "settings-theme");
   }
 
-  await updateTheme(theme);
+  await settings.theme.update(theme);
   await logActivity(`Theme set to ${theme}`);
   return redirect("/admin/settings", `Theme updated to ${theme}`, true, {
     formId: "settings-theme",
@@ -829,7 +774,7 @@ const handleThemePost = settingsRoute(processThemeForm);
 /** Validate and save show-public-site from form submission */
 const processShowPublicSiteForm: SettingsFormHandler = async (form) => {
   const value = form.get("show_public_site") === "true";
-  await updateShowPublicSite(value);
+  await settings.showPublicSite.update(value);
   await logActivity(`Public site ${value ? "enabled" : "disabled"}`);
   return redirect(
     "/admin/settings",
@@ -845,7 +790,7 @@ const handleShowPublicSitePost = settingsRoute(processShowPublicSiteForm);
 /** Validate and save show-public-api from form submission */
 const processShowPublicApiForm: SettingsFormHandler = async (form) => {
   const value = form.get("show_public_api") === "true";
-  await updateShowPublicApi(value);
+  await settings.showPublicApi.update(value);
   await logActivity(`Public API ${value ? "enabled" : "disabled"}`);
   return redirect(
     "/admin/settings-advanced",
@@ -871,7 +816,7 @@ const processBookingFeeForm: SettingsFormHandler = async (form, errorPage) => {
     );
   }
 
-  await updateBookingFee(String(value));
+  await settings.bookingFee.update(String(value));
   await logActivity(`Booking fee set to ${value}%`);
   return redirect("/admin/settings", `Booking fee updated to ${value}%`, true, {
     formId: "settings-booking-fee",
@@ -905,7 +850,7 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
     }
 
     // Delete old header image if one exists (best-effort, don't block new upload)
-    const existingUrl = await getHeaderImageUrlFromDb();
+    const existingUrl = await settings.headerImageUrl.get();
     if (existingUrl) {
       await tryDeleteImage(
         existingUrl,
@@ -918,7 +863,7 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
       uploadImage(data, validation.detectedType),
     ]);
     if (uploadResult.status === "fulfilled") {
-      await updateHeaderImageUrl(uploadResult.value);
+      await settings.headerImageUrl.update(uploadResult.value);
       await logActivity("Header image uploaded");
       return redirect("/admin/settings", "Header image uploaded", true, {
         formId: "settings-header-image",
@@ -933,14 +878,14 @@ const handleHeaderImagePost = (request: Request): Promise<Response> =>
 
 /** Handle POST /admin/settings/header-image/delete - owner only */
 const handleHeaderImageDeletePost = settingsRoute(async (_form, _errorPage) => {
-  const existingUrl = await getHeaderImageUrlFromDb();
+  const existingUrl = await settings.headerImageUrl.get();
   if (!existingUrl) {
     return htmlResponse("No header image to remove", 400);
   }
 
   const [deleteResult] = await Promise.allSettled([deleteImage(existingUrl)]);
   if (deleteResult.status === "fulfilled") {
-    await updateHeaderImageUrl("");
+    await settings.headerImageUrl.update("");
     await logActivity("Header image removed");
     return redirect("/admin/settings", "Header image removed", true, {
       formId: "settings-header-image-delete",
@@ -960,9 +905,9 @@ const handleEmailPost = advancedSettingsRoute(async (form, errorPage) => {
   const fromAddress = form.getString("email_from_address");
 
   if (provider === "") {
-    await updateEmailProvider("");
-    await updateEmailApiKey("");
-    await updateEmailFromAddress("");
+    await settings.email.provider.update("");
+    await settings.email.apiKey.update("");
+    await settings.email.fromAddress.update("");
     await logActivity("Email provider disabled");
     return redirect(
       "/admin/settings-advanced",
@@ -984,10 +929,10 @@ const handleEmailPost = advancedSettingsRoute(async (form, errorPage) => {
     );
   }
 
-  await updateEmailProvider(provider);
+  await settings.email.provider.update(provider);
   if (apiKeyField.action === "provided")
-    await updateEmailApiKey(apiKeyField.value);
-  if (fromAddress) await updateEmailFromAddress(fromAddress);
+    await settings.email.apiKey.update(apiKeyField.value);
+  if (fromAddress) await settings.email.fromAddress.update(fromAddress);
   await logActivity(`Email provider set to ${provider}`);
   return redirect("/admin/settings-advanced", "Email settings updated", true, {
     formId: "settings-email",
@@ -1074,9 +1019,9 @@ const handleEmailTemplatePost = (type: EmailTemplateType) =>
     }
 
     await Promise.all([
-      updateEmailTemplate(type, "subject", subject.trim()),
-      updateEmailTemplate(type, "html", html.trim()),
-      updateEmailTemplate(type, "text", text.trim()),
+      settings.email.template.update(type, "subject", subject.trim()),
+      settings.email.template.update(type, "html", html.trim()),
+      settings.email.template.update(type, "text", text.trim()),
     ]);
 
     const label =
@@ -1195,7 +1140,7 @@ const handleCustomDomainPost = advancedSettingsRoute(
     const raw = form.getString("custom_domain").toLowerCase();
 
     if (raw === "") {
-      await updateCustomDomain("");
+      await settings.customDomain.update("");
       await logActivity("Custom domain cleared");
       return redirect(
         "/admin/settings-advanced",
@@ -1210,13 +1155,13 @@ const handleCustomDomainPost = advancedSettingsRoute(
       return errorPage("Invalid domain format", 400, "settings-custom-domain");
     }
 
-    await updateCustomDomain(raw);
+    await settings.customDomain.update(raw);
     await logActivity(`Custom domain set to ${raw}`);
 
     // Attempt validation immediately after saving
     const result = await validateCustomDomain(raw);
     if (result.ok) {
-      await updateCustomDomainLastValidated();
+      await settings.customDomain.lastValidated.update();
       await logActivity(`Custom domain validated: ${raw}`);
       return redirect(
         "/admin/settings-advanced",
@@ -1246,7 +1191,7 @@ const handleCustomDomainValidatePost = advancedSettingsRoute(
       );
     }
 
-    const customDomain = await getCustomDomainFromDb();
+    const customDomain = await settings.customDomain.get();
     if (!customDomain) {
       return errorPage(
         "No custom domain is configured",
@@ -1260,7 +1205,7 @@ const handleCustomDomainValidatePost = advancedSettingsRoute(
       return errorPage(result.error, 502, "settings-custom-domain-validate");
     }
 
-    await updateCustomDomainLastValidated();
+    await settings.customDomain.lastValidated.update();
     await logActivity(`Custom domain validated: ${customDomain}`);
     return redirect(
       "/admin/settings-advanced",
@@ -1290,11 +1235,11 @@ const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
     wwdrField.action === "cleared"
   ) {
     await Promise.all([
-      updateAppleWalletPassTypeId(""),
-      updateAppleWalletTeamId(""),
-      updateAppleWalletSigningCert(""),
-      updateAppleWalletSigningKey(""),
-      updateAppleWalletWwdrCert(""),
+      settings.appleWallet.passTypeId.update(""),
+      settings.appleWallet.teamId.update(""),
+      settings.appleWallet.signingCert.update(""),
+      settings.appleWallet.signingKey.update(""),
+      settings.appleWallet.wwdrCert.update(""),
     ]);
     await logActivity("Apple Wallet configuration cleared");
     return redirect(
@@ -1314,7 +1259,7 @@ const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
   }
 
   // For initial setup, require all three PEM fields
-  const isConfigured = await hasAppleWalletDbConfig();
+  const isConfigured = await settings.appleWallet.hasDbConfig();
   if (!isConfigured) {
     if (certField.action !== "provided") {
       return errorPage(
@@ -1368,14 +1313,14 @@ const handleAppleWalletPost = advancedSettingsRoute(async (form, errorPage) => {
     );
   }
 
-  await updateAppleWalletPassTypeId(passTypeId);
-  await updateAppleWalletTeamId(teamId);
+  await settings.appleWallet.passTypeId.update(passTypeId);
+  await settings.appleWallet.teamId.update(teamId);
   if (certField.action === "provided")
-    await updateAppleWalletSigningCert(certField.value);
+    await settings.appleWallet.signingCert.update(certField.value);
   if (keyField.action === "provided")
-    await updateAppleWalletSigningKey(keyField.value);
+    await settings.appleWallet.signingKey.update(keyField.value);
   if (wwdrField.action === "provided")
-    await updateAppleWalletWwdrCert(wwdrField.value);
+    await settings.appleWallet.wwdrCert.update(wwdrField.value);
 
   await logActivity("Apple Wallet configuration updated");
   return redirect(
@@ -1403,9 +1348,9 @@ const handleGoogleWalletPost = advancedSettingsRoute(
     // If everything is cleared, remove all settings
     if (!issuerId && !email && keyField.action === "cleared") {
       await Promise.all([
-        updateGoogleWalletIssuerId(""),
-        updateGoogleWalletServiceAccountEmail(""),
-        updateGoogleWalletServiceAccountKey(""),
+        settings.googleWallet.issuerId.update(""),
+        settings.googleWallet.serviceAccountEmail.update(""),
+        settings.googleWallet.serviceAccountKey.update(""),
       ]);
       await logActivity("Google Wallet configuration cleared");
       return redirect(
@@ -1429,7 +1374,7 @@ const handleGoogleWalletPost = advancedSettingsRoute(
     }
 
     // For initial setup, require the private key
-    const isConfigured = await hasGoogleWalletDbConfig();
+    const isConfigured = await settings.googleWallet.hasDbConfig();
     if (!isConfigured && keyField.action !== "provided") {
       return errorPage(
         "Service account private key is required",
@@ -1450,10 +1395,10 @@ const handleGoogleWalletPost = advancedSettingsRoute(
       );
     }
 
-    await updateGoogleWalletIssuerId(issuerId);
-    await updateGoogleWalletServiceAccountEmail(email);
+    await settings.googleWallet.issuerId.update(issuerId);
+    await settings.googleWallet.serviceAccountEmail.update(email);
     if (keyField.action === "provided")
-      await updateGoogleWalletServiceAccountKey(keyField.value);
+      await settings.googleWallet.serviceAccountKey.update(keyField.value);
 
     await logActivity("Google Wallet configuration updated");
     return redirect(

--- a/src/routes/admin/site.ts
+++ b/src/routes/admin/site.ts
@@ -5,14 +5,9 @@
 
 import { logActivity } from "#lib/db/activityLog.ts";
 import {
-  getContactPageTextFromDb,
-  getHomepageTextFromDb,
-  getWebsiteTitleFromDb,
   MAX_PAGE_TEXT_LENGTH,
   MAX_WEBSITE_TITLE_LENGTH,
-  updateContactPageText,
-  updateHomepageText,
-  updateWebsiteTitle,
+  settings,
 } from "#lib/db/settings.ts";
 import {
   applyDemoOverrides,
@@ -71,15 +66,15 @@ const sitePostRoute =
 /** Render homepage editor with current state */
 const renderHomePage: PageRenderer = async (session, error, success) => {
   const [websiteTitle, homepageText] = await Promise.all([
-    getWebsiteTitleFromDb(),
-    getHomepageTextFromDb(),
+    settings.websiteTitle.get(),
+    settings.homepageText.get(),
   ]);
   return adminSiteHomePage(session, websiteTitle, homepageText, error, success);
 };
 
 /** Render contact editor with current state */
 const renderContactPage: PageRenderer = async (session, error, success) => {
-  const contactText = await getContactPageTextFromDb();
+  const contactText = await settings.contactPageText.get();
   return adminSiteContactPage(session, contactText, error, success);
 };
 
@@ -104,8 +99,8 @@ const handleSiteHomePost = sitePostRoute(async (session, form) => {
     );
   }
 
-  await updateWebsiteTitle(titleRaw);
-  await updateHomepageText(textRaw);
+  await settings.websiteTitle.update(titleRaw);
+  await settings.homepageText.update(textRaw);
   await logActivity("Site homepage updated");
   return redirect("/admin/site", "Homepage updated", true);
 });
@@ -121,7 +116,7 @@ const handleSiteContactPost = sitePostRoute(async (session, form) => {
     );
   }
 
-  await updateContactPageText(textRaw);
+  await settings.contactPageText.update(textRaw);
   await logActivity("Site contact page updated");
   return redirect("/admin/site/contact", "Contact page updated", true);
 });

--- a/src/routes/admin/site.ts
+++ b/src/routes/admin/site.ts
@@ -33,21 +33,21 @@ type PageRenderer = (
   session: AuthSession,
   error?: string,
   success?: string,
-) => Promise<string>;
+) => string;
 
 /** Build error page callback for a given renderer */
 const errorPageFor =
   (session: AuthSession, render: PageRenderer) =>
-  async (error: string, status: number): Promise<Response> =>
-    htmlResponse(await render(session, error), status);
+  (error: string, status: number): Response =>
+    htmlResponse(render(session, error), status);
 
 /** Owner-only GET route that renders a site editor page */
 const siteGetRoute =
   (render: PageRenderer) =>
   (request: Request): Promise<Response> => {
     const flash = getFlash();
-    return requireOwnerOr(request, async (session) => {
-      const html = await render(session, flash.error, flash.success);
+    return requireOwnerOr(request, (session) => {
+      const html = render(session, flash.error, flash.success);
       return htmlResponse(html);
     });
   };
@@ -64,17 +64,15 @@ const sitePostRoute =
     withOwnerAuthForm(request, handler);
 
 /** Render homepage editor with current state */
-const renderHomePage: PageRenderer = async (session, error, success) => {
-  const [websiteTitle, homepageText] = await Promise.all([
-    settings.websiteTitle.get(),
-    settings.homepageText.get(),
-  ]);
+const renderHomePage: PageRenderer = (session, error, success) => {
+  const websiteTitle = settings.websiteTitle;
+  const homepageText = settings.homepageText;
   return adminSiteHomePage(session, websiteTitle, homepageText, error, success);
 };
 
 /** Render contact editor with current state */
-const renderContactPage: PageRenderer = async (session, error, success) => {
-  const contactText = await settings.contactPageText.get();
+const renderContactPage: PageRenderer = (session, error, success) => {
+  const contactText = settings.contactPageText;
   return adminSiteContactPage(session, contactText, error, success);
 };
 
@@ -99,8 +97,8 @@ const handleSiteHomePost = sitePostRoute(async (session, form) => {
     );
   }
 
-  await settings.websiteTitle.update(titleRaw);
-  await settings.homepageText.update(textRaw);
+  await settings.update.websiteTitle(titleRaw);
+  await settings.update.homepageText(textRaw);
   await logActivity("Site homepage updated");
   return redirect("/admin/site", "Homepage updated", true);
 });
@@ -116,7 +114,7 @@ const handleSiteContactPost = sitePostRoute(async (session, form) => {
     );
   }
 
-  await settings.contactPageText.update(textRaw);
+  await settings.update.contactPageText(textRaw);
   await logActivity("Site contact page updated");
   return redirect("/admin/site/contact", "Contact page updated", true);
 });

--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -7,7 +7,7 @@
 import { filter, map } from "#fp";
 import { getEffectiveDomain } from "#lib/config.ts";
 import { decryptAttendees, updateCheckedIn } from "#lib/db/attendees.ts";
-import { getPhonePrefixFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { Attendee } from "#lib/types.ts";
 import {
   createTokenRoute,
@@ -59,7 +59,7 @@ const renderAdminView = async (
 ): Promise<Response> => {
   const decrypted = await decryptWithSession(rawAttendees, session);
   const entries = await resolveEntries(decrypted);
-  const phonePrefix = await getPhonePrefixFromDb();
+  const phonePrefix = await settings.phonePrefix.get();
   return htmlResponse(
     checkinAdminPage(
       entries,

--- a/src/routes/checkin.ts
+++ b/src/routes/checkin.ts
@@ -59,7 +59,7 @@ const renderAdminView = async (
 ): Promise<Response> => {
   const decrypted = await decryptWithSession(rawAttendees, session);
   const entries = await resolveEntries(decrypted);
-  const phonePrefix = await settings.phonePrefix.get();
+  const phonePrefix = settings.phonePrefix;
   return htmlResponse(
     checkinAdminPage(
       entries,

--- a/src/routes/feeds.ts
+++ b/src/routes/feeds.ts
@@ -7,10 +7,7 @@ import { map, pipe } from "#fp";
 import { getEffectiveDomain } from "#lib/config.ts";
 import { getAllEvents } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
-import {
-  getShowPublicSiteFromDb,
-  getWebsiteTitleFromDb,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { type EventWithCount, sortEvents } from "#lib/sort-events.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import {
@@ -52,7 +49,7 @@ const loadFeedData = async (): Promise<FeedData> => {
   const [allEvents, holidays, websiteTitle] = await Promise.all([
     getAllEvents(),
     getActiveHolidays(),
-    getWebsiteTitleFromDb(),
+    settings.websiteTitle.get(),
   ]);
   const events = sortEvents(
     allEvents.filter((e) => e.active && !e.hidden && !isRegistrationClosed(e)),
@@ -69,7 +66,7 @@ const loadFeedData = async (): Promise<FeedData> => {
 const requirePublicSite = async <T>(
   fn: () => Promise<T>,
 ): Promise<T | Response> =>
-  (await getShowPublicSiteFromDb()) ? fn() : redirectResponse("/admin/");
+  (await settings.showPublicSite.get()) ? fn() : redirectResponse("/admin/");
 
 /** Build a single VEVENT block */
 const buildVEvent = (

--- a/src/routes/feeds.ts
+++ b/src/routes/feeds.ts
@@ -46,10 +46,10 @@ type FeedData = { events: EventWithCount[]; domain: string; title: string };
 
 /** Load feed data: active open events with domain and title */
 const loadFeedData = async (): Promise<FeedData> => {
-  const [allEvents, holidays, websiteTitle] = await Promise.all([
+  const websiteTitle = settings.websiteTitle;
+  const [allEvents, holidays] = await Promise.all([
     getAllEvents(),
     getActiveHolidays(),
-    settings.websiteTitle.get(),
   ]);
   const events = sortEvents(
     allEvents.filter((e) => e.active && !e.hidden && !isRegistrationClosed(e)),
@@ -63,10 +63,8 @@ const loadFeedData = async (): Promise<FeedData> => {
 };
 
 /** Guard: redirect to admin if public site is disabled */
-const requirePublicSite = async <T>(
-  fn: () => Promise<T>,
-): Promise<T | Response> =>
-  (await settings.showPublicSite.get()) ? fn() : redirectResponse("/admin/");
+const requirePublicSite = <T>(fn: () => Promise<T>): Promise<T> | Response =>
+  settings.showPublicSite ? fn() : redirectResponse("/admin/");
 
 /** Build a single VEVENT block */
 const buildVEvent = (

--- a/src/routes/google-wallet.ts
+++ b/src/routes/google-wallet.ts
@@ -3,7 +3,7 @@
  * Generates a signed JWT and redirects to the Google Wallet save URL.
  */
 
-import { getGoogleWalletConfig } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { buildGoogleWalletUrl } from "#lib/google-wallet.ts";
 import {
   createTokenRoute,
@@ -17,7 +17,7 @@ const handleGoogleWalletGet = async (
   _request: Request,
   tokens: string[],
 ): Promise<Response> => {
-  const config = await getGoogleWalletConfig();
+  const config = await settings.googleWallet.getConfig();
   if (!config) return notFoundResponse();
 
   const result = await lookupSingleTokenPassData(tokens);

--- a/src/routes/google-wallet.ts
+++ b/src/routes/google-wallet.ts
@@ -17,7 +17,7 @@ const handleGoogleWalletGet = async (
   _request: Request,
   tokens: string[],
 ): Promise<Response> => {
-  const config = await settings.googleWallet.getConfig();
+  const config = settings.googleWallet.config;
   if (!config) return notFoundResponse();
 
   const result = await lookupSingleTokenPassData(tokens);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -253,7 +253,7 @@ const prefixHandlers: Record<string, RouterFn> = {
     );
     if (adminResult) return adminResult;
     // Public API requires feature flag
-    return (await settings.showPublicApi.get())
+    return settings.showPublicApi
       ? (await loadApiRoutes())(request, path, method, server)
       : null;
   },
@@ -298,9 +298,9 @@ const handleRequestInternal = async (
     return redirectResponse("/setup");
   }
 
-  await loadCurrencyCode();
-  await loadTheme();
-  await loadHeaderImage();
+  loadCurrencyCode();
+  loadTheme();
+  loadHeaderImage();
   return (await routeMainApp(request, path, method, server))!;
 };
 
@@ -374,7 +374,7 @@ export const handleRequest = async (
 
             // Load effective domain (custom_domain from DB if set, else ALLOWED_DOMAIN)
             // before domain validation so redirects go to the right host.
-            await loadEffectiveDomain();
+            loadEffectiveDomain();
 
             // Domain validation: redirect requests from unauthorized domains to the effective domain
             if (!isValidDomain(effectiveRequest)) {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,7 +12,7 @@ import {
 } from "#lib/cookies.ts";
 import { loadCurrencyCode } from "#lib/currency.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
-import { getShowPublicApiFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   hasFlash,
   resetFlashContext,
@@ -253,7 +253,7 @@ const prefixHandlers: Record<string, RouterFn> = {
     );
     if (adminResult) return adminResult;
     // Public API requires feature flag
-    return (await getShowPublicApiFromDb())
+    return (await settings.showPublicApi.get())
       ? (await loadApiRoutes())(request, path, method, server)
       : null;
   },

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -278,8 +278,8 @@ export const applySecurityHeaders = async (
   }
 
   // Rebuild CSP with payment-provider-specific directives
-  const provider = await getPaymentProvider();
-  const sandbox = provider === "square" ? await getSquareSandbox() : undefined;
+  const provider = getPaymentProvider();
+  const sandbox = provider === "square" ? getSquareSandbox() : undefined;
   response.headers.set(
     "content-security-policy",
     buildCspHeader(embeddable, { provider, sandbox }),

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -97,45 +97,39 @@ const loadHomepageEvents = async (): Promise<MultiTicketEvent[]> => {
 };
 
 /** Guard: redirect to admin if public site is disabled */
-const requirePublicSite = async (
-  fn: () => Promise<Response>,
-): Promise<Response> =>
-  (await settings.showPublicSite.get()) ? fn() : redirectResponse("/admin/");
+const requirePublicSite = <T>(fn: () => T): T | Response =>
+  settings.showPublicSite ? fn() : redirectResponse("/admin/");
 
-/** Render a public site page with website title and content fetched in parallel */
+/** Render a public site page with website title and content */
 const renderPublicPage = (
   pageType: PublicPageType,
-  getContent: () => Promise<string | null>,
-): Promise<Response> =>
-  requirePublicSite(async () => {
-    const [websiteTitle, content] = await Promise.all([
-      settings.websiteTitle.get(),
-      getContent(),
-    ]);
+  getContent: () => string | null,
+): Response =>
+  requirePublicSite(() => {
+    const websiteTitle = settings.websiteTitle;
+    const content = getContent();
     return htmlResponse(publicSitePage(pageType, websiteTitle, content));
   });
 
 /** Handle GET / (home page) - redirect to admin or show public site */
-export const handleHome = (): Promise<Response> =>
-  renderPublicPage("home", settings.homepageText.get);
+export const handleHome = (): Response =>
+  renderPublicPage("home", () => settings.homepageText);
 
 /** Handle GET /events - public events listing */
-export const handlePublicEvents = (): Promise<Response> =>
+export const handlePublicEvents = (): Response | Promise<Response> =>
   requirePublicSite(async () => {
-    const [events, websiteTitle] = await Promise.all([
-      loadHomepageEvents(),
-      settings.websiteTitle.get(),
-    ]);
+    const websiteTitle = settings.websiteTitle;
+    const events = await loadHomepageEvents();
     return htmlResponse(homepagePage(events, websiteTitle));
   });
 
 /** Handle GET /terms - public terms and conditions page */
-export const handlePublicTerms = (): Promise<Response> =>
-  renderPublicPage("terms", settings.terms.get);
+export const handlePublicTerms = (): Response =>
+  renderPublicPage("terms", () => settings.terms);
 
 /** Handle GET /contact - public contact page */
-export const handlePublicContact = (): Promise<Response> =>
-  renderPublicPage("contact", settings.contactPageText.get);
+export const handlePublicContact = (): Response =>
+  renderPublicPage("contact", () => settings.contactPageText);
 
 /** Render a ticket page with the given context */
 const renderTicketPage = (
@@ -199,7 +193,7 @@ const handleSingleTicketGet = (
     await signCsrfToken();
     const [dates, terms, questions] = await Promise.all([
       computeDatesForEvent(event),
-      settings.terms.get(),
+      Promise.resolve(settings.terms),
       getQuestionsForEvent(event.id),
     ]);
     const ctx: TicketContext = { dates, terms, questions };
@@ -417,7 +411,7 @@ const processTicketReservation = async (
   event: EventWithCount,
 ): Promise<Response> => {
   const [terms, questions] = await Promise.all([
-    settings.terms.get(),
+    Promise.resolve(settings.terms),
     getQuestionsForEvent(event.id),
   ]);
   const ctx: TicketContext = { dates: undefined, terms, questions };
@@ -587,7 +581,7 @@ const getMultiTicketContext = async (
   const eventIds = activeEvents.map((e) => e.event.id);
   const [dates, terms, questionsResult] = await Promise.all([
     computeSharedDates(activeEvents),
-    settings.terms.get(),
+    Promise.resolve(settings.terms),
     getQuestionsWithEventIds(eventIds),
   ]);
   return { dates, terms: terms ?? "", ...questionsResult };
@@ -881,10 +875,8 @@ const buildMultiRegistrationItems = (
 };
 
 /** Check if any selected event requires payment */
-const anyRequiresPayment = async (
-  items: MultiRegistrationItem[],
-): Promise<boolean> => {
-  const paymentsEnabled = await isPaymentsEnabled();
+const anyRequiresPayment = (items: MultiRegistrationItem[]): boolean => {
+  const paymentsEnabled = isPaymentsEnabled();
   if (!paymentsEnabled) return false;
   return items.some((item) => item.unitPrice > 0);
 };
@@ -933,7 +925,7 @@ const processMultiFreeReservation = async (
     }
     entries.push({ event, attendee: result.attendee });
   }
-  await logAndNotifyMultiRegistration(entries, await getCurrencyCode());
+  await logAndNotifyMultiRegistration(entries, getCurrencyCode());
   return {
     success: true,
     tokens: entries.map((entry) => entry.attendee.ticket_token),
@@ -948,7 +940,7 @@ const getGroupMultiTicketContext =
     const eventIds = events.map((e) => e.event.id);
     const [dates, globalTerms, questionsResult] = await Promise.all([
       computeSharedDates(events),
-      settings.terms.get(),
+      Promise.resolve(settings.terms),
       getQuestionsWithEventIds(eventIds),
     ]);
     const terms = group.terms_and_conditions || globalTerms || "";

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -34,13 +34,7 @@ import {
   type QuestionWithAnswers,
   saveAttendeeAnswers,
 } from "#lib/db/questions.ts";
-import {
-  getContactPageTextFromDb,
-  getHomepageTextFromDb,
-  getShowPublicSiteFromDb,
-  getTermsAndConditionsFromDb,
-  getWebsiteTitleFromDb,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import type { EmailEntry } from "#lib/email.ts";
 import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
@@ -106,7 +100,7 @@ const loadHomepageEvents = async (): Promise<MultiTicketEvent[]> => {
 const requirePublicSite = async (
   fn: () => Promise<Response>,
 ): Promise<Response> =>
-  (await getShowPublicSiteFromDb()) ? fn() : redirectResponse("/admin/");
+  (await settings.showPublicSite.get()) ? fn() : redirectResponse("/admin/");
 
 /** Render a public site page with website title and content fetched in parallel */
 const renderPublicPage = (
@@ -115,7 +109,7 @@ const renderPublicPage = (
 ): Promise<Response> =>
   requirePublicSite(async () => {
     const [websiteTitle, content] = await Promise.all([
-      getWebsiteTitleFromDb(),
+      settings.websiteTitle.get(),
       getContent(),
     ]);
     return htmlResponse(publicSitePage(pageType, websiteTitle, content));
@@ -123,25 +117,25 @@ const renderPublicPage = (
 
 /** Handle GET / (home page) - redirect to admin or show public site */
 export const handleHome = (): Promise<Response> =>
-  renderPublicPage("home", getHomepageTextFromDb);
+  renderPublicPage("home", settings.homepageText.get);
 
 /** Handle GET /events - public events listing */
 export const handlePublicEvents = (): Promise<Response> =>
   requirePublicSite(async () => {
     const [events, websiteTitle] = await Promise.all([
       loadHomepageEvents(),
-      getWebsiteTitleFromDb(),
+      settings.websiteTitle.get(),
     ]);
     return htmlResponse(homepagePage(events, websiteTitle));
   });
 
 /** Handle GET /terms - public terms and conditions page */
 export const handlePublicTerms = (): Promise<Response> =>
-  renderPublicPage("terms", getTermsAndConditionsFromDb);
+  renderPublicPage("terms", settings.terms.get);
 
 /** Handle GET /contact - public contact page */
 export const handlePublicContact = (): Promise<Response> =>
-  renderPublicPage("contact", getContactPageTextFromDb);
+  renderPublicPage("contact", settings.contactPageText.get);
 
 /** Render a ticket page with the given context */
 const renderTicketPage = (
@@ -205,7 +199,7 @@ const handleSingleTicketGet = (
     await signCsrfToken();
     const [dates, terms, questions] = await Promise.all([
       computeDatesForEvent(event),
-      getTermsAndConditionsFromDb(),
+      settings.terms.get(),
       getQuestionsForEvent(event.id),
     ]);
     const ctx: TicketContext = { dates, terms, questions };
@@ -423,7 +417,7 @@ const processTicketReservation = async (
   event: EventWithCount,
 ): Promise<Response> => {
   const [terms, questions] = await Promise.all([
-    getTermsAndConditionsFromDb(),
+    settings.terms.get(),
     getQuestionsForEvent(event.id),
   ]);
   const ctx: TicketContext = { dates: undefined, terms, questions };
@@ -593,7 +587,7 @@ const getMultiTicketContext = async (
   const eventIds = activeEvents.map((e) => e.event.id);
   const [dates, terms, questionsResult] = await Promise.all([
     computeSharedDates(activeEvents),
-    getTermsAndConditionsFromDb(),
+    settings.terms.get(),
     getQuestionsWithEventIds(eventIds),
   ]);
   return { dates, terms: terms ?? "", ...questionsResult };
@@ -954,7 +948,7 @@ const getGroupMultiTicketContext =
     const eventIds = events.map((e) => e.event.id);
     const [dates, globalTerms, questionsResult] = await Promise.all([
       computeSharedDates(events),
-      getTermsAndConditionsFromDb(),
+      settings.terms.get(),
       getQuestionsWithEventIds(eventIds),
     ]);
     const terms = group.terms_and_conditions || globalTerms || "";

--- a/src/routes/setup.ts
+++ b/src/routes/setup.ts
@@ -5,7 +5,7 @@
 import { isValidCountry } from "#lib/countries.ts";
 import { signCsrfToken, verifySignedCsrfToken } from "#lib/csrf.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
-import { settingsApi } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { FormParams } from "#lib/form-data.ts";
 import { validateForm } from "#lib/forms.tsx";
 import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
@@ -139,7 +139,7 @@ const handleSetupPost = async (
   logDebug("Setup", "Form validation passed, completing setup...");
 
   try {
-    await settingsApi.completeSetup(
+    await settings.setup.complete(
       validation.username,
       validation.password,
       validation.country,

--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -46,11 +46,9 @@ const handleTicketView = async (
   const result = await lookupAttendees(tokens);
   if (!result.ok) return result.response;
 
-  const [entries, appleWalletEnabled, googleWalletEnabled] = await Promise.all([
-    resolveEntries(result.attendees),
-    settings.appleWallet.hasConfig(),
-    settings.googleWallet.hasConfig(),
-  ]);
+  const entries = await resolveEntries(result.attendees);
+  const appleWalletEnabled = settings.appleWallet.hasConfig;
+  const googleWalletEnabled = settings.googleWallet.hasConfig;
   for (const entry of entries) {
     entry.attendee.price_paid = String(entry.attendee.price_paid_v2);
   }

--- a/src/routes/tickets.ts
+++ b/src/routes/tickets.ts
@@ -6,10 +6,7 @@
 
 import { signAttachmentUrl } from "#lib/attachment-url.ts";
 import { getEffectiveDomain } from "#lib/config.ts";
-import {
-  hasAppleWalletConfig,
-  hasGoogleWalletConfig,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import {
   createTokenRoute,
@@ -51,8 +48,8 @@ const handleTicketView = async (
 
   const [entries, appleWalletEnabled, googleWalletEnabled] = await Promise.all([
     resolveEntries(result.attendees),
-    hasAppleWalletConfig(),
-    hasGoogleWalletConfig(),
+    settings.appleWallet.hasConfig(),
+    settings.googleWallet.hasConfig(),
   ]);
   for (const entry of entries) {
     entry.attendee.price_paid = String(entry.attendee.price_paid_v2);

--- a/src/routes/token-utils.ts
+++ b/src/routes/token-utils.ts
@@ -34,13 +34,13 @@ export type WalletPassData = {
 export const WALLET_CACHE_CONTROL = "public, max-age=300, s-maxage=3600";
 
 /** Build shared wallet pass data from a resolved token entry */
-export const buildWalletPassData = async (
+export const buildWalletPassData = (
   entry: TokenEntry,
   token: string,
-): Promise<WalletPassData> => {
+): WalletPassData => {
   const { event, attendee } = entry;
   const domain = getEffectiveDomain();
-  const currencyCode = await settings.currency.get();
+  const currencyCode = settings.currency;
   const pricePaid = attendee.price_paid_v2;
 
   return {
@@ -89,7 +89,7 @@ export type TokenRouteFn = (
 type TokenMethodHandler = (
   request: Request,
   tokens: string[],
-) => Promise<Response>;
+) => Response | Promise<Response>;
 
 /** Map of HTTP method to handler */
 type TokenMethodMap = Record<string, TokenMethodHandler>;
@@ -140,12 +140,12 @@ export const lookupAttendees = async (
  */
 export const createTokenRoute =
   (prefix: string, methods: TokenMethodMap): TokenRouteFn =>
-  (request, path, method) => {
+  async (request, path, method) => {
     const tokensStr = extractTokenSegment(prefix, path);
-    if (!tokensStr) return Promise.resolve(null);
+    if (!tokensStr) return null;
 
     const handler = methods[method];
-    if (!handler) return Promise.resolve(null);
+    if (!handler) return null;
 
-    return handler(request, parseTokens(tokensStr));
+    return await handler(request, parseTokens(tokensStr));
   };

--- a/src/routes/token-utils.ts
+++ b/src/routes/token-utils.ts
@@ -6,7 +6,7 @@ import { compact, map } from "#fp";
 import { getEffectiveDomain } from "#lib/config.ts";
 import { getAttendeesByTokens } from "#lib/db/attendees.ts";
 import { getEventWithCount } from "#lib/db/events.ts";
-import { getCurrencyCodeFromDb } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { Attendee, EventWithCount } from "#lib/types.ts";
 import { notFoundResponse } from "#routes/utils.ts";
 
@@ -40,7 +40,7 @@ export const buildWalletPassData = async (
 ): Promise<WalletPassData> => {
   const { event, attendee } = entry;
   const domain = getEffectiveDomain();
-  const currencyCode = await getCurrencyCodeFromDb();
+  const currencyCode = await settings.currency.get();
   const pricePaid = attendee.price_paid_v2;
 
   return {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -17,7 +17,7 @@ import {
 import { getApiKeyByToken, touchApiKeyLastUsed } from "#lib/db/api-keys.ts";
 import { getEventWithCount, getEventWithCountBySlug } from "#lib/db/events.ts";
 import { deleteSession, getSession } from "#lib/db/sessions.ts";
-import { getWrappedPrivateKey } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { decryptAdminLevel, getUserById } from "#lib/db/users.ts";
 import { FormParams } from "#lib/form-data.ts";
 import { setSavedFormData } from "#lib/forms.tsx";
@@ -229,7 +229,7 @@ export const getPrivateKey = async (session: {
 }): Promise<CryptoKey | null> => {
   if (!session.wrappedDataKey) return null;
 
-  const wrappedPrivateKey = await getWrappedPrivateKey();
+  const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
   if (!wrappedPrivateKey) return null;
 
   try {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -229,7 +229,7 @@ export const getPrivateKey = async (session: {
 }): Promise<CryptoKey | null> => {
   if (!session.wrappedDataKey) return null;
 
-  const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
+  const wrappedPrivateKey = settings.wrappedPrivateKey;
   if (!wrappedPrivateKey) return null;
 
   try {

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -23,8 +23,8 @@ const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 const withVerifiedPass =
   (failStatus: number) =>
   (handler: (config: SigningCredentials) => Response | Promise<Response>) =>
-  async (passType: string): Promise<Response> => {
-    const config = await settings.appleWallet.getConfig();
+  (passType: string): Response | Promise<Response> => {
+    const config = settings.appleWallet.config;
     return config && passType === config.passTypeId
       ? handler(config)
       : new Response(null, { status: failStatus });

--- a/src/routes/wallet-webservice.ts
+++ b/src/routes/wallet-webservice.ts
@@ -13,7 +13,7 @@
  */
 
 import { type SigningCredentials, trimAuthToken } from "#lib/apple-wallet.ts";
-import { getAppleWalletConfig } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import { buildPkpassForToken } from "#routes/wallet.ts";
 
@@ -24,7 +24,7 @@ const withVerifiedPass =
   (failStatus: number) =>
   (handler: (config: SigningCredentials) => Response | Promise<Response>) =>
   async (passType: string): Promise<Response> => {
-    const config = await getAppleWalletConfig();
+    const config = await settings.appleWallet.getConfig();
     return config && passType === config.passTypeId
       ? handler(config)
       : new Response(null, { status: failStatus });

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -21,10 +21,10 @@ const PKPASS_CONTENT_TYPE = "application/vnd.apple.pkpass";
 const PKPASS_EXT = ".pkpass";
 
 /** Handle GET /wallet/:token.pkpass — generate and return .pkpass */
-const handleWalletGet = async (
+const handleWalletGet = (
   _request: Request,
   tokens: string[],
-): Promise<Response> => {
+): Response | Promise<Response> => {
   const raw = tokens[0];
   if (!raw || tokens.length > 1) return notFoundResponse();
 
@@ -32,7 +32,7 @@ const handleWalletGet = async (
   if (!raw.endsWith(PKPASS_EXT)) return notFoundResponse();
   const token = raw.slice(0, -PKPASS_EXT.length);
 
-  const config = await settings.appleWallet.getConfig();
+  const config = settings.appleWallet.config;
   if (!config) return notFoundResponse();
 
   return buildPkpassForToken(token, config);

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -6,7 +6,7 @@
 
 import { buildPkpass, type SigningCredentials } from "#lib/apple-wallet.ts";
 import { getEffectiveDomain } from "#lib/config.ts";
-import { getAppleWalletConfig } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   createTokenRoute,
   lookupSingleTokenPassData,
@@ -32,7 +32,7 @@ const handleWalletGet = async (
   if (!raw.endsWith(PKPASS_EXT)) return notFoundResponse();
   const token = raw.slice(0, -PKPASS_EXT.length);
 
-  const config = await getAppleWalletConfig();
+  const config = await settings.appleWallet.getConfig();
   if (!config) return notFoundResponse();
 
   return buildPkpassForToken(token, config);

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -543,7 +543,7 @@ const processPaymentSession = async (
 
   // Price validation
   const hasPerItemPrices = intent.items.some((item) => item.p > 0);
-  const bookingFeePercent = await getBookingFee();
+  const bookingFeePercent = getBookingFee();
 
   if (hasPerItemPrices) {
     // Per-item prices are ticket-only (no fee), so validate without booking fee
@@ -662,10 +662,7 @@ const processPaymentSession = async (
     options?.storeTokens === false ? [] : ticketTokens,
   );
 
-  await logAndNotifyMultiRegistration(
-    createdAttendees,
-    await getCurrencyCode(),
-  );
+  await logAndNotifyMultiRegistration(createdAttendees, getCurrencyCode());
 
   return {
     success: true,

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -2,7 +2,7 @@
  * Shared admin navigation component
  */
 
-import { getShowPublicSiteCached } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { CsrfForm } from "#lib/forms.tsx";
 import type { AdminSession } from "#lib/types.ts";
 
@@ -31,7 +31,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
       {session.adminLevel === "owner" &&
         navLink("/admin/users", "Users", active)}
       {session.adminLevel === "owner" &&
-        getShowPublicSiteCached() &&
+        settings.showPublicSite.getCached() &&
         navLink("/admin/site", "Site", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/settings", "Settings", active)}

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -31,7 +31,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
       {session.adminLevel === "owner" &&
         navLink("/admin/users", "Users", active)}
       {session.adminLevel === "owner" &&
-        settings.showPublicSite.getCached() &&
+        settings.showPublicSite &&
         navLink("/admin/site", "Site", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/settings", "Settings", active)}

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -4,7 +4,7 @@
 
 import { formatCurrency } from "#lib/currency.ts";
 import { DAY_NAMES } from "#lib/dates.ts";
-import { CONFIG_KEYS, getSettingCached } from "#lib/db/settings.ts";
+import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
 import {
   mergeEventFields,
   parseEventFields,
@@ -644,7 +644,7 @@ const contactFieldMap: Record<ContactField, Field> = {
 export { mergeEventFields, parseEventFields };
 
 /** Stubbable API for testing */
-export const fieldsApi = { getSettingCached };
+export const fieldsApi = { getSettingCached: settings.getCached };
 
 /**
  * Get ticket form fields based on event fields setting.

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -644,7 +644,7 @@ const contactFieldMap: Record<ContactField, Field> = {
 export { mergeEventFields, parseEventFields };
 
 /** Stubbable API for testing */
-export const fieldsApi = { getSettingCached: settings.getCached };
+export const fieldsApi = { getSettingCached: settings.getCachedRaw };
 
 /**
  * Get ticket form fields based on event fields setting.

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -230,8 +230,10 @@ export const createTestDbWithSetup = async (country = "GB"): Promise<void> => {
         });
       }
     }
+    settings.invalidateCache();
+    await settings.loadAll();
     setCurrencyCodeForTest(getCountry(country).currency);
-    settings.timezone.setForTest("UTC");
+    settings.setForTest({ timezone: "UTC" });
     return;
   }
 
@@ -240,11 +242,12 @@ export const createTestDbWithSetup = async (country = "GB"): Promise<void> => {
     TEST_ADMIN_PASSWORD,
     country,
   );
-  await settings.attendeeBlobMigrated.set();
+  await settings.update.attendeeBlobMigrated();
+  await settings.loadAll();
   setCurrencyCodeForTest(getCountry(country).currency);
 
   // Default timezone to UTC for tests so datetime-local values pass through unchanged
-  settings.timezone.setForTest("UTC");
+  settings.setForTest({ timezone: "UTC" });
 
   // Snapshot settings AND users for reuse
   const result = await getClient().execute("SELECT key, value FROM settings");
@@ -297,7 +300,7 @@ export const resetDb = (): void => {
   resetAllowedDomain();
   resetHostEmailConfig();
   settings.appleWallet.resetHostConfig();
-  settings.timezone.resetTestOverride();
+  settings.clearTestOverrides();
 };
 
 /**
@@ -1621,9 +1624,9 @@ export const submitMultiTicketForm = async (
  * Configure Stripe as the payment provider for tests.
  */
 export const setupStripe = async (key = "sk_test_mock"): Promise<void> => {
-  const { settings } = await import("#lib/db/settings.ts");
-  await settings.stripe.secretKey.update(key);
-  await settings.paymentProvider.set("stripe");
+  const { settings: s } = await import("#lib/db/settings.ts");
+  await s.update.stripe.secretKey(key);
+  await s.update.paymentProvider("stripe");
 };
 
 /**

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -36,15 +36,7 @@ import { type GroupInput, invalidateGroupsCache } from "#lib/db/groups.ts";
 import { invalidateHolidaysCache } from "#lib/db/holidays.ts";
 import { initDb, LATEST_UPDATE } from "#lib/db/migrations.ts";
 import { getSession, resetSessionCache } from "#lib/db/sessions.ts";
-import {
-  clearSetupCompleteCache,
-  completeSetup,
-  invalidateSettingsCache,
-  resetHostAppleWalletConfig,
-  resetTimezoneTestOverride,
-  setAttendeeBlobMigrated,
-  setTimezoneForTest,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { resetHostEmailConfig } from "#lib/email.ts";
@@ -164,7 +156,7 @@ const isSchemaIntact = async (client: Client): Promise<boolean> => {
 /** Common setup: env, caches, and reuse-or-create the client */
 const prepareTestClient = async (): Promise<{ reused: boolean }> => {
   setupTestEncryptionKey();
-  clearSetupCompleteCache();
+  settings.setup.clearCache();
   resetSessionCache();
   invalidateUsersCache();
   invalidateEventsCache();
@@ -239,16 +231,20 @@ export const createTestDbWithSetup = async (country = "GB"): Promise<void> => {
       }
     }
     setCurrencyCodeForTest(getCountry(country).currency);
-    setTimezoneForTest("UTC");
+    settings.timezone.setForTest("UTC");
     return;
   }
 
-  await completeSetup(TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD, country);
-  await setAttendeeBlobMigrated();
+  await settings.setup.complete(
+    TEST_ADMIN_USERNAME,
+    TEST_ADMIN_PASSWORD,
+    country,
+  );
+  await settings.attendeeBlobMigrated.set();
   setCurrencyCodeForTest(getCountry(country).currency);
 
   // Default timezone to UTC for tests so datetime-local values pass through unchanged
-  setTimezoneForTest("UTC");
+  settings.timezone.setForTest("UTC");
 
   // Snapshot settings AND users for reuse
   const result = await getClient().execute("SELECT key, value FROM settings");
@@ -288,8 +284,8 @@ export const createTestDbWithSetup = async (country = "GB"): Promise<void> => {
  */
 export const resetDb = (): void => {
   setDb(null);
-  clearSetupCompleteCache();
-  invalidateSettingsCache();
+  settings.setup.clearCache();
+  settings.invalidateCache();
   invalidateUsersCache();
   invalidateEventsCache();
   invalidateHolidaysCache();
@@ -300,8 +296,8 @@ export const resetDb = (): void => {
   setDemoModeForTest(false);
   resetAllowedDomain();
   resetHostEmailConfig();
-  resetHostAppleWalletConfig();
-  resetTimezoneTestOverride();
+  settings.appleWallet.resetHostConfig();
+  settings.timezone.resetTestOverride();
 };
 
 /**
@@ -1625,11 +1621,9 @@ export const submitMultiTicketForm = async (
  * Configure Stripe as the payment provider for tests.
  */
 export const setupStripe = async (key = "sk_test_mock"): Promise<void> => {
-  const { updateStripeKey, setPaymentProvider } = await import(
-    "#lib/db/settings.ts"
-  );
-  await updateStripeKey(key);
-  await setPaymentProvider("stripe");
+  const { settings } = await import("#lib/db/settings.ts");
+  await settings.stripe.secretKey.update(key);
+  await settings.paymentProvider.set("stripe");
 };
 
 /**

--- a/test/lib/booking-fee.test.ts
+++ b/test/lib/booking-fee.test.ts
@@ -5,7 +5,7 @@ import {
   getBookingFeeAmount,
   itemsSubtotal,
 } from "#lib/booking-fee.ts";
-import { updateBookingFee } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { createTestDb, resetDb } from "#test-utils";
 
 describe("calculateBookingFee", () => {
@@ -65,7 +65,7 @@ describe("getBookingFeeAmount", () => {
   });
 
   test("returns calculated fee when booking fee is set", async () => {
-    await updateBookingFee("2.5");
+    await settings.bookingFee.update("2.5");
     // 1000 * 2.5 / 100 = 25
     expect(await getBookingFeeAmount(1000)).toBe(25);
   });

--- a/test/lib/booking-fee.test.ts
+++ b/test/lib/booking-fee.test.ts
@@ -65,7 +65,7 @@ describe("getBookingFeeAmount", () => {
   });
 
   test("returns calculated fee when booking fee is set", async () => {
-    await settings.bookingFee.update("2.5");
+    await settings.update.bookingFee("2.5");
     // 1000 * 2.5 / 100 = 25
     expect(await getBookingFeeAmount(1000)).toBe(25);
   });

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -9,12 +9,7 @@ import {
   resetAllowedDomain,
   setAllowedDomainForTest,
 } from "#lib/config.ts";
-import {
-  getCustomDomainFromDb,
-  getCustomDomainLastValidatedFromDb,
-  updateCustomDomain,
-  updateCustomDomainLastValidated,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { createTestDb, describeWithEnv, resetDb, withMocks } from "#test-utils";
 
 /** Temporarily replace bunnyCdnApi.validateCustomDomain with a mock */
@@ -497,27 +492,27 @@ describe("custom domain settings", () => {
   });
 
   test("getCustomDomainFromDb returns null when not set", async () => {
-    expect(await getCustomDomainFromDb()).toBeNull();
+    expect(await settings.customDomain.get()).toBeNull();
   });
 
   test("updateCustomDomain stores and retrieves domain", async () => {
-    await updateCustomDomain("tickets.example.com");
-    expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+    await settings.customDomain.update("tickets.example.com");
+    expect(await settings.customDomain.get()).toBe("tickets.example.com");
   });
 
   test("updateCustomDomain with empty string clears domain", async () => {
-    await updateCustomDomain("tickets.example.com");
-    await updateCustomDomain("");
-    expect(await getCustomDomainFromDb()).toBeNull();
+    await settings.customDomain.update("tickets.example.com");
+    await settings.customDomain.update("");
+    expect(await settings.customDomain.get()).toBeNull();
   });
 
   test("getCustomDomainLastValidatedFromDb returns null when not set", async () => {
-    expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
+    expect(await settings.customDomain.lastValidated.get()).toBeNull();
   });
 
   test("updateCustomDomainLastValidated stores a timestamp", async () => {
-    await updateCustomDomainLastValidated();
-    const value = await getCustomDomainLastValidatedFromDb();
+    await settings.customDomain.lastValidated.update();
+    const value = await settings.customDomain.lastValidated.get();
     expect(value).not.toBeNull();
     // Should be a valid ISO 8601 date
     expect(new Date(value!).toISOString()).toBe(value);

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -483,28 +483,28 @@ describeWithEnv(
 );
 
 describeWithEnv("custom domain settings", { db: true }, () => {
-  test("getCustomDomainFromDb returns null when not set", async () => {
-    expect(await settings.customDomain.get()).toBeNull();
+  test("getCustomDomainFromDb returns null when not set", () => {
+    expect(settings.customDomain).toBeNull();
   });
 
   test("updateCustomDomain stores and retrieves domain", async () => {
-    await settings.customDomain.update("tickets.example.com");
-    expect(await settings.customDomain.get()).toBe("tickets.example.com");
+    await settings.update.customDomain("tickets.example.com");
+    expect(settings.customDomain).toBe("tickets.example.com");
   });
 
   test("updateCustomDomain with empty string clears domain", async () => {
-    await settings.customDomain.update("tickets.example.com");
-    await settings.customDomain.update("");
-    expect(await settings.customDomain.get()).toBeNull();
+    await settings.update.customDomain("tickets.example.com");
+    await settings.update.customDomain("");
+    expect(settings.customDomain).toBeNull();
   });
 
-  test("getCustomDomainLastValidatedFromDb returns null when not set", async () => {
-    expect(await settings.customDomain.lastValidated.get()).toBeNull();
+  test("getCustomDomainLastValidatedFromDb returns null when not set", () => {
+    expect(settings.customDomainLastValidated).toBeNull();
   });
 
   test("updateCustomDomainLastValidated stores a timestamp", async () => {
-    await settings.customDomain.lastValidated.update();
-    const value = await settings.customDomain.lastValidated.get();
+    await settings.update.customDomainLastValidated();
+    const value = settings.customDomainLastValidated;
     expect(value).not.toBeNull();
     // Should be a valid ISO 8601 date
     expect(new Date(value!).toISOString()).toBe(value);

--- a/test/lib/business-email.test.ts
+++ b/test/lib/business-email.test.ts
@@ -194,6 +194,7 @@ describeWithEnv("business-email", { db: true }, () => {
     test("invalidateSettingsCache forces decrypt from database", async () => {
       await updateBusinessEmail("encrypted@example.com");
       settings.invalidateCache();
+      await settings.loadAll();
 
       const result = await getBusinessEmailFromDb();
       expect(result).toBe("encrypted@example.com");

--- a/test/lib/business-email.test.ts
+++ b/test/lib/business-email.test.ts
@@ -6,7 +6,7 @@ import {
   normalizeBusinessEmail,
   updateBusinessEmail,
 } from "#lib/business-email.ts";
-import { invalidateSettingsCache } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { createTestDbWithSetup, resetDb } from "#test-utils";
 
 describe("business-email", () => {
@@ -201,7 +201,7 @@ describe("business-email", () => {
 
     test("invalidateSettingsCache forces decrypt from database", async () => {
       await updateBusinessEmail("encrypted@example.com");
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const result = await getBusinessEmailFromDb();
       expect(result).toBe("encrypted@example.com");

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -46,6 +46,8 @@ const ALLOWED_FILES_STATE = [
   ...TEST_UTILITY_FILES,
   // Session cache with 10s TTL - legitimate performance optimization
   "lib/db/sessions.ts",
+  // Settings test overrides Map for injecting test values into the snapshot
+  "lib/db/settings.ts",
 ];
 
 /**
@@ -277,6 +279,8 @@ describe("code quality", () => {
       "lib/crypto.ts:setEncryptionKeyForTest",
       // Reset cached Stripe client between tests
       "lib/stripe.ts:resetStripeClient",
+      // TTL constant used by page-cache tests to verify caching behaviour
+      "lib/db/settings.ts:SETTINGS_CACHE_TTL_MS",
       // (settings.ts functions now accessed via settings namespace, not individual exports)
       // Reset cached sessions between tests
       "lib/db/sessions.ts:resetSessionCache",
@@ -333,6 +337,8 @@ describe("code quality", () => {
       "lib/storage.ts:MAX_ATTACHMENT_SIZE",
       // readLimit used in production (module-level constants) but test pattern doesn't detect same-file usage
       "lib/limits.ts:readLimit",
+      // Settings cache TTL constant used by tests to verify caching behavior
+      "lib/db/settings.ts:SETTINGS_CACHE_TTL_MS",
     ];
 
     /**

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -277,10 +277,7 @@ describe("code quality", () => {
       "lib/crypto.ts:setEncryptionKeyForTest",
       // Reset cached Stripe client between tests
       "lib/stripe.ts:resetStripeClient",
-      // Reset cached setup complete status between tests
-      "lib/db/settings.ts:clearSetupCompleteCache",
-      // Reset cached settings between tests
-      "lib/db/settings.ts:invalidateSettingsCache",
+      // (settings.ts functions now accessed via settings namespace, not individual exports)
       // Reset cached sessions between tests
       "lib/db/sessions.ts:resetSessionCache",
       // DB version constant used in production but test pattern doesn't detect constant comparison
@@ -330,12 +327,6 @@ describe("code quality", () => {
       // Reset/set host email config between tests without env var races
       "lib/email.ts:setHostEmailConfigForTest",
       "lib/email.ts:resetHostEmailConfig",
-      // Reset/set host Apple Wallet config between tests without env var races
-      "lib/db/settings.ts:setHostAppleWalletConfigForTest",
-      "lib/db/settings.ts:resetHostAppleWalletConfig",
-      // Set/reset timezone override between tests (survives cache invalidation)
-      "lib/db/settings.ts:setTimezoneForTest",
-      "lib/db/settings.ts:resetTimezoneTestOverride",
       // Timezone validation utility (timezone now derived from country, but still useful for tests)
       "lib/timezone.ts:isValidTimezone",
       // Attachment size constant (now re-exported from limits.ts, not detected by export patterns)

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -20,19 +20,7 @@ import {
   setAllowedDomainForTest,
   setEffectiveDomainForTest,
 } from "#lib/config.ts";
-import {
-  completeSetup,
-  invalidateSettingsCache,
-  setPaymentProvider,
-  setSetting,
-  updateBookingFee,
-  updateCustomDomain,
-  updateCustomDomainLastValidated,
-  updateSquareAccessToken,
-  updateSquareLocationId,
-  updateSquareWebhookSignatureKey,
-  updateStripeKey,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { getEnv } from "#lib/env.ts";
 import { getActivePaymentProvider } from "#lib/payments.ts";
 import { createTestDb, resetDb, setTestEnv, setupStripe } from "#test-utils";
@@ -52,17 +40,17 @@ describe("config", () => {
     });
 
     test("returns stripe when set to stripe", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       expect(await getPaymentProvider()).toBe("stripe");
     });
 
     test("returns square when set to square", async () => {
-      await setPaymentProvider("square");
+      await settings.paymentProvider.set("square");
       expect(await getPaymentProvider()).toBe("square");
     });
 
     test("returns null for unknown provider", async () => {
-      await setSetting("payment_provider", "unknown");
+      await settings.set("payment_provider", "unknown");
       expect(await getPaymentProvider()).toBeNull();
     });
   });
@@ -73,7 +61,7 @@ describe("config", () => {
     });
 
     test("returns key when set in database", async () => {
-      await updateStripeKey("sk_test_123");
+      await settings.stripe.secretKey.update("sk_test_123");
       expect(await getStripeSecretKey()).toBe("sk_test_123");
     });
   });
@@ -84,12 +72,12 @@ describe("config", () => {
     });
 
     test("returns false when provider set but no stripe key", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       expect(await isPaymentsEnabled()).toBe(false);
     });
 
     test("returns false when stripe key set but no provider", async () => {
-      await updateStripeKey("sk_test_123");
+      await settings.stripe.secretKey.update("sk_test_123");
       expect(await isPaymentsEnabled()).toBe(false);
     });
 
@@ -99,13 +87,13 @@ describe("config", () => {
     });
 
     test("returns false when provider is square but no token", async () => {
-      await setPaymentProvider("square");
+      await settings.paymentProvider.set("square");
       expect(await isPaymentsEnabled()).toBe(false);
     });
 
     test("returns true when provider is square and token is set", async () => {
-      await setPaymentProvider("square");
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.paymentProvider.set("square");
+      await settings.square.accessToken.update("EAAAl_test_123");
       expect(await isPaymentsEnabled()).toBe(true);
     });
   });
@@ -116,8 +104,8 @@ describe("config", () => {
     });
 
     test("returns currency from country setting", async () => {
-      await setSetting("country", "US");
-      invalidateSettingsCache();
+      await settings.set("country", "US");
+      settings.invalidateCache();
       expect(await getCurrencyCode()).toBe("USD");
     });
   });
@@ -128,7 +116,7 @@ describe("config", () => {
     });
 
     test("returns true when setup is complete", async () => {
-      await completeSetup("testadmin", "password123", "GBP");
+      await settings.setup.complete("testadmin", "password123", "GBP");
       expect(await isSetupComplete()).toBe(true);
     });
   });
@@ -139,7 +127,7 @@ describe("config", () => {
     });
 
     test("returns token when set in database", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
       expect(await getSquareAccessToken()).toBe("EAAAl_test_123");
     });
   });
@@ -150,7 +138,7 @@ describe("config", () => {
     });
 
     test("returns key when set in database", async () => {
-      await updateSquareWebhookSignatureKey("sig_key_test");
+      await settings.square.webhookSignatureKey.update("sig_key_test");
       expect(await getSquareWebhookSignatureKey()).toBe("sig_key_test");
     });
   });
@@ -161,7 +149,7 @@ describe("config", () => {
     });
 
     test("returns location ID when set in database", async () => {
-      await updateSquareLocationId("L_test_123");
+      await settings.square.locationId.update("L_test_123");
       expect(await getSquareLocationId()).toBe("L_test_123");
     });
   });
@@ -195,9 +183,9 @@ describe("config", () => {
 
     test("returns custom domain when set and validated in DB", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      invalidateSettingsCache();
+      await settings.customDomain.update("tickets.example.com");
+      await settings.customDomain.lastValidated.update();
+      settings.invalidateCache();
       const result = await loadEffectiveDomain();
       expect(result).toBe("tickets.example.com");
       expect(getEffectiveDomain()).toBe("tickets.example.com");
@@ -205,8 +193,8 @@ describe("config", () => {
 
     test("falls back to ALLOWED_DOMAIN when custom domain is set but not validated", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await updateCustomDomain("tickets.example.com");
-      invalidateSettingsCache();
+      await settings.customDomain.update("tickets.example.com");
+      settings.invalidateCache();
       const result = await loadEffectiveDomain();
       expect(result).toBe("mysite.bunny.run");
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
@@ -214,14 +202,14 @@ describe("config", () => {
 
     test("falls back to ALLOWED_DOMAIN after custom domain is cleared", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      invalidateSettingsCache();
+      await settings.customDomain.update("tickets.example.com");
+      await settings.customDomain.lastValidated.update();
+      settings.invalidateCache();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("tickets.example.com");
 
-      await updateCustomDomain("");
-      invalidateSettingsCache();
+      await settings.customDomain.update("");
+      settings.invalidateCache();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
     });
@@ -239,9 +227,9 @@ describe("config", () => {
 
     test("resetEffectiveDomain clears the cached value", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await updateCustomDomain("tickets.example.com");
-      await updateCustomDomainLastValidated();
-      invalidateSettingsCache();
+      await settings.customDomain.update("tickets.example.com");
+      await settings.customDomain.lastValidated.update();
+      settings.invalidateCache();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("tickets.example.com");
 
@@ -253,8 +241,8 @@ describe("config", () => {
   describe("isPaymentsEnabled - non-stripe provider", () => {
     test("returns false when provider is set to unknown value", async () => {
       // Set provider to a non-stripe value that getPaymentProvider will return null for
-      await setSetting("payment_provider", "paypal");
-      await updateStripeKey("sk_test_123");
+      await settings.set("payment_provider", "paypal");
+      await settings.stripe.secretKey.update("sk_test_123");
       // getPaymentProvider returns null for unknown providers, so isPaymentsEnabled returns false
       expect(await isPaymentsEnabled()).toBe(false);
     });
@@ -266,12 +254,12 @@ describe("config", () => {
     });
 
     test("returns parsed value when set", async () => {
-      await updateBookingFee("1.5");
+      await settings.bookingFee.update("1.5");
       expect(await getBookingFee()).toBe(1.5);
     });
 
     test("returns 0 for unparseable value", async () => {
-      await updateBookingFee("abc");
+      await settings.bookingFee.update("abc");
       expect(await getBookingFee()).toBe(0);
     });
   });
@@ -321,20 +309,20 @@ describe("payments", () => {
 
   test("getActivePaymentProvider returns null for unknown provider type", async () => {
     // Set a non-stripe provider type directly
-    await setSetting("payment_provider", "unknown_provider");
+    await settings.set("payment_provider", "unknown_provider");
     const provider = await getActivePaymentProvider();
     expect(provider).toBeNull();
   });
 
   test("getActivePaymentProvider returns stripe provider when configured", async () => {
-    await setPaymentProvider("stripe");
+    await settings.paymentProvider.set("stripe");
     const provider = await getActivePaymentProvider();
     expect(provider).not.toBeNull();
     expect(provider?.type).toBe("stripe");
   });
 
   test("getActivePaymentProvider returns square provider when configured", async () => {
-    await setPaymentProvider("square");
+    await settings.paymentProvider.set("square");
     const provider = await getActivePaymentProvider();
     expect(provider).not.toBeNull();
     expect(provider?.type).toBe("square");

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -40,17 +40,17 @@ describe("config", () => {
     });
 
     test("returns stripe when set to stripe", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       expect(await getPaymentProvider()).toBe("stripe");
     });
 
     test("returns square when set to square", async () => {
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
       expect(await getPaymentProvider()).toBe("square");
     });
 
     test("returns null for unknown provider", async () => {
-      await settings.set("payment_provider", "unknown");
+      await settings.setRaw("payment_provider", "unknown");
       expect(await getPaymentProvider()).toBeNull();
     });
   });
@@ -61,7 +61,7 @@ describe("config", () => {
     });
 
     test("returns key when set in database", async () => {
-      await settings.stripe.secretKey.update("sk_test_123");
+      await settings.update.stripe.secretKey("sk_test_123");
       expect(await getStripeSecretKey()).toBe("sk_test_123");
     });
   });
@@ -72,12 +72,12 @@ describe("config", () => {
     });
 
     test("returns false when provider set but no stripe key", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       expect(await isPaymentsEnabled()).toBe(false);
     });
 
     test("returns false when stripe key set but no provider", async () => {
-      await settings.stripe.secretKey.update("sk_test_123");
+      await settings.update.stripe.secretKey("sk_test_123");
       expect(await isPaymentsEnabled()).toBe(false);
     });
 
@@ -87,13 +87,13 @@ describe("config", () => {
     });
 
     test("returns false when provider is square but no token", async () => {
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
       expect(await isPaymentsEnabled()).toBe(false);
     });
 
     test("returns true when provider is square and token is set", async () => {
-      await settings.paymentProvider.set("square");
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.paymentProvider("square");
+      await settings.update.square.accessToken("EAAAl_test_123");
       expect(await isPaymentsEnabled()).toBe(true);
     });
   });
@@ -104,8 +104,9 @@ describe("config", () => {
     });
 
     test("returns currency from country setting", async () => {
-      await settings.set("country", "US");
+      await settings.setRaw("country", "US");
       settings.invalidateCache();
+      await settings.loadAll();
       expect(await getCurrencyCode()).toBe("USD");
     });
   });
@@ -127,7 +128,7 @@ describe("config", () => {
     });
 
     test("returns token when set in database", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
       expect(await getSquareAccessToken()).toBe("EAAAl_test_123");
     });
   });
@@ -138,7 +139,7 @@ describe("config", () => {
     });
 
     test("returns key when set in database", async () => {
-      await settings.square.webhookSignatureKey.update("sig_key_test");
+      await settings.update.square.webhookSignatureKey("sig_key_test");
       expect(await getSquareWebhookSignatureKey()).toBe("sig_key_test");
     });
   });
@@ -149,7 +150,7 @@ describe("config", () => {
     });
 
     test("returns location ID when set in database", async () => {
-      await settings.square.locationId.update("L_test_123");
+      await settings.update.square.locationId("L_test_123");
       expect(await getSquareLocationId()).toBe("L_test_123");
     });
   });
@@ -183,9 +184,10 @@ describe("config", () => {
 
     test("returns custom domain when set and validated in DB", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await settings.customDomain.update("tickets.example.com");
-      await settings.customDomain.lastValidated.update();
+      await settings.update.customDomain("tickets.example.com");
+      await settings.update.customDomainLastValidated();
       settings.invalidateCache();
+      await settings.loadAll();
       const result = await loadEffectiveDomain();
       expect(result).toBe("tickets.example.com");
       expect(getEffectiveDomain()).toBe("tickets.example.com");
@@ -193,7 +195,7 @@ describe("config", () => {
 
     test("falls back to ALLOWED_DOMAIN when custom domain is set but not validated", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await settings.customDomain.update("tickets.example.com");
+      await settings.update.customDomain("tickets.example.com");
       settings.invalidateCache();
       const result = await loadEffectiveDomain();
       expect(result).toBe("mysite.bunny.run");
@@ -202,14 +204,16 @@ describe("config", () => {
 
     test("falls back to ALLOWED_DOMAIN after custom domain is cleared", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await settings.customDomain.update("tickets.example.com");
-      await settings.customDomain.lastValidated.update();
+      await settings.update.customDomain("tickets.example.com");
+      await settings.update.customDomainLastValidated();
       settings.invalidateCache();
+      await settings.loadAll();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("tickets.example.com");
 
-      await settings.customDomain.update("");
+      await settings.update.customDomain("");
       settings.invalidateCache();
+      await settings.loadAll();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
     });
@@ -227,9 +231,10 @@ describe("config", () => {
 
     test("resetEffectiveDomain clears the cached value", async () => {
       setAllowedDomainForTest("mysite.bunny.run");
-      await settings.customDomain.update("tickets.example.com");
-      await settings.customDomain.lastValidated.update();
+      await settings.update.customDomain("tickets.example.com");
+      await settings.update.customDomainLastValidated();
       settings.invalidateCache();
+      await settings.loadAll();
       await loadEffectiveDomain();
       expect(getEffectiveDomain()).toBe("tickets.example.com");
 
@@ -241,8 +246,8 @@ describe("config", () => {
   describe("isPaymentsEnabled - non-stripe provider", () => {
     test("returns false when provider is set to unknown value", async () => {
       // Set provider to a non-stripe value that getPaymentProvider will return null for
-      await settings.set("payment_provider", "paypal");
-      await settings.stripe.secretKey.update("sk_test_123");
+      await settings.setRaw("payment_provider", "paypal");
+      await settings.update.stripe.secretKey("sk_test_123");
       // getPaymentProvider returns null for unknown providers, so isPaymentsEnabled returns false
       expect(await isPaymentsEnabled()).toBe(false);
     });
@@ -254,12 +259,12 @@ describe("config", () => {
     });
 
     test("returns parsed value when set", async () => {
-      await settings.bookingFee.update("1.5");
+      await settings.update.bookingFee("1.5");
       expect(await getBookingFee()).toBe(1.5);
     });
 
     test("returns 0 for unparseable value", async () => {
-      await settings.bookingFee.update("abc");
+      await settings.update.bookingFee("abc");
       expect(await getBookingFee()).toBe(0);
     });
   });
@@ -310,20 +315,20 @@ describe("payments", () => {
 
   test("getActivePaymentProvider returns null for unknown provider type", async () => {
     // Set a non-stripe provider type directly
-    await settings.set("payment_provider", "unknown_provider");
+    await settings.setRaw("payment_provider", "unknown_provider");
     const provider = await getActivePaymentProvider();
     expect(provider).toBeNull();
   });
 
   test("getActivePaymentProvider returns stripe provider when configured", async () => {
-    await settings.paymentProvider.set("stripe");
+    await settings.update.paymentProvider("stripe");
     const provider = await getActivePaymentProvider();
     expect(provider).not.toBeNull();
     expect(provider?.type).toBe("stripe");
   });
 
   test("getActivePaymentProvider returns square provider when configured", async () => {
-    await settings.paymentProvider.set("square");
+    await settings.update.paymentProvider("square");
     const provider = await getActivePaymentProvider();
     expect(provider).not.toBeNull();
     expect(provider?.type).toBe("square");

--- a/test/lib/currency.test.ts
+++ b/test/lib/currency.test.ts
@@ -9,6 +9,7 @@ import {
   toMajorUnits,
   toMinorUnits,
 } from "#lib/currency.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   createTestDbWithSetup,
   resetDb,
@@ -156,6 +157,7 @@ describe("currency", () => {
     beforeEach(async () => {
       setupTestEncryptionKey();
       await createTestDbWithSetup("US");
+      await settings.loadAll();
       resetCurrencyCode();
     });
 

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -10,7 +10,7 @@ import {
   getNextBookableDate,
   normalizeDatetime,
 } from "#lib/dates.ts";
-import { setTimezoneForTest } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import { createTestDbWithSetup, resetDb, testEvent } from "#test-utils";
 
@@ -30,7 +30,7 @@ const ALL_DAYS = [
 describe("dates", () => {
   beforeEach(async () => {
     await createTestDbWithSetup();
-    setTimezoneForTest("UTC");
+    settings.timezone.setForTest("UTC");
   });
 
   afterEach(() => {
@@ -309,7 +309,7 @@ describe("dates", () => {
 
     test("converts datetime-local to UTC using timezone", () => {
       // 14:30 BST (June) = 13:30 UTC
-      setTimezoneForTest("Europe/London");
+      settings.timezone.setForTest("Europe/London");
       const result = normalizeDatetime("2026-06-15T14:30", "date");
       expect(result).toBe("2026-06-15T13:30:00.000Z");
     });
@@ -324,7 +324,7 @@ describe("dates", () => {
 
     test("converts UTC datetime to local date in timezone", () => {
       // 23:30 UTC on June 15 = 00:30 BST on June 16 (Europe/London in summer)
-      setTimezoneForTest("Europe/London");
+      settings.timezone.setForTest("Europe/London");
       expect(eventDateToCalendarDate("2026-06-15T23:30:00.000Z")).toBe(
         "2026-06-16",
       );
@@ -339,7 +339,7 @@ describe("dates", () => {
     });
 
     test("returns null for invalid timezone", () => {
-      setTimezoneForTest("Invalid/Zone");
+      settings.timezone.setForTest("Invalid/Zone");
       expect(eventDateToCalendarDate("2026-06-15T14:00:00.000Z")).toBeNull();
     });
 

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -300,7 +300,7 @@ describeWithEnv("dates", { db: true }, () => {
 
     test("converts datetime-local to UTC using timezone", () => {
       // 14:30 BST (June) = 13:30 UTC
-      settings.timezone.setForTest("Europe/London");
+      settings.setForTest({ timezone: "Europe/London" });
       const result = normalizeDatetime("2026-06-15T14:30", "date");
       expect(result).toBe("2026-06-15T13:30:00.000Z");
     });
@@ -315,7 +315,7 @@ describeWithEnv("dates", { db: true }, () => {
 
     test("converts UTC datetime to local date in timezone", () => {
       // 23:30 UTC on June 15 = 00:30 BST on June 16 (Europe/London in summer)
-      settings.timezone.setForTest("Europe/London");
+      settings.setForTest({ timezone: "Europe/London" });
       expect(eventDateToCalendarDate("2026-06-15T23:30:00.000Z")).toBe(
         "2026-06-16",
       );
@@ -330,7 +330,7 @@ describeWithEnv("dates", { db: true }, () => {
     });
 
     test("returns null for invalid timezone", () => {
-      settings.timezone.setForTest("Invalid/Zone");
+      settings.setForTest({ timezone: "Invalid/Zone" });
       expect(eventDateToCalendarDate("2026-06-15T14:00:00.000Z")).toBeNull();
     });
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -97,7 +97,7 @@ const getTestPrivateKey = async (): Promise<CryptoKey> => {
     throw new Error("Test setup failed: no wrapped data key");
   const kek = await deriveKEK(passwordHash);
   const dataKey = await unwrapKey(user.wrapped_data_key, kek);
-  const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
+  const wrappedPrivateKey = settings.wrappedPrivateKey;
   if (!wrappedPrivateKey)
     throw new Error("Test setup failed: no wrapped private key");
   const privateKeyJwk = await decryptWithKey(wrappedPrivateKey, dataKey);
@@ -199,7 +199,7 @@ describeWithEnv("db", { db: true }, () => {
 
       // Verify we can create new data
       await settings.setup.complete("testadmin", TEST_ADMIN_PASSWORD, "USD");
-      await settings.attendeeBlobMigrated.set();
+      await settings.update.attendeeBlobMigrated();
       const event = await createTestEvent({
         name: "New Event",
         maxAttendees: 25,
@@ -212,21 +212,23 @@ describeWithEnv("db", { db: true }, () => {
   });
 
   describe("settings", () => {
-    test("getSetting returns null for missing key", async () => {
-      const value = await settings.get("missing");
+    test("getSetting returns null for missing key", () => {
+      const value = settings.getCachedRaw("missing");
       expect(value).toBeNull();
     });
 
     test("setSetting and getSetting work together", async () => {
-      await settings.set("test_key", "test_value");
-      const value = await settings.get("test_key");
+      await settings.setRaw("test_key", "test_value");
+      await settings.loadAll();
+      const value = settings.getCachedRaw("test_key");
       expect(value).toBe("test_value");
     });
 
     test("setSetting overwrites existing value", async () => {
-      await settings.set("key", "value1");
-      await settings.set("key", "value2");
-      const value = await settings.get("key");
+      await settings.setRaw("key", "value1");
+      await settings.setRaw("key", "value2");
+      await settings.loadAll();
+      const value = settings.getCachedRaw("key");
       expect(value).toBe("value2");
     });
   });
@@ -237,6 +239,8 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute("DELETE FROM users");
       await getDb().execute("DELETE FROM settings");
       await settings.setup.complete("setupuser", "mypassword", "US");
+      settings.invalidateCache();
+      await settings.loadAll();
 
       expect(await settings.setup.isComplete()).toBe(true);
       // Password is now stored on the user row, verify via user-based API
@@ -245,12 +249,12 @@ describeWithEnv("db", { db: true }, () => {
       const hash = await verifyUserPassword(user!, "mypassword");
       expect(hash).toBeTruthy();
       expect(hash).toContain("pbkdf2:");
-      expect(await settings.currency.get()).toBe("USD");
+      expect(settings.currency).toBe("USD");
 
       // Key hierarchy should be generated
-      expect(await settings.publicKey.get()).toBeTruthy();
+      expect(settings.publicKey).toBeTruthy();
       expect(user!.wrapped_data_key).toBeTruthy();
-      expect(await settings.wrappedPrivateKey.get()).toBeTruthy();
+      expect(settings.wrappedPrivateKey).toBeTruthy();
     });
 
     test("CONFIG_KEYS contains expected keys", () => {
@@ -261,71 +265,72 @@ describeWithEnv("db", { db: true }, () => {
       expect(CONFIG_KEYS.STRIPE_SECRET_KEY).toBe("stripe_secret_key");
     });
 
-    test("getCurrencyCodeFromDb returns GBP by default", async () => {
-      expect(await settings.currency.get()).toBe("GBP");
+    test("getCurrencyCodeFromDb returns GBP by default", () => {
+      expect(settings.currency).toBe("GBP");
     });
 
     test("getCountryFromDb returns GB when no country is stored", async () => {
       await getDb().execute("DELETE FROM settings");
       settings.invalidateCache();
-      expect(await settings.country.get()).toBe("GB");
+      expect(settings.country).toBe("GB");
     });
   });
 
   describe("stripe key", () => {
-    test("hasStripeKey returns false when not set", async () => {
-      expect(await settings.stripe.secretKey.has()).toBe(false);
+    test("hasStripeKey returns false when not set", () => {
+      expect(settings.stripe.hasKey).toBe(false);
     });
 
     test("hasStripeKey returns true after setting key", async () => {
-      await settings.stripe.secretKey.update("sk_test_123");
-      expect(await settings.stripe.secretKey.has()).toBe(true);
+      await settings.update.stripe.secretKey("sk_test_123");
+      expect(settings.stripe.hasKey).toBe(true);
     });
 
-    test("getStripeSecretKeyFromDb returns null when not set", async () => {
-      expect(await settings.stripe.secretKey.get()).toBeNull();
+    test("getStripeSecretKeyFromDb returns null when not set", () => {
+      expect(settings.stripe.secretKey).toBeNull();
     });
 
     test("getStripeSecretKeyFromDb returns decrypted key after setting", async () => {
-      await settings.stripe.secretKey.update("sk_test_secret_key");
-      const key = await settings.stripe.secretKey.get();
+      await settings.update.stripe.secretKey("sk_test_secret_key");
+      const key = settings.stripe.secretKey;
       expect(key).toBe("sk_test_secret_key");
     });
 
     test("updateStripeKey stores key encrypted", async () => {
-      await settings.stripe.secretKey.update("sk_test_encrypted");
+      await settings.update.stripe.secretKey("sk_test_encrypted");
+      await settings.loadAll();
       // Verify the raw value in DB is encrypted (starts with enc:1:)
-      const rawValue = await settings.get(CONFIG_KEYS.STRIPE_SECRET_KEY);
+      const rawValue = settings.getCachedRaw(CONFIG_KEYS.STRIPE_SECRET_KEY);
       expect(rawValue).toMatch(/^enc:1:/);
       // But getStripeSecretKeyFromDb returns decrypted
-      expect(await settings.stripe.secretKey.get()).toBe("sk_test_encrypted");
+      expect(settings.stripe.secretKey).toBe("sk_test_encrypted");
     });
 
     test("updateStripeKey overwrites existing key", async () => {
-      await settings.stripe.secretKey.update("sk_test_first");
-      expect(await settings.stripe.secretKey.get()).toBe("sk_test_first");
+      await settings.update.stripe.secretKey("sk_test_first");
+      expect(settings.stripe.secretKey).toBe("sk_test_first");
 
-      await settings.stripe.secretKey.update("sk_test_second");
-      expect(await settings.stripe.secretKey.get()).toBe("sk_test_second");
+      await settings.update.stripe.secretKey("sk_test_second");
+      expect(settings.stripe.secretKey).toBe("sk_test_second");
     });
 
-    test("getStripeKeyMode returns null when no key is set", async () => {
-      expect(await settings.stripe.secretKey.mode()).toBeNull();
+    test("getStripeKeyMode returns null when no key is set", () => {
+      expect(settings.stripe.keyMode).toBeNull();
     });
 
     test("getStripeKeyMode returns test for sk_test_ key", async () => {
-      await settings.stripe.secretKey.update("sk_test_abc123");
-      expect(await settings.stripe.secretKey.mode()).toBe("test");
+      await settings.update.stripe.secretKey("sk_test_abc123");
+      expect(settings.stripe.keyMode).toBe("test");
     });
 
     test("getStripeKeyMode returns live for sk_live_ key", async () => {
-      await settings.stripe.secretKey.update("sk_live_abc123");
-      expect(await settings.stripe.secretKey.mode()).toBe("live");
+      await settings.update.stripe.secretKey("sk_live_abc123");
+      expect(settings.stripe.keyMode).toBe("live");
     });
 
     test("getStripeKeyMode returns null for unrecognised key prefix", async () => {
-      await settings.stripe.secretKey.update("rk_invalid_abc123");
-      expect(await settings.stripe.secretKey.mode()).toBeNull();
+      await settings.update.stripe.secretKey("rk_invalid_abc123");
+      expect(settings.stripe.keyMode).toBeNull();
     });
   });
 
@@ -456,7 +461,7 @@ describeWithEnv("db", { db: true }, () => {
       const kek = await deriveKEK(newPasswordHash!);
       const dataKey = await unwrapKey(updatedUser!.wrapped_data_key!, kek);
 
-      const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
+      const wrappedPrivateKey = settings.wrappedPrivateKey;
       expect(wrappedPrivateKey).toBeTruthy();
 
       const privateKeyJwk = await decryptWithKey(wrappedPrivateKey!, dataKey);
@@ -2319,11 +2324,57 @@ describeWithEnv("db", { db: true }, () => {
 
   describe("settings - additional coverage", () => {
     test("clearPaymentProvider removes payment provider setting", async () => {
-      await settings.paymentProvider.set("stripe");
-      expect(await settings.get(CONFIG_KEYS.PAYMENT_PROVIDER)).toBe("stripe");
+      await settings.update.paymentProvider("stripe");
+      await settings.loadAll();
+      expect(settings.getCachedRaw(CONFIG_KEYS.PAYMENT_PROVIDER)).toBe(
+        "stripe",
+      );
 
-      await settings.paymentProvider.clear();
-      expect(await settings.get(CONFIG_KEYS.PAYMENT_PROVIDER)).toBeNull();
+      await settings.update.clearPaymentProvider();
+      await settings.loadAll();
+      expect(settings.getCachedRaw(CONFIG_KEYS.PAYMENT_PROVIDER)).toBeNull();
+    });
+
+    test("loadAll sets theme to dark when stored value is dark", async () => {
+      await settings.setRaw(CONFIG_KEYS.THEME, "dark");
+      settings.invalidateCache();
+      await settings.loadAll();
+      expect(settings.theme).toBe("dark");
+    });
+
+    test("update.bookingFee with empty string resets to 0", async () => {
+      await settings.update.bookingFee("500");
+      expect(settings.bookingFee).toBe("500");
+      await settings.update.bookingFee("");
+      expect(settings.bookingFee).toBe("0");
+    });
+
+    test("update.stripe.secretKey with empty string sets null", async () => {
+      await settings.update.stripe.secretKey("sk_test_abc");
+      expect(settings.stripe.secretKey).toBe("sk_test_abc");
+      await settings.update.stripe.secretKey("");
+      expect(settings.stripe.secretKey).toBeNull();
+    });
+
+    test("update.square.accessToken with empty string sets null", async () => {
+      await settings.update.square.accessToken("token_123");
+      expect(settings.square.accessToken).toBe("token_123");
+      await settings.update.square.accessToken("");
+      expect(settings.square.accessToken).toBeNull();
+    });
+
+    test("update.square.webhookSignatureKey with empty string sets null", async () => {
+      await settings.update.square.webhookSignatureKey("sig_key_123");
+      expect(settings.square.webhookSignatureKey).toBe("sig_key_123");
+      await settings.update.square.webhookSignatureKey("");
+      expect(settings.square.webhookSignatureKey).toBeNull();
+    });
+
+    test("update.square.locationId with empty string sets null", async () => {
+      await settings.update.square.locationId("loc_123");
+      expect(settings.square.locationId).toBe("loc_123");
+      await settings.update.square.locationId("");
+      expect(settings.square.locationId).toBeNull();
     });
 
     test("updateUserPassword returns false when dataKey unwrap fails", async () => {
@@ -2347,12 +2398,12 @@ describeWithEnv("db", { db: true }, () => {
 
   describe("timezone cache", () => {
     beforeEach(() => {
-      settings.timezone.resetTestOverride();
+      settings.clearTestOverrides();
     });
 
     test("getTimezoneCached returns default when no cache exists", () => {
       settings.invalidateCache();
-      expect(settings.timezone.getCached()).toBe("Europe/London");
+      expect(settings.timezone).toBe("Europe/London");
     });
 
     test("getTimezoneFromDb returns default when no country is stored", async () => {
@@ -2362,7 +2413,7 @@ describeWithEnv("db", { db: true }, () => {
         args: [CONFIG_KEYS.COUNTRY],
       });
       settings.invalidateCache();
-      const value = await settings.timezone.get();
+      const value = settings.timezone;
       expect(value).toBe("Europe/London");
     });
 
@@ -2374,44 +2425,46 @@ describeWithEnv("db", { db: true }, () => {
       });
       settings.invalidateCache();
       // Load the settings cache (without country key)
-      await settings.get(CONFIG_KEYS.COUNTRY);
+      settings.getCachedRaw(CONFIG_KEYS.COUNTRY);
       // Permanent cache should not be set, so it reads from TTL cache
       // TTL cache has no country key → falls back to default
-      expect(settings.timezone.getCached()).toBe("Europe/London");
+      expect(settings.timezone).toBe("Europe/London");
     });
 
     test("getTimezoneCached returns value after getTimezoneFromDb populates cache", async () => {
-      await settings.country.update("US");
+      await settings.update.country("US");
       settings.invalidateCache();
-      const value = await settings.timezone.get();
+      await settings.loadAll();
+      const value = settings.timezone;
       expect(value).toBe("America/New_York");
-      expect(settings.timezone.getCached()).toBe("America/New_York");
+      expect(settings.timezone).toBe("America/New_York");
     });
 
     test("getTimezoneCached reads from TTL cache when permanent cache is empty", async () => {
-      await settings.country.update("JP");
+      await settings.update.country("JP");
       settings.invalidateCache();
+      await settings.loadAll();
       // Force TTL cache to load by calling getSetting
-      await settings.get(CONFIG_KEYS.COUNTRY);
-      expect(settings.timezone.getCached()).toBe("Asia/Tokyo");
+      settings.getCachedRaw(CONFIG_KEYS.COUNTRY);
+      expect(settings.timezone).toBe("Asia/Tokyo");
     });
 
     test("updateCountry updates the permanent cache immediately", async () => {
-      await settings.country.update("NZ");
-      expect(settings.timezone.getCached()).toBe("Pacific/Auckland");
+      await settings.update.country("NZ");
+      expect(settings.timezone).toBe("Pacific/Auckland");
     });
 
-    test("getTimezoneFromDb returns test override when set", async () => {
-      settings.timezone.setForTest("America/Chicago");
-      const value = await settings.timezone.get();
+    test("getTimezoneFromDb returns test override when set", () => {
+      settings.setForTest({ timezone: "America/Chicago" });
+      const value = settings.timezone;
       expect(value).toBe("America/Chicago");
     });
 
-    test("getTimezoneFromDb returns permanent cache when set", async () => {
+    test("getTimezoneFromDb returns permanent cache when set", () => {
       // Populate permanent cache via getTimezoneFromDb
-      const value = await settings.timezone.get();
+      const value = settings.timezone;
       // Now the permanent cache is set; calling again should return from cache
-      const cached = await settings.timezone.get();
+      const cached = settings.timezone;
       expect(cached).toBe(value);
     });
   });
@@ -2624,6 +2677,7 @@ describeWithEnv("db", { db: true }, () => {
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
       // Re-run migrations - should backfill checked_in
       await initDb();
@@ -2660,6 +2714,7 @@ describeWithEnv("db", { db: true }, () => {
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
       // Re-run migrations - should backfill ticket_token
       await initDb();
@@ -2696,6 +2751,7 @@ describeWithEnv("db", { db: true }, () => {
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
       await initDb();
 
       // Verify token is now encrypted and index is generated
@@ -2880,6 +2936,7 @@ describeWithEnv("db", { db: true }, () => {
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
       await initDb();
 
       // Verify the event now has encrypted closes_at (not NULL)
@@ -2915,6 +2972,7 @@ describeWithEnv("db", { db: true }, () => {
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
       await initDb();
 
       // Verify it still decrypts correctly (not double-encrypted)
@@ -3364,8 +3422,8 @@ describeWithEnv("db", { db: true }, () => {
 
       // Simulate pre-migration state: admin credentials in settings, no users
       const passwordHash = await hashPassword("existingpassword");
-      await settings.set("admin_password", passwordHash);
-      await settings.set("wrapped_data_key", "test-wrapped-key");
+      await settings.setRaw("admin_password", passwordHash);
+      await settings.setRaw("wrapped_data_key", "test-wrapped-key");
       await getDb().execute("DELETE FROM users");
 
       // Force re-migration
@@ -3373,6 +3431,7 @@ describeWithEnv("db", { db: true }, () => {
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
       await initDb();
 
       // Verify an owner user was created
@@ -3395,8 +3454,8 @@ describeWithEnv("db", { db: true }, () => {
 
     test("skips migration when users already exist", async () => {
       // createTestDbWithSetup already created a user
-      await settings.set("admin_password", "old-hash");
-      await settings.set("wrapped_data_key", "old-key");
+      await settings.setRaw("admin_password", "old-hash");
+      await settings.setRaw("wrapped_data_key", "old-key");
 
       const beforeCount = await getDb().execute(
         "SELECT COUNT(*) as count FROM users",
@@ -3409,6 +3468,7 @@ describeWithEnv("db", { db: true }, () => {
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
       await initDb();
 
       // Verify no additional user was created
@@ -3429,6 +3489,7 @@ describeWithEnv("db", { db: true }, () => {
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
       settings.invalidateCache();
+      await settings.loadAll();
       await initDb();
 
       // Verify no user was created

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -72,30 +72,7 @@ import {
   getAllSessions,
   getSession,
 } from "#lib/db/sessions.ts";
-import {
-  CONFIG_KEYS,
-  clearPaymentProvider,
-  completeSetup,
-  getCountryFromDb,
-  getCurrencyCodeFromDb,
-  getPublicKey,
-  getSetting,
-  getStripeKeyMode,
-  getStripeSecretKeyFromDb,
-  getTimezoneCached,
-  getTimezoneFromDb,
-  getWrappedPrivateKey,
-  hasStripeKey,
-  invalidateSettingsCache,
-  isSetupComplete,
-  resetTimezoneTestOverride,
-  setAttendeeBlobMigrated,
-  setPaymentProvider,
-  setSetting,
-  setTimezoneForTest,
-  updateCountry,
-  updateStripeKey,
-} from "#lib/db/settings.ts";
+import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
 import { getUserByUsername, verifyUserPassword } from "#lib/db/users.ts";
 import { nowMs } from "#lib/now.ts";
 import {
@@ -120,7 +97,7 @@ const getTestPrivateKey = async (): Promise<CryptoKey> => {
     throw new Error("Test setup failed: no wrapped data key");
   const kek = await deriveKEK(passwordHash);
   const dataKey = await unwrapKey(user.wrapped_data_key, kek);
-  const wrappedPrivateKey = await getWrappedPrivateKey();
+  const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
   if (!wrappedPrivateKey)
     throw new Error("Test setup failed: no wrapped private key");
   const privateKeyJwk = await decryptWithKey(wrappedPrivateKey, dataKey);
@@ -221,8 +198,8 @@ describeWithEnv("db", { db: true }, () => {
       await initDb();
 
       // Verify we can create new data
-      await completeSetup("testadmin", TEST_ADMIN_PASSWORD, "USD");
-      await setAttendeeBlobMigrated();
+      await settings.setup.complete("testadmin", TEST_ADMIN_PASSWORD, "USD");
+      await settings.attendeeBlobMigrated.set();
       const event = await createTestEvent({
         name: "New Event",
         maxAttendees: 25,
@@ -236,20 +213,20 @@ describeWithEnv("db", { db: true }, () => {
 
   describe("settings", () => {
     test("getSetting returns null for missing key", async () => {
-      const value = await getSetting("missing");
+      const value = await settings.get("missing");
       expect(value).toBeNull();
     });
 
     test("setSetting and getSetting work together", async () => {
-      await setSetting("test_key", "test_value");
-      const value = await getSetting("test_key");
+      await settings.set("test_key", "test_value");
+      const value = await settings.get("test_key");
       expect(value).toBe("test_value");
     });
 
     test("setSetting overwrites existing value", async () => {
-      await setSetting("key", "value1");
-      await setSetting("key", "value2");
-      const value = await getSetting("key");
+      await settings.set("key", "value1");
+      await settings.set("key", "value2");
+      const value = await settings.get("key");
       expect(value).toBe("value2");
     });
   });
@@ -259,21 +236,21 @@ describeWithEnv("db", { db: true }, () => {
       // Delete existing user from createTestDbWithSetup to test fresh setup
       await getDb().execute("DELETE FROM users");
       await getDb().execute("DELETE FROM settings");
-      await completeSetup("setupuser", "mypassword", "US");
+      await settings.setup.complete("setupuser", "mypassword", "US");
 
-      expect(await isSetupComplete()).toBe(true);
+      expect(await settings.setup.isComplete()).toBe(true);
       // Password is now stored on the user row, verify via user-based API
       const user = await getUserByUsername("setupuser");
       expect(user).not.toBeNull();
       const hash = await verifyUserPassword(user!, "mypassword");
       expect(hash).toBeTruthy();
       expect(hash).toContain("pbkdf2:");
-      expect(await getCurrencyCodeFromDb()).toBe("USD");
+      expect(await settings.currency.get()).toBe("USD");
 
       // Key hierarchy should be generated
-      expect(await getPublicKey()).toBeTruthy();
+      expect(await settings.publicKey.get()).toBeTruthy();
       expect(user!.wrapped_data_key).toBeTruthy();
-      expect(await getWrappedPrivateKey()).toBeTruthy();
+      expect(await settings.wrappedPrivateKey.get()).toBeTruthy();
     });
 
     test("CONFIG_KEYS contains expected keys", () => {
@@ -285,70 +262,70 @@ describeWithEnv("db", { db: true }, () => {
     });
 
     test("getCurrencyCodeFromDb returns GBP by default", async () => {
-      expect(await getCurrencyCodeFromDb()).toBe("GBP");
+      expect(await settings.currency.get()).toBe("GBP");
     });
 
     test("getCountryFromDb returns GB when no country is stored", async () => {
       await getDb().execute("DELETE FROM settings");
-      invalidateSettingsCache();
-      expect(await getCountryFromDb()).toBe("GB");
+      settings.invalidateCache();
+      expect(await settings.country.get()).toBe("GB");
     });
   });
 
   describe("stripe key", () => {
     test("hasStripeKey returns false when not set", async () => {
-      expect(await hasStripeKey()).toBe(false);
+      expect(await settings.stripe.secretKey.has()).toBe(false);
     });
 
     test("hasStripeKey returns true after setting key", async () => {
-      await updateStripeKey("sk_test_123");
-      expect(await hasStripeKey()).toBe(true);
+      await settings.stripe.secretKey.update("sk_test_123");
+      expect(await settings.stripe.secretKey.has()).toBe(true);
     });
 
     test("getStripeSecretKeyFromDb returns null when not set", async () => {
-      expect(await getStripeSecretKeyFromDb()).toBeNull();
+      expect(await settings.stripe.secretKey.get()).toBeNull();
     });
 
     test("getStripeSecretKeyFromDb returns decrypted key after setting", async () => {
-      await updateStripeKey("sk_test_secret_key");
-      const key = await getStripeSecretKeyFromDb();
+      await settings.stripe.secretKey.update("sk_test_secret_key");
+      const key = await settings.stripe.secretKey.get();
       expect(key).toBe("sk_test_secret_key");
     });
 
     test("updateStripeKey stores key encrypted", async () => {
-      await updateStripeKey("sk_test_encrypted");
+      await settings.stripe.secretKey.update("sk_test_encrypted");
       // Verify the raw value in DB is encrypted (starts with enc:1:)
-      const rawValue = await getSetting(CONFIG_KEYS.STRIPE_SECRET_KEY);
+      const rawValue = await settings.get(CONFIG_KEYS.STRIPE_SECRET_KEY);
       expect(rawValue).toMatch(/^enc:1:/);
       // But getStripeSecretKeyFromDb returns decrypted
-      expect(await getStripeSecretKeyFromDb()).toBe("sk_test_encrypted");
+      expect(await settings.stripe.secretKey.get()).toBe("sk_test_encrypted");
     });
 
     test("updateStripeKey overwrites existing key", async () => {
-      await updateStripeKey("sk_test_first");
-      expect(await getStripeSecretKeyFromDb()).toBe("sk_test_first");
+      await settings.stripe.secretKey.update("sk_test_first");
+      expect(await settings.stripe.secretKey.get()).toBe("sk_test_first");
 
-      await updateStripeKey("sk_test_second");
-      expect(await getStripeSecretKeyFromDb()).toBe("sk_test_second");
+      await settings.stripe.secretKey.update("sk_test_second");
+      expect(await settings.stripe.secretKey.get()).toBe("sk_test_second");
     });
 
     test("getStripeKeyMode returns null when no key is set", async () => {
-      expect(await getStripeKeyMode()).toBeNull();
+      expect(await settings.stripe.secretKey.mode()).toBeNull();
     });
 
     test("getStripeKeyMode returns test for sk_test_ key", async () => {
-      await updateStripeKey("sk_test_abc123");
-      expect(await getStripeKeyMode()).toBe("test");
+      await settings.stripe.secretKey.update("sk_test_abc123");
+      expect(await settings.stripe.secretKey.mode()).toBe("test");
     });
 
     test("getStripeKeyMode returns live for sk_live_ key", async () => {
-      await updateStripeKey("sk_live_abc123");
-      expect(await getStripeKeyMode()).toBe("live");
+      await settings.stripe.secretKey.update("sk_live_abc123");
+      expect(await settings.stripe.secretKey.mode()).toBe("live");
     });
 
     test("getStripeKeyMode returns null for unrecognised key prefix", async () => {
-      await updateStripeKey("rk_invalid_abc123");
-      expect(await getStripeKeyMode()).toBeNull();
+      await settings.stripe.secretKey.update("rk_invalid_abc123");
+      expect(await settings.stripe.secretKey.mode()).toBeNull();
     });
   });
 
@@ -378,8 +355,7 @@ describeWithEnv("db", { db: true }, () => {
       const oldHash = await verifyUserPassword(user!, TEST_ADMIN_PASSWORD);
       expect(oldHash).toBeTruthy();
 
-      const { updateUserPassword } = await import("#lib/db/settings.ts");
-      const success = await updateUserPassword(
+      const success = await settings.updateUserPassword(
         user!.id,
         oldHash!,
         user!.wrapped_data_key!,
@@ -406,9 +382,9 @@ describeWithEnv("db", { db: true }, () => {
       const user = await getUserByUsername(TEST_ADMIN_USERNAME);
       expect(user).not.toBeNull();
 
-      const { updateUserPassword } = await import("#lib/db/settings.ts");
+      const { settings: s } = await import("#lib/db/settings.ts");
       // Pass a bogus password hash - KEK derivation will produce wrong key
-      const success = await updateUserPassword(
+      const success = await s.updateUserPassword(
         user!.id,
         "pbkdf2:bogus:hash",
         user!.wrapped_data_key!,
@@ -450,8 +426,7 @@ describeWithEnv("db", { db: true }, () => {
       const oldHash = await verifyUserPassword(user!, TEST_ADMIN_PASSWORD);
       expect(oldHash).toBeTruthy();
 
-      const { updateUserPassword } = await import("#lib/db/settings.ts");
-      const changeSuccess = await updateUserPassword(
+      const changeSuccess = await settings.updateUserPassword(
         user!.id,
         oldHash!,
         user!.wrapped_data_key!,
@@ -481,7 +456,7 @@ describeWithEnv("db", { db: true }, () => {
       const kek = await deriveKEK(newPasswordHash!);
       const dataKey = await unwrapKey(updatedUser!.wrapped_data_key!, kek);
 
-      const wrappedPrivateKey = await getWrappedPrivateKey();
+      const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
       expect(wrappedPrivateKey).toBeTruthy();
 
       const privateKeyJwk = await decryptWithKey(wrappedPrivateKey!, dataKey);
@@ -1121,7 +1096,7 @@ describeWithEnv("db", { db: true }, () => {
         sql: "DELETE FROM settings WHERE key = ?",
         args: [CONFIG_KEYS.PUBLIC_KEY],
       });
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const result = await createAttendeeAtomic({
         eventId: event.id,
@@ -1519,8 +1494,7 @@ describeWithEnv("db", { db: true }, () => {
       expect(initialHash).toBeTruthy();
 
       // Update password using user-based API
-      const { updateUserPassword } = await import("#lib/db/settings.ts");
-      const success = await updateUserPassword(
+      const success = await settings.updateUserPassword(
         user!.id,
         initialHash!,
         user!.wrapped_data_key!,
@@ -2345,11 +2319,11 @@ describeWithEnv("db", { db: true }, () => {
 
   describe("settings - additional coverage", () => {
     test("clearPaymentProvider removes payment provider setting", async () => {
-      await setPaymentProvider("stripe");
-      expect(await getSetting(CONFIG_KEYS.PAYMENT_PROVIDER)).toBe("stripe");
+      await settings.paymentProvider.set("stripe");
+      expect(await settings.get(CONFIG_KEYS.PAYMENT_PROVIDER)).toBe("stripe");
 
-      await clearPaymentProvider();
-      expect(await getSetting(CONFIG_KEYS.PAYMENT_PROVIDER)).toBeNull();
+      await settings.paymentProvider.clear();
+      expect(await settings.get(CONFIG_KEYS.PAYMENT_PROVIDER)).toBeNull();
     });
 
     test("updateUserPassword returns false when dataKey unwrap fails", async () => {
@@ -2360,8 +2334,8 @@ describeWithEnv("db", { db: true }, () => {
       expect(passwordHash).toBeTruthy();
 
       // Pass corrupted wrapped_data_key - unwrap will fail
-      const { updateUserPassword } = await import("#lib/db/settings.ts");
-      const result = await updateUserPassword(
+      const { settings: s } = await import("#lib/db/settings.ts");
+      const result = await s.updateUserPassword(
         user!.id,
         passwordHash!,
         "corrupted_wrapped_data_key",
@@ -2373,12 +2347,12 @@ describeWithEnv("db", { db: true }, () => {
 
   describe("timezone cache", () => {
     beforeEach(() => {
-      resetTimezoneTestOverride();
+      settings.timezone.resetTestOverride();
     });
 
     test("getTimezoneCached returns default when no cache exists", () => {
-      invalidateSettingsCache();
-      expect(getTimezoneCached()).toBe("Europe/London");
+      settings.invalidateCache();
+      expect(settings.timezone.getCached()).toBe("Europe/London");
     });
 
     test("getTimezoneFromDb returns default when no country is stored", async () => {
@@ -2387,8 +2361,8 @@ describeWithEnv("db", { db: true }, () => {
         sql: "DELETE FROM settings WHERE key = ?",
         args: [CONFIG_KEYS.COUNTRY],
       });
-      invalidateSettingsCache();
-      const value = await getTimezoneFromDb();
+      settings.invalidateCache();
+      const value = await settings.timezone.get();
       expect(value).toBe("Europe/London");
     });
 
@@ -2398,46 +2372,46 @@ describeWithEnv("db", { db: true }, () => {
         sql: "DELETE FROM settings WHERE key = ?",
         args: [CONFIG_KEYS.COUNTRY],
       });
-      invalidateSettingsCache();
+      settings.invalidateCache();
       // Load the settings cache (without country key)
-      await getSetting(CONFIG_KEYS.COUNTRY);
+      await settings.get(CONFIG_KEYS.COUNTRY);
       // Permanent cache should not be set, so it reads from TTL cache
       // TTL cache has no country key → falls back to default
-      expect(getTimezoneCached()).toBe("Europe/London");
+      expect(settings.timezone.getCached()).toBe("Europe/London");
     });
 
     test("getTimezoneCached returns value after getTimezoneFromDb populates cache", async () => {
-      await updateCountry("US");
-      invalidateSettingsCache();
-      const value = await getTimezoneFromDb();
+      await settings.country.update("US");
+      settings.invalidateCache();
+      const value = await settings.timezone.get();
       expect(value).toBe("America/New_York");
-      expect(getTimezoneCached()).toBe("America/New_York");
+      expect(settings.timezone.getCached()).toBe("America/New_York");
     });
 
     test("getTimezoneCached reads from TTL cache when permanent cache is empty", async () => {
-      await updateCountry("JP");
-      invalidateSettingsCache();
+      await settings.country.update("JP");
+      settings.invalidateCache();
       // Force TTL cache to load by calling getSetting
-      await getSetting(CONFIG_KEYS.COUNTRY);
-      expect(getTimezoneCached()).toBe("Asia/Tokyo");
+      await settings.get(CONFIG_KEYS.COUNTRY);
+      expect(settings.timezone.getCached()).toBe("Asia/Tokyo");
     });
 
     test("updateCountry updates the permanent cache immediately", async () => {
-      await updateCountry("NZ");
-      expect(getTimezoneCached()).toBe("Pacific/Auckland");
+      await settings.country.update("NZ");
+      expect(settings.timezone.getCached()).toBe("Pacific/Auckland");
     });
 
     test("getTimezoneFromDb returns test override when set", async () => {
-      setTimezoneForTest("America/Chicago");
-      const value = await getTimezoneFromDb();
+      settings.timezone.setForTest("America/Chicago");
+      const value = await settings.timezone.get();
       expect(value).toBe("America/Chicago");
     });
 
     test("getTimezoneFromDb returns permanent cache when set", async () => {
       // Populate permanent cache via getTimezoneFromDb
-      const value = await getTimezoneFromDb();
+      const value = await settings.timezone.get();
       // Now the permanent cache is set; calling again should return from cache
-      const cached = await getTimezoneFromDb();
+      const cached = await settings.timezone.get();
       expect(cached).toBe(value);
     });
   });
@@ -2649,7 +2623,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       // Re-run migrations - should backfill checked_in
       await initDb();
@@ -2685,7 +2659,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       // Re-run migrations - should backfill ticket_token
       await initDb();
@@ -2721,7 +2695,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "DELETE FROM settings WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
       await initDb();
 
       // Verify token is now encrypted and index is generated
@@ -2905,7 +2879,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
       await initDb();
 
       // Verify the event now has encrypted closes_at (not NULL)
@@ -2940,7 +2914,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
       await initDb();
 
       // Verify it still decrypts correctly (not double-encrypted)
@@ -3390,15 +3364,15 @@ describeWithEnv("db", { db: true }, () => {
 
       // Simulate pre-migration state: admin credentials in settings, no users
       const passwordHash = await hashPassword("existingpassword");
-      await setSetting("admin_password", passwordHash);
-      await setSetting("wrapped_data_key", "test-wrapped-key");
+      await settings.set("admin_password", passwordHash);
+      await settings.set("wrapped_data_key", "test-wrapped-key");
       await getDb().execute("DELETE FROM users");
 
       // Force re-migration
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
       await initDb();
 
       // Verify an owner user was created
@@ -3421,8 +3395,8 @@ describeWithEnv("db", { db: true }, () => {
 
     test("skips migration when users already exist", async () => {
       // createTestDbWithSetup already created a user
-      await setSetting("admin_password", "old-hash");
-      await setSetting("wrapped_data_key", "old-key");
+      await settings.set("admin_password", "old-hash");
+      await settings.set("wrapped_data_key", "old-key");
 
       const beforeCount = await getDb().execute(
         "SELECT COUNT(*) as count FROM users",
@@ -3434,7 +3408,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
       await initDb();
 
       // Verify no additional user was created
@@ -3454,7 +3428,7 @@ describeWithEnv("db", { db: true }, () => {
       await getDb().execute(
         "UPDATE settings SET value = 'outdated' WHERE key = 'latest_db_update'",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
       await initDb();
 
       // Verify no user was created

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -273,22 +273,23 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("uses custom templates when set", async () => {
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "subject",
         "Custom: {{ event_names }}",
       );
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "html",
         "<b>Custom HTML for {{ attendee.name }}</b>",
       );
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "text",
         "Custom text for {{ attendee.name }}",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
       const entries = [makeEntry()];
       const data = buildTemplateData(
@@ -304,12 +305,13 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("falls back to default on custom template render error", async () => {
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "subject",
         "{{ invalid | nonexistent_filter }}",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
       const errorSpy = spy(console, "error");
       try {
@@ -427,13 +429,14 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("uses mix of custom and default parts", async () => {
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "subject",
         "Custom Subject: {{ event_names }}",
       );
       // html and text remain default
       settings.invalidateCache();
+      await settings.loadAll();
 
       const entries = [makeEntry()];
       const data = buildTemplateData(
@@ -450,12 +453,13 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("logs non-Error thrown values as strings", async () => {
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "subject",
         "Custom {{ event_names }}",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
       // Stub parseAndRender to throw a non-Error value on first call, then succeed
       let callCount = 0;
@@ -492,15 +496,17 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("resets to defaults after clearing custom template", async () => {
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "subject",
         "Custom Subject",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
-      await settings.email.template.update("confirmation", "subject", "");
+      await settings.update.email.template("confirmation", "subject", "");
       settings.invalidateCache();
+      await settings.loadAll();
 
       const entries = [makeEntry()];
       const data = buildTemplateData(

--- a/test/lib/email-renderer.test.ts
+++ b/test/lib/email-renderer.test.ts
@@ -4,10 +4,7 @@ import { spy, stub } from "@std/testing/mock";
 import { Liquid } from "liquidjs";
 import { map } from "#fp";
 import { resetCurrencyCode, setCurrencyCodeForTest } from "#lib/currency.ts";
-import {
-  invalidateSettingsCache,
-  updateEmailTemplate,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { TemplateData } from "#lib/email-renderer.ts";
 import {
   buildTemplateData,
@@ -276,22 +273,22 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("uses custom templates when set", async () => {
-      await updateEmailTemplate(
+      await settings.email.template.update(
         "confirmation",
         "subject",
         "Custom: {{ event_names }}",
       );
-      await updateEmailTemplate(
+      await settings.email.template.update(
         "confirmation",
         "html",
         "<b>Custom HTML for {{ attendee.name }}</b>",
       );
-      await updateEmailTemplate(
+      await settings.email.template.update(
         "confirmation",
         "text",
         "Custom text for {{ attendee.name }}",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const entries = [makeEntry()];
       const data = buildTemplateData(
@@ -307,12 +304,12 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("falls back to default on custom template render error", async () => {
-      await updateEmailTemplate(
+      await settings.email.template.update(
         "confirmation",
         "subject",
         "{{ invalid | nonexistent_filter }}",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const errorSpy = spy(console, "error");
       try {
@@ -430,13 +427,13 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("uses mix of custom and default parts", async () => {
-      await updateEmailTemplate(
+      await settings.email.template.update(
         "confirmation",
         "subject",
         "Custom Subject: {{ event_names }}",
       );
       // html and text remain default
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const entries = [makeEntry()];
       const data = buildTemplateData(
@@ -453,12 +450,12 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("logs non-Error thrown values as strings", async () => {
-      await updateEmailTemplate(
+      await settings.email.template.update(
         "confirmation",
         "subject",
         "Custom {{ event_names }}",
       );
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       // Stub parseAndRender to throw a non-Error value on first call, then succeed
       let callCount = 0;
@@ -495,11 +492,15 @@ describeWithEnv("email-renderer", { db: true }, () => {
     });
 
     test("resets to defaults after clearing custom template", async () => {
-      await updateEmailTemplate("confirmation", "subject", "Custom Subject");
-      invalidateSettingsCache();
+      await settings.email.template.update(
+        "confirmation",
+        "subject",
+        "Custom Subject",
+      );
+      settings.invalidateCache();
 
-      await updateEmailTemplate("confirmation", "subject", "");
-      invalidateSettingsCache();
+      await settings.email.template.update("confirmation", "subject", "");
+      settings.invalidateCache();
 
       const entries = [makeEntry()];
       const data = buildTemplateData(

--- a/test/lib/email-templates-admin.test.ts
+++ b/test/lib/email-templates-admin.test.ts
@@ -38,7 +38,7 @@ describeWithEnv("admin email templates", { db: true }, () => {
     );
   }
 
-  async function expectTemplatesMatch(
+  function expectTemplatesMatch(
     type: "confirmation" | "admin",
     expected: {
       subject: string | null;
@@ -46,14 +46,14 @@ describeWithEnv("admin email templates", { db: true }, () => {
       text: string | null;
     },
   ) {
-    const templates = await settings.email.template.getSet(type);
+    const templates = settings.email.templateSet(type);
     expect(templates.subject).toBe(expected.subject);
     expect(templates.html).toBe(expected.html);
     expect(templates.text).toBe(expected.text);
   }
 
-  async function expectTemplatesAllNull(type: "confirmation" | "admin") {
-    const templates = await settings.email.template.getSet(type);
+  function expectTemplatesAllNull(type: "confirmation" | "admin") {
+    const templates = settings.email.templateSet(type);
     expect(templates.subject).toBeNull();
     expect(templates.html).toBeNull();
     expect(templates.text).toBeNull();
@@ -163,21 +163,22 @@ describeWithEnv("admin email templates", { db: true }, () => {
         html: "<b>{{ attendee.name }}</b>",
         text: "Hi {{ attendee.name }}",
       });
+      await settings.loadAll();
 
       // Raw DB values should be encrypted, not plaintext
-      const rawSubject = await settings.get(
+      const rawSubject = settings.getCachedRaw(
         CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_SUBJECT,
       );
       expect(rawSubject).not.toBeNull();
       expect(rawSubject!.startsWith("enc:1:")).toBe(true);
       expect(rawSubject).not.toContain("event_names");
 
-      const rawHtml = await settings.get(
+      const rawHtml = settings.getCachedRaw(
         CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML,
       );
       expect(rawHtml!.startsWith("enc:1:")).toBe(true);
 
-      const rawText = await settings.get(
+      const rawText = settings.getCachedRaw(
         CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT,
       );
       expect(rawText!.startsWith("enc:1:")).toBe(true);
@@ -191,12 +192,13 @@ describeWithEnv("admin email templates", { db: true }, () => {
     });
 
     test("clears template when empty values submitted", async () => {
-      await settings.email.template.update(
+      await settings.update.email.template(
         "confirmation",
         "subject",
         "Custom subject",
       );
       settings.invalidateCache();
+      await settings.loadAll();
 
       const response = await postTemplateForm(
         "/admin/settings/email-templates/confirmation",
@@ -252,7 +254,7 @@ describeWithEnv("admin email templates", { db: true }, () => {
       );
 
       expect(response.status).toBe(302);
-      const templates = await settings.email.template.getSet("admin");
+      const templates = settings.email.templateSet("admin");
       expect(templates.subject).toBe("New: {{ attendee.name }}");
     });
   });

--- a/test/lib/email-templates-admin.test.ts
+++ b/test/lib/email-templates-admin.test.ts
@@ -1,13 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { resetCurrencyCode, setCurrencyCodeForTest } from "#lib/currency.ts";
-import {
-  CONFIG_KEYS,
-  getEmailTemplateSet,
-  getSetting,
-  invalidateSettingsCache,
-  updateEmailTemplate,
-} from "#lib/db/settings.ts";
+import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
 import { resetEngine } from "#lib/email-renderer.ts";
 import { handleRequest } from "#routes";
 import {
@@ -52,14 +46,14 @@ describeWithEnv("admin email templates", { db: true }, () => {
       text: string | null;
     },
   ) {
-    const templates = await getEmailTemplateSet(type);
+    const templates = await settings.email.template.getSet(type);
     expect(templates.subject).toBe(expected.subject);
     expect(templates.html).toBe(expected.html);
     expect(templates.text).toBe(expected.text);
   }
 
   async function expectTemplatesAllNull(type: "confirmation" | "admin") {
-    const templates = await getEmailTemplateSet(type);
+    const templates = await settings.email.template.getSet(type);
     expect(templates.subject).toBeNull();
     expect(templates.html).toBeNull();
     expect(templates.text).toBeNull();
@@ -171,17 +165,21 @@ describeWithEnv("admin email templates", { db: true }, () => {
       });
 
       // Raw DB values should be encrypted, not plaintext
-      const rawSubject = await getSetting(
+      const rawSubject = await settings.get(
         CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_SUBJECT,
       );
       expect(rawSubject).not.toBeNull();
       expect(rawSubject!.startsWith("enc:1:")).toBe(true);
       expect(rawSubject).not.toContain("event_names");
 
-      const rawHtml = await getSetting(CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML);
+      const rawHtml = await settings.get(
+        CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_HTML,
+      );
       expect(rawHtml!.startsWith("enc:1:")).toBe(true);
 
-      const rawText = await getSetting(CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT);
+      const rawText = await settings.get(
+        CONFIG_KEYS.EMAIL_TPL_CONFIRMATION_TEXT,
+      );
       expect(rawText!.startsWith("enc:1:")).toBe(true);
 
       // But getEmailTemplateSet should return decrypted values
@@ -193,8 +191,12 @@ describeWithEnv("admin email templates", { db: true }, () => {
     });
 
     test("clears template when empty values submitted", async () => {
-      await updateEmailTemplate("confirmation", "subject", "Custom subject");
-      invalidateSettingsCache();
+      await settings.email.template.update(
+        "confirmation",
+        "subject",
+        "Custom subject",
+      );
+      settings.invalidateCache();
 
       const response = await postTemplateForm(
         "/admin/settings/email-templates/confirmation",
@@ -250,7 +252,7 @@ describeWithEnv("admin email templates", { db: true }, () => {
       );
 
       expect(response.status).toBe(302);
-      const templates = await getEmailTemplateSet("admin");
+      const templates = await settings.email.template.getSet("admin");
       expect(templates.subject).toBe("New: {{ attendee.name }}");
     });
   });

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -3,12 +3,7 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { bracket, map } from "#fp";
 import { updateBusinessEmail } from "#lib/business-email.ts";
-import {
-  invalidateSettingsCache,
-  updateEmailApiKey,
-  updateEmailFromAddress,
-  updateEmailProvider,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   buildSvgTicketData,
   buildTicketAttachments,
@@ -148,13 +143,13 @@ describe("email", () => {
   const setupDbEmailConfig = async (
     opts: { businessEmail?: string } = {},
   ): Promise<void> => {
-    await updateEmailProvider("resend");
-    await updateEmailApiKey("test-key");
-    await updateEmailFromAddress("from@test.com");
+    await settings.email.provider.update("resend");
+    await settings.email.apiKey.update("test-key");
+    await settings.email.fromAddress.update("from@test.com");
     if (opts.businessEmail) {
       await updateBusinessEmail(opts.businessEmail);
     }
-    invalidateSettingsCache();
+    settings.invalidateCache();
   };
 
   describe("sendEmail", () => {
@@ -476,16 +471,16 @@ describe("email", () => {
 
   describe("getEmailConfig", () => {
     test("returns null when no provider configured", async () => {
-      invalidateSettingsCache();
+      settings.invalidateCache();
       const config = await getEmailConfig();
       expect(config).toBeNull();
     });
 
     test("returns config when all settings present", async () => {
-      await updateEmailProvider("resend");
-      await updateEmailApiKey("test-key");
-      await updateEmailFromAddress("from@test.com");
-      invalidateSettingsCache();
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("test-key");
+      await settings.email.fromAddress.update("from@test.com");
+      settings.invalidateCache();
 
       const config = await getEmailConfig();
       expect(config).toEqual({
@@ -496,19 +491,19 @@ describe("email", () => {
     });
 
     test("returns null when API key missing", async () => {
-      await updateEmailProvider("resend");
-      await updateEmailFromAddress("from@test.com");
-      invalidateSettingsCache();
+      await settings.email.provider.update("resend");
+      await settings.email.fromAddress.update("from@test.com");
+      settings.invalidateCache();
 
       const config = await getEmailConfig();
       expect(config).toBeNull();
     });
 
     test("falls back to business email when from address not set", async () => {
-      await updateEmailProvider("resend");
-      await updateEmailApiKey("test-key");
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("test-key");
       await updateBusinessEmail("biz@example.com");
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const config = await getEmailConfig();
       expect(config).toEqual({
@@ -519,9 +514,9 @@ describe("email", () => {
     });
 
     test("returns null when neither from address nor business email set", async () => {
-      await updateEmailProvider("resend");
-      await updateEmailApiKey("test-key");
-      invalidateSettingsCache();
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("test-key");
+      settings.invalidateCache();
 
       const config = await getEmailConfig();
       expect(config).toBeNull();
@@ -622,7 +617,7 @@ describe("email", () => {
         Deno.env.set("HOST_EMAIL_PROVIDER", "mailgun-us");
         Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
         Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
-        invalidateSettingsCache();
+        settings.invalidateCache();
 
         await sendRegistrationEmails([makeEntry()], "GBP");
 

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -136,13 +136,14 @@ describeWithEnv("email", { db: true }, () => {
   const setupDbEmailConfig = async (
     opts: { businessEmail?: string } = {},
   ): Promise<void> => {
-    await settings.email.provider.update("resend");
-    await settings.email.apiKey.update("test-key");
-    await settings.email.fromAddress.update("from@test.com");
+    await settings.update.email.provider("resend");
+    await settings.update.email.apiKey("test-key");
+    await settings.update.email.fromAddress("from@test.com");
     if (opts.businessEmail) {
       await updateBusinessEmail(opts.businessEmail);
     }
     settings.invalidateCache();
+    await settings.loadAll();
   };
 
   describe("sendEmail", () => {
@@ -465,15 +466,17 @@ describeWithEnv("email", { db: true }, () => {
   describe("getEmailConfig", () => {
     test("returns null when no provider configured", async () => {
       settings.invalidateCache();
+      await settings.loadAll();
       const config = await getEmailConfig();
       expect(config).toBeNull();
     });
 
     test("returns config when all settings present", async () => {
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("test-key");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("test-key");
+      await settings.update.email.fromAddress("from@test.com");
       settings.invalidateCache();
+      await settings.loadAll();
 
       const config = await getEmailConfig();
       expect(config).toEqual({
@@ -484,19 +487,21 @@ describeWithEnv("email", { db: true }, () => {
     });
 
     test("returns null when API key missing", async () => {
-      await settings.email.provider.update("resend");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.fromAddress("from@test.com");
       settings.invalidateCache();
+      await settings.loadAll();
 
       const config = await getEmailConfig();
       expect(config).toBeNull();
     });
 
     test("falls back to business email when from address not set", async () => {
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("test-key");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("test-key");
       await updateBusinessEmail("biz@example.com");
       settings.invalidateCache();
+      await settings.loadAll();
 
       const config = await getEmailConfig();
       expect(config).toEqual({
@@ -507,9 +512,10 @@ describeWithEnv("email", { db: true }, () => {
     });
 
     test("returns null when neither from address nor business email set", async () => {
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("test-key");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("test-key");
       settings.invalidateCache();
+      await settings.loadAll();
 
       const config = await getEmailConfig();
       expect(config).toBeNull();
@@ -611,6 +617,7 @@ describeWithEnv("email", { db: true }, () => {
         Deno.env.set("HOST_EMAIL_API_KEY", "key-123");
         Deno.env.set("HOST_EMAIL_FROM_ADDRESS", "noreply@example.com");
         settings.invalidateCache();
+        await settings.loadAll();
 
         await sendRegistrationEmails([makeEntry()], "GBP");
 

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -1,10 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { encryptBytes } from "#lib/crypto.ts";
-import {
-  getHeaderImageUrlFromDb,
-  updateHeaderImageUrl,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   getHeaderImageUrl,
   loadHeaderImage,
@@ -162,20 +159,20 @@ describe("header image", () => {
     });
 
     test("returns filename after updating database", async () => {
-      await updateHeaderImageUrl("my-header.jpg");
+      await settings.headerImageUrl.update("my-header.jpg");
       const url = await loadHeaderImage();
       expect(url).toBe("my-header.jpg");
     });
 
     test("makes header image available via getHeaderImageUrl after loading", async () => {
-      await updateHeaderImageUrl("my-header.png");
+      await settings.headerImageUrl.update("my-header.png");
       await loadHeaderImage();
       expect(getHeaderImageUrl()).toBe("my-header.png");
     });
 
     test("returns null after clearing header image", async () => {
-      await updateHeaderImageUrl("my-header.jpg");
-      await updateHeaderImageUrl("");
+      await settings.headerImageUrl.update("my-header.jpg");
+      await settings.headerImageUrl.update("");
       const url = await loadHeaderImage();
       expect(url).toBeNull();
     });
@@ -193,20 +190,20 @@ describe("header image settings DB", () => {
   });
 
   test("getHeaderImageUrlFromDb returns null when not set", async () => {
-    const url = await getHeaderImageUrlFromDb();
+    const url = await settings.headerImageUrl.get();
     expect(url).toBeNull();
   });
 
   test("getHeaderImageUrlFromDb returns decrypted filename after update", async () => {
-    await updateHeaderImageUrl("abc123.jpg");
-    const url = await getHeaderImageUrlFromDb();
+    await settings.headerImageUrl.update("abc123.jpg");
+    const url = await settings.headerImageUrl.get();
     expect(url).toBe("abc123.jpg");
   });
 
   test("updateHeaderImageUrl with empty string clears the setting", async () => {
-    await updateHeaderImageUrl("abc123.jpg");
-    await updateHeaderImageUrl("");
-    const url = await getHeaderImageUrlFromDb();
+    await settings.headerImageUrl.update("abc123.jpg");
+    await settings.headerImageUrl.update("");
+    const url = await settings.headerImageUrl.get();
     expect(url).toBeNull();
   });
 });
@@ -244,7 +241,7 @@ describeWithEnv(
       });
 
       test("shows remove button when header image is set", async () => {
-        await updateHeaderImageUrl("existing.jpg");
+        await settings.headerImageUrl.update("existing.jpg");
         const { response } = await adminGet("/admin/settings");
         await expectHtmlResponse(
           response,
@@ -266,7 +263,7 @@ describeWithEnv(
           const response = await submitHeaderJpeg("logo.jpg");
           expectSettingsRedirect(response);
 
-          const url = await getHeaderImageUrlFromDb();
+          const url = await settings.headerImageUrl.get();
           expect(url).not.toBeNull();
           expect(url).toMatch(/\.jpg$/);
         });
@@ -337,7 +334,7 @@ describeWithEnv(
       });
 
       test("deletes old header image when uploading new one", async () => {
-        await updateHeaderImageUrl("old-header.jpg");
+        await settings.headerImageUrl.update("old-header.jpg");
 
         await withStorageMock(async (fetchCalls) => {
           const response = await submitHeaderJpeg("new-logo.jpg");
@@ -348,7 +345,7 @@ describeWithEnv(
           );
           expect(deleteCall).not.toBeUndefined();
 
-          const url = await getHeaderImageUrlFromDb();
+          const url = await settings.headerImageUrl.get();
           expect(url).toMatch(/\.jpg$/);
           expect(url).not.toBe("old-header.jpg");
         });
@@ -383,13 +380,13 @@ describeWithEnv(
 
     describe("POST /admin/settings/header-image/delete", () => {
       test("removes header image", async () => {
-        await updateHeaderImageUrl("to-delete.jpg");
+        await settings.headerImageUrl.update("to-delete.jpg");
 
         await withStorageMock(async () => {
           const response = await submitHeaderImageDelete();
           expectSettingsRedirect(response);
 
-          const url = await getHeaderImageUrlFromDb();
+          const url = await settings.headerImageUrl.get();
           expect(url).toBeNull();
         });
       });
@@ -400,7 +397,7 @@ describeWithEnv(
       });
 
       test("reports error when storage delete throws", async () => {
-        await updateHeaderImageUrl("failing.jpg");
+        await settings.headerImageUrl.update("failing.jpg");
 
         const originalFetch = globalThis.fetch;
         globalThis.fetch = (): Promise<Response> => {
@@ -413,7 +410,7 @@ describeWithEnv(
           expectFlash(response, "Header image removal failed", false);
 
           // DB record should NOT be cleared when CDN delete fails
-          const url = await getHeaderImageUrlFromDb();
+          const url = await settings.headerImageUrl.get();
           expect(url).toBe("failing.jpg");
         } finally {
           globalThis.fetch = originalFetch;
@@ -423,7 +420,7 @@ describeWithEnv(
 
     describe("header image in layout", () => {
       test("renders header image in page when set", async () => {
-        await updateHeaderImageUrl("my-header.jpg");
+        await settings.headerImageUrl.update("my-header.jpg");
         const { response } = await adminGet("/admin/settings");
         await expectHtmlResponse(
           response,

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -150,20 +150,20 @@ describe("header image", () => {
     });
 
     test("returns filename after updating database", async () => {
-      await settings.headerImageUrl.update("my-header.jpg");
+      await settings.update.headerImageUrl("my-header.jpg");
       const url = await loadHeaderImage();
       expect(url).toBe("my-header.jpg");
     });
 
     test("makes header image available via getHeaderImageUrl after loading", async () => {
-      await settings.headerImageUrl.update("my-header.png");
+      await settings.update.headerImageUrl("my-header.png");
       await loadHeaderImage();
       expect(getHeaderImageUrl()).toBe("my-header.png");
     });
 
     test("returns null after clearing header image", async () => {
-      await settings.headerImageUrl.update("my-header.jpg");
-      await settings.headerImageUrl.update("");
+      await settings.update.headerImageUrl("my-header.jpg");
+      await settings.update.headerImageUrl("");
       const url = await loadHeaderImage();
       expect(url).toBeNull();
     });
@@ -171,21 +171,21 @@ describe("header image", () => {
 });
 
 describeWithEnv("header image settings DB", { db: true }, () => {
-  test("getHeaderImageUrlFromDb returns null when not set", async () => {
-    const url = await settings.headerImageUrl.get();
+  test("getHeaderImageUrlFromDb returns null when not set", () => {
+    const url = settings.headerImageUrl;
     expect(url).toBeNull();
   });
 
   test("getHeaderImageUrlFromDb returns decrypted filename after update", async () => {
-    await settings.headerImageUrl.update("abc123.jpg");
-    const url = await settings.headerImageUrl.get();
+    await settings.update.headerImageUrl("abc123.jpg");
+    const url = settings.headerImageUrl;
     expect(url).toBe("abc123.jpg");
   });
 
   test("updateHeaderImageUrl with empty string clears the setting", async () => {
-    await settings.headerImageUrl.update("abc123.jpg");
-    await settings.headerImageUrl.update("");
-    const url = await settings.headerImageUrl.get();
+    await settings.update.headerImageUrl("abc123.jpg");
+    await settings.update.headerImageUrl("");
+    const url = settings.headerImageUrl;
     expect(url).toBeNull();
   });
 });
@@ -223,7 +223,7 @@ describeWithEnv(
       });
 
       test("shows remove button when header image is set", async () => {
-        await settings.headerImageUrl.update("existing.jpg");
+        await settings.update.headerImageUrl("existing.jpg");
         const { response } = await adminGet("/admin/settings");
         await expectHtmlResponse(
           response,
@@ -245,7 +245,7 @@ describeWithEnv(
           const response = await submitHeaderJpeg("logo.jpg");
           expectSettingsRedirect(response);
 
-          const url = await settings.headerImageUrl.get();
+          const url = settings.headerImageUrl;
           expect(url).not.toBeNull();
           expect(url).toMatch(/\.jpg$/);
         });
@@ -316,7 +316,7 @@ describeWithEnv(
       });
 
       test("deletes old header image when uploading new one", async () => {
-        await settings.headerImageUrl.update("old-header.jpg");
+        await settings.update.headerImageUrl("old-header.jpg");
 
         await withStorageMock(async (fetchCalls) => {
           const response = await submitHeaderJpeg("new-logo.jpg");
@@ -327,7 +327,7 @@ describeWithEnv(
           );
           expect(deleteCall).not.toBeUndefined();
 
-          const url = await settings.headerImageUrl.get();
+          const url = settings.headerImageUrl;
           expect(url).toMatch(/\.jpg$/);
           expect(url).not.toBe("old-header.jpg");
         });
@@ -362,13 +362,13 @@ describeWithEnv(
 
     describe("POST /admin/settings/header-image/delete", () => {
       test("removes header image", async () => {
-        await settings.headerImageUrl.update("to-delete.jpg");
+        await settings.update.headerImageUrl("to-delete.jpg");
 
         await withStorageMock(async () => {
           const response = await submitHeaderImageDelete();
           expectSettingsRedirect(response);
 
-          const url = await settings.headerImageUrl.get();
+          const url = settings.headerImageUrl;
           expect(url).toBeNull();
         });
       });
@@ -379,7 +379,7 @@ describeWithEnv(
       });
 
       test("reports error when storage delete throws", async () => {
-        await settings.headerImageUrl.update("failing.jpg");
+        await settings.update.headerImageUrl("failing.jpg");
 
         const originalFetch = globalThis.fetch;
         globalThis.fetch = (): Promise<Response> => {
@@ -392,7 +392,7 @@ describeWithEnv(
           expectFlash(response, "Header image removal failed", false);
 
           // DB record should NOT be cleared when CDN delete fails
-          const url = await settings.headerImageUrl.get();
+          const url = settings.headerImageUrl;
           expect(url).toBe("failing.jpg");
         } finally {
           globalThis.fetch = originalFetch;
@@ -402,7 +402,7 @@ describeWithEnv(
 
     describe("header image in layout", () => {
       test("renders header image in page when set", async () => {
-        await settings.headerImageUrl.update("my-header.jpg");
+        await settings.update.headerImageUrl("my-header.jpg");
         const { response } = await adminGet("/admin/settings");
         await expectHtmlResponse(
           response,

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -44,7 +44,7 @@ const getTestPrivateKey = async (): Promise<CryptoKey> => {
     throw new Error("Test setup failed: no wrapped data key");
   const kek = await deriveKEK(passwordHash);
   const dataKey = await unwrapKey(user.wrapped_data_key, kek);
-  const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
+  const wrappedPrivateKey = settings.wrappedPrivateKey;
   if (!wrappedPrivateKey)
     throw new Error("Test setup failed: no wrapped private key");
   const privateKeyJwk = await decryptWithKey(wrappedPrivateKey, dataKey);
@@ -64,7 +64,7 @@ const insertLegacyAttendee = async (
     refunded?: boolean;
   },
 ) => {
-  const pubKey = (await settings.publicKey.get())!;
+  const pubKey = settings.publicKey!;
   const [encName, encEmail, encPhone, encPaymentId, encPricePaid] =
     await Promise.all([
       encryptAttendeePII(fields.name, pubKey),
@@ -103,26 +103,30 @@ const insertLegacyAttendee = async (
 const createTestEventForMigration = async (
   overrides: Parameters<typeof createTestEvent>[0] = {},
 ) => {
-  await settings.attendeeBlobMigrated.set();
+  await settings.update.attendeeBlobMigrated();
   const event = await createTestEvent(overrides);
-  await settings.set("attendee_blob_migrated", "");
+  await settings.setRaw("attendee_blob_migrated", "");
+  settings.invalidateCache();
+  await settings.loadAll();
   return event;
 };
 
 describeWithEnv("attendee blob migration", { db: true }, () => {
   // createTestDbWithSetup marks migration as complete; clear it for migration tests
   beforeEach(async () => {
-    await settings.set("attendee_blob_migrated", "");
+    await settings.setRaw("attendee_blob_migrated", "");
+    settings.invalidateCache();
+    await settings.loadAll();
   });
 
   describe("isAttendeeBlobMigrated", () => {
-    test("returns false when setting is empty", async () => {
-      expect(await settings.attendeeBlobMigrated.is()).toBe(false);
+    test("returns false when setting is empty", () => {
+      expect(settings.attendeeBlobMigrated).toBe(false);
     });
 
     test("returns true after setAttendeeBlobMigrated", async () => {
-      await settings.attendeeBlobMigrated.set();
-      expect(await settings.attendeeBlobMigrated.is()).toBe(true);
+      await settings.update.attendeeBlobMigrated();
+      expect(settings.attendeeBlobMigrated).toBe(true);
     });
   });
 
@@ -227,7 +231,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     test("decrypts pre-versioned blobs without v field", async () => {
       const event = await createTestEventForMigration({ maxAttendees: 10 });
       // Manually create a blob without the v field (simulating pre-versioned data)
-      const pubKey = (await settings.publicKey.get())!;
+      const pubKey = settings.publicKey!;
       const blobWithoutVersion = JSON.stringify({
         n: "OldBlob",
         e: "old@test.com",
@@ -395,7 +399,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     });
 
     test("shows completion message when already migrated", async () => {
-      await settings.attendeeBlobMigrated.set();
+      await settings.update.attendeeBlobMigrated();
       const { response } = await adminGet("/admin/migrate");
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -440,14 +444,14 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
         expect(response.headers.get("location")).toBe("/admin/migrate");
 
         // Migration should NOT be marked complete
-        expect(await settings.attendeeBlobMigrated.is()).toBe(false);
+        expect(settings.attendeeBlobMigrated).toBe(false);
       } finally {
         restore();
       }
     });
 
     test("redirects when already migrated", async () => {
-      await settings.attendeeBlobMigrated.set();
+      await settings.update.attendeeBlobMigrated();
       const { response } = await adminFormPost("/admin/migrate");
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("/admin/migrate");
@@ -474,7 +478,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     });
 
     test("allows dashboard after migration", async () => {
-      await settings.attendeeBlobMigrated.set();
+      await settings.update.attendeeBlobMigrated();
       const { response } = await adminGet("/admin/");
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -495,14 +499,14 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
 
   describe("auto-complete migration for fresh databases", () => {
     test("GET /admin/migrate auto-completes when no attendees exist", async () => {
-      expect(await settings.attendeeBlobMigrated.is()).toBe(false);
+      expect(settings.attendeeBlobMigrated).toBe(false);
 
       const { response } = await adminGet("/admin/migrate");
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Migration complete");
 
-      expect(await settings.attendeeBlobMigrated.is()).toBe(true);
+      expect(settings.attendeeBlobMigrated).toBe(true);
     });
 
     test("GET /admin/migrate auto-completes when all attendees already migrated", async () => {
@@ -514,14 +518,14 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
         "done@test.com",
       );
 
-      expect(await settings.attendeeBlobMigrated.is()).toBe(false);
+      expect(settings.attendeeBlobMigrated).toBe(false);
 
       const { response } = await adminGet("/admin/migrate");
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Migration complete");
 
-      expect(await settings.attendeeBlobMigrated.is()).toBe(true);
+      expect(settings.attendeeBlobMigrated).toBe(true);
     });
   });
 });

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -20,13 +20,7 @@ import {
   updateCheckedIn,
 } from "#lib/db/attendees.ts";
 import { getDb } from "#lib/db/client.ts";
-import {
-  getPublicKey,
-  getWrappedPrivateKey,
-  isAttendeeBlobMigrated,
-  setAttendeeBlobMigrated,
-  setSetting,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { getUserByUsername, verifyUserPassword } from "#lib/db/users.ts";
 import {
   adminFormPost,
@@ -49,7 +43,7 @@ const getTestPrivateKey = async (): Promise<CryptoKey> => {
     throw new Error("Test setup failed: no wrapped data key");
   const kek = await deriveKEK(passwordHash);
   const dataKey = await unwrapKey(user.wrapped_data_key, kek);
-  const wrappedPrivateKey = await getWrappedPrivateKey();
+  const wrappedPrivateKey = await settings.wrappedPrivateKey.get();
   if (!wrappedPrivateKey)
     throw new Error("Test setup failed: no wrapped private key");
   const privateKeyJwk = await decryptWithKey(wrappedPrivateKey, dataKey);
@@ -69,7 +63,7 @@ const insertLegacyAttendee = async (
     refunded?: boolean;
   },
 ) => {
-  const pubKey = (await getPublicKey())!;
+  const pubKey = (await settings.publicKey.get())!;
   const [encName, encEmail, encPhone, encPaymentId, encPricePaid] =
     await Promise.all([
       encryptAttendeePII(fields.name, pubKey),
@@ -108,26 +102,26 @@ const insertLegacyAttendee = async (
 const createTestEventForMigration = async (
   overrides: Parameters<typeof createTestEvent>[0] = {},
 ) => {
-  await setAttendeeBlobMigrated();
+  await settings.attendeeBlobMigrated.set();
   const event = await createTestEvent(overrides);
-  await setSetting("attendee_blob_migrated", "");
+  await settings.set("attendee_blob_migrated", "");
   return event;
 };
 
 describeWithEnv("attendee blob migration", { db: true }, () => {
   // createTestDbWithSetup marks migration as complete; clear it for migration tests
   beforeEach(async () => {
-    await setSetting("attendee_blob_migrated", "");
+    await settings.set("attendee_blob_migrated", "");
   });
 
   describe("isAttendeeBlobMigrated", () => {
     test("returns false when setting is empty", async () => {
-      expect(await isAttendeeBlobMigrated()).toBe(false);
+      expect(await settings.attendeeBlobMigrated.is()).toBe(false);
     });
 
     test("returns true after setAttendeeBlobMigrated", async () => {
-      await setAttendeeBlobMigrated();
-      expect(await isAttendeeBlobMigrated()).toBe(true);
+      await settings.attendeeBlobMigrated.set();
+      expect(await settings.attendeeBlobMigrated.is()).toBe(true);
     });
   });
 
@@ -232,7 +226,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     test("decrypts pre-versioned blobs without v field", async () => {
       const event = await createTestEventForMigration({ maxAttendees: 10 });
       // Manually create a blob without the v field (simulating pre-versioned data)
-      const pubKey = (await getPublicKey())!;
+      const pubKey = (await settings.publicKey.get())!;
       const blobWithoutVersion = JSON.stringify({
         n: "OldBlob",
         e: "old@test.com",
@@ -400,7 +394,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     });
 
     test("shows completion message when already migrated", async () => {
-      await setAttendeeBlobMigrated();
+      await settings.attendeeBlobMigrated.set();
       const { response } = await adminGet("/admin/migrate");
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -427,7 +421,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     });
 
     test("redirects when already migrated", async () => {
-      await setAttendeeBlobMigrated();
+      await settings.attendeeBlobMigrated.set();
       const { response } = await adminFormPost("/admin/migrate");
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("/admin/migrate");
@@ -454,7 +448,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     });
 
     test("allows dashboard after migration", async () => {
-      await setAttendeeBlobMigrated();
+      await settings.attendeeBlobMigrated.set();
       const { response } = await adminGet("/admin/");
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -475,14 +469,14 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
 
   describe("auto-complete migration for fresh databases", () => {
     test("GET /admin/migrate auto-completes when no attendees exist", async () => {
-      expect(await isAttendeeBlobMigrated()).toBe(false);
+      expect(await settings.attendeeBlobMigrated.is()).toBe(false);
 
       const { response } = await adminGet("/admin/migrate");
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Migration complete");
 
-      expect(await isAttendeeBlobMigrated()).toBe(true);
+      expect(await settings.attendeeBlobMigrated.is()).toBe(true);
     });
 
     test("GET /admin/migrate auto-completes when all attendees already migrated", async () => {
@@ -494,14 +488,14 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
         "done@test.com",
       );
 
-      expect(await isAttendeeBlobMigrated()).toBe(false);
+      expect(await settings.attendeeBlobMigrated.is()).toBe(false);
 
       const { response } = await adminGet("/admin/migrate");
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Migration complete");
 
-      expect(await isAttendeeBlobMigrated()).toBe(true);
+      expect(await settings.attendeeBlobMigrated.is()).toBe(true);
     });
   });
 });

--- a/test/lib/page-cache.test.ts
+++ b/test/lib/page-cache.test.ts
@@ -1,12 +1,13 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
-
-const { PAGE_CACHE_TTL_MS } = settings;
-
 import { encrypt } from "#lib/crypto.ts";
 import { getDb } from "#lib/db/client.ts";
+import {
+  CONFIG_KEYS,
+  SETTINGS_CACHE_TTL_MS,
+  settings,
+} from "#lib/db/settings.ts";
 import { describeWithEnv } from "#test-utils";
 
 describeWithEnv("page content cache", { db: true }, () => {
@@ -18,88 +19,88 @@ describeWithEnv("page content cache", { db: true }, () => {
   });
 
   describe("getWebsiteTitleFromDb", () => {
-    test("returns null when not set", async () => {
-      expect(await settings.websiteTitle.get()).toBeNull();
+    test("returns null when not set", () => {
+      expect(settings.websiteTitle).toBeNull();
     });
 
     test("returns decrypted value after update", async () => {
-      await settings.websiteTitle.update("My Site");
-      expect(await settings.websiteTitle.get()).toBe("My Site");
+      await settings.update.websiteTitle("My Site");
+      expect(settings.websiteTitle).toBe("My Site");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await settings.websiteTitle.update("Old Title");
-      expect(await settings.websiteTitle.get()).toBe("Old Title");
-      await settings.websiteTitle.update("New Title");
-      expect(await settings.websiteTitle.get()).toBe("New Title");
+      await settings.update.websiteTitle("Old Title");
+      expect(settings.websiteTitle).toBe("Old Title");
+      await settings.update.websiteTitle("New Title");
+      expect(settings.websiteTitle).toBe("New Title");
     });
 
     test("returns null after clearing with empty string", async () => {
-      await settings.websiteTitle.update("Title");
-      expect(await settings.websiteTitle.get()).toBe("Title");
-      await settings.websiteTitle.update("");
-      expect(await settings.websiteTitle.get()).toBeNull();
+      await settings.update.websiteTitle("Title");
+      expect(settings.websiteTitle).toBe("Title");
+      await settings.update.websiteTitle("");
+      expect(settings.websiteTitle).toBeNull();
     });
   });
 
   describe("getHomepageTextFromDb", () => {
-    test("returns null when not set", async () => {
-      expect(await settings.homepageText.get()).toBeNull();
+    test("returns null when not set", () => {
+      expect(settings.homepageText).toBeNull();
     });
 
     test("returns decrypted value after update", async () => {
-      await settings.homepageText.update("Welcome!");
-      expect(await settings.homepageText.get()).toBe("Welcome!");
+      await settings.update.homepageText("Welcome!");
+      expect(settings.homepageText).toBe("Welcome!");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await settings.homepageText.update("Old text");
-      expect(await settings.homepageText.get()).toBe("Old text");
-      await settings.homepageText.update("New text");
-      expect(await settings.homepageText.get()).toBe("New text");
+      await settings.update.homepageText("Old text");
+      expect(settings.homepageText).toBe("Old text");
+      await settings.update.homepageText("New text");
+      expect(settings.homepageText).toBe("New text");
     });
   });
 
   describe("getContactPageTextFromDb", () => {
-    test("returns null when not set", async () => {
-      expect(await settings.contactPageText.get()).toBeNull();
+    test("returns null when not set", () => {
+      expect(settings.contactPageText).toBeNull();
     });
 
     test("returns decrypted value after update", async () => {
-      await settings.contactPageText.update("Contact us here");
-      expect(await settings.contactPageText.get()).toBe("Contact us here");
+      await settings.update.contactPageText("Contact us here");
+      expect(settings.contactPageText).toBe("Contact us here");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await settings.contactPageText.update("Old contact");
-      expect(await settings.contactPageText.get()).toBe("Old contact");
-      await settings.contactPageText.update("New contact");
-      expect(await settings.contactPageText.get()).toBe("New contact");
+      await settings.update.contactPageText("Old contact");
+      expect(settings.contactPageText).toBe("Old contact");
+      await settings.update.contactPageText("New contact");
+      expect(settings.contactPageText).toBe("New contact");
     });
   });
 
   describe("getTermsAndConditionsFromDb", () => {
-    test("returns null when not set", async () => {
-      expect(await settings.terms.get()).toBeNull();
+    test("returns null when not set", () => {
+      expect(settings.terms).toBeNull();
     });
 
     test("returns value after update", async () => {
-      await settings.terms.update("Terms text");
-      expect(await settings.terms.get()).toBe("Terms text");
+      await settings.update.terms("Terms text");
+      expect(settings.terms).toBe("Terms text");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await settings.terms.update("Old terms");
-      expect(await settings.terms.get()).toBe("Old terms");
-      await settings.terms.update("New terms");
-      expect(await settings.terms.get()).toBe("New terms");
+      await settings.update.terms("Old terms");
+      expect(settings.terms).toBe("Old terms");
+      await settings.update.terms("New terms");
+      expect(settings.terms).toBe("New terms");
     });
 
     test("returns null after clearing with empty string", async () => {
-      await settings.terms.update("Terms");
-      expect(await settings.terms.get()).toBe("Terms");
-      await settings.terms.update("");
-      expect(await settings.terms.get()).toBeNull();
+      await settings.update.terms("Terms");
+      expect(settings.terms).toBe("Terms");
+      await settings.update.terms("");
+      expect(settings.terms).toBeNull();
     });
   });
 
@@ -109,8 +110,8 @@ describeWithEnv("page content cache", { db: true }, () => {
       const startTime = Date.now();
       fakeTime = new FakeTime(startTime);
 
-      await settings.terms.update("Original");
-      expect(await settings.terms.get()).toBe("Original");
+      await settings.update.terms("Original");
+      expect(settings.terms).toBe("Original");
 
       // Write directly to DB, bypassing page cache invalidation
       await getDb().execute({
@@ -124,25 +125,26 @@ describeWithEnv("page content cache", { db: true }, () => {
       const startTime = await seedAndBypassCache();
 
       // Advance to just before TTL boundary — cache still valid
-      fakeTime!.now = startTime + PAGE_CACHE_TTL_MS - 1;
-      expect(await settings.terms.get()).toBe("Original");
+      fakeTime!.now = startTime + SETTINGS_CACHE_TTL_MS - 1;
+      expect(settings.terms).toBe("Original");
     });
 
     test("re-fetches from DB after TTL expires", async () => {
       const startTime = await seedAndBypassCache();
 
       // Advance past TTL
-      fakeTime!.now = startTime + PAGE_CACHE_TTL_MS + 1;
-      // Cache expired — re-fetches from DB and picks up new value
-      expect(await settings.terms.get()).toBe("Changed");
+      fakeTime!.now = startTime + SETTINGS_CACHE_TTL_MS + 1;
+      // Cache expired — loadAll() re-fetches from DB and picks up new value
+      await settings.loadAll();
+      expect(settings.terms).toBe("Changed");
     });
 
     test("serves stale cached encrypted value when DB changes within TTL", async () => {
       const startTime = Date.now();
       fakeTime = new FakeTime(startTime);
 
-      await settings.websiteTitle.update("Original Title");
-      expect(await settings.websiteTitle.get()).toBe("Original Title");
+      await settings.update.websiteTitle("Original Title");
+      expect(settings.websiteTitle).toBe("Original Title");
 
       // Write a different encrypted value directly to DB
       const newEncrypted = await encrypt("Changed Title");
@@ -152,48 +154,50 @@ describeWithEnv("page content cache", { db: true }, () => {
       });
 
       // Within TTL — cache still serves decrypted "Original Title"
-      fakeTime.now = startTime + PAGE_CACHE_TTL_MS - 1;
-      expect(await settings.websiteTitle.get()).toBe("Original Title");
+      fakeTime.now = startTime + SETTINGS_CACHE_TTL_MS - 1;
+      expect(settings.websiteTitle).toBe("Original Title");
     });
   });
 
   describe("invalidatePageCache", () => {
     /** Assert all four page getters return the seeded values */
-    const expectAllPages = async () => {
-      expect(await settings.websiteTitle.get()).toBe("Title");
-      expect(await settings.homepageText.get()).toBe("Homepage");
-      expect(await settings.contactPageText.get()).toBe("Contact");
-      expect(await settings.terms.get()).toBe("Terms");
+    const expectAllPages = () => {
+      expect(settings.websiteTitle).toBe("Title");
+      expect(settings.homepageText).toBe("Homepage");
+      expect(settings.contactPageText).toBe("Contact");
+      expect(settings.terms).toBe("Terms");
     };
 
     test("clears all cached page entries", async () => {
-      await settings.websiteTitle.update("Title");
-      await settings.homepageText.update("Homepage");
-      await settings.contactPageText.update("Contact");
-      await settings.terms.update("Terms");
+      await settings.update.websiteTitle("Title");
+      await settings.update.homepageText("Homepage");
+      await settings.update.contactPageText("Contact");
+      await settings.update.terms("Terms");
 
       // Populate all caches
       await expectAllPages();
 
-      // Clear all
-      settings.invalidatePageCache();
+      // Clear all and reload
+      settings.invalidateCache();
+      await settings.loadAll();
 
-      // Values should still be correct (re-fetched from DB)
-      await expectAllPages();
+      // Values should still be correct (reloaded from DB)
+      expectAllPages();
     });
   });
 
   describe("invalidateSettingsCache clears page cache", () => {
     test("page cache is cleared when settings cache is invalidated", async () => {
-      await settings.websiteTitle.update("Title");
+      await settings.update.websiteTitle("Title");
       // Populate page cache
-      expect(await settings.websiteTitle.get()).toBe("Title");
+      expect(settings.websiteTitle).toBe("Title");
 
-      // invalidateSettingsCache should also clear the page cache
+      // invalidateCache clears the snapshot; loadAll re-populates
       settings.invalidateCache();
+      await settings.loadAll();
 
-      // Still returns correct value (re-fetched from DB)
-      expect(await settings.websiteTitle.get()).toBe("Title");
+      // Returns correct value after reload
+      expect(settings.websiteTitle).toBe("Title");
     });
   });
 
@@ -218,7 +222,7 @@ describeWithEnv("page content cache", { db: true }, () => {
   describe("null value caching", () => {
     test("serves cached null when value is added to DB within TTL", async () => {
       // First read populates page cache with null
-      expect(await settings.terms.get()).toBeNull();
+      expect(settings.terms).toBeNull();
 
       // Write directly to DB, bypassing page cache invalidation
       await getDb().execute({
@@ -227,7 +231,7 @@ describeWithEnv("page content cache", { db: true }, () => {
       });
 
       // Page cache still holds null
-      expect(await settings.terms.get()).toBeNull();
+      expect(settings.terms).toBeNull();
     });
   });
 });

--- a/test/lib/page-cache.test.ts
+++ b/test/lib/page-cache.test.ts
@@ -1,22 +1,9 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import {
-  CONFIG_KEYS,
-  getContactPageTextFromDb,
-  getHomepageTextFromDb,
-  getTermsAndConditionsFromDb,
-  getWebsiteTitleFromDb,
-  invalidatePageCache,
-  invalidateSettingsCache,
-  settingsApi,
-  updateContactPageText,
-  updateHomepageText,
-  updateTermsAndConditions,
-  updateWebsiteTitle,
-} from "#lib/db/settings.ts";
+import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
 
-const { PAGE_CACHE_TTL_MS } = settingsApi;
+const { PAGE_CACHE_TTL_MS } = settings;
 
 import { encrypt } from "#lib/crypto.ts";
 import { getDb } from "#lib/db/client.ts";
@@ -32,87 +19,87 @@ describeWithEnv("page content cache", { db: true }, () => {
 
   describe("getWebsiteTitleFromDb", () => {
     test("returns null when not set", async () => {
-      expect(await getWebsiteTitleFromDb()).toBeNull();
+      expect(await settings.websiteTitle.get()).toBeNull();
     });
 
     test("returns decrypted value after update", async () => {
-      await updateWebsiteTitle("My Site");
-      expect(await getWebsiteTitleFromDb()).toBe("My Site");
+      await settings.websiteTitle.update("My Site");
+      expect(await settings.websiteTitle.get()).toBe("My Site");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await updateWebsiteTitle("Old Title");
-      expect(await getWebsiteTitleFromDb()).toBe("Old Title");
-      await updateWebsiteTitle("New Title");
-      expect(await getWebsiteTitleFromDb()).toBe("New Title");
+      await settings.websiteTitle.update("Old Title");
+      expect(await settings.websiteTitle.get()).toBe("Old Title");
+      await settings.websiteTitle.update("New Title");
+      expect(await settings.websiteTitle.get()).toBe("New Title");
     });
 
     test("returns null after clearing with empty string", async () => {
-      await updateWebsiteTitle("Title");
-      expect(await getWebsiteTitleFromDb()).toBe("Title");
-      await updateWebsiteTitle("");
-      expect(await getWebsiteTitleFromDb()).toBeNull();
+      await settings.websiteTitle.update("Title");
+      expect(await settings.websiteTitle.get()).toBe("Title");
+      await settings.websiteTitle.update("");
+      expect(await settings.websiteTitle.get()).toBeNull();
     });
   });
 
   describe("getHomepageTextFromDb", () => {
     test("returns null when not set", async () => {
-      expect(await getHomepageTextFromDb()).toBeNull();
+      expect(await settings.homepageText.get()).toBeNull();
     });
 
     test("returns decrypted value after update", async () => {
-      await updateHomepageText("Welcome!");
-      expect(await getHomepageTextFromDb()).toBe("Welcome!");
+      await settings.homepageText.update("Welcome!");
+      expect(await settings.homepageText.get()).toBe("Welcome!");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await updateHomepageText("Old text");
-      expect(await getHomepageTextFromDb()).toBe("Old text");
-      await updateHomepageText("New text");
-      expect(await getHomepageTextFromDb()).toBe("New text");
+      await settings.homepageText.update("Old text");
+      expect(await settings.homepageText.get()).toBe("Old text");
+      await settings.homepageText.update("New text");
+      expect(await settings.homepageText.get()).toBe("New text");
     });
   });
 
   describe("getContactPageTextFromDb", () => {
     test("returns null when not set", async () => {
-      expect(await getContactPageTextFromDb()).toBeNull();
+      expect(await settings.contactPageText.get()).toBeNull();
     });
 
     test("returns decrypted value after update", async () => {
-      await updateContactPageText("Contact us here");
-      expect(await getContactPageTextFromDb()).toBe("Contact us here");
+      await settings.contactPageText.update("Contact us here");
+      expect(await settings.contactPageText.get()).toBe("Contact us here");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await updateContactPageText("Old contact");
-      expect(await getContactPageTextFromDb()).toBe("Old contact");
-      await updateContactPageText("New contact");
-      expect(await getContactPageTextFromDb()).toBe("New contact");
+      await settings.contactPageText.update("Old contact");
+      expect(await settings.contactPageText.get()).toBe("Old contact");
+      await settings.contactPageText.update("New contact");
+      expect(await settings.contactPageText.get()).toBe("New contact");
     });
   });
 
   describe("getTermsAndConditionsFromDb", () => {
     test("returns null when not set", async () => {
-      expect(await getTermsAndConditionsFromDb()).toBeNull();
+      expect(await settings.terms.get()).toBeNull();
     });
 
     test("returns value after update", async () => {
-      await updateTermsAndConditions("Terms text");
-      expect(await getTermsAndConditionsFromDb()).toBe("Terms text");
+      await settings.terms.update("Terms text");
+      expect(await settings.terms.get()).toBe("Terms text");
     });
 
     test("returns updated value after update invalidates cache", async () => {
-      await updateTermsAndConditions("Old terms");
-      expect(await getTermsAndConditionsFromDb()).toBe("Old terms");
-      await updateTermsAndConditions("New terms");
-      expect(await getTermsAndConditionsFromDb()).toBe("New terms");
+      await settings.terms.update("Old terms");
+      expect(await settings.terms.get()).toBe("Old terms");
+      await settings.terms.update("New terms");
+      expect(await settings.terms.get()).toBe("New terms");
     });
 
     test("returns null after clearing with empty string", async () => {
-      await updateTermsAndConditions("Terms");
-      expect(await getTermsAndConditionsFromDb()).toBe("Terms");
-      await updateTermsAndConditions("");
-      expect(await getTermsAndConditionsFromDb()).toBeNull();
+      await settings.terms.update("Terms");
+      expect(await settings.terms.get()).toBe("Terms");
+      await settings.terms.update("");
+      expect(await settings.terms.get()).toBeNull();
     });
   });
 
@@ -122,8 +109,8 @@ describeWithEnv("page content cache", { db: true }, () => {
       const startTime = Date.now();
       fakeTime = new FakeTime(startTime);
 
-      await updateTermsAndConditions("Original");
-      expect(await getTermsAndConditionsFromDb()).toBe("Original");
+      await settings.terms.update("Original");
+      expect(await settings.terms.get()).toBe("Original");
 
       // Write directly to DB, bypassing page cache invalidation
       await getDb().execute({
@@ -138,7 +125,7 @@ describeWithEnv("page content cache", { db: true }, () => {
 
       // Advance to just before TTL boundary — cache still valid
       fakeTime!.now = startTime + PAGE_CACHE_TTL_MS - 1;
-      expect(await getTermsAndConditionsFromDb()).toBe("Original");
+      expect(await settings.terms.get()).toBe("Original");
     });
 
     test("re-fetches from DB after TTL expires", async () => {
@@ -147,15 +134,15 @@ describeWithEnv("page content cache", { db: true }, () => {
       // Advance past TTL
       fakeTime!.now = startTime + PAGE_CACHE_TTL_MS + 1;
       // Cache expired — re-fetches from DB and picks up new value
-      expect(await getTermsAndConditionsFromDb()).toBe("Changed");
+      expect(await settings.terms.get()).toBe("Changed");
     });
 
     test("serves stale cached encrypted value when DB changes within TTL", async () => {
       const startTime = Date.now();
       fakeTime = new FakeTime(startTime);
 
-      await updateWebsiteTitle("Original Title");
-      expect(await getWebsiteTitleFromDb()).toBe("Original Title");
+      await settings.websiteTitle.update("Original Title");
+      expect(await settings.websiteTitle.get()).toBe("Original Title");
 
       // Write a different encrypted value directly to DB
       const newEncrypted = await encrypt("Changed Title");
@@ -166,30 +153,30 @@ describeWithEnv("page content cache", { db: true }, () => {
 
       // Within TTL — cache still serves decrypted "Original Title"
       fakeTime.now = startTime + PAGE_CACHE_TTL_MS - 1;
-      expect(await getWebsiteTitleFromDb()).toBe("Original Title");
+      expect(await settings.websiteTitle.get()).toBe("Original Title");
     });
   });
 
   describe("invalidatePageCache", () => {
     /** Assert all four page getters return the seeded values */
     const expectAllPages = async () => {
-      expect(await getWebsiteTitleFromDb()).toBe("Title");
-      expect(await getHomepageTextFromDb()).toBe("Homepage");
-      expect(await getContactPageTextFromDb()).toBe("Contact");
-      expect(await getTermsAndConditionsFromDb()).toBe("Terms");
+      expect(await settings.websiteTitle.get()).toBe("Title");
+      expect(await settings.homepageText.get()).toBe("Homepage");
+      expect(await settings.contactPageText.get()).toBe("Contact");
+      expect(await settings.terms.get()).toBe("Terms");
     };
 
     test("clears all cached page entries", async () => {
-      await updateWebsiteTitle("Title");
-      await updateHomepageText("Homepage");
-      await updateContactPageText("Contact");
-      await updateTermsAndConditions("Terms");
+      await settings.websiteTitle.update("Title");
+      await settings.homepageText.update("Homepage");
+      await settings.contactPageText.update("Contact");
+      await settings.terms.update("Terms");
 
       // Populate all caches
       await expectAllPages();
 
       // Clear all
-      invalidatePageCache();
+      settings.invalidatePageCache();
 
       // Values should still be correct (re-fetched from DB)
       await expectAllPages();
@@ -198,15 +185,15 @@ describeWithEnv("page content cache", { db: true }, () => {
 
   describe("invalidateSettingsCache clears page cache", () => {
     test("page cache is cleared when settings cache is invalidated", async () => {
-      await updateWebsiteTitle("Title");
+      await settings.websiteTitle.update("Title");
       // Populate page cache
-      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      expect(await settings.websiteTitle.get()).toBe("Title");
 
       // invalidateSettingsCache should also clear the page cache
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       // Still returns correct value (re-fetched from DB)
-      expect(await getWebsiteTitleFromDb()).toBe("Title");
+      expect(await settings.websiteTitle.get()).toBe("Title");
     });
   });
 
@@ -215,13 +202,13 @@ describeWithEnv("page content cache", { db: true }, () => {
       const { getAllCacheStats } = await import("#lib/cache-registry.ts");
 
       // Load settings to populate cache
-      const { loadAllSettings } = await import("#lib/db/settings.ts");
-      await loadAllSettings();
+      const { settings: s } = await import("#lib/db/settings.ts");
+      await s.loadAll();
 
       const before = getAllCacheStats().find((s) => s.name === "settings");
       expect(before!.entries).toBeGreaterThan(0);
 
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const after = getAllCacheStats().find((s) => s.name === "settings");
       expect(after!.entries).toBe(0);
@@ -231,7 +218,7 @@ describeWithEnv("page content cache", { db: true }, () => {
   describe("null value caching", () => {
     test("serves cached null when value is added to DB within TTL", async () => {
       // First read populates page cache with null
-      expect(await getTermsAndConditionsFromDb()).toBeNull();
+      expect(await settings.terms.get()).toBeNull();
 
       // Write directly to DB, bypassing page cache invalidation
       await getDb().execute({
@@ -240,7 +227,7 @@ describeWithEnv("page content cache", { db: true }, () => {
       });
 
       // Page cache still holds null
-      expect(await getTermsAndConditionsFromDb()).toBeNull();
+      expect(await settings.terms.get()).toBeNull();
     });
   });
 });

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -2224,10 +2224,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "pi_no_provider",
       );
       await withMocks(
-        () =>
-          stub(paymentsApi, "getConfiguredProvider", () =>
-            Promise.resolve(null),
-          ),
+        () => stub(paymentsApi, "getConfiguredProvider", () => null),
         async () => {
           const response = await handleRequest(
             mockFormRequest(
@@ -2255,7 +2252,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       await withMocks(
         () =>
           stub(paymentsApi, "getConfiguredProvider", () =>
-            Promise.resolve(mockProviderType("stripe")),
+            mockProviderType("stripe"),
           ),
         async () => {
           const { stripePaymentProvider } = await import(
@@ -2301,7 +2298,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       await withMocks(
         () =>
           stub(paymentsApi, "getConfiguredProvider", () =>
-            Promise.resolve(mockProviderType("stripe")),
+            mockProviderType("stripe"),
           ),
         async () => {
           const { stripePaymentProvider } = await import(

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -1,19 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import {
-  setPaymentProvider,
-  setStripeWebhookConfig,
-  updateAppleWalletPassTypeId,
-  updateAppleWalletSigningCert,
-  updateAppleWalletSigningKey,
-  updateAppleWalletTeamId,
-  updateAppleWalletWwdrCert,
-  updateGoogleWalletIssuerId,
-  updateGoogleWalletServiceAccountEmail,
-  updateGoogleWalletServiceAccountKey,
-  updateSquareWebhookSignatureKey,
-  updateStripeKey,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { LIMIT_ENTRIES } from "#lib/limits.ts";
 import { handleRequest } from "#routes";
 import {
@@ -155,9 +142,9 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
   describe("GET /admin/debug with Stripe configured", () => {
     test("shows stripe as provider with key and webhook status", async () => {
-      await setPaymentProvider("stripe");
-      await updateStripeKey("sk_test_fake");
-      await setStripeWebhookConfig({
+      await settings.paymentProvider.set("stripe");
+      await settings.stripe.secretKey.update("sk_test_fake");
+      await settings.stripe.setWebhookConfig({
         secret: "whsec_fake",
         endpointId: "we_fake",
       });
@@ -170,8 +157,8 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
   describe("GET /admin/debug with Square configured", () => {
     test("shows square as provider with webhook status", async () => {
-      await setPaymentProvider("square");
-      await updateSquareWebhookSignatureKey("sig_fake");
+      await settings.paymentProvider.set("square");
+      await settings.square.webhookSignatureKey.update("sig_fake");
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("square");
@@ -182,11 +169,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     test("shows Database as source with valid cert status", async () => {
       const certs = generateTestCerts();
       await Promise.all([
-        updateAppleWalletPassTypeId("pass.com.test.tickets"),
-        updateAppleWalletTeamId("TESTTEAM01"),
-        updateAppleWalletSigningCert(certs.signingCert),
-        updateAppleWalletSigningKey(certs.signingKey),
-        updateAppleWalletWwdrCert(certs.wwdrCert),
+        settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
+        settings.appleWallet.teamId.update("TESTTEAM01"),
+        settings.appleWallet.signingCert.update(certs.signingCert),
+        settings.appleWallet.signingKey.update(certs.signingKey),
+        settings.appleWallet.wwdrCert.update(certs.wwdrCert),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
@@ -197,11 +184,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
     test("shows Invalid PEM for bad certificate data", async () => {
       await Promise.all([
-        updateAppleWalletPassTypeId("pass.com.test.tickets"),
-        updateAppleWalletTeamId("TESTTEAM01"),
-        updateAppleWalletSigningCert("not-a-valid-pem"),
-        updateAppleWalletSigningKey("not-a-valid-pem"),
-        updateAppleWalletWwdrCert("not-a-valid-pem"),
+        settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
+        settings.appleWallet.teamId.update("TESTTEAM01"),
+        settings.appleWallet.signingCert.update("not-a-valid-pem"),
+        settings.appleWallet.signingKey.update("not-a-valid-pem"),
+        settings.appleWallet.wwdrCert.update("not-a-valid-pem"),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
@@ -262,9 +249,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     test("shows Database as source with valid key status", async () => {
       const creds = await generateGoogleTestCreds();
       await Promise.all([
-        updateGoogleWalletIssuerId(creds.issuerId),
-        updateGoogleWalletServiceAccountEmail(creds.serviceAccountEmail),
-        updateGoogleWalletServiceAccountKey(creds.serviceAccountKey),
+        settings.googleWallet.issuerId.update(creds.issuerId),
+        settings.googleWallet.serviceAccountEmail.update(
+          creds.serviceAccountEmail,
+        ),
+        settings.googleWallet.serviceAccountKey.update(creds.serviceAccountKey),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
@@ -275,11 +264,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
     test("shows Invalid key for bad private key data", async () => {
       await Promise.all([
-        updateGoogleWalletIssuerId("1234567890"),
-        updateGoogleWalletServiceAccountEmail(
+        settings.googleWallet.issuerId.update("1234567890"),
+        settings.googleWallet.serviceAccountEmail.update(
           "test@test.iam.gserviceaccount.com",
         ),
-        updateGoogleWalletServiceAccountKey("not-a-valid-key"),
+        settings.googleWallet.serviceAccountKey.update("not-a-valid-key"),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -142,9 +142,9 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
   describe("GET /admin/debug with Stripe configured", () => {
     test("shows stripe as provider with key and webhook status", async () => {
-      await settings.paymentProvider.set("stripe");
-      await settings.stripe.secretKey.update("sk_test_fake");
-      await settings.stripe.setWebhookConfig({
+      await settings.update.paymentProvider("stripe");
+      await settings.update.stripe.secretKey("sk_test_fake");
+      await settings.update.stripe.webhookConfig({
         secret: "whsec_fake",
         endpointId: "we_fake",
       });
@@ -157,8 +157,8 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
   describe("GET /admin/debug with Square configured", () => {
     test("shows square as provider with webhook status", async () => {
-      await settings.paymentProvider.set("square");
-      await settings.square.webhookSignatureKey.update("sig_fake");
+      await settings.update.paymentProvider("square");
+      await settings.update.square.webhookSignatureKey("sig_fake");
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("square");
@@ -169,11 +169,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     test("shows Database as source with valid cert status", async () => {
       const certs = generateTestCerts();
       await Promise.all([
-        settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
-        settings.appleWallet.teamId.update("TESTTEAM01"),
-        settings.appleWallet.signingCert.update(certs.signingCert),
-        settings.appleWallet.signingKey.update(certs.signingKey),
-        settings.appleWallet.wwdrCert.update(certs.wwdrCert),
+        settings.update.appleWallet.passTypeId("pass.com.test.tickets"),
+        settings.update.appleWallet.teamId("TESTTEAM01"),
+        settings.update.appleWallet.signingCert(certs.signingCert),
+        settings.update.appleWallet.signingKey(certs.signingKey),
+        settings.update.appleWallet.wwdrCert(certs.wwdrCert),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
@@ -184,11 +184,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
     test("shows Invalid PEM for bad certificate data", async () => {
       await Promise.all([
-        settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
-        settings.appleWallet.teamId.update("TESTTEAM01"),
-        settings.appleWallet.signingCert.update("not-a-valid-pem"),
-        settings.appleWallet.signingKey.update("not-a-valid-pem"),
-        settings.appleWallet.wwdrCert.update("not-a-valid-pem"),
+        settings.update.appleWallet.passTypeId("pass.com.test.tickets"),
+        settings.update.appleWallet.teamId("TESTTEAM01"),
+        settings.update.appleWallet.signingCert("not-a-valid-pem"),
+        settings.update.appleWallet.signingKey("not-a-valid-pem"),
+        settings.update.appleWallet.wwdrCert("not-a-valid-pem"),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
@@ -249,11 +249,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     test("shows Database as source with valid key status", async () => {
       const creds = await generateGoogleTestCreds();
       await Promise.all([
-        settings.googleWallet.issuerId.update(creds.issuerId),
-        settings.googleWallet.serviceAccountEmail.update(
+        settings.update.googleWallet.issuerId(creds.issuerId),
+        settings.update.googleWallet.serviceAccountEmail(
           creds.serviceAccountEmail,
         ),
-        settings.googleWallet.serviceAccountKey.update(creds.serviceAccountKey),
+        settings.update.googleWallet.serviceAccountKey(creds.serviceAccountKey),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
@@ -264,11 +264,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
     test("shows Invalid key for bad private key data", async () => {
       await Promise.all([
-        settings.googleWallet.issuerId.update("1234567890"),
-        settings.googleWallet.serviceAccountEmail.update(
+        settings.update.googleWallet.issuerId("1234567890"),
+        settings.update.googleWallet.serviceAccountEmail(
           "test@test.iam.gserviceaccount.com",
         ),
-        settings.googleWallet.serviceAccountKey.update("not-a-valid-key"),
+        settings.update.googleWallet.serviceAccountKey("not-a-valid-key"),
       ]);
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();

--- a/test/lib/server-embed-hosts.test.ts
+++ b/test/lib/server-embed-hosts.test.ts
@@ -42,7 +42,7 @@ async function postEmbedHostsExpectRedirect(
 /** Create an embeddable event and return its ticket page CSP header */
 async function getTicketCsp(setupEmbedHosts?: string): Promise<string> {
   if (setupEmbedHosts !== undefined) {
-    await settings.embedHosts.update(setupEmbedHosts);
+    await settings.update.embedHosts(setupEmbedHosts);
   }
   const response = await getEmbeddableTicketResponse();
   return getHeader(response, "content-security-policy");
@@ -61,7 +61,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
     });
 
     test("shows current embed hosts value when configured", async () => {
-      await settings.embedHosts.update("example.com, *.mysite.org");
+      await settings.update.embedHosts("example.com, *.mysite.org");
       const { response } = await adminGet("/admin/settings");
       await expectHtmlResponse(response, 200, "example.com, *.mysite.org");
     });
@@ -161,7 +161,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
     });
 
     test("non-embeddable pages still have frame-ancestors none regardless of embed hosts", async () => {
-      await settings.embedHosts.update("example.com");
+      await settings.update.embedHosts("example.com");
 
       const response = await handleRequest(mockRequest("/"));
       const csp = getHeader(response, "content-security-policy");
@@ -170,7 +170,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
     });
 
     test("ticket page has no X-Frame-Options when embed hosts configured", async () => {
-      await settings.embedHosts.update("example.com");
+      await settings.update.embedHosts("example.com");
       const response = await getEmbeddableTicketResponse();
       expect(response.headers.get("x-frame-options")).toBeNull();
     });

--- a/test/lib/server-embed-hosts.test.ts
+++ b/test/lib/server-embed-hosts.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { updateEmbedHosts } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   adminFormPost,
@@ -42,7 +42,7 @@ async function postEmbedHostsExpectRedirect(
 /** Create an embeddable event and return its ticket page CSP header */
 async function getTicketCsp(setupEmbedHosts?: string): Promise<string> {
   if (setupEmbedHosts !== undefined) {
-    await updateEmbedHosts(setupEmbedHosts);
+    await settings.embedHosts.update(setupEmbedHosts);
   }
   const response = await getEmbeddableTicketResponse();
   return getHeader(response, "content-security-policy");
@@ -61,7 +61,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
     });
 
     test("shows current embed hosts value when configured", async () => {
-      await updateEmbedHosts("example.com, *.mysite.org");
+      await settings.embedHosts.update("example.com, *.mysite.org");
       const { response } = await adminGet("/admin/settings");
       await expectHtmlResponse(response, 200, "example.com, *.mysite.org");
     });
@@ -161,7 +161,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
     });
 
     test("non-embeddable pages still have frame-ancestors none regardless of embed hosts", async () => {
-      await updateEmbedHosts("example.com");
+      await settings.embedHosts.update("example.com");
 
       const response = await handleRequest(mockRequest("/"));
       const csp = getHeader(response, "content-security-policy");
@@ -170,7 +170,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
     });
 
     test("ticket page has no X-Frame-Options when embed hosts configured", async () => {
-      await updateEmbedHosts("example.com");
+      await settings.embedHosts.update("example.com");
       const response = await getEmbeddableTicketResponse();
       expect(response.headers.get("x-frame-options")).toBeNull();
     });

--- a/test/lib/server-feeds.test.ts
+++ b/test/lib/server-feeds.test.ts
@@ -22,7 +22,7 @@ const fetchFeedBody = async (feedPath: string): Promise<string> => {
 
 /** Assert a deactivated event is excluded from a feed */
 const expectExcludesInactive = async (feedPath: string, absentTag: string) => {
-  await settings.showPublicSite.update(true);
+  await settings.update.showPublicSite(true);
   const event = await createTestEvent({ name: "Hidden", maxAttendees: 100 });
   await deactivateTestEvent(event.id);
   const body = await fetchFeedBody(feedPath);
@@ -35,7 +35,7 @@ const expectExcludesClosedRegistration = async (
   feedPath: string,
   absentTag: string,
 ) => {
-  await settings.showPublicSite.update(true);
+  await settings.update.showPublicSite(true);
   const pastDate = new Date(Date.now() - 60000).toISOString().slice(0, 16);
   await createTestEvent({
     name: "Closed Event",
@@ -56,7 +56,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns text/calendar content type", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe(
@@ -65,7 +65,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns valid VCALENDAR wrapper with no events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
       expect(body).toContain("BEGIN:VCALENDAR");
@@ -76,22 +76,22 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("uses website title as calendar name", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Events");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Events");
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
       expect(body).toContain("X-WR-CALNAME:My Events");
     });
 
     test("defaults calendar name to Events when no title set", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
       expect(body).toContain("X-WR-CALNAME:Events");
     });
 
     test("includes VEVENT for active events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({
         name: "Concert",
         maxAttendees: 100,
@@ -105,7 +105,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes UID and DTSTAMP", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({ name: "Show", maxAttendees: 50 });
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
@@ -114,7 +114,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes DTSTART when event has a date", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Dated Event",
         maxAttendees: 100,
@@ -126,7 +126,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes DESCRIPTION when event has a description", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Described",
         maxAttendees: 100,
@@ -138,7 +138,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes LOCATION when event has a location", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Located",
         maxAttendees: 100,
@@ -161,7 +161,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("excludes hidden events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Secret Event",
         maxAttendees: 100,
@@ -174,7 +174,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("escapes special characters in event fields", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Rock, Paper; Scissors",
         maxAttendees: 100,
@@ -197,7 +197,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns application/rss+xml content type", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe(
@@ -206,7 +206,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns valid RSS wrapper with no events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).toContain('<?xml version="1.0"');
@@ -218,8 +218,8 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("uses website title in channel", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Events");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Events");
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).toContain("<title>My Events</title>");
@@ -229,14 +229,14 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("defaults title to Events when no title set", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).toContain("<title>Events</title>");
     });
 
     test("includes items for active events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({
         name: "Concert",
         maxAttendees: 100,
@@ -251,7 +251,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes guid as permalink", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({ name: "Show", maxAttendees: 50 });
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
@@ -260,7 +260,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes description when event has one", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Described",
         maxAttendees: 100,
@@ -272,7 +272,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes date in description when event has a date", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Dated",
         maxAttendees: 100,
@@ -285,7 +285,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes location in description when event has a location", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Located",
         maxAttendees: 100,
@@ -297,7 +297,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes description, date, and location together", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Full Event",
         maxAttendees: 100,
@@ -321,7 +321,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("excludes hidden events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Secret Event",
         maxAttendees: 100,
@@ -334,7 +334,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("XML-escapes special characters", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Rock & Roll <Live>",
         maxAttendees: 100,

--- a/test/lib/server-feeds.test.ts
+++ b/test/lib/server-feeds.test.ts
@@ -4,7 +4,7 @@
 
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { updateShowPublicSite, updateWebsiteTitle } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import { escapeIcs, escapeXml } from "#routes/feeds.ts";
 import {
@@ -22,7 +22,7 @@ const fetchFeedBody = async (feedPath: string): Promise<string> => {
 
 /** Assert a deactivated event is excluded from a feed */
 const expectExcludesInactive = async (feedPath: string, absentTag: string) => {
-  await updateShowPublicSite(true);
+  await settings.showPublicSite.update(true);
   const event = await createTestEvent({ name: "Hidden", maxAttendees: 100 });
   await deactivateTestEvent(event.id);
   const body = await fetchFeedBody(feedPath);
@@ -35,7 +35,7 @@ const expectExcludesClosedRegistration = async (
   feedPath: string,
   absentTag: string,
 ) => {
-  await updateShowPublicSite(true);
+  await settings.showPublicSite.update(true);
   const pastDate = new Date(Date.now() - 60000).toISOString().slice(0, 16);
   await createTestEvent({
     name: "Closed Event",
@@ -56,7 +56,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns text/calendar content type", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe(
@@ -65,7 +65,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns valid VCALENDAR wrapper with no events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
       expect(body).toContain("BEGIN:VCALENDAR");
@@ -76,22 +76,22 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("uses website title as calendar name", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Events");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Events");
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
       expect(body).toContain("X-WR-CALNAME:My Events");
     });
 
     test("defaults calendar name to Events when no title set", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
       expect(body).toContain("X-WR-CALNAME:Events");
     });
 
     test("includes VEVENT for active events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({
         name: "Concert",
         maxAttendees: 100,
@@ -105,7 +105,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes UID and DTSTAMP", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({ name: "Show", maxAttendees: 50 });
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       const body = await response.text();
@@ -114,7 +114,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes DTSTART when event has a date", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Dated Event",
         maxAttendees: 100,
@@ -126,7 +126,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes DESCRIPTION when event has a description", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Described",
         maxAttendees: 100,
@@ -138,7 +138,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes LOCATION when event has a location", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Located",
         maxAttendees: 100,
@@ -161,7 +161,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("excludes hidden events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Secret Event",
         maxAttendees: 100,
@@ -174,7 +174,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("escapes special characters in event fields", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Rock, Paper; Scissors",
         maxAttendees: 100,
@@ -197,7 +197,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns application/rss+xml content type", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe(
@@ -206,7 +206,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("returns valid RSS wrapper with no events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).toContain('<?xml version="1.0"');
@@ -218,8 +218,8 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("uses website title in channel", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Events");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Events");
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).toContain("<title>My Events</title>");
@@ -229,14 +229,14 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("defaults title to Events when no title set", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).toContain("<title>Events</title>");
     });
 
     test("includes items for active events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({
         name: "Concert",
         maxAttendees: 100,
@@ -251,7 +251,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes guid as permalink", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({ name: "Show", maxAttendees: 50 });
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
@@ -260,7 +260,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes description when event has one", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Described",
         maxAttendees: 100,
@@ -272,7 +272,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes date in description when event has a date", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Dated",
         maxAttendees: 100,
@@ -285,7 +285,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes location in description when event has a location", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Located",
         maxAttendees: 100,
@@ -297,7 +297,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("includes description, date, and location together", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Full Event",
         maxAttendees: 100,
@@ -321,7 +321,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("excludes hidden events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Secret Event",
         maxAttendees: 100,
@@ -334,7 +334,7 @@ describeWithEnv("feeds", { db: true }, () => {
     });
 
     test("XML-escapes special characters", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Rock & Roll <Live>",
         maxAttendees: 100,

--- a/test/lib/server-google-wallet.test.ts
+++ b/test/lib/server-google-wallet.test.ts
@@ -24,11 +24,11 @@ let testCreds: GoogleWalletCredentials;
 const configureGoogleWallet = async () => {
   if (!testCreds) testCreds = await generateGoogleTestCreds();
   await Promise.all([
-    settings.googleWallet.issuerId.update(testCreds.issuerId),
-    settings.googleWallet.serviceAccountEmail.update(
+    settings.update.googleWallet.issuerId(testCreds.issuerId),
+    settings.update.googleWallet.serviceAccountEmail(
       testCreds.serviceAccountEmail,
     ),
-    settings.googleWallet.serviceAccountKey.update(testCreds.serviceAccountKey),
+    settings.update.googleWallet.serviceAccountKey(testCreds.serviceAccountKey),
   ]);
 };
 
@@ -268,16 +268,16 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
     expect(response.status).toBe(302);
     expectFlash(response, "Google Wallet settings updated");
 
-    expect(await settings.googleWallet.hasConfig()).toBe(true);
-    expect(await settings.googleWallet.issuerId.get()).toBe("1234567890");
-    expect(await settings.googleWallet.serviceAccountEmail.get()).toBe(
+    expect(settings.googleWallet.hasConfig).toBe(true);
+    expect(settings.googleWallet.issuerId).toBe("1234567890");
+    expect(settings.googleWallet.serviceAccountEmail).toBe(
       "test@test.iam.gserviceaccount.com",
     );
   });
 
   test("clears all settings when everything is empty", async () => {
     await configureGoogleWallet();
-    expect(await settings.googleWallet.hasConfig()).toBe(true);
+    expect(settings.googleWallet.hasConfig).toBe(true);
 
     const { cookie, csrfToken } = await loginAsAdmin();
     const response = await handleRequest(
@@ -295,7 +295,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
 
     expect(response.status).toBe(302);
     expectFlash(response, "Google Wallet configuration cleared");
-    expect(await settings.googleWallet.hasDbConfig()).toBe(false);
+    expect(settings.googleWallet.hasDbConfig).toBe(false);
   });
 
   test("shows Google Wallet section with values when configured", async () => {
@@ -336,17 +336,17 @@ describeWithEnv(
   },
   () => {
     test("returns null when no env vars are set", () => {
-      expect(settings.googleWallet.getHostConfig()).toBeNull();
+      expect(settings.googleWallet.hostConfig).toBeNull();
     });
 
     test("returns null when only some env vars are set", () => {
       Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "123");
-      expect(settings.googleWallet.getHostConfig()).toBeNull();
+      expect(settings.googleWallet.hostConfig).toBeNull();
     });
 
     test("returns config when all env vars are set", async () => {
       await setGoogleWalletEnvVars();
-      const config = settings.googleWallet.getHostConfig();
+      const config = settings.googleWallet.hostConfig;
       expect(config).not.toBeNull();
       expect(config!.issuerId).toBe("9876543210");
       expect(config!.serviceAccountEmail).toBe(
@@ -374,13 +374,13 @@ describeWithEnv(
 
     test("hasGoogleWalletConfig returns true with env vars when DB not configured", async () => {
       await setGoogleWalletEnvVars();
-      expect(await settings.googleWallet.hasDbConfig()).toBe(false);
-      expect(await settings.googleWallet.hasConfig()).toBe(true);
+      expect(settings.googleWallet.hasDbConfig).toBe(false);
+      expect(settings.googleWallet.hasConfig).toBe(true);
     });
 
     test("getGoogleWalletConfig falls back to env vars when DB not configured", async () => {
       await setGoogleWalletEnvVars();
-      const config = await settings.googleWallet.getConfig();
+      const config = settings.googleWallet.config;
       expect(config).not.toBeNull();
       expect(config!.issuerId).toBe("9876543210");
     });
@@ -388,7 +388,7 @@ describeWithEnv(
     test("getGoogleWalletConfig prefers DB config over env vars", async () => {
       await setGoogleWalletEnvVars();
       await configureGoogleWallet();
-      const config = await settings.googleWallet.getConfig();
+      const config = settings.googleWallet.config;
       expect(config).not.toBeNull();
       expect(config!.issuerId).toBe("1234567890");
     });

--- a/test/lib/server-google-wallet.test.ts
+++ b/test/lib/server-google-wallet.test.ts
@@ -1,16 +1,6 @@
 import { expect } from "@std/expect";
 import { beforeEach, it as test } from "@std/testing/bdd";
-import {
-  getGoogleWalletConfig,
-  getGoogleWalletIssuerIdFromDb,
-  getGoogleWalletServiceAccountEmailFromDb,
-  getHostGoogleWalletConfig,
-  hasGoogleWalletConfig,
-  hasGoogleWalletDbConfig,
-  updateGoogleWalletIssuerId,
-  updateGoogleWalletServiceAccountEmail,
-  updateGoogleWalletServiceAccountKey,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { GoogleWalletCredentials } from "#lib/google-wallet.ts";
 import { handleRequest } from "#routes";
 import {
@@ -34,9 +24,11 @@ let testCreds: GoogleWalletCredentials;
 const configureGoogleWallet = async () => {
   if (!testCreds) testCreds = await generateGoogleTestCreds();
   await Promise.all([
-    updateGoogleWalletIssuerId(testCreds.issuerId),
-    updateGoogleWalletServiceAccountEmail(testCreds.serviceAccountEmail),
-    updateGoogleWalletServiceAccountKey(testCreds.serviceAccountKey),
+    settings.googleWallet.issuerId.update(testCreds.issuerId),
+    settings.googleWallet.serviceAccountEmail.update(
+      testCreds.serviceAccountEmail,
+    ),
+    settings.googleWallet.serviceAccountKey.update(testCreds.serviceAccountKey),
   ]);
 };
 
@@ -276,16 +268,16 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
     expect(response.status).toBe(302);
     expectFlash(response, "Google Wallet settings updated");
 
-    expect(await hasGoogleWalletConfig()).toBe(true);
-    expect(await getGoogleWalletIssuerIdFromDb()).toBe("1234567890");
-    expect(await getGoogleWalletServiceAccountEmailFromDb()).toBe(
+    expect(await settings.googleWallet.hasConfig()).toBe(true);
+    expect(await settings.googleWallet.issuerId.get()).toBe("1234567890");
+    expect(await settings.googleWallet.serviceAccountEmail.get()).toBe(
       "test@test.iam.gserviceaccount.com",
     );
   });
 
   test("clears all settings when everything is empty", async () => {
     await configureGoogleWallet();
-    expect(await hasGoogleWalletConfig()).toBe(true);
+    expect(await settings.googleWallet.hasConfig()).toBe(true);
 
     const { cookie, csrfToken } = await loginAsAdmin();
     const response = await handleRequest(
@@ -303,7 +295,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
 
     expect(response.status).toBe(302);
     expectFlash(response, "Google Wallet configuration cleared");
-    expect(await hasGoogleWalletDbConfig()).toBe(false);
+    expect(await settings.googleWallet.hasDbConfig()).toBe(false);
   });
 
   test("shows Google Wallet section with values when configured", async () => {
@@ -344,17 +336,17 @@ describeWithEnv(
   },
   () => {
     test("returns null when no env vars are set", () => {
-      expect(getHostGoogleWalletConfig()).toBeNull();
+      expect(settings.googleWallet.getHostConfig()).toBeNull();
     });
 
     test("returns null when only some env vars are set", () => {
       Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "123");
-      expect(getHostGoogleWalletConfig()).toBeNull();
+      expect(settings.googleWallet.getHostConfig()).toBeNull();
     });
 
     test("returns config when all env vars are set", async () => {
       await setGoogleWalletEnvVars();
-      const config = getHostGoogleWalletConfig();
+      const config = settings.googleWallet.getHostConfig();
       expect(config).not.toBeNull();
       expect(config!.issuerId).toBe("9876543210");
       expect(config!.serviceAccountEmail).toBe(
@@ -382,13 +374,13 @@ describeWithEnv(
 
     test("hasGoogleWalletConfig returns true with env vars when DB not configured", async () => {
       await setGoogleWalletEnvVars();
-      expect(await hasGoogleWalletDbConfig()).toBe(false);
-      expect(await hasGoogleWalletConfig()).toBe(true);
+      expect(await settings.googleWallet.hasDbConfig()).toBe(false);
+      expect(await settings.googleWallet.hasConfig()).toBe(true);
     });
 
     test("getGoogleWalletConfig falls back to env vars when DB not configured", async () => {
       await setGoogleWalletEnvVars();
-      const config = await getGoogleWalletConfig();
+      const config = await settings.googleWallet.getConfig();
       expect(config).not.toBeNull();
       expect(config!.issuerId).toBe("9876543210");
     });
@@ -396,7 +388,7 @@ describeWithEnv(
     test("getGoogleWalletConfig prefers DB config over env vars", async () => {
       await setGoogleWalletEnvVars();
       await configureGoogleWallet();
-      const config = await getGoogleWalletConfig();
+      const config = await settings.googleWallet.getConfig();
       expect(config).not.toBeNull();
       expect(config!.issuerId).toBe("1234567890");
     });

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -1,9 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import {
-  resetHostAppleWalletConfig,
-  setHostAppleWalletConfigForTest,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { handleRequest } from "#routes";
 import {
@@ -223,7 +220,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
     });
 
     test("shows host wallet config and setup instructions when configured", async () => {
-      setHostAppleWalletConfigForTest({
+      settings.appleWallet.setHostConfigForTest({
         passTypeId: "pass.com.host.tickets",
         teamId: "HOSTTEAM01",
         signingCert: "cert-data",
@@ -239,7 +236,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         expect(html).toContain("pass.com.host.tickets");
         expect(html).toContain("You need five values from");
       } finally {
-        resetHostAppleWalletConfig();
+        settings.appleWallet.resetHostConfig();
       }
     });
   });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
-import { setPaymentProvider, updateSquareSandbox } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import { runWithRequestId } from "#lib/logger.ts";
 import {
@@ -126,8 +126,8 @@ describe("server (misc)", () => {
       });
 
       test("square sandbox CSP includes sandbox domains", async () => {
-        await setPaymentProvider("square");
-        await updateSquareSandbox(true);
+        await settings.paymentProvider.set("square");
+        await settings.square.sandbox.update(true);
         const response = await handleRequest(mockRequest("/"));
         const csp = getHeader(response, "content-security-policy");
         expect(csp).toContain("squareupsandbox.com");
@@ -263,14 +263,12 @@ describe("server (misc)", () => {
 
     test("returns null when wrappedPrivateKey is not set in DB", async () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
-      const { invalidateSettingsCache: invalidateCache } = await import(
-        "#lib/db/settings.ts"
-      );
+      const { settings: s } = await import("#lib/db/settings.ts");
       await getDbFn().execute({
         sql: "DELETE FROM settings WHERE key = 'wrapped_private_key'",
         args: [],
       });
-      invalidateCache();
+      s.invalidateCache();
 
       const { getPrivateKey } = await import("#routes/utils.ts");
       const result = await getPrivateKey({
@@ -788,13 +786,13 @@ describe("server (misc)", () => {
     test("rethrows unhandled errors in test mode", async () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
       const { invalidateEventsCache } = await import("#lib/db/events.ts");
-      const { loadAllSettings } = await import("#lib/db/settings.ts");
+      const { settings: s } = await import("#lib/db/settings.ts");
       const db = getDbFn();
       invalidateEventsCache();
       // Warm the settings cache so loadEffectiveDomain/isSetupComplete/etc.
       // resolve from cache; the stub then only affects route-handler queries
       // inside the inner try/catch.
-      await loadAllSettings();
+      await s.loadAll();
       const executeStub = stub(db, "execute", () => {
         throw new Error("synthetic db failure");
       });
@@ -809,14 +807,14 @@ describe("server (misc)", () => {
 
     test("SessionKeyError clears cookie and redirects to /admin", async () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
-      const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
+      const { settings: s } = await import("#lib/db/settings.ts");
 
       // Remove wrapped_private_key so requirePrivateKey throws SessionKeyError
       await getDbFn().execute({
         sql: "DELETE FROM settings WHERE key = 'wrapped_private_key'",
         args: [],
       });
-      invalidateSettingsCache();
+      s.invalidateCache();
 
       await withExpectedError(async () => {
         // Hit admin dashboard (GET /admin with session) which calls requirePrivateKey

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -116,8 +116,8 @@ describeWithEnv("server (misc)", { db: true }, () => {
       });
 
       test("square sandbox CSP includes sandbox domains", async () => {
-        await settings.paymentProvider.set("square");
-        await settings.square.sandbox.update(true);
+        await settings.update.paymentProvider("square");
+        await settings.update.square.sandbox(true);
         const response = await handleRequest(mockRequest("/"));
         const csp = getHeader(response, "content-security-policy");
         expect(csp).toContain("squareupsandbox.com");

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -50,33 +50,33 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows public homepage when enabled", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "Home", "/admin/login");
     });
 
     test("shows website title on homepage", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Cool Site");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Cool Site");
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "My Cool Site");
     });
 
     test("shows homepage text when configured", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.homepageText.update("Welcome to our events!");
+      await settings.update.showPublicSite(true);
+      await settings.update.homepageText("Welcome to our events!");
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "Welcome to our events!");
     });
 
     test("shows no content message when homepage text not set", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "No content.");
     });
 
     test("shows public nav links", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(
         response,
@@ -89,7 +89,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows login link styled as footer", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(
         response,
@@ -106,8 +106,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("renders markdown paragraphs in homepage text", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.homepageText.update("Line one\n\nLine two");
+      await settings.update.showPublicSite(true);
+      await settings.update.homepageText("Line one\n\nLine two");
       const response = await handleRequest(mockRequest("/"));
       const html = await expectHtmlResponse(response, 200, "Line one");
       expect(html).toContain("<p>Line one</p>");
@@ -115,7 +115,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -130,7 +130,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows no events message when enabled but no events exist", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(
         response,
@@ -141,14 +141,14 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows website title with no events message", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Events");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Events");
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(response, 200, "No events listed.", "My Events");
     });
 
     test("shows active events with book now links", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({
         name: "Concert",
         maxAttendees: 100,
@@ -164,7 +164,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("does not show inactive events", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({
         name: "Hidden Event",
         maxAttendees: 100,
@@ -176,7 +176,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("does not show hidden events in public events list", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({ name: "Secret Event", hidden: true });
       const response = await handleRequest(mockRequest("/events"));
       const html = await expectHtmlResponse(response, 200, "No events listed.");
@@ -184,7 +184,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows non-hidden events alongside hidden ones", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({ name: "Visible Event" });
       await createTestEvent({ name: "Secret Event", hidden: true });
       const response = await handleRequest(mockRequest("/events"));
@@ -228,7 +228,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows sold out for events at capacity", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const event = await createTestEvent({
         name: "Full Event",
         maxAttendees: 1,
@@ -245,7 +245,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows registration closed for events past closes_at", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const pastDate = new Date(Date.now() - 60000).toISOString().slice(0, 16);
       await createTestEvent({
         name: "Closed Event",
@@ -257,7 +257,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows event location when set", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Located Event",
         maxAttendees: 100,
@@ -268,7 +268,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows event date when set", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Dated Event",
         maxAttendees: 100,
@@ -279,7 +279,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows event description when set", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       await createTestEvent({
         name: "Described Event",
         maxAttendees: 100,
@@ -290,15 +290,15 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows website title on events page", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Events Site");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Events Site");
       await createTestEvent({ name: "Concert", maxAttendees: 100 });
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(response, 200, "My Events Site");
     });
 
     test("shows public nav on events page", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(
         response,
@@ -311,7 +311,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("returns 404 for POST requests", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(
         mockFormRequest("/events", { name: "Test" }),
       );
@@ -319,7 +319,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/events"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -334,8 +334,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows terms page when enabled", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.terms.update("Our terms and conditions.");
+      await settings.update.showPublicSite(true);
+      await settings.update.terms("Our terms and conditions.");
       const response = await handleRequest(mockRequest("/terms"));
       await expectHtmlResponse(
         response,
@@ -346,20 +346,20 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows no content when terms not configured", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/terms"));
       await expectHtmlResponse(response, 200, "No content.");
     });
 
     test("shows website title on terms page", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Site");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Site");
       const response = await handleRequest(mockRequest("/terms"));
       await expectHtmlResponse(response, 200, "My Site");
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/terms"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -374,8 +374,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows contact page when enabled", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.contactPageText.update("Get in touch with us");
+      await settings.update.showPublicSite(true);
+      await settings.update.contactPageText("Get in touch with us");
       const response = await handleRequest(mockRequest("/contact"));
       await expectHtmlResponse(
         response,
@@ -386,21 +386,21 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows no content when contact text not configured", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/contact"));
       await expectHtmlResponse(response, 200, "No content.");
     });
 
     test("shows website title on contact page", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.websiteTitle.update("My Site");
+      await settings.update.showPublicSite(true);
+      await settings.update.websiteTitle("My Site");
       const response = await handleRequest(mockRequest("/contact"));
       await expectHtmlResponse(response, 200, "My Site");
     });
 
     test("renders markdown paragraphs in contact text", async () => {
-      await settings.showPublicSite.update(true);
-      await settings.contactPageText.update(
+      await settings.update.showPublicSite(true);
+      await settings.update.contactPageText(
         "Phone: 123\n\nAddress: 1 High Street",
       );
       const response = await handleRequest(mockRequest("/contact"));
@@ -417,7 +417,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/contact"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -965,7 +965,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("group terms override global terms", async () => {
-      await settings.terms.update("GLOBAL TERMS UNIQUE");
+      await settings.update.terms("GLOBAL TERMS UNIQUE");
       const group = await createTestGroup({
         name: "Terms Group",
         slug: "terms-group",
@@ -986,7 +986,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("group terms fall back to global when group terms are empty", async () => {
-      await settings.terms.update("GLOBAL FALLBACK UNIQUE");
+      await settings.update.terms("GLOBAL FALLBACK UNIQUE");
       const group = await createTestGroup({
         name: "Fallback Group",
         slug: "fallback-group",
@@ -2261,7 +2261,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
       // Now clear the provider to simulate no provider
       const { settings: s } = await import("#lib/db/settings.ts");
-      await s.paymentProvider.clear();
+      await s.update.clearPaymentProvider();
 
       const path = `/ticket/${event1.slug}+${event2.slug}`;
       const getResponse = await handleRequest(mockRequest(path));
@@ -2785,8 +2785,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       // Mock paymentsApi.getConfiguredProvider to return null so getActivePaymentProvider
       // returns null, while isPaymentsEnabled still returns true from the DB
       const { paymentsApi } = await import("#lib/payments.ts");
-      const mockConfigured = stub(paymentsApi, "getConfiguredProvider", () =>
-        Promise.resolve(null),
+      const mockConfigured = stub(
+        paymentsApi,
+        "getConfiguredProvider",
+        () => null,
       );
 
       try {
@@ -3484,7 +3486,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("terms and conditions (single ticket)", () => {
     test("shows terms checkbox when terms are configured", async () => {
-      await settings.terms.update("I agree to the event rules.");
+      await settings.update.terms("I agree to the event rules.");
 
       const event = await createTestEvent({ maxAttendees: 50 });
       const response = await handleRequest(
@@ -3510,7 +3512,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("rejects submission without agreeing to terms", async () => {
-      await settings.terms.update("You must accept the rules.");
+      await settings.update.terms("You must accept the rules.");
 
       const event = await createTestEvent({ maxAttendees: 50 });
       const response = await submitTicketForm(event.slug, {
@@ -3525,7 +3527,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("accepts submission when terms are agreed to", async () => {
-      await settings.terms.update("You must accept the rules.");
+      await settings.update.terms("You must accept the rules.");
 
       const event = await createTestEvent({
         maxAttendees: 50,
@@ -3554,7 +3556,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("terms and conditions (multi-ticket)", () => {
     test("shows terms checkbox on multi-ticket page when configured", async () => {
-      await settings.terms.update("Multi-event terms apply.");
+      await settings.update.terms("Multi-event terms apply.");
 
       const event1 = await createTestEvent({
         name: "TC Multi 1",
@@ -3576,7 +3578,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("rejects multi-ticket submission without agreeing to terms", async () => {
-      await settings.terms.update("Must agree to policy.");
+      await settings.update.terms("Must agree to policy.");
 
       const event1 = await createTestEvent({
         name: "TC Multi Rej 1",
@@ -3613,7 +3615,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("accepts multi-ticket submission when terms are agreed to", async () => {
-      await settings.terms.update("Must agree to policy.");
+      await settings.update.terms("Must agree to policy.");
 
       const event1 = await createTestEvent({
         name: "TC Multi Ok 1",

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -9,13 +9,7 @@ import {
   questionsTable,
   setEventQuestions,
 } from "#lib/db/questions.ts";
-import {
-  updateContactPageText,
-  updateHomepageText,
-  updateShowPublicSite,
-  updateTermsAndConditions,
-  updateWebsiteTitle,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { resetStripeClient } from "#lib/stripe.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import { handleRequest } from "#routes";
@@ -56,33 +50,33 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows public homepage when enabled", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "Home", "/admin/login");
     });
 
     test("shows website title on homepage", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Cool Site");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Cool Site");
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "My Cool Site");
     });
 
     test("shows homepage text when configured", async () => {
-      await updateShowPublicSite(true);
-      await updateHomepageText("Welcome to our events!");
+      await settings.showPublicSite.update(true);
+      await settings.homepageText.update("Welcome to our events!");
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "Welcome to our events!");
     });
 
     test("shows no content message when homepage text not set", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(response, 200, "No content.");
     });
 
     test("shows public nav links", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(
         response,
@@ -95,7 +89,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows login link styled as footer", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(
         response,
@@ -112,8 +106,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("renders markdown paragraphs in homepage text", async () => {
-      await updateShowPublicSite(true);
-      await updateHomepageText("Line one\n\nLine two");
+      await settings.showPublicSite.update(true);
+      await settings.homepageText.update("Line one\n\nLine two");
       const response = await handleRequest(mockRequest("/"));
       const html = await expectHtmlResponse(response, 200, "Line one");
       expect(html).toContain("<p>Line one</p>");
@@ -121,7 +115,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -136,7 +130,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows no events message when enabled but no events exist", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(
         response,
@@ -147,14 +141,14 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows website title with no events message", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Events");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Events");
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(response, 200, "No events listed.", "My Events");
     });
 
     test("shows active events with book now links", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({
         name: "Concert",
         maxAttendees: 100,
@@ -170,7 +164,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("does not show inactive events", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({
         name: "Hidden Event",
         maxAttendees: 100,
@@ -182,7 +176,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("does not show hidden events in public events list", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({ name: "Secret Event", hidden: true });
       const response = await handleRequest(mockRequest("/events"));
       const html = await expectHtmlResponse(response, 200, "No events listed.");
@@ -190,7 +184,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows non-hidden events alongside hidden ones", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({ name: "Visible Event" });
       await createTestEvent({ name: "Secret Event", hidden: true });
       const response = await handleRequest(mockRequest("/events"));
@@ -234,7 +228,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows sold out for events at capacity", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const event = await createTestEvent({
         name: "Full Event",
         maxAttendees: 1,
@@ -251,7 +245,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows registration closed for events past closes_at", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const pastDate = new Date(Date.now() - 60000).toISOString().slice(0, 16);
       await createTestEvent({
         name: "Closed Event",
@@ -263,7 +257,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows event location when set", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Located Event",
         maxAttendees: 100,
@@ -274,7 +268,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows event date when set", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Dated Event",
         maxAttendees: 100,
@@ -285,7 +279,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows event description when set", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       await createTestEvent({
         name: "Described Event",
         maxAttendees: 100,
@@ -296,15 +290,15 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows website title on events page", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Events Site");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Events Site");
       await createTestEvent({ name: "Concert", maxAttendees: 100 });
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(response, 200, "My Events Site");
     });
 
     test("shows public nav on events page", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(
         response,
@@ -317,7 +311,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("returns 404 for POST requests", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(
         mockFormRequest("/events", { name: "Test" }),
       );
@@ -325,7 +319,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/events"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -340,8 +334,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows terms page when enabled", async () => {
-      await updateShowPublicSite(true);
-      await updateTermsAndConditions("Our terms and conditions.");
+      await settings.showPublicSite.update(true);
+      await settings.terms.update("Our terms and conditions.");
       const response = await handleRequest(mockRequest("/terms"));
       await expectHtmlResponse(
         response,
@@ -352,20 +346,20 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows no content when terms not configured", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/terms"));
       await expectHtmlResponse(response, 200, "No content.");
     });
 
     test("shows website title on terms page", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Site");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Site");
       const response = await handleRequest(mockRequest("/terms"));
       await expectHtmlResponse(response, 200, "My Site");
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/terms"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -380,8 +374,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows contact page when enabled", async () => {
-      await updateShowPublicSite(true);
-      await updateContactPageText("Get in touch with us");
+      await settings.showPublicSite.update(true);
+      await settings.contactPageText.update("Get in touch with us");
       const response = await handleRequest(mockRequest("/contact"));
       await expectHtmlResponse(
         response,
@@ -392,21 +386,23 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("shows no content when contact text not configured", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/contact"));
       await expectHtmlResponse(response, 200, "No content.");
     });
 
     test("shows website title on contact page", async () => {
-      await updateShowPublicSite(true);
-      await updateWebsiteTitle("My Site");
+      await settings.showPublicSite.update(true);
+      await settings.websiteTitle.update("My Site");
       const response = await handleRequest(mockRequest("/contact"));
       await expectHtmlResponse(response, 200, "My Site");
     });
 
     test("renders markdown paragraphs in contact text", async () => {
-      await updateShowPublicSite(true);
-      await updateContactPageText("Phone: 123\n\nAddress: 1 High Street");
+      await settings.showPublicSite.update(true);
+      await settings.contactPageText.update(
+        "Phone: 123\n\nAddress: 1 High Street",
+      );
       const response = await handleRequest(mockRequest("/contact"));
       const html = await expectHtmlResponse(response, 200, "Phone: 123");
       expect(html).toContain("<p>Phone: 123</p>");
@@ -421,7 +417,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await handleRequest(mockRequest("/contact"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -969,7 +965,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("group terms override global terms", async () => {
-      await updateTermsAndConditions("GLOBAL TERMS UNIQUE");
+      await settings.terms.update("GLOBAL TERMS UNIQUE");
       const group = await createTestGroup({
         name: "Terms Group",
         slug: "terms-group",
@@ -990,7 +986,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("group terms fall back to global when group terms are empty", async () => {
-      await updateTermsAndConditions("GLOBAL FALLBACK UNIQUE");
+      await settings.terms.update("GLOBAL FALLBACK UNIQUE");
       const group = await createTestGroup({
         name: "Fallback Group",
         slug: "fallback-group",
@@ -2264,8 +2260,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
 
       // Now clear the provider to simulate no provider
-      const { clearPaymentProvider } = await import("#lib/db/settings.ts");
-      await clearPaymentProvider();
+      const { settings: s } = await import("#lib/db/settings.ts");
+      await s.paymentProvider.clear();
 
       const path = `/ticket/${event1.slug}+${event2.slug}`;
       const getResponse = await handleRequest(mockRequest(path));
@@ -3488,7 +3484,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("terms and conditions (single ticket)", () => {
     test("shows terms checkbox when terms are configured", async () => {
-      await updateTermsAndConditions("I agree to the event rules.");
+      await settings.terms.update("I agree to the event rules.");
 
       const event = await createTestEvent({ maxAttendees: 50 });
       const response = await handleRequest(
@@ -3514,7 +3510,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("rejects submission without agreeing to terms", async () => {
-      await updateTermsAndConditions("You must accept the rules.");
+      await settings.terms.update("You must accept the rules.");
 
       const event = await createTestEvent({ maxAttendees: 50 });
       const response = await submitTicketForm(event.slug, {
@@ -3529,7 +3525,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("accepts submission when terms are agreed to", async () => {
-      await updateTermsAndConditions("You must accept the rules.");
+      await settings.terms.update("You must accept the rules.");
 
       const event = await createTestEvent({
         maxAttendees: 50,
@@ -3558,7 +3554,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("terms and conditions (multi-ticket)", () => {
     test("shows terms checkbox on multi-ticket page when configured", async () => {
-      await updateTermsAndConditions("Multi-event terms apply.");
+      await settings.terms.update("Multi-event terms apply.");
 
       const event1 = await createTestEvent({
         name: "TC Multi 1",
@@ -3580,7 +3576,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("rejects multi-ticket submission without agreeing to terms", async () => {
-      await updateTermsAndConditions("Must agree to policy.");
+      await settings.terms.update("Must agree to policy.");
 
       const event1 = await createTestEvent({
         name: "TC Multi Rej 1",
@@ -3617,7 +3613,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("accepts multi-ticket submission when terms are agreed to", async () => {
-      await updateTermsAndConditions("Must agree to policy.");
+      await settings.terms.update("Must agree to policy.");
 
       const event1 = await createTestEvent({
         name: "TC Multi Ok 1",

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -100,7 +100,7 @@ const withRefundMock = async (
   await withMocks(
     () =>
       stub(paymentsApi, "getConfiguredProvider", () =>
-        Promise.resolve(mockProviderType("stripe")),
+        mockProviderType("stripe"),
       ),
     async () => {
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -435,14 +435,14 @@ describeWithEnv("QR Scanner", { db: true }, () => {
 
     test("returns 500 when private key is unavailable", async () => {
       const { getDb } = await import("#lib/db/client.ts");
-      const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
+      const { settings: s } = await import("#lib/db/settings.ts");
 
       // Remove wrapped_private_key from settings to make key derivation fail
       await getDb().execute({
         sql: "DELETE FROM settings WHERE key = 'wrapped_private_key'",
         args: [],
       });
-      invalidateSettingsCache();
+      s.invalidateCache();
 
       const { response } = await setupLoginAndScan({ token: "some-token" });
 

--- a/test/lib/server-seeds.test.ts
+++ b/test/lib/server-seeds.test.ts
@@ -3,7 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { getAttendeesRaw } from "#lib/db/attendees.ts";
 import { getDb } from "#lib/db/client.ts";
 import { getAllEvents } from "#lib/db/events.ts";
-import { invalidateSettingsCache } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { createSeeds, SEED_MAX_ATTENDEES } from "#lib/seeds.ts";
 import { handleRequest } from "#routes";
 import { MAX_SEED_EVENTS } from "#routes/admin/seeds.ts";
@@ -235,7 +235,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
     test("redirects with error when seed creation fails", async () => {
       // Remove public key to cause createSeeds to fail
       await getDb().execute("DELETE FROM settings WHERE key = 'public_key'");
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       const response = await handleRequest(
         mockFormRequest(
@@ -294,7 +294,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
     test("throws when public key is not configured", async () => {
       // Remove public key to cause createSeeds to throw
       await getDb().execute("DELETE FROM settings WHERE key = 'public_key'");
-      invalidateSettingsCache();
+      settings.invalidateCache();
 
       await expect(createSeeds(1, 0)).rejects.toThrow(
         "Public key not configured",

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -171,7 +171,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
     test("setting persists in database", async () => {
       const { settings } = await import("#lib/db/settings.ts");
 
-      expect(await settings.showPublicApi.get()).toBe(false);
+      expect(settings.showPublicApi).toBe(false);
 
       await handleRequest(
         mockFormRequest(
@@ -184,7 +184,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         ),
       );
 
-      expect(await settings.showPublicApi.get()).toBe(true);
+      expect(settings.showPublicApi).toBe(true);
     });
 
     test("advanced settings page displays enable public API section", async () => {
@@ -354,9 +354,9 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
     test("shows error when no business email set", async () => {
       const { settings } = await import("#lib/db/settings.ts");
 
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("re_test_key");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("re_test_key");
+      await settings.update.email.fromAddress("from@test.com");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -375,9 +375,9 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         "#lib/business-email.ts"
       );
 
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("re_test_key");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("re_test_key");
+      await settings.update.email.fromAddress("from@test.com");
       await setBizEmail("admin@test.com");
       settings.invalidateCache();
 
@@ -407,9 +407,9 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         "#lib/business-email.ts"
       );
 
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("re_test_key");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("re_test_key");
+      await settings.update.email.fromAddress("from@test.com");
       await setBizEmail("admin@test.com");
       settings.invalidateCache();
 
@@ -440,9 +440,9 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         "#lib/business-email.ts"
       );
 
-      await settings.email.provider.update("resend");
-      await settings.email.apiKey.update("re_test_key");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("re_test_key");
+      await settings.update.email.fromAddress("from@test.com");
       await setBizEmail("admin@test.com");
       settings.invalidateCache();
 
@@ -472,8 +472,8 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
     test("shows email provider when configured", async () => {
       const { settings } = await import("#lib/db/settings.ts");
 
-      await settings.email.provider.update("resend");
-      await settings.email.fromAddress.update("from@test.com");
+      await settings.update.email.provider("resend");
+      await settings.update.email.fromAddress("from@test.com");
 
       const response = await awaitTestRequest("/admin/settings-advanced", {
         cookie: await testCookie(),
@@ -626,7 +626,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
       test("shows validate form and CNAME instructions when custom domain is saved", async () => {
         setBunnyEnv();
-        await settings.customDomain.update("tickets.example.com");
+        await settings.update.customDomain("tickets.example.com");
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
         });
@@ -640,7 +640,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
       test("shows warning when custom domain is not validated", async () => {
         setBunnyEnv();
-        await settings.customDomain.update("tickets.example.com");
+        await settings.update.customDomain("tickets.example.com");
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
         });
@@ -651,8 +651,8 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
       test("does not show warning when custom domain is validated", async () => {
         setBunnyEnv();
-        await settings.customDomain.update("tickets.example.com");
-        await settings.customDomain.lastValidated.update();
+        await settings.update.customDomain("tickets.example.com");
+        await settings.update.customDomainLastValidated();
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
         });
@@ -666,8 +666,8 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         // then re-format the cookie for the secure domain cookie name.
         const cookie = await testCookie();
         const token = cookie.split("=").slice(1).join("=");
-        await settings.customDomain.update("tickets.example.com");
-        await settings.customDomain.lastValidated.update();
+        await settings.update.customDomain("tickets.example.com");
+        await settings.update.customDomainLastValidated();
         const response = await handleRequest(
           mockRequestWithHost(
             "/admin/settings-advanced",
@@ -718,12 +718,8 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
               response,
               expect.stringContaining("Custom domain saved and validated"),
             );
-            expect(await settings.customDomain.get()).toBe(
-              "tickets.example.com",
-            );
-            expect(
-              await settings.customDomain.lastValidated.get(),
-            ).not.toBeNull();
+            expect(settings.customDomain).toBe("tickets.example.com");
+            expect(settings.customDomainLastValidated).not.toBeNull();
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
           }
@@ -759,10 +755,8 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
               expect.stringContaining("DNS not configured"),
               false,
             );
-            expect(await settings.customDomain.get()).toBe(
-              "tickets.example.com",
-            );
-            expect(await settings.customDomain.lastValidated.get()).toBeNull();
+            expect(settings.customDomain).toBe("tickets.example.com");
+            expect(settings.customDomainLastValidated).toBeNull();
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
           }
@@ -784,9 +778,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
                 await testCookie(),
               ),
             );
-            expect(await settings.customDomain.get()).toBe(
-              "tickets.example.com",
-            );
+            expect(settings.customDomain).toBe("tickets.example.com");
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
           }
@@ -794,7 +786,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
         test("clears custom domain when empty", async () => {
           setBunnyEnv();
-          await settings.customDomain.update("tickets.example.com");
+          await settings.update.customDomain("tickets.example.com");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain",
@@ -810,12 +802,12 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
             response,
             expect.stringContaining("Custom domain cleared"),
           );
-          expect(await settings.customDomain.get()).toBeNull();
+          expect(settings.customDomain).toBeNull();
         });
 
         test("clears domain when field is missing from form", async () => {
           setBunnyEnv();
-          await settings.customDomain.update("tickets.example.com");
+          await settings.update.customDomain("tickets.example.com");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain",
@@ -830,7 +822,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
             response,
             expect.stringContaining("Custom domain cleared"),
           );
-          expect(await settings.customDomain.get()).toBeNull();
+          expect(settings.customDomain).toBeNull();
         });
 
         test("rejects invalid domain format", async () => {
@@ -932,7 +924,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
         test("calls Bunny API and saves timestamp on success", async () => {
           setBunnyEnv();
-          await settings.customDomain.update("tickets.example.com");
+          await settings.update.customDomain("tickets.example.com");
           const original = bunnyCdnApi.validateCustomDomain;
           bunnyCdnApi.validateCustomDomain = () =>
             Promise.resolve({ ok: true as const });
@@ -951,8 +943,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
               response,
               expect.stringContaining("Custom domain validated successfully"),
             );
-            const lastValidated =
-              await settings.customDomain.lastValidated.get();
+            const lastValidated = settings.customDomainLastValidated;
             expect(lastValidated).not.toBeNull();
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
@@ -961,7 +952,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
         test("returns error when Bunny API fails", async () => {
           setBunnyEnv();
-          await settings.customDomain.update("tickets.example.com");
+          await settings.update.customDomain("tickets.example.com");
           const original = bunnyCdnApi.validateCustomDomain;
           bunnyCdnApi.validateCustomDomain = () =>
             Promise.resolve({
@@ -986,7 +977,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
         test("logs activity on successful validation", async () => {
           setBunnyEnv();
-          await settings.customDomain.update("tickets.example.com");
+          await settings.update.customDomain("tickets.example.com");
           const original = bunnyCdnApi.validateCustomDomain;
           bunnyCdnApi.validateCustomDomain = () =>
             Promise.resolve({ ok: true as const });

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -4,12 +4,7 @@ import { stub } from "@std/testing/mock";
 import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
-import {
-  getCustomDomainFromDb,
-  getCustomDomainLastValidatedFromDb,
-  updateCustomDomain,
-  updateCustomDomainLastValidated,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { handleRequest } from "#routes";
 import {
@@ -183,9 +178,9 @@ describe("server (admin settings-advanced)", () => {
     });
 
     test("setting persists in database", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
-      expect(await settingsApi.getShowPublicApiFromDb()).toBe(false);
+      expect(await settings.showPublicApi.get()).toBe(false);
 
       await handleRequest(
         mockFormRequest(
@@ -198,7 +193,7 @@ describe("server (admin settings-advanced)", () => {
         ),
       );
 
-      expect(await settingsApi.getShowPublicApiFromDb()).toBe(true);
+      expect(await settings.showPublicApi.get()).toBe(true);
     });
 
     test("advanced settings page displays enable public API section", async () => {
@@ -366,11 +361,11 @@ describe("server (admin settings-advanced)", () => {
     });
 
     test("shows error when no business email set", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("re_test_key");
+      await settings.email.fromAddress.update("from@test.com");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -384,16 +379,16 @@ describe("server (admin settings-advanced)", () => {
     });
 
     test("sends test email and redirects with success including status code", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
       const { updateBusinessEmail: setBizEmail } = await import(
         "#lib/business-email.ts"
       );
 
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("re_test_key");
+      await settings.email.fromAddress.update("from@test.com");
       await setBizEmail("admin@test.com");
-      settingsApi.invalidateSettingsCache();
+      settings.invalidateCache();
 
       await withMocks(
         () => stub(globalThis, "fetch", () => Promise.resolve(new Response())),
@@ -416,16 +411,16 @@ describe("server (admin settings-advanced)", () => {
     });
 
     test("shows error when email API returns non-2xx status", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
       const { updateBusinessEmail: setBizEmail } = await import(
         "#lib/business-email.ts"
       );
 
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("re_test_key");
+      await settings.email.fromAddress.update("from@test.com");
       await setBizEmail("admin@test.com");
-      settingsApi.invalidateSettingsCache();
+      settings.invalidateCache();
 
       await withMocks(
         () =>
@@ -449,16 +444,16 @@ describe("server (admin settings-advanced)", () => {
     });
 
     test("shows error when email send encounters network error", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
       const { updateBusinessEmail: setBizEmail } = await import(
         "#lib/business-email.ts"
       );
 
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_test_key");
-      await settingsApi.updateEmailFromAddress("from@test.com");
+      await settings.email.provider.update("resend");
+      await settings.email.apiKey.update("re_test_key");
+      await settings.email.fromAddress.update("from@test.com");
       await setBizEmail("admin@test.com");
-      settingsApi.invalidateSettingsCache();
+      settings.invalidateCache();
 
       await withMocks(
         () =>
@@ -484,10 +479,10 @@ describe("server (admin settings-advanced)", () => {
 
   describe("settings-advanced page email provider display", () => {
     test("shows email provider when configured", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailFromAddress("from@test.com");
+      await settings.email.provider.update("resend");
+      await settings.email.fromAddress.update("from@test.com");
 
       const response = await awaitTestRequest("/admin/settings-advanced", {
         cookie: await testCookie(),
@@ -640,7 +635,7 @@ describe("server (admin settings-advanced)", () => {
 
       test("shows validate form and CNAME instructions when custom domain is saved", async () => {
         setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
+        await settings.customDomain.update("tickets.example.com");
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
         });
@@ -654,7 +649,7 @@ describe("server (admin settings-advanced)", () => {
 
       test("shows warning when custom domain is not validated", async () => {
         setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
+        await settings.customDomain.update("tickets.example.com");
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
         });
@@ -665,8 +660,8 @@ describe("server (admin settings-advanced)", () => {
 
       test("does not show warning when custom domain is validated", async () => {
         setBunnyEnv();
-        await updateCustomDomain("tickets.example.com");
-        await updateCustomDomainLastValidated();
+        await settings.customDomain.update("tickets.example.com");
+        await settings.customDomain.lastValidated.update();
         const response = await awaitTestRequest("/admin/settings-advanced", {
           cookie: await testCookie(),
         });
@@ -680,8 +675,8 @@ describe("server (admin settings-advanced)", () => {
         // then re-format the cookie for the secure domain cookie name.
         const cookie = await testCookie();
         const token = cookie.split("=").slice(1).join("=");
-        await updateCustomDomain("tickets.example.com");
-        await updateCustomDomainLastValidated();
+        await settings.customDomain.update("tickets.example.com");
+        await settings.customDomain.lastValidated.update();
         const response = await handleRequest(
           mockRequestWithHost(
             "/admin/settings-advanced",
@@ -732,8 +727,12 @@ describe("server (admin settings-advanced)", () => {
               response,
               expect.stringContaining("Custom domain saved and validated"),
             );
-            expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-            expect(await getCustomDomainLastValidatedFromDb()).not.toBeNull();
+            expect(await settings.customDomain.get()).toBe(
+              "tickets.example.com",
+            );
+            expect(
+              await settings.customDomain.lastValidated.get(),
+            ).not.toBeNull();
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
           }
@@ -769,8 +768,10 @@ describe("server (admin settings-advanced)", () => {
               expect.stringContaining("DNS not configured"),
               false,
             );
-            expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
-            expect(await getCustomDomainLastValidatedFromDb()).toBeNull();
+            expect(await settings.customDomain.get()).toBe(
+              "tickets.example.com",
+            );
+            expect(await settings.customDomain.lastValidated.get()).toBeNull();
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
           }
@@ -792,7 +793,9 @@ describe("server (admin settings-advanced)", () => {
                 await testCookie(),
               ),
             );
-            expect(await getCustomDomainFromDb()).toBe("tickets.example.com");
+            expect(await settings.customDomain.get()).toBe(
+              "tickets.example.com",
+            );
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
           }
@@ -800,7 +803,7 @@ describe("server (admin settings-advanced)", () => {
 
         test("clears custom domain when empty", async () => {
           setBunnyEnv();
-          await updateCustomDomain("tickets.example.com");
+          await settings.customDomain.update("tickets.example.com");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain",
@@ -816,12 +819,12 @@ describe("server (admin settings-advanced)", () => {
             response,
             expect.stringContaining("Custom domain cleared"),
           );
-          expect(await getCustomDomainFromDb()).toBeNull();
+          expect(await settings.customDomain.get()).toBeNull();
         });
 
         test("clears domain when field is missing from form", async () => {
           setBunnyEnv();
-          await updateCustomDomain("tickets.example.com");
+          await settings.customDomain.update("tickets.example.com");
           const response = await handleRequest(
             mockFormRequest(
               "/admin/settings/custom-domain",
@@ -836,7 +839,7 @@ describe("server (admin settings-advanced)", () => {
             response,
             expect.stringContaining("Custom domain cleared"),
           );
-          expect(await getCustomDomainFromDb()).toBeNull();
+          expect(await settings.customDomain.get()).toBeNull();
         });
 
         test("rejects invalid domain format", async () => {
@@ -938,7 +941,7 @@ describe("server (admin settings-advanced)", () => {
 
         test("calls Bunny API and saves timestamp on success", async () => {
           setBunnyEnv();
-          await updateCustomDomain("tickets.example.com");
+          await settings.customDomain.update("tickets.example.com");
           const original = bunnyCdnApi.validateCustomDomain;
           bunnyCdnApi.validateCustomDomain = () =>
             Promise.resolve({ ok: true as const });
@@ -957,7 +960,8 @@ describe("server (admin settings-advanced)", () => {
               response,
               expect.stringContaining("Custom domain validated successfully"),
             );
-            const lastValidated = await getCustomDomainLastValidatedFromDb();
+            const lastValidated =
+              await settings.customDomain.lastValidated.get();
             expect(lastValidated).not.toBeNull();
           } finally {
             bunnyCdnApi.validateCustomDomain = original;
@@ -966,7 +970,7 @@ describe("server (admin settings-advanced)", () => {
 
         test("returns error when Bunny API fails", async () => {
           setBunnyEnv();
-          await updateCustomDomain("tickets.example.com");
+          await settings.customDomain.update("tickets.example.com");
           const original = bunnyCdnApi.validateCustomDomain;
           bunnyCdnApi.validateCustomDomain = () =>
             Promise.resolve({
@@ -991,7 +995,7 @@ describe("server (admin settings-advanced)", () => {
 
         test("logs activity on successful validation", async () => {
           setBunnyEnv();
-          await updateCustomDomain("tickets.example.com");
+          await settings.customDomain.update("tickets.example.com");
           const original = bunnyCdnApi.validateCustomDomain;
           bunnyCdnApi.validateCustomDomain = () =>
             Promise.resolve({ ok: true as const });

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -4,12 +4,7 @@ import { stub } from "@std/testing/mock";
 import { getSessionCookieName } from "#lib/cookies.ts";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { eventsTable } from "#lib/db/events.ts";
-import {
-  getEmbedHostsFromDb,
-  setPaymentProvider,
-  updateStripeKey,
-  updateTermsAndConditions,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { squareApi } from "#lib/square.ts";
@@ -327,7 +322,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects invalid stripe key format", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/stripe",
@@ -348,7 +343,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects restricted key format", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/stripe",
@@ -393,7 +388,7 @@ describe("server (admin settings)", () => {
     });
 
     test("settings page shows Stripe is not configured initially", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -508,8 +503,8 @@ describe("server (admin settings)", () => {
 
     test("backfills mode indicator when key exists but mode was never stored", async () => {
       // Simulate pre-sentinel setup: key stored directly without mode
-      await updateStripeKey("sk_test_backfill");
-      await setPaymentProvider("stripe");
+      await settings.stripe.secretKey.update("sk_test_backfill");
+      await settings.paymentProvider.set("stripe");
 
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
@@ -666,7 +661,7 @@ describe("server (admin settings)", () => {
         response,
         expect.stringContaining("Embed host restrictions removed"),
       );
-      expect(await getEmbedHostsFromDb()).toBe(null);
+      expect(await settings.embedHosts.get()).toBe(null);
     });
 
     test("rejects invalid embed host pattern", async () => {
@@ -698,7 +693,7 @@ describe("server (admin settings)", () => {
         response,
         expect.stringContaining("Allowed embed hosts updated"),
       );
-      expect(await getEmbedHostsFromDb()).toBe(
+      expect(await settings.embedHosts.get()).toBe(
         "example.com, *.sub.example.com",
       );
     });
@@ -781,7 +776,7 @@ describe("server (admin settings)", () => {
     });
 
     test("settings page shows Square is not configured initially", async () => {
-      await setPaymentProvider("square");
+      await settings.paymentProvider.set("square");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -1075,7 +1070,7 @@ describe("server (admin settings)", () => {
       );
 
       try {
-        await setPaymentProvider("stripe");
+        await settings.paymentProvider.set("stripe");
 
         const response = await handleRequest(
           mockFormRequest(
@@ -1268,7 +1263,7 @@ describe("server (admin settings)", () => {
     });
 
     test("settings page shows current terms when configured", async () => {
-      await updateTermsAndConditions("You must be 18 or older.");
+      await settings.terms.update("You must be 18 or older.");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -1278,9 +1273,8 @@ describe("server (admin settings)", () => {
 
   describe("templates/admin/settings.tsx (Square webhook coverage)", () => {
     test("settings page shows Square webhook config when square provider set", async () => {
-      await setPaymentProvider("square");
-      const { updateSquareAccessToken } = await import("#lib/db/settings.ts");
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.paymentProvider.set("square");
+      await settings.square.accessToken.update("EAAAl_test_123");
 
       const response = await handleRequest(
         new Request("http://localhost/admin/settings", {
@@ -1294,11 +1288,9 @@ describe("server (admin settings)", () => {
     });
 
     test("settings page shows Square webhook configured message", async () => {
-      await setPaymentProvider("square");
-      const { updateSquareAccessToken, updateSquareWebhookSignatureKey } =
-        await import("#lib/db/settings.ts");
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareWebhookSignatureKey("sig_key_test");
+      await settings.paymentProvider.set("square");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.webhookSignatureKey.update("sig_key_test");
 
       const response = await handleRequest(
         new Request("http://localhost/admin/settings", {
@@ -1740,10 +1732,10 @@ describe("server (admin settings)", () => {
     });
 
     test("theme setting persists in database", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
       // Initially should be "light"
-      expect(await settingsApi.getThemeFromDb()).toBe("light");
+      expect(await settings.theme.get()).toBe("light");
 
       // Update to dark
       await handleRequest(
@@ -1758,14 +1750,14 @@ describe("server (admin settings)", () => {
       );
 
       // Should now be "dark"
-      expect(await settingsApi.getThemeFromDb()).toBe("dark");
+      expect(await settings.theme.get()).toBe("dark");
     });
 
     test("settings page displays current theme selection", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
       // Set theme to dark
-      await settingsApi.updateTheme("dark");
+      await settings.theme.update("dark");
 
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
@@ -1835,10 +1827,10 @@ describe("server (admin settings)", () => {
     });
 
     test("setting persists in database", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
       // Initially should be false
-      expect(await settingsApi.getShowPublicSiteFromDb()).toBe(false);
+      expect(await settings.showPublicSite.get()).toBe(false);
 
       // Enable it
       await handleRequest(
@@ -1852,7 +1844,7 @@ describe("server (admin settings)", () => {
         ),
       );
 
-      expect(await settingsApi.getShowPublicSiteFromDb()).toBe(true);
+      expect(await settings.showPublicSite.get()).toBe(true);
     });
 
     test("settings page displays show public site section", async () => {
@@ -1938,10 +1930,10 @@ describe("server (admin settings)", () => {
     });
 
     test("setting persists and derives phone prefix", async () => {
-      const { settingsApi } = await import("#lib/db/settings.ts");
+      const { settings } = await import("#lib/db/settings.ts");
 
       // Default should be GB → "44"
-      expect(await settingsApi.getPhonePrefixFromDb()).toBe("44");
+      expect(await settings.phonePrefix.get()).toBe("44");
 
       // Update to US
       await handleRequest(
@@ -1955,9 +1947,9 @@ describe("server (admin settings)", () => {
         ),
       );
 
-      expect(await settingsApi.getCountryFromDb()).toBe("US");
-      expect(await settingsApi.getPhonePrefixFromDb()).toBe("1");
-      expect(await settingsApi.getCurrencyCodeFromDb()).toBe("USD");
+      expect(await settings.country.get()).toBe("US");
+      expect(await settings.phonePrefix.get()).toBe("1");
+      expect(await settings.currency.get()).toBe("USD");
     });
 
     test("settings page displays country form", async () => {
@@ -2012,8 +2004,8 @@ describe("server (admin settings)", () => {
         expect.stringContaining("Booking fee updated to 1.5%"),
       );
 
-      const { settingsApi } = await import("#lib/db/settings.ts");
-      expect(await settingsApi.getBookingFeeFromDb()).toBe("1.5");
+      const { settings } = await import("#lib/db/settings.ts");
+      expect(await settings.bookingFee.get()).toBe("1.5");
     });
 
     test("saves zero booking fee", async () => {
@@ -2035,7 +2027,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects value exceeding 10", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2054,7 +2046,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects negative value", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2073,7 +2065,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects non-numeric value", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2092,7 +2084,7 @@ describe("server (admin settings)", () => {
     });
 
     test("settings page displays booking fee form when payment provider is set", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -2108,7 +2100,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects missing booking_fee field", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2147,7 +2139,7 @@ describe("server (admin settings)", () => {
   describe("sensitive field masking", () => {
     test("shows mask sentinel for configured Stripe key", async () => {
       const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
 
       await withMocks(
         () =>
@@ -2184,7 +2176,7 @@ describe("server (admin settings)", () => {
 
     test("shows mask sentinel for configured Square token", async () => {
       const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
-      await setPaymentProvider("square");
+      await settings.paymentProvider.set("square");
 
       // Configure Square credentials
       await handleRequest(
@@ -2208,12 +2200,12 @@ describe("server (admin settings)", () => {
     });
 
     test("shows mask sentinel for configured email API key", async () => {
-      const { MASK_SENTINEL, settingsApi } = await import(
+      const { MASK_SENTINEL, settings: s } = await import(
         "#lib/db/settings.ts"
       );
 
-      await settingsApi.updateEmailProvider("resend");
-      await settingsApi.updateEmailApiKey("re_real_secret_key");
+      await s.email.provider.update("resend");
+      await s.email.apiKey.update("re_real_secret_key");
 
       const response = await awaitTestRequest("/admin/settings-advanced", {
         cookie: await testCookie(),
@@ -2224,10 +2216,10 @@ describe("server (admin settings)", () => {
     });
 
     test("submitting sentinel for Stripe key does not overwrite existing key", async () => {
-      const { MASK_SENTINEL, getStripeSecretKeyFromDb } = await import(
+      const { MASK_SENTINEL, settings: s } = await import(
         "#lib/db/settings.ts"
       );
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
 
       await withMocks(
         () =>
@@ -2265,18 +2257,16 @@ describe("server (admin settings)", () => {
 
           expect(response.status).toBe(302);
           expectFlash(response, expect.stringContaining("unchanged"));
-          expect(await getStripeSecretKeyFromDb()).toBe("sk_test_original");
+          expect(await s.stripe.secretKey.get()).toBe("sk_test_original");
         },
       );
     });
 
     test("submitting sentinel for Square token preserves token but updates location", async () => {
-      const {
-        MASK_SENTINEL,
-        getSquareAccessTokenFromDb,
-        getSquareLocationIdFromDb,
-      } = await import("#lib/db/settings.ts");
-      await setPaymentProvider("square");
+      const { MASK_SENTINEL, settings: s } = await import(
+        "#lib/db/settings.ts"
+      );
+      await settings.paymentProvider.set("square");
 
       // Configure Square credentials
       await handleRequest(
@@ -2305,8 +2295,8 @@ describe("server (admin settings)", () => {
       );
 
       expect(response.status).toBe(302);
-      expect(await getSquareAccessTokenFromDb()).toBe("EAAAl_original");
-      expect(await getSquareLocationIdFromDb()).toBe("L_updated");
+      expect(await s.square.accessToken.get()).toBe("EAAAl_original");
+      expect(await s.square.locationId.get()).toBe("L_updated");
     });
 
     test("submitting sentinel for Square webhook key does not overwrite", async () => {
@@ -2341,7 +2331,7 @@ describe("server (admin settings)", () => {
     });
 
     test("submitting sentinel for email API key does not overwrite existing key", async () => {
-      const { MASK_SENTINEL, getEmailApiKeyFromDb } = await import(
+      const { MASK_SENTINEL, settings: s } = await import(
         "#lib/db/settings.ts"
       );
 
@@ -2373,12 +2363,12 @@ describe("server (admin settings)", () => {
       );
 
       expect(response.status).toBe(302);
-      expect(await getEmailApiKeyFromDb()).toBe("re_original_key");
+      expect(await s.email.apiKey.get()).toBe("re_original_key");
     });
 
     test("submitting new value still updates the key", async () => {
-      const { getStripeSecretKeyFromDb } = await import("#lib/db/settings.ts");
-      await setPaymentProvider("stripe");
+      const { settings: s } = await import("#lib/db/settings.ts");
+      await settings.paymentProvider.set("stripe");
 
       await withMocks(
         () =>
@@ -2414,14 +2404,14 @@ describe("server (admin settings)", () => {
             ),
           );
 
-          expect(await getStripeSecretKeyFromDb()).toBe("sk_test_new");
+          expect(await s.stripe.secretKey.get()).toBe("sk_test_new");
         },
       );
     });
 
     test("empty Stripe key with existing key is a no-op", async () => {
-      const { getStripeSecretKeyFromDb } = await import("#lib/db/settings.ts");
-      await setPaymentProvider("stripe");
+      const { settings: s } = await import("#lib/db/settings.ts");
+      await settings.paymentProvider.set("stripe");
 
       await withMocks(
         () =>
@@ -2456,13 +2446,13 @@ describe("server (admin settings)", () => {
 
           expect(response.status).toBe(302);
           expectFlash(response, expect.stringContaining("unchanged"));
-          expect(await getStripeSecretKeyFromDb()).toBe("sk_test_keep_me");
+          expect(await s.stripe.secretKey.get()).toBe("sk_test_keep_me");
         },
       );
     });
 
     test("empty Stripe key rejected when no key is configured", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2476,7 +2466,7 @@ describe("server (admin settings)", () => {
     });
 
     test("empty Square token rejected when no token is configured", async () => {
-      await setPaymentProvider("square");
+      await settings.paymentProvider.set("square");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2519,7 +2509,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects Stripe key configuration", async () => {
-      await setPaymentProvider("stripe");
+      await settings.paymentProvider.set("stripe");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2540,7 +2530,7 @@ describe("server (admin settings)", () => {
     });
 
     test("rejects Square credentials configuration", async () => {
-      await setPaymentProvider("square");
+      await settings.paymentProvider.set("square");
 
       const response = await handleRequest(
         mockFormRequest(

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -314,7 +314,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects invalid stripe key format", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/stripe",
@@ -335,7 +335,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects restricted key format", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/stripe",
@@ -380,7 +380,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("settings page shows Stripe is not configured initially", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -495,8 +495,8 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
 
     test("backfills mode indicator when key exists but mode was never stored", async () => {
       // Simulate pre-sentinel setup: key stored directly without mode
-      await settings.stripe.secretKey.update("sk_test_backfill");
-      await settings.paymentProvider.set("stripe");
+      await settings.update.stripe.secretKey("sk_test_backfill");
+      await settings.update.paymentProvider("stripe");
 
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
@@ -653,7 +653,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         response,
         expect.stringContaining("Embed host restrictions removed"),
       );
-      expect(await settings.embedHosts.get()).toBe(null);
+      expect(settings.embedHosts).toBe(null);
     });
 
     test("rejects invalid embed host pattern", async () => {
@@ -685,9 +685,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         response,
         expect.stringContaining("Allowed embed hosts updated"),
       );
-      expect(await settings.embedHosts.get()).toBe(
-        "example.com, *.sub.example.com",
-      );
+      expect(settings.embedHosts).toBe("example.com, *.sub.example.com");
     });
   });
 
@@ -768,7 +766,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("settings page shows Square is not configured initially", async () => {
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -1062,7 +1060,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       );
 
       try {
-        await settings.paymentProvider.set("stripe");
+        await settings.update.paymentProvider("stripe");
 
         const response = await handleRequest(
           mockFormRequest(
@@ -1255,7 +1253,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("settings page shows current terms when configured", async () => {
-      await settings.terms.update("You must be 18 or older.");
+      await settings.update.terms("You must be 18 or older.");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -1265,8 +1263,8 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
 
   describe("templates/admin/settings.tsx (Square webhook coverage)", () => {
     test("settings page shows Square webhook config when square provider set", async () => {
-      await settings.paymentProvider.set("square");
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.paymentProvider("square");
+      await settings.update.square.accessToken("EAAAl_test_123");
 
       const response = await handleRequest(
         new Request("http://localhost/admin/settings", {
@@ -1280,9 +1278,9 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("settings page shows Square webhook configured message", async () => {
-      await settings.paymentProvider.set("square");
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.webhookSignatureKey.update("sig_key_test");
+      await settings.update.paymentProvider("square");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.webhookSignatureKey("sig_key_test");
 
       const response = await handleRequest(
         new Request("http://localhost/admin/settings", {
@@ -1727,7 +1725,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       const { settings } = await import("#lib/db/settings.ts");
 
       // Initially should be "light"
-      expect(await settings.theme.get()).toBe("light");
+      expect(settings.theme).toBe("light");
 
       // Update to dark
       await handleRequest(
@@ -1742,14 +1740,14 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       );
 
       // Should now be "dark"
-      expect(await settings.theme.get()).toBe("dark");
+      expect(settings.theme).toBe("dark");
     });
 
     test("settings page displays current theme selection", async () => {
       const { settings } = await import("#lib/db/settings.ts");
 
       // Set theme to dark
-      await settings.theme.update("dark");
+      await settings.update.theme("dark");
 
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
@@ -1822,7 +1820,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       const { settings } = await import("#lib/db/settings.ts");
 
       // Initially should be false
-      expect(await settings.showPublicSite.get()).toBe(false);
+      expect(settings.showPublicSite).toBe(false);
 
       // Enable it
       await handleRequest(
@@ -1836,7 +1834,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         ),
       );
 
-      expect(await settings.showPublicSite.get()).toBe(true);
+      expect(settings.showPublicSite).toBe(true);
     });
 
     test("settings page displays show public site section", async () => {
@@ -1925,7 +1923,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       const { settings } = await import("#lib/db/settings.ts");
 
       // Default should be GB → "44"
-      expect(await settings.phonePrefix.get()).toBe("44");
+      expect(settings.phonePrefix).toBe("44");
 
       // Update to US
       await handleRequest(
@@ -1939,9 +1937,9 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         ),
       );
 
-      expect(await settings.country.get()).toBe("US");
-      expect(await settings.phonePrefix.get()).toBe("1");
-      expect(await settings.currency.get()).toBe("USD");
+      expect(settings.country).toBe("US");
+      expect(settings.phonePrefix).toBe("1");
+      expect(settings.currency).toBe("USD");
     });
 
     test("settings page displays country form", async () => {
@@ -1997,7 +1995,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       );
 
       const { settings } = await import("#lib/db/settings.ts");
-      expect(await settings.bookingFee.get()).toBe("1.5");
+      expect(settings.bookingFee).toBe("1.5");
     });
 
     test("saves zero booking fee", async () => {
@@ -2019,7 +2017,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects value exceeding 10", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2038,7 +2036,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects negative value", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2057,7 +2055,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects non-numeric value", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2076,7 +2074,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("settings page displays booking fee form when payment provider is set", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await awaitTestRequest("/admin/settings", {
         cookie: await testCookie(),
       });
@@ -2092,7 +2090,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects missing booking_fee field", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/settings/booking-fee",
@@ -2131,7 +2129,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
   describe("sensitive field masking", () => {
     test("shows mask sentinel for configured Stripe key", async () => {
       const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
 
       await withMocks(
         () =>
@@ -2168,7 +2166,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
 
     test("shows mask sentinel for configured Square token", async () => {
       const { MASK_SENTINEL } = await import("#lib/db/settings.ts");
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
 
       // Configure Square credentials
       await handleRequest(
@@ -2196,8 +2194,8 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         "#lib/db/settings.ts"
       );
 
-      await s.email.provider.update("resend");
-      await s.email.apiKey.update("re_real_secret_key");
+      await s.update.email.provider("resend");
+      await s.update.email.apiKey("re_real_secret_key");
 
       const response = await awaitTestRequest("/admin/settings-advanced", {
         cookie: await testCookie(),
@@ -2211,7 +2209,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       const { MASK_SENTINEL, settings: s } = await import(
         "#lib/db/settings.ts"
       );
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
 
       await withMocks(
         () =>
@@ -2249,7 +2247,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
 
           expect(response.status).toBe(302);
           expectFlash(response, expect.stringContaining("unchanged"));
-          expect(await s.stripe.secretKey.get()).toBe("sk_test_original");
+          expect(s.stripe.secretKey).toBe("sk_test_original");
         },
       );
     });
@@ -2258,7 +2256,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       const { MASK_SENTINEL, settings: s } = await import(
         "#lib/db/settings.ts"
       );
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
 
       // Configure Square credentials
       await handleRequest(
@@ -2287,8 +2285,8 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       );
 
       expect(response.status).toBe(302);
-      expect(await s.square.accessToken.get()).toBe("EAAAl_original");
-      expect(await s.square.locationId.get()).toBe("L_updated");
+      expect(s.square.accessToken).toBe("EAAAl_original");
+      expect(s.square.locationId).toBe("L_updated");
     });
 
     test("submitting sentinel for Square webhook key does not overwrite", async () => {
@@ -2355,12 +2353,12 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       );
 
       expect(response.status).toBe(302);
-      expect(await s.email.apiKey.get()).toBe("re_original_key");
+      expect(s.email.apiKey).toBe("re_original_key");
     });
 
     test("submitting new value still updates the key", async () => {
       const { settings: s } = await import("#lib/db/settings.ts");
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
 
       await withMocks(
         () =>
@@ -2396,14 +2394,14 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
             ),
           );
 
-          expect(await s.stripe.secretKey.get()).toBe("sk_test_new");
+          expect(s.stripe.secretKey).toBe("sk_test_new");
         },
       );
     });
 
     test("empty Stripe key with existing key is a no-op", async () => {
       const { settings: s } = await import("#lib/db/settings.ts");
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
 
       await withMocks(
         () =>
@@ -2438,13 +2436,13 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
 
           expect(response.status).toBe(302);
           expectFlash(response, expect.stringContaining("unchanged"));
-          expect(await s.stripe.secretKey.get()).toBe("sk_test_keep_me");
+          expect(s.stripe.secretKey).toBe("sk_test_keep_me");
         },
       );
     });
 
     test("empty Stripe key rejected when no key is configured", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2458,7 +2456,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("empty Square token rejected when no token is configured", async () => {
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2501,7 +2499,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects Stripe key configuration", async () => {
-      await settings.paymentProvider.set("stripe");
+      await settings.update.paymentProvider("stripe");
 
       const response = await handleRequest(
         mockFormRequest(
@@ -2522,7 +2520,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects Square credentials configuration", async () => {
-      await settings.paymentProvider.set("square");
+      await settings.update.paymentProvider("square");
 
       const response = await handleRequest(
         mockFormRequest(

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -177,7 +177,7 @@ describe("server (setup)", () => {
 
       test("POST /setup/ returns 503 when completeSetup fails", async () => {
         const { stub } = await import("@std/testing/mock");
-        const { settingsApi } = await import("#lib/db/settings.ts");
+        const { settings } = await import("#lib/db/settings.ts");
 
         const getResponse = await handleRequest(mockRequest("/setup/"));
         const csrfToken = getSetupCsrfToken(await getResponse.text());
@@ -185,7 +185,7 @@ describe("server (setup)", () => {
         await withExpectedError(async () => {
           await withMocks(
             () => ({
-              mockCompleteSetup: stub(settingsApi, "completeSetup", () =>
+              mockCompleteSetup: stub(settings.setup, "complete", () =>
                 Promise.reject(new Error("Database error")),
               ),
               mockConsoleError: stub(console, "error", () => {}),

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -49,8 +49,8 @@ describeWithEnv("server (admin site)", { db: true }, () => {
     });
 
     test("displays existing values", async () => {
-      await settings.websiteTitle.update("My Events");
-      await settings.homepageText.update("Welcome!");
+      await settings.update.websiteTitle("My Events");
+      await settings.update.homepageText("Welcome!");
       const response = await awaitTestRequest("/admin/site", {
         cookie: await testCookie(),
       });
@@ -108,13 +108,13 @@ describeWithEnv("server (admin site)", { db: true }, () => {
       );
       expectRedirectContaining(response, "Homepage updated");
 
-      expect(await settings.websiteTitle.get()).toBe("My Site");
-      expect(await settings.homepageText.get()).toBe("Welcome!");
+      expect(settings.websiteTitle).toBe("My Site");
+      expect(settings.homepageText).toBe("Welcome!");
     });
 
     test("clears values when empty", async () => {
-      await settings.websiteTitle.update("Old Title");
-      await settings.homepageText.update("Old Text");
+      await settings.update.websiteTitle("Old Title");
+      await settings.update.homepageText("Old Text");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/site",
@@ -127,8 +127,8 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(await settings.websiteTitle.get()).toBe(null);
-      expect(await settings.homepageText.get()).toBe(null);
+      expect(settings.websiteTitle).toBe(null);
+      expect(settings.homepageText).toBe(null);
     });
 
     test("rejects title exceeding max length", async () => {
@@ -201,7 +201,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
     });
 
     test("displays existing contact text", async () => {
-      await settings.contactPageText.update("Call us!");
+      await settings.update.contactPageText("Call us!");
       const response = await awaitTestRequest("/admin/site/contact", {
         cookie: await testCookie(),
       });
@@ -252,11 +252,11 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         ),
       );
       expectRedirectContaining(response, "Contact page updated");
-      expect(await settings.contactPageText.get()).toBe("Email us!");
+      expect(settings.contactPageText).toBe("Email us!");
     });
 
     test("clears contact text when empty", async () => {
-      await settings.contactPageText.update("Old text");
+      await settings.update.contactPageText("Old text");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/site/contact",
@@ -265,7 +265,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(await settings.contactPageText.get()).toBe(null);
+      expect(settings.contactPageText).toBe(null);
     });
 
     test("rejects text exceeding max length", async () => {
@@ -322,7 +322,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
 
   describe("admin nav", () => {
     test("shows Site link when public site is enabled", async () => {
-      await settings.showPublicSite.update(true);
+      await settings.update.showPublicSite(true);
       const response = await awaitTestRequest("/admin/site", {
         cookie: await testCookie(),
       });

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -1,15 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
-  getContactPageTextFromDb,
-  getHomepageTextFromDb,
-  getWebsiteTitleFromDb,
   MAX_PAGE_TEXT_LENGTH,
   MAX_WEBSITE_TITLE_LENGTH,
-  updateContactPageText,
-  updateHomepageText,
-  updateShowPublicSite,
-  updateWebsiteTitle,
+  settings,
 } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
@@ -55,8 +49,8 @@ describeWithEnv("server (admin site)", { db: true }, () => {
     });
 
     test("displays existing values", async () => {
-      await updateWebsiteTitle("My Events");
-      await updateHomepageText("Welcome!");
+      await settings.websiteTitle.update("My Events");
+      await settings.homepageText.update("Welcome!");
       const response = await awaitTestRequest("/admin/site", {
         cookie: await testCookie(),
       });
@@ -114,13 +108,13 @@ describeWithEnv("server (admin site)", { db: true }, () => {
       );
       expectRedirectContaining(response, "Homepage updated");
 
-      expect(await getWebsiteTitleFromDb()).toBe("My Site");
-      expect(await getHomepageTextFromDb()).toBe("Welcome!");
+      expect(await settings.websiteTitle.get()).toBe("My Site");
+      expect(await settings.homepageText.get()).toBe("Welcome!");
     });
 
     test("clears values when empty", async () => {
-      await updateWebsiteTitle("Old Title");
-      await updateHomepageText("Old Text");
+      await settings.websiteTitle.update("Old Title");
+      await settings.homepageText.update("Old Text");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/site",
@@ -133,8 +127,8 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(await getWebsiteTitleFromDb()).toBe(null);
-      expect(await getHomepageTextFromDb()).toBe(null);
+      expect(await settings.websiteTitle.get()).toBe(null);
+      expect(await settings.homepageText.get()).toBe(null);
     });
 
     test("rejects title exceeding max length", async () => {
@@ -207,7 +201,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
     });
 
     test("displays existing contact text", async () => {
-      await updateContactPageText("Call us!");
+      await settings.contactPageText.update("Call us!");
       const response = await awaitTestRequest("/admin/site/contact", {
         cookie: await testCookie(),
       });
@@ -258,11 +252,11 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         ),
       );
       expectRedirectContaining(response, "Contact page updated");
-      expect(await getContactPageTextFromDb()).toBe("Email us!");
+      expect(await settings.contactPageText.get()).toBe("Email us!");
     });
 
     test("clears contact text when empty", async () => {
-      await updateContactPageText("Old text");
+      await settings.contactPageText.update("Old text");
       const response = await handleRequest(
         mockFormRequest(
           "/admin/site/contact",
@@ -271,7 +265,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(await getContactPageTextFromDb()).toBe(null);
+      expect(await settings.contactPageText.get()).toBe(null);
     });
 
     test("rejects text exceeding max length", async () => {
@@ -328,7 +322,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
 
   describe("admin nav", () => {
     test("shows Site link when public site is enabled", async () => {
-      await updateShowPublicSite(true);
+      await settings.showPublicSite.update(true);
       const response = await awaitTestRequest("/admin/site", {
         cookie: await testCookie(),
       });

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -700,12 +700,9 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       const { getDb: getDbFn } = await import("#lib/db/client.ts");
       await getDbFn().execute("DELETE FROM settings");
       await getDbFn().execute("DELETE FROM users");
-      const {
-        clearSetupCompleteCache,
-        invalidateSettingsCache: invalidateCache,
-      } = await import("#lib/db/settings.ts");
-      clearSetupCompleteCache();
-      invalidateCache();
+      const { settings: s } = await import("#lib/db/settings.ts");
+      s.setup.clearCache();
+      s.invalidateCache();
       invalidateUsersCache();
 
       const response = await handleRequest(mockRequest("/setup/"));

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -14,11 +14,11 @@ const testCerts = generateTestCerts();
 /** Configure all Apple Wallet settings in the database */
 const configureAppleWallet = async () => {
   await Promise.all([
-    settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
-    settings.appleWallet.teamId.update("TESTTEAM01"),
-    settings.appleWallet.signingCert.update(testCerts.signingCert),
-    settings.appleWallet.signingKey.update(testCerts.signingKey),
-    settings.appleWallet.wwdrCert.update(testCerts.wwdrCert),
+    settings.update.appleWallet.passTypeId("pass.com.test.tickets"),
+    settings.update.appleWallet.teamId("TESTTEAM01"),
+    settings.update.appleWallet.signingCert(testCerts.signingCert),
+    settings.update.appleWallet.signingKey(testCerts.signingKey),
+    settings.update.appleWallet.wwdrCert(testCerts.wwdrCert),
   ]);
 };
 

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -1,13 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { unzipSync } from "fflate";
-import {
-  updateAppleWalletPassTypeId,
-  updateAppleWalletSigningCert,
-  updateAppleWalletSigningKey,
-  updateAppleWalletTeamId,
-  updateAppleWalletWwdrCert,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   createTestAttendeeWithToken,
@@ -20,11 +14,11 @@ const testCerts = generateTestCerts();
 /** Configure all Apple Wallet settings in the database */
 const configureAppleWallet = async () => {
   await Promise.all([
-    updateAppleWalletPassTypeId("pass.com.test.tickets"),
-    updateAppleWalletTeamId("TESTTEAM01"),
-    updateAppleWalletSigningCert(testCerts.signingCert),
-    updateAppleWalletSigningKey(testCerts.signingKey),
-    updateAppleWalletWwdrCert(testCerts.wwdrCert),
+    settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
+    settings.appleWallet.teamId.update("TESTTEAM01"),
+    settings.appleWallet.signingCert.update(testCerts.signingCert),
+    settings.appleWallet.signingKey.update(testCerts.signingKey),
+    settings.appleWallet.wwdrCert.update(testCerts.wwdrCert),
   ]);
 };
 

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -1,19 +1,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { unzipSync } from "fflate";
-import {
-  getAppleWalletConfig,
-  getAppleWalletPassTypeIdFromDb,
-  getAppleWalletTeamIdFromDb,
-  getHostAppleWalletConfig,
-  hasAppleWalletConfig,
-  hasAppleWalletDbConfig,
-  updateAppleWalletPassTypeId,
-  updateAppleWalletSigningCert,
-  updateAppleWalletSigningKey,
-  updateAppleWalletTeamId,
-  updateAppleWalletWwdrCert,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
@@ -91,11 +79,11 @@ const fetchValidPkpassForNewAttendee = async () => {
 /** Configure all Apple Wallet settings in the database */
 const configureAppleWallet = async () => {
   await Promise.all([
-    updateAppleWalletPassTypeId("pass.com.test.tickets"),
-    updateAppleWalletTeamId("TESTTEAM01"),
-    updateAppleWalletSigningCert(testCerts.signingCert),
-    updateAppleWalletSigningKey(testCerts.signingKey),
-    updateAppleWalletWwdrCert(testCerts.wwdrCert),
+    settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
+    settings.appleWallet.teamId.update("TESTTEAM01"),
+    settings.appleWallet.signingCert.update(testCerts.signingCert),
+    settings.appleWallet.signingKey.update(testCerts.signingKey),
+    settings.appleWallet.wwdrCert.update(testCerts.wwdrCert),
   ]);
 };
 
@@ -345,16 +333,16 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     expect(response.status).toBe(302);
     expectFlash(response, "Apple Wallet settings updated");
 
-    expect(await hasAppleWalletConfig()).toBe(true);
-    expect(await getAppleWalletPassTypeIdFromDb()).toBe(
+    expect(await settings.appleWallet.hasConfig()).toBe(true);
+    expect(await settings.appleWallet.passTypeId.get()).toBe(
       "pass.com.test.tickets",
     );
-    expect(await getAppleWalletTeamIdFromDb()).toBe("TESTTEAM01");
+    expect(await settings.appleWallet.teamId.get()).toBe("TESTTEAM01");
   });
 
   test("clears all settings when everything is empty", async () => {
     await configureAppleWallet();
-    expect(await hasAppleWalletConfig()).toBe(true);
+    expect(await settings.appleWallet.hasConfig()).toBe(true);
 
     const response = await submitWalletSettingsForm({
       apple_wallet_pass_type_id: "",
@@ -366,7 +354,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
 
     expect(response.status).toBe(302);
     expectFlash(response, "Apple Wallet configuration cleared");
-    expect(await hasAppleWalletConfig()).toBe(false);
+    expect(await settings.appleWallet.hasConfig()).toBe(false);
   });
 
   test("shows Apple Wallet section with masked values when configured", async () => {
@@ -409,18 +397,18 @@ describeWithEnv(
   },
   () => {
     test("returns null when no env vars are set", () => {
-      expect(getHostAppleWalletConfig()).toBeNull();
+      expect(settings.appleWallet.getHostConfig()).toBeNull();
     });
 
     test("returns null when only some env vars are set", () => {
       Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.test");
       Deno.env.set("APPLE_WALLET_TEAM_ID", "TEAM01");
-      expect(getHostAppleWalletConfig()).toBeNull();
+      expect(settings.appleWallet.getHostConfig()).toBeNull();
     });
 
     test("returns config when all env vars are set", () => {
       setWalletEnvVars();
-      const config = getHostAppleWalletConfig();
+      const config = settings.appleWallet.getHostConfig();
       expect(config).not.toBeNull();
       expect(config!.passTypeId).toBe("pass.com.env.tickets");
       expect(config!.teamId).toBe("ENVTEAM001");
@@ -446,13 +434,13 @@ describeWithEnv(
   () => {
     test("hasAppleWalletConfig returns true with env vars when DB not configured", async () => {
       setWalletEnvVars();
-      expect(await hasAppleWalletDbConfig()).toBe(false);
-      expect(await hasAppleWalletConfig()).toBe(true);
+      expect(await settings.appleWallet.hasDbConfig()).toBe(false);
+      expect(await settings.appleWallet.hasConfig()).toBe(true);
     });
 
     test("getAppleWalletConfig falls back to env vars when DB not configured", async () => {
       setWalletEnvVars();
-      const config = await getAppleWalletConfig();
+      const config = await settings.appleWallet.getConfig();
       expect(config).not.toBeNull();
       expect(config!.passTypeId).toBe("pass.com.env.tickets");
       expect(config!.teamId).toBe("ENVTEAM001");
@@ -461,7 +449,7 @@ describeWithEnv(
     test("getAppleWalletConfig prefers DB config over env vars", async () => {
       setWalletEnvVars();
       await configureAppleWallet();
-      const config = await getAppleWalletConfig();
+      const config = await settings.appleWallet.getConfig();
       expect(config).not.toBeNull();
       expect(config!.passTypeId).toBe("pass.com.test.tickets");
       expect(config!.teamId).toBe("TESTTEAM01");

--- a/test/lib/server-wallet.test.ts
+++ b/test/lib/server-wallet.test.ts
@@ -79,11 +79,11 @@ const fetchValidPkpassForNewAttendee = async () => {
 /** Configure all Apple Wallet settings in the database */
 const configureAppleWallet = async () => {
   await Promise.all([
-    settings.appleWallet.passTypeId.update("pass.com.test.tickets"),
-    settings.appleWallet.teamId.update("TESTTEAM01"),
-    settings.appleWallet.signingCert.update(testCerts.signingCert),
-    settings.appleWallet.signingKey.update(testCerts.signingKey),
-    settings.appleWallet.wwdrCert.update(testCerts.wwdrCert),
+    settings.update.appleWallet.passTypeId("pass.com.test.tickets"),
+    settings.update.appleWallet.teamId("TESTTEAM01"),
+    settings.update.appleWallet.signingCert(testCerts.signingCert),
+    settings.update.appleWallet.signingKey(testCerts.signingKey),
+    settings.update.appleWallet.wwdrCert(testCerts.wwdrCert),
   ]);
 };
 
@@ -333,16 +333,14 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     expect(response.status).toBe(302);
     expectFlash(response, "Apple Wallet settings updated");
 
-    expect(await settings.appleWallet.hasConfig()).toBe(true);
-    expect(await settings.appleWallet.passTypeId.get()).toBe(
-      "pass.com.test.tickets",
-    );
-    expect(await settings.appleWallet.teamId.get()).toBe("TESTTEAM01");
+    expect(settings.appleWallet.hasConfig).toBe(true);
+    expect(settings.appleWallet.passTypeId).toBe("pass.com.test.tickets");
+    expect(settings.appleWallet.teamId).toBe("TESTTEAM01");
   });
 
   test("clears all settings when everything is empty", async () => {
     await configureAppleWallet();
-    expect(await settings.appleWallet.hasConfig()).toBe(true);
+    expect(settings.appleWallet.hasConfig).toBe(true);
 
     const response = await submitWalletSettingsForm({
       apple_wallet_pass_type_id: "",
@@ -354,7 +352,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
 
     expect(response.status).toBe(302);
     expectFlash(response, "Apple Wallet configuration cleared");
-    expect(await settings.appleWallet.hasConfig()).toBe(false);
+    expect(settings.appleWallet.hasConfig).toBe(false);
   });
 
   test("shows Apple Wallet section with masked values when configured", async () => {
@@ -397,18 +395,18 @@ describeWithEnv(
   },
   () => {
     test("returns null when no env vars are set", () => {
-      expect(settings.appleWallet.getHostConfig()).toBeNull();
+      expect(settings.appleWallet.hostConfig).toBeNull();
     });
 
     test("returns null when only some env vars are set", () => {
       Deno.env.set("APPLE_WALLET_PASS_TYPE_ID", "pass.com.test");
       Deno.env.set("APPLE_WALLET_TEAM_ID", "TEAM01");
-      expect(settings.appleWallet.getHostConfig()).toBeNull();
+      expect(settings.appleWallet.hostConfig).toBeNull();
     });
 
     test("returns config when all env vars are set", () => {
       setWalletEnvVars();
-      const config = settings.appleWallet.getHostConfig();
+      const config = settings.appleWallet.hostConfig;
       expect(config).not.toBeNull();
       expect(config!.passTypeId).toBe("pass.com.env.tickets");
       expect(config!.teamId).toBe("ENVTEAM001");
@@ -432,15 +430,15 @@ describeWithEnv(
     db: true,
   },
   () => {
-    test("hasAppleWalletConfig returns true with env vars when DB not configured", async () => {
+    test("hasAppleWalletConfig returns true with env vars when DB not configured", () => {
       setWalletEnvVars();
-      expect(await settings.appleWallet.hasDbConfig()).toBe(false);
-      expect(await settings.appleWallet.hasConfig()).toBe(true);
+      expect(settings.appleWallet.hasDbConfig).toBe(false);
+      expect(settings.appleWallet.hasConfig).toBe(true);
     });
 
-    test("getAppleWalletConfig falls back to env vars when DB not configured", async () => {
+    test("getAppleWalletConfig falls back to env vars when DB not configured", () => {
       setWalletEnvVars();
-      const config = await settings.appleWallet.getConfig();
+      const config = settings.appleWallet.config;
       expect(config).not.toBeNull();
       expect(config!.passTypeId).toBe("pass.com.env.tickets");
       expect(config!.teamId).toBe("ENVTEAM001");
@@ -449,7 +447,7 @@ describeWithEnv(
     test("getAppleWalletConfig prefers DB config over env vars", async () => {
       setWalletEnvVars();
       await configureAppleWallet();
-      const config = await settings.appleWallet.getConfig();
+      const config = settings.appleWallet.config;
       expect(config).not.toBeNull();
       expect(config!.passTypeId).toBe("pass.com.test.tickets");
       expect(config!.teamId).toBe("TESTTEAM01");

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -1846,7 +1846,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         () => {
           callCount++;
           // First call: webhook handler needs provider; second call: tryRefund should get null
-          return callCount <= 1 ? origGetConfigured() : Promise.resolve(null);
+          return callCount <= 1 ? origGetConfigured() : null;
         },
       );
 

--- a/test/lib/sort-events.test.ts
+++ b/test/lib/sort-events.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { addDays } from "#lib/dates.ts";
-import { setTimezoneForTest } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { sortEvents } from "#lib/sort-events.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import type { EventWithCount, Holiday } from "#lib/types.ts";
@@ -28,7 +28,7 @@ const expectAlphaBeforeBravo = (
 describe("sortEvents", () => {
   beforeEach(async () => {
     await createTestDbWithSetup();
-    setTimezoneForTest("UTC");
+    settings.timezone.setForTest("UTC");
   });
 
   afterEach(() => {

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -74,13 +74,13 @@ describe("square", () => {
     });
 
     test("returns client when access token is set in database", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
       const client = await getSquareClient();
       expect(client).not.toBeNull();
     });
 
     test("returns cached client on second call with same token", async () => {
-      await settings.square.accessToken.update("EAAAl_cache_test");
+      await settings.update.square.accessToken("EAAAl_cache_test");
       const client1 = await getSquareClient();
       expect(client1).not.toBeNull();
 
@@ -90,20 +90,20 @@ describe("square", () => {
     });
 
     test("returns client in sandbox mode when sandbox setting enabled", async () => {
-      await settings.square.accessToken.update("EAAAl_sandbox_123");
-      await settings.square.sandbox.update(true);
+      await settings.update.square.accessToken("EAAAl_sandbox_123");
+      await settings.update.square.sandbox(true);
       const client = await getSquareClient();
       expect(client).not.toBeNull();
     });
 
     test("recreates client when sandbox setting changes", async () => {
-      await settings.square.accessToken.update("EAAAl_sandbox_toggle");
-      await settings.square.sandbox.update(false);
+      await settings.update.square.accessToken("EAAAl_sandbox_toggle");
+      await settings.update.square.sandbox(false);
       const client1 = await getSquareClient();
       expect(client1).not.toBeNull();
 
       // Toggle sandbox mode - should create new client
-      await settings.square.sandbox.update(true);
+      await settings.update.square.sandbox(true);
       const client2 = await getSquareClient();
       expect(client2).not.toBeNull();
     });
@@ -111,7 +111,7 @@ describe("square", () => {
 
   describe("resetSquareClient", () => {
     test("resets client state after token removed from db", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
       const client1 = await getSquareClient();
       expect(client1).not.toBeNull();
 
@@ -135,16 +135,13 @@ describe("square", () => {
     });
 
     test("returns error when locations list fails", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
       const mock = createMockClient({
         locationsList: () => Promise.reject(new Error("Invalid access token")),
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.ok).toBe(false);
@@ -155,10 +152,10 @@ describe("square", () => {
     });
 
     test("returns sandbox mode with valid token and all checks pass", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.sandbox.update(true);
-      await settings.square.locationId.update("L_test_123");
-      await settings.square.webhookSignatureKey.update("sig_key_test");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.sandbox(true);
+      await settings.update.square.locationId("L_test_123");
+      await settings.update.square.webhookSignatureKey("sig_key_test");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -169,10 +166,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.ok).toBe(true);
@@ -187,10 +181,10 @@ describe("square", () => {
     });
 
     test("returns production mode when sandbox disabled", async () => {
-      await settings.square.accessToken.update("EAAAl_live_123");
-      await settings.square.sandbox.update(false);
-      await settings.square.locationId.update("L_live_123");
-      await settings.square.webhookSignatureKey.update("sig_key_live");
+      await settings.update.square.accessToken("EAAAl_live_123");
+      await settings.update.square.sandbox(false);
+      await settings.update.square.locationId("L_live_123");
+      await settings.update.square.webhookSignatureKey("sig_key_live");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -201,10 +195,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.ok).toBe(true);
@@ -215,9 +206,9 @@ describe("square", () => {
     });
 
     test("returns location error when location ID not found", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_wrong");
-      await settings.square.webhookSignatureKey.update("sig_key_test");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_wrong");
+      await settings.update.square.webhookSignatureKey("sig_key_test");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -228,10 +219,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.ok).toBe(false);
@@ -245,18 +233,15 @@ describe("square", () => {
     });
 
     test("returns location error when no location ID configured", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.webhookSignatureKey.update("sig_key_test");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.webhookSignatureKey("sig_key_test");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({ locations: [{ id: "L_test_123" }] }),
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.ok).toBe(false);
@@ -267,19 +252,16 @@ describe("square", () => {
     });
 
     test("handles empty locations response", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.sandbox.update(true);
-      await settings.square.locationId.update("L_test_123");
-      await settings.square.webhookSignatureKey.update("sig_key_test");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.sandbox(true);
+      await settings.update.square.locationId("L_test_123");
+      await settings.update.square.webhookSignatureKey("sig_key_test");
       const mock = createMockClient({
         locationsList: () => Promise.resolve({}),
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.accessToken.valid).toBe(true);
@@ -292,8 +274,8 @@ describe("square", () => {
     });
 
     test("returns webhook error when no signature key configured", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_test_123");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -304,10 +286,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () =>
-          stub(squareApi, "getSquareClient", () =>
-            Promise.resolve(mock.client),
-          ),
+        () => stub(squareApi, "getSquareClient", () => mock.client),
         async () => {
           const result = await testSquareConnection();
           expect(result.ok).toBe(false);
@@ -440,7 +419,7 @@ describe("square", () => {
     });
 
     test("returns null when location ID not configured", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
       // No location ID set
       const event = {
         id: 1,
@@ -498,8 +477,8 @@ describe("square", () => {
     });
 
     test("constructs correct SDK call for single-event checkout", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -511,7 +490,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = {
             id: 7,
@@ -608,9 +587,9 @@ describe("square", () => {
 
     test("includes booking fee line item when fee is set", async () => {
       const { settings: s } = await import("#lib/db/settings.ts");
-      await s.bookingFee.update("2.5");
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await s.update.bookingFee("2.5");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -622,7 +601,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({ unit_price: 1000 });
           const intent = {
@@ -653,8 +632,8 @@ describe("square", () => {
     });
 
     test("omits phone from pre-populated data when empty", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -666,7 +645,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = {
             id: 1,
@@ -728,8 +707,8 @@ describe("square", () => {
     });
 
     test("returns null when SDK response missing orderId", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -738,7 +717,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = {
             id: 1,
@@ -799,8 +778,8 @@ describe("square", () => {
     });
 
     test("returns null when name exceeds metadata limit but truncates gracefully", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -812,7 +791,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = {
             id: 1,
@@ -878,12 +857,12 @@ describe("square", () => {
     });
 
     test("returns null when non-truncatable metadata exceeds limit", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client } = createMockClient();
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -943,7 +922,7 @@ describe("square", () => {
     });
 
     test("returns null when location ID not configured", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.update.square.accessToken("EAAAl_test_123");
       const intent = {
         name: "John Doe",
         email: "john@example.com",
@@ -968,8 +947,8 @@ describe("square", () => {
     });
 
     test("returns null when SDK response missing orderId", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_multi_loc");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_multi_loc");
       const { client } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -978,7 +957,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const intent = {
             name: "Bob Missing",
@@ -1007,8 +986,8 @@ describe("square", () => {
     });
 
     test("constructs correct SDK call with multiple line items", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_multi_loc");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_multi_loc");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -1020,7 +999,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const intent = {
             name: "Alice Wonder",
@@ -1096,12 +1075,12 @@ describe("square", () => {
     });
 
     test("returns null when items metadata exceeds Square limit", async () => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_multi_loc");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_multi_loc");
       const { client, checkoutCreate } = createMockClient();
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           // Generate enough items to exceed 255-char serialized metadata
           const items = Array.from({ length: 30 }, (_, i) => ({
@@ -1148,8 +1127,8 @@ describe("square", () => {
 
     /** Set up Square credentials and a mock client with a failing checkout */
     const setupFailingCheckout = async (sdkError: Error) => {
-      await settings.square.accessToken.update("EAAAl_test_123");
-      await settings.square.locationId.update("L_loc_456");
+      await settings.update.square.accessToken("EAAAl_test_123");
+      await settings.update.square.locationId("L_loc_456");
       const { client } = createMockClient({
         checkoutCreate: () => Promise.reject(sdkError),
       });
@@ -1167,7 +1146,7 @@ describe("square", () => {
       );
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -1196,7 +1175,7 @@ describe("square", () => {
       );
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -1227,7 +1206,7 @@ describe("square", () => {
       );
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -1251,7 +1230,7 @@ describe("square", () => {
       );
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -1271,7 +1250,7 @@ describe("square", () => {
       const client = await setupFailingCheckout(new Error("Network timeout"));
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -1293,7 +1272,7 @@ describe("square", () => {
       );
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const event = testEvent({
             unit_price: 1000,
@@ -1322,7 +1301,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.retrieveOrder("order_missing");
           expect(result).toBeNull();
@@ -1355,7 +1334,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.retrieveOrder("order_tenders");
           expect(result).not.toBeNull();
@@ -1381,7 +1360,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.retrieveOrder("order_shape");
           expect(result).not.toBeNull();
@@ -1412,7 +1391,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.retrieveOrder("order_with_total");
           expect(result).not.toBeNull();
@@ -1435,7 +1414,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.retrievePayment("pay_missing");
           expect(result).toBeNull();
@@ -1467,7 +1446,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.retrievePayment("pay_full");
           expect(result).not.toBeNull();
@@ -1498,7 +1477,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await retrievePayment("pay_wrapper");
           expect(result).not.toBeNull();
@@ -1546,7 +1525,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.refundPayment("pay_refund_me");
           expect(result).toBe(true);
@@ -1584,7 +1563,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result = await squareApi.refundPayment("pay_fail");
           expect(result).toBe(false);
@@ -1599,7 +1578,7 @@ describe("square", () => {
     const toBytes = (s: string) => new TextEncoder().encode(s);
 
     beforeEach(async () => {
-      await settings.square.webhookSignatureKey.update(TEST_SECRET);
+      await settings.update.square.webhookSignatureKey(TEST_SECRET);
     });
 
     test("returns error when webhook signature key not configured", async () => {
@@ -1727,7 +1706,7 @@ describe("square", () => {
       expect(signature).toMatch(/^[A-Za-z0-9+/]+=*$/);
 
       // Signature should be verifiable with the same secret (stored in DB)
-      await settings.square.webhookSignatureKey.update(secret);
+      await settings.update.square.webhookSignatureKey(secret);
       const result = await verifyWebhookSignature(
         payload,
         signature,
@@ -1757,8 +1736,8 @@ describe("square", () => {
 
     beforeEach(async () => {
       originalFetch = globalThis.fetch;
-      await settings.square.accessToken.update("EAAAl_rest_test");
-      await settings.square.sandbox.update(true);
+      await settings.update.square.accessToken("EAAAl_rest_test");
+      await settings.update.square.sandbox(true);
     });
 
     afterEach(() => {
@@ -2140,7 +2119,7 @@ describe("square", () => {
 
     test("uses production URL when sandbox is disabled", async () => {
       resetSquareClient();
-      await settings.square.sandbox.update(false);
+      await settings.update.square.sandbox(false);
       installMockFetch(() =>
         Promise.resolve({
           ok: true,
@@ -2181,7 +2160,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_paid");
@@ -2216,7 +2195,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_open");
@@ -2239,7 +2218,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_no_meta");
@@ -2261,7 +2240,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_bad_meta");
@@ -2276,7 +2255,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_gone");
@@ -2309,7 +2288,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_with_amount");
@@ -2349,7 +2328,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_multi");
@@ -2373,10 +2352,10 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
-          await settings.square.accessToken.update("EAAAl_test_123");
-          await settings.square.locationId.update("L_loc_prov");
+          await settings.update.square.accessToken("EAAAl_test_123");
+          await settings.update.square.locationId("L_loc_prov");
           const event = {
             id: 1,
             group_id: 0,
@@ -2451,10 +2430,10 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
-          await settings.square.accessToken.update("EAAAl_test_123");
-          await settings.square.locationId.update("L_loc_prov");
+          await settings.update.square.accessToken("EAAAl_test_123");
+          await settings.update.square.locationId("L_loc_prov");
           const intent = {
             name: "John",
             email: "john@example.com",
@@ -2503,7 +2482,7 @@ describe("square", () => {
       });
 
       await withMocks(
-        () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
+        () => stub(squareApi, "getSquareClient", () => client),
         async () => {
           const result =
             await squarePaymentProvider.refundPayment("pay_prov_ref");

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -1,12 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
-import {
-  updateSquareAccessToken,
-  updateSquareLocationId,
-  updateSquareSandbox,
-  updateSquareWebhookSignatureKey,
-} from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { PaymentUserError } from "#lib/payment-helpers.ts";
 import type { WebhookEvent } from "#lib/payments.ts";
 import {
@@ -79,13 +74,13 @@ describe("square", () => {
     });
 
     test("returns client when access token is set in database", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
       const client = await getSquareClient();
       expect(client).not.toBeNull();
     });
 
     test("returns cached client on second call with same token", async () => {
-      await updateSquareAccessToken("EAAAl_cache_test");
+      await settings.square.accessToken.update("EAAAl_cache_test");
       const client1 = await getSquareClient();
       expect(client1).not.toBeNull();
 
@@ -95,20 +90,20 @@ describe("square", () => {
     });
 
     test("returns client in sandbox mode when sandbox setting enabled", async () => {
-      await updateSquareAccessToken("EAAAl_sandbox_123");
-      await updateSquareSandbox(true);
+      await settings.square.accessToken.update("EAAAl_sandbox_123");
+      await settings.square.sandbox.update(true);
       const client = await getSquareClient();
       expect(client).not.toBeNull();
     });
 
     test("recreates client when sandbox setting changes", async () => {
-      await updateSquareAccessToken("EAAAl_sandbox_toggle");
-      await updateSquareSandbox(false);
+      await settings.square.accessToken.update("EAAAl_sandbox_toggle");
+      await settings.square.sandbox.update(false);
       const client1 = await getSquareClient();
       expect(client1).not.toBeNull();
 
       // Toggle sandbox mode - should create new client
-      await updateSquareSandbox(true);
+      await settings.square.sandbox.update(true);
       const client2 = await getSquareClient();
       expect(client2).not.toBeNull();
     });
@@ -116,7 +111,7 @@ describe("square", () => {
 
   describe("resetSquareClient", () => {
     test("resets client state after token removed from db", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
       const client1 = await getSquareClient();
       expect(client1).not.toBeNull();
 
@@ -140,7 +135,7 @@ describe("square", () => {
     });
 
     test("returns error when locations list fails", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
       const mock = createMockClient({
         locationsList: () => Promise.reject(new Error("Invalid access token")),
       });
@@ -160,10 +155,10 @@ describe("square", () => {
     });
 
     test("returns sandbox mode with valid token and all checks pass", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareSandbox(true);
-      await updateSquareLocationId("L_test_123");
-      await updateSquareWebhookSignatureKey("sig_key_test");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.sandbox.update(true);
+      await settings.square.locationId.update("L_test_123");
+      await settings.square.webhookSignatureKey.update("sig_key_test");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -192,10 +187,10 @@ describe("square", () => {
     });
 
     test("returns production mode when sandbox disabled", async () => {
-      await updateSquareAccessToken("EAAAl_live_123");
-      await updateSquareSandbox(false);
-      await updateSquareLocationId("L_live_123");
-      await updateSquareWebhookSignatureKey("sig_key_live");
+      await settings.square.accessToken.update("EAAAl_live_123");
+      await settings.square.sandbox.update(false);
+      await settings.square.locationId.update("L_live_123");
+      await settings.square.webhookSignatureKey.update("sig_key_live");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -220,9 +215,9 @@ describe("square", () => {
     });
 
     test("returns location error when location ID not found", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_wrong");
-      await updateSquareWebhookSignatureKey("sig_key_test");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_wrong");
+      await settings.square.webhookSignatureKey.update("sig_key_test");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -250,8 +245,8 @@ describe("square", () => {
     });
 
     test("returns location error when no location ID configured", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareWebhookSignatureKey("sig_key_test");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.webhookSignatureKey.update("sig_key_test");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({ locations: [{ id: "L_test_123" }] }),
@@ -272,10 +267,10 @@ describe("square", () => {
     });
 
     test("handles empty locations response", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareSandbox(true);
-      await updateSquareLocationId("L_test_123");
-      await updateSquareWebhookSignatureKey("sig_key_test");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.sandbox.update(true);
+      await settings.square.locationId.update("L_test_123");
+      await settings.square.webhookSignatureKey.update("sig_key_test");
       const mock = createMockClient({
         locationsList: () => Promise.resolve({}),
       });
@@ -297,8 +292,8 @@ describe("square", () => {
     });
 
     test("returns webhook error when no signature key configured", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_test_123");
       const mock = createMockClient({
         locationsList: () =>
           Promise.resolve({
@@ -445,7 +440,7 @@ describe("square", () => {
     });
 
     test("returns null when location ID not configured", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
       // No location ID set
       const event = {
         id: 1,
@@ -503,8 +498,8 @@ describe("square", () => {
     });
 
     test("constructs correct SDK call for single-event checkout", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -612,10 +607,10 @@ describe("square", () => {
     });
 
     test("includes booking fee line item when fee is set", async () => {
-      const { updateBookingFee } = await import("#lib/db/settings.ts");
-      await updateBookingFee("2.5");
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      const { settings: s } = await import("#lib/db/settings.ts");
+      await s.bookingFee.update("2.5");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -658,8 +653,8 @@ describe("square", () => {
     });
 
     test("omits phone from pre-populated data when empty", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -733,8 +728,8 @@ describe("square", () => {
     });
 
     test("returns null when SDK response missing orderId", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -804,8 +799,8 @@ describe("square", () => {
     });
 
     test("returns null when name exceeds metadata limit but truncates gracefully", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -883,8 +878,8 @@ describe("square", () => {
     });
 
     test("returns null when non-truncatable metadata exceeds limit", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client } = createMockClient();
 
       await withMocks(
@@ -948,7 +943,7 @@ describe("square", () => {
     });
 
     test("returns null when location ID not configured", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
+      await settings.square.accessToken.update("EAAAl_test_123");
       const intent = {
         name: "John Doe",
         email: "john@example.com",
@@ -973,8 +968,8 @@ describe("square", () => {
     });
 
     test("returns null when SDK response missing orderId", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_multi_loc");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_multi_loc");
       const { client } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -1012,8 +1007,8 @@ describe("square", () => {
     });
 
     test("constructs correct SDK call with multiple line items", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_multi_loc");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_multi_loc");
       const { client, checkoutCreate } = createMockClient({
         checkoutCreate: () =>
           Promise.resolve({
@@ -1101,8 +1096,8 @@ describe("square", () => {
     });
 
     test("returns null when items metadata exceeds Square limit", async () => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_multi_loc");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_multi_loc");
       const { client, checkoutCreate } = createMockClient();
 
       await withMocks(
@@ -1153,8 +1148,8 @@ describe("square", () => {
 
     /** Set up Square credentials and a mock client with a failing checkout */
     const setupFailingCheckout = async (sdkError: Error) => {
-      await updateSquareAccessToken("EAAAl_test_123");
-      await updateSquareLocationId("L_loc_456");
+      await settings.square.accessToken.update("EAAAl_test_123");
+      await settings.square.locationId.update("L_loc_456");
       const { client } = createMockClient({
         checkoutCreate: () => Promise.reject(sdkError),
       });
@@ -1604,7 +1599,7 @@ describe("square", () => {
     const toBytes = (s: string) => new TextEncoder().encode(s);
 
     beforeEach(async () => {
-      await updateSquareWebhookSignatureKey(TEST_SECRET);
+      await settings.square.webhookSignatureKey.update(TEST_SECRET);
     });
 
     test("returns error when webhook signature key not configured", async () => {
@@ -1732,7 +1727,7 @@ describe("square", () => {
       expect(signature).toMatch(/^[A-Za-z0-9+/]+=*$/);
 
       // Signature should be verifiable with the same secret (stored in DB)
-      await updateSquareWebhookSignatureKey(secret);
+      await settings.square.webhookSignatureKey.update(secret);
       const result = await verifyWebhookSignature(
         payload,
         signature,
@@ -1762,8 +1757,8 @@ describe("square", () => {
 
     beforeEach(async () => {
       originalFetch = globalThis.fetch;
-      await updateSquareAccessToken("EAAAl_rest_test");
-      await updateSquareSandbox(true);
+      await settings.square.accessToken.update("EAAAl_rest_test");
+      await settings.square.sandbox.update(true);
     });
 
     afterEach(() => {
@@ -2145,7 +2140,7 @@ describe("square", () => {
 
     test("uses production URL when sandbox is disabled", async () => {
       resetSquareClient();
-      await updateSquareSandbox(false);
+      await settings.square.sandbox.update(false);
       installMockFetch(() =>
         Promise.resolve({
           ok: true,
@@ -2380,8 +2375,8 @@ describe("square", () => {
       await withMocks(
         () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
         async () => {
-          await updateSquareAccessToken("EAAAl_test_123");
-          await updateSquareLocationId("L_loc_prov");
+          await settings.square.accessToken.update("EAAAl_test_123");
+          await settings.square.locationId.update("L_loc_prov");
           const event = {
             id: 1,
             group_id: 0,
@@ -2458,8 +2453,8 @@ describe("square", () => {
       await withMocks(
         () => stub(squareApi, "getSquareClient", () => Promise.resolve(client)),
         async () => {
-          await updateSquareAccessToken("EAAAl_test_123");
-          await updateSquareLocationId("L_loc_prov");
+          await settings.square.accessToken.update("EAAAl_test_123");
+          await settings.square.locationId.update("L_loc_prov");
           const intent = {
             name: "John",
             email: "john@example.com",

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
-import { setStripeWebhookConfig, updateStripeKey } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   constructTestWebhookEvent,
   createCheckoutSessionWithIntent,
@@ -59,13 +59,13 @@ describeWithEnv(
       });
 
       test("returns client when stripe key is set in database", async () => {
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         const client = await getStripeClient();
         expect(client).not.toBeNull();
       });
 
       test("returns same client on subsequent calls", async () => {
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         const client1 = await getStripeClient();
         const client2 = await getStripeClient();
         expect(client1).toBe(client2);
@@ -74,7 +74,7 @@ describeWithEnv(
 
     describe("resetStripeClient", () => {
       test("resets client to null after key removed from db", async () => {
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         const client1 = await getStripeClient();
         expect(client1).not.toBeNull();
 
@@ -96,7 +96,7 @@ describeWithEnv(
 
       test("returns null when Stripe API throws error", async () => {
         // Enable Stripe with mock
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -118,7 +118,7 @@ describeWithEnv(
     describe("mock configuration", () => {
       test("creates client with mock config when STRIPE_MOCK_HOST is set", async () => {
         // This test exercises the getMockConfig code path
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         Deno.env.set("STRIPE_MOCK_HOST", "localhost");
         Deno.env.set("STRIPE_MOCK_PORT", "12111");
 
@@ -128,7 +128,7 @@ describeWithEnv(
       });
 
       test("uses default port 12111 when STRIPE_MOCK_PORT not set", async () => {
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         Deno.env.set("STRIPE_MOCK_HOST", "localhost");
         Deno.env.delete("STRIPE_MOCK_PORT");
 
@@ -142,7 +142,7 @@ describeWithEnv(
       // STRIPE_MOCK_HOST/PORT are set in test/setup.ts
 
       test("retrieves checkout session with stripe-mock", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         // First create a session using intent-based flow
         const event = {
@@ -209,7 +209,7 @@ describeWithEnv(
       });
 
       test("creates checkout session with intent metadata", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         const event = {
           id: 1,
@@ -273,7 +273,7 @@ describeWithEnv(
       });
 
       test("refunds payment with stripe-mock", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         // stripe-mock accepts any payment_intent ID
         const refund = await refundPayment("pi_test_123");
@@ -341,9 +341,9 @@ describeWithEnv(
       });
 
       test("includes booking fee line item when fee is set", async () => {
-        const { updateBookingFee } = await import("#lib/db/settings.ts");
-        await updateBookingFee("5");
-        await updateStripeKey("sk_test_mock");
+        const { settings: s } = await import("#lib/db/settings.ts");
+        await s.bookingFee.update("5");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -403,7 +403,7 @@ describeWithEnv(
       });
 
       test("returns null when Stripe API throws error", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -426,7 +426,7 @@ describeWithEnv(
 
       beforeEach(async () => {
         // Set webhook secret in database (encrypted)
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_endpoint",
         });
@@ -638,7 +638,7 @@ describeWithEnv(
       });
 
       test("returns error when balance.retrieve fails", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -657,7 +657,7 @@ describeWithEnv(
       });
 
       test("returns test mode when API key is valid and no webhooks exist", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -685,7 +685,7 @@ describeWithEnv(
       });
 
       test("returns live mode for live key", async () => {
-        await updateStripeKey("sk_live_mock");
+        await settings.stripe.secretKey.update("sk_live_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -711,7 +711,7 @@ describeWithEnv(
       });
 
       test("returns webhook error when list fails", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -742,8 +742,8 @@ describeWithEnv(
       });
 
       test("returns full success when API key valid and webhooks exist", async () => {
-        await updateStripeKey("sk_test_mock");
-        await setStripeWebhookConfig({
+        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.stripe.setWebhookConfig({
           secret: "whsec_test",
           endpointId: "we_test_valid",
         });
@@ -829,7 +829,7 @@ describeWithEnv(
         expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]+$/);
 
         // Signature should be verifiable with the same secret (stored in DB)
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret,
           endpointId: "we_test_construction",
         });
@@ -926,7 +926,7 @@ describeWithEnv(
 
     describe("createCheckoutSessionWithIntent - phone metadata", () => {
       test("includes phone in metadata when provided", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         const event = testEvent({ unit_price: 1000 });
         const intent = {
@@ -953,7 +953,7 @@ describeWithEnv(
 
     describe("createCheckoutSessionWithIntent - no email", () => {
       test("creates checkout session without customer_email when email is empty", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         const event = testEvent({ unit_price: 1000 });
         const intent = {
@@ -980,7 +980,7 @@ describeWithEnv(
 
     describe("createMultiCheckoutSession", () => {
       test("creates multi-checkout session with phone metadata", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         const intent = {
           name: "Jane Doe",
@@ -1041,7 +1041,7 @@ describeWithEnv(
       });
 
       test("creates multi-checkout session without customer_email when email is empty", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
 
         const intent = {
           name: "No Email Multi",
@@ -1080,7 +1080,7 @@ describeWithEnv(
 
     describe("refundPayment - non-Error exception", () => {
       test("handles non-Error thrown value in refund", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1100,7 +1100,7 @@ describeWithEnv(
 
     describe("testStripeConnection - non-Error exception", () => {
       test("handles non-Error thrown value in balance check", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1119,7 +1119,7 @@ describeWithEnv(
       });
 
       test("handles non-Error thrown value in webhook list", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1232,7 +1232,7 @@ describeWithEnv(
 
         // The getMockConfig is a once() function, so we can't easily re-test it.
         // But getStripeClient exercises the createStripeClient path
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         // Without mock config, a real Stripe client would be created
         // We just verify no crash occurs
         const client = await getStripeClient();
@@ -1364,7 +1364,7 @@ describeWithEnv(
       const TEST_SECRET = "whsec_test_secret_key_for_timestamp_test";
 
       test("handles timestamp value that needs parseInt", async () => {
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_ts",
         });
@@ -1386,7 +1386,7 @@ describeWithEnv(
       });
 
       test("parses timestamp with parseInt when t key has value", async () => {
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_parse",
         });
@@ -1421,7 +1421,7 @@ describeWithEnv(
       });
 
       test("treats t key without equals as zero timestamp via parseInt fallback", async () => {
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_nullish",
         });
@@ -1440,7 +1440,7 @@ describeWithEnv(
       });
 
       test("secureCompare handles strings of different lengths", async () => {
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_len",
         });
@@ -1463,7 +1463,7 @@ describeWithEnv(
       const TEST_SECRET = "whsec_test_secret_key_for_detail_tests";
 
       beforeEach(async () => {
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_details",
         });
@@ -1601,7 +1601,7 @@ describeWithEnv(
 
     describe("toCheckoutResult - session with no URL", () => {
       test("returns null when session has no URL", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1640,7 +1640,7 @@ describeWithEnv(
       });
 
       test("returns null when session is null", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1675,7 +1675,7 @@ describeWithEnv(
 
     describe("retrieveSession - edge cases", () => {
       test("returns null for non-multi session without event_id", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1702,7 +1702,7 @@ describeWithEnv(
       });
 
       test("returns null when session is null from Stripe", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1720,7 +1720,7 @@ describeWithEnv(
       });
 
       test("returns null when metadata is missing name or email", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1745,7 +1745,7 @@ describeWithEnv(
       });
 
       test("returns valid session for multi-ticket checkout", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1778,7 +1778,7 @@ describeWithEnv(
       });
 
       test("returns valid session for single-event checkout", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1811,7 +1811,7 @@ describeWithEnv(
       });
 
       test("returns amountTotal when session has numeric amount_total", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1842,7 +1842,7 @@ describeWithEnv(
       });
 
       test("returns null when amount_total is null", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1871,7 +1871,7 @@ describeWithEnv(
       });
 
       test("falls back to unpaid for invalid payment_status", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1901,7 +1901,7 @@ describeWithEnv(
       });
 
       test("casts amount_total to number", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1934,7 +1934,7 @@ describeWithEnv(
     describe("verifyWebhookSignature delegation", () => {
       test("delegates to stripe.ts verifyWebhookSignature", async () => {
         const TEST_SECRET = "whsec_provider_verify_test";
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_provider_test",
         });
@@ -1964,7 +1964,7 @@ describeWithEnv(
 
       test("returns error for invalid signature", async () => {
         const TEST_SECRET = "whsec_provider_invalid_test";
-        await setStripeWebhookConfig({
+        await settings.stripe.setWebhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_provider_inv",
         });
@@ -2015,13 +2015,13 @@ describeWithEnv(
 
     describe("refundPayment delegation", () => {
       test("returns true when refund succeeds", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const result = await stripePaymentProvider.refundPayment("pi_test_123");
         expect(result).toBe(true);
       });
 
       test("returns false when refund fails", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2048,7 +2048,7 @@ describeWithEnv(
 
     describe("getMockConfig without STRIPE_MOCK_HOST", () => {
       test("creates client without mock config when STRIPE_MOCK_HOST not set", async () => {
-        await updateStripeKey("sk_test_123");
+        await settings.stripe.secretKey.update("sk_test_123");
         Deno.env.delete("STRIPE_MOCK_HOST");
         Deno.env.delete("STRIPE_MOCK_PORT");
 
@@ -2068,7 +2068,7 @@ describeWithEnv(
       });
 
       test("returns null when Stripe API throws error", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -2088,7 +2088,7 @@ describeWithEnv(
 
     describe("isPaymentRefunded", () => {
       test("returns true when latest_charge is refunded", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2109,7 +2109,7 @@ describeWithEnv(
       });
 
       test("returns false when latest_charge is not refunded", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2130,7 +2130,7 @@ describeWithEnv(
       });
 
       test("returns false when payment intent not found", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2148,7 +2148,7 @@ describeWithEnv(
       });
 
       test("returns false when latest_charge is a string ID", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2171,7 +2171,7 @@ describeWithEnv(
 
     describe("createMultiCheckoutSession - via provider", () => {
       test("returns null when session has no URL", async () => {
-        await updateStripeKey("sk_test_mock");
+        await settings.stripe.secretKey.update("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -59,13 +59,13 @@ describeWithEnv(
       });
 
       test("returns client when stripe key is set in database", async () => {
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         const client = await getStripeClient();
         expect(client).not.toBeNull();
       });
 
       test("returns same client on subsequent calls", async () => {
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         const client1 = await getStripeClient();
         const client2 = await getStripeClient();
         expect(client1).toBe(client2);
@@ -74,7 +74,7 @@ describeWithEnv(
 
     describe("resetStripeClient", () => {
       test("resets client to null after key removed from db", async () => {
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         const client1 = await getStripeClient();
         expect(client1).not.toBeNull();
 
@@ -96,7 +96,7 @@ describeWithEnv(
 
       test("returns null when Stripe API throws error", async () => {
         // Enable Stripe with mock
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -118,7 +118,7 @@ describeWithEnv(
     describe("mock configuration", () => {
       test("creates client with mock config when STRIPE_MOCK_HOST is set", async () => {
         // This test exercises the getMockConfig code path
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         Deno.env.set("STRIPE_MOCK_HOST", "localhost");
         Deno.env.set("STRIPE_MOCK_PORT", "12111");
 
@@ -128,7 +128,7 @@ describeWithEnv(
       });
 
       test("uses default port 12111 when STRIPE_MOCK_PORT not set", async () => {
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         Deno.env.set("STRIPE_MOCK_HOST", "localhost");
         Deno.env.delete("STRIPE_MOCK_PORT");
 
@@ -142,7 +142,7 @@ describeWithEnv(
       // STRIPE_MOCK_HOST/PORT are set in test/setup.ts
 
       test("retrieves checkout session with stripe-mock", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         // First create a session using intent-based flow
         const event = {
@@ -209,7 +209,7 @@ describeWithEnv(
       });
 
       test("creates checkout session with intent metadata", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         const event = {
           id: 1,
@@ -273,7 +273,7 @@ describeWithEnv(
       });
 
       test("refunds payment with stripe-mock", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         // stripe-mock accepts any payment_intent ID
         const refund = await refundPayment("pi_test_123");
@@ -342,8 +342,8 @@ describeWithEnv(
 
       test("includes booking fee line item when fee is set", async () => {
         const { settings: s } = await import("#lib/db/settings.ts");
-        await s.bookingFee.update("5");
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await s.update.bookingFee("5");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -403,7 +403,7 @@ describeWithEnv(
       });
 
       test("returns null when Stripe API throws error", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -426,7 +426,7 @@ describeWithEnv(
 
       beforeEach(async () => {
         // Set webhook secret in database (encrypted)
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_endpoint",
         });
@@ -638,7 +638,7 @@ describeWithEnv(
       });
 
       test("returns error when balance.retrieve fails", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -657,7 +657,7 @@ describeWithEnv(
       });
 
       test("returns test mode when API key is valid and no webhooks exist", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -685,7 +685,7 @@ describeWithEnv(
       });
 
       test("returns live mode for live key", async () => {
-        await settings.stripe.secretKey.update("sk_live_mock");
+        await settings.update.stripe.secretKey("sk_live_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -711,7 +711,7 @@ describeWithEnv(
       });
 
       test("returns webhook error when list fails", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -742,8 +742,8 @@ describeWithEnv(
       });
 
       test("returns full success when API key valid and webhooks exist", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.secretKey("sk_test_mock");
+        await settings.update.stripe.webhookConfig({
           secret: "whsec_test",
           endpointId: "we_test_valid",
         });
@@ -829,7 +829,7 @@ describeWithEnv(
         expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]+$/);
 
         // Signature should be verifiable with the same secret (stored in DB)
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret,
           endpointId: "we_test_construction",
         });
@@ -926,7 +926,7 @@ describeWithEnv(
 
     describe("createCheckoutSessionWithIntent - phone metadata", () => {
       test("includes phone in metadata when provided", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         const event = testEvent({ unit_price: 1000 });
         const intent = {
@@ -953,7 +953,7 @@ describeWithEnv(
 
     describe("createCheckoutSessionWithIntent - no email", () => {
       test("creates checkout session without customer_email when email is empty", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         const event = testEvent({ unit_price: 1000 });
         const intent = {
@@ -980,7 +980,7 @@ describeWithEnv(
 
     describe("createMultiCheckoutSession", () => {
       test("creates multi-checkout session with phone metadata", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         const intent = {
           name: "Jane Doe",
@@ -1041,7 +1041,7 @@ describeWithEnv(
       });
 
       test("creates multi-checkout session without customer_email when email is empty", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
 
         const intent = {
           name: "No Email Multi",
@@ -1080,7 +1080,7 @@ describeWithEnv(
 
     describe("refundPayment - non-Error exception", () => {
       test("handles non-Error thrown value in refund", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1100,7 +1100,7 @@ describeWithEnv(
 
     describe("testStripeConnection - non-Error exception", () => {
       test("handles non-Error thrown value in balance check", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1119,7 +1119,7 @@ describeWithEnv(
       });
 
       test("handles non-Error thrown value in webhook list", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -1232,7 +1232,7 @@ describeWithEnv(
 
         // The getMockConfig is a once() function, so we can't easily re-test it.
         // But getStripeClient exercises the createStripeClient path
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         // Without mock config, a real Stripe client would be created
         // We just verify no crash occurs
         const client = await getStripeClient();
@@ -1364,7 +1364,7 @@ describeWithEnv(
       const TEST_SECRET = "whsec_test_secret_key_for_timestamp_test";
 
       test("handles timestamp value that needs parseInt", async () => {
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_ts",
         });
@@ -1386,7 +1386,7 @@ describeWithEnv(
       });
 
       test("parses timestamp with parseInt when t key has value", async () => {
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_parse",
         });
@@ -1421,7 +1421,7 @@ describeWithEnv(
       });
 
       test("treats t key without equals as zero timestamp via parseInt fallback", async () => {
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_nullish",
         });
@@ -1440,7 +1440,7 @@ describeWithEnv(
       });
 
       test("secureCompare handles strings of different lengths", async () => {
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_len",
         });
@@ -1463,7 +1463,7 @@ describeWithEnv(
       const TEST_SECRET = "whsec_test_secret_key_for_detail_tests";
 
       beforeEach(async () => {
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_test_details",
         });
@@ -1601,7 +1601,7 @@ describeWithEnv(
 
     describe("toCheckoutResult - session with no URL", () => {
       test("returns null when session has no URL", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1640,7 +1640,7 @@ describeWithEnv(
       });
 
       test("returns null when session is null", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1675,7 +1675,7 @@ describeWithEnv(
 
     describe("retrieveSession - edge cases", () => {
       test("returns null for non-multi session without event_id", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1702,7 +1702,7 @@ describeWithEnv(
       });
 
       test("returns null when session is null from Stripe", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1720,7 +1720,7 @@ describeWithEnv(
       });
 
       test("returns null when metadata is missing name or email", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1745,7 +1745,7 @@ describeWithEnv(
       });
 
       test("returns valid session for multi-ticket checkout", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1778,7 +1778,7 @@ describeWithEnv(
       });
 
       test("returns valid session for single-event checkout", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1811,7 +1811,7 @@ describeWithEnv(
       });
 
       test("returns amountTotal when session has numeric amount_total", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1842,7 +1842,7 @@ describeWithEnv(
       });
 
       test("returns null when amount_total is null", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1871,7 +1871,7 @@ describeWithEnv(
       });
 
       test("falls back to unpaid for invalid payment_status", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1901,7 +1901,7 @@ describeWithEnv(
       });
 
       test("casts amount_total to number", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -1934,7 +1934,7 @@ describeWithEnv(
     describe("verifyWebhookSignature delegation", () => {
       test("delegates to stripe.ts verifyWebhookSignature", async () => {
         const TEST_SECRET = "whsec_provider_verify_test";
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_provider_test",
         });
@@ -1964,7 +1964,7 @@ describeWithEnv(
 
       test("returns error for invalid signature", async () => {
         const TEST_SECRET = "whsec_provider_invalid_test";
-        await settings.stripe.setWebhookConfig({
+        await settings.update.stripe.webhookConfig({
           secret: TEST_SECRET,
           endpointId: "we_provider_inv",
         });
@@ -2015,13 +2015,13 @@ describeWithEnv(
 
     describe("refundPayment delegation", () => {
       test("returns true when refund succeeds", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const result = await stripePaymentProvider.refundPayment("pi_test_123");
         expect(result).toBe(true);
       });
 
       test("returns false when refund fails", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2048,7 +2048,7 @@ describeWithEnv(
 
     describe("getMockConfig without STRIPE_MOCK_HOST", () => {
       test("creates client without mock config when STRIPE_MOCK_HOST not set", async () => {
-        await settings.stripe.secretKey.update("sk_test_123");
+        await settings.update.stripe.secretKey("sk_test_123");
         Deno.env.delete("STRIPE_MOCK_HOST");
         Deno.env.delete("STRIPE_MOCK_PORT");
 
@@ -2068,7 +2068,7 @@ describeWithEnv(
       });
 
       test("returns null when Stripe API throws error", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client to be defined");
 
@@ -2088,7 +2088,7 @@ describeWithEnv(
 
     describe("isPaymentRefunded", () => {
       test("returns true when latest_charge is refunded", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2109,7 +2109,7 @@ describeWithEnv(
       });
 
       test("returns false when latest_charge is not refunded", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2130,7 +2130,7 @@ describeWithEnv(
       });
 
       test("returns false when payment intent not found", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2148,7 +2148,7 @@ describeWithEnv(
       });
 
       test("returns false when latest_charge is a string ID", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 
@@ -2171,7 +2171,7 @@ describeWithEnv(
 
     describe("createMultiCheckoutSession - via provider", () => {
       test("returns null when session has no URL", async () => {
-        await settings.stripe.secretKey.update("sk_test_mock");
+        await settings.update.stripe.secretKey("sk_test_mock");
         const client = await getStripeClient();
         if (!client) throw new Error("Expected client");
 

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -476,15 +476,15 @@ describe("test-utils", () => {
     test("configures Stripe as payment provider", async () => {
       await createTestDbWithSetup();
       await setupStripe();
-      const { getPaymentProviderFromDb } = await import("#lib/db/settings.ts");
-      expect(await getPaymentProviderFromDb()).toBe("stripe");
+      const { settings: s } = await import("#lib/db/settings.ts");
+      expect(await s.paymentProvider.get()).toBe("stripe");
     });
 
     test("accepts a custom key", async () => {
       await createTestDbWithSetup();
       await setupStripe("sk_test_custom");
-      const { getPaymentProviderFromDb } = await import("#lib/db/settings.ts");
-      expect(await getPaymentProviderFromDb()).toBe("stripe");
+      const { settings: s } = await import("#lib/db/settings.ts");
+      expect(await s.paymentProvider.get()).toBe("stripe");
     });
   });
 

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -477,14 +477,14 @@ describe("test-utils", () => {
       await createTestDbWithSetup();
       await setupStripe();
       const { settings: s } = await import("#lib/db/settings.ts");
-      expect(await s.paymentProvider.get()).toBe("stripe");
+      expect(s.paymentProvider).toBe("stripe");
     });
 
     test("accepts a custom key", async () => {
       await createTestDbWithSetup();
       await setupStripe("sk_test_custom");
       const { settings: s } = await import("#lib/db/settings.ts");
-      expect(await s.paymentProvider.get()).toBe("stripe");
+      expect(s.paymentProvider).toBe("stripe");
     });
   });
 

--- a/test/lib/theme.test.ts
+++ b/test/lib/theme.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { updateTheme } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import {
   getTheme,
   loadTheme,
@@ -54,13 +54,13 @@ describe("theme", () => {
     });
 
     test("loads dark theme after updating database", async () => {
-      await updateTheme("dark");
+      await settings.theme.update("dark");
       const theme = await loadTheme();
       expect(theme).toBe("dark");
     });
 
     test("makes theme available via getTheme after loading", async () => {
-      await updateTheme("dark");
+      await settings.theme.update("dark");
       await loadTheme();
       expect(getTheme()).toBe("dark");
     });

--- a/test/lib/theme.test.ts
+++ b/test/lib/theme.test.ts
@@ -44,13 +44,13 @@ describe("theme", () => {
     });
 
     test("loads dark theme after updating database", async () => {
-      await settings.theme.update("dark");
+      await settings.update.theme("dark");
       const theme = await loadTheme();
       expect(theme).toBe("dark");
     });
 
     test("makes theme available via getTheme after loading", async () => {
-      await settings.theme.update("dark");
+      await settings.update.theme("dark");
       await loadTheme();
       expect(getTheme()).toBe("dark");
     });

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -36,8 +36,8 @@ describe("webhook example", () => {
     await resetDb();
     await createTestDbWithSetup(EXAMPLE_CURRENCY);
 
-    const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
-    invalidateSettingsCache();
+    const { settings: s } = await import("#lib/db/settings.ts");
+    s.invalidateCache();
 
     // Set business email to match the example
     const { updateBusinessEmail } = await import("#lib/business-email.ts");

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -86,8 +86,8 @@ describe("webhook", () => {
 
   describeWithEnv("buildWebhookPayload", { db: true }, () => {
     beforeEach(async () => {
-      const { invalidateSettingsCache } = await import("#lib/db/settings.ts");
-      invalidateSettingsCache();
+      const { settings: s } = await import("#lib/db/settings.ts");
+      s.invalidateCache();
     });
 
     test("builds payload for a single free event", async () => {

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { updateShowPublicApi } from "#lib/db/settings.ts";
+import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
   createDailyTestEvent,
@@ -43,7 +43,7 @@ const expectCorsHeaders = (response: Response): void => {
 
 describeWithEnv("Public API", { db: true }, () => {
   beforeEach(async () => {
-    await updateShowPublicApi(true);
+    await settings.showPublicApi.update(true);
   });
 
   /** Fetch the events list and return parsed events array */
@@ -680,7 +680,7 @@ describeWithEnv("Public API", { db: true }, () => {
 
   describe("API disabled", () => {
     test("returns 404 when public API setting is disabled", async () => {
-      await updateShowPublicApi(false);
+      await settings.showPublicApi.update(false);
       const response = await handleRequest(apiRequest("/api/events"));
       expect(response.status).toBe(404);
     });

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -43,7 +43,7 @@ const expectCorsHeaders = (response: Response): void => {
 
 describeWithEnv("Public API", { db: true }, () => {
   beforeEach(async () => {
-    await settings.showPublicApi.update(true);
+    await settings.update.showPublicApi(true);
   });
 
   /** Fetch the events list and return parsed events array */
@@ -680,7 +680,7 @@ describeWithEnv("Public API", { db: true }, () => {
 
   describe("API disabled", () => {
     test("returns 404 when public API setting is disabled", async () => {
-      await settings.showPublicApi.update(false);
+      await settings.update.showPublicApi(false);
       const response = await handleRequest(apiRequest("/api/events"));
       expect(response.status).toBe(404);
     });


### PR DESCRIPTION
## Summary

- Replace ~80 individually-exported settings functions with a single `settings` namespace object organized by category
- Consumers now `import { settings }` instead of long lists like `getStripeSecretKeyFromDb, updateStripeKey, getShowPublicSiteFromDb, ...`
- Constants (`CONFIG_KEYS`, `MASK_SENTINEL`, `MAX_*`) and types remain as individual exports
- Net reduction of 261 lines across 72 files (-1500/+1239)

**Before:**
```typescript
import {
  getStripeSecretKeyFromDb, updateStripeKey, hasStripeKey,
  getShowPublicSiteFromDb, updateShowPublicSite, getThemeFromDb,
  updateTheme, getEmailProviderFromDb, updateEmailProvider, ...
} from "#lib/db/settings.ts";
```

**After:**
```typescript
import { settings } from "#lib/db/settings.ts";
settings.stripe.secretKey.get() / .update() / .has()
settings.showPublicSite.get() / .update() / .getCached()
settings.theme.get() / .update()
settings.email.provider.get() / .update()
```

## Test plan

- [x] All 154 tests pass
- [x] TypeScript typecheck passes
- [x] Deno lint passes
- [x] Full precommit suite passes (typecheck + lint + cpd + build + test:coverage)

https://claude.ai/code/session_01PxLwNzx5AREiDnJEy9TUBa