### PR TITLE
Fix flaky fetch response body leak errors in tests

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -840,6 +840,7 @@ export const loginAsAdmin = async (): Promise<{
       loginCsrfToken,
     ),
   );
+  loginResponse.body?.cancel();
   const cookie = loginResponse.headers
     .getSetCookie()
     .find((c) => c.startsWith(getSessionCookieName() + "="));
@@ -935,6 +936,7 @@ const authenticatedRequest = async <T>(
       session.cookie,
     ),
   );
+  response.body?.cancel();
 
   if (response.status !== 302) {
     throw new Error(`Failed to ${errorContext}: ${response.status}`);
@@ -1195,6 +1197,7 @@ export const createTestAttendee = async (
       `Failed to create attendee: ${response.status} - ${body.slice(0, 200)}`,
     );
   }
+  response.body?.cancel();
 
   // Return the most recent attendee (DESC order puts newest first)
   const afterAttendees = await getAttendeesRaw(eventId);
@@ -1248,6 +1251,7 @@ export const expectRedirect = (
   ...patterns: (string | RegExp)[]
 ): string => {
   expect(response.status).toBe(302);
+  response.body?.cancel();
   const location = getRedirectLocation(response);
   for (const p of patterns) {
     if (typeof p === "string") {
@@ -1277,6 +1281,7 @@ export const expectFlash = (
   message: string | any,
   succeeded = true,
 ): Response => {
+  response.body?.cancel();
   const cookies = response.headers.getSetCookie();
   const flash = cookies.find((c) => c.startsWith("flash_"));
   if (!flash) throw new Error("No flash cookie in response");
@@ -1563,6 +1568,7 @@ export const createTestInvite = async (
       cookie,
     ),
   );
+  inviteResponse.body?.cancel();
   const location = inviteResponse.headers.get("location") ?? "";
   const url = new URL(location, "http://localhost");
   const inviteLink = url.searchParams.get("invite") ?? "";


### PR DESCRIPTION
## Summary

- Fixes intermittent "Leaks detected: A fetch response body was created during the test, but not consumed" errors in the "db" and "server (admin events)" test suites
- Adds `response.body?.cancel()` to 6 test utility functions that create HTTP responses but only read headers/status, never the body
- Affected functions: `loginAsAdmin`, `authenticatedRequest`, `createTestInvite`, `createTestAttendee`, `expectRedirect`, `expectFlash`

## Test plan

- [x] `deno task test` passes with 154/154 tests (verified twice)
- [x] `deno task precommit` passes (typecheck, lint, tests, 100% coverage)
- [x] Previously flaky "db" and "server (admin events)" suites no longer leak

https://claude.ai/code/session_014ovu9kPz4YsWEkKREESLnN