### PR TITLE
Hide navigation and footer in print view, fix table overflow

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1466,6 +1466,16 @@ button.secondary:hover {
   [data-theme="dark"] .ticket-card-description {
     color: #666;
   }
+
+  nav,
+  main > footer {
+    display: none;
+  }
+
+  .table-scroll {
+    overflow: visible;
+    max-width: 100%;
+  }
 }
 
 /* Hide email API key and from address fields when provider is "None" */


### PR DESCRIPTION
## Summary
Updated print styles to improve the print layout by hiding navigation elements and adjusting table scrolling behavior for better page rendering.

## Key Changes
- Hide `nav` and `main > footer` elements in print media queries to reduce clutter and focus on main content
- Modified `.table-scroll` to use `overflow: visible` and `max-width: 100%` for print, ensuring tables display properly without horizontal scrolling on printed pages

## Implementation Details
These changes are applied within the existing `@media print` block in the stylesheet, ensuring they only affect printed output and not the normal web view. This improves the print experience by removing navigation elements that aren't needed on paper and allowing tables to expand to full width rather than being constrained by scroll containers.

https://claude.ai/code/session_01Q5LGiYr4oC2J8c38CmkeL4