### PR TITLE
Add guide links to sessions, activity log, holidays, and admin email template pages

### DIFF
--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -38,6 +38,11 @@ export const adminEventActivityLogPage = (
   String(
     <Layout title={`Log: ${event.name}`}>
       <AdminNav session={session} active="/admin/log" />
+      <p>
+        <a href={`/admin/event/${event.id}`}>&larr; {event.name}</a>
+        {" | "}
+        <a href="/admin/guide#activity-log">Activity log guide</a>
+      </p>
       <div class="table-scroll">
         <table>
           <thead>
@@ -65,6 +70,9 @@ export const adminGlobalActivityLogPage = (
   String(
     <Layout title="Log">
       <AdminNav session={session} active="/admin/log" />
+      <p>
+        <a href="/admin/guide#activity-log">Activity log guide</a>
+      </p>
       <div class="table-scroll">
         <table>
           <thead>

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -953,7 +953,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Daily Events &amp; Holidays">
+      <Section id="holidays" title="Daily Events &amp; Holidays">
         <Q q="How do daily events work?">
           <p>
             Daily events let attendees choose a specific date when booking. You
@@ -1278,7 +1278,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Webhooks">
+      <Section id="webhooks" title="Webhooks">
         <Q q="What are webhooks for?">
           <p>
             Webhooks send an automatic notification to a URL of your choice
@@ -1364,7 +1364,7 @@ export const adminGuidePage = (
         </Q>
       </Section>
 
-      <Section title="Activity Log">
+      <Section id="activity-log" title="Activity Log">
         <Q q="What is the activity log?">
           <p>
             The <strong>Log</strong> page shows a chronological list of admin

--- a/src/templates/admin/holidays.tsx
+++ b/src/templates/admin/holidays.tsx
@@ -23,6 +23,8 @@ export const adminHolidaysPage = (
       <Flash success={successMessage} />
       <p>
         <a href="/admin/holidays/new">Add Holiday</a>
+        {" | "}
+        <a href="/admin/guide#holidays">Holidays guide</a>
       </p>
       {holidays.length === 0 ? (
         <p>No holidays configured.</p>

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -55,6 +55,10 @@ export const adminSessionsPage = (
 
       <Flash success={success} />
 
+      <p>
+        <a href="/admin/guide#login">Sessions guide</a>
+      </p>
+
       <div class="table-scroll">
         <table>
           <thead>

--- a/src/templates/admin/settings/email-tpl-admin.tsx
+++ b/src/templates/admin/settings/email-tpl-admin.tsx
@@ -16,7 +16,9 @@ export const AdminEmailTemplateForm = (
     <h2>Admin Notification Email Template</h2>
     <p>
       Customise the notification email sent to the business email when a
-      registration comes in. Leave blank to use the default template.
+      registration comes in (
+      <a href="/admin/guide#email-templates">template guide</a>). Leave blank to
+      use the default template.
     </p>
     <label>
       Subject

--- a/test/lib/processed-payments/locking.test.ts
+++ b/test/lib/processed-payments/locking.test.ts
@@ -135,7 +135,10 @@ describeWithEnv("processed-payments / locking", { db: true }, () => {
 
     test("stores ticket tokens encrypted when provided", async () => {
       await reserveSession("cs_with_tokens");
-      await finalizeSession("cs_with_tokens", attendeeId, ["tok_abc", "tok_def"]);
+      await finalizeSession("cs_with_tokens", attendeeId, [
+        "tok_abc",
+        "tok_def",
+      ]);
 
       const record = await isSessionProcessed("cs_with_tokens");
       expect(record?.ticket_tokens).toMatch(/^enc:1:/);

--- a/test/lib/processed-payments/staleness.test.ts
+++ b/test/lib/processed-payments/staleness.test.ts
@@ -109,9 +109,9 @@ describeWithEnv("processed-payments / staleness", { db: true }, () => {
       });
 
       expect(await deleteAllStaleReservations()).toBe(0);
-      expect(
-        (await isSessionProcessed("cs_finalized_bulk"))?.attendee_id,
-      ).toBe(attendeeId);
+      expect((await isSessionProcessed("cs_finalized_bulk"))?.attendee_id).toBe(
+        attendeeId,
+      );
     });
 
     test("returns 0 when no stale reservations exist", async () => {


### PR DESCRIPTION
## Summary

- Added `id` attributes to 3 guide sections (Activity Log, Daily Events & Holidays, Webhooks) that were missing them, making them linkable from other admin pages
- Added contextual guide help links to 4 admin pages that were missing them: Sessions, Activity Log (both global and per-event), Holidays, and Admin Notification Email Template
- Follows the established pattern already used across 13 other admin templates

## Detail

During a deep-dive comparing the admin guide against the actual codebase, I found the guide content is very accurate — all specific claims (login limits, reservation window, session duration, API endpoints, email providers, CSV fields, etc.) match the code exactly.

The main gap was that several admin pages lacked contextual help links to the guide, despite 13 other pages already following this pattern. Three guide sections also lacked `id` attributes needed to make them linkable.

### Guide changes (`guide.tsx`)
- `Activity Log` section → added `id="activity-log"`
- `Daily Events & Holidays` section → added `id="holidays"`
- `Webhooks` section → added `id="webhooks"`

### Admin page changes
| Page | Link added | Target |
|------|-----------|--------|
| Sessions (`sessions.tsx`) | "Sessions guide" | `#login` |
| Activity Log - global (`activityLog.tsx`) | "Activity log guide" | `#activity-log` |
| Activity Log - per-event (`activityLog.tsx`) | Back link + "Activity log guide" | `#activity-log` |
| Holidays (`holidays.tsx`) | "Holidays guide" (next to Add Holiday) | `#holidays` |
| Admin Email Template (`email-tpl-admin.tsx`) | "template guide" (inline, matching confirmation template pattern) | `#email-templates` |

## Test plan

- [x] All precommit checks pass (typecheck, lint, cpd, edge build, test:coverage)
- [ ] Verify guide section anchors are reachable (e.g. `/admin/guide#activity-log`)
- [ ] Verify each new link renders correctly on its admin page
- [ ] Confirm no visual regressions on modified pages

https://claude.ai/code/session_0148rFSBBPZHAh9vstr5LRQE