### PR TITLE
Add site builder feature for creating Tickets instances

### DIFF
--- a/src/docs/crypto.ts
+++ b/src/docs/crypto.ts
@@ -10,9 +10,9 @@
  * @module
  */
 
-export * from "#lib/crypto/utils.ts";
 export * from "#lib/crypto/encryption.ts";
 export * from "#lib/crypto/hashing.ts";
 export * from "#lib/crypto/keys.ts";
+export * from "#lib/crypto/utils.ts";
 export * from "#lib/csrf.ts";
 export * from "#lib/payment-crypto.ts";

--- a/src/lib/attachment-url.ts
+++ b/src/lib/attachment-url.ts
@@ -6,8 +6,8 @@
  * their ticket page to get a fresh URL (prevents sharing).
  */
 
-import { base64ToBase64Url, constantTimeEqual } from "#lib/crypto/utils.ts";
 import { hmacHash } from "#lib/crypto/hashing.ts";
+import { base64ToBase64Url, constantTimeEqual } from "#lib/crypto/utils.ts";
 import { ATTACHMENT_URL_MAX_AGE_S } from "#lib/limits.ts";
 import { nowMs } from "#lib/now.ts";
 

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -1,0 +1,155 @@
+/**
+ * Site builder — creates new Tickets instances via the Bunny API.
+ *
+ * Flow:
+ * 1. Fetch latest release code from GitHub
+ * 2. Create a new Bunny edge script with the code
+ * 3. Set secrets: user-provided (DB_URL, DB_TOKEN), generated (DB_ENCRYPTION_KEY),
+ *    and copied from host (email, wallet, ntfy, storage, DNS config)
+ * 4. Test database connection
+ * 5. Publish the script
+ * 6. Record the built site in the local database
+ */
+
+import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
+import { toBase64 } from "#lib/crypto/utils.ts";
+import { getEnv } from "#lib/env.ts";
+import { fetchText } from "#lib/fetch.ts";
+import { fetchLatestRelease } from "#lib/update.ts";
+
+/** Secrets copied from the host environment (if set) */
+const HOST_SECRET_KEYS = [
+  "NTFY_URL",
+  "STORAGE_ZONE_NAME",
+  "STORAGE_ZONE_KEY",
+  "HOST_EMAIL_PROVIDER",
+  "HOST_EMAIL_API_KEY",
+  "HOST_EMAIL_FROM_ADDRESS",
+  "BUNNY_API_KEY",
+  "BUNNY_DNS_ZONE_ID",
+  "BUNNY_DNS_SUBDOMAIN_SUFFIX",
+  "APPLE_WALLET_PASS_TYPE_ID",
+  "APPLE_WALLET_TEAM_ID",
+  "APPLE_WALLET_SIGNING_CERT",
+  "APPLE_WALLET_SIGNING_KEY",
+  "APPLE_WALLET_WWDR_CERT",
+  "GOOGLE_WALLET_ISSUER_ID",
+  "GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL",
+  "GOOGLE_WALLET_SERVICE_ACCOUNT_KEY",
+] as const;
+
+export type BuildSiteInput = {
+  siteName: string;
+  dbUrl: string;
+  dbToken: string;
+};
+
+export type BuildSiteResult =
+  | { ok: true; scriptId: number; defaultHostname: string }
+  | { ok: false; error: string };
+
+/** Generate a random 32-byte base64 encryption key */
+export const generateEncryptionKey = (): string => {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return toBase64(bytes);
+};
+
+/** Test a libsql database connection by running a simple query */
+export const testDbConnection = async (
+  dbUrl: string,
+  dbToken: string,
+): Promise<{ ok: true } | { ok: false; error: string }> => {
+  try {
+    const { createClient } = await import("@libsql/client");
+    const client = createClient({ url: dbUrl, authToken: dbToken });
+    await client.execute("SELECT 1");
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+};
+
+/** Set multiple secrets on a Bunny edge script, collecting errors */
+const setSecrets = async (
+  scriptId: number,
+  secrets: [name: string, value: string][],
+): Promise<string[]> => {
+  const errors: string[] = [];
+  for (const [name, value] of secrets) {
+    const result = await bunnyCdnApi.setEdgeScriptSecret(scriptId, name, value);
+    if (!result.ok) errors.push(result.error);
+  }
+  return errors;
+};
+
+/**
+ * Build a new site: create edge script, configure secrets, publish.
+ */
+export const buildSite = async (
+  input: BuildSiteInput,
+): Promise<BuildSiteResult> => {
+  const fullName = `Tickets - ${input.siteName}`;
+
+  // 1. Fetch latest release code
+  let code: string;
+  try {
+    const release = await fetchLatestRelease();
+    if (!release.assetUrl) {
+      return { ok: false, error: "No release asset found on GitHub" };
+    }
+    const assetResponse = await fetchText(release.assetUrl);
+    if (!assetResponse.ok) {
+      return {
+        ok: false,
+        error: `Failed to download release: ${assetResponse.status}`,
+      };
+    }
+    code = assetResponse.text;
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Failed to fetch release: ${(e as Error).message}`,
+    };
+  }
+
+  // 2. Create edge script
+  const createResult = await bunnyCdnApi.createEdgeScript(fullName, code);
+  if (!createResult.ok) return createResult;
+
+  const { scriptId, defaultHostname } = createResult;
+
+  // 3. Generate encryption key
+  const encryptionKey = builderApi.generateEncryptionKey();
+
+  // 4. Set secrets
+  const secrets: [string, string][] = [
+    ["DB_URL", input.dbUrl],
+    ["DB_TOKEN", input.dbToken],
+    ["DB_ENCRYPTION_KEY", encryptionKey],
+    ["BUNNY_SCRIPT_ID", String(scriptId)],
+  ];
+
+  // Copy host secrets that are set
+  for (const key of HOST_SECRET_KEYS) {
+    const value = getEnv(key);
+    if (value) secrets.push([key, value]);
+  }
+
+  const secretErrors = await setSecrets(scriptId, secrets);
+  if (secretErrors.length > 0) {
+    return { ok: false, error: `Failed to set secrets: ${secretErrors[0]}` };
+  }
+
+  // 5. Publish
+  const publishResult = await bunnyCdnApi.publishEdgeScript(scriptId);
+  if (!publishResult.ok) return publishResult;
+
+  return { ok: true, scriptId, defaultHostname };
+};
+
+/** Stubbable API for testing */
+export const builderApi = {
+  generateEncryptionKey,
+  testDbConnection,
+  buildSite,
+};

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -395,6 +395,111 @@ const deleteDnsRecordImpl = async (
 };
 
 // ---------------------------------------------------------------------------
+// Compute script helpers (shared by builder + self-update)
+// ---------------------------------------------------------------------------
+
+/** POST/PUT to a compute script endpoint with JSON body and AccessKey auth. */
+const computeScriptRequest = (
+  path: string,
+  method: string,
+  body: string,
+): Promise<FetchResult> =>
+  fetchText(`${BUNNY_API_BASE}${path}`, {
+    method,
+    headers: {
+      AccessKey: getBunnyApiKey(),
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+
+/** POST/PUT to /compute/script/{id}/{action} */
+const scriptAction = (
+  scriptId: number | string,
+  action: string,
+  method: string,
+  body: string,
+): Promise<FetchResult> =>
+  computeScriptRequest(
+    `/compute/script/${encodeURIComponent(scriptId)}/${action}`,
+    method,
+    body,
+  );
+
+/** Publish a Bunny edge script by ID. */
+const publishScript = async (
+  scriptId: number | string,
+  label: string,
+): Promise<BunnyApiResult> =>
+  okOrError(await scriptAction(scriptId, "publish", "POST", "{}"), label);
+
+// ---------------------------------------------------------------------------
+// Edge script creation (site builder)
+// ---------------------------------------------------------------------------
+
+interface CreateEdgeScriptResult {
+  ok: true;
+  scriptId: number;
+  defaultHostname: string;
+}
+
+/**
+ * Create a new Bunny edge script with the given name and code.
+ * ScriptType 2 = standalone (no linked pull zone auto-created by default).
+ * CreateLinkedPullZone = true to get a default hostname.
+ */
+const createEdgeScriptImpl = async (
+  name: string,
+  code: string,
+): Promise<CreateEdgeScriptResult | { ok: false; error: string }> => {
+  const response = await computeScriptRequest(
+    "/compute/script",
+    "POST",
+    JSON.stringify({
+      Name: name,
+      Code: code,
+      ScriptType: 2,
+      CreateLinkedPullZone: true,
+    }),
+  );
+
+  if (!response.ok) {
+    return parseBunnyError(response, "Create edge script");
+  }
+
+  const data = JSON.parse(response.text);
+  return {
+    ok: true,
+    scriptId: data.Id,
+    defaultHostname: data.DefaultHostname ?? "",
+  };
+};
+
+/**
+ * Set a secret on a Bunny edge script.
+ */
+const setEdgeScriptSecretImpl = async (
+  scriptId: number,
+  name: string,
+  value: string,
+): Promise<BunnyApiResult> =>
+  okOrError(
+    await scriptAction(
+      scriptId,
+      "secrets",
+      "PUT",
+      JSON.stringify({ Name: name, Secret: value }),
+    ),
+    `Set secret ${name}`,
+  );
+
+/**
+ * Publish a Bunny edge script.
+ */
+const publishEdgeScriptImpl = (scriptId: number): Promise<BunnyApiResult> =>
+  publishScript(scriptId, "Publish edge script");
+
+// ---------------------------------------------------------------------------
 // Compute script deployment (self-update)
 // ---------------------------------------------------------------------------
 
@@ -404,29 +509,18 @@ const deleteDnsRecordImpl = async (
  */
 const deployScriptCodeImpl = async (code: string): Promise<BunnyApiResult> => {
   const scriptId = getBunnyScriptId();
-  const apiKey = getBunnyApiKey();
 
-  const upload = await fetchText(
-    `${BUNNY_API_BASE}/compute/script/${encodeURIComponent(scriptId)}/code`,
-    {
-      method: "POST",
-      headers: { AccessKey: apiKey, "Content-Type": "application/json" },
-      body: JSON.stringify({ Code: code }),
-    },
+  const upload = await scriptAction(
+    scriptId,
+    "code",
+    "POST",
+    JSON.stringify({ Code: code }),
   );
   if (!upload.ok) {
     return okOrError(upload, "Upload script code");
   }
 
-  const publish = await fetchText(
-    `${BUNNY_API_BASE}/compute/script/${encodeURIComponent(scriptId)}/publish`,
-    {
-      method: "POST",
-      headers: { AccessKey: apiKey, "Content-Type": "application/json" },
-      body: "{}",
-    },
-  );
-  return okOrError(publish, "Publish script");
+  return publishScript(scriptId, "Publish script");
 };
 
 /** Stubbable API for testing */
@@ -440,6 +534,9 @@ export const bunnyCdnApi = {
   getCdnHostname: getCdnHostnameImpl,
   deleteDnsRecord: deleteDnsRecordImpl,
   deployScriptCode: deployScriptCodeImpl,
+  createEdgeScript: createEdgeScriptImpl,
+  setEdgeScriptSecret: setEdgeScriptSecretImpl,
+  publishEdgeScript: publishEdgeScriptImpl,
   delay,
 };
 
@@ -463,3 +560,22 @@ export const getCdnHostname = (): Promise<CdnHostnameResult> =>
 /** Upload and publish new script code to Bunny CDN. */
 export const deployScriptCode = (code: string): Promise<BunnyApiResult> =>
   bunnyCdnApi.deployScriptCode(code);
+
+/** Create a new Bunny edge script. */
+export const createEdgeScript = (
+  name: string,
+  code: string,
+): ReturnType<typeof createEdgeScriptImpl> =>
+  bunnyCdnApi.createEdgeScript(name, code);
+
+/** Set a secret on a Bunny edge script. */
+export const setEdgeScriptSecret = (
+  scriptId: number,
+  name: string,
+  value: string,
+): Promise<BunnyApiResult> =>
+  bunnyCdnApi.setEdgeScriptSecret(scriptId, name, value);
+
+/** Publish a Bunny edge script. */
+export const publishEdgeScript = (scriptId: number): Promise<BunnyApiResult> =>
+  bunnyCdnApi.publishEdgeScript(scriptId);

--- a/src/lib/crypto/encryption.ts
+++ b/src/lib/crypto/encryption.ts
@@ -304,4 +304,3 @@ export const importHmacKey = async (): Promise<CryptoKey> => {
   setHmacKeyResolved(key);
   return key;
 };
-

--- a/src/lib/crypto/hashing.ts
+++ b/src/lib/crypto/hashing.ts
@@ -2,9 +2,9 @@
  * Password hashing (PBKDF2), session token hashing, HMAC, and ticket token indexing
  */
 
-import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
-import { importHmacKey } from "./encryption.ts";
 import { getEnv } from "#lib/env.ts";
+import { importHmacKey } from "./encryption.ts";
+import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
 
 /**
  * Password hashing using PBKDF2 via Web Crypto API
@@ -14,7 +14,9 @@ const PBKDF2_ITERATIONS_DEFAULT = 600000; // OWASP recommended minimum for SHA-2
 const PBKDF2_ITERATIONS_TEST = 1000; // Fast iterations for tests
 
 export const getPbkdf2Iterations = (): number =>
-  getEnv("TEST_FAST_PBKDF2") ? PBKDF2_ITERATIONS_TEST : PBKDF2_ITERATIONS_DEFAULT;
+  getEnv("TEST_FAST_PBKDF2")
+    ? PBKDF2_ITERATIONS_TEST
+    : PBKDF2_ITERATIONS_DEFAULT;
 const PBKDF2_HASH_LENGTH = 32; // Output key length in bytes
 const PASSWORD_PREFIX = "pbkdf2";
 

--- a/src/lib/crypto/keys.ts
+++ b/src/lib/crypto/keys.ts
@@ -5,7 +5,6 @@
 import { ttlCache } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
 import { getEnv } from "#lib/env.ts";
-import { fromBase64 } from "./utils.ts";
 import {
   aesGcmDecryptRaw,
   aesGcmEncryptRaw,
@@ -16,6 +15,7 @@ import {
   parseEncryptedPayload,
 } from "./encryption.ts";
 import { getPbkdf2Iterations } from "./hashing.ts";
+import { fromBase64 } from "./utils.ts";
 
 /**
  * =============================================================================

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -7,8 +7,12 @@
  * Instagram) where Safari/WebKit blocks third-party cookies.
  */
 
-import { base64ToBase64Url, constantTimeEqual, generateSecureToken } from "#lib/crypto/utils.ts";
 import { hmacHash } from "#lib/crypto/hashing.ts";
+import {
+  base64ToBase64Url,
+  constantTimeEqual,
+  generateSecureToken,
+} from "#lib/crypto/utils.ts";
 import { nowMs } from "#lib/now.ts";
 
 const SIGNED_PREFIX = "s1.";

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -7,10 +7,10 @@
  */
 
 import { filter, map, reduce } from "#fp";
-import { generateTicketToken } from "#lib/crypto/utils.ts";
 import { decrypt } from "#lib/crypto/encryption.ts";
 import { computeTicketTokenIndex } from "#lib/crypto/hashing.ts";
 import { decryptAttendeePII, encryptAttendeePII } from "#lib/crypto/keys.ts";
+import { generateTicketToken } from "#lib/crypto/utils.ts";
 import {
   executeBatch,
   getDb,

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -1,0 +1,84 @@
+/**
+ * Built sites — stores records of sites created via the admin builder.
+ * Site data (name, bunny URL) is encrypted in a single blob for privacy.
+ */
+
+import { decrypt, encrypt } from "#lib/crypto/encryption.ts";
+import { queryAll } from "#lib/db/client.ts";
+import { col, defineTable } from "#lib/db/table.ts";
+import { nowIso } from "#lib/now.ts";
+
+/** Encrypted site data blob shape */
+export interface SiteDataBlob {
+  v: 1;
+  /** Site name */
+  n: string;
+  /** Bunny URL (default hostname) */
+  u: string;
+}
+
+/** Built site row as stored in the database */
+export interface BuiltSiteRow {
+  id: number;
+  site_data: string;
+  created: string;
+}
+
+/** Built site input for creating a new row */
+export type BuiltSiteInput = {
+  siteData: string;
+};
+
+/** Decrypted built site for display */
+export interface BuiltSite {
+  id: number;
+  name: string;
+  bunnyUrl: string;
+  created: string;
+}
+
+export const builtSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
+  name: "built_sites",
+  primaryKey: "id",
+  schema: {
+    id: col.generated<number>(),
+    site_data: col.encrypted<string>(encrypt, decrypt),
+    created: col.withDefault(() => nowIso()),
+  },
+});
+
+/** Build the encrypted site data blob */
+export const buildSiteDataBlob = (name: string, bunnyUrl: string): string =>
+  JSON.stringify({ v: 1, n: name, u: bunnyUrl } satisfies SiteDataBlob);
+
+/** Parse a decrypted site data blob */
+export const parseSiteDataBlob = (json: string): SiteDataBlob =>
+  JSON.parse(json) as SiteDataBlob;
+
+/** Insert a new built site record */
+export const insertBuiltSite = (
+  name: string,
+  bunnyUrl: string,
+): Promise<BuiltSiteRow> =>
+  builtSitesTable.insert({ siteData: buildSiteDataBlob(name, bunnyUrl) });
+
+/** Get all built sites, decrypted and sorted by name */
+export const getAllBuiltSites = async (): Promise<BuiltSite[]> => {
+  const rows = await queryAll<BuiltSiteRow>(
+    "SELECT * FROM built_sites ORDER BY created DESC",
+  );
+  const decrypted = await Promise.all(
+    rows.map((row) => builtSitesTable.fromDb(row)),
+  );
+  const sites = decrypted.map((row) => {
+    const blob = parseSiteDataBlob(row.site_data);
+    return {
+      id: row.id,
+      name: blob.n,
+      bunnyUrl: blob.u,
+      created: row.created,
+    };
+  });
+  sites.sort((a, b) => a.name.localeCompare(b.name));
+  return sites;
+};

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -31,7 +31,7 @@ type Table = {
 
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
-export const LATEST_UPDATE = "declarative schema migrations";
+export const LATEST_UPDATE = "add built_sites table";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 
@@ -306,6 +306,17 @@ const SCHEMA: [name: string, table: Table][] = [
           columns: ["event_id", "question_id"],
           unique: true,
         },
+      ],
+    },
+  ],
+
+  [
+    "built_sites",
+    {
+      columns: [
+        ["id", "INTEGER PRIMARY KEY AUTOINCREMENT"],
+        ["site_data", "TEXT NOT NULL"],
+        ["created", "TEXT NOT NULL"],
       ],
     },
   ],

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -4,7 +4,12 @@
 
 import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt } from "#lib/crypto/encryption.ts";
-import { hashPassword, hashSessionToken, hmacHash, verifyPassword } from "#lib/crypto/hashing.ts";
+import {
+  hashPassword,
+  hashSessionToken,
+  hmacHash,
+  verifyPassword,
+} from "#lib/crypto/hashing.ts";
 import { deriveKEK, wrapKey } from "#lib/crypto/keys.ts";
 import { deleteByFieldBatch, getDb, queryAll } from "#lib/db/client.ts";
 import { now } from "#lib/now.ts";

--- a/src/lib/seeds.ts
+++ b/src/lib/seeds.ts
@@ -4,10 +4,10 @@
  */
 
 import { map, reduce } from "#fp";
-import { generateTicketToken } from "#lib/crypto/utils.ts";
 import { encrypt } from "#lib/crypto/encryption.ts";
 import { computeTicketTokenIndex, hmacHash } from "#lib/crypto/hashing.ts";
 import { encryptAttendeePII } from "#lib/crypto/keys.ts";
+import { generateTicketToken } from "#lib/crypto/utils.ts";
 import { executeBatch, queryAll } from "#lib/db/client.ts";
 import { invalidateEventsCache } from "#lib/db/events.ts";
 import { settings } from "#lib/db/settings.ts";

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -6,8 +6,8 @@ import {
   ADMIN_API_ENDPOINTS,
   PUBLIC_API_ENDPOINTS,
 } from "#lib/admin-api-example.ts";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
 import {
   createApiKey,
   deleteApiKey,

--- a/src/routes/admin/builder.ts
+++ b/src/routes/admin/builder.ts
@@ -1,0 +1,113 @@
+/**
+ * Admin builder routes — create new Tickets instances via Bunny API
+ * Owner-only access, gated behind CAN_BUILD_SITES=true env var
+ */
+
+import { builderApi } from "#lib/builder.ts";
+import { logActivity } from "#lib/db/activityLog.ts";
+import { getAllBuiltSites, insertBuiltSite } from "#lib/db/built-sites.ts";
+import { settings } from "#lib/db/settings.ts";
+import { getEnv } from "#lib/env.ts";
+import { defineRoutes } from "#routes/router.ts";
+import {
+  applyFlash,
+  errorRedirect,
+  htmlResponse,
+  notFoundResponse,
+  OWNER_FORM,
+  redirect,
+  requireOwnerOr,
+  withAuth,
+} from "#routes/utils.ts";
+import {
+  adminBuilderPage,
+  type BuiltSiteDisplay,
+} from "#templates/admin/builder.tsx";
+
+const BUILDER_PATH = "/admin/builder";
+
+/** Check if the builder feature is enabled */
+export const isBuilderEnabled = (): boolean =>
+  getEnv("CAN_BUILD_SITES") === "true";
+
+/** Convert built sites to display format */
+const toDisplay = (
+  sites: Awaited<ReturnType<typeof getAllBuiltSites>>,
+): BuiltSiteDisplay[] =>
+  sites.map((s) => ({
+    name: s.name,
+    bunnyUrl: s.bunnyUrl,
+    created: new Date(s.created).toLocaleDateString("en-GB", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }),
+  }));
+
+/** GET /admin/builder — show builder form and built sites list */
+const handleBuilderGet = (request: Request): Promise<Response> => {
+  if (!isBuilderEnabled()) return Promise.resolve(notFoundResponse());
+
+  return requireOwnerOr(request, async (session) => {
+    const { error, success } = applyFlash(request);
+    const sites = toDisplay(await getAllBuiltSites());
+    return htmlResponse(adminBuilderPage(session, sites, error, success));
+  });
+};
+
+/** POST /admin/builder — create a new site */
+const handleBuilderPost = async (
+  _session: unknown,
+  form: import("#lib/form-data.ts").FormParams,
+): Promise<Response> => {
+  if (!isBuilderEnabled()) return notFoundResponse();
+
+  const siteName = form.getString("site_name");
+  const dbUrl = form.getString("db_url");
+  const dbToken = form.getString("db_token");
+
+  if (!siteName) return errorRedirect(BUILDER_PATH, "Site name is required");
+  if (!dbUrl) return errorRedirect(BUILDER_PATH, "Database URL is required");
+  if (!dbToken) {
+    return errorRedirect(BUILDER_PATH, "Database token is required");
+  }
+
+  // Test database connection first
+  const dbTest = await builderApi.testDbConnection(dbUrl, dbToken);
+  if (!dbTest.ok) {
+    return errorRedirect(
+      BUILDER_PATH,
+      `Database connection failed: ${dbTest.error}`,
+    );
+  }
+
+  // Build the site
+  const result = await settings.withCurrentTask("builder", () =>
+    builderApi.buildSite({ siteName, dbUrl, dbToken }),
+  );
+
+  if (!result.ok) {
+    return errorRedirect(BUILDER_PATH, result.error);
+  }
+
+  const buildResult = result.value;
+  if (!buildResult.ok) {
+    return errorRedirect(BUILDER_PATH, buildResult.error);
+  }
+
+  // Record the built site
+  await insertBuiltSite(siteName, buildResult.defaultHostname);
+  await logActivity(`Built new site: ${siteName}`);
+
+  return redirect(
+    BUILDER_PATH,
+    `Site "${siteName}" created successfully at ${buildResult.defaultHostname}`,
+    true,
+  );
+};
+
+export const builderRoutes = defineRoutes({
+  "GET /admin/builder": handleBuilderGet,
+  "POST /admin/builder": (r: Request) =>
+    withAuth(r, OWNER_FORM, handleBuilderPost),
+});

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -13,6 +13,7 @@ import { apiKeysRoutes } from "#routes/admin/api-keys.ts";
 import { attendeeRefundRoutes } from "#routes/admin/attendee-refunds.ts";
 import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
+import { builderRoutes } from "#routes/admin/builder.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
 import { dashboardRoutes } from "#routes/admin/dashboard.ts";
 import { debugRoutes } from "#routes/admin/debug.ts";
@@ -53,6 +54,7 @@ const adminRoutes = {
   ...scannerRoutes,
   ...seedsRoutes,
   ...migrateRoutes,
+  ...builderRoutes,
   ...updateRoutes,
 };
 

--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -2,13 +2,13 @@
  * Group ticket context and routing
  */
 
-/* jscpd:ignore-start */
-import { getActiveHolidays } from "#lib/db/holidays.ts";
 import {
   computeGroupSlugIndex,
   getActiveEventsByGroupId,
   getGroupBySlugIndex,
 } from "#lib/db/groups.ts";
+/* jscpd:ignore-start */
+import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { getQuestionsWithEventIds } from "#lib/db/questions.ts";
 import { settings } from "#lib/db/settings.ts";
 /* jscpd:ignore-end */
@@ -19,8 +19,8 @@ import type { TicketEvent } from "#templates/public.tsx";
 import { computeSharedDates } from "./ticket-payment.ts";
 import { handleTicket } from "./ticket-submit.ts";
 import {
-  getActiveEvents,
   type AsyncHandler,
+  getActiveEvents,
   type TicketContextProvider,
 } from "./types.ts";
 

--- a/src/routes/public/pages.ts
+++ b/src/routes/public/pages.ts
@@ -6,18 +6,18 @@ import { settings } from "#lib/db/settings.ts";
 import { loadSortedEvents } from "#lib/sort-events.ts";
 import type { EventWithCount } from "#lib/types.ts";
 import {
+  htmlResponse,
+  isRegistrationClosed,
+  notFoundResponse,
+  redirectResponse,
+} from "#routes/utils.ts";
+import {
   buildTicketEvent,
   homepagePage,
   type PublicPageType,
   publicSitePage,
   type TicketEvent,
 } from "#templates/public.tsx";
-import {
-  htmlResponse,
-  isRegistrationClosed,
-  notFoundResponse,
-  redirectResponse,
-} from "#routes/utils.ts";
 
 /** Active+visible filter for public event listings */
 const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;

--- a/src/routes/public/ticket-form.ts
+++ b/src/routes/public/ticket-form.ts
@@ -5,9 +5,10 @@
 import { filter, map } from "#fp";
 import { validatePrice } from "#lib/currency.ts";
 import type {
-  QuestionWithAnswers,
   QuestionEventMap,
+  QuestionWithAnswers,
 } from "#lib/db/questions.ts";
+import type { FormParams } from "#lib/form-data.ts";
 import type { EventFields } from "#lib/types.ts";
 import {
   errorRedirect,
@@ -15,9 +16,8 @@ import {
   htmlResponse,
 } from "#routes/utils.ts";
 import { extractContact, mergeEventFields } from "#templates/fields.ts";
-import { ticketPage, type TicketEvent } from "#templates/public.tsx";
-import type { FormParams } from "#lib/form-data.ts";
-import type { TicketCtx, EventQty } from "./types.ts";
+import { type TicketEvent, ticketPage } from "#templates/public.tsx";
+import type { EventQty, TicketCtx } from "./types.ts";
 
 /** Parse and validate a quantity value from a raw string, capping at max */
 export const parseQuantityValue = (

--- a/src/routes/public/ticket-payment.ts
+++ b/src/routes/public/ticket-payment.ts
@@ -4,6 +4,7 @@
 
 import { compact } from "#fp";
 import { isPaymentsEnabled } from "#lib/config.ts";
+import { getAvailableDates } from "#lib/dates.ts";
 import {
   checkBatchAvailability,
   createAttendeeAtomic,
@@ -12,7 +13,6 @@ import { getEventsBySlugsBatch } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { getQuestionsWithEventIds } from "#lib/db/questions.ts";
 import { settings } from "#lib/db/settings.ts";
-import { getAvailableDates } from "#lib/dates.ts";
 import type { EmailEntry } from "#lib/email.ts";
 import { logDebug } from "#lib/logger.ts";
 import {
@@ -30,15 +30,8 @@ import {
   notFoundResponse,
 } from "#routes/utils.ts";
 import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
-import {
-  eventsWithQuantity,
-  formatAtomicError,
-} from "./ticket-form.ts";
-import type {
-  AsyncHandler,
-  TicketCtx,
-  TicketSharedContext,
-} from "./types.ts";
+import { eventsWithQuantity, formatAtomicError } from "./ticket-form.ts";
+import type { AsyncHandler, TicketCtx, TicketSharedContext } from "./types.ts";
 
 /** Try to redirect to checkout, or return error using provided handler.
  * When in iframe mode, returns a popup page instead of redirect since Stripe cannot run in iframes. */

--- a/src/routes/public/ticket-routes.ts
+++ b/src/routes/public/ticket-routes.ts
@@ -4,17 +4,11 @@
 
 import { getEffectiveDomain } from "#lib/config.ts";
 import { getEventWithCountBySlug } from "#lib/db/events.ts";
-import {
-  computeGroupSlugIndex,
-  getGroupBySlugIndex,
-} from "#lib/db/groups.ts";
+import { computeGroupSlugIndex, getGroupBySlugIndex } from "#lib/db/groups.ts";
 import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
-import {
-  htmlResponse,
-  notFoundResponse,
-} from "#routes/utils.ts";
+import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { successPage } from "#templates/payment.tsx";
 import { handleGroupTicketBySlug } from "./groups.ts";
 import { handleTicketBySlugs } from "./ticket-submit.ts";

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -4,8 +4,8 @@
 
 import { reduce } from "#fp";
 import { signCsrfToken } from "#lib/csrf.ts";
-import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import { saveAttendeeAnswers } from "#lib/db/questions.ts";
+import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import { isPaidEvent } from "#lib/types.ts";
 import {
   applyFlash,
@@ -31,10 +31,10 @@ import {
   anyRequiresPayment,
   buildRegistrationItems,
   checkAvailability,
+  getTicketContext,
   handleMultiPaymentFlow,
   processFreeReservation,
   withActiveEvents,
-  getTicketContext,
 } from "./ticket-payment.ts";
 import {
   applyHiddenNoindex,

--- a/src/routes/public/types.ts
+++ b/src/routes/public/types.ts
@@ -3,13 +3,13 @@
  */
 
 import { compact, filter, map, pipe } from "#fp";
-import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
-import type { EventWithCount } from "#lib/types.ts";
 import type {
   QuestionEventMap,
   QuestionWithAnswers,
 } from "#lib/db/questions.ts";
+import type { EventWithCount } from "#lib/types.ts";
 import { isRegistrationClosed } from "#routes/utils.ts";
+import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
 
 /** Shared rendering context for ticket pages */
 export type TicketCtx = {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -4,8 +4,11 @@
 
 import { compact, map, pipe, reduce } from "#fp";
 import { buildFlashCookie, getSessionCookieName } from "#lib/cookies.ts";
+import {
+  getPrivateKeyFromSession,
+  unwrapKeyWithToken,
+} from "#lib/crypto/keys.ts";
 import { generateSecureToken } from "#lib/crypto/utils.ts";
-import { getPrivateKeyFromSession, unwrapKeyWithToken } from "#lib/crypto/keys.ts";
 import {
   CSRF_INVALID_FORM_MESSAGE,
   signCsrfToken,

--- a/src/templates/admin/builder.tsx
+++ b/src/templates/admin/builder.tsx
@@ -1,0 +1,127 @@
+/**
+ * Admin builder page template — create new Tickets instances
+ */
+
+import { CsrfForm } from "#lib/forms.tsx";
+import type { AdminSession } from "#lib/types.ts";
+import { AdminNav } from "#templates/admin/nav.tsx";
+import { Layout } from "#templates/layout.tsx";
+
+export type BuiltSiteDisplay = {
+  name: string;
+  bunnyUrl: string;
+  created: string;
+};
+
+/** Form to create a new site */
+const BuilderForm = (): JSX.Element => (
+  <section>
+    <div class="prose">
+      <h2>Create New Site</h2>
+      <p>
+        This will create a new Tickets instance as a Bunny edge script, copy
+        host configuration, and configure the database.
+      </p>
+    </div>
+    <CsrfForm action="/admin/builder" id="builder-form">
+      <label for="site_name">
+        Site Name
+        <input
+          type="text"
+          id="site_name"
+          name="site_name"
+          required
+          placeholder="My Event Site"
+          minlength={1}
+          maxlength={64}
+        />
+      </label>
+      <label for="db_url">
+        Database URL
+        <input
+          type="url"
+          id="db_url"
+          name="db_url"
+          required
+          placeholder="libsql://your-db.turso.io"
+        />
+      </label>
+      <label for="db_token">
+        Database Token
+        <input
+          type="password"
+          id="db_token"
+          name="db_token"
+          required
+          placeholder="Token for the database"
+        />
+      </label>
+      <button type="submit">Build Site</button>
+    </CsrfForm>
+  </section>
+);
+
+/** Table showing previously built sites */
+const BuiltSitesTable = ({
+  sites,
+}: {
+  sites: BuiltSiteDisplay[];
+}): JSX.Element =>
+  sites.length === 0 ? (
+    <p>
+      <em>No sites have been built yet.</em>
+    </p>
+  ) : (
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>URL</th>
+          <th>Built</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sites.map((site) => (
+          <tr>
+            <td>{site.name}</td>
+            <td>
+              <a
+                href={`https://${site.bunnyUrl}`}
+                target="_blank"
+                rel="noopener"
+              >
+                {site.bunnyUrl}
+              </a>
+            </td>
+            <td>{site.created}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+export const adminBuilderPage = (
+  session: AdminSession,
+  sites: BuiltSiteDisplay[],
+  error?: string,
+  success?: string,
+): string =>
+  String(
+    <Layout title="Site Builder">
+      <AdminNav session={session} active="/admin/settings" />
+
+      {error && <div class="error">{error}</div>}
+      {success && <div class="success">{success}</div>}
+
+      <h2>Site Builder</h2>
+
+      <BuilderForm />
+
+      <section>
+        <div class="prose">
+          <h2>Built Sites</h2>
+        </div>
+        <BuiltSitesTable sites={sites} />
+      </section>
+    </Layout>,
+  );

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -16,9 +16,9 @@ import type { SigningCredentials } from "#lib/apple-wallet.ts";
 import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { resetEffectiveDomain } from "#lib/config.ts";
 import { getSessionCookieName, parseFlashValue } from "#lib/cookies.ts";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
 import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { toMajorUnits } from "#lib/currency.ts";
 import { createApiKey } from "#lib/db/api-keys.ts";
@@ -790,8 +790,9 @@ const createDirectAdminSession = async (): Promise<{
   csrfToken: string;
 }> => {
   const { generateSecureToken } = await import("#lib/crypto/utils.ts");
-  const { deriveKEK, unwrapKey, wrapKeyWithToken } =
-    await import("#lib/crypto/keys.ts");
+  const { deriveKEK, unwrapKey, wrapKeyWithToken } = await import(
+    "#lib/crypto/keys.ts"
+  );
   const { createSession: createDbSession } = await import(
     "#lib/db/sessions.ts"
   );
@@ -2249,8 +2250,9 @@ export const createTestManagerSession = async (
 ): Promise<string> => {
   const { encrypt: enc } = await import("#lib/crypto/encryption.ts");
   const { hmacHash } = await import("#lib/crypto/hashing.ts");
-  const { deriveKEK, unwrapKey, wrapKeyWithToken } =
-    await import("#lib/crypto/keys.ts");
+  const { deriveKEK, unwrapKey, wrapKeyWithToken } = await import(
+    "#lib/crypto/keys.ts"
+  );
   const { getDb } = await import("#lib/db/client.ts");
   const { createSession } = await import("#lib/db/sessions.ts");
   const {

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { buildSessionCookie } from "#lib/cookies.ts";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { hmacHash } from "#lib/crypto/hashing.ts";
 import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
 
 import { signCsrfToken } from "#lib/csrf.ts";
 import {

--- a/test/lib/builder-template.test.ts
+++ b/test/lib/builder-template.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { AdminSession } from "#lib/types.ts";
+import {
+  adminBuilderPage,
+  type BuiltSiteDisplay,
+} from "#templates/admin/builder.tsx";
+
+const SESSION: AdminSession = {
+  adminLevel: "owner",
+};
+
+describe("adminBuilderPage", () => {
+  test("renders form fields", () => {
+    const html = adminBuilderPage(SESSION, []);
+    expect(html).toContain("Site Name");
+    expect(html).toContain("Database URL");
+    expect(html).toContain("Database Token");
+    expect(html).toContain('name="site_name"');
+    expect(html).toContain('name="db_url"');
+    expect(html).toContain('name="db_token"');
+    expect(html).toContain("Build Site");
+  });
+
+  test("renders empty state when no sites", () => {
+    const html = adminBuilderPage(SESSION, []);
+    expect(html).toContain("No sites have been built yet");
+  });
+
+  test("renders sites table with data", () => {
+    const sites: BuiltSiteDisplay[] = [
+      { name: "Alpha", bunnyUrl: "alpha.b-cdn.net", created: "1 Jan 2026" },
+      { name: "Beta", bunnyUrl: "beta.b-cdn.net", created: "2 Jan 2026" },
+    ];
+    const html = adminBuilderPage(SESSION, sites);
+    expect(html).toContain("Alpha");
+    expect(html).toContain("alpha.b-cdn.net");
+    expect(html).toContain("Beta");
+    expect(html).toContain("beta.b-cdn.net");
+    expect(html).toContain("1 Jan 2026");
+    expect(html).not.toContain("No sites have been built yet");
+  });
+
+  test("renders sites as clickable links", () => {
+    const sites: BuiltSiteDisplay[] = [
+      { name: "Test", bunnyUrl: "test.b-cdn.net", created: "1 Jan 2026" },
+    ];
+    const html = adminBuilderPage(SESSION, sites);
+    expect(html).toContain('href="https://test.b-cdn.net"');
+    expect(html).toContain('target="_blank"');
+  });
+
+  test("renders error message", () => {
+    const html = adminBuilderPage(SESSION, [], "Something went wrong");
+    expect(html).toContain("Something went wrong");
+    expect(html).toContain('class="error"');
+  });
+
+  test("renders success message", () => {
+    const html = adminBuilderPage(SESSION, [], undefined, "Site created!");
+    expect(html).toContain("Site created!");
+    expect(html).toContain('class="success"');
+  });
+
+  test("renders page title", () => {
+    const html = adminBuilderPage(SESSION, []);
+    expect(html).toContain("Site Builder");
+  });
+});

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -1,0 +1,494 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { builderApi } from "#lib/builder.ts";
+import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
+import { describeWithEnv, withMocks } from "#test-utils";
+
+describeWithEnv(
+  "builder",
+  { db: true, env: { NTFY_URL: "https://ntfy.example.com/test" } },
+  () => {
+    test("generateEncryptionKey returns 32-byte base64 string", () => {
+      const key = builderApi.generateEncryptionKey();
+      const bytes = Uint8Array.from(atob(key), (c) => c.charCodeAt(0));
+      expect(bytes.length).toBe(32);
+    });
+
+    test("generateEncryptionKey produces unique keys", () => {
+      const key1 = builderApi.generateEncryptionKey();
+      const key2 = builderApi.generateEncryptionKey();
+      expect(key1).not.toBe(key2);
+    });
+
+    test("buildSite returns error when release has no asset", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  tag_name: "v2026-01-01-000000",
+                  name: "Test",
+                  published_at: "2026-01-01T00:00:00Z",
+                  assets: [],
+                }),
+                { status: 200 },
+              ),
+            ),
+          ),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("No release asset");
+          }
+        },
+      );
+    });
+
+    test("buildSite returns error when GitHub API fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Not Found", { status: 404 })),
+          ),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Failed to fetch release");
+          }
+        },
+      );
+    });
+
+    test("testDbConnection succeeds with valid in-memory database", async () => {
+      const result = await builderApi.testDbConnection(":memory:", "");
+      expect(result.ok).toBe(true);
+    });
+
+    test("testDbConnection returns error for invalid URL", async () => {
+      const result = await builderApi.testDbConnection(
+        "libsql://nonexistent.invalid.host.example",
+        "bad-token",
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeTruthy();
+      }
+    });
+
+    test("buildSite returns error when release download fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes("releases/latest")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    tag_name: "v2026-01-01-000000",
+                    name: "Test",
+                    published_at: "2026-01-01T00:00:00Z",
+                    assets: [
+                      {
+                        name: "bunny-script.ts",
+                        browser_download_url: "https://example.com/script.ts",
+                      },
+                    ],
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            // Asset download fails
+            return Promise.resolve(new Response("Not Found", { status: 404 }));
+          }),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Failed to download release");
+          }
+        },
+      );
+    });
+
+    test("buildSite copies host secrets when env vars are set", async () => {
+      const secretsSet: [string, string][] = [];
+
+      await withMocks(
+        () => ({
+          fetchStub: stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request) => {
+              const url = String(input);
+              if (url.includes("releases/latest")) {
+                return Promise.resolve(
+                  new Response(
+                    JSON.stringify({
+                      tag_name: "v2026-01-01-000000",
+                      name: "Test Release",
+                      published_at: "2026-01-01T00:00:00Z",
+                      assets: [
+                        {
+                          name: "bunny-script.ts",
+                          browser_download_url: "https://example.com/script.ts",
+                        },
+                      ],
+                    }),
+                    { status: 200 },
+                  ),
+                );
+              }
+              if (url.includes("example.com/script.ts")) {
+                return Promise.resolve(
+                  new Response("console.log('code')", { status: 200 }),
+                );
+              }
+              return Promise.resolve(new Response("error", { status: 500 }));
+            },
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              ok: true as const,
+              scriptId: 42,
+              defaultHostname: "test-42.b-cdn.net",
+            }),
+          ),
+          secretStub: stub(
+            bunnyCdnApi,
+            "setEdgeScriptSecret",
+            (_id: number, name: string, value: string) => {
+              secretsSet.push([name, value]);
+              return Promise.resolve({ ok: true as const });
+            },
+          ),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          encKeyStub: stub(
+            builderApi,
+            "generateEncryptionKey",
+            () => "dGVzdGtleQ==",
+          ),
+        }),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+
+          expect(result.ok).toBe(true);
+
+          // NTFY_URL should have been copied from env
+          const ntfySecret = secretsSet.find(([n]) => n === "NTFY_URL");
+          expect(ntfySecret).toBeDefined();
+          expect(ntfySecret![1]).toBe("https://ntfy.example.com/test");
+        },
+      );
+    });
+
+    test("buildSite returns error when edge script creation fails", async () => {
+      await withMocks(
+        () => ({
+          fetchStub: stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request) => {
+              const url = String(input);
+              if (url.includes("releases/latest")) {
+                return Promise.resolve(
+                  new Response(
+                    JSON.stringify({
+                      tag_name: "v2026-01-01-000000",
+                      name: "Test",
+                      published_at: "2026-01-01T00:00:00Z",
+                      assets: [
+                        {
+                          name: "bunny-script.ts",
+                          browser_download_url: "https://example.com/script.ts",
+                        },
+                      ],
+                    }),
+                    { status: 200 },
+                  ),
+                );
+              }
+              if (url.includes("example.com/script.ts")) {
+                return Promise.resolve(
+                  new Response("console.log('code')", { status: 200 }),
+                );
+              }
+              return Promise.resolve(new Response("error", { status: 500 }));
+            },
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "Create edge script failed (500): Server Error",
+            }),
+          ),
+        }),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Create edge script failed");
+          }
+        },
+      );
+    });
+
+    test("buildSite succeeds with all steps", async () => {
+      const secretsSet: [string, string][] = [];
+
+      await withMocks(
+        () => ({
+          fetchStub: stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request) => {
+              const url = String(input);
+              if (url.includes("releases/latest")) {
+                return Promise.resolve(
+                  new Response(
+                    JSON.stringify({
+                      tag_name: "v2026-01-01-000000",
+                      name: "Test Release",
+                      published_at: "2026-01-01T00:00:00Z",
+                      assets: [
+                        {
+                          name: "bunny-script.ts",
+                          browser_download_url: "https://example.com/script.ts",
+                        },
+                      ],
+                    }),
+                    { status: 200 },
+                  ),
+                );
+              }
+              if (url.includes("example.com/script.ts")) {
+                return Promise.resolve(
+                  new Response("console.log('code')", { status: 200 }),
+                );
+              }
+              return Promise.resolve(new Response("error", { status: 500 }));
+            },
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              ok: true as const,
+              scriptId: 42,
+              defaultHostname: "test-42.b-cdn.net",
+            }),
+          ),
+          secretStub: stub(
+            bunnyCdnApi,
+            "setEdgeScriptSecret",
+            (_id: number, name: string, value: string) => {
+              secretsSet.push([name, value]);
+              return Promise.resolve({ ok: true as const });
+            },
+          ),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          encKeyStub: stub(
+            builderApi,
+            "generateEncryptionKey",
+            () => "dGVzdGtleQ==",
+          ),
+        }),
+        async ({ createStub, publishStub }) => {
+          const result = await builderApi.buildSite({
+            siteName: "My Site",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+
+          expect(result.ok).toBe(true);
+          if (result.ok) {
+            expect(result.scriptId).toBe(42);
+            expect(result.defaultHostname).toBe("test-42.b-cdn.net");
+          }
+
+          // Verify script was created with correct name
+          expect(createStub.calls[0]!.args[0]).toBe("Tickets - My Site");
+
+          // Verify required secrets were set
+          const secretNames = secretsSet.map(([name]) => name);
+          expect(secretNames).toContain("DB_URL");
+          expect(secretNames).toContain("DB_TOKEN");
+          expect(secretNames).toContain("DB_ENCRYPTION_KEY");
+          expect(secretNames).toContain("BUNNY_SCRIPT_ID");
+
+          // Verify secret values
+          const dbUrlSecret = secretsSet.find(([n]) => n === "DB_URL");
+          expect(dbUrlSecret![1]).toBe("libsql://test.turso.io");
+          const scriptIdSecret = secretsSet.find(
+            ([n]) => n === "BUNNY_SCRIPT_ID",
+          );
+          expect(scriptIdSecret![1]).toBe("42");
+
+          // Verify publish was called
+          expect(publishStub.calls.length).toBe(1);
+          expect(publishStub.calls[0]!.args[0]).toBe(42);
+        },
+      );
+    });
+
+    test("buildSite returns error when secret setting fails", async () => {
+      await withMocks(
+        () => ({
+          fetchStub: stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request) => {
+              const url = String(input);
+              if (url.includes("releases/latest")) {
+                return Promise.resolve(
+                  new Response(
+                    JSON.stringify({
+                      tag_name: "v2026-01-01-000000",
+                      name: "Test",
+                      published_at: "2026-01-01T00:00:00Z",
+                      assets: [
+                        {
+                          name: "bunny-script.ts",
+                          browser_download_url: "https://example.com/script.ts",
+                        },
+                      ],
+                    }),
+                    { status: 200 },
+                  ),
+                );
+              }
+              return Promise.resolve(
+                new Response("console.log('code')", { status: 200 }),
+              );
+            },
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              ok: true as const,
+              scriptId: 42,
+              defaultHostname: "test.b-cdn.net",
+            }),
+          ),
+          secretStub: stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "Set secret DB_URL failed (403): Forbidden",
+            }),
+          ),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          encKeyStub: stub(
+            builderApi,
+            "generateEncryptionKey",
+            () => "dGVzdGtleQ==",
+          ),
+        }),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Failed to set secrets");
+          }
+        },
+      );
+    });
+
+    test("buildSite returns error when publish fails", async () => {
+      await withMocks(
+        () => ({
+          fetchStub: stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request) => {
+              const url = String(input);
+              if (url.includes("releases/latest")) {
+                return Promise.resolve(
+                  new Response(
+                    JSON.stringify({
+                      tag_name: "v2026-01-01-000000",
+                      name: "Test",
+                      published_at: "2026-01-01T00:00:00Z",
+                      assets: [
+                        {
+                          name: "bunny-script.ts",
+                          browser_download_url: "https://example.com/script.ts",
+                        },
+                      ],
+                    }),
+                    { status: 200 },
+                  ),
+                );
+              }
+              return Promise.resolve(
+                new Response("console.log('code')", { status: 200 }),
+              );
+            },
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              ok: true as const,
+              scriptId: 42,
+              defaultHostname: "test.b-cdn.net",
+            }),
+          ),
+          secretStub: stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "Publish edge script failed (500): Error",
+            }),
+          ),
+          encKeyStub: stub(
+            builderApi,
+            "generateEncryptionKey",
+            () => "dGVzdGtleQ==",
+          ),
+        }),
+        async () => {
+          const result = await builderApi.buildSite({
+            siteName: "Test",
+            dbUrl: "libsql://test.turso.io",
+            dbToken: "token123",
+          });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Publish edge script failed");
+          }
+        },
+      );
+    });
+  },
+);

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import {
+  buildSiteDataBlob,
+  getAllBuiltSites,
+  insertBuiltSite,
+  parseSiteDataBlob,
+} from "#lib/db/built-sites.ts";
+import { describeWithEnv } from "#test-utils";
+
+describeWithEnv("built-sites", { db: true }, () => {
+  test("buildSiteDataBlob creates valid JSON with version", () => {
+    const blob = buildSiteDataBlob("Test Site", "test.bunny.run");
+    const parsed = JSON.parse(blob);
+    expect(parsed.v).toBe(1);
+    expect(parsed.n).toBe("Test Site");
+    expect(parsed.u).toBe("test.bunny.run");
+  });
+
+  test("parseSiteDataBlob roundtrips with buildSiteDataBlob", () => {
+    const blob = buildSiteDataBlob("My Site", "my.bunny.run");
+    const parsed = parseSiteDataBlob(blob);
+    expect(parsed.v).toBe(1);
+    expect(parsed.n).toBe("My Site");
+    expect(parsed.u).toBe("my.bunny.run");
+  });
+
+  test("insertBuiltSite creates a row with encrypted site_data", async () => {
+    const row = await insertBuiltSite("Alpha Site", "alpha.bunny.run");
+    expect(row.id).toBe(1);
+    expect(row.created).toBeTruthy();
+  });
+
+  test("getAllBuiltSites returns decrypted sites sorted by name", async () => {
+    await insertBuiltSite("Charlie", "charlie.bunny.run");
+    await insertBuiltSite("Alpha", "alpha.bunny.run");
+    await insertBuiltSite("Bravo", "bravo.bunny.run");
+
+    const sites = await getAllBuiltSites();
+    expect(sites).toHaveLength(3);
+    expect(sites[0]!.name).toBe("Alpha");
+    expect(sites[0]!.bunnyUrl).toBe("alpha.bunny.run");
+    expect(sites[1]!.name).toBe("Bravo");
+    expect(sites[2]!.name).toBe("Charlie");
+  });
+
+  test("getAllBuiltSites returns empty array when no sites exist", async () => {
+    const sites = await getAllBuiltSites();
+    expect(sites).toHaveLength(0);
+  });
+});

--- a/test/lib/bunny-cdn.test.ts
+++ b/test/lib/bunny-cdn.test.ts
@@ -1069,3 +1069,195 @@ describeWithEnv("domain settings", { db: true }, () => {
     expect(settings.bunnySubdomain).toBe("");
   });
 });
+
+describeWithEnv(
+  "createEdgeScript",
+  { env: { BUNNY_API_KEY: "test-bunny-key", BUNNY_SCRIPT_ID: "99" } },
+  () => {
+    test("returns script ID and hostname on success", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  Id: 42,
+                  DefaultHostname: "test-42.b-cdn.net",
+                }),
+              ),
+            ),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.createEdgeScript(
+            "Test Script",
+            "console.log('test')",
+          );
+          expect(result).toEqual({
+            ok: true,
+            scriptId: 42,
+            defaultHostname: "test-42.b-cdn.net",
+          });
+        },
+      );
+    });
+
+    test("defaults hostname to empty string when not in response", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response(JSON.stringify({ Id: 7 }))),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.createEdgeScript("Test", "code");
+          expect(result).toEqual({
+            ok: true,
+            scriptId: 7,
+            defaultHostname: "",
+          });
+        },
+      );
+    });
+
+    test("returns error on API failure", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(
+              new Response(JSON.stringify({ Message: "Bad Request" }), {
+                status: 400,
+              }),
+            ),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.createEdgeScript("Test", "code");
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Create edge script failed");
+          }
+        },
+      );
+    });
+
+    test("sends correct request body with ScriptType 2", async () => {
+      const calls: { url: string; init: RequestInit | undefined }[] = [];
+      await withMocks(
+        () =>
+          stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request, init?: RequestInit) => {
+              calls.push({ url: String(input), init });
+              return Promise.resolve(
+                new Response(JSON.stringify({ Id: 1, DefaultHostname: "" })),
+              );
+            },
+          ),
+        async () => {
+          await bunnyCdnApi.createEdgeScript("My Script", "code");
+          expect(calls).toHaveLength(1);
+          const body = JSON.parse(calls[0]!.init!.body as string);
+          expect(body.Name).toBe("My Script");
+          expect(body.ScriptType).toBe(2);
+          expect(body.CreateLinkedPullZone).toBe(true);
+        },
+      );
+    });
+  },
+);
+
+describeWithEnv(
+  "setEdgeScriptSecret",
+  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  () => {
+    test("sends PUT request with secret payload", async () => {
+      const calls: { url: string; init: RequestInit | undefined }[] = [];
+      await withMocks(
+        () =>
+          stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request, init?: RequestInit) => {
+              calls.push({ url: String(input), init });
+              return Promise.resolve(new Response(null, { status: 204 }));
+            },
+          ),
+        async () => {
+          const result = await bunnyCdnApi.setEdgeScriptSecret(
+            42,
+            "DB_URL",
+            "libsql://test",
+          );
+          expect(result.ok).toBe(true);
+          expect(calls[0]!.url).toContain("/compute/script/42/secrets");
+          expect(calls[0]!.init!.method).toBe("PUT");
+          const body = JSON.parse(calls[0]!.init!.body as string);
+          expect(body.Name).toBe("DB_URL");
+          expect(body.Secret).toBe("libsql://test");
+        },
+      );
+    });
+
+    test("returns error on API failure", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Forbidden", { status: 403 })),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.setEdgeScriptSecret(
+            42,
+            "DB_URL",
+            "test",
+          );
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Set secret DB_URL failed");
+          }
+        },
+      );
+    });
+  },
+);
+
+describeWithEnv(
+  "publishEdgeScript",
+  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  () => {
+    test("sends POST to publish endpoint", async () => {
+      const calls: { url: string; init: RequestInit | undefined }[] = [];
+      await withMocks(
+        () =>
+          stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request, init?: RequestInit) => {
+              calls.push({ url: String(input), init });
+              return Promise.resolve(new Response(null, { status: 204 }));
+            },
+          ),
+        async () => {
+          const result = await bunnyCdnApi.publishEdgeScript(42);
+          expect(result.ok).toBe(true);
+          expect(calls[0]!.url).toContain("/compute/script/42/publish");
+          expect(calls[0]!.init!.method).toBe("POST");
+        },
+      );
+    });
+
+    test("returns error on API failure", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Server Error", { status: 500 })),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.publishEdgeScript(42);
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Publish edge script failed");
+          }
+        },
+      );
+    });
+  },
+);

--- a/test/lib/crypto/hashing.test.ts
+++ b/test/lib/crypto/hashing.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
 import {
   computeTicketTokenIndex,
   hashPassword,
@@ -7,7 +8,6 @@ import {
   hmacHash,
   verifyPassword,
 } from "#lib/crypto/hashing.ts";
-import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
 import {
   describeWithEnv,
   setTestEnv,

--- a/test/lib/crypto/keys.test.ts
+++ b/test/lib/crypto/keys.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { decryptWithKey, encryptWithKey } from "#lib/crypto/encryption.ts";
 import {
   deriveKEK,
@@ -15,10 +14,8 @@ import {
   wrapKey,
   wrapKeyWithToken,
 } from "#lib/crypto/keys.ts";
-import {
-  describeWithEnv,
-  setTestEnv,
-} from "#test-utils";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
+import { describeWithEnv, setTestEnv } from "#test-utils";
 
 describeWithEnv("KEK derivation", { encryptionKey: true }, () => {
   it("derives a usable CryptoKey", async () => {

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -1,7 +1,13 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { decryptWithKey, encrypt } from "#lib/crypto/encryption.ts";
-import { decryptAttendeePII, deriveKEK, encryptAttendeePII, importPrivateKey, unwrapKey } from "#lib/crypto/keys.ts";
+import {
+  decryptAttendeePII,
+  deriveKEK,
+  encryptAttendeePII,
+  importPrivateKey,
+  unwrapKey,
+} from "#lib/crypto/keys.ts";
 import {
   decryptAttendees,
   getAttendeesRaw,

--- a/test/lib/server-builder.test.ts
+++ b/test/lib/server-builder.test.ts
@@ -1,0 +1,322 @@
+import { expect } from "@std/expect";
+import { afterEach, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { builderApi } from "#lib/builder.ts";
+import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
+import { getAllBuiltSites } from "#lib/db/built-sites.ts";
+import { settings } from "#lib/db/settings.ts";
+import { handleRequest } from "#routes";
+import {
+  adminFormPost,
+  awaitTestRequest,
+  describeWithEnv,
+  expectAdminRedirect,
+  expectFlash,
+  expectHtmlResponse,
+  expectRedirect,
+  FLASH_TEST_ID,
+  flashCookieHeader,
+  mockRequest,
+  testCookie,
+  withMocks,
+} from "#test-utils";
+
+/** Stub all Bunny + GitHub APIs for a successful build */
+const stubSuccessfulBuild = () => ({
+  fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes("releases/latest")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            tag_name: "v2026-01-01-000000",
+            name: "Test Release",
+            published_at: "2026-01-01T00:00:00Z",
+            assets: [
+              {
+                name: "bunny-script.ts",
+                browser_download_url: "https://example.com/script.ts",
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+    }
+    if (url.includes("example.com/script.ts")) {
+      return Promise.resolve(
+        new Response("console.log('code')", { status: 200 }),
+      );
+    }
+    return Promise.resolve(new Response("error", { status: 500 }));
+  }),
+  createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+    Promise.resolve({
+      ok: true as const,
+      scriptId: 42,
+      defaultHostname: "test-42.b-cdn.net",
+    }),
+  ),
+  secretStub: stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+    Promise.resolve({ ok: true as const }),
+  ),
+  publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+    Promise.resolve({ ok: true as const }),
+  ),
+  encKeyStub: stub(builderApi, "generateEncryptionKey", () => "dGVzdGtleQ=="),
+  dbTestStub: stub(builderApi, "testDbConnection", () =>
+    Promise.resolve({ ok: true as const }),
+  ),
+});
+
+describeWithEnv(
+  "server (admin builder)",
+  {
+    db: true,
+    env: { CAN_BUILD_SITES: "true" },
+  },
+  () => {
+    afterEach(() => {
+      settings.clearTestOverrides();
+    });
+
+    test("GET /admin/builder returns 404 when CAN_BUILD_SITES is not set", async () => {
+      Deno.env.delete("CAN_BUILD_SITES");
+      const cookie = await testCookie();
+      const response = await awaitTestRequest("/admin/builder", { cookie });
+      expect(response.status).toBe(404);
+    });
+
+    test("GET /admin/builder redirects to login when not authenticated", async () => {
+      const response = await handleRequest(mockRequest("/admin/builder"));
+      expectAdminRedirect(response);
+    });
+
+    test("GET /admin/builder shows builder page when authenticated", async () => {
+      const response = await awaitTestRequest("/admin/builder", {
+        cookie: await testCookie(),
+      });
+      await expectHtmlResponse(
+        response,
+        200,
+        "Site Builder",
+        "Create New Site",
+        "Site Name",
+        "Database URL",
+        "Database Token",
+        "Built Sites",
+      );
+    });
+
+    test("GET /admin/builder shows empty sites message", async () => {
+      const response = await awaitTestRequest("/admin/builder", {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      expect(html).toContain("No sites have been built yet");
+    });
+
+    test("GET /admin/builder displays success flash", async () => {
+      const cookie = await testCookie();
+      const response = await awaitTestRequest(
+        `/admin/builder?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Site created")}`,
+        },
+      );
+      const html = await response.text();
+      expect(html).toContain("Site created");
+    });
+
+    test("GET /admin/builder displays error flash", async () => {
+      const cookie = await testCookie();
+      const response = await awaitTestRequest(
+        `/admin/builder?flash=${FLASH_TEST_ID}`,
+        {
+          cookie: `${cookie}; ${flashCookieHeader("Build failed", false)}`,
+        },
+      );
+      const html = await response.text();
+      expect(html).toContain("Build failed");
+    });
+
+    test("POST /admin/builder returns error when site name is empty", async () => {
+      const { response } = await adminFormPost("/admin/builder", {
+        site_name: "",
+        db_url: "libsql://test.turso.io",
+        db_token: "token",
+      });
+      expectRedirect(response, "/admin/builder");
+      expectFlash(
+        response,
+        expect.stringContaining("Site name is required"),
+        false,
+      );
+    });
+
+    test("POST /admin/builder returns error when db_url is empty", async () => {
+      const { response } = await adminFormPost("/admin/builder", {
+        site_name: "Test",
+        db_url: "",
+        db_token: "token",
+      });
+      expectRedirect(response, "/admin/builder");
+      expectFlash(
+        response,
+        expect.stringContaining("Database URL is required"),
+        false,
+      );
+    });
+
+    test("POST /admin/builder returns error when db_token is empty", async () => {
+      const { response } = await adminFormPost("/admin/builder", {
+        site_name: "Test",
+        db_url: "libsql://test.turso.io",
+        db_token: "",
+      });
+      expectRedirect(response, "/admin/builder");
+      expectFlash(
+        response,
+        expect.stringContaining("Database token is required"),
+        false,
+      );
+    });
+
+    test("POST /admin/builder returns error when db connection fails", async () => {
+      await withMocks(
+        () =>
+          stub(builderApi, "testDbConnection", () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "Connection refused",
+            }),
+          ),
+        async () => {
+          const { response } = await adminFormPost("/admin/builder", {
+            site_name: "Test",
+            db_url: "libsql://test.turso.io",
+            db_token: "token",
+          });
+          expectRedirect(response, "/admin/builder");
+          expectFlash(
+            response,
+            expect.stringContaining("Database connection failed"),
+            false,
+          );
+        },
+      );
+    });
+
+    test("POST /admin/builder creates site and records it on success", async () => {
+      await withMocks(stubSuccessfulBuild, async () => {
+        const { response } = await adminFormPost("/admin/builder", {
+          site_name: "My Test Site",
+          db_url: "libsql://test.turso.io",
+          db_token: "token123",
+        });
+
+        expectRedirect(response, "/admin/builder");
+        expectFlash(response, expect.stringContaining("created successfully"));
+
+        // Verify site was recorded
+        const sites = await getAllBuiltSites();
+        expect(sites).toHaveLength(1);
+        expect(sites[0]!.name).toBe("My Test Site");
+        expect(sites[0]!.bunnyUrl).toBe("test-42.b-cdn.net");
+      });
+    });
+
+    test("POST /admin/builder returns error when build fails", async () => {
+      await withMocks(
+        () => ({
+          dbTestStub: stub(builderApi, "testDbConnection", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          buildStub: stub(builderApi, "buildSite", () =>
+            Promise.resolve({
+              ok: false as const,
+              error: "Create edge script failed (500): Error",
+            }),
+          ),
+        }),
+        async () => {
+          const { response } = await adminFormPost("/admin/builder", {
+            site_name: "Test",
+            db_url: "libsql://test.turso.io",
+            db_token: "token",
+          });
+          expectRedirect(response, "/admin/builder");
+          expectFlash(
+            response,
+            expect.stringContaining("Create edge script failed"),
+            false,
+          );
+        },
+      );
+    });
+
+    test("POST /admin/builder returns 404 when CAN_BUILD_SITES is not set", async () => {
+      Deno.env.delete("CAN_BUILD_SITES");
+      const { response } = await adminFormPost("/admin/builder", {
+        site_name: "Test",
+        db_url: "libsql://test.turso.io",
+        db_token: "token",
+      });
+      expect(response.status).toBe(404);
+    });
+
+    test("POST /admin/builder returns error when another task in progress", async () => {
+      await settings.update.currentTask("other-task");
+      settings.invalidateCache();
+      await settings.loadAll();
+
+      await withMocks(
+        () => ({
+          dbTestStub: stub(builderApi, "testDbConnection", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          buildStub: stub(builderApi, "buildSite", () =>
+            Promise.resolve({
+              ok: true as const,
+              scriptId: 1,
+              defaultHostname: "test.b-cdn.net",
+            }),
+          ),
+        }),
+        async () => {
+          const { response } = await adminFormPost("/admin/builder", {
+            site_name: "Test",
+            db_url: "libsql://test.turso.io",
+            db_token: "token",
+          });
+          expectRedirect(response, "/admin/builder");
+          expectFlash(
+            response,
+            expect.stringContaining("already in progress"),
+            false,
+          );
+        },
+      );
+
+      await settings.update.currentTask("");
+    });
+
+    test("GET /admin/builder shows built sites in table", async () => {
+      // Build a site first
+      await withMocks(stubSuccessfulBuild, async () => {
+        await adminFormPost("/admin/builder", {
+          site_name: "Table Test Site",
+          db_url: "libsql://test.turso.io",
+          db_token: "token123",
+        });
+      });
+
+      const response = await awaitTestRequest("/admin/builder", {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      expect(html).toContain("Table Test Site");
+      expect(html).toContain("test-42.b-cdn.net");
+    });
+  },
+);


### PR DESCRIPTION
## Summary
This PR adds a complete site builder feature that allows administrators to create new Tickets instances as Bunny edge scripts. The builder handles the full deployment pipeline: fetching release code from GitHub, creating edge scripts, configuring secrets, and recording built sites.

## Key Changes

### New Builder API (`src/lib/builder.ts`)
- `generateEncryptionKey()` - Creates random 32-byte base64 encryption keys
- `testDbConnection()` - Validates libsql database connectivity
- `buildSite()` - Orchestrates the full build process:
  1. Fetches latest release code from GitHub
  2. Creates a new Bunny edge script with the code
  3. Sets secrets (user-provided DB credentials, generated encryption key, and host environment variables)
  4. Tests database connection
  5. Publishes the script
  6. Records the built site in the database

### Bunny CDN API Extensions (`src/lib/bunny-cdn.ts`)
- `createEdgeScriptImpl()` - Creates new edge scripts with ScriptType 2 and linked pull zone
- `setEdgeScriptSecretImpl()` - Sets individual secrets on edge scripts
- `publishEdgeScriptImpl()` - Publishes edge scripts
- Refactored compute script operations into shared helpers (`computeScriptRequest`, `scriptAction`, `publishScript`)

### Admin Routes (`src/routes/admin/builder.ts`)
- `GET /admin/builder` - Displays builder form and list of previously built sites
- `POST /admin/builder` - Handles site creation with validation:
  - Validates required fields (site name, database URL, token)
  - Tests database connection before building
  - Records successful builds with activity logging
  - Returns flash messages for success/error feedback
- Feature gated behind `CAN_BUILD_SITES=true` environment variable

### Database Layer (`src/lib/db/built-sites.ts`)
- New `built_sites` table to store records of created sites
- Encrypted storage of site name and Bunny URL
- `insertBuiltSite()` and `getAllBuiltSites()` functions for CRUD operations
- Versioned blob format for future extensibility

### Admin UI (`src/templates/admin/builder.tsx`)
- Builder form with fields for site name, database URL, and token
- Table displaying previously built sites with links to their Bunny URLs
- Empty state messaging when no sites have been built
- Flash message support for success/error feedback

### Comprehensive Test Coverage
- `test/lib/builder.test.ts` - 494 lines testing builder API with mocked GitHub/Bunny APIs
- `test/lib/server-builder.test.ts` - 322 lines testing admin routes and form handling
- `test/lib/bunny-cdn.test.ts` - Extended with tests for new edge script operations
- `test/lib/builder-template.test.ts` - Template rendering tests
- `test/lib/built-sites.test.ts` - Database layer tests

## Notable Implementation Details

- **Host Secret Copying**: The builder automatically copies configured host environment variables (email, wallet, storage, DNS, ntfy) to new instances for seamless configuration inheritance
- **Error Handling**: Comprehensive error handling at each build stage with descriptive messages
- **Database Encryption**: Built site records use the same encryption infrastructure as other sensitive data
- **Activity Logging**: Successful builds are logged to the activity log for audit trails
- **Atomic Operations**: Database connection testing happens before the build to fail fast on invalid credentials

https://claude.ai/code/session_01P6Cq4ut2QE3vHq31UKUrQE