### PR TITLE
Add Backups section to admin guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1564,6 +1564,10 @@ export const adminGuidePage = (
               your site (Bunny CDN only)
             </li>
             <li>
+              <strong>Backups</strong> &mdash; create, download, and restore
+              full database backups (requires CDN storage)
+            </li>
+            <li>
               <strong>Software updates</strong> &mdash; check for and install
               new versions
             </li>
@@ -1807,6 +1811,59 @@ export const adminGuidePage = (
             The <a href="/admin/api-keys/docs">API documentation page</a> has a
             complete reference for both public and admin API endpoints, with
             example request and response payloads for each.
+          </p>
+        </Q>
+      </Section>
+
+      <Section id="backups" title="Backups">
+        <Q q="What is the backup feature?">
+          <p>
+            The <strong>Backups</strong> page (owners only, under{" "}
+            <a href="/admin/backup">Settings &rarr; Backups</a>) lets you create
+            and restore full database backups. Each backup is a .zip archive
+            containing SQL statements for every table. Backups are stored on
+            your configured CDN storage (Bunny CDN).
+          </p>
+        </Q>
+
+        <Q q="How do I create a backup?">
+          <p>
+            Go to <a href="/admin/backup">Backups</a> and click{" "}
+            <strong>Create Backup Now</strong>. The system exports all database
+            tables into a .zip file and uploads it to your storage. Previous
+            backups are listed with their timestamps and can be downloaded at
+            any time.
+          </p>
+        </Q>
+
+        <Q q="How do I restore from a backup?">
+          <p>
+            On the Backups page, upload a .zip backup file using the restore
+            form. You'll see a summary of how many SQL statements it contains
+            and whether the schema version matches. Type the full confirmation
+            phrase to proceed. <strong>Warning:</strong> restoring drops all
+            existing tables and replaces them with the backup contents. This
+            cannot be undone.
+          </p>
+        </Q>
+
+        <Q q="What is the encryption key shown on the backup page?">
+          <p>
+            The encryption key is needed if you ever restore a backup to a{" "}
+            <strong>different</strong> site. All personal data in the database
+            is encrypted at the field level, so you need the same encryption key
+            to read it. Store this key securely &mdash; it cannot be recovered
+            if lost.
+          </p>
+        </Q>
+
+        <Q q="Do backups require any special configuration?">
+          <p>
+            Yes. Backups require CDN storage to be configured (
+            <code>STORAGE_ZONE_NAME</code> and <code>STORAGE_ZONE_KEY</code>).
+            The feature is designed for remote databases (<code>libsql://</code>
+            ). If storage is not configured, the backup page will show a message
+            explaining this.
           </p>
         </Q>
       </Section>


### PR DESCRIPTION
## Summary

- Adds a new **Backups** section to the admin guide (`/admin/guide`) documenting the backup/restore feature at `/admin/backup`
- Adds **Backups** to the Advanced Settings list in the Settings Overview section

## Why

The backup/restore feature is fully implemented (create, download, restore .zip archives) and accessible from the Settings sub-navigation (Settings → Advanced → **Backups** → Debug), but was completely absent from the guide. This was the most significant gap found when cross-referencing the guide against the actual codebase.

The new section covers 5 Q&A items:
- What the backup feature is
- How to create a backup
- How to restore from a backup (with warning about destructive nature)
- What the encryption key is for (cross-site restores)
- Storage/database requirements (CDN storage + remote libsql)

## Test plan

- [ ] Verify the guide page renders correctly at `/admin/guide`
- [ ] Verify the new Backups section appears between Feeds & Mobilizon and Software Updates
- [ ] Verify Backups appears in the Advanced Settings list
- [ ] Confirm all Q&A items expand/collapse correctly

https://claude.ai/code/session_01GEmMWRPmD6RcP4abQ6bqhE