### PR TITLE
refactor(routes): reduce public page and admin route boilerplate

### DIFF
--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -7,6 +7,7 @@
  * re-reading which intermittently fails on Bunny Edge.
  */
 
+import { reduce } from "#fp";
 import { enableQueryLog } from "#lib/db/query-log.ts";
 import { settings } from "#lib/db/settings.ts";
 import { apiKeysRoutes } from "#routes/admin/api-keys.ts";
@@ -31,34 +32,39 @@ import { settingsRoutes } from "#routes/admin/settings.ts";
 import { siteRoutes } from "#routes/admin/site.ts";
 import { updateRoutes } from "#routes/admin/update.ts";
 import { usersRoutes } from "#routes/admin/users.ts";
-import { createRouter } from "#routes/router.ts";
+import { createRouter, type RouteHandlerFn } from "#routes/router.ts";
 import { getAuthenticatedSession } from "#routes/utils.ts";
 
-/** Combined admin routes */
-const adminRoutes = {
-  ...dashboardRoutes,
-  ...authRoutes,
-  ...apiKeysRoutes,
-  ...settingsRoutes,
-  ...debugRoutes,
-  ...siteRoutes,
-  ...sessionsRoutes,
-  ...calendarRoutes,
-  ...eventsRoutes,
-  ...attendeesRoutes,
-  ...attendeeRefundRoutes,
-  ...usersRoutes,
-  ...guideRoutes,
-  ...groupsRoutes,
-  ...holidaysRoutes,
-  ...questionsRoutes,
-  ...scannerRoutes,
-  ...seedsRoutes,
-  ...builderRoutes,
-  ...builtSitesRoutes,
-  ...updateRoutes,
-  ...backupRoutes,
-};
+/** Route maps merged in order (later keys override earlier on conflict) */
+const adminRouteModules: Record<string, RouteHandlerFn>[] = [
+  dashboardRoutes,
+  authRoutes,
+  apiKeysRoutes,
+  settingsRoutes,
+  debugRoutes,
+  siteRoutes,
+  sessionsRoutes,
+  calendarRoutes,
+  eventsRoutes,
+  attendeesRoutes,
+  attendeeRefundRoutes,
+  usersRoutes,
+  guideRoutes,
+  groupsRoutes,
+  holidaysRoutes,
+  questionsRoutes,
+  scannerRoutes,
+  seedsRoutes,
+  builderRoutes,
+  builtSitesRoutes,
+  updateRoutes,
+  backupRoutes,
+];
+
+const adminRoutes = reduce(
+  (acc, mod) => Object.assign(acc, mod),
+  {} as Record<string, RouteHandlerFn>,
+)(adminRouteModules);
 
 const innerRouter = createRouter(adminRoutes);
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -263,23 +263,26 @@ const readOnlyGuard = (path: string, method: string): Response | null => {
 
 type PublicPagesModule = Awaited<ReturnType<typeof loadPublicPages>>;
 
-/** Single-segment GET pages under prefix dispatch (path must match exactly) */
+/** Exact path for a single-segment public page (must stay aligned with getPrefix) */
+const publicPagePath = (prefix: string): string =>
+  prefix === "" ? "/" : `/${prefix}`;
+
 type PublicGetPageSpec = {
   prefix: string;
-  path: string;
   pick: (pages: PublicPagesModule) => () => Response | Promise<Response>;
 };
 
 const PUBLIC_GET_PAGES: PublicGetPageSpec[] = [
-  { prefix: "", path: "/", pick: (p) => p.handleHome },
-  { prefix: "events", path: "/events", pick: (p) => p.handlePublicEvents },
-  { prefix: "terms", path: "/terms", pick: (p) => p.handlePublicTerms },
-  { prefix: "contact", path: "/contact", pick: (p) => p.handlePublicContact },
+  { prefix: "", pick: (p) => p.handleHome },
+  { prefix: "events", pick: (p) => p.handlePublicEvents },
+  { prefix: "terms", pick: (p) => p.handlePublicTerms },
+  { prefix: "contact", pick: (p) => p.handlePublicContact },
 ];
 
 const publicPageHandlers = reduce(
   (acc: Record<string, RouterFn>, spec: PublicGetPageSpec) => {
-    const { prefix, path, pick } = spec;
+    const { prefix, pick } = spec;
+    const path = publicPagePath(prefix);
     acc[prefix] = async (_request, reqPath, method) => {
       if (reqPath !== path || method !== "GET") return null;
       return pick(await loadPublicPages())();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,7 @@
  * Uses lazy loading to minimize startup time for edge scripts
  */
 
-import { lazyRef, once } from "#fp";
+import { lazyRef, once, reduce } from "#fp";
 import { loadEffectiveDomain } from "#lib/config.ts";
 import {
   clearFlashCookie,
@@ -261,29 +261,37 @@ const readOnlyGuard = (path: string, method: string): Response | null => {
   return null;
 };
 
+type PublicPagesModule = Awaited<ReturnType<typeof loadPublicPages>>;
+
+/** Single-segment GET pages under prefix dispatch (path must match exactly) */
+type PublicGetPageSpec = {
+  prefix: string;
+  path: string;
+  pick: (pages: PublicPagesModule) => () => Response | Promise<Response>;
+};
+
+const PUBLIC_GET_PAGES: PublicGetPageSpec[] = [
+  { prefix: "", path: "/", pick: (p) => p.handleHome },
+  { prefix: "events", path: "/events", pick: (p) => p.handlePublicEvents },
+  { prefix: "terms", path: "/terms", pick: (p) => p.handlePublicTerms },
+  { prefix: "contact", path: "/contact", pick: (p) => p.handlePublicContact },
+];
+
+const publicPageHandlers = reduce(
+  (acc: Record<string, RouterFn>, spec: PublicGetPageSpec) => {
+    const { prefix, path, pick } = spec;
+    acc[prefix] = async (_request, reqPath, method) => {
+      if (reqPath !== path || method !== "GET") return null;
+      return pick(await loadPublicPages())();
+    };
+    return acc;
+  },
+  {} as Record<string, RouterFn>,
+)(PUBLIC_GET_PAGES);
+
 /** Prefix dispatch table — O(1) lookup replaces the sequential ?? chain */
 const prefixHandlers: Record<string, RouterFn> = {
-  // Exact-match public pages
-  "": async (_request, path, method) => {
-    if (path !== "/" || method !== "GET") return null;
-    const { handleHome } = await loadPublicPages();
-    return handleHome();
-  },
-  events: async (_request, path, method) => {
-    if (path !== "/events" || method !== "GET") return null;
-    const { handlePublicEvents } = await loadPublicPages();
-    return handlePublicEvents();
-  },
-  terms: async (_request, path, method) => {
-    if (path !== "/terms" || method !== "GET") return null;
-    const { handlePublicTerms } = await loadPublicPages();
-    return handlePublicTerms();
-  },
-  contact: async (_request, path, method) => {
-    if (path !== "/contact" || method !== "GET") return null;
-    const { handlePublicContact } = await loadPublicPages();
-    return handlePublicContact();
-  },
+  ...publicPageHandlers,
   // Prefix-matched lazy-loaded route groups
   admin: lazyRoute(loadAdminRoutes),
   ticket: lazyRoute(loadTicketRoutes),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This applies two low-risk refactors discussed in routing review:

1. **Public marketing pages** — Home, `/events`, `/terms`, and `/contact` are now driven by a small `PUBLIC_GET_PAGES` table and a `reduce` that builds the same prefix handlers as before (exact path + GET + `loadPublicPages()`).

2. **Admin route aggregation** — The long object spread is replaced by an ordered `adminRouteModules` array merged with `reduce` and `Object.assign`, preserving the same override semantics as object spread (later modules win on duplicate keys).

## Testing

- `deno task precommit` (via `./setup.sh`) — typecheck, lint, cpd, build:edge, test:coverage all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7966237-95ad-45dc-973e-c0f8bb586311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7966237-95ad-45dc-973e-c0f8bb586311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

