### PR TITLE
Fix CDN mock response body leak causing sporadic test failures

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2470,11 +2470,10 @@ export const JPEG_HEADER = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
 /** PDF magic bytes for test attachments / invalid-image-type tests */
 export const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
 
-/** Standard CDN 201 success response */
+/** Standard CDN 201 success response (null body avoids ReadableStream leaks
+ *  when the Bunny SDK doesn't consume the response body after upload/remove) */
 export const cdnOkResponse = (): Response =>
-  new Response(JSON.stringify({ HttpCode: 201, Message: "OK" }), {
-    status: 201,
-  });
+  new Response(null, { status: 201 });
 
 /** Mock fetch to intercept Bunny CDN API calls, forwarding others to real fetch */
 export const withStorageMock = (


### PR DESCRIPTION
## Summary

- Fix sporadic "Leaks detected: fetch response body not consumed" errors under heavy concurrent test load
- Change `cdnOkResponse()` to return `new Response(null, { status: 201 })` instead of a Response with a JSON body

## Root Cause

The `@bunny.net/storage-sdk`'s `upload()` and `remove()` functions call `fetch()` internally but **never consume the response body** — they only check `response.ok`. When our test mock `cdnOkResponse()` returned a `Response` with a JSON body (`{ HttpCode: 201, Message: "OK" }`), the unconsumed `ReadableStream` triggered Deno's leak detector sporadically under concurrent test execution.

This also explains the second failure (empty `attachment_url` in the server-images test) — under heavy concurrency, the leaked stream could interfere with test isolation, causing the upload operation to not complete properly.

The existing `fetchText` wrapper correctly solves this for all **production** `fetch()` calls, but the Bunny SDK's internal `fetch()` calls bypass `fetchText` entirely, so the fix must be in the mock layer.

## Test plan

- [ ] Verify all tests pass, especially `server-attendees` and `server-images`
- [ ] Run with high concurrency (`--parallel`) to confirm leak is resolved

https://claude.ai/code/session_01YBBEAXHzvww3nYm3ngzya1