### PR TITLE
Add guide links from Advanced Settings pages

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -879,7 +879,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Check-in &amp; QR Scanner">
+      <Section id="checkin" title="Check-in &amp; QR Scanner">
         <Q q="How does check-in work?">
           <p>
             Each ticket has a unique QR code. When an attendee arrives, they
@@ -943,7 +943,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Apple Wallet">
+      <Section id="apple-wallet" title="Apple Wallet">
         <Q q="What is Apple Wallet integration?">
           <p>
             When configured, attendees see an{" "}
@@ -1011,7 +1011,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Google Wallet">
+      <Section id="google-wallet" title="Google Wallet">
         <Q q="What is Google Wallet integration?">
           <p>
             When configured, attendees see an{" "}
@@ -1224,7 +1224,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Email Notifications">
+      <Section id="email" title="Email Notifications">
         <Q q="What are email notifications?">
           <p>
             When configured, the system can send up to two emails after each
@@ -1339,7 +1339,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Email Templates">
+      <Section id="email-templates" title="Email Templates">
         <Q q="Can I customise the emails that are sent?">
           <p>
             Yes. In <a href="/admin/settings">Settings</a>, scroll to the email
@@ -1410,7 +1410,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Host Subdomain">
+      <Section id="host-subdomain" title="Host Subdomain">
         <Q q="What is a host subdomain?">
           <p>
             If your server administrator has enabled subdomain registration, you
@@ -1457,7 +1457,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Custom Domain">
+      <Section id="custom-domain" title="Custom Domain">
         <Q q="How do I set up a custom domain?">
           <p>
             If your site runs on Bunny CDN and the <code>BUNNY_API_KEY</code>{" "}

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -54,7 +54,8 @@ const SubdomainIntroProse = (): SafeHtml => (
     <p>
       You can choose a prettier domain name for your tickets site. Enter a
       subdomain into the box below to preview the full URL &mdash; you can
-      change your mind before saving, but once set this cannot be changed.
+      change your mind before saving, but once set this cannot be changed.{" "}
+      <a href="/admin/guide#host-subdomain">Learn more</a>.
     </p>
   </div>
 );
@@ -180,7 +181,8 @@ export const adminAdvancedSettingsPage = (
         <h2>Apple Wallet</h2>
         <p>
           Configure Apple Wallet pass signing to show an &ldquo;Add to Apple
-          Wallet&rdquo; button on ticket pages.
+          Wallet&rdquo; button on ticket pages.{" "}
+          <a href="/admin/guide#apple-wallet">Setup guide</a>.
           {s.hostAppleWalletLabel && !s.appleWalletConfigured
             ? ` Currently using: ${s.hostAppleWalletLabel}. Override below or leave empty to keep using host config.`
             : s.hostAppleWalletLabel && s.appleWalletConfigured
@@ -248,7 +250,8 @@ export const adminAdvancedSettingsPage = (
         <p>
           Configure Google Wallet to show an &ldquo;Add to Google Wallet&rdquo;
           button on ticket pages. Requires a Google Cloud service account with
-          the Google Wallet API enabled.
+          the Google Wallet API enabled.{" "}
+          <a href="/admin/guide#google-wallet">Setup guide</a>.
           {s.hostGoogleWalletLabel && !s.googleWalletConfigured
             ? ` Currently using: ${s.hostGoogleWalletLabel}. Override below or leave empty to keep using host config.`
             : s.hostGoogleWalletLabel && s.googleWalletConfigured
@@ -294,7 +297,8 @@ export const adminAdvancedSettingsPage = (
       >
         <h2>Confirmation Email Template</h2>
         <p>
-          Customise the registration confirmation email sent to attendees. Uses{" "}
+          Customise the registration confirmation email sent to attendees (
+          <a href="/admin/guide#email-templates">template guide</a>). Uses{" "}
           <a href="https://liquidjs.com/" target="_blank" rel="noopener">
             Liquid
           </a>{" "}
@@ -490,7 +494,7 @@ export const adminAdvancedSettingsPage = (
         <h2>Email Notifications</h2>
         <p>
           Send confirmation emails to attendees and admin notifications when
-          registrations come in.
+          registrations come in. <a href="/admin/guide#email">Setup guide</a>.
         </p>
         <label>
           Email Provider
@@ -553,7 +557,8 @@ export const adminAdvancedSettingsPage = (
           >
             <h2>Custom Domain</h2>
             <p>
-              Set a custom domain for your tickets site.
+              Set a custom domain for your tickets site.{" "}
+              <a href="/admin/guide#custom-domain">Setup guide</a>.
               {s.bunnySubdomain &&
                 " Your host subdomain can be active at the same time as a custom domain."}
             </p>


### PR DESCRIPTION
## Summary

- Adds `id` attributes to 7 guide sections (Apple Wallet, Google Wallet, Email Notifications, Email Templates, Host Subdomain, Custom Domain, Check-in & QR Scanner) so they can be deep-linked
- Adds "Setup guide" / "Learn more" links from the corresponding Advanced Settings forms to their guide sections
- Follows the existing pattern used by Stripe/Square payment settings, which already link to `/admin/guide#payment-setup`

**Why:** The Advanced Settings page has complex configuration (wallet certificates, email provider setup, custom domain DNS) but previously had no links to the guide's detailed instructions. Users configuring these features had to separately navigate to the guide and find the right section. Now each settings form links directly to its relevant guide section.

## Test plan

- [x] `deno task precommit` passes (typecheck, lint, tests, coverage)
- [ ] Visit `/admin/settings-advanced` and verify each new guide link navigates to the correct section
- [ ] Verify the guide sections scroll to the correct heading via the `#id` fragment

https://claude.ai/code/session_01978YG8zMvi7wWGAACkwrYy