### PR TITLE
Skip encryption for empty strings in encryptedText column

### DIFF
--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -410,7 +410,11 @@ export const col = {
   encryptedText: (
     encrypt: ColumnTransform<string>,
     decrypt: ColumnTransform<string>,
-  ): ColumnDef<string> => ({ default: () => "", write: encrypt, read: decrypt }),
+  ): ColumnDef<string> => ({
+    default: () => "",
+    write: (v: string) => (v === "" ? v : encrypt(v)),
+    read: (v: string) => (v === "" ? v : decrypt(v)),
+  }),
 
   /** Wrap an existing encrypted column def to pass through null values */
   encryptedNullable: <T>(def: ColumnDef<T>): ColumnDef<T | null> => ({

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -1737,6 +1737,18 @@ describeWithEnv("db", { db: true }, () => {
       expect(await def.read?.("enc:hello")).toBe("hello");
     });
 
+    test("col.encryptedText passes through empty strings without encrypting", async () => {
+      const { col } = await import("#lib/db/table.ts");
+      const encrypt = (v: string) => Promise.resolve(`enc:${v}`);
+      const decrypt = (v: string) => Promise.resolve(v.replace("enc:", ""));
+      const def = col.encryptedText(encrypt, decrypt);
+      expect(def.default?.()).toBe("");
+      expect(await def.write?.("")).toBe("");
+      expect(await def.read?.("")).toBe("");
+      expect(await def.write?.("hello")).toBe("enc:hello");
+      expect(await def.read?.("enc:hello")).toBe("hello");
+    });
+
     test("col.encryptedNullable wrapping simple column has no transforms", async () => {
       const { col } = await import("#lib/db/table.ts");
       const def = col.encryptedNullable(col.simple());


### PR DESCRIPTION
## Summary
Modified the `col.encryptedText` column definition to pass through empty strings without applying encryption/decryption transforms. This optimization avoids unnecessary encryption operations for empty values while maintaining the same behavior for non-empty strings.

## Changes
- Updated `encryptedText` column definition to check if the value is an empty string before applying encryption in the `write` transform
- Updated the `read` transform to skip decryption for empty strings
- Added test case to verify empty strings are passed through unchanged while non-empty strings are still encrypted/decrypted normally

## Implementation Details
The implementation uses simple conditional checks (`v === ""`) in both the write and read transforms to bypass the encrypt/decrypt functions for empty strings. This is a common pattern for handling empty values in encrypted fields, as encrypting an empty string provides no security benefit and adds unnecessary computational overhead.

https://claude.ai/code/session_01C2MyZYDWkbGZmHWZ8W4qSq