### PR TITLE
Add Host Subdomain section to admin guide

### DIFF
--- a/src/routes/admin/guide.ts
+++ b/src/routes/admin/guide.ts
@@ -2,6 +2,7 @@
  * Admin guide route
  */
 
+import { getBunnyDnsSubdomainSuffix, isBunnyDnsEnabled } from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
 import { EMAIL_PROVIDER_LABELS, getHostEmailConfig } from "#lib/email.ts";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
@@ -26,6 +27,9 @@ const handleAdminGuideGet = (request: Request): Promise<Response> =>
         hostGoogleWalletIssuerId:
           settings.googleWallet.hostConfig?.issuerId ?? null,
         builderEnabled: isBuilderEnabled(),
+        bunnyDnsSubdomainSuffix: isBunnyDnsEnabled()
+          ? getBunnyDnsSubdomainSuffix()
+          : null,
       }),
     );
   });

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -25,6 +25,7 @@ export type GuideHostConfig = {
   hostAppleWalletPassTypeId: string | null;
   hostGoogleWalletIssuerId: string | null;
   builderEnabled: boolean;
+  bunnyDnsSubdomainSuffix: string | null;
 };
 
 const Section = ({
@@ -1412,8 +1413,11 @@ export const adminGuidePage = (
           <p>
             If your server administrator has enabled subdomain registration, you
             can claim a pretty subdomain for your tickets site (e.g.{" "}
-            <code>my-business.example.com</code>) instead of using the default
-            CDN hostname. The option appears in{" "}
+            <code>
+              my-business
+              {hostConfig?.bunnyDnsSubdomainSuffix || ".example.com"}
+            </code>
+            ) instead of using the default CDN hostname. The option appears in{" "}
             <strong>Advanced Settings</strong> under{" "}
             <strong>Host Subdomain</strong>.
           </p>
@@ -1440,9 +1444,9 @@ export const adminGuidePage = (
             </li>
           </ol>
           <p>
-            <strong>Important:</strong> Once registered, a subdomain{" "}
-            <strong>cannot be changed</strong>. DNS, SSL, and CDN configuration
-            are handled automatically.
+            <strong>Important:</strong> Once registered, a subdomain is{" "}
+            <strong>permanent and cannot be changed</strong>. DNS, SSL, and CDN
+            configuration are handled automatically.
           </p>
         </Q>
 
@@ -1460,9 +1464,10 @@ export const adminGuidePage = (
             If your site runs on Bunny CDN and the <code>BUNNY_API_KEY</code>{" "}
             environment variable is configured, you'll see a{" "}
             <strong>Custom Domain</strong> section in{" "}
-            <a href="/admin/settings">Settings</a>. Enter your domain (e.g.{" "}
-            <code>tickets.yourdomain.com</code>) and save, then follow the CNAME
-            instructions shown and click <strong>Validate</strong>.
+            <a href="/admin/settings-advanced">Advanced Settings</a>. Enter your
+            domain (e.g. <code>tickets.yourdomain.com</code>) and save, then
+            follow the CNAME instructions shown and click{" "}
+            <strong>Validate</strong>.
           </p>
         </Q>
 

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -291,5 +291,22 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         settings.appleWallet.resetHostConfig();
       }
     });
+
+    test("contains host subdomain section", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "Host Subdomain",
+        "permanent and cannot be changed",
+        "host subdomain and a custom domain",
+      );
+    });
+
+    test("contains host subdomain in advanced settings list", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "Host subdomain",
+        "register a pretty",
+      );
+    });
   });
 });

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -297,7 +297,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         "/admin/guide",
         "Host Subdomain",
         "permanent and cannot be changed",
-        "host subdomain and a custom domain",
+        "host subdomain and custom domain",
       );
     });
 
@@ -307,6 +307,22 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         "Host subdomain",
         "register a pretty",
       );
+    });
+
+    test("shows subdomain suffix when Bunny DNS is configured", async () => {
+      const restore = setTestEnv({
+        BUNNY_API_KEY: "test-key",
+        BUNNY_DNS_ZONE_ID: "test-zone",
+        BUNNY_DNS_SUBDOMAIN_SUFFIX: ".tickets.example.com",
+      });
+      try {
+        await assertAdminHtml(
+          "/admin/guide",
+          ".tickets.example.com",
+        );
+      } finally {
+        restore();
+      }
     });
   });
 });


### PR DESCRIPTION
The host subdomain feature was fully implemented but completely undocumented in the admin guide. This adds a new section covering what it is, how to set it up, its permanence, and that it can coexist with a custom domain. Also adds it to the Advanced Settings list and fixes the Custom Domain link to point to Advanced Settings.

https://claude.ai/code/session_01CJJ7hGsGxmXdTRQNaAo1CF