### PR TITLE
Fix event_attendees migration to handle FK constraints in remote libsql

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -455,7 +455,18 @@ const createIndexesForTable = async (
   }
 };
 
-/** Recreate a table from its SCHEMA definition, preserving data for matching columns */
+/**
+ * Recreate a table from its SCHEMA definition, preserving data for matching columns.
+ *
+ * The new table is created WITHOUT foreign keys (only column definitions).
+ * This means any FKs the original table had are removed after recreation.
+ *
+ * IMPORTANT: If other tables have FKs referencing this table and contain data,
+ * those tables must be recreated FIRST (to remove their FK constraints).
+ * Otherwise DROP TABLE will fail with FOREIGN KEY constraint in libsql.
+ * We do NOT use PRAGMA foreign_keys=OFF because it doesn't persist across
+ * HTTP requests in remote libsql (Turso).
+ */
 const recreateTable = async (tableName: string): Promise<void> => {
   const tableSchema = SCHEMA.find(([name]) => name === tableName)!;
   const cols = tableSchema[1].columns;
@@ -463,8 +474,6 @@ const recreateTable = async (tableName: string): Promise<void> => {
   const colDefs = cols.map(([col, type]) => `${col} ${type}`).join(", ");
   const tmpName = `${tableName}_new`;
 
-  // PRAGMA must be outside the batch — libsql validates FKs per-batch regardless
-  await getDb().execute("PRAGMA foreign_keys = OFF");
   await getDb().batch(
     [
       { sql: `CREATE TABLE ${tmpName} (${colDefs})`, args: [] },
@@ -477,7 +486,6 @@ const recreateTable = async (tableName: string): Promise<void> => {
     ],
     "write",
   );
-  await getDb().execute("PRAGMA foreign_keys = ON");
 
   await createIndexesForTable(tableName, tableSchema[1].indexes ?? []);
 };
@@ -496,17 +504,19 @@ const dropDeprecatedAttendeeColumns = async (): Promise<void> => {
     );
     return;
   }
-  // Recreate attendees + all tables whose FKs reference attendees(id).
-  // After DROP TABLE + rename, their FK references point to the dropped table
-  // and cause constraint errors when libsql FK enforcement is enabled.
-  logDebug("Migration", "Recreating attendees table...");
-  await recreateTable("attendees");
-  logDebug("Migration", "Recreating event_attendees table...");
-  await recreateTable("event_attendees");
+  // Recreate tables that FK-reference attendees(id) FIRST — this removes
+  // their FK constraints so that DROP TABLE attendees won't violate them.
+  // In remote libsql (Turso), PRAGMA foreign_keys=OFF doesn't persist across
+  // HTTP requests, so we can't rely on it to suppress FK checks.
   logDebug("Migration", "Recreating processed_payments table...");
   await recreateTable("processed_payments");
   logDebug("Migration", "Recreating attendee_answers table...");
   await recreateTable("attendee_answers");
+  // Now safe to recreate attendees — no FK references remain
+  logDebug("Migration", "Recreating attendees table...");
+  await recreateTable("attendees");
+  logDebug("Migration", "Recreating event_attendees table...");
+  await recreateTable("event_attendees");
   logDebug("Migration", "Table recreation complete.");
 };
 

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
-import { beforeEach, describe, it as test } from "@std/testing/bdd";
-import { spy } from "@std/testing/mock";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { spy, stub } from "@std/testing/mock";
+import { createClient, type ResultSet } from "@libsql/client";
 import { FakeTime } from "@std/testing/time";
 import { decryptWithKey } from "#lib/crypto/encryption.ts";
 import { deriveKEK, importPrivateKey, unwrapKey } from "#lib/crypto/keys.ts";
@@ -83,7 +84,9 @@ import {
   createTestGroup,
   describeWithEnv,
   invalidateTestDbCache,
+  resetDb,
   setTestEnv,
+  setupTestEncryptionKey,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
 } from "#test-utils";
@@ -3497,5 +3500,283 @@ describeWithEnv("db", { db: true }, () => {
         ]),
       ).toBe(true);
     });
+  });
+});
+
+/**
+ * Migration test: verifies that migrating from the main-branch schema
+ * (attendees with event_id FK) to the new schema (event_attendees table)
+ * works correctly even when PRAGMA foreign_keys=OFF is ineffective
+ * (as happens in remote libsql / Turso where it doesn't persist across
+ * HTTP requests).
+ *
+ * The legacy schema has:
+ *   attendees.event_id → FOREIGN KEY REFERENCES events(id)
+ *   processed_payments.attendee_id → FOREIGN KEY REFERENCES attendees(id)
+ *   attendee_answers.attendee_id → FOREIGN KEY REFERENCES attendees(id)
+ *
+ * The migration needs to recreate the attendees table (to drop event_id,
+ * date, quantity columns). DROP TABLE attendees fails with FK constraint
+ * when processed_payments or attendee_answers have data referencing it.
+ */
+describe("event_attendees migration from legacy schema", () => {
+  afterEach(() => {
+    resetDb();
+  });
+
+  /** SQL statements that create the complete legacy schema (as on main) */
+  const LEGACY_SCHEMA_SQL = [
+    `CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+    `CREATE TABLE events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      created TEXT NOT NULL,
+      max_attendees INTEGER NOT NULL,
+      thank_you_url TEXT,
+      unit_price INTEGER,
+      max_quantity INTEGER NOT NULL DEFAULT 1,
+      webhook_url TEXT,
+      slug TEXT,
+      slug_index TEXT,
+      group_id INTEGER NOT NULL DEFAULT 0,
+      active INTEGER NOT NULL DEFAULT 1,
+      fields TEXT NOT NULL DEFAULT 'email',
+      closes_at TEXT,
+      name TEXT NOT NULL DEFAULT '',
+      description TEXT NOT NULL DEFAULT '',
+      event_type TEXT NOT NULL DEFAULT 'standard',
+      bookable_days TEXT NOT NULL DEFAULT '["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]',
+      minimum_days_before INTEGER NOT NULL DEFAULT 1,
+      maximum_days_after INTEGER NOT NULL DEFAULT 90,
+      date TEXT NOT NULL DEFAULT '',
+      location TEXT NOT NULL DEFAULT '',
+      image_url TEXT NOT NULL DEFAULT '',
+      attachment_url TEXT NOT NULL DEFAULT '',
+      attachment_name TEXT NOT NULL DEFAULT '',
+      non_transferable INTEGER NOT NULL DEFAULT 0,
+      can_pay_more INTEGER NOT NULL DEFAULT 0,
+      hidden INTEGER NOT NULL DEFAULT 0,
+      max_price INTEGER NOT NULL DEFAULT 0
+    )`,
+    `CREATE UNIQUE INDEX idx_events_slug_index ON events(slug_index)`,
+    `CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username_hash TEXT NOT NULL,
+      username_index TEXT NOT NULL,
+      password_hash TEXT NOT NULL DEFAULT '',
+      wrapped_data_key TEXT,
+      admin_level TEXT NOT NULL,
+      invite_code_hash TEXT,
+      invite_expiry TEXT
+    )`,
+    `CREATE UNIQUE INDEX idx_users_username_index ON users(username_index)`,
+    `CREATE TABLE sessions (
+      token TEXT PRIMARY KEY,
+      csrf_token TEXT NOT NULL,
+      expires INTEGER NOT NULL,
+      wrapped_data_key TEXT,
+      user_id INTEGER
+    )`,
+    `CREATE TABLE login_attempts (
+      ip TEXT PRIMARY KEY,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      locked_until INTEGER
+    )`,
+    `CREATE TABLE attendees (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL,
+      created TEXT NOT NULL,
+      payment_id TEXT,
+      quantity INTEGER NOT NULL DEFAULT 1,
+      phone TEXT NOT NULL DEFAULT '',
+      ticket_token TEXT NOT NULL DEFAULT '',
+      price_paid TEXT,
+      checked_in TEXT NOT NULL DEFAULT '',
+      date TEXT DEFAULT NULL,
+      address TEXT NOT NULL DEFAULT '',
+      special_instructions TEXT NOT NULL DEFAULT '',
+      ticket_token_index TEXT,
+      refunded TEXT NOT NULL DEFAULT '',
+      attachment_downloads INTEGER NOT NULL DEFAULT 0,
+      pii_blob TEXT NOT NULL DEFAULT '',
+      checked_in_v2 INTEGER NOT NULL DEFAULT 0,
+      refunded_v2 INTEGER NOT NULL DEFAULT 0,
+      price_paid_v2 INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (event_id) REFERENCES events(id)
+    )`,
+    `CREATE UNIQUE INDEX idx_attendees_ticket_token_index ON attendees(ticket_token_index)`,
+    `CREATE TABLE processed_payments (
+      payment_session_id TEXT PRIMARY KEY,
+      attendee_id INTEGER,
+      processed_at TEXT NOT NULL,
+      ticket_tokens TEXT NOT NULL DEFAULT '',
+      FOREIGN KEY (attendee_id) REFERENCES attendees(id)
+    )`,
+    `CREATE TABLE activity_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      created TEXT NOT NULL,
+      event_id INTEGER,
+      message TEXT NOT NULL,
+      FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE SET NULL
+    )`,
+    `CREATE TABLE groups (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      slug TEXT NOT NULL,
+      slug_index TEXT NOT NULL,
+      name TEXT NOT NULL,
+      terms_and_conditions TEXT NOT NULL DEFAULT '',
+      max_attendees INTEGER NOT NULL DEFAULT 0
+    )`,
+    `CREATE UNIQUE INDEX idx_groups_slug_index ON groups(slug_index)`,
+    `CREATE TABLE holidays (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      end_date TEXT NOT NULL
+    )`,
+    `CREATE TABLE api_keys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      key_index TEXT NOT NULL,
+      wrapped_data_key TEXT NOT NULL,
+      name TEXT NOT NULL,
+      created TEXT NOT NULL,
+      last_used TEXT NOT NULL DEFAULT '',
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    )`,
+    `CREATE UNIQUE INDEX idx_api_keys_key_index ON api_keys(key_index)`,
+    `CREATE TABLE questions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      text TEXT NOT NULL
+    )`,
+    `CREATE TABLE answers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      question_id INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (question_id) REFERENCES questions(id)
+    )`,
+    `CREATE INDEX idx_answers_question_id ON answers(question_id)`,
+    `CREATE TABLE event_questions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id INTEGER NOT NULL,
+      question_id INTEGER NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (event_id) REFERENCES events(id),
+      FOREIGN KEY (question_id) REFERENCES questions(id)
+    )`,
+    `CREATE INDEX idx_event_questions_event_id ON event_questions(event_id)`,
+    `CREATE UNIQUE INDEX idx_event_questions_unique ON event_questions(event_id, question_id)`,
+    `CREATE TABLE built_sites (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      site_data TEXT NOT NULL,
+      created TEXT NOT NULL
+    )`,
+    `CREATE TABLE attendee_answers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      attendee_id INTEGER NOT NULL,
+      answer_id INTEGER NOT NULL,
+      FOREIGN KEY (attendee_id) REFERENCES attendees(id),
+      FOREIGN KEY (answer_id) REFERENCES answers(id)
+    )`,
+    `CREATE INDEX idx_attendee_answers_attendee_id ON attendee_answers(attendee_id)`,
+    `CREATE INDEX idx_attendee_answers_answer_id ON attendee_answers(answer_id)`,
+    `CREATE UNIQUE INDEX idx_attendee_answers_unique ON attendee_answers(attendee_id, answer_id)`,
+  ];
+
+  /** Create the legacy schema and return the client */
+  const createLegacyDb = async () => {
+    setupTestEncryptionKey();
+    const client = createClient({ url: ":memory:" });
+    setDb(client);
+    for (const sql of LEGACY_SCHEMA_SQL) {
+      await client.execute(sql);
+    }
+    return client;
+  };
+
+  /**
+   * Stub PRAGMA foreign_keys = OFF to be a no-op.
+   * This simulates remote libsql (Turso) where PRAGMA doesn't persist
+   * across HTTP requests — the execute() and batch() calls are separate
+   * requests, so PRAGMA set in execute() doesn't affect the batch().
+   *
+   * In the in-memory client, PRAGMA carries over (single connection),
+   * so without this stub the migration would succeed and hide the bug.
+   */
+  const stubPragmaForeignKeysOff = (client: ReturnType<typeof createClient>) => {
+    const origExecute = client.execute.bind(client);
+    return stub(client, "execute", (stmt: unknown) => {
+      const sql =
+        typeof stmt === "string" ? stmt : (stmt as { sql: string }).sql;
+      if (/PRAGMA\s+foreign_keys\s*=\s*OFF/i.test(sql)) {
+        return Promise.resolve({
+          columns: [],
+          columnTypes: [],
+          rows: [],
+          rowsAffected: 0,
+          lastInsertRowid: 0n,
+          toJSON: () => ({
+            columns: [],
+            columnTypes: [],
+            rows: [],
+            rowsAffected: 0,
+            lastInsertRowid: "0",
+          }),
+        } as ResultSet);
+      }
+      return origExecute(stmt as Parameters<typeof origExecute>[0]);
+    });
+  };
+
+  test("migration backfills event_attendees and preserves processed_payments", async () => {
+    const client = await createLegacyDb();
+
+    // Insert legacy data: event with a date, attendee, and a processed payment
+    await client.execute(
+      "INSERT INTO events (id, created, max_attendees, name) VALUES (1, '2024-01-01T00:00:00Z', 100, 'Test Event')",
+    );
+    await client.execute(
+      `INSERT INTO attendees (id, event_id, name, email, created, quantity, date, checked_in_v2, refunded_v2, price_paid_v2)
+       VALUES (1, 1, 'Test User', 'test@example.com', '2024-01-01T00:00:00Z', 2, '2024-06-15', 0, 0, 1000)`,
+    );
+    await client.execute(
+      `INSERT INTO processed_payments (payment_session_id, attendee_id, processed_at)
+       VALUES ('ps_test_123', 1, '2024-01-01T00:00:00Z')`,
+    );
+
+    // Simulate production: PRAGMA foreign_keys=OFF doesn't work
+    const pragmaStub = stubPragmaForeignKeysOff(client);
+    try {
+      await initDb();
+    } finally {
+      pragmaStub.restore();
+    }
+
+    // Verify attendee was migrated to event_attendees
+    const ea = await client.execute("SELECT * FROM event_attendees");
+    expect(ea.rows.length).toBe(1);
+    expect(ea.rows[0]!.event_id).toBe(1);
+    expect(ea.rows[0]!.attendee_id).toBe(1);
+    expect(ea.rows[0]!.quantity).toBe(2);
+    expect(ea.rows[0]!.price_paid).toBe(1000);
+    // date "2024-06-15" → start_at "2024-06-15T00:00:00Z", end_at "2024-06-16T00:00:00Z"
+    expect(ea.rows[0]!.start_at).toBe("2024-06-15T00:00:00Z");
+    expect(ea.rows[0]!.end_at).toBe("2024-06-16T00:00:00Z");
+
+    // Verify attendees table no longer has deprecated columns
+    const cols = await client.execute("PRAGMA table_info(attendees)");
+    const colNames = cols.rows.map((r) => r.name);
+    expect(colNames).not.toContain("event_id");
+    expect(colNames).not.toContain("date");
+    expect(colNames).not.toContain("quantity");
+    expect(colNames).toContain("id");
+    expect(colNames).toContain("name");
+
+    // Verify processed_payments data survived the migration
+    const payments = await client.execute("SELECT * FROM processed_payments");
+    expect(payments.rows.length).toBe(1);
+    expect(payments.rows[0]!.attendee_id).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
Fixes a critical bug in the `event_attendees` migration that causes failures when running against remote libsql instances (Turso) where `PRAGMA foreign_keys=OFF` doesn't persist across HTTP requests.

## Problem
The migration recreates the `attendees` table to drop deprecated columns (`event_id`, `date`, `quantity`). However, other tables (`processed_payments`, `attendee_answers`) have foreign key constraints referencing `attendees(id)`. When `PRAGMA foreign_keys=OFF` is executed in one HTTP request and the table recreation happens in a separate batch request, the PRAGMA setting doesn't carry over, causing `DROP TABLE attendees` to fail with a foreign key constraint violation.

## Solution
Changed the migration to recreate dependent tables **before** recreating `attendees`:

1. **Recreate tables with FK references first** (`processed_payments`, `attendee_answers`) — this removes their FK constraints pointing to `attendees`
2. **Then recreate `attendees`** — now safe since no FK references remain
3. **Removed `PRAGMA foreign_keys=OFF/ON`** — unreliable in remote libsql; instead rely on the order of table recreation

## Key Changes
- **src/lib/db/migrations.ts**: 
  - Reordered table recreation in `dropDeprecatedAttendeeColumns()` to process dependent tables first
  - Removed `PRAGMA foreign_keys` calls from `recreateTable()` 
  - Updated comments to explain the FK constraint handling strategy
  
- **test/lib/db.test.ts**:
  - Added comprehensive migration test that verifies the fix works even when `PRAGMA foreign_keys=OFF` is ineffective
  - Test creates legacy schema, inserts data with FK relationships, stubs the PRAGMA to be a no-op, and verifies migration succeeds and preserves data

## Implementation Details
- The test uses a stub to simulate remote libsql behavior where `PRAGMA foreign_keys=OFF` is ignored
- Migration correctly backfills `event_attendees` table and preserves `processed_payments` data
- Deprecated columns are successfully removed from `attendees` table

https://claude.ai/code/session_01U3WxZt8Vd91HQFVBvj3u26