### PR TITLE
Drop legacy indexes during database initialization

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -420,12 +420,25 @@ export const initDb = async (): Promise<void> => {
   }
 
   // 3. Create indexes
+  const declaredIndexNames = new Set<string>();
   for (const [name, table] of SCHEMA) {
     for (const idx of table.indexes ?? []) {
+      declaredIndexNames.add(idx.name);
       const unique = idx.unique ? "UNIQUE " : "";
       await runMigration(
         `CREATE ${unique}INDEX IF NOT EXISTS ${idx.name} ON ${name}(${idx.columns.join(", ")})`,
       );
+    }
+  }
+
+  // 3b. Drop legacy indexes not in current schema (prefix-matched to our naming convention)
+  const allIndexes = await getDb().execute(
+    "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%'",
+  );
+  for (const row of allIndexes.rows) {
+    const indexName = String(row.name);
+    if (!declaredIndexNames.has(indexName)) {
+      await runMigration(`DROP INDEX IF EXISTS ${indexName}`);
     }
   }
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -180,6 +180,31 @@ describeWithEnv("db", { db: true }, () => {
       // We just check it completes without error
       expect(duration).toBeLessThan(100);
     });
+
+    test("initDb drops legacy indexes not in declarative schema", async () => {
+      // Create a legacy index that the declarative schema doesn't declare
+      await getDb().execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_attendees_ticket_token ON attendees(ticket_token)",
+      );
+
+      // Verify the legacy index exists
+      const before = await getDb().execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_attendees_ticket_token'",
+      );
+      expect(before.rows.length).toBe(1);
+
+      // Force re-run by invalidating schema hash
+      await getDb().execute(
+        "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
+      );
+      await initDb();
+
+      // Legacy index should be dropped
+      const after = await getDb().execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_attendees_ticket_token'",
+      );
+      expect(after.rows.length).toBe(0);
+    });
   });
 
   describe("resetDatabase", () => {


### PR DESCRIPTION
## Summary
This change adds automatic cleanup of legacy database indexes during `initDb()` to ensure the database schema stays in sync with the declarative schema definition. Any indexes that follow the naming convention (`idx_*`) but are not declared in the current schema are now dropped during initialization.

## Key Changes
- **Index tracking**: Modified `initDb()` to collect all declared index names from the schema while creating indexes
- **Legacy index cleanup**: Added logic to query all existing indexes matching the naming convention and drop those not present in the current schema declaration
- **Test coverage**: Added a test case verifying that legacy indexes are properly dropped when `initDb()` is re-run after invalidating the schema hash

## Implementation Details
- The cleanup uses a prefix-based filter (`LIKE 'idx_%'`) to target only application-managed indexes, avoiding system indexes
- Indexes are dropped using `DROP INDEX IF EXISTS` to safely handle cases where indexes may have already been removed
- The cleanup runs after all declared indexes are created, ensuring no conflicts during the migration process

https://claude.ai/code/session_01YPWYxNNY3AD96zEACMZzmu