### PR TITLE
Optimize image type validation and detection logic

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -54,6 +54,7 @@ const IMAGE_TYPES = [
 /** Derived lookups */
 const MIME_TO_EXT = Object.fromEntries(IMAGE_TYPES.map((t) => [t.mime, t.ext]));
 const EXT_TO_MIME = Object.fromEntries(IMAGE_TYPES.map((t) => [t.ext, t.mime]));
+const VALID_IMAGE_MIMES = new Set(IMAGE_TYPES.map((t) => t.mime));
 
 /**
  * Check if image storage is enabled (both env vars are set)
@@ -84,10 +85,15 @@ export const getMimeTypeFromFilename = (filename: string): string | null => {
  * Returns the MIME type if matched, null otherwise.
  */
 export const detectImageType = (data: Uint8Array): string | null => {
-  for (const { mime, magic } of IMAGE_TYPES) {
-    if (data.length >= magic.length && magic.every((b, i) => data[i] === b)) {
-      return mime;
+  // Explicit loop instead of `magic.every(callback)` — V8's JIT compiler
+  // can inline the `every` callback unpredictably, causing the coverage
+  // instrumentation to drop a branch on some runs.
+  outer: for (const { mime, magic } of IMAGE_TYPES) {
+    if (data.length < magic.length) continue;
+    for (let i = 0; i < magic.length; i++) {
+      if (data[i] !== magic[i]) continue outer;
     }
+    return mime;
   }
   return null;
 };
@@ -114,7 +120,7 @@ export const validateImage = (
     return { valid: false, error: "too_large" };
   }
 
-  if (!IMAGE_TYPES.some((t) => t.mime === contentType)) {
+  if (!VALID_IMAGE_MIMES.has(contentType)) {
     return { valid: false, error: "invalid_type" };
   }
 


### PR DESCRIPTION
## Summary
This PR improves the performance and reliability of image type validation and detection in the storage module through targeted optimizations.

## Key Changes
- **Added `VALID_IMAGE_MIMES` Set**: Replaced linear search in `validateImage()` with O(1) Set lookup for checking if a MIME type is valid
- **Refactored `detectImageType()` magic byte matching**: Replaced `Array.every()` with explicit nested loops to improve V8 JIT compiler behavior and ensure consistent code coverage instrumentation
- **Improved code clarity**: Added explanatory comment documenting the rationale for the explicit loop implementation

## Implementation Details
The magic byte detection refactoring uses a labeled outer loop (`outer:`) with `continue outer` to break out of the inner comparison loop when a byte mismatch is found. This explicit approach avoids potential issues with callback inlining in V8's JIT compiler that could cause inconsistent branch coverage during instrumented test runs.

The MIME type validation now uses a Set for O(1) lookup instead of the previous O(n) `Array.some()` approach, providing better performance especially as the list of supported image types grows.

https://claude.ai/code/session_01LbRgrKFSYrkqhJ5TnWXZhx