### PR TITLE
Simplify slug collision test with Math.random stub

### DIFF
--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -1,10 +1,9 @@
-import type { Client, ResultSet } from "@libsql/client";
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { addDays } from "#lib/dates.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
-import { getDb, setDb } from "#lib/db/client.ts";
+import { getDb } from "#lib/db/client.ts";
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { nowMs } from "#lib/now.ts";
@@ -36,7 +35,6 @@ import {
   testCookie,
   testCsrfToken,
   updateTestEvent,
-  withExpectedError,
 } from "#test-utils";
 
 describeWithEnv("server (admin events)", { db: true }, () => {
@@ -2215,48 +2213,29 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
   describe("slug collision on create", () => {
     test("throws when all slug generation attempts collide", async () => {
-      // Install a proxy client via setDb so the intercept follows getDb()
-      // even if the underlying reference changes — avoids the flakiness of
-      // stubbing a specific instance's execute method.
-      const realDb = getDb();
-      const proxy: Client = Object.create(realDb, {
-        execute: {
-          value: async (
-            query: Parameters<Client["execute"]>[0],
-          ): Promise<ResultSet> => {
-            const sql =
-              typeof query === "string"
-                ? query
-                : (query as { sql: string }).sql;
-            if (
-              sql.includes("SELECT 1 WHERE EXISTS") &&
-              sql.includes("FROM events WHERE slug_index")
-            ) {
-              return {
-                rows: [{ "1": 1 }],
-                columns: ["1"],
-                rowsAffected: 0,
-                lastInsertRowid: 0n,
-              } as unknown as ResultSet;
-            }
-            return await realDb.execute(query);
-          },
-        },
-      });
-      setDb(proxy);
-
+      // Stub Math.random to make generateSlug deterministic — every attempt
+      // produces the same slug, so after the first event claims it the
+      // second creation exhausts all 10 retries and throws.
+      const randomStub = stub(Math, "random", () => 0.5);
       try {
-        await withExpectedError(async () => {
-          const { response } = await adminFormPost("/admin/event", {
+        // First event succeeds, claiming the only slug Math.random can produce
+        await adminFormPost("/admin/event", {
+          name: "First Event",
+          max_attendees: "50",
+          max_quantity: "1",
+          thank_you_url: "https://example.com",
+        });
+        // Second event: all 10 attempts generate the same taken slug
+        await expect(
+          adminFormPost("/admin/event", {
             name: "Collision Event",
             max_attendees: "50",
             max_quantity: "1",
             thank_you_url: "https://example.com",
-          });
-          await expectHtmlResponse(response, 503, "Temporary Error");
-        });
+          }),
+        ).rejects.toThrow("Failed to generate unique slug after 10 attempts");
       } finally {
-        setDb(realDb);
+        randomStub.restore();
       }
     });
   });


### PR DESCRIPTION
## Summary
Refactored the slug collision test to use a simpler and more direct approach for making slug generation deterministic, replacing a complex database client proxy with a Math.random stub.

## Key Changes
- Removed unused imports (`Client`, `ResultSet` types and `setDb` function)
- Removed `withExpectedError` test utility import
- Replaced database client proxy interception with `Math.random` stubbing to make `generateSlug` deterministic
- Simplified test flow: first event claims the slug, second event exhausts retries and throws
- Changed assertion from checking HTTP 503 response to directly asserting the thrown error message
- Improved test clarity and reduced setup complexity

## Implementation Details
The original test used a proxy client to intercept database queries and force slug collision detection. The new approach is more straightforward:
- Stub `Math.random` to always return 0.5, making every slug generation attempt produce the same slug
- Create a first event to claim that slug
- Attempt to create a second event, which will fail after 10 retry attempts with a clear error message
- This approach is less fragile and more directly tests the slug generation retry logic

https://claude.ai/code/session_017ZimeQMgQVFYX6C7WnLTqw