### PR TITLE
Add requestAsApiKey and requestAsSession test helpers

### DIFF
--- a/src/routes/admin/attendee-refunds.ts
+++ b/src/routes/admin/attendee-refunds.ts
@@ -28,10 +28,10 @@ import {
   adminRefundAttendeePage,
 } from "#templates/admin/attendees.tsx";
 import {
-  type EventRouteParams,
-  NO_PROVIDER_ERROR,
   attendeeGetRoute,
+  type EventRouteParams,
   getReturnUrl,
+  NO_PROVIDER_ERROR,
   verifiedAttendeeForm,
 } from "./attendees.ts";
 

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -34,10 +34,7 @@ import { ErrorCode, logError } from "#lib/logger.ts";
 import { getActivePaymentProvider } from "#lib/payments.ts";
 import { type Attendee, type EventWithCount, isPaidEvent } from "#lib/types.ts";
 import { logAndNotifyRegistration } from "#lib/webhook.ts";
-import {
-  requirePrivateKey,
-  verifyOrRedirect,
-} from "#routes/admin/utils.ts";
+import { requirePrivateKey, verifyOrRedirect } from "#routes/admin/utils.ts";
 import { defineRoutes } from "#routes/router.ts";
 import {
   type AuthSession,

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2544,6 +2544,31 @@ export const createTestApiKeyFull = async (
   return { apiKey, id, dataKey };
 };
 
+/** Create a mock request authenticated with an API key Bearer token */
+export const requestAsApiKey = (
+  path: string,
+  apiKey: string,
+  opts: RequestInit = {},
+): Request => {
+  const headers = new Headers(opts.headers);
+  headers.set("authorization", `Bearer ${apiKey}`);
+  if (!headers.has("host")) headers.set("host", "localhost");
+  return new Request(`http://localhost${path}`, { ...opts, headers });
+};
+
+/** Create a mock request authenticated with a session cookie + CSRF token */
+export const requestAsSession = (
+  path: string,
+  session: { cookie: string; csrfToken: string },
+  opts: RequestInit = {},
+): Request => {
+  const headers = new Headers(opts.headers);
+  headers.set("cookie", session.cookie);
+  headers.set("x-csrf-token", session.csrfToken);
+  if (!headers.has("host")) headers.set("host", "localhost");
+  return new Request(`http://localhost${path}`, { ...opts, headers });
+};
+
 /** Make an authenticated JSON API request using an API key (or auto-creating one) */
 export const apiRequest = async (
   path: string,
@@ -2555,17 +2580,13 @@ export const apiRequest = async (
 ): Promise<Response> => {
   const { handleRequest } = await import("#routes");
   const apiKey = options.apiKey ?? (await createTestApiKeyToken());
-  const headers: Record<string, string> = {
-    authorization: `Bearer ${apiKey}`,
-  };
   const method = options.method ?? "GET";
-  if (method !== "GET") {
-    headers["content-type"] = "application/json";
-  }
+  const headers: HeadersInit =
+    method !== "GET" ? { "content-type": "application/json" } : {};
   const init: RequestInit = {
     method,
     headers,
     body: method !== "GET" ? JSON.stringify(options.body ?? {}) : undefined,
   };
-  return handleRequest(mockRequest(path, init));
+  return handleRequest(requestAsApiKey(path, apiKey, init));
 };

--- a/test/admin-api-events.test.ts
+++ b/test/admin-api-events.test.ts
@@ -15,6 +15,7 @@ import {
   createTestGroup,
   describeWithEnv,
   mockRequest,
+  requestAsSession,
   testCookie,
   testCsrfToken,
   testEventWithCount,
@@ -56,8 +57,9 @@ describeWithEnv("Admin API - Events", { db: true }, () => {
 
       await assertJson(
         handleRequest(
-          mockRequest(`/api/admin/events/${event.id}`, {
-            headers: { cookie, "x-csrf-token": csrfToken },
+          requestAsSession(`/api/admin/events/${event.id}`, {
+            cookie,
+            csrfToken,
           }),
         ),
         200,

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -32,6 +32,8 @@ import {
   FLASH_TEST_ID,
   flashCookieHeader,
   mockRequest,
+  requestAsApiKey,
+  requestAsSession,
   testCookie,
   testCsrfToken,
 } from "#test-utils";
@@ -424,11 +426,7 @@ describeWithEnv("API Keys", { db: true }, () => {
       const { apiKey } = await createTestApiKeyFull("Auth Test");
 
       await assertJson(
-        handleRequest(
-          mockRequest("/api/admin/events", {
-            headers: { authorization: `Bearer ${apiKey}` },
-          }),
-        ),
+        handleRequest(requestAsApiKey("/api/admin/events", apiKey)),
         200,
         (body) => {
           expect(body.events).toBeDefined();
@@ -441,32 +439,24 @@ describeWithEnv("API Keys", { db: true }, () => {
 
       // Bearer should NOT authenticate admin UI routes
       const dashboardResponse = await handleRequest(
-        mockRequest("/admin/api-keys/docs", {
-          headers: { authorization: `Bearer ${apiKey}` },
-        }),
+        requestAsApiKey("/admin/api-keys/docs", apiKey),
       );
       expect(dashboardResponse.status).toBe(302);
 
       const settingsResponse = await handleRequest(
-        mockRequest("/admin/settings", {
-          headers: { authorization: `Bearer ${apiKey}` },
-        }),
+        requestAsApiKey("/admin/settings", apiKey),
       );
       expect(settingsResponse.status).toBe(302);
 
       const keysResponse = await handleRequest(
-        mockRequest("/admin/api-keys", {
-          headers: { authorization: `Bearer ${apiKey}` },
-        }),
+        requestAsApiKey("/admin/api-keys", apiKey),
       );
       expect(keysResponse.status).toBe(302);
     });
 
     test("rejects invalid Bearer token", async () => {
       const response = await handleRequest(
-        mockRequest("/api/admin/events", {
-          headers: { authorization: "Bearer invalid-token" },
-        }),
+        requestAsApiKey("/api/admin/events", "invalid-token"),
       );
 
       expect(response.status).toBe(401);
@@ -538,11 +528,7 @@ describeWithEnv("API Keys", { db: true }, () => {
       const { apiKey } = await createTestApiKeyFull("Events API");
 
       const body = await assertJson(
-        handleRequest(
-          mockRequest("/api/admin/events", {
-            headers: { authorization: `Bearer ${apiKey}` },
-          }),
-        ),
+        handleRequest(requestAsApiKey("/api/admin/events", apiKey)),
         200,
         (body) => {
           expect(body.events).toBeDefined();
@@ -568,12 +554,7 @@ describeWithEnv("API Keys", { db: true }, () => {
 
       await assertJson(
         handleRequest(
-          mockRequest("/api/admin/events", {
-            headers: {
-              cookie,
-              "x-csrf-token": csrfToken,
-            },
-          }),
+          requestAsSession("/api/admin/events", { cookie, csrfToken }),
         ),
         200,
         (body) => {
@@ -584,9 +565,7 @@ describeWithEnv("API Keys", { db: true }, () => {
 
     test("GET /api/admin/events returns 401 for invalid API key", async () => {
       const response = await handleRequest(
-        mockRequest("/api/admin/events", {
-          headers: { authorization: "Bearer bad-key" },
-        }),
+        requestAsApiKey("/api/admin/events", "bad-key"),
       );
 
       expect(response.status).toBe(401);
@@ -612,9 +591,7 @@ describeWithEnv("API Keys", { db: true }, () => {
       await getDb().execute({ sql: "PRAGMA foreign_keys = ON", args: [] });
 
       const response = await handleRequest(
-        mockRequest("/api/admin/events", {
-          headers: { authorization: `Bearer ${token}` },
-        }),
+        requestAsApiKey("/api/admin/events", token),
       );
 
       expect(response.status).toBe(401);
@@ -630,9 +607,7 @@ describeWithEnv("API Keys", { db: true }, () => {
       });
 
       const response = await handleRequest(
-        mockRequest("/api/admin/events", {
-          headers: { authorization: `Bearer ${apiKey}` },
-        }),
+        requestAsApiKey("/api/admin/events", apiKey),
       );
 
       expect(response.status).toBe(401);

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -16,6 +16,7 @@ import {
   createTestEvent,
   describeWithEnv,
   expectHtmlResponse,
+  requestAsSession,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
@@ -28,16 +29,15 @@ const mockScanRequest = (
   cookie: string,
   csrfToken: string,
 ): Request =>
-  new Request(`http://localhost/admin/event/${eventId}/scan`, {
-    method: "POST",
-    headers: {
-      host: "localhost",
-      "content-type": "application/json",
-      "x-csrf-token": csrfToken,
-      cookie,
+  requestAsSession(
+    `/admin/event/${eventId}/scan`,
+    { cookie, csrfToken },
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-  });
+  );
 
 /** Create event + attendee and return session + scan-ready token */
 const setupScanTest = async (


### PR DESCRIPTION
Reduce repeated auth header boilerplate in tests by extracting two
helpers into #test-utils. requestAsApiKey wraps Bearer token auth and
requestAsSession wraps cookie + CSRF token auth. Updated api-keys,
admin-api-events, and server-scanner tests to use the new helpers.
apiRequest now delegates to requestAsApiKey internally.

https://claude.ai/code/session_01AwV7r2E8M1KvLZCW4VmMn2