### PR TITLE
Add CRUD pages for built sites (list, add, edit, delete)

### DIFF
--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -3,10 +3,14 @@
  * Site data (name, bunny URL) is encrypted in a single blob for privacy.
  */
 
+import type { InValue } from "@libsql/client";
+import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt } from "#lib/crypto/encryption.ts";
 import { queryAll } from "#lib/db/client.ts";
-import { col, defineTable } from "#lib/db/table.ts";
+import type { ColumnDef, Table } from "#lib/db/table.ts";
+import { col, defineTable, withCacheInvalidation } from "#lib/db/table.ts";
 import { nowIso } from "#lib/now.ts";
+import { requestCache } from "#lib/request-cache.ts";
 
 /** Encrypted site data blob shape */
 export interface SiteDataBlob {
@@ -37,13 +41,22 @@ export interface BuiltSite {
   created: string;
 }
 
-export const builtSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
+/** Form input for CRUD operations */
+export type BuiltSiteFormInput = {
+  name: string;
+  bunnyUrl: string;
+};
+
+const idCol = col.generated<number>();
+const createdCol = col.withDefault(() => nowIso());
+
+const rawBuiltSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
   name: "built_sites",
   primaryKey: "id",
   schema: {
-    id: col.generated<number>(),
+    id: idCol,
     site_data: col.encrypted<string>(encrypt, decrypt),
-    created: col.withDefault(() => nowIso()),
+    created: createdCol,
   },
 });
 
@@ -55,6 +68,100 @@ export const buildSiteDataBlob = (name: string, bunnyUrl: string): string =>
 export const parseSiteDataBlob = (json: string): SiteDataBlob =>
   JSON.parse(json) as SiteDataBlob;
 
+/** Convert a raw DB row (after decryption) to a BuiltSite */
+const rowToBuiltSite = (row: BuiltSiteRow): BuiltSite => {
+  const blob = parseSiteDataBlob(row.site_data);
+  return { id: row.id, name: blob.n, bunnyUrl: blob.u, created: row.created };
+};
+
+const builtSitesCache = requestCache(() =>
+  queryAndDecrypt("SELECT * FROM built_sites ORDER BY created DESC"),
+);
+
+registerCache(() => ({ name: "built_sites", entries: builtSitesCache.size() }));
+
+/** Invalidate the built sites cache */
+export const invalidateBuiltSitesCache = (): void => {
+  builtSitesCache.invalidate();
+};
+
+/** Query and decrypt built site rows */
+const queryAndDecrypt = async (sql: string): Promise<BuiltSite[]> => {
+  const rows = await queryAll<BuiltSiteRow>(sql);
+  const decrypted = await Promise.all(
+    rows.map((row) => rawBuiltSitesTable.fromDb(row)),
+  );
+  const sites = decrypted.map(rowToBuiltSite);
+  sites.sort((a, b) => a.name.localeCompare(b.name));
+  return sites;
+};
+
+/** Raw table with cache invalidation on writes */
+export const builtSitesTable = withCacheInvalidation(
+  rawBuiltSitesTable,
+  invalidateBuiltSitesCache,
+);
+
+/**
+ * CRUD-compatible table adapter that presents BuiltSite (with individual fields)
+ * while storing data as an encrypted blob underneath.
+ */
+export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
+  name: "built_sites",
+  primaryKey: "id",
+  schema: {
+    id: idCol,
+    name: {} as ColumnDef<string>,
+    bunnyUrl: {} as ColumnDef<string>,
+    created: createdCol,
+  },
+  inputKeyMap: { name: "name", bunny_url: "bunnyUrl" },
+
+  insert: async (input: BuiltSiteFormInput): Promise<BuiltSite> => {
+    const row = await builtSitesTable.insert({
+      siteData: buildSiteDataBlob(input.name, input.bunnyUrl),
+    });
+    // insert() returns the row with unencrypted input values, so parse directly
+    return rowToBuiltSite(row);
+  },
+
+  update: async (
+    id: InValue,
+    input: Partial<BuiltSiteFormInput>,
+  ): Promise<BuiltSite | null> => {
+    const existing = await builtSitesCrudTable.findById(id);
+    if (!existing) return null;
+    const name = input.name ?? existing.name;
+    const bunnyUrl = input.bunnyUrl ?? existing.bunnyUrl;
+    // Row exists (checked above), so update always returns non-null
+    const row = (await builtSitesTable.update(id, {
+      siteData: buildSiteDataBlob(name, bunnyUrl),
+    })) as BuiltSiteRow;
+    // update() returns the row with unencrypted input values, so parse directly
+    return rowToBuiltSite(row);
+  },
+
+  findById: async (id: InValue): Promise<BuiltSite | null> => {
+    // findById already decrypts via fromDb internally
+    const row = await rawBuiltSitesTable.findById(id);
+    if (!row) return null;
+    return rowToBuiltSite(row);
+  },
+
+  deleteById: (id: InValue): Promise<void> => builtSitesTable.deleteById(id),
+
+  findAll: (): Promise<BuiltSite[]> => builtSitesCache.getAll(),
+
+  fromDb: (row: BuiltSite): Promise<BuiltSite> => Promise.resolve(row),
+
+  toDbValues: (
+    input: BuiltSiteFormInput | Partial<BuiltSiteFormInput>,
+  ): Promise<Record<string, InValue>> =>
+    Promise.resolve({
+      site_data: buildSiteDataBlob(input.name ?? "", input.bunnyUrl ?? ""),
+    }),
+};
+
 /** Insert a new built site record */
 export const insertBuiltSite = (
   name: string,
@@ -63,22 +170,5 @@ export const insertBuiltSite = (
   builtSitesTable.insert({ siteData: buildSiteDataBlob(name, bunnyUrl) });
 
 /** Get all built sites, decrypted and sorted by name */
-export const getAllBuiltSites = async (): Promise<BuiltSite[]> => {
-  const rows = await queryAll<BuiltSiteRow>(
-    "SELECT * FROM built_sites ORDER BY created DESC",
-  );
-  const decrypted = await Promise.all(
-    rows.map((row) => builtSitesTable.fromDb(row)),
-  );
-  const sites = decrypted.map((row) => {
-    const blob = parseSiteDataBlob(row.site_data);
-    return {
-      id: row.id,
-      name: blob.n,
-      bunnyUrl: blob.u,
-      created: row.created,
-    };
-  });
-  sites.sort((a, b) => a.name.localeCompare(b.name));
-  return sites;
-};
+export const getAllBuiltSites = (): Promise<BuiltSite[]> =>
+  builtSitesCache.getAll();

--- a/src/routes/admin/built-sites.ts
+++ b/src/routes/admin/built-sites.ts
@@ -1,0 +1,49 @@
+/**
+ * Admin built site management routes - owner only
+ */
+
+import {
+  type BuiltSiteFormInput,
+  builtSitesCrudTable,
+  getAllBuiltSites,
+} from "#lib/db/built-sites.ts";
+import { defineNamedResource } from "#lib/rest/resource.ts";
+import { createOwnerCrudHandlers } from "#routes/admin/owner-crud.ts";
+import {
+  adminBuiltSiteDeletePage,
+  adminBuiltSiteEditPage,
+  adminBuiltSiteNewPage,
+  adminBuiltSitesPage,
+} from "#templates/admin/built-sites.tsx";
+import { builtSiteFields } from "#templates/fields.ts";
+
+/** Extract built site input from validated form values */
+const extractBuiltSiteInput = (
+  values: Record<string, string | number | null>,
+): BuiltSiteFormInput => ({
+  name: String(values.name),
+  bunnyUrl: String(values.bunny_url),
+});
+
+/** Built sites resource for REST create/update operations */
+const builtSitesResource = defineNamedResource({
+  table: builtSitesCrudTable,
+  fields: builtSiteFields,
+  toInput: extractBuiltSiteInput,
+  nameField: "name",
+});
+
+const crud = createOwnerCrudHandlers({
+  singular: "Built site",
+  listPath: "/admin/built-sites",
+  getAll: getAllBuiltSites,
+  resource: builtSitesResource,
+  renderList: adminBuiltSitesPage,
+  renderNew: adminBuiltSiteNewPage,
+  renderEdit: adminBuiltSiteEditPage,
+  renderDelete: adminBuiltSiteDeletePage,
+  getName: (s) => s.name,
+});
+
+/** Built site routes */
+export const builtSitesRoutes = crud.routes;

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -14,6 +14,7 @@ import { attendeeRefundRoutes } from "#routes/admin/attendee-refunds.ts";
 import { attendeesRoutes } from "#routes/admin/attendees.ts";
 import { authRoutes } from "#routes/admin/auth.ts";
 import { builderRoutes } from "#routes/admin/builder.ts";
+import { builtSitesRoutes } from "#routes/admin/built-sites.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
 import { dashboardRoutes } from "#routes/admin/dashboard.ts";
 import { debugRoutes } from "#routes/admin/debug.ts";
@@ -55,6 +56,7 @@ const adminRoutes = {
   ...seedsRoutes,
   ...migrateRoutes,
   ...builderRoutes,
+  ...builtSitesRoutes,
   ...updateRoutes,
 };
 

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -1,0 +1,146 @@
+/**
+ * Admin built sites management page templates
+ */
+
+import type { BuiltSite } from "#lib/db/built-sites.ts";
+import {
+  ConfirmForm,
+  CsrfForm,
+  renderError,
+  renderFields,
+  renderSuccess,
+} from "#lib/forms.tsx";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import type { AdminSession } from "#lib/types.ts";
+import { AdminNav } from "#templates/admin/nav.tsx";
+import { builtSiteFields } from "#templates/fields.ts";
+import { Layout } from "#templates/layout.tsx";
+
+/**
+ * Admin built sites list page
+ */
+export const adminBuiltSitesPage = (
+  sites: BuiltSite[],
+  session: AdminSession,
+  successMessage?: string,
+): string =>
+  String(
+    <Layout title="Built Sites">
+      <AdminNav session={session} active="/admin/built-sites" />
+      <Raw html={renderSuccess(successMessage)} />
+      <p>
+        <a href="/admin/built-sites/new">Add Built Site</a>
+      </p>
+      {sites.length === 0 ? (
+        <p>No built sites recorded.</p>
+      ) : (
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Bunny URL</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sites.map((site) => (
+                <tr>
+                  <td>{site.name}</td>
+                  <td>
+                    <a href={site.bunnyUrl} target="_blank" rel="noopener">
+                      {site.bunnyUrl}
+                    </a>
+                  </td>
+                  <td>
+                    <a href={`/admin/built-sites/${site.id}/edit`}>Edit</a>{" "}
+                    <a href={`/admin/built-sites/${site.id}/delete`}>Delete</a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Layout>,
+  );
+
+/**
+ * Built site create/edit form values
+ */
+export const builtSiteToFieldValues = (
+  site?: BuiltSite,
+): Record<string, string | number | null> => ({
+  name: site?.name ?? "",
+  bunny_url: site?.bunnyUrl ?? "",
+});
+
+/**
+ * Admin built site create page
+ */
+export const adminBuiltSiteNewPage = (
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title="Add Built Site">
+      <AdminNav session={session} active="/admin/built-sites" />
+      <h1>Add Built Site</h1>
+      <Raw html={renderError(error)} />
+      <CsrfForm action="/admin/built-sites">
+        <Raw html={renderFields(builtSiteFields)} />
+        <button type="submit">Create Built Site</button>
+      </CsrfForm>
+    </Layout>,
+  );
+
+/**
+ * Admin built site edit page
+ */
+export const adminBuiltSiteEditPage = (
+  site: BuiltSite,
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title="Edit Built Site">
+      <AdminNav session={session} active="/admin/built-sites" />
+      <h1>Edit Built Site</h1>
+      <Raw html={renderError(error)} />
+      <CsrfForm action={`/admin/built-sites/${site.id}/edit`}>
+        <Raw
+          html={renderFields(builtSiteFields, builtSiteToFieldValues(site))}
+        />
+        <button type="submit">Save Changes</button>
+      </CsrfForm>
+    </Layout>,
+  );
+
+/**
+ * Admin built site delete confirmation page
+ */
+export const adminBuiltSiteDeletePage = (
+  site: BuiltSite,
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title="Delete Built Site">
+      <AdminNav session={session} active="/admin/built-sites" />
+      <h1>Delete Built Site</h1>
+      <Raw html={renderError(error)} />
+      <ConfirmForm
+        action={`/admin/built-sites/${site.id}/delete`}
+        name={site.name}
+        label="Site name"
+        buttonText="Delete Built Site"
+        danger={false}
+      >
+        <p>
+          Are you sure you want to delete the built site{" "}
+          <strong>{site.name}</strong>?
+        </p>
+        <p>Type the site name "{site.name}" to confirm:</p>
+      </ConfirmForm>
+    </Layout>,
+  );

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -39,6 +39,8 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
       {navLink("/admin/groups", "Groups", active)}
       {session.adminLevel === "owner" &&
         navLink("/admin/holidays", "Holidays", active)}
+      {session.adminLevel === "owner" &&
+        navLink("/admin/built-sites", "Built Sites", active)}
       {navLink("/admin/guide", "Guide", active)}
       <li>
         <CsrfForm action="/admin/logout" class="inline">

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -506,6 +506,26 @@ export const holidayFields: Field[] = [
   },
 ];
 
+/**
+ * Built site form field definitions
+ */
+export const builtSiteFields: Field[] = [
+  {
+    name: "name",
+    label: "Site Name",
+    type: "text",
+    required: true,
+    placeholder: "My Ticket Site",
+  },
+  {
+    name: "bunny_url",
+    label: "Bunny URL",
+    type: "url",
+    required: true,
+    placeholder: "https://example.b-cdn.net",
+  },
+];
+
 /** Image upload field for event forms (appended when storage is enabled) */
 export const imageField: Field = {
   name: "image",

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2015,6 +2015,86 @@ export const deleteTestHoliday = async (holidayId: number): Promise<void> => {
 
 export type { GroupInput, HolidayInput };
 
+import type { BuiltSite, BuiltSiteFormInput } from "#lib/db/built-sites.ts";
+
+/** Create a test BuiltSite with sensible defaults. Override any field via `overrides`. */
+export const testBuiltSite = (
+  overrides: Partial<BuiltSite> = {},
+): BuiltSite => ({
+  id: 1,
+  name: "Test Site",
+  bunnyUrl: "https://test.b-cdn.net",
+  created: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+/**
+ * Create a built site via the REST API
+ */
+export const createTestBuiltSite = (
+  overrides: Partial<BuiltSiteFormInput> = {},
+): Promise<BuiltSite> => {
+  const input: BuiltSiteFormInput = {
+    name: overrides.name ?? "Test Site",
+    bunnyUrl: overrides.bunnyUrl ?? "https://test.b-cdn.net",
+  };
+
+  return authenticatedFormRequest(
+    "/admin/built-sites",
+    {
+      name: input.name,
+      bunny_url: input.bunnyUrl,
+    },
+    async () => {
+      const { getAllBuiltSites } = await import("#lib/db/built-sites.ts");
+      const sites = await getAllBuiltSites();
+      return sites[sites.length - 1] as BuiltSite;
+    },
+    "create built site",
+  );
+};
+
+/**
+ * Update a built site via the REST API
+ */
+export const updateTestBuiltSite = async (
+  siteId: number,
+  updates: Partial<BuiltSiteFormInput>,
+): Promise<BuiltSite> => {
+  const { builtSitesCrudTable } = await import("#lib/db/built-sites.ts");
+  const existing = (await builtSitesCrudTable.findById(siteId)) as BuiltSite;
+
+  return authenticatedFormRequest(
+    `/admin/built-sites/${siteId}/edit`,
+    {
+      name: updates.name ?? existing.name,
+      bunny_url: updates.bunnyUrl ?? existing.bunnyUrl,
+    },
+    async () => {
+      const updated = await builtSitesCrudTable.findById(siteId);
+      return updated as BuiltSite;
+    },
+    "update built site",
+  );
+};
+
+/**
+ * Delete a built site via the REST API
+ */
+export const deleteTestBuiltSite = async (siteId: number): Promise<void> => {
+  const { builtSitesCrudTable } = await import("#lib/db/built-sites.ts");
+  const existing = (await builtSitesCrudTable.findById(siteId)) as BuiltSite;
+
+  return authenticatedFormRequest(
+    `/admin/built-sites/${siteId}/delete`,
+    { confirm_identifier: existing.name },
+    async () => {},
+    "delete built site",
+  );
+};
+
+export type { BuiltSiteFormInput };
+
 /**
  * Create an attendee directly using createAttendeeAtomic (bypasses HTTP layer).
  * Returns the plaintext token just like production code receives it.

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import {
   buildSiteDataBlob,
+  builtSitesCrudTable,
   getAllBuiltSites,
   insertBuiltSite,
   parseSiteDataBlob,
@@ -47,5 +48,75 @@ describeWithEnv("built-sites", { db: true }, () => {
   test("getAllBuiltSites returns empty array when no sites exist", async () => {
     const sites = await getAllBuiltSites();
     expect(sites).toHaveLength(0);
+  });
+
+  describe("builtSitesCrudTable", () => {
+    test("findAll returns all built sites", async () => {
+      await insertBuiltSite("Site A", "a.bunny.run");
+      await insertBuiltSite("Site B", "b.bunny.run");
+
+      const sites = await builtSitesCrudTable.findAll();
+      expect(sites).toHaveLength(2);
+    });
+
+    test("fromDb returns the row unchanged", async () => {
+      const site = {
+        id: 1,
+        name: "Test",
+        bunnyUrl: "test.bunny.run",
+        created: "2026-01-01",
+      };
+      const result = await builtSitesCrudTable.fromDb(site);
+      expect(result).toEqual(site);
+    });
+
+    test("toDbValues builds encrypted blob from input", async () => {
+      const values = await builtSitesCrudTable.toDbValues({
+        name: "Test",
+        bunnyUrl: "test.bunny.run",
+      });
+      expect(values.site_data).toBeTruthy();
+      const parsed = parseSiteDataBlob(values.site_data as string);
+      expect(parsed.n).toBe("Test");
+      expect(parsed.u).toBe("test.bunny.run");
+    });
+
+    test("update preserves existing name when only bunnyUrl provided", async () => {
+      const site = await builtSitesCrudTable.insert({
+        name: "Original",
+        bunnyUrl: "original.bunny.run",
+      });
+      const updated = await builtSitesCrudTable.update(site.id, {
+        bunnyUrl: "new.bunny.run",
+      });
+      expect(updated!.name).toBe("Original");
+      expect(updated!.bunnyUrl).toBe("new.bunny.run");
+    });
+
+    test("update preserves existing bunnyUrl when only name provided", async () => {
+      const site = await builtSitesCrudTable.insert({
+        name: "Original",
+        bunnyUrl: "original.bunny.run",
+      });
+      const updated = await builtSitesCrudTable.update(site.id, {
+        name: "Updated",
+      });
+      expect(updated!.name).toBe("Updated");
+      expect(updated!.bunnyUrl).toBe("original.bunny.run");
+    });
+
+    test("update returns null for non-existent id", async () => {
+      const result = await builtSitesCrudTable.update(999, {
+        name: "Test",
+      });
+      expect(result).toBeNull();
+    });
+
+    test("toDbValues handles partial input with missing fields", async () => {
+      const values = await builtSitesCrudTable.toDbValues({});
+      const parsed = parseSiteDataBlob(values.site_data as string);
+      expect(parsed.n).toBe("");
+      expect(parsed.u).toBe("");
+    });
   });
 });

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -1,0 +1,373 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+
+import { handleRequest } from "#routes";
+import {
+  adminFormPost,
+  adminGet,
+  createTestBuiltSite,
+  deleteTestBuiltSite,
+  describeWithEnv,
+  expectAdminRedirect,
+  expectFlash,
+  expectHtmlResponse,
+  expectRedirectWithFlash,
+  expectStatus,
+  mockFormRequest,
+  mockRequest,
+  testBuiltSite,
+  updateTestBuiltSite,
+} from "#test-utils";
+
+describeWithEnv("server (admin built sites)", { db: true }, () => {
+  describe("GET /admin/built-sites", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(mockRequest("/admin/built-sites"));
+      expectAdminRedirect(response);
+    });
+
+    test("shows empty built sites list", async () => {
+      const { response } = await adminGet("/admin/built-sites");
+      await expectHtmlResponse(
+        response,
+        200,
+        "Built Sites",
+        "No built sites recorded",
+      );
+    });
+
+    test("shows built sites in table when present", async () => {
+      const site = await createTestBuiltSite({
+        name: "My Site",
+        bunnyUrl: "https://mysite.b-cdn.net",
+      });
+      const { response } = await adminGet("/admin/built-sites");
+      await expectHtmlResponse(
+        response,
+        200,
+        "My Site",
+        "https://mysite.b-cdn.net",
+        `/admin/built-sites/${site.id}/edit`,
+        `/admin/built-sites/${site.id}/delete`,
+      );
+    });
+  });
+
+  describe("GET /admin/built-sites/new", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockRequest("/admin/built-sites/new"),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("shows create built site form", async () => {
+      const { response } = await adminGet("/admin/built-sites/new");
+      await expectHtmlResponse(
+        response,
+        200,
+        "Add Built Site",
+        "Site Name",
+        "Bunny URL",
+      );
+    });
+  });
+
+  describe("POST /admin/built-sites", () => {
+    test("redirects to login when not authenticated", async () => {
+      const response = await handleRequest(
+        mockFormRequest("/admin/built-sites", {
+          name: "Test",
+          bunny_url: "https://test.b-cdn.net",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("creates built site and redirects", async () => {
+      const site = await createTestBuiltSite({
+        name: "New Site",
+        bunnyUrl: "https://new.b-cdn.net",
+      });
+      expect(site.name).toBe("New Site");
+      expect(site.bunnyUrl).toBe("https://new.b-cdn.net");
+    });
+
+    test("rejects missing name", async () => {
+      const { response } = await adminFormPost("/admin/built-sites", {
+        name: "",
+        bunny_url: "https://test.b-cdn.net",
+      });
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining("Site Name is required"),
+        false,
+      );
+    });
+
+    test("rejects missing bunny_url", async () => {
+      const { response } = await adminFormPost("/admin/built-sites", {
+        name: "Test",
+        bunny_url: "",
+      });
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining("Bunny URL is required"),
+        false,
+      );
+    });
+  });
+
+  describe("GET /admin/built-sites/:id/edit", () => {
+    test("redirects to login when not authenticated", async () => {
+      const site = await createTestBuiltSite();
+      const response = await handleRequest(
+        mockRequest(`/admin/built-sites/${site.id}/edit`),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("shows edit form with pre-filled values", async () => {
+      const site = await createTestBuiltSite({
+        name: "Edit Me",
+        bunnyUrl: "https://editme.b-cdn.net",
+      });
+      const { response } = await adminGet(`/admin/built-sites/${site.id}/edit`);
+      await expectHtmlResponse(
+        response,
+        200,
+        "Edit Built Site",
+        "Edit Me",
+        "https://editme.b-cdn.net",
+      );
+    });
+
+    test("returns 404 for non-existent built site", async () => {
+      const { response } = await adminGet("/admin/built-sites/999/edit");
+      expectStatus(404)(response);
+    });
+  });
+
+  describe("POST /admin/built-sites/:id/edit", () => {
+    test("redirects to login when not authenticated", async () => {
+      const site = await createTestBuiltSite();
+      const response = await handleRequest(
+        mockFormRequest(`/admin/built-sites/${site.id}/edit`, {
+          name: "Updated",
+          bunny_url: "https://updated.b-cdn.net",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("updates built site", async () => {
+      const site = await createTestBuiltSite({ name: "Original" });
+      const updated = await updateTestBuiltSite(site.id, {
+        name: "Updated",
+      });
+      expect(updated.name).toBe("Updated");
+    });
+
+    test("returns 404 for non-existent built site", async () => {
+      const { response } = await adminFormPost("/admin/built-sites/999/edit", {
+        name: "Test",
+        bunny_url: "https://test.b-cdn.net",
+      });
+      expectStatus(404)(response);
+    });
+
+    test("rejects invalid form data on edit", async () => {
+      const site = await createTestBuiltSite();
+      const { response } = await adminFormPost(
+        `/admin/built-sites/${site.id}/edit`,
+        {
+          name: "",
+          bunny_url: "https://test.b-cdn.net",
+        },
+      );
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining("Site Name is required"),
+        false,
+      );
+    });
+  });
+
+  describe("GET /admin/built-sites/:id/delete", () => {
+    test("redirects to login when not authenticated", async () => {
+      const site = await createTestBuiltSite();
+      const response = await handleRequest(
+        mockRequest(`/admin/built-sites/${site.id}/delete`),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("shows delete confirmation page", async () => {
+      const site = await createTestBuiltSite({ name: "Delete Me" });
+      const { response } = await adminGet(
+        `/admin/built-sites/${site.id}/delete`,
+      );
+      await expectHtmlResponse(
+        response,
+        200,
+        "Delete Built Site",
+        "Delete Me",
+        "confirm_identifier",
+      );
+    });
+
+    test("returns 404 for non-existent built site", async () => {
+      const { response } = await adminGet("/admin/built-sites/999/delete");
+      expectStatus(404)(response);
+    });
+  });
+
+  describe("POST /admin/built-sites/:id/delete", () => {
+    test("redirects to login when not authenticated", async () => {
+      const site = await createTestBuiltSite();
+      const response = await handleRequest(
+        mockFormRequest(`/admin/built-sites/${site.id}/delete`, {
+          confirm_identifier: "Test Site",
+        }),
+      );
+      expectAdminRedirect(response);
+    });
+
+    test("deletes built site with correct name confirmation", async () => {
+      const site = await createTestBuiltSite({ name: "To Delete" });
+      await deleteTestBuiltSite(site.id);
+
+      const { builtSitesCrudTable } = await import("#lib/db/built-sites.ts");
+      const found = await builtSitesCrudTable.findById(site.id);
+      expect(found).toBeNull();
+    });
+
+    test("rejects deletion with wrong name", async () => {
+      const site = await createTestBuiltSite({ name: "Keep Me" });
+      const { response } = await adminFormPost(
+        `/admin/built-sites/${site.id}/delete`,
+        {
+          confirm_identifier: "Wrong Name",
+        },
+      );
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining("Built site name does not match"),
+        false,
+      );
+
+      const { builtSitesCrudTable } = await import("#lib/db/built-sites.ts");
+      const found = await builtSitesCrudTable.findById(site.id);
+      expect(found).not.toBeNull();
+    });
+
+    test("name confirmation is case-insensitive", async () => {
+      const site = await createTestBuiltSite({ name: "Case Test" });
+      const { response } = await adminFormPost(
+        `/admin/built-sites/${site.id}/delete`,
+        {
+          confirm_identifier: "case test",
+        },
+      );
+      expectRedirectWithFlash(
+        "/admin/built-sites",
+        "Built site deleted",
+      )(response);
+    });
+
+    test("returns 404 for non-existent built site", async () => {
+      const { response } = await adminFormPost(
+        "/admin/built-sites/999/delete",
+        {
+          confirm_identifier: "Test",
+        },
+      );
+      expectStatus(404)(response);
+    });
+  });
+
+  describe("nav link", () => {
+    test("built sites link visible to owners", async () => {
+      const { response } = await adminGet("/admin/built-sites");
+      const body = await response.text();
+      expect(body).toContain("/admin/built-sites");
+      expect(body).toContain("Built Sites");
+    });
+  });
+
+  describe("activity logging", () => {
+    test("logs built site creation", async () => {
+      await createTestBuiltSite({ name: "Logged Site" });
+      const { response } = await adminGet("/admin/log");
+      const body = await response.text();
+      expect(body).toContain("Logged Site");
+      expect(body).toContain("created");
+    });
+
+    test("logs built site update", async () => {
+      const site = await createTestBuiltSite({ name: "Before Update" });
+      await updateTestBuiltSite(site.id, { name: "After Update" });
+      const { response } = await adminGet("/admin/log");
+      const body = await response.text();
+      expect(body).toContain("After Update");
+      expect(body).toContain("updated");
+    });
+
+    test("logs built site deletion", async () => {
+      const site = await createTestBuiltSite({ name: "Deleted Site" });
+      await deleteTestBuiltSite(site.id);
+      const { response } = await adminGet("/admin/log");
+      const body = await response.text();
+      expect(body).toContain("Deleted Site");
+      expect(body).toContain("deleted");
+    });
+  });
+
+  describe("builtSiteToFieldValues", () => {
+    test("returns empty defaults when no site provided", async () => {
+      const { builtSiteToFieldValues } = await import(
+        "#templates/admin/built-sites.tsx"
+      );
+      const values = builtSiteToFieldValues();
+      expect(values.name).toBe("");
+      expect(values.bunny_url).toBe("");
+    });
+
+    test("returns site values when site provided", async () => {
+      const { builtSiteToFieldValues } = await import(
+        "#templates/admin/built-sites.tsx"
+      );
+      const site = testBuiltSite({
+        name: "Test",
+        bunnyUrl: "https://test.b-cdn.net",
+      });
+      const values = builtSiteToFieldValues(site);
+      expect(values.name).toBe("Test");
+      expect(values.bunny_url).toBe("https://test.b-cdn.net");
+    });
+  });
+
+  describe("edit/delete error fallback", () => {
+    test("returns 404 when built site not found during edit error", async () => {
+      const { response } = await adminFormPost("/admin/built-sites/999/edit", {
+        name: "",
+        bunny_url: "https://test.b-cdn.net",
+      });
+      expectStatus(404)(response);
+    });
+
+    test("returns 404 when built site not found during delete error", async () => {
+      const { response } = await adminFormPost(
+        "/admin/built-sites/999/delete",
+        {
+          confirm_identifier: "Wrong",
+        },
+      );
+      expectStatus(404)(response);
+    });
+  });
+});


### PR DESCRIPTION
Adds owner-only admin pages for managing built sites, following the same
CRUD patterns as holidays. Includes a table adapter that bridges the
encrypted blob storage with the form-based CRUD framework.

https://claude.ai/code/session_017GnnSkzT4rJxKShPfrUA8G