### PR TITLE
Improve textareas: aspect ratio, char limits, nav hiding

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -338,6 +338,24 @@ setupTestButton(
   },
 );
 
+/* Remaining chars counter for textareas with maxlength */
+for (const ta of document.querySelectorAll<HTMLTextAreaElement>(
+  "textarea[maxlength]",
+)) {
+  const max = Number(ta.getAttribute("maxlength"));
+  if (!max) continue;
+  const counter = document.createElement("small");
+  counter.className = "char-counter";
+  const update = () => {
+    const remaining = max - ta.value.length;
+    counter.textContent = `${remaining} / ${max}`;
+    counter.classList.toggle("char-counter-warn", remaining < max * 0.1);
+  };
+  update();
+  ta.addEventListener("input", update);
+  ta.parentNode!.insertBefore(counter, ta.nextSibling);
+}
+
 /* Multi-ticket question visibility: show questions only when at least one
  * associated event has quantity > 0. Questions without data-event-ids are
  * always visible (single-event pages). */

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -504,9 +504,7 @@ const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
 // Constants
 // ---------------------------------------------------------------------------
 
-export const MAX_TERMS_LENGTH = 10_240;
 export const MAX_WEBSITE_TITLE_LENGTH = 128;
-export const MAX_PAGE_TEXT_LENGTH = 2048;
 export const MAX_EMAIL_TEMPLATE_LENGTH = 51_200;
 
 // ---------------------------------------------------------------------------

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -122,9 +122,9 @@ export const renderField = (field: Field, value: string = ""): string =>
       {field.type === "textarea" ? (
         <textarea
           name={field.name}
-          rows="3"
           required={field.required}
           placeholder={field.placeholder}
+          maxlength={field.maxlength}
         >
           <Raw html={escapeHtml(value)} />
         </textarea>

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -33,6 +33,13 @@ export const MAX_ATTACHMENT_SIZE = readLimit(
 );
 
 // ---------------------------------------------------------------------------
+// Text limits
+// ---------------------------------------------------------------------------
+
+/** Maximum textarea content length in characters (default: 10240 = 10KB) */
+export const MAX_TEXTAREA_LENGTH = readLimit("MAX_TEXTAREA_LENGTH", 10_240);
+
+// ---------------------------------------------------------------------------
 // Timing limits
 // ---------------------------------------------------------------------------
 
@@ -111,6 +118,7 @@ export const formatLimitValue = (value: number, unit: string): string => {
   if (unit === "bytes") return formatBytes(value);
   if (unit === "ms") return formatMs(value);
   if (unit === "seconds") return formatSeconds(value);
+  if (unit === "chars") return `${value} chars`;
   return `${value} ${unit}`;
 };
 
@@ -123,6 +131,13 @@ type LimitEntry = {
 };
 
 export const LIMIT_ENTRIES: readonly LimitEntry[] = [
+  {
+    label: "Max textarea length",
+    envKey: "MAX_TEXTAREA_LENGTH",
+    defaultValue: 10_240,
+    current: MAX_TEXTAREA_LENGTH,
+    unit: "chars",
+  },
   {
     label: "Max image size",
     envKey: "MAX_IMAGE_SIZE",

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -26,7 +26,6 @@ import {
   type EmailTemplateType,
   isMaskSentinel,
   MAX_EMAIL_TEMPLATE_LENGTH,
-  MAX_TERMS_LENGTH,
   settings,
 } from "#lib/db/settings.ts";
 import { getUserById, verifyUserPassword } from "#lib/db/users.ts";
@@ -56,6 +55,7 @@ import { getFlash } from "#lib/flash-context.ts";
 import type { FormParams } from "#lib/form-data.ts";
 import { setFormError, setFormSuccess, validateForm } from "#lib/forms.tsx";
 import { isValidGooglePrivateKey } from "#lib/google-wallet.ts";
+import { MAX_TEXTAREA_LENGTH } from "#lib/limits.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import type { PaymentProviderType } from "#lib/payments.ts";
 import { testSquareConnection } from "#lib/square.ts";
@@ -603,9 +603,9 @@ const handleTermsPost = settingsRoute(async (form, errorPage) => {
   applyDemoOverrides(form, TERMS_DEMO_FIELDS);
   const trimmed = form.getString("terms_and_conditions");
 
-  if (trimmed.length > MAX_TERMS_LENGTH) {
+  if (trimmed.length > MAX_TEXTAREA_LENGTH) {
     return errorPage(
-      `Terms must be ${MAX_TERMS_LENGTH} characters or fewer (currently ${trimmed.length})`,
+      `Terms must be ${MAX_TEXTAREA_LENGTH} characters or fewer (currently ${trimmed.length})`,
       400,
       "settings-terms",
     );

--- a/src/routes/admin/site.ts
+++ b/src/routes/admin/site.ts
@@ -4,11 +4,7 @@
  */
 
 import { logActivity } from "#lib/db/activityLog.ts";
-import {
-  MAX_PAGE_TEXT_LENGTH,
-  MAX_WEBSITE_TITLE_LENGTH,
-  settings,
-} from "#lib/db/settings.ts";
+import { MAX_WEBSITE_TITLE_LENGTH, settings } from "#lib/db/settings.ts";
 import {
   applyDemoOverrides,
   SITE_CONTACT_DEMO_FIELDS,
@@ -16,6 +12,7 @@ import {
 } from "#lib/demo.ts";
 import { getFlash } from "#lib/flash-context.ts";
 import type { FormParams } from "#lib/form-data.ts";
+import { MAX_TEXTAREA_LENGTH } from "#lib/limits.ts";
 import { defineRoutes } from "#routes/router.ts";
 import {
   type AuthSession,
@@ -98,9 +95,9 @@ const handleSiteHomePost = sitePostRoute(async (session, form) => {
   }
 
   const textRaw = form.getString("homepage_text");
-  if (textRaw.length > MAX_PAGE_TEXT_LENGTH) {
+  if (textRaw.length > MAX_TEXTAREA_LENGTH) {
     return showError(
-      `Homepage text must be ${MAX_PAGE_TEXT_LENGTH} characters or fewer (currently ${textRaw.length})`,
+      `Homepage text must be ${MAX_TEXTAREA_LENGTH} characters or fewer (currently ${textRaw.length})`,
       400,
     );
   }
@@ -115,9 +112,9 @@ const handleSiteHomePost = sitePostRoute(async (session, form) => {
 const handleSiteContactPost = sitePostRoute(async (session, form) => {
   applyDemoOverrides(form, SITE_CONTACT_DEMO_FIELDS);
   const textRaw = form.getString("contact_page_text");
-  if (textRaw.length > MAX_PAGE_TEXT_LENGTH) {
+  if (textRaw.length > MAX_TEXTAREA_LENGTH) {
     return errorPageFor(session, renderContactPage)(
-      `Contact page text must be ${MAX_PAGE_TEXT_LENGTH} characters or fewer (currently ${textRaw.length})`,
+      `Contact page text must be ${MAX_TEXTAREA_LENGTH} characters or fewer (currently ${textRaw.length})`,
       400,
     );
   }

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -119,13 +119,29 @@ export const handlePublicEvents = (): Response | Promise<Response> =>
     return htmlResponse(homepagePage(events, settings.websiteTitle));
   });
 
-/** Handle GET /terms - public terms and conditions page */
+/** Handle GET /terms - public terms and conditions page (404 when empty) */
 export const handlePublicTerms = (): Response =>
-  renderPublicPage("terms", () => settings.terms);
+  requirePublicSite(() =>
+    settings.terms
+      ? htmlResponse(
+          publicSitePage("terms", settings.websiteTitle, settings.terms),
+        )
+      : notFoundResponse(),
+  );
 
-/** Handle GET /contact - public contact page */
+/** Handle GET /contact - public contact page (404 when empty) */
 export const handlePublicContact = (): Response =>
-  renderPublicPage("contact", () => settings.contactPageText);
+  requirePublicSite(() =>
+    settings.contactPageText
+      ? htmlResponse(
+          publicSitePage(
+            "contact",
+            settings.websiteTitle,
+            settings.contactPageText,
+          ),
+        )
+      : notFoundResponse(),
+  );
 
 /** Render a ticket page with the given context */
 const renderTicketPage = (

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -591,9 +591,24 @@ input[type="file"] {
   box-sizing: border-box;
 }
 
+textarea {
+  aspect-ratio: 4 / 3;
+  resize: vertical;
+}
+
 input[readonly],
 textarea[readonly] {
   background-color: var(--color-bg-secondary);
+}
+
+.char-counter {
+  display: block;
+  text-align: right;
+  color: var(--color-text-secondary);
+  font-weight: normal;
+}
+.char-counter-warn {
+  color: #c00;
 }
 
 label {

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -6,7 +6,11 @@ import { COUNTRIES, type CountryData } from "#lib/countries.ts";
 import { MASK_SENTINEL } from "#lib/db/settings.ts";
 import { CsrfForm, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
-import { formatBytes, MAX_IMAGE_SIZE } from "#lib/limits.ts";
+import {
+  formatBytes,
+  MAX_IMAGE_SIZE,
+  MAX_TEXTAREA_LENGTH,
+} from "#lib/limits.ts";
 import { getImageProxyUrl } from "#lib/storage.ts";
 import type { AdminSession, Theme } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
@@ -373,7 +377,7 @@ export const adminSettingsPage = (
           </p>
           <textarea
             name="terms_and_conditions"
-            rows="4"
+            maxlength={MAX_TEXTAREA_LENGTH}
             placeholder="Enter terms and conditions that attendees must agree to before registering. Leave blank to disable."
           >
             {s.termsAndConditions}

--- a/src/templates/admin/site.tsx
+++ b/src/templates/admin/site.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { MAX_TEXTAREA_LENGTH } from "#lib/limits.ts";
 import type { AdminSession } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { FORMATTING_HINT } from "#templates/fields.ts";
@@ -63,14 +64,14 @@ export const adminSiteHomePage = (
         <label for="homepage_text">Homepage Text</label>
         <p>
           <small>
-            Text displayed on the public homepage (max 2048 characters).{" "}
-            <Raw html={FORMATTING_HINT} />
+            Text displayed on the public homepage (max {MAX_TEXTAREA_LENGTH}{" "}
+            characters). <Raw html={FORMATTING_HINT} />
           </small>
         </p>
         <textarea
           id="homepage_text"
           name="homepage_text"
-          rows="4"
+          maxlength={MAX_TEXTAREA_LENGTH}
           placeholder="Welcome to our site..."
         >
           {homepageText ?? ""}
@@ -104,14 +105,14 @@ export const adminSiteContactPage = (
         <label for="contact_page_text">Contact Page Text</label>
         <p>
           <small>
-            Text displayed on the public contact page (max 2048 characters).{" "}
-            <Raw html={FORMATTING_HINT} />
+            Text displayed on the public contact page (max {MAX_TEXTAREA_LENGTH}{" "}
+            characters). <Raw html={FORMATTING_HINT} />
           </small>
         </p>
         <textarea
           id="contact_page_text"
           name="contact_page_text"
-          rows="4"
+          maxlength={MAX_TEXTAREA_LENGTH}
           placeholder="Get in touch with us..."
         >
           {contactPageText ?? ""}

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -16,6 +16,7 @@ import {
   formatBytes,
   MAX_ATTACHMENT_SIZE,
   MAX_IMAGE_SIZE,
+  MAX_TEXTAREA_LENGTH,
 } from "#lib/limits.ts";
 import { normalizeSlug, validateSlug } from "#lib/slug.ts";
 import { isValidDatetime } from "#lib/timezone.ts";
@@ -281,15 +282,12 @@ export const validateBookableDays = (value: string): string | null => {
 
 /** Shared formatting hint linking to the admin guide */
 export const FORMATTING_HINT =
-  '<a href="/admin/guide#text-formatting">Formatting help</a>';
-
-/** Max length for event description */
-const MAX_DESCRIPTION_LENGTH = 256;
+  '<a href="/admin/guide#text-formatting" target="_blank" rel="noopener">Formatting help</a>';
 
 /** Validate description length */
 const validateDescription = (value: string): string | null =>
-  value.length > MAX_DESCRIPTION_LENGTH
-    ? `Description must be ${MAX_DESCRIPTION_LENGTH} characters or fewer`
+  value.length > MAX_TEXTAREA_LENGTH
+    ? `Description must be ${MAX_TEXTAREA_LENGTH} characters or fewer`
     : null;
 
 /** Validate a datetime value is parseable */
@@ -322,11 +320,11 @@ export const eventFields: Field[] = [
   {
     name: "description",
     label: "Description (optional)",
-    type: "text",
+    type: "textarea",
     placeholder: "A short description of the event",
-    hint: "Shown on the ticket page. Max 256 characters.",
+    hint: "Shown on the ticket page.",
     hintHtml: FORMATTING_HINT,
-    maxlength: MAX_DESCRIPTION_LENGTH,
+    maxlength: MAX_TEXTAREA_LENGTH,
     validate: validateDescription,
   },
   {
@@ -556,6 +554,11 @@ export const groupCreateFields: Field[] = [
     type: "textarea",
     hint: "If set, overrides the global terms and conditions for this group ticket page",
     hintHtml: FORMATTING_HINT,
+    maxlength: MAX_TEXTAREA_LENGTH,
+    validate: (value: string) =>
+      value.length > MAX_TEXTAREA_LENGTH
+        ? `Terms must be ${MAX_TEXTAREA_LENGTH} characters or fewer`
+        : null,
   },
 ];
 

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -9,6 +9,7 @@ import type {
   QuestionEventMap,
   QuestionWithAnswers,
 } from "#lib/db/questions.ts";
+import { settings } from "#lib/db/settings.ts";
 import type { Field } from "#lib/forms.tsx";
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
 import { getIframeMode } from "#lib/iframe.ts";
@@ -23,8 +24,14 @@ import {
 import { getTicketFields, mergeEventFields } from "#templates/fields.ts";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
 
-/** Public site navigation */
-const PublicNav = (): JSX.Element => (
+/** Public site navigation - hides terms/contact links when those pages are empty */
+const PublicNav = ({
+  hasTerms,
+  hasContact,
+}: {
+  hasTerms?: boolean;
+  hasContact?: boolean;
+}): JSX.Element => (
   <nav>
     <ul>
       <li>
@@ -33,15 +40,25 @@ const PublicNav = (): JSX.Element => (
       <li>
         <a href="/events">Events</a>
       </li>
-      <li>
-        <a href="/terms">T&amp;Cs</a>
-      </li>
-      <li>
-        <a href="/contact">Contact</a>
-      </li>
+      {hasTerms && (
+        <li>
+          <a href="/terms">T&amp;Cs</a>
+        </li>
+      )}
+      {hasContact && (
+        <li>
+          <a href="/contact">Contact</a>
+        </li>
+      )}
     </ul>
   </nav>
 );
+
+/** Compute which public pages have content */
+const navFlags = () => ({
+  hasTerms: !!settings.terms,
+  hasContact: !!settings.contactPageText,
+});
 
 /** Public site page type */
 export type PublicPageType = "home" | "terms" | "contact";
@@ -66,7 +83,7 @@ export const publicSitePage = (
   return String(
     <Layout title={pageTitle} headExtra={FEED_DISCOVERY_TAGS}>
       {websiteTitle && <h1>{websiteTitle}</h1>}
-      <PublicNav />
+      <PublicNav {...navFlags()} />
       <div class="prose">
         {content ? (
           <Raw html={renderMarkdown(content)} />
@@ -129,7 +146,7 @@ export const homepagePage = (
     return String(
       <Layout title={title} headExtra={FEED_DISCOVERY_TAGS}>
         {websiteTitle && <h1>{websiteTitle}</h1>}
-        <PublicNav />
+        <PublicNav {...navFlags()} />
         <p>
           <em>No events listed.</em>
         </p>
@@ -149,7 +166,7 @@ export const homepagePage = (
   return String(
     <Layout title={title} headExtra={FEED_DISCOVERY_TAGS}>
       {websiteTitle && <h1>{websiteTitle}</h1>}
-      <PublicNav />
+      <PublicNav {...navFlags()} />
       <h2>All bookable events</h2>
       <Raw html={eventListings} />
       <footer class="homepage-footer">

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -17,11 +17,13 @@ import {
   validateForm,
 } from "#lib/forms.tsx";
 import { detectIframeMode } from "#lib/iframe.ts";
+import { MAX_TEXTAREA_LENGTH } from "#lib/limits.ts";
 import {
   changePasswordFields,
   eventFields,
   fieldsApi,
   getTicketFields,
+  groupCreateFields,
   holidayFields,
   joinFields,
   loginFields,
@@ -168,7 +170,6 @@ describe("forms", () => {
         type: "textarea",
       });
       expect(html).toContain("<textarea");
-      expect(html).toContain('rows="3"');
       expect(html).not.toContain("<input");
     });
 
@@ -427,25 +428,45 @@ describe("forms", () => {
     });
 
     test("validates description rejects values exceeding max length", () => {
-      const longDescription = "a".repeat(257);
-      expectInvalid("Description must be 256 characters or fewer")(
-        eventFields,
-        eventForm({ description: longDescription }),
-      );
+      const longDescription = "a".repeat(MAX_TEXTAREA_LENGTH + 1);
+      expectInvalid(
+        `Description must be ${MAX_TEXTAREA_LENGTH} characters or fewer`,
+      )(eventFields, eventForm({ description: longDescription }));
     });
 
     test("validates description accepts values within max length", () => {
-      expectValid(eventFields, eventForm({ description: "a".repeat(256) }));
+      expectValid(
+        eventFields,
+        eventForm({ description: "a".repeat(MAX_TEXTAREA_LENGTH) }),
+      );
     });
 
     test("validates description accepts empty value", () => {
       expectValid(eventFields, eventForm({ description: "" }));
     });
 
-    test("description field has maxlength of 256", () => {
+    test("description field has maxlength matching MAX_TEXTAREA_LENGTH", () => {
       const descField = eventFields.find((f) => f.name === "description");
       expect(descField).toBeDefined();
-      expect(descField!.maxlength).toBe(256);
+      expect(descField!.maxlength).toBe(MAX_TEXTAREA_LENGTH);
+    });
+  });
+
+  describe("groupCreateFields validation", () => {
+    test("rejects terms_and_conditions exceeding MAX_TEXTAREA_LENGTH", () => {
+      const termsField = groupCreateFields.find(
+        (f) => f.name === "terms_and_conditions",
+      )!;
+      const error = termsField.validate!("x".repeat(MAX_TEXTAREA_LENGTH + 1));
+      expect(error).toContain(`${MAX_TEXTAREA_LENGTH} characters or fewer`);
+    });
+
+    test("accepts terms_and_conditions within MAX_TEXTAREA_LENGTH", () => {
+      const termsField = groupCreateFields.find(
+        (f) => f.name === "terms_and_conditions",
+      )!;
+      const error = termsField.validate!("x".repeat(MAX_TEXTAREA_LENGTH));
+      expect(error).toBeNull();
     });
   });
 

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -77,6 +77,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
     test("shows public nav links", async () => {
       await settings.update.showPublicSite(true);
+      await settings.update.terms("Some terms");
+      await settings.update.contactPageText("Contact us");
       const response = await handleRequest(mockRequest("/"));
       await expectHtmlResponse(
         response,
@@ -86,6 +88,15 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         'href="/terms"',
         'href="/contact"',
       );
+    });
+
+    test("hides terms and contact nav links when pages are empty", async () => {
+      await settings.update.showPublicSite(true);
+      const response = await handleRequest(mockRequest("/"));
+      const html = await expectHtmlResponse(response, 200, 'href="/"');
+      expect(html).toContain('href="/events"');
+      expect(html).not.toContain('href="/terms"');
+      expect(html).not.toContain('href="/contact"');
     });
 
     test("shows login link styled as footer", async () => {
@@ -299,6 +310,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
     test("shows public nav on events page", async () => {
       await settings.update.showPublicSite(true);
+      await settings.update.terms("Some terms");
+      await settings.update.contactPageText("Contact us");
       const response = await handleRequest(mockRequest("/events"));
       await expectHtmlResponse(
         response,
@@ -345,21 +358,15 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("shows no content when terms not configured", async () => {
+    test("returns 404 when terms not configured", async () => {
       await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/terms"));
-      await expectHtmlResponse(response, 200, "No content.");
-    });
-
-    test("shows website title on terms page", async () => {
-      await settings.update.showPublicSite(true);
-      await settings.update.websiteTitle("My Site");
-      const response = await handleRequest(mockRequest("/terms"));
-      await expectHtmlResponse(response, 200, "My Site");
+      expect(response.status).toBe(404);
     });
 
     test("includes RSS and ICS feed discovery tags", async () => {
       await settings.update.showPublicSite(true);
+      await settings.update.terms("Some terms");
       const response = await handleRequest(mockRequest("/terms"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);
@@ -385,17 +392,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("shows no content when contact text not configured", async () => {
+    test("returns 404 when contact text not configured", async () => {
       await settings.update.showPublicSite(true);
       const response = await handleRequest(mockRequest("/contact"));
-      await expectHtmlResponse(response, 200, "No content.");
-    });
-
-    test("shows website title on contact page", async () => {
-      await settings.update.showPublicSite(true);
-      await settings.update.websiteTitle("My Site");
-      const response = await handleRequest(mockRequest("/contact"));
-      await expectHtmlResponse(response, 200, "My Site");
+      expect(response.status).toBe(404);
     });
 
     test("renders markdown paragraphs in contact text", async () => {
@@ -418,6 +418,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
     test("includes RSS and ICS feed discovery tags", async () => {
       await settings.update.showPublicSite(true);
+      await settings.update.contactPageText("Contact us");
       const response = await handleRequest(mockRequest("/contact"));
       const html = await expectHtmlResponse(response, 200);
       expect(html).toContain(RSS_DISCOVERY_TAG);

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -7,6 +7,7 @@ import { eventsTable } from "#lib/db/events.ts";
 import { settings } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
+import { MAX_TEXTAREA_LENGTH } from "#lib/limits.ts";
 import { squareApi } from "#lib/square.ts";
 import { stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
@@ -1162,14 +1163,18 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         mockFormRequest(
           "/admin/settings/terms",
           {
-            terms_and_conditions: "x".repeat(10_241),
+            terms_and_conditions: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
             csrf_token: await testCsrfToken(),
           },
           await testCookie(),
         ),
       );
 
-      await expectHtmlResponse(response, 400, "10240 characters or fewer");
+      await expectHtmlResponse(
+        response,
+        400,
+        `${MAX_TEXTAREA_LENGTH} characters or fewer`,
+      );
     });
 
     test("accepts terms at exactly max length", async () => {
@@ -1177,7 +1182,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         mockFormRequest(
           "/admin/settings/terms",
           {
-            terms_and_conditions: "x".repeat(10_240),
+            terms_and_conditions: "x".repeat(MAX_TEXTAREA_LENGTH),
             csrf_token: await testCsrfToken(),
           },
           await testCookie(),

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -1,10 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import {
-  MAX_PAGE_TEXT_LENGTH,
-  MAX_WEBSITE_TITLE_LENGTH,
-  settings,
-} from "#lib/db/settings.ts";
+import { MAX_WEBSITE_TITLE_LENGTH, settings } from "#lib/db/settings.ts";
+import { MAX_TEXTAREA_LENGTH } from "#lib/limits.ts";
 import { handleRequest } from "#routes";
 import {
   awaitTestRequest,
@@ -156,7 +153,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
           "/admin/site",
           {
             website_title: "",
-            homepage_text: "x".repeat(MAX_PAGE_TEXT_LENGTH + 1),
+            homepage_text: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
             csrf_token: await testCsrfToken(),
           },
           await testCookie(),
@@ -165,7 +162,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         400,
-        `${MAX_PAGE_TEXT_LENGTH} characters or fewer`,
+        `${MAX_TEXTAREA_LENGTH} characters or fewer`,
       );
     });
 
@@ -273,7 +270,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         mockFormRequest(
           "/admin/site/contact",
           {
-            contact_page_text: "x".repeat(MAX_PAGE_TEXT_LENGTH + 1),
+            contact_page_text: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
             csrf_token: await testCsrfToken(),
           },
           await testCookie(),
@@ -282,7 +279,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         400,
-        `${MAX_PAGE_TEXT_LENGTH} characters or fewer`,
+        `${MAX_TEXTAREA_LENGTH} characters or fewer`,
       );
     });
 


### PR DESCRIPTION
- Change event description from text input to textarea
- Add 4/3 aspect-ratio CSS default for all textareas
- Make formatting help links open in new windows (target="_blank")
- Add configurable MAX_TEXTAREA_LENGTH (default 10KB) via env var,
  applied to event descriptions, terms, contact, homepage, group terms
- Show MAX_TEXTAREA_LENGTH on /admin/debug limits table
- Add remaining chars counter on textareas with maxlength (minimal JS)
- Hide terms/contact nav links and return 404 when pages are empty

https://claude.ai/code/session_01TKqYdryoU8jSYpwi71Rf4h