### PR TITLE
Add Software Updates section to admin guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1562,6 +1562,10 @@ export const adminGuidePage = (
               your site (Bunny CDN only)
             </li>
             <li>
+              <strong>Software updates</strong> &mdash; check for and install
+              new versions
+            </li>
+            <li>
               <strong>Database reset</strong> &mdash; permanently delete all
               data
             </li>
@@ -1758,6 +1762,39 @@ export const adminGuidePage = (
             The <a href="/admin/api-keys/docs">API documentation page</a> has a
             complete reference for both public and admin API endpoints, with
             example request and response payloads for each.
+          </p>
+        </Q>
+      </Section>
+
+      <Section title="Software Updates">
+        <Q q="How do I check for updates?">
+          <p>
+            Go to <code>/admin/update</code> to see your current build date and
+            commit. Click <strong>Check for Updates</strong> to query GitHub for
+            the latest release. If a newer version is available, you'll see its
+            name and version number.
+          </p>
+        </Q>
+
+        <Q q="How do I install an update?">
+          <p>
+            If an update is available and your server has{" "}
+            <code>BUNNY_API_KEY</code> and <code>BUNNY_SCRIPT_ID</code>{" "}
+            configured, an <strong>Update Now</strong> button appears. Click it
+            to download and deploy the new version automatically via Bunny CDN.
+            The update is logged in the activity log. If the Bunny environment
+            variables are not set, you'll need to deploy the update manually.
+          </p>
+        </Q>
+
+        <Q q="Where can I read the release notes?">
+          <p>
+            The update page includes a link to the{" "}
+            <a href="https://github.com/chobbledotcom/tickets/releases">
+              release notes on GitHub
+            </a>
+            , where you can see what changed in each version before deciding to
+            update.
           </p>
         </Q>
       </Section>

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -622,6 +622,13 @@ export const adminAdvancedSettingsPage = (
         </div>
       )}
 
+      <div class="stack-md column">
+        <h2>Software Updates</h2>
+        <p>
+          <a href="/admin/update">Check for and install software updates</a>
+        </p>
+      </div>
+
       <ResetDatabaseForm
         action="/admin/settings/reset-database"
         id="settings-reset-database"


### PR DESCRIPTION
## Summary

- The `/admin/update` page (check for and install software updates) was completely undocumented in the admin guide — this adds a new **Software Updates** section with three Q&A entries covering how to check for updates, how to install them, and where to read release notes
- Adds a **Software Updates** link on the Advanced Settings page so admins can discover the feature without needing to know the URL
- Updates the **Settings Overview** section in the guide to list software updates as an Advanced Settings item

## Context

Deep-dive of the guide vs the actual system found that permissions, session/invite expiry values, and all other documented features match the code accurately. The software update feature was the only significant admin capability with no guide coverage and no discoverable link from any other admin page.

## Test plan

- [x] `deno task precommit` passes (typecheck, lint, cpd, build, tests with 100% coverage)

https://claude.ai/code/session_01LKvuKxN9Wpb3RVpKbP12cB