### PR TITLE
Deduplicate tokens in ticket URLs and minor formatting fixes

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -31,7 +31,8 @@ type Table = {
 
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
-export const LATEST_UPDATE = "drop PII columns from attendees (now in pii_blob)";
+export const LATEST_UPDATE =
+  "drop PII columns from attendees (now in pii_blob)";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -58,9 +58,7 @@ const narrowCheckoutSession = (
   id: session.id,
   payment_status: session.payment_status,
   payment_intent:
-    typeof session.payment_intent === "string"
-      ? session.payment_intent
-      : null,
+    typeof session.payment_intent === "string" ? session.payment_intent : null,
   metadata: session.metadata,
   amount_total: session.amount_total,
 });

--- a/src/routes/token-utils.ts
+++ b/src/routes/token-utils.ts
@@ -108,9 +108,9 @@ export const extractTokenSegment = (
   return match?.[1] ?? null;
 };
 
-/** Parse +-separated tokens from a combined string */
+/** Parse +-separated tokens from a combined string, removing duplicates */
 export const parseTokens = (tokensStr: string): string[] =>
-  tokensStr.split("+").filter((s) => s.length > 0);
+  unique(tokensStr.split("+").filter((s) => s.length > 0));
 
 /** Build an Attendee object from base attendee data + one booking's per-event data */
 const buildAttendeeView = (

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -87,6 +87,17 @@ describeWithEnv("ticket view (/t/:tokens)", { db: true }, () => {
     expect(body).toContain("Quantity: 1");
   });
 
+  test("deduplicates repeated tokens in URL", async () => {
+    const { event, token } = await createTestAttendeeWithToken(
+      "Eve",
+      "eve@test.com",
+    );
+
+    const body = await fetchTicketBody(`${token}+${token}`);
+    expect(body).toContain(event.name);
+    expect(body).toContain("1 Ticket");
+  });
+
   test("skips invalid tokens among valid ones", async () => {
     const { event, token } = await createTestAttendeeWithToken(
       "Dave",


### PR DESCRIPTION
## Summary
This PR adds deduplication of repeated tokens when parsing ticket URLs, ensuring that duplicate tokens in the URL query string are treated as a single ticket rather than multiple copies.

## Key Changes
- **Token deduplication**: Modified `parseTokens()` in `src/routes/token-utils.ts` to remove duplicate tokens using a `unique()` function, preventing users from inflating ticket counts by repeating tokens in the URL
- **Test coverage**: Added test case "deduplicates repeated tokens in URL" to verify that repeated tokens (e.g., `token+token`) are properly deduplicated and display as "1 Ticket"
- **Code formatting**: Minor formatting improvements in `src/lib/stripe.ts` (ternary operator alignment) and `src/lib/db/migrations.ts` (line wrapping for readability)

## Implementation Details
The deduplication is applied at the token parsing stage, so any downstream code that uses `parseTokens()` automatically benefits from this behavior without requiring additional changes.

https://claude.ai/code/session_01Ahzyiq7L5mZdVAjAY1Gq1A