### PR TITLE
Display group name and description on multi-event ticket pages

### DIFF
--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -7,42 +7,14 @@ import {
   getActiveEventsByGroupId,
   getGroupBySlugIndex,
 } from "#lib/db/groups.ts";
-/* jscpd:ignore-start */
 import { getActiveHolidays } from "#lib/db/holidays.ts";
-import { getQuestionsWithEventIds } from "#lib/db/questions.ts";
-import { settings } from "#lib/db/settings.ts";
-/* jscpd:ignore-end */
 import { sortEvents } from "#lib/sort-events.ts";
 import type { Group } from "#lib/types.ts";
 import { notFoundResponse } from "#routes/utils.ts";
 import type { TicketEvent } from "#templates/public.tsx";
-import { computeSharedDates } from "./ticket-payment.ts";
+import { getTicketContext } from "./ticket-payment.ts";
 import { handleTicket } from "./ticket-submit.ts";
-import {
-  type AsyncHandler,
-  getActiveEvents,
-  type TicketContextProvider,
-} from "./types.ts";
-
-/** Context provider for group pages (terms override + shared dates) */
-const getGroupTicketContext =
-  (group: Group): TicketContextProvider =>
-  async (events) => {
-    const eventIds = events.map((e) => e.event.id);
-    const [dates, globalTerms, questionsResult] = await Promise.all([
-      computeSharedDates(events),
-      Promise.resolve(settings.terms),
-      getQuestionsWithEventIds(eventIds),
-    ]);
-    const terms = group.terms_and_conditions || globalTerms || "";
-    return {
-      dates,
-      terms,
-      ...questionsResult,
-      groupName: group.name,
-      groupDescription: group.description,
-    };
-  };
+import { type AsyncHandler, getActiveEvents } from "./types.ts";
 
 /** Load group by slug and its active events, return 404 if empty */
 const withActiveGroupEventsBySlug = async (
@@ -69,5 +41,7 @@ export const handleGroupTicketBySlug = (
   slug: string,
 ): Promise<Response> =>
   withActiveGroupEventsBySlug(slug, (group, activeEvents) =>
-    handleTicket(request, [slug], activeEvents, getGroupTicketContext(group)),
+    handleTicket(request, [slug], activeEvents, (events) =>
+      getTicketContext(events, group),
+    ),
   );

--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -35,7 +35,13 @@ const getGroupTicketContext =
       getQuestionsWithEventIds(eventIds),
     ]);
     const terms = group.terms_and_conditions || globalTerms || "";
-    return { dates, terms, ...questionsResult };
+    return {
+      dates,
+      terms,
+      ...questionsResult,
+      groupName: group.name,
+      groupDescription: group.description,
+    };
   };
 
 /** Load group by slug and its active events, return 404 if empty */

--- a/src/routes/public/ticket-payment.ts
+++ b/src/routes/public/ticket-payment.ts
@@ -39,6 +39,7 @@ import type {
   TicketCtx,
   TicketSharedContext,
 } from "./types.ts";
+import type { Group } from "#lib/types.ts";
 
 /** Try to redirect to checkout, or return error using provided handler.
  * When in iframe mode, returns a popup page instead of redirect since Stripe cannot run in iframes. */
@@ -264,15 +265,25 @@ export const computeSharedDates = async (
   return [...dateSets[0]!].filter((d) => dateSets.every((s) => s.has(d)));
 };
 
-/** Fetch shared context for ticket pages: dates, terms, questions */
+/** Fetch shared context for ticket pages: dates, terms, questions.
+ * When a group is provided, its terms override global terms and its name/description are included. */
 export const getTicketContext = async (
   activeEvents: TicketEvent[],
+  group?: Group,
 ): Promise<TicketSharedContext> => {
   const eventIds = activeEvents.map((e) => e.event.id);
-  const [dates, terms, questionsResult] = await Promise.all([
+  const [dates, globalTerms, questionsResult] = await Promise.all([
     computeSharedDates(activeEvents),
     Promise.resolve(settings.terms),
     getQuestionsWithEventIds(eventIds),
   ]);
-  return { dates, terms, ...questionsResult };
+  const terms = group
+    ? group.terms_and_conditions || globalTerms || ""
+    : globalTerms;
+  return {
+    dates,
+    terms,
+    ...questionsResult,
+    ...(group && { groupName: group.name, groupDescription: group.description }),
+  };
 };

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -228,10 +228,9 @@ export const handleTicket = async (
   activeEvents: TicketEvent[],
   getContext: TicketContextProvider,
 ): Promise<Response> => {
-  const [{ dates, terms, questions, questionEventMap }] = await Promise.all([
-    getContext(activeEvents),
-    signCsrfToken(),
-  ]);
+  const [
+    { dates, terms, questions, questionEventMap, groupName, groupDescription },
+  ] = await Promise.all([getContext(activeEvents), signCsrfToken()]);
   const ctx: TicketCtx = {
     slugs: actionSlugs,
     events: activeEvents,
@@ -240,6 +239,8 @@ export const handleTicket = async (
     questions,
     questionEventMap,
     baseUrl: getBaseUrl(request),
+    groupName,
+    groupDescription,
   };
   if (request.method === "GET") applyFlash(request);
   const response =

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -228,19 +228,15 @@ export const handleTicket = async (
   activeEvents: TicketEvent[],
   getContext: TicketContextProvider,
 ): Promise<Response> => {
-  const [
-    { dates, terms, questions, questionEventMap, groupName, groupDescription },
-  ] = await Promise.all([getContext(activeEvents), signCsrfToken()]);
+  const [sharedCtx] = await Promise.all([
+    getContext(activeEvents),
+    signCsrfToken(),
+  ]);
   const ctx: TicketCtx = {
     slugs: actionSlugs,
     events: activeEvents,
-    dates,
-    terms,
-    questions,
-    questionEventMap,
     baseUrl: getBaseUrl(request),
-    groupName,
-    groupDescription,
+    ...sharedCtx,
   };
   if (request.method === "GET") applyFlash(request);
   const response =

--- a/src/routes/public/types.ts
+++ b/src/routes/public/types.ts
@@ -20,6 +20,8 @@ export type TicketCtx = {
   questions: QuestionWithAnswers[];
   questionEventMap: QuestionEventMap;
   baseUrl?: string;
+  groupName?: string;
+  groupDescription?: string;
 };
 
 /** Possibly-async response handler */
@@ -33,6 +35,8 @@ export type TicketSharedContext = {
   terms: string;
   questions: QuestionWithAnswers[];
   questionEventMap: QuestionEventMap;
+  groupName?: string;
+  groupDescription?: string;
 };
 
 /** Shared context provider for ticket pages */

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -482,7 +482,10 @@ export const ticketPage = ({
     ? renderSingleEventControls(events[0]!, hideQuantity)
     : events.map((e) => renderEventRow(e, hideQuantity)).join("");
 
-  const title = singleEvent ? singleEvent.name : groupName || "Reserve Tickets";
+  // Unified header: single events use event details, groups use group metadata
+  const headerName = singleEvent?.name ?? groupName;
+  const headerDescription = singleEvent?.description ?? groupDescription;
+  const title = headerName || "Reserve Tickets";
   const headExtra =
     singleEvent && baseUrl ? buildOgTags(singleEvent, baseUrl) : undefined;
   const buttonText = "Continue";
@@ -493,17 +496,17 @@ export const ticketPage = ({
       bodyClass={inIframe ? "iframe" : undefined}
       headExtra={headExtra}
     >
-      {singleEvent && !inIframe && (
+      {headerName && !inIframe && (
         <>
-          <Raw html={renderEventImage(singleEvent)} />
+          {singleEvent && <Raw html={renderEventImage(singleEvent)} />}
           <div class="prose">
-            <h1>{singleEvent.name}</h1>
-            {singleEvent.description && (
+            <h1>{headerName}</h1>
+            {headerDescription && (
               <div class="description">
-                <Raw html={renderMarkdownInline(singleEvent.description)} />
+                <Raw html={renderMarkdownInline(headerDescription)} />
               </div>
             )}
-            {singleEvent.date && (
+            {singleEvent?.date && (
               <p>
                 <strong>Date:</strong> {formatDatetimeLabel(singleEvent.date)}
                 {pastDays !== null && (
@@ -514,7 +517,7 @@ export const ticketPage = ({
                 )}
               </p>
             )}
-            {singleEvent.location && (
+            {singleEvent?.location && (
               <p>
                 <strong>Location:</strong> {singleEvent.location}
               </p>
@@ -522,29 +525,15 @@ export const ticketPage = ({
           </div>
         </>
       )}
-      {!singleEvent && !inIframe && groupName && (
-        <div class="prose">
-          <h1>{groupName}</h1>
-          {groupDescription && (
-            <div class="description">
-              <Raw html={renderMarkdownInline(groupDescription)} />
-            </div>
-          )}
-        </div>
-      )}
       <Flash error={error} />
 
       {allUnavailable || isReadOnly() ? (
         <div class="error" role="alert">
-          {isReadOnly()
+          {isReadOnly() || allClosed
             ? "Registration closed."
             : isSingleEvent
-              ? allClosed
-                ? "Registration closed."
-                : "Sorry, this event is full."
-              : allClosed
-                ? "Registration closed."
-                : "Sorry, all events are sold out."}
+              ? "Sorry, this event is full."
+              : "Sorry, all events are sold out."}
         </div>
       ) : (
         <CsrfForm action={`/ticket/${slugs.join("+")}`}>

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -439,6 +439,8 @@ export type TicketPageOptions = {
   questions?: QuestionWithAnswers[];
   questionEventMap?: QuestionEventMap;
   baseUrl?: string;
+  groupName?: string;
+  groupDescription?: string;
 };
 
 /**
@@ -455,6 +457,8 @@ export const ticketPage = ({
   questions,
   questionEventMap,
   baseUrl,
+  groupName,
+  groupDescription,
 }: TicketPageOptions): string => {
   const inIframe = getIframeMode();
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
@@ -478,7 +482,7 @@ export const ticketPage = ({
     ? renderSingleEventControls(events[0]!, hideQuantity)
     : events.map((e) => renderEventRow(e, hideQuantity)).join("");
 
-  const title = singleEvent ? singleEvent.name : "Reserve Tickets";
+  const title = singleEvent ? singleEvent.name : groupName || "Reserve Tickets";
   const headExtra =
     singleEvent && baseUrl ? buildOgTags(singleEvent, baseUrl) : undefined;
   const buttonText = "Continue";
@@ -517,6 +521,16 @@ export const ticketPage = ({
             )}
           </div>
         </>
+      )}
+      {!singleEvent && !inIframe && groupName && (
+        <div class="prose">
+          <h1>{groupName}</h1>
+          {groupDescription && (
+            <div class="description">
+              <Raw html={renderMarkdownInline(groupDescription)} />
+            </div>
+          )}
+        </div>
       )}
       <Flash error={error} />
 

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -1061,6 +1061,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         200,
+        "Public Group",
         "Continue",
         "Select Tickets",
         "Group Event 1",
@@ -1068,6 +1069,34 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         `action="/ticket/${group.slug}"`,
         `quantity_${event1.id}`,
         `quantity_${event2.id}`,
+      );
+    });
+
+    test("shows group name and description on multi-event group page", async () => {
+      const group = await createTestGroup({
+        name: "Festival Group",
+        slug: "festival-group",
+        description: "A wonderful festival with multiple events",
+      });
+      await createTestEvent({
+        name: "Festival Event A",
+        groupId: group.id,
+        maxAttendees: 50,
+      });
+      await createTestEvent({
+        name: "Festival Event B",
+        groupId: group.id,
+        maxAttendees: 50,
+      });
+
+      const response = await handleRequest(
+        mockRequest(`/ticket/${group.slug}`),
+      );
+      await expectHtmlResponse(
+        response,
+        200,
+        "Festival Group",
+        "A wonderful festival with multiple events",
       );
     });
 


### PR DESCRIPTION
## Summary
This PR adds support for displaying group metadata (name and description) on ticket pages when multiple events from the same group are shown together. Previously, multi-event group pages only displayed "Reserve Tickets" as the header with no group context.

## Key Changes
- **Template updates**: Modified `ticketPage` to accept optional `groupName` and `groupDescription` parameters and use them as fallbacks when displaying a group (no single event)
- **Context propagation**: Updated `getTicketContext` in `ticket-payment.ts` to accept an optional `Group` parameter and include group metadata in the returned context
- **Group route simplification**: Refactored `groups.ts` to use the unified `getTicketContext` function instead of a custom `getGroupTicketContext`, reducing code duplication
- **Type definitions**: Added `groupName` and `groupDescription` fields to `TicketCtx` and `TicketSharedContext` types
- **Conditional rendering**: Updated template to show group name/description header when available, with event-specific details (image, date, location) only shown for single events
- **Error message cleanup**: Simplified error message logic by removing redundant conditional branches

## Implementation Details
- Group terms override global terms when a group is provided to `getTicketContext`
- The header displays event name for single-event pages and group name for multi-event group pages
- Event-specific metadata (image, date, location) is only rendered when a single event is present
- Tests added to verify group name and description display on multi-event group pages

https://claude.ai/code/session_01RqLRm8T4FpTD3dqaQKeEEf