### PR TITLE
Replace setTestEnv with runWithStorageConfig for storage tests

### DIFF
--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -15,12 +15,12 @@ import {
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
-  setTestEnv,
   testCookie,
   testCsrfToken,
   withStorageDisabled,
   withStorageMock,
 } from "#test-utils";
+import { runWithStorageConfig } from "#lib/storage.ts";
 
 /** Submit a file to the header-image upload endpoint */
 const submitHeaderImage = async (
@@ -392,47 +392,44 @@ describeWithEnv(
       test("serves header image via proxy route", async () => {
         const encrypted = await encryptBytes(JPEG_HEADER);
 
-        // Set storage env vars in the test body so concurrent tests that
-        // clear them (e.g. "when storage is disabled") don't cause a race
-        // where isStorageEnabled() returns false.
-        const restoreEnv = setTestEnv({
-          STORAGE_ZONE_NAME: "testzone",
-          STORAGE_ZONE_KEY: "testkey",
-        });
-        const originalFetch = globalThis.fetch;
-        globalThis.fetch = (
-          input: string | URL | Request,
-        ): Promise<Response> => {
-          const url =
-            typeof input === "string"
-              ? input
-              : input instanceof URL
-                ? input.toString()
-                : input.url;
-          if (url.includes("storage.bunnycdn.com")) {
-            return Promise.resolve(
-              // deno-lint-ignore no-explicit-any
-              new Response(encrypted as any, { status: 200 }),
-            );
-          }
-          return originalFetch(input);
-        };
+        await runWithStorageConfig(
+          { zoneName: "testzone", zoneKey: "testkey" },
+          async () => {
+            const originalFetch = globalThis.fetch;
+            globalThis.fetch = (
+              input: string | URL | Request,
+            ): Promise<Response> => {
+              const url =
+                typeof input === "string"
+                  ? input
+                  : input instanceof URL
+                    ? input.toString()
+                    : input.url;
+              if (url.includes("storage.bunnycdn.com")) {
+                return Promise.resolve(
+                  // deno-lint-ignore no-explicit-any
+                  new Response(encrypted as any, { status: 200 }),
+                );
+              }
+              return originalFetch(input);
+            };
 
-        try {
-          const response = await handleRequest(
-            mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-          );
-          expect(response.status).toBe(200);
-          const headers = response.headers;
-          expect(headers.get("content-type")).toBe("image/jpeg");
-          expect(headers.get("cache-control")).toContain("immutable");
-          expect(new Uint8Array(await response.arrayBuffer())).toEqual(
-            JPEG_HEADER,
-          );
-        } finally {
-          globalThis.fetch = originalFetch;
-          restoreEnv();
-        }
+            try {
+              const response = await handleRequest(
+                mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
+              );
+              expect(response.status).toBe(200);
+              const headers = response.headers;
+              expect(headers.get("content-type")).toBe("image/jpeg");
+              expect(headers.get("cache-control")).toContain("immutable");
+              expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+                JPEG_HEADER,
+              );
+            } finally {
+              globalThis.fetch = originalFetch;
+            }
+          },
+        );
       });
     });
   },

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -83,6 +83,7 @@ import {
   testGroup,
   withStorageDisabled,
 } from "#test-utils";
+import { runWithStorageConfig } from "#lib/storage.ts";
 
 const TEST_SESSION = { adminLevel: "owner" as const };
 
@@ -3833,11 +3834,13 @@ describe("html", () => {
         });
 
         test("shows current image and remove button when image is set", () => {
-          const event = testEventWithCount({ image_url: "current.jpg" });
-          const html = adminEventEditPage(event, [], TEST_SESSION);
-          expect(html).toContain("/image/current.jpg");
-          expect(html).toContain("Remove Image");
-          expect(html).toContain("/image/delete");
+          runWithStorageConfig({ zoneName: "testzone", zoneKey: "testkey" }, () => {
+            const event = testEventWithCount({ image_url: "current.jpg" });
+            const html = adminEventEditPage(event, [], TEST_SESSION);
+            expect(html).toContain("/image/current.jpg");
+            expect(html).toContain("Remove Image");
+            expect(html).toContain("/image/delete");
+          });
         });
 
         test("does not show image field when storage is not enabled", () => {
@@ -3850,10 +3853,12 @@ describe("html", () => {
         });
 
         test("shows full-width image preview when event has image", () => {
-          const event = testEventWithCount({ image_url: "preview.jpg" });
-          const html = adminEventEditPage(event, [], TEST_SESSION);
-          expect(html).toContain("event-image-full");
-          expect(html).toContain("/image/preview.jpg");
+          runWithStorageConfig({ zoneName: "testzone", zoneKey: "testkey" }, () => {
+            const event = testEventWithCount({ image_url: "preview.jpg" });
+            const html = adminEventEditPage(event, [], TEST_SESSION);
+            expect(html).toContain("event-image-full");
+            expect(html).toContain("/image/preview.jpg");
+          });
         });
       });
 
@@ -3878,10 +3883,12 @@ describe("html", () => {
 
       describe("adminEventNewPage image section", () => {
         test("shows image upload field on create form when storage enabled", () => {
-          const html = adminEventNewPage([], TEST_SESSION);
-          expect(html).toContain('type="file"');
-          expect(html).toContain('name="image"');
-          expect(html).toContain("multipart/form-data");
+          runWithStorageConfig({ zoneName: "testzone", zoneKey: "testkey" }, () => {
+            const html = adminEventNewPage([], TEST_SESSION);
+            expect(html).toContain('type="file"');
+            expect(html).toContain('name="image"');
+            expect(html).toContain("multipart/form-data");
+          });
         });
 
         test("does not show image field on create form when storage is not enabled", () => {

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -38,35 +38,23 @@ describeWithEnv(
         });
       });
 
-      describeWithEnv(
-        "when only STORAGE_ZONE_NAME is set",
-        { env: { STORAGE_ZONE_NAME: "myzone" } },
-        () => {
-          test("returns false", () => {
-            expect(isStorageEnabled()).toBe(false);
-          });
-        },
-      );
+      test("returns false when only zoneName is set", () => {
+        runWithStorageConfig({ zoneName: "myzone", zoneKey: "" }, () => {
+          expect(isStorageEnabled()).toBe(false);
+        });
+      });
 
-      describeWithEnv(
-        "when only STORAGE_ZONE_KEY is set",
-        { env: { STORAGE_ZONE_KEY: "mykey" } },
-        () => {
-          test("returns false", () => {
-            expect(isStorageEnabled()).toBe(false);
-          });
-        },
-      );
+      test("returns false when only zoneKey is set", () => {
+        runWithStorageConfig({ zoneName: "", zoneKey: "mykey" }, () => {
+          expect(isStorageEnabled()).toBe(false);
+        });
+      });
 
-      describeWithEnv(
-        "when both env vars are set",
-        { env: { STORAGE_ZONE_NAME: "myzone", STORAGE_ZONE_KEY: "mykey" } },
-        () => {
-          test("returns true", () => {
-            expect(isStorageEnabled()).toBe(true);
-          });
-        },
-      );
+      test("returns true when both are set", () => {
+        runWithStorageConfig({ zoneName: "myzone", zoneKey: "mykey" }, () => {
+          expect(isStorageEnabled()).toBe(true);
+        });
+      });
     });
 
     describe("getImageProxyUrl", () => {

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -4,6 +4,7 @@ import { decryptBytes, encryptBytes } from "#lib/crypto.ts";
 import {
   ATTACHMENT_ERROR_MESSAGES,
   deleteAllEventStorageFiles,
+  deleteImage,
   detectImageType,
   generateAttachmentFilename,
   generateImageFilename,
@@ -53,6 +54,16 @@ describeWithEnv(
       test("returns true when both are set", () => {
         runWithStorageConfig({ zoneName: "myzone", zoneKey: "mykey" }, () => {
           expect(isStorageEnabled()).toBe(true);
+        });
+      });
+    });
+
+    describe("deleteImage", () => {
+      test("throws when storage is not configured", async () => {
+        await withStorageDisabled(async () => {
+          await expect(deleteImage("test.jpg")).rejects.toThrow(
+            "Required environment variable STORAGE_ZONE_NAME is not set",
+          );
         });
       });
     });


### PR DESCRIPTION
## Summary
Refactored test utilities to use a new `runWithStorageConfig` helper function instead of the `setTestEnv` approach for managing storage configuration in tests. This provides better encapsulation and cleaner test code.

## Key Changes
- Replaced `setTestEnv()` calls with `runWithStorageConfig()` in header-image tests, providing a callback-based approach that automatically handles cleanup
- Updated storage.test.ts to use `runWithStorageConfig()` instead of `describeWithEnv()` for individual test cases, simplifying the test structure
- Updated html.test.ts tests to wrap storage-dependent assertions in `runWithStorageConfig()` callbacks
- Removed import of `setTestEnv` from test-utils and added imports of `runWithStorageConfig` from lib/storage.ts where needed

## Implementation Details
- The new `runWithStorageConfig()` function accepts a configuration object with `zoneName` and `zoneKey` properties and a callback function
- This approach eliminates the need for manual cleanup via `restoreEnv()` calls and reduces the risk of test pollution from concurrent tests
- Tests that require storage to be enabled now explicitly wrap their assertions in the config callback, making the dependency more visible

https://claude.ai/code/session_015gsqnRdrGViZAXr6AS1HEA