### PR TITLE
Fix subdomain certificate loading after DNS creation

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -274,9 +274,20 @@ const checkSubdomainAvailableImpl = async (
   return { ok: true, available: !taken, fullDomain };
 };
 
+/** Delay helper for retry backoff. */
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Maximum number of retries for certificate loading after DNS record creation. */
+const CERT_RETRY_COUNT = 4;
+
+/** Delay in ms between certificate loading retries (5s, 10s, 15s, 20s). */
+const certRetryDelay = (attempt: number): number => (attempt + 1) * 5000;
+
 /**
  * Register a bunny subdomain: add a CNAME DNS record pointing to ALLOWED_DOMAIN,
  * then register the hostname with the CDN pull zone (SSL + force SSL).
+ * Retries certificate loading to allow DNS propagation after record creation.
  */
 const registerBunnySubdomainImpl = async (
   subdomain: string,
@@ -331,7 +342,16 @@ const registerBunnySubdomainImpl = async (
   }
 
   // 3. Register hostname with pull zone (add hostname + SSL)
-  const cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
+  //    Retry to allow DNS propagation after CNAME record creation.
+  let cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
+  for (let attempt = 0; attempt < CERT_RETRY_COUNT && !cdnResult.ok; attempt++) {
+    logDebug(
+      "Domain",
+      `Certificate not ready, retrying in ${certRetryDelay(attempt)}ms (attempt ${attempt + 1}/${CERT_RETRY_COUNT})`,
+    );
+    await bunnyCdnApi.delay(certRetryDelay(attempt));
+    cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
+  }
   if (!cdnResult.ok) return cdnResult;
 
   return { ok: true, fullDomain };
@@ -346,6 +366,7 @@ export const bunnyCdnApi = {
   registerBunnySubdomain: registerBunnySubdomainImpl,
   getEdgeScript: getEdgeScriptImpl,
   getCdnHostname: getCdnHostnameImpl,
+  delay,
 };
 
 /** Validate a custom domain (delegates to bunnyCdnApi for testability). */

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -341,6 +341,15 @@ const registerBunnySubdomainImpl = async (
     return err;
   }
 
+  // Extract record ID from response for cleanup on failure
+  let dnsRecordId: number | undefined;
+  try {
+    const parsed = JSON.parse(addResponse.text);
+    if (parsed.Id) dnsRecordId = parsed.Id;
+  } catch {
+    /* response may not be JSON; cleanup will rely on zone lookup */
+  }
+
   // 3. Register hostname with pull zone (add hostname + SSL)
   //    Retry to allow DNS propagation after CNAME record creation.
   let cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
@@ -352,9 +361,33 @@ const registerBunnySubdomainImpl = async (
     await bunnyCdnApi.delay(certRetryDelay(attempt));
     cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
   }
-  if (!cdnResult.ok) return cdnResult;
+
+  if (!cdnResult.ok) {
+    // Clean up: remove the DNS record we created since certificate setup failed
+    if (dnsRecordId !== undefined) {
+      await bunnyCdnApi.deleteDnsRecord(zoneId, dnsRecordId);
+    }
+    return cdnResult;
+  }
 
   return { ok: true, fullDomain };
+};
+
+/**
+ * Delete a DNS record by ID. Used to clean up CNAME records when
+ * certificate provisioning fails after DNS record creation.
+ */
+const deleteDnsRecordImpl = async (
+  zoneId: string,
+  recordId: number,
+): Promise<BunnyApiResult> => {
+  const url = `${BUNNY_API_BASE}/dnszone/${zoneId}/records/${recordId}`;
+  logDebug("Domain", `Deleting DNS record: ${url}`);
+  const response = await fetchText(url, {
+    method: "DELETE",
+    headers: { AccessKey: getBunnyApiKey() },
+  });
+  return okOrError(response, "Delete DNS record");
 };
 
 /** Stubbable API for testing */
@@ -366,6 +399,7 @@ export const bunnyCdnApi = {
   registerBunnySubdomain: registerBunnySubdomainImpl,
   getEdgeScript: getEdgeScriptImpl,
   getCdnHostname: getCdnHostnameImpl,
+  deleteDnsRecord: deleteDnsRecordImpl,
   delay,
 };
 

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -834,8 +834,10 @@ describeWithEnv(
       });
     });
 
-    test("returns error when CDN validation fails after all retries", async () => {
+    test("returns error and deletes DNS record when CDN validation fails after all retries", async () => {
       let validateCallCount = 0;
+      let deletedZoneId: string | undefined;
+      let deletedRecordId: number | undefined;
       await withMockBunnyCdnApi(
         {
           ...availableMock,
@@ -843,18 +845,27 @@ describeWithEnv(
             validateCallCount++;
             return Promise.resolve({ ok: false as const, error: "SSL failed" });
           },
+          deleteDnsRecord: (zoneId: string, recordId: number) => {
+            deletedZoneId = zoneId;
+            deletedRecordId = recordId;
+            return Promise.resolve({ ok: true as const });
+          },
           delay: () => Promise.resolve(),
         },
         async () => {
           await withMocks(
             () =>
               stub(globalThis, "fetch", () =>
-                Promise.resolve(new Response(null, { status: 204 })),
+                Promise.resolve(
+                  new Response(JSON.stringify({ Id: 999 }), { status: 200 }),
+                ),
               ),
             async () => {
               const result = await registerBunnySubdomain("myevent");
               expect(result).toEqual({ ok: false, error: "SSL failed" });
               expect(validateCallCount).toBe(5);
+              expect(deletedZoneId).toBe("42");
+              expect(deletedRecordId).toBe(999);
             },
           );
         },
@@ -923,6 +934,44 @@ describeWithEnv(
               expect(validateCallCount).toBe(1);
             },
           );
+        },
+      );
+    });
+  },
+);
+
+describeWithEnv(
+  "deleteDnsRecord",
+  { env: { BUNNY_API_KEY: "test-key", BUNNY_DNS_ZONE_ID: "42" } },
+  () => {
+    test("sends DELETE request to correct URL", async () => {
+      const calls: { url: string; init: RequestInit | undefined }[] = [];
+      await withMocks(
+        () => stubFetchWithRecorder(calls),
+        async () => {
+          const result = await bunnyCdnApi.deleteDnsRecord("42", 999);
+          expect(result).toEqual({ ok: true });
+          expect(calls).toHaveLength(1);
+          expect(calls.at(0)!.url).toBe(
+            "https://api.bunny.net/dnszone/42/records/999",
+          );
+          expect(calls.at(0)!.init!.method).toBe("DELETE");
+        },
+      );
+    });
+
+    test("returns error when API fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Not found", { status: 404 })),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.deleteDnsRecord("42", 999);
+          expect(result).toEqual({
+            ok: false,
+            error: "Delete DNS record failed (404): Not found",
+          });
         },
       );
     });

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -834,12 +834,16 @@ describeWithEnv(
       });
     });
 
-    test("returns error when CDN validation fails", async () => {
+    test("returns error when CDN validation fails after all retries", async () => {
+      let validateCallCount = 0;
       await withMockBunnyCdnApi(
         {
           ...availableMock,
-          validateCustomDomain: () =>
-            Promise.resolve({ ok: false as const, error: "SSL failed" }),
+          validateCustomDomain: () => {
+            validateCallCount++;
+            return Promise.resolve({ ok: false as const, error: "SSL failed" });
+          },
+          delay: () => Promise.resolve(),
         },
         async () => {
           await withMocks(
@@ -850,6 +854,73 @@ describeWithEnv(
             async () => {
               const result = await registerBunnySubdomain("myevent");
               expect(result).toEqual({ ok: false, error: "SSL failed" });
+              expect(validateCallCount).toBe(5);
+            },
+          );
+        },
+      );
+    });
+
+    test("retries certificate loading and succeeds after DNS propagation", async () => {
+      let validateCallCount = 0;
+      await withMockBunnyCdnApi(
+        {
+          ...availableMock,
+          validateCustomDomain: () => {
+            validateCallCount++;
+            if (validateCallCount < 3) {
+              return Promise.resolve({
+                ok: false as const,
+                error: "Not pointing to our servers",
+              });
+            }
+            return Promise.resolve({ ok: true as const });
+          },
+          delay: () => Promise.resolve(),
+        },
+        async () => {
+          await withMocks(
+            () =>
+              stub(globalThis, "fetch", () =>
+                Promise.resolve(new Response(null, { status: 204 })),
+              ),
+            async () => {
+              const result = await registerBunnySubdomain("myevent");
+              expect(result).toEqual({
+                ok: true,
+                fullDomain: "myevent.tickets.example.com",
+              });
+              expect(validateCallCount).toBe(3);
+            },
+          );
+        },
+      );
+    });
+
+    test("does not retry when first validation succeeds", async () => {
+      let validateCallCount = 0;
+      await withMockBunnyCdnApi(
+        {
+          ...availableMock,
+          validateCustomDomain: () => {
+            validateCallCount++;
+            return Promise.resolve({ ok: true as const });
+          },
+          delay: () => Promise.resolve(),
+        },
+        async () => {
+          await withMocks(
+            () =>
+              stub(globalThis, "fetch", () =>
+                Promise.resolve(new Response(null, { status: 204 })),
+              ),
+            async () => {
+              const result = await registerBunnySubdomain("myevent");
+              expect(result).toEqual({
+                ok: true,
+                fullDomain: "myevent.tickets.example.com",
+              });
+              expect(validateCallCount).toBe(1);
             },
           );
         },


### PR DESCRIPTION
## Summary

- Fixes "The domain is not pointing to our servers" error when setting up a host subdomain
- After creating a CNAME DNS record, the code now retries certificate loading up to 4 times with increasing delays (5s, 10s, 15s, 20s) to allow DNS propagation
- The `delay` function is exposed on `bunnyCdnApi` for testability (no real waits in tests)

## Root Cause

In `registerBunnySubdomainImpl`, after creating the DNS CNAME record via Bunny's API, `validateCustomDomain` was called immediately. The `loadFreeCertificate` API checks that the domain resolves to Bunny's servers, but the newly created DNS record hadn't propagated yet, causing a 400 error.

## Test plan

- [x] Existing tests pass (164 passed)
- [x] New test: retries and succeeds after DNS propagation (simulated 2 failures then success)
- [x] New test: returns error after all retries exhausted (5 total attempts)
- [x] New test: no retry when first validation succeeds

https://claude.ai/code/session_01G2gEzADztWo3LNK7LbkLZN