### PR TITLE
Add hidden group feature for public events listing

### DIFF
--- a/src/lib/db/groups.ts
+++ b/src/lib/db/groups.ts
@@ -25,6 +25,7 @@ export type GroupInput = {
   name: string;
   termsAndConditions: string;
   maxAttendees: number;
+  hidden: boolean;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -37,6 +38,7 @@ const rawGroupsTable = defineIdTable<Group, GroupInput>("groups", {
   ...idAndEncryptedSlugSchema(encrypt, decrypt),
   terms_and_conditions: { default: () => "", write: encrypt, read: decrypt },
   max_attendees: col.simple<number>(),
+  hidden: col.boolean(false),
 });
 
 /** Execute a query and decrypt the resulting group rows */

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -214,6 +214,7 @@ const SCHEMA: [name: string, table: Table][] = [
         ["name", "TEXT NOT NULL"],
         ["terms_and_conditions", "TEXT NOT NULL DEFAULT ''"],
         ["max_attendees", "INTEGER NOT NULL DEFAULT 0"],
+        ["hidden", "INTEGER NOT NULL DEFAULT 0"],
       ],
       indexes: [
         {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -195,6 +195,7 @@ export interface Group {
   name: string;
   terms_and_conditions: string;
   max_attendees: number;
+  hidden: boolean;
 }
 
 export interface EventWithCount extends Event {

--- a/src/routes/admin/api-groups.ts
+++ b/src/routes/admin/api-groups.ts
@@ -24,6 +24,7 @@ export type CreateGroupBody = {
   name: string;
   max_attendees?: number;
   terms_and_conditions?: string;
+  hidden?: boolean;
 };
 
 /** JSON body accepted by PUT /api/admin/groups/:groupId */
@@ -71,6 +72,7 @@ export const groupApiRoutes = defineCrudApi<Group, GroupInput>({
             : "",
         maxAttendees:
           typeof body.max_attendees === "number" ? body.max_attendees : 0,
+        hidden: body.hidden === true,
       },
     };
   },
@@ -100,6 +102,8 @@ export const groupApiRoutes = defineCrudApi<Group, GroupInput>({
           typeof body.max_attendees === "number"
             ? body.max_attendees
             : existing.max_attendees,
+        hidden:
+          typeof body.hidden === "boolean" ? body.hidden : existing.hidden,
       },
     };
   },

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -56,19 +56,20 @@ import {
 export const generateUniqueGroupSlug = () =>
   generateUniqueSlug(computeGroupSlugIndex, isGroupSlugTaken);
 
+/** Shared fields from group form values */
+const sharedGroupFields = (values: GroupCreateFormValues) => ({
+  name: values.name,
+  termsAndConditions: values.terms_and_conditions,
+  maxAttendees: values.max_attendees ?? 0,
+  hidden: values.hidden === "1",
+});
+
 /** Extract group input from create form values (auto-generates slug) */
 const extractGroupCreateInput = async (
   values: GroupCreateFormValues,
 ): Promise<GroupInput> => {
   const { slug, slugIndex } = await generateUniqueGroupSlug();
-  return {
-    name: values.name,
-    slug,
-    slugIndex,
-    termsAndConditions: values.terms_and_conditions,
-    maxAttendees: values.max_attendees ?? 0,
-    hidden: values.hidden === "1",
-  };
+  return { ...sharedGroupFields(values), slug, slugIndex };
 };
 
 /** Extract group input from edit form values (uses provided slug) */
@@ -77,12 +78,9 @@ const extractGroupEditInput = async (
 ): Promise<GroupInput> => {
   const slug = normalizeSlug(values.slug);
   return {
-    name: values.name,
+    ...sharedGroupFields(values),
     slug,
     slugIndex: await computeGroupSlugIndex(slug),
-    termsAndConditions: values.terms_and_conditions,
-    maxAttendees: values.max_attendees ?? 0,
-    hidden: values.hidden === "1",
   };
 };
 

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -67,7 +67,7 @@ const extractGroupCreateInput = async (
     slugIndex,
     termsAndConditions: values.terms_and_conditions,
     maxAttendees: values.max_attendees ?? 0,
-    hidden: values.hidden,
+    hidden: values.hidden === "1",
   };
 };
 
@@ -82,7 +82,7 @@ const extractGroupEditInput = async (
     slugIndex: await computeGroupSlugIndex(slug),
     termsAndConditions: values.terms_and_conditions,
     maxAttendees: values.max_attendees ?? 0,
-    hidden: values.hidden,
+    hidden: values.hidden === "1",
   };
 };
 

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -67,6 +67,7 @@ const extractGroupCreateInput = async (
     slugIndex,
     termsAndConditions: values.terms_and_conditions,
     maxAttendees: values.max_attendees ?? 0,
+    hidden: values.hidden,
   };
 };
 
@@ -81,6 +82,7 @@ const extractGroupEditInput = async (
     slugIndex: await computeGroupSlugIndex(slug),
     termsAndConditions: values.terms_and_conditions,
     maxAttendees: values.max_attendees ?? 0,
+    hidden: values.hidden,
   };
 };
 

--- a/src/routes/public/pages.ts
+++ b/src/routes/public/pages.ts
@@ -2,9 +2,10 @@
  * Public pages - home, events, terms, contact
  */
 
+import { getAllGroups } from "#lib/db/groups.ts";
 import { settings } from "#lib/db/settings.ts";
 import { loadSortedEvents } from "#lib/sort-events.ts";
-import type { EventWithCount } from "#lib/types.ts";
+import type { EventWithCount, Group } from "#lib/types.ts";
 import {
   htmlResponse,
   isRegistrationClosed,
@@ -22,10 +23,14 @@ import {
 /** Active+visible filter for public event listings */
 const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;
 
-/** Load active events for the homepage, sorted and with registration status */
-const loadHomepageEvents = async (): Promise<TicketEvent[]> => {
-  const { events } = await loadSortedEvents(isPublicEvent);
-  return events.map((e) => buildTicketEvent(e, isRegistrationClosed(e)));
+/** Filter for ungrouped public events (grouped events are shown via their group) */
+const isUngroupedPublicEvent = (e: EventWithCount): boolean =>
+  isPublicEvent(e) && e.group_id === 0;
+
+/** Load non-hidden groups (for public listing) */
+const loadPublicGroups = async (): Promise<Group[]> => {
+  const groups = await getAllGroups();
+  return groups.filter((g) => !g.hidden);
 };
 
 /** Guard: redirect to admin login if public site is disabled */
@@ -51,8 +56,16 @@ export const handleHome = (): Response =>
 /** Handle GET /events - public events listing */
 export const handlePublicEvents = (): Response | Promise<Response> =>
   requirePublicSite(async () => {
-    const events = await loadHomepageEvents();
-    return htmlResponse(homepagePage(events, settings.websiteTitle));
+    const [groups, { events }] = await Promise.all([
+      loadPublicGroups(),
+      loadSortedEvents(isUngroupedPublicEvent),
+    ]);
+    const ticketEvents = events.map((e) =>
+      buildTicketEvent(e, isRegistrationClosed(e)),
+    );
+    return htmlResponse(
+      homepagePage(ticketEvents, settings.websiteTitle, groups),
+    );
   });
 
 /** Handle GET /terms - public terms and conditions page (404 when empty) */

--- a/src/routes/public/pages.ts
+++ b/src/routes/public/pages.ts
@@ -17,7 +17,6 @@ import {
   homepagePage,
   type PublicPageType,
   publicSitePage,
-  type TicketEvent,
 } from "#templates/public.tsx";
 
 /** Active+visible filter for public event listings */

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -91,7 +91,8 @@ export const groupToFieldValues = (
   const slug = group?.slug ?? "";
   const terms = group?.terms_and_conditions ?? "";
   const max_attendees = group?.max_attendees || null;
-  return { name, slug, terms_and_conditions: terms, max_attendees };
+  const hidden = group?.hidden ? "1" : "";
+  return { name, slug, terms_and_conditions: terms, max_attendees, hidden };
 };
 
 /**
@@ -296,6 +297,12 @@ export const adminGroupDetailPage = (
                   />
                 </td>
               </tr>
+              {group.hidden && (
+                <tr>
+                  <th>Hidden</th>
+                  <td>Yes &mdash; not shown in public events list</td>
+                </tr>
+              )}
               <Raw html={renderDetailRows(sharedRows)} />
             </tbody>
           </table>

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -74,7 +74,7 @@ export type GroupCreateFormValues = {
   name: string;
   terms_and_conditions: string;
   max_attendees: number | null;
-  hidden: boolean;
+  hidden: string;
 };
 
 /** Typed values from group edit form validation (includes slug) */
@@ -83,7 +83,7 @@ export type GroupFormValues = {
   slug: string;
   terms_and_conditions: string;
   max_attendees: number | null;
-  hidden: boolean;
+  hidden: string;
 };
 
 /** Typed values from ticket form (field presence varies by event config) */

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -74,6 +74,7 @@ export type GroupCreateFormValues = {
   name: string;
   terms_and_conditions: string;
   max_attendees: number | null;
+  hidden: boolean;
 };
 
 /** Typed values from group edit form validation (includes slug) */
@@ -82,6 +83,7 @@ export type GroupFormValues = {
   slug: string;
   terms_and_conditions: string;
   max_attendees: number | null;
+  hidden: boolean;
 };
 
 /** Typed values from ticket form (field presence varies by event config) */
@@ -568,6 +570,15 @@ const groupMaxAttendeesField: Field = {
   hint: "Limits total attendees across all events in this group. Leave blank for no limit. Works best when all events in the group are the same type (daily or standard).",
 };
 
+/** Hidden group field (same as event hidden field) */
+const groupHiddenField: Field = {
+  name: "hidden",
+  label: "Hidden Group",
+  type: "checkbox-group",
+  hint: "Hide from the public events page and search engines. The group is still bookable via its direct link.",
+  options: [{ value: "1", label: "Hide from public events list" }],
+};
+
 /** Group form fields for creation (no slug - auto-generated) */
 export const groupCreateFields: Field[] = [
   {
@@ -590,6 +601,7 @@ export const groupCreateFields: Field[] = [
         ? `Terms must be ${MAX_TEXTAREA_LENGTH} characters or fewer`
         : null,
   },
+  groupHiddenField,
 ];
 
 /** Group form field definitions (edit - includes slug) */
@@ -598,6 +610,7 @@ export const groupFields: Field[] = [
   slugField,
   groupCreateFields[1]!,
   groupCreateFields[2]!,
+  groupHiddenField,
 ];
 
 /** Name field shown on all ticket forms */

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -20,6 +20,7 @@ import { getImageProxyUrl } from "#lib/storage.ts";
 import {
   type EventFields,
   type EventWithCount,
+  type Group,
   isPaidEvent,
 } from "#lib/types.ts";
 import { getTicketFields, mergeEventFields } from "#templates/fields.ts";
@@ -126,6 +127,15 @@ const renderEventListing = (info: TicketEvent): string => {
   return `<div class="prose"><h2>${escapeHtml(event.name)}</h2>${descriptionHtml}</div>${detailsHtml}${linkHtml}`;
 };
 
+/** Render a single group listing for the events page (same style as events) */
+const renderGroupListing = (group: Group): string => {
+  const linkHtml = isReadOnly()
+    ? "<p><strong>Registration Closed</strong></p>"
+    : `<p><a href="/ticket/${escapeHtml(group.slug)}"><strong>Book now</strong></a></p>`;
+
+  return `<div class="prose"><h2>${escapeHtml(group.name)}</h2></div>${linkHtml}`;
+};
+
 /**
  * Homepage with events - lists all active upcoming events with booking links
  */
@@ -140,10 +150,11 @@ export const FEED_DISCOVERY_TAGS = `${RSS_DISCOVERY_TAG}\n${ICS_DISCOVERY_TAG}`;
 export const homepagePage = (
   events: TicketEvent[],
   websiteTitle?: string | null,
+  groups: Group[] = [],
 ): string => {
   const title = websiteTitle ? `Events - ${websiteTitle}` : "Events";
 
-  if (events.length === 0) {
+  if (events.length === 0 && groups.length === 0) {
     return String(
       <Layout title={title} headExtra={FEED_DISCOVERY_TAGS}>
         {websiteTitle && <h1>{websiteTitle}</h1>}
@@ -160,6 +171,10 @@ export const homepagePage = (
     );
   }
 
+  const groupListings = pipe(map(renderGroupListing), (rows: string[]) =>
+    rows.join(""),
+  )(groups);
+
   const eventListings = pipe(map(renderEventListing), (rows: string[]) =>
     rows.join(""),
   )(events);
@@ -169,6 +184,7 @@ export const homepagePage = (
       {websiteTitle && <h1>{websiteTitle}</h1>}
       <PublicNav {...navFlags()} />
       <h2>All bookable events</h2>
+      <Raw html={groupListings} />
       <Raw html={eventListings} />
       <footer class="homepage-footer">
         <p>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1905,6 +1905,7 @@ export const createTestGroup = async (
     name: overrides.name ?? "Test Group",
     termsAndConditions: overrides.termsAndConditions ?? "",
     maxAttendees: overrides.maxAttendees ?? 0,
+    hidden: overrides.hidden ?? false,
   };
 
   const group = await authenticatedFormRequest(
@@ -1913,6 +1914,7 @@ export const createTestGroup = async (
       name: input.name,
       terms_and_conditions: input.termsAndConditions,
       max_attendees: String(input.maxAttendees),
+      ...(input.hidden ? { hidden: "1" } : {}),
     },
     async () => {
       const { getAllGroups } = await import("#lib/db/groups.ts");
@@ -1928,6 +1930,7 @@ export const createTestGroup = async (
       slug: overrides.slug,
       termsAndConditions: group.terms_and_conditions,
       maxAttendees: group.max_attendees,
+      hidden: group.hidden,
     });
   }
 
@@ -1944,6 +1947,7 @@ export const updateTestGroup = async (
   const { groupsTable } = await import("#lib/db/groups.ts");
   const existing = (await groupsTable.findById(groupId)) as Group;
 
+  const hidden = updates.hidden ?? existing.hidden;
   return authenticatedFormRequest(
     `/admin/groups/${groupId}/edit`,
     {
@@ -1952,6 +1956,7 @@ export const updateTestGroup = async (
       terms_and_conditions:
         updates.termsAndConditions ?? existing.terms_and_conditions,
       max_attendees: String(updates.maxAttendees ?? existing.max_attendees),
+      ...(hidden ? { hidden: "1" } : {}),
     },
     async () => {
       const updated = await groupsTable.findById(groupId);

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1890,6 +1890,7 @@ export const testGroup = (overrides: Partial<Group> = {}): Group => ({
   slug_index: "test-group-index",
   terms_and_conditions: "",
   max_attendees: 0,
+  hidden: false,
   ...overrides,
 });
 

--- a/test/admin-api-groups.test.ts
+++ b/test/admin-api-groups.test.ts
@@ -124,6 +124,33 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
       );
     });
 
+    test("creates group with hidden flag", async () => {
+      await assertJson(
+        apiRequest("/api/admin/groups", {
+          method: "POST",
+          body: { name: "Hidden Group", hidden: true },
+        }),
+        201,
+        (body) => {
+          expect(body.group.name).toBe("Hidden Group");
+          expect(body.group.hidden).toBe(true);
+        },
+      );
+    });
+
+    test("creates group without hidden flag by default", async () => {
+      await assertJson(
+        apiRequest("/api/admin/groups", {
+          method: "POST",
+          body: { name: "Visible Group" },
+        }),
+        201,
+        (body) => {
+          expect(body.group.hidden).toBe(false);
+        },
+      );
+    });
+
     test("returns error when name is missing", async () => {
       await assertJson(
         apiRequest("/api/admin/groups", {
@@ -209,6 +236,32 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
           expect(body.group.max_attendees).toBe(100);
           expect(body.group.terms_and_conditions).toBe("Updated terms");
           expect(body.group.name).toBe("Update Fields");
+        },
+      );
+    });
+
+    test("updates hidden flag", async () => {
+      const group = await createTestGroup({ name: "Toggle Group" });
+
+      await assertJson(
+        apiRequest(`/api/admin/groups/${group.id}`, {
+          method: "PUT",
+          body: { hidden: true },
+        }),
+        200,
+        (body) => {
+          expect(body.group.hidden).toBe(true);
+        },
+      );
+
+      await assertJson(
+        apiRequest(`/api/admin/groups/${group.id}`, {
+          method: "PUT",
+          body: { hidden: false },
+        }),
+        200,
+        (body) => {
+          expect(body.group.hidden).toBe(false);
         },
       );
     });

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -141,6 +141,22 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
       expect(group.terms_and_conditions).toBe("Group terms");
     });
 
+    test("creates group with hidden flag", async () => {
+      const group = await createTestGroup({
+        name: "Hidden Group",
+        hidden: true,
+      });
+      expect(group.name).toBe("Hidden Group");
+      expect(group.hidden).toBe(true);
+    });
+
+    test("creates group without hidden flag by default", async () => {
+      const group = await createTestGroup({
+        name: "Visible Group",
+      });
+      expect(group.hidden).toBe(false);
+    });
+
     test("creates group and allows slug to be set via edit", async () => {
       const group = await createTestGroup({
         name: "New Group",
@@ -169,6 +185,17 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         "editable",
         "Original terms",
       );
+    });
+
+    test("shows hidden checkbox checked for hidden group", async () => {
+      const group = await createTestGroup({
+        name: "Hidden Editable",
+        slug: "hidden-editable",
+        hidden: true,
+      });
+      const { response } = await adminGet(`/admin/groups/${group.id}/edit`);
+      const html = await expectHtmlResponse(response, 200, "Edit Group");
+      expect(html).toContain("checked");
     });
 
     test("returns 404 for non-existent group", async () => {
@@ -214,6 +241,18 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
       expect(updated.name).toBe("After");
       expect(updated.slug).toBe("after");
       expect(updated.terms_and_conditions).toBe("Updated terms");
+    });
+
+    test("updates group hidden flag", async () => {
+      const group = await createTestGroup({
+        name: "Toggle Hidden",
+        slug: "toggle-hidden",
+      });
+      expect(group.hidden).toBe(false);
+      const updated = await updateTestGroup(group.id, { hidden: true });
+      expect(updated.hidden).toBe(true);
+      const unhidden = await updateTestGroup(group.id, { hidden: false });
+      expect(unhidden.hidden).toBe(false);
     });
 
     test("rejects slug collision with another group", async () => {
@@ -420,6 +459,31 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         "Embed Iframe",
         "iframe",
       );
+    });
+
+    test("shows hidden status on detail page when group is hidden", async () => {
+      const group = await createTestGroup({
+        name: "Hidden Detail",
+        slug: "hidden-detail",
+        hidden: true,
+      });
+      const { response } = await adminGet(`/admin/groups/${group.id}`);
+      await expectHtmlResponse(
+        response,
+        200,
+        "Hidden",
+        "not shown in public events list",
+      );
+    });
+
+    test("does not show hidden status when group is visible", async () => {
+      const group = await createTestGroup({
+        name: "Visible Detail",
+        slug: "visible-detail",
+      });
+      const { response } = await adminGet(`/admin/groups/${group.id}`);
+      const html = await response.text();
+      expect(html).not.toContain("not shown in public events list");
     });
 
     test("shows empty events message when group has no events", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -242,6 +242,86 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(response.headers.has("x-robots-noindex")).toBe(false);
     });
 
+    test("shows groups with active events on events page", async () => {
+      await settings.update.showPublicSite(true);
+      const group = await createTestGroup({
+        name: "Summer Festival",
+        slug: "summer-festival",
+      });
+      await createTestEvent({
+        name: "Festival Event",
+        groupId: group.id,
+        maxAttendees: 50,
+      });
+      const response = await handleRequest(mockRequest("/events"));
+      await expectHtmlResponse(
+        response,
+        200,
+        "Summer Festival",
+        `href="/ticket/${group.slug}"`,
+        "Book now",
+      );
+    });
+
+    test("does not show hidden groups on events page", async () => {
+      await settings.update.showPublicSite(true);
+      const group = await createTestGroup({
+        name: "Secret Group",
+        slug: "secret-group",
+        hidden: true,
+      });
+      await createTestEvent({
+        name: "Secret Group Event",
+        groupId: group.id,
+        maxAttendees: 50,
+      });
+      const response = await handleRequest(mockRequest("/events"));
+      const html = await response.text();
+      expect(html).not.toContain("Secret Group");
+    });
+
+    test("hidden group is still accessible via direct ticket URL", async () => {
+      const group = await createTestGroup({
+        name: "Hidden Group",
+        slug: "hidden-group",
+        hidden: true,
+      });
+      await createTestEvent({
+        name: "Hidden Group Event",
+        groupId: group.id,
+        maxAttendees: 50,
+      });
+      const response = await handleRequest(
+        mockRequest(`/ticket/${group.slug}`),
+      );
+      await expectHtmlResponse(response, 200, "Hidden Group Event");
+    });
+
+    test("grouped events do not appear individually on events page", async () => {
+      await settings.update.showPublicSite(true);
+      const group = await createTestGroup({
+        name: "My Group",
+        slug: "my-group",
+      });
+      await createTestEvent({
+        name: "Grouped Event",
+        groupId: group.id,
+        maxAttendees: 50,
+      });
+      await createTestEvent({
+        name: "Ungrouped Event",
+        maxAttendees: 50,
+      });
+      const response = await handleRequest(mockRequest("/events"));
+      const html = await expectHtmlResponse(
+        response,
+        200,
+        "My Group",
+        "Ungrouped Event",
+      );
+      expect(html).not.toContain("Grouped Event");
+    });
+
     test("shows sold out for events at capacity", async () => {
       await settings.update.showPublicSite(true);
       const event = await createTestEvent({

--- a/test/routes/read-only.test.ts
+++ b/test/routes/read-only.test.ts
@@ -165,6 +165,38 @@ describeWithEnv(
       expect(res.headers.get("location")).not.toBe("/read-only");
     });
 
+    test("groups on events page show Registration Closed in read-only mode", async () => {
+      const { settings } = await import("#lib/db/settings.ts");
+      const { groupsTable, computeGroupSlugIndex } = await import(
+        "#lib/db/groups.ts"
+      );
+      const { eventsTable, computeSlugIndex } = await import(
+        "#lib/db/events.ts"
+      );
+      await settings.update.showPublicSite(true);
+      const slugIndex = await computeGroupSlugIndex("ro-group");
+      const group = await groupsTable.insert({
+        name: "Read Only Group",
+        slug: "ro-group",
+        slugIndex,
+        termsAndConditions: "",
+        maxAttendees: 0,
+        hidden: false,
+      });
+      await eventsTable.insert({
+        name: "RO Event",
+        slug: "ro-event",
+        slugIndex: await computeSlugIndex("ro-event"),
+        maxAttendees: 50,
+        maxPrice: 0,
+        groupId: group.id,
+      });
+      const res = await handleRequest(mockRequest("/events"));
+      const html = await res.text();
+      expect(html).toContain("Read Only Group");
+      expect(html).toContain("Registration Closed");
+    });
+
     test("GET /ticket/my-event is allowed (view form)", async () => {
       const res = await handleRequest(mockRequest("/ticket/my-event"));
       // 404 (no such event) is fine — not blocked by read-only


### PR DESCRIPTION
## Summary
This PR adds a "hidden" flag to groups, allowing administrators to hide groups from the public events page while keeping them accessible via direct links. This enables more control over which groups appear in public listings.

## Key Changes

- **Database Schema**: Added `hidden` boolean column to the groups table (defaults to false)

- **Group Model & API**: 
  - Added `hidden` field to `Group` type and `GroupInput`
  - Updated admin API endpoints to accept and return the `hidden` flag
  - Added support for creating and updating groups with the hidden flag

- **Admin UI**:
  - Added "Hidden Group" checkbox field to group creation and edit forms
  - Display hidden status on group detail pages with explanatory text
  - Form values properly convert between checkbox state and boolean

- **Public Events Page**:
  - Modified to display groups separately from ungrouped events
  - Only shows non-hidden groups in the public listing
  - Grouped events no longer appear individually on the events page
  - Hidden groups remain accessible via direct `/ticket/{slug}` URLs

- **Read-Only Mode**: Groups on the events page properly display "Registration Closed" status in read-only mode

- **Test Coverage**: Comprehensive tests added for:
  - Creating groups with/without hidden flag
  - Hiding/showing groups on public events page
  - Direct access to hidden groups via URL
  - Grouped vs ungrouped event display
  - Admin UI checkbox state
  - API endpoints for hidden flag management

## Implementation Details

The public events page now loads both groups and ungrouped events separately, filtering out hidden groups while still allowing direct access. The feature integrates seamlessly with existing registration status indicators and read-only mode behavior.

https://claude.ai/code/session_01PYharpizKYR5zdir6m6Bp2