### PR TITLE
Switch type checking to typescript-go (tsgo)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "lint": "deno lint src test scripts",
     "lint:fix": "deno lint --fix src test scripts",
     "fmt": "deno fmt src test scripts",
-    "typecheck": "deno check src/**/*.ts src/**/*.tsx test/**/*.ts",
+    "typecheck": "deno check --unstable-tsgo src/**/*.ts src/**/*.tsx test/**/*.ts",
     "cpd": "deno run -A npm:jscpd src --config .jscpd.json",
     "biome:fix": "deno run -A npm:@biomejs/biome check --write src test scripts",
     "biome:check": "deno run -A npm:@biomejs/biome check src test scripts",

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         default = pkgs.mkShell {
           packages = [
             pkgs.deno
+            pkgs.typescript-go
             pkgs.openssl
             pkgs.buildah
           ];


### PR DESCRIPTION
## Summary
- Enable Deno's `--unstable-tsgo` flag on the `typecheck` task for ~10x faster type checking via the Go-based TypeScript compiler
- Add `pkgs.typescript-go` to the Nix dev shell so `tsgo` is available for ad-hoc use

## Details

Deno 2.6+ integrates Microsoft's typescript-go natively. Adding `--unstable-tsgo` to `deno check` switches the type checker from the JS-based tsc to the Go-based tsgo. No workflow changes needed since CI runs `deno task typecheck`.

## Test plan
- [ ] `deno task typecheck` passes with the new flag
- [ ] `deno task precommit` passes end-to-end
- [ ] CI passes on this branch
- [ ] `nix develop` provides `tsgo` binary

https://claude.ai/code/session_01AAj85gbkR8TizU7Qd68Zat