### PR TITLE
Wrap public site page content in prose div

### DIFF
--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -67,13 +67,15 @@ export const publicSitePage = (
     <Layout title={pageTitle} headExtra={FEED_DISCOVERY_TAGS}>
       {websiteTitle && <h1>{websiteTitle}</h1>}
       <PublicNav />
-      {content ? (
-        <Raw html={renderMarkdown(content)} />
-      ) : (
-        <p>
-          <em>No content.</em>
-        </p>
-      )}
+      <div class="prose">
+        {content ? (
+          <Raw html={renderMarkdown(content)} />
+        ) : (
+          <p>
+            <em>No content.</em>
+          </p>
+        )}
+      </div>
       <footer class="homepage-footer">
         <p>
           <a href="/admin/login">Login</a>

--- a/test/admin-api-events.test.ts
+++ b/test/admin-api-events.test.ts
@@ -70,7 +70,6 @@ const apiRequest = async (
 };
 
 describeWithEnv("Admin API - Events", { db: true }, () => {
-
   describe("GET /api/admin/events/:eventId", () => {
     test("returns single event by ID", async () => {
       const event = await createTestEvent({ name: "Detail Event" });

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -47,7 +47,6 @@ const getTestDataKey = async (): Promise<CryptoKey> => {
 };
 
 describeWithEnv("API Keys", { db: true }, () => {
-
   describe("database operations", () => {
     test("creates and retrieves an API key", async () => {
       const dataKey = await getTestDataKey();

--- a/test/lib/business-email.test.ts
+++ b/test/lib/business-email.test.ts
@@ -10,7 +10,6 @@ import { invalidateSettingsCache } from "#lib/db/settings.ts";
 import { describeWithEnv } from "#test-utils";
 
 describeWithEnv("business-email", { db: true }, () => {
-
   describe("isValidBusinessEmail", () => {
     test("accepts valid email", () => {
       expect(isValidBusinessEmail("test@example.com")).toBe(true);

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -28,7 +28,6 @@ const ALL_DAYS = [
 ] as const;
 
 describeWithEnv("dates", { db: true }, () => {
-
   describe("addDays", () => {
     test("adds positive days to a date", () => {
       expect(addDays("2026-01-01", 5)).toBe("2026-01-06");

--- a/test/lib/owner-footer.test.ts
+++ b/test/lib/owner-footer.test.ts
@@ -14,7 +14,6 @@ import {
 } from "#test-utils";
 
 describeWithEnv("admin debug footer", { db: true }, () => {
-
   test("owner sees footer on admin dashboard", async () => {
     const { response } = await adminGet("/admin/");
     const html = await response.text();

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -34,7 +34,6 @@ const createAttendee = async (eventId: number, name = "Alice") => {
 };
 
 describeWithEnv("custom questions", { db: true }, () => {
-
   describe("questions CRUD", () => {
     test("creates and retrieves a question", async () => {
       const q = await questionsTable.insert({ text: "Favourite colour?" });

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -34,7 +34,6 @@ import {
 } from "#test-utils";
 
 describeWithEnv("server (misc)", { db: true }, () => {
-
   /** Create an embeddable test event and return its ticket page response */
   const getTicketPageResponse = getEmbeddableTicketResponse;
 

--- a/test/lib/server-questions.test.ts
+++ b/test/lib/server-questions.test.ts
@@ -51,7 +51,6 @@ const addAnswer = async (questionId: number, text: string): Promise<number> => {
 };
 
 describeWithEnv("server (admin questions)", { db: true }, () => {
-
   describe("GET /admin/questions", () => {
     test("redirects to login when not authenticated", async () => {
       const response = await handleRequest(mockRequest("/admin/questions"));

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -18,7 +18,6 @@ import {
 } from "#test-utils";
 
 describeWithEnv("server (setup)", { db: true }, () => {
-
   /** Get CSRF token from setup page and submit setup form with given fields */
   async function submitSetupForm(
     fields: Record<string, string>,

--- a/test/lib/sort-events.test.ts
+++ b/test/lib/sort-events.test.ts
@@ -20,7 +20,6 @@ const expectAlphaBeforeBravo = (
 };
 
 describeWithEnv("sortEvents", { db: true }, () => {
-
   test("returns empty array for empty input", () => {
     expect(sortEvents([], [])).toEqual([]);
   });

--- a/test/lib/svg-ticket.test.ts
+++ b/test/lib/svg-ticket.test.ts
@@ -24,7 +24,6 @@ const makeTicketData = (
 });
 
 describeWithEnv("svg-ticket", { db: true }, () => {
-
   describe("extractSvgContent", () => {
     test("extracts inner content from svg element", () => {
       const svg =


### PR DESCRIPTION
## Summary
- Wraps the user-provided markdown content on `/`, `/terms`, and `/contact` pages (`publicSitePage`) in `<div class="prose">` for proper typography styling
- Existing prose wrappers on `/events` listings and ticket page event details are left as-is

## Test plan
- [ ] Verify `/`, `/terms`, `/contact` pages render content inside `<div class="prose">`
- [ ] Verify `/events` page still has per-event `<div class="prose">` wrappers (not double-wrapped)
- [ ] Verify ticket page prose wrapper is unchanged
- [ ] All tests pass with 100% coverage

https://claude.ai/code/session_01MhqDP8EHg8UCwcu2AmaiEK