### PR TITLE
Add Built Sites section to admin guide

### DIFF
--- a/src/routes/admin/guide.ts
+++ b/src/routes/admin/guide.ts
@@ -4,6 +4,7 @@
 
 import { settings } from "#lib/db/settings.ts";
 import { EMAIL_PROVIDER_LABELS, getHostEmailConfig } from "#lib/email.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { htmlResponse, requireSessionOr } from "#routes/utils.ts";
 import { adminGuidePage } from "#templates/admin/guide.tsx";
@@ -24,6 +25,7 @@ const handleAdminGuideGet = (request: Request): Promise<Response> =>
           settings.appleWallet.hostConfig?.passTypeId ?? null,
         hostGoogleWalletIssuerId:
           settings.googleWallet.hostConfig?.issuerId ?? null,
+        builderEnabled: isBuilderEnabled(),
       }),
     );
   });

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1074,11 +1074,10 @@ export const adminGuidePage = (
           <p>
             <strong>Owners</strong> have full access: events, calendar, groups,
             questions, holidays, users, site pages, settings, API keys,
-            sessions, built sites, and the activity log.{" "}
-            <strong>Managers</strong> can manage events, view the calendar,
-            manage groups, and view the activity log. They cannot change
-            settings, manage users, manage questions or holidays, create API
-            keys, edit site pages, or view sessions.
+            sessions, and the activity log. <strong>Managers</strong> can manage
+            events, view the calendar, manage groups, and view the activity log.
+            They cannot change settings, manage users, manage questions or
+            holidays, create API keys, edit site pages, or view sessions.
           </p>
         </Q>
 

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -24,6 +24,7 @@ export type GuideHostConfig = {
   hostEmailFromAddress: string | null;
   hostAppleWalletPassTypeId: string | null;
   hostGoogleWalletIssuerId: string | null;
+  builderEnabled: boolean;
 };
 
 const Section = ({
@@ -1581,50 +1582,48 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section id="built-sites" title="Built Sites">
-        <Q q="What are built sites?">
-          <p>
-            The <strong>Built Sites</strong> page (owners only) keeps a registry
-            of Tickets instances you've deployed. Each entry records the site
-            name and its Bunny CDN URL. You can add, edit, and delete entries to
-            keep track of all the instances you manage.
-          </p>
-        </Q>
+      {hostConfig?.builderEnabled && (
+        <Section id="built-sites" title="Built Sites">
+          <Q q="What are built sites?">
+            <p>
+              The <strong>Built Sites</strong> page (owners only) keeps a
+              registry of Tickets instances you've deployed. Each entry records
+              the site name and its Bunny CDN URL. You can add, edit, and delete
+              entries to keep track of all the instances you manage.
+            </p>
+          </Q>
 
-        <Q q="How do I create a new Tickets instance?">
-          <p>
-            If your server administrator has enabled the site builder (
-            <code>CAN_BUILD_SITES=true</code>), you can visit{" "}
-            <code>/admin/builder</code> to deploy a new instance. Enter a site
-            name, database URL (libsql format), and database token. The builder
-            will fetch the latest release code from GitHub, create a Bunny edge
-            script, configure secrets (including a generated encryption key),
-            test the database connection, and publish the site. Host-level
-            configuration such as email, wallet, and storage settings are copied
-            automatically.
-          </p>
-        </Q>
+          <Q q="How do I create a new Tickets instance?">
+            <p>
+              Visit <code>/admin/builder</code> to deploy a new instance. Enter
+              a site name, database URL (libsql format), and database token. The
+              builder will fetch the latest release code from GitHub, create a
+              Bunny edge script, configure secrets (including a generated
+              encryption key), test the database connection, and publish the
+              site. Host-level configuration such as email, wallet, and storage
+              settings are copied automatically.
+            </p>
+          </Q>
 
-        <Q q="What do I need before building a site?">
-          <p>
-            You need a libsql database (e.g. from{" "}
-            <a href="https://turso.tech">Turso</a>) with its URL and auth token.
-            The server must have <code>BUNNY_API_KEY</code> configured and the{" "}
-            <code>CAN_BUILD_SITES</code> environment variable set to{" "}
-            <code>true</code>. The builder is owner-only and won't appear if
-            these aren't set.
-          </p>
-        </Q>
+          <Q q="What do I need before building a site?">
+            <p>
+              You need a libsql database (e.g. from{" "}
+              <a href="https://turso.tech">Turso</a>) with its URL and auth
+              token. The server must have <code>BUNNY_API_KEY</code> configured.
+              The builder is owner-only.
+            </p>
+          </Q>
 
-        <Q q="Can I add a site record without using the builder?">
-          <p>
-            Yes. On the <strong>Built Sites</strong> page, click{" "}
-            <strong>Add Built Site</strong> to manually record a site name and
-            URL. This is useful for tracking instances you deployed by other
-            means.
-          </p>
-        </Q>
-      </Section>
+          <Q q="Can I add a site record without using the builder?">
+            <p>
+              Yes. On the <strong>Built Sites</strong> page, click{" "}
+              <strong>Add Built Site</strong> to manually record a site name and
+              URL. This is useful for tracking instances you deployed by other
+              means.
+            </p>
+          </Q>
+        </Section>
+      )}
 
       <Section title="Feeds &amp; Mobilizon">
         <Q q="What event feeds are available?">

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1073,10 +1073,11 @@ export const adminGuidePage = (
           <p>
             <strong>Owners</strong> have full access: events, calendar, groups,
             questions, holidays, users, site pages, settings, API keys,
-            sessions, and the activity log. <strong>Managers</strong> can manage
-            events, view the calendar, manage groups, and view the activity log.
-            They cannot change settings, manage users, manage questions or
-            holidays, create API keys, edit site pages, or view sessions.
+            sessions, built sites, and the activity log.{" "}
+            <strong>Managers</strong> can manage events, view the calendar,
+            manage groups, and view the activity log. They cannot change
+            settings, manage users, manage questions or holidays, create API
+            keys, edit site pages, or view sessions.
           </p>
         </Q>
 
@@ -1576,6 +1577,51 @@ export const adminGuidePage = (
             revealing any secrets or API keys. It's useful for troubleshooting
             setup issues &mdash; you can quickly see which services are
             configured and which are missing.
+          </p>
+        </Q>
+      </Section>
+
+      <Section id="built-sites" title="Built Sites">
+        <Q q="What are built sites?">
+          <p>
+            The <strong>Built Sites</strong> page (owners only) keeps a registry
+            of Tickets instances you've deployed. Each entry records the site
+            name and its Bunny CDN URL. You can add, edit, and delete entries to
+            keep track of all the instances you manage.
+          </p>
+        </Q>
+
+        <Q q="How do I create a new Tickets instance?">
+          <p>
+            If your server administrator has enabled the site builder (
+            <code>CAN_BUILD_SITES=true</code>), you can visit{" "}
+            <code>/admin/builder</code> to deploy a new instance. Enter a site
+            name, database URL (libsql format), and database token. The builder
+            will fetch the latest release code from GitHub, create a Bunny edge
+            script, configure secrets (including a generated encryption key),
+            test the database connection, and publish the site. Host-level
+            configuration such as email, wallet, and storage settings are copied
+            automatically.
+          </p>
+        </Q>
+
+        <Q q="What do I need before building a site?">
+          <p>
+            You need a libsql database (e.g. from{" "}
+            <a href="https://turso.tech">Turso</a>) with its URL and auth token.
+            The server must have <code>BUNNY_API_KEY</code> configured and the{" "}
+            <code>CAN_BUILD_SITES</code> environment variable set to{" "}
+            <code>true</code>. The builder is owner-only and won't appear if
+            these aren't set.
+          </p>
+        </Q>
+
+        <Q q="Can I add a site record without using the builder?">
+          <p>
+            Yes. On the <strong>Built Sites</strong> page, click{" "}
+            <strong>Add Built Site</strong> to manually record a site name and
+            URL. This is useful for tracking instances you deployed by other
+            means.
           </p>
         </Q>
       </Section>

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -10,6 +10,7 @@ import {
   expectAdminRedirect,
   expectHtmlResponse,
   mockRequest,
+  setTestEnv,
 } from "#test-utils";
 
 describeWithEnv("server (admin guide)", { db: true }, () => {
@@ -242,14 +243,23 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       }
     });
 
-    test("contains built sites section", async () => {
-      await assertAdminHtml(
-        "/admin/guide",
-        "Built Sites",
-        'id="built-sites"',
-        "CAN_BUILD_SITES",
-        "Add Built Site",
-      );
+    test("hides built sites section when builder is disabled", async () => {
+      const { response } = await adminGet("/admin/guide");
+      const html = await response.text();
+      expect(html).not.toContain('id="built-sites"');
+    });
+
+    test("shows built sites section when builder is enabled", async () => {
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      try {
+        await assertAdminHtml(
+          "/admin/guide",
+          'id="built-sites"',
+          "Add Built Site",
+        );
+      } finally {
+        restore();
+      }
     });
 
     test("shows default wallet setup instructions when no host wallet configured", async () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -242,6 +242,16 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       }
     });
 
+    test("contains built sites section", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "Built Sites",
+        'id="built-sites"',
+        "CAN_BUILD_SITES",
+        "Add Built Site",
+      );
+    });
+
     test("shows default wallet setup instructions when no host wallet configured", async () => {
       const html = await assertAdminHtml(
         "/admin/guide",


### PR DESCRIPTION
## Summary

- The **Built Sites** feature is visible in the admin nav for owners but was completely undocumented in the admin guide
- Adds a new "Built Sites" section with 4 Q&A items covering: what built sites are, how the site builder works (`/admin/builder`), prerequisites (`CAN_BUILD_SITES`, libsql database, `BUNNY_API_KEY`), and manual site registration
- Updates the "Users & Permissions" section to list "built sites" as an owner-only feature
- Adds a test verifying the new section renders correctly

## Test plan

- [x] `deno task precommit` passes (typecheck, lint, cpd, build, test:coverage)
- [x] New test `contains built sites section` verifies the section ID, key content, and env var reference all render
- [ ] Verify the guide page renders correctly in a browser at `/admin/guide`

https://claude.ai/code/session_01JnDpfHAmC3p6ChXAxFPxgK