### PR TITLE
Refactor attendee actions to use verified action wrapper

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -205,6 +205,33 @@ const attendeeFormAction =
       handler(data, session, form, eventId, attendeeId),
     );
 
+/** Attendee action handler after name verification */
+type VerifiedAction = (
+  data: AttendeeWithEvent,
+  form: FormParams,
+  eventId: number,
+  attendeeId: number,
+) => Response | Promise<Response>;
+
+/** Create an attendee form handler that first verifies the attendee name */
+const verifiedAttendeeAction = (
+  action: string,
+  confirmLabel: string | undefined,
+  handler: VerifiedAction,
+) =>
+  attendeeFormAction(async (data, _session, form, eventId, attendeeId) => {
+    const error = verifyNameForAction(
+      form,
+      data,
+      eventId,
+      attendeeId,
+      action,
+      confirmLabel,
+    );
+    if (error) return error;
+    return handler(data, form, eventId, attendeeId);
+  });
+
 /** Handle GET /admin/event/:eventId/attendee/:attendeeId/delete */
 const handleAdminAttendeeDeleteGet = attendeeGetRoute(
   (data, session, request) => {
@@ -216,18 +243,10 @@ const handleAdminAttendeeDeleteGet = attendeeGetRoute(
 );
 
 /** Handle POST /admin/event/:eventId/attendee/:attendeeId/delete */
-const handleAttendeeDelete = attendeeFormAction(
-  async (data, _session, form, eventId, attendeeId) => {
-    const error = verifyNameForAction(
-      form,
-      data,
-      eventId,
-      attendeeId,
-      "delete",
-      "deletion",
-    );
-    if (error) return error;
-
+const handleAttendeeDelete = verifiedAttendeeAction(
+  "delete",
+  "deletion",
+  async (data, form, eventId, attendeeId) => {
     await deleteAttendee(attendeeId);
     await logActivity(`Attendee deleted from '${data.event.name}'`, eventId);
     return redirect(`/admin/event/${eventId}`, "Attendee deleted", true, {
@@ -331,17 +350,10 @@ const handleAdminAttendeeRefundGet = attendeeGetRoute(
 );
 
 /** Handle POST /admin/event/:eventId/attendee/:attendeeId/refund */
-const handleAttendeeRefund = attendeeFormAction(
-  async (data, _session, form, eventId, attendeeId) => {
-    const nameError = verifyNameForAction(
-      form,
-      data,
-      eventId,
-      attendeeId,
-      "refund",
-      "refund",
-    );
-    if (nameError) return nameError;
+const handleAttendeeRefund = verifiedAttendeeAction(
+  "refund",
+  "refund",
+  async (data, form, eventId, attendeeId) => {
 
     if (!data.attendee.payment_id)
       return refundError(eventId, attendeeId, NO_PAYMENT_ERROR);
@@ -746,17 +758,10 @@ const handleAdminResendNotificationGet = attendeeGetRoute(
 );
 
 /** Handle POST /admin/event/:eventId/attendee/:attendeeId/resend-notification */
-const handleResendNotification = attendeeFormAction(
-  async (data, _session, form, eventId, attendeeId) => {
-    const error = verifyNameForAction(
-      form,
-      data,
-      eventId,
-      attendeeId,
-      "resend-notification",
-    );
-    if (error) return error;
-
+const handleResendNotification = verifiedAttendeeAction(
+  "resend-notification",
+  undefined,
+  async (data, form, eventId, attendeeId) => {
     await Promise.all([
       logAndNotifyRegistration([
         { event: data.event, attendee: data.attendee },


### PR DESCRIPTION
## Summary
This PR refactors repetitive name verification logic in attendee action handlers by introducing a new `verifiedAttendeeAction` wrapper function. This eliminates code duplication across multiple attendee operations while maintaining the same verification behavior.

## Key Changes
- **New `verifiedAttendeeAction` wrapper**: Created a higher-order function that wraps `attendeeFormAction` to automatically handle name verification before executing the handler logic
- **Refactored delete handler**: Updated `handleAttendeeDelete` to use the new wrapper, removing inline verification code
- **Refactored refund handler**: Updated `handleAttendeeRefund` to use the new wrapper, removing inline verification code
- **Refactored resend notification handler**: Updated `handleResendNotification` to use the new wrapper, removing inline verification code

## Implementation Details
- The `verifiedAttendeeAction` function accepts an action name, optional confirm label, and a handler function
- It calls `verifyNameForAction` before executing the handler, returning early if verification fails
- The handler signature is simplified by removing the `session` parameter (prefixed with `_session` in the original code, indicating it wasn't used)
- All three refactored handlers maintain identical verification behavior while reducing code duplication by ~40 lines

https://claude.ai/code/session_014XsP8pRFyo6QiSqK9aLsos