### PR TITLE
Stub Stripe checkout creation in multi-ticket webhook test

### DIFF
--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -4042,18 +4042,35 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
 
       // Submit multi-ticket form with a question answer selected.
       // One event is paid, so this triggers the payment flow.
+      // Stub checkout creation to avoid flaky stripe-mock HTTP calls under
+      // high concurrency — this test verifies webhook processing, not checkout.
+      const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
+      const mockCreate = stub(
+        stripePaymentProvider,
+        "createMultiCheckoutSession",
+        () =>
+          Promise.resolve({
+            sessionId: "cs_multi_q_stub",
+            checkoutUrl: "https://checkout.stripe.com/pay/cs_multi_q_stub",
+          }),
+      );
+
       const { submitMultiTicketForm, expectCheckoutRedirect } = await import(
         "#test-utils"
       );
       const slug = `${event1.slug}+${event2.slug}`;
-      const checkoutResponse = await submitMultiTicketForm(slug, {
-        name: "Q Buyer",
-        email: "qbuyer@example.com",
-        [`quantity_${event1.id}`]: "1",
-        [`quantity_${event2.id}`]: "1",
-        [`question_${q.id}`]: String(a1.id),
-      });
-      expectCheckoutRedirect(checkoutResponse);
+      try {
+        const checkoutResponse = await submitMultiTicketForm(slug, {
+          name: "Q Buyer",
+          email: "qbuyer@example.com",
+          [`quantity_${event1.id}`]: "1",
+          [`quantity_${event2.id}`]: "1",
+          [`question_${q.id}`]: String(a1.id),
+        });
+        expectCheckoutRedirect(checkoutResponse);
+      } finally {
+        mockCreate.restore();
+      }
 
       // Now simulate the webhook callback from the payment provider.
       // The metadata includes answer_ids serialized during checkout.


### PR DESCRIPTION
## Summary
This change improves test reliability by stubbing the Stripe checkout session creation in the multi-ticket webhook test, preventing flaky HTTP calls to stripe-mock under high concurrency conditions.

## Key Changes
- Added a stub for `stripePaymentProvider.createMultiCheckoutSession()` that returns a mock checkout session instead of making actual HTTP calls to stripe-mock
- Wrapped the form submission and assertion in a try-finally block to ensure the stub is properly restored after the test completes
- Added clarifying comment explaining that this test verifies webhook processing, not checkout creation

## Implementation Details
The stub returns a minimal but valid checkout session object with:
- `sessionId`: "cs_multi_q_stub"
- `checkoutUrl`: "https://checkout.stripe.com/pay/cs_multi_q_stub"

This allows the test to focus on its actual purpose—verifying webhook processing—without being affected by the flakiness of external Stripe mock HTTP calls during concurrent test execution.

https://claude.ai/code/session_019rq9PGuyJo8UpwdwEzL98L