### PR TITLE
Add manual check-in form with autocomplete to scanner page

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -349,10 +349,95 @@ for (const ta of document.querySelectorAll<HTMLTextAreaElement>(
   ta.parentNode!.insertBefore(counter, ta.nextSibling);
 }
 
+/* Manual check-in: fetch-based form submission for scanner page autocomplete.
+ * Posts to the scan JSON API without a page reload so the camera keeps running. */
+{
+  const form = document.querySelector<HTMLFormElement>("[data-manual-checkin]");
+  if (form) {
+    const input = form.querySelector<HTMLInputElement>(
+      "#manual-checkin-input",
+    )!;
+    const datalist = document.getElementById(
+      "ticket-options",
+    ) as HTMLDataListElement;
+    const statusEl = document.getElementById("manual-checkin-status")!;
+    const eventId = form.dataset.eventId!;
+    const csrfInput = form.querySelector<HTMLInputElement>(
+      'input[name="csrf_token"]',
+    )!;
+
+    const showCheckinStatus = (
+      message: string,
+      type: "success" | "warning" | "error",
+    ) => {
+      statusEl.textContent = message;
+      statusEl.classList.remove(
+        "hidden",
+        "scanner-status-success",
+        "scanner-status-warning",
+        "scanner-status-error",
+      );
+      statusEl.classList.add("scanner-status", `scanner-status-${type}`);
+    };
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const token = input.value.trim();
+      if (!token) return;
+
+      const submitBtn = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]',
+      )!;
+      submitBtn.disabled = true;
+
+      try {
+        const res = await fetch(`/admin/event/${eventId}/scan`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-csrf-token": csrfInput.value,
+          },
+          body: JSON.stringify({ token }),
+        });
+        const result = await res.json();
+
+        if (result.status === "checked_in") {
+          const qty = Number.isFinite(result.quantity) ? result.quantity : 1;
+          showCheckinStatus(
+            `${result.name} checked in (${qty} ticket${qty === 1 ? "" : "s"})`,
+            "success",
+          );
+          // Remove the checked-in option from the datalist
+          for (const opt of datalist.querySelectorAll("option")) {
+            if (opt.value === token) {
+              opt.remove();
+              break;
+            }
+          }
+          input.value = "";
+        } else if (result.status === "already_checked_in") {
+          showCheckinStatus(`${result.name} already checked in`, "warning");
+        } else if (result.status === "refunded") {
+          showCheckinStatus(`${result.name} has been refunded`, "error");
+        } else if (result.status === "not_found") {
+          showCheckinStatus("Ticket not found", "error");
+        } else {
+          showCheckinStatus(result.message ?? "Error", "error");
+        }
+      } catch {
+        showCheckinStatus("Network error", "error");
+      }
+
+      submitBtn.disabled = false;
+    });
+  }
+}
+
 /* Disable form on submit: prevent double-submission for normal POST forms.
- * Uses requestAnimationFrame so the browser sends the form before disabling. */
+ * Uses requestAnimationFrame so the browser sends the form before disabling.
+ * Skips the manual check-in form which handles its own submission. */
 for (const form of document.querySelectorAll<HTMLFormElement>(
-  'form[method="POST"]',
+  'form[method="POST"]:not([data-manual-checkin])',
 )) {
   form.addEventListener("submit", () => {
     requestAnimationFrame(() => {

--- a/src/routes/admin/scanner.ts
+++ b/src/routes/admin/scanner.ts
@@ -4,27 +4,51 @@
  * POST /admin/event/:id/scan - JSON API for processing scanned tokens
  */
 
+import { filter, map, pipe } from "#fp";
 import { logActivity } from "#lib/db/activityLog.ts";
 import {
   decryptAttendees,
   getAttendeesByTokens,
+  getAttendeesRaw,
   updateCheckedIn,
 } from "#lib/db/attendees.ts";
 import { getEventWithCount } from "#lib/db/events.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import type { Attendee } from "#lib/types.ts";
+import { requirePrivateKey } from "#routes/admin/utils.ts";
 import { defineRoutes } from "#routes/router.ts";
 import {
   AUTH_JSON,
   getPrivateKey,
+  htmlResponse,
   jsonResponse,
+  orNotFound,
+  requireSessionOr,
   withAuth,
-  withEventPage,
 } from "#routes/utils.ts";
 import { adminScannerPage } from "#templates/admin/scanner.tsx";
 
 /** Handle GET /admin/event/:id/scanner - render scanner page */
-const handleScannerGet = withEventPage(adminScannerPage);
+const handleScannerGet = (
+  request: Request,
+  { id }: { id: number },
+): Promise<Response> =>
+  requireSessionOr(request, (session) =>
+    orNotFound(getEventWithCount(id), async (event) => {
+      const privateKey = await requirePrivateKey(session);
+      const rawAttendees = await getAttendeesRaw(event.id);
+      const attendees = await decryptAttendees(rawAttendees, privateKey);
+      const uncheckedIn = pipe(
+        filter((a: Attendee) => !a.checked_in && !a.refunded),
+        map((a: Attendee) => ({
+          token: a.ticket_token,
+          name: a.name,
+          quantity: a.quantity,
+        })),
+      )(attendees);
+      return htmlResponse(adminScannerPage(event, session, uncheckedIn));
+    }),
+  );
 
 /** Look up attendee by token and decrypt */
 const resolveTokenAttendee = async (

--- a/src/routes/admin/scanner.ts
+++ b/src/routes/admin/scanner.ts
@@ -21,6 +21,7 @@ import {
   AUTH_JSON,
   getPrivateKey,
   htmlResponse,
+  type IdRouteHandler,
   jsonResponse,
   orNotFound,
   requireSessionOr,
@@ -29,10 +30,7 @@ import {
 import { adminScannerPage } from "#templates/admin/scanner.tsx";
 
 /** Handle GET /admin/event/:id/scanner - render scanner page */
-const handleScannerGet = (
-  request: Request,
-  { id }: { id: number },
-): Promise<Response> =>
+const handleScannerGet: IdRouteHandler = (request, { id }) =>
   requireSessionOr(request, (session) =>
     orNotFound(getEventWithCount(id), async (event) => {
       const privateKey = await requirePrivateKey(session);
@@ -74,10 +72,7 @@ const getEventName = async (eventId: number): Promise<string> => {
  * Scanner is intentionally one-way (check-in only, no check-out) to prevent
  * accidental check-outs from double-scans during rapid door check-in.
  */
-const handleScanPost = (
-  request: Request,
-  { id }: { id: number },
-): Promise<Response> =>
+const handleScanPost: IdRouteHandler = (request, { id }) =>
   withAuth(request, AUTH_JSON, async (session, body) => {
     if (typeof body.token !== "string") {
       return jsonResponse({ status: "error", message: "Missing token" }, 400);

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -6,14 +6,22 @@ import { SCANNER_JS_PATH } from "#lib/asset-paths.ts";
 import { getCurrentCsrfToken } from "#lib/csrf.ts";
 import type { AdminSession, EventWithCount } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { Layout } from "#templates/layout.tsx";
+import { escapeHtml, Layout } from "#templates/layout.tsx";
+
+/** Ticket option for the manual check-in autocomplete */
+export interface TicketOption {
+  token: string;
+  name: string;
+  quantity: number;
+}
 
 /**
- * Scanner page - camera feed with auto check-in
+ * Scanner page - camera feed with auto check-in + manual autocomplete
  */
 export const adminScannerPage = (
   event: EventWithCount,
   session: AdminSession,
+  uncheckedIn: TicketOption[] = [],
 ): string =>
   String(
     <Layout
@@ -62,6 +70,49 @@ export const adminScannerPage = (
         <button id="scanner-start" type="button">
           Start Camera
         </button>
+      </article>
+
+      <article>
+        <h2>Manual Check-in</h2>
+        <form
+          id="manual-checkin"
+          method="POST"
+          action={`/admin/event/${event.id}/scan`}
+          data-manual-checkin
+          data-event-id={String(event.id)}
+        >
+          <input
+            type="hidden"
+            name="csrf_token"
+            value={getCurrentCsrfToken()}
+          />
+          <label for="manual-checkin-input">
+            Search by name or ticket token
+          </label>
+          <input
+            id="manual-checkin-input"
+            name="token"
+            type="text"
+            list="ticket-options"
+            autocomplete="off"
+            placeholder={
+              uncheckedIn.length > 0
+                ? `${uncheckedIn.length} tickets available`
+                : "No tickets to check in"
+            }
+            required
+          />
+          <datalist id="ticket-options">
+            {uncheckedIn.map((t) => (
+              <option
+                value={t.token}
+                label={`${escapeHtml(t.name)} (${t.quantity} ticket${t.quantity === 1 ? "" : "s"})`}
+              ></option>
+            ))}
+          </datalist>
+          <div id="manual-checkin-status" class="hidden"></div>
+          <button type="submit">Check In</button>
+        </form>
       </article>
     </Layout>,
   );

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -274,6 +274,72 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       const { response } = await adminGet("/admin/event/99999/scanner");
       expect(response.status).toBe(404);
     });
+
+    test("includes manual check-in form with datalist", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      const body = await getScannerBody(event.id);
+      expect(body).toContain("Manual Check-in");
+      expect(body).toContain("data-manual-checkin");
+      expect(body).toContain('id="ticket-options"');
+      expect(body).toContain('list="ticket-options"');
+    });
+
+    test("datalist includes unchecked-in attendees", async () => {
+      const { event, token } = await createTestAttendeeWithToken(
+        "Alice Unchecked",
+        "alice-uc@test.com",
+      );
+      const body = await getScannerBody(event.id);
+      expect(body).toContain(token);
+      expect(body).toContain("Alice Unchecked");
+    });
+
+    test("datalist excludes checked-in attendees", async () => {
+      const { event, token, session } = await setupScanTest(
+        "Bob Checked",
+        "bob-checked@test.com",
+      );
+      // Check in the attendee
+      await handleRequest(
+        mockScanRequest(event.id, { token }, session.cookie, session.csrfToken),
+      );
+      const body = await getScannerBody(event.id);
+      expect(body).not.toContain(token);
+    });
+
+    test("datalist excludes refunded attendees", async () => {
+      const { getAttendeesByTokens, markRefunded } = await import(
+        "#lib/db/attendees.ts"
+      );
+      const { event, token } = await createTestAttendeeWithToken(
+        "Carol Refunded",
+        "carol-ref@test.com",
+      );
+      const attendees = await getAttendeesByTokens([token]);
+      await markRefunded(attendees[0]!.id);
+      const body = await getScannerBody(event.id);
+      expect(body).not.toContain(token);
+    });
+
+    test("datalist shows ticket quantity", async () => {
+      const { event } = await createTestAttendeeWithToken(
+        "Dave Multi",
+        "dave-multi@test.com",
+        {},
+        3,
+      );
+      const body = await getScannerBody(event.id);
+      expect(body).toContain("3 tickets");
+    });
+
+    test("datalist shows singular ticket for quantity 1", async () => {
+      const { event } = await createTestAttendeeWithToken(
+        "Eve Single",
+        "eve-single@test.com",
+      );
+      const body = await getScannerBody(event.id);
+      expect(body).toContain("1 ticket)");
+    });
   });
 
   describe("POST /admin/event/:id/scan", () => {


### PR DESCRIPTION
## Summary
This PR adds a manual check-in form to the scanner page, allowing administrators to search and check in attendees by name or ticket token without relying solely on QR code scanning. The form uses fetch-based submission to avoid page reloads, keeping the camera feed active.

## Key Changes
- **Manual check-in form UI**: Added a new form section with autocomplete input that searches through unchecked-in attendees
- **Client-side form handling**: Implemented fetch-based form submission in `admin.ts` that posts to the scan JSON API without page reloads, with status feedback (success/warning/error messages)
- **Datalist population**: The form includes a `<datalist>` element populated with unchecked-in attendees, showing their names and ticket quantities
- **Backend data preparation**: Modified the scanner GET route to fetch and decrypt attendees, filtering to only unchecked-in and non-refunded attendees, then passing this data to the template
- **Form exclusion from double-submit protection**: Updated the generic form submission handler to skip the manual check-in form since it manages its own submission
- **Comprehensive test coverage**: Added 6 new tests verifying the datalist includes/excludes appropriate attendees and displays ticket quantities correctly

## Notable Implementation Details
- Uses functional programming utilities (`pipe`, `filter`, `map`) for clean attendee filtering
- Dynamically removes checked-in options from the datalist after successful check-in
- Handles multiple response statuses: `checked_in`, `already_checked_in`, `refunded`, `not_found`
- Displays singular/plural "ticket(s)" based on quantity
- Disables submit button during request to prevent double-submission
- Gracefully handles network errors with user-friendly messaging

https://claude.ai/code/session_01H9QaP5avBDTZB7mSsDBEAS