### PR TITLE
Wrap event name and description in prose div for styling

### DIFF
--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -103,7 +103,7 @@ const renderEventListing = (info: MultiTicketEvent): string => {
       ? "<p><strong>Registration Closed</strong></p>"
       : `<p><a href="/ticket/${escapeHtml(event.slug)}"><strong>Book now</strong></a></p>`;
 
-  return `<h2>${escapeHtml(event.name)}</h2>${detailsHtml}${descriptionHtml}${linkHtml}`;
+  return `<div class="prose"><h2>${escapeHtml(event.name)}</h2>${descriptionHtml}</div>${detailsHtml}${linkHtml}`;
 };
 
 /**


### PR DESCRIPTION
## Summary
Updated the event listing HTML structure to wrap the event name and description in a `prose` class div, improving styling consistency and semantic markup.

## Key Changes
- Wrapped `<h2>` heading and description content in a `<div class="prose">` container
- Moved the `detailsHtml` and `linkHtml` outside the prose div to maintain their original styling context
- This change allows prose-specific CSS styling to be applied to the event name and description while keeping other elements unaffected

## Implementation Details
The restructuring maintains all existing content while improving the HTML organization. The prose class can now be used to apply typography and spacing rules specifically to the event title and description section, separate from the event details and booking link.

https://claude.ai/code/session_019gFM7seuEGzfwh4PrwHp2r