### PR TITLE
Fix form input spacing and fieldset padding

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -555,6 +555,7 @@ input[type="checkbox"],
 input[type="radio"] {
   display: inline-block;
   flex: 0;
+  margin: 0;
 }
 
 input[type="checkbox"] + label,
@@ -1006,6 +1007,7 @@ body.iframe form {
 
 fieldset {
   border: 0;
+  padding: 0 1rem;
 }
 
 .checkbox-group {


### PR DESCRIPTION
## Summary
This PR adjusts the styling of form elements to improve visual consistency and spacing. Two CSS modifications are made to the MVP stylesheet to address margin and padding issues.

## Key Changes
- **Checkbox and radio inputs**: Added `margin: 0` to explicitly reset default margins on checkbox and radio input elements, ensuring consistent spacing across browsers
- **Fieldset element**: Added `padding: 0 1rem` to provide horizontal padding within fieldset containers, improving the visual hierarchy and spacing of grouped form controls

## Implementation Details
These changes target the form styling rules in `src/static/mvp.css`:
- The margin reset on checkboxes/radios (line 558) prevents browser default margins from affecting layout
- The fieldset padding (line 1010) adds breathing room around grouped form elements while maintaining the existing `border: 0` rule

https://claude.ai/code/session_01MFP58mCYC5HjdH2oAWsb35