### PR TITLE
Fix guide accuracy and add help links from admin pages

### DIFF
--- a/src/templates/admin/backup.tsx
+++ b/src/templates/admin/backup.tsx
@@ -30,6 +30,9 @@ export const adminBackupPage = (
       <AdminNav session={session} active="/admin/settings" />
       <SettingsSubNav />
       <h1>Database Backup &amp; Restore</h1>
+      <p>
+        <a href="/admin/guide#backups">Backup guide</a>
+      </p>
       <Flash error={error} success={success} />
 
       {!state.isRemote && (

--- a/src/templates/admin/calendar.tsx
+++ b/src/templates/admin/calendar.tsx
@@ -103,6 +103,10 @@ export const adminCalendarPage = (
     <Layout title="Calendar">
       <AdminNav session={session} active="/admin/calendar" />
 
+      <p>
+        <a href="/admin/guide#calendar">Calendar guide</a>
+      </p>
+
       <article>
         <h2 id="attendees">Attendees by Date</h2>
         <Raw

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -337,7 +337,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Booking Questions">
+      <Section id="questions" title="Booking Questions">
         <Q q="What are custom booking questions?">
           <p>
             Custom booking questions let you ask attendees a multiple-choice
@@ -765,7 +765,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Refunds">
+      <Section id="refunds" title="Refunds">
         <Q q="When do automatic refunds happen?">
           <p>
             Automatic refunds happen in two scenarios. First, when an event
@@ -1099,9 +1099,10 @@ export const adminGuidePage = (
             <strong>Owners</strong> have full access: events, calendar, groups,
             questions, holidays, users, site pages, settings, API keys,
             sessions, and the activity log. <strong>Managers</strong> can manage
-            events, view the calendar, manage groups, and view the activity log.
-            They cannot change settings, manage users, manage questions or
-            holidays, create API keys, edit site pages, or view sessions.
+            events, view the calendar, manage groups, issue refunds, and view
+            the activity log. They cannot change settings, manage users, manage
+            questions or holidays, create API keys, edit site pages, or view
+            sessions.
           </p>
         </Q>
 
@@ -1221,7 +1222,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Calendar">
+      <Section id="calendar" title="Calendar">
         <Q q="What is the calendar page?">
           <p>
             The <strong>Calendar</strong> page lets you pick a date and see

--- a/src/templates/admin/questions.tsx
+++ b/src/templates/admin/questions.tsx
@@ -20,6 +20,9 @@ export const adminQuestionsPage = (
       <AdminNav session={session} active="/admin/questions" />
 
       <h1>Custom Questions</h1>
+      <p>
+        <a href="/admin/guide#questions">Questions guide</a>
+      </p>
       <Flash error={error} />
 
       <CsrfForm action="/admin/questions" id="new-question">


### PR DESCRIPTION
- Document that managers can issue refunds in Users & Permissions section (refund routes use AUTH_FORM, not OWNER_FORM, so both roles have access)
- Add anchor IDs to Booking Questions, Calendar, and Refunds guide sections so admin pages can deep-link to them
- Add "guide" links from Backup, Custom Questions, and Calendar pages to their relevant guide sections, matching the pattern used by Settings, Scanner, and Users pages

https://claude.ai/code/session_01PLH516RvibntNK1exmZm5k