### PR TITLE
Tag each deployment with timestamp

### DIFF
--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -44,6 +44,6 @@ jobs:
 
       - name: Tag deployment
         run: |
-          TAG="deploy-$(date +%s)"
+          TAG="deploy-$(date -u +%Y-%m-%d-%H%M)"
           git tag "$TAG"
           git push origin "$TAG"

--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -41,3 +41,9 @@ jobs:
           script_id: ${{ inputs.script_id || secrets.BUNNY_SCRIPT_ID }}
           file: "bunny-script.ts"
           api_key: ${{ secrets.BUNNY_ACCESS_KEY }}
+
+      - name: Tag deployment
+        run: |
+          TAG="deploy-$(date +%s)"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- After a successful Bunny Edge deploy, automatically creates a git tag like `deploy-1711234567`
- Enables easy rollback by checking out and redeploying any tagged commit
- Changed `contents` permission from `read` to `write` so the workflow can push tags

## Test plan
- [ ] Merge to main and verify a `deploy-*` tag is created after successful deployment
- [ ] Verify `git tag -l 'deploy-*'` lists the new tag

https://claude.ai/code/session_01BUYGP1HVwGwmaktzSqZyoq