### PR TITLE
Add database credentials support to built sites

### DIFF
--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -19,6 +19,10 @@ export interface SiteDataBlob {
   n: string;
   /** Bunny URL (default hostname) */
   u: string;
+  /** Database URL (optional, absent in older blobs) */
+  d?: string;
+  /** Database token (optional, absent in older blobs) */
+  t?: string;
 }
 
 /** Built site row as stored in the database */
@@ -38,6 +42,8 @@ export interface BuiltSite {
   id: number;
   name: string;
   bunnyUrl: string;
+  dbUrl: string;
+  dbToken: string;
   created: string;
 }
 
@@ -45,6 +51,8 @@ export interface BuiltSite {
 export type BuiltSiteFormInput = {
   name: string;
   bunnyUrl: string;
+  dbUrl: string;
+  dbToken: string;
 };
 
 const idCol = col.generated<number>();
@@ -61,8 +69,19 @@ const rawBuiltSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
 });
 
 /** Build the encrypted site data blob */
-export const buildSiteDataBlob = (name: string, bunnyUrl: string): string =>
-  JSON.stringify({ v: 1, n: name, u: bunnyUrl } satisfies SiteDataBlob);
+export const buildSiteDataBlob = (
+  name: string,
+  bunnyUrl: string,
+  dbUrl = "",
+  dbToken = "",
+): string =>
+  JSON.stringify({
+    v: 1,
+    n: name,
+    u: bunnyUrl,
+    ...(dbUrl ? { d: dbUrl } : {}),
+    ...(dbToken ? { t: dbToken } : {}),
+  } satisfies SiteDataBlob);
 
 /** Parse a decrypted site data blob */
 export const parseSiteDataBlob = (json: string): SiteDataBlob =>
@@ -71,7 +90,14 @@ export const parseSiteDataBlob = (json: string): SiteDataBlob =>
 /** Convert a raw DB row (after decryption) to a BuiltSite */
 const rowToBuiltSite = (row: BuiltSiteRow): BuiltSite => {
   const blob = parseSiteDataBlob(row.site_data);
-  return { id: row.id, name: blob.n, bunnyUrl: blob.u, created: row.created };
+  return {
+    id: row.id,
+    name: blob.n,
+    bunnyUrl: blob.u,
+    dbUrl: blob.d ?? "",
+    dbToken: blob.t ?? "",
+    created: row.created,
+  };
 };
 
 const builtSitesCache = requestCache(() =>
@@ -113,13 +139,25 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     id: idCol,
     name: {} as ColumnDef<string>,
     bunnyUrl: {} as ColumnDef<string>,
+    dbUrl: {} as ColumnDef<string>,
+    dbToken: {} as ColumnDef<string>,
     created: createdCol,
   },
-  inputKeyMap: { name: "name", bunny_url: "bunnyUrl" },
+  inputKeyMap: {
+    name: "name",
+    bunny_url: "bunnyUrl",
+    db_url: "dbUrl",
+    db_token: "dbToken",
+  },
 
   insert: async (input: BuiltSiteFormInput): Promise<BuiltSite> => {
     const row = await builtSitesTable.insert({
-      siteData: buildSiteDataBlob(input.name, input.bunnyUrl),
+      siteData: buildSiteDataBlob(
+        input.name,
+        input.bunnyUrl,
+        input.dbUrl,
+        input.dbToken,
+      ),
     });
     // insert() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
@@ -133,9 +171,11 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     if (!existing) return null;
     const name = input.name ?? existing.name;
     const bunnyUrl = input.bunnyUrl ?? existing.bunnyUrl;
+    const dbUrl = input.dbUrl ?? existing.dbUrl;
+    const dbToken = input.dbToken ?? existing.dbToken;
     // Row exists (checked above), so update always returns non-null
     const row = (await builtSitesTable.update(id, {
-      siteData: buildSiteDataBlob(name, bunnyUrl),
+      siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
     })) as BuiltSiteRow;
     // update() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
@@ -158,7 +198,12 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     input: BuiltSiteFormInput | Partial<BuiltSiteFormInput>,
   ): Promise<Record<string, InValue>> =>
     Promise.resolve({
-      site_data: buildSiteDataBlob(input.name ?? "", input.bunnyUrl ?? ""),
+      site_data: buildSiteDataBlob(
+        input.name ?? "",
+        input.bunnyUrl ?? "",
+        input.dbUrl ?? "",
+        input.dbToken ?? "",
+      ),
     }),
 };
 
@@ -166,8 +211,12 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
 export const insertBuiltSite = (
   name: string,
   bunnyUrl: string,
+  dbUrl = "",
+  dbToken = "",
 ): Promise<BuiltSiteRow> =>
-  builtSitesTable.insert({ siteData: buildSiteDataBlob(name, bunnyUrl) });
+  builtSitesTable.insert({
+    siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
+  });
 
 /** Get all built sites, decrypted and sorted by name */
 export const getAllBuiltSites = (): Promise<BuiltSite[]> =>

--- a/src/routes/admin/builder.ts
+++ b/src/routes/admin/builder.ts
@@ -95,8 +95,8 @@ const handleBuilderPost = async (
     return errorRedirect(BUILDER_PATH, buildResult.error);
   }
 
-  // Record the built site
-  await insertBuiltSite(siteName, buildResult.defaultHostname);
+  // Record the built site (including db credentials for future reference)
+  await insertBuiltSite(siteName, buildResult.defaultHostname, dbUrl, dbToken);
   await logActivity(`Built new site: ${siteName}`);
 
   return redirect(

--- a/src/routes/admin/built-sites.ts
+++ b/src/routes/admin/built-sites.ts
@@ -23,8 +23,8 @@ const extractBuiltSiteInput = (
 ): BuiltSiteFormInput => ({
   name: String(values.name),
   bunnyUrl: String(values.bunny_url),
-  dbUrl: String(values.db_url ?? ""),
-  dbToken: String(values.db_token ?? ""),
+  dbUrl: String(values.db_url),
+  dbToken: String(values.db_token),
 });
 
 /** Built sites resource for REST create/update operations */

--- a/src/routes/admin/built-sites.ts
+++ b/src/routes/admin/built-sites.ts
@@ -23,6 +23,8 @@ const extractBuiltSiteInput = (
 ): BuiltSiteFormInput => ({
   name: String(values.name),
   bunnyUrl: String(values.bunny_url),
+  dbUrl: String(values.db_url ?? ""),
+  dbToken: String(values.db_token ?? ""),
 });
 
 /** Built sites resource for REST create/update operations */

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -67,6 +67,8 @@ export const builtSiteToFieldValues = (
 ): Record<string, string | number | null> => ({
   name: site?.name ?? "",
   bunny_url: site?.bunnyUrl ?? "",
+  db_url: site?.dbUrl ?? "",
+  db_token: site?.dbToken ?? "",
 });
 
 /**

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -23,7 +23,8 @@ export const adminBuiltSitesPage = (
       <AdminNav session={session} active="/admin/built-sites" />
       <Flash success={successMessage} />
       <p>
-        <a href="/admin/built-sites/new">Add Built Site</a>
+        <a href="/admin/built-sites/new">Add Built Site</a>{" "}
+        <a href="/admin/builder">Build New Site</a>
       </p>
       {sites.length === 0 ? (
         <p>No built sites recorded.</p>

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -531,6 +531,18 @@ export const builtSiteFields: Field[] = [
     required: true,
     placeholder: "https://example.b-cdn.net",
   },
+  {
+    name: "db_url",
+    label: "Database URL",
+    type: "url",
+    placeholder: "libsql://your-db.turso.io",
+  },
+  {
+    name: "db_token",
+    label: "Database Token",
+    type: "password",
+    placeholder: "Database auth token",
+  },
 ];
 
 /** Image upload field for event forms (appended when storage is enabled) */

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2079,6 +2079,8 @@ export const testBuiltSite = (
   id: 1,
   name: "Test Site",
   bunnyUrl: "https://test.b-cdn.net",
+  dbUrl: "",
+  dbToken: "",
   created: "2026-01-01T00:00:00Z",
   ...overrides,
 });
@@ -2092,6 +2094,8 @@ export const createTestBuiltSite = (
   const input: BuiltSiteFormInput = {
     name: overrides.name ?? "Test Site",
     bunnyUrl: overrides.bunnyUrl ?? "https://test.b-cdn.net",
+    dbUrl: overrides.dbUrl ?? "",
+    dbToken: overrides.dbToken ?? "",
   };
 
   return authenticatedFormRequest(
@@ -2099,6 +2103,8 @@ export const createTestBuiltSite = (
     {
       name: input.name,
       bunny_url: input.bunnyUrl,
+      db_url: input.dbUrl,
+      db_token: input.dbToken,
     },
     async () => {
       const { getAllBuiltSites } = await import("#lib/db/built-sites.ts");
@@ -2124,6 +2130,8 @@ export const updateTestBuiltSite = async (
     {
       name: updates.name ?? existing.name,
       bunny_url: updates.bunnyUrl ?? existing.bunnyUrl,
+      db_url: updates.dbUrl ?? existing.dbUrl,
+      db_token: updates.dbToken ?? existing.dbToken,
     },
     async () => {
       const updated = await builtSitesCrudTable.findById(siteId);

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -18,6 +18,25 @@ describeWithEnv("built-sites", { db: true }, () => {
     expect(parsed.u).toBe("test.b-cdn.net");
   });
 
+  test("buildSiteDataBlob includes db credentials when provided", () => {
+    const blob = buildSiteDataBlob(
+      "Test Site",
+      "test.b-cdn.net",
+      "libsql://db.turso.io",
+      "secret-token",
+    );
+    const parsed = JSON.parse(blob);
+    expect(parsed.d).toBe("libsql://db.turso.io");
+    expect(parsed.t).toBe("secret-token");
+  });
+
+  test("buildSiteDataBlob omits db keys when empty", () => {
+    const blob = buildSiteDataBlob("Test Site", "test.b-cdn.net");
+    const parsed = JSON.parse(blob);
+    expect(parsed.d).toBeUndefined();
+    expect(parsed.t).toBeUndefined();
+  });
+
   test("parseSiteDataBlob roundtrips with buildSiteDataBlob", () => {
     const blob = buildSiteDataBlob("My Site", "my.b-cdn.net");
     const parsed = parseSiteDataBlob(blob);
@@ -26,10 +45,42 @@ describeWithEnv("built-sites", { db: true }, () => {
     expect(parsed.u).toBe("my.b-cdn.net");
   });
 
+  test("parseSiteDataBlob handles legacy blobs without db keys", () => {
+    const legacyBlob = JSON.stringify({
+      v: 1,
+      n: "Old Site",
+      u: "old.b-cdn.net",
+    });
+    const parsed = parseSiteDataBlob(legacyBlob);
+    expect(parsed.d).toBeUndefined();
+    expect(parsed.t).toBeUndefined();
+  });
+
   test("insertBuiltSite creates a row with encrypted site_data", async () => {
     const row = await insertBuiltSite("Alpha Site", "alpha.b-cdn.net");
     expect(row.id).toBe(1);
     expect(row.created).toBeTruthy();
+  });
+
+  test("insertBuiltSite stores db credentials when provided", async () => {
+    await insertBuiltSite(
+      "DB Site",
+      "db.b-cdn.net",
+      "libsql://db.turso.io",
+      "secret-token",
+    );
+    const sites = await getAllBuiltSites();
+    const site = sites.find((s) => s.name === "DB Site")!;
+    expect(site.dbUrl).toBe("libsql://db.turso.io");
+    expect(site.dbToken).toBe("secret-token");
+  });
+
+  test("insertBuiltSite defaults db credentials to empty strings", async () => {
+    await insertBuiltSite("No DB Site", "nodb.b-cdn.net");
+    const sites = await getAllBuiltSites();
+    const site = sites.find((s) => s.name === "No DB Site")!;
+    expect(site.dbUrl).toBe("");
+    expect(site.dbToken).toBe("");
   });
 
   test("getAllBuiltSites returns decrypted sites sorted by name", async () => {
@@ -64,6 +115,8 @@ describeWithEnv("built-sites", { db: true }, () => {
         id: 1,
         name: "Test",
         bunnyUrl: "test.bunny.run",
+        dbUrl: "",
+        dbToken: "",
         created: "2026-01-01",
       };
       const result = await builtSitesCrudTable.fromDb(site);
@@ -74,17 +127,23 @@ describeWithEnv("built-sites", { db: true }, () => {
       const values = await builtSitesCrudTable.toDbValues({
         name: "Test",
         bunnyUrl: "test.bunny.run",
+        dbUrl: "libsql://test.turso.io",
+        dbToken: "tok123",
       });
       expect(values.site_data).toBeTruthy();
       const parsed = parseSiteDataBlob(values.site_data as string);
       expect(parsed.n).toBe("Test");
       expect(parsed.u).toBe("test.bunny.run");
+      expect(parsed.d).toBe("libsql://test.turso.io");
+      expect(parsed.t).toBe("tok123");
     });
 
     test("update preserves existing name when only bunnyUrl provided", async () => {
       const site = await builtSitesCrudTable.insert({
         name: "Original",
         bunnyUrl: "original.bunny.run",
+        dbUrl: "",
+        dbToken: "",
       });
       const updated = await builtSitesCrudTable.update(site.id, {
         bunnyUrl: "new.bunny.run",
@@ -97,12 +156,28 @@ describeWithEnv("built-sites", { db: true }, () => {
       const site = await builtSitesCrudTable.insert({
         name: "Original",
         bunnyUrl: "original.bunny.run",
+        dbUrl: "",
+        dbToken: "",
       });
       const updated = await builtSitesCrudTable.update(site.id, {
         name: "Updated",
       });
       expect(updated!.name).toBe("Updated");
       expect(updated!.bunnyUrl).toBe("original.bunny.run");
+    });
+
+    test("update preserves existing db credentials when not provided", async () => {
+      const site = await builtSitesCrudTable.insert({
+        name: "Original",
+        bunnyUrl: "original.bunny.run",
+        dbUrl: "libsql://db.turso.io",
+        dbToken: "tok123",
+      });
+      const updated = await builtSitesCrudTable.update(site.id, {
+        name: "Updated",
+      });
+      expect(updated!.dbUrl).toBe("libsql://db.turso.io");
+      expect(updated!.dbToken).toBe("tok123");
     });
 
     test("update returns null for non-existent id", async () => {

--- a/test/lib/server-builder.test.ts
+++ b/test/lib/server-builder.test.ts
@@ -222,11 +222,13 @@ describeWithEnv(
         expectRedirect(response, "/admin/builder");
         expectFlash(response, expect.stringContaining("created successfully"));
 
-        // Verify site was recorded
+        // Verify site was recorded with db credentials
         const sites = await getAllBuiltSites();
         expect(sites).toHaveLength(1);
         expect(sites[0]!.name).toBe("My Test Site");
         expect(sites[0]!.bunnyUrl).toBe("https://test-42.b-cdn.net");
+        expect(sites[0]!.dbUrl).toBe("libsql://test.turso.io");
+        expect(sites[0]!.dbToken).toBe("token123");
       });
     });
 

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -95,6 +95,17 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
       expect(site.bunnyUrl).toBe("https://new.b-cdn.net");
     });
 
+    test("creates built site without db credentials", async () => {
+      const { response } = await adminFormPost("/admin/built-sites", {
+        name: "No DB Site",
+        bunny_url: "https://nodb.b-cdn.net",
+      });
+      expectRedirectWithFlash(
+        "/admin/built-sites",
+        expect.stringContaining("created"),
+      )(response);
+    });
+
     test("rejects missing name", async () => {
       const { response } = await adminFormPost("/admin/built-sites", {
         name: "",

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -69,6 +69,8 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
         "Add Built Site",
         "Site Name",
         "Bunny URL",
+        "Database URL",
+        "Database Token",
       );
     });
   });
@@ -347,6 +349,8 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
       const values = builtSiteToFieldValues();
       expect(values.name).toBe("");
       expect(values.bunny_url).toBe("");
+      expect(values.db_url).toBe("");
+      expect(values.db_token).toBe("");
     });
 
     test("returns site values when site provided", async () => {
@@ -356,10 +360,14 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
       const site = testBuiltSite({
         name: "Test",
         bunnyUrl: "https://test.b-cdn.net",
+        dbUrl: "libsql://test.turso.io",
+        dbToken: "tok123",
       });
       const values = builtSiteToFieldValues(site);
       expect(values.name).toBe("Test");
       expect(values.bunny_url).toBe("https://test.b-cdn.net");
+      expect(values.db_url).toBe("libsql://test.turso.io");
+      expect(values.db_token).toBe("tok123");
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds support for storing and managing database credentials (URL and token) alongside built site records. Database credentials are now captured during site creation and can be updated independently of other site properties.

## Key Changes
- **Database credential fields**: Added `dbUrl` and `dbToken` fields to the `BuiltSite` interface and form inputs
- **Site data blob schema**: Extended `SiteDataBlob` with optional `d` (database URL) and `t` (database token) fields, with backward compatibility for legacy blobs without these fields
- **Builder integration**: Modified the builder route to capture and store database credentials when recording newly built sites
- **CRUD operations**: Updated insert, update, and form conversion methods to handle database credentials with proper preservation during partial updates
- **UI fields**: Added database URL and token input fields to the built sites admin form
- **Test coverage**: Added comprehensive tests for credential storage, legacy blob handling, and CRUD operations with database credentials

## Implementation Details
- Database credentials are optional and default to empty strings when not provided
- The `buildSiteDataBlob` function conditionally includes credential fields only when non-empty, maintaining a clean JSON structure
- Update operations preserve existing credentials when not explicitly provided in the update input
- Legacy site data blobs without credential fields are handled gracefully with undefined fallbacks
- Database token field uses password input type for security in the UI

https://claude.ai/code/session_01KuSb3RcfsGgi1EzADmWzMR