### PR TITLE
Skip non-existent tables during backup creation

### DIFF
--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -50,6 +50,15 @@ const quoteId = (name: string): string => `"${name}"`;
 const getColumns = (table: string): Promise<ColumnInfo[]> =>
   queryAll<ColumnInfo>(`PRAGMA table_info(${quoteId(table)})`);
 
+/** Check if a table exists in the database */
+const tableExists = async (table: string): Promise<boolean> => {
+  const result = await getDb().execute({
+    sql: "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+    args: [table],
+  });
+  return result.rows.length > 0;
+};
+
 /** Escape a SQL string value (single quotes doubled) */
 const escapeSql = (value: unknown): string => {
   if (value === null || value === undefined) return "NULL";
@@ -124,10 +133,12 @@ export const exportTable = async (table: string): Promise<string> => {
   return lines.join("\n");
 };
 
-/** Create a full backup — one TableBackup per table in SCHEMA order */
+/** Create a full backup — one TableBackup per table in SCHEMA order.
+ *  Skips tables that don't exist yet (e.g. new tables about to be created by a migration). */
 export const createBackup = async (): Promise<TableBackup[]> => {
   const backups: TableBackup[] = [];
   for (const table of SCHEMA_TABLE_NAMES) {
+    if (!(await tableExists(table))) continue;
     const sql = await exportTable(table);
     backups.push({ table, sql });
   }

--- a/test/lib/backup.test.ts
+++ b/test/lib/backup.test.ts
@@ -16,9 +16,9 @@ import {
   restoreFromZip,
   splitStatements,
 } from "#lib/db/backup.ts";
-import { queryAll } from "#lib/db/client.ts";
+import { getDb, queryAll } from "#lib/db/client.ts";
 import { eventsTable } from "#lib/db/events.ts";
-import { SCHEMA_HASH, SCHEMA_TABLE_NAMES } from "#lib/db/migrations.ts";
+import { initDb, SCHEMA_HASH, SCHEMA_TABLE_NAMES } from "#lib/db/migrations.ts";
 import { createTestEvent, describeWithEnv, setTestEnv } from "#test-utils";
 
 describeWithEnv("backup", { db: true }, () => {
@@ -71,6 +71,18 @@ describeWithEnv("backup", { db: true }, () => {
     test("returns tables in SCHEMA order", async () => {
       const backups = await createBackup();
       expect(backups.map((b) => b.table)).toEqual(SCHEMA_TABLE_NAMES);
+    });
+
+    test("skips tables that do not exist", async () => {
+      await getDb().execute("DROP TABLE IF EXISTS holidays");
+      try {
+        const backups = await createBackup();
+        const names = backups.map((b) => b.table);
+        expect(names).not.toContain("holidays");
+        expect(names.length).toBe(SCHEMA_TABLE_NAMES.length - 1);
+      } finally {
+        await initDb();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Modified the backup creation process to gracefully handle tables that don't exist in the database, rather than failing when encountering missing tables.

## Key Changes
- Added `tableExists()` helper function to check if a table exists in the database using SQLite's `sqlite_master` table
- Updated `createBackup()` to skip tables that don't exist, allowing backups to be created even when the schema includes tables that haven't been created yet
- Added test case to verify that `createBackup()` correctly skips non-existent tables and returns the expected number of backups
- Updated imports to include `getDb` from `#lib/db/client.ts` and `initDb` from `#lib/db/migrations.ts` for test support

## Implementation Details
- The `tableExists()` function queries SQLite's `sqlite_master` system table to check for table existence
- The backup creation loop now checks each table before attempting to export it, continuing to the next table if it doesn't exist
- The test demonstrates the fix by dropping a table, creating a backup, verifying it's skipped, and then reinitializing the database to restore the schema

https://claude.ai/code/session_014fXPw7RVuH28fDKTkkAqck