### PR TITLE
Use widescreen aspect ratio for textareas on desktop

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -596,6 +596,12 @@ textarea {
   resize: vertical;
 }
 
+@media (min-width: 769px) {
+  textarea {
+    aspect-ratio: 16 / 9;
+  }
+}
+
 input[readonly],
 textarea[readonly] {
   background-color: var(--color-bg-secondary);


### PR DESCRIPTION
## Summary
- Textareas default to `4/3` aspect ratio which is too tall on desktop screens
- Added a media query at `769px+` to switch to `16/9` widescreen aspect ratio
- Mobile screens keep the existing `4/3` ratio

## Test plan
- [ ] Verify textareas appear with 4/3 ratio on mobile/narrow viewports
- [ ] Verify textareas switch to 16/9 on desktop/wide viewports (769px+)
- [ ] Check textarea resize behavior still works correctly

https://claude.ai/code/session_012meS7Lo5JEdz7Mj7diyXC3