### PR TITLE
Improve dark mode focus states with outline instead of border

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -85,8 +85,8 @@ html[data-theme="dark"] {
 [data-theme="dark"] input[type="email"]:focus,
 [data-theme="dark"] select:focus,
 [data-theme="dark"] textarea:focus {
-  border-color: #ffffff;
-  outline: none;
+  border-color: transparent;
+  outline: 2px solid #ffffff;
 }
 [data-theme="dark"] table {
   border-width: 2px;


### PR DESCRIPTION
## Summary
Updated the dark mode focus styling for form inputs to use an outline instead of a border color change, providing better visual feedback and accessibility.

## Key Changes
- Changed focused input `border-color` from `#ffffff` to `transparent` for dark mode
- Added `outline: 2px solid #ffffff` to provide a visible focus indicator
- Affects all dark mode focused form elements: input[type="email"], select, and textarea

## Implementation Details
This change improves the focus state UX by:
- Using a standard outline pattern which is more accessible and doesn't affect layout
- Providing a clearer visual distinction between the focused and unfocused states
- Following better accessibility practices for keyboard navigation

https://claude.ai/code/session_01FP8Y67SRAJwogxmv5B8aRt