### PR TITLE
Downgrade unrecognized payment session webhooks to debug log

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -927,11 +927,10 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   }
 
   if (!sessionResult) {
-    logError({
-      code: ErrorCode.PAYMENT_SESSION,
-      detail: "Ignoring webhook for unrecognized payment session",
-    });
-    logDebug("Webhook", `Ignored payload: ${payload}`);
+    logDebug(
+      "Webhook",
+      `Ignoring webhook for unrecognized payment session: ${payload}`,
+    );
     return webhookAckResponse();
   }
 
@@ -942,11 +941,10 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   // carry our _origin marker.
   const origin = session.metadata._origin;
   if (origin !== getEffectiveDomain()) {
-    logError({
-      code: ErrorCode.PAYMENT_SESSION,
-      detail: "Ignoring webhook for unrecognized payment session",
-    });
-    logDebug("Webhook", `Ignored payload: ${payload}`);
+    logDebug(
+      "Webhook",
+      `Ignoring webhook for unrecognized payment session (origin=${origin}): ${payload}`,
+    );
     return webhookAckResponse();
   }
 


### PR DESCRIPTION
## Summary

- Replaced `logError` with `logDebug` for two "unrecognized payment session" cases in the webhook handler (no matching session, and origin mismatch)
- These are benign events (webhooks from other systems sharing the same payment provider) that don't need error-level logging, ntfy alerts, or activity log entries

## Test plan

- [x] All 158 tests pass
- [ ] Verify production logs show debug-level entries instead of error-level for unrecognized webhooks

https://claude.ai/code/session_01NHDP7LpbTToNakkvXztmXa