### PR TITLE
Add purchase_only event type for non-attendance items

### DIFF
--- a/src/lib/api-example.ts
+++ b/src/lib/api-example.ts
@@ -41,6 +41,7 @@ export const API_EXAMPLE_EVENT: EventWithCount = {
   can_pay_more: false,
   max_price: EXAMPLE_EVENT.unit_price,
   hidden: false,
+  purchase_only: false,
   attendee_count: 3,
 };
 

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -64,6 +64,7 @@ export type EventInput = {
   canPayMore?: boolean;
   maxPrice: number;
   hidden?: boolean;
+  purchaseOnly?: boolean;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -162,6 +163,7 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
   can_pay_more: col.boolean(false),
   max_price: col.withDefault(() => 0),
   hidden: col.boolean(false),
+  purchase_only: col.boolean(false),
 });
 
 export const eventsTable = withCacheInvalidation(rawEventsTable, () =>

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -80,6 +80,7 @@ const SCHEMA: [name: string, table: Table][] = [
         ["non_transferable", "INTEGER NOT NULL DEFAULT 0"],
         ["can_pay_more", "INTEGER NOT NULL DEFAULT 0"],
         ["hidden", "INTEGER NOT NULL DEFAULT 0"],
+        ["purchase_only", "INTEGER NOT NULL DEFAULT 0"],
         ["max_price", "INTEGER NOT NULL DEFAULT 0"],
       ],
       indexes: [

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -19,6 +19,7 @@ import type { WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
 export type EmailEvent = WebhookEvent & {
   date: string;
   location: string;
+  purchase_only: boolean;
 };
 
 /** Attendee + event pair for email rendering */
@@ -274,6 +275,7 @@ export const buildSvgTicketData = (
   pricePaid: entry.attendee.price_paid,
   currency,
   checkinUrl: `https://${getEffectiveDomain()}/checkin/${entry.attendee.ticket_token}`,
+  purchaseOnly: entry.event.purchase_only,
 });
 
 /** Generate SVG ticket attachments for all entries */

--- a/src/lib/svg-ticket.ts
+++ b/src/lib/svg-ticket.ts
@@ -19,7 +19,7 @@ export type SvgTicketData = Pick<
   | "attendeeDate"
   | "quantity"
   | "checkinUrl"
-> & { pricePaid: string; currency: string };
+> & { pricePaid: string; currency: string; purchaseOnly?: boolean };
 
 /** SVG dimensions */
 const WIDTH = 400;
@@ -77,18 +77,8 @@ export const buildInfoLines = (data: SvgTicketData): string[] => {
 export const generateSvgTicket = async (
   data: SvgTicketData,
 ): Promise<string> => {
-  const qrSvg = await generateQrSvg(data.checkinUrl);
-  const qrViewBox = extractViewBox(qrSvg);
-  const qrContent = extractSvgContent(qrSvg);
-  const scale = QR_SIZE / qrViewBox.width;
-
   const infoLines = buildInfoLines(data);
   const infoHeight = infoLines.length * LINE_HEIGHT;
-
-  const qrY = HEADER_Y + infoHeight + 16;
-  const totalHeight = qrY + QR_SIZE + MARGIN;
-  const qrX = (WIDTH - QR_SIZE) / 2;
-
   const escapedName = escapeHtml(data.eventName);
   const linesSvg = infoLines
     .map(
@@ -96,6 +86,25 @@ export const generateSvgTicket = async (
         `<text x="${MARGIN}" y="${HEADER_Y + (i + 1) * LINE_HEIGHT}" font-family="sans-serif" font-size="13" fill="#555">${escapeHtml(line)}</text>`,
     )
     .join("\n    ");
+
+  if (data.purchaseOnly) {
+    const totalHeight = HEADER_Y + infoHeight + MARGIN;
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${totalHeight}" viewBox="0 0 ${WIDTH} ${totalHeight}">
+  <rect width="${WIDTH}" height="${totalHeight}" rx="8" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="${MARGIN}" y="${HEADER_Y}" font-family="sans-serif" font-size="18" font-weight="bold" fill="#333">${escapedName}</text>
+    ${linesSvg}
+</svg>`;
+  }
+
+  const qrSvg = await generateQrSvg(data.checkinUrl);
+  const qrViewBox = extractViewBox(qrSvg);
+  const qrContent = extractSvgContent(qrSvg);
+  const scale = QR_SIZE / qrViewBox.width;
+
+  const qrY = HEADER_Y + infoHeight + 16;
+  const totalHeight = qrY + QR_SIZE + MARGIN;
+  const qrX = (WIDTH - QR_SIZE) / 2;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${totalHeight}" viewBox="0 0 ${WIDTH} ${totalHeight}">

--- a/src/lib/svg-ticket.ts
+++ b/src/lib/svg-ticket.ts
@@ -87,32 +87,24 @@ export const generateSvgTicket = async (
     )
     .join("\n    ");
 
-  if (data.purchaseOnly) {
-    const totalHeight = HEADER_Y + infoHeight + MARGIN;
-    return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${totalHeight}" viewBox="0 0 ${WIDTH} ${totalHeight}">
-  <rect width="${WIDTH}" height="${totalHeight}" rx="8" fill="#fff" stroke="#ddd" stroke-width="1"/>
-  <text x="${MARGIN}" y="${HEADER_Y}" font-family="sans-serif" font-size="18" font-weight="bold" fill="#333">${escapedName}</text>
-    ${linesSvg}
-</svg>`;
+  let qrSection = "";
+  let totalHeight = HEADER_Y + infoHeight + MARGIN;
+
+  if (!data.purchaseOnly) {
+    const qrSvg = await generateQrSvg(data.checkinUrl);
+    const qrViewBox = extractViewBox(qrSvg);
+    const qrContent = extractSvgContent(qrSvg);
+    const scale = QR_SIZE / qrViewBox.width;
+    const qrY = HEADER_Y + infoHeight + 16;
+    const qrX = (WIDTH - QR_SIZE) / 2;
+    totalHeight = qrY + QR_SIZE + MARGIN;
+    qrSection = `\n  <g transform="translate(${qrX}, ${qrY}) scale(${scale})">\n    ${qrContent}\n  </g>`;
   }
-
-  const qrSvg = await generateQrSvg(data.checkinUrl);
-  const qrViewBox = extractViewBox(qrSvg);
-  const qrContent = extractSvgContent(qrSvg);
-  const scale = QR_SIZE / qrViewBox.width;
-
-  const qrY = HEADER_Y + infoHeight + 16;
-  const totalHeight = qrY + QR_SIZE + MARGIN;
-  const qrX = (WIDTH - QR_SIZE) / 2;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${totalHeight}" viewBox="0 0 ${WIDTH} ${totalHeight}">
   <rect width="${WIDTH}" height="${totalHeight}" rx="8" fill="#fff" stroke="#ddd" stroke-width="1"/>
   <text x="${MARGIN}" y="${HEADER_Y}" font-family="sans-serif" font-size="18" font-weight="bold" fill="#333">${escapedName}</text>
-    ${linesSvg}
-  <g transform="translate(${qrX}, ${qrY}) scale(${scale})">
-    ${qrContent}
-  </g>
+    ${linesSvg}${qrSection}
 </svg>`;
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,6 +100,7 @@ export interface Event {
   can_pay_more: boolean;
   max_price: number;
   hidden: boolean;
+  purchase_only: boolean;
 }
 
 export interface Attendee extends ContactInfo {

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -133,6 +133,7 @@ const extractCommonFields = (values: EventFormValues) => {
     canPayMore: values.can_pay_more === "1",
     maxPrice: toMinorUnits(Number.parseFloat(values.max_price)),
     hidden: values.hidden === "1",
+    purchaseOnly: values.purchase_only === "1",
   };
 };
 

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -803,6 +803,7 @@ const PREVIEW_BOOKINGS = [
       can_pay_more: false,
       date: "2026-07-15T19:00:00Z",
       location: "Town Hall",
+      purchase_only: false,
     },
     attendee: {
       id: 1,
@@ -830,6 +831,7 @@ const PREVIEW_BOOKINGS = [
       can_pay_more: false,
       date: "",
       location: "",
+      purchase_only: false,
     },
     attendee: {
       id: 2,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -62,6 +62,7 @@ export type PublicEvent = {
   canPayMore: boolean;
   maxPrice: number;
   nonTransferable: boolean;
+  purchaseOnly: boolean;
   fields: string;
   eventType: string;
   isSoldOut: boolean;
@@ -92,6 +93,7 @@ export const toPublicEvent = (
     canPayMore: event.can_pay_more,
     maxPrice: event.max_price,
     nonTransferable: event.non_transferable,
+    purchaseOnly: event.purchase_only,
     fields: event.fields,
     eventType: event.event_type,
     isSoldOut,

--- a/src/routes/feeds.ts
+++ b/src/routes/feeds.ts
@@ -45,7 +45,8 @@ type FeedData = { events: EventWithCount[]; domain: string; title: string };
 /** Load feed data: active open events with domain and title */
 const loadFeedData = async (): Promise<FeedData> => {
   const { events } = await loadSortedEvents(
-    (e) => e.active && !e.hidden && !isRegistrationClosed(e),
+    (e) =>
+      e.active && !e.hidden && !e.purchase_only && !isRegistrationClosed(e),
   );
   return {
     events,

--- a/src/routes/public/ticket-routes.ts
+++ b/src/routes/public/ticket-routes.ts
@@ -8,7 +8,6 @@ import { computeGroupSlugIndex, getGroupBySlugIndex } from "#lib/db/groups.ts";
 import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
-import { lookupAttendees, resolveEntries } from "#routes/token-utils.ts";
 import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { successPage } from "#templates/payment.tsx";
 import { handleGroupTicketBySlug } from "./groups.ts";
@@ -30,15 +29,7 @@ const handleReservedGet = async (request: Request): Promise<Response> => {
   const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
   const fromEmail = tokens.length > 0 ? await getFromEmailIfConfigured() : "";
 
-  let purchaseOnly = false;
-  if (tokens.length > 0) {
-    const result = await lookupAttendees(tokens);
-    if (result.ok) {
-      const entries = await resolveEntries(result.attendees);
-      purchaseOnly = entries.every((e) => e.event.purchase_only);
-    }
-  }
-  return htmlResponse(successPage({ ticketUrl, fromEmail, purchaseOnly }));
+  return htmlResponse(successPage({ ticketUrl, fromEmail }));
 };
 
 /** Handle ticket request: try events by slugs, fall back to group for single slugs */

--- a/src/routes/public/ticket-routes.ts
+++ b/src/routes/public/ticket-routes.ts
@@ -8,6 +8,7 @@ import { computeGroupSlugIndex, getGroupBySlugIndex } from "#lib/db/groups.ts";
 import { getEmailConfig, getHostEmailConfig } from "#lib/email.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
+import { lookupAttendees, resolveEntries } from "#routes/token-utils.ts";
 import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { successPage } from "#templates/payment.tsx";
 import { handleGroupTicketBySlug } from "./groups.ts";
@@ -29,7 +30,14 @@ const handleReservedGet = async (request: Request): Promise<Response> => {
   const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
   const fromEmail = tokens.length > 0 ? await getFromEmailIfConfigured() : "";
 
-  const purchaseOnly = url.searchParams.get("po") === "1";
+  let purchaseOnly = false;
+  if (tokens.length > 0) {
+    const result = await lookupAttendees(tokens);
+    if (result.ok) {
+      const entries = await resolveEntries(result.attendees);
+      purchaseOnly = entries.every((e) => e.event.purchase_only);
+    }
+  }
   return htmlResponse(successPage({ ticketUrl, fromEmail, purchaseOnly }));
 };
 

--- a/src/routes/public/ticket-routes.ts
+++ b/src/routes/public/ticket-routes.ts
@@ -29,7 +29,8 @@ const handleReservedGet = async (request: Request): Promise<Response> => {
   const ticketUrl = tokens.length > 0 ? `/t/${tokens.join("+")}` : null;
   const fromEmail = tokens.length > 0 ? await getFromEmailIfConfigured() : "";
 
-  return htmlResponse(successPage({ ticketUrl, fromEmail }));
+  const purchaseOnly = url.searchParams.get("po") === "1";
+  return htmlResponse(successPage({ ticketUrl, fromEmail, purchaseOnly }));
 };
 
 /** Handle ticket request: try events by slugs, fall back to group for single slugs */

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -217,7 +217,9 @@ const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
       }
 
       const tokens = encodeURIComponent(result.tokens.join("+"));
-      return redirectResponse(`/ticket/reserved?tokens=${tokens}`);
+      const allPurchaseOnly = ctx.events.every((e) => e.event.purchase_only);
+      const poParam = allPurchaseOnly ? "&po=1" : "";
+      return redirectResponse(`/ticket/reserved?tokens=${tokens}${poParam}`);
     },
   );
 

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -217,9 +217,7 @@ const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
       }
 
       const tokens = encodeURIComponent(result.tokens.join("+"));
-      const allPurchaseOnly = ctx.events.every((e) => e.event.purchase_only);
-      const poParam = allPurchaseOnly ? "&po=1" : "";
-      return redirectResponse(`/ticket/reserved?tokens=${tokens}${poParam}`);
+      return redirectResponse(`/ticket/reserved?tokens=${tokens}`);
     },
   );
 

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -303,9 +303,11 @@ export const adminEventPage = ({
           <li>
             <a href={`/admin/event/${event.id}/log`}>Log</a>
           </li>
-          <li>
-            <a href={`/admin/event/${event.id}/scanner`}>Scanner</a>
-          </li>
+          {!event.purchase_only && (
+            <li>
+              <a href={`/admin/event/${event.id}/scanner`}>Scanner</a>
+            </li>
+          )}
           <li>
             <a href={`/admin/event/${event.id}/questions`}>Questions</a>
           </li>

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -62,6 +62,7 @@ export type EventFormValues = {
   can_pay_more: string;
   max_price: string;
   hidden: string;
+  purchase_only: string;
 };
 
 /** Typed values from event edit form (includes slug) */
@@ -466,6 +467,13 @@ export const eventFields: Field[] = [
     type: "checkbox-group",
     hint: "Hide from the public events page and search engines. The event is still bookable via its direct link.",
     options: [{ value: "1", label: "Hide from public events list" }],
+  },
+  {
+    name: "purchase_only",
+    label: "Purchase Only",
+    type: "checkbox-group",
+    hint: "For raffles, fundraisers, donations, or other non-attendance items. Hides QR codes, check-in, and wallet passes. Shows \u2018Buy now\u2019 instead of \u2018Reserve\u2019.",
+    options: [{ value: "1", label: "No attendance required" }],
   },
 ];
 

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -48,28 +48,16 @@ export const successPage = ({
   thankYouUrl = "",
   paid = false,
   fromEmail = "",
-  purchaseOnly = false,
 }: {
   ticketUrl: string | null;
   thankYouUrl?: string;
   paid?: boolean;
   fromEmail?: string;
-  purchaseOnly?: boolean;
 }): string => {
   const inIframe = getIframeMode();
-  const title = paid
-    ? "Payment Successful"
-    : purchaseOnly
-      ? "Purchase Complete"
-      : "Ticket Reserved";
-  const heading = paid
-    ? "Payment Successful!"
-    : purchaseOnly
-      ? "Purchase complete."
-      : "Ticket reserved successfully.";
   return String(
     <Layout
-      title={title}
+      title="Order Successful"
       headExtra={
         thankYouUrl
           ? `<meta http-equiv="refresh" content="3;url=${escapeHtml(thankYouUrl)}">`
@@ -81,12 +69,7 @@ export const successPage = ({
         data-payment-result={paid ? "success" : undefined}
         data-scroll-into-view={inIframe || undefined}
       >
-        <h1>{heading}</h1>
-        {paid ? (
-          <div class="success" role="alert">
-            <p>Thank you for your payment. Your ticket has been confirmed.</p>
-          </div>
-        ) : null}
+        <h1>Thank you for your order.</h1>
         {fromEmail ? (
           <p>
             <small>

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -48,17 +48,25 @@ export const successPage = ({
   thankYouUrl = "",
   paid = false,
   fromEmail = "",
+  purchaseOnly = false,
 }: {
   ticketUrl: string | null;
   thankYouUrl?: string;
   paid?: boolean;
   fromEmail?: string;
+  purchaseOnly?: boolean;
 }): string => {
   const inIframe = getIframeMode();
-  const title = paid ? "Payment Successful" : "Ticket Reserved";
+  const title = paid
+    ? "Payment Successful"
+    : purchaseOnly
+      ? "Purchase Complete"
+      : "Ticket Reserved";
   const heading = paid
     ? "Payment Successful!"
-    : "Ticket reserved successfully.";
+    : purchaseOnly
+      ? "Purchase complete."
+      : "Ticket reserved successfully.";
   return String(
     <Layout
       title={title}

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -462,12 +462,7 @@ export const ticketPage = ({
   const title = singleEvent ? singleEvent.name : "Reserve Tickets";
   const headExtra =
     singleEvent && baseUrl ? buildOgTags(singleEvent, baseUrl) : undefined;
-  const allPurchaseOnly = events.every((e) => e.event.purchase_only);
-  const buttonText = allPurchaseOnly
-    ? "Buy now"
-    : isSingleEvent && hideQuantity
-      ? "Reserve Ticket"
-      : "Reserve Tickets";
+  const buttonText = "Continue";
 
   return String(
     <Layout

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -117,11 +117,12 @@ const renderEventListing = (info: TicketEvent): string => {
   const descriptionHtml = event.description
     ? `<p>${renderMarkdownInline(event.description)}</p>`
     : "";
+  const bookLabel = event.purchase_only ? "Buy now" : "Book now";
   const linkHtml = isSoldOut
     ? "<p><strong>Sold Out</strong></p>"
     : isClosed || isReadOnly()
       ? "<p><strong>Registration Closed</strong></p>"
-      : `<p><a href="/ticket/${escapeHtml(event.slug)}"><strong>Book now</strong></a></p>`;
+      : `<p><a href="/ticket/${escapeHtml(event.slug)}"><strong>${bookLabel}</strong></a></p>`;
 
   return `<div class="prose"><h2>${escapeHtml(event.name)}</h2>${descriptionHtml}</div>${detailsHtml}${linkHtml}`;
 };
@@ -461,8 +462,12 @@ export const ticketPage = ({
   const title = singleEvent ? singleEvent.name : "Reserve Tickets";
   const headExtra =
     singleEvent && baseUrl ? buildOgTags(singleEvent, baseUrl) : undefined;
-  const buttonText =
-    isSingleEvent && hideQuantity ? "Reserve Ticket" : "Reserve Tickets";
+  const allPurchaseOnly = events.every((e) => e.event.purchase_only);
+  const buttonText = allPurchaseOnly
+    ? "Buy now"
+    : isSingleEvent && hideQuantity
+      ? "Reserve Ticket"
+      : "Reserve Tickets";
 
   return String(
     <Layout

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -63,16 +63,19 @@ const renderTicketCard = (
       ? `<div class="ticket-card-price">Price: ${escapeHtml(formatCurrency(pricePaid))}</div>`
       : "";
 
-  const nonTransferableHtml = event.non_transferable
-    ? `<div class="ticket-card-notice">Non-transferable &mdash; ID required at entry</div>`
-    : "";
+  const nonTransferableHtml =
+    event.non_transferable && !event.purchase_only
+      ? `<div class="ticket-card-notice">Non-transferable &mdash; ID required at entry</div>`
+      : "";
 
-  const walletLinks = [
-    appleWalletEnabled ? renderAppleWalletLink(token) : "",
-    googleWalletEnabled ? renderGoogleWalletLink(token) : "",
-  ]
-    .filter(Boolean)
-    .join(" / ");
+  const walletLinks = event.purchase_only
+    ? ""
+    : [
+        appleWalletEnabled ? renderAppleWalletLink(token) : "",
+        googleWalletEnabled ? renderGoogleWalletLink(token) : "",
+      ]
+        .filter(Boolean)
+        .join(" / ");
   const walletHtml = walletLinks
     ? `<div class="ticket-card-wallet">Add to: ${walletLinks}</div>`
     : "";
@@ -93,8 +96,12 @@ const renderTicketCard = (
       <div class="ticket-card-quantity">Quantity: ${attendee.quantity}</div>
       ${priceHtml}
       ${attachmentHtml}
-      <div class="ticket-card-qr"><img src="/t/${escapeHtml(token)}/svg" alt="QR code" /></div>
-      <div class="ticket-card-token">${escapeHtml(token)}</div>
+      ${
+        event.purchase_only
+          ? ""
+          : `<div class="ticket-card-qr"><img src="/t/${escapeHtml(token)}/svg" alt="QR code" /></div>
+      <div class="ticket-card-token">${escapeHtml(token)}</div>`
+      }
       ${walletHtml}
     </div>
   `;
@@ -116,9 +123,13 @@ export const ticketViewPage = (
     (c: string[]) => c.join(""),
   )(cards);
 
+  const allPurchaseOnly = cards.every((c) => c.entry.event.purchase_only);
+  const heading = allPurchaseOnly ? "Your Purchase" : ticketCount(cards.length);
+  const title = allPurchaseOnly ? "Your Purchase" : "Your Tickets";
+
   return String(
-    <Layout title="Your Tickets">
-      <h1>{ticketCount(cards.length)}</h1>
+    <Layout title={title}>
+      <h1>{heading}</h1>
       <div class="ticket-slider">
         <Raw html={cardHtml} />
       </div>

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1063,6 +1063,7 @@ export const createTestEvent = (
       can_pay_more: input.canPayMore ? "1" : "",
       max_price: priceFormValue(input.maxPrice),
       hidden: input.hidden ? "1" : "",
+      purchase_only: input.purchaseOnly ? "1" : "",
     },
     async () => {
       // Get the most recently created event (302 redirect guarantees creation succeeded)
@@ -1605,6 +1606,7 @@ export const testEvent = (overrides: Partial<Event> = {}): Event => ({
   can_pay_more: false,
   max_price: 0,
   hidden: false,
+  purchase_only: false,
   ...overrides,
 });
 
@@ -2561,6 +2563,7 @@ export const makeTestEvent = (
   can_pay_more: false,
   date: "",
   location: "",
+  purchase_only: false,
   ...overrides,
 });
 

--- a/test/e2e/booking.test.ts
+++ b/test/e2e/booking.test.ts
@@ -208,13 +208,9 @@ describe("e2e: full booking flow", () => {
     expect(mediumMatch).toBeTruthy();
     formData[mediumMatch![1]!] = mediumMatch![2]!;
 
-    // Group bookings use "Reserve Tickets" (plural), single events use "Reserve Ticket"
-    const reserveButton = browser.containsText("Reserve Tickets")
-      ? "Reserve Tickets"
-      : "Reserve Ticket";
-    await browser.submitForm(formData, reserveButton);
+    await browser.submitForm(formData, "Continue");
     // Should be on the success page
-    expect(browser.containsText("reserved successfully")).toBe(true);
+    expect(browser.containsText("Thank you for your order")).toBe(true);
 
     // 10. Click to view the ticket
     await browser.clickLink("Click here to view your ticket");

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -780,6 +780,16 @@ describe("html", () => {
       expect(html).not.toContain("Reserve Tickets"); // Not plural
     });
 
+    test("shows Buy now button for purchase_only event", () => {
+      const poEvent = testEventWithCount({
+        attendee_count: 50,
+        purchase_only: true,
+      });
+      const html = renderTicket(poEvent);
+      expect(html).toContain("Buy now");
+      expect(html).not.toContain("Reserve Ticket");
+    });
+
     test("shows phone field for phone-only events", () => {
       const phoneEvent = testEventWithCount({
         attendee_count: 50,
@@ -1150,6 +1160,26 @@ describe("html", () => {
     test("does not show email notice when fromEmail is empty", () => {
       const html = successPage({ ticketUrl: "/t/abc123", paid: true });
       expect(html).not.toContain("Junk/Spam");
+    });
+
+    test("renders purchase complete message for purchaseOnly", () => {
+      const html = successPage({
+        ticketUrl: "/t/abc123",
+        purchaseOnly: true,
+      });
+      expect(html).toContain("Purchase Complete");
+      expect(html).toContain("Purchase complete.");
+      expect(html).not.toContain("Ticket Reserved");
+    });
+
+    test("renders payment successful for paid purchaseOnly events", () => {
+      const html = successPage({
+        ticketUrl: "/t/abc123",
+        paid: true,
+        purchaseOnly: true,
+      });
+      expect(html).toContain("Payment Successful");
+      expect(html).not.toContain("Purchase Complete");
     });
   });
 
@@ -3677,6 +3707,92 @@ describe("html", () => {
       expect(html).toContain("/t/AABB0011CCDDEEF1/svg");
       expect(html).toContain("/t/AABB0011CCDDEEF2/svg");
       expect(html).toContain("2 Tickets");
+    });
+
+    test("hides QR code and token for purchase_only events", () => {
+      const cards = [
+        {
+          entry: {
+            event: testEventWithCount({ purchase_only: true }),
+            attendee: testAttendee(),
+          },
+          token,
+        },
+      ];
+      const html = ticketViewPage(cards);
+      expect(html).not.toContain("ticket-card-qr");
+      expect(html).not.toContain("ticket-card-token");
+      expect(html).not.toContain("/svg");
+    });
+
+    test("hides wallet links for purchase_only events", () => {
+      const cards = [
+        {
+          entry: {
+            event: testEventWithCount({ purchase_only: true }),
+            attendee: testAttendee(),
+          },
+          token,
+        },
+      ];
+      const html = ticketViewPage(cards, true, true);
+      expect(html).not.toContain("wallet-link");
+      expect(html).not.toContain("Apple Wallet");
+      expect(html).not.toContain("Google Wallet");
+    });
+
+    test("hides non-transferable notice for purchase_only events", () => {
+      const cards = [
+        {
+          entry: {
+            event: testEventWithCount({
+              purchase_only: true,
+              non_transferable: true,
+            }),
+            attendee: testAttendee(),
+          },
+          token,
+        },
+      ];
+      const html = ticketViewPage(cards);
+      expect(html).not.toContain("Non-transferable");
+    });
+
+    test("shows Your Purchase heading for purchase_only events", () => {
+      const cards = [
+        {
+          entry: {
+            event: testEventWithCount({ purchase_only: true }),
+            attendee: testAttendee(),
+          },
+          token,
+        },
+      ];
+      const html = ticketViewPage(cards);
+      expect(html).toContain("Your Purchase");
+      expect(html).not.toContain("Ticket");
+    });
+
+    test("shows ticket count heading for mixed events", () => {
+      const cards = [
+        {
+          entry: {
+            event: testEventWithCount({ id: 1, purchase_only: true }),
+            attendee: testAttendee({ id: 1 }),
+          },
+          token: "AABB0011CCDDEEF1",
+        },
+        {
+          entry: {
+            event: testEventWithCount({ id: 2, purchase_only: false }),
+            attendee: testAttendee({ id: 2 }),
+          },
+          token: "AABB0011CCDDEEF2",
+        },
+      ];
+      const html = ticketViewPage(cards);
+      expect(html).toContain("2 Tickets");
+      expect(html).not.toContain("Your Purchase");
     });
   });
 

--- a/test/lib/html.test.ts
+++ b/test/lib/html.test.ts
@@ -717,7 +717,7 @@ describe("html", () => {
       expect(html).toContain('action="/ticket/ab12c"');
       expect(html).toContain('name="name"');
       expect(html).toContain('name="email"');
-      expect(html).toContain("Reserve Ticket");
+      expect(html).toContain("Continue");
     });
 
     test("includes CSRF token in form", () => {
@@ -756,7 +756,7 @@ describe("html", () => {
       expect(html).toContain(`name="quantity_${multiQtyEvent.id}"`);
       expect(html).toContain('<option value="1">1</option>');
       expect(html).toContain('<option value="5">5</option>');
-      expect(html).toContain("Reserve Tickets"); // Plural
+      expect(html).toContain("Continue");
     });
 
     test("limits quantity selector to remaining spots", () => {
@@ -776,18 +776,16 @@ describe("html", () => {
       expect(html).toContain(
         `type="hidden" name="quantity_${event.id}" value="1"`,
       );
-      expect(html).toContain("Reserve Ticket"); // Singular
-      expect(html).not.toContain("Reserve Tickets"); // Not plural
+      expect(html).toContain("Continue");
     });
 
-    test("shows Buy now button for purchase_only event", () => {
+    test("shows Continue button for purchase_only event", () => {
       const poEvent = testEventWithCount({
         attendee_count: 50,
         purchase_only: true,
       });
       const html = renderTicket(poEvent);
-      expect(html).toContain("Buy now");
-      expect(html).not.toContain("Reserve Ticket");
+      expect(html).toContain("Continue");
     });
 
     test("shows phone field for phone-only events", () => {
@@ -1047,21 +1045,20 @@ describe("html", () => {
   });
 
   describe("successPage", () => {
-    test("renders payment success message when paid", () => {
+    test("renders order success message when paid", () => {
       const html = successPage({
         ticketUrl: null,
         thankYouUrl: "https://example.com/thanks",
         paid: true,
       });
-      expect(html).toContain("Payment Successful");
+      expect(html).toContain("Thank you for your order");
       expect(html).toContain("https://example.com/thanks");
     });
 
-    test("renders reservation success message when not paid", () => {
+    test("renders order success message when not paid", () => {
       const html = successPage({ ticketUrl: "/t/abc123" });
-      expect(html).toContain("Ticket Reserved");
-      expect(html).toContain("Ticket reserved successfully.");
-      expect(html).not.toContain("Payment Successful");
+      expect(html).toContain("Order Successful");
+      expect(html).toContain("Thank you for your order");
     });
 
     test("includes meta refresh redirect", () => {
@@ -1162,25 +1159,6 @@ describe("html", () => {
       expect(html).not.toContain("Junk/Spam");
     });
 
-    test("renders purchase complete message for purchaseOnly", () => {
-      const html = successPage({
-        ticketUrl: "/t/abc123",
-        purchaseOnly: true,
-      });
-      expect(html).toContain("Purchase Complete");
-      expect(html).toContain("Purchase complete.");
-      expect(html).not.toContain("Ticket Reserved");
-    });
-
-    test("renders payment successful for paid purchaseOnly events", () => {
-      const html = successPage({
-        ticketUrl: "/t/abc123",
-        paid: true,
-        purchaseOnly: true,
-      });
-      expect(html).toContain("Payment Successful");
-      expect(html).not.toContain("Purchase Complete");
-    });
   });
 
   describe("paymentCancelPage", () => {
@@ -4428,7 +4406,7 @@ describeWithEnv(
         dates: [],
       });
       expect(html).toContain("Registration closed.");
-      expect(html).not.toContain("Reserve Ticket");
+      expect(html).not.toContain("Continue");
     });
   },
 );

--- a/test/lib/server-feeds.test.ts
+++ b/test/lib/server-feeds.test.ts
@@ -173,6 +173,19 @@ describeWithEnv("feeds", { db: true }, () => {
       expect(body).not.toContain("BEGIN:VEVENT");
     });
 
+    test("excludes purchase_only events", async () => {
+      await settings.update.showPublicSite(true);
+      await createTestEvent({
+        name: "Raffle Tickets",
+        maxAttendees: 100,
+        purchaseOnly: true,
+      });
+      const response = await handleRequest(mockRequest("/feeds/events.ics"));
+      const body = await response.text();
+      expect(body).not.toContain("Raffle Tickets");
+      expect(body).not.toContain("BEGIN:VEVENT");
+    });
+
     test("escapes special characters in event fields", async () => {
       await settings.update.showPublicSite(true);
       await createTestEvent({
@@ -330,6 +343,19 @@ describeWithEnv("feeds", { db: true }, () => {
       const response = await handleRequest(mockRequest("/feeds/events.rss"));
       const body = await response.text();
       expect(body).not.toContain("Secret Event");
+      expect(body).not.toContain("<item>");
+    });
+
+    test("excludes purchase_only events", async () => {
+      await settings.update.showPublicSite(true);
+      await createTestEvent({
+        name: "Raffle Tickets",
+        maxAttendees: 100,
+        purchaseOnly: true,
+      });
+      const response = await handleRequest(mockRequest("/feeds/events.rss"));
+      const body = await response.text();
+      expect(body).not.toContain("Raffle Tickets");
       expect(body).not.toContain("<item>");
     });
 

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -665,7 +665,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
           await expectHtmlResponse(
             response,
             200,
-            "Payment Successful",
+            "Thank you for your order",
             "https://example.com/thanks",
             "Click here to view your ticket",
             'target="_blank"',
@@ -936,7 +936,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         const html = await expectHtmlResponse(
           response,
           200,
-          "Payment Successful",
+          "Thank you for your order",
           "Click here to view your tickets",
         );
         // Multi-slug ticket should NOT have thank_you_url (different events)
@@ -1258,7 +1258,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         );
         expect(response2.status).toBe(200);
         const html = await response2.text();
-        expect(html).toContain("Payment Successful");
+        expect(html).toContain("Thank you for your order");
 
         // Should still only have one attendee
         const { getAttendeesRaw } = await import("#lib/db/attendees.ts");
@@ -1315,7 +1315,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         );
         expect(response2.status).toBe(200);
         const html = await response2.text();
-        expect(html).toContain("Payment Successful");
+        expect(html).toContain("Thank you for your order");
         // Single-item cart replay also shows thank_you_url
         expect(html).toContain("redirected");
       } finally {
@@ -1371,7 +1371,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         );
         expect(response2.status).toBe(200);
         const html = await response2.text();
-        expect(html).toContain("Payment Successful");
+        expect(html).toContain("Thank you for your order");
       } finally {
         mockRetrieve.restore();
       }

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -692,7 +692,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         200,
-        "Reserve Ticket",
+        "Continue",
         `action="/ticket/${event.slug}"`,
       );
     });
@@ -805,7 +805,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       const html = await expectHtmlResponse(response, 200, 'class="iframe"');
       expect(html).not.toContain("<h1>");
       expect(html).not.toContain("A <b>great</b> event");
-      expect(html).toContain("Reserve Ticket");
+      expect(html).toContain("Continue");
     });
 
     test("shows header and description without iframe param", async () => {
@@ -960,7 +960,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         200,
-        "Reserve Tickets",
+        "Continue",
         "Select Tickets",
         "Group Event 1",
         "Group Event 2",
@@ -1340,7 +1340,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectRedirect(response, "https://example.com/thanks");
     });
 
-    test("shows purchase complete for purchase_only event", async () => {
+    test("shows order success for purchase_only event", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,
         purchaseOnly: true,
@@ -1357,8 +1357,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       // Follow the redirect and check the success page
       const successResponse = await handleRequest(mockRequest(location));
       const html = await successResponse.text();
-      expect(html).toContain("Purchase Complete");
-      expect(html).not.toContain("Ticket Reserved");
+      expect(html).toContain("Thank you for your order");
     });
 
     test("rejects when event is full", async () => {
@@ -1418,7 +1417,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         200,
-        "Reserve Tickets",
+        "Continue",
         "Multi Event 1",
         "Multi Event 2",
         "Select Tickets",
@@ -1793,7 +1792,11 @@ describeWithEnv("server (public routes)", { db: true }, () => {
   describe("GET /ticket/reserved", () => {
     test("shows reservation success page", async () => {
       const response = await handleRequest(mockRequest("/ticket/reserved"));
-      const html = await expectHtmlResponse(response, 200, "success");
+      const html = await expectHtmlResponse(
+        response,
+        200,
+        "Thank you for your order",
+      );
       expect(html).not.toContain("view your ticket");
     });
 
@@ -1851,7 +1854,11 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       const response = await handleRequest(
         mockRequest("/ticket/reserved?tokens=abc123"),
       );
-      const html = await expectHtmlResponse(response, 200, "success");
+      const html = await expectHtmlResponse(
+        response,
+        200,
+        "Thank you for your order",
+      );
       expect(html).not.toContain("Junk/Spam");
     });
   });
@@ -2953,7 +2960,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         200,
         "Registration closed.",
       );
-      expect(html).not.toContain("Reserve Ticket");
+      expect(html).not.toContain("Continue");
     });
 
     test("shows form when closes_at is in the future", async () => {
@@ -2968,7 +2975,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).not.toContain("Registration closed.");
-      expect(html).toContain("Reserve Ticket");
+      expect(html).toContain("Continue");
     });
 
     test("shows form when closes_at is null", async () => {
@@ -2980,7 +2987,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).not.toContain("Registration closed.");
-      expect(html).toContain("Reserve Ticket");
+      expect(html).toContain("Continue");
     });
 
     test("shows 'registration closed while you were submitting' on POST when closes_at is past", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1340,7 +1340,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       expectRedirect(response, "https://example.com/thanks");
     });
 
-    test("redirects with po=1 param for purchase_only event", async () => {
+    test("shows purchase complete for purchase_only event", async () => {
       const event = await createTestEvent({
         maxAttendees: 50,
         purchaseOnly: true,
@@ -1352,7 +1352,13 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
       expect(response.status).toBe(302);
       const location = response.headers.get("location") || "";
-      expect(location).toContain("po=1");
+      expect(location).toContain("/ticket/reserved?tokens=");
+
+      // Follow the redirect and check the success page
+      const successResponse = await handleRequest(mockRequest(location));
+      const html = await successResponse.text();
+      expect(html).toContain("Purchase Complete");
+      expect(html).not.toContain("Ticket Reserved");
     });
 
     test("rejects when event is full", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -178,6 +178,18 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
     });
 
+    test("shows Buy now link for purchase_only events", async () => {
+      await settings.update.showPublicSite(true);
+      await createTestEvent({
+        name: "Raffle",
+        maxAttendees: 100,
+        purchaseOnly: true,
+      });
+      const response = await handleRequest(mockRequest("/events"));
+      const html = await expectHtmlResponse(response, 200, "Raffle", "Buy now");
+      expect(html).not.toContain("Book now");
+    });
+
     test("does not show inactive events", async () => {
       await settings.update.showPublicSite(true);
       const event = await createTestEvent({
@@ -1326,6 +1338,21 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         email: "john@example.com",
       });
       expectRedirect(response, "https://example.com/thanks");
+    });
+
+    test("redirects with po=1 param for purchase_only event", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        purchaseOnly: true,
+        thankYouUrl: "",
+      });
+      const response = await submitTicketForm(event.slug, {
+        name: "Jane Doe",
+        email: "jane@example.com",
+      });
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location") || "";
+      expect(location).toContain("po=1");
     });
 
     test("rejects when event is full", async () => {

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -195,7 +195,7 @@ describeWithEnv(
           {
             zoneName: "",
             zoneKey: "",
-            localPath: "/tmp/nonexistent-dir-" + crypto.randomUUID(),
+            localPath: `/tmp/nonexistent-dir-${crypto.randomUUID()}`,
           },
           async () => {
             const files = await listFiles("backup-");

--- a/test/lib/svg-ticket.test.ts
+++ b/test/lib/svg-ticket.test.ts
@@ -157,5 +157,27 @@ describeWithEnv("svg-ticket", { db: true }, () => {
       );
       expect(svg).toContain("June");
     });
+
+    test("omits QR code when purchaseOnly is true", async () => {
+      const svg = await generateSvgTicket(
+        makeTicketData({ purchaseOnly: true }),
+      );
+      expect(svg).toContain("Summer Concert");
+      expect(svg).not.toContain("<path");
+      expect(svg).not.toContain("checkin");
+    });
+
+    test("includes event name and info lines when purchaseOnly is true", async () => {
+      const svg = await generateSvgTicket(
+        makeTicketData({
+          purchaseOnly: true,
+          eventLocation: "Online",
+          pricePaid: "1000",
+        }),
+      );
+      expect(svg).toContain("Summer Concert");
+      expect(svg).toContain("Online");
+      expect(svg).toContain("Price:");
+    });
   });
 });


### PR DESCRIPTION
## Summary
Introduces a new "purchase_only" event type for raffles, fundraisers, donations, and other non-attendance items. These events hide check-in functionality (QR codes, tokens, wallet passes) and display "Buy now" instead of "Book now" or "Reserve" language throughout the UI.

## Key Changes

- **Event Model**: Added `purchase_only` boolean field to Event type and database schema
- **UI Labels**: Changed button text from "Reserve Ticket(s)" to "Continue" for all events; updated public listing to show "Buy now" for purchase_only events and "Book now" for regular events
- **Success Page**: Unified success messaging to "Thank you for your order" regardless of payment status
- **Ticket Display**: 
  - Hides QR codes, check-in tokens, and wallet pass links for purchase_only events
  - Hides non-transferable notice for purchase_only events
  - Shows "Your Purchase" heading instead of "Your Tickets" when all items are purchase_only
- **SVG Tickets**: Generates simplified SVG without QR code for purchase_only events
- **Admin**: Hides scanner link for purchase_only events
- **Feeds**: Excludes purchase_only events from public iCalendar and RSS feeds
- **Form**: Added purchase_only checkbox field to event creation/editing form with hint text

## Implementation Details

- Purchase_only status is checked throughout templates to conditionally render check-in and wallet features
- Success page messaging is now unified and event-type agnostic
- Public event listing intelligently shows appropriate call-to-action based on event type
- Database migration adds new column with default value of 0 (false)

https://claude.ai/code/session_01VTBKEQmLhUEAo57HDv6e6B