### PR TITLE
Add debug log suppression to avoid env var races in tests

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -41,6 +41,26 @@ const shouldSuppressRequestLogs = (): boolean => {
   return !!Deno.env.get("TEST_SUPPRESS_REQUEST_LOGS");
 };
 
+/**
+ * Module-level override for debug log suppression.
+ * Bypasses Deno.env to avoid races between parallel test workers.
+ */
+const [getSuppressDebugOverride, setSuppressDebugOverride] = lazyRef<
+  boolean | null
+>(() => null);
+
+/** Set module-level debug log suppression (avoids env race in parallel tests). */
+export const setSuppressDebugLogs = (value: boolean | null): void => {
+  setSuppressDebugOverride(value);
+};
+
+/** Check if debug logs should be suppressed */
+const shouldSuppressDebugLogs = (): boolean => {
+  const override = getSuppressDebugOverride();
+  if (override !== null) return override;
+  return !!Deno.env.get("TEST_SUPPRESS_DEBUG_LOGS");
+};
+
 /** Generate a 4-char lowercase hex string */
 const generateRequestId = (): string => {
   const buf = crypto.getRandomValues(new Uint8Array(2));
@@ -343,5 +363,6 @@ export type LogCategory =
  * For detailed debugging during development
  */
 export const logDebug = (category: LogCategory, message: string): void => {
+  if (shouldSuppressDebugLogs()) return;
   console.debug(`${getLogPrefix()}[${category}] ${message}`);
 };

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -39,7 +39,7 @@ import { setDemoModeForTest } from "#lib/demo.ts";
 import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { FormParams } from "#lib/form-data.ts";
 import type { GoogleWalletCredentials } from "#lib/google-wallet.ts";
-import { setSuppressRequestLogs } from "#lib/logger.ts";
+import { setSuppressDebugLogs, setSuppressRequestLogs } from "#lib/logger.ts";
 import { runWithStorageConfig } from "#lib/storage.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
 import { setSkipLoginDelayForTest } from "#routes/admin/auth.ts";
@@ -72,6 +72,7 @@ export const setupTestEncryptionKey = (): void => {
   setSkipLoginDelayForTest(true);
   setRsaKeySizeForTest(1024);
   setSuppressRequestLogs(true);
+  setSuppressDebugLogs(true);
   setRethrowErrorsForTest(true);
 };
 
@@ -86,6 +87,7 @@ export const clearTestEncryptionKey = (): void => {
   setSkipLoginDelayForTest(false);
   setRsaKeySizeForTest(null);
   setSuppressRequestLogs(null);
+  setSuppressDebugLogs(null);
   setRethrowErrorsForTest(null);
 };
 

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -333,8 +333,9 @@ describe("code quality", () => {
       "lib/limits.ts:readLimit",
       // Settings cache TTL constant used by tests to verify caching behavior
       "lib/db/settings.ts:SETTINGS_CACHE_TTL_MS",
-      // Set request log suppression directly to avoid env var races between parallel tests
+      // Set log suppression directly to avoid env var races between parallel tests
       "lib/logger.ts:setSuppressRequestLogs",
+      "lib/logger.ts:setSuppressDebugLogs",
       // Rethrow errors in tests without env var races
       "routes/index.ts:setRethrowErrorsForTest",
       // Override BUILD_TIMESTAMP in tests (compile-time constant can't be changed otherwise)

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -17,6 +17,7 @@ import {
   logRequest,
   redactPath,
   runWithRequestId,
+  setSuppressDebugLogs,
   setSuppressRequestLogs,
 } from "#lib/logger.ts";
 import { flushPendingWork, runWithPendingWork } from "#lib/pending-work.ts";
@@ -510,11 +511,13 @@ describe("logger", () => {
     let debugSpy: Spy<Console, [message?: unknown, ...args: unknown[]], void>;
 
     beforeEach(() => {
+      setSuppressDebugLogs(false);
       debugSpy = spy(console, "debug");
     });
 
     afterEach(() => {
       debugSpy.restore();
+      setSuppressDebugLogs(null);
     });
 
     test("logs with Setup category", () => {
@@ -545,6 +548,22 @@ describe("logger", () => {
         .slice(before)
         .some((c) => c.args[0] === "[Stripe] Creating checkout session");
       expect(found).toBe(true);
+    });
+
+    test("suppresses output when setSuppressDebugLogs(true)", () => {
+      setSuppressDebugLogs(true);
+      const before = debugSpy.calls.length;
+      logDebug("Migration", "Step 1: applying schema changes...");
+      expect(debugSpy.calls.length).toBe(before);
+      setSuppressDebugLogs(null);
+    });
+
+    test("logs output when setSuppressDebugLogs(false)", () => {
+      setSuppressDebugLogs(false);
+      const before = debugSpy.calls.length;
+      logDebug("Migration", "Step 1: applying schema changes...");
+      expect(debugSpy.calls.length).toBeGreaterThan(before);
+      setSuppressDebugLogs(null);
     });
   });
 

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -8,6 +8,7 @@ import {
   questionsTable,
   setEventQuestions,
 } from "#lib/db/questions.ts";
+import { setSuppressDebugLogs } from "#lib/logger.ts";
 import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
@@ -3195,6 +3196,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
 
       const debugLogs: string[] = [];
       const origDebug = console.debug;
+      setSuppressDebugLogs(false);
       console.debug = (...args: unknown[]) => {
         debugLogs.push(args.join(" "));
       };
@@ -3225,6 +3227,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         );
       } finally {
         console.debug = origDebug;
+        setSuppressDebugLogs(null);
         mockVerify.restore();
         mockRefund.restore();
       }


### PR DESCRIPTION
## Summary
This PR adds a module-level debug log suppression mechanism to the logger, mirroring the existing request log suppression pattern. This allows tests to suppress debug logs without relying on environment variables, which can cause race conditions when running parallel test workers.

## Key Changes
- Added `setSuppressDebugLogs()` export to allow tests to control debug log suppression via a module-level override
- Implemented `shouldSuppressDebugLogs()` that checks the override first, then falls back to the `TEST_SUPPRESS_DEBUG_LOGS` environment variable
- Updated `logDebug()` to respect the suppression setting before logging
- Integrated the new suppression into test setup/teardown in `setupTestEncryptionKey()` and `clearTestEncryptionKey()`
- Added comprehensive test coverage for the new suppression functionality
- Updated code quality allowlist to document the new export alongside the existing `setSuppressRequestLogs`

## Implementation Details
- Uses the same `lazyRef` pattern as the existing request log suppression for consistency
- The override accepts `boolean | null`, where `null` resets to environment variable behavior
- Tests properly initialize suppression to `false` before each test and reset to `null` after, ensuring clean state
- Applied to both unit tests and integration tests that capture debug output

https://claude.ai/code/session_017XJguw8d8UBotGR2Wv1UiU