### PR TITLE
Format code and add styling class to backup form

### DIFF
--- a/src/routes/admin/backup.ts
+++ b/src/routes/admin/backup.ts
@@ -118,7 +118,10 @@ const handleBackupDownload: TypedRouteHandler<
     const data = await downloadRaw(filename);
     if (!data) return htmlResponse("Backup file not found", 404);
 
-    const body = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+    const body = data.buffer.slice(
+      data.byteOffset,
+      data.byteOffset + data.byteLength,
+    ) as ArrayBuffer;
     return new Response(body, {
       headers: {
         "content-type": "application/zip",

--- a/src/templates/admin/backup.tsx
+++ b/src/templates/admin/backup.tsx
@@ -72,7 +72,11 @@ export const adminBackupPage = (
               table. Backups are not encrypted (the sensitive contents are
               already encrypted at the field level).
             </p>
-            <CsrfForm action="/admin/backup/create" id="backup-create">
+            <CsrfForm
+              action="/admin/backup/create"
+              id="backup-create"
+              class="no-bg"
+            >
               <button type="submit">Create Backup Now</button>
             </CsrfForm>
           </section>


### PR DESCRIPTION
## Summary
This PR includes minor code formatting improvements and adds a styling class to the backup creation form.

## Key Changes
- Added `class="no-bg"` to the CsrfForm component in the admin backup template to apply background styling
- Reformatted the CsrfForm component props for improved readability by splitting them across multiple lines
- Reformatted the `data.buffer.slice()` call in the backup download handler to improve code readability by breaking the arguments across multiple lines

## Implementation Details
- The `no-bg` class is applied to the backup creation form, likely to remove default background styling from the form element
- Code formatting changes follow consistent multi-line formatting patterns for better maintainability

https://claude.ai/code/session_016NBiHxNnM6ofGNzQgMrXEi