### PR TITLE
Synchronize build timestamp with release tag generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,21 @@ jobs:
       - name: Install dependencies
         run: deno install --allow-scripts
 
+      - name: Generate release tag
+        id: tag
+        run: echo "TAG=v$(date -u +%Y-%m-%d-%H%M%S)" >> "$GITHUB_OUTPUT"
+
       - name: Build edge script
         run: deno task build:edge
         env:
           BUILD_COMMIT: ${{ github.sha }}
+          BUILD_TAG: ${{ steps.tag.outputs.TAG }}
 
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="v$(date -u +%Y-%m-%d-%H%M%S)"
+          TAG="${{ steps.tag.outputs.TAG }}"
           TITLE="$(date -u +%Y-%m-%d) - ${{ inputs.release_name }}"
           git tag "$TAG"
           git push origin "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,21 +27,16 @@ jobs:
       - name: Install dependencies
         run: deno install --allow-scripts
 
-      - name: Generate release tag
-        id: tag
-        run: echo "TAG=v$(date -u +%Y-%m-%d-%H%M%S)" >> "$GITHUB_OUTPUT"
-
       - name: Build edge script
         run: deno task build:edge
         env:
           BUILD_COMMIT: ${{ github.sha }}
-          BUILD_TAG: ${{ steps.tag.outputs.TAG }}
 
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${{ steps.tag.outputs.TAG }}"
+          TAG="$(cat .build-tag)"
           TITLE="$(date -u +%Y-%m-%d) - ${{ inputs.release_name }}"
           git tag "$TAG"
           git push origin "$TAG"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage*/
 cov_profile/
 .jscpd-report/
 bunny-script.ts
+.build-tag
 src/static/admin.js
 src/static/scanner.js
 src/static/embed.js

--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -64,9 +64,22 @@ const EDGE_SUBPATHS: Record<string, string> = {
   "@bunny.net/edgescript-sdk": "/esm-bunny/lib.mjs",
 };
 
+/**
+ * Derive BUILD_TIMESTAMP from BUILD_TAG (vYYYY-MM-DD-HHMMSS) when available,
+ * so the baked-in timestamp matches the release tag exactly. This ensures
+ * isNewerVersion() correctly detects same-version vs newer-version releases.
+ * Falls back to current time for non-release builds (deploy workflows, local).
+ */
+const buildTimestampFromTag = (): string => {
+  const tag = Deno.env.get("BUILD_TAG") ?? "";
+  const m = tag.match(/^v(\d{4})-(\d{2})-(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z`;
+  return new Date().toISOString();
+};
+
 /** Build the inline build-info module with timestamp and commit SHA */
 const buildBuildInfoModule = (): string => {
-  const timestamp = new Date().toISOString();
+  const timestamp = buildTimestampFromTag();
   const commit = Deno.env.get("BUILD_COMMIT") ?? "";
   return [
     `export const BUILD_TIMESTAMP = ${JSON.stringify(timestamp)};`,

--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -65,24 +65,26 @@ const EDGE_SUBPATHS: Record<string, string> = {
 };
 
 /**
- * Derive BUILD_TIMESTAMP from BUILD_TAG (vYYYY-MM-DD-HHMMSS) when available,
- * so the baked-in timestamp matches the release tag exactly. This ensures
- * isNewerVersion() correctly detects same-version vs newer-version releases.
- * Falls back to current time for non-release builds (deploy workflows, local).
+ * Build timestamp — always the current time. Used both as BUILD_TIMESTAMP
+ * and (formatted) as the release tag in release builds, so the two always match.
  */
-const buildTimestampFromTag = (): string => {
-  const tag = Deno.env.get("BUILD_TAG") ?? "";
-  const m = tag.match(/^v(\d{4})-(\d{2})-(\d{2})-(\d{2})(\d{2})(\d{2})$/);
-  if (m) return `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z`;
-  return new Date().toISOString();
+const BUILD_ISO = new Date().toISOString();
+
+/**
+ * Format an ISO timestamp as a release-style tag: vYYYY-MM-DD-HHMMSS.
+ * Written to .build-tag so the release workflow can read it.
+ */
+const isoToTag = (iso: string): string => {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `v${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`;
 };
 
 /** Build the inline build-info module with timestamp and commit SHA */
 const buildBuildInfoModule = (): string => {
-  const timestamp = buildTimestampFromTag();
   const commit = Deno.env.get("BUILD_COMMIT") ?? "";
   return [
-    `export const BUILD_TIMESTAMP = ${JSON.stringify(timestamp)};`,
+    `export const BUILD_TIMESTAMP = ${JSON.stringify(BUILD_ISO)};`,
     `export const BUILD_COMMIT = ${JSON.stringify(commit)};`,
   ].join("\n");
 };
@@ -378,6 +380,10 @@ if (content.length > BUNNY_MAX_SCRIPT_SIZE) {
 }
 
 await Deno.writeTextFile("./bunny-script.ts", content);
+
+// Write the build tag so the release workflow can use it as the git tag.
+// This ensures the release tag exactly matches the baked-in BUILD_TIMESTAMP.
+await Deno.writeTextFile(".build-tag", isoToTag(BUILD_ISO));
 
 console.log(`Build complete: bunny-script.ts (${content.length} bytes)`);
 


### PR DESCRIPTION
## Summary
This change ensures that the build timestamp baked into the compiled script exactly matches the git tag created during release, eliminating potential time drift between the two.

## Key Changes
- **Centralized timestamp**: Introduced `BUILD_ISO` constant that captures the build time once and reuses it for both the `BUILD_TIMESTAMP` export and release tag generation
- **Deterministic tag format**: Added `isoToTag()` function that converts ISO timestamps to the release tag format (`vYYYY-MM-DD-HHMMSS`)
- **Build artifact**: The build script now writes the computed tag to `.build-tag` file, which the release workflow reads instead of generating a new timestamp
- **Release workflow update**: Modified `release.yml` to use the pre-computed tag from `.build-tag` rather than calling `date` at release time
- **Gitignore**: Added `.build-tag` to ignore list

## Implementation Details
- The `BUILD_ISO` timestamp is captured at build time and used consistently throughout the build process
- The tag format conversion handles UTC date/time formatting with zero-padding for consistency
- This approach guarantees that `BUILD_TIMESTAMP` in the compiled code will always match the git tag, making releases fully reproducible and traceable

https://claude.ai/code/session_01BicuMwFKghtR5SNPEoXhge