### PR TITLE
Add HTML coverage report generation and artifact upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,14 @@ jobs:
           STRIPE_MOCK_PORT: "12111"
           DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
         run: deno task test:coverage
+
+      - name: Generate HTML coverage report
+        if: always()
+        run: deno coverage coverage --html
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/html/


### PR DESCRIPTION
## Summary
Enhanced the CI/CD pipeline to generate and persist HTML coverage reports as build artifacts, making coverage metrics more accessible and easier to review.

## Key Changes
- Added step to generate HTML coverage report from coverage data using `deno coverage coverage --html`
- Added step to upload the generated HTML coverage report as a GitHub Actions artifact
- Both new steps are configured to run even if previous steps fail using `if: always()`

## Implementation Details
- The HTML coverage report is generated in the `coverage/html/` directory
- The artifact is named `coverage-report` for easy identification
- Uses `actions/upload-artifact@v4` for reliable artifact storage
- The `if: always()` condition ensures coverage reports are generated and uploaded regardless of test results, providing visibility into coverage even when tests fail

https://claude.ai/code/session_01DS2LCFPU7p5Ht55YzG7U1s