### PR TITLE
Allow managers to access /admin/migrate

### DIFF
--- a/src/routes/admin/migrate.ts
+++ b/src/routes/admin/migrate.ts
@@ -1,7 +1,7 @@
 /**
  * Admin database migration route — migrates attendees from per-field
  * encryption to consolidated PII blob + plaintext status columns.
- * Owner-only access. Processes in manual batches of 100.
+ * Accessible to owners and managers. Processes in manual batches of 100.
  */
 
 import {
@@ -16,8 +16,8 @@ import type { AuthSession } from "#routes/utils.ts";
 import {
   htmlResponse,
   redirectResponse,
-  requireOwnerOr,
-  withOwnerAuthForm,
+  requireSessionOr,
+  withAuthForm,
 } from "#routes/utils.ts";
 import { adminMigratePage } from "#templates/admin/migrate.tsx";
 
@@ -34,7 +34,7 @@ const whenNotMigrated =
  * Handle GET /admin/migrate — show migration status page
  */
 const handleMigrateGet: TypedRouteHandler<"GET /admin/migrate"> = (request) =>
-  requireOwnerOr(
+  requireSessionOr(
     request,
     whenNotMigrated((session) =>
       htmlResponse(adminMigratePage(session, { done: true })),
@@ -60,7 +60,7 @@ const handleMigrateGet: TypedRouteHandler<"GET /admin/migrate"> = (request) =>
  * Handle POST /admin/migrate — process one batch of attendees
  */
 const handleMigratePost = (request: Request): Promise<Response> =>
-  withOwnerAuthForm(
+  withAuthForm(
     request,
     whenNotMigrated(() => redirectResponse("/admin/migrate"))(
       async (session) => {

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -25,10 +25,13 @@ import { getUserByUsername, verifyUserPassword } from "#lib/db/users.ts";
 import {
   adminFormPost,
   adminGet,
+  awaitTestRequest,
   createPaidTestAttendee,
   createTestAttendee,
   createTestEvent,
+  createTestManagerSession,
   describeWithEnv,
+  mockFormRequest,
   setTestEnv,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
@@ -405,6 +408,17 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
       const html = await response.text();
       expect(html).toContain("Migration complete");
     });
+
+    test("accessible to managers", async () => {
+      await settings.update.attendeeBlobMigrated();
+      const managerCookie = await createTestManagerSession();
+      const response = await awaitTestRequest("/admin/migrate", {
+        cookie: managerCookie,
+      });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Migration complete");
+    });
   });
 
   describe("POST /admin/migrate", () => {
@@ -453,6 +467,23 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
     test("redirects when already migrated", async () => {
       await settings.update.attendeeBlobMigrated();
       const { response } = await adminFormPost("/admin/migrate");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/migrate");
+    });
+
+    test("accessible to managers", async () => {
+      await settings.update.attendeeBlobMigrated();
+      const managerCookie = await createTestManagerSession();
+      const { signCsrfToken } = await import("#lib/csrf.ts");
+      const csrfToken = await signCsrfToken();
+      const { handleRequest } = await import("#routes");
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/migrate",
+          { csrf_token: csrfToken },
+          managerCookie,
+        ),
+      );
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("/admin/migrate");
     });


### PR DESCRIPTION
## Summary
- Changed `/admin/migrate` GET handler from `requireOwnerOr` to `requireSessionOr` so managers can view the migration page
- Changed `/admin/migrate` POST handler from `withOwnerAuthForm` to `withAuthForm` so managers can run migration batches
- Added tests verifying manager access to both GET and POST migrate routes

## Test plan
- [x] All 154 existing tests pass
- [x] New test: GET /admin/migrate returns 200 for manager users
- [x] New test: POST /admin/migrate returns 302 (not 403) for manager users

https://claude.ai/code/session_013DXJvUvqqQTmFwSx2yXPbm