### PR TITLE
Fix encryption async leak in logError

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -10,7 +10,11 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { sendNtfyError } from "#lib/ntfy.ts";
-import { addPendingWork, runWithPendingWork } from "#lib/pending-work.ts";
+import {
+  addPendingWork,
+  hasPendingWorkScope,
+  runWithPendingWork,
+} from "#lib/pending-work.ts";
 
 /** Request-scoped random ID for correlating log entries */
 const requestIdStorage = new AsyncLocalStorage<string>();
@@ -282,8 +286,10 @@ export const logErrorLocal = (context: ErrorContext): void => {
 export const logError = (context: ErrorContext): void => {
   logErrorLocal(context);
 
-  addPendingWork(sendNtfyError(context.code));
-  addPendingWork(persistErrorToActivityLog(context));
+  if (hasPendingWorkScope()) {
+    addPendingWork(sendNtfyError(context.code));
+    addPendingWork(persistErrorToActivityLog(context));
+  }
 };
 
 /**

--- a/src/lib/pending-work.ts
+++ b/src/lib/pending-work.ts
@@ -16,6 +16,10 @@ const pendingWork = new AsyncLocalStorage<Promise<void>[]>();
 export const runWithPendingWork = <T>(fn: () => T): T =>
   pendingWork.run([], fn);
 
+/** True when running inside a `runWithPendingWork` scope (i.e. a request). */
+export const hasPendingWorkScope = (): boolean =>
+  pendingWork.getStore() !== undefined;
+
 /** Queue a promise that must complete before the response is sent */
 export const addPendingWork = (p: Promise<void>): void => {
   const pending = pendingWork.getStore();

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -19,6 +19,10 @@ import {
   runWithRequestId,
 } from "#lib/logger.ts";
 import {
+  flushPendingWork,
+  runWithPendingWork,
+} from "#lib/pending-work.ts";
+import {
   createTestDbWithSetup,
   createTestEvent,
   describeWithEnv,
@@ -240,13 +244,16 @@ describe("logger", () => {
       ]);
     });
 
-    test("sends ntfy notification when NTFY_URL is configured", () => {
+    test("sends ntfy notification when NTFY_URL is configured", async () => {
       const restore = setTestEnv({ NTFY_URL: "https://ntfy.sh/test-topic" });
       const fetchStub = stub(globalThis, "fetch", () =>
         Promise.resolve(new Response()),
       );
 
-      logError({ code: ErrorCode.DB_QUERY });
+      await runWithPendingWork(async () => {
+        logError({ code: ErrorCode.DB_QUERY });
+        await flushPendingWork();
+      });
 
       expect(fetchStub.calls.length).toBe(1);
       const [url, options] = fetchStub.calls[0]!.args as [string, RequestInit];
@@ -260,10 +267,6 @@ describe("logger", () => {
     describe("activity log persistence", () => {
       beforeEach(async () => {
         await createTestDbWithSetup();
-        // Drain floating promises from earlier logError calls in the parent block
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        resetDb();
-        await createTestDbWithSetup();
       });
 
       afterEach(() => {
@@ -271,11 +274,13 @@ describe("logger", () => {
       });
 
       test("persists error to activity log", async () => {
-        logError({
-          code: ErrorCode.STRIPE_CHECKOUT,
-          detail: "session creation failed",
+        await runWithPendingWork(async () => {
+          logError({
+            code: ErrorCode.STRIPE_CHECKOUT,
+            detail: "session creation failed",
+          });
+          await flushPendingWork();
         });
-        await new Promise((resolve) => setTimeout(resolve, 50));
 
         const entries = await getAllActivityLog();
         const match = entries.find(
@@ -289,12 +294,14 @@ describe("logger", () => {
 
       test("persists error with event ID to activity log", async () => {
         const event = await createTestEvent();
-        logError({
-          code: ErrorCode.PAYMENT_REFUND,
-          eventId: event.id,
-          detail: "refund declined",
+        await runWithPendingWork(async () => {
+          logError({
+            code: ErrorCode.PAYMENT_REFUND,
+            eventId: event.id,
+            detail: "refund declined",
+          });
+          await flushPendingWork();
         });
-        await new Promise((resolve) => setTimeout(resolve, 50));
 
         const entries = await getAllActivityLog();
         const match = entries.find(
@@ -305,8 +312,10 @@ describe("logger", () => {
       });
 
       test("persists error without detail to activity log", async () => {
-        logError({ code: ErrorCode.DB_CONNECTION });
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await runWithPendingWork(async () => {
+          logError({ code: ErrorCode.DB_CONNECTION });
+          await flushPendingWork();
+        });
 
         const entries = await getAllActivityLog();
         const match = entries.find(
@@ -318,9 +327,11 @@ describe("logger", () => {
       test("guards against recursive logError during persistence", async () => {
         // Call logError twice rapidly — the guard prevents the second from
         // persisting to the activity log while the first is still writing
-        logError({ code: ErrorCode.DB_CONNECTION });
-        logError({ code: ErrorCode.DB_QUERY });
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await runWithPendingWork(async () => {
+          logError({ code: ErrorCode.DB_CONNECTION });
+          logError({ code: ErrorCode.DB_QUERY });
+          await flushPendingWork();
+        });
 
         const entries = await getAllActivityLog();
         const connError = entries.find(

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -4,6 +4,10 @@ import { spy, stub } from "@std/testing/mock";
 import { bracket, map } from "#fp";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
 import {
+  flushPendingWork,
+  runWithPendingWork,
+} from "#lib/pending-work.ts";
+import {
   buildWebhookPayload,
   type RegistrationEntry,
   sendRegistrationWebhooks,
@@ -316,15 +320,17 @@ describe("webhook", () => {
     ): Promise<
       ReturnType<typeof getAllActivityLog> extends Promise<infer T> ? T : never
     > => {
-      await withErrorSpy(async () => {
-        restubFetch(() => Promise.resolve(new Response("Error", { status })));
-        const payload = await buildWebhookPayload(
-          registrationEntries ?? defaultEntries(),
-          "GBP",
-        );
-        await sendWebhook("https://example.com/webhook", payload);
+      await runWithPendingWork(async () => {
+        await withErrorSpy(async () => {
+          restubFetch(() => Promise.resolve(new Response("Error", { status })));
+          const payload = await buildWebhookPayload(
+            registrationEntries ?? defaultEntries(),
+            "GBP",
+          );
+          await sendWebhook("https://example.com/webhook", payload);
+        });
+        await flushPendingWork();
       });
-      await new Promise((resolve) => setTimeout(resolve, 50));
       return getAllActivityLog();
     };
 


### PR DESCRIPTION
## Summary

- `logError()` fired async operations (ntfy notifications + activity log persistence with encryption) even when called outside a request's pending work scope. With parallel test execution (`DENO_JOBS=15`), these orphaned `crypto.subtle.encrypt` operations leaked across test boundaries, triggering Deno's async sanitizer on the `registerBunnySubdomain` test block.
- Added `hasPendingWorkScope()` guard so `logError` only starts async side-effects inside a request scope where they'll be properly tracked and flushed.
- Updated logger and webhook tests to use `runWithPendingWork`/`flushPendingWork` instead of `setTimeout`-based draining.

## Test plan

- [x] All 163 tests pass with 0 failures
- [x] 100% line and branch coverage maintained
- [ ] Verify `registerBunnySubdomain` no longer leaks with `DENO_JOBS=15`

https://claude.ai/code/session_017DFbBAXTzxgL7nXrsjj9nV