### PR TITLE
Refactor event API to use generic CRUD builder

### DIFF
--- a/src/lib/rest/crud-api.ts
+++ b/src/lib/rest/crud-api.ts
@@ -41,13 +41,37 @@ export const requireString = (
     : null;
 
 /** Result of parsing a JSON body into a typed input */
-type ParseResult<Input> =
+export type ParseResult<Input> =
   | { ok: true; input: Input }
   | { ok: false; error: string };
 
 /** JSON error response for API endpoints */
 export const apiErrorResponse = (message: string, status = 400): Response =>
   jsonResponse({ status: "error", message }, status);
+
+/** Result of parsing + validating: either the input or a pre-built error response */
+export type ValidatedInput<Input> =
+  | { ok: true; input: Input }
+  | { ok: false; response: Response };
+
+/**
+ * Parse + validate a JSON body into a typed input, returning a ready-to-return
+ * error response on failure. Used by route handlers to short-circuit on error.
+ */
+export const parseAndValidate = async <Input>(
+  parsed: ParseResult<Input> | Promise<ParseResult<Input>>,
+  validate?: (input: Input, id?: number) => Promise<string | null>,
+  id?: number,
+): Promise<ValidatedInput<Input>> => {
+  const result = await parsed;
+  if (!result.ok)
+    return { ok: false, response: apiErrorResponse(result.error) };
+  if (validate) {
+    const error = await validate(result.input, id);
+    if (error) return { ok: false, response: apiErrorResponse(error) };
+  }
+  return { ok: true, input: result.input };
+};
 
 /**
  * Parse an optional slug field from a JSON body for update operations.
@@ -79,15 +103,15 @@ export const parseUpdateName = (
 };
 
 /** Configuration for defineCrudApi */
-export interface CrudApiConfig<Row, Input> {
+export interface CrudApiConfig<Row, Input, FullRow extends Row = Row> {
   /** Resource name (lowercase plural, used in routes and log messages) */
   name: string;
   /** Singular display name for activity log (e.g. "Holiday") */
   singular: string;
   /** Table with CRUD operations */
   table: Table<Row, Input>;
-  /** Fetch all rows (from cache) */
-  getAll: () => Promise<Row[]>;
+  /** Fetch all rows (from cache) — may return a richer row type than the table (e.g. joined counts) */
+  getAll: () => Promise<FullRow[]>;
   /** Convert JSON body to Input for create */
   toCreateInput: (
     body: Record<string, unknown>,
@@ -95,16 +119,24 @@ export interface CrudApiConfig<Row, Input> {
   /** Convert JSON body + existing row to Input for update */
   toUpdateInput: (
     body: Record<string, unknown>,
-    existing: Row,
+    existing: FullRow,
   ) => ParseResult<Input> | Promise<ParseResult<Input>>;
   /** Optional validation (return error message or null) */
   validate?: (input: Input, id?: number) => Promise<string | null>;
   /** Field on Row that holds the display name (for delete confirmation) */
-  nameField: keyof Row & string;
+  nameField: keyof FullRow & string;
   /** Keys to strip from response (e.g. "slug_index") */
   stripKeys?: string[];
   /** Custom delete logic (e.g. cascade). If not provided, uses table.deleteById */
   onDelete?: (id: InValue) => Promise<void>;
+  /** Custom single-row lookup (e.g. to include joined counts). Defaults to table.findById. */
+  lookup?: (id: number) => Promise<FullRow | null>;
+  /** Extra keys added to the list response alongside the row array (e.g. admin_level) */
+  listExtras?: (session: AdminSession) => Record<string, unknown>;
+  /** When true, activity log entries for create/update are linked to the row's id as event_id */
+  linkActivityToRow?: boolean;
+  /** Extra route entries to merge in (can also override generated routes) */
+  extraRoutes?: Record<string, RouteHandlerFn>;
 }
 
 /** Callback receiving an entity row plus auth context */
@@ -132,21 +164,6 @@ export const withApiEntity = <Row>(
     return handler(row, session, body);
   });
 
-/** Config-aware entity lookup */
-const withEntity = <Row, Input>(
-  config: CrudApiConfig<Row, Input>,
-  request: Request,
-  id: number,
-  handler: EntityHandler<Row>,
-): Promise<Response> =>
-  withApiEntity(
-    request,
-    (i) => config.table.findById(i),
-    id,
-    config.singular,
-    handler,
-  );
-
 /** Strip internal keys from a row before sending in the response */
 const stripRow = <Row>(row: Row, keys: string[]): Record<string, unknown> => {
   if (keys.length === 0) return row as Record<string, unknown>;
@@ -165,58 +182,68 @@ const stripRow = <Row>(row: Row, keys: string[]): Record<string, unknown> => {
  *   PUT    /api/admin/{name}/:id      — update
  *   DELETE /api/admin/{name}/:id      — delete (with confirm_identifier)
  */
-export const defineCrudApi = <Row extends { id: number; name: string }, Input>(
-  config: CrudApiConfig<Row, Input>,
+export const defineCrudApi = <
+  Row extends { id: number; name: string },
+  Input,
+  FullRow extends Row = Row,
+>(
+  config: CrudApiConfig<Row, Input, FullRow>,
 ): Record<string, RouteHandlerFn> => {
   const { name, singular, table, getAll, nameField, stripKeys = [] } = config;
   const responseKey = singular.toLowerCase();
   const listKey = name;
+  const lookup: (id: number) => Promise<FullRow | null> =
+    config.lookup ??
+    ((id) => table.findById(id) as unknown as Promise<FullRow | null>);
 
   /** Clean a row for JSON response */
-  const toResponse = (row: Row) => stripRow(row, stripKeys);
+  const toResponse = (row: FullRow) => stripRow(row, stripKeys);
 
-  /** Parse input and run validation, returning error response or validated input */
-  const parseAndValidate = async (
-    parsed: ParseResult<Input> | Promise<ParseResult<Input>>,
-    id?: number,
-  ): Promise<
-    { ok: true; input: Input } | { ok: false; response: Response }
-  > => {
-    const result = await parsed;
-    if (!result.ok)
-      return { ok: false, response: apiErrorResponse(result.error) };
-    if (config.validate) {
-      const error = await config.validate(result.input, id);
-      if (error) return { ok: false, response: apiErrorResponse(error) };
-    }
-    return { ok: true, input: result.input };
-  };
+  /** Log create/update, optionally linking to the row's id as event_id */
+  const logAction = (action: string, row: Row): Promise<unknown> =>
+    logActivity(
+      `${singular} '${row.name}' ${action}`,
+      config.linkActivityToRow ? row : undefined,
+    );
+
+  /** Re-fetch the full row when a custom lookup is configured, otherwise reuse the written row */
+  const toFullRow = async (row: Row): Promise<FullRow> =>
+    config.lookup
+      ? (await config.lookup(row.id))!
+      : (row as unknown as FullRow);
 
   /** List all */
   const handleList: RouteHandlerFn = (request) =>
-    withAuth(request, ADMIN_API, async () => {
+    withAuth(request, ADMIN_API, async (session) => {
       const rows = await getAll();
-      return jsonResponse({ [listKey]: rows.map(toResponse) });
+      const extras = config.listExtras ? config.listExtras(session) : {};
+      return jsonResponse({ [listKey]: rows.map(toResponse), ...extras });
     });
 
   /** Create */
   const handleCreate: RouteHandlerFn = (request) =>
     withAuth(request, ADMIN_API, async (_session, body) => {
-      const result = await parseAndValidate(config.toCreateInput(body));
+      const result = await parseAndValidate(
+        config.toCreateInput(body),
+        config.validate,
+      );
       if (!result.ok) return result.response;
 
       const row = await table.insert(result.input);
-      await logActivity(`${singular} '${row.name}' created`);
-      return jsonResponse({ [responseKey]: toResponse(row) }, 201);
+      await logAction("created", row);
+      return jsonResponse(
+        { [responseKey]: toResponse(await toFullRow(row)) },
+        201,
+      );
     });
 
   // Build the route param name from the singular (e.g. "Holiday" → "holidayId")
   const paramName = `${singular.toLowerCase()}Id`;
 
-  /** Route handler that extracts the entity ID from params and delegates to withEntity */
+  /** Route handler that extracts the entity ID and loads the full row, delegating to handler */
   const entityRoute = (
     handler: (
-      row: Row,
+      row: FullRow,
       session: AdminSession,
       body: Record<string, unknown>,
       id: number,
@@ -226,8 +253,8 @@ export const defineCrudApi = <Row extends { id: number; name: string }, Input>(
       params: Record<string, string | number | undefined>,
     ): number => params[paramName] as number;
     return (request, params) =>
-      withEntity(config, request, getId(params), (row, session, body) =>
-        handler(row, session, body, getId(params)),
+      withApiEntity(request, lookup, getId(params), singular, (row, s, b) =>
+        handler(row, s, b, getId(params)),
       );
   };
 
@@ -240,13 +267,16 @@ export const defineCrudApi = <Row extends { id: number; name: string }, Input>(
   const handleUpdate = entityRoute(async (existing, _session, body, id) => {
     const result = await parseAndValidate(
       config.toUpdateInput(body, existing),
+      config.validate,
       id,
     );
     if (!result.ok) return result.response;
 
     const row = (await table.update(existing.id, result.input))!;
-    await logActivity(`${singular} '${row.name}' updated`);
-    return jsonResponse({ [responseKey]: toResponse(row) });
+    await logAction("updated", row);
+    return jsonResponse({
+      [responseKey]: toResponse(await toFullRow(row)),
+    });
   });
 
   /** Delete */
@@ -273,5 +303,6 @@ export const defineCrudApi = <Row extends { id: number; name: string }, Input>(
     [`POST /api/admin/${name}`]: handleCreate,
     [`PUT /api/admin/${name}/:${paramName}`]: handleUpdate,
     [`DELETE /api/admin/${name}/:${paramName}`]: handleDelete,
+    ...(config.extraRoutes ?? {}),
   };
 };

--- a/src/routes/admin/api.ts
+++ b/src/routes/admin/api.ts
@@ -7,8 +7,6 @@
  *   - Session cookie + x-csrf-token header
  */
 
-import { map } from "#fp";
-import { logActivity } from "#lib/db/activityLog.ts";
 import {
   computeSlugIndex,
   type EventInput,
@@ -25,6 +23,8 @@ import {
 import {
   apiErrorResponse,
   type DeleteBody,
+  defineCrudApi,
+  type ParseResult,
   parseUpdateName,
   parseUpdateSlug,
   withApiEntity,
@@ -32,15 +32,15 @@ import {
 import { normalizeSlug } from "#lib/slug.ts";
 import type {
   AdminEvent,
-  AdminSession,
+  Event,
   EventType,
   EventWithCount,
 } from "#lib/types.ts";
 import { groupApiRoutes } from "#routes/admin/api-groups.ts";
 import { holidayApiRoutes } from "#routes/admin/api-holidays.ts";
 import { verifyIdentifierOrJsonError } from "#routes/admin/utils.ts";
-import { defineRoutes } from "#routes/router.ts";
-import { ADMIN_API, jsonResponse, withAuth } from "#routes/utils.ts";
+import type { RouteHandlerFn } from "#routes/router.ts";
+import { jsonResponse } from "#routes/utils.ts";
 
 // =============================================================================
 // Published API types — the contract for callers
@@ -169,37 +169,10 @@ const existingToDefaults = (existing: EventWithCount): FieldRecord => {
 // Body → EventInput converters
 // =============================================================================
 
-/** Strip internal fields from an event, returning the admin API shape */
-export const toAdminEvent = ({
-  slug_index: _,
-  ...event
-}: EventWithCount): AdminEvent => event;
-
-/** Result type for body parsing */
-type BodyParseResult =
-  | { ok: true; input: EventInput }
-  | { ok: false; error: string };
-
-/**
- * Auth + event lookup helper.
- * Calls withAuth, fetches the event, and passes it to the callback.
- * Returns 404 automatically if the event doesn't exist.
- */
-const withEventApi = (
-  request: Request,
-  eventId: number,
-  handler: (
-    event: EventWithCount,
-    session: AdminSession,
-    body: Record<string, unknown>,
-  ) => Promise<Response>,
-): Promise<Response> =>
-  withApiEntity(request, getEventWithCount, eventId, "Event", handler);
-
 /** Convert JSON body to EventInput for create (auto-generates slug) */
 export const bodyToCreateInput = async (
   body: Record<string, unknown>,
-): Promise<BodyParseResult> => {
+): Promise<ParseResult<EventInput>> => {
   if (typeof body.name !== "string" || body.name.trim() === "") {
     return { ok: false, error: "name is required" };
   }
@@ -226,7 +199,7 @@ export const bodyToCreateInput = async (
 export const bodyToUpdateInput = async (
   body: Record<string, unknown>,
   existing: EventWithCount,
-): Promise<BodyParseResult> => {
+): Promise<ParseResult<EventInput>> => {
   const parsedName = parseUpdateName(body, existing.name);
   if (!parsedName.ok) return parsedName;
 
@@ -263,17 +236,36 @@ export const bodyToUpdateInput = async (
 };
 
 // =============================================================================
-// Route handlers
+// Custom routes (delete with cleanup, activate/deactivate)
 // =============================================================================
 
-/** GET /api/admin/events — list all events with counts */
-const handleListEvents = (request: Request): Promise<Response> =>
-  withAuth(request, ADMIN_API, async (session) => {
-    const events = await getAllEvents();
-    return jsonResponse({
-      events: map(toAdminEvent)(events),
-      admin_level: session.adminLevel,
-    });
+const withEvent = (
+  request: Request,
+  eventId: number,
+  handler: (
+    event: EventWithCount,
+    body: Record<string, unknown>,
+  ) => Promise<Response>,
+): Promise<Response> =>
+  withApiEntity(
+    request,
+    getEventWithCount,
+    eventId,
+    "Event",
+    (event, _session, body) => handler(event, body),
+  );
+
+/** Custom DELETE handler: performEventDelete handles storage cleanup + logging with counts */
+const handleDeleteEvent: RouteHandlerFn = (request, { eventId }) =>
+  withEvent(request, eventId as number, async (event, body) => {
+    const error = verifyIdentifierOrJsonError(
+      event.name,
+      body.confirm_identifier,
+      "Event name",
+    );
+    if (error) return apiErrorResponse(error);
+    await performEventDelete(event);
+    return jsonResponse({ status: "ok" });
   });
 
 /** Toggle event active/inactive state */
@@ -282,7 +274,7 @@ const handleToggleActive = (
   eventId: number,
   active: boolean,
 ): Promise<Response> =>
-  withEventApi(request, eventId, async (event) => {
+  withEvent(request, eventId, async (event) => {
     const updated = await toggleEventActive(eventId, event, active);
     if (!updated)
       return apiErrorResponse(
@@ -291,73 +283,36 @@ const handleToggleActive = (
     return jsonResponse({ event: toAdminEvent(updated) });
   });
 
-/** Run body parsing and validation, returning the input or an error response. */
-const parseAndValidateEventBody = async (
-  parsed: BodyParseResult,
-  existingId?: number,
-): Promise<
-  { ok: true; input: EventInput } | { ok: false; response: Response }
-> => {
-  if (!parsed.ok)
-    return { ok: false, response: apiErrorResponse(parsed.error) };
-  const error = await validateEventInput(parsed.input, existingId);
-  return error
-    ? { ok: false, response: apiErrorResponse(error) }
-    : { ok: true, input: parsed.input };
-};
+/** Strip slug_index from event row, producing the admin API shape */
+export const toAdminEvent = ({
+  slug_index: _,
+  ...rest
+}: EventWithCount): AdminEvent => rest;
 
-/** POST /api/admin/events — create event */
-const handleCreateEvent = (request: Request): Promise<Response> =>
-  withAuth(request, ADMIN_API, async (_session, body) => {
-    const result = await parseAndValidateEventBody(
-      await bodyToCreateInput(body),
-    );
-    if (!result.ok) return result.response;
-
-    const row = await eventsTable.insert(result.input);
-    const event = await getEventWithCount(row.id);
-    await logActivity(`Event '${row.name}' created`, row);
-    return jsonResponse({ event: toAdminEvent(event!) }, 201);
-  });
+const eventApiRoutes = defineCrudApi<Event, EventInput, EventWithCount>({
+  name: "events",
+  singular: "Event",
+  table: eventsTable,
+  getAll: getAllEvents,
+  lookup: getEventWithCount,
+  toCreateInput: bodyToCreateInput,
+  toUpdateInput: bodyToUpdateInput,
+  validate: validateEventInput,
+  nameField: "name",
+  stripKeys: ["slug_index"],
+  linkActivityToRow: true,
+  listExtras: (session) => ({ admin_level: session.adminLevel }),
+  extraRoutes: {
+    "DELETE /api/admin/events/:eventId": handleDeleteEvent,
+    "POST /api/admin/events/:eventId/deactivate": (request, { eventId }) =>
+      handleToggleActive(request, eventId as number, false),
+    "POST /api/admin/events/:eventId/reactivate": (request, { eventId }) =>
+      handleToggleActive(request, eventId as number, true),
+  },
+});
 
 export const adminApiRoutes = {
   ...holidayApiRoutes,
   ...groupApiRoutes,
-  ...defineRoutes({
-    "GET /api/admin/events": handleListEvents,
-    "GET /api/admin/events/:eventId": (request, { eventId }) =>
-      withEventApi(request, eventId, (event) =>
-        Promise.resolve(jsonResponse({ event: toAdminEvent(event) })),
-      ),
-    "POST /api/admin/events": handleCreateEvent,
-    "PUT /api/admin/events/:eventId": (request, { eventId }) =>
-      withEventApi(request, eventId, async (existing, _session, body) => {
-        const result = await parseAndValidateEventBody(
-          await bodyToUpdateInput(body, existing),
-          eventId,
-        );
-        if (!result.ok) return result.response;
-
-        const row = (await eventsTable.update(eventId, result.input))!;
-        const updated = await getEventWithCount(row.id);
-        await logActivity(`Event '${row.name}' updated`, row);
-        return jsonResponse({ event: toAdminEvent(updated!) });
-      }),
-    "DELETE /api/admin/events/:eventId": (request, { eventId }) =>
-      withEventApi(request, eventId, async (event, _session, body) => {
-        const error = verifyIdentifierOrJsonError(
-          event.name,
-          body.confirm_identifier,
-          "Event name",
-        );
-        if (error) return apiErrorResponse(error);
-
-        await performEventDelete(event);
-        return jsonResponse({ status: "ok" });
-      }),
-    "POST /api/admin/events/:eventId/deactivate": (request, { eventId }) =>
-      handleToggleActive(request, eventId, false),
-    "POST /api/admin/events/:eventId/reactivate": (request, { eventId }) =>
-      handleToggleActive(request, eventId, true),
-  }),
+  ...eventApiRoutes,
 };


### PR DESCRIPTION
## Summary
Refactored the event admin API to use a new generic `defineCrudApi` builder function, eliminating repetitive route handler boilerplate and improving code reusability across admin API endpoints.

## Key Changes

- **Extracted generic CRUD builder**: Created `defineCrudApi<Row, Input, FullRow>` in `crud-api.ts` that generates standard REST routes (GET list, GET by id, POST create, PUT update, DELETE) with configurable behavior
  
- **Enhanced ParseResult utilities**: 
  - Exported `ParseResult<Input>` type for reuse
  - Added `ValidatedInput<Input>` type for parse+validate results
  - Extracted `parseAndValidate()` helper to consolidate error handling logic

- **Simplified event API**: Replaced ~70 lines of explicit route handlers with a single `defineCrudApi` configuration that specifies:
  - Table operations and data fetching
  - Input converters (`bodyToCreateInput`, `bodyToUpdateInput`)
  - Validation logic
  - Response field stripping (e.g., `slug_index`)
  - Activity logging with optional row linking
  - Extra list response fields (e.g., `admin_level`)
  - Custom routes for delete with cleanup and activate/deactivate toggles

- **Improved flexibility**: 
  - Added optional `lookup` parameter to support custom row fetching (e.g., with joined counts)
  - Added `listExtras` callback for augmenting list responses with session-dependent data
  - Added `linkActivityToRow` flag to control whether activity logs reference the row's id
  - Added `extraRoutes` to allow custom route overrides alongside generated ones

- **Removed unused imports**: Cleaned up `map` from `#fp` and direct `withAuth`/`defineRoutes` usage in event API

## Implementation Details

The builder pattern centralizes common CRUD patterns while maintaining extensibility through configuration. The event API now serves as a reference implementation that can be replicated for other admin resources (holidays, groups) with minimal code.

https://claude.ai/code/session_01RT5f1JA3wBvNNXapYBpVLP