### PR TITLE
Update login error message to be more user-friendly

### DIFF
--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -106,14 +106,14 @@ const handleAdminLogin = async (
   const user = await getUserByUsername(username);
   if (!user) {
     await recordFailedLogin(clientIp);
-    return errorRedirect("/admin", "Invalid credentials");
+    return errorRedirect("/admin", "Username or password was wrong");
   }
 
   // Verify password (decrypt stored hash, then verify)
   const passwordHash = await verifyUserPassword(user, password);
   if (!passwordHash) {
     await recordFailedLogin(clientIp);
-    return errorRedirect("/admin", "Invalid credentials");
+    return errorRedirect("/admin", "Username or password was wrong");
   }
 
   // Clear failed attempts on successful login
@@ -134,7 +134,7 @@ const handleAdminLogin = async (
     dataKey = await unwrapKey(user.wrapped_data_key, kek);
   } catch {
     // KEK mismatch - this shouldn't happen if password verification passed
-    return errorRedirect("/admin", "Invalid credentials");
+    return errorRedirect("/admin", "Username or password was wrong");
   }
 
   return createLoginSession(dataKey, user.id);

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -13,6 +13,7 @@ import {
   expectRedirectWithFlash,
   FLASH_TEST_ID,
   flashCookieHeader,
+  followRedirectWithFlash,
   loginAsAdmin,
   mockAdminLoginRequest,
   mockFormRequest,
@@ -83,7 +84,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       expect(response.status).toBe(302);
       expectFlash(
         response,
-        expect.stringContaining("Invalid credentials"),
+        expect.stringContaining("Username or password was wrong"),
         false,
       );
     });
@@ -175,7 +176,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       expect(response.status).toBe(302);
       expectFlash(
         response,
-        expect.stringContaining("Invalid credentials"),
+        expect.stringContaining("Username or password was wrong"),
         false,
       );
     });
@@ -197,7 +198,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       expect(response.status).toBe(302);
       expectFlash(
         response,
-        expect.stringContaining("Invalid credentials"),
+        expect.stringContaining("Username or password was wrong"),
         false,
       );
     });
@@ -472,7 +473,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       expect(response.status).toBe(302);
       expectFlash(
         response,
-        expect.stringContaining("Invalid credentials"),
+        expect.stringContaining("Username or password was wrong"),
         false,
       );
     });
@@ -606,6 +607,45 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       expect(html).toContain("username");
       expect(html).toContain("password");
       expect(html.length).toBeGreaterThan(200); // Substantial content
+    });
+  });
+
+  describe("login error display", () => {
+    test("displays error from flash cookie on login page", async () => {
+      const response = await handleRequest(
+        mockRequest(`/admin?flash=${FLASH_TEST_ID}`, {
+          headers: {
+            cookie: flashCookieHeader("Username or password was wrong", false),
+          },
+        }),
+      );
+      await expectHtmlResponse(
+        response,
+        200,
+        "Login",
+        "Username or password was wrong",
+      );
+    });
+
+    test("shows error after failed login attempt", async () => {
+      const postResponse = await handleRequest(
+        await mockAdminLoginRequest({
+          username: "testadmin",
+          password: "wrong",
+        }),
+      );
+      expect(postResponse.status).toBe(302);
+
+      const getResponse = await followRedirectWithFlash(
+        postResponse,
+        handleRequest,
+      );
+      await expectHtmlResponse(
+        getResponse,
+        200,
+        "Login",
+        "Username or password was wrong",
+      );
     });
   });
 });

--- a/test/lib/server-users.test.ts
+++ b/test/lib/server-users.test.ts
@@ -508,7 +508,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       );
       expectRedirectWithFlash(
         "/admin",
-        expect.stringContaining("Invalid credentials"),
+        expect.stringContaining("Username or password was wrong"),
         false,
       )(response);
     });
@@ -522,7 +522,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       );
       expectRedirectWithFlash(
         "/admin",
-        expect.stringContaining("Invalid credentials"),
+        expect.stringContaining("Username or password was wrong"),
         false,
       )(response);
     });


### PR DESCRIPTION
## Summary
Updated the admin login error message from "Invalid credentials" to "Username or password was wrong" to provide clearer feedback to users about authentication failures.

## Changes
- **Error message update**: Changed all login failure messages in `src/routes/admin/auth.ts` to use the more descriptive "Username or password was wrong" text
  - Applied to username lookup failures
  - Applied to password verification failures
  - Applied to key unwrapping failures (KEK mismatch)

- **Test updates**: Updated all test assertions across test files to expect the new error message
  - `test/lib/server-auth.test.ts`: Updated 4 existing test assertions and added 2 new tests for login error display
  - `test/lib/server-users.test.ts`: Updated 2 test assertions

- **New test helper**: Added `followRedirectWithFlash` import to support testing the complete login flow with flash message handling

## Implementation Details
The new error message is more user-friendly as it clearly indicates that either the username or password was incorrect, without revealing which field caused the authentication failure (a security best practice). This message is now consistently used across all authentication failure scenarios in the login flow.

https://claude.ai/code/session_01XuWYFkYWY8H8S3uw1b9KsG