### PR TITLE
Fix admin guide Google Wallet test race condition

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -517,12 +517,20 @@ const toGoogleCredentials = (
     ? { issuerId, serviceAccountEmail, serviceAccountKey }
     : null;
 
-const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null =>
-  toGoogleCredentials(
-    getEnv("GOOGLE_WALLET_ISSUER_ID"),
-    getEnv("GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL"),
-    getEnv("GOOGLE_WALLET_SERVICE_ACCOUNT_KEY"),
-  );
+const [getHostGoogleWalletOverride, setHostGoogleWalletOverride] = lazyRef<
+  GoogleWalletCredentials | null | undefined
+>(() => undefined);
+
+const getHostGoogleWalletConfig = (): GoogleWalletCredentials | null => {
+  const override = getHostGoogleWalletOverride();
+  return override !== undefined
+    ? override
+    : toGoogleCredentials(
+        getEnv("GOOGLE_WALLET_ISSUER_ID"),
+        getEnv("GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL"),
+        getEnv("GOOGLE_WALLET_SERVICE_ACCOUNT_KEY"),
+      );
+};
 
 // ---------------------------------------------------------------------------
 // Current-task guard — prevents duplicate heavy operations
@@ -846,6 +854,9 @@ export const settings = {
     get hasConfig(): boolean {
       return this.config !== null;
     },
+    setHostConfigForTest: (c: GoogleWalletCredentials | null): void =>
+      setHostGoogleWalletOverride(c),
+    resetHostConfig: (): void => setHostGoogleWalletOverride(undefined),
   },
 
   // --- Setup & auth ---

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -224,12 +224,11 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
     });
 
     test("shows host Google Wallet config when env vars set", async () => {
-      Deno.env.set("GOOGLE_WALLET_ISSUER_ID", "3388000000012345678");
-      Deno.env.set(
-        "GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL",
-        "wallet@project.iam.gserviceaccount.com",
-      );
-      Deno.env.set("GOOGLE_WALLET_SERVICE_ACCOUNT_KEY", "pem-key-data");
+      settings.googleWallet.setHostConfigForTest({
+        issuerId: "3388000000012345678",
+        serviceAccountEmail: "wallet@project.iam.gserviceaccount.com",
+        serviceAccountKey: "pem-key-data",
+      });
       try {
         const { response } = await adminGet("/admin/guide");
         const html = await response.text();
@@ -239,9 +238,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         expect(html).toContain("3388000000012345678");
         expect(html).toContain("You need three values from");
       } finally {
-        Deno.env.delete("GOOGLE_WALLET_ISSUER_ID");
-        Deno.env.delete("GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL");
-        Deno.env.delete("GOOGLE_WALLET_SERVICE_ACCOUNT_KEY");
+        settings.googleWallet.resetHostConfig();
       }
     });
 


### PR DESCRIPTION
Use a test override (setHostConfigForTest/resetHostConfig) for the Google Wallet host config instead of manipulating env vars directly via Deno.env. This mirrors the pattern already used by Apple Wallet and avoids a race condition where process.env and Deno.env can get out of sync in parallel test execution.

https://claude.ai/code/session_01FF21r7rUMHhsfiyp5eM98x