### PR TITLE
Wrap ConfirmForm children with prose styling

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -420,7 +420,7 @@ export const ConfirmForm = ({
   children?: Child;
 }): JSX.Element => (
   <>
-    {children}
+    <div class="prose">{children}</div>
 
     <CsrfForm action={action}>
       {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}


### PR DESCRIPTION
## Summary
Added prose styling to the children content rendered in the ConfirmForm component to improve typography and readability.

## Changes
- Wrapped the `children` prop in a `<div>` with the `prose` class in the ConfirmForm component
- This applies prose styling to any child content passed to the form, ensuring consistent text formatting and spacing

## Implementation Details
The change is minimal and non-breaking - it only adds a wrapper div with the `prose` class around existing children content. This allows the form's child elements to benefit from prose-based typography styling without affecting the form's functionality or the CSRF form structure.

https://claude.ai/code/session_01HBonGQ6UjgWKEZQs81VSRX