### PR TITLE
Refactor database restore confirmation to use ConfirmForm

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -407,6 +407,8 @@ export const ConfirmForm = ({
   buttonText,
   danger = true,
   returnUrl,
+  id,
+  hiddenFields,
   children,
 }: {
   action: string;
@@ -415,13 +417,19 @@ export const ConfirmForm = ({
   buttonText: string;
   danger?: boolean;
   returnUrl?: string;
+  id?: string;
+  hiddenFields?: Record<string, string>;
   children?: Child;
 }): JSX.Element => (
   <>
     <div class="prose">{children}</div>
 
-    <CsrfForm action={action}>
+    <CsrfForm action={action} id={id}>
       {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
+      {hiddenFields &&
+        Object.entries(hiddenFields).map(([fieldName, value]) => (
+          <input type="hidden" name={fieldName} value={value} />
+        ))}
       <label>
         {label}
         <input

--- a/src/templates/admin/backup.tsx
+++ b/src/templates/admin/backup.tsx
@@ -2,7 +2,12 @@
  * Admin backup/restore page template
  */
 
-import { CsrfForm, renderError, renderSuccess } from "#lib/forms.tsx";
+import {
+  ConfirmForm,
+  CsrfForm,
+  renderError,
+  renderSuccess,
+} from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#lib/types.ts";
 import { AdminNav, Breadcrumb, SettingsSubNav } from "#templates/admin/nav.tsx";
@@ -156,35 +161,27 @@ export const adminRestoreConfirmPage = (
         </div>
       )}
 
-      <p>
-        You are about to restore from an uploaded backup containing{" "}
-        <strong>{lineCount}</strong> SQL statements. This will:
-      </p>
-      <ul>
-        <li>Drop all existing tables</li>
-        <li>Recreate the database schema</li>
-        <li>Import all data from the backup</li>
-      </ul>
-      <p>
-        <strong>This action cannot be undone.</strong> Type{" "}
-        <code>{RESTORE_CONFIRM_PHRASE}</code> below to confirm.
-      </p>
-
-      <CsrfForm
+      <ConfirmForm
         action="/admin/backup/restore/confirm"
         id="backup-restore-confirm"
+        name={RESTORE_CONFIRM_PHRASE}
+        label="Confirmation phrase"
+        buttonText="Restore Database"
+        hiddenFields={{ backup_filename: filename }}
       >
-        <input type="hidden" name="backup_filename" value={filename} />
-        <label>
-          Confirmation phrase
-          <input
-            type="text"
-            name="confirm_identifier"
-            placeholder={RESTORE_CONFIRM_PHRASE}
-            required
-          />
-        </label>
-        <button type="submit">Restore Database</button>
-      </CsrfForm>
+        <p>
+          You are about to restore from an uploaded backup containing{" "}
+          <strong>{lineCount}</strong> SQL statements. This will:
+        </p>
+        <ul>
+          <li>Drop all existing tables</li>
+          <li>Recreate the database schema</li>
+          <li>Import all data from the backup</li>
+        </ul>
+        <p>
+          <strong>This action cannot be undone.</strong> Type{" "}
+          <code>{RESTORE_CONFIRM_PHRASE}</code> below to confirm.
+        </p>
+      </ConfirmForm>
     </Layout>,
   );


### PR DESCRIPTION
## Summary
Refactored the admin backup restore confirmation page to use the reusable `ConfirmForm` component instead of manually constructing the form with `CsrfForm`. This reduces code duplication and improves maintainability.

## Key Changes
- **Updated imports**: Added `ConfirmForm` to the imports from `#lib/forms.tsx`
- **Refactored restore confirmation form**: Replaced manual `CsrfForm` implementation with `ConfirmForm` component, moving the confirmation instructions into the component's children
- **Enhanced ConfirmForm component**: Extended `ConfirmForm` to support:
  - Optional `id` prop for form identification
  - Optional `hiddenFields` prop to dynamically add hidden input fields via an object map
- **Simplified form structure**: The backup filename is now passed via the new `hiddenFields` prop instead of manually creating a hidden input element

## Implementation Details
The `ConfirmForm` component now accepts a `hiddenFields` object that gets mapped to hidden input elements, making it more flexible for forms that need to pass additional data without cluttering the JSX. This change maintains backward compatibility while providing a cleaner API for the restore confirmation use case.

https://claude.ai/code/session_01LAjUrrgLTwCUsciZ2yxjsA