### PR TITLE
Fix logger tests: suppress NTFY_URL and use local error logging

### DIFF
--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -544,7 +544,7 @@ describe("logger", () => {
 
   describeWithEnv(
     "runWithRequestId",
-    { env: { TEST_SUPPRESS_REQUEST_LOGS: undefined } },
+    { env: { TEST_SUPPRESS_REQUEST_LOGS: undefined, NTFY_URL: undefined } },
     () => {
       test("getRequestId returns ID inside request context", () => {
         runWithRequestId(() => {
@@ -591,7 +591,7 @@ describe("logger", () => {
               status: 200,
               durationMs: 5,
             });
-            logError({ code: ErrorCode.DB_CONNECTION });
+            logErrorLocal({ code: ErrorCode.DB_CONNECTION });
           });
 
           const expected = `[${id}] [Error] E_DB_CONNECTION`;


### PR DESCRIPTION
## Summary
This PR fixes two issues in the logger test suite to ensure tests run reliably without external dependencies.

## Key Changes
- Added `NTFY_URL: undefined` to the test environment setup in the `runWithRequestId` test suite to suppress notification URL configuration during tests
- Changed `logError()` to `logErrorLocal()` in the error logging test to use local error logging instead of potentially sending external notifications

## Implementation Details
These changes ensure that the logger tests are isolated from external services and environment variables that might affect test execution. By explicitly setting `NTFY_URL` to undefined and using the local error logging function, the tests can run consistently without relying on external notification services.

https://claude.ai/code/session_01TpDhpyCXtGGyw9BEneEEVp