### PR TITLE
Simplify migration page to only show in-progress state

### DIFF
--- a/src/routes/admin/migrate.ts
+++ b/src/routes/admin/migrate.ts
@@ -16,18 +16,18 @@ import {
   AUTH_FORM,
   type AuthSession,
   htmlResponse,
+  redirect,
   redirectResponse,
   requireSessionOr,
   withAuth,
 } from "#routes/utils.ts";
 import { adminMigratePage } from "#templates/admin/migrate.tsx";
 
-/** Run handler only when migration is incomplete; return doneResponse otherwise */
+/** Run handler only when migration is incomplete; redirect to dashboard otherwise */
 const whenNotMigrated =
-  (doneResponse: (session: AuthSession) => Response | Promise<Response>) =>
   (handler: (session: AuthSession) => Promise<Response>) =>
   (session: AuthSession): Response | Promise<Response> => {
-    if (settings.attendeeBlobMigrated) return doneResponse(session);
+    if (settings.attendeeBlobMigrated) return redirectResponse("/admin/");
     return handler(session);
   };
 
@@ -37,18 +37,15 @@ const whenNotMigrated =
 const handleMigrateGet: TypedRouteHandler<"GET /admin/migrate"> = (request) =>
   requireSessionOr(
     request,
-    whenNotMigrated((session) =>
-      htmlResponse(adminMigratePage(session, { done: true })),
-    )(async (session) => {
+    whenNotMigrated(async (session) => {
       const progress = await getMigrationProgress();
       // Auto-complete: fresh DBs and fully-migrated DBs have 0 remaining
       if (progress.remaining === 0) {
         await settings.update.attendeeBlobMigrated();
-        return htmlResponse(adminMigratePage(session, { done: true }));
+        return redirectResponse("/admin/");
       }
       return htmlResponse(
         adminMigratePage(session, {
-          done: false,
           total: progress.total,
           remaining: progress.remaining,
           batchSize: MIGRATE_BATCH_SIZE,
@@ -64,17 +61,19 @@ const handleMigratePost = (request: Request): Promise<Response> =>
   withAuth(
     request,
     AUTH_FORM,
-    whenNotMigrated(() => redirectResponse("/admin/migrate"))(
-      async (session) => {
-        const privateKey = await requirePrivateKey(session);
-        const result = await migrateAttendeeBatch(privateKey);
-        if (result.remaining === 0) {
-          await settings.update.attendeeBlobMigrated();
-          return redirectResponse("/admin/");
-        }
-        return redirectResponse("/admin/migrate");
-      },
-    ),
+    whenNotMigrated(async (session) => {
+      const privateKey = await requirePrivateKey(session);
+      const result = await migrateAttendeeBatch(privateKey);
+      if (result.remaining === 0) {
+        await settings.update.attendeeBlobMigrated();
+        return redirect(
+          "/admin/",
+          "Migration complete. All attendee records have been upgraded.",
+          true,
+        );
+      }
+      return redirectResponse("/admin/migrate");
+    }),
   );
 
 /** Migration routes */

--- a/src/templates/admin/migrate.tsx
+++ b/src/templates/admin/migrate.tsx
@@ -7,12 +7,15 @@ import type { AdminSession } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
 
-type MigratePageState =
-  | { done: true }
-  | { done: false; total: number; remaining: number; batchSize: number };
+type MigratePageState = {
+  total: number;
+  remaining: number;
+  batchSize: number;
+};
 
 /**
- * Admin migration page
+ * Admin migration page — in-progress view only.
+ * When migration is complete or has nothing to do, the route redirects to /admin/.
  */
 export const adminMigratePage = (
   session: AdminSession,
@@ -21,56 +24,41 @@ export const adminMigratePage = (
   String(
     <Layout title="Database Migration">
       <AdminNav session={session} active="" />
-      {state.done ? (
-        <section>
-          <div>
-            <h2>Database Migration</h2>
-            <p>Migration complete. All attendee records have been upgraded.</p>
-            <p>
-              <a href="/admin/">Back to dashboard</a>
-            </p>
-          </div>
-        </section>
-      ) : (
-        <section>
-          <div>
-            <h2>Database Migration</h2>
-            <p>
-              We're restructuring the database to improve performance. Attendee
-              data will be consolidated into a more efficient format, reducing
-              storage by approximately 68%.
-            </p>
-            <p>
-              This requires decrypting and re-encrypting each attendee record.
-              Press the button below to process a batch of {state.batchSize}{" "}
-              records at a time.
-            </p>
-          </div>
+      <section>
+        <div>
+          <h2>Database Migration</h2>
+          <p>
+            We're restructuring the database to improve performance. Attendee
+            data will be consolidated into a more efficient format, reducing
+            storage by approximately 68%.
+          </p>
+          <p>
+            This requires decrypting and re-encrypting each attendee record.
+            Press the button below to process a batch of {state.batchSize}{" "}
+            records at a time.
+          </p>
+        </div>
 
-          <div id="migrate-status">
-            <p>
-              <strong>
-                {state.total - state.remaining} / {state.total}
-              </strong>{" "}
-              records migrated ({state.remaining} remaining)
-            </p>
-            {state.total > 0 && (
-              <progress
-                value={state.total - state.remaining}
-                max={state.total}
-              />
-            )}
-          </div>
+        <div id="migrate-status">
+          <p>
+            <strong>
+              {state.total - state.remaining} / {state.total}
+            </strong>{" "}
+            records migrated ({state.remaining} remaining)
+          </p>
+          {state.total > 0 && (
+            <progress value={state.total - state.remaining} max={state.total} />
+          )}
+        </div>
 
-          <CsrfForm action="/admin/migrate" id="migrate-form" class="inline">
-            <button type="submit" id="migrate-btn">
-              Process next batch
-            </button>
-          </CsrfForm>
+        <CsrfForm action="/admin/migrate" id="migrate-form" class="inline">
+          <button type="submit" id="migrate-btn">
+            Process next batch
+          </button>
+        </CsrfForm>
 
-          <p id="migrate-error" class="error" hidden />
-          <p id="migrate-log" />
-        </section>
-      )}
+        <p id="migrate-error" class="error" hidden />
+        <p id="migrate-log" />
+      </section>
     </Layout>,
   );

--- a/test/lib/migrate.test.ts
+++ b/test/lib/migrate.test.ts
@@ -400,28 +400,26 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
       expect(html).toContain("1 remaining");
     });
 
-    test("shows completion message when already migrated", async () => {
+    test("redirects to dashboard when already migrated", async () => {
       await settings.update.attendeeBlobMigrated();
       const { response } = await adminGet("/admin/migrate");
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Migration complete");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/");
     });
 
-    test("accessible to managers", async () => {
+    test("accessible to managers and redirects when migrated", async () => {
       await settings.update.attendeeBlobMigrated();
       const managerCookie = await createTestManagerSession();
       const response = await awaitTestRequest("/admin/migrate", {
         cookie: managerCookie,
       });
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Migration complete");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/");
     });
   });
 
   describe("POST /admin/migrate", () => {
-    test("processes a batch and redirects to dashboard when done", async () => {
+    test("processes a batch and redirects to dashboard with flash when done", async () => {
       const event = await createTestEventForMigration({ maxAttendees: 10 });
       await createTestAttendee(event.id, event.slug, "Mig", "mig@test.com");
       // Simulate pre-migration
@@ -431,7 +429,9 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
 
       const { response } = await adminFormPost("/admin/migrate");
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/");
+      const location = response.headers.get("location")!;
+      expect(location).toContain("/admin/");
+      expect(location).toContain("flash=");
 
       // Verify the batch was actually processed
       const progress = await getMigrationProgress();
@@ -463,14 +463,14 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
       }
     });
 
-    test("redirects when already migrated", async () => {
+    test("redirects to dashboard when already migrated", async () => {
       await settings.update.attendeeBlobMigrated();
       const { response } = await adminFormPost("/admin/migrate");
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/migrate");
+      expect(response.headers.get("location")).toBe("/admin/");
     });
 
-    test("accessible to managers", async () => {
+    test("accessible to managers and redirects when migrated", async () => {
       await settings.update.attendeeBlobMigrated();
       const managerCookie = await createTestManagerSession();
       const { signCsrfToken } = await import("#lib/csrf.ts");
@@ -484,7 +484,7 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/admin/migrate");
+      expect(response.headers.get("location")).toBe("/admin/");
     });
   });
 
@@ -528,18 +528,17 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
   });
 
   describe("auto-complete migration for fresh databases", () => {
-    test("GET /admin/migrate auto-completes when no attendees exist", async () => {
+    test("GET /admin/migrate auto-completes and redirects when no attendees exist", async () => {
       expect(settings.attendeeBlobMigrated).toBe(false);
 
       const { response } = await adminGet("/admin/migrate");
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Migration complete");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/");
 
       expect(settings.attendeeBlobMigrated).toBe(true);
     });
 
-    test("GET /admin/migrate auto-completes when all attendees already migrated", async () => {
+    test("GET /admin/migrate auto-completes and redirects when all attendees already migrated", async () => {
       const event = await createTestEventForMigration({ maxAttendees: 10 });
       await createTestAttendee(
         event.id,
@@ -551,9 +550,8 @@ describeWithEnv("attendee blob migration", { db: true }, () => {
       expect(settings.attendeeBlobMigrated).toBe(false);
 
       const { response } = await adminGet("/admin/migrate");
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Migration complete");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin/");
 
       expect(settings.attendeeBlobMigrated).toBe(true);
     });


### PR DESCRIPTION
## Summary
Refactored the database migration admin page to remove the completion state UI. The page now only displays the in-progress migration view, with redirects to the dashboard handling all completion scenarios (already migrated, auto-complete on fresh DB, or batch processing complete).

## Key Changes
- **Simplified state type**: Removed the `done` discriminated union from `MigratePageState`, keeping only the in-progress fields (`total`, `remaining`, `batchSize`)
- **Removed completion UI**: Deleted the conditional rendering that showed "Migration complete" message when `done: true`
- **Unified redirect behavior**: Both GET and POST handlers now redirect to `/admin/` when migration is complete or unnecessary, instead of rendering a completion page
- **Added flash message**: POST handler now includes a flash message when migration completes: "Migration complete. All attendee records have been upgraded."
- **Updated route handler**: Simplified `whenNotMigrated` wrapper to always redirect to dashboard on completion, removing the need for a `doneResponse` callback
- **Updated tests**: Changed test expectations to verify 302 redirects instead of 200 responses with completion messages

## Implementation Details
- The migration page is now purely a progress/action view - users see it only while migration is in progress
- Auto-completion logic (for fresh DBs or fully-migrated DBs) now redirects immediately instead of showing a completion page
- The flash message provides user feedback on successful completion without requiring a dedicated page
- Cleaner separation of concerns: the route handler manages completion logic, the template only handles the in-progress UI

https://claude.ai/code/session_01Sq5NafZpqXGcTW8HBDSfAt