### PR TITLE
Move form headers and messages inside form elements

### DIFF
--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -446,28 +446,25 @@ export const ConfirmForm = ({
   hiddenFields?: Record<string, string>;
   children?: Child;
 }): JSX.Element => (
-  <>
-    <div class="prose">{children}</div>
-
-    <CsrfForm action={action} id={id}>
-      {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
-      {hiddenFields &&
-        Object.entries(hiddenFields).map(([fieldName, value]) => (
-          <input type="hidden" name={fieldName} value={value} />
-        ))}
-      <label>
-        {label}
-        <input
-          type="text"
-          name="confirm_identifier"
-          placeholder={name}
-          autocomplete="off"
-          required
-        />
-      </label>
-      <button type="submit" class={danger ? "danger" : undefined}>
-        {buttonText}
-      </button>
-    </CsrfForm>
-  </>
+  <CsrfForm action={action} id={id}>
+    {children && <div class="prose">{children}</div>}
+    {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
+    {hiddenFields &&
+      Object.entries(hiddenFields).map(([fieldName, value]) => (
+        <input type="hidden" name={fieldName} value={value} />
+      ))}
+    <label>
+      {label}
+      <input
+        type="text"
+        name="confirm_identifier"
+        placeholder={name}
+        autocomplete="off"
+        required
+      />
+    </label>
+    <button type="submit" class={danger ? "danger" : undefined}>
+      {buttonText}
+    </button>
+  </CsrfForm>
 );

--- a/src/templates/admin/backup.tsx
+++ b/src/templates/admin/backup.tsx
@@ -147,17 +147,6 @@ export const adminRestoreConfirmPage = (
       <AdminNav session={session} active="/admin/settings" />
       <SettingsSubNav />
 
-      <h1>Confirm Database Restore</h1>
-      <Flash error={error} />
-
-      {schemaMismatch && (
-        <div class="error" role="alert">
-          <strong>Schema mismatch:</strong> This backup was created with a
-          different database schema version. The restore will apply current
-          migrations after importing data, but some data may be incompatible.
-        </div>
-      )}
-
       <ConfirmForm
         action="/admin/backup/restore/confirm"
         id="backup-restore-confirm"
@@ -166,6 +155,16 @@ export const adminRestoreConfirmPage = (
         buttonText="Restore Database"
         hiddenFields={{ backup_filename: filename }}
       >
+        <h1>Confirm Database Restore</h1>
+        <Flash error={error} />
+
+        {schemaMismatch && (
+          <div class="error" role="alert">
+            <strong>Schema mismatch:</strong> This backup was created with a
+            different database schema version. The restore will apply current
+            migrations after importing data, but some data may be incompatible.
+          </div>
+        )}
         <p>
           You are about to restore from an uploaded backup containing{" "}
           <strong>{lineCount}</strong> SQL statements. This will:

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -79,9 +79,9 @@ export const adminBuiltSiteNewPage = (
   String(
     <Layout title="Add Built Site">
       <AdminNav session={session} active="/admin/built-sites" />
-      <h1>Add Built Site</h1>
-      <Flash error={error} />
       <CsrfForm action="/admin/built-sites">
+        <h1>Add Built Site</h1>
+        <Flash error={error} />
         <Raw html={renderFields(builtSiteFields)} />
         <button type="submit">Create Built Site</button>
       </CsrfForm>
@@ -99,9 +99,9 @@ export const adminBuiltSiteEditPage = (
   String(
     <Layout title="Edit Built Site">
       <AdminNav session={session} active="/admin/built-sites" />
-      <h1>Edit Built Site</h1>
-      <Flash error={error} />
       <CsrfForm action={`/admin/built-sites/${site.id}/edit`}>
+        <h1>Edit Built Site</h1>
+        <Flash error={error} />
         <Raw
           html={renderFields(builtSiteFields, builtSiteToFieldValues(site))}
         />
@@ -121,8 +121,6 @@ export const adminBuiltSiteDeletePage = (
   String(
     <Layout title="Delete Built Site">
       <AdminNav session={session} active="/admin/built-sites" />
-      <h1>Delete Built Site</h1>
-      <Flash error={error} />
       <ConfirmForm
         action={`/admin/built-sites/${site.id}/delete`}
         name={site.name}
@@ -130,6 +128,8 @@ export const adminBuiltSiteDeletePage = (
         buttonText="Delete Built Site"
         danger={false}
       >
+        <h1>Delete Built Site</h1>
+        <Flash error={error} />
         <p>
           Are you sure you want to delete the built site{" "}
           <strong>{site.name}</strong>?

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -702,9 +702,9 @@ export const adminEventNewPage = (
     <Layout title="Add Event">
       <AdminNav session={session} active="/admin/" />
 
-      <h1>Add Event</h1>
-      <Flash error={error} />
       <CsrfForm action="/admin/event" enctype="multipart/form-data">
+        <h1>Add Event</h1>
+        <Flash error={error} />
         <Raw html={renderFields(fields)} />
         <EventGroupSelect groups={groups} selectedGroupId={0} />
         <button type="submit">Create Event</button>

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -104,9 +104,9 @@ export const adminGroupNewPage = (
   String(
     <Layout title="Add Group">
       <AdminNav session={session} active="/admin/groups" />
-      <h1>Add Group</h1>
-      <Flash error={error} />
       <CsrfForm action="/admin/groups">
+        <h1>Add Group</h1>
+        <Flash error={error} />
         <Raw html={renderFields(groupCreateFields, groupToFieldValues())} />
         <button type="submit">Create Group</button>
       </CsrfForm>
@@ -124,9 +124,9 @@ export const adminGroupEditPage = (
   String(
     <Layout title="Edit Group">
       <AdminNav session={session} active="/admin/groups" />
-      <h1>Edit Group</h1>
-      <Flash error={error} />
       <CsrfForm action={`/admin/groups/${group.id}/edit`}>
+        <h1>Edit Group</h1>
+        <Flash error={error} />
         <Raw html={renderFields(groupFields, groupToFieldValues(group))} />
         <button type="submit">Save Changes</button>
       </CsrfForm>
@@ -144,8 +144,6 @@ export const adminGroupDeletePage = (
   String(
     <Layout title="Delete Group">
       <AdminNav session={session} active="/admin/groups" />
-      <h1>Delete Group</h1>
-      <Flash error={error} />
       <ConfirmForm
         action={`/admin/groups/${group.id}/delete`}
         name={group.name}
@@ -153,6 +151,8 @@ export const adminGroupDeletePage = (
         buttonText="Delete Group"
         danger={false}
       >
+        <h1>Delete Group</h1>
+        <Flash error={error} />
         <p>
           Are you sure you want to delete the group{" "}
           <strong>{group.name}</strong> ({group.slug})?

--- a/src/templates/admin/holidays.tsx
+++ b/src/templates/admin/holidays.tsx
@@ -77,9 +77,9 @@ export const adminHolidayNewPage = (
   String(
     <Layout title="Add Holiday">
       <AdminNav session={session} active="/admin/holidays" />
-      <h1>Add Holiday</h1>
-      <Flash error={error} />
       <CsrfForm action="/admin/holidays">
+        <h1>Add Holiday</h1>
+        <Flash error={error} />
         <Raw html={renderFields(holidayFields)} />
         <button type="submit">Create Holiday</button>
       </CsrfForm>
@@ -97,9 +97,9 @@ export const adminHolidayEditPage = (
   String(
     <Layout title="Edit Holiday">
       <AdminNav session={session} active="/admin/holidays" />
-      <h1>Edit Holiday</h1>
-      <Flash error={error} />
       <CsrfForm action={`/admin/holidays/${holiday.id}/edit`}>
+        <h1>Edit Holiday</h1>
+        <Flash error={error} />
         <Raw
           html={renderFields(holidayFields, holidayToFieldValues(holiday))}
         />
@@ -119,8 +119,6 @@ export const adminHolidayDeletePage = (
   String(
     <Layout title="Delete Holiday">
       <AdminNav session={session} active="/admin/holidays" />
-      <h1>Delete Holiday</h1>
-      <Flash error={error} />
       <ConfirmForm
         action={`/admin/holidays/${holiday.id}/delete`}
         name={holiday.name}
@@ -128,6 +126,8 @@ export const adminHolidayDeletePage = (
         buttonText="Delete Holiday"
         danger={false}
       >
+        <h1>Delete Holiday</h1>
+        <Flash error={error} />
         <p>
           Are you sure you want to delete the holiday{" "}
           <strong>{holiday.name}</strong> ({holiday.start_date} to{" "}

--- a/src/templates/admin/questions.tsx
+++ b/src/templates/admin/questions.tsx
@@ -150,15 +150,14 @@ export const adminQuestionDeletePage = (
     <Layout title="Delete Question">
       <AdminNav session={session} active="/admin/questions" />
 
-      <h1>Delete Question</h1>
-      <Flash error={error} />
-
       <ConfirmForm
         action={`/admin/questions/${question.id}/delete`}
         name={question.text}
         label="Question text"
         buttonText="Delete Question"
       >
+        <h1>Delete Question</h1>
+        <Flash error={error} />
         <p>
           This will permanently delete the question, all its answers, and all
           attendee responses.
@@ -182,15 +181,14 @@ export const adminAnswerDeletePage = (
     <Layout title="Delete Answer">
       <AdminNav session={session} active="/admin/questions" />
 
-      <h1>Delete Answer</h1>
-      <Flash error={error} />
-
       <ConfirmForm
         action={`/admin/questions/${question.id}/answers/${answer.id}/delete`}
         name={answer.text}
         label="Answer text"
         buttonText="Delete Answer"
       >
+        <h1>Delete Answer</h1>
+        <Flash error={error} />
         <p>
           This will permanently delete the answer "{answer.text}" from the
           question "{question.text}" and remove all attendee responses for it.

--- a/src/templates/admin/seeds.tsx
+++ b/src/templates/admin/seeds.tsx
@@ -16,15 +16,13 @@ export const adminSeedsPage = (
   String(
     <Layout title="Seed Data">
       <AdminNav session={session} active="" />
-      <h1>Seed Data</h1>
-      <p>
-        Create sample events and attendees from demo data. Useful for testing
-        and development.
-      </p>
-
-      <Flash error={error} success={success} />
-
       <CsrfForm action="/admin/seeds">
+        <h1>Seed Data</h1>
+        <p>
+          Create sample events and attendees from demo data. Useful for testing
+          and development.
+        </p>
+        <Flash error={error} success={success} />
         <label for="event_count">Number of events</label>
         <input
           type="number"

--- a/src/templates/admin/users.tsx
+++ b/src/templates/admin/users.tsx
@@ -117,15 +117,14 @@ export const adminUserDeletePage = (
     <Layout title={`Delete User: ${user.username}`}>
       <AdminNav session={session} active="/admin/users" />
 
-      <h1>Delete User</h1>
-      <Flash error={error} />
-
       <ConfirmForm
         action={`/admin/users/${user.id}/delete`}
         name={user.username}
         label="Username"
         buttonText="Delete User"
       >
+        <h1>Delete User</h1>
+        <Flash error={error} />
         <p>
           <strong>Warning:</strong> This will permanently delete the user{" "}
           <strong>{user.username}</strong> ({user.adminLevel}) and all their
@@ -150,9 +149,9 @@ export const adminUserNewPage = (
     <Layout title="Invite User">
       <AdminNav session={session} active="/admin/users" />
 
-      <h1>Invite User</h1>
-      <Flash error={error} />
       <CsrfForm action="/admin/users">
+        <h1>Invite User</h1>
+        <Flash error={error} />
         <Raw html={renderFields(inviteUserFields)} />
         <button type="submit">Create Invite</button>
       </CsrfForm>

--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -45,9 +45,9 @@ export const checkinAdminPage = (
 
   return String(
     <Layout title="Check-in">
-      <h1>Check-in</h1>
-      <Flash success={message} />
       <CsrfForm action={checkinPath}>
+        <h1>Check-in</h1>
+        <Flash success={message} />
         <input type="hidden" name="check_in" value={nextValue} />
         <button type="submit" class={buttonClass}>
           {buttonLabel}

--- a/src/templates/join.tsx
+++ b/src/templates/join.tsx
@@ -17,10 +17,10 @@ export const joinPage = (
 ): string =>
   String(
     <Layout title="Set Your Password">
-      <h1>Welcome, {username}</h1>
-      <p>Set your password to complete your account setup.</p>
-      <Flash error={error} />
       <CsrfForm action={`/join/${code}`}>
+        <h1>Welcome, {username}</h1>
+        <p>Set your password to complete your account setup.</p>
+        <Flash error={error} />
         <Raw html={renderFields(joinFields)} />
         <button type="submit">Set Password</button>
       </CsrfForm>

--- a/src/templates/setup.tsx
+++ b/src/templates/setup.tsx
@@ -64,10 +64,10 @@ const DataControllerAgreement = (): JSX.Element => (
 export const setupPage = (error?: string): string =>
   String(
     <Layout title="Setup">
-      <h1>Initial Setup</h1>
-      <p>Welcome! Please configure your ticket reservation system.</p>
-      <Flash error={error} />
       <CsrfForm action="/setup/">
+        <h1>Initial Setup</h1>
+        <p>Welcome! Please configure your ticket reservation system.</p>
+        <Flash error={error} />
         <Raw html={renderFields(setupFields)} />
         <div class="field">
           <label>


### PR DESCRIPTION
## Summary
Refactored form layouts to move headings, descriptions, and flash messages inside form elements (`CsrfForm` and `ConfirmForm`) rather than having them as siblings. This improves semantic HTML structure and ensures all form-related content is contained within the form element.

## Key Changes
- **ConfirmForm component**: Removed wrapper fragment and moved prose content inside the form, made children rendering conditional
- **CsrfForm pages**: Moved `<h1>`, `<p>`, and `<Flash>` components from outside forms to inside them across multiple admin templates:
  - Admin backup restore confirmation
  - Admin seeds
  - Admin built sites (new, edit, delete)
  - Admin groups (new, edit, delete)
  - Admin holidays (new, edit, delete)
  - Admin questions (delete)
  - Admin answers (delete)
  - Admin users (new, delete)
  - Admin events (new)
  - User join/password setup
  - Initial setup
  - Check-in

## Implementation Details
- The `ConfirmForm` component now conditionally renders children with `{children && <div class="prose">{children}</div>}` to handle cases where no children are provided
- All form-related UI elements (titles, descriptions, error/success messages) are now semantically grouped within their respective form elements
- This change maintains visual appearance while improving HTML structure and accessibility

https://claude.ai/code/session_01FLLG5JsBQdZBooz2YsntCf