### PR TITLE
Improve attendee list UI and fix error flash display

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -447,6 +447,7 @@ const handleEditAttendeeGet = (
           session,
           getReturnUrl(request),
           flash.success,
+          flash.error,
         ),
       );
     }),

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -226,11 +226,12 @@ export const adminEditAttendeePage = (
   session: AdminSession,
   returnUrl?: string,
   success?: string,
+  error?: string,
 ): string =>
   String(
     <Layout title={`Edit Attendee: ${attendee.name}`}>
       <AdminNav session={session} active="/admin/" />
-      <Flash success={success} />
+      <Flash success={success} error={error} />
 
       <h2>Edit Attendee</h2>
 
@@ -311,7 +312,7 @@ export const adminEditAttendeePage = (
               <th>Date</th>
               <th>Qty</th>
               <th>Status</th>
-              <th></th>
+              <th style="width:1%"></th>
             </tr>
           </thead>
           <tbody>
@@ -347,7 +348,7 @@ export const adminEditAttendeePage = (
                     <span class="badge danger">Refunded</span>
                   )}
                 </td>
-                <td>
+                <td style="white-space:nowrap">
                   <CsrfForm
                     action={`/admin/attendees/${attendee.id}/unlink/${evt.id}`}
                     class="inline"


### PR DESCRIPTION
- Narrow action column with width:1% on th and white-space:nowrap on td
- Fix bug where error messages (e.g. "cannot remove last event") were
  silently dropped — pass flash.error through to the template and Flash
  component

Event name links and inline quantity form class were already present.

https://claude.ai/code/session_0135XzUqCguboRUNuXp6Nc7Y