### PR TITLE
Remove ALLOWED_DOMAIN requirement and use request hostname

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -22,6 +22,3 @@ spec:
         - key: DB_ENCRYPTION_KEY
           scope: RUN_TIME
           type: SECRET
-        - key: ALLOWED_DOMAIN
-          scope: RUN_TIME
-          type: GENERAL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,5 @@ jobs:
         env:
           STRIPE_MOCK_HOST: localhost
           STRIPE_MOCK_PORT: "12111"
-          ALLOWED_DOMAIN: localhost
           DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
         run: deno task test:coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,6 @@ Environment variables are configured as **Bunny native secrets** in the Bunny Ed
 - `DB_URL` - Database URL (required, e.g. `libsql://your-db.turso.io`)
 - `DB_TOKEN` - Database auth token (required for remote databases)
 - `DB_ENCRYPTION_KEY` - 32-byte base64-encoded encryption key (required)
-- `ALLOWED_DOMAIN` - Domain for security validation (required)
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The recommended deployment. Fork the repo, connect it to Bunny, and deploy via G
    | `DB_URL` | Your Bunny database URL |
    | `DB_TOKEN` | Your Bunny database auth token |
    | `DB_ENCRYPTION_KEY` | 32-byte base64-encoded AES-256 key |
-   | `ALLOWED_DOMAIN` | Your domain (e.g. `tickets.example.com`) |
 
 5. **Add GitHub Actions secrets** to your repository: `BUNNY_SCRIPT_ID` and `BUNNY_ACCESS_KEY`
 
@@ -193,7 +192,6 @@ docker run -p 3000:3000 \
   -v tickets-data:/data \
   -e DB_URL="file:/data/tickets.db" \
   -e DB_ENCRYPTION_KEY="your-base64-key" \
-  -e ALLOWED_DOMAIN="your-domain.com" \
   chobble-tickets
 ```
 
@@ -215,8 +213,7 @@ Also deployable with [Fly.io](https://fly.io) (`fly launch`) or any Docker host.
 
 # Run locally
 DB_URL=libsql://your-db.turso.io DB_TOKEN=your-token \
-  DB_ENCRYPTION_KEY=your-base64-key ALLOWED_DOMAIN=localhost \
-  deno task start
+  DB_ENCRYPTION_KEY=your-base64-key deno task start
 
 # Run tests (stripe-mock downloaded automatically)
 deno task test
@@ -244,7 +241,6 @@ deno task precommit      # All checks (typecheck, lint, cpd, build:edge, test:co
 | `DB_URL` | Yes | libsql database URL |
 | `DB_TOKEN` | Yes* | Database auth token (*remote databases) |
 | `DB_ENCRYPTION_KEY` | Yes | 32-byte base64-encoded AES-256 key |
-| `ALLOWED_DOMAIN` | Yes | Domain for security validation |
 
 See the [CONFIG_KEYS reference](https://chobbledotcom.github.io/tickets/doc.ts/~/CONFIG_KEYS.html) for all optional variables (email providers, Apple Wallet, image uploads, and more).
 

--- a/app.json
+++ b/app.json
@@ -16,10 +16,6 @@
     "DB_ENCRYPTION_KEY": {
       "description": "32-byte base64-encoded AES-256 encryption key",
       "required": true
-    },
-    "ALLOWED_DOMAIN": {
-      "description": "Domain for security validation (e.g. your-app.herokuapp.com)",
-      "required": true
     }
   }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
             export DB_ENCRYPTION_KEY="$(openssl rand -base64 32)"
             export DB_URL=":memory:"
             export PORT=8080
-            export ALLOWED_DOMAIN="localhost"
           '';
         };
       });

--- a/render.yaml
+++ b/render.yaml
@@ -11,7 +11,5 @@ services:
         sync: false
       - key: DB_ENCRYPTION_KEY
         sync: false
-      - key: ALLOWED_DOMAIN
-        sync: false
       - key: PORT
         value: "3000"

--- a/scripts/profile-cold-boot.ts
+++ b/scripts/profile-cold-boot.ts
@@ -63,9 +63,6 @@ const printReport = () => {
 const main = async () => {
   log("Profiling cold boot performance...\n");
 
-  // Set up test environment
-  Deno.env.set("ALLOWED_DOMAIN", "localhost");
-
   // Use in-memory DB to isolate JS overhead from network latency
   const client = createClient({ url: ":memory:" });
 

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -125,7 +125,6 @@ const runTests = async (useCoverage: boolean): Promise<number> => {
       ...Deno.env.toObject(),
       STRIPE_MOCK_HOST: "localhost",
       STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
-      ALLOWED_DOMAIN: "localhost",
       DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "3",
     },
   });
@@ -253,7 +252,6 @@ const main = async (): Promise<void> => {
 
   Deno.env.set("STRIPE_MOCK_HOST", "localhost");
   Deno.env.set("STRIPE_MOCK_PORT", String(STRIPE_MOCK_PORT));
-  Deno.env.set("ALLOWED_DOMAIN", "localhost");
 
   const useCoverage = Deno.args.includes("--coverage");
   const exitCode = await runTests(useCoverage);

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -32,7 +32,7 @@ interface BunnyPullZoneListResponse {
 
 /**
  * Find the pull zone ID by searching pull zones for the CDN hostname
- * (ALLOWED_DOMAIN with .bunny.run replaced by .b-cdn.net).
+ * (effective domain with .bunny.run replaced by .b-cdn.net).
  */
 const findPullZoneIdImpl = async (): Promise<
   { ok: true; id: number } | { ok: false; error: string; errorKey?: string }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,6 @@
  * Payment provider and keys are configured via admin settings (stored encrypted in DB)
  */
 
-import { lazyRef } from "#fp";
 import { settings } from "#lib/db/settings.ts";
 import { getEnv, requireEnv } from "#lib/env.ts";
 
@@ -26,45 +25,24 @@ export const getBookingFee = (): number =>
   Number.parseFloat(settings.bookingFee!) || 0;
 
 /**
- * Get allowed domain for security validation (runtime config via Bunny secrets)
- * This is a required configuration that hardens origin validation
- */
-const [getAllowedDomainOverride, setAllowedDomainOverride] = lazyRef<
-  string | null
->(() => null);
-
-export const getAllowedDomain = (): string =>
-  getAllowedDomainOverride() ?? requireEnv("ALLOWED_DOMAIN");
-
-/** Reset cached allowed domain value (for testing and cache invalidation) */
-export const resetAllowedDomain = (): void => setAllowedDomainOverride(null);
-
-/**
- * Explicitly set allowed domain (for testing).
- * Bypasses Deno.env to avoid races between parallel test workers.
- */
-export const setAllowedDomainForTest = (domain: string): void =>
-  setAllowedDomainOverride(domain);
-
-/**
- * Effective domain: custom_domain (from DB) if set, otherwise ALLOWED_DOMAIN.
- * Loaded async once per request via loadEffectiveDomain(), then read
+ * Effective domain: custom_domain (from DB) if set, otherwise the request's
+ * own hostname. Loaded once per request via loadEffectiveDomain(), then read
  * synchronously via getEffectiveDomain().
  */
 const effectiveDomainState = { domain: null as string | null };
 
-/** Load the effective domain from DB (call early in request pipeline). */
-export const loadEffectiveDomain = (): string => {
+/** Load the effective domain from DB, falling back to the request URL hostname. */
+export const loadEffectiveDomain = (requestUrl: string): string => {
   const custom = settings.customDomain;
   const validated = custom ? settings.customDomainLastValidated : null;
   effectiveDomainState.domain =
-    custom && validated ? custom : getAllowedDomain();
+    custom && validated ? custom : new URL(requestUrl).hostname;
   return effectiveDomainState.domain;
 };
 
-/** Get the effective domain synchronously (falls back to ALLOWED_DOMAIN). */
+/** Get the effective domain synchronously (must call loadEffectiveDomain first). */
 export const getEffectiveDomain = (): string =>
-  effectiveDomainState.domain ?? getAllowedDomain();
+  effectiveDomainState.domain ?? "localhost";
 
 /** Reset effective domain cache (for testing). */
 export const resetEffectiveDomain = (): void => {
@@ -99,8 +77,8 @@ export const isBunnyCdnEnabled = (): boolean => !!getEnv("BUNNY_API_KEY");
 export const getBunnyApiKey = (): string => requireEnv("BUNNY_API_KEY");
 
 /**
- * Get the CDN hostname derived from ALLOWED_DOMAIN.
+ * Get the CDN hostname derived from the effective domain.
  * Replaces ".bunny.run" with ".b-cdn.net" for the CNAME target.
  */
 export const getCdnHostname = (): string =>
-  getAllowedDomain().replace(/\.bunny\.run$/, ".b-cdn.net");
+  getEffectiveDomain().replace(/\.bunny\.run$/, ".b-cdn.net");

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -23,7 +23,6 @@ import {
   createRequestTimer,
   ErrorCode,
   formatRequestError,
-  logDebug,
   logError,
   logRequest,
   runWithRequestId,
@@ -33,14 +32,10 @@ import { runWithRequestCache } from "#lib/request-cache.ts";
 import { runWithSessionContext } from "#lib/session-context.ts";
 import {
   applySecurityHeaders,
-  buildDomainRedirectUrl,
   contentTypeRejectionResponse,
-  domainRedirectResponse,
   getCleanUrl,
-  getDomainRejectionReason,
   isEmbeddablePath,
   isValidContentType,
-  isValidDomain,
   isWebhookPath,
 } from "#routes/middleware.ts";
 import { createRouter } from "#routes/router.ts";
@@ -184,8 +179,6 @@ export {
   getSecurityHeaders,
   isEmbeddablePath,
   isValidContentType,
-  isValidDomain,
-  normalizeHostname,
 } from "#routes/middleware.ts";
 
 // Re-export types
@@ -372,24 +365,8 @@ export const handleRequest = async (
               }
             }
 
-            // Load effective domain (custom_domain from DB if set, else ALLOWED_DOMAIN)
-            // before domain validation so redirects go to the right host.
-            loadEffectiveDomain();
-
-            // Domain validation: redirect requests from unauthorized domains to the effective domain
-            if (!isValidDomain(effectiveRequest)) {
-              const redirectUrl = buildDomainRedirectUrl(effectiveRequest);
-              logDebug(
-                "Domain",
-                `Redirecting to ${redirectUrl} (${getDomainRejectionReason(effectiveRequest)})`,
-              );
-              return logAndReturn(
-                domainRedirectResponse(redirectUrl),
-                method,
-                path,
-                getElapsed,
-              );
-            }
+            // Load effective domain (custom_domain from DB if set, else request hostname)
+            loadEffectiveDomain(effectiveRequest.url);
 
             const embeddable = isEmbeddablePath(path);
 

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -86,65 +86,6 @@ export const isEmbeddablePath = (path: string): boolean =>
   EMBEDDABLE_PATH.test(path);
 
 /**
- * Normalize a hostname for comparison:
- * - Strip port (Host header may include :443 or :3000)
- * - Lowercase (DNS names are case-insensitive)
- * - Strip trailing dot (FQDN notation: "example.com." === "example.com")
- */
-export const normalizeHostname = (host: string): string => {
-  const colonIndex = host.indexOf(":");
-  const withoutPort = colonIndex === -1 ? host : host.slice(0, colonIndex);
-  const lowered = withoutPort.toLowerCase();
-  return lowered.endsWith(".") ? lowered.slice(0, -1) : lowered;
-};
-
-/**
- * Validate request domain against ALLOWED_DOMAIN.
- * Checks the Host header to prevent the app being served through unauthorized proxies.
- * Falls back to the request URL hostname for HTTP/2 requests or proxied
- * environments (e.g. Facebook in-app browser) where the Host header may be
- * absent or rewritten.
- * Returns true if the request should be allowed.
- */
-export const isValidDomain = (request: Request): boolean => {
-  const allowed = normalizeHostname(getEffectiveDomain());
-
-  // Check Host header (standard for HTTP/1.1)
-  const host = request.headers.get("host");
-  if (host && normalizeHostname(host) === allowed) {
-    return true;
-  }
-
-  // Fallback: check the request URL hostname (covers HTTP/2 :authority
-  // and CDN-rewritten requests where the Host header is missing or altered)
-  return normalizeHostname(new URL(request.url).host) === allowed;
-};
-
-/**
- * Build a redirect URL to the allowed domain, preserving the original path and query.
- */
-export const buildDomainRedirectUrl = (request: Request): string => {
-  const url = new URL(request.url);
-  const allowed = getEffectiveDomain();
-  const scheme = allowed === "localhost" ? "http" : "https";
-  return `${scheme}://${allowed}${url.pathname}${url.search}`;
-};
-
-/**
- * Build a privacy-safe rejection reason for domain validation failures.
- * Includes the Host header and URL hostname so operators can diagnose
- * why a request was rejected (e.g. Facebook in-app browser sending
- * unexpected headers).
- */
-export const getDomainRejectionReason = (request: Request): string => {
-  const host = request.headers.get("host");
-  const urlHost = new URL(request.url).host;
-  return host
-    ? `host=${normalizeHostname(host)} url=${normalizeHostname(urlHost)}`
-    : `host=missing url=${normalizeHostname(urlHost)}`;
-};
-
-/**
  * Check if path is a webhook endpoint that accepts JSON
  */
 export const isWebhookPath = (path: string): boolean =>
@@ -196,18 +137,6 @@ export const contentTypeRejectionResponse = (): Response =>
     status: 400,
     headers: {
       "content-type": "text/plain",
-      ...getSecurityHeaders(false),
-    },
-  });
-
-/**
- * Create domain redirect response (301 to allowed domain)
- */
-export const domainRedirectResponse = (redirectUrl: string): Response =>
-  new Response(null, {
-    status: 301,
-    headers: {
-      location: redirectUrl,
       ...getSecurityHeaders(false),
     },
   });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -16,11 +16,7 @@
 
 import { map, unique } from "#fp";
 import { calculateBookingFee } from "#lib/booking-fee.ts";
-import {
-  getAllowedDomain,
-  getBookingFee,
-  getEffectiveDomain,
-} from "#lib/config.ts";
+import { getBookingFee, getEffectiveDomain } from "#lib/config.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import {
   createAttendeeAtomic,
@@ -945,7 +941,7 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   // different application sharing the same payment provider account will not
   // carry our _origin marker.
   const origin = session.metadata._origin;
-  if (origin !== getEffectiveDomain() && origin !== getAllowedDomain()) {
+  if (origin !== getEffectiveDomain()) {
     logError({
       code: ErrorCode.PAYMENT_SESSION,
       detail: "Ignoring webhook for unrecognized payment session",

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -291,7 +291,7 @@ export const adminDebugPage = (
         <table>
           <tbody>
             <tr>
-              <td>ALLOWED_DOMAIN</td>
+              <td>Effective Domain</td>
               <td>{s.domain}</td>
             </tr>
           </tbody>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -13,7 +13,7 @@ import { stub } from "@std/testing/mock";
 import forge from "node-forge";
 import { bracket } from "#fp";
 import type { SigningCredentials } from "#lib/apple-wallet.ts";
-import { resetAllowedDomain } from "#lib/config.ts";
+import { resetEffectiveDomain } from "#lib/config.ts";
 import { getSessionCookieName, parseFlashValue } from "#lib/cookies.ts";
 import {
   clearEncryptionKeyCache,
@@ -292,7 +292,7 @@ export const resetDb = (): void => {
   resetSessionCache();
   resetTestSession();
   setDemoModeForTest(false);
-  resetAllowedDomain();
+  resetEffectiveDomain();
   resetHostEmailConfig();
   settings.appleWallet.resetHostConfig();
   settings.clearTestOverrides();

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -6,8 +6,8 @@ import {
   getBunnyApiKey,
   getCdnHostname,
   isBunnyCdnEnabled,
-  resetAllowedDomain,
-  setAllowedDomainForTest,
+  resetEffectiveDomain,
+  setEffectiveDomainForTest,
 } from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
 import { describeWithEnv, withMocks } from "#test-utils";
@@ -76,15 +76,15 @@ describeWithEnv(
 );
 
 describe("getCdnHostname", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("replaces .bunny.run with .b-cdn.net", () => {
-    setAllowedDomainForTest("mysite.bunny.run");
+    setEffectiveDomainForTest("mysite.bunny.run");
     expect(getCdnHostname()).toBe("mysite.b-cdn.net");
   });
 
   test("returns domain unchanged when not .bunny.run", () => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
     expect(getCdnHostname()).toBe("example.com");
   });
 });
@@ -118,8 +118,8 @@ describeWithEnv(
   "findPullZoneId",
   { env: { BUNNY_API_KEY: "test-bunny-key" } },
   () => {
-    beforeEach(() => setAllowedDomainForTest("mysite.bunny.run"));
-    afterEach(() => resetAllowedDomain());
+    beforeEach(() => setEffectiveDomainForTest("mysite.bunny.run"));
+    afterEach(() => resetEffectiveDomain());
 
     test("returns pull zone ID when matching hostname is found", async () => {
       await withMocks(
@@ -224,8 +224,8 @@ describeWithEnv(
   "validateCustomDomain (real implementation)",
   { env: { BUNNY_API_KEY: "test-bunny-key" } },
   () => {
-    beforeEach(() => setAllowedDomainForTest("mysite.bunny.run"));
-    afterEach(() => resetAllowedDomain());
+    beforeEach(() => setEffectiveDomainForTest("mysite.bunny.run"));
+    afterEach(() => resetEffectiveDomain());
 
     /** Helper: stub findPullZoneId to return a fixed ID */
     const withFixedPullZoneId = (fn: () => Promise<void>): Promise<void> => {

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -315,9 +315,6 @@ describe("code quality", () => {
       "routes/utils.ts:withCookie",
       // Reset cache registry between tests
       "lib/cache-registry.ts:resetCacheRegistry",
-      // Reset cached allowed domain between tests
-      "lib/config.ts:resetAllowedDomain",
-      "lib/config.ts:setAllowedDomainForTest",
       // Reset cached effective domain between tests
       "lib/config.ts:resetEffectiveDomain",
       "lib/config.ts:setEffectiveDomainForTest",

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -2,14 +2,11 @@ import process from "node:process";
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import {
-  getAllowedDomain,
   getBookingFee,
   getEffectiveDomain,
   isPaymentsEnabled,
   loadEffectiveDomain,
-  resetAllowedDomain,
   resetEffectiveDomain,
-  setAllowedDomainForTest,
   setEffectiveDomainForTest,
 } from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
@@ -58,91 +55,69 @@ describe("config", () => {
     });
   });
 
-  describe("getAllowedDomain", () => {
-    afterEach(() => resetAllowedDomain());
-
-    test("returns set value via test override", () => {
-      setAllowedDomainForTest("example.com");
-      expect(getAllowedDomain()).toBe("example.com");
-    });
-
-    test("returns localhost when set for testing", () => {
-      setAllowedDomainForTest("localhost");
-      expect(getAllowedDomain()).toBe("localhost");
-    });
-  });
-
   describe("getEffectiveDomain", () => {
     afterEach(() => {
-      resetAllowedDomain();
       resetEffectiveDomain();
     });
 
-    test("returns ALLOWED_DOMAIN when no custom domain is set", async () => {
-      setAllowedDomainForTest("mysite.bunny.run");
-      const result = await loadEffectiveDomain();
+    test("returns request hostname when no custom domain is set", async () => {
+      const result = await loadEffectiveDomain("https://mysite.bunny.run/");
       expect(result).toBe("mysite.bunny.run");
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
     });
 
     test("returns custom domain when set and validated in DB", async () => {
-      setAllowedDomainForTest("mysite.bunny.run");
       await settings.update.customDomain("tickets.example.com");
       await settings.update.customDomainLastValidated();
       settings.invalidateCache();
       await settings.loadAll();
-      const result = await loadEffectiveDomain();
+      const result = await loadEffectiveDomain("https://mysite.bunny.run/");
       expect(result).toBe("tickets.example.com");
       expect(getEffectiveDomain()).toBe("tickets.example.com");
     });
 
-    test("falls back to ALLOWED_DOMAIN when custom domain is set but not validated", async () => {
-      setAllowedDomainForTest("mysite.bunny.run");
+    test("falls back to request hostname when custom domain is set but not validated", async () => {
       await settings.update.customDomain("tickets.example.com");
       settings.invalidateCache();
-      const result = await loadEffectiveDomain();
+      const result = await loadEffectiveDomain("https://mysite.bunny.run/");
       expect(result).toBe("mysite.bunny.run");
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
     });
 
-    test("falls back to ALLOWED_DOMAIN after custom domain is cleared", async () => {
-      setAllowedDomainForTest("mysite.bunny.run");
+    test("falls back to request hostname after custom domain is cleared", async () => {
       await settings.update.customDomain("tickets.example.com");
       await settings.update.customDomainLastValidated();
       settings.invalidateCache();
       await settings.loadAll();
-      await loadEffectiveDomain();
+      await loadEffectiveDomain("https://mysite.bunny.run/");
       expect(getEffectiveDomain()).toBe("tickets.example.com");
 
       await settings.update.customDomain("");
       settings.invalidateCache();
       await settings.loadAll();
-      await loadEffectiveDomain();
+      await loadEffectiveDomain("https://mysite.bunny.run/");
       expect(getEffectiveDomain()).toBe("mysite.bunny.run");
     });
 
-    test("falls back to ALLOWED_DOMAIN before loadEffectiveDomain is called", () => {
-      setAllowedDomainForTest("mysite.bunny.run");
-      expect(getEffectiveDomain()).toBe("mysite.bunny.run");
+    test("returns localhost before loadEffectiveDomain is called", () => {
+      expect(getEffectiveDomain()).toBe("localhost");
     });
 
     test("setEffectiveDomainForTest overrides the cached value", () => {
-      setAllowedDomainForTest("mysite.bunny.run");
       setEffectiveDomainForTest("custom.example.com");
       expect(getEffectiveDomain()).toBe("custom.example.com");
     });
 
     test("resetEffectiveDomain clears the cached value", async () => {
-      setAllowedDomainForTest("mysite.bunny.run");
       await settings.update.customDomain("tickets.example.com");
       await settings.update.customDomainLastValidated();
       settings.invalidateCache();
       await settings.loadAll();
-      await loadEffectiveDomain();
+      await loadEffectiveDomain("https://mysite.bunny.run/");
       expect(getEffectiveDomain()).toBe("tickets.example.com");
 
       resetEffectiveDomain();
-      expect(getEffectiveDomain()).toBe("mysite.bunny.run");
+      expect(getEffectiveDomain()).toBe("localhost");
     });
   });
 

--- a/test/lib/cookies.test.ts
+++ b/test/lib/cookies.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
+import {
+  resetEffectiveDomain,
+  setEffectiveDomainForTest,
+} from "#lib/config.ts";
 import {
   buildFlashCookie,
   buildSessionCookie,
@@ -28,38 +31,38 @@ const expectSecureCookieAttributes = (cookie: string) => {
 };
 
 describe("isSecureMode", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("returns true for non-localhost domains", () => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
     expect(isSecureMode()).toBe(true);
   });
 
   test("returns false for localhost", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     expect(isSecureMode()).toBe(false);
   });
 });
 
 describe("getSessionCookieName", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("returns __Host-session in secure mode", () => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
     expect(getSessionCookieName()).toBe("__Host-session");
   });
 
   test("returns 'session' in dev mode", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     expect(getSessionCookieName()).toBe("session");
   });
 });
 
 describe("buildSessionCookie", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("includes __Host-session in secure mode with all required attributes", () => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
     const cookie = buildSessionCookie("test-token");
     expect(cookie).toContain("__Host-session=test-token");
     expectSecureCookieAttributes(cookie);
@@ -67,7 +70,7 @@ describe("buildSessionCookie", () => {
   });
 
   test("includes 'session' in dev mode without Secure flag", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = buildSessionCookie("test-token");
     expect(cookie).toContain("session=test-token");
     expectDevCookieAttributes(cookie);
@@ -75,17 +78,17 @@ describe("buildSessionCookie", () => {
   });
 
   test("respects custom maxAge", () => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
     const cookie = buildSessionCookie("test-token", { maxAge: 3600 });
     expect(cookie).toContain("Max-Age=3600");
   });
 });
 
 describe("clearSessionCookie", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("includes __Host-session in secure mode with Max-Age=0", () => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
     const cookie = clearSessionCookie();
     expect(cookie).toContain("__Host-session=");
     expectSecureCookieAttributes(cookie);
@@ -93,7 +96,7 @@ describe("clearSessionCookie", () => {
   });
 
   test("includes 'session' in dev mode without Secure flag", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = clearSessionCookie();
     expect(cookie).toContain("session=");
     expectDevCookieAttributes(cookie);
@@ -102,38 +105,38 @@ describe("clearSessionCookie", () => {
 });
 
 describe("buildFlashCookie", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("keys cookie name by flash ID", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = buildFlashCookie("abc123", "Saved", true);
     expect(cookie).toMatch(/^flash_abc123=/);
   });
 
   test("encodes success message", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = buildFlashCookie("abc123", "Saved", true);
     expect(cookie).toContain(encodeURIComponent("s:Saved"));
   });
 
   test("encodes error message", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = buildFlashCookie("abc123", "Failed", false);
     expect(cookie).toContain(encodeURIComponent("e:Failed"));
   });
 
   test("sets short Max-Age", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = buildFlashCookie("abc123", "Saved", true);
     expect(cookie).toContain("Max-Age=10");
   });
 });
 
 describe("clearFlashCookie", () => {
-  afterEach(() => resetAllowedDomain());
+  afterEach(() => resetEffectiveDomain());
 
   test("clears the keyed cookie with Max-Age=0", () => {
-    setAllowedDomainForTest("localhost");
+    setEffectiveDomainForTest("localhost");
     const cookie = clearFlashCookie("abc123");
     expect(cookie).toMatch(/^flash_abc123=/);
     expect(cookie).toContain("Max-Age=0");

--- a/test/lib/csv-questions.test.ts
+++ b/test/lib/csv-questions.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
+import {
+  resetEffectiveDomain,
+  setEffectiveDomainForTest,
+} from "#lib/config.ts";
 import type { QuestionWithAnswers } from "#lib/db/questions.ts";
 import type { Attendee } from "#lib/types.ts";
 import { generateAttendeesCsv } from "#templates/csv.ts";
@@ -50,11 +53,11 @@ const makeQuestions = (): QuestionWithAnswers[] => [
 
 describe("CSV with custom questions", () => {
   beforeEach(() => {
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
   });
 
   afterEach(() => {
-    resetAllowedDomain();
+    resetEffectiveDomain();
   });
 
   test("includes question columns in header", () => {

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -112,11 +112,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
       expect(html).toContain("DB_URL");
     });
 
-    test("shows Domain section with ALLOWED_DOMAIN", async () => {
+    test("shows Domain section with effective domain", async () => {
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
       expect(html).toContain("Domain");
-      expect(html).toContain("ALLOWED_DOMAIN");
+      expect(html).toContain("Effective Domain");
     });
 
     test("does not expose secret keys or full URLs", async () => {

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -1,16 +1,14 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { spy, stub } from "@std/testing/mock";
-import { resetAllowedDomain, setAllowedDomainForTest } from "#lib/config.ts";
+import { stub } from "@std/testing/mock";
+import {
+  resetEffectiveDomain,
+  setEffectiveDomainForTest,
+} from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import { runWithRequestId } from "#lib/logger.ts";
-import {
-  getCleanUrl,
-  handleRequest,
-  isValidContentType,
-  normalizeHostname,
-} from "#routes";
+import { getCleanUrl, handleRequest, isValidContentType } from "#routes";
 import {
   redirect,
   redirectResponse,
@@ -27,7 +25,6 @@ import {
   getHeader,
   mockFormRequest,
   mockRequest,
-  mockRequestWithHost,
   resetDb,
   testCookie,
   withExpectedError,
@@ -48,16 +45,6 @@ describeWithEnv("server (misc)", { db: true }, () => {
       thankYouUrl: "https://example.com",
     });
     return handleRequest(mockRequest(`/ticket/${event1.slug}+${event2.slug}`));
-  }
-
-  /** Run a request to an invalid domain and return the [Domain] debug log line */
-  async function getDomainDebugLog(request: Request) {
-    const debugSpy = spy(console, "debug");
-    await handleRequest(request);
-    const calls = debugSpy.calls.map((c) => c.args[0] as string);
-    const domainLog = calls.find((c) => c.includes("[Domain]"))!;
-    expect(domainLog).toBeDefined();
-    return { debugSpy, domainLog };
   }
 
   describe("security headers", () => {
@@ -148,14 +135,16 @@ describeWithEnv("server (misc)", { db: true }, () => {
       });
 
       test("includes Strict-Transport-Security on non-localhost domains", async () => {
-        setAllowedDomainForTest("example.com");
+        setEffectiveDomainForTest("example.com");
         try {
-          const response = await handleRequest(mockRequest("/"));
+          const response = await handleRequest(
+            mockRequest("https://example.com/"),
+          );
           expect(response.headers.get("strict-transport-security")).toBe(
             "max-age=63072000; includeSubDomains; preload",
           );
         } finally {
-          resetAllowedDomain();
+          resetEffectiveDomain();
         }
       });
 
@@ -448,145 +437,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
     });
   });
 
-  describe("normalizeHostname", () => {
-    test("strips port from host", () => {
-      expect(normalizeHostname("localhost:3000")).toBe("localhost");
-    });
 
-    test("lowercases hostname", () => {
-      expect(normalizeHostname("LocalHost")).toBe("localhost");
-    });
-
-    test("strips trailing FQDN dot", () => {
-      expect(normalizeHostname("example.com.")).toBe("example.com");
-    });
-
-    test("handles port and trailing dot together", () => {
-      expect(normalizeHostname("Example.COM.:443")).toBe("example.com");
-    });
-
-    test("returns plain hostname unchanged", () => {
-      expect(normalizeHostname("localhost")).toBe("localhost");
-    });
-  });
-
-  describe("Domain validation", () => {
-    test("allows requests with valid domain", async () => {
-      const response = await handleRequest(mockRequest("/"));
-      expect(response.status).toBe(302); // Homepage redirects to /admin/
-    });
-
-    test("redirects GET requests from invalid domain to allowed domain", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/", "evil.com"),
-      );
-      expect(response.status).toBe(301);
-      expect(response.headers.get("location")).toBe("http://localhost/");
-    });
-
-    test("redirects POST requests from invalid domain to allowed domain", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/admin/login", "evil.com", {
-          method: "POST",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-          },
-          body: "password=test",
-        }),
-      );
-      expect(response.status).toBe(301);
-      expect(response.headers.get("location")).toBe(
-        "http://localhost/admin/login",
-      );
-    });
-
-    test("allows requests with valid domain including port", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/", "localhost:3000"),
-      );
-      expect(response.status).toBe(302); // Homepage redirects to /admin/
-    });
-
-    test("allows requests with case-different Host header", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/", "LocalHost"),
-      );
-      expect(response.status).toBe(302);
-    });
-
-    test("allows requests with trailing FQDN dot in Host header", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/", "localhost."),
-      );
-      expect(response.status).toBe(302);
-    });
-
-    test("allows requests without Host header when URL hostname matches", async () => {
-      const response = await handleRequest(
-        new Request("http://localhost/", {}),
-      );
-      expect(response.status).toBe(302);
-    });
-
-    test("redirects requests where neither Host header nor URL matches", async () => {
-      const request = new Request("http://evil.com/", {});
-      const response = await handleRequest(request);
-      expect(response.status).toBe(301);
-      expect(response.headers.get("location")).toBe("http://localhost/");
-    });
-
-    test("domain redirect response has security headers", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/", "evil.com"),
-      );
-      expect(response.headers.get("x-frame-options")).toBe("DENY");
-      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
-      expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
-    });
-
-    test("logs debug message with host details on domain redirect", async () => {
-      const { debugSpy, domainLog } = await getDomainDebugLog(
-        mockRequestWithHost("/", "evil.com"),
-      );
-      expect(domainLog).toContain("host=evil.com");
-      expect(domainLog).toContain("Redirecting to");
-      debugSpy.restore();
-    });
-
-    test("logs missing host header in domain redirect debug message", async () => {
-      const { debugSpy, domainLog } = await getDomainDebugLog(
-        new Request("http://evil.com/", {}),
-      );
-      expect(domainLog).toContain("host=missing");
-      expect(domainLog).toContain("url=evil.com");
-      debugSpy.restore();
-    });
-
-    test("preserves path and query string in domain redirect", async () => {
-      const response = await handleRequest(
-        mockRequestWithHost("/ticket/my-event?qty=2", "evil.com"),
-      );
-      expect(response.status).toBe(301);
-      expect(response.headers.get("location")).toBe(
-        "http://localhost/ticket/my-event?qty=2",
-      );
-    });
-
-    test("uses https scheme when allowed domain is not localhost", async () => {
-      setAllowedDomainForTest("example.com");
-      try {
-        const response = await handleRequest(
-          mockRequestWithHost("/ticket/my-event", "evil.com"),
-        );
-        expect(response.status).toBe(301);
-        expect(response.headers.get("location")).toBe(
-          "https://example.com/ticket/my-event",
-        );
-      } finally {
-        resetAllowedDomain();
-      }
-    });
-  });
 
   describe("Tracking parameter stripping", () => {
     describe("getCleanUrl", () => {

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -634,7 +634,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         expect(html).toContain('id="settings-custom-domain-validate"');
         expect(html).toContain("CNAME");
         expect(html).toContain("tickets.example.com");
-        // CDN hostname is derived from ALLOWED_DOMAIN (localhost in tests)
+        // CDN hostname is derived from the effective domain (localhost in tests)
         expect(html).toContain("localhost");
       });
 

--- a/test/lib/square-provider.test.ts
+++ b/test/lib/square-provider.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { setAllowedDomainForTest } from "#lib/config.ts";
+import { setEffectiveDomainForTest } from "#lib/config.ts";
 import { PaymentUserError } from "#lib/payment-helpers.ts";
 import { squareApi } from "#lib/square.ts";
 import { squarePaymentProvider } from "#lib/square-provider.ts";
@@ -10,7 +10,7 @@ import { createTestDb, resetDb, testEvent, withMocks } from "#test-utils";
 describe("square-provider", () => {
   beforeEach(async () => {
     await createTestDb();
-    setAllowedDomainForTest("example.com");
+    setEffectiveDomainForTest("example.com");
   });
 
   afterEach(() => {

--- a/test/lib/webhook-example.test.ts
+++ b/test/lib/webhook-example.test.ts
@@ -9,9 +9,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
 import {
-  resetAllowedDomain,
   resetEffectiveDomain,
-  setAllowedDomainForTest,
   setEffectiveDomainForTest,
 } from "#lib/config.ts";
 import { buildWebhookPayload, type RegistrationEntry } from "#lib/webhook.ts";
@@ -43,12 +41,10 @@ describe("webhook example", () => {
     const { updateBusinessEmail } = await import("#lib/business-email.ts");
     await updateBusinessEmail(EXAMPLE_BUSINESS_EMAIL);
 
-    // Set ALLOWED_DOMAIN and effective domain to match the example domain
-    setAllowedDomainForTest(exampleDomain);
+    // Set effective domain to match the example domain
     setEffectiveDomainForTest(exampleDomain);
     domainStub = {
       restore: () => {
-        resetAllowedDomain();
         resetEffectiveDomain();
       },
     };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -15,11 +15,6 @@ const manager = new StripeMockManager();
 // Configure encryption key for tests
 setupTestEncryptionKey();
 
-// Configure allowed domain for tests (security middleware)
-// Set via env var (not override) so it's the default for all tests.
-// Tests that need a different domain use setAllowedDomainForTest().
-Deno.env.set("ALLOWED_DOMAIN", "localhost");
-
 // Configure stripe-mock env vars
 Deno.env.set("STRIPE_MOCK_HOST", "localhost");
 Deno.env.set("STRIPE_MOCK_PORT", String(STRIPE_MOCK_PORT));


### PR DESCRIPTION
## Summary
This PR removes the `ALLOWED_DOMAIN` environment variable requirement and replaces it with a request-driven approach where the effective domain is derived from the request URL hostname. This simplifies deployment configuration and eliminates the need for domain validation middleware.

## Key Changes

- **Removed domain validation middleware**: Deleted `normalizeHostname()`, `isValidDomain()`, `buildDomainRedirectUrl()`, `getDomainRejectionReason()`, and `domainRedirectResponse()` functions that enforced domain-based request filtering
- **Removed ALLOWED_DOMAIN config**: Eliminated the `getAllowedDomain()`, `setAllowedDomainForTest()`, and `resetAllowedDomain()` functions from config
- **Updated domain loading**: Modified `loadEffectiveDomain()` to accept a request URL and extract the hostname directly, falling back to the request's own hostname instead of a pre-configured domain
- **Simplified effective domain**: Changed `getEffectiveDomain()` to default to "localhost" instead of requiring `ALLOWED_DOMAIN`
- **Updated CDN hostname derivation**: Changed `getCdnHostname()` to use `getEffectiveDomain()` instead of `getAllowedDomain()`
- **Removed domain redirect tests**: Deleted 15+ test cases that validated domain-based request filtering and redirects
- **Updated test utilities**: Replaced all `setAllowedDomainForTest()` calls with `setEffectiveDomainForTest()` throughout the test suite
- **Updated deployment configs**: Removed `ALLOWED_DOMAIN` from README, app.json, render.yaml, .do/deploy.template.yaml, and GitHub Actions workflows

## Implementation Details

- The request hostname is now extracted directly from the request URL in `loadEffectiveDomain(requestUrl)` rather than relying on a pre-configured environment variable
- Custom domains (from database settings) still take precedence over the request hostname when validated
- The change maintains backward compatibility for custom domain functionality while removing the security validation layer that redirected requests from unauthorized domains
- All test setup code that previously configured `ALLOWED_DOMAIN` has been removed, simplifying test initialization

https://claude.ai/code/session_01QBeEwRqApjMNrT37XioK9F