### PR TITLE
Add documentation for running individual test files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,28 @@ const result = reduce((acc, item) => {
 - `deno task build:edge` - Build for Bunny Edge deployment
 - `deno task precommit` - Run all checks (typecheck, lint, tests)
 
+### Running Individual Test Files
+
+**Do NOT use `deno task test -- --filter`** to debug a specific test — it still loads the entire test suite and is very slow.
+
+Instead, run `deno test` directly on the specific file:
+
+```bash
+deno test --no-check --allow-all test/lib/dates.test.ts
+```
+
+To filter to a specific test case within that file, add `--filter`:
+
+```bash
+deno test --no-check --allow-all test/lib/dates.test.ts --filter "formats date"
+```
+
+For tests that depend on stripe-mock (anything importing Stripe), ensure stripe-mock is running first by running `deno task test` once, or start it manually from `.bin/stripe-mock -http-port 12111`. Then set the env vars:
+
+```bash
+STRIPE_MOCK_HOST=localhost STRIPE_MOCK_PORT=12111 deno test --no-check --allow-all test/lib/stripe-mock.test.ts
+```
+
 ## Environment Variables
 
 Environment variables are configured as **Bunny native secrets** in the Bunny Edge Scripting dashboard. They are read at runtime via `process.env`.


### PR DESCRIPTION
## Summary
Added comprehensive documentation to CLAUDE.md explaining how to efficiently run and debug individual test files in the Deno test suite.

## Key Changes
- Added a new "Running Individual Test Files" section with clear guidance on test execution patterns
- Documented the performance issue with using `deno task test -- --filter` and provided the recommended alternative of running `deno test` directly on specific files
- Included examples for:
  - Running a single test file with basic flags
  - Filtering to specific test cases within a file using `--filter`
  - Running tests that depend on stripe-mock with proper environment variable setup
- Clarified the stripe-mock setup requirements for tests that import the Stripe module

## Notable Details
- Emphasizes performance considerations when debugging tests
- Provides complete command examples with all necessary flags (`--no-check --allow-all`)
- Includes instructions for manually starting stripe-mock if needed

https://claude.ai/code/session_0126d7LwyyaPvDovNpm3G6oL