### PR TITLE
Fix CNAME record display in custom domain settings

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -84,8 +84,14 @@ const findPullZoneIdImpl = (): Promise<
  * Get the CDN hostname (DefaultHostname) from the edge script.
  * This is the stable hostname for CNAME targets, independent of request URL.
  */
+const toCnameTarget = (hostname: string): string =>
+  hostname.replace(/^https?:\/\//, "").replace(/\.bunny\.run$/, ".b-cdn.net");
+
 const getCdnHostnameImpl = (): Promise<CdnHostnameResult> =>
-  withEdgeScript((data) => ({ ok: true as const, hostname: data.DefaultHostname }));
+  withEdgeScript((data) => ({
+    ok: true as const,
+    hostname: toCnameTarget(data.DefaultHostname),
+  }));
 
 /** Parse a Bunny API error response into a BunnyApiResult. */
 const parseBunnyError = async (

--- a/src/routes/admin/api.ts
+++ b/src/routes/admin/api.ts
@@ -147,9 +147,7 @@ const pickTypedFields = (
  * Build EventInput defaults from an existing event (for updates).
  * Maps snake_case Event fields to camelCase EventInput keys.
  */
-const existingToDefaults = (
-  existing: EventWithCount,
-): FieldRecord => {
+const existingToDefaults = (existing: EventWithCount): FieldRecord => {
   const result: FieldRecord = {};
   for (const [apiKey, outKey] of optionalFields) {
     const val = existing[apiKey as keyof EventWithCount];

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -295,7 +295,18 @@ describeWithEnv(
   "getCdnHostname (real implementation)",
   { env: { BUNNY_API_KEY: "test-bunny-key", BUNNY_SCRIPT_ID: "99" } },
   () => {
-    test("returns DefaultHostname from edge script", async () => {
+    test("strips https and converts bunny.run to b-cdn.net", async () => {
+      const response = edgeScriptResponse([], "https://mysite.bunny.run");
+      await withMocks(
+        () => stubFetchJson(response),
+        async () => {
+          const result = await bunnyCdnApi.getCdnHostname();
+          expect(result).toEqual({ ok: true, hostname: "mysite.b-cdn.net" });
+        },
+      );
+    });
+
+    test("passes through already-correct b-cdn.net hostname", async () => {
       const response = edgeScriptResponse([], "mysite.b-cdn.net");
       await withMocks(
         () => stubFetchJson(response),


### PR DESCRIPTION
## Summary
- Strip `https://` prefix from the Bunny API's `DefaultHostname` before displaying as CNAME target
- Convert `.bunny.run` suffix to `.b-cdn.net` which is the correct CNAME target for DNS records
- Added `toCnameTarget` helper in `bunny-cdn.ts` to handle the transformation

## Test plan
- [x] Updated existing test to verify `https://mysite.bunny.run` → `mysite.b-cdn.net`
- [x] Added test for passthrough of already-correct `b-cdn.net` hostnames
- [x] All 158 tests pass with 100% coverage

https://claude.ai/code/session_012fpiKtWA2uzUDr9CsMFSPx