### PR TITLE
Replace CNAME record table with bullet list

### DIFF
--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -582,26 +582,20 @@ export const adminAdvancedSettingsPage = (
                     To use your custom domain, create a <strong>CNAME</strong>{" "}
                     record:
                   </p>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Type</th>
-                        <th>Name</th>
-                        <th>Value</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>CNAME</td>
-                        <td>
-                          <code>{s.customDomain}</code>
-                        </td>
-                        <td>
-                          <code>{s.cdnHostname}</code>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+                  <ul>
+                    <li>
+                      <strong>Type:</strong> CNAME
+                    </li>
+                    <li>
+                      <strong>Name:</strong> <code>{s.customDomain}</code>
+                    </li>
+                    <li>
+                      <strong>Value:</strong> <code>{s.cdnHostname}</code>
+                    </li>
+                    <li>
+                      <strong>TTL:</strong> 3600
+                    </li>
+                  </ul>
                   <p>
                     Once the DNS record is in place, click the button below to
                     validate and enable SSL.

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -23,8 +23,8 @@ import {
   unwrapKeyWithToken,
 } from "#lib/crypto.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
-import { createApiKey } from "#lib/db/api-keys.ts";
 import { toMajorUnits } from "#lib/currency.ts";
+import { createApiKey } from "#lib/db/api-keys.ts";
 import { setDb } from "#lib/db/client.ts";
 import {
   type EventInput,
@@ -1307,16 +1307,13 @@ export const expectStatus =
 export const expectJsonResponse =
   // biome-ignore lint/suspicious/noExplicitAny: response.json() returns any; callers access nested fields freely
   // deno-lint-ignore no-explicit-any
-  <T = any>(
-    status: number,
-    assertions?: (body: T) => void,
-  ) =>
-  async (response: Response): Promise<T> => {
-    expect(response.status).toBe(status);
-    const body = (await response.json()) as T;
-    assertions?.(body);
-    return body;
-  };
+    <T = any>(status: number, assertions?: (body: T) => void) =>
+    async (response: Response): Promise<T> => {
+      expect(response.status).toBe(status);
+      const body = (await response.json()) as T;
+      assertions?.(body);
+      return body;
+    };
 
 /**
  * Assert status and JSON body on a response promise in one call.

--- a/test/admin-api-events.test.ts
+++ b/test/admin-api-events.test.ts
@@ -148,7 +148,9 @@ describeWithEnv("Admin API - Events", { db: true }, () => {
         }),
         400,
         (body) => {
-          expect(body.message).toBe("max_attendees is required and must be >= 1");
+          expect(body.message).toBe(
+            "max_attendees is required and must be >= 1",
+          );
         },
       );
     });
@@ -366,10 +368,9 @@ describeWithEnv("Admin API - Events", { db: true }, () => {
       const event = await createTestEvent({ name: "Active Event" });
 
       await assertJson(
-        apiRequest(
-          `/api/admin/events/${event.id}/deactivate`,
-          { method: "POST" },
-        ),
+        apiRequest(`/api/admin/events/${event.id}/deactivate`, {
+          method: "POST",
+        }),
         200,
         (body) => {
           expect(body.event.active).toBe(false);
@@ -390,10 +391,10 @@ describeWithEnv("Admin API - Events", { db: true }, () => {
 
       // Try to deactivate again
       await assertJson(
-        apiRequest(
-          `/api/admin/events/${event.id}/deactivate`,
-          { method: "POST", apiKey },
-        ),
+        apiRequest(`/api/admin/events/${event.id}/deactivate`, {
+          method: "POST",
+          apiKey,
+        }),
         400,
         (body) => {
           expect(body.message).toBe("Event is already deactivated");
@@ -423,10 +424,10 @@ describeWithEnv("Admin API - Events", { db: true }, () => {
 
       // Now reactivate
       await assertJson(
-        apiRequest(
-          `/api/admin/events/${event.id}/reactivate`,
-          { method: "POST", apiKey },
-        ),
+        apiRequest(`/api/admin/events/${event.id}/reactivate`, {
+          method: "POST",
+          apiKey,
+        }),
         200,
         (body) => {
           expect(body.event.active).toBe(true);
@@ -439,10 +440,9 @@ describeWithEnv("Admin API - Events", { db: true }, () => {
       const event = await createTestEvent({ name: "Already Active" });
 
       await assertJson(
-        apiRequest(
-          `/api/admin/events/${event.id}/reactivate`,
-          { method: "POST" },
-        ),
+        apiRequest(`/api/admin/events/${event.id}/reactivate`, {
+          method: "POST",
+        }),
         400,
         (body) => {
           expect(body.message).toBe("Event is already active");

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -22,6 +22,7 @@ import { getDb } from "#lib/db/client.ts";
 import { createSession } from "#lib/db/sessions.ts";
 import { handleRequest } from "#routes";
 import {
+  assertJson,
   createTestApiKeyFull,
   createTestEvent,
   describeWithEnv,
@@ -30,7 +31,6 @@ import {
   extractCsrfToken,
   FLASH_TEST_ID,
   flashCookieHeader,
-  assertJson,
   mockRequest,
   testCookie,
   testCsrfToken,

--- a/test/lib/email-templates-admin.test.ts
+++ b/test/lib/email-templates-admin.test.ts
@@ -5,11 +5,11 @@ import { CONFIG_KEYS, settings } from "#lib/db/settings.ts";
 import { resetEngine } from "#lib/email-renderer.ts";
 import { handleRequest } from "#routes";
 import {
+  assertJson,
   awaitTestRequest,
   describeWithEnv,
   expectAdminRedirect,
   expectHtmlResponse,
-  assertJson,
   mockFormRequest,
   testCookie,
   testCsrfToken,

--- a/test/lib/owner-footer.test.ts
+++ b/test/lib/owner-footer.test.ts
@@ -16,7 +16,12 @@ import {
 
 describeWithEnv("admin debug footer", { db: true }, () => {
   test("owner sees footer on admin dashboard", async () => {
-    await assertAdminHtml("/admin/", "Chobble Tickets", "<details>", "<summary>");
+    await assertAdminHtml(
+      "/admin/",
+      "Chobble Tickets",
+      "<details>",
+      "<summary>",
+    );
   });
 
   test("footer contains SQL queries", async () => {

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -700,14 +700,11 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     });
 
     test("returns 404 for non-existent event", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event/999/attendee",
-        {
-          name: "Jane Doe",
-          email: "jane@example.com",
-          quantity: "1",
-        },
-      );
+      const { response } = await adminFormPost("/admin/event/999/attendee", {
+        name: "Jane Doe",
+        email: "jane@example.com",
+        quantity: "1",
+      });
       expect(response.status).toBe(404);
     });
 
@@ -1090,17 +1087,14 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     });
 
     test("returns 404 for non-existent attendee", async () => {
-      const { response } = await adminFormPost(
-        "/admin/attendees/999",
-        {
-          name: "Jane Doe",
-          email: "jane@example.com",
-          phone: "",
-          address: "",
-          special_instructions: "",
-          event_id: "1",
-        },
-      );
+      const { response } = await adminFormPost("/admin/attendees/999", {
+        name: "Jane Doe",
+        email: "jane@example.com",
+        phone: "",
+        address: "",
+        special_instructions: "",
+        event_id: "1",
+      });
       expect(response.status).toBe(404);
     });
 

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -33,7 +33,11 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     });
 
     test("shows breadcrumb back to settings", async () => {
-      await assertAdminHtml("/admin/debug", 'href="/admin/settings"', "Settings");
+      await assertAdminHtml(
+        "/admin/debug",
+        'href="/admin/settings"',
+        "Settings",
+      );
     });
 
     test("shows Build section", async () => {
@@ -62,7 +66,13 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     });
 
     test("shows Payments section", async () => {
-      await assertAdminHtml("/admin/debug", "Payments", "Provider", "API key", "Webhook");
+      await assertAdminHtml(
+        "/admin/debug",
+        "Payments",
+        "Provider",
+        "API key",
+        "Webhook",
+      );
     });
 
     test("shows Email section", async () => {
@@ -227,7 +237,12 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
         ),
         settings.update.googleWallet.serviceAccountKey(creds.serviceAccountKey),
       ]);
-      await assertAdminHtml("/admin/debug", "Database", creds.issuerId, "Valid");
+      await assertAdminHtml(
+        "/admin/debug",
+        "Database",
+        creds.issuerId,
+        "Valid",
+      );
     });
 
     test("shows Invalid key for bad private key data", async () => {

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -11,8 +11,8 @@ import { todayInTz } from "#lib/timezone.ts";
 import { handleRequest } from "#routes";
 import { formatCountdown, withCookie } from "#routes/utils.ts";
 import {
-  adminGet,
   adminFormPost,
+  adminGet,
   awaitTestRequest,
   createTestAttendee,
   createTestEvent,
@@ -740,16 +740,13 @@ describeWithEnv("server (admin events)", { db: true }, () => {
     });
 
     test("returns 404 for non-existent event", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event/999/edit",
-        {
-          name: "Updated Event",
-          slug: "updated-event",
-          max_attendees: "50",
-          max_quantity: "1",
-          thank_you_url: "https://example.com/updated",
-        },
-      );
+      const { response } = await adminFormPost("/admin/event/999/edit", {
+        name: "Updated Event",
+        slug: "updated-event",
+        max_attendees: "50",
+        max_quantity: "1",
+        thank_you_url: "https://example.com/updated",
+      });
       expect(response.status).toBe(404);
     });
 
@@ -1390,10 +1387,9 @@ describeWithEnv("server (admin events)", { db: true }, () => {
     });
 
     test("returns 404 for non-existent event", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event/999/delete",
-        { confirm_identifier: "Test Event" },
-      );
+      const { response } = await adminFormPost("/admin/event/999/delete", {
+        confirm_identifier: "Test Event",
+      });
       expect(response.status).toBe(404);
     });
 
@@ -1586,16 +1582,13 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
   describe("POST /admin/event with unit_price", () => {
     test("creates event with unit_price when authenticated", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event",
-        {
-          name: "Paid Event",
-          max_attendees: "50",
-          max_quantity: "1",
-          thank_you_url: "https://example.com/thanks",
-          unit_price: "10.00",
-        },
-      );
+      const { response } = await adminFormPost("/admin/event", {
+        name: "Paid Event",
+        max_attendees: "50",
+        max_quantity: "1",
+        thank_you_url: "https://example.com/thanks",
+        unit_price: "10.00",
+      });
       expect(response.status).toBe(302);
     });
   });
@@ -1806,20 +1799,18 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
   describe("POST /admin/event/:id/deactivate (event not found)", () => {
     test("returns 404 when event does not exist", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event/999/deactivate",
-        { confirm_identifier: "something" },
-      );
+      const { response } = await adminFormPost("/admin/event/999/deactivate", {
+        confirm_identifier: "something",
+      });
       expect(response.status).toBe(404);
     });
   });
 
   describe("POST /admin/event/:id/reactivate (event not found)", () => {
     test("returns 404 when event does not exist", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event/999/reactivate",
-        { confirm_identifier: "something" },
-      );
+      const { response } = await adminFormPost("/admin/event/999/reactivate", {
+        confirm_identifier: "something",
+      });
       expect(response.status).toBe(404);
     });
   });
@@ -1942,13 +1933,10 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
   describe("POST /admin/event/:id/edit validation error", () => {
     test("shows error when editing non-existent event", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event/99999/edit",
-        {
-          name: "Updated Name",
-          max_attendees: "50",
-        },
-      );
+      const { response } = await adminFormPost("/admin/event/99999/edit", {
+        name: "Updated Name",
+        max_attendees: "50",
+      });
       expect(response.status).toBe(404);
     });
 
@@ -2157,15 +2145,12 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
       try {
         await withExpectedError(async () => {
-          const { response } = await adminFormPost(
-            "/admin/event",
-            {
-              name: "Collision Event",
-              max_attendees: "50",
-              max_quantity: "1",
-              thank_you_url: "https://example.com",
-            },
-          );
+          const { response } = await adminFormPost("/admin/event", {
+            name: "Collision Event",
+            max_attendees: "50",
+            max_quantity: "1",
+            thank_you_url: "https://example.com",
+          });
           await expectHtmlResponse(response, 503, "Temporary Error");
         });
       } finally {
@@ -2750,16 +2735,13 @@ describeWithEnv("server (admin events)", { db: true }, () => {
     });
 
     test("rejects invalid event_type value", async () => {
-      const { response } = await adminFormPost(
-        "/admin/event",
-        {
-          name: "Bad Type Event",
-          max_attendees: "50",
-          max_quantity: "1",
-          thank_you_url: "https://example.com",
-          event_type: "invalid",
-        },
-      );
+      const { response } = await adminFormPost("/admin/event", {
+        name: "Bad Type Event",
+        max_attendees: "50",
+        max_quantity: "1",
+        thank_you_url: "https://example.com",
+        event_type: "invalid",
+      });
       expectStatus(400)(response);
     });
 

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -857,7 +857,11 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         maxAttendees: 25,
       });
 
-      await assertAdminHtml(`/admin/group/${group.id}/edit`, "max_attendees", "25");
+      await assertAdminHtml(
+        `/admin/group/${group.id}/edit`,
+        "max_attendees",
+        "25",
+      );
     });
 
     test("updates max_attendees via edit", async () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -126,12 +126,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
     });
 
     test("contains allow pay more info with max price", async () => {
-      await assertAdminHtml(
-        "/admin/guide",
-        "Allow Pay More",
-        "maximum",
-        "£1",
-      );
+      await assertAdminHtml("/admin/guide", "Allow Pay More", "maximum", "£1");
     });
 
     test("contains non-transferable tickets info", async () => {
@@ -177,12 +172,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
     });
 
     test("contains admin navigation", async () => {
-      await assertAdminHtml(
-        "/admin/guide",
-        "/admin/guide",
-        "Events",
-        "Logout",
-      );
+      await assertAdminHtml("/admin/guide", "/admin/guide", "Events", "Logout");
     });
 
     test("shows default email setup instructions when no host email configured", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -15,6 +15,7 @@ import { todayInTz } from "#lib/timezone.ts";
 import { handleRequest } from "#routes";
 import { ICS_DISCOVERY_TAG, RSS_DISCOVERY_TAG } from "#templates/public.tsx";
 import {
+  assertJson,
   awaitTestRequest,
   createTestEvent,
   createTestGroup,
@@ -23,7 +24,6 @@ import {
   describeWithEnv,
   expectCheckoutRedirect,
   expectHtmlResponse,
-  assertJson,
   expectRedirect,
   getTicketCsrfToken,
   matchGroup,
@@ -445,13 +445,9 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("GET /health", () => {
     test("returns health status", async () => {
-      await assertJson(
-        handleRequest(mockRequest("/health")),
-        200,
-        (json) => {
-          expect(json).toEqual({ status: "ok" });
-        },
-      );
+      await assertJson(handleRequest(mockRequest("/health")), 200, (json) => {
+        expect(json).toEqual({ status: "ok" });
+      });
     });
 
     test("returns 404 for non-GET requests to /health", async () => {

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -10,11 +10,11 @@ import { handleRequest } from "#routes";
 import { isJsonApiPath } from "#routes/middleware.ts";
 import {
   adminGet,
+  assertJson,
   awaitTestRequest,
   createTestAttendeeWithToken,
   createTestEvent,
   describeWithEnv,
-  assertJson,
   expectHtmlResponse,
   setupEventAndLogin,
   testCookie,

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -275,9 +275,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
 
   describe("POST /admin/settings/email/test", () => {
     test("shows error when email not configured", async () => {
-      const { response } = await adminFormPost(
-        "/admin/settings/email/test",
-      );
+      const { response } = await adminFormPost("/admin/settings/email/test");
 
       await expectHtmlResponse(response, 400, "Email not configured");
     });
@@ -289,9 +287,7 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
       await settings.update.email.apiKey("re_test_key");
       await settings.update.email.fromAddress("from@test.com");
 
-      const { response } = await adminFormPost(
-        "/admin/settings/email/test",
-      );
+      const { response } = await adminFormPost("/admin/settings/email/test");
 
       await expectHtmlResponse(response, 400, "No business email set");
     });
@@ -540,7 +536,9 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
         const html = await response.text();
         expect(html).toContain('id="settings-host-subdomain"');
         expect(html).toContain("Host Subdomain");
-        expect(html).toContain("Check Availability &amp; Preview Complete Domain");
+        expect(html).toContain(
+          "Check Availability &amp; Preview Complete Domain",
+        );
       });
 
       test("shows existing subdomain as read-only with redirect message when custom domain set", async () => {

--- a/test/lib/server-settings.test.ts
+++ b/test/lib/server-settings.test.ts
@@ -14,13 +14,13 @@ import { handleRequest } from "#routes";
 import {
   adminFormPost,
   assertFormRedirect,
+  assertJson,
   awaitTestRequest,
   createTestEvent,
   describeWithEnv,
   expectAdminRedirect,
   expectFlash,
   expectHtmlResponse,
-  assertJson,
   expectRedirect,
   expectRedirectWithFlash,
   FLASH_TEST_ID,
@@ -459,17 +459,13 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
           expect(response.headers.get("content-type")).toBe(
             "application/json; charset=utf-8",
           );
-          await assertJson(
-            Promise.resolve(response),
-            200,
-            (json) => {
-              expect(json.ok).toBe(false);
-              expect(json.apiKey.valid).toBe(false);
-              expect(json.apiKey.error).toContain(
-                "No Stripe secret key configured",
-              );
-            },
-          );
+          await assertJson(Promise.resolve(response), 200, (json) => {
+            expect(json.ok).toBe(false);
+            expect(json.apiKey.valid).toBe(false);
+            expect(json.apiKey.error).toContain(
+              "No Stripe secret key configured",
+            );
+          });
         },
       );
     });
@@ -496,23 +492,19 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
           const { response } = await adminFormPost(
             "/admin/settings/stripe/test",
           );
-          await assertJson(
-            Promise.resolve(response),
-            200,
-            (json) => {
-              expect(json.ok).toBe(true);
-              expect(json.apiKey.valid).toBe(true);
-              expect(json.apiKey.mode).toBe("test");
-              expect(json.webhooks).toHaveLength(1);
-              expect(json.webhooks[0].url).toBe(
-                "https://example.com/payment/webhook",
-              );
-              expect(json.webhooks[0].status).toBe("enabled");
-              expect(json.webhooks[0].enabledEvents).toContain(
-                "checkout.session.completed",
-              );
-            },
-          );
+          await assertJson(Promise.resolve(response), 200, (json) => {
+            expect(json.ok).toBe(true);
+            expect(json.apiKey.valid).toBe(true);
+            expect(json.apiKey.mode).toBe("test");
+            expect(json.webhooks).toHaveLength(1);
+            expect(json.webhooks[0].url).toBe(
+              "https://example.com/payment/webhook",
+            );
+            expect(json.webhooks[0].status).toBe("enabled");
+            expect(json.webhooks[0].enabledEvents).toContain(
+              "checkout.session.completed",
+            );
+          });
         },
       );
     });
@@ -531,15 +523,11 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
           const { response } = await adminFormPost(
             "/admin/settings/stripe/test",
           );
-          await assertJson(
-            Promise.resolve(response),
-            200,
-            (json) => {
-              expect(json.ok).toBe(false);
-              expect(json.apiKey.valid).toBe(true);
-              expect(json.webhooks).toHaveLength(0);
-            },
-          );
+          await assertJson(Promise.resolve(response), 200, (json) => {
+            expect(json.ok).toBe(false);
+            expect(json.apiKey.valid).toBe(true);
+            expect(json.webhooks).toHaveLength(0);
+          });
         },
       );
     });
@@ -547,10 +535,9 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
 
   describe("POST /admin/settings/embed-hosts", () => {
     test("clears embed hosts when empty", async () => {
-      const { response } = await adminFormPost(
-        "/admin/settings/embed-hosts",
-        { embed_hosts: "   " },
-      );
+      const { response } = await adminFormPost("/admin/settings/embed-hosts", {
+        embed_hosts: "   ",
+      });
 
       expect(response.status).toBe(302);
       expectFlash(
@@ -561,19 +548,17 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
     });
 
     test("rejects invalid embed host pattern", async () => {
-      const { response } = await adminFormPost(
-        "/admin/settings/embed-hosts",
-        { embed_hosts: "*" },
-      );
+      const { response } = await adminFormPost("/admin/settings/embed-hosts", {
+        embed_hosts: "*",
+      });
 
       await expectHtmlResponse(response, 400, "Bare wildcard");
     });
 
     test("normalizes and saves embed hosts", async () => {
-      const { response } = await adminFormPost(
-        "/admin/settings/embed-hosts",
-        { embed_hosts: "Example.com, *.Sub.Example.com" },
-      );
+      const { response } = await adminFormPost("/admin/settings/embed-hosts", {
+        embed_hosts: "Example.com, *.Sub.Example.com",
+      });
 
       expect(response.status).toBe(302);
       expectFlash(
@@ -740,17 +725,13 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
           expect(response.headers.get("content-type")).toBe(
             "application/json; charset=utf-8",
           );
-          await assertJson(
-            Promise.resolve(response),
-            200,
-            (json) => {
-              expect(json.ok).toBe(false);
-              expect(json.accessToken.valid).toBe(false);
-              expect(json.accessToken.error).toContain(
-                "No Square access token configured",
-              );
-            },
-          );
+          await assertJson(Promise.resolve(response), 200, (json) => {
+            expect(json.ok).toBe(false);
+            expect(json.accessToken.valid).toBe(false);
+            expect(json.accessToken.error).toContain(
+              "No Square access token configured",
+            );
+          });
         },
       );
     });
@@ -775,18 +756,14 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
           const { response } = await adminFormPost(
             "/admin/settings/square/test",
           );
-          await assertJson(
-            Promise.resolve(response),
-            200,
-            (json) => {
-              expect(json.ok).toBe(true);
-              expect(json.accessToken.valid).toBe(true);
-              expect(json.accessToken.mode).toBe("sandbox");
-              expect(json.location.configured).toBe(true);
-              expect(json.location.name).toBe("Test Location");
-              expect(json.webhook.configured).toBe(true);
-            },
-          );
+          await assertJson(Promise.resolve(response), 200, (json) => {
+            expect(json.ok).toBe(true);
+            expect(json.accessToken.valid).toBe(true);
+            expect(json.accessToken.mode).toBe("sandbox");
+            expect(json.location.configured).toBe(true);
+            expect(json.location.name).toBe("Test Location");
+            expect(json.webhook.configured).toBe(true);
+          });
         },
       );
     });
@@ -809,16 +786,12 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
           const { response } = await adminFormPost(
             "/admin/settings/square/test",
           );
-          await assertJson(
-            Promise.resolve(response),
-            200,
-            (json) => {
-              expect(json.ok).toBe(false);
-              expect(json.accessToken.valid).toBe(true);
-              expect(json.location.configured).toBe(false);
-              expect(json.location.error).toContain("No location ID configured");
-            },
-          );
+          await assertJson(Promise.resolve(response), 200, (json) => {
+            expect(json.ok).toBe(false);
+            expect(json.accessToken.valid).toBe(true);
+            expect(json.location.configured).toBe(false);
+            expect(json.location.error).toContain("No location ID configured");
+          });
         },
       );
     });

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import { handleRequest } from "#routes";
 import {
+  assertJson,
   awaitTestRequest,
   createTestDb,
   describeWithEnv,
   expectHtmlResponse,
-  assertJson,
   expectRedirect,
   getSetupCsrfToken,
   mockFormRequest,
@@ -61,13 +61,9 @@ describeWithEnv("server (setup)", { db: true }, () => {
       });
 
       test("health check still works", async () => {
-        await assertJson(
-          handleRequest(mockRequest("/health")),
-          200,
-          (json) => {
-            expect(json).toEqual({ status: "ok" });
-          },
-        );
+        await assertJson(handleRequest(mockRequest("/health")), 200, (json) => {
+          expect(json).toEqual({ status: "ok" });
+        });
       });
 
       test("GET /setup/ shows setup page", async () => {

--- a/test/lib/server-wallet-webservice.test.ts
+++ b/test/lib/server-wallet-webservice.test.ts
@@ -4,9 +4,9 @@ import { unzipSync } from "fflate";
 import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
+  assertJson,
   createTestAttendeeWithToken,
   describeWithEnv,
-  assertJson,
   generateTestCerts,
 } from "#test-utils";
 

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -11,6 +11,7 @@ import {
 import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
+  assertJson,
   createTestEvent,
   deactivateTestEvent,
   describeWithEnv,
@@ -21,7 +22,6 @@ import {
   setupStripe,
   stubWebhookVerify,
   webhookMeta,
-  assertJson,
   withExpectedError,
 } from "#test-utils";
 

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -4,12 +4,12 @@ import { stub } from "@std/testing/mock";
 import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
 import {
+  assertJson,
   createDailyTestEvent,
   createTestAttendeeDirect,
   createTestEvent,
   deactivateTestEvent,
   describeWithEnv,
-  assertJson,
   setupStripe,
 } from "#test-utils";
 
@@ -282,7 +282,10 @@ describeWithEnv("Public API", { db: true }, () => {
 
     test("preserves quantity 0 instead of defaulting to 1", async () => {
       const event = await createTestEvent({ maxAttendees: 10 });
-      const { response, body } = await fetchAvailability(event.slug, "quantity=0");
+      const { response, body } = await fetchAvailability(
+        event.slug,
+        "quantity=0",
+      );
       expect(response.status).toBe(200);
       // quantity=0 should be treated as 0, not silently become 1
       expect(body.available).toBe(true);
@@ -290,7 +293,10 @@ describeWithEnv("Public API", { db: true }, () => {
 
     test("handles invalid quantity gracefully", async () => {
       const event = await createTestEvent({ maxAttendees: 10 });
-      const { response, body } = await fetchAvailability(event.slug, "quantity=abc");
+      const { response, body } = await fetchAvailability(
+        event.slug,
+        "quantity=abc",
+      );
       expect(response.status).toBe(200);
       expect(body.available).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Replaced the HTML table for CNAME record instructions with a bullet point list (keeping code formatting for hosts)
- Added TTL of 3600 to the DNS record instructions

## Test plan
- [x] All 163 tests pass
- [ ] Verify the bullet list renders correctly on the custom domain settings page

https://claude.ai/code/session_01Em4UXkuoWjDqK98wquiyMW