### PR TITLE
Fix event description markdown rendering, image max-width, and qty input width

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -669,7 +669,7 @@ label > input[type="time"] {
 
 label > select[name="quantity"],
 label > select[name^="quantity_"] {
-  width: 6ch;
+  width: 8ch;
   flex: 0 0 auto;
 }
 
@@ -1183,7 +1183,7 @@ button.secondary:hover {
 }
 
 .ticket-card-image {
-  width: calc(100% + 1rem);
+  max-width: calc(100% + 1rem);
   margin: -0.5rem -0.5rem 0.5rem;
   border-radius: var(--border-radius) var(--border-radius) 0 0;
   display: block;

--- a/src/templates/tickets.tsx
+++ b/src/templates/tickets.tsx
@@ -6,6 +6,7 @@ import { map, pipe } from "#fp";
 import { formatCurrency } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeLabel } from "#lib/dates.ts";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { renderMarkdownInline } from "#lib/markdown.ts";
 import type { TokenEntry } from "#routes/token-utils.ts";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
 import { renderEventImage } from "#templates/public.tsx";
@@ -50,7 +51,7 @@ const renderTicketCard = (
     : "";
 
   const descriptionHtml = event.description
-    ? `<div class="ticket-card-description">${escapeHtml(event.description)}</div>`
+    ? `<div class="ticket-card-description">${renderMarkdownInline(event.description)}</div>`
     : "";
 
   const attendeeDateHtml = attendee.date


### PR DESCRIPTION
- Render event descriptions as markdown on ticket view page (was escaping HTML)
- Use max-width instead of width for ticket card images to prevent upscaling
- Widen quantity select from 6ch to 8ch

https://claude.ai/code/session_018u1sePPChLeGHMjE1GBRqD