### PR TITLE
Fix HTML escaping in attendee merge decision tables

### DIFF
--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -528,7 +528,7 @@ const MergeAnswersDecisionTable = ({
               if (!item.conflict) {
                 // Non-conflicting: show info only (no decision needed)
                 const { answer, from } = nonConflictAnswerLabel(item);
-                return String(
+                return (
                   <tr>
                     <th scope="row">{item.questionText}</th>
                     <td colspan="3">
@@ -536,12 +536,12 @@ const MergeAnswersDecisionTable = ({
                         {answer} ({from} — auto-kept)
                       </span>
                     </td>
-                  </tr>,
+                  </tr>
                 );
               }
               const targetLabel = item.targetAnswerText!;
               const sourceLabel = item.sourceAnswerText!;
-              return String(
+              return (
                 <tr>
                   <th scope="row">{item.questionText}</th>
                   <td>
@@ -561,7 +561,7 @@ const MergeAnswersDecisionTable = ({
                       <input type="radio" name={name} value="clear" /> None
                     </label>
                   </td>
-                </tr>,
+                </tr>
               );
             })}
           </tbody>
@@ -601,7 +601,7 @@ const MergeBookingsDecisionTable = ({
               const dateStr = item.startAt ? item.startAt.slice(0, 10) : "—";
 
               if (item.conflictClass === "moveable") {
-                return String(
+                return (
                   <tr>
                     <td>Event #{item.eventId}</td>
                     <td>{dateStr}</td>
@@ -610,7 +610,7 @@ const MergeBookingsDecisionTable = ({
                       <span class="muted">Will be moved</span>
                     </td>
                     <Raw html={moveableExtraCell} />
-                  </tr>,
+                  </tr>
                 );
               }
 
@@ -618,7 +618,7 @@ const MergeBookingsDecisionTable = ({
               const targetQty = item.targetBooking!.quantity;
               const sourceQty = item.sourceBooking.quantity;
 
-              return String(
+              return (
                 <tr>
                   <td>Event #{item.eventId}</td>
                   <td>{dateStr}</td>
@@ -649,7 +649,7 @@ const MergeBookingsDecisionTable = ({
                       Skip source
                     </label>
                   </td>
-                </tr>,
+                </tr>
               );
             })}
           </tbody>


### PR DESCRIPTION
Map callbacks in MergeBookingsDecisionTable and MergeAnswersDecisionTable
were wrapping JSX in String(), converting SafeHtml to plain strings. When
those strings were embedded as children in the outer JSX, renderChild
treated them as text and HTML-escaped them, causing raw HTML like
<span class="muted">Will be moved</span> to appear in the output.

Removing String() lets the map return SafeHtml objects directly, which
renderChild correctly passes through unescaped.

https://claude.ai/code/session_017mCyUP6jQZoitTXzFQTocc