### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: "Release name (will be suffixed to date, e.g. '2026-01-30 - your name')"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubicloud-standard-16
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies
+        run: deno install --allow-scripts
+
+      - name: Build edge script
+        run: deno task build:edge
+        env:
+          BUILD_COMMIT: ${{ github.sha }}
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v$(date -u +%Y-%m-%d-%H%M%S)"
+          TITLE="$(date -u +%Y-%m-%d) - ${{ inputs.release_name }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --generate-notes \
+            bunny-script.ts


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow to automate the creation of releases for the project.

## Key Changes
- Added `.github/workflows/release.yml` workflow that:
  - Triggers on manual dispatch with a customizable release name input
  - Checks out the repository and sets up Deno v2.x
  - Installs dependencies and builds the edge script with the current commit SHA
  - Creates a git tag with timestamp format `v{YYYY-MM-DD-HHMMSS}`
  - Pushes the tag to origin
  - Creates a GitHub release with auto-generated release notes and includes the `bunny-script.ts` artifact

## Implementation Details
- Uses `workflow_dispatch` to allow manual triggering with a release name parameter
- Release title is formatted as `{YYYY-MM-DD} - {release_name}` for consistency
- Requires `contents: write` permission to create tags and releases
- Runs on `ubicloud-standard-16` runner
- Passes `BUILD_COMMIT` environment variable during the build step to embed the commit SHA

https://claude.ai/code/session_017Z1czR1MbFJPLZeyeBAT6z