### PR TITLE
Fix flaky test: bypass handleRequest in session setup

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -256,8 +256,10 @@ export const createTestDbWithSetup = async (country = "GB"): Promise<void> => {
   const usersResult = await getClient().execute("SELECT * FROM users");
   cachedSetupUsers = usersResult.rows.map((r) => ({ ...r }));
 
-  // Perform one admin login and cache the session for reuse
-  const session = await loginAsAdmin();
+  // Create admin session directly (bypasses handleRequest pipeline whose
+  // isSetupComplete() check can fail under parallel test execution when
+  // another worker invalidates the shared settings cache singleton).
+  const session = await createDirectAdminSession();
   const sessionsResult = await getClient().execute(
     "SELECT token, csrf_token, expires, wrapped_data_key, user_id FROM sessions LIMIT 1",
   );
@@ -814,6 +816,47 @@ export const testEventInput = (
 
 /** Cached session for test event creation */
 let testSession: { cookie: string; csrfToken: string } | null = null;
+
+/**
+ * Create an admin session directly in the DB without going through handleRequest().
+ * This avoids the isSetupComplete() check in the request pipeline, which can
+ * return false under parallel test execution when another worker invalidates
+ * the shared settings cache singleton between loadAll() and isSetupComplete().
+ */
+const createDirectAdminSession = async (): Promise<{
+  cookie: string;
+  csrfToken: string;
+}> => {
+  const { deriveKEK, generateSecureToken, unwrapKey, wrapKeyWithToken } =
+    await import("#lib/crypto.ts");
+  const { createSession: createDbSession } = await import(
+    "#lib/db/sessions.ts"
+  );
+  const { buildSessionCookie } = await import("#lib/cookies.ts");
+  const { getUserByUsername, verifyUserPassword } = await import(
+    "#lib/db/users.ts"
+  );
+  const { nowMs } = await import("#lib/now.ts");
+
+  const user = await getUserByUsername(TEST_ADMIN_USERNAME);
+  if (!user?.wrapped_data_key)
+    throw new Error("Admin user not found after setup");
+  const passwordHash = await verifyUserPassword(user, TEST_ADMIN_PASSWORD);
+  if (!passwordHash)
+    throw new Error("Admin password verification failed after setup");
+  const kek = await deriveKEK(passwordHash);
+  const dataKey = await unwrapKey(user.wrapped_data_key, kek);
+
+  const token = generateSecureToken();
+  const csrfToken = generateSecureToken();
+  const expires = nowMs() + 24 * 60 * 60 * 1000;
+  const wrappedDataKey = await wrapKeyWithToken(dataKey, token);
+  await createDbSession(token, csrfToken, expires, wrappedDataKey, user.id);
+
+  const cookie = buildSessionCookie(token);
+  const signedCsrf = await signCsrfToken();
+  return { cookie, csrfToken: signedCsrf };
+};
 
 /**
  * Perform a fresh admin login and return the cookie and CSRF token.


### PR DESCRIPTION
## Summary

- `createTestDbWithSetup()` previously called `loginAsAdmin()` which goes through the full `handleRequest()` pipeline including the `isSetupComplete()` check
- Under high parallelism (`DENO_JOBS=15`), the shared settings cache singleton can be invalidated by another worker between `loadAll()` and `isSetupComplete()`, causing an incorrect redirect to `/setup/` and a "No session cookie in login response" error
- Replace with `createDirectAdminSession()` that creates the session directly in the DB, bypassing the request pipeline entirely
- `loginAsAdmin()` is preserved unchanged for tests that explicitly test the login flow

## Test plan

- [ ] CI passes with default `DENO_JOBS=3`
- [ ] CI passes with `DENO_JOBS=15` (the concurrency level that reproduced the flake)
- [ ] Existing `loginAsAdmin` tests in `test-utils.test.ts` still pass (they call `loginAsAdmin()` after `createTestDbWithSetup()`)
- [ ] "custom domain settings" tests in `bunny-cdn.test.ts` no longer flake

https://claude.ai/code/session_012texJK8N6wn8RL8rHJJDez