### PR TITLE
Fix DNS CNAME record type for subdomain registration

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -223,8 +223,8 @@ interface BunnyDnsZone {
   Records: BunnyDnsRecord[];
 }
 
-/** Bunny DNS record type for CNAME */
-const DNS_RECORD_TYPE_CNAME = 5;
+/** Bunny DNS record type for CNAME (0=A, 1=AAAA, 2=CNAME, 3=TXT, 4=MX, 5=Redirect) */
+const DNS_RECORD_TYPE_CNAME = 2;
 
 /**
  * Get a DNS zone by ID, returning the zone domain and records.

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -93,11 +93,8 @@ const SubdomainFormContent = (s: AdvancedSettingsPageState): SafeHtml => {
         </label>
         <footer>
           <button type="submit">Register Subdomain</button>
-          <a
-            href="/admin/settings/advanced#settings-host-subdomain"
-            class="secondary"
-          >
-            Cancel
+          <a href="/admin/settings/advanced#settings-host-subdomain">
+            <strong>Cancel</strong>
           </a>
         </footer>
       </>

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -2,10 +2,10 @@
  * Admin advanced settings page template
  */
 
+import type { SafeHtml } from "#jsx/jsx-runtime";
 import { MASK_SENTINEL } from "#lib/db/settings.ts";
 import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#lib/email.ts";
 import { CsrfForm } from "#lib/forms.tsx";
-import type { SafeHtml } from "#jsx/jsx-runtime";
 import type { AdminSession, Theme } from "#lib/types.ts";
 import { ResetDatabaseForm } from "#templates/admin/database-reset.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
@@ -93,7 +93,12 @@ const SubdomainFormContent = (s: AdvancedSettingsPageState): SafeHtml => {
         </label>
         <footer>
           <button type="submit">Register Subdomain</button>
-          <a href="/admin/settings/advanced#settings-host-subdomain" class="secondary">Cancel</a>
+          <a
+            href="/admin/settings/advanced#settings-host-subdomain"
+            class="secondary"
+          >
+            Cancel
+          </a>
         </footer>
       </>
     );

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -566,7 +566,7 @@ describeWithEnv(
       const zone = {
         Id: 42,
         Domain: "example.com",
-        Records: [{ Id: 1, Type: 5, Name: "existing", Value: "target.com" }],
+        Records: [{ Id: 1, Type: 2, Name: "existing", Value: "target.com" }],
       };
       await withMocks(
         () => stubFetchJson(zone),
@@ -629,7 +629,7 @@ const mockDnsZone = (records: { Name: string }[]) => ({
         Domain: "example.com",
         Records: records.map((r, i) => ({
           Id: i,
-          Type: 5,
+          Type: 2,
           ...r,
           Value: "target.com",
         })),
@@ -791,7 +791,7 @@ describeWithEnv(
                 "https://api.bunny.net/dnszone/42/records",
               );
               expect(JSON.parse(calls.at(0)!.init!.body as string)).toEqual({
-                Type: 5,
+                Type: 2,
                 Name: "myevent.tickets",
                 Value: "mysite.b-cdn.net",
                 Ttl: 300,

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -18,10 +18,7 @@ import {
   redactPath,
   runWithRequestId,
 } from "#lib/logger.ts";
-import {
-  flushPendingWork,
-  runWithPendingWork,
-} from "#lib/pending-work.ts";
+import { flushPendingWork, runWithPendingWork } from "#lib/pending-work.ts";
 import {
   createTestDbWithSetup,
   createTestEvent,

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -3,10 +3,7 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { bracket, map } from "#fp";
 import { getAllActivityLog } from "#lib/db/activityLog.ts";
-import {
-  flushPendingWork,
-  runWithPendingWork,
-} from "#lib/pending-work.ts";
+import { flushPendingWork, runWithPendingWork } from "#lib/pending-work.ts";
 import {
   buildWebhookPayload,
   type RegistrationEntry,


### PR DESCRIPTION
## Summary
- Fix `DNS_RECORD_TYPE_CNAME` constant from `5` (Redirect) to `2` (CNAME) per the Bunny DNS API spec
- Type 5 is "Redirect" which validates the Value as a URL, causing "The requested URL is not valid" when we pass a hostname like `tickets-g71vh.b-cdn.net`
- Updated test fixtures to use the correct type value

## Test plan
- [x] All 163 existing tests pass
- [ ] Verify subdomain registration works end-to-end in production

https://claude.ai/code/session_01YbiRHHjsXveFPk5DcuGruA