### PR TITLE
Fix flaky concurrent test in logger

### DIFF
--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -516,8 +516,9 @@ describe("logger", () => {
       test("prefixes logRequest with 4-char hex ID", () => {
         const debugSpy = spy(console, "debug");
         try {
-          const callsBefore = debugSpy.calls.length;
+          let id = "";
           runWithRequestId(() => {
+            id = getRequestId();
             logRequest({
               method: "GET",
               path: "/admin",
@@ -526,22 +527,20 @@ describe("logger", () => {
             });
           });
 
-          const message = debugSpy.calls[callsBefore]!.args[0] as string;
-          expect(message).toMatch(
-            /^\[[0-9a-f]{4}\] \[Request\] GET \/admin 200 10ms$/,
-          );
+          const expected = `[${id}] [Request] GET /admin 200 10ms`;
+          const found = debugSpy.calls.some((c) => c.args[0] === expected);
+          expect(found).toBe(true);
         } finally {
           debugSpy.restore();
         }
       });
 
       test("prefixes logError with same request ID", () => {
-        const debugSpy = spy(console, "debug");
         const errorSpy = spy(console, "error");
         try {
-          const debugBefore = debugSpy.calls.length;
-          const errorBefore = errorSpy.calls.length;
+          let id = "";
           runWithRequestId(() => {
+            id = getRequestId();
             logRequest({
               method: "GET",
               path: "/admin",
@@ -551,12 +550,10 @@ describe("logger", () => {
             logError({ code: ErrorCode.DB_CONNECTION });
           });
 
-          const requestMsg = debugSpy.calls[debugBefore]!.args[0] as string;
-          const errorMsg = errorSpy.calls[errorBefore]!.args[0] as string;
-          const requestId = requestMsg.slice(1, 5);
-          expect(errorMsg).toBe(`[${requestId}] [Error] E_DB_CONNECTION`);
+          const expected = `[${id}] [Error] E_DB_CONNECTION`;
+          const found = errorSpy.calls.some((c) => c.args[0] === expected);
+          expect(found).toBe(true);
         } finally {
-          debugSpy.restore();
           errorSpy.restore();
         }
       });
@@ -564,13 +561,15 @@ describe("logger", () => {
       test("prefixes logDebug with request ID", () => {
         const debugSpy = spy(console, "debug");
         try {
-          const callsBefore = debugSpy.calls.length;
+          let id = "";
           runWithRequestId(() => {
+            id = getRequestId();
             logDebug("Setup", "test message");
           });
 
-          const message = debugSpy.calls[callsBefore]!.args[0] as string;
-          expect(message).toMatch(/^\[[0-9a-f]{4}\] \[Setup\] test message$/);
+          const expected = `[${id}] [Setup] test message`;
+          const found = debugSpy.calls.some((c) => c.args[0] === expected);
+          expect(found).toBe(true);
         } finally {
           debugSpy.restore();
         }
@@ -592,7 +591,6 @@ describe("logger", () => {
       test("no prefix outside request context", () => {
         const debugSpy = spy(console, "debug");
         try {
-          const callsBefore = debugSpy.calls.length;
           logRequest({
             method: "GET",
             path: "/admin",
@@ -600,9 +598,9 @@ describe("logger", () => {
             durationMs: 10,
           });
 
-          expect(debugSpy.calls[callsBefore]!.args).toEqual([
-            "[Request] GET /admin 200 10ms",
-          ]);
+          const expected = "[Request] GET /admin 200 10ms";
+          const found = debugSpy.calls.some((c) => c.args[0] === expected);
+          expect(found).toBe(true);
         } finally {
           debugSpy.restore();
         }

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -577,29 +577,16 @@ describe("logger", () => {
       });
 
       test("different requests get different IDs", () => {
-        const debugSpy = spy(console, "debug");
-        try {
-          const ids: string[] = [];
-          for (let i = 0; i < 10; i++) {
-            const callsBefore = debugSpy.calls.length;
-            runWithRequestId(() => {
-              logRequest({
-                method: "GET",
-                path: "/",
-                status: 200,
-                durationMs: 0,
-              });
-            });
-            const call = debugSpy.calls[callsBefore];
-            ids.push((call!.args[0] as string).slice(1, 5));
-          }
-
-          // With 65536 possible values, 10 samples should not all be identical
-          const unique = new Set(ids);
-          expect(unique.size).toBeGreaterThan(1);
-        } finally {
-          debugSpy.restore();
+        const ids: string[] = [];
+        for (let i = 0; i < 10; i++) {
+          runWithRequestId(() => {
+            ids.push(getRequestId());
+          });
         }
+
+        // With 65536 possible values, 10 samples should not all be identical
+        const unique = new Set(ids);
+        expect(unique.size).toBeGreaterThan(1);
       });
 
       test("no prefix outside request context", () => {


### PR DESCRIPTION
## Summary

- Fix flaky "different requests get different IDs" test that fails in concurrent test environments
- Replace fragile spy-based ID extraction (`debugSpy.calls[callsBefore]`) with direct `getRequestId()` calls inside the `runWithRequestId` callback
- Eliminates spy interleaving issue where concurrent tests spying on `console.debug` simultaneously cause `undefined` call lookups

## Root cause

When multiple tests run concurrently and each calls `spy(console, "debug")`, the spies shadow each other. Test A's spy may not see calls that go through test B's spy, causing `debugSpy.calls[callsBefore]` to be `undefined`. The test doesn't actually need to verify log output format here — it only needs to verify that different request contexts get different IDs, which `getRequestId()` provides directly.

## Test plan

- [x] All 165 tests pass (0 failed)
- [ ] Verify no more flaky failures in CI concurrent runs

https://claude.ai/code/session_01FgwRk6gDorGWRvQXWF27V6