### PR TITLE
Improve test utilities: batch DB operations and fix resource leaks

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -91,6 +91,7 @@ const getMockConfigImpl = (): Stripe.StripeConfig | undefined => {
     host: mockHost,
     port: mockPort,
     protocol: "http",
+    maxNetworkRetries: 0,
   };
 };
 

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -128,7 +128,7 @@ const clearDataTables = async (client: Client): Promise<void> => {
   const result = await client.execute(
     "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
   );
-  const tables = (result.rows as Array<{ name: string }>).map((r) => r.name);
+  const tables = result.rows.map((r) => r.name as string);
 
   // Batch all DELETEs into a single round-trip for speed
   await client.batch([

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -121,20 +121,22 @@ let cachedAdminSession: {
 
 /** Clear all data tables and reset autoincrement counters */
 const clearDataTables = async (client: Client): Promise<void> => {
-  // Disable FK checks so deletion order doesn't matter
+  // Disable FK checks outside the batch (PRAGMAs don't work inside transactions)
   await client.execute("PRAGMA foreign_keys = OFF");
-  // Discover all user tables dynamically (handles custom test tables like test_items)
+
+  // Discover all tables (including any test-created ones like test_items)
   const result = await client.execute(
     "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
   );
-  for (const row of result.rows) {
-    const name = row.name as string;
-    await client.execute(`DELETE FROM ${name}`);
-  }
-  // Reset autoincrement counters so IDs start from 1 (table may not exist)
-  await client.execute(
+  const tables = (result.rows as Array<{ name: string }>).map((r) => r.name);
+
+  // Batch all DELETEs into a single round-trip for speed
+  await client.batch([
+    ...tables.map((t) => `DELETE FROM ${t}`),
+    // Reset autoincrement counters so IDs start from 1
     "DELETE FROM sqlite_sequence WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type='table' AND name='sqlite_sequence')",
-  );
+  ]);
+
   await client.execute("PRAGMA foreign_keys = ON");
 };
 

--- a/src/test-utils/stripe-mock.ts
+++ b/src/test-utils/stripe-mock.ts
@@ -83,7 +83,9 @@ export const isStripeMockRunning = async (
   port: number = STRIPE_MOCK_PORT,
 ): Promise<boolean> => {
   try {
-    await fetch(`http://localhost:${port}/`);
+    const res = await fetch(`http://localhost:${port}/`);
+    // Consume the body to avoid resource leaks in Deno's test runner
+    await res.body?.cancel();
     // Any response (including 401) means the server is running
     return true;
   } catch {
@@ -119,8 +121,10 @@ export class StripeMockManager {
 
   /**
    * Start stripe-mock server
+   * @param maxAttempts Maximum readiness poll attempts (default 30)
+   * @param delayMs Delay between readiness polls in ms (default 100)
    */
-  async start(): Promise<void> {
+  async start(maxAttempts = 30, delayMs = 100): Promise<void> {
     // Check if already running (e.g., in dev mode)
     if (await isStripeMockRunning(this.port)) {
       return;
@@ -138,7 +142,7 @@ export class StripeMockManager {
     this.process = command.spawn();
 
     // Wait for it to be ready
-    const ready = await waitForStripeMock(this.port);
+    const ready = await waitForStripeMock(this.port, maxAttempts, delayMs);
     if (!ready) {
       throw new Error("stripe-mock failed to start");
     }

--- a/test/lib/stripe-mock.test.ts
+++ b/test/lib/stripe-mock.test.ts
@@ -201,7 +201,7 @@ describe("stripe-mock utilities", () => {
         }).output();
         renamed = true;
 
-        await expect(manager.start()).rejects.toThrow(
+        await expect(manager.start(3, 10)).rejects.toThrow(
           "stripe-mock failed to start",
         );
       } finally {


### PR DESCRIPTION
## Summary
This PR improves test utility reliability and performance by batching database operations, fixing resource leaks in HTTP requests, and adding configurable parameters to the Stripe mock manager.

## Key Changes

- **Database cleanup optimization**: Batch all `DELETE` statements into a single round-trip using `client.batch()` instead of executing them individually, improving performance and reducing network overhead
- **PRAGMA comment clarification**: Updated comment to explain that `PRAGMA foreign_keys` must be executed outside transactions
- **Resource leak fix**: Properly consume the response body in `isStripeMockRunning()` to prevent resource leaks in Deno's test runner
- **Stripe mock configurability**: Added `maxAttempts` and `delayMs` parameters to `StripeMockManager.start()` method to allow tests to customize readiness polling behavior
- **Stripe mock test adjustment**: Updated test to use shorter polling parameters (3 attempts, 10ms delay) for faster failure detection
- **Stripe client configuration**: Disabled network retries (`maxNetworkRetries: 0`) in mock Stripe client to prevent unnecessary retry delays during testing

## Implementation Details

The database cleanup refactoring extracts table names into an array first, then batches all DELETE operations together. This reduces the number of client round-trips from N+2 (where N is the number of tables) to just 2 (one for discovery, one for batch deletion).

The Stripe mock manager changes allow tests to fail faster when the mock server doesn't start, which is particularly useful in CI environments where startup delays might be longer.

https://claude.ai/code/session_01KG5GyXZVu2if6pco83mbDc