### PR TITLE
Add "How do I delete an attendee?" FAQ to admin guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -327,6 +327,22 @@ export const adminGuidePage = (
           </p>
         </Q>
 
+        <Q q="How do I delete an attendee?">
+          <p>
+            Open the event's attendee list and click <strong>Delete</strong>{" "}
+            next to the attendee. You'll see a confirmation page showing their
+            name, email, quantity, and registration date. Type the attendee's
+            exact name to confirm, then click <strong>Delete Attendee</strong>.
+            This permanently removes the attendee and any associated payment
+            records.
+          </p>
+          <p>
+            If the attendee has paid, <strong>refund them first</strong> before
+            deleting &mdash; once deleted, there is no payment record to refund
+            against. See the <strong>Refunds</strong> section below.
+          </p>
+        </Q>
+
         <Q q="How do I add terms and conditions?">
           <p>
             In <strong>Settings</strong>, enter your terms in the "Terms and


### PR DESCRIPTION
The guide's Refunds section tells users to "delete the attendee separately after refunding" but never explains how deletion works. This adds a FAQ entry covering the deletion flow: where to find the Delete button, the name-confirmation safety step, and the reminder to refund before deleting paid attendees.

https://claude.ai/code/session_01Uar4VzMcitHBNRXdMFY2GU