### PR TITLE
Add debug logging to DNS CNAME record creation

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -11,7 +11,7 @@ import {
   getBunnyDnsZoneId,
   getBunnyScriptId,
 } from "#lib/config.ts";
-import { ErrorCode, logError } from "#lib/logger.ts";
+import { ErrorCode, logDebug, logError } from "#lib/logger.ts";
 
 const BUNNY_API_BASE = "https://api.bunny.net";
 
@@ -300,26 +300,32 @@ const registerBunnySubdomainImpl = async (
 
   // 2. Add CNAME record in DNS zone
   const zoneId = getBunnyDnsZoneId();
-  const addResponse = await fetch(
-    `${BUNNY_API_BASE}/dnszone/${zoneId}/records`,
-    {
-      method: "PUT",
-      headers: {
-        AccessKey: getBunnyApiKey(),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        Type: DNS_RECORD_TYPE_CNAME,
-        Name: recordName,
-        Value: target,
-        Ttl: 300,
-      }),
-    },
+  const dnsRecordBody = {
+    Type: DNS_RECORD_TYPE_CNAME,
+    Name: recordName,
+    Value: target,
+    Ttl: 300,
+  };
+  const dnsUrl = `${BUNNY_API_BASE}/dnszone/${zoneId}/records`;
+  logDebug(
+    "Domain",
+    `Adding DNS CNAME: url=${dnsUrl} name=${recordName} value=${target} fullDomain=${fullDomain}`,
   );
+  const addResponse = await fetch(dnsUrl, {
+    method: "PUT",
+    headers: {
+      AccessKey: getBunnyApiKey(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(dnsRecordBody),
+  });
 
   if (!addResponse.ok) {
     const err = await parseBunnyError(addResponse, "Add DNS CNAME record");
-    logError({ code: ErrorCode.CDN_REQUEST, detail: err.error });
+    logError({
+      code: ErrorCode.CDN_REQUEST,
+      detail: `${err.error} | url=${dnsUrl} body=${JSON.stringify(dnsRecordBody)}`,
+    });
     return err;
   }
 


### PR DESCRIPTION
## Summary
- Adds `logDebug` call before the Bunny DNS CNAME API request, logging the full URL, record name, CNAME target value, and full domain
- Enriches the `logError` detail on failure to include the request URL and body payload
- Helps diagnose the `400: The requested URL is not valid` error by showing exactly what was sent to the Bunny API

## Test plan
- [x] All existing tests pass (163 passed)
- [ ] Deploy and trigger subdomain registration to observe the debug logs

https://claude.ai/code/session_01H6VvFduJZVLREfoYr2ajfF