### PR TITLE
Hide actions column, debug footer, and add-attendee form in print view

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1476,6 +1476,18 @@ button.secondary:hover {
     overflow: visible;
     max-width: 100%;
   }
+
+  .debug-footer {
+    display: none;
+  }
+
+  article:has(#add-attendee) {
+    display: none;
+  }
+
+  .actions-col {
+    display: none;
+  }
 }
 
 /* Hide email API key and from address fields when provider is "None" */

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -3,12 +3,7 @@
  */
 
 import type { BuiltSite } from "#lib/db/built-sites.ts";
-import {
-  ConfirmForm,
-  CsrfForm,
-  Flash,
-  renderFields,
-} from "#lib/forms.tsx";
+import { ConfirmForm, CsrfForm, Flash, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -5,12 +5,7 @@
 import { joinStrings, map, pipe, reduce } from "#fp";
 import { buildEmbedSnippets } from "#lib/embed.ts";
 import { isReadOnly } from "#lib/env.ts";
-import {
-  ConfirmForm,
-  CsrfForm,
-  Flash,
-  renderFields,
-} from "#lib/forms.tsx";
+import { ConfirmForm, CsrfForm, Flash, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import {
   type AdminSession,

--- a/src/templates/admin/holidays.tsx
+++ b/src/templates/admin/holidays.tsx
@@ -2,12 +2,7 @@
  * Admin holiday management page templates
  */
 
-import {
-  ConfirmForm,
-  CsrfForm,
-  Flash,
-  renderFields,
-} from "#lib/forms.tsx";
+import { ConfirmForm, CsrfForm, Flash, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminSession, Holiday } from "#lib/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";

--- a/src/templates/admin/users.tsx
+++ b/src/templates/admin/users.tsx
@@ -2,12 +2,7 @@
  * Admin user management page template
  */
 
-import {
-  ConfirmForm,
-  CsrfForm,
-  Flash,
-  renderFields,
-} from "#lib/forms.tsx";
+import { ConfirmForm, CsrfForm, Flash, renderFields } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import type { AdminLevel, AdminSession } from "#lib/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -293,7 +293,7 @@ const AttendeeRow = ({
   return String(
     <tr>
       {showActions && (
-        <td>
+        <td class="actions-col">
           <Raw html={StatusCell({ row, opts })} />
         </td>
       )}
@@ -340,7 +340,7 @@ const AttendeeRow = ({
       </td>
       <td>{new Date(a.created).toLocaleString()}</td>
       {showActions && (
-        <td>
+        <td class="actions-col">
           <Raw html={ActionsCell({ row, returnUrl: opts.returnUrl })} />
         </td>
       )}
@@ -396,7 +396,7 @@ export const AttendeeTable = (opts: AttendeeTableOptions): string => {
     <table>
       <thead>
         <tr>
-          {showActions && <th></th>}
+          {showActions && <th class="actions-col"></th>}
           {vis.showEvent && <th>Event</th>}
           {vis.showDate && <th>Date</th>}
           <th>Name</th>
@@ -408,7 +408,7 @@ export const AttendeeTable = (opts: AttendeeTableOptions): string => {
           <th>Qty</th>
           <th>Ticket</th>
           <th>Registered</th>
-          {showActions && <th></th>}
+          {showActions && <th class="actions-col"></th>}
         </tr>
       </thead>
       <tbody>

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -113,7 +113,7 @@ describe("AttendeeTable", () => {
       const html = AttendeeTable(
         makeOpts({ rows, showEvent: true, showDate: true }),
       );
-      const headers = [...html.matchAll(/<th>(.*?)<\/th>/g)].map((m) => m[1]);
+      const headers = [...html.matchAll(/<th(?:\s[^>]*)?>([^<]*)<\/th>/g)].map((m) => m[1]);
       // Empty headers are for Checked In (first) and Actions (last)
       expect(headers).toEqual([
         "",

--- a/test/lib/forms.test.ts
+++ b/test/lib/forms.test.ts
@@ -5,9 +5,9 @@ import { getCurrentCsrfToken, signCsrfToken } from "#lib/csrf.ts";
 import { FormParams } from "#lib/form-data.ts";
 import {
   CsrfForm,
-  Flash,
   clearSavedFormData,
   type Field,
+  Flash,
   renderError,
   renderField,
   renderFields,

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -2239,7 +2239,6 @@ describe("html", () => {
     });
   });
 
-
   describe("adminSessionsPage", () => {
     test("renders session rows", () => {
       const sessions = [


### PR DESCRIPTION
Add CSS print rules to hide interactive elements that aren't useful on
paper: attendee table actions columns (via new .actions-col class),
the .debug-footer, and the add-attendee form.

https://claude.ai/code/session_01DidBLPReNagmWa5PJ8jyqs