### PR TITLE
Fix flaky header image test via describeWithEnv

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -74,11 +74,11 @@ export const adminGuidePage = (
           <p>
             From the <strong>Events</strong> page, click{" "}
             <strong>Add Event</strong>. Give your event a name, set the
-            capacity, and choose which
-            contact details to collect (any combination of email, phone, postal
-            address, and special instructions &mdash; or none at all for
-            name-only registration). You can leave the price blank for free
-            events. Once created, share the booking link with your attendees.
+            capacity, and choose which contact details to collect (any
+            combination of email, phone, postal address, and special
+            instructions &mdash; or none at all for name-only registration). You
+            can leave the price blank for free events. Once created, share the
+            booking link with your attendees.
           </p>
         </Q>
 
@@ -246,8 +246,8 @@ export const adminGuidePage = (
             When creating or editing an event, enter a URL in the "thank you
             URL" field. After a successful booking or payment, attendees are
             redirected to that address instead of seeing the default
-            confirmation page. The URL must use HTTPS, or you can use a
-            relative path starting with <code>/</code>.
+            confirmation page. The URL must use HTTPS, or you can use a relative
+            path starting with <code>/</code>.
           </p>
         </Q>
 
@@ -255,8 +255,8 @@ export const adminGuidePage = (
           <p>
             When creating or editing an event, use the image upload field to
             attach a picture. The image is displayed on the booking page and in
-            the public events listing. Supported formats are JPEG, PNG, GIF,
-            and WebP.
+            the public events listing. Supported formats are JPEG, PNG, GIF, and
+            WebP.
           </p>
         </Q>
 
@@ -322,10 +322,9 @@ export const adminGuidePage = (
             Open the event's attendee list, find the attendee, and click{" "}
             <strong>Edit</strong>. You can update their name, email, phone,
             address, special instructions, quantity, and custom question
-            answers. You can also reassign
-            them to a different event using the event dropdown. Quantity changes
-            are validated against the event's capacity and maximum tickets per
-            purchase.
+            answers. You can also reassign them to a different event using the
+            event dropdown. Quantity changes are validated against the event's
+            capacity and maximum tickets per purchase.
           </p>
         </Q>
 
@@ -414,10 +413,10 @@ export const adminGuidePage = (
             When enabled in <strong>Settings</strong>, your domain shows a
             public website with navigation for Home and Events, plus T&amp;Cs
             and Contact links if you've set those up. The{" "}
-            <strong>Events</strong> page
-            lists all active events with booking links. Visitors can browse
-            event details and book directly. If the public site is disabled,
-            visitors can still book via direct ticket links.
+            <strong>Events</strong> page lists all active events with booking
+            links. Visitors can browse event details and book directly. If the
+            public site is disabled, visitors can still book via direct ticket
+            links.
           </p>
         </Q>
 
@@ -1064,10 +1063,10 @@ export const adminGuidePage = (
             Yes. On any event's attendee list, click <strong>Export CSV</strong>
             . The export includes name, email, phone, address, special
             instructions, quantity, registration date, amount paid, transaction
-            ID, check-in status, ticket token, and ticket URL. For daily
-            events, the attendee list has a date filter &mdash; select a date
-            to see only that day's attendees, and the CSV export respects the
-            same filter.
+            ID, check-in status, ticket token, and ticket URL. For daily events,
+            the attendee list has a date filter &mdash; select a date to see
+            only that day's attendees, and the CSV export respects the same
+            filter.
           </p>
         </Q>
 
@@ -1075,9 +1074,9 @@ export const adminGuidePage = (
           <p>
             It permanently deletes <strong>everything</strong>: all events,
             attendees, groups, questions, users, holidays, API keys, activity
-            logs, payment configuration, and sessions. The system
-            returns to its initial setup state. You must type a confirmation
-            phrase to proceed. This cannot be undone.
+            logs, payment configuration, and sessions. The system returns to its
+            initial setup state. You must type a confirmation phrase to proceed.
+            This cannot be undone.
           </p>
         </Q>
       </Section>
@@ -1154,10 +1153,10 @@ export const adminGuidePage = (
         <Q q="What is the activity log?">
           <p>
             The <strong>Log</strong> page shows a chronological list of admin
-            actions such as event creation, event updates, attendee changes,
-            and question changes. Both owners and managers can view the log. Each event also
-            has its own log, accessible from the event page, showing only
-            actions related to that event.
+            actions such as event creation, event updates, attendee changes, and
+            question changes. Both owners and managers can view the log. Each
+            event also has its own log, accessible from the event page, showing
+            only actions related to that event.
           </p>
         </Q>
       </Section>
@@ -1460,9 +1459,9 @@ export const adminGuidePage = (
             The debug page at <code>/admin/debug</code> shows the configuration
             status of all integrated services (payments, email, Apple Wallet,
             Google Wallet, storage, CDN, notifications, database) without
-            revealing any secrets or API
-            keys. It's useful for troubleshooting setup issues &mdash; you can
-            quickly see which services are configured and which are missing.
+            revealing any secrets or API keys. It's useful for troubleshooting
+            setup issues &mdash; you can quickly see which services are
+            configured and which are missing.
           </p>
         </Q>
       </Section>

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -179,13 +179,17 @@ describeWithEnv(
         await expectHtmlResponse(response, 200, "Header Image");
       });
 
-      test("hides header image section when storage is disabled", async () => {
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
-        const { response } = await adminGet("/admin/settings");
-        const html = await response.text();
-        expect(html).not.toContain("Header Image");
-      });
+      describeWithEnv(
+        "when storage is disabled",
+        { env: { STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined } },
+        () => {
+          test("hides header image section", async () => {
+            const { response } = await adminGet("/admin/settings");
+            const html = await response.text();
+            expect(html).not.toContain("Header Image");
+          });
+        },
+      );
 
       test("shows remove button when header image is set", async () => {
         await settings.update.headerImageUrl("existing.jpg");
@@ -268,17 +272,20 @@ describeWithEnv(
         await expectHtmlResponse(response, 400, "No image file provided");
       });
 
-      test("returns error when storage is not configured", async () => {
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
-
-        const response = await submitHeaderJpeg("logo.jpg");
-        await expectHtmlResponse(
-          response,
-          400,
-          "Image storage is not configured",
-        );
-      });
+      describeWithEnv(
+        "when storage is not configured",
+        { env: { STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined } },
+        () => {
+          test("returns error", async () => {
+            const response = await submitHeaderJpeg("logo.jpg");
+            await expectHtmlResponse(
+              response,
+              400,
+              "Image storage is not configured",
+            );
+          });
+        },
+      );
 
       test("deletes old header image when uploading new one", async () => {
         await settings.update.headerImageUrl("old-header.jpg");

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -213,21 +213,25 @@ describeWithEnv(
   },
   () => {
     describe("POST /admin/event/:id/edit (image upload via edit form)", () => {
-      test("ignores image when storage is not configured", async () => {
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
-        const { event, cookie, csrfToken } = await setupEventAndLogin();
+      describeWithEnv(
+        "when storage is not configured",
+        { env: { STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined } },
+        () => {
+          test("ignores image", async () => {
+            const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-        const response = await submitEditJpeg(
-          event.id,
-          cookie,
-          csrfToken,
-          "test.jpg",
-        );
-        expect(response.status).toBe(302);
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.image_url).toBe("");
-      });
+            const response = await submitEditJpeg(
+              event.id,
+              cookie,
+              csrfToken,
+              "test.jpg",
+            );
+            expect(response.status).toBe(302);
+            const updated = await getEventWithCount(event.id);
+            expect(updated?.image_url).toBe("");
+          });
+        },
+      );
 
       test("updates event without image when no file is uploaded", async () => {
         const event = await createTestEvent();
@@ -552,11 +556,15 @@ describeWithEnv(
         expect((await proxyRequest("bmp")).status).toBe(404);
       });
 
-      test("returns 404 when storage is not enabled", async () => {
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
-        expect((await proxyRequest()).status).toBe(404);
-      });
+      describeWithEnv(
+        "when storage is not enabled",
+        { env: { STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined } },
+        () => {
+          test("returns 404", async () => {
+            expect((await proxyRequest()).status).toBe(404);
+          });
+        },
+      );
 
       test("returns 404 for non-GET method", async () => {
         const request = new Request(`http://localhost${PROXY_PATH}.jpg`, {
@@ -601,29 +609,33 @@ describeWithEnv(
         });
       });
 
-      test("ignores attachment when storage is not configured", async () => {
-        Deno.env.delete("STORAGE_ZONE_NAME");
-        Deno.env.delete("STORAGE_ZONE_KEY");
-        const { event, cookie, csrfToken } = await setupEventAndLogin();
+      describeWithEnv(
+        "when storage is not configured",
+        { env: { STORAGE_ZONE_NAME: undefined, STORAGE_ZONE_KEY: undefined } },
+        () => {
+          test("ignores attachment", async () => {
+            const { event, cookie, csrfToken } = await setupEventAndLogin();
 
-        const fields = await editFormData(event.id, csrfToken);
-        const response = await handleRequest(
-          mockMultipartRequest(
-            `/admin/event/${event.id}/edit`,
-            fields,
-            cookie,
-            {
-              fieldName: "attachment",
-              name: "guide.pdf",
-              data: PDF_BYTES,
-              contentType: "application/pdf",
-            },
-          ),
-        );
-        expect(response.status).toBe(302);
-        const updated = await getEventWithCount(event.id);
-        expect(updated?.attachment_url).toBe("");
-      });
+            const fields = await editFormData(event.id, csrfToken);
+            const response = await handleRequest(
+              mockMultipartRequest(
+                `/admin/event/${event.id}/edit`,
+                fields,
+                cookie,
+                {
+                  fieldName: "attachment",
+                  name: "guide.pdf",
+                  data: PDF_BYTES,
+                  contentType: "application/pdf",
+                },
+              ),
+            );
+            expect(response.status).toBe(302);
+            const updated = await getEventWithCount(event.id);
+            expect(updated?.attachment_url).toBe("");
+          });
+        },
+      );
 
       test("uploads attachment and updates event", async () => {
         const { event, cookie, csrfToken } = await setupEventAndLogin();

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -30,21 +30,35 @@ describeWithEnv(
         expect(isStorageEnabled()).toBe(false);
       });
 
-      test("returns false when only STORAGE_ZONE_NAME is set", () => {
-        Deno.env.set("STORAGE_ZONE_NAME", "myzone");
-        expect(isStorageEnabled()).toBe(false);
-      });
+      describeWithEnv(
+        "when only STORAGE_ZONE_NAME is set",
+        { env: { STORAGE_ZONE_NAME: "myzone" } },
+        () => {
+          test("returns false", () => {
+            expect(isStorageEnabled()).toBe(false);
+          });
+        },
+      );
 
-      test("returns false when only STORAGE_ZONE_KEY is set", () => {
-        Deno.env.set("STORAGE_ZONE_KEY", "mykey");
-        expect(isStorageEnabled()).toBe(false);
-      });
+      describeWithEnv(
+        "when only STORAGE_ZONE_KEY is set",
+        { env: { STORAGE_ZONE_KEY: "mykey" } },
+        () => {
+          test("returns false", () => {
+            expect(isStorageEnabled()).toBe(false);
+          });
+        },
+      );
 
-      test("returns true when both env vars are set", () => {
-        Deno.env.set("STORAGE_ZONE_NAME", "myzone");
-        Deno.env.set("STORAGE_ZONE_KEY", "mykey");
-        expect(isStorageEnabled()).toBe(true);
-      });
+      describeWithEnv(
+        "when both env vars are set",
+        { env: { STORAGE_ZONE_NAME: "myzone", STORAGE_ZONE_KEY: "mykey" } },
+        () => {
+          test("returns true", () => {
+            expect(isStorageEnabled()).toBe(true);
+          });
+        },
+      );
     });
 
     describe("getImageProxyUrl", () => {


### PR DESCRIPTION
## Summary
- Wrapped direct `Deno.env.delete()` calls for `STORAGE_ZONE_NAME`/`STORAGE_ZONE_KEY` in `describeWithEnv` blocks across `header-image.test.ts`, `server-images.test.ts`, and `storage.test.ts`
- Since tests run with `--parallel` and `Deno.env` is process-global, bare env var mutations could leak to concurrent test files, causing the header image upload test to intermittently fail when `requireEnv("STORAGE_ZONE_NAME")` throws mid-upload

## Test plan
- [x] All 163 tests pass locally
- [ ] Verify the header image upload test no longer flakes in CI

https://claude.ai/code/session_01MJtpMn5PD8PUF28EMsJPUD