### PR TITLE
Refactor flash context to use AsyncLocalStorage

### DIFF
--- a/src/lib/flash-context.ts
+++ b/src/lib/flash-context.ts
@@ -1,36 +1,42 @@
 /**
- * Per-request flash message context.
+ * Per-request flash message context via AsyncLocalStorage.
  * Populated automatically by middleware from the flash cookie.
  * Consumed by templates via getFlash() — no manual reading needed in handlers.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /** Flash message shape — fields are only present when a message exists */
 export type Flash = { success?: string; error?: string; result?: string };
 
-/** The current request's flash message, set by middleware before rendering */
-const _flash: Flash = {};
+const flashStore = new AsyncLocalStorage<Flash>();
+
+/** Run a function within a flash context scope */
+export const runWithFlashContext = <T>(fn: () => T): T =>
+  flashStore.run({}, fn);
 
 /** Set the flash context for the current request (called by middleware) */
 export const setFlashContext = (flash: Flash): void => {
-  _flash.success = flash.success;
-  _flash.error = flash.error;
-  _flash.result = flash.result;
-};
-
-/** Reset the flash context (called by middleware after response) */
-export const resetFlashContext = (): void => {
-  _flash.success = undefined;
-  _flash.error = undefined;
-  _flash.result = undefined;
+  const store = flashStore.getStore();
+  if (store) {
+    store.success = flash.success;
+    store.error = flash.error;
+    store.result = flash.result;
+  }
 };
 
 /** Get the current flash message (for use in templates/handlers) */
-export const getFlash = (): Flash => ({
-  success: _flash.success,
-  error: _flash.error,
-  result: _flash.result,
-});
+export const getFlash = (): Flash => {
+  const store = flashStore.getStore();
+  return {
+    success: store?.success,
+    error: store?.error,
+    result: store?.result,
+  };
+};
 
 /** Whether the current request has a flash message */
-export const hasFlash = (): boolean =>
-  _flash.success !== undefined || _flash.error !== undefined;
+export const hasFlash = (): boolean => {
+  const store = flashStore.getStore();
+  return store?.success !== undefined || store?.error !== undefined;
+};

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -423,9 +423,7 @@ export const ConfirmForm = ({
     {children}
 
     <CsrfForm action={action}>
-      {returnUrl && (
-        <input type="hidden" name="return_url" value={returnUrl} />
-      )}
+      {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
       <label>
         {label}
         <input

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -14,7 +14,7 @@ import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { settings } from "#lib/db/settings.ts";
 import {
   hasFlash,
-  resetFlashContext,
+  runWithFlashContext,
   setFlashContext,
 } from "#lib/flash-context.ts";
 import { clearSavedFormData } from "#lib/forms.tsx";
@@ -342,112 +342,113 @@ export const handleRequest = async (
   return runWithRequestId(() =>
     runWithRequestCache(() =>
       runWithQueryLogContext(() =>
-        runWithSessionContext(async () => {
-          const { url, path, method } = parseRequest(effectiveRequest);
-          const getElapsed = createRequestTimer();
-          detectIframeMode(effectiveRequest.url);
-          clearSavedFormData();
-
-          try {
-            // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues
-            if (method === "GET") {
-              const cleanUrl = getCleanUrl(url);
-              if (cleanUrl) {
-                return logAndReturn(
-                  new Response(null, {
-                    status: 301,
-                    headers: { location: cleanUrl },
-                  }),
-                  method,
-                  path,
-                  getElapsed,
-                );
-              }
-            }
-
-            // Ensure settings cache is populated before reading custom domain.
-            // loadAll() is a no-op when the cache is still valid (60 s TTL).
-            await settings.loadAll();
-
-            // Load effective domain (custom_domain from DB if set, else request hostname)
-            loadEffectiveDomain(effectiveRequest.url);
-
-            const embeddable = isEmbeddablePath(path);
-
-            // Content-Type validation: reject POST requests without proper Content-Type
-            // (webhook endpoints accept JSON, all others require form-urlencoded)
-            if (!isValidContentType(effectiveRequest, path)) {
-              return logAndReturn(
-                contentTypeRejectionResponse(),
-                method,
-                path,
-                getElapsed,
-              );
-            }
+        runWithFlashContext(() =>
+          runWithSessionContext(async () => {
+            const { url, path, method } = parseRequest(effectiveRequest);
+            const getElapsed = createRequestTimer();
+            detectIframeMode(effectiveRequest.url);
+            clearSavedFormData();
 
             try {
-              // Populate flash context from keyed cookie (flash ID in URL)
-              const flashId = new URL(effectiveRequest.url).searchParams.get(
-                "flash",
-              );
-              const flashRaw = flashId
-                ? parseCookies(effectiveRequest).get(`flash_${flashId}`)
-                : null;
-              const flash = flashRaw ? parseFlashValue(flashRaw) : null;
-              if (flash) setFlashContext(flash);
-
-              const response = await handleRequestInternal(
-                effectiveRequest,
-                path,
-                method,
-                server,
-              );
-
-              // Clear keyed flash cookie if one was consumed
-              if (flashId && flash && hasFlash()) {
-                withCookie(response, clearFlashCookie(flashId));
+              // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues
+              if (method === "GET") {
+                const cleanUrl = getCleanUrl(url);
+                if (cleanUrl) {
+                  return logAndReturn(
+                    new Response(null, {
+                      status: 301,
+                      headers: { location: cleanUrl },
+                    }),
+                    method,
+                    path,
+                    getElapsed,
+                  );
+                }
               }
-              resetFlashContext();
 
-              return logAndReturn(
-                await applySecurityHeaders(response, embeddable),
-                method,
-                path,
-                getElapsed,
-              );
-            } catch (error) {
-              logError({
-                code: ErrorCode.CDN_REQUEST,
-                detail: formatRequestError(method, path, error),
-              });
-              // In tests, surface the real error instead of swallowing it
-              // behind a generic "Temporary Error" page
-              if (
-                Deno.env.get("TEST_RETHROW_ERRORS") &&
-                !(error instanceof SessionKeyError) &&
-                !Deno.env.get("TEST_EXPECT_ERROR")
-              ) {
-                throw error;
-              }
-              if (error instanceof SessionKeyError) {
+              // Ensure settings cache is populated before reading custom domain.
+              // loadAll() is a no-op when the cache is still valid (60 s TTL).
+              await settings.loadAll();
+
+              // Load effective domain (custom_domain from DB if set, else request hostname)
+              loadEffectiveDomain(effectiveRequest.url);
+
+              const embeddable = isEmbeddablePath(path);
+
+              // Content-Type validation: reject POST requests without proper Content-Type
+              // (webhook endpoints accept JSON, all others require form-urlencoded)
+              if (!isValidContentType(effectiveRequest, path)) {
                 return logAndReturn(
-                  redirectResponse("/admin", clearSessionCookie()),
+                  contentTypeRejectionResponse(),
                   method,
                   path,
                   getElapsed,
                 );
               }
-              return logAndReturn(
-                temporaryErrorResponse(),
-                method,
-                path,
-                getElapsed,
-              );
+
+              try {
+                // Populate flash context from keyed cookie (flash ID in URL)
+                const flashId = new URL(effectiveRequest.url).searchParams.get(
+                  "flash",
+                );
+                const flashRaw = flashId
+                  ? parseCookies(effectiveRequest).get(`flash_${flashId}`)
+                  : null;
+                const flash = flashRaw ? parseFlashValue(flashRaw) : null;
+                if (flash) setFlashContext(flash);
+
+                const response = await handleRequestInternal(
+                  effectiveRequest,
+                  path,
+                  method,
+                  server,
+                );
+
+                // Clear keyed flash cookie if one was consumed
+                if (flashId && flash && hasFlash()) {
+                  withCookie(response, clearFlashCookie(flashId));
+                }
+
+                return logAndReturn(
+                  await applySecurityHeaders(response, embeddable),
+                  method,
+                  path,
+                  getElapsed,
+                );
+              } catch (error) {
+                logError({
+                  code: ErrorCode.CDN_REQUEST,
+                  detail: formatRequestError(method, path, error),
+                });
+                // In tests, surface the real error instead of swallowing it
+                // behind a generic "Temporary Error" page
+                if (
+                  Deno.env.get("TEST_RETHROW_ERRORS") &&
+                  !(error instanceof SessionKeyError) &&
+                  !Deno.env.get("TEST_EXPECT_ERROR")
+                ) {
+                  throw error;
+                }
+                if (error instanceof SessionKeyError) {
+                  return logAndReturn(
+                    redirectResponse("/admin", clearSessionCookie()),
+                    method,
+                    path,
+                    getElapsed,
+                  );
+                }
+                return logAndReturn(
+                  temporaryErrorResponse(),
+                  method,
+                  path,
+                  getElapsed,
+                );
+              }
+            } finally {
+              await flushPendingWork();
             }
-          } finally {
-            await flushPendingWork();
-          }
-        }),
+          }),
+        ),
       ),
     ),
   );

--- a/src/templates/admin/users.tsx
+++ b/src/templates/admin/users.tsx
@@ -2,7 +2,12 @@
  * Admin user management page template
  */
 
-import { ConfirmForm, CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
+import {
+  ConfirmForm,
+  CsrfForm,
+  renderError,
+  renderFields,
+} from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminLevel, AdminSession } from "#lib/types.ts";
 import { AdminNav, Breadcrumb, UsersSubNav } from "#templates/admin/nav.tsx";

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -9,6 +9,7 @@ import {
 } from "#lib/asset-paths.ts";
 import { getCurrentCsrfToken, signCsrfToken } from "#lib/csrf.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
+import { runWithStorageConfig } from "#lib/storage.ts";
 import {
   adminEventActivityLogPage,
   adminGlobalActivityLogPage,
@@ -83,7 +84,6 @@ import {
   testGroup,
   withStorageDisabled,
 } from "#test-utils";
-import { runWithStorageConfig } from "#lib/storage.ts";
 
 const TEST_SESSION = { adminLevel: "owner" as const };
 
@@ -3834,13 +3834,16 @@ describe("html", () => {
         });
 
         test("shows current image and remove button when image is set", () => {
-          runWithStorageConfig({ zoneName: "testzone", zoneKey: "testkey" }, () => {
-            const event = testEventWithCount({ image_url: "current.jpg" });
-            const html = adminEventEditPage(event, [], TEST_SESSION);
-            expect(html).toContain("/image/current.jpg");
-            expect(html).toContain("Remove Image");
-            expect(html).toContain("/image/delete");
-          });
+          runWithStorageConfig(
+            { zoneName: "testzone", zoneKey: "testkey" },
+            () => {
+              const event = testEventWithCount({ image_url: "current.jpg" });
+              const html = adminEventEditPage(event, [], TEST_SESSION);
+              expect(html).toContain("/image/current.jpg");
+              expect(html).toContain("Remove Image");
+              expect(html).toContain("/image/delete");
+            },
+          );
         });
 
         test("does not show image field when storage is not enabled", () => {
@@ -3853,12 +3856,15 @@ describe("html", () => {
         });
 
         test("shows full-width image preview when event has image", () => {
-          runWithStorageConfig({ zoneName: "testzone", zoneKey: "testkey" }, () => {
-            const event = testEventWithCount({ image_url: "preview.jpg" });
-            const html = adminEventEditPage(event, [], TEST_SESSION);
-            expect(html).toContain("event-image-full");
-            expect(html).toContain("/image/preview.jpg");
-          });
+          runWithStorageConfig(
+            { zoneName: "testzone", zoneKey: "testkey" },
+            () => {
+              const event = testEventWithCount({ image_url: "preview.jpg" });
+              const html = adminEventEditPage(event, [], TEST_SESSION);
+              expect(html).toContain("event-image-full");
+              expect(html).toContain("/image/preview.jpg");
+            },
+          );
         });
       });
 
@@ -3883,12 +3889,15 @@ describe("html", () => {
 
       describe("adminEventNewPage image section", () => {
         test("shows image upload field on create form when storage enabled", () => {
-          runWithStorageConfig({ zoneName: "testzone", zoneKey: "testkey" }, () => {
-            const html = adminEventNewPage([], TEST_SESSION);
-            expect(html).toContain('type="file"');
-            expect(html).toContain('name="image"');
-            expect(html).toContain("multipart/form-data");
-          });
+          runWithStorageConfig(
+            { zoneName: "testzone", zoneKey: "testkey" },
+            () => {
+              const html = adminEventNewPage([], TEST_SESSION);
+              expect(html).toContain('type="file"');
+              expect(html).toContain('name="image"');
+              expect(html).toContain("multipart/form-data");
+            },
+          );
         });
 
         test("does not show image field on create form when storage is not enabled", () => {


### PR DESCRIPTION
## Summary
Refactored the flash message context system to use Node's `AsyncLocalStorage` instead of a module-level object, enabling proper isolation of flash state across concurrent requests.

## Key Changes
- **Flash context isolation**: Replaced the shared `_flash` object with `AsyncLocalStorage<Flash>` to ensure each request has its own isolated flash context
- **New `runWithFlashContext` wrapper**: Added a new context runner function that establishes the flash storage scope for each request
- **Removed `resetFlashContext`**: Eliminated the manual reset function since `AsyncLocalStorage` automatically cleans up context when exiting the scope
- **Updated request handler**: Wrapped the session context with `runWithFlashContext` to establish proper context nesting
- **Updated imports**: Changed the import from `resetFlashContext` to `runWithFlashContext` in the routes module
- **Code formatting**: Fixed import ordering and formatting in test files and templates for consistency

## Implementation Details
- The flash context is now established at the outermost level of request handling (after query log context but before session context)
- `setFlashContext` and `getFlash` now read/write to the `AsyncLocalStorage` store instead of a shared object
- `hasFlash` checks the store's current state to determine if a flash message exists
- This change ensures thread-safe flash message handling in concurrent request scenarios

https://claude.ai/code/session_01RH33TqEr6LkMSrwErUcpK1