### PR TITLE
Style update form without background in admin panel

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -190,6 +190,7 @@ hr {
 
 section {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
   justify-content: var(--justify-important);
   gap: var(--space-m);
@@ -523,6 +524,13 @@ form.one-button {
   box-shadow: none;
   padding-left: 0;
   padding-right: 0;
+}
+
+form.no-bg {
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 0;
 }
 
 form > * {

--- a/src/templates/admin/update.tsx
+++ b/src/templates/admin/update.tsx
@@ -56,7 +56,7 @@ const UpdateAvailable = ({
       </p>
     </div>
     {state.bunnyConfigured ? (
-      <CsrfForm action="/admin/update" id="update-deploy">
+      <CsrfForm action="/admin/update" id="update-deploy" class="no-bg">
         <button type="submit">Update Now</button>
       </CsrfForm>
     ) : (


### PR DESCRIPTION
## Summary
Updated the styling of the update deployment form in the admin panel to remove its default background styling, and made a structural improvement to the section layout CSS.

## Key Changes
- Added `flex-direction: column` to the `section` CSS rule to ensure consistent vertical stacking of flex items
- Created a new `form.no-bg` CSS class that removes background, border, box-shadow, and padding from forms
- Applied the `no-bg` class to the update deployment form in the admin update template to display it without the default form styling

## Implementation Details
The `form.no-bg` class provides a way to style forms as minimal/transparent elements while maintaining their functionality. This is useful for forms that should blend seamlessly into their surrounding context rather than appearing as distinct styled containers.

https://claude.ai/code/session_01DkF1L9AYHN3e2U7ZGjZuWV