### PR TITLE
Reduce default Deno test parallelism from 15 to 3

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -125,7 +125,7 @@ const runTests = async (useCoverage: boolean): Promise<number> => {
       ...Deno.env.toObject(),
       STRIPE_MOCK_HOST: "localhost",
       STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
-      DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "15",
+      DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "3",
     },
   });
   const result = await testCmd.output();


### PR DESCRIPTION
## Summary
Reduced the default number of parallel Deno test jobs from 15 to 3 to improve test stability and resource utilization.

## Changes
- Updated the default `DENO_JOBS` environment variable from `"15"` to `"3"` in the test runner configuration
- This change allows the `DENO_JOBS` environment variable to still be overridden if explicitly set by the user

## Details
The test runner now defaults to running 3 parallel test jobs instead of 15. This lower concurrency level may help reduce resource contention, flakiness, or timeout issues that could occur when running tests with high parallelism. Users can still override this default by explicitly setting the `DENO_JOBS` environment variable before running tests.

https://claude.ai/code/session_012LwqPBDmSfESthNhJSGqPG