### PR TITLE
Fix: Log out existing session on failed login attempt

### DIFF
--- a/src/routes/admin/auth.ts
+++ b/src/routes/admin/auth.ts
@@ -3,7 +3,11 @@
  */
 
 import { lazyRef } from "#fp";
-import { buildSessionCookie, clearSessionCookie } from "#lib/cookies.ts";
+import {
+  buildSessionCookie,
+  clearSessionCookie,
+  getSessionCookieName,
+} from "#lib/cookies.ts";
 import { deriveKEK, unwrapKey, wrapKeyWithToken } from "#lib/crypto/keys.ts";
 import { verifySignedCsrfToken } from "#lib/csrf.ts";
 import {
@@ -25,6 +29,7 @@ import {
   generateSecureToken,
   getAuthenticatedSession,
   getClientIp,
+  parseCookies,
   parseFormData,
   redirect,
   withAuth,
@@ -94,6 +99,17 @@ const handleAdminLogin = async (
     );
   }
 
+  // A failed credential check should also log the user out of any existing
+  // session, so the redirect lands on the login page (not the dashboard).
+  const existingToken = parseCookies(request).get(getSessionCookieName());
+  const failedCredentialsRedirect = async (): Promise<Response> => {
+    await recordFailedLogin(clientIp);
+    if (existingToken) await deleteSession(existingToken);
+    return redirect("/admin", "Username or password was wrong", false, {
+      cookie: existingToken ? clearSessionCookie() : undefined,
+    });
+  };
+
   const validation = validateForm<LoginFormValues>(form, loginFields);
 
   if (!validation.valid) {
@@ -104,17 +120,11 @@ const handleAdminLogin = async (
 
   // Look up user by username
   const user = await getUserByUsername(username);
-  if (!user) {
-    await recordFailedLogin(clientIp);
-    return errorRedirect("/admin", "Username or password was wrong");
-  }
+  if (!user) return failedCredentialsRedirect();
 
   // Verify password (decrypt stored hash, then verify)
   const passwordHash = await verifyUserPassword(user, password);
-  if (!passwordHash) {
-    await recordFailedLogin(clientIp);
-    return errorRedirect("/admin", "Username or password was wrong");
-  }
+  if (!passwordHash) return failedCredentialsRedirect();
 
   // Clear failed attempts on successful login
   await clearLoginAttempts(clientIp);
@@ -134,7 +144,7 @@ const handleAdminLogin = async (
     dataKey = await unwrapKey(user.wrapped_data_key, kek);
   } catch {
     // KEK mismatch - this shouldn't happen if password verification passed
-    return errorRedirect("/admin", "Username or password was wrong");
+    return failedCredentialsRedirect();
   }
 
   return createLoginSession(dataKey, user.id);

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { getSessionCookieName } from "#lib/cookies.ts";
+import { signCsrfToken } from "#lib/csrf.ts";
 import { createSession, getSession } from "#lib/db/sessions.ts";
 import { handleRequest } from "#routes";
 import { setSkipLoginDelayForTest } from "#routes/admin/auth.ts";
@@ -646,6 +647,42 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
         "Login",
         "Username or password was wrong",
       );
+    });
+
+    test("failed login with existing session shows login page, not dashboard", async () => {
+      // Simulate a user who is already logged in but tries to log in again
+      // with wrong credentials. They should be redirected to the login page,
+      // not left logged in on the dashboard.
+      const { cookie } = await loginAsAdmin();
+
+      const csrfToken = await signCsrfToken();
+      const postResponse = await handleRequest(
+        mockFormRequest(
+          "/admin/login",
+          {
+            username: "testadmin",
+            password: "wrong",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+      );
+      expect(postResponse.status).toBe(302);
+
+      // Follow the redirect, carrying both the original session cookie and
+      // the flash cookie from the failed login response.
+      const getResponse = await followRedirectWithFlash(
+        postResponse,
+        handleRequest,
+        cookie,
+      );
+
+      // Should land on the login page with the error, NOT the dashboard.
+      const html = await getResponse.text();
+      expect(getResponse.status).toBe(200);
+      expect(html).toContain("Login");
+      expect(html).toContain("Username or password was wrong");
+      expect(html).not.toContain("Event Name");
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixed a security issue where users with an existing valid session could remain logged in on the dashboard after attempting to log in with incorrect credentials. Now, failed login attempts properly clear any existing session and redirect to the login page.

## Key Changes
- **Session cleanup on failed login**: When a login attempt fails (invalid username, password, or KEK mismatch), any existing session cookie is now deleted before redirecting to the login page
- **Refactored error handling**: Consolidated duplicate failed login logic into a `failedCredentialsRedirect()` helper function that:
  - Records the failed login attempt
  - Deletes any existing session if present
  - Clears the session cookie in the response
  - Redirects to the login page with an error message
- **Added test coverage**: New test case verifies that a logged-in user attempting to log in with wrong credentials is redirected to the login page (not the dashboard) and sees the error message

## Implementation Details
- The fix checks for an existing session token via `parseCookies()` and `getSessionCookieName()`
- If a session exists during a failed login, it's deleted via `deleteSession()` and the response includes `clearSessionCookie()`
- The redirect helper now accepts an optional `cookie` parameter to include the cleared session cookie in the response
- All three failed credential scenarios (missing user, invalid password, KEK mismatch) now use the same error handling path

https://claude.ai/code/session_013m5H22qHdpGokTWLVMyJCV