### PR TITLE
Reduce CPD duplication with shared helpers

### DIFF
--- a/src/docs/crypto.ts
+++ b/src/docs/crypto.ts
@@ -10,9 +10,9 @@
  * @module
  */
 
-export * from "#lib/crypto/utils.ts";
 export * from "#lib/crypto/encryption.ts";
 export * from "#lib/crypto/hashing.ts";
 export * from "#lib/crypto/keys.ts";
+export * from "#lib/crypto/utils.ts";
 export * from "#lib/csrf.ts";
 export * from "#lib/payment-crypto.ts";

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -182,6 +182,12 @@ export const bracket =
   };
 
 /**
+ * Join an array of strings into a single string (curried reduce shorthand).
+ * Replaces the common pattern: reduce((acc: string, s: string) => acc + s, "")
+ */
+export const joinStrings = reduce((acc: string, s: string) => acc + s, "");
+
+/**
  * Split an array into chunks of a given size
  */
 export const chunk =

--- a/src/lib/attachment-url.ts
+++ b/src/lib/attachment-url.ts
@@ -6,8 +6,8 @@
  * their ticket page to get a fresh URL (prevents sharing).
  */
 
-import { base64ToBase64Url, constantTimeEqual } from "#lib/crypto/utils.ts";
 import { hmacHash } from "#lib/crypto/hashing.ts";
+import { base64ToBase64Url, constantTimeEqual } from "#lib/crypto/utils.ts";
 import { ATTACHMENT_URL_MAX_AGE_S } from "#lib/limits.ts";
 import { nowMs } from "#lib/now.ts";
 

--- a/src/lib/crypto/encryption.ts
+++ b/src/lib/crypto/encryption.ts
@@ -304,4 +304,3 @@ export const importHmacKey = async (): Promise<CryptoKey> => {
   setHmacKeyResolved(key);
   return key;
 };
-

--- a/src/lib/crypto/hashing.ts
+++ b/src/lib/crypto/hashing.ts
@@ -2,9 +2,9 @@
  * Password hashing (PBKDF2), session token hashing, HMAC, and ticket token indexing
  */
 
-import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
-import { importHmacKey } from "./encryption.ts";
 import { getEnv } from "#lib/env.ts";
+import { importHmacKey } from "./encryption.ts";
+import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
 
 /**
  * Password hashing using PBKDF2 via Web Crypto API
@@ -14,7 +14,9 @@ const PBKDF2_ITERATIONS_DEFAULT = 600000; // OWASP recommended minimum for SHA-2
 const PBKDF2_ITERATIONS_TEST = 1000; // Fast iterations for tests
 
 export const getPbkdf2Iterations = (): number =>
-  getEnv("TEST_FAST_PBKDF2") ? PBKDF2_ITERATIONS_TEST : PBKDF2_ITERATIONS_DEFAULT;
+  getEnv("TEST_FAST_PBKDF2")
+    ? PBKDF2_ITERATIONS_TEST
+    : PBKDF2_ITERATIONS_DEFAULT;
 const PBKDF2_HASH_LENGTH = 32; // Output key length in bytes
 const PASSWORD_PREFIX = "pbkdf2";
 

--- a/src/lib/crypto/keys.ts
+++ b/src/lib/crypto/keys.ts
@@ -5,7 +5,6 @@
 import { ttlCache } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
 import { getEnv } from "#lib/env.ts";
-import { fromBase64 } from "./utils.ts";
 import {
   aesGcmDecryptRaw,
   aesGcmEncryptRaw,
@@ -16,6 +15,7 @@ import {
   parseEncryptedPayload,
 } from "./encryption.ts";
 import { getPbkdf2Iterations } from "./hashing.ts";
+import { fromBase64 } from "./utils.ts";
 
 /**
  * =============================================================================

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -7,8 +7,12 @@
  * Instagram) where Safari/WebKit blocks third-party cookies.
  */
 
-import { base64ToBase64Url, constantTimeEqual, generateSecureToken } from "#lib/crypto/utils.ts";
 import { hmacHash } from "#lib/crypto/hashing.ts";
+import {
+  base64ToBase64Url,
+  constantTimeEqual,
+  generateSecureToken,
+} from "#lib/crypto/utils.ts";
 import { nowMs } from "#lib/now.ts";
 
 const SIGNED_PREFIX = "s1.";

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -7,10 +7,10 @@
  */
 
 import { filter, map, reduce } from "#fp";
-import { generateTicketToken } from "#lib/crypto/utils.ts";
 import { decrypt } from "#lib/crypto/encryption.ts";
 import { computeTicketTokenIndex } from "#lib/crypto/hashing.ts";
 import { decryptAttendeePII, encryptAttendeePII } from "#lib/crypto/keys.ts";
+import { generateTicketToken } from "#lib/crypto/utils.ts";
 import {
   executeBatch,
   getDb,

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -20,7 +20,7 @@ import {
   idAndEncryptedSlugSchema,
   registerCache,
 } from "#lib/db/common-schema.ts";
-import { col } from "#lib/db/table.ts";
+import { col, withCacheInvalidation } from "#lib/db/table.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { nowIso } from "#lib/now.ts";
 import { requestCache } from "#lib/request-cache.ts";
@@ -164,23 +164,9 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
   hidden: col.boolean(false),
 });
 
-export const eventsTable: typeof rawEventsTable = {
-  ...rawEventsTable,
-  insert: async (input) => {
-    const result = await rawEventsTable.insert(input);
-    invalidateEventsCache();
-    return result;
-  },
-  update: async (id, input) => {
-    const result = await rawEventsTable.update(id, input);
-    invalidateEventsCache();
-    return result;
-  },
-  deleteById: async (id) => {
-    await rawEventsTable.deleteById(id);
-    invalidateEventsCache();
-  },
-};
+export const eventsTable = withCacheInvalidation(rawEventsTable, () =>
+  invalidateEventsCache(),
+);
 
 /** Find a cached event by ID */
 const findCachedEventById = async (

--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -14,7 +14,7 @@ import {
 } from "#lib/db/common-schema.ts";
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
 import { queryAndMap } from "#lib/db/query.ts";
-import { col } from "#lib/db/table.ts";
+import { col, withCacheInvalidation } from "#lib/db/table.ts";
 import { requestCache } from "#lib/request-cache.ts";
 import type { Event, EventType, EventWithCount, Group } from "#lib/types.ts";
 
@@ -56,23 +56,10 @@ export const invalidateGroupsCache = (): void => {
 };
 
 /** Groups table with CRUD operations — writes auto-invalidate the cache */
-export const groupsTable: typeof rawGroupsTable = {
-  ...rawGroupsTable,
-  insert: async (input) => {
-    const result = await rawGroupsTable.insert(input);
-    invalidateGroupsCache();
-    return result;
-  },
-  update: async (id, input) => {
-    const result = await rawGroupsTable.update(id, input);
-    invalidateGroupsCache();
-    return result;
-  },
-  deleteById: async (id) => {
-    await rawGroupsTable.deleteById(id);
-    invalidateGroupsCache();
-  },
-};
+export const groupsTable = withCacheInvalidation(
+  rawGroupsTable,
+  invalidateGroupsCache,
+);
 
 /**
  * Get all groups, decrypted, ordered by id (from cache)

--- a/src/lib/db/holidays.ts
+++ b/src/lib/db/holidays.ts
@@ -7,7 +7,7 @@ import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt } from "#lib/crypto/encryption.ts";
 import { queryAndMap } from "#lib/db/query.ts";
 import { settings } from "#lib/db/settings.ts";
-import { col, defineTable } from "#lib/db/table.ts";
+import { col, defineTable, withCacheInvalidation } from "#lib/db/table.ts";
 import { requestCache } from "#lib/request-cache.ts";
 import { todayInTz } from "#lib/timezone.ts";
 import type { Holiday } from "#lib/types.ts";
@@ -48,23 +48,10 @@ export const invalidateHolidaysCache = (): void => {
 };
 
 /** Holidays table with CRUD operations — writes auto-invalidate the cache */
-export const holidaysTable: typeof rawHolidaysTable = {
-  ...rawHolidaysTable,
-  insert: async (input) => {
-    const result = await rawHolidaysTable.insert(input);
-    invalidateHolidaysCache();
-    return result;
-  },
-  update: async (id, input) => {
-    const result = await rawHolidaysTable.update(id, input);
-    invalidateHolidaysCache();
-    return result;
-  },
-  deleteById: async (id) => {
-    await rawHolidaysTable.deleteById(id);
-    invalidateHolidaysCache();
-  },
-};
+export const holidaysTable = withCacheInvalidation(
+  rawHolidaysTable,
+  invalidateHolidaysCache,
+);
 
 /**
  * Get all holidays, decrypted, ordered by start_date (from cache)

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -353,6 +353,32 @@ export const defineTable = <Row, Input = Row>(config: {
   };
 };
 
+/**
+ * Wrap a table so that insert, update, and deleteById automatically
+ * call an invalidation callback (e.g. cache invalidation).
+ * Eliminates the repeated spread-and-override pattern in groups/holidays/events.
+ */
+export const withCacheInvalidation = <Row, Input>(
+  table: Table<Row, Input>,
+  invalidate: () => void,
+): Table<Row, Input> => ({
+  ...table,
+  insert: async (input) => {
+    const result = await table.insert(input);
+    invalidate();
+    return result;
+  },
+  update: async (id, input) => {
+    const result = await table.update(id, input);
+    invalidate();
+    return result;
+  },
+  deleteById: async (id) => {
+    await table.deleteById(id);
+    invalidate();
+  },
+});
+
 /** Transform function type for column read/write */
 type ColumnTransform<T> = (v: T) => Promise<T> | T;
 

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -4,7 +4,12 @@
 
 import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt } from "#lib/crypto/encryption.ts";
-import { hashPassword, hashSessionToken, hmacHash, verifyPassword } from "#lib/crypto/hashing.ts";
+import {
+  hashPassword,
+  hashSessionToken,
+  hmacHash,
+  verifyPassword,
+} from "#lib/crypto/hashing.ts";
 import { deriveKEK, wrapKey } from "#lib/crypto/keys.ts";
 import { deleteByFieldBatch, getDb, queryAll } from "#lib/db/client.ts";
 import { now } from "#lib/now.ts";

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -2,7 +2,7 @@
  * Minimal form framework for declarative form handling
  */
 
-import { map, pipe, reduce } from "#fp";
+import { joinStrings, map, pipe } from "#fp";
 import { type Child, Raw } from "#jsx/jsx-runtime.ts";
 import { getCurrentCsrfToken } from "#lib/csrf.ts";
 import type { FormParams } from "#lib/form-data.ts";
@@ -62,8 +62,6 @@ export type ValidationResult<T = FieldValues> =
 type FieldValidationResult =
   | { valid: true; value: string | number | null }
   | { valid: false; error: string };
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 /** Render select options HTML */
 const renderSelectOptions = (

--- a/src/lib/rest/crud-api.ts
+++ b/src/lib/rest/crud-api.ts
@@ -25,6 +25,21 @@ import { verifyIdentifierOrJsonError } from "#routes/admin/utils.ts";
 import type { RouteHandlerFn } from "#routes/router.ts";
 import { ADMIN_API, jsonResponse, withAuth } from "#routes/utils.ts";
 
+/** JSON body for confirmed delete endpoints */
+export type DeleteBody = { confirm_identifier: string };
+
+/**
+ * Parse a required non-empty string field from a JSON body.
+ * Returns the trimmed string or null if missing/empty.
+ */
+export const requireString = (
+  body: Record<string, unknown>,
+  key: string,
+): string | null =>
+  typeof body[key] === "string" && body[key].trim() !== ""
+    ? body[key].trim()
+    : null;
+
 /** Result of parsing a JSON body into a typed input */
 type ParseResult<Input> =
   | { ok: true; input: Input }

--- a/src/lib/seeds.ts
+++ b/src/lib/seeds.ts
@@ -4,10 +4,10 @@
  */
 
 import { map, reduce } from "#fp";
-import { generateTicketToken } from "#lib/crypto/utils.ts";
 import { encrypt } from "#lib/crypto/encryption.ts";
 import { computeTicketTokenIndex, hmacHash } from "#lib/crypto/hashing.ts";
 import { encryptAttendeePII } from "#lib/crypto/keys.ts";
+import { generateTicketToken } from "#lib/crypto/utils.ts";
 import { executeBatch, queryAll } from "#lib/db/client.ts";
 import { invalidateEventsCache } from "#lib/db/events.ts";
 import { settings } from "#lib/db/settings.ts";

--- a/src/routes/admin/api-groups.ts
+++ b/src/routes/admin/api-groups.ts
@@ -10,6 +10,7 @@ import {
   isGroupSlugTaken,
 } from "#lib/db/groups.ts";
 import {
+  type DeleteBody,
   defineCrudApi,
   parseUpdateName,
   parseUpdateSlug,
@@ -29,7 +30,7 @@ export type CreateGroupBody = {
 export type UpdateGroupBody = Partial<CreateGroupBody> & { slug?: string };
 
 /** JSON body accepted by DELETE /api/admin/groups/:groupId */
-export type DeleteGroupBody = { confirm_identifier: string };
+export type DeleteGroupBody = DeleteBody;
 
 /** Strip slug_index from response */
 const STRIP_KEYS = ["slug_index"];

--- a/src/routes/admin/api-holidays.ts
+++ b/src/routes/admin/api-holidays.ts
@@ -7,7 +7,12 @@ import {
   type HolidayInput,
   holidaysTable,
 } from "#lib/db/holidays.ts";
-import { defineCrudApi, parseUpdateName } from "#lib/rest/crud-api.ts";
+import {
+  type DeleteBody,
+  defineCrudApi,
+  parseUpdateName,
+  requireString,
+} from "#lib/rest/crud-api.ts";
 import type { Holiday } from "#lib/types.ts";
 import { validateDateRange } from "#routes/admin/holidays.ts";
 
@@ -22,16 +27,7 @@ export type CreateHolidayBody = {
 export type UpdateHolidayBody = Partial<CreateHolidayBody>;
 
 /** JSON body accepted by DELETE /api/admin/holidays/:holidayId */
-export type DeleteHolidayBody = { confirm_identifier: string };
-
-/** Parse required string field from body */
-const requireString = (
-  body: Record<string, unknown>,
-  key: string,
-): string | null =>
-  typeof body[key] === "string" && body[key].trim() !== ""
-    ? body[key].trim()
-    : null;
+export type DeleteHolidayBody = DeleteBody;
 
 export const holidayApiRoutes = defineCrudApi<Holiday, HolidayInput>({
   name: "holidays",

--- a/src/routes/admin/api-keys.ts
+++ b/src/routes/admin/api-keys.ts
@@ -6,8 +6,8 @@ import {
   ADMIN_API_ENDPOINTS,
   PUBLIC_API_ENDPOINTS,
 } from "#lib/admin-api-example.ts";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
 import {
   createApiKey,
   deleteApiKey,

--- a/src/routes/admin/api.ts
+++ b/src/routes/admin/api.ts
@@ -25,6 +25,7 @@ import {
 } from "#lib/events-actions.ts";
 import {
   apiErrorResponse,
+  type DeleteBody,
   parseUpdateName,
   parseUpdateSlug,
   withApiEntity,
@@ -75,7 +76,7 @@ export type CreateEventBody = {
 export type UpdateEventBody = Partial<CreateEventBody> & { slug?: string };
 
 /** JSON body accepted by DELETE /api/admin/events/:eventId */
-export type DeleteEventBody = { confirm_identifier: string };
+export type DeleteEventBody = DeleteBody;
 
 // =============================================================================
 // Schema-driven field extraction

--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -2,13 +2,13 @@
  * Group ticket context and routing
  */
 
-/* jscpd:ignore-start */
-import { getActiveHolidays } from "#lib/db/holidays.ts";
 import {
   computeGroupSlugIndex,
   getActiveEventsByGroupId,
   getGroupBySlugIndex,
 } from "#lib/db/groups.ts";
+/* jscpd:ignore-start */
+import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { getQuestionsWithEventIds } from "#lib/db/questions.ts";
 import { settings } from "#lib/db/settings.ts";
 /* jscpd:ignore-end */
@@ -19,8 +19,8 @@ import type { TicketEvent } from "#templates/public.tsx";
 import { computeSharedDates } from "./ticket-payment.ts";
 import { handleTicket } from "./ticket-submit.ts";
 import {
-  getActiveEvents,
   type AsyncHandler,
+  getActiveEvents,
   type TicketContextProvider,
 } from "./types.ts";
 

--- a/src/routes/public/pages.ts
+++ b/src/routes/public/pages.ts
@@ -6,18 +6,18 @@ import { settings } from "#lib/db/settings.ts";
 import { loadSortedEvents } from "#lib/sort-events.ts";
 import type { EventWithCount } from "#lib/types.ts";
 import {
+  htmlResponse,
+  isRegistrationClosed,
+  notFoundResponse,
+  redirectResponse,
+} from "#routes/utils.ts";
+import {
   buildTicketEvent,
   homepagePage,
   type PublicPageType,
   publicSitePage,
   type TicketEvent,
 } from "#templates/public.tsx";
-import {
-  htmlResponse,
-  isRegistrationClosed,
-  notFoundResponse,
-  redirectResponse,
-} from "#routes/utils.ts";
 
 /** Active+visible filter for public event listings */
 const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;

--- a/src/routes/public/ticket-form.ts
+++ b/src/routes/public/ticket-form.ts
@@ -5,9 +5,10 @@
 import { filter, map } from "#fp";
 import { validatePrice } from "#lib/currency.ts";
 import type {
-  QuestionWithAnswers,
   QuestionEventMap,
+  QuestionWithAnswers,
 } from "#lib/db/questions.ts";
+import type { FormParams } from "#lib/form-data.ts";
 import type { EventFields } from "#lib/types.ts";
 import {
   errorRedirect,
@@ -15,9 +16,8 @@ import {
   htmlResponse,
 } from "#routes/utils.ts";
 import { extractContact, mergeEventFields } from "#templates/fields.ts";
-import { ticketPage, type TicketEvent } from "#templates/public.tsx";
-import type { FormParams } from "#lib/form-data.ts";
-import type { TicketCtx, EventQty } from "./types.ts";
+import { type TicketEvent, ticketPage } from "#templates/public.tsx";
+import type { EventQty, TicketCtx } from "./types.ts";
 
 /** Parse and validate a quantity value from a raw string, capping at max */
 export const parseQuantityValue = (

--- a/src/routes/public/ticket-payment.ts
+++ b/src/routes/public/ticket-payment.ts
@@ -4,6 +4,7 @@
 
 import { compact } from "#fp";
 import { isPaymentsEnabled } from "#lib/config.ts";
+import { getAvailableDates } from "#lib/dates.ts";
 import {
   checkBatchAvailability,
   createAttendeeAtomic,
@@ -12,7 +13,6 @@ import { getEventsBySlugsBatch } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { getQuestionsWithEventIds } from "#lib/db/questions.ts";
 import { settings } from "#lib/db/settings.ts";
-import { getAvailableDates } from "#lib/dates.ts";
 import type { EmailEntry } from "#lib/email.ts";
 import { logDebug } from "#lib/logger.ts";
 import {
@@ -30,15 +30,8 @@ import {
   notFoundResponse,
 } from "#routes/utils.ts";
 import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
-import {
-  eventsWithQuantity,
-  formatAtomicError,
-} from "./ticket-form.ts";
-import type {
-  AsyncHandler,
-  TicketCtx,
-  TicketSharedContext,
-} from "./types.ts";
+import { eventsWithQuantity, formatAtomicError } from "./ticket-form.ts";
+import type { AsyncHandler, TicketCtx, TicketSharedContext } from "./types.ts";
 
 /** Try to redirect to checkout, or return error using provided handler.
  * When in iframe mode, returns a popup page instead of redirect since Stripe cannot run in iframes. */

--- a/src/routes/public/ticket-routes.ts
+++ b/src/routes/public/ticket-routes.ts
@@ -4,17 +4,11 @@
 
 import { getEffectiveDomain } from "#lib/config.ts";
 import { getEventWithCountBySlug } from "#lib/db/events.ts";
-import {
-  computeGroupSlugIndex,
-  getGroupBySlugIndex,
-} from "#lib/db/groups.ts";
+import { computeGroupSlugIndex, getGroupBySlugIndex } from "#lib/db/groups.ts";
 import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
-import {
-  htmlResponse,
-  notFoundResponse,
-} from "#routes/utils.ts";
+import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { successPage } from "#templates/payment.tsx";
 import { handleGroupTicketBySlug } from "./groups.ts";
 import { handleTicketBySlugs } from "./ticket-submit.ts";

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -4,8 +4,8 @@
 
 import { reduce } from "#fp";
 import { signCsrfToken } from "#lib/csrf.ts";
-import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import { saveAttendeeAnswers } from "#lib/db/questions.ts";
+import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import { isPaidEvent } from "#lib/types.ts";
 import {
   applyFlash,
@@ -31,10 +31,10 @@ import {
   anyRequiresPayment,
   buildRegistrationItems,
   checkAvailability,
+  getTicketContext,
   handleMultiPaymentFlow,
   processFreeReservation,
   withActiveEvents,
-  getTicketContext,
 } from "./ticket-payment.ts";
 import {
   applyHiddenNoindex,

--- a/src/routes/public/types.ts
+++ b/src/routes/public/types.ts
@@ -3,13 +3,13 @@
  */
 
 import { compact, filter, map, pipe } from "#fp";
-import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
-import type { EventWithCount } from "#lib/types.ts";
 import type {
   QuestionEventMap,
   QuestionWithAnswers,
 } from "#lib/db/questions.ts";
+import type { EventWithCount } from "#lib/types.ts";
 import { isRegistrationClosed } from "#routes/utils.ts";
+import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
 
 /** Shared rendering context for ticket pages */
 export type TicketCtx = {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -4,8 +4,11 @@
 
 import { compact, map, pipe, reduce } from "#fp";
 import { buildFlashCookie, getSessionCookieName } from "#lib/cookies.ts";
+import {
+  getPrivateKeyFromSession,
+  unwrapKeyWithToken,
+} from "#lib/crypto/keys.ts";
 import { generateSecureToken } from "#lib/crypto/utils.ts";
-import { getPrivateKeyFromSession, unwrapKeyWithToken } from "#lib/crypto/keys.ts";
 import {
   CSRF_INVALID_FORM_MESSAGE,
   signCsrfToken,

--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -2,14 +2,12 @@
  * Admin activity log page template
  */
 
-import { map, pipe, reduce } from "#fp";
+import { joinStrings, map, pipe } from "#fp";
 import type { ActivityLogEntry } from "#lib/db/activityLog.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, EventWithCount } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 const ActivityLogRow = ({ entry }: { entry: ActivityLogEntry }): string =>
   String(

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -2,15 +2,13 @@
  * Admin API keys page template
  */
 
-import { map, pipe, reduce } from "#fp";
+import { joinStrings, map, pipe } from "#fp";
 import type { EndpointDoc } from "#lib/admin-api-example.ts";
 import { ConfirmForm, CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#lib/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 type ApiKeyDisplay = {
   id: number;

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -2,7 +2,7 @@
  * Admin dashboard page template
  */
 
-import { filter, map, pipe, reduce } from "#fp";
+import { filter, joinStrings, map, pipe, reduce } from "#fp";
 import { getEffectiveDomain } from "#lib/config.ts";
 import { formatCurrency } from "#lib/currency.ts";
 import type { ActiveEventStats } from "#lib/db/attendees.ts";
@@ -16,8 +16,6 @@ import {
 } from "#templates/attendee-table.tsx";
 import { Layout } from "#templates/layout.tsx";
 import { renderEventImage } from "#templates/public.tsx";
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 export const EventRow = ({ e }: { e: EventWithCount }): string => {
   const isInactive = !e.active;

--- a/src/templates/admin/detail-rows.tsx
+++ b/src/templates/admin/detail-rows.tsx
@@ -2,7 +2,7 @@
  * Shared detail table rows for admin pages (event, group, calendar)
  */
 
-import { map, reduce } from "#fp";
+import { joinStrings, map, reduce } from "#fp";
 import { formatCurrency } from "#lib/currency.ts";
 import type { Attendee } from "#lib/types.ts";
 import type { TableQuestionData } from "#templates/attendee-table.tsx";
@@ -12,9 +12,6 @@ export type DetailRow = {
   key: string;
   value: string;
 };
-
-/** Concatenate strings (curried reducer for use in pipe) */
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 /** Render an array of DetailRows as <tr><th>…</th><td>…</td></tr> HTML */
 export const renderDetailRows = (rows: DetailRow[]): string =>

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -2,7 +2,7 @@
  * Admin event page templates - detail, edit, delete
  */
 
-import { filter, map, pipe, reduce } from "#fp";
+import { filter, joinStrings, map, pipe } from "#fp";
 import { toMajorUnits } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
 import { settings } from "#lib/db/settings.ts";
@@ -90,9 +90,6 @@ export const isIncompletePayment = (
   hasPaidEvent &&
   !attendee.payment_id &&
   Number.parseInt(attendee.price_paid, 10) > 0;
-
-/** Concatenate strings (curried reducer for use in pipe) */
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 /** Render a single row in the Failed Payments table */
 const FailedPaymentRow = ({

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -2,7 +2,7 @@
  * Admin group management page templates
  */
 
-import { map, pipe, reduce } from "#fp";
+import { joinStrings, map, pipe, reduce } from "#fp";
 import { buildEmbedSnippets } from "#lib/embed.ts";
 import {
   ConfirmForm,
@@ -32,8 +32,6 @@ import {
 } from "#templates/attendee-table.tsx";
 import { groupCreateFields, groupFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 /**
  * Admin groups list page

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -2,14 +2,12 @@
  * Admin sessions page template
  */
 
-import { map, pipe, reduce } from "#fp";
+import { joinStrings, map, pipe } from "#fp";
 import { CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, Session } from "#lib/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 const SessionRow = ({
   session,

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -3,15 +3,13 @@
  * across the event detail, check-in, and calendar views.
  */
 
-import { flatMap, map, pipe, reduce, sort } from "#fp";
+import { flatMap, joinStrings, map, pipe, reduce, sort } from "#fp";
 import { formatDateLabel } from "#lib/dates.ts";
 import type { Answer, QuestionWithAnswers } from "#lib/db/questions.ts";
 import { CsrfForm } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import { normalizePhone } from "#lib/phone.ts";
 import type { Attendee } from "#lib/types.ts";
-
-const joinStrings = reduce((acc: string, s: string) => acc + s, "");
 
 /** A single row in the unified attendee table */
 export type AttendeeTableRow = {

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -16,9 +16,9 @@ import type { SigningCredentials } from "#lib/apple-wallet.ts";
 import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { resetEffectiveDomain } from "#lib/config.ts";
 import { getSessionCookieName, parseFlashValue } from "#lib/cookies.ts";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
 import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { toMajorUnits } from "#lib/currency.ts";
 import { createApiKey } from "#lib/db/api-keys.ts";
@@ -790,8 +790,9 @@ const createDirectAdminSession = async (): Promise<{
   csrfToken: string;
 }> => {
   const { generateSecureToken } = await import("#lib/crypto/utils.ts");
-  const { deriveKEK, unwrapKey, wrapKeyWithToken } =
-    await import("#lib/crypto/keys.ts");
+  const { deriveKEK, unwrapKey, wrapKeyWithToken } = await import(
+    "#lib/crypto/keys.ts"
+  );
   const { createSession: createDbSession } = await import(
     "#lib/db/sessions.ts"
   );
@@ -2249,8 +2250,9 @@ export const createTestManagerSession = async (
 ): Promise<string> => {
   const { encrypt: enc } = await import("#lib/crypto/encryption.ts");
   const { hmacHash } = await import("#lib/crypto/hashing.ts");
-  const { deriveKEK, unwrapKey, wrapKeyWithToken } =
-    await import("#lib/crypto/keys.ts");
+  const { deriveKEK, unwrapKey, wrapKeyWithToken } = await import(
+    "#lib/crypto/keys.ts"
+  );
   const { getDb } = await import("#lib/db/client.ts");
   const { createSession } = await import("#lib/db/sessions.ts");
   const {

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { buildSessionCookie } from "#lib/cookies.ts";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { hmacHash } from "#lib/crypto/hashing.ts";
 import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
 
 import { signCsrfToken } from "#lib/csrf.ts";
 import {

--- a/test/lib/crypto/hashing.test.ts
+++ b/test/lib/crypto/hashing.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
 import {
   computeTicketTokenIndex,
   hashPassword,
@@ -7,7 +8,6 @@ import {
   hmacHash,
   verifyPassword,
 } from "#lib/crypto/hashing.ts";
-import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
 import {
   describeWithEnv,
   setTestEnv,

--- a/test/lib/crypto/keys.test.ts
+++ b/test/lib/crypto/keys.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { decryptWithKey, encryptWithKey } from "#lib/crypto/encryption.ts";
 import {
   deriveKEK,
@@ -15,10 +14,8 @@ import {
   wrapKey,
   wrapKeyWithToken,
 } from "#lib/crypto/keys.ts";
-import {
-  describeWithEnv,
-  setTestEnv,
-} from "#test-utils";
+import { generateSecureToken } from "#lib/crypto/utils.ts";
+import { describeWithEnv, setTestEnv } from "#test-utils";
 
 describeWithEnv("KEK derivation", { encryptionKey: true }, () => {
   it("derives a usable CryptoKey", async () => {

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -1,7 +1,13 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { decryptWithKey, encrypt } from "#lib/crypto/encryption.ts";
-import { decryptAttendeePII, deriveKEK, encryptAttendeePII, importPrivateKey, unwrapKey } from "#lib/crypto/keys.ts";
+import {
+  decryptAttendeePII,
+  deriveKEK,
+  encryptAttendeePII,
+  importPrivateKey,
+  unwrapKey,
+} from "#lib/crypto/keys.ts";
 import {
   decryptAttendees,
   getAttendeesRaw,


### PR DESCRIPTION
- Extract `joinStrings` to #fp, removing 9 identical local definitions
- Add `withCacheInvalidation` table wrapper to deduplicate groups/holidays/events cache logic
- Add shared `DeleteBody` type and `requireString` helper to crud-api.ts

https://claude.ai/code/session_011T2cRK8i9wrAAm9XP3ziuB