### PR TITLE
Add current_task setting to prevent duplicate heavy operations

### DIFF
--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -353,7 +353,11 @@ const registerBunnySubdomainImpl = async (
   // 3. Register hostname with pull zone (add hostname + SSL)
   //    Retry to allow DNS propagation after CNAME record creation.
   let cdnResult = await bunnyCdnApi.validateCustomDomain(fullDomain);
-  for (let attempt = 0; attempt < CERT_RETRY_COUNT && !cdnResult.ok; attempt++) {
+  for (
+    let attempt = 0;
+    attempt < CERT_RETRY_COUNT && !cdnResult.ok;
+    attempt++
+  ) {
     logDebug(
       "Domain",
       `Certificate not ready, retrying in ${certRetryDelay(attempt)}ms (attempt ${attempt + 1}/${CERT_RETRY_COUNT})`,

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -546,11 +546,9 @@ const withCurrentTask = async <T>(
     args: [taskName, CONFIG_KEYS.CURRENT_TASK],
   });
   if (claim.rowsAffected === 0) {
-    // Another task holds the lock — read its name for the error message
-    const existing = snap("current_task") || "(unknown)";
     return {
       ok: false,
-      error: `Another task is already in progress: ${existing}`,
+      error: "Another task is already in progress",
     };
   }
   const state = getCacheState();

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -527,19 +527,34 @@ const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
  * Run `fn` while holding the `current_task` lock for `taskName`.
  * If a task is already in progress, returns `{ ok: false, error }`.
  * The lock is always cleared when `fn` completes (success or error).
+ *
+ * Uses an atomic UPDATE … WHERE value = '' to avoid race conditions
+ * between concurrent requests on the same node.
  */
 const withCurrentTask = async <T>(
   taskName: string,
   fn: () => Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false; error: string }> => {
-  const existing = snap("current_task");
-  if (existing) {
+  // Ensure the row exists (no-op if already present)
+  await getDb().execute({
+    sql: "INSERT OR IGNORE INTO settings (key, value) VALUES (?, '')",
+    args: [CONFIG_KEYS.CURRENT_TASK],
+  });
+  // Atomic claim: only succeeds when no task is running
+  const claim = await getDb().execute({
+    sql: "UPDATE settings SET value = ? WHERE key = ? AND value = ''",
+    args: [taskName, CONFIG_KEYS.CURRENT_TASK],
+  });
+  if (claim.rowsAffected === 0) {
+    // Another task holds the lock — read its name for the error message
+    const existing = snap("current_task") || "(unknown)";
     return {
       ok: false,
       error: `Another task is already in progress: ${existing}`,
     };
   }
-  await writeOrDelete(CONFIG_KEYS.CURRENT_TASK, taskName);
+  const state = getCacheState();
+  if (state.entries) state.entries.set(CONFIG_KEYS.CURRENT_TASK, taskName);
   setSnapshotField("current_task", taskName);
   try {
     const value = await fn();

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -87,6 +87,7 @@ export const CONFIG_KEYS = {
   GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL: "google_wallet_service_account_email",
   GOOGLE_WALLET_SERVICE_ACCOUNT_KEY: "google_wallet_service_account_key",
   BUNNY_SUBDOMAIN: "bunny_subdomain",
+  CURRENT_TASK: "current_task",
   ATTENDEE_BLOB_MIGRATED: "attendee_blob_migrated",
 } as const;
 
@@ -147,6 +148,7 @@ const PLAINTEXT_KEYS = [
   CONFIG_KEYS.CUSTOM_DOMAIN,
   CONFIG_KEYS.CUSTOM_DOMAIN_LAST_VALIDATED,
   CONFIG_KEYS.BUNNY_SUBDOMAIN,
+  CONFIG_KEYS.CURRENT_TASK,
   CONFIG_KEYS.PUBLIC_KEY,
   CONFIG_KEYS.WRAPPED_PRIVATE_KEY,
   CONFIG_KEYS.SQUARE_LOCATION_ID,
@@ -518,6 +520,37 @@ const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
   );
 
 // ---------------------------------------------------------------------------
+// Current-task guard — prevents duplicate heavy operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `fn` while holding the `current_task` lock for `taskName`.
+ * If a task is already in progress, returns `{ ok: false, error }`.
+ * The lock is always cleared when `fn` completes (success or error).
+ */
+const withCurrentTask = async <T>(
+  taskName: string,
+  fn: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; error: string }> => {
+  const existing = snap("current_task");
+  if (existing) {
+    return {
+      ok: false,
+      error: `Another task is already in progress: ${existing}`,
+    };
+  }
+  await writeOrDelete(CONFIG_KEYS.CURRENT_TASK, taskName);
+  setSnapshotField("current_task", taskName);
+  try {
+    const value = await fn();
+    return { ok: true, value };
+  } finally {
+    await writeOrDelete(CONFIG_KEYS.CURRENT_TASK, "");
+    setSnapshotField("current_task", "");
+  }
+};
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
@@ -532,6 +565,7 @@ export const settings = {
   // --- Core ---
   loadAll,
   invalidateCache,
+  withCurrentTask,
 
   /** Read a raw (possibly encrypted) value from the cache. */
   getCachedRaw: getRawCached,
@@ -593,6 +627,9 @@ export const settings = {
   },
   get bunnySubdomain(): string {
     return snap("bunny_subdomain");
+  },
+  get currentTask(): string {
+    return snap("current_task");
   },
   get publicKey(): string {
     return snap("public_key");
@@ -836,6 +873,7 @@ export const settings = {
       data.custom_domain_last_validated = ts;
     },
     bunnySubdomain: plaintextUpdate(CONFIG_KEYS.BUNNY_SUBDOMAIN),
+    currentTask: plaintextUpdate(CONFIG_KEYS.CURRENT_TASK),
     headerImageUrl: encryptedUpdate(CONFIG_KEYS.HEADER_IMAGE_URL),
     websiteTitle: encryptedUpdate(CONFIG_KEYS.WEBSITE_TITLE),
     homepageText: encryptedUpdate(CONFIG_KEYS.HOMEPAGE_TEXT),

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -1113,28 +1113,38 @@ const handleCustomDomainPost = advancedSettingsRoute(
       return errorPage("Invalid domain format", 400, "settings-custom-domain");
     }
 
-    await settings.update.customDomain(raw);
-    await logActivity(`Custom domain set to ${raw}`);
+    const taskResult = await settings.withCurrentTask(
+      "custom-domain",
+      async () => {
+        await settings.update.customDomain(raw);
+        await logActivity(`Custom domain set to ${raw}`);
 
-    // Attempt validation immediately after saving
-    const result = await validateCustomDomain(raw);
-    if (result.ok) {
-      await settings.update.customDomainLastValidated();
-      await logActivity(`Custom domain validated: ${raw}`);
-      return redirect(
-        "/admin/settings-advanced",
-        "Custom domain saved and validated",
-        true,
-        { formId: "settings-custom-domain" },
-      );
-    }
+        // Attempt validation immediately after saving
+        const result = await validateCustomDomain(raw);
+        if (result.ok) {
+          await settings.update.customDomainLastValidated();
+          await logActivity(`Custom domain validated: ${raw}`);
+          return redirect(
+            "/admin/settings-advanced",
+            "Custom domain saved and validated",
+            true,
+            { formId: "settings-custom-domain" },
+          );
+        }
 
-    return redirect(
-      "/admin/settings-advanced",
-      `Custom domain saved but validation failed: ${result.error}`,
-      false,
-      { formId: "settings-custom-domain" },
+        return redirect(
+          "/admin/settings-advanced",
+          `Custom domain saved but validation failed: ${result.error}`,
+          false,
+          { formId: "settings-custom-domain" },
+        );
+      },
     );
+
+    if (!taskResult.ok) {
+      return errorPage(taskResult.error, 409, "settings-custom-domain");
+    }
+    return taskResult.value;
   },
 );
 
@@ -1158,19 +1168,37 @@ const handleCustomDomainValidatePost = advancedSettingsRoute(
       );
     }
 
-    const result = await validateCustomDomain(customDomain);
-    if (!result.ok) {
-      return errorPage(result.error, 502, "settings-custom-domain-validate");
-    }
+    const taskResult = await settings.withCurrentTask(
+      "custom-domain-validate",
+      async () => {
+        const result = await validateCustomDomain(customDomain);
+        if (!result.ok) {
+          return errorPage(
+            result.error,
+            502,
+            "settings-custom-domain-validate",
+          );
+        }
 
-    await settings.update.customDomainLastValidated();
-    await logActivity(`Custom domain validated: ${customDomain}`);
-    return redirect(
-      "/admin/settings-advanced",
-      "Custom domain validated successfully",
-      true,
-      { formId: "settings-custom-domain-validate" },
+        await settings.update.customDomainLastValidated();
+        await logActivity(`Custom domain validated: ${customDomain}`);
+        return redirect(
+          "/admin/settings-advanced",
+          "Custom domain validated successfully",
+          true,
+          { formId: "settings-custom-domain-validate" },
+        );
+      },
     );
+
+    if (!taskResult.ok) {
+      return errorPage(
+        taskResult.error,
+        409,
+        "settings-custom-domain-validate",
+      );
+    }
+    return taskResult.value;
   },
 );
 
@@ -1224,20 +1252,30 @@ const handleHostSubdomainPost = advancedSettingsRoute(
       );
     }
 
-    // Save: actually register
-    const result = await registerBunnySubdomain(raw);
-    if (!result.ok) {
-      return errorPage(result.error, 502, FORM_ID_HOST_SUBDOMAIN);
-    }
+    // Save: actually register (guarded by current_task)
+    const taskResult = await settings.withCurrentTask(
+      "host-subdomain",
+      async () => {
+        const result = await registerBunnySubdomain(raw);
+        if (!result.ok) {
+          return errorPage(result.error, 502, FORM_ID_HOST_SUBDOMAIN);
+        }
 
-    await settings.update.bunnySubdomain(result.fullDomain);
-    await logActivity(`Host subdomain set to ${result.fullDomain}`);
-    return redirect(
-      "/admin/settings-advanced",
-      `Subdomain registered: ${result.fullDomain}`,
-      true,
-      { formId: FORM_ID_HOST_SUBDOMAIN },
+        await settings.update.bunnySubdomain(result.fullDomain);
+        await logActivity(`Host subdomain set to ${result.fullDomain}`);
+        return redirect(
+          "/admin/settings-advanced",
+          `Subdomain registered: ${result.fullDomain}`,
+          true,
+          { formId: FORM_ID_HOST_SUBDOMAIN },
+        );
+      },
     );
+
+    if (!taskResult.ok) {
+      return errorPage(taskResult.error, 409, FORM_ID_HOST_SUBDOMAIN);
+    }
+    return taskResult.value;
   },
 );
 

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -1087,6 +1087,91 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
           }
         });
       });
+
+      describe("current_task guard", () => {
+        test("rejects custom-domain save when a task is already in progress", async () => {
+          setBunnyEnv();
+          await settings.update.currentTask("some-other-task");
+          try {
+            const { response } = await adminFormPost(
+              "/admin/settings/custom-domain",
+              { custom_domain: "tickets.example.com" },
+            );
+            expect(response.status).toBe(409);
+            const html = await response.text();
+            expect(html).toContain("Another task is already in progress");
+          } finally {
+            await settings.update.currentTask("");
+          }
+        });
+
+        test("rejects custom-domain validate when a task is already in progress", async () => {
+          setBunnyEnv();
+          await settings.update.customDomain("tickets.example.com");
+          await settings.update.currentTask("some-other-task");
+          try {
+            const { response } = await adminFormPost(
+              "/admin/settings/custom-domain/validate",
+            );
+            expect(response.status).toBe(409);
+            const html = await response.text();
+            expect(html).toContain("Another task is already in progress");
+          } finally {
+            await settings.update.currentTask("");
+          }
+        });
+
+        test("clears current_task after successful custom-domain save", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({ ok: true as const });
+          try {
+            await adminFormPost("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+            });
+            expect(settings.currentTask).toBe("");
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("clears current_task after failed custom-domain validation", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "DNS not configured",
+            });
+          try {
+            await adminFormPost("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+            });
+            expect(settings.currentTask).toBe("");
+          } finally {
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+
+        test("clears current_task even when the task throws", async () => {
+          setBunnyEnv();
+          const original = bunnyCdnApi.validateCustomDomain;
+          bunnyCdnApi.validateCustomDomain = () => {
+            throw new Error("network failure");
+          };
+          Deno.env.set("TEST_EXPECT_ERROR", "1");
+          try {
+            await adminFormPost("/admin/settings/custom-domain", {
+              custom_domain: "tickets.example.com",
+            });
+            expect(settings.currentTask).toBe("");
+          } finally {
+            Deno.env.delete("TEST_EXPECT_ERROR");
+            bunnyCdnApi.validateCustomDomain = original;
+          }
+        });
+      });
     },
   );
 });

--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -742,6 +742,29 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
             },
           );
         });
+
+        test("rejects registration when a task is already in progress", async () => {
+          setBunnyDnsEnv();
+          await settings.update.currentTask("some-other-task");
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                "/admin/settings/host-subdomain",
+                {
+                  subdomain: "myevent",
+                  save: "1",
+                  csrf_token: await testCsrfToken(),
+                },
+                await testCookie(),
+              ),
+            );
+            expect(response.status).toBe(409);
+            const html = await response.text();
+            expect(html).toContain("Another task is already in progress");
+          } finally {
+            await settings.update.currentTask("");
+          }
+        });
       });
     },
   );


### PR DESCRIPTION
## Summary

- Adds a `current_task` plaintext setting that acts as a mutex for long-running admin operations
- When a heavy task is in progress, concurrent attempts are rejected with HTTP 409 and a descriptive error message
- The lock is always cleared in a `finally` block, even if the operation throws

**Protected operations:**
- Custom domain save (`POST /admin/settings/custom-domain`)
- Custom domain validate (`POST /admin/settings/custom-domain/validate`)
- Host subdomain registration (`POST /admin/settings/host-subdomain` save mode)

## Test plan

- [x] Existing tests pass (165 tests, 0 failures)
- [x] New tests verify 409 rejection when a task is already in progress (custom-domain save + validate)
- [x] New tests verify `current_task` is cleared after success, failure, and thrown errors

https://claude.ai/code/session_019Rmr8j9iUDPd7MgsxpuSf4