### PR TITLE
Simplify available tags display in column order settings

### DIFF
--- a/src/templates/admin/settings/column-order.tsx
+++ b/src/templates/admin/settings/column-order.tsx
@@ -29,8 +29,8 @@ const AvailableTags = ({
 }): JSX.Element => (
   <small>
     Available:{" "}
-    {Object.entries(columns)
-      .map(([key, col]) => `{{${key}}} (${col.label})`)
+    {Object.keys(columns)
+      .map((key) => `{{${key}}}`)
       .join(", ")}
   </small>
 );


### PR DESCRIPTION
## Summary
Simplified the available tags display in the column order settings template by removing column labels from the output.

## Key Changes
- Changed from `Object.entries()` to `Object.keys()` to only iterate over column keys
- Removed the column label information from the displayed tags, showing only the template variable syntax `{{key}}`
- Reduced the visual complexity of the available tags list while maintaining the essential information needed for template variable reference

## Implementation Details
The change streamlines the UI by displaying only the template variable names (e.g., `{{columnName}}`) instead of the previous format that included labels (e.g., `{{columnName}} (Column Label)`). This makes the available tags list more concise and easier to scan while still providing users with the necessary information to construct template variables.

https://claude.ai/code/session_01Sez2E4oVzZ1FaXQM1BWCsV