### PR TITLE
Add skip navigation link for accessibility (WCAG 2.4.1)

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1497,22 +1497,19 @@ button.secondary:hover {
 }
 
 /* Skip navigation link (SC 2.4.1 Bypass Blocks) */
-.skip-nav {
+.skip-nav:not(:focus) {
+  clip-path: inset(50%);
   position: absolute;
-  left: -9999px;
-  top: auto;
   width: 1px;
   height: 1px;
   overflow: hidden;
-  z-index: 100;
+  white-space: nowrap;
 }
 
 .skip-nav:focus {
   position: fixed;
   top: 0;
   left: 0;
-  width: auto;
-  height: auto;
   padding: 0.5rem 1rem;
   background: var(--color-link);
   color: var(--color-bg);

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1496,4 +1496,29 @@ button.secondary:hover {
   font-size: smaller;
 }
 
+/* Skip navigation link (SC 2.4.1 Bypass Blocks) */
+.skip-nav {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: 100;
+}
+
+.skip-nav:focus {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  background: var(--color-link);
+  color: var(--color-bg);
+  font-size: 1rem;
+  text-decoration: none;
+  z-index: 9999;
+}
+
 /* Guide page */

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1497,7 +1497,7 @@ button.secondary:hover {
 }
 
 /* Skip navigation link (SC 2.4.1 Bypass Blocks) */
-.skip-nav:not(:focus) {
+.skip-nav:not(:focus-visible) {
   clip-path: inset(50%);
   position: absolute;
   width: 1px;
@@ -1506,7 +1506,7 @@ button.secondary:hover {
   white-space: nowrap;
 }
 
-.skip-nav:focus {
+.skip-nav:focus-visible {
   position: fixed;
   top: 0;
   left: 0;
@@ -1516,6 +1516,10 @@ button.secondary:hover {
   font-size: 1rem;
   text-decoration: none;
   z-index: 9999;
+}
+
+#main-content:focus {
+  outline: none;
 }
 
 /* Guide page */

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -61,7 +61,7 @@ export const Layout = ({
             Skip to content
           </a>
           {isDemoMode() && <Raw html={DEMO_BANNER} />}
-          <main id="main-content">
+          <main id="main-content" tabindex="-1">
             {headerImage && (
               <img
                 src={getImageProxyUrl(headerImage)}

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -57,8 +57,11 @@ export const Layout = ({
           {headExtra && <Raw html={headExtra} />}
         </head>
         <body class={bodyClass || undefined}>
+          <a href="#main-content" class="skip-nav">
+            Skip to content
+          </a>
           {isDemoMode() && <Raw html={DEMO_BANNER} />}
-          <main>
+          <main id="main-content">
             {headerImage && (
               <img
                 src={getImageProxyUrl(headerImage)}

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -62,6 +62,7 @@ import {
   generateCalendarCsv,
 } from "#templates/csv.ts";
 import { eventFields } from "#templates/fields.ts";
+import { Layout } from "#templates/layout.tsx";
 import {
   checkoutPopupPage,
   paymentCancelPage,
@@ -136,6 +137,16 @@ describe("asset-paths", () => {
 describe("html", () => {
   afterEach(() => {
     detectIframeMode("https://example.com/");
+  });
+
+  describe("Layout skip navigation", () => {
+    test("renders skip-nav link targeting main-content", () => {
+      const html = String(Layout({ title: "Test", children: "" }));
+      expect(html).toContain('class="skip-nav"');
+      expect(html).toContain('href="#main-content"');
+      expect(html).toContain("Skip to content");
+      expect(html).toContain('id="main-content"');
+    });
   });
 
   describe("adminLoginPage", () => {

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -146,6 +146,7 @@ describe("html", () => {
       expect(html).toContain('href="#main-content"');
       expect(html).toContain("Skip to content");
       expect(html).toContain('id="main-content"');
+      expect(html).toContain('tabindex="-1"');
     });
   });
 


### PR DESCRIPTION
## Summary
This PR implements a skip navigation link to improve keyboard accessibility and comply with WCAG 2.4.1 (Bypass Blocks) guidelines. Users can now quickly navigate to the main content without tabbing through navigation elements.

## Key Changes
- **CSS styling** (`src/static/mvp.css`): Added styles for `.skip-nav` link that is visually hidden by default but becomes visible and fixed-positioned when focused
- **Layout component** (`src/templates/layout.tsx`): Added a skip navigation link at the top of the body that targets the main content area, and added `id="main-content"` and `tabindex="-1"` to the main element
- **Tests** (`test/lib/html.test.ts`): Added test suite to verify the skip navigation link is properly rendered with correct attributes and text

## Implementation Details
- The skip link uses `clip-path: inset(50%)` for hiding instead of `display: none` to maintain accessibility for screen readers
- The link becomes visible on `:focus-visible` with a fixed position at the top-left corner for easy access
- The main content area uses `tabindex="-1"` to allow programmatic focus without being in the natural tab order
- Styling uses CSS custom properties (`--color-link`, `--color-bg`) for consistency with the existing design system

https://claude.ai/code/session_01FmsXEAxZeRk6FsWHMQP3kd