### PR TITLE
Add HTML5 client-side form validation attributes

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -37,9 +37,12 @@ export interface Field {
   hint?: string;
   hintHtml?: string;
   min?: number;
+  max?: number;
+  minlength?: number;
   inputmode?: string;
   maxlength?: number;
   pattern?: string;
+  title?: string;
   accept?: string;
   autofocus?: boolean;
   autocomplete?: string;
@@ -125,6 +128,7 @@ export const renderField = (field: Field, value: string = ""): string =>
           required={field.required}
           placeholder={field.placeholder}
           maxlength={field.maxlength}
+          autocomplete={field.autocomplete}
         >
           <Raw html={escapeHtml(value)} />
         </textarea>
@@ -152,9 +156,12 @@ export const renderField = (field: Field, value: string = ""): string =>
           required={field.required}
           placeholder={field.placeholder}
           min={field.min}
+          max={field.max}
+          minlength={field.minlength}
           inputmode={field.inputmode}
           maxlength={field.maxlength}
           pattern={field.pattern}
+          title={field.title}
           autofocus={field.autofocus}
           autocomplete={field.autocomplete}
         />

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -339,12 +339,14 @@ export const adminEditAttendeePage = (
             id="phone"
             name="phone"
             value={attendee.phone || ""}
+            pattern="[+\d][\d\s\-()]{5,}"
+            title="Phone number (digits, spaces, hyphens, parentheses, optional leading +)"
           />
         </label>
 
         <label for="address">
           Address
-          <textarea id="address" name="address" rows={3}>
+          <textarea id="address" name="address" rows={3} maxlength={250}>
             {attendee.address || ""}
           </textarea>
         </label>
@@ -355,6 +357,7 @@ export const adminEditAttendeePage = (
             id="special_instructions"
             name="special_instructions"
             rows={3}
+            maxlength={250}
           >
             {attendee.special_instructions || ""}
           </textarea>

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -216,6 +216,10 @@ const usernameFieldBase: Field = {
   label: "Username",
   type: "text",
   required: true,
+  minlength: 2,
+  maxlength: 32,
+  pattern: "[a-zA-Z0-9_-]+",
+  title: "Letters, numbers, hyphens, and underscores only",
 };
 
 /**
@@ -397,6 +401,8 @@ export const eventFields: Field[] = [
     label: "Ticket Price (leave empty for free)",
     type: "text",
     inputmode: "decimal",
+    pattern: "\\d+(\\.\\d{1,2})?",
+    title: "A non-negative number (e.g. 10.00)",
     placeholder: "e.g. 10.00",
     validate: validateNonNegativePrice,
   },
@@ -412,6 +418,8 @@ export const eventFields: Field[] = [
     label: "Maximum Price (for pay more)",
     type: "text",
     inputmode: "decimal",
+    pattern: "\\d+(\\.\\d{1,2})?",
+    title: "A non-negative number (e.g. 100.00)",
     placeholder: "e.g. 100.00",
     defaultValue: "100.00",
     get hint() {
@@ -519,6 +527,8 @@ export const slugField: Field = {
   label: "Slug",
   type: "text",
   required: true,
+  pattern: "[a-z0-9-]+",
+  title: "Lowercase letters, numbers, and hyphens only",
   hint: "URL-friendly identifier (lowercase letters, numbers, and hyphens). Changing this will break any existing links, embeds, or QR codes that point to this page. Only change if you know what you're doing.",
   validate: (value: string) => validateSlug(normalizeSlug(value)),
 };
@@ -596,6 +606,9 @@ const phoneField: Field = {
   type: "text",
   required: true,
   autocomplete: "tel",
+  pattern: "[+\\d][\\d\\s\\-()]{5,}",
+  title:
+    "Phone number (digits, spaces, hyphens, parentheses, optional leading +)",
   validate: validatePhone,
 };
 
@@ -614,6 +627,7 @@ const addressField: Field = {
   label: "Your Address",
   type: "textarea",
   required: true,
+  maxlength: MAX_ADDRESS_LENGTH,
   autocomplete: "street-address",
   validate: validateAddress,
 };
@@ -633,6 +647,7 @@ const specialInstructionsField: Field = {
   label: "Special Instructions",
   type: "textarea",
   required: true,
+  maxlength: MAX_SPECIAL_INSTRUCTIONS_LENGTH,
   validate: validateSpecialInstructions,
 };
 
@@ -742,6 +757,7 @@ export const setupFields: Field[] = [
     label: "Admin Password *",
     type: "password",
     required: true,
+    minlength: 8,
     hint: "Minimum 8 characters",
     autocomplete: "new-password",
   },
@@ -770,6 +786,7 @@ export const changePasswordFields: Field[] = [
     label: "New Password",
     type: "password",
     required: true,
+    minlength: 8,
     hint: "Minimum 8 characters",
     autocomplete: "new-password",
   },
@@ -861,6 +878,7 @@ export const joinFields: Field[] = [
     label: "Password",
     type: "password",
     required: true,
+    minlength: 8,
     hint: "Minimum 8 characters",
     autocomplete: "new-password",
   },

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -738,6 +738,26 @@ export const getAddAttendeeFields = (
   return result;
 };
 
+/** New password field (reused across setup, change password, and join forms) */
+const newPasswordField = (name: string, label: string): Field => ({
+  name,
+  label,
+  type: "password",
+  required: true,
+  minlength: 8,
+  hint: "Minimum 8 characters",
+  autocomplete: "new-password",
+});
+
+/** Confirm password field (reused across setup, change password, and join forms) */
+const confirmPasswordField = (name: string, label: string): Field => ({
+  name,
+  label,
+  type: "password",
+  required: true,
+  autocomplete: "new-password",
+});
+
 /**
  * Setup form field definitions
  * Note: Stripe keys are now configured via environment variables
@@ -752,22 +772,8 @@ export const setupFields: Field[] = [
     autocomplete: "username",
     validate: validateUsername,
   },
-  {
-    name: "admin_password",
-    label: "Admin Password *",
-    type: "password",
-    required: true,
-    minlength: 8,
-    hint: "Minimum 8 characters",
-    autocomplete: "new-password",
-  },
-  {
-    name: "admin_password_confirm",
-    label: "Confirm Admin Password *",
-    type: "password",
-    required: true,
-    autocomplete: "new-password",
-  },
+  newPasswordField("admin_password", "Admin Password *"),
+  confirmPasswordField("admin_password_confirm", "Confirm Admin Password *"),
 ];
 
 /**
@@ -781,22 +787,8 @@ export const changePasswordFields: Field[] = [
     required: true,
     autocomplete: "current-password",
   },
-  {
-    name: "new_password",
-    label: "New Password",
-    type: "password",
-    required: true,
-    minlength: 8,
-    hint: "Minimum 8 characters",
-    autocomplete: "new-password",
-  },
-  {
-    name: "new_password_confirm",
-    label: "Confirm New Password",
-    type: "password",
-    required: true,
-    autocomplete: "new-password",
-  },
+  newPasswordField("new_password", "New Password"),
+  confirmPasswordField("new_password_confirm", "Confirm New Password"),
 ];
 
 /**
@@ -873,20 +865,6 @@ export const inviteUserFields: Field[] = [
  * Join (set password) form field definitions
  */
 export const joinFields: Field[] = [
-  {
-    name: "password",
-    label: "Password",
-    type: "password",
-    required: true,
-    minlength: 8,
-    hint: "Minimum 8 characters",
-    autocomplete: "new-password",
-  },
-  {
-    name: "password_confirm",
-    label: "Confirm Password",
-    type: "password",
-    required: true,
-    autocomplete: "new-password",
-  },
+  newPasswordField("password", "Password"),
+  confirmPasswordField("password_confirm", "Confirm Password"),
 ];

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -738,24 +738,18 @@ export const getAddAttendeeFields = (
   return result;
 };
 
-/** New password field (reused across setup, change password, and join forms) */
-const newPasswordField = (name: string, label: string): Field => ({
-  name,
-  label,
-  type: "password",
-  required: true,
-  minlength: 8,
-  hint: "Minimum 8 characters",
-  autocomplete: "new-password",
-});
-
-/** Confirm password field (reused across setup, change password, and join forms) */
-const confirmPasswordField = (name: string, label: string): Field => ({
+/** Password field with new-password autocomplete (reused across setup, change password, and join forms) */
+const newPasswordField = (
+  name: string,
+  label: string,
+  { confirm }: { confirm?: boolean } = {},
+): Field => ({
   name,
   label,
   type: "password",
   required: true,
   autocomplete: "new-password",
+  ...(!confirm && { minlength: 8, hint: "Minimum 8 characters" }),
 });
 
 /**
@@ -773,7 +767,7 @@ export const setupFields: Field[] = [
     validate: validateUsername,
   },
   newPasswordField("admin_password", "Admin Password *"),
-  confirmPasswordField("admin_password_confirm", "Confirm Admin Password *"),
+  newPasswordField("admin_password_confirm", "Confirm Admin Password *", { confirm: true }),
 ];
 
 /**
@@ -788,7 +782,7 @@ export const changePasswordFields: Field[] = [
     autocomplete: "current-password",
   },
   newPasswordField("new_password", "New Password"),
-  confirmPasswordField("new_password_confirm", "Confirm New Password"),
+  newPasswordField("new_password_confirm", "Confirm New Password", { confirm: true }),
 ];
 
 /**
@@ -866,5 +860,5 @@ export const inviteUserFields: Field[] = [
  */
 export const joinFields: Field[] = [
   newPasswordField("password", "Password"),
-  confirmPasswordField("password_confirm", "Confirm Password"),
+  newPasswordField("password_confirm", "Confirm Password", { confirm: true }),
 ];

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -244,7 +244,7 @@ const renderPayMoreInput = (
       : `Your Price (optional, up to ${formatCurrency(maxPrice)})`;
   return (
     `<label>${rangeHint}` +
-    `<input type="text" inputmode="decimal" name="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}"${minPrice > 0 ? " required" : ""} /></label>`
+    `<input type="text" inputmode="decimal" name="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}" pattern="\\d+(\\.\\d{1,2})?" title="A non-negative number (e.g. 10.00)"${minPrice > 0 ? " required" : ""} /></label>`
   );
 };
 


### PR DESCRIPTION
## Summary

- Add HTML5 validation attributes (`minlength`, `maxlength`, `pattern`, `title`) to form fields so browsers validate before submission, reducing unnecessary server round trips
- No JavaScript added — pure HTML5 constraint validation
- Server-side validation remains unchanged as the authoritative check

## Changes

| Field | Attribute added |
|-------|----------------|
| Username (setup, invite, login) | `pattern="[a-zA-Z0-9_-]+"`, `minlength=2`, `maxlength=32` |
| Password (setup, change, join) | `minlength=8` |
| Phone | `pattern` matching server-side regex |
| Address textarea | `maxlength=250` |
| Special instructions textarea | `maxlength=250` |
| Price fields (event + public) | `pattern` for decimal numbers |
| Slug | `pattern="[a-z0-9-]+"` |
| Attendee edit (inline) | `maxlength` on textareas, `pattern` on phone |

Also extended the `Field` interface with `max`, `minlength`, and `title` properties, and updated `renderField` to emit them.

## Test plan

- [x] Typecheck passes
- [x] All forms tests pass
- [ ] Manual: submit forms with invalid data and verify browser shows validation messages before POST

https://claude.ai/code/session_01VaupNpXP6kBEboRYKUFDRS