### PR TITLE
Add Bunny DNS debug info and consolidate debug sections

### DIFF
--- a/src/routes/admin/debug.ts
+++ b/src/routes/admin/debug.ts
@@ -9,7 +9,12 @@ import {
 } from "#lib/apple-wallet.ts";
 import { BUILD_COMMIT, BUILD_TIMESTAMP } from "#lib/build-info.ts";
 import { getCdnHostname } from "#lib/bunny-cdn.ts";
-import { getEffectiveDomain, isBunnyCdnEnabled } from "#lib/config.ts";
+import {
+  getBunnyDnsSubdomainSuffix,
+  getEffectiveDomain,
+  isBunnyCdnEnabled,
+  isBunnyDnsEnabled,
+} from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
 import { getHostEmailConfig } from "#lib/email.ts";
 import { getEnv } from "#lib/env.ts";
@@ -143,13 +148,14 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     ntfy: {
       configured: !!getEnv("NTFY_URL"),
     },
-    storage: {
-      enabled: isStorageEnabled(),
-    },
-    bunnyCdn: {
-      enabled: bunnyCdnEnabled,
+    bunny: {
+      storageEnabled: isStorageEnabled(),
+      cdnEnabled: bunnyCdnEnabled,
       cdnHostname: bunnyCdnCdnHostname,
       customDomain: bunnyCdnEnabled ? settings.customDomain : "",
+      dnsEnabled: isBunnyDnsEnabled(),
+      subdomainSuffix: getBunnyDnsSubdomainSuffix(),
+      registeredSubdomain: settings.bunnySubdomain,
     },
     database: {
       hostConfigured: !!getEnv("DB_URL"),

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -40,13 +40,14 @@ export type DebugPageState = {
   ntfy: {
     configured: boolean;
   };
-  storage: {
-    enabled: boolean;
-  };
-  bunnyCdn: {
-    enabled: boolean;
+  bunny: {
+    storageEnabled: boolean;
+    cdnEnabled: boolean;
     cdnHostname: string;
     customDomain: string;
+    dnsEnabled: boolean;
+    subdomainSuffix: string;
+    registeredSubdomain: string;
   };
   database: {
     hostConfigured: boolean;
@@ -237,43 +238,49 @@ export const adminDebugPage = (
       </article>
 
       <article>
-        <h2>Bunny Storage (images)</h2>
+        <h2>Bunny</h2>
         <table>
           <tbody>
             <tr>
-              <td>Storage zone</td>
+              <td>Storage zone (images)</td>
               <td>
-                <StatusBadge ok={s.storage.enabled} />
+                <StatusBadge ok={s.bunny.storageEnabled} />
               </td>
             </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Bunny CDN</h2>
-        <table>
-          <tbody>
             <tr>
               <td>CDN management</td>
               <td>
-                <StatusBadge ok={s.bunnyCdn.enabled} />
+                <StatusBadge ok={s.bunny.cdnEnabled} />
               </td>
             </tr>
             <tr>
               <td>CDN hostname</td>
-              <td>{s.bunnyCdn.cdnHostname || "—"}</td>
+              <td>{s.bunny.cdnHostname || "—"}</td>
             </tr>
             <tr>
               <td>Custom domain</td>
-              <td>{s.bunnyCdn.customDomain || "—"}</td>
+              <td>{s.bunny.customDomain || "—"}</td>
+            </tr>
+            <tr>
+              <td>DNS subdomain</td>
+              <td>
+                <StatusBadge ok={s.bunny.dnsEnabled} />
+              </td>
+            </tr>
+            <tr>
+              <td>Subdomain suffix</td>
+              <td>{s.bunny.subdomainSuffix || "—"}</td>
+            </tr>
+            <tr>
+              <td>Registered subdomain</td>
+              <td>{s.bunny.registeredSubdomain || "—"}</td>
             </tr>
           </tbody>
         </table>
       </article>
 
       <article>
-        <h2>Database</h2>
+        <h2>Database &amp; Domain</h2>
         <table>
           <tbody>
             <tr>
@@ -282,16 +289,8 @@ export const adminDebugPage = (
                 <StatusBadge ok={s.database.hostConfigured} />
               </td>
             </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Domain</h2>
-        <table>
-          <tbody>
             <tr>
-              <td>Effective Domain</td>
+              <td>Effective domain</td>
               <td>{s.domain}</td>
             </tr>
           </tbody>

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -90,34 +90,25 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
       expect(html).toContain("NTFY URL");
     });
 
-    test("shows Bunny Storage section", async () => {
+    test("shows combined Bunny section with storage, CDN, and DNS", async () => {
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
-      expect(html).toContain("Bunny Storage (images)");
-      expect(html).toContain("Storage zone");
-    });
-
-    test("shows Bunny CDN section", async () => {
-      const { response } = await adminGet("/admin/debug");
-      const html = await response.text();
-      expect(html).toContain("Bunny CDN");
+      expect(html).toContain("Bunny");
+      expect(html).toContain("Storage zone (images)");
       expect(html).toContain("CDN management");
       expect(html).toContain("CDN hostname");
       expect(html).toContain("Custom domain");
+      expect(html).toContain("DNS subdomain");
+      expect(html).toContain("Subdomain suffix");
+      expect(html).toContain("Registered subdomain");
     });
 
-    test("shows Database section", async () => {
+    test("shows combined Database &amp; Domain section", async () => {
       const { response } = await adminGet("/admin/debug");
       const html = await response.text();
-      expect(html).toContain("Database");
+      expect(html).toContain("Database &amp; Domain");
       expect(html).toContain("DB_URL");
-    });
-
-    test("shows Domain section with effective domain", async () => {
-      const { response } = await adminGet("/admin/debug");
-      const html = await response.text();
-      expect(html).toContain("Domain");
-      expect(html).toContain("Effective Domain");
+      expect(html).toContain("Effective domain");
     });
 
     test("does not expose secret keys or full URLs", async () => {
@@ -339,6 +330,77 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     });
   });
 
+  describe("GET /admin/debug with Bunny DNS enabled", () => {
+    let restoreEnv: () => void;
+
+    afterEach(() => restoreEnv());
+
+    test("shows DNS subdomain as configured with suffix", async () => {
+      restoreEnv = setTestEnv({
+        BUNNY_API_KEY: "test-key",
+        BUNNY_DNS_ZONE_ID: "12345",
+        BUNNY_DNS_SUBDOMAIN_SUFFIX: ".tickets",
+      });
+      const { response } = await adminGet("/admin/debug");
+      const html = await response.text();
+      expect(html).toContain("DNS subdomain");
+      expect(html).toContain(".tickets");
+    });
+
+    test("shows registered subdomain when set", () => {
+      const state: DebugPageState = {
+        build: { timestamp: "", commit: "" },
+        appleWallet: {
+          dbConfigured: false,
+          envConfigured: false,
+          passTypeId: "",
+          source: "",
+          certValidation: {
+            signingCert: "Not set",
+            signingKey: "Not set",
+            wwdrCert: "Not set",
+          },
+        },
+        googleWallet: {
+          dbConfigured: false,
+          envConfigured: false,
+          issuerId: "",
+          source: "",
+          privateKeyValid: "Not set",
+        },
+        payment: {
+          provider: "",
+          keyConfigured: false,
+          webhookConfigured: false,
+        },
+        email: {
+          provider: "",
+          apiKeyConfigured: false,
+          fromAddress: "",
+          hostProvider: "",
+        },
+        ntfy: { configured: false },
+        bunny: {
+          storageEnabled: false,
+          cdnEnabled: false,
+          cdnHostname: "",
+          customDomain: "",
+          dnsEnabled: true,
+          subdomainSuffix: ".tickets",
+          registeredSubdomain: "myevent.example.com",
+        },
+        database: { hostConfigured: false },
+        domain: "localhost",
+        limits: [],
+        theme: "light",
+      };
+      const session = { adminLevel: "owner" as const };
+      const html = adminDebugPage(session, state);
+      expect(html).toContain("myevent.example.com");
+      expect(html).toContain(".tickets");
+    });
+  });
+
   describe("Limits section", () => {
     test("shows limits table with all entries", async () => {
       const { response } = await adminGet("/admin/debug");
@@ -383,8 +445,15 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
           hostProvider: "",
         },
         ntfy: { configured: false },
-        storage: { enabled: false },
-        bunnyCdn: { enabled: false, cdnHostname: "", customDomain: "" },
+        bunny: {
+          storageEnabled: false,
+          cdnEnabled: false,
+          cdnHostname: "",
+          customDomain: "",
+          dnsEnabled: false,
+          subdomainSuffix: "",
+          registeredSubdomain: "",
+        },
         database: { hostConfigured: false },
         domain: "localhost",
         limits: [


### PR DESCRIPTION
## Summary

- Consolidate separate "Bunny Storage (images)", "Bunny CDN" into a single **Bunny** section on `/admin/debug`
- Add DNS subdomain info: enabled status, subdomain suffix, and registered subdomain
- Merge "Database" and "Domain" into a single **Database & Domain** section
- No private info leaked — API keys shown only as Configured/Not configured badges

## Test plan

- [x] All 163 tests pass
- [x] Full precommit passes (typecheck, lint, cpd, coverage)
- [ ] Verify `/admin/debug` page renders the consolidated Bunny section with DNS info
- [ ] Confirm no API keys or secrets appear in the debug output

https://claude.ai/code/session_01818hXxQPJZhHTqkTpCbMW9