### PR TITLE
Adjust textarea aspect ratios for address and special instructions

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -605,9 +605,19 @@ textarea {
   resize: vertical;
 }
 
+textarea[name="address"],
+textarea[name="special_instructions"] {
+  aspect-ratio: 4 / 1;
+}
+
 @media (min-width: 769px) {
   textarea {
     aspect-ratio: 16 / 9;
+  }
+
+  textarea[name="address"],
+  textarea[name="special_instructions"] {
+    aspect-ratio: 16 / 3;
   }
 }
 

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -316,10 +316,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         BUNNY_DNS_SUBDOMAIN_SUFFIX: ".tickets.example.com",
       });
       try {
-        await assertAdminHtml(
-          "/admin/guide",
-          ".tickets.example.com",
-        );
+        await assertAdminHtml("/admin/guide", ".tickets.example.com");
       } finally {
         restore();
       }


### PR DESCRIPTION
## Summary
This PR adjusts the aspect ratio styling for address and special instructions textarea fields to be more compact than standard textareas, improving the visual layout of forms.

## Key Changes
- Added specific aspect ratio rules for `textarea[name="address"]` and `textarea[name="special_instructions"]` fields:
  - Mobile: `4 / 1` aspect ratio (more compact)
  - Desktop (769px+): `16 / 3` aspect ratio (wider but still more compact than standard `16 / 9`)
- Minor code formatting: Reformatted a multi-line function call in tests to fit on a single line for better readability

## Implementation Details
The changes use CSS attribute selectors to target specific textarea fields by their `name` attribute, allowing these fields to have different proportions than the default textarea styling while maintaining consistency across responsive breakpoints.

https://claude.ai/code/session_019wi7XahqzEqanaXMeuZLYB