### PR TITLE
Remove prose styling class from migration page sections

### DIFF
--- a/src/templates/admin/migrate.tsx
+++ b/src/templates/admin/migrate.tsx
@@ -22,26 +22,30 @@ export const adminMigratePage = (
     <Layout title="Database Migration">
       <AdminNav session={session} active="" />
       {state.done ? (
-        <section class="prose">
-          <h2>Database Migration</h2>
-          <p>Migration complete. All attendee records have been upgraded.</p>
-          <p>
-            <a href="/admin/">Back to dashboard</a>
-          </p>
+        <section>
+          <div>
+            <h2>Database Migration</h2>
+            <p>Migration complete. All attendee records have been upgraded.</p>
+            <p>
+              <a href="/admin/">Back to dashboard</a>
+            </p>
+          </div>
         </section>
       ) : (
-        <section class="prose">
-          <h2>Database Migration</h2>
-          <p>
-            We're restructuring the database to improve performance. Attendee
-            data will be consolidated into a more efficient format, reducing
-            storage by approximately 68%.
-          </p>
-          <p>
-            This requires decrypting and re-encrypting each attendee record.
-            Press the button below to process a batch of {state.batchSize}{" "}
-            records at a time.
-          </p>
+        <section>
+          <div>
+            <h2>Database Migration</h2>
+            <p>
+              We're restructuring the database to improve performance. Attendee
+              data will be consolidated into a more efficient format, reducing
+              storage by approximately 68%.
+            </p>
+            <p>
+              This requires decrypting and re-encrypting each attendee record.
+              Press the button below to process a batch of {state.batchSize}{" "}
+              records at a time.
+            </p>
+          </div>
 
           <div id="migrate-status">
             <p>


### PR DESCRIPTION
## Summary
Removed the `prose` CSS class from the section elements on the database migration admin page and wrapped the content in an additional `div` container for better layout control.

## Changes
- Removed `class="prose"` from both the completion and in-progress section elements
- Wrapped the heading and paragraph content in a new `<div>` container within each section
- Maintained all existing content and functionality

## Details
This change decouples the migration page from the prose styling utility class, allowing for more flexible custom styling of the migration interface. The additional `div` wrapper provides a structural container for the content that can be independently styled without relying on prose typography defaults.

https://claude.ai/code/session_019EAYqupFrSYnbsshPvXcU5