### PR TITLE
Simplify host subdomain and custom domain settings forms

### DIFF
--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -130,7 +130,10 @@ const getSettingsPageState = () => {
 };
 
 /** Gather state for the advanced settings page */
-const getAdvancedSettingsPageState = async (subdomainPreview = "") => {
+const getAdvancedSettingsPageState = async (
+  subdomainPreview = "",
+  subdomainPreviewFullDomain = "",
+) => {
   const bunnyCdnConfigured = isBunnyCdnEnabled();
   const bunnyDnsEnabled = isBunnyDnsEnabled();
   const confirmationTemplates = settings.email.templateSet("confirmation");
@@ -157,6 +160,7 @@ const getAdvancedSettingsPageState = async (subdomainPreview = "") => {
       ? getBunnyDnsSubdomainSuffix()
       : "",
     subdomainPreview,
+    subdomainPreviewFullDomain,
     customDomain: (bunnyCdnConfigured ? settings.customDomain : null) ?? "",
     customDomainLastValidated:
       (bunnyCdnConfigured ? settings.customDomainLastValidated : null) ?? "",
@@ -191,8 +195,12 @@ const renderSettingsPage = (session: AuthSession) => {
 const renderAdvancedSettingsPage = async (
   session: AuthSession,
   subdomainPreview = "",
+  subdomainPreviewFullDomain = "",
 ) => {
-  const state = await getAdvancedSettingsPageState(subdomainPreview);
+  const state = await getAdvancedSettingsPageState(
+    subdomainPreview,
+    subdomainPreviewFullDomain,
+  );
   return adminAdvancedSettingsPage(session, state);
 };
 
@@ -288,8 +296,15 @@ const handleAdminSettingsAdvancedGet: TypedRouteHandler<
     const subdomainPreview = flash.success
       ? getSearchParam(request, "subdomain")
       : "";
+    const subdomainPreviewFullDomain = flash.success
+      ? getSearchParam(request, "fullDomain")
+      : "";
     return htmlResponse(
-      await renderAdvancedSettingsPage(session, subdomainPreview),
+      await renderAdvancedSettingsPage(
+        session,
+        subdomainPreview,
+        subdomainPreviewFullDomain,
+      ),
     );
   });
 
@@ -1200,11 +1215,11 @@ const handleHostSubdomainPost = advancedSettingsRoute(
       }
       return redirect(
         "/admin/settings-advanced",
-        `${raw}${getBunnyDnsSubdomainSuffix()} is available`,
+        `${check.fullDomain} is available`,
         true,
         {
           formId: FORM_ID_HOST_SUBDOMAIN,
-          params: { subdomain: raw },
+          params: { subdomain: raw, fullDomain: check.fullDomain },
         },
       );
     }

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -393,7 +393,8 @@ pre samp {
   white-space: pre-wrap;
 }
 
-small {
+small,
+.muted {
   color: var(--color-text-secondary);
 }
 

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -74,11 +74,11 @@ export const adminGuidePage = (
           <p>
             From the <strong>Events</strong> page, click{" "}
             <strong>Add Event</strong>. Give your event a name, set the
-            capacity, and choose which
-            contact details to collect (any combination of email, phone, postal
-            address, and special instructions &mdash; or none at all for
-            name-only registration). You can leave the price blank for free
-            events. Once created, share the booking link with your attendees.
+            capacity, and choose which contact details to collect (any
+            combination of email, phone, postal address, and special
+            instructions &mdash; or none at all for name-only registration). You
+            can leave the price blank for free events. Once created, share the
+            booking link with your attendees.
           </p>
         </Q>
 
@@ -246,8 +246,8 @@ export const adminGuidePage = (
             When creating or editing an event, enter a URL in the "thank you
             URL" field. After a successful booking or payment, attendees are
             redirected to that address instead of seeing the default
-            confirmation page. The URL must use HTTPS, or you can use a
-            relative path starting with <code>/</code>.
+            confirmation page. The URL must use HTTPS, or you can use a relative
+            path starting with <code>/</code>.
           </p>
         </Q>
 
@@ -255,8 +255,8 @@ export const adminGuidePage = (
           <p>
             When creating or editing an event, use the image upload field to
             attach a picture. The image is displayed on the booking page and in
-            the public events listing. Supported formats are JPEG, PNG, GIF,
-            and WebP.
+            the public events listing. Supported formats are JPEG, PNG, GIF, and
+            WebP.
           </p>
         </Q>
 
@@ -322,10 +322,9 @@ export const adminGuidePage = (
             Open the event's attendee list, find the attendee, and click{" "}
             <strong>Edit</strong>. You can update their name, email, phone,
             address, special instructions, quantity, and custom question
-            answers. You can also reassign
-            them to a different event using the event dropdown. Quantity changes
-            are validated against the event's capacity and maximum tickets per
-            purchase.
+            answers. You can also reassign them to a different event using the
+            event dropdown. Quantity changes are validated against the event's
+            capacity and maximum tickets per purchase.
           </p>
         </Q>
 
@@ -414,10 +413,10 @@ export const adminGuidePage = (
             When enabled in <strong>Settings</strong>, your domain shows a
             public website with navigation for Home and Events, plus T&amp;Cs
             and Contact links if you've set those up. The{" "}
-            <strong>Events</strong> page
-            lists all active events with booking links. Visitors can browse
-            event details and book directly. If the public site is disabled,
-            visitors can still book via direct ticket links.
+            <strong>Events</strong> page lists all active events with booking
+            links. Visitors can browse event details and book directly. If the
+            public site is disabled, visitors can still book via direct ticket
+            links.
           </p>
         </Q>
 
@@ -1064,10 +1063,10 @@ export const adminGuidePage = (
             Yes. On any event's attendee list, click <strong>Export CSV</strong>
             . The export includes name, email, phone, address, special
             instructions, quantity, registration date, amount paid, transaction
-            ID, check-in status, ticket token, and ticket URL. For daily
-            events, the attendee list has a date filter &mdash; select a date
-            to see only that day's attendees, and the CSV export respects the
-            same filter.
+            ID, check-in status, ticket token, and ticket URL. For daily events,
+            the attendee list has a date filter &mdash; select a date to see
+            only that day's attendees, and the CSV export respects the same
+            filter.
           </p>
         </Q>
 
@@ -1075,9 +1074,9 @@ export const adminGuidePage = (
           <p>
             It permanently deletes <strong>everything</strong>: all events,
             attendees, groups, questions, users, holidays, API keys, activity
-            logs, payment configuration, and sessions. The system
-            returns to its initial setup state. You must type a confirmation
-            phrase to proceed. This cannot be undone.
+            logs, payment configuration, and sessions. The system returns to its
+            initial setup state. You must type a confirmation phrase to proceed.
+            This cannot be undone.
           </p>
         </Q>
       </Section>
@@ -1154,10 +1153,10 @@ export const adminGuidePage = (
         <Q q="What is the activity log?">
           <p>
             The <strong>Log</strong> page shows a chronological list of admin
-            actions such as event creation, event updates, attendee changes,
-            and question changes. Both owners and managers can view the log. Each event also
-            has its own log, accessible from the event page, showing only
-            actions related to that event.
+            actions such as event creation, event updates, attendee changes, and
+            question changes. Both owners and managers can view the log. Each
+            event also has its own log, accessible from the event page, showing
+            only actions related to that event.
           </p>
         </Q>
       </Section>
@@ -1460,9 +1459,9 @@ export const adminGuidePage = (
             The debug page at <code>/admin/debug</code> shows the configuration
             status of all integrated services (payments, email, Apple Wallet,
             Google Wallet, storage, CDN, notifications, database) without
-            revealing any secrets or API
-            keys. It's useful for troubleshooting setup issues &mdash; you can
-            quickly see which services are configured and which are missing.
+            revealing any secrets or API keys. It's useful for troubleshooting
+            setup issues &mdash; you can quickly see which services are
+            configured and which are missing.
           </p>
         </Q>
       </Section>

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -33,6 +33,7 @@ export type AdvancedSettingsPageState = {
   bunnySubdomain: string;
   bunnyDnsSubdomainSuffix: string;
   subdomainPreview: string;
+  subdomainPreviewFullDomain: string;
   customDomain: string;
   customDomainLastValidated: string;
   cdnHostname: string;
@@ -487,19 +488,19 @@ export const adminAdvancedSettingsPage = (
             </div>
           ) : (
             <div>
-              <p>
-                Choose a subdomain for your booking site. This cannot be changed
-                once set.
-              </p>
+              <div class="prose">
+                <p>
+                  You can choose a prettier domain name for your tickets site.
+                  Enter a subdomain into the box below to preview the full URL
+                  &mdash; you can change your mind before saving, but once set
+                  this cannot be changed.
+                </p>
+              </div>
               {s.subdomainPreview ? (
                 <div>
                   <p>
-                    Subdomain{" "}
-                    <strong>
-                      {s.subdomainPreview}
-                      {s.bunnyDnsSubdomainSuffix}
-                    </strong>{" "}
-                    is available.
+                    <strong>{s.subdomainPreviewFullDomain}</strong> is
+                    available.
                   </p>
                   <input
                     type="hidden"
@@ -516,20 +517,18 @@ export const adminAdvancedSettingsPage = (
                 <div>
                   <label>
                     Subdomain
-                    <div class="subdomain-input-group">
-                      <input
-                        type="text"
-                        name="subdomain"
-                        placeholder="myevent"
-                        autocomplete="off"
-                        pattern="[a-z0-9]([a-z0-9-]{'{'}0,61{'}'}[a-z0-9])?"
-                      />
-                      <span class="subdomain-suffix">
-                        {s.bunnyDnsSubdomainSuffix}
-                      </span>
-                    </div>
+                    <input
+                      type="text"
+                      name="subdomain"
+                      placeholder="myevent"
+                      autocomplete="off"
+                      pattern="[a-z0-9]([a-z0-9-]{'{'}0,61{'}'}[a-z0-9])?"
+                    />
+                    <span class="muted">{s.bunnyDnsSubdomainSuffix}</span>
                   </label>
-                  <button type="submit">Check Availability</button>
+                  <button type="submit">
+                    Check Availability &amp; Preview Complete Domain
+                  </button>
                 </div>
               )}
             </div>
@@ -538,13 +537,17 @@ export const adminAdvancedSettingsPage = (
       )}
 
       {s.bunnyCdnEnabled && (
-        <div>
+        <div class="stack stack-sm">
           <CsrfForm
             action="/admin/settings/custom-domain"
             id="settings-custom-domain"
           >
             <h2>Custom Domain</h2>
-            <p>Set a custom domain for your booking site.</p>
+            <p>
+              Set a custom domain for your tickets site.
+              {s.bunnySubdomain &&
+                " Your host subdomain can be active at the same time as a custom domain."}
+            </p>
             <label>
               Domain
               <input

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -2743,6 +2743,7 @@ describe("html", () => {
         googleWalletServiceAccountEmail: "",
         hostGoogleWalletLabel: "",
         subdomainPreview: "",
+        subdomainPreviewFullDomain: "",
         theme: "light",
       };
 
@@ -2819,6 +2820,7 @@ describe("html", () => {
         bunnyDnsEnabled: true,
         bunnyDnsSubdomainSuffix: ".tickets.example.com",
         subdomainPreview: "myevent",
+        subdomainPreviewFullDomain: "myevent.tickets.example.com",
       });
       expect(html).toContain("myevent.tickets.example.com");
       expect(html).toContain("is available");

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -638,7 +638,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         const html = await response.text();
         expect(html).toContain('id="settings-host-subdomain"');
         expect(html).toContain("Host Subdomain");
-        expect(html).toContain("Check Availability");
+        expect(html).toContain("Check Availability &amp; Preview Complete Domain");
       });
 
       test("shows existing subdomain as read-only with redirect message when custom domain set", async () => {


### PR DESCRIPTION
## Summary

- Removed `subdomain-input-group` wrapper div — input and suffix span are now nested directly inside the label
- Changed `subdomain-suffix` class to `.muted` (new utility class sharing `small` element styling)
- Show the full complete domain name (input + suffix + host domain) in the availability preview instead of just subdomain + suffix
- Renamed button to "Check Availability & Preview Complete Domain"
- Wrapped subdomain description in `<div class="prose">` with updated copy explaining the feature more clearly
- Changed custom domain wrapper `<div>` to `<div class="stack stack-sm">` for consistent spacing
- Custom domain section now detects if host subdomain is active and appends "Your host subdomain can be active at the same time as a custom domain."
- Changed "booking site" to "tickets site" in both sections

## Test plan

- [x] All 163 tests pass
- [x] TypeScript typecheck passes
- [ ] Verify subdomain form renders correctly without wrapper divs
- [ ] Verify availability check shows full domain (e.g. `myevent.tickets.example.com`)
- [ ] Verify custom domain section shows subdomain coexistence message when subdomain is set

https://claude.ai/code/session_01VYBWqHviEkhFy1RE81TERD