### PR TITLE
Redirect to /admin/login instead of /admin/ when public site disabled

### DIFF
--- a/src/routes/feeds.ts
+++ b/src/routes/feeds.ts
@@ -62,9 +62,9 @@ const loadFeedData = async (): Promise<FeedData> => {
   };
 };
 
-/** Guard: redirect to admin if public site is disabled */
+/** Guard: redirect to admin login if public site is disabled */
 const requirePublicSite = <T>(fn: () => Promise<T>): Promise<T> | Response =>
-  settings.showPublicSite ? fn() : redirectResponse("/admin/");
+  settings.showPublicSite ? fn() : redirectResponse("/admin/login");
 
 /** Build a single VEVENT block */
 const buildVEvent = (

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -96,9 +96,9 @@ const loadHomepageEvents = async (): Promise<MultiTicketEvent[]> => {
   return sorted.map((e) => buildMultiTicketEvent(e, isRegistrationClosed(e)));
 };
 
-/** Guard: redirect to admin if public site is disabled */
+/** Guard: redirect to admin login if public site is disabled */
 const requirePublicSite = <T>(fn: () => T): T | Response =>
-  settings.showPublicSite ? fn() : redirectResponse("/admin/");
+  settings.showPublicSite ? fn() : redirectResponse("/admin/login");
 
 /** Render a public site page with website title and content */
 const renderPublicPage = (

--- a/test/lib/server-feeds.test.ts
+++ b/test/lib/server-feeds.test.ts
@@ -52,7 +52,7 @@ describeWithEnv("feeds", { db: true }, () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/feeds/events.ics"));
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/");
+      expect(response.headers.get("location")).toBe("/admin/login");
     });
 
     test("returns text/calendar content type", async () => {
@@ -193,7 +193,7 @@ describeWithEnv("feeds", { db: true }, () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/");
+      expect(response.headers.get("location")).toBe("/admin/login");
     });
 
     test("returns application/rss+xml content type", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -46,7 +46,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   describe("GET /", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/"));
-      expectRedirect(response, /^\/admin\/$/);
+      expectRedirect(response, /^\/admin\/login$/);
     });
 
     test("shows public homepage when enabled", async () => {
@@ -126,7 +126,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   describe("GET /events", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/events"));
-      expectRedirect(response, /^\/admin\/$/);
+      expectRedirect(response, /^\/admin\/login$/);
     });
 
     test("shows no events message when enabled but no events exist", async () => {
@@ -330,7 +330,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   describe("GET /terms", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/terms"));
-      expectRedirect(response, /^\/admin\/$/);
+      expectRedirect(response, /^\/admin\/login$/);
     });
 
     test("shows terms page when enabled", async () => {
@@ -370,7 +370,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   describe("GET /contact", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/contact"));
-      expectRedirect(response, /^\/admin\/$/);
+      expectRedirect(response, /^\/admin\/login$/);
     });
 
     test("shows contact page when enabled", async () => {


### PR DESCRIPTION
## Summary\n\n- When the public site is disabled, visiting `/`, `/events`, `/terms`, `/contact`, or feed URLs now redirects to `/admin/login` instead of `/admin/`\n- Fixes a broken flow where users with expired sessions would hit `/admin/` → migration gate → `/admin/migrate` → 403\n- `/admin/login` is already in the migration ungated list, so users go straight to the login form\n\n## Test plan\n\n- [x] All existing tests updated and passing\n- [x] 100% test coverage maintained\n- [ ] Verify: visit `/` with expired session cookie on unmigrated site → see login form\n- [ ] Verify: visit `/` without cookies on unmigrated site → see login form\n\nhttps://claude.ai/code/session_01NxjmHkRiL4TgaQ5YqSGnVM