### PR TITLE
Replace environment variables with module-level test overrides

### DIFF
--- a/src/lib/crypto/hashing.ts
+++ b/src/lib/crypto/hashing.ts
@@ -2,7 +2,7 @@
  * Password hashing (PBKDF2), session token hashing, HMAC, and ticket token indexing
  */
 
-import { getEnv } from "#lib/env.ts";
+import { lazyRef } from "#fp";
 import { importHmacKey } from "./encryption.ts";
 import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
 
@@ -13,10 +13,15 @@ import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
 const PBKDF2_ITERATIONS_DEFAULT = 600000; // OWASP recommended minimum for SHA-256
 const PBKDF2_ITERATIONS_TEST = 1000; // Fast iterations for tests
 
+/** Module-level override avoids env race in parallel tests */
+const [getFastPbkdf2, setFastPbkdf2] = lazyRef<boolean | null>(() => null);
+
+/** Explicitly enable/disable fast PBKDF2 for testing without env var races */
+export const setFastPbkdf2ForTest = (fast: boolean | null): void =>
+  setFastPbkdf2(fast);
+
 export const getPbkdf2Iterations = (): number =>
-  getEnv("TEST_FAST_PBKDF2")
-    ? PBKDF2_ITERATIONS_TEST
-    : PBKDF2_ITERATIONS_DEFAULT;
+  getFastPbkdf2() ? PBKDF2_ITERATIONS_TEST : PBKDF2_ITERATIONS_DEFAULT;
 const PBKDF2_HASH_LENGTH = 32; // Output key length in bytes
 const PASSWORD_PREFIX = "pbkdf2";
 

--- a/src/lib/crypto/keys.ts
+++ b/src/lib/crypto/keys.ts
@@ -2,9 +2,8 @@
  * Key management: KEK derivation, key wrapping, RSA key pairs, hybrid encryption, PII
  */
 
-import { ttlCache } from "#fp";
+import { lazyRef, ttlCache } from "#fp";
 import { registerCache } from "#lib/cache-registry.ts";
-import { getEnv } from "#lib/env.ts";
 import {
   aesGcmDecryptRaw,
   aesGcmEncryptRaw,
@@ -193,6 +192,13 @@ export const unwrapKeyWithToken = async (
  * Hybrid encryption: RSA encrypts a random AES key, AES encrypts the data.
  */
 
+/** Module-level override avoids env race in parallel tests */
+const [getRsaKeySize, setRsaKeySize] = lazyRef<number | null>(() => null);
+
+/** Explicitly set RSA key size for testing without env var races */
+export const setRsaKeySizeForTest = (size: number | null): void =>
+  setRsaKeySize(size);
+
 /**
  * Generate an RSA key pair for asymmetric encryption
  * Returns { publicKey, privateKey } as exportable JWK strings
@@ -204,9 +210,7 @@ export const generateKeyPair = async (): Promise<{
   const keyPair = await crypto.subtle.generateKey(
     {
       name: "RSA-OAEP",
-      modulusLength: getEnv("TEST_RSA_KEY_SIZE")
-        ? Number(getEnv("TEST_RSA_KEY_SIZE"))
-        : 2048,
+      modulusLength: getRsaKeySize() ?? 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: "SHA-256",
     },

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,7 @@
  * Uses lazy loading to minimize startup time for edge scripts
  */
 
-import { once } from "#fp";
+import { lazyRef, once } from "#fp";
 import { loadEffectiveDomain } from "#lib/config.ts";
 import {
   clearFlashCookie,
@@ -54,6 +54,15 @@ import {
 
 /** Router function type - reuse from router.ts */
 type RouterFn = ReturnType<typeof createRouter>;
+
+/** Module-level override avoids env race in parallel tests */
+const [getRethrowErrors, setRethrowErrors] = lazyRef<boolean | null>(
+  () => null,
+);
+
+/** Explicitly enable/disable test error rethrowing without env var races */
+export const setRethrowErrorsForTest = (rethrow: boolean | null): void =>
+  setRethrowErrors(rethrow);
 
 /** Lazy-load admin routes (only needed for authenticated admin requests) */
 const loadAdminRoutes = once(async () => {
@@ -423,7 +432,7 @@ export const handleRequest = async (
                 // In tests, surface the real error instead of swallowing it
                 // behind a generic "Temporary Error" page
                 if (
-                  Deno.env.get("TEST_RETHROW_ERRORS") &&
+                  getRethrowErrors() &&
                   !(error instanceof SessionKeyError) &&
                   !Deno.env.get("TEST_EXPECT_ERROR")
                 ) {

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -499,6 +499,19 @@ export const describeWithEnv = (
   describe(name, () => {
     let restoreEnv: () => void;
     beforeEach(async () => {
+      // Set up env overlay FIRST so that setupTestEncryptionKey writes
+      // (DB_ENCRYPTION_KEY, TEST_FAST_PBKDF2, etc.) land in the overlay
+      // instead of the real process env, preventing cross-worker leakage.
+      const envVars: Record<string, string | undefined> = {};
+      if (options.encryptionKey || options.db) {
+        envVars.DB_ENCRYPTION_KEY = undefined;
+        envVars.TEST_FAST_PBKDF2 = undefined;
+        envVars.TEST_SKIP_LOGIN_DELAY = undefined;
+        envVars.TEST_RSA_KEY_SIZE = undefined;
+      }
+      if (options.env) Object.assign(envVars, options.env);
+      if (Object.keys(envVars).length > 0) restoreEnv = setTestEnv(envVars);
+
       if (options.encryptionKey) setupTestEncryptionKey();
       if (options.db) {
         resetTestSlugCounter();
@@ -507,11 +520,10 @@ export const describeWithEnv = (
         settings.googleWallet.setHostConfigForTest(null);
         await createTestDbWithSetup();
       }
-      if (options.env) restoreEnv = setTestEnv(options.env);
     });
     afterEach(() => {
       if (options.db) resetDb();
-      if (options.env) restoreEnv();
+      if (restoreEnv) restoreEnv();
     });
     fn();
   });

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -17,7 +17,8 @@ import { bunnyCdnApi } from "#lib/bunny-cdn.ts";
 import { resetEffectiveDomain } from "#lib/config.ts";
 import { getSessionCookieName, parseFlashValue } from "#lib/cookies.ts";
 import { setEncryptionKeyForTest } from "#lib/crypto/encryption.ts";
-import { unwrapKeyWithToken } from "#lib/crypto/keys.ts";
+import { setFastPbkdf2ForTest } from "#lib/crypto/hashing.ts";
+import { setRsaKeySizeForTest, unwrapKeyWithToken } from "#lib/crypto/keys.ts";
 import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { toMajorUnits } from "#lib/currency.ts";
@@ -41,6 +42,8 @@ import type { GoogleWalletCredentials } from "#lib/google-wallet.ts";
 import { setSuppressRequestLogs } from "#lib/logger.ts";
 import { runWithStorageConfig } from "#lib/storage.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
+import { setSkipLoginDelayForTest } from "#routes/admin/auth.ts";
+import { setRethrowErrorsForTest } from "#routes/index.ts";
 
 /**
  * Default test admin username
@@ -65,12 +68,11 @@ export const TEST_ENCRYPTION_KEY =
  */
 export const setupTestEncryptionKey = (): void => {
   setEncryptionKeyForTest(TEST_ENCRYPTION_KEY); // Also clears all crypto caches via callbacks
-  Deno.env.set("DB_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY);
-  Deno.env.set("TEST_FAST_PBKDF2", "1"); // Fast password hashing for tests
-  Deno.env.set("TEST_SKIP_LOGIN_DELAY", "1"); // Skip timing-attack delay in tests
-  Deno.env.set("TEST_RSA_KEY_SIZE", "1024"); // Use smaller RSA keys for faster test setup
-  setSuppressRequestLogs(true); // Module-level override avoids env race in parallel tests
-  Deno.env.set("TEST_RETHROW_ERRORS", "1"); // Surface real errors instead of "Temporary Error" page
+  setFastPbkdf2ForTest(true); // Module-level override avoids env race in parallel tests
+  setSkipLoginDelayForTest(true);
+  setRsaKeySizeForTest(1024);
+  setSuppressRequestLogs(true);
+  setRethrowErrorsForTest(true);
 };
 
 /**
@@ -79,12 +81,12 @@ export const setupTestEncryptionKey = (): void => {
 export const clearTestEncryptionKey = (): void => {
   // Use empty string (not null) so the override stays active and doesn't
   // fall through to Deno.env, avoiding races with parallel test workers.
-  setEncryptionKeyForTest(""); // Also clears all crypto caches via callbacks
-  Deno.env.delete("DB_ENCRYPTION_KEY");
-  Deno.env.delete("TEST_FAST_PBKDF2");
-  Deno.env.delete("TEST_SKIP_LOGIN_DELAY");
-  Deno.env.delete("TEST_RSA_KEY_SIZE");
-  setSuppressRequestLogs(null); // Clear module-level override, fall through to Deno.env
+  setEncryptionKeyForTest("");
+  setFastPbkdf2ForTest(null);
+  setSkipLoginDelayForTest(false);
+  setRsaKeySizeForTest(null);
+  setSuppressRequestLogs(null);
+  setRethrowErrorsForTest(null);
 };
 
 // ---------------------------------------------------------------------------
@@ -499,19 +501,6 @@ export const describeWithEnv = (
   describe(name, () => {
     let restoreEnv: () => void;
     beforeEach(async () => {
-      // Set up env overlay FIRST so that setupTestEncryptionKey writes
-      // (DB_ENCRYPTION_KEY, TEST_FAST_PBKDF2, etc.) land in the overlay
-      // instead of the real process env, preventing cross-worker leakage.
-      const envVars: Record<string, string | undefined> = {};
-      if (options.encryptionKey || options.db) {
-        envVars.DB_ENCRYPTION_KEY = undefined;
-        envVars.TEST_FAST_PBKDF2 = undefined;
-        envVars.TEST_SKIP_LOGIN_DELAY = undefined;
-        envVars.TEST_RSA_KEY_SIZE = undefined;
-      }
-      if (options.env) Object.assign(envVars, options.env);
-      if (Object.keys(envVars).length > 0) restoreEnv = setTestEnv(envVars);
-
       if (options.encryptionKey) setupTestEncryptionKey();
       if (options.db) {
         resetTestSlugCounter();
@@ -520,10 +509,11 @@ export const describeWithEnv = (
         settings.googleWallet.setHostConfigForTest(null);
         await createTestDbWithSetup();
       }
+      if (options.env) restoreEnv = setTestEnv(options.env);
     });
     afterEach(() => {
       if (options.db) resetDb();
-      if (restoreEnv) restoreEnv();
+      if (options.env) restoreEnv();
     });
     fn();
   });

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -276,6 +276,10 @@ describe("code quality", () => {
       "lib/db/client.ts:setDb",
       // Set encryption key directly to avoid env var races between parallel tests
       "lib/crypto/encryption.ts:setEncryptionKeyForTest",
+      // Set fast PBKDF2 directly to avoid env var races between parallel tests
+      "lib/crypto/hashing.ts:setFastPbkdf2ForTest",
+      // Set RSA key size directly to avoid env var races between parallel tests
+      "lib/crypto/keys.ts:setRsaKeySizeForTest",
       // Reset cached Stripe client between tests
       "lib/stripe.ts:resetStripeClient",
       // TTL constant used by page-cache tests to verify caching behaviour
@@ -331,6 +335,8 @@ describe("code quality", () => {
       "lib/db/settings.ts:SETTINGS_CACHE_TTL_MS",
       // Set request log suppression directly to avoid env var races between parallel tests
       "lib/logger.ts:setSuppressRequestLogs",
+      // Rethrow errors in tests without env var races
+      "routes/index.ts:setRethrowErrorsForTest",
       // Override BUILD_TIMESTAMP in tests (compile-time constant can't be changed otherwise)
       "lib/update.ts:setBuildTimestampForTest",
     ];

--- a/test/lib/crypto/keys.test.ts
+++ b/test/lib/crypto/keys.test.ts
@@ -9,13 +9,14 @@ import {
   hybridEncrypt,
   importPrivateKey,
   importPublicKey,
+  setRsaKeySizeForTest,
   unwrapKey,
   unwrapKeyWithToken,
   wrapKey,
   wrapKeyWithToken,
 } from "#lib/crypto/keys.ts";
 import { generateSecureToken } from "#lib/crypto/utils.ts";
-import { describeWithEnv, setTestEnv } from "#test-utils";
+import { describeWithEnv } from "#test-utils";
 
 describeWithEnv("KEK derivation", { encryptionKey: true }, () => {
   it("derives a usable CryptoKey", async () => {
@@ -151,14 +152,14 @@ describe("RSA key pair and hybrid encryption", () => {
     });
 
     it("uses production key size when TEST_RSA_KEY_SIZE is unset", async () => {
-      const restore = setTestEnv({ TEST_RSA_KEY_SIZE: undefined });
+      setRsaKeySizeForTest(null);
       try {
         const pair = await generateKeyPair();
         const jwk = JSON.parse(pair.publicKey);
         // 2048-bit RSA key: n (modulus) is 256 bytes = 344 base64url chars
         expect(jwk.n.length).toBeGreaterThan(300);
       } finally {
-        restore();
+        setRsaKeySizeForTest(1024);
       }
     });
 

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -30,6 +30,7 @@ import {
 describeWithEnv(
   "storage",
   {
+    encryptionKey: true,
     env: {
       STORAGE_ZONE_NAME: undefined,
       STORAGE_ZONE_KEY: undefined,


### PR DESCRIPTION
## Summary
Refactored test configuration to use explicit module-level setter functions instead of environment variables, eliminating race conditions in parallel test execution.

## Key Changes
- **Crypto module overrides**: Replaced `TEST_FAST_PBKDF2` and `TEST_RSA_KEY_SIZE` environment variables with `setFastPbkdf2ForTest()` and `setRsaKeySizeForTest()` functions using `lazyRef` for thread-safe state management
- **Router error handling**: Replaced `TEST_RETHROW_ERRORS` environment variable with `setRethrowErrorsForTest()` function
- **Login delay override**: Replaced `TEST_SKIP_LOGIN_DELAY` environment variable with `setSkipLoginDelayForTest()` function (imported from admin auth routes)
- **Test utilities**: Updated `setupTestEncryptionKey()` and `clearTestEncryptionKey()` to call the new setter functions instead of manipulating `Deno.env`
- **Test updates**: Updated test files to use the new setter functions directly instead of `setTestEnv()` helper

## Implementation Details
- Used `lazyRef` pattern (similar to existing `setEncryptionKeyForTest`) to create getter/setter pairs that maintain module-level state without environment variable races
- Setter functions accept `null` to clear overrides, allowing tests to restore default behavior
- All setters are called during test setup/teardown in `setupTestEncryptionKey()` and `clearTestEncryptionKey()`
- Updated code quality allowlist to document the new test-only exports

https://claude.ai/code/session_01WmJxJrLZJEpYr7X1cEzKxQ