### PR TITLE
Unify single and multi-ticket flows into one ticket page

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -375,7 +375,7 @@ for (const form of document.querySelectorAll<HTMLFormElement>(
   });
 }
 
-/* Multi-ticket question visibility: show questions only when at least one
+/* Question visibility: show questions only when at least one
  * associated event has quantity > 0. Questions without data-event-ids are
  * always visible (single-event pages). */
 {

--- a/src/lib/payment-helpers.ts
+++ b/src/lib/payment-helpers.ts
@@ -103,7 +103,7 @@ type SingleIntentMetadata = ContactFields & {
 /**
  * Build intent metadata for a single-event checkout.
  * Common fields: event_id, name, email, quantity, optional phone/address/date.
- * Answer IDs are stored in per-event format (same as multi-ticket) for consistency.
+ * Answer IDs are stored in per-event format for consistency.
  */
 export const buildSingleIntentMetadata = (
   eventId: number,

--- a/src/lib/sort-events.ts
+++ b/src/lib/sort-events.ts
@@ -7,6 +7,8 @@
  */
 
 import { getNextBookableDate } from "#lib/dates.ts";
+import { getAllEvents } from "#lib/db/events.ts";
+import { getActiveHolidays } from "#lib/db/holidays.ts";
 import type { Event, EventWithCount, Holiday } from "#lib/types.ts";
 
 export type { EventWithCount };
@@ -61,4 +63,16 @@ export const sortEvents = <T extends Event>(
     }
   }
   return [...events].sort(compareEvents(nextDates));
+};
+
+/** Load all events with holidays and return them sorted, filtered by predicate. */
+export const loadSortedEvents = async (
+  predicate: (e: EventWithCount) => boolean,
+): Promise<{ events: EventWithCount[]; holidays: Holiday[] }> => {
+  const [allEvents, holidays] = await Promise.all([
+    getAllEvents(),
+    getActiveHolidays(),
+  ]);
+  const events = sortEvents(allEvents.filter(predicate), holidays);
+  return { events, holidays };
 };

--- a/src/routes/feeds.ts
+++ b/src/routes/feeds.ts
@@ -5,10 +5,8 @@
 
 import { map, pipe } from "#fp";
 import { getEffectiveDomain } from "#lib/config.ts";
-import { getAllEvents } from "#lib/db/events.ts";
-import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { settings } from "#lib/db/settings.ts";
-import { type EventWithCount, sortEvents } from "#lib/sort-events.ts";
+import { type EventWithCount, loadSortedEvents } from "#lib/sort-events.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import {
   icsResponse,
@@ -46,13 +44,8 @@ type FeedData = { events: EventWithCount[]; domain: string; title: string };
 
 /** Load feed data: active open events with domain and title */
 const loadFeedData = async (): Promise<FeedData> => {
-  const [allEvents, holidays] = await Promise.all([
-    getAllEvents(),
-    getActiveHolidays(),
-  ]);
-  const events = sortEvents(
-    allEvents.filter((e) => e.active && !e.hidden && !isRegistrationClosed(e)),
-    holidays,
+  const { events } = await loadSortedEvents(
+    (e) => e.active && !e.hidden && !isRegistrationClosed(e),
   );
   return {
     events,

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -68,21 +68,21 @@ import {
 } from "#templates/fields.ts";
 import { successPage } from "#templates/payment.tsx";
 import {
-  buildMultiTicketEvent,
+  buildTicketEvent,
   homepagePage,
-  type MultiTicketEvent,
-  multiTicketPage,
   type PublicPageType,
   publicSitePage,
+  type TicketEvent,
+  ticketPage,
 } from "#templates/public.tsx";
 
 /** Active+visible filter for public event listings */
 const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;
 
 /** Load active events for the homepage, sorted and with registration status */
-const loadHomepageEvents = async (): Promise<MultiTicketEvent[]> => {
+const loadHomepageEvents = async (): Promise<TicketEvent[]> => {
   const { events } = await loadSortedEvents(isPublicEvent);
-  return events.map((e) => buildMultiTicketEvent(e, isRegistrationClosed(e)));
+  return events.map((e) => buildTicketEvent(e, isRegistrationClosed(e)));
 };
 
 /** Guard: redirect to admin login if public site is disabled */
@@ -310,31 +310,27 @@ const validateSubmittedDate = (
 const parseSlugs = (slug: string): string[] =>
   slug.split("+").filter((s) => s.length > 0);
 
-/** Filter and transform events to active multi-ticket events */
-const getActiveMultiEvents = (
-  events: (EventWithCount | null)[],
-): MultiTicketEvent[] =>
+/** Filter and transform events to active ticket events */
+const getActiveEvents = (events: (EventWithCount | null)[]): TicketEvent[] =>
   pipe(
     filter((e: EventWithCount) => e.active),
-    map((e: EventWithCount) =>
-      buildMultiTicketEvent(e, isRegistrationClosed(e)),
-    ),
+    map((e: EventWithCount) => buildTicketEvent(e, isRegistrationClosed(e))),
   )(compact(events));
 
 /** Render ticket HTML (CSRF token auto-embedded by CsrfForm) */
-const renderMultiTicketPage = (ctx: MultiTicketCtx, error?: string) =>
-  multiTicketPage({ ...ctx, error });
+const renderTicketPage = (ctx: TicketCtx, error?: string) =>
+  ticketPage({ ...ctx, error });
 
-/** Multi-ticket response builder */
-const multiTicketResponse =
-  (ctx: MultiTicketCtx) =>
+/** Ticket response builder */
+const ticketResponse =
+  (ctx: TicketCtx) =>
   (error?: string, status = 200) =>
-    htmlResponse(renderMultiTicketPage(ctx, error), status);
+    htmlResponse(renderTicketPage(ctx, error), status);
 
 /** Shared rendering context for ticket pages */
-type MultiTicketCtx = {
+type TicketCtx = {
   slugs: string[];
-  events: MultiTicketEvent[];
+  events: TicketEvent[];
   dates: string[];
   terms: string;
   questions: QuestionWithAnswers[];
@@ -342,8 +338,8 @@ type MultiTicketCtx = {
   baseUrl?: string;
 };
 
-/** Multi-ticket form error redirect (after CSRF passed) */
-const multiTicketFormErrorResponse = (ctx: MultiTicketCtx) => {
+/** Ticket form error redirect (after CSRF passed) */
+const ticketFormErrorResponse = (ctx: TicketCtx) => {
   const url = `/ticket/${ctx.slugs.join("+")}`;
   return (error: string, _status = 400) => errorRedirect(url, error);
 };
@@ -353,23 +349,21 @@ type AsyncHandler<T extends unknown[]> = (
   ...args: T
 ) => Response | Promise<Response>;
 
-/** Load and validate active events for multi-ticket, return 404 if none */
-const withActiveMultiEvents = async (
+/** Load and validate active events, return 404 if none */
+const withActiveEvents = async (
   slugs: string[],
-  handler: AsyncHandler<[MultiTicketEvent[]]>,
+  handler: AsyncHandler<[TicketEvent[]]>,
 ): Promise<Response> => {
   const events = await getEventsBySlugsBatch(slugs);
   const active = compact(events).filter((e) => e.active);
   const activeEvents = active.map((e) =>
-    buildMultiTicketEvent(e, isRegistrationClosed(e)),
+    buildTicketEvent(e, isRegistrationClosed(e)),
   );
   return activeEvents.length === 0 ? notFoundResponse() : handler(activeEvents);
 };
 
 /** Compute shared available dates across all daily events (intersection) */
-const computeSharedDates = async (
-  events: MultiTicketEvent[],
-): Promise<string[]> => {
+const computeSharedDates = async (events: TicketEvent[]): Promise<string[]> => {
   const dailyEvents = events.filter((e) => e.event.event_type === "daily");
   if (dailyEvents.length === 0) return [];
   const holidays = await getActiveHolidays();
@@ -379,18 +373,18 @@ const computeSharedDates = async (
   return [...dateSets[0]!].filter((d) => dateSets.every((s) => s.has(d)));
 };
 
-/** Multi-ticket shared context shape */
-type MultiTicketSharedContext = {
+/** Ticket shared context shape */
+type TicketSharedContext = {
   dates: string[];
   terms: string;
   questions: QuestionWithAnswers[];
   questionEventMap: QuestionEventMap;
 };
 
-/** Fetch shared context for multi-ticket pages: dates, terms, questions */
-const getMultiTicketContext = async (
-  activeEvents: MultiTicketEvent[],
-): Promise<MultiTicketSharedContext> => {
+/** Fetch shared context for ticket pages: dates, terms, questions */
+const getTicketContext = async (
+  activeEvents: TicketEvent[],
+): Promise<TicketSharedContext> => {
   const eventIds = activeEvents.map((e) => e.event.id);
   const [dates, terms, questionsResult] = await Promise.all([
     computeSharedDates(activeEvents),
@@ -400,16 +394,13 @@ const getMultiTicketContext = async (
   return { dates, terms, ...questionsResult };
 };
 
-/** Shared context provider for multi-ticket pages */
-type MultiTicketContextProvider = (
-  events: MultiTicketEvent[],
-) => Promise<MultiTicketSharedContext>;
+/** Shared context provider for ticket pages */
+type TicketContextProvider = (
+  events: TicketEvent[],
+) => Promise<TicketSharedContext>;
 
-/** Handle POST for multi-ticket registration */
-const submitMultiTicket = (
-  request: Request,
-  ctx: MultiTicketCtx,
-): Promise<Response> =>
+/** Handle POST for ticket registration */
+const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
   withCsrfForm(
     request,
     (message) => errorRedirect(`/ticket/${ctx.slugs.join("+")}`, message),
@@ -419,11 +410,11 @@ const submitMultiTicket = (
       applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
 
       // Validate fields based on merged event settings
-      const errorResponse = multiTicketFormErrorResponse(ctx);
+      const errorResponse = ticketFormErrorResponse(ctx);
       const anyPaid = ctx.events.some((e) => isPaidEvent(e.event));
       const fieldResult = tryValidateTicketFields(
         form,
-        getMultiTicketFieldsSetting(ctx.events),
+        getTicketFieldsSetting(ctx.events),
         errorResponse,
         anyPaid,
       );
@@ -440,7 +431,7 @@ const submitMultiTicket = (
       const allUnavailable = ctx.events.every((e) => e.isSoldOut || e.isClosed);
       if (allUnavailable) {
         const allClosed = ctx.events.every((e) => e.isClosed);
-        return multiTicketFormErrorResponse(ctx)(
+        return ticketFormErrorResponse(ctx)(
           allClosed
             ? REGISTRATION_CLOSED_SUBMIT_MESSAGE
             : "Sorry, not enough spots available",
@@ -454,14 +445,14 @@ const submitMultiTicket = (
           10,
         );
         if (isClosed && selectedQty > 0) {
-          return multiTicketFormErrorResponse(ctx)(
+          return ticketFormErrorResponse(ctx)(
             REGISTRATION_CLOSED_SUBMIT_MESSAGE,
           );
         }
       }
 
       // Parse quantities
-      const quantities = parseMultiQuantities(form, ctx.events);
+      const quantities = parseQuantities(form, ctx.events);
 
       // Check at least one ticket selected
       const totalQuantity = reduce(
@@ -469,7 +460,7 @@ const submitMultiTicket = (
         0,
       )(Array.from(quantities.values()));
       if (totalQuantity === 0) {
-        return multiTicketFormErrorResponse(ctx)(
+        return ticketFormErrorResponse(ctx)(
           "Please select at least one ticket",
         );
       }
@@ -492,9 +483,7 @@ const submitMultiTicket = (
       if (dates.length > 0) {
         date = validateSubmittedDate(form, dates);
         if (!date) {
-          return multiTicketFormErrorResponse(ctx)(
-            "Please select a valid date",
-          );
+          return ticketFormErrorResponse(ctx)("Please select a valid date");
         }
       }
 
@@ -511,7 +500,7 @@ const submitMultiTicket = (
               event.max_price,
             );
             if (!priceResult.ok) {
-              return multiTicketFormErrorResponse(ctx)(
+              return ticketFormErrorResponse(ctx)(
                 `${event.name}: ${priceResult.error}`,
               );
             }
@@ -521,7 +510,7 @@ const submitMultiTicket = (
       }
 
       // Build registration items
-      const items = buildMultiRegistrationItems(
+      const items = buildRegistrationItems(
         ctx.events,
         quantities,
         customPrices,
@@ -529,13 +518,9 @@ const submitMultiTicket = (
 
       // Check if payment required
       if (await anyRequiresPayment(items)) {
-        const available = await checkMultiAvailability(
-          ctx.events,
-          quantities,
-          date,
-        );
+        const available = await checkAvailability(ctx.events, quantities, date);
         if (!available) {
-          return multiTicketFormErrorResponse(ctx)(
+          return ticketFormErrorResponse(ctx)(
             "Sorry, some tickets are no longer available",
           );
         }
@@ -559,7 +544,7 @@ const submitMultiTicket = (
       }
 
       // Free registration
-      const result = await processMultiFreeReservation(
+      const result = await processFreeReservation(
         ctx.events,
         quantities,
         contact,
@@ -567,7 +552,7 @@ const submitMultiTicket = (
       );
 
       if (!result.success) {
-        return multiTicketFormErrorResponse(ctx)(result.error);
+        return ticketFormErrorResponse(ctx)(result.error);
       }
 
       // Save per-event answers for each attendee
@@ -597,17 +582,17 @@ const submitMultiTicket = (
     },
   );
 
-const handleMultiTicket = async (
+const handleTicket = async (
   request: Request,
   actionSlugs: string[],
-  activeEvents: MultiTicketEvent[],
-  getContext: MultiTicketContextProvider,
+  activeEvents: TicketEvent[],
+  getContext: TicketContextProvider,
 ): Promise<Response> => {
   const [{ dates, terms, questions, questionEventMap }] = await Promise.all([
     getContext(activeEvents),
     signCsrfToken(),
   ]);
-  const ctx: MultiTicketCtx = {
+  const ctx: TicketCtx = {
     slugs: actionSlugs,
     events: activeEvents,
     dates,
@@ -619,24 +604,24 @@ const handleMultiTicket = async (
   if (request.method === "GET") applyFlash(request);
   const response =
     request.method === "GET"
-      ? multiTicketResponse(ctx)()
-      : await submitMultiTicket(request, ctx);
+      ? ticketResponse(ctx)()
+      : await submitTicket(request, ctx);
   const anyHidden = activeEvents.some((e) => e.event.hidden);
   return applyHiddenNoindex(response, anyHidden);
 };
 
-const handleMultiTicketBySlugs = (
+const handleTicketBySlugs = (
   request: Request,
   slugs: string[],
 ): Promise<Response> =>
-  withActiveMultiEvents(slugs, (activeEvents) =>
-    handleMultiTicket(request, slugs, activeEvents, getMultiTicketContext),
+  withActiveEvents(slugs, (activeEvents) =>
+    handleTicket(request, slugs, activeEvents, getTicketContext),
   );
 
-/** Parse quantity values from multi-ticket form */
-const parseMultiQuantities = (
+/** Parse quantity values from ticket form */
+const parseQuantities = (
   form: FormParams,
-  events: MultiTicketEvent[],
+  events: TicketEvent[],
 ): Map<number, number> => {
   const quantities = new Map<number, number>();
 
@@ -658,10 +643,10 @@ type EventQty = { event: EventWithCount; qty: number };
 
 /** Filter events to those with selected quantity, returning event and quantity */
 const eventsWithQuantity = (
-  events: MultiTicketEvent[],
+  events: TicketEvent[],
   quantities: Map<number, number>,
 ): EventQty[] => {
-  const withQty: EventQty[] = map(({ event }: MultiTicketEvent) => ({
+  const withQty: EventQty[] = map(({ event }: TicketEvent) => ({
     event,
     qty: quantities.get(event.id) ?? 0,
   }))(events);
@@ -669,8 +654,8 @@ const eventsWithQuantity = (
 };
 
 /** Check if all selected events have available spots (single efficient query) */
-const checkMultiAvailability = (
-  events: MultiTicketEvent[],
+const checkAvailability = (
+  events: TicketEvent[],
   quantities: Map<number, number>,
   date?: string | null,
 ): Promise<boolean> =>
@@ -682,17 +667,17 @@ const checkMultiAvailability = (
     date,
   );
 
-/** Build multi-registration items from events and quantities */
-const buildMultiRegistrationItems = (
-  events: MultiTicketEvent[],
+/** Build registration items from events and quantities */
+const buildRegistrationItems = (
+  events: TicketEvent[],
   quantities: Map<number, number>,
   customPrices: Map<number, number>,
 ): MultiRegistrationItem[] => {
-  const selected = filter(({ event }: MultiTicketEvent) => {
+  const selected = filter(({ event }: TicketEvent) => {
     const qty = quantities.get(event.id);
     return qty !== undefined && qty > 0;
   })(events);
-  return map(({ event }: MultiTicketEvent) => ({
+  return map(({ event }: TicketEvent) => ({
     eventId: event.id,
     quantity: quantities.get(event.id)!,
     unitPrice: customPrices.get(event.id) ?? event.unit_price,
@@ -708,26 +693,26 @@ const anyRequiresPayment = (items: MultiRegistrationItem[]): boolean => {
   return items.some((item) => item.unitPrice > 0);
 };
 
-/** Handle payment flow for multi-ticket purchase */
+/** Handle payment flow for ticket purchase */
 const handleMultiPaymentFlow = (
   request: Request,
   intent: MultiRegistrationIntent,
-  ctx: MultiTicketCtx,
+  ctx: TicketCtx,
 ): Promise<Response> =>
   runCheckoutFlow(
-    `multi-ticket items=${intent.items.length}`,
+    `ticket items=${intent.items.length}`,
     request,
     (provider, baseUrl) => provider.createMultiCheckoutSession(intent, baseUrl),
     (msg) => errorRedirect(`/ticket/${ctx.slugs.join("+")}`, msg),
   );
 
-/** Determine merged fields setting for multi-ticket events */
-const getMultiTicketFieldsSetting = (events: MultiTicketEvent[]): EventFields =>
+/** Determine merged fields setting for selected events */
+const getTicketFieldsSetting = (events: TicketEvent[]): EventFields =>
   mergeEventFields(events.map((e) => e.event.fields));
 
-/** Handle free multi-ticket registration */
-const processMultiFreeReservation = async (
-  events: MultiTicketEvent[],
+/** Handle free ticket registration */
+const processFreeReservation = async (
+  events: TicketEvent[],
   quantities: Map<number, number>,
   contact: ContactInfo,
   date: string | null,
@@ -761,8 +746,8 @@ const processMultiFreeReservation = async (
 };
 
 /** Context provider for group pages (terms override + shared dates) */
-const getGroupMultiTicketContext =
-  (group: Group): MultiTicketContextProvider =>
+const getGroupTicketContext =
+  (group: Group): TicketContextProvider =>
   async (events) => {
     const eventIds = events.map((e) => e.event.id);
     const [dates, globalTerms, questionsResult] = await Promise.all([
@@ -777,7 +762,7 @@ const getGroupMultiTicketContext =
 /** Load group by slug and its active events, return 404 if empty */
 const withActiveGroupEventsBySlug = async (
   slug: string,
-  handler: AsyncHandler<[Group, MultiTicketEvent[]]>,
+  handler: AsyncHandler<[Group, TicketEvent[]]>,
 ): Promise<Response> => {
   const slugIndex = await computeGroupSlugIndex(slug);
   const group = await getGroupBySlugIndex(slugIndex);
@@ -787,7 +772,7 @@ const withActiveGroupEventsBySlug = async (
     getActiveEventsByGroupId(group.id),
     getActiveHolidays(),
   ]);
-  const activeEvents = getActiveMultiEvents(sortEvents(events, holidays));
+  const activeEvents = getActiveEvents(sortEvents(events, holidays));
   return activeEvents.length === 0
     ? notFoundResponse()
     : handler(group, activeEvents);
@@ -798,12 +783,7 @@ const handleGroupTicketBySlug = (
   slug: string,
 ): Promise<Response> =>
   withActiveGroupEventsBySlug(slug, (group, activeEvents) =>
-    handleMultiTicket(
-      request,
-      [slug],
-      activeEvents,
-      getGroupMultiTicketContext(group),
-    ),
+    handleTicket(request, [slug], activeEvents, getGroupTicketContext(group)),
   );
 
 /** Get the email from-address if email is configured. Returns empty string if not. */
@@ -830,7 +810,7 @@ const handleTicketBySlug = async (
   { slug }: { slug: string },
 ): Promise<Response> => {
   const slugs = parseSlugs(slug);
-  const response = await handleMultiTicketBySlugs(request, slugs);
+  const response = await handleTicketBySlugs(request, slugs);
   // For single slugs, fall back to group lookup on 404
   if (response.status === 404 && slugs.length === 1) {
     return handleGroupTicketBySlug(request, slugs[0]!);

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -3,7 +3,6 @@
  */
 
 import { compact, filter, map, pipe, reduce } from "#fp";
-import { type BookingResult, processBooking } from "#lib/booking.ts";
 import { getEffectiveDomain, isPaymentsEnabled } from "#lib/config.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { validatePrice } from "#lib/currency.ts";
@@ -13,7 +12,6 @@ import {
   createAttendeeAtomic,
 } from "#lib/db/attendees.ts";
 import {
-  getAllEvents,
   getEventsBySlugsBatch,
   getEventWithCountBySlug,
 } from "#lib/db/events.ts";
@@ -24,7 +22,6 @@ import {
 } from "#lib/db/groups.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import {
-  getQuestionsForEvent,
   getQuestionsWithEventIds,
   type QuestionEventMap,
   type QuestionWithAnswers,
@@ -42,7 +39,7 @@ import {
   type MultiRegistrationItem,
 } from "#lib/payments.ts";
 import { generateQrSvg } from "#lib/qr.ts";
-import { sortEvents } from "#lib/sort-events.ts";
+import { loadSortedEvents, sortEvents } from "#lib/sort-events.ts";
 import {
   type ContactInfo,
   type EventFields,
@@ -62,7 +59,6 @@ import {
   isRegistrationClosed,
   notFoundResponse,
   redirectResponse,
-  withActiveEventBySlug,
   withCsrfForm,
 } from "#routes/utils.ts";
 import {
@@ -78,20 +74,15 @@ import {
   multiTicketPage,
   type PublicPageType,
   publicSitePage,
-  ticketPage,
 } from "#templates/public.tsx";
+
+/** Active+visible filter for public event listings */
+const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;
 
 /** Load active events for the homepage, sorted and with registration status */
 const loadHomepageEvents = async (): Promise<MultiTicketEvent[]> => {
-  const [allEvents, holidays] = await Promise.all([
-    getAllEvents(),
-    getActiveHolidays(),
-  ]);
-  const sorted = sortEvents(
-    allEvents.filter((e) => e.active && !e.hidden),
-    holidays,
-  );
-  return sorted.map((e) => buildMultiTicketEvent(e, isRegistrationClosed(e)));
+  const { events } = await loadSortedEvents(isPublicEvent);
+  return events.map((e) => buildMultiTicketEvent(e, isRegistrationClosed(e)));
 };
 
 /** Guard: redirect to admin login if public site is disabled */
@@ -145,105 +136,10 @@ export const handlePublicContact = (): Response =>
       : notFoundResponse(),
   );
 
-/** Render a ticket page with the given context */
-const renderTicketPage = (
-  event: EventWithCount,
-  ctx: TicketContext,
-  opts: { isClosed: boolean; baseUrl?: string; error?: string },
-) =>
-  ticketPage(
-    event,
-    opts.error,
-    opts.isClosed,
-    ctx.dates,
-    ctx.terms,
-    opts.baseUrl,
-    ctx.questions,
-  );
-
-/** Ticket response builder (CSRF token auto-embedded by CsrfForm) */
-const ticketResponseWithToken =
-  (
-    event: EventWithCount,
-    ctx: TicketContext,
-    opts: { isClosed: boolean; baseUrl?: string },
-  ) =>
-  (error?: string, status = 200) =>
-    htmlResponse(renderTicketPage(event, ctx, { ...opts, error }), status);
-
-/** Ticket error redirect - for validation errors after CSRF passed */
-const ticketError =
-  (event: EventWithCount, _ctx: TicketContext) =>
-  (error: string, _status = 400) =>
-    errorRedirect(`/ticket/${event.slug}`, error);
-
-/** Compute available dates for a daily event, or undefined for standard */
-const computeDatesForEvent = async (
-  event: EventWithCount,
-): Promise<string[] | undefined> => {
-  if (event.event_type !== "daily") return undefined;
-  return getAvailableDates(event, await getActiveHolidays());
-};
-
 /** Set noindex signal header on response for hidden events */
 const applyHiddenNoindex = (response: Response, hidden: boolean): Response => {
   if (hidden) response.headers.set("x-robots-noindex", "true");
   return response;
-};
-
-/** Handle GET for a single-ticket page */
-const handleSingleTicketGet = (
-  slug: string,
-  request: Request,
-): Promise<Response> =>
-  withActiveEventBySlug(slug, async (event) => {
-    const closed = isRegistrationClosed(event);
-    applyFlash(request);
-    await signCsrfToken();
-    const [dates, terms, questions] = await Promise.all([
-      computeDatesForEvent(event),
-      Promise.resolve(settings.terms),
-      getQuestionsForEvent(event.id),
-    ]);
-    const ctx: TicketContext = { dates, terms, questions };
-    return applyHiddenNoindex(
-      ticketResponseWithToken(event, ctx, {
-        isClosed: closed,
-        baseUrl: getBaseUrl(request),
-      })(),
-      event.hidden,
-    );
-  });
-
-/** Map a BookingResult to a web response for single-ticket pages */
-const bookingResultToWebResponse = async (
-  result: BookingResult,
-  event: EventWithCount,
-  ctx: TicketContext,
-  answerIds: number[] = [],
-): Promise<Response> => {
-  const showError = ticketError(event, ctx);
-  switch (result.type) {
-    case "success": {
-      if (answerIds.length > 0) {
-        await saveAttendeeAnswers([result.attendee.id], answerIds);
-      }
-      if (event.thank_you_url) return redirectResponse(event.thank_you_url);
-      return redirectResponse(
-        `/ticket/reserved?tokens=${encodeURIComponent(result.attendee.ticket_token)}`,
-      );
-    }
-    case "checkout":
-      return checkoutResponse(result.checkoutUrl);
-    case "sold_out":
-      return showError("Sorry, not enough spots available");
-    case "checkout_failed":
-      return result.error
-        ? showError(result.error)
-        : showError("Failed to create payment session. Please try again.", 500);
-    case "creation_failed":
-      return showError(formatAtomicError(result.reason));
-  }
 };
 
 /** Try to redirect to checkout, or return error using provided handler.
@@ -320,13 +216,6 @@ const runCheckoutFlow = (
   );
 };
 
-/** Shared context for ticket page rendering */
-type TicketContext = {
-  dates: string[] | undefined;
-  terms: string | null | undefined;
-  questions: QuestionWithAnswers[];
-};
-
 /** Parse and validate a quantity value from a raw string, capping at max */
 const parseQuantityValue = (
   raw: string,
@@ -338,10 +227,6 @@ const parseQuantityValue = (
   return Math.min(quantity, max);
 };
 
-/** Parse quantity from single-ticket form */
-const parseQuantity = (form: FormParams, event: EventWithCount): number =>
-  parseQuantityValue(form.get("quantity") || "1", event.max_quantity);
-
 /** Parse and validate a custom unit price from a form field.
  * Returns the price in minor units, or an error string if invalid. */
 const parseCustomPrice = (
@@ -352,11 +237,17 @@ const parseCustomPrice = (
 ) => validatePrice(form.getString(fieldName), minPrice, maxPrice);
 
 /** Format error message for failed attendee creation */
-const formatAtomicError = formatCreationError(
-  "Sorry, not enough spots available",
-  (name) => `Sorry, ${name} no longer has enough spots available`,
-  "Registration failed. Please try again.",
-);
+const formatAtomicError = (
+  reason: "capacity_exceeded" | "encryption_error",
+  eventName = "",
+): string =>
+  formatCreationError(
+    "Sorry, not enough spots available",
+    (name) => `Sorry, ${name} no longer has enough spots available`,
+    "Registration failed. Please try again.",
+    reason,
+    eventName,
+  );
 
 /** Parse and validate answers for custom questions from form data.
  * Returns answer IDs if valid, or an error message if any required question is unanswered. */
@@ -415,98 +306,8 @@ const validateSubmittedDate = (
   return submitted && dates.includes(submitted) ? submitted : null;
 };
 
-const processTicketReservation = async (
-  request: Request,
-  event: EventWithCount,
-): Promise<Response> => {
-  const [terms, questions] = await Promise.all([
-    Promise.resolve(settings.terms),
-    getQuestionsForEvent(event.id),
-  ]);
-  const ctx: TicketContext = { dates: undefined, terms, questions };
-  const showError = ticketError(event, ctx);
-
-  return withCsrfForm(
-    request,
-    (message) => errorRedirect(`/ticket/${event.slug}`, message),
-    async (form) => {
-      if (isRegistrationClosed(event)) {
-        return showError(REGISTRATION_CLOSED_SUBMIT_MESSAGE);
-      }
-
-      applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-      const valResult = tryValidateTicketFields(
-        form,
-        event.fields,
-        (msg) => showError(msg),
-        isPaidEvent(event),
-      );
-      if (valResult instanceof Response) return valResult;
-      const values = valResult;
-
-      if (terms && form.get("agree_terms") !== "1") {
-        return showError("You must agree to the terms and conditions");
-      }
-
-      const answersResult = parseQuestionAnswers(form, questions);
-      if (!answersResult.ok) return showError(answersResult.error);
-
-      // For daily events, validate the submitted date against available dates
-      let date: string | null = null;
-      if (event.event_type === "daily") {
-        ctx.dates = getAvailableDates(event, await getActiveHolidays());
-        date = validateSubmittedDate(form, ctx.dates);
-        if (!date) return showError("Please select a valid date");
-      }
-      const quantity = parseQuantity(form, event);
-
-      // Parse custom price for pay-more events
-      let customUnitPrice: number | undefined;
-      if (event.can_pay_more) {
-        const priceResult = parseCustomPrice(
-          form,
-          "custom_price",
-          event.unit_price,
-          event.max_price,
-        );
-        if (!priceResult.ok) return showError(priceResult.error);
-        customUnitPrice = priceResult.price;
-      }
-
-      const contact = extractContact(values);
-      const bookingResult = await processBooking(
-        event,
-        contact,
-        quantity,
-        date,
-        getBaseUrl(request),
-        customUnitPrice,
-        answersResult.answerIds,
-      );
-      return bookingResultToWebResponse(
-        bookingResult,
-        event,
-        ctx,
-        answersResult.answerIds,
-      );
-    },
-  );
-};
-
-/** Handle POST for a single-ticket reservation */
-const handleSingleTicketPost = (
-  request: Request,
-  slug: string,
-): Promise<Response> =>
-  withActiveEventBySlug(slug, (event) =>
-    processTicketReservation(request, event),
-  );
-
-/** Check if slug contains multiple events (has + separator) */
-const isMultiSlug = (slug: string): boolean => slug.includes("+");
-
-/** Parse multi-ticket slugs from a combined slug string */
-const parseMultiSlugs = (slug: string): string[] =>
+/** Parse slugs from a slug string (may contain + separator for multiple events) */
+const parseSlugs = (slug: string): string[] =>
   slug.split("+").filter((s) => s.length > 0);
 
 /** Filter and transform events to active multi-ticket events */
@@ -520,7 +321,7 @@ const getActiveMultiEvents = (
     ),
   )(compact(events));
 
-/** Render multi-ticket HTML (CSRF token auto-embedded by CsrfForm) */
+/** Render ticket HTML (CSRF token auto-embedded by CsrfForm) */
 const renderMultiTicketPage = (ctx: MultiTicketCtx, error?: string) =>
   multiTicketPage({ ...ctx, error });
 
@@ -530,7 +331,7 @@ const multiTicketResponse =
   (error?: string, status = 200) =>
     htmlResponse(renderMultiTicketPage(ctx, error), status);
 
-/** Shared rendering context for multi-ticket error responses */
+/** Shared rendering context for ticket pages */
 type MultiTicketCtx = {
   slugs: string[];
   events: MultiTicketEvent[];
@@ -538,6 +339,7 @@ type MultiTicketCtx = {
   terms: string;
   questions: QuestionWithAnswers[];
   questionEventMap: QuestionEventMap;
+  baseUrl?: string;
 };
 
 /** Multi-ticket form error redirect (after CSRF passed) */
@@ -603,12 +405,6 @@ type MultiTicketContextProvider = (
   events: MultiTicketEvent[],
 ) => Promise<MultiTicketSharedContext>;
 
-/** Load shared meta for multi-ticket pages */
-const loadMultiTicketMeta = (
-  activeEvents: MultiTicketEvent[],
-  getContext: MultiTicketContextProvider,
-): Promise<MultiTicketSharedContext> => getContext(activeEvents);
-
 /** Handle POST for multi-ticket registration */
 const submitMultiTicket = (
   request: Request,
@@ -637,6 +433,18 @@ const submitMultiTicket = (
       // Validate terms and conditions acceptance if configured
       if (terms && form.get("agree_terms") !== "1") {
         return errorResponse("You must agree to the terms and conditions");
+      }
+
+      // Re-check registration status: events may have closed or sold out
+      // since the form was rendered
+      const allUnavailable = ctx.events.every((e) => e.isSoldOut || e.isClosed);
+      if (allUnavailable) {
+        const allClosed = ctx.events.every((e) => e.isClosed);
+        return multiTicketFormErrorResponse(ctx)(
+          allClosed
+            ? REGISTRATION_CLOSED_SUBMIT_MESSAGE
+            : "Sorry, not enough spots available",
+        );
       }
 
       // Check if any event the user selected is now closed
@@ -778,6 +586,12 @@ const submitMultiTicket = (
         }
       }
 
+      // For single-event bookings, respect the event's custom thank-you URL
+      if (ctx.events.length === 1) {
+        const thankYouUrl = ctx.events[0]!.event.thank_you_url;
+        if (thankYouUrl) return redirectResponse(thankYouUrl);
+      }
+
       const tokens = encodeURIComponent(result.tokens.join("+"));
       return redirectResponse(`/ticket/reserved?tokens=${tokens}`);
     },
@@ -790,7 +604,7 @@ const handleMultiTicket = async (
   getContext: MultiTicketContextProvider,
 ): Promise<Response> => {
   const [{ dates, terms, questions, questionEventMap }] = await Promise.all([
-    loadMultiTicketMeta(activeEvents, getContext),
+    getContext(activeEvents),
     signCsrfToken(),
   ]);
   const ctx: MultiTicketCtx = {
@@ -800,6 +614,7 @@ const handleMultiTicket = async (
     terms,
     questions,
     questionEventMap,
+    baseUrl: getBaseUrl(request),
   };
   if (request.method === "GET") applyFlash(request);
   const response =
@@ -1009,38 +824,19 @@ const handleReservedGet = async (request: Request): Promise<Response> => {
   return htmlResponse(successPage({ ticketUrl, fromEmail }));
 };
 
-/** Create a slug route that dispatches single vs multi-ticket requests */
-const slugRoute =
-  (
-    onSingle: (request: Request, slug: string) => Promise<Response>,
-    onMulti: (request: Request, slugs: string[]) => Promise<Response>,
-  ) =>
-  (request: Request, { slug }: { slug: string }): Promise<Response> =>
-    isMultiSlug(slug)
-      ? onMulti(request, parseMultiSlugs(slug))
-      : onSingle(request, slug);
-
-/** Wrap a single-slug handler with group fallback on 404 */
-const withGroupFallback =
-  (fn: (request: Request, slug: string) => Promise<Response>) =>
-  async (request: Request, slug: string): Promise<Response> => {
-    const response = await fn(request, slug);
-    return response.status === 404
-      ? handleGroupTicketBySlug(request, slug)
-      : response;
-  };
-
-/** Handle GET /ticket/:slug (event first, then group fallback) */
-const handleTicketGet = slugRoute(
-  withGroupFallback((request, slug) => handleSingleTicketGet(slug, request)),
-  handleMultiTicketBySlugs,
-);
-
-/** Handle POST /ticket/:slug (event first, then group fallback) */
-const handleTicketPost = slugRoute(
-  withGroupFallback(handleSingleTicketPost),
-  handleMultiTicketBySlugs,
-);
+/** Handle ticket request: try events by slugs, fall back to group for single slugs */
+const handleTicketBySlug = async (
+  request: Request,
+  { slug }: { slug: string },
+): Promise<Response> => {
+  const slugs = parseSlugs(slug);
+  const response = await handleMultiTicketBySlugs(request, slugs);
+  // For single slugs, fall back to group lookup on 404
+  if (response.status === 404 && slugs.length === 1) {
+    return handleGroupTicketBySlug(request, slugs[0]!);
+  }
+  return response;
+};
 
 /** Generate a QR code SVG response for a given slug */
 const qrResponse = async (slug: string): Promise<Response> => {
@@ -1070,8 +866,8 @@ export const handleTicketQrGet = async (
 const publicRoutes = defineRoutes({
   "GET /ticket/reserved": handleReservedGet,
   "GET /ticket/:slug/qr": handleTicketQrGet,
-  "GET /ticket/:slug": handleTicketGet,
-  "POST /ticket/:slug": handleTicketPost,
+  "GET /ticket/:slug": handleTicketBySlug,
+  "POST /ticket/:slug": handleTicketBySlug,
 });
 
 /** Route ticket requests */

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -71,7 +71,7 @@ const isNumericParam = (name: string): boolean =>
 const getParamPattern = (name: string): string => {
   // Params ending in Id match digits only (e.g., eventId, attendeeId)
   if (isNumericParam(name)) return "(\\d+)";
-  // Slugs match lowercase alphanumeric with hyphens and + (for multi-ticket URLs)
+  // Slugs match lowercase alphanumeric with hyphens and + (for multi-event URLs)
   if (name === "slug") return "([a-z0-9]+(?:[-+][a-z0-9]+)*)";
   // Default: match any non-slash characters
   return "([^/]+)";

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -15,7 +15,7 @@ import {
   verifySignedCsrfToken,
 } from "#lib/csrf.ts";
 import { getApiKeyByToken, touchApiKeyLastUsed } from "#lib/db/api-keys.ts";
-import { getEventWithCount, getEventWithCountBySlug } from "#lib/db/events.ts";
+import { getEventWithCount } from "#lib/db/events.ts";
 import { deleteSession, getSession } from "#lib/db/sessions.ts";
 import { settings } from "#lib/db/settings.ts";
 import { decryptAdminLevel, getUserById } from "#lib/db/users.ts";
@@ -453,49 +453,25 @@ export const withEventPage = (
     htmlResponse(renderPage(event, session)),
   );
 
-/** Handler function that takes an event and returns a Response */
-type EventHandler = (event: EventWithCount) => Response | Promise<Response>;
-
-/** Load event by slug or return 404 */
-export const withEventBySlug = (
-  slug: string,
-  handler: EventHandler,
-): Promise<Response> => orNotFound(getEventWithCountBySlug(slug), handler);
-
-/** Check if event is active, return 404 if not */
-const requireActiveEvent =
-  (handler: (event: EventWithCount) => Response | Promise<Response>) =>
-  (event: EventWithCount): Response | Promise<Response> =>
-    event.active ? handler(event) : notFoundResponse();
-
-/** Handle event by slug with active check - return 404 if not found or inactive */
-export const withActiveEventBySlug = (
-  slug: string,
-  fn: (event: EventWithCount) => Response | Promise<Response>,
-): Promise<Response> => withEventBySlug(slug, requireActiveEvent(fn));
-
 /** Check if an event's registration period has closed */
 export const isRegistrationClosed = (event: {
   closes_at: string | null;
 }): boolean =>
   event.closes_at !== null && new Date(event.closes_at).getTime() < nowMs();
 
-/** Create a formatter for attendee creation failures (capacity_exceeded / encryption_error) */
-export const formatCreationError =
-  (
-    capacityMsg: string,
-    capacityMsgWithName: (name: string) => string,
-    fallbackMsg: string,
-  ) =>
-  (
-    reason: "capacity_exceeded" | "encryption_error",
-    eventName?: string,
-  ): string =>
-    reason === "capacity_exceeded"
-      ? eventName
-        ? capacityMsgWithName(eventName)
-        : capacityMsg
-      : fallbackMsg;
+/** Format an attendee creation failure (capacity_exceeded / encryption_error).
+ * Dispatches on reason and optional eventName. */
+export const formatCreationError = (
+  capacityMsg: string,
+  capacityMsgWithName: (name: string) => string,
+  fallbackMsg: string,
+  reason: "capacity_exceeded" | "encryption_error",
+  eventName: string,
+): string => {
+  if (reason !== "capacity_exceeded") return fallbackMsg;
+  if (eventName) return capacityMsgWithName(eventName);
+  return capacityMsg;
+};
 
 /** Format a countdown from now to a future closes_at date, e.g. "3 days and 5 hours from now" */
 export const formatCountdown = (closesAt: string): string => {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -373,11 +373,17 @@ const hasPriceMismatch = (
 };
 
 /** Format error for post-payment attendee creation failure */
-const formatPostPaymentError = formatCreationError(
-  "Sorry, this event sold out while you were completing payment.",
-  (name) => `Sorry, ${name} sold out while you were completing payment.`,
-  "Registration failed.",
-);
+const formatPostPaymentError = (
+  reason: "capacity_exceeded" | "encryption_error",
+  eventName = "",
+): string =>
+  formatCreationError(
+    "Sorry, this event sold out while you were completing payment.",
+    (name) => `Sorry, ${name} sold out while you were completing payment.`,
+    "Registration failed.",
+    reason,
+    eventName,
+  );
 
 /** Return success result for an already-processed session */
 const alreadyProcessedResult = async (

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -223,14 +223,6 @@ const renderDateSelector = (dates: string[]): string =>
 /** Quantity values parsed from multi-ticket form */
 export type MultiTicketQuantities = Map<number, number>;
 
-/**
- * Build quantity select options
- */
-const quantityOptions = (max: number): string =>
-  Array.from({ length: max }, (_, i) => i + 1)
-    .map((n) => `<option value="${n}">${n}</option>`)
-    .join("");
-
 /** Render a price input for pay-more events */
 const renderPayMoreInput = (
   event: Pick<EventWithCount, "unit_price" | "max_price">,
@@ -276,100 +268,6 @@ export const renderQuestions = (
       return `<fieldset class="custom-question"${eventAttr}><legend>${escapeHtml(q.text)}</legend>${options}</fieldset>`;
     })
     .join("");
-};
-
-/**
- * Public ticket page
- */
-export const ticketPage = (
-  event: EventWithCount,
-  error: string | undefined,
-  isClosed: boolean,
-  availableDates: string[] | undefined,
-  termsAndConditions: string | null | undefined,
-  baseUrl?: string,
-  questions?: QuestionWithAnswers[],
-): string => {
-  const inIframe = getIframeMode();
-  const spotsRemaining = event.max_attendees - event.attendee_count;
-  const isFull = spotsRemaining <= 0;
-  const maxPurchasable = Math.min(event.max_quantity, spotsRemaining);
-  const showQuantity = maxPurchasable > 1;
-  const fields: Field[] = getTicketFields(event.fields, isPaidEvent(event));
-  const isDaily = event.event_type === "daily";
-  const headExtra = baseUrl ? buildOgTags(event, baseUrl) : undefined;
-  const showPayMore = event.can_pay_more;
-  const pastDays = event.date ? daysAgo(event.date) : null;
-
-  return String(
-    <Layout
-      title={event.name}
-      bodyClass={inIframe ? "iframe" : undefined}
-      headExtra={headExtra}
-    >
-      {!inIframe && (
-        <>
-          <Raw html={renderEventImage(event)} />
-          <div class="prose">
-            <h1>{event.name}</h1>
-            {event.description && (
-              <div class="description">
-                <Raw html={renderMarkdownInline(event.description)} />
-              </div>
-            )}
-            {event.date && (
-              <p>
-                <strong>Date:</strong> {formatDatetimeLabel(event.date)}
-                {pastDays !== null && (
-                  <span class="badge-alert">
-                    {" "}
-                    {pastDays} {pastDays === 1 ? "day" : "days"} ago
-                  </span>
-                )}
-              </p>
-            )}
-            {event.location && (
-              <p>
-                <strong>Location:</strong> {event.location}
-              </p>
-            )}
-          </div>
-        </>
-      )}
-      <Raw html={renderError(error)} />
-
-      {isClosed ? (
-        <div class="error">Registration closed.</div>
-      ) : isFull ? (
-        <div class="error">Sorry, this event is full.</div>
-      ) : (
-        <CsrfForm action={`/ticket/${event.slug}`}>
-          <Raw html={renderFields(fields)} />
-          {isDaily && availableDates && (
-            <Raw html={renderDateSelector(availableDates)} />
-          )}
-          {showQuantity ? (
-            <label>
-              Number of Tickets
-              <select name="quantity">
-                <Raw html={quantityOptions(maxPurchasable)} />
-              </select>
-            </label>
-          ) : (
-            <input type="hidden" name="quantity" value="1" />
-          )}
-          {showPayMore && <Raw html={renderPayMoreInput(event)} />}
-          {questions && questions.length > 0 && (
-            <Raw html={renderQuestions(questions)} />
-          )}
-          {termsAndConditions && (
-            <Raw html={renderTermsAndCheckbox(termsAndConditions)} />
-          )}
-          <button type="submit">Reserve Ticket{showQuantity ? "s" : ""}</button>
-        </CsrfForm>
-      )}
-    </Layout>,
-  );
 };
 
 /**
@@ -477,13 +375,33 @@ const renderMultiEventRow = (
   `;
 };
 
+/** Render controls for a single event: quantity input + pay-more (no event name/image/description). */
+const renderSingleEventControls = (
+  info: MultiTicketEvent,
+  hideQuantity: boolean,
+): string => {
+  const { event, maxPurchasable } = info;
+  const fieldName = `quantity_${event.id}`;
+  const quantityHtml = hideQuantity
+    ? `<input type="hidden" name="${fieldName}" value="1" />`
+    : (() => {
+        const options = Array.from({ length: maxPurchasable + 1 }, (_, i) => i)
+          .map((n) => `<option value="${n}">${n}</option>`)
+          .join("");
+        return `<label>Number of Tickets<select name="${fieldName}">${options}</select></label>`;
+      })();
+  const showPayMore = event.can_pay_more;
+  const priceFieldName = `custom_price_${event.id}`;
+  return `${quantityHtml}${showPayMore ? renderPayMoreInput(event, priceFieldName) : ""}`;
+};
+
 /**
  * Determine the merged fields setting for a set of multi-ticket events
  */
 const getMultiTicketFieldsSetting = (events: MultiTicketEvent[]): EventFields =>
   mergeEventFields(events.map((e) => e.event.fields));
 
-/** Options for the multi-ticket page */
+/** Options for the ticket page */
 export type MultiTicketPageOptions = {
   events: MultiTicketEvent[];
   slugs: string[];
@@ -492,10 +410,13 @@ export type MultiTicketPageOptions = {
   terms?: string | null;
   questions?: QuestionWithAnswers[];
   questionEventMap?: QuestionEventMap;
+  baseUrl?: string;
 };
 
 /**
- * Multi-ticket page - register for multiple events at once
+ * Ticket page - register for one or more events
+ * Single events show rich details (image, description, date, location).
+ * Multiple events show a compact row layout with per-event quantity selectors.
  */
 export const multiTicketPage = ({
   events,
@@ -505,6 +426,7 @@ export const multiTicketPage = ({
   terms,
   questions,
   questionEventMap,
+  baseUrl,
 }: MultiTicketPageOptions): string => {
   const inIframe = getIframeMode();
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
@@ -514,30 +436,79 @@ export const multiTicketPage = ({
   const fields: Field[] = getTicketFields(fieldsSetting, anyPaid);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
 
+  const isSingleEvent = events.length === 1;
+  const singleEvent = isSingleEvent ? events[0]!.event : null;
+  const pastDays = singleEvent?.date ? daysAgo(singleEvent.date) : null;
+
   const availableEvents = events.filter((e) => !e.isSoldOut && !e.isClosed);
   const hideQuantity =
     availableEvents.length === 1 && availableEvents[0]?.maxPurchasable === 1;
 
-  const eventRows = events
-    .map((e) => renderMultiEventRow(e, hideQuantity))
-    .join("");
+  // For single events, render just the quantity/pay-more controls (event details are in the header).
+  // For multiple events, render full event rows with name, image, and description.
+  const eventRows = isSingleEvent
+    ? renderSingleEventControls(events[0]!, hideQuantity)
+    : events.map((e) => renderMultiEventRow(e, hideQuantity)).join("");
+
+  const title = singleEvent ? singleEvent.name : "Reserve Tickets";
+  const headExtra =
+    singleEvent && baseUrl ? buildOgTags(singleEvent, baseUrl) : undefined;
+  const buttonText =
+    isSingleEvent && hideQuantity ? "Reserve Ticket" : "Reserve Tickets";
 
   return String(
-    <Layout title="Reserve Tickets" bodyClass={inIframe ? "iframe" : undefined}>
+    <Layout
+      title={title}
+      bodyClass={inIframe ? "iframe" : undefined}
+      headExtra={headExtra}
+    >
+      {singleEvent && !inIframe && (
+        <>
+          <Raw html={renderEventImage(singleEvent)} />
+          <div class="prose">
+            <h1>{singleEvent.name}</h1>
+            {singleEvent.description && (
+              <div class="description">
+                <Raw html={renderMarkdownInline(singleEvent.description)} />
+              </div>
+            )}
+            {singleEvent.date && (
+              <p>
+                <strong>Date:</strong> {formatDatetimeLabel(singleEvent.date)}
+                {pastDays !== null && (
+                  <span class="badge-alert">
+                    {" "}
+                    {pastDays} {pastDays === 1 ? "day" : "days"} ago
+                  </span>
+                )}
+              </p>
+            )}
+            {singleEvent.location && (
+              <p>
+                <strong>Location:</strong> {singleEvent.location}
+              </p>
+            )}
+          </div>
+        </>
+      )}
       <Raw html={renderError(error)} />
 
       {allUnavailable ? (
         <div class="error">
-          {allClosed
-            ? "Registration closed."
-            : "Sorry, all events are sold out."}
+          {isSingleEvent
+            ? allClosed
+              ? "Registration closed."
+              : "Sorry, this event is full."
+            : allClosed
+              ? "Registration closed."
+              : "Sorry, all events are sold out."}
         </div>
       ) : (
         <CsrfForm action={`/ticket/${slugs.join("+")}`}>
           <Raw html={renderFields(fields)} />
           {hasDaily && dates && <Raw html={renderDateSelector(dates)} />}
 
-          {hideQuantity ? (
+          {hideQuantity || isSingleEvent ? (
             <Raw html={eventRows} />
           ) : (
             <fieldset class="multi-ticket-events">
@@ -550,7 +521,7 @@ export const multiTicketPage = ({
             <Raw html={renderQuestions(questions, questionEventMap)} />
           )}
           {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
-          <button type="submit">Reserve Tickets</button>
+          <button type="submit">{buttonText}</button>
         </CsrfForm>
       )}
     </Layout>,

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -103,7 +103,7 @@ export const publicSitePage = (
 };
 
 /** Render a single event listing for the events page */
-const renderEventListing = (info: MultiTicketEvent): string => {
+const renderEventListing = (info: TicketEvent): string => {
   const { event, isSoldOut, isClosed } = info;
   const details: string[] = [];
   if (event.location)
@@ -137,7 +137,7 @@ export const ICS_DISCOVERY_TAG =
 export const FEED_DISCOVERY_TAGS = `${RSS_DISCOVERY_TAG}\n${ICS_DISCOVERY_TAG}`;
 
 export const homepagePage = (
-  events: MultiTicketEvent[],
+  events: TicketEvent[],
   websiteTitle?: string | null,
 ): string => {
   const title = websiteTitle ? `Events - ${websiteTitle}` : "Events";
@@ -220,8 +220,8 @@ const renderDateSelector = (dates: string[]): string =>
          ${dates.map((d) => `<option value="${d}">${formatDateLabel(d)}</option>`).join("")}
        </select>`;
 
-/** Quantity values parsed from multi-ticket form */
-export type MultiTicketQuantities = Map<number, number>;
+/** Quantity values parsed from ticket form */
+export type TicketQuantities = Map<number, number>;
 
 /** Render a price input for pay-more events */
 const renderPayMoreInput = (
@@ -246,7 +246,7 @@ const renderTermsAndCheckbox = (terms: string): string =>
   `<label class="terms-agree"><input type="checkbox" name="agree_terms" value="1" required> I agree to the terms above</label>`;
 
 /** Render custom multiple-choice question fields (radio buttons).
- * When questionEventMap is provided (multi-ticket), adds data-event-ids
+ * When questionEventMap is provided, adds data-event-ids
  * so JS can show/hide questions based on selected event quantities. */
 export const renderQuestions = (
   questions: QuestionWithAnswers[],
@@ -297,19 +297,19 @@ export const temporaryErrorPage = (): string =>
     </Layout>,
   );
 
-/** Event info for multi-ticket display */
-export type MultiTicketEvent = {
+/** Event info for ticket display */
+export type TicketEvent = {
   event: EventWithCount;
   isSoldOut: boolean;
   isClosed: boolean;
   maxPurchasable: number;
 };
 
-/** Build multi-ticket event info from event */
-export const buildMultiTicketEvent = (
+/** Build ticket event info from event */
+export const buildTicketEvent = (
   event: EventWithCount,
   closed = false,
-): MultiTicketEvent => {
+): TicketEvent => {
   const spotsRemaining = event.max_attendees - event.attendee_count;
   const isSoldOut = spotsRemaining <= 0;
   const maxPurchasable =
@@ -317,24 +317,21 @@ export const buildMultiTicketEvent = (
   return { event, isSoldOut, isClosed: closed, maxPurchasable };
 };
 
-/** Render description HTML for multi-ticket event row */
-const renderMultiEventDescription = (description: string): string =>
+/** Render description HTML for event row */
+const renderEventDescription = (description: string): string =>
   description
     ? `<div class="description-compact">${renderMarkdownInline(description)}</div>`
     : "";
 
-/** Render quantity selector for a single event in multi-ticket form */
-const renderMultiEventRow = (
-  info: MultiTicketEvent,
-  hideQuantity = false,
-): string => {
+/** Render quantity selector for an event row */
+const renderEventRow = (info: TicketEvent, hideQuantity = false): string => {
   const { event, isSoldOut, isClosed, maxPurchasable } = info;
   const fieldName = `quantity_${event.id}`;
   const imageHtml = renderEventImage(event);
 
   if (isClosed) {
     return `
-      <div class="multi-ticket-row sold-out">
+      <div class="ticket-row sold-out">
         ${imageHtml}
         <label>${escapeHtml(event.name)}</label>
         <span class="sold-out-label">Registration Closed</span>
@@ -344,10 +341,10 @@ const renderMultiEventRow = (
 
   if (isSoldOut) {
     return `
-      <div class="multi-ticket-row sold-out">
+      <div class="ticket-row sold-out">
         ${imageHtml}
         <label>${escapeHtml(event.name)}</label>
-        ${renderMultiEventDescription(event.description)}
+        ${renderEventDescription(event.description)}
         <span class="sold-out-label">Sold Out</span>
       </div>
     `;
@@ -366,10 +363,10 @@ const renderMultiEventRow = (
   const priceFieldName = `custom_price_${event.id}`;
 
   return `
-    <div class="multi-ticket-row">
+    <div class="ticket-row">
       ${imageHtml}
       <label>${escapeHtml(event.name)}${quantityHtml}</label>
-      ${renderMultiEventDescription(event.description)}
+      ${renderEventDescription(event.description)}
       ${showPayMore ? renderPayMoreInput(event, priceFieldName) : ""}
     </div>
   `;
@@ -377,7 +374,7 @@ const renderMultiEventRow = (
 
 /** Render controls for a single event: quantity input + pay-more (no event name/image/description). */
 const renderSingleEventControls = (
-  info: MultiTicketEvent,
+  info: TicketEvent,
   hideQuantity: boolean,
 ): string => {
   const { event, maxPurchasable } = info;
@@ -396,14 +393,14 @@ const renderSingleEventControls = (
 };
 
 /**
- * Determine the merged fields setting for a set of multi-ticket events
+ * Determine the merged fields setting for the selected events
  */
-const getMultiTicketFieldsSetting = (events: MultiTicketEvent[]): EventFields =>
+const getTicketFieldsSetting = (events: TicketEvent[]): EventFields =>
   mergeEventFields(events.map((e) => e.event.fields));
 
 /** Options for the ticket page */
-export type MultiTicketPageOptions = {
-  events: MultiTicketEvent[];
+export type TicketPageOptions = {
+  events: TicketEvent[];
   slugs: string[];
   error?: string;
   dates?: string[];
@@ -418,7 +415,7 @@ export type MultiTicketPageOptions = {
  * Single events show rich details (image, description, date, location).
  * Multiple events show a compact row layout with per-event quantity selectors.
  */
-export const multiTicketPage = ({
+export const ticketPage = ({
   events,
   slugs,
   error,
@@ -427,11 +424,11 @@ export const multiTicketPage = ({
   questions,
   questionEventMap,
   baseUrl,
-}: MultiTicketPageOptions): string => {
+}: TicketPageOptions): string => {
   const inIframe = getIframeMode();
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
   const allClosed = events.every((e) => e.isClosed);
-  const fieldsSetting = getMultiTicketFieldsSetting(events);
+  const fieldsSetting = getTicketFieldsSetting(events);
   const anyPaid = events.some((e) => isPaidEvent(e.event));
   const fields: Field[] = getTicketFields(fieldsSetting, anyPaid);
   const hasDaily = events.some((e) => e.event.event_type === "daily");
@@ -448,7 +445,7 @@ export const multiTicketPage = ({
   // For multiple events, render full event rows with name, image, and description.
   const eventRows = isSingleEvent
     ? renderSingleEventControls(events[0]!, hideQuantity)
-    : events.map((e) => renderMultiEventRow(e, hideQuantity)).join("");
+    : events.map((e) => renderEventRow(e, hideQuantity)).join("");
 
   const title = singleEvent ? singleEvent.name : "Reserve Tickets";
   const headExtra =
@@ -511,7 +508,7 @@ export const multiTicketPage = ({
           {hideQuantity || isSingleEvent ? (
             <Raw html={eventRows} />
           ) : (
-            <fieldset class="multi-ticket-events">
+            <fieldset class="ticket-events">
               <legend>Select Tickets</legend>
               <Raw html={eventRows} />
             </fieldset>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1190,11 +1190,11 @@ export const createTestAttendee = async (
   // (e.g. event at capacity / sold out / deactivated)
   const csrfToken = extractCsrfToken(pageHtml) ?? (await signCsrfToken());
 
-  // Submit the ticket form
+  // Submit the ticket form (using quantity_{eventId} format for unified multi-ticket flow)
   const response = await handleRequest(
     mockTicketFormRequest(
       eventSlug,
-      { name, email, phone, quantity: String(quantity) },
+      { name, email, phone, [`quantity_${eventId}`]: String(quantity) },
       csrfToken,
     ),
   );
@@ -1712,9 +1712,43 @@ export const createTestInvite = async (
   return { inviteCode: codeMatch[1], cookie, csrfToken };
 };
 
+/** Extract event ID from a ticket page's quantity field name (quantity_123 → "123") */
+const extractQuantityEventId = (html: string): string | null => {
+  const match = html.match(/name="quantity_(\d+)"/);
+  return match?.[1] ?? null;
+};
+
+/** Normalize single-event form fields to per-event format (quantity → quantity_{id},
+ * custom_price → custom_price_{id}). When no event ID can be extracted from the HTML
+ * (e.g. sold-out page with no form), returns data unchanged. */
+const normalizeSingleEventFields = (
+  data: Record<string, string>,
+  html: string,
+): Record<string, string> => {
+  const eventId = extractQuantityEventId(html);
+  if (!eventId) return data;
+  const result = { ...data };
+  // Normalize quantity
+  if (!(`quantity_${eventId}` in result)) {
+    if ("quantity" in result) {
+      result[`quantity_${eventId}`] = result.quantity;
+      delete result.quantity;
+    } else {
+      result[`quantity_${eventId}`] = "1";
+    }
+  }
+  // Normalize custom_price
+  if ("custom_price" in result && !(`custom_price_${eventId}` in result)) {
+    result[`custom_price_${eventId}`] = result.custom_price;
+    delete result.custom_price;
+  }
+  return result;
+};
+
 /**
  * Submit a ticket form with automatic CSRF token handling.
  * GETs the ticket page first to obtain a CSRF token, then POSTs the form.
+ * Automatically converts `quantity` to `quantity_{eventId}` for single-event forms.
  */
 export const submitTicketForm = async (
   slug: string,
@@ -1726,7 +1760,8 @@ export const submitTicketForm = async (
   // Extract from form HTML, or fall back to a signed token when the page
   // doesn't show a form (e.g. event at capacity / sold out)
   const csrfToken = extractCsrfToken(html) ?? (await signCsrfToken());
-  return handleRequest(mockTicketFormRequest(slug, data, csrfToken));
+  const normalizedData = normalizeSingleEventFields(data, html);
+  return handleRequest(mockTicketFormRequest(slug, normalizedData, csrfToken));
 };
 
 /**

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1190,7 +1190,7 @@ export const createTestAttendee = async (
   // (e.g. event at capacity / sold out / deactivated)
   const csrfToken = extractCsrfToken(pageHtml) ?? (await signCsrfToken());
 
-  // Submit the ticket form (using quantity_{eventId} format for unified multi-ticket flow)
+  // Submit the ticket form (using quantity_{eventId} format)
   const response = await handleRequest(
     mockTicketFormRequest(
       eventSlug,
@@ -1765,9 +1765,8 @@ export const submitTicketForm = async (
 };
 
 /**
- * Submit a multi-ticket form with automatic CSRF token handling.
- * GETs the multi-ticket page first to obtain a CSRF token, then POSTs the form.
- * The slug should be in multi-ticket format: "slug1+slug2".
+ * Submit a ticket form for multi-slug URLs (e.g. "slug1+slug2").
+ * GETs the page first to obtain a CSRF token, then POSTs the form.
  */
 export const submitMultiTicketForm = async (
   slug: string,
@@ -1777,7 +1776,7 @@ export const submitMultiTicketForm = async (
   const path = `/ticket/${slug}`;
   const getResponse = await handleRequest(mockRequest(path));
   const csrfToken = extractCsrfToken(await getResponse.text()) ?? "";
-  if (!csrfToken) throw new Error("No CSRF token found on multi-ticket page");
+  if (!csrfToken) throw new Error("No CSRF token found on ticket page");
   return handleRequest(
     mockFormRequest(
       path,

--- a/src/test-utils/test-browser.ts
+++ b/src/test-utils/test-browser.ts
@@ -195,6 +195,7 @@ export class TestBrowser {
     const handler = await this.getHandler();
     const response = await handler(req);
     if (this.debug) {
+      // biome-ignore lint/suspicious/noConsole: debug logging for test browser
       console.log(
         `[browser] ${debugLabel} -> ${response.status}${formatCookies(response)}`,
       );

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -13,6 +13,7 @@ import { settings } from "#lib/db/settings.ts";
 import { detectIframeMode } from "#lib/iframe.ts";
 import { runWithStorageConfig } from "#lib/storage.ts";
 import { todayInTz } from "#lib/timezone.ts";
+import type { EventWithCount } from "#lib/types.ts";
 import {
   adminEventActivityLogPage,
   adminGlobalActivityLogPage,
@@ -75,7 +76,6 @@ import {
   notFoundPage,
   renderEventImage,
   temporaryErrorPage,
-  ticketPage,
 } from "#templates/public.tsx";
 import { ticketViewPage } from "#templates/tickets.tsx";
 import {
@@ -659,27 +659,40 @@ describe("html", () => {
     });
   });
 
-  describe("ticketPage", () => {
+  describe("ticketPage (single event via multiTicketPage)", () => {
     const event = testEventWithCount({ attendee_count: 50 });
     const renderTicket = (
-      ev: Parameters<typeof ticketPage>[0],
+      ev: EventWithCount,
       opts?: {
         error?: string;
         isClosed?: boolean;
         iframe?: boolean;
         dates?: string[];
         terms?: string | null;
+        baseUrl?: string;
+        questions?: {
+          id: number;
+          text: string;
+          answers: {
+            id: number;
+            question_id: number;
+            text: string;
+            sort_order: number;
+          }[];
+        }[];
       },
     ) => {
       if (opts?.iframe) detectIframeMode("https://example.com/?iframe=true");
       else detectIframeMode("https://example.com/");
-      return ticketPage(
-        ev,
-        opts?.error,
-        opts?.isClosed ?? false,
-        opts?.dates,
-        opts?.terms,
-      );
+      return multiTicketPage({
+        events: [buildMultiTicketEvent(ev, opts?.isClosed)],
+        slugs: [ev.slug],
+        error: opts?.error,
+        dates: opts?.dates ?? [],
+        terms: opts?.terms,
+        baseUrl: opts?.baseUrl,
+        questions: opts?.questions,
+      });
     };
 
     test("renders page title", () => {
@@ -722,13 +735,13 @@ describe("html", () => {
     });
 
     test("shows quantity selector when max_quantity > 1 and spots available", () => {
-      const multiTicketEvent = testEventWithCount({
+      const multiQtyEvent = testEventWithCount({
         max_quantity: 5,
         attendee_count: 0,
       });
-      const html = renderTicket(multiTicketEvent);
+      const html = renderTicket(multiQtyEvent);
       expect(html).toContain("Number of Tickets");
-      expect(html).toContain('name="quantity"');
+      expect(html).toContain(`name="quantity_${multiQtyEvent.id}"`);
       expect(html).toContain('<option value="1">1</option>');
       expect(html).toContain('<option value="5">5</option>');
       expect(html).toContain("Reserve Tickets"); // Plural
@@ -748,7 +761,9 @@ describe("html", () => {
     test("hides quantity selector when max_quantity is 1", () => {
       const html = renderTicket(event); // max_quantity is 1
       expect(html).not.toContain("Number of Tickets");
-      expect(html).toContain('type="hidden" name="quantity" value="1"');
+      expect(html).toContain(
+        `type="hidden" name="quantity_${event.id}" value="1"`,
+      );
       expect(html).toContain("Reserve Ticket"); // Singular
       expect(html).not.toContain("Reserve Tickets"); // Not plural
     });
@@ -814,33 +829,23 @@ describe("html", () => {
     });
 
     test("renders terms and conditions with checkbox", () => {
-      const html = ticketPage(
-        event,
-        undefined,
-        false,
-        undefined,
-        "No refunds allowed",
-      );
+      const html = renderTicket(event, { terms: "No refunds allowed" });
       expect(html).toContain("No refunds allowed");
       expect(html).toContain('class="prose"');
       expect(html).toContain('name="agree_terms"');
     });
 
     test("renders markdown paragraphs in terms and conditions", () => {
-      const html = ticketPage(
-        event,
-        undefined,
-        false,
-        undefined,
-        "Line one\n\nLine two\n\nLine three",
-      );
+      const html = renderTicket(event, {
+        terms: "Line one\n\nLine two\n\nLine three",
+      });
       expect(html).toContain("<p>Line one</p>");
       expect(html).toContain("<p>Line two</p>");
       expect(html).toContain("<p>Line three</p>");
     });
 
     test("does not render terms when not provided", () => {
-      const html = ticketPage(event, undefined, false, undefined, undefined);
+      const html = renderTicket(event);
       expect(html).not.toContain('class="terms"');
       expect(html).not.toContain('name="agree_terms"');
     });
@@ -856,15 +861,7 @@ describe("html", () => {
           ],
         },
       ];
-      const html = ticketPage(
-        event,
-        undefined,
-        false,
-        undefined,
-        undefined,
-        undefined,
-        questions,
-      );
+      const html = renderTicket(event, { questions });
       expect(html).toContain("Size?");
       expect(html).toContain('name="question_1"');
     });
@@ -875,14 +872,9 @@ describe("html", () => {
         slug: "birthday-party",
         description: "A fun party",
       });
-      const html = ticketPage(
-        ev,
-        undefined,
-        false,
-        undefined,
-        undefined,
-        "https://tix.example.com",
-      );
+      const html = renderTicket(ev, {
+        baseUrl: "https://tix.example.com",
+      });
       expect(html).toContain(
         '<meta property="og:title" content="Birthday Party">',
       );
@@ -896,7 +888,7 @@ describe("html", () => {
     });
 
     test("does not include OpenGraph tags when baseUrl is not provided", () => {
-      const html = ticketPage(event, undefined, false, undefined, undefined);
+      const html = renderTicket(event);
       expect(html).not.toContain("og:title");
     });
   });
@@ -2602,7 +2594,7 @@ describe("html", () => {
       const html = multiTicketPage({ events, slugs: ["ab12c"] });
       expect(html).toContain("<select");
       expect(html).toContain('name="quantity_1"');
-      expect(html).toContain("Select Tickets");
+      expect(html).toContain("Number of Tickets");
       expect(html).not.toContain('name="quantity_1" value="1"');
     });
 
@@ -3481,13 +3473,14 @@ describe("html", () => {
   });
 
   describe("ticketPage event date and location", () => {
-    const renderTicket = (
-      ev: Parameters<typeof ticketPage>[0],
-      opts?: { iframe?: boolean },
-    ) => {
+    const renderTicket = (ev: EventWithCount, opts?: { iframe?: boolean }) => {
       if (opts?.iframe) detectIframeMode("https://example.com/?iframe=true");
       else detectIframeMode("https://example.com/");
-      return ticketPage(ev, undefined, false, undefined, undefined);
+      return multiTicketPage({
+        events: [buildMultiTicketEvent(ev)],
+        slugs: [ev.slug],
+        dates: [],
+      });
     };
 
     test("shows date on public ticket page when event has date", () => {
@@ -3716,23 +3709,31 @@ describe("html", () => {
       });
 
       describe("ticketPage with image", () => {
+        const renderSingleEvent = (ev: EventWithCount) =>
+          multiTicketPage({
+            events: [buildMultiTicketEvent(ev)],
+            slugs: [ev.slug],
+            dates: [],
+            terms: null,
+          });
+
         test("shows event image when image_url is set", () => {
           const event = testEventWithCount({ image_url: "event-img.jpg" });
-          const html = ticketPage(event, undefined, false, undefined, null);
+          const html = renderSingleEvent(event);
           expect(html).toContain("/image/event-img.jpg");
           expect(html).toContain('class="event-image"');
         });
 
         test("does not show image when image_url is null", () => {
           const event = testEventWithCount({ image_url: "" });
-          const html = ticketPage(event, undefined, false, undefined, null);
+          const html = renderSingleEvent(event);
           expect(html).not.toContain("/image/");
         });
 
         test("does not show image in iframe mode", () => {
           detectIframeMode("https://example.com/?iframe=true");
           const event = testEventWithCount({ image_url: "event-img.jpg" });
-          const html = ticketPage(event, undefined, false, undefined, null);
+          const html = renderSingleEvent(event);
           expect(html).not.toContain("event-img.jpg");
           detectIframeMode("https://example.com/");
         });

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -70,12 +70,12 @@ import {
   successPage,
 } from "#templates/payment.tsx";
 import {
-  buildMultiTicketEvent,
   buildOgTags,
-  multiTicketPage,
+  buildTicketEvent,
   notFoundPage,
   renderEventImage,
   temporaryErrorPage,
+  ticketPage,
 } from "#templates/public.tsx";
 import { ticketViewPage } from "#templates/tickets.tsx";
 import {
@@ -659,7 +659,7 @@ describe("html", () => {
     });
   });
 
-  describe("ticketPage (single event via multiTicketPage)", () => {
+  describe("ticketPage (single event)", () => {
     const event = testEventWithCount({ attendee_count: 50 });
     const renderTicket = (
       ev: EventWithCount,
@@ -684,8 +684,8 @@ describe("html", () => {
     ) => {
       if (opts?.iframe) detectIframeMode("https://example.com/?iframe=true");
       else detectIframeMode("https://example.com/");
-      return multiTicketPage({
-        events: [buildMultiTicketEvent(ev, opts?.isClosed)],
+      return ticketPage({
+        events: [buildTicketEvent(ev, opts?.isClosed)],
         slugs: [ev.slug],
         error: opts?.error,
         dates: opts?.dates ?? [],
@@ -2416,10 +2416,10 @@ describe("html", () => {
     });
   });
 
-  describe("multiTicketPage", () => {
+  describe("ticketPage", () => {
     test("shows all sold out message when every event is sold out", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2428,7 +2428,7 @@ describe("html", () => {
             max_attendees: 100,
           }),
         ),
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 2,
             slug: "cd34e",
@@ -2438,14 +2438,14 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c", "cd34e"] });
+      const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
       expect(html).toContain("Sorry, all events are sold out.");
       expect(html).not.toContain("Reserve Tickets</button>");
     });
 
     test("renders markdown paragraphs in terms and conditions", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2454,7 +2454,7 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({
+      const html = ticketPage({
         events,
         slugs: ["ab12c"],
         terms: "Rule one\n\nRule two",
@@ -2466,7 +2466,7 @@ describe("html", () => {
 
     test("renders custom questions with event IDs", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2483,7 +2483,7 @@ describe("html", () => {
         },
       ];
       const questionEventMap = new Map([[5, [1]]]);
-      const html = multiTicketPage({
+      const html = ticketPage({
         events,
         slugs: ["ab12c"],
         questions,
@@ -2497,7 +2497,7 @@ describe("html", () => {
     test("appends ?iframe=true to form action in iframe mode", () => {
       detectIframeMode("https://example.com/?iframe=true");
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2506,7 +2506,7 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c"] });
+      const html = ticketPage({ events, slugs: ["ab12c"] });
       expect(html).toContain('action="/ticket/ab12c?iframe=true"');
       expect(html).toContain('class="iframe"');
       detectIframeMode("https://example.com/");
@@ -2515,7 +2515,7 @@ describe("html", () => {
     test("includes iframe-resizer child script in iframe mode", () => {
       detectIframeMode("https://example.com/?iframe=true");
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2524,14 +2524,14 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c"] });
+      const html = ticketPage({ events, slugs: ["ab12c"] });
       expect(html).toContain("iframe-resizer-child.js");
       detectIframeMode("https://example.com/");
     });
 
     test("excludes iframe-resizer child script without iframe mode", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2540,13 +2540,13 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c"] });
+      const html = ticketPage({ events, slugs: ["ab12c"] });
       expect(html).not.toContain("iframe-resizer-child.js");
     });
 
     test("does not append ?iframe=true without iframe mode", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2555,7 +2555,7 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c"] });
+      const html = ticketPage({ events, slugs: ["ab12c"] });
       expect(html).toContain('action="/ticket/ab12c"');
       expect(html).not.toContain("?iframe=true");
       expect(html).not.toContain('class="iframe"');
@@ -2563,7 +2563,7 @@ describe("html", () => {
 
     test("hides quantity selector for single event with max quantity 1", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2573,7 +2573,7 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c"] });
+      const html = ticketPage({ events, slugs: ["ab12c"] });
       expect(html).toContain('name="quantity_1" value="1"');
       expect(html).not.toContain("<select");
       expect(html).not.toContain("Select Tickets");
@@ -2581,7 +2581,7 @@ describe("html", () => {
 
     test("shows quantity selector for single event with max quantity above 1", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2591,7 +2591,7 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c"] });
+      const html = ticketPage({ events, slugs: ["ab12c"] });
       expect(html).toContain("<select");
       expect(html).toContain('name="quantity_1"');
       expect(html).toContain("Number of Tickets");
@@ -2600,7 +2600,7 @@ describe("html", () => {
 
     test("shows quantity selector for multiple events even with max quantity 1", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2609,7 +2609,7 @@ describe("html", () => {
             max_quantity: 1,
           }),
         ),
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 2,
             slug: "cd34e",
@@ -2619,14 +2619,14 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c", "cd34e"] });
+      const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
       expect(html).toContain("<select");
       expect(html).toContain("Select Tickets");
     });
 
     test("hides quantity selector when one event available and one sold out", () => {
       const events = [
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 1,
             slug: "ab12c",
@@ -2635,7 +2635,7 @@ describe("html", () => {
             max_quantity: 1,
           }),
         ),
-        buildMultiTicketEvent(
+        buildTicketEvent(
           testEventWithCount({
             id: 2,
             slug: "cd34e",
@@ -2645,7 +2645,7 @@ describe("html", () => {
           }),
         ),
       ];
-      const html = multiTicketPage({ events, slugs: ["ab12c", "cd34e"] });
+      const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
       expect(html).toContain('name="quantity_1" value="1"');
       expect(html).not.toContain("Select Tickets");
     });
@@ -3476,8 +3476,8 @@ describe("html", () => {
     const renderTicket = (ev: EventWithCount, opts?: { iframe?: boolean }) => {
       if (opts?.iframe) detectIframeMode("https://example.com/?iframe=true");
       else detectIframeMode("https://example.com/");
-      return multiTicketPage({
-        events: [buildMultiTicketEvent(ev)],
+      return ticketPage({
+        events: [buildTicketEvent(ev)],
         slugs: [ev.slug],
         dates: [],
       });
@@ -3710,8 +3710,8 @@ describe("html", () => {
 
       describe("ticketPage with image", () => {
         const renderSingleEvent = (ev: EventWithCount) =>
-          multiTicketPage({
-            events: [buildMultiTicketEvent(ev)],
+          ticketPage({
+            events: [buildTicketEvent(ev)],
             slugs: [ev.slug],
             dates: [],
             terms: null,
@@ -3739,17 +3739,17 @@ describe("html", () => {
         });
       });
 
-      describe("multiTicketPage with images", () => {
+      describe("ticketPage with images", () => {
         test("shows image before each event with image_url", () => {
           const events = [
-            buildMultiTicketEvent(
+            buildTicketEvent(
               testEventWithCount({
                 id: 1,
                 name: "Event A",
                 image_url: "img-a.jpg",
               }),
             ),
-            buildMultiTicketEvent(
+            buildTicketEvent(
               testEventWithCount({
                 id: 2,
                 name: "Event B",
@@ -3757,18 +3757,18 @@ describe("html", () => {
               }),
             ),
           ];
-          const html = multiTicketPage({ events, slugs: ["slug-a", "slug-b"] });
+          const html = ticketPage({ events, slugs: ["slug-a", "slug-b"] });
           expect(html).toContain("/image/img-a.jpg");
           expect(html).toContain("/image/img-b.jpg");
         });
 
         test("does not show images when image_url is null", () => {
           const events = [
-            buildMultiTicketEvent(
+            buildTicketEvent(
               testEventWithCount({ id: 1, name: "Event A", image_url: "" }),
             ),
           ];
-          const html = multiTicketPage({ events, slugs: ["slug-a"] });
+          const html = ticketPage({ events, slugs: ["slug-a"] });
           expect(html).not.toContain("/image/");
         });
       });

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -364,7 +364,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       );
     });
 
-    test("shows cancel page for multi-ticket session", async () => {
+    test("shows cancel page for ticket session", async () => {
       const { stub } = await import("@std/testing/mock");
       const { stripeApi } = await import("#lib/stripe.ts");
       await setupStripe();
@@ -414,7 +414,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       );
     });
 
-    test("returns 404 for multi-ticket session with invalid items", async () => {
+    test("returns 404 for ticket session with invalid items", async () => {
       const { stub } = await import("@std/testing/mock");
       const { stripeApi } = await import("#lib/stripe.ts");
       await setupStripe();
@@ -894,12 +894,12 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
     });
   });
 
-  describe("GET /payment/success (multi-ticket)", () => {
+  describe("GET /payment/success (ticket)", () => {
     afterEach(() => {
       resetStripeClient();
     });
 
-    test("processes multi-ticket payment success", async () => {
+    test("processes ticket payment success", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -937,7 +937,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         const redirectResponse = await handleRequest(
           mockRequest("/payment/success?session_id=cs_multi_success"),
         );
-        // Multi-ticket should have multiple tokens joined by + (URL-encoded as %2B)
+        // Ticket should have multiple tokens joined by + (URL-encoded as %2B)
         expectRedirect(
           redirectResponse,
           /^\/payment\/success\?tokens=.+%2B.+$/,
@@ -950,7 +950,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
           "Payment Successful",
           "Click here to view your tickets",
         );
-        // Multi-ticket should NOT have thank_you_url (different events)
+        // Multi-slug ticket should NOT have thank_you_url (different events)
         expect(html).not.toContain("redirected");
 
         // Verify attendees created for both events
@@ -965,7 +965,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       }
     });
 
-    test("returns error for invalid multi-ticket metadata", async () => {
+    test("returns error for invalid ticket metadata", async () => {
       await setupStripe();
 
       const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
@@ -994,7 +994,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       }
     });
 
-    test("skips refund for multi-ticket payment when event not found", async () => {
+    test("skips refund for ticket payment when event not found", async () => {
       await setupStripe();
 
       const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
@@ -1028,7 +1028,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       }
     });
 
-    test("refunds multi-ticket payment when event is inactive", async () => {
+    test("refunds ticket payment when event is inactive", async () => {
       await setupStripe();
 
       const event = await createTestEvent({
@@ -1125,7 +1125,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       }
     });
 
-    test("multi-ticket payment sold out rolls back and refunds", async () => {
+    test("ticket payment sold out rolls back and refunds", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -1337,7 +1337,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       }
     });
 
-    test("handles multi-ticket duplicate session replay (already processed)", async () => {
+    test("handles ticket duplicate session replay (already processed)", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -500,11 +500,11 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         unitPrice: 1000,
       });
 
-      // Mock createCheckoutSession to return a validation error result
+      // Mock createMultiCheckoutSession to return a validation error result
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
       const mockCreate = stub(
         stripePaymentProvider,
-        "createCheckoutSession",
+        "createMultiCheckoutSession",
         () =>
           Promise.resolve({
             error:

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -925,7 +925,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("renders multi-ticket page for group slug", async () => {
+    test("renders ticket page for group slug", async () => {
       const group = await createTestGroup({
         name: "Public Group",
         slug: "public-group",
@@ -1361,7 +1361,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("GET /ticket/:slug1+:slug2 (multi-ticket)", () => {
+  describe("GET /ticket/:slug1+:slug2", () => {
     test("returns 404 when no valid events", async () => {
       const response = await handleRequest(
         mockRequest("/ticket/nonexistent1+nonexistent2"),
@@ -1369,7 +1369,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(response.status).toBe(404);
     });
 
-    test("shows multi-ticket page for multiple existing events", async () => {
+    test("shows ticket page for multiple existing events", async () => {
       const event1 = await createTestEvent({
         name: "Multi Event 1",
         maxAttendees: 50,
@@ -1391,7 +1391,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("shows description beneath each event in multi-ticket page", async () => {
+    test("shows description beneath each event in ticket page", async () => {
       const event1 = await createTestEvent({
         name: "Multi Desc 1",
         maxAttendees: 50,
@@ -1413,7 +1413,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("omits description div in multi-ticket when description is empty", async () => {
+    test("omits description div in ticket when description is empty", async () => {
       const event1 = await createTestEvent({
         name: "Multi No Desc",
         maxAttendees: 50,
@@ -1452,7 +1452,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       await expectHtmlResponse(response, 200, "Sold Out");
     });
 
-    test("shows description for sold-out event in multi-ticket page", async () => {
+    test("shows description for sold-out event in ticket page", async () => {
       const event1 = await createTestEvent({
         name: "Multi Avail Desc",
         maxAttendees: 50,
@@ -1545,7 +1545,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(zebraPos).toBeLessThan(alphaPos);
     });
 
-    test("does not set CSRF cookies for multi-ticket (uses signed tokens)", async () => {
+    test("does not set CSRF cookies for ticket (uses signed tokens)", async () => {
       const event1 = await createTestEvent({ maxAttendees: 50 });
       const event2 = await createTestEvent({ maxAttendees: 50 });
       const response = await handleRequest(
@@ -1567,7 +1567,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("multi-ticket GET returns signed CSRF token in form", async () => {
+    test("ticket GET returns signed CSRF token in form", async () => {
       const event1 = await createTestEvent({ maxAttendees: 50 });
       const event2 = await createTestEvent({ maxAttendees: 50 });
       const response = await handleRequest(
@@ -1577,7 +1577,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(html).toMatch(/name="csrf_token" value="s1\./);
     });
 
-    test("multi-ticket POST succeeds with signed token and no cookie", async () => {
+    test("ticket POST succeeds with signed token and no cookie", async () => {
       const event1 = await createTestEvent({ maxAttendees: 50 });
       const event2 = await createTestEvent({ maxAttendees: 50 });
       const path = `/ticket/${event1.slug}+${event2.slug}`;
@@ -1601,8 +1601,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("POST /ticket/:slug1+:slug2 (multi-ticket)", () => {
-    /** Helper to submit multi-ticket form with CSRF */
+  describe("POST /ticket/:slug1+:slug2", () => {
+    /** Helper to submit ticket form with CSRF */
     const submitMultiTicketForm = async (
       slugs: string[],
       data: Record<string, string>,
@@ -1864,12 +1864,12 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("multi-ticket paid flow", () => {
+  describe("ticket paid flow", () => {
     afterEach(() => {
       resetStripeClient();
     });
 
-    test("redirects to checkout for multi-ticket paid events", async () => {
+    test("redirects to checkout for ticket paid events", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -1911,7 +1911,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(location?.startsWith("https://")).toBe(true);
     });
 
-    test("shows error when no tickets selected in multi-ticket paid form", async () => {
+    test("shows error when no tickets selected in ticket paid form", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -1956,8 +1956,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("multi-ticket free flow (capacity exceeded)", () => {
-    test("shows error when free multi-ticket atomic create fails capacity", async () => {
+  describe("ticket free flow (capacity exceeded)", () => {
+    test("shows error when free ticket atomic create fails capacity", async () => {
       const event1 = await createTestEvent({
         name: "Multi Free Cap 1",
         maxAttendees: 50,
@@ -2019,7 +2019,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       }
     });
 
-    test("multi-ticket free registration succeeds for both events", async () => {
+    test("ticket free registration succeeds for both events", async () => {
       const event1 = await createTestEvent({
         name: "Multi Free Ok 1",
         maxAttendees: 50,
@@ -2064,7 +2064,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   });
 
   describe("POST /ticket/:slug1+:slug2 (unsupported method)", () => {
-    test("returns 404 for PUT on multi-ticket route", async () => {
+    test("returns 404 for PUT on ticket route", async () => {
       const event1 = await createTestEvent({
         name: "Multi Put 1",
         maxAttendees: 50,
@@ -2118,7 +2118,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("multi-ticket skips sold-out events in quantity parsing", async () => {
+    test("skips sold-out events in quantity parsing", async () => {
       const event1 = await createTestEvent({
         name: "Multi Soldout Parse 1",
         maxAttendees: 1,
@@ -2138,7 +2138,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         quantity: 1,
       });
 
-      // GET the multi-ticket page (sold-out event will show Sold Out label)
+      // GET the ticket page (sold-out event will show Sold Out label)
       const path = `/ticket/${event1.slug}+${event2.slug}`;
       const getResponse = await handleRequest(mockRequest(path));
       expect(getResponse.status).toBe(200);
@@ -2165,7 +2165,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectReservedRedirectWithTokens(response);
     });
 
-    test("multi-ticket with invalid quantity form value falls back to 0", async () => {
+    test("ticket with invalid quantity form value falls back to 0", async () => {
       const event1 = await createTestEvent({
         name: "Multi Invalid Qty 1",
         maxAttendees: 50,
@@ -2206,7 +2206,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(attendees2.length).toBe(1);
     });
 
-    test("multi-ticket paid checks availability and rejects sold out", async () => {
+    test("ticket paid checks availability and rejects sold out", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2266,8 +2266,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("routes/public.ts (multi-ticket CSRF)", () => {
-    test("multi-ticket POST rejects invalid CSRF token", async () => {
+  describe("routes/public.ts (ticket CSRF)", () => {
+    test("ticket POST rejects invalid CSRF token", async () => {
       const event1 = await createTestEvent({
         name: "Multi Csrf 1",
         maxAttendees: 50,
@@ -2294,7 +2294,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   });
 
   describe("routes/public.ts (withPaymentProvider onMissing path)", () => {
-    test("shows payment not configured error for multi-ticket when no provider", async () => {
+    test("shows payment not configured error for ticket when no provider", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2339,8 +2339,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("POST multi-ticket capacity check via atomic create", () => {
-    test("shows error for free multi-ticket when atomic create fails", async () => {
+  describe("POST ticket capacity check via atomic create", () => {
+    test("shows error for free ticket when atomic create fails", async () => {
       const event1 = await createTestEvent({
         name: "Multi Free Atomic 1",
         maxAttendees: 50,
@@ -2396,12 +2396,12 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("routes/public.ts (multi-ticket paid flow)", () => {
+  describe("routes/public.ts (ticket paid flow)", () => {
     afterEach(() => {
       resetStripeClient();
     });
 
-    test("multi-ticket paid flow redirects to Stripe checkout", async () => {
+    test("ticket paid flow redirects to Stripe checkout", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2439,7 +2439,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(location).toContain("checkout.stripe.com");
     });
 
-    test("multi-ticket paid flow shows error when session creation fails", async () => {
+    test("ticket paid flow shows error when session creation fails", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2491,7 +2491,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       }
     });
 
-    test("multi-ticket paid flow shows validation error from checkout session", async () => {
+    test("ticket paid flow shows validation error from checkout session", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2542,7 +2542,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       }
     });
 
-    test("multi-ticket skips sold-out events in quantity parsing", async () => {
+    test("skips sold-out events in quantity parsing", async () => {
       const event1 = await createTestEvent({
         name: "Multi Soldout 1",
         maxAttendees: 1,
@@ -2639,8 +2639,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("routes/public.ts (multi-ticket quantity field missing from form)", () => {
-    test("defaults to 0 when quantity field is absent from multi-ticket form", async () => {
+  describe("routes/public.ts (ticket quantity field missing from form)", () => {
+    test("defaults to 0 when quantity field is absent from ticket form", async () => {
       const event1 = await createTestEvent({
         name: "Multi Nofield 1",
         maxAttendees: 50,
@@ -2681,12 +2681,12 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("routes/public.ts (multi-ticket paid availability check fails)", () => {
+  describe("routes/public.ts (ticket paid availability check fails)", () => {
     afterEach(() => {
       resetStripeClient();
     });
 
-    test("returns error when paid multi-ticket availability check fails", async () => {
+    test("returns error when paid ticket availability check fails", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2800,7 +2800,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(location?.startsWith("https://")).toBe(true);
     });
 
-    test("returns popup page for multi-ticket paid event in iframe", async () => {
+    test("returns popup page for ticket paid event in iframe", async () => {
       await setupStripe();
       const event1 = await createTestEvent({
         name: "Iframe Multi 1",
@@ -2844,12 +2844,12 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("routes/public.ts (withPaymentProvider onMissing multi-ticket)", () => {
+  describe("routes/public.ts (withPaymentProvider onMissing ticket)", () => {
     afterEach(() => {
       resetStripeClient();
     });
 
-    test("shows payment not configured error when provider returns null for multi-ticket", async () => {
+    test("shows payment not configured error when provider returns null for ticket", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -2990,7 +2990,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("closes_at (multi-ticket)", () => {
+  describe("closes_at (ticket)", () => {
     test("shows 'Registration closed.' when all events are closed", async () => {
       const pastDate = new Date(Date.now() - 60000).toISOString().slice(0, 16);
       const event1 = await createTestEvent({ closesAt: pastDate });
@@ -3002,7 +3002,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       await expectHtmlResponse(response, 200, "Registration closed.");
     });
 
-    test("shows 'Registration Closed' label for individual closed event in multi-ticket", async () => {
+    test("shows 'Registration Closed' label for individual closed event in ticket", async () => {
       const pastDate = new Date(Date.now() - 60000).toISOString().slice(0, 16);
       const event1 = await createTestEvent({ closesAt: pastDate });
       const event2 = await createTestEvent();
@@ -3337,10 +3337,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("daily events (multi-ticket)", () => {
+  describe("daily events (ticket)", () => {
     const validDate = addDays(todayInTz("UTC"), 1);
 
-    test("GET shows date selector for multi-ticket with daily events", async () => {
+    test("GET shows date selector for ticket with daily events", async () => {
       const event1 = await createTestEvent({
         eventType: "daily",
         bookableDays: [
@@ -3380,7 +3380,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("POST rejects multi-ticket daily event without date", async () => {
+    test("POST rejects ticket daily event without date", async () => {
       const event1 = await createTestEvent({
         eventType: "daily",
         bookableDays: [
@@ -3436,7 +3436,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("POST succeeds for free multi-ticket daily events with valid date", async () => {
+    test("POST succeeds for free ticket daily events with valid date", async () => {
       const event1 = await createTestEvent({
         eventType: "daily",
         bookableDays: [
@@ -3488,7 +3488,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectReservedRedirectWithTokens(response);
     });
 
-    test("POST redirects to checkout for paid multi-ticket daily events", async () => {
+    test("POST redirects to checkout for paid ticket daily events", async () => {
       await setupStripe();
 
       const event1 = await createTestEvent({
@@ -3548,7 +3548,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       resetStripeClient();
     });
 
-    test("shows date and location on multi-ticket page when events have them", async () => {
+    test("shows date and location on ticket page when events have them", async () => {
       const event1 = await createTestEvent({
         name: "Multi Date 1",
         maxAttendees: 50,
@@ -3674,8 +3674,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("terms and conditions (multi-ticket)", () => {
-    test("shows terms checkbox on multi-ticket page when configured", async () => {
+  describe("terms and conditions (ticket)", () => {
+    test("shows terms checkbox on ticket page when configured", async () => {
       await settings.update.terms("Multi-event terms apply.");
 
       const event1 = await createTestEvent({
@@ -3697,7 +3697,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("rejects multi-ticket submission without agreeing to terms", async () => {
+    test("rejects ticket submission without agreeing to terms", async () => {
       await settings.update.terms("Must agree to policy.");
 
       const event1 = await createTestEvent({
@@ -3735,7 +3735,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
-    test("accepts multi-ticket submission when terms are agreed to", async () => {
+    test("accepts ticket submission when terms are agreed to", async () => {
       await settings.update.terms("Must agree to policy.");
 
       const event1 = await createTestEvent({
@@ -4002,7 +4002,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectFlash(response, expect.stringContaining("valid price"), false);
     });
 
-    test("GET multi-ticket page shows pay-more inputs only for can_pay_more events", async () => {
+    test("GET ticket page shows pay-more inputs only for can_pay_more events", async () => {
       const event1 = await payMoreEvent({
         name: "Pay More Multi",
         unitPrice: 500,
@@ -4020,7 +4020,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(html).not.toContain(`name="custom_price_${event2.id}"`);
     });
 
-    test("POST multi-ticket with can_pay_more redirects to checkout", async () => {
+    test("POST ticket with can_pay_more redirects to checkout", async () => {
       await setupStripe();
       const event1 = await payMoreEvent({
         name: "Pay More A",
@@ -4044,7 +4044,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectCheckoutRedirect(response);
     });
 
-    test("POST multi-ticket rejects custom_price below minimum", async () => {
+    test("POST ticket rejects custom_price below minimum", async () => {
       const event1 = await payMoreEvent({
         name: "Pay More Reject",
         unitPrice: 500,
@@ -4068,7 +4068,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectFlash(response, expect.stringContaining("minimum"), false);
     });
 
-    test("POST multi-ticket rejects custom_price above maximum", async () => {
+    test("POST ticket rejects custom_price above maximum", async () => {
       const event1 = await payMoreEvent({
         name: "Pay More Max Reject",
         unitPrice: 500,
@@ -4092,7 +4092,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectFlash(response, expect.stringContaining("maximum"), false);
     });
 
-    test("POST multi-ticket skips price check for can_pay_more event with qty 0", async () => {
+    test("POST ticket skips price check for can_pay_more event with qty 0", async () => {
       await setupStripe();
       const event1 = await payMoreEvent({
         name: "Pay More Skip",
@@ -4115,7 +4115,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectCheckoutRedirect(response);
     });
 
-    test("POST multi-ticket free can_pay_more with custom price redirects to checkout", async () => {
+    test("POST ticket free can_pay_more with custom price redirects to checkout", async () => {
       await setupStripe();
       const event1 = await payMoreEvent({
         name: "Free Donate",
@@ -4139,7 +4139,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectCheckoutRedirect(response);
     });
 
-    test("POST multi-ticket free can_pay_more with zero price still processes paid event", async () => {
+    test("POST ticket free can_pay_more with zero price still processes paid event", async () => {
       await setupStripe();
       const event1 = await payMoreEvent({
         name: "Free No Donate",
@@ -4238,7 +4238,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(otherAttendees.length).toBe(0);
     });
 
-    test("multi-ticket form ignores quantity fields for events not in URL", async () => {
+    test("ticket form ignores quantity fields for events not in URL", async () => {
       const event1 = await createTestEvent({
         name: "Legit Event 1",
         maxAttendees: 50,
@@ -4255,7 +4255,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         maxQuantity: 5,
       });
 
-      // Submit multi-ticket form with only event1+event2 in URL
+      // Submit ticket form with only event1+event2 in URL
       // but inject quantity for the secret event
       const path = `/ticket/${event1.slug}+${event2.slug}`;
       const getResponse = await handleRequest(mockRequest(path));
@@ -4284,7 +4284,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(secretAttendees.length).toBe(0);
     });
 
-    test("multi-ticket URL cannot book inactive events", async () => {
+    test("ticket URL cannot book inactive events", async () => {
       const active = await createTestEvent({
         name: "Active Event",
         maxAttendees: 50,
@@ -4295,7 +4295,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
       await deactivateTestEvent(inactive.id);
 
-      // Try to load multi-ticket page with inactive event in URL
+      // Try to load ticket page with inactive event in URL
       const path = `/ticket/${active.slug}+${inactive.slug}`;
       const getResponse = await handleRequest(mockRequest(path));
       const html = await getResponse.text();
@@ -4406,7 +4406,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("multi-ticket with custom questions", () => {
+  describe("ticket with custom questions", () => {
     const setupQuestionForEvents = async (eventIds: number[]) => {
       const q = await questionsTable.insert({ text: "Dietary needs?" });
       const a1 = await answersTable.insert({
@@ -4425,7 +4425,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       return { question: q, answer1: a1, answer2: a2 };
     };
 
-    test("saves answers for all attendees in multi-ticket reservation", async () => {
+    test("saves answers for all attendees in ticket reservation", async () => {
       const event1 = await createTestEvent({
         name: "Multi Q1",
         maxAttendees: 50,
@@ -4580,7 +4580,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectReservedRedirectWithTokens(response);
     });
 
-    test("returns error when multi-ticket question is unanswered", async () => {
+    test("returns error when ticket question is unanswered", async () => {
       const event1 = await createTestEvent({
         name: "Multi Q Error 1",
         maxAttendees: 50,

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -13,6 +13,7 @@ import { settings } from "#lib/db/settings.ts";
 import { resetStripeClient } from "#lib/stripe.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import { handleRequest } from "#routes";
+import { formatCreationError } from "#routes/utils.ts";
 import { ICS_DISCOVERY_TAG, RSS_DISCOVERY_TAG } from "#templates/public.tsx";
 import {
   assertJson,
@@ -850,7 +851,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockFormRequest(`/ticket/${event.slug}?iframe=true`, {
           name: "Test User",
           email: "test@example.com",
-          quantity: "1",
+          [`quantity_${event.id}`]: "1",
           csrf_token: csrfToken!,
         }),
       );
@@ -900,7 +901,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockFormRequest(`/ticket/${event.slug}`, {
           name: "Test User",
           email: "test@example.com",
-          quantity: "1",
+          [`quantity_${event.id}`]: "1",
           csrf_token: signedToken,
         }),
       );
@@ -1852,7 +1853,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockFormRequest(`/ticket/${event.slug}?iframe=true`, {
           name: "Jane Doe",
           email: "jane@example.com",
-          quantity: "1",
+          [`quantity_${event.id}`]: "1",
           csrf_token: csrfToken!,
         }),
       );
@@ -2096,21 +2097,25 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectRedirect(response, "https://example.com/thanks");
     });
 
-    test("ticket form with invalid quantity falls back to minimum", async () => {
+    test("ticket form with invalid quantity rejects submission", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,
         thankYouUrl: "https://example.com/thanks",
         maxQuantity: 5,
       });
 
-      // Submit with non-numeric quantity
+      // Submit with non-numeric quantity — parsed as 0, rejected
       const response = await submitTicketForm(event.slug, {
         name: "John Doe",
         email: "john@example.com",
-        quantity: "abc",
+        [`quantity_${event.id}`]: "abc",
       });
-      // Should still succeed with quantity falling back to 1
-      expectRedirect(response, "https://example.com/thanks");
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining("select at least one ticket"),
+        false,
+      );
     });
 
     test("multi-ticket skips sold-out events in quantity parsing", async () => {
@@ -2610,6 +2615,30 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
+  describe("formatCreationError", () => {
+    test("returns event-specific message for capacity_exceeded with event name", () => {
+      const result = formatCreationError(
+        "generic",
+        (name) => `${name} is full`,
+        "fallback",
+        "capacity_exceeded",
+        "My Event",
+      );
+      expect(result).toBe("My Event is full");
+    });
+
+    test("returns generic capacity message when event name is empty", () => {
+      const result = formatCreationError(
+        "generic",
+        (name) => `${name} is full`,
+        "fallback",
+        "capacity_exceeded",
+        "",
+      );
+      expect(result).toBe("generic");
+    });
+  });
+
   describe("routes/public.ts (multi-ticket quantity field missing from form)", () => {
     test("defaults to 0 when quantity field is absent from multi-ticket form", async () => {
       const event1 = await createTestEvent({
@@ -2736,6 +2765,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
           {
             name: "John Doe",
             email: "john@example.com",
+            [`quantity_${event.id}`]: "1",
             csrf_token: csrfToken,
           },
           `csrf_token=${csrfToken}`,
@@ -2943,7 +2973,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
           {
             name: "Test User",
             email: "test@example.com",
-            quantity: "1",
+            [`quantity_${event.id}`]: "1",
             csrf_token: csrfToken,
           },
           `csrf_token=${csrfToken}`,
@@ -3759,7 +3789,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`/ticket/${event.slug}`),
       );
       const html = await response.text();
-      expect(html).toContain('name="custom_price"');
+      expect(html).toMatch(/name="custom_price(_\d+)?"/);
+
       expect(html).toContain("Your Price (£10 minimum)");
       expect(html).toContain('value="10.00"');
       expect(html).toContain("required");
@@ -3774,7 +3805,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`/ticket/${event.slug}`),
       );
       const html = await response.text();
-      expect(html).not.toContain('name="custom_price"');
+      expect(html).not.toMatch(/name="custom_price(_\d+)?"/);
     });
 
     test("GET shows price input for can_pay_more events with zero unit_price", async () => {
@@ -3783,7 +3814,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`/ticket/${event.slug}`),
       );
       const html = await response.text();
-      expect(html).toContain('name="custom_price"');
+      expect(html).toMatch(/name="custom_price(_\d+)?"/);
+
       expect(html).toContain("Your Price (optional, up to £100)");
       expect(html).toContain('min="0.00"');
     });
@@ -3794,7 +3826,8 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`/ticket/${event.slug}`),
       );
       const html = await response.text();
-      expect(html).toContain('name="custom_price"');
+      expect(html).toMatch(/name="custom_price(_\d+)?"/);
+
       expect(html).toContain("Your Price (optional, up to £100)");
       expect(html).toContain('value="0.00" min="0.00" max="100.00"');
     });


### PR DESCRIPTION
## Summary
This PR consolidates the separate single-ticket and multi-ticket registration flows into a unified ticket page system. Previously, single events used a dedicated `ticketPage` template while multiple events used `multiTicketPage`. Now both cases are handled by `multiTicketPage`, which intelligently adapts its layout based on the number of events.

## Key Changes

- **Unified ticket page rendering**: Removed the separate `ticketPage` template and `handleSingleTicketGet`/`handleSingleTicketPost` handlers. Both single and multi-event registrations now use `multiTicketPage` and `handleMultiTicketBySlugs`.

- **Simplified routing**: Replaced `slugRoute`, `withGroupFallback`, `handleTicketGet`, and `handleTicketPost` with a single `handleTicketBySlug` function that dispatches to multi-ticket logic and falls back to group lookup for single slugs on 404.

- **Smart form field naming**: Quantity and custom price fields now use per-event naming (`quantity_{eventId}`, `custom_price_{eventId}`) consistently across single and multi-event forms. Test utilities automatically normalize legacy `quantity` field names to the new format.

- **Adaptive page layout**: `multiTicketPage` now:
  - Shows rich event details (image, description, date, location) for single events
  - Displays compact event rows for multiple events
  - Renders appropriate button text ("Reserve Ticket" vs "Reserve Tickets")
  - Includes OpenGraph tags for single events when baseUrl is provided

- **Consolidated error handling**: Removed `renderTicketPage`, `ticketResponseWithToken`, `ticketError`, and `bookingResultToWebResponse` functions. Error handling is now unified in the multi-ticket flow.

- **Improved event loading**: Added `loadSortedEvents` helper in `sort-events.ts` to centralize the pattern of loading all events, filtering by predicate, and sorting with holidays. Used in homepage and feed generation.

- **Enhanced validation**: Added re-check for registration status in multi-ticket submission to catch events that closed or sold out between form render and submission.

- **Thank-you URL support**: Single-event bookings now respect the event's custom `thank_you_url` redirect.

## Implementation Details

- Form field normalization in test utilities (`normalizeSingleEventFields`) ensures backward compatibility with existing test code while supporting the new per-event field naming.
- The `isPublicEvent` predicate filters active, non-hidden events for public listings.
- `formatCreationError` signature changed from curried to direct parameters for clearer intent.
- Removed unused imports and handlers (`getAllEvents`, `getQuestionsForEvent`, `withActiveEventBySlug`).

https://claude.ai/code/session_01HAA5yZdfw9zYeLYYNyURL2