### PR TITLE
Hide forms and show banner in read-only mode

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -228,6 +228,7 @@ const READ_ONLY_POST_PATTERNS = [
   /^\/admin\/event\/\d+\/edit$/,
   /^\/admin\/groups$/,
   /^\/admin\/groups\/\d+\/edit$/,
+  /^\/admin\/groups\/\d+\/add-events$/,
   /^\/admin\/event\/\d+\/attendee$/,
 ];
 

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1385,6 +1385,15 @@ button.secondary:hover {
   font-weight: bold;
 }
 
+/* Read-only mode banner */
+.read-only-banner {
+  background: #f59e0b;
+  color: #000;
+  text-align: center;
+  padding: 8px;
+  font-weight: bold;
+}
+
 /* Stripe/Square test result */
 .stripe-test-result,
 .square-test-result {

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -343,7 +343,7 @@ export const adminGroupDetailPage = (
         </div>
       </article>
 
-      {ungroupedEvents.length > 0 && (
+      {!isReadOnly() && ungroupedEvents.length > 0 && (
         <>
           <h2>Add Events to Group</h2>
           <CsrfForm action={`/admin/groups/${group.id}/add-events`}>

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -3,8 +3,14 @@
  */
 
 import { settings } from "#lib/db/settings.ts";
+import { isReadOnly } from "#lib/env.ts";
 import { CsrfForm } from "#lib/forms.tsx";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#lib/types.ts";
+
+/** Read-only mode banner HTML */
+export const READ_ONLY_BANNER =
+  '<div class="read-only-banner">This site is in read-only mode</div>';
 
 interface AdminNavProps {
   session: AdminSession;
@@ -24,31 +30,34 @@ const navLink = (href: string, label: string, active: string): JSX.Element => (
  * Users, Settings, and Sessions links only shown to owners
  */
 export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
-  <nav id="main-nav">
-    <ul>
-      {navLink("/admin/", "Events", active)}
-      {navLink("/admin/calendar", "Calendar", active)}
-      {session.adminLevel === "owner" &&
-        navLink("/admin/users", "Users", active)}
-      {session.adminLevel === "owner" &&
-        settings.showPublicSite &&
-        navLink("/admin/site", "Site", active)}
-      {session.adminLevel === "owner" &&
-        navLink("/admin/settings", "Settings", active)}
-      {navLink("/admin/log", "Log", active)}
-      {navLink("/admin/groups", "Groups", active)}
-      {session.adminLevel === "owner" &&
-        navLink("/admin/holidays", "Holidays", active)}
-      {session.adminLevel === "owner" &&
-        navLink("/admin/built-sites", "Built Sites", active)}
-      {navLink("/admin/guide", "Guide", active)}
-      <li>
-        <CsrfForm action="/admin/logout" class="inline">
-          <button type="submit">Logout</button>
-        </CsrfForm>
-      </li>
-    </ul>
-  </nav>
+  <>
+    {isReadOnly() && <Raw html={READ_ONLY_BANNER} />}
+    <nav id="main-nav">
+      <ul>
+        {navLink("/admin/", "Events", active)}
+        {navLink("/admin/calendar", "Calendar", active)}
+        {session.adminLevel === "owner" &&
+          navLink("/admin/users", "Users", active)}
+        {session.adminLevel === "owner" &&
+          settings.showPublicSite &&
+          navLink("/admin/site", "Site", active)}
+        {session.adminLevel === "owner" &&
+          navLink("/admin/settings", "Settings", active)}
+        {navLink("/admin/log", "Log", active)}
+        {navLink("/admin/groups", "Groups", active)}
+        {session.adminLevel === "owner" &&
+          navLink("/admin/holidays", "Holidays", active)}
+        {session.adminLevel === "owner" &&
+          navLink("/admin/built-sites", "Built Sites", active)}
+        {navLink("/admin/guide", "Guide", active)}
+        <li>
+          <CsrfForm action="/admin/logout" class="inline">
+            <button type="submit">Logout</button>
+          </CsrfForm>
+        </li>
+      </ul>
+    </nav>
+  </>
 );
 
 /** Sub-navigation for user-related pages */

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -501,15 +501,17 @@ export const ticketPage = ({
       )}
       <Raw html={renderError(error)} />
 
-      {allUnavailable ? (
+      {allUnavailable || isReadOnly() ? (
         <div class="error">
-          {isSingleEvent
-            ? allClosed
-              ? "Registration closed."
-              : "Sorry, this event is full."
-            : allClosed
-              ? "Registration closed."
-              : "Sorry, all events are sold out."}
+          {isReadOnly()
+            ? "Registration closed."
+            : isSingleEvent
+              ? allClosed
+                ? "Registration closed."
+                : "Sorry, this event is full."
+              : allClosed
+                ? "Registration closed."
+                : "Sorry, all events are sold out."}
         </div>
       ) : (
         <CsrfForm action={`/ticket/${slugs.join("+")}`}>

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -40,7 +40,7 @@ import {
   nearCapacity,
 } from "#templates/admin/events.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
-import { Breadcrumb } from "#templates/admin/nav.tsx";
+import { AdminNav, Breadcrumb } from "#templates/admin/nav.tsx";
 import {
   adminAnswerDeletePage,
   adminEventQuestionsPage,
@@ -4292,3 +4292,28 @@ describe("html", () => {
     });
   });
 });
+
+describeWithEnv(
+  "read-only mode templates",
+  { env: { READ_ONLY: "true" } },
+  () => {
+    test("AdminNav shows read-only banner", () => {
+      const html = String(
+        AdminNav({ session: TEST_SESSION, active: "/admin/" }),
+      );
+      expect(html).toContain("read-only-banner");
+      expect(html).toContain("This site is in read-only mode");
+    });
+
+    test("ticketPage hides booking form in read-only mode", () => {
+      const event = testEventWithCount({ attendee_count: 0 });
+      const html = ticketPage({
+        events: [buildTicketEvent(event)],
+        slugs: [event.slug],
+        dates: [],
+      });
+      expect(html).toContain("Registration closed.");
+      expect(html).not.toContain("Reserve Ticket");
+    });
+  },
+);

--- a/test/routes/read-only.test.ts
+++ b/test/routes/read-only.test.ts
@@ -182,6 +182,18 @@ describeWithEnv(
       expect(res.headers.get("location")).not.toBe("/read-only");
     });
 
+    test("POST /admin/groups/5/add-events redirects to /read-only", async () => {
+      const res = await handleRequest(
+        mockRequest("/admin/groups/5/add-events", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "event_ids=1",
+        }),
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/read-only");
+    });
+
     test("POST /read-only returns 404", async () => {
       const res = await handleRequest(
         mockRequest("/read-only", {


### PR DESCRIPTION
- Hide booking form on ticket page (show "Registration closed" instead)
- Hide "Add Events to Group" form on group detail page
- Block POST /admin/groups/:id/add-events endpoint in read-only mode
- Show read-only banner on all admin pages (via AdminNav)

https://claude.ai/code/session_01SHvJSdyzW3RYV8241JsrRb