### PR TITLE
Use Edge Script API for Bunny pull zone lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ Environment variables are configured as **Bunny native secrets** in the Bunny Ed
 ### Optional
 
 - `PORT` - Server port (defaults to 3000, local dev only)
+- `BUNNY_API_KEY` - Bunny API key (required for custom domain management, with `BUNNY_SCRIPT_ID`)
+- `BUNNY_SCRIPT_ID` - Bunny Edge Script ID (required for custom domain management, with `BUNNY_API_KEY`)
 - `STORAGE_ZONE_NAME` - Bunny CDN storage zone name (required for image uploads)
 - `STORAGE_ZONE_KEY` - Bunny CDN storage zone access key (required for image uploads)
 - `NTFY_URL` - Ntfy endpoint URL for error notifications (e.g. `https://ntfy.sh/your-topic`). Sends domain and error code only, no personal or encrypted data.

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -1,11 +1,11 @@
 /**
  * Bunny CDN pull zone API integration.
  * Adds a custom hostname to a pull zone and enables force SSL.
- * Only used when BUNNY_API_KEY env var is set.
- * The pull zone ID is discovered automatically by matching hostnames.
+ * Only used when BUNNY_API_KEY and BUNNY_SCRIPT_ID env vars are set.
+ * The pull zone is discovered via the Edge Script API, not request hostname.
  */
 
-import { getBunnyApiKey, getCdnHostname } from "#lib/config.ts";
+import { getBunnyApiKey, getBunnyScriptId } from "#lib/config.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 
 const BUNNY_API_BASE = "https://api.bunny.net";
@@ -16,50 +16,70 @@ type BunnyApiResult =
 
 const HOSTNAME_ALREADY_REGISTERED = "pullzone.hostname_already_registered";
 
-interface BunnyHostname {
-  Value: string;
-}
-
-interface BunnyPullZone {
+interface EdgeScriptLinkedPullZone {
   Id: number;
-  Hostnames: BunnyHostname[];
+  PullZoneName: string;
+  DefaultHostname: string;
 }
 
-interface BunnyPullZoneListResponse {
-  Items: BunnyPullZone[];
-  HasMoreItems: boolean;
+interface EdgeScriptResponse {
+  Id: number;
+  DefaultHostname: string;
+  LinkedPullZones: EdgeScriptLinkedPullZone[];
 }
 
 /**
- * Find the pull zone ID by searching pull zones for the CDN hostname
- * (effective domain with .bunny.run replaced by .b-cdn.net).
+ * Fetch the edge script details from the Bunny API using BUNNY_SCRIPT_ID.
+ * Returns the DefaultHostname and LinkedPullZones.
  */
-const findPullZoneIdImpl = async (): Promise<
-  { ok: true; id: number } | { ok: false; error: string; errorKey?: string }
+const getEdgeScriptImpl = async (): Promise<
+  | { ok: true; data: EdgeScriptResponse }
+  | { ok: false; error: string; errorKey?: string }
 > => {
-  const cdnHostname = getCdnHostname();
+  const scriptId = getBunnyScriptId();
   const response = await fetch(
-    `${BUNNY_API_BASE}/pullzone?search=${encodeURIComponent(cdnHostname)}`,
+    `${BUNNY_API_BASE}/compute/script/${encodeURIComponent(scriptId)}`,
     { headers: { AccessKey: getBunnyApiKey() } },
   );
 
   if (!response.ok) {
-    return parseBunnyError(response, "List pull zones");
+    return parseBunnyError(response, "Get edge script");
   }
 
-  const data: BunnyPullZoneListResponse = await response.json();
-  const zone = data.Items.find((z) =>
-    z.Hostnames.some((h) => h.Value === cdnHostname),
-  );
+  const data: EdgeScriptResponse = await response.json();
+  return { ok: true, data };
+};
 
+/**
+ * Find the pull zone ID via the edge script's linked pull zones.
+ */
+const findPullZoneIdImpl = async (): Promise<
+  { ok: true; id: number } | { ok: false; error: string; errorKey?: string }
+> => {
+  const result = await bunnyCdnApi.getEdgeScript();
+  if (!result.ok) return result;
+
+  const zone = result.data.LinkedPullZones[0];
   if (!zone) {
     return {
       ok: false,
-      error: `No pull zone found with hostname ${cdnHostname}`,
+      error: `Edge script ${getBunnyScriptId()} has no linked pull zones`,
     };
   }
 
   return { ok: true, id: zone.Id };
+};
+
+/**
+ * Get the CDN hostname (DefaultHostname) from the edge script.
+ * This is the stable hostname for CNAME targets, independent of request URL.
+ */
+const getCdnHostnameImpl = async (): Promise<
+  { ok: true; hostname: string } | { ok: false; error: string }
+> => {
+  const result = await bunnyCdnApi.getEdgeScript();
+  if (!result.ok) return result;
+  return { ok: true, hostname: result.data.DefaultHostname };
 };
 
 /** Parse a Bunny API error response into a BunnyApiResult. */
@@ -174,9 +194,16 @@ const validateCustomDomainImpl = async (
 export const bunnyCdnApi = {
   validateCustomDomain: validateCustomDomainImpl,
   findPullZoneId: findPullZoneIdImpl,
+  getEdgeScript: getEdgeScriptImpl,
+  getCdnHostname: getCdnHostnameImpl,
 };
 
 /** Validate a custom domain (delegates to bunnyCdnApi for testability). */
 export const validateCustomDomain = (
   hostname: string,
 ): Promise<BunnyApiResult> => bunnyCdnApi.validateCustomDomain(hostname);
+
+/** Get CDN hostname (delegates to bunnyCdnApi for testability). */
+export const getCdnHostname = (): Promise<
+  { ok: true; hostname: string } | { ok: false; error: string }
+> => bunnyCdnApi.getCdnHostname();

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -14,6 +14,10 @@ type BunnyApiResult =
   | { ok: true }
   | { ok: false; error: string; errorKey?: string };
 
+type CdnHostnameResult =
+  | { ok: true; hostname: string }
+  | { ok: false; error: string };
+
 const HOSTNAME_ALREADY_REGISTERED = "pullzone.hostname_already_registered";
 
 interface EdgeScriptLinkedPullZone {
@@ -50,37 +54,38 @@ const getEdgeScriptImpl = async (): Promise<
   return { ok: true, data };
 };
 
+/** Map edge script data to a result, returning early on API error. */
+const withEdgeScript = async <T>(
+  fn: (data: EdgeScriptResponse) => T,
+): Promise<T | { ok: false; error: string; errorKey?: string }> => {
+  const result = await bunnyCdnApi.getEdgeScript();
+  if (!result.ok) return result;
+  return fn(result.data);
+};
+
 /**
  * Find the pull zone ID via the edge script's linked pull zones.
  */
 const findPullZoneIdImpl = async (): Promise<
   { ok: true; id: number } | { ok: false; error: string; errorKey?: string }
-> => {
-  const result = await bunnyCdnApi.getEdgeScript();
-  if (!result.ok) return result;
-
-  const zone = result.data.LinkedPullZones[0];
-  if (!zone) {
-    return {
-      ok: false,
-      error: `Edge script ${getBunnyScriptId()} has no linked pull zones`,
-    };
-  }
-
-  return { ok: true, id: zone.Id };
-};
+> =>
+  withEdgeScript((data) => {
+    const zone = data.LinkedPullZones[0];
+    if (!zone) {
+      return {
+        ok: false as const,
+        error: `Edge script ${getBunnyScriptId()} has no linked pull zones`,
+      };
+    }
+    return { ok: true as const, id: zone.Id };
+  });
 
 /**
  * Get the CDN hostname (DefaultHostname) from the edge script.
  * This is the stable hostname for CNAME targets, independent of request URL.
  */
-const getCdnHostnameImpl = async (): Promise<
-  { ok: true; hostname: string } | { ok: false; error: string }
-> => {
-  const result = await bunnyCdnApi.getEdgeScript();
-  if (!result.ok) return result;
-  return { ok: true, hostname: result.data.DefaultHostname };
-};
+const getCdnHostnameImpl = (): Promise<CdnHostnameResult> =>
+  withEdgeScript((data) => ({ ok: true as const, hostname: data.DefaultHostname }));
 
 /** Parse a Bunny API error response into a BunnyApiResult. */
 const parseBunnyError = async (
@@ -204,6 +209,5 @@ export const validateCustomDomain = (
 ): Promise<BunnyApiResult> => bunnyCdnApi.validateCustomDomain(hostname);
 
 /** Get CDN hostname (delegates to bunnyCdnApi for testability). */
-export const getCdnHostname = (): Promise<
-  { ok: true; hostname: string } | { ok: false; error: string }
-> => bunnyCdnApi.getCdnHostname();
+export const getCdnHostname = (): Promise<CdnHostnameResult> =>
+  bunnyCdnApi.getCdnHostname();

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -66,7 +66,7 @@ const withEdgeScript = async <T>(
 /**
  * Find the pull zone ID via the edge script's linked pull zones.
  */
-const findPullZoneIdImpl = async (): Promise<
+const findPullZoneIdImpl = (): Promise<
   { ok: true; id: number } | { ok: false; error: string; errorKey?: string }
 > =>
   withEdgeScript((data) => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -67,9 +67,10 @@ export const getEmbedHosts = async (): Promise<string[]> => {
 
 /**
  * Check if Bunny CDN pull zone management is enabled
- * Requires BUNNY_API_KEY to be set
+ * Requires both BUNNY_API_KEY and BUNNY_SCRIPT_ID to be set
  */
-export const isBunnyCdnEnabled = (): boolean => !!getEnv("BUNNY_API_KEY");
+export const isBunnyCdnEnabled = (): boolean =>
+  !!getEnv("BUNNY_API_KEY") && !!getEnv("BUNNY_SCRIPT_ID");
 
 /**
  * Get the Bunny CDN API key from environment
@@ -77,8 +78,6 @@ export const isBunnyCdnEnabled = (): boolean => !!getEnv("BUNNY_API_KEY");
 export const getBunnyApiKey = (): string => requireEnv("BUNNY_API_KEY");
 
 /**
- * Get the CDN hostname derived from the effective domain.
- * Replaces ".bunny.run" with ".b-cdn.net" for the CNAME target.
+ * Get the Bunny Edge Script ID from environment
  */
-export const getCdnHostname = (): string =>
-  getEffectiveDomain().replace(/\.bunny\.run$/, ".b-cdn.net");
+export const getBunnyScriptId = (): string => requireEnv("BUNNY_SCRIPT_ID");

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -8,11 +8,8 @@ import {
   isValidPemPrivateKey,
 } from "#lib/apple-wallet.ts";
 import { BUILD_COMMIT, BUILD_TIMESTAMP } from "#lib/build-info.ts";
-import {
-  getCdnHostname,
-  getEffectiveDomain,
-  isBunnyCdnEnabled,
-} from "#lib/config.ts";
+import { getCdnHostname } from "#lib/bunny-cdn.ts";
+import { getEffectiveDomain, isBunnyCdnEnabled } from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
 import { getHostEmailConfig } from "#lib/email.ts";
 import { getEnv } from "#lib/env.ts";
@@ -149,7 +146,11 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     },
     bunnyCdn: {
       enabled: bunnyCdnEnabled,
-      cdnHostname: bunnyCdnEnabled ? getCdnHostname() : "",
+      cdnHostname: await (async () => {
+        if (!bunnyCdnEnabled) return "";
+        const r = await getCdnHostname();
+        return r.ok ? r.hostname : "";
+      })(),
       customDomain: (bunnyCdnEnabled ? settings.customDomain : null) ?? "",
     },
     database: {

--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -55,6 +55,8 @@ const validateAppleWalletCerts = (
 /** Gather debug state concurrently */
 const getDebugPageState = async (): Promise<DebugPageState> => {
   const bunnyCdnEnabled = isBunnyCdnEnabled();
+  const bunnyCdnResult = bunnyCdnEnabled ? await getCdnHostname() : null;
+  const bunnyCdnCdnHostname = bunnyCdnResult?.ok ? bunnyCdnResult.hostname : "";
 
   const hostEmailConfig = getHostEmailConfig();
   const appleWalletEnvConfigured = settings.appleWallet.hostConfig !== null;
@@ -146,11 +148,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     },
     bunnyCdn: {
       enabled: bunnyCdnEnabled,
-      cdnHostname: await (async () => {
-        if (!bunnyCdnEnabled) return "";
-        const r = await getCdnHostname();
-        return r.ok ? r.hostname : "";
-      })(),
+      cdnHostname: bunnyCdnCdnHostname,
       customDomain: (bunnyCdnEnabled ? settings.customDomain : null) ?? "",
     },
     database: {

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -7,16 +7,12 @@ import {
   isValidPemCertificate,
   isValidPemPrivateKey,
 } from "#lib/apple-wallet.ts";
-import { validateCustomDomain } from "#lib/bunny-cdn.ts";
+import { getCdnHostname, validateCustomDomain } from "#lib/bunny-cdn.ts";
 import {
   isValidBusinessEmail,
   updateBusinessEmail,
 } from "#lib/business-email.ts";
-import {
-  getCdnHostname,
-  getEffectiveDomain,
-  isBunnyCdnEnabled,
-} from "#lib/config.ts";
+import { getEffectiveDomain, isBunnyCdnEnabled } from "#lib/config.ts";
 import { clearSessionCookie } from "#lib/cookies.ts";
 import { isValidCountry } from "#lib/countries.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
@@ -124,10 +120,11 @@ const getSettingsPageState = () => {
 };
 
 /** Gather state for the advanced settings page */
-const getAdvancedSettingsPageState = () => {
+const getAdvancedSettingsPageState = async () => {
   const bunnyCdnConfigured = isBunnyCdnEnabled();
   const confirmationTemplates = settings.email.templateSet("confirmation");
   const adminTemplates = settings.email.templateSet("admin");
+  const cdnResult = bunnyCdnConfigured ? await getCdnHostname() : null;
   return {
     showPublicApi: settings.showPublicApi,
     emailProvider: settings.email.provider ?? "",
@@ -154,7 +151,7 @@ const getAdvancedSettingsPageState = () => {
     customDomain: (bunnyCdnConfigured ? settings.customDomain : null) ?? "",
     customDomainLastValidated:
       (bunnyCdnConfigured ? settings.customDomainLastValidated : null) ?? "",
-    cdnHostname: bunnyCdnConfigured ? getCdnHostname() : "",
+    cdnHostname: cdnResult?.ok ? cdnResult.hostname : "",
     appleWalletConfigured: settings.appleWallet.hasDbConfig,
     appleWalletPassTypeId: settings.appleWallet.passTypeId ?? "",
     appleWalletTeamId: settings.appleWallet.teamId ?? "",
@@ -183,8 +180,8 @@ const renderSettingsPage = (session: AuthSession) => {
 };
 
 /** Render the advanced settings page with current state */
-const renderAdvancedSettingsPage = (session: AuthSession) => {
-  const state = getAdvancedSettingsPageState();
+const renderAdvancedSettingsPage = async (session: AuthSession) => {
+  const state = await getAdvancedSettingsPageState();
   return adminAdvancedSettingsPage(session, state);
 };
 

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -1,13 +1,15 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { bunnyCdnApi, validateCustomDomain } from "#lib/bunny-cdn.ts";
+import {
+  bunnyCdnApi,
+  getCdnHostname,
+  validateCustomDomain,
+} from "#lib/bunny-cdn.ts";
 import {
   getBunnyApiKey,
-  getCdnHostname,
+  getBunnyScriptId,
   isBunnyCdnEnabled,
-  resetEffectiveDomain,
-  setEffectiveDomainForTest,
 } from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
 import { describeWithEnv, withMocks } from "#test-utils";
@@ -48,46 +50,45 @@ const stubFetchWithRecorder = (
     },
   );
 
-/** Build a pull zone Items response */
-const pullZoneResponse = (
-  items: { Id: number; hostname: string }[],
-  hasMore = false,
+/** Build an edge script API response */
+const edgeScriptResponse = (
+  pullZones: {
+    Id: number;
+    PullZoneName: string;
+    DefaultHostname: string;
+  }[] = [],
+  defaultHostname = "mysite.b-cdn.net",
 ) => ({
-  Items: items.map(({ Id, hostname }) => ({
-    Id,
-    Hostnames: [{ Value: hostname }],
-  })),
-  HasMoreItems: hasMore,
+  Id: 1,
+  DefaultHostname: defaultHostname,
+  LinkedPullZones: pullZones,
 });
 
 describeWithEnv(
   "isBunnyCdnEnabled",
-  { env: { BUNNY_API_KEY: undefined } },
+  { env: { BUNNY_API_KEY: undefined, BUNNY_SCRIPT_ID: undefined } },
   () => {
-    test("returns false when BUNNY_API_KEY is not set", () => {
+    test("returns false when neither env var is set", () => {
       expect(isBunnyCdnEnabled()).toBe(false);
     });
 
-    test("returns true when BUNNY_API_KEY is set", () => {
+    test("returns false when only BUNNY_API_KEY is set", () => {
       Deno.env.set("BUNNY_API_KEY", "test-key");
+      expect(isBunnyCdnEnabled()).toBe(false);
+    });
+
+    test("returns false when only BUNNY_SCRIPT_ID is set", () => {
+      Deno.env.set("BUNNY_SCRIPT_ID", "123");
+      expect(isBunnyCdnEnabled()).toBe(false);
+    });
+
+    test("returns true when both env vars are set", () => {
+      Deno.env.set("BUNNY_API_KEY", "test-key");
+      Deno.env.set("BUNNY_SCRIPT_ID", "123");
       expect(isBunnyCdnEnabled()).toBe(true);
     });
   },
 );
-
-describe("getCdnHostname", () => {
-  afterEach(() => resetEffectiveDomain());
-
-  test("replaces .bunny.run with .b-cdn.net", () => {
-    setEffectiveDomainForTest("mysite.bunny.run");
-    expect(getCdnHostname()).toBe("mysite.b-cdn.net");
-  });
-
-  test("returns domain unchanged when not .bunny.run", () => {
-    setEffectiveDomainForTest("example.com");
-    expect(getCdnHostname()).toBe("example.com");
-  });
-});
 
 describe("validateCustomDomain", () => {
   test("delegates to bunnyCdnApi.validateCustomDomain", async () => {
@@ -115,33 +116,40 @@ describeWithEnv("getBunnyApiKey", { env: { BUNNY_API_KEY: undefined } }, () => {
 });
 
 describeWithEnv(
-  "findPullZoneId",
-  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  "getBunnyScriptId",
+  { env: { BUNNY_SCRIPT_ID: undefined } },
   () => {
-    beforeEach(() => setEffectiveDomainForTest("mysite.bunny.run"));
-    afterEach(() => resetEffectiveDomain());
+    test("getBunnyScriptId returns the env var value", () => {
+      Deno.env.set("BUNNY_SCRIPT_ID", "42");
+      expect(getBunnyScriptId()).toBe("42");
+    });
+  },
+);
 
-    test("returns pull zone ID when matching hostname is found", async () => {
+describeWithEnv(
+  "getEdgeScript",
+  { env: { BUNNY_API_KEY: "test-bunny-key", BUNNY_SCRIPT_ID: "99" } },
+  () => {
+    test("returns edge script data on success", async () => {
+      const response = edgeScriptResponse([
+        {
+          Id: 222,
+          PullZoneName: "mysite",
+          DefaultHostname: "mysite.b-cdn.net",
+        },
+      ]);
       await withMocks(
-        () =>
-          stubFetchJson(
-            pullZoneResponse([
-              { Id: 111, hostname: "other.b-cdn.net" },
-              { Id: 222, hostname: "mysite.b-cdn.net" },
-            ]),
-          ),
+        () => stubFetchJson(response),
         async () => {
-          const result = await bunnyCdnApi.findPullZoneId();
-          expect(result).toEqual({ ok: true, id: 222 });
+          const result = await bunnyCdnApi.getEdgeScript();
+          expect(result).toEqual({ ok: true, data: response });
         },
       );
     });
 
     test("sends correct request to Bunny API", async () => {
       const calls: { url: string; init: RequestInit | undefined }[] = [];
-      const response = pullZoneResponse([
-        { Id: 42, hostname: "mysite.b-cdn.net" },
-      ]);
+      const response = edgeScriptResponse();
       await withMocks(
         () =>
           stub(
@@ -153,29 +161,13 @@ describeWithEnv(
             },
           ),
         async () => {
-          await bunnyCdnApi.findPullZoneId();
+          await bunnyCdnApi.getEdgeScript();
           expect(calls).toHaveLength(1);
           expect(calls.at(0)!.url).toBe(
-            "https://api.bunny.net/pullzone?search=mysite.b-cdn.net",
+            "https://api.bunny.net/compute/script/99",
           );
           expect(calls.at(0)!.init!.headers).toEqual({
             AccessKey: "test-bunny-key",
-          });
-        },
-      );
-    });
-
-    test("returns error when no matching pull zone is found", async () => {
-      await withMocks(
-        () =>
-          stubFetchJson(
-            pullZoneResponse([{ Id: 111, hostname: "other.b-cdn.net" }]),
-          ),
-        async () => {
-          const result = await bunnyCdnApi.findPullZoneId();
-          expect(result).toEqual({
-            ok: false,
-            error: "No pull zone found with hostname mysite.b-cdn.net",
           });
         },
       );
@@ -188,10 +180,10 @@ describeWithEnv(
             Promise.resolve(new Response("Unauthorized", { status: 401 })),
           ),
         async () => {
-          const result = await bunnyCdnApi.findPullZoneId();
+          const result = await bunnyCdnApi.getEdgeScript();
           expect(result).toEqual({
             ok: false,
-            error: "List pull zones failed (401): Unauthorized",
+            error: "Get edge script failed (401): Unauthorized",
           });
         },
       );
@@ -199,20 +191,132 @@ describeWithEnv(
 
     test("returns errorKey from JSON error response", async () => {
       const jsonBody = JSON.stringify({
-        ErrorKey: "pullzone.rate_limited",
-        Message: "Too many requests.",
+        ErrorKey: "script.not_found",
+        Message: "Script not found.",
       });
       await withMocks(
         () =>
           stub(globalThis, "fetch", () =>
-            Promise.resolve(new Response(jsonBody, { status: 429 })),
+            Promise.resolve(new Response(jsonBody, { status: 404 })),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.getEdgeScript();
+          expect(result).toEqual({
+            ok: false,
+            error: "Get edge script failed (404): Script not found.",
+            errorKey: "script.not_found",
+          });
+        },
+      );
+    });
+  },
+);
+
+describeWithEnv(
+  "findPullZoneId",
+  { env: { BUNNY_API_KEY: "test-bunny-key", BUNNY_SCRIPT_ID: "99" } },
+  () => {
+    test("returns pull zone ID from first linked pull zone", async () => {
+      const response = edgeScriptResponse([
+        {
+          Id: 222,
+          PullZoneName: "mysite",
+          DefaultHostname: "mysite.b-cdn.net",
+        },
+      ]);
+      await withMocks(
+        () => stubFetchJson(response),
+        async () => {
+          const result = await bunnyCdnApi.findPullZoneId();
+          expect(result).toEqual({ ok: true, id: 222 });
+        },
+      );
+    });
+
+    test("returns error when no linked pull zones", async () => {
+      const response = edgeScriptResponse([]);
+      await withMocks(
+        () => stubFetchJson(response),
+        async () => {
+          const result = await bunnyCdnApi.findPullZoneId();
+          expect(result).toEqual({
+            ok: false,
+            error: "Edge script 99 has no linked pull zones",
+          });
+        },
+      );
+    });
+
+    test("returns error when edge script API fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Unauthorized", { status: 401 })),
           ),
         async () => {
           const result = await bunnyCdnApi.findPullZoneId();
           expect(result).toEqual({
             ok: false,
-            error: "List pull zones failed (429): Too many requests.",
-            errorKey: "pullzone.rate_limited",
+            error: "Get edge script failed (401): Unauthorized",
+          });
+        },
+      );
+    });
+  },
+);
+
+describe("getCdnHostname", () => {
+  test("delegates to bunnyCdnApi.getCdnHostname", async () => {
+    const original = bunnyCdnApi.getCdnHostname;
+    bunnyCdnApi.getCdnHostname = () =>
+      Promise.resolve({ ok: true as const, hostname: "mysite.b-cdn.net" });
+    try {
+      const result = await getCdnHostname();
+      expect(result).toEqual({ ok: true, hostname: "mysite.b-cdn.net" });
+    } finally {
+      bunnyCdnApi.getCdnHostname = original;
+    }
+  });
+
+  test("returns error from bunnyCdnApi", async () => {
+    const original = bunnyCdnApi.getCdnHostname;
+    bunnyCdnApi.getCdnHostname = () =>
+      Promise.resolve({ ok: false as const, error: "API error" });
+    try {
+      const result = await getCdnHostname();
+      expect(result).toEqual({ ok: false, error: "API error" });
+    } finally {
+      bunnyCdnApi.getCdnHostname = original;
+    }
+  });
+});
+
+describeWithEnv(
+  "getCdnHostname (real implementation)",
+  { env: { BUNNY_API_KEY: "test-bunny-key", BUNNY_SCRIPT_ID: "99" } },
+  () => {
+    test("returns DefaultHostname from edge script", async () => {
+      const response = edgeScriptResponse([], "mysite.b-cdn.net");
+      await withMocks(
+        () => stubFetchJson(response),
+        async () => {
+          const result = await bunnyCdnApi.getCdnHostname();
+          expect(result).toEqual({ ok: true, hostname: "mysite.b-cdn.net" });
+        },
+      );
+    });
+
+    test("returns error when edge script API fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Not found", { status: 404 })),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.getCdnHostname();
+          expect(result).toEqual({
+            ok: false,
+            error: "Get edge script failed (404): Not found",
           });
         },
       );
@@ -222,11 +326,8 @@ describeWithEnv(
 
 describeWithEnv(
   "validateCustomDomain (real implementation)",
-  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  { env: { BUNNY_API_KEY: "test-bunny-key", BUNNY_SCRIPT_ID: "99" } },
   () => {
-    beforeEach(() => setEffectiveDomainForTest("mysite.bunny.run"));
-    afterEach(() => resetEffectiveDomain());
-
     /** Helper: stub findPullZoneId to return a fixed ID */
     const withFixedPullZoneId = (fn: () => Promise<void>): Promise<void> => {
       const original = bunnyCdnApi.findPullZoneId;
@@ -299,14 +400,14 @@ describeWithEnv(
       bunnyCdnApi.findPullZoneId = () =>
         Promise.resolve({
           ok: false as const,
-          error: "No pull zone found with hostname mysite.b-cdn.net",
+          error: "Edge script 99 has no linked pull zones",
         });
       try {
         const result =
           await bunnyCdnApi.validateCustomDomain("cdn.example.com");
         expect(result).toEqual({
           ok: false,
-          error: "No pull zone found with hostname mysite.b-cdn.net",
+          error: "Edge script 99 has no linked pull zones",
         });
       } finally {
         bunnyCdnApi.findPullZoneId = original;

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -67,19 +67,15 @@ describe("logger", () => {
     });
 
     test("redacts device ID in wallet webservice device paths", () => {
-      expect(
-        redactPath("/v1/devices/abc123/registrations/pass.com.test"),
-      ).toBe("/v1/devices/[redacted]/registrations/pass.com.test");
+      expect(redactPath("/v1/devices/abc123/registrations/pass.com.test")).toBe(
+        "/v1/devices/[redacted]/registrations/pass.com.test",
+      );
     });
 
     test("redacts token in wallet webservice registration paths", () => {
       expect(
-        redactPath(
-          "/v1/devices/abc123/registrations/pass.com.test/my-token",
-        ),
-      ).toBe(
-        "/v1/devices/[redacted]/registrations/pass.com.test/[redacted]",
-      );
+        redactPath("/v1/devices/abc123/registrations/pass.com.test/my-token"),
+      ).toBe("/v1/devices/[redacted]/registrations/pass.com.test/[redacted]");
     });
 
     test("redacts token in wallet webservice pass paths", () => {
@@ -89,9 +85,7 @@ describe("logger", () => {
     });
 
     test("redacts token in wallet download paths", () => {
-      expect(redactPath("/wallet/abc123.pkpass")).toBe(
-        "/wallet/[redacted]",
-      );
+      expect(redactPath("/wallet/abc123.pkpass")).toBe("/wallet/[redacted]");
     });
 
     test("redacts token in checkin paths", () => {

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -314,6 +314,25 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
         const html = await response.text();
         expect(html).toContain("badge-ok");
         expect(html).toContain("CDN management");
+        expect(html).toContain("mysite.b-cdn.net");
+      } finally {
+        bunnyCdnApi.getCdnHostname = original;
+      }
+    });
+
+    test("shows empty CDN hostname when edge script API fails", async () => {
+      restoreEnv = setTestEnv({
+        BUNNY_API_KEY: "test-key",
+        BUNNY_SCRIPT_ID: "99",
+      });
+      const original = bunnyCdnApi.getCdnHostname;
+      bunnyCdnApi.getCdnHostname = () =>
+        Promise.resolve({ ok: false as const, error: "API error" });
+      try {
+        const { response } = await adminGet("/admin/debug");
+        const html = await response.text();
+        expect(html).toContain("badge-ok");
+        expect(html).not.toContain("mysite.b-cdn.net");
       } finally {
         bunnyCdnApi.getCdnHostname = original;
       }

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { settings } from "#lib/db/settings.ts";
 import { LIMIT_ENTRIES } from "#lib/limits.ts";
 import { handleRequest } from "#routes";
@@ -301,11 +302,21 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     afterEach(() => restoreEnv());
 
     test("shows CDN as configured when Bunny CDN is enabled", async () => {
-      restoreEnv = setTestEnv({ BUNNY_API_KEY: "test-key" });
-      const { response } = await adminGet("/admin/debug");
-      const html = await response.text();
-      expect(html).toContain("badge-ok");
-      expect(html).toContain("CDN management");
+      restoreEnv = setTestEnv({
+        BUNNY_API_KEY: "test-key",
+        BUNNY_SCRIPT_ID: "99",
+      });
+      const original = bunnyCdnApi.getCdnHostname;
+      bunnyCdnApi.getCdnHostname = () =>
+        Promise.resolve({ ok: true as const, hostname: "mysite.b-cdn.net" });
+      try {
+        const { response } = await adminGet("/admin/debug");
+        const html = await response.text();
+        expect(html).toContain("badge-ok");
+        expect(html).toContain("CDN management");
+      } finally {
+        bunnyCdnApi.getCdnHostname = original;
+      }
     });
   });
 

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -590,10 +590,28 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
   describeWithEnv(
     "custom domain",
-    { env: { BUNNY_API_KEY: undefined } },
+    { env: { BUNNY_API_KEY: undefined, BUNNY_SCRIPT_ID: undefined } },
     () => {
+      let restoreCdnHostname: (() => void) | null = null;
+      afterEach(() => {
+        if (restoreCdnHostname) {
+          restoreCdnHostname();
+          restoreCdnHostname = null;
+        }
+      });
+
       const setBunnyEnv = () => {
         Deno.env.set("BUNNY_API_KEY", "test-bunny-key");
+        Deno.env.set("BUNNY_SCRIPT_ID", "99");
+        const original = bunnyCdnApi.getCdnHostname;
+        bunnyCdnApi.getCdnHostname = () =>
+          Promise.resolve({
+            ok: true as const,
+            hostname: "mysite.b-cdn.net",
+          });
+        restoreCdnHostname = () => {
+          bunnyCdnApi.getCdnHostname = original;
+        };
       };
 
       test("does not show custom domain form when Bunny CDN is not configured", async () => {
@@ -634,8 +652,8 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         expect(html).toContain('id="settings-custom-domain-validate"');
         expect(html).toContain("CNAME");
         expect(html).toContain("tickets.example.com");
-        // CDN hostname is derived from the effective domain (localhost in tests)
-        expect(html).toContain("localhost");
+        // CDN hostname is fetched from the edge script API
+        expect(html).toContain("mysite.b-cdn.net");
       });
 
       test("shows warning when custom domain is not validated", async () => {


### PR DESCRIPTION
## Summary

- **Fix custom domain changes breaking**: The previous approach derived the CDN hostname from the request URL (`.bunny.run` → `.b-cdn.net`), which fails when visiting from an existing custom domain. Now uses `GET /compute/script/{BUNNY_SCRIPT_ID}` to get `DefaultHostname` and `LinkedPullZones` directly.
- **Add `BUNNY_SCRIPT_ID` env var**: Required alongside `BUNNY_API_KEY` for CDN features. Already used in the deploy workflow.
- **Replace sync `getCdnHostname`** (config.ts) with async version (bunny-cdn.ts) that fetches from the Edge Script API.

## Test plan

- [x] All 158 tests pass
- [x] Lint clean
- [ ] Verify with real Bunny account: set `BUNNY_SCRIPT_ID` + `BUNNY_API_KEY`, confirm custom domain save/validate works
- [ ] Verify changing from one custom domain to another works when visiting from the first custom domain

https://claude.ai/code/session_014eorbHExhaq6ffL7QLYc1C