### PR TITLE
Tighten type declarations to reduce defensive code

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -127,8 +127,9 @@ export type EmailTemplateType = "confirmation" | "admin";
 /** Valid email template formats */
 export type EmailTemplateFormat = "subject" | "html" | "text";
 
-/** Template type:format → config key (no separate mapping needed). */
-const TEMPLATE_KEYS: Record<string, StringSettingKey> = {
+/** Template type:format → config key */
+type TemplateKeyMap = `${EmailTemplateType}:${EmailTemplateFormat}`;
+const TEMPLATE_KEYS: Record<TemplateKeyMap, StringSettingKey> = {
   "confirmation:subject": "email_tpl_confirmation_subject",
   "confirmation:html": "email_tpl_confirmation_html",
   "confirmation:text": "email_tpl_confirmation_text",
@@ -471,11 +472,11 @@ const updateUserPassword = async (
 // ---------------------------------------------------------------------------
 
 const toCredentials = (
-  passTypeId: string | null | undefined,
-  teamId: string | null | undefined,
-  signingCert: string | null | undefined,
-  signingKey: string | null | undefined,
-  wwdrCert: string | null | undefined,
+  passTypeId: string | undefined,
+  teamId: string | undefined,
+  signingCert: string | undefined,
+  signingKey: string | undefined,
+  wwdrCert: string | undefined,
 ): SigningCredentials | null =>
   passTypeId && teamId && signingCert && signingKey && wwdrCert
     ? { passTypeId, teamId, signingCert, signingKey, wwdrCert }
@@ -504,9 +505,9 @@ const getHostAppleWalletConfig = (): SigningCredentials | null => {
 // ---------------------------------------------------------------------------
 
 const toGoogleCredentials = (
-  issuerId: string | null | undefined,
-  serviceAccountEmail: string | null | undefined,
-  serviceAccountKey: string | null | undefined,
+  issuerId: string | undefined,
+  serviceAccountEmail: string | undefined,
+  serviceAccountKey: string | undefined,
 ): GoogleWalletCredentials | null =>
   issuerId && serviceAccountEmail && serviceAccountKey
     ? { issuerId, serviceAccountEmail, serviceAccountKey }
@@ -740,7 +741,7 @@ export const settings = {
       return snap("email_from_address");
     },
     template(type: EmailTemplateType, format: EmailTemplateFormat): string {
-      return snap(TEMPLATE_KEYS[`${type}:${format}`]!);
+      return snap(TEMPLATE_KEYS[`${type}:${format}`]);
     },
     templateSet(type: EmailTemplateType): {
       subject: string;
@@ -947,7 +948,7 @@ export const settings = {
         format: EmailTemplateFormat,
         content: string,
       ): Promise<void> => {
-        const key = TEMPLATE_KEYS[`${type}:${format}`]!;
+        const key = TEMPLATE_KEYS[`${type}:${format}`];
         await writeEncrypted(key, content);
         setSnapshotField(key, content);
       },

--- a/src/lib/payment-helpers.ts
+++ b/src/lib/payment-helpers.ts
@@ -83,7 +83,7 @@ export const serializeBookingItems = (
 const optionalFields = (
   intent: Partial<
     Pick<ContactInfo, "phone" | "address" | "special_instructions">
-  > & { date?: string | null },
+  > & { date: string | null },
 ): Record<string, string> => ({
   ...(intent.phone ? { phone: intent.phone } : {}),
   ...(intent.address ? { address: intent.address } : {}),
@@ -96,7 +96,7 @@ const optionalFields = (
 /** Single-event checkout intent for metadata building */
 type SingleIntentMetadata = ContactFields & {
   quantity: number;
-  date?: string | null;
+  date: string | null;
   answerIds?: number[];
 };
 

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -8,7 +8,12 @@
 
 import { settings } from "#lib/db/settings.ts";
 import { logDebug } from "#lib/logger.ts";
-import type { ContactInfo, Event, PaymentProviderType } from "#lib/types.ts";
+import {
+  type ContactInfo,
+  createTypeGuard,
+  type Event,
+  type PaymentProviderType,
+} from "#lib/types.ts";
 
 /** Stubbable API for internal calls (testable via spyOn, like stripeApi/squareApi) */
 export const paymentsApi = {
@@ -24,7 +29,7 @@ export type RegistrationIntent = ContactInfo & {
   eventId: number;
   quantity: number;
   /** Selected date for daily events; null means no date selected */
-  date?: string | null;
+  date: string | null;
   /** Custom unit price (minor units) when can_pay_more is enabled; overrides event.unit_price */
   customUnitPrice?: number;
   /** Custom question answer IDs selected during checkout */
@@ -45,7 +50,7 @@ export type BookingItem = { e: number; q: number; p: number };
 
 /** Registration intent for multi-event checkout */
 export type MultiRegistrationIntent = ContactInfo & {
-  date?: string | null;
+  date: string | null;
   items: MultiRegistrationItem[];
   /** Per-event answer IDs: maps eventId → answerIds for that event's questions */
   eventAnswerIds?: Record<string, number[]>;
@@ -93,9 +98,16 @@ export type SessionMetadata = {
 /** Valid payment status values */
 export type PaymentStatus = "paid" | "unpaid" | "no_payment_required";
 
+/** Runtime array of valid payment status values */
+const PAYMENT_STATUSES: readonly PaymentStatus[] = [
+  "paid",
+  "unpaid",
+  "no_payment_required",
+];
+
 /** Type guard: check if a string is a valid PaymentStatus */
-export const isPaymentStatus = (s: string): s is PaymentStatus =>
-  s === "paid" || s === "unpaid" || s === "no_payment_required";
+export const isPaymentStatus: (s: string) => s is PaymentStatus =
+  createTypeGuard(PAYMENT_STATUSES);
 
 /** A validated payment session returned after checkout completion */
 export type ValidatedPaymentSession = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,12 @@
  * Types for the ticket reservation system
  */
 
+/** Create a type guard from a readonly array of string literal values */
+export const createTypeGuard =
+  <T extends string>(values: readonly T[]) =>
+  (s: string): s is T =>
+    (values as readonly string[]).includes(s);
+
 /** Individual contact field name */
 export type ContactField =
   | "email"
@@ -18,10 +24,12 @@ export const CONTACT_FIELDS: readonly ContactField[] = [
 ];
 
 /** Type guard: check if an arbitrary string is a valid ContactField */
-export const isContactField = (s: string): s is ContactField =>
-  (CONTACT_FIELDS as readonly string[]).includes(s);
+export const isContactField = createTypeGuard(CONTACT_FIELDS);
 
-/** Contact fields setting for an event (comma-separated ContactField names, or empty for name-only) */
+/**
+ * Contact fields setting for an event (comma-separated ContactField names, or empty for name-only).
+ * Alias kept for documentation; runtime enforcement happens in parseEventFields.
+ */
 export type EventFields = string;
 
 /** Attendee contact details — the core PII fields collected at registration */
@@ -47,8 +55,7 @@ export type PaymentProviderType = "stripe" | "square";
 const PAYMENT_PROVIDERS: readonly PaymentProviderType[] = ["stripe", "square"];
 
 /** Type guard: check if a string is a valid PaymentProviderType */
-export const isPaymentProvider = (s: string): s is PaymentProviderType =>
-  (PAYMENT_PROVIDERS as readonly string[]).includes(s);
+export const isPaymentProvider = createTypeGuard(PAYMENT_PROVIDERS);
 
 /** Event type: standard (one-time) or daily (date-based booking) */
 export type EventType = "standard" | "daily";
@@ -57,8 +64,7 @@ export type EventType = "standard" | "daily";
 const EVENT_TYPES: readonly EventType[] = ["standard", "daily"];
 
 /** Type guard: check if an arbitrary string is a valid EventType */
-export const isEventType = (s: string): s is EventType =>
-  (EVENT_TYPES as readonly string[]).includes(s);
+export const isEventType = createTypeGuard(EVENT_TYPES);
 
 /** Whether an event can accept payments (has a price or allows pay-what-you-want) */
 export const isPaidEvent = (
@@ -143,9 +149,11 @@ export interface Session {
 /** Admin role levels */
 export type AdminLevel = "owner" | "manager";
 
+/** Valid admin level values */
+const ADMIN_LEVELS: readonly AdminLevel[] = ["owner", "manager"];
+
 /** Type guard: check if a string is a valid AdminLevel */
-export const isAdminLevel = (s: string): s is AdminLevel =>
-  s === "owner" || s === "manager";
+export const isAdminLevel = createTypeGuard(ADMIN_LEVELS);
 
 /** Session data needed by admin page templates */
 export type AdminSession = {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -650,7 +650,6 @@ export const withCsrfForm = async (
   return csrf.ok ? handler(csrf.form) : csrf.response;
 };
 
-
 /**
  * Authenticated GET-by-ID route handler factory.
  * Loads entity by ID, returns 404 if missing, renders with session context.
@@ -829,8 +828,7 @@ const resolveSession = async (
   if (allowApiKey) {
     const s = await getAuthenticatedApiKey(request);
     if (s) return { session: s, authKind: "apiKey" };
-    if (getBearerToken(request))
-      return authFailure(channel, "invalid-api-key");
+    if (getBearerToken(request)) return authFailure(channel, "invalid-api-key");
   }
   const session = await getAuthenticatedSession(request);
   if (!session) return authFailure(channel, "not-authenticated");

--- a/test/lib/payment-helpers.test.ts
+++ b/test/lib/payment-helpers.test.ts
@@ -52,6 +52,7 @@ describe("payment-helpers", () => {
         phone: "+9876543210",
         address: "",
         special_instructions: "",
+        date: null,
         items: [
           {
             eventId: 1,
@@ -117,6 +118,7 @@ describe("payment-helpers", () => {
         email: "min@example.com",
         address: "",
         special_instructions: "",
+        date: null,
         quantity: 1,
       });
 
@@ -137,6 +139,7 @@ describe("payment-helpers", () => {
         phone: "",
         address: "",
         special_instructions: "",
+        date: null,
         items: [
           { eventId: 5, quantity: 1, unitPrice: 100, slug: "e", name: "E" },
         ],
@@ -178,6 +181,7 @@ describe("payment-helpers", () => {
       const metadata = buildSingleIntentMetadata(1, {
         name: "X",
         email: "x@x.com",
+        date: null,
         quantity: 1,
         answerIds: [],
       });

--- a/test/lib/square-provider.test.ts
+++ b/test/lib/square-provider.test.ts
@@ -243,6 +243,7 @@ describe("square-provider", () => {
         address: "",
         special_instructions: "",
         quantity: 1,
+        date: null,
       };
       await withMocks(
         () =>
@@ -274,6 +275,7 @@ describe("square-provider", () => {
         address: "",
         special_instructions: "",
         quantity: 1,
+        date: null,
       };
       await withMocks(
         () =>
@@ -300,6 +302,7 @@ describe("square-provider", () => {
         phone: "",
         address: "",
         special_instructions: "",
+        date: null,
         items: [
           {
             eventId: 1,

--- a/test/lib/square.test.ts
+++ b/test/lib/square.test.ts
@@ -409,6 +409,7 @@ describe("square", () => {
         address: "",
         special_instructions: "",
         quantity: 1,
+        date: null,
       };
       const result = await squareApi.createPaymentLink(
         event,
@@ -467,6 +468,7 @@ describe("square", () => {
         address: "",
         special_instructions: "",
         quantity: 1,
+        date: null,
       };
       const result = await squareApi.createPaymentLink(
         event,
@@ -538,6 +540,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 3,
+            date: null,
           };
 
           const result = await squareApi.createPaymentLink(
@@ -612,6 +615,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 2,
+            date: null,
           };
 
           await squareApi.createPaymentLink(
@@ -693,6 +697,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           await squareApi.createPaymentLink(event, intent, "http://localhost");
@@ -765,6 +770,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           const result = await squareApi.createPaymentLink(
@@ -839,6 +845,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           const result = await squareApi.createPaymentLink(
@@ -876,6 +883,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           const result = await squareApi.createPaymentLink(
@@ -897,6 +905,7 @@ describe("square", () => {
         phone: "",
         address: "",
         special_instructions: "",
+        date: null,
         items: [
           {
             eventId: 1,
@@ -929,6 +938,7 @@ describe("square", () => {
         phone: "",
         address: "",
         special_instructions: "",
+        date: null,
         items: [
           {
             eventId: 1,
@@ -965,6 +975,7 @@ describe("square", () => {
             phone: "",
             address: "",
             special_instructions: "",
+            date: null,
             items: [
               {
                 eventId: 1,
@@ -1007,6 +1018,7 @@ describe("square", () => {
             phone: "555-1111",
             address: "",
             special_instructions: "",
+            date: null,
             items: [
               {
                 eventId: 10,
@@ -1097,6 +1109,7 @@ describe("square", () => {
             phone: "",
             address: "",
             special_instructions: "",
+            date: null,
             items,
           };
 
@@ -1123,6 +1136,7 @@ describe("square", () => {
       address: "",
       special_instructions: "",
       quantity: 1,
+      date: null,
     };
 
     /** Set up Square credentials and a mock client with a failing checkout */
@@ -2367,6 +2381,7 @@ describe("square", () => {
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           const result = await squarePaymentProvider.createCheckoutSession(
@@ -2405,6 +2420,7 @@ describe("square", () => {
             phone: "",
             address: "",
             special_instructions: "",
+            date: null,
             items: [
               {
                 eventId: 1,

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -191,6 +191,7 @@ describeWithEnv(
           address: "",
           special_instructions: "",
           quantity: 1,
+          date: null,
         };
 
         const createdSession = await createCheckoutSessionWithIntent(
@@ -258,6 +259,7 @@ describeWithEnv(
           address: "",
           special_instructions: "",
           quantity: 2,
+          date: null,
         };
 
         const session = await createCheckoutSessionWithIntent(
@@ -331,6 +333,7 @@ describeWithEnv(
           address: "",
           special_instructions: "",
           quantity: 1,
+          date: null,
         };
         const result = await createCheckoutSessionWithIntent(
           event,
@@ -365,6 +368,7 @@ describeWithEnv(
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           await createCheckoutSessionWithIntent(
@@ -937,6 +941,7 @@ describeWithEnv(
           address: "",
           special_instructions: "",
           quantity: 1,
+          date: null,
         };
 
         const session = await createCheckoutSessionWithIntent(
@@ -964,6 +969,7 @@ describeWithEnv(
           address: "",
           special_instructions: "",
           quantity: 1,
+          date: null,
         };
 
         const session = await createCheckoutSessionWithIntent(
@@ -988,6 +994,7 @@ describeWithEnv(
           phone: "+44 7700 900001",
           address: "",
           special_instructions: "",
+          date: null,
           items: [
             {
               eventId: 1,
@@ -1022,6 +1029,7 @@ describeWithEnv(
           phone: "",
           address: "",
           special_instructions: "",
+          date: null,
           items: [
             {
               eventId: 1,
@@ -1049,6 +1057,7 @@ describeWithEnv(
           phone: "+44 7700 900002",
           address: "",
           special_instructions: "",
+          date: null,
           items: [
             {
               eventId: 1,
@@ -1624,6 +1633,7 @@ describeWithEnv(
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           // Use stripePaymentProvider which wraps via toCheckoutResult
@@ -1658,6 +1668,7 @@ describeWithEnv(
             address: "",
             special_instructions: "",
             quantity: 1,
+            date: null,
           };
 
           const result = await stripePaymentProvider.createCheckoutSession(
@@ -2190,6 +2201,7 @@ describeWithEnv(
             phone: "",
             address: "",
             special_instructions: "",
+            date: null,
             items: [
               {
                 eventId: 1,


### PR DESCRIPTION
- Add createTypeGuard factory to deduplicate 5 type guard functions
- Make RegistrationIntent.date and MultiRegistrationIntent.date required
  (string | null) since callers always provide a value
- Use template literal key type for TEMPLATE_KEYS, removing ! assertions
- Narrow toCredentials/toGoogleCredentials params from string | null | undefined
  to string | undefined (null is never passed)
- Tighten SingleIntentMetadata.date and optionalFields date param

https://claude.ai/code/session_01LK5SfzWGvYPKUzPt1bWfum