### PR TITLE
Fix flaky test by eliminating Deno.env races in parallel workers

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -40,3 +40,18 @@ export function requireEnv(key: string): string {
   }
   return value;
 }
+
+// ---------------------------------------------------------------------------
+// Per-worker test flag: "expect error" mode
+// Module-level state avoids Deno.env races when tests run with --parallel.
+// ---------------------------------------------------------------------------
+
+const expectErrorState = { active: false };
+
+/** Check whether expected-error mode is active (per-worker, no env race). */
+export const isExpectError = (): boolean => expectErrorState.active;
+
+/** Set expected-error mode (for test-utils withExpectedError). */
+export const setExpectError = (value: boolean): void => {
+  expectErrorState.active = value;
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@
 
 import { once } from "#fp";
 import { loadEffectiveDomain } from "#lib/config.ts";
+import { isExpectError } from "#lib/env.ts";
 import {
   clearFlashCookie,
   clearSessionCookie,
@@ -425,7 +426,7 @@ export const handleRequest = async (
               if (
                 Deno.env.get("TEST_RETHROW_ERRORS") &&
                 !(error instanceof SessionKeyError) &&
-                !Deno.env.get("TEST_EXPECT_ERROR")
+                !isExpectError()
               ) {
                 throw error;
               }

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -34,6 +34,7 @@ import { getSession, resetSessionCache } from "#lib/db/sessions.ts";
 import { settings } from "#lib/db/settings.ts";
 import { invalidateUsersCache } from "#lib/db/users.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
+import { setExpectError } from "#lib/env.ts";
 import { resetHostEmailConfig } from "#lib/email.ts";
 import { FormParams } from "#lib/form-data.ts";
 import type { GoogleWalletCredentials } from "#lib/google-wallet.ts";
@@ -72,18 +73,13 @@ export const setupTestEncryptionKey = (): void => {
 };
 
 /**
- * Clear test encryption key from environment
+ * Clear test encryption key (module-level only, no env var mutations).
+ * Uses empty string override so getEncryptionKeyOverride() returns ""
+ * (not null/undefined), preventing fallthrough to Deno.env via ??.
+ * Avoids deleting shared Deno.env vars that race with parallel workers.
  */
 export const clearTestEncryptionKey = (): void => {
-  // Use empty string (not null) so the override stays active and doesn't
-  // fall through to Deno.env, avoiding races with parallel test workers.
   setEncryptionKeyForTest("");
-  Deno.env.delete("DB_ENCRYPTION_KEY");
-  Deno.env.delete("TEST_PBKDF2_ITERATIONS");
-  Deno.env.delete("TEST_SKIP_LOGIN_DELAY");
-  Deno.env.delete("TEST_RSA_KEY_SIZE");
-  Deno.env.delete("TEST_SUPPRESS_REQUEST_LOGS");
-  clearEncryptionKeyCache();
 };
 
 // ---------------------------------------------------------------------------
@@ -409,15 +405,16 @@ export const urlFromFetchInput = (input: string | URL | Request): string =>
 
 /**
  * Run a callback that intentionally triggers an error caught by handleRequest.
- * Temporarily sets TEST_EXPECT_ERROR so the error is returned as a response
- * instead of being rethrown by the TEST_RETHROW_ERRORS guard.
+ * Temporarily enables "expect error" mode so the error is returned as a
+ * response instead of being rethrown by the TEST_RETHROW_ERRORS guard.
+ * Uses per-worker module state (not Deno.env) to avoid races with --parallel.
  */
 export const withExpectedError = bracket(
   () => {
-    Deno.env.set("TEST_EXPECT_ERROR", "1");
+    setExpectError(true);
   },
   () => {
-    Deno.env.delete("TEST_EXPECT_ERROR");
+    setExpectError(false);
   },
 );
 


### PR DESCRIPTION
## Summary

- **`clearTestEncryptionKey()`** deleted 5 shared `Deno.env` vars unnecessarily — the module-level override via `setEncryptionKeyForTest("")` is sufficient since `""` is not null/undefined, so `??` doesn't fall through to `Deno.env`
- **`withExpectedError`** used `Deno.env.set("TEST_EXPECT_ERROR")` which leaked to other parallel workers, causing their `handleRequest` to swallow errors silently instead of rethrowing — replaced with per-worker module-level state in `env.ts`

Both issues caused races when tests run with `--parallel` (3 workers sharing `Deno.env`), leading to intermittent "No session cookie in login response" failures in unrelated test suites like `custom domain settings`.

## Test plan

- [x] All 155 tests pass
- [x] 100% line and branch coverage maintained
- [x] Code quality checks pass (no module-level `let`)

https://claude.ai/code/session_01M2gC7Dt4p17H7bYEt3LdZw