### PR TITLE
Use empty alt text for decorative event images

### DIFF
--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -181,11 +181,11 @@ export const homepagePage = (
 
 /** Render event image HTML if image_url is set */
 export const renderEventImage = (
-  event: { image_url: string; name: string },
+  event: { image_url: string },
   className = "event-image",
 ): string =>
   event.image_url
-    ? `<img src="${escapeHtml(getImageProxyUrl(event.image_url))}" alt="${escapeHtml(event.name)}" class="${className}" />`
+    ? `<img src="${escapeHtml(getImageProxyUrl(event.image_url))}" alt="" class="${className}" />`
     : "";
 
 /** Build OpenGraph meta tags for a public event page */

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -3685,27 +3685,24 @@ describe("html", () => {
     () => {
       describe("renderEventImage", () => {
         test("returns empty string when image_url is null", () => {
-          const html = renderEventImage({ image_url: "", name: "Test" });
+          const html = renderEventImage({ image_url: "" });
           expect(html).toBe("");
         });
 
         test("renders img tag with proxy URL when image_url is set", () => {
           const html = renderEventImage({
             image_url: "abc123.jpg",
-            name: "Test Event",
           });
           expect(html).toContain("/image/abc123.jpg");
-          expect(html).toContain('alt="Test Event"');
+          expect(html).toContain('alt=""');
           expect(html).toContain('class="event-image"');
         });
 
-        test("escapes HTML in event name for alt attribute", () => {
+        test("uses empty alt text for decorative image", () => {
           const html = renderEventImage({
             image_url: "img.jpg",
-            name: '<script>alert("xss")</script>',
           });
-          expect(html).not.toContain("<script>");
-          expect(html).toContain("&lt;script&gt;");
+          expect(html).toContain('alt=""');
         });
       });
 


### PR DESCRIPTION
## Summary
Updated the `renderEventImage` function to use empty alt text for event images, treating them as decorative elements rather than content-bearing images.

## Key Changes
- Removed the `name` parameter from the `renderEventImage` function signature
- Changed the alt attribute from `escapeHtml(event.name)` to an empty string (`alt=""`)
- Updated all test cases to reflect the new behavior:
  - Removed `name` property from test inputs
  - Updated assertions to expect `alt=""` instead of the event name
  - Replaced HTML escaping test with a simpler decorative image test

## Implementation Details
This change follows accessibility best practices by using empty alt text (`alt=""`) for purely decorative images. Since event images serve as visual decoration rather than conveying essential information (the event name is displayed separately in the page content), an empty alt attribute is more appropriate than repeating the event name. This prevents screen readers from announcing redundant information to users with visual impairments.

https://claude.ai/code/session_018aN4rYmYx9viwK1KVYt6te