### PR TITLE
Increase default DENO_JOBS from 3 to 15 for test execution

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -125,7 +125,7 @@ const runTests = async (useCoverage: boolean): Promise<number> => {
       ...Deno.env.toObject(),
       STRIPE_MOCK_HOST: "localhost",
       STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
-      DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "3",
+      DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "15",
     },
   });
   const result = await testCmd.output();


### PR DESCRIPTION
## Summary
Increased the default number of parallel jobs for Deno test execution from 3 to 15 to improve test suite performance.

## Changes
- Updated the default `DENO_JOBS` environment variable from `"3"` to `"15"` in the test runner script
- This change allows more test files to run concurrently, reducing overall test execution time
- The environment variable can still be overridden by explicitly setting `DENO_JOBS` before running tests

## Details
The change maintains backward compatibility by using the nullish coalescing operator (`??`), which respects any user-provided `DENO_JOBS` value while only applying the new default of 15 when the environment variable is not set.

https://claude.ai/code/session_01RR1q4SDGMzHvvGUnToXVVF