### PR TITLE
Prevent double form submission and improve code formatting

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -365,6 +365,21 @@ for (const ta of document.querySelectorAll<HTMLTextAreaElement>(
   ta.parentNode!.insertBefore(counter, ta.nextSibling);
 }
 
+/* Disable form on submit: prevent double-submission for normal POST forms.
+ * Uses requestAnimationFrame so the browser sends the form before disabling. */
+for (const form of document.querySelectorAll<HTMLFormElement>(
+  'form[method="POST"]',
+)) {
+  form.addEventListener("submit", () => {
+    requestAnimationFrame(() => {
+      for (let i = 0; i < form.elements.length; i++) {
+        (form.elements[i] as HTMLInputElement | HTMLButtonElement).disabled =
+          true;
+      }
+    });
+  });
+}
+
 /* Multi-ticket question visibility: show questions only when at least one
  * associated event has quantity > 0. Questions without data-event-ids are
  * always visible (single-event pages). */

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -353,7 +353,11 @@ const registerBunnySubdomainImpl = async (
   // 3. Register hostname with pull zone (add hostname + SSL)
   //    Retry to allow DNS propagation after CNAME record creation.
   let cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
-  for (let attempt = 0; attempt < CERT_RETRY_COUNT && !cdnResult.ok; attempt++) {
+  for (
+    let attempt = 0;
+    attempt < CERT_RETRY_COUNT && !cdnResult.ok;
+    attempt++
+  ) {
     logDebug(
       "Domain",
       `Certificate not ready, retrying in ${certRetryDelay(attempt)}ms (attempt ${attempt + 1}/${CERT_RETRY_COUNT})`,


### PR DESCRIPTION
## Summary
This PR adds form submission protection to prevent accidental double-submissions and applies minor code formatting improvements.

## Key Changes
- **Form submission protection**: Added event listener to all POST forms that disables form elements after submission using `requestAnimationFrame`. This ensures the browser sends the form data before the UI is disabled, preventing users from accidentally submitting the same form twice.
- **Code formatting**: Improved line wrapping in the certificate retry loop in `bunny-cdn.ts` for better readability.

## Implementation Details
- The form disabling logic uses `requestAnimationFrame` to defer the disabling until after the browser has initiated the form submission, ensuring the POST request is sent before form elements become disabled.
- All input and button elements within POST forms are disabled to provide clear visual feedback and prevent re-submission attempts.

https://claude.ai/code/session_01VutTtY46moWXqXShWjQdgB