### PR TITLE
Add READ_ONLY env var to disable all mutating operations

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -33,6 +33,9 @@ export function getEnv(key: string): string | undefined {
  * Get a required environment variable, throwing if not set.
  * Use this instead of `getEnv(key) as string` when the variable must exist.
  */
+/** Check if the system is in read-only mode (READ_ONLY env var) */
+export const isReadOnly = (): boolean => getEnv("READ_ONLY") === "true";
+
 export function requireEnv(key: string): string {
   const value = getEnv(key);
   if (value === undefined) {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ import {
 } from "#lib/cookies.ts";
 import { runWithQueryLogContext } from "#lib/db/query-log.ts";
 import { settings } from "#lib/db/settings.ts";
+import { isReadOnly } from "#lib/env.ts";
 import {
   hasFlash,
   runWithFlashContext,
@@ -42,6 +43,8 @@ import { createRouter } from "#routes/router.ts";
 import { routeStatic } from "#routes/static.ts";
 import type { ServerContext } from "#routes/types.ts";
 import {
+  htmlResponse,
+  jsonResponse,
   normalizePath,
   notFoundResponse,
   parseCookies,
@@ -51,6 +54,7 @@ import {
   temporaryErrorResponse,
   withCookie,
 } from "#routes/utils.ts";
+import { readOnlyPage } from "#templates/public.tsx";
 
 /** Router function type - reuse from router.ts */
 type RouterFn = ReturnType<typeof createRouter>;
@@ -205,6 +209,57 @@ const lazyRoute =
   async (request, path, method, server) =>
     (await load())(request, path, method, server);
 
+/** Read-only mode message */
+const READ_ONLY_MESSAGE = "This site is in read-only mode";
+
+/** Paths that should redirect to /read-only when visited via GET in read-only mode */
+const READ_ONLY_GET_PATTERNS = [
+  /^\/admin\/event\/new$/,
+  /^\/admin\/event\/\d+\/edit$/,
+  /^\/admin\/event\/\d+\/duplicate$/,
+  /^\/admin\/groups\/new$/,
+  /^\/admin\/groups\/\d+\/edit$/,
+];
+
+/** Paths that should be blocked when POSTed in read-only mode */
+const READ_ONLY_POST_PATTERNS = [
+  /^\/ticket\//,
+  /^\/admin\/event$/,
+  /^\/admin\/event\/\d+\/edit$/,
+  /^\/admin\/groups$/,
+  /^\/admin\/groups\/\d+\/edit$/,
+  /^\/admin\/event\/\d+\/attendee$/,
+];
+
+/**
+ * Guard that blocks mutating requests in read-only mode.
+ * Returns a response to send, or null to allow the request through.
+ */
+const readOnlyGuard = (path: string, method: string): Response | null => {
+  if (!isReadOnly()) return null;
+
+  // Block all JSON API mutations (POST/PUT/DELETE on /api/*)
+  if (path.startsWith("/api/") && method !== "GET" && method !== "OPTIONS") {
+    return jsonResponse({ error: true, message: READ_ONLY_MESSAGE }, 403);
+  }
+
+  // Block GET pages for create/edit forms
+  if (method === "GET") {
+    for (const pattern of READ_ONLY_GET_PATTERNS) {
+      if (pattern.test(path)) return redirectResponse("/read-only");
+    }
+  }
+
+  // Block form POSTs for create/edit actions
+  if (method === "POST") {
+    for (const pattern of READ_ONLY_POST_PATTERNS) {
+      if (pattern.test(path)) return redirectResponse("/read-only");
+    }
+  }
+
+  return null;
+};
+
 /** Prefix dispatch table — O(1) lookup replaces the sequential ?? chain */
 const prefixHandlers: Record<string, RouterFn> = {
   // Exact-match public pages
@@ -242,6 +297,10 @@ const prefixHandlers: Record<string, RouterFn> = {
   gwallet: lazyRoute(loadGoogleWalletRoutes),
   v1: lazyRoute(loadWalletWebserviceRoutes),
   demo: lazyRoute(loadDemoResetRoutes),
+  "read-only": (_request, path, method) =>
+    path === "/read-only" && method === "GET"
+      ? Promise.resolve(htmlResponse(readOnlyPage()))
+      : Promise.resolve(null),
   api: async (request, path, method, server) => {
     // Admin API is always available (auth-protected)
     const adminResult = await (await loadAdminApiRoutes())(
@@ -263,6 +322,9 @@ const prefixHandlers: Record<string, RouterFn> = {
  * Uses prefix dispatch for O(1) route group lookup instead of sequential matching
  */
 const routeMainApp: RouterFn = async (request, path, method, server) => {
+  const blocked = readOnlyGuard(path, method);
+  if (blocked) return blocked;
+
   const prefix = getPrefix(path);
   if (!Object.hasOwn(prefixHandlers, prefix)) return notFoundResponse();
   return (

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -6,6 +6,7 @@ import { filter, joinStrings, map, pipe, reduce } from "#fp";
 import { getEffectiveDomain } from "#lib/config.ts";
 import { formatCurrency } from "#lib/currency.ts";
 import type { ActiveEventStats } from "#lib/db/attendees.ts";
+import { isReadOnly } from "#lib/env.ts";
 import { renderSuccess } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, Attendee, EventWithCount } from "#lib/types.ts";
@@ -187,9 +188,11 @@ export const adminDashboardPage = (
 
       {imageError && <p class="error">{imageError}</p>}
 
-      <p>
-        <a href="/admin/event/new">Add Event</a>
-      </p>
+      {!isReadOnly() && (
+        <p>
+          <a href="/admin/event/new">Add Event</a>
+        </p>
+      )}
 
       <div class="table-scroll">
         <table>

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -7,6 +7,7 @@ import { toMajorUnits } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
 import { settings } from "#lib/db/settings.ts";
 import { buildEmbedSnippets } from "#lib/embed.ts";
+import { isReadOnly } from "#lib/env.ts";
 import type { Field } from "#lib/forms.tsx";
 import {
   ConfirmForm,
@@ -290,12 +291,16 @@ export const adminEventPage = ({
 
       <nav>
         <ul>
-          <li>
-            <a href={`/admin/event/${event.id}/edit`}>Edit</a>
-          </li>
-          <li>
-            <a href={`/admin/event/${event.id}/duplicate`}>Duplicate</a>
-          </li>
+          {!isReadOnly() && (
+            <li>
+              <a href={`/admin/event/${event.id}/edit`}>Edit</a>
+            </li>
+          )}
+          {!isReadOnly() && (
+            <li>
+              <a href={`/admin/event/${event.id}/duplicate`}>Duplicate</a>
+            </li>
+          )}
           <li>
             <a href={`/admin/event/${event.id}/log`}>Log</a>
           </li>
@@ -622,17 +627,22 @@ export const adminEventPage = ({
         </article>
       )}
 
-      <article>
-        <h2 id="add-attendee">Add Attendee</h2>
-        <CsrfForm action={`/admin/event/${event.id}/attendee`}>
-          <Raw
-            html={renderFields(
-              getAddAttendeeFields(event.fields, event.event_type === "daily"),
-            )}
-          />
-          <button type="submit">Add Attendee</button>
-        </CsrfForm>
-      </article>
+      {!isReadOnly() && (
+        <article>
+          <h2 id="add-attendee">Add Attendee</h2>
+          <CsrfForm action={`/admin/event/${event.id}/attendee`}>
+            <Raw
+              html={renderFields(
+                getAddAttendeeFields(
+                  event.fields,
+                  event.event_type === "daily",
+                ),
+              )}
+            />
+            <button type="submit">Add Attendee</button>
+          </CsrfForm>
+        </article>
+      )}
     </Layout>,
   );
 };

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -4,6 +4,7 @@
 
 import { joinStrings, map, pipe, reduce } from "#fp";
 import { buildEmbedSnippets } from "#lib/embed.ts";
+import { isReadOnly } from "#lib/env.ts";
 import {
   ConfirmForm,
   CsrfForm,
@@ -45,9 +46,11 @@ export const adminGroupsPage = (
     <Layout title="Groups">
       <AdminNav session={session} active="/admin/groups" />
       <Raw html={renderSuccess(successMessage)} />
-      <p>
-        <a href="/admin/groups/new">Add Group</a>
-      </p>
+      {!isReadOnly() && (
+        <p>
+          <a href="/admin/groups/new">Add Group</a>
+        </p>
+      )}
       {groups.length === 0 ? (
         <p>No groups configured.</p>
       ) : (
@@ -68,7 +71,11 @@ export const adminGroupsPage = (
                   </td>
                   <td>{g.slug}</td>
                   <td>
-                    <a href={`/admin/groups/${g.id}/edit`}>Edit</a>{" "}
+                    {!isReadOnly() && (
+                      <>
+                        <a href={`/admin/groups/${g.id}/edit`}>Edit</a>{" "}
+                      </>
+                    )}
                     <a href={`/admin/groups/${g.id}/delete`}>Delete</a>
                   </td>
                 </tr>
@@ -240,7 +247,11 @@ export const adminGroupDetailPage = (
       <AdminNav session={session} active="/admin/groups" />
       <Raw html={renderSuccess(successMessage)} />
       <p>
-        <a href={`/admin/groups/${group.id}/edit`}>Edit Group</a>{" "}
+        {!isReadOnly() && (
+          <>
+            <a href={`/admin/groups/${group.id}/edit`}>Edit Group</a>{" "}
+          </>
+        )}
         <a href={`/admin/groups/${group.id}/delete`}>Delete Group</a>
       </p>
 

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -10,6 +10,7 @@ import type {
   QuestionWithAnswers,
 } from "#lib/db/questions.ts";
 import { settings } from "#lib/db/settings.ts";
+import { isReadOnly } from "#lib/env.ts";
 import type { Field } from "#lib/forms.tsx";
 import { CsrfForm, renderError, renderFields } from "#lib/forms.tsx";
 import { getIframeMode } from "#lib/iframe.ts";
@@ -118,7 +119,7 @@ const renderEventListing = (info: TicketEvent): string => {
     : "";
   const linkHtml = isSoldOut
     ? "<p><strong>Sold Out</strong></p>"
-    : isClosed
+    : isClosed || isReadOnly()
       ? "<p><strong>Registration Closed</strong></p>"
       : `<p><a href="/ticket/${escapeHtml(event.slug)}"><strong>Book now</strong></a></p>`;
 
@@ -294,6 +295,16 @@ export const temporaryErrorPage = (): string =>
       <p>
         Something went wrong loading this page. Retrying automatically&hellip;
       </p>
+    </Layout>,
+  );
+
+/**
+ * Read-only mode page
+ */
+export const readOnlyPage = (): string =>
+  String(
+    <Layout title="Read Only">
+      <p>Disabled: This site is in read-only mode.</p>
     </Layout>,
   );
 

--- a/test/routes/read-only.test.ts
+++ b/test/routes/read-only.test.ts
@@ -1,0 +1,196 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { handleRequest } from "#routes";
+import { readOnlyPage } from "#templates/public.tsx";
+import { describeWithEnv, mockRequest } from "#test-utils";
+
+/** Create a JSON API request */
+const apiRequest = (
+  path: string,
+  method = "GET",
+  body?: Record<string, unknown>,
+): Request => {
+  const headers: Record<string, string> = { host: "localhost" };
+  const init: RequestInit = { method, headers };
+  if (body) {
+    headers["content-type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`http://localhost${path}`, init);
+};
+
+describeWithEnv(
+  "read-only mode",
+  { db: true, env: { READ_ONLY: "true" } },
+  () => {
+    test("GET /read-only returns the read-only page", async () => {
+      const res = await handleRequest(mockRequest("/read-only"));
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Disabled: This site is in read-only mode.");
+    });
+
+    test("readOnlyPage contains the expected message", () => {
+      const html = readOnlyPage();
+      expect(html).toContain("Disabled: This site is in read-only mode.");
+    });
+
+    test("POST /api/admin/events returns 403 JSON", async () => {
+      const res = await handleRequest(
+        apiRequest("/api/admin/events", "POST", { name: "test" }),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(true);
+      expect(body.message).toBe("This site is in read-only mode");
+    });
+
+    test("PUT /api/admin/events/1 returns 403 JSON", async () => {
+      const res = await handleRequest(
+        apiRequest("/api/admin/events/1", "PUT", { name: "test" }),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(true);
+    });
+
+    test("DELETE /api/admin/events/1 returns 403 JSON", async () => {
+      const res = await handleRequest(
+        apiRequest("/api/admin/events/1", "DELETE"),
+      );
+      expect(res.status).toBe(403);
+    });
+
+    test("POST /api/events/my-event/book returns 403 JSON", async () => {
+      const res = await handleRequest(
+        apiRequest("/api/events/my-event/book", "POST", { name: "test" }),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(true);
+    });
+
+    test("GET /api/admin/events is allowed", async () => {
+      const res = await handleRequest(apiRequest("/api/admin/events"));
+      // Should not be 403 — may be 401 (no auth) but not blocked by read-only
+      expect(res.status).not.toBe(403);
+    });
+
+    test("GET /admin/event/new redirects to /read-only", async () => {
+      const res = await handleRequest(mockRequest("/admin/event/new"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("GET /admin/event/42/edit redirects to /read-only", async () => {
+      const res = await handleRequest(mockRequest("/admin/event/42/edit"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("GET /admin/event/42/duplicate redirects to /read-only", async () => {
+      const res = await handleRequest(mockRequest("/admin/event/42/duplicate"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("GET /admin/groups/new redirects to /read-only", async () => {
+      const res = await handleRequest(mockRequest("/admin/groups/new"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("GET /admin/groups/7/edit redirects to /read-only", async () => {
+      const res = await handleRequest(mockRequest("/admin/groups/7/edit"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("POST /ticket/my-event redirects to /read-only", async () => {
+      const res = await handleRequest(
+        mockRequest("/ticket/my-event", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "name=test",
+        }),
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("POST /admin/event redirects to /read-only", async () => {
+      const res = await handleRequest(
+        mockRequest("/admin/event", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "name=test",
+        }),
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("POST /admin/groups redirects to /read-only", async () => {
+      const res = await handleRequest(
+        mockRequest("/admin/groups", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "name=test",
+        }),
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("POST /admin/event/42/attendee redirects to /read-only", async () => {
+      const res = await handleRequest(
+        mockRequest("/admin/event/42/attendee", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "name=test",
+        }),
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
+    test("GET / is not blocked by read-only guard", async () => {
+      const res = await handleRequest(mockRequest("/"));
+      // May redirect to /admin/login if public site is disabled, but not to /read-only
+      expect(res.headers.get("location")).not.toBe("/read-only");
+    });
+
+    test("GET /events is not blocked by read-only guard", async () => {
+      const res = await handleRequest(mockRequest("/events"));
+      expect(res.headers.get("location")).not.toBe("/read-only");
+    });
+
+    test("GET /ticket/my-event is allowed (view form)", async () => {
+      const res = await handleRequest(mockRequest("/ticket/my-event"));
+      // 404 (no such event) is fine — not blocked by read-only
+      expect(res.status).not.toBe(302);
+    });
+
+    test("POST /admin/login is not blocked (unrelated POST)", async () => {
+      const res = await handleRequest(
+        mockRequest("/admin/login", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "password=test",
+        }),
+      );
+      expect(res.headers.get("location")).not.toBe("/read-only");
+    });
+
+    test("POST /read-only returns 404", async () => {
+      const res = await handleRequest(
+        mockRequest("/read-only", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "test=1",
+        }),
+      );
+      expect(res.status).toBe(404);
+    });
+  },
+);


### PR DESCRIPTION
When READ_ONLY=true, a centralized guard in the main router blocks
mutations: JSON API POST/PUT/DELETE returns 403, HTML form pages
redirect to /read-only, and UI elements (Book now, Add Event, Add
Group, Edit, Duplicate, Add Attendee) are hidden.

https://claude.ai/code/session_01FobeZzddBxGoKhT4ASuvPN