### PR TITLE
Remove custom find-in-page dialog trigger

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -86,17 +86,6 @@ if (multiUrl) {
   }
 }
 
-/* Find in page: trigger browser's native find dialog via window.find() */
-const findLink = document.querySelector<HTMLAnchorElement>(
-  "[data-find-in-page]",
-);
-if (findLink) {
-  findLink.addEventListener("click", (e) => {
-    e.preventDefault();
-    (window as unknown as { find?: () => void }).find?.();
-  });
-}
-
 /* Fill default template: clicking "Edit default template" fills the textarea */
 for (const link of document.querySelectorAll<HTMLAnchorElement>(
   "[data-fill-default]",

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -63,11 +63,7 @@ export const adminGuidePage = (
 
       <p class="search-hint">
         Press <kbd>Ctrl</kbd>+<kbd>F</kbd> (or <kbd>&#8984;</kbd>+<kbd>F</kbd>{" "}
-        on Mac) to{" "}
-        <a href="#" data-find-in-page>
-          search this page
-        </a>
-        .
+        on Mac) to search this page.
       </p>
 
       <Section title="Getting Started">


### PR DESCRIPTION
## Summary
Removed the custom JavaScript implementation that triggered the browser's native find dialog via `window.find()`. Users can now rely on the standard browser keyboard shortcut (Ctrl+F / Cmd+F) instead.

## Changes
- Removed the event listener that intercepted clicks on the "search this page" link and called `window.find()`
- Updated the admin guide template to remove the interactive link element and simplify the text to just mention the keyboard shortcut
- The find functionality is now entirely delegated to the browser's native implementation

## Details
The removed code was attempting to provide a clickable alternative to the browser's native find dialog. Since the keyboard shortcut (Ctrl+F on Windows/Linux, Cmd+F on Mac) is universally understood and more reliable, the custom implementation is no longer necessary. This simplifies the codebase and reduces unnecessary JavaScript execution.

https://claude.ai/code/session_015sPFuDbs3UnyFeegEN8u7n