### PR TITLE
Add built site assignment to ticket bookings

### DIFF
--- a/src/lib/api-example.ts
+++ b/src/lib/api-example.ts
@@ -42,6 +42,7 @@ export const API_EXAMPLE_EVENT: EventWithCount = {
   max_price: EXAMPLE_EVENT.unit_price,
   hidden: false,
   purchase_only: false,
+  assign_built_site: false,
   attendee_count: 3,
 };
 

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -6,7 +6,7 @@
 import type { InValue } from "@libsql/client";
 import { registerCache } from "#lib/cache-registry.ts";
 import { decrypt, encrypt } from "#lib/crypto/encryption.ts";
-import { queryAll } from "#lib/db/client.ts";
+import { queryAll, queryOne } from "#lib/db/client.ts";
 import type { ColumnDef, Table } from "#lib/db/table.ts";
 import { col, defineTable, withCacheInvalidation } from "#lib/db/table.ts";
 import { nowIso } from "#lib/now.ts";
@@ -23,18 +23,24 @@ export interface SiteDataBlob {
   d?: string;
   /** Database token (optional, absent in older blobs) */
   t?: string;
+  /** Assigned attendee ID (set when site is assigned to a booking) */
+  ai?: number;
+  /** Assigned event ID (set when site is assigned to a booking) */
+  ei?: number;
 }
 
 /** Built site row as stored in the database */
 export interface BuiltSiteRow {
   id: number;
   site_data: string;
+  assignable: number;
   created: string;
 }
 
 /** Built site input for creating a new row */
 export type BuiltSiteInput = {
   siteData: string;
+  assignable?: number;
 };
 
 /** Decrypted built site for display */
@@ -44,6 +50,9 @@ export interface BuiltSite {
   bunnyUrl: string;
   dbUrl: string;
   dbToken: string;
+  assignable: boolean;
+  assignedAttendeeId: number | null;
+  assignedEventId: number | null;
   created: string;
 }
 
@@ -53,10 +62,13 @@ export type BuiltSiteFormInput = {
   bunnyUrl: string;
   dbUrl: string;
   dbToken: string;
+  assignable: boolean;
 };
 
 const idCol = col.generated<number>();
 const createdCol = col.withDefault(() => nowIso());
+
+const assignableCol = col.withDefault(() => 0);
 
 const rawBuiltSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
   name: "built_sites",
@@ -64,6 +76,7 @@ const rawBuiltSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
   schema: {
     id: idCol,
     site_data: col.encrypted<string>(encrypt, decrypt),
+    assignable: assignableCol,
     created: createdCol,
   },
 });
@@ -74,6 +87,8 @@ export const buildSiteDataBlob = (
   bunnyUrl: string,
   dbUrl = "",
   dbToken = "",
+  assignedAttendeeId?: number,
+  assignedEventId?: number,
 ): string =>
   JSON.stringify({
     v: 1,
@@ -81,6 +96,8 @@ export const buildSiteDataBlob = (
     u: bunnyUrl,
     ...(dbUrl ? { d: dbUrl } : {}),
     ...(dbToken ? { t: dbToken } : {}),
+    ...(assignedAttendeeId ? { ai: assignedAttendeeId } : {}),
+    ...(assignedEventId ? { ei: assignedEventId } : {}),
   } satisfies SiteDataBlob);
 
 /** Parse a decrypted site data blob */
@@ -96,6 +113,9 @@ const rowToBuiltSite = (row: BuiltSiteRow): BuiltSite => {
     bunnyUrl: blob.u,
     dbUrl: blob.d ?? "",
     dbToken: blob.t ?? "",
+    assignable: Boolean(row.assignable),
+    assignedAttendeeId: blob.ai ?? null,
+    assignedEventId: blob.ei ?? null,
     created: row.created,
   };
 };
@@ -141,6 +161,9 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     bunnyUrl: {} as ColumnDef<string>,
     dbUrl: {} as ColumnDef<string>,
     dbToken: {} as ColumnDef<string>,
+    assignable: {} as ColumnDef<boolean>,
+    assignedAttendeeId: {} as ColumnDef<number | null>,
+    assignedEventId: {} as ColumnDef<number | null>,
     created: createdCol,
   },
   inputKeyMap: {
@@ -148,6 +171,7 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     bunny_url: "bunnyUrl",
     db_url: "dbUrl",
     db_token: "dbToken",
+    assignable: "assignable",
   },
 
   insert: async (input: BuiltSiteFormInput): Promise<BuiltSite> => {
@@ -158,6 +182,7 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
         input.dbUrl,
         input.dbToken,
       ),
+      assignable: input.assignable ? 1 : 0,
     });
     // insert() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
@@ -173,9 +198,18 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     const bunnyUrl = input.bunnyUrl ?? existing.bunnyUrl;
     const dbUrl = input.dbUrl ?? existing.dbUrl;
     const dbToken = input.dbToken ?? existing.dbToken;
+    const assignable = input.assignable ?? existing.assignable;
     // Row exists (checked above), so update always returns non-null
     const row = (await builtSitesTable.update(id, {
-      siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
+      siteData: buildSiteDataBlob(
+        name,
+        bunnyUrl,
+        dbUrl,
+        dbToken,
+        existing.assignedAttendeeId ?? undefined,
+        existing.assignedEventId ?? undefined,
+      ),
+      assignable: assignable ? 1 : 0,
     })) as BuiltSiteRow;
     // update() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
@@ -204,6 +238,7 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
         input.dbUrl ?? "",
         input.dbToken ?? "",
       ),
+      assignable: input.assignable ? 1 : 0,
     }),
 };
 
@@ -213,11 +248,49 @@ export const insertBuiltSite = (
   bunnyUrl: string,
   dbUrl = "",
   dbToken = "",
+  assignable = false,
 ): Promise<BuiltSiteRow> =>
   builtSitesTable.insert({
     siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
+    assignable: assignable ? 1 : 0,
   });
 
 /** Get all built sites, decrypted and sorted by name */
 export const getAllBuiltSites = (): Promise<BuiltSite[]> =>
   builtSitesCache.getAll();
+
+/** Count assignable sites (fast SQL, no decryption) */
+export const countAssignableSites = async (): Promise<number> => {
+  const row = await queryOne<{ cnt: number }>(
+    "SELECT COUNT(*) as cnt FROM built_sites WHERE assignable = 1",
+  );
+  return row?.cnt ?? 0;
+};
+
+/** Get all assignable built sites */
+export const getAssignableBuiltSites = async (): Promise<BuiltSite[]> => {
+  const all = await getAllBuiltSites();
+  return all.filter((s) => s.assignable);
+};
+
+/** Assign a built site to an attendee/event — sets assignable=0 and stores IDs in blob */
+export const assignBuiltSite = async (
+  siteId: number,
+  attendeeId: number,
+  eventId: number,
+): Promise<BuiltSite | null> => {
+  const existing = await builtSitesCrudTable.findById(siteId);
+  if (!existing) return null;
+  const row = (await builtSitesTable.update(siteId, {
+    siteData: buildSiteDataBlob(
+      existing.name,
+      existing.bunnyUrl,
+      existing.dbUrl,
+      existing.dbToken,
+      attendeeId,
+      eventId,
+    ),
+    assignable: 0,
+  })) as BuiltSiteRow;
+  return rowToBuiltSite(row);
+};

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -23,10 +23,6 @@ export interface SiteDataBlob {
   d?: string;
   /** Database token (optional, absent in older blobs) */
   t?: string;
-  /** Assigned attendee ID (set when site is assigned to a booking) */
-  ai?: number;
-  /** Assigned event ID (set when site is assigned to a booking) */
-  ei?: number;
 }
 
 /** Built site row as stored in the database */
@@ -34,6 +30,8 @@ export interface BuiltSiteRow {
   id: number;
   site_data: string;
   assignable: number;
+  assigned_attendee_id: number | null;
+  assigned_event_id: number | null;
   created: string;
 }
 
@@ -41,6 +39,8 @@ export interface BuiltSiteRow {
 export type BuiltSiteInput = {
   siteData: string;
   assignable?: number;
+  assignedAttendeeId?: number | null;
+  assignedEventId?: number | null;
 };
 
 /** Decrypted built site for display */
@@ -69,6 +69,7 @@ const idCol = col.generated<number>();
 const createdCol = col.withDefault(() => nowIso());
 
 const assignableCol = col.withDefault(() => 0);
+const nullCol = col.withDefault<number | null>(() => null);
 
 const rawBuiltSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
   name: "built_sites",
@@ -77,6 +78,8 @@ const rawBuiltSitesTable = defineTable<BuiltSiteRow, BuiltSiteInput>({
     id: idCol,
     site_data: col.encrypted<string>(encrypt, decrypt),
     assignable: assignableCol,
+    assigned_attendee_id: nullCol,
+    assigned_event_id: nullCol,
     created: createdCol,
   },
 });
@@ -87,8 +90,6 @@ export const buildSiteDataBlob = (
   bunnyUrl: string,
   dbUrl = "",
   dbToken = "",
-  assignedAttendeeId?: number,
-  assignedEventId?: number,
 ): string =>
   JSON.stringify({
     v: 1,
@@ -96,8 +97,6 @@ export const buildSiteDataBlob = (
     u: bunnyUrl,
     ...(dbUrl ? { d: dbUrl } : {}),
     ...(dbToken ? { t: dbToken } : {}),
-    ...(assignedAttendeeId ? { ai: assignedAttendeeId } : {}),
-    ...(assignedEventId ? { ei: assignedEventId } : {}),
   } satisfies SiteDataBlob);
 
 /** Parse a decrypted site data blob */
@@ -114,8 +113,8 @@ const rowToBuiltSite = (row: BuiltSiteRow): BuiltSite => {
     dbUrl: blob.d ?? "",
     dbToken: blob.t ?? "",
     assignable: Boolean(row.assignable),
-    assignedAttendeeId: blob.ai ?? null,
-    assignedEventId: blob.ei ?? null,
+    assignedAttendeeId: row.assigned_attendee_id ?? null,
+    assignedEventId: row.assigned_event_id ?? null,
     created: row.created,
   };
 };
@@ -201,14 +200,7 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     const assignable = input.assignable ?? existing.assignable;
     // Row exists (checked above), so update always returns non-null
     const row = (await builtSitesTable.update(id, {
-      siteData: buildSiteDataBlob(
-        name,
-        bunnyUrl,
-        dbUrl,
-        dbToken,
-        existing.assignedAttendeeId ?? undefined,
-        existing.assignedEventId ?? undefined,
-      ),
+      siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
       assignable: assignable ? 1 : 0,
     })) as BuiltSiteRow;
     // update() returns the row with unencrypted input values, so parse directly
@@ -273,7 +265,7 @@ export const getAssignableBuiltSites = async (): Promise<BuiltSite[]> => {
   return all.filter((s) => s.assignable);
 };
 
-/** Assign a built site to an attendee/event — sets assignable=0 and stores IDs in blob */
+/** Assign a built site to an attendee/event — sets assignable=0 and stores IDs */
 export const assignBuiltSite = async (
   siteId: number,
   attendeeId: number,
@@ -282,15 +274,9 @@ export const assignBuiltSite = async (
   const existing = await builtSitesCrudTable.findById(siteId);
   if (!existing) return null;
   const row = (await builtSitesTable.update(siteId, {
-    siteData: buildSiteDataBlob(
-      existing.name,
-      existing.bunnyUrl,
-      existing.dbUrl,
-      existing.dbToken,
-      attendeeId,
-      eventId,
-    ),
     assignable: 0,
+    assignedAttendeeId: attendeeId,
+    assignedEventId: eventId,
   })) as BuiltSiteRow;
   return rowToBuiltSite(row);
 };

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -255,6 +255,7 @@ export const getAllBuiltSites = (): Promise<BuiltSite[]> =>
 export const countAssignableSites = async (): Promise<number> => {
   const row = await queryOne<{ cnt: number }>(
     "SELECT COUNT(*) as cnt FROM built_sites WHERE assignable = 1",
+    [],
   );
   return row?.cnt ?? 0;
 };

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -187,7 +187,13 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
 
   insert: async (input: BuiltSiteFormInput): Promise<BuiltSite> => {
     const row = await builtSitesTable.insert(
-      toRawInput(input.name, input.bunnyUrl, input.dbUrl, input.dbToken, input.assignable),
+      toRawInput(
+        input.name,
+        input.bunnyUrl,
+        input.dbUrl,
+        input.dbToken,
+        input.assignable,
+      ),
     );
     // insert() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
@@ -205,7 +211,8 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     const dbToken = input.dbToken ?? existing.dbToken;
     const assignable = input.assignable ?? existing.assignable;
     // Row exists (checked above), so update always returns non-null
-    const row = (await builtSitesTable.update(id,
+    const row = (await builtSitesTable.update(
+      id,
       toRawInput(name, bunnyUrl, dbUrl, dbToken, assignable),
     )) as BuiltSiteRow;
     // update() returns the row with unencrypted input values, so parse directly
@@ -247,7 +254,9 @@ export const insertBuiltSite = (
   dbToken = "",
   assignable = false,
 ): Promise<BuiltSiteRow> =>
-  builtSitesTable.insert(toRawInput(name, bunnyUrl, dbUrl, dbToken, assignable));
+  builtSitesTable.insert(
+    toRawInput(name, bunnyUrl, dbUrl, dbToken, assignable),
+  );
 
 /** Get all built sites, decrypted and sorted by name */
 export const getAllBuiltSites = (): Promise<BuiltSite[]> =>
@@ -255,11 +264,12 @@ export const getAllBuiltSites = (): Promise<BuiltSite[]> =>
 
 /** Count assignable sites (fast SQL, no decryption) */
 export const countAssignableSites = async (): Promise<number> => {
-  const row = await queryOne<{ cnt: number }>(
+  // COUNT(*) always returns exactly one row
+  const row = (await queryOne<{ cnt: number }>(
     "SELECT COUNT(*) as cnt FROM built_sites WHERE assignable = 1",
     [],
-  );
-  return row?.cnt ?? 0;
+  ))!;
+  return row.cnt;
 };
 
 /** Get all assignable built sites */

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -99,6 +99,18 @@ export const buildSiteDataBlob = (
     ...(dbToken ? { t: dbToken } : {}),
   } satisfies SiteDataBlob);
 
+/** Build raw table input from individual fields */
+const toRawInput = (
+  name: string,
+  bunnyUrl: string,
+  dbUrl: string,
+  dbToken: string,
+  assignable: boolean,
+): BuiltSiteInput => ({
+  siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
+  assignable: assignable ? 1 : 0,
+});
+
 /** Parse a decrypted site data blob */
 export const parseSiteDataBlob = (json: string): SiteDataBlob =>
   JSON.parse(json) as SiteDataBlob;
@@ -174,15 +186,9 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
   },
 
   insert: async (input: BuiltSiteFormInput): Promise<BuiltSite> => {
-    const row = await builtSitesTable.insert({
-      siteData: buildSiteDataBlob(
-        input.name,
-        input.bunnyUrl,
-        input.dbUrl,
-        input.dbToken,
-      ),
-      assignable: input.assignable ? 1 : 0,
-    });
+    const row = await builtSitesTable.insert(
+      toRawInput(input.name, input.bunnyUrl, input.dbUrl, input.dbToken, input.assignable),
+    );
     // insert() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
   },
@@ -199,10 +205,9 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
     const dbToken = input.dbToken ?? existing.dbToken;
     const assignable = input.assignable ?? existing.assignable;
     // Row exists (checked above), so update always returns non-null
-    const row = (await builtSitesTable.update(id, {
-      siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
-      assignable: assignable ? 1 : 0,
-    })) as BuiltSiteRow;
+    const row = (await builtSitesTable.update(id,
+      toRawInput(name, bunnyUrl, dbUrl, dbToken, assignable),
+    )) as BuiltSiteRow;
     // update() returns the row with unencrypted input values, so parse directly
     return rowToBuiltSite(row);
   },
@@ -242,10 +247,7 @@ export const insertBuiltSite = (
   dbToken = "",
   assignable = false,
 ): Promise<BuiltSiteRow> =>
-  builtSitesTable.insert({
-    siteData: buildSiteDataBlob(name, bunnyUrl, dbUrl, dbToken),
-    assignable: assignable ? 1 : 0,
-  });
+  builtSitesTable.insert(toRawInput(name, bunnyUrl, dbUrl, dbToken, assignable));
 
 /** Get all built sites, decrypted and sorted by name */
 export const getAllBuiltSites = (): Promise<BuiltSite[]> =>

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -70,6 +70,7 @@ export type EventInput = {
   maxPrice: number;
   hidden?: boolean;
   purchaseOnly?: boolean;
+  assignBuiltSite?: boolean;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -169,6 +170,7 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
   max_price: col.withDefault(() => 0),
   hidden: col.boolean(false),
   purchase_only: col.boolean(false),
+  assign_built_site: col.boolean(false),
 });
 
 export const eventsTable = withCacheInvalidation(rawEventsTable, () =>

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -336,6 +336,8 @@ const SCHEMA: [name: string, table: Table][] = [
         ["id", "INTEGER PRIMARY KEY AUTOINCREMENT"],
         ["site_data", "TEXT NOT NULL"],
         ["assignable", "INTEGER NOT NULL DEFAULT 0"],
+        ["assigned_attendee_id", "INTEGER DEFAULT NULL"],
+        ["assigned_event_id", "INTEGER DEFAULT NULL"],
         ["created", "TEXT NOT NULL"],
       ],
     },

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -84,6 +84,7 @@ const SCHEMA: [name: string, table: Table][] = [
         ["can_pay_more", "INTEGER NOT NULL DEFAULT 0"],
         ["hidden", "INTEGER NOT NULL DEFAULT 0"],
         ["purchase_only", "INTEGER NOT NULL DEFAULT 0"],
+        ["assign_built_site", "INTEGER NOT NULL DEFAULT 0"],
         ["max_price", "INTEGER NOT NULL DEFAULT 0"],
       ],
       indexes: [
@@ -334,6 +335,7 @@ const SCHEMA: [name: string, table: Table][] = [
       columns: [
         ["id", "INTEGER PRIMARY KEY AUTOINCREMENT"],
         ["site_data", "TEXT NOT NULL"],
+        ["assignable", "INTEGER NOT NULL DEFAULT 0"],
         ["created", "TEXT NOT NULL"],
       ],
     },

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -19,6 +19,7 @@ export type EmailEvent = WebhookEvent & {
   date: string;
   location: string;
   purchase_only: boolean;
+  assign_built_site: boolean;
 };
 
 /** Attendee + event pair for email rendering */

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -14,7 +14,7 @@ import { generateSvgTicket, type SvgTicketData } from "#lib/svg-ticket.ts";
 import { buildCheckinUrl, buildTicketUrl } from "#lib/ticket-url.ts";
 import type { WebhookAttendee, WebhookEvent } from "#lib/webhook.ts";
 
-/** Event data needed for email rendering (extends webhook event with display fields) */
+/** Event data needed for registration pipeline (extends webhook event with display + assignment fields) */
 export type EmailEvent = WebhookEvent & {
   date: string;
   location: string;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,8 +5,8 @@
  * - Deno: uses Deno.env.get()
  * - Bunny Edge: uses process.env (Node.js compatibility)
  *
- * Tests can override values via setGetEnvOverride() without touching the
- * real environment, avoiding split-brain issues between Deno.env and process.env.
+ * Tests can intercept reads via setGetEnvOverlay() to inject values
+ * that are visible to getEnv() without touching the real environment.
  */
 
 declare const Deno:
@@ -16,26 +16,35 @@ declare const Deno:
 /** Augment globalThis to include optional process.env (Bunny Edge runtime) */
 declare const process: { env: Record<string, string | undefined> } | undefined;
 
-/** Optional test override — when set, getEnv delegates to this function */
-let _getEnvOverride: ((key: string) => string | undefined) | null = null;
+import { lazyRef } from "#fp";
 
-/** Replace getEnv's implementation for testing. Returns a restore function. */
-export const setGetEnvOverride = (
-  fn: ((key: string) => string | undefined) | null,
+/**
+ * Optional test overlay for getEnv(). When set, keys present in the overlay
+ * are returned from the overlay; keys NOT in the overlay fall through to
+ * the real process.env / Deno.env lookup. This avoids the split-brain where
+ * Deno.env patches don't propagate to process.env.
+ */
+const [getOverlay, setOverlay] = lazyRef<Record<
+  string,
+  string | undefined
+> | null>(() => null);
+
+/** Set a getEnv overlay for testing. Returns a restore function. */
+export const setGetEnvOverlay = (
+  overlay: Record<string, string | undefined> | null,
 ): (() => void) => {
-  const prev = _getEnvOverride;
-  _getEnvOverride = fn;
-  return () => {
-    _getEnvOverride = prev;
-  };
+  const prev = getOverlay();
+  setOverlay(overlay);
+  return () => setOverlay(prev);
 };
 
 /**
  * Get an environment variable value
- * Checks process.env first (Bunny Edge), falls back to Deno.env (local dev)
+ * Checks test overlay first, then process.env (Bunny Edge), then Deno.env
  */
 export function getEnv(key: string): string | undefined {
-  if (_getEnvOverride) return _getEnvOverride(key);
+  const overlay = getOverlay();
+  if (overlay && key in overlay) return overlay[key];
 
   // Try process.env first (available in Bunny Edge via node:process)
   if (process?.env && key in process.env) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,8 +5,10 @@
  * - Deno: uses Deno.env.get()
  * - Bunny Edge: uses process.env (Node.js compatibility)
  *
- * Tests can intercept reads via setGetEnvOverlay() to inject values
- * that are visible to getEnv() without touching the real environment.
+ * Note: In Deno, process.env is a proxy over Deno.env — they share the
+ * same backing store. The test overlay (setTestEnv in test-utils) patches
+ * Deno.env.get/set/delete, which automatically affects process.env reads
+ * and writes too.
  */
 
 declare const Deno:
@@ -16,36 +18,11 @@ declare const Deno:
 /** Augment globalThis to include optional process.env (Bunny Edge runtime) */
 declare const process: { env: Record<string, string | undefined> } | undefined;
 
-import { lazyRef } from "#fp";
-
-/**
- * Optional test overlay for getEnv(). When set, keys present in the overlay
- * are returned from the overlay; keys NOT in the overlay fall through to
- * the real process.env / Deno.env lookup. This avoids the split-brain where
- * Deno.env patches don't propagate to process.env.
- */
-const [getOverlay, setOverlay] = lazyRef<Record<
-  string,
-  string | undefined
-> | null>(() => null);
-
-/** Set a getEnv overlay for testing. Returns a restore function. */
-export const setGetEnvOverlay = (
-  overlay: Record<string, string | undefined> | null,
-): (() => void) => {
-  const prev = getOverlay();
-  setOverlay(overlay);
-  return () => setOverlay(prev);
-};
-
 /**
  * Get an environment variable value
- * Checks test overlay first, then process.env (Bunny Edge), then Deno.env
+ * Checks process.env first (Bunny Edge), falls back to Deno.env (local dev)
  */
 export function getEnv(key: string): string | undefined {
-  const overlay = getOverlay();
-  if (overlay && key in overlay) return overlay[key];
-
   // Try process.env first (available in Bunny Edge via node:process)
   if (process?.env && key in process.env) {
     return process.env[key];

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,6 +4,9 @@
  *
  * - Deno: uses Deno.env.get()
  * - Bunny Edge: uses process.env (Node.js compatibility)
+ *
+ * Tests can override values via setGetEnvOverride() without touching the
+ * real environment, avoiding split-brain issues between Deno.env and process.env.
  */
 
 declare const Deno:
@@ -13,11 +16,27 @@ declare const Deno:
 /** Augment globalThis to include optional process.env (Bunny Edge runtime) */
 declare const process: { env: Record<string, string | undefined> } | undefined;
 
+/** Optional test override — when set, getEnv delegates to this function */
+let _getEnvOverride: ((key: string) => string | undefined) | null = null;
+
+/** Replace getEnv's implementation for testing. Returns a restore function. */
+export const setGetEnvOverride = (
+  fn: ((key: string) => string | undefined) | null,
+): (() => void) => {
+  const prev = _getEnvOverride;
+  _getEnvOverride = fn;
+  return () => {
+    _getEnvOverride = prev;
+  };
+};
+
 /**
  * Get an environment variable value
  * Checks process.env first (Bunny Edge), falls back to Deno.env (local dev)
  */
 export function getEnv(key: string): string | undefined {
+  if (_getEnvOverride) return _getEnvOverride(key);
+
   // Try process.env first (available in Bunny Edge via node:process)
   if (process?.env && key in process.env) {
     return process.env[key];
@@ -28,13 +47,13 @@ export function getEnv(key: string): string | undefined {
   return Deno!.env.get(key);
 }
 
+/** Check if the system is in read-only mode (READ_ONLY env var) */
+export const isReadOnly = (): boolean => getEnv("READ_ONLY") === "true";
+
 /**
  * Get a required environment variable, throwing if not set.
  * Use this instead of `getEnv(key) as string` when the variable must exist.
  */
-/** Check if the system is in read-only mode (READ_ONLY env var) */
-export const isReadOnly = (): boolean => getEnv("READ_ONLY") === "true";
-
 export function requireEnv(key: string): string {
   const value = getEnv(key);
   if (value === undefined) {

--- a/src/lib/site-assignment.ts
+++ b/src/lib/site-assignment.ts
@@ -95,8 +95,6 @@ export const assignAndNotifyBuiltSites = async (
   const assignments = await assignSitesForEntries(entries);
   if (assignments.length === 0) return;
 
-  const email = entries[0]?.attendee.email;
-  if (email) {
-    await sendSiteAssignmentEmail(email, assignments);
-  }
+  const email = entries[0]!.attendee.email;
+  await sendSiteAssignmentEmail(email, assignments);
 };

--- a/src/lib/site-assignment.ts
+++ b/src/lib/site-assignment.ts
@@ -9,11 +9,7 @@ import {
   getAssignableBuiltSites,
 } from "#lib/db/built-sites.ts";
 import { settings } from "#lib/db/settings.ts";
-import {
-  getEmailConfig,
-  getHostEmailConfig,
-  sendEmail,
-} from "#lib/email.ts";
+import { getEmailConfig, getHostEmailConfig, sendEmail } from "#lib/email.ts";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 
 /** Entry with the fields needed for site assignment */
@@ -68,8 +64,7 @@ const sendSiteAssignmentEmail = async (
 
   const siteListHtml = assignments
     .map(
-      (a) =>
-        `<li>${a.eventName}: <a href="${a.siteUrl}">${a.siteUrl}</a></li>`,
+      (a) => `<li>${a.eventName}: <a href="${a.siteUrl}">${a.siteUrl}</a></li>`,
     )
     .join("");
 

--- a/src/lib/site-assignment.ts
+++ b/src/lib/site-assignment.ts
@@ -17,19 +17,19 @@ import {
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 
 /** Entry with the fields needed for site assignment */
-export type SiteAssignmentEntry = {
+type SiteAssignmentEntry = {
   event: { id: number; name: string; assign_built_site: boolean };
   attendee: { id: number; email: string; quantity: number };
 };
 
 /** Info about an assigned site for email rendering */
-export type SiteAssignment = {
+type SiteAssignment = {
   siteUrl: string;
   eventName: string;
 };
 
 /** Assign built sites to entries that need them. Returns assigned URLs. */
-export const assignSitesForEntries = async (
+const assignSitesForEntries = async (
   entries: SiteAssignmentEntry[],
 ): Promise<SiteAssignment[]> => {
   const needsSite = entries.filter((e) => e.event.assign_built_site);
@@ -54,7 +54,7 @@ export const assignSitesForEntries = async (
 };
 
 /** Send site assignment notification email */
-export const sendSiteAssignmentEmail = async (
+const sendSiteAssignmentEmail = async (
   to: string,
   assignments: SiteAssignment[],
 ): Promise<void> => {

--- a/src/lib/site-assignment.ts
+++ b/src/lib/site-assignment.ts
@@ -1,6 +1,7 @@
 /**
  * Built site assignment — assigns sites to attendees after booking completion.
  * Sends a separate notification email with site URLs.
+ * All assignment logic is gated behind CAN_BUILD_SITES.
  */
 
 import {
@@ -8,12 +9,18 @@ import {
   getAssignableBuiltSites,
 } from "#lib/db/built-sites.ts";
 import { settings } from "#lib/db/settings.ts";
-import type { EmailEntry } from "#lib/email.ts";
 import {
   getEmailConfig,
   getHostEmailConfig,
   sendEmail,
 } from "#lib/email.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
+
+/** Entry with the fields needed for site assignment */
+export type SiteAssignmentEntry = {
+  event: { id: number; name: string; assign_built_site: boolean };
+  attendee: { id: number; email: string; quantity: number };
+};
 
 /** Info about an assigned site for email rendering */
 export type SiteAssignment = {
@@ -23,7 +30,7 @@ export type SiteAssignment = {
 
 /** Assign built sites to entries that need them. Returns assigned URLs. */
 export const assignSitesForEntries = async (
-  entries: EmailEntry[],
+  entries: SiteAssignmentEntry[],
 ): Promise<SiteAssignment[]> => {
   const needsSite = entries.filter((e) => e.event.assign_built_site);
   if (needsSite.length === 0) return [];
@@ -78,10 +85,13 @@ export const sendSiteAssignmentEmail = async (
   await sendEmail(config, { to, subject, html, text, replyTo });
 };
 
-/** Assign sites and send notification email. Designed to be called via addPendingWork. */
+/** Assign sites and send notification email. Designed to be called via addPendingWork.
+ * No-ops when CAN_BUILD_SITES is not enabled. */
 export const assignAndNotifyBuiltSites = async (
-  entries: EmailEntry[],
+  entries: SiteAssignmentEntry[],
 ): Promise<void> => {
+  if (!isBuilderEnabled()) return;
+
   const assignments = await assignSitesForEntries(entries);
   if (assignments.length === 0) return;
 

--- a/src/lib/site-assignment.ts
+++ b/src/lib/site-assignment.ts
@@ -1,0 +1,92 @@
+/**
+ * Built site assignment — assigns sites to attendees after booking completion.
+ * Sends a separate notification email with site URLs.
+ */
+
+import {
+  assignBuiltSite,
+  getAssignableBuiltSites,
+} from "#lib/db/built-sites.ts";
+import { settings } from "#lib/db/settings.ts";
+import type { EmailEntry } from "#lib/email.ts";
+import {
+  getEmailConfig,
+  getHostEmailConfig,
+  sendEmail,
+} from "#lib/email.ts";
+
+/** Info about an assigned site for email rendering */
+export type SiteAssignment = {
+  siteUrl: string;
+  eventName: string;
+};
+
+/** Assign built sites to entries that need them. Returns assigned URLs. */
+export const assignSitesForEntries = async (
+  entries: EmailEntry[],
+): Promise<SiteAssignment[]> => {
+  const needsSite = entries.filter((e) => e.event.assign_built_site);
+  if (needsSite.length === 0) return [];
+
+  const assignments: SiteAssignment[] = [];
+  const available = await getAssignableBuiltSites();
+  let idx = 0;
+
+  for (const { event, attendee } of needsSite) {
+    const qty = attendee.quantity;
+    for (let i = 0; i < qty; i++) {
+      const site = available[idx];
+      if (!site) break; // edge case: ran out (paid booking race)
+      await assignBuiltSite(site.id, attendee.id, event.id);
+      assignments.push({ siteUrl: site.bunnyUrl, eventName: event.name });
+      idx++;
+    }
+  }
+
+  return assignments;
+};
+
+/** Send site assignment notification email */
+export const sendSiteAssignmentEmail = async (
+  to: string,
+  assignments: SiteAssignment[],
+): Promise<void> => {
+  const config = getEmailConfig() ?? getHostEmailConfig();
+  if (!config) return;
+
+  const subject =
+    assignments.length === 1
+      ? "Your new site is ready"
+      : `Your ${assignments.length} new sites are ready`;
+
+  const siteListHtml = assignments
+    .map(
+      (a) =>
+        `<li>${a.eventName}: <a href="${a.siteUrl}">${a.siteUrl}</a></li>`,
+    )
+    .join("");
+
+  const html = `<p>Your new site${assignments.length > 1 ? "s are" : " is"} ready!</p><ul>${siteListHtml}</ul>`;
+
+  const siteListText = assignments
+    .map((a) => `- ${a.eventName}: ${a.siteUrl}`)
+    .join("\n");
+
+  const text = `Your new site${assignments.length > 1 ? "s are" : " is"} ready!\n\n${siteListText}`;
+
+  const replyTo = settings.businessEmail || undefined;
+  await sendEmail(config, { to, subject, html, text, replyTo });
+};
+
+/** Assign sites and send notification email. Designed to be called via addPendingWork. */
+export const assignAndNotifyBuiltSites = async (
+  entries: EmailEntry[],
+): Promise<void> => {
+  const assignments = await assignSitesForEntries(entries);
+  if (assignments.length === 0) return;
+
+  const email = entries[0]?.attendee.email;
+  if (email) {
+    await sendSiteAssignmentEmail(email, assignments);
+  }
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,7 @@ export interface Event {
   max_price: number;
   hidden: boolean;
   purchase_only: boolean;
+  assign_built_site: boolean;
 }
 
 export interface Attendee extends ContactInfo {

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -11,6 +11,7 @@ import { fetchText } from "#lib/fetch.ts";
 import { ErrorCode, logError } from "#lib/logger.ts";
 import { nowIso } from "#lib/now.ts";
 import { addPendingWork } from "#lib/pending-work.ts";
+import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
 import { buildTicketUrl } from "#lib/ticket-url.ts";
 import { type ContactInfo, isPaidEvent } from "#lib/types.ts";
 
@@ -169,4 +170,5 @@ export const logAndNotifyRegistration = async (
   const currency = settings.currency;
   addPendingWork(sendRegistrationWebhooks(entries, currency));
   addPendingWork(sendRegistrationEmails(entries, currency));
+  addPendingWork(assignAndNotifyBuiltSites(entries));
 };

--- a/src/routes/admin/builder.ts
+++ b/src/routes/admin/builder.ts
@@ -65,6 +65,7 @@ const handleBuilderPost = async (
   const siteName = form.getString("site_name");
   const dbUrl = form.getString("db_url");
   const dbToken = form.getString("db_token");
+  const assignable = form.getString("assignable") === "1";
 
   if (!siteName) return errorRedirect(BUILDER_PATH, "Site name is required");
   if (!dbUrl) return errorRedirect(BUILDER_PATH, "Database URL is required");
@@ -96,7 +97,13 @@ const handleBuilderPost = async (
   }
 
   // Record the built site (including db credentials for future reference)
-  await insertBuiltSite(siteName, buildResult.defaultHostname, dbUrl, dbToken);
+  await insertBuiltSite(
+    siteName,
+    buildResult.defaultHostname,
+    dbUrl,
+    dbToken,
+    assignable,
+  );
   await logActivity(`Built new site: ${siteName}`);
 
   return redirect(

--- a/src/routes/admin/built-sites.ts
+++ b/src/routes/admin/built-sites.ts
@@ -25,6 +25,7 @@ const extractBuiltSiteInput = (
   bunnyUrl: String(values.bunny_url),
   dbUrl: String(values.db_url),
   dbToken: String(values.db_token),
+  assignable: values.assignable === "1",
 });
 
 /** Built sites resource for REST create/update operations */

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -46,6 +46,7 @@ import {
   validateAttachment,
   validateImage,
 } from "#lib/storage.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import type {
   AdminSession,
   Attendee,
@@ -133,7 +134,7 @@ const extractCommonFields = (values: EventFormValues) => {
     maxPrice: toMinorUnits(Number.parseFloat(values.max_price)),
     hidden: values.hidden === "1",
     purchaseOnly: values.purchase_only === "1",
-    assignBuiltSite: values.assign_built_site === "1",
+    assignBuiltSite: isBuilderEnabled() && values.assign_built_site === "1",
   };
 };
 

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -46,13 +46,13 @@ import {
   validateAttachment,
   validateImage,
 } from "#lib/storage.ts";
-import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import type {
   AdminSession,
   Attendee,
   EventWithCount,
   Group,
 } from "#lib/types.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import {
   createConfirmedHandlers,
   csvResponse,
@@ -91,6 +91,7 @@ import type {
   EventFormValues,
 } from "#templates/fields.ts";
 import {
+  assignBuiltSiteField,
   eventFields,
   groupIdField,
   slugField,
@@ -158,7 +159,7 @@ const extractEventUpdateInput = async (
 /** Events resource for REST create operations */
 const eventsResource = defineResource({
   table: eventsTable,
-  fields: [...eventFields, groupIdField],
+  fields: [...eventFields, assignBuiltSiteField, groupIdField],
   toInput: extractEventInput,
   nameField: "name",
   validate: validateEventInput,
@@ -482,7 +483,7 @@ const handleAdminEventEditPost: TypedRouteHandler<
     // by validateEventInput when existingId is set.
     const updateResource = defineResource({
       table: eventsTable,
-      fields: [...eventFields, slugField, groupIdField],
+      fields: [...eventFields, assignBuiltSiteField, slugField, groupIdField],
       toInput: extractEventUpdateInput,
       nameField: "name",
       validate: validateEventInput,

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -133,6 +133,7 @@ const extractCommonFields = (values: EventFormValues) => {
     maxPrice: toMinorUnits(Number.parseFloat(values.max_price)),
     hidden: values.hidden === "1",
     purchaseOnly: values.purchase_only === "1",
+    assignBuiltSite: values.assign_built_site === "1",
   };
 };
 

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -809,6 +809,7 @@ const PREVIEW_BOOKINGS = [
       date: "2026-07-15T19:00:00Z",
       location: "Town Hall",
       purchase_only: false,
+      assign_built_site: false,
     },
     attendee: {
       id: 1,
@@ -837,6 +838,7 @@ const PREVIEW_BOOKINGS = [
       date: "",
       location: "",
       purchase_only: false,
+      assign_built_site: false,
     },
     attendee: {
       id: 2,

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -43,6 +43,20 @@ import {
   type TicketCtx,
 } from "./types.ts";
 
+/** Sum quantity needed across events with assign_built_site enabled */
+const totalSitesNeeded = (
+  events: TicketEvent[],
+  quantities: Map<number, number>,
+): number => {
+  let total = 0;
+  for (const { event } of events) {
+    if (event.assign_built_site) {
+      total += quantities.get(event.id) ?? 0;
+    }
+  }
+  return total;
+};
+
 /** Handle POST for ticket registration */
 const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
   withCsrfForm(
@@ -159,6 +173,20 @@ const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
         quantities,
         customPrices,
       );
+
+      // Check built site availability for assign_built_site events
+      const sitesNeeded = totalSitesNeeded(ctx.events, quantities);
+      if (sitesNeeded > 0) {
+        const { countAssignableSites } = await import(
+          "#lib/db/built-sites.ts"
+        );
+        const availableSites = await countAssignableSites();
+        if (availableSites < sitesNeeded) {
+          return ticketFormErrorResponse(ctx)(
+            "Sorry, not enough sites available",
+          );
+        }
+      }
 
       // Check if payment required
       if (await anyRequiresPayment(items)) {

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -3,6 +3,7 @@
  */
 
 import { reduce } from "#fp";
+import { countAssignableSites } from "#lib/db/built-sites.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { saveEventAnswers } from "#lib/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
@@ -180,9 +181,6 @@ const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
       if (sitesNeeded > 0) {
         const { isBuilderEnabled } = await import("#routes/admin/builder.ts");
         if (isBuilderEnabled()) {
-          const { countAssignableSites } = await import(
-            "#lib/db/built-sites.ts"
-          );
           const availableSites = await countAssignableSites();
           if (availableSites < sitesNeeded) {
             return ticketFormErrorResponse(ctx)(

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -175,16 +175,20 @@ const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
       );
 
       // Check built site availability for assign_built_site events
+      // Only runs when the builder feature is enabled
       const sitesNeeded = totalSitesNeeded(ctx.events, quantities);
       if (sitesNeeded > 0) {
-        const { countAssignableSites } = await import(
-          "#lib/db/built-sites.ts"
-        );
-        const availableSites = await countAssignableSites();
-        if (availableSites < sitesNeeded) {
-          return ticketFormErrorResponse(ctx)(
-            "Sorry, not enough sites available",
+        const { isBuilderEnabled } = await import("#routes/admin/builder.ts");
+        if (isBuilderEnabled()) {
+          const { countAssignableSites } = await import(
+            "#lib/db/built-sites.ts"
           );
+          const availableSites = await countAssignableSites();
+          if (availableSites < sitesNeeded) {
+            return ticketFormErrorResponse(ctx)(
+              "Sorry, not enough sites available",
+            );
+          }
         }
       }
 

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -5,6 +5,7 @@
 import { reduce } from "#fp";
 import { countAssignableSites } from "#lib/db/built-sites.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { saveEventAnswers } from "#lib/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import { isPaidEvent } from "#lib/types.ts";
@@ -178,15 +179,12 @@ const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
       // Check built site availability for assign_built_site events
       // Only runs when the builder feature is enabled
       const sitesNeeded = totalSitesNeeded(ctx.events, quantities);
-      if (sitesNeeded > 0) {
-        const { isBuilderEnabled } = await import("#routes/admin/builder.ts");
-        if (isBuilderEnabled()) {
-          const availableSites = await countAssignableSites();
-          if (availableSites < sitesNeeded) {
-            return ticketFormErrorResponse(ctx)(
-              "Sorry, not enough sites available",
-            );
-          }
+      if (sitesNeeded > 0 && isBuilderEnabled()) {
+        const availableSites = await countAssignableSites();
+        if (availableSites < sitesNeeded) {
+          return ticketFormErrorResponse(ctx)(
+            "Sorry, not enough sites available",
+          );
         }
       }
 

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -3,12 +3,12 @@
  */
 
 import { reduce } from "#fp";
-import { countAssignableSites } from "#lib/db/built-sites.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
-import { isBuilderEnabled } from "#routes/admin/builder.ts";
+import { countAssignableSites } from "#lib/db/built-sites.ts";
 import { saveEventAnswers } from "#lib/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import { isPaidEvent } from "#lib/types.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import {
   applyFlash,
   errorRedirect,
@@ -53,7 +53,8 @@ const totalSitesNeeded = (
   let total = 0;
   for (const { event } of events) {
     if (event.assign_built_site) {
-      total += quantities.get(event.id) ?? 0;
+      // quantities is always populated for every event by parseQuantities
+      total += quantities.get(event.id)!;
     }
   }
   return total;

--- a/src/templates/admin/builder.tsx
+++ b/src/templates/admin/builder.tsx
@@ -56,6 +56,13 @@ const BuilderForm = (): JSX.Element => (
           placeholder="Token for the database"
         />
       </label>
+      <fieldset>
+        <label>
+          <input type="checkbox" name="assignable" value="1" />
+          Available for assignment
+        </label>
+        <small>Make this site available for automatic assignment when a ticket is purchased</small>
+      </fieldset>
       <button type="submit">Build Site</button>
     </CsrfForm>
   </section>

--- a/src/templates/admin/builder.tsx
+++ b/src/templates/admin/builder.tsx
@@ -61,7 +61,10 @@ const BuilderForm = (): JSX.Element => (
           <input type="checkbox" name="assignable" value="1" />
           Available for assignment
         </label>
-        <small>Make this site available for automatic assignment when a ticket is purchased</small>
+        <small>
+          Make this site available for automatic assignment when a ticket is
+          purchased
+        </small>
       </fieldset>
       <button type="submit">Build Site</button>
     </CsrfForm>

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -35,6 +35,7 @@ export const adminBuiltSitesPage = (
               <tr>
                 <th>Name</th>
                 <th>Bunny URL</th>
+                <th>Status</th>
                 <th>Actions</th>
               </tr>
             </thead>
@@ -46,6 +47,13 @@ export const adminBuiltSitesPage = (
                     <a href={site.bunnyUrl} target="_blank" rel="noopener">
                       {site.bunnyUrl}
                     </a>
+                  </td>
+                  <td>
+                    {site.assignedAttendeeId
+                      ? `Assigned (attendee #${site.assignedAttendeeId})`
+                      : site.assignable
+                        ? "Available"
+                        : "Not assignable"}
                   </td>
                   <td>
                     <a href={`/admin/built-sites/${site.id}/edit`}>Edit</a>{" "}
@@ -70,6 +78,7 @@ export const builtSiteToFieldValues = (
   bunny_url: site?.bunnyUrl ?? "",
   db_url: site?.dbUrl ?? "",
   db_token: site?.dbToken ?? "",
+  assignable: site?.assignable ? "1" : "",
 });
 
 /**

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -41,12 +41,14 @@ import {
   type TableQuestionData,
 } from "#templates/attendee-table.tsx";
 import {
+  assignBuiltSiteField,
   attachmentField,
   eventFields,
   getAddAttendeeFields,
   imageField,
   slugField,
 } from "#templates/fields.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { Layout } from "#templates/layout.tsx";
 import { renderEventImage } from "#templates/public.tsx";
 
@@ -685,6 +687,7 @@ const eventToFieldValues = (event: EventWithCount): FieldValues => ({
   webhook_url: event.webhook_url,
   non_transferable: event.non_transferable ? "1" : "",
   hidden: event.hidden ? "1" : "",
+  assign_built_site: event.assign_built_site ? "1" : "",
 });
 
 /** Event fields with autofocus on the name field */
@@ -701,9 +704,12 @@ export const adminEventNewPage = (
   error?: string,
 ): string => {
   const storageEnabled = isStorageEnabled();
-  const fields = storageEnabled
-    ? [...eventFields, imageField, attachmentField]
-    : eventFields;
+  const builderEnabled = isBuilderEnabled();
+  const fields = [
+    ...eventFields,
+    ...(builderEnabled ? [assignBuiltSiteField] : []),
+    ...(storageEnabled ? [imageField, attachmentField] : []),
+  ];
   return String(
     <Layout title="Add Event">
       <AdminNav session={session} active="/admin/" />
@@ -729,6 +735,13 @@ export const adminDuplicateEventPage = (
 ): string => {
   const values = eventToFieldValues(event);
   values.name = "";
+  const builderEnabled = isBuilderEnabled();
+  const storageEnabled = isStorageEnabled();
+  const dupFields = [
+    ...eventFieldsWithAutofocus,
+    ...(builderEnabled ? [assignBuiltSiteField] : []),
+    ...(storageEnabled ? [imageField, attachmentField] : []),
+  ];
 
   return String(
     <Layout title={`Duplicate: ${event.name}`}>
@@ -738,7 +751,7 @@ export const adminDuplicateEventPage = (
         Creating a new event based on <strong>{event.name}</strong>.
       </p>
       <CsrfForm action="/admin/event" enctype="multipart/form-data">
-        <Raw html={renderFields(eventFieldsWithAutofocus, values)} />
+        <Raw html={renderFields(dupFields, values)} />
         <EventGroupSelect groups={groups} selectedGroupId={event.group_id} />
         <button type="submit">Create Event</button>
       </CsrfForm>
@@ -756,9 +769,12 @@ export const adminEventEditPage = (
   error?: string,
 ): string => {
   const storageEnabled = isStorageEnabled();
-  const fields = storageEnabled
-    ? [...eventFields, imageField, attachmentField]
-    : eventFields;
+  const builderEnabled = isBuilderEnabled();
+  const fields = [
+    ...eventFields,
+    ...(builderEnabled ? [assignBuiltSiteField] : []),
+    ...(storageEnabled ? [imageField, attachmentField] : []),
+  ];
   return String(
     <Layout title={`Edit: ${event.name}`}>
       <AdminNav session={session} active="/admin/" />

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -31,6 +31,7 @@ import {
   type Group,
   isPaidEvent,
 } from "#lib/types.ts";
+import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { formatCountdown } from "#routes/utils.ts";
 import { buildSharedDetailRows } from "#templates/admin/detail-rows.tsx";
 import { EventGroupSelect } from "#templates/admin/group-select.tsx";
@@ -48,7 +49,6 @@ import {
   imageField,
   slugField,
 } from "#templates/fields.ts";
-import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { Layout } from "#templates/layout.tsx";
 import { renderEventImage } from "#templates/public.tsx";
 

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -736,10 +736,11 @@ export const adminDuplicateEventPage = (
   const values = eventToFieldValues(event);
   values.name = "";
   const builderEnabled = isBuilderEnabled();
-  // Duplicate page omits image/attachment fields — files aren't duplicated
+  const storageEnabled = isStorageEnabled();
   const dupFields = [
     ...eventFieldsWithAutofocus,
     ...(builderEnabled ? [assignBuiltSiteField] : []),
+    ...(storageEnabled ? [imageField, attachmentField] : []),
   ];
 
   return String(

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -736,11 +736,10 @@ export const adminDuplicateEventPage = (
   const values = eventToFieldValues(event);
   values.name = "";
   const builderEnabled = isBuilderEnabled();
-  const storageEnabled = isStorageEnabled();
+  // Duplicate page omits image/attachment fields — files aren't duplicated
   const dupFields = [
     ...eventFieldsWithAutofocus,
     ...(builderEnabled ? [assignBuiltSiteField] : []),
-    ...(storageEnabled ? [imageField, attachmentField] : []),
   ];
 
   return String(

--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -63,6 +63,7 @@ export type EventFormValues = {
   max_price: string;
   hidden: string;
   purchase_only: string;
+  assign_built_site: string;
 };
 
 /** Typed values from event edit form (includes slug) */
@@ -543,7 +544,23 @@ export const builtSiteFields: Field[] = [
     type: "password",
     placeholder: "Database auth token",
   },
+  {
+    name: "assignable",
+    label: "Assignable",
+    type: "checkbox-group",
+    hint: "Make this site available for automatic assignment when a ticket is purchased",
+    options: [{ value: "1", label: "Available for assignment" }],
+  },
 ];
+
+/** Field for assign_built_site on events (conditionally shown when CAN_BUILD_SITES is enabled) */
+export const assignBuiltSiteField: Field = {
+  name: "assign_built_site",
+  label: "Assign Built Site",
+  type: "checkbox-group",
+  hint: "Automatically assign a built site to each ticket purchased for this event",
+  options: [{ value: "1", label: "Assign a site on booking" }],
+};
 
 /** Image upload field for event forms (appended when storage is enabled) */
 export const imageField: Field = {

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -438,11 +438,11 @@ Deno.env.delete = (key: string): void => {
   else _realDelete(key);
 };
 
-import { setGetEnvOverride } from "#lib/env.ts";
+import { setGetEnvOverlay } from "#lib/env.ts";
 
 /**
  * Set env vars for a test and return a restore function that puts them back.
- * Uses a per-worker overlay on Deno.env AND a getEnv() override so that
+ * Uses a per-worker overlay on Deno.env AND a getEnv() overlay so that
  * both Deno.env.get() and getEnv() (which checks process.env first) see
  * test values. Parallel test workers cannot leak env vars to each other.
  * Pass `undefined` as a value to delete the key (useful for ensuring a clean slate).
@@ -474,8 +474,10 @@ export const setTestEnv = (
     if (value !== undefined) Deno.env.set(key, value);
     else Deno.env.delete(key);
   }
-  // Hook getEnv() so process.env-first code paths also see overlay values
-  const restoreGetEnv = setGetEnvOverride((key) => Deno.env.get(key));
+  // Hook getEnv() so process.env-first code paths also see overlay values.
+  // Only keys IN the overlay are intercepted; other keys fall through to
+  // the real getEnv() logic (preserving process.env priority).
+  const restoreGetEnv = setGetEnvOverlay(layer);
   return () => {
     restoreGetEnv();
     _overlay = prev;

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1066,6 +1066,7 @@ export const createTestEvent = (
       max_price: priceFormValue(input.maxPrice),
       hidden: input.hidden ? "1" : "",
       purchase_only: input.purchaseOnly ? "1" : "",
+      assign_built_site: input.assignBuiltSite ? "1" : "",
     },
     async () => {
       // Get the most recently created event (302 redirect guarantees creation succeeded)
@@ -1167,6 +1168,9 @@ export const updateTestEvent = async (
       can_pay_more: (updates.canPayMore ?? existing.can_pay_more) ? "1" : "",
       max_price: priceFormValue(updates.maxPrice ?? existing.max_price),
       hidden: (updates.hidden ?? existing.hidden) ? "1" : "",
+      purchase_only: (updates.purchaseOnly ?? existing.purchase_only) ? "1" : "",
+      assign_built_site:
+        (updates.assignBuiltSite ?? existing.assign_built_site) ? "1" : "",
     },
     async () => (await getEventWithCount(eventId)) as EventWithCount,
     "update event",
@@ -1609,6 +1613,7 @@ export const testEvent = (overrides: Partial<Event> = {}): Event => ({
   max_price: 0,
   hidden: false,
   purchase_only: false,
+  assign_built_site: false,
   ...overrides,
 });
 
@@ -2081,6 +2086,9 @@ export const testBuiltSite = (
   bunnyUrl: "https://test.b-cdn.net",
   dbUrl: "",
   dbToken: "",
+  assignable: false,
+  assignedAttendeeId: null,
+  assignedEventId: null,
   created: "2026-01-01T00:00:00Z",
   ...overrides,
 });
@@ -2096,6 +2104,7 @@ export const createTestBuiltSite = (
     bunnyUrl: overrides.bunnyUrl ?? "https://test.b-cdn.net",
     dbUrl: overrides.dbUrl ?? "",
     dbToken: overrides.dbToken ?? "",
+    assignable: overrides.assignable ?? false,
   };
 
   return authenticatedFormRequest(
@@ -2105,6 +2114,7 @@ export const createTestBuiltSite = (
       bunny_url: input.bunnyUrl,
       db_url: input.dbUrl,
       db_token: input.dbToken,
+      ...(input.assignable ? { assignable: "1" } : {}),
     },
     async () => {
       const { getAllBuiltSites } = await import("#lib/db/built-sites.ts");
@@ -2125,6 +2135,7 @@ export const updateTestBuiltSite = async (
   const { builtSitesCrudTable } = await import("#lib/db/built-sites.ts");
   const existing = (await builtSitesCrudTable.findById(siteId)) as BuiltSite;
 
+  const assignable = updates.assignable ?? existing.assignable;
   return authenticatedFormRequest(
     `/admin/built-sites/${siteId}/edit`,
     {
@@ -2132,6 +2143,7 @@ export const updateTestBuiltSite = async (
       bunny_url: updates.bunnyUrl ?? existing.bunnyUrl,
       db_url: updates.dbUrl ?? existing.dbUrl,
       db_token: updates.dbToken ?? existing.dbToken,
+      ...(assignable ? { assignable: "1" } : {}),
     },
     async () => {
       const updated = await builtSitesCrudTable.findById(siteId);

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1176,7 +1176,8 @@ export const updateTestEvent = async (
       can_pay_more: (updates.canPayMore ?? existing.can_pay_more) ? "1" : "",
       max_price: priceFormValue(updates.maxPrice ?? existing.max_price),
       hidden: (updates.hidden ?? existing.hidden) ? "1" : "",
-      purchase_only: (updates.purchaseOnly ?? existing.purchase_only) ? "1" : "",
+      purchase_only:
+        (updates.purchaseOnly ?? existing.purchase_only) ? "1" : "",
       assign_built_site:
         (updates.assignBuiltSite ?? existing.assign_built_site) ? "1" : "",
     },

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -475,9 +475,15 @@ export const setTestEnv = (
     else Deno.env.delete(key);
   }
   // Hook getEnv() so process.env-first code paths also see overlay values.
-  // Only keys IN the overlay are intercepted; other keys fall through to
-  // the real getEnv() logic (preserving process.env priority).
-  const restoreGetEnv = setGetEnvOverlay(layer);
+  // Only DEFINED values are included — keys set to undefined (deletions)
+  // don't need interception since the Deno.env overlay already handles them.
+  // Uses a snapshot so that Deno.env.set() calls inside tests don't leak
+  // into the getEnv overlay (important for env.test.ts which tests process.env priority).
+  const getEnvLayer: Record<string, string | undefined> = Object.create(null);
+  for (const key of Object.keys(layer)) {
+    if (layer[key] !== undefined) getEnvLayer[key] = layer[key];
+  }
+  const restoreGetEnv = setGetEnvOverlay(getEnvLayer);
   return () => {
     restoreGetEnv();
     _overlay = prev;

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -413,10 +413,13 @@ export const installUrlHandler = (
 
 // ---------------------------------------------------------------------------
 // Per-worker Deno.env overlay for test isolation.
-// Intercepts both Deno.env.get/set/delete AND getEnv() so that env vars
-// set during a test stay local to this worker and never leak to parallel
-// workers via the real env. The getEnv override ensures process.env-first
-// code paths also see test values.
+// Intercepts Deno.env.get/set/delete so that env vars set during a test stay
+// local to this worker and never leak to parallel workers via the real env.
+// When no overlay is active, Deno.env behaves normally.
+//
+// In Deno, process.env is a proxy over Deno.env — they share the same backing
+// store. Patching Deno.env automatically affects process.env reads/writes too,
+// so getEnv() (which checks process.env first) sees overlay values correctly.
 // ---------------------------------------------------------------------------
 const _realGet = Deno.env.get.bind(Deno.env);
 const _realSet = Deno.env.set.bind(Deno.env);
@@ -438,13 +441,15 @@ Deno.env.delete = (key: string): void => {
   else _realDelete(key);
 };
 
-import { setGetEnvOverlay } from "#lib/env.ts";
-
 /**
  * Set env vars for a test and return a restore function that puts them back.
- * Uses a per-worker overlay on Deno.env AND a getEnv() overlay so that
- * both Deno.env.get() and getEnv() (which checks process.env first) see
- * test values. Parallel test workers cannot leak env vars to each other.
+ * Uses a per-worker overlay on Deno.env so parallel test workers cannot leak
+ * env vars to each other. All Deno.env.get/set/delete calls within the scope
+ * are transparently intercepted for the managed keys.
+ *
+ * In Deno, process.env is a proxy over Deno.env, so getEnv() (which checks
+ * process.env first) also sees overlay values — no separate hook needed.
+ *
  * Pass `undefined` as a value to delete the key (useful for ensuring a clean slate).
  *
  * @example
@@ -474,18 +479,7 @@ export const setTestEnv = (
     if (value !== undefined) Deno.env.set(key, value);
     else Deno.env.delete(key);
   }
-  // Hook getEnv() so process.env-first code paths also see overlay values.
-  // Only DEFINED values are included — keys set to undefined (deletions)
-  // don't need interception since the Deno.env overlay already handles them.
-  // Uses a snapshot so that Deno.env.set() calls inside tests don't leak
-  // into the getEnv overlay (important for env.test.ts which tests process.env priority).
-  const getEnvLayer: Record<string, string | undefined> = Object.create(null);
-  for (const key of Object.keys(layer)) {
-    if (layer[key] !== undefined) getEnvLayer[key] = layer[key];
-  }
-  const restoreGetEnv = setGetEnvOverlay(getEnvLayer);
   return () => {
-    restoreGetEnv();
     _overlay = prev;
   };
 };

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2591,6 +2591,7 @@ export const makeTestEvent = (
   date: "",
   location: "",
   purchase_only: false,
+  assign_built_site: false,
   ...overrides,
 });
 

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -413,9 +413,10 @@ export const installUrlHandler = (
 
 // ---------------------------------------------------------------------------
 // Per-worker Deno.env overlay for test isolation.
-// Intercepts Deno.env.get/set/delete so that env vars set during a test stay
-// local to this worker and never leak to parallel workers via the real env.
-// When no overlay is active, Deno.env behaves normally.
+// Intercepts both Deno.env.get/set/delete AND getEnv() so that env vars
+// set during a test stay local to this worker and never leak to parallel
+// workers via the real env. The getEnv override ensures process.env-first
+// code paths also see test values.
 // ---------------------------------------------------------------------------
 const _realGet = Deno.env.get.bind(Deno.env);
 const _realSet = Deno.env.set.bind(Deno.env);
@@ -437,11 +438,13 @@ Deno.env.delete = (key: string): void => {
   else _realDelete(key);
 };
 
+import { setGetEnvOverride } from "#lib/env.ts";
+
 /**
  * Set env vars for a test and return a restore function that puts them back.
- * Uses a per-worker overlay on Deno.env so parallel test workers cannot leak
- * env vars to each other. All Deno.env.get/set/delete calls within the scope
- * are transparently intercepted for the managed keys.
+ * Uses a per-worker overlay on Deno.env AND a getEnv() override so that
+ * both Deno.env.get() and getEnv() (which checks process.env first) see
+ * test values. Parallel test workers cannot leak env vars to each other.
  * Pass `undefined` as a value to delete the key (useful for ensuring a clean slate).
  *
  * @example
@@ -471,7 +474,10 @@ export const setTestEnv = (
     if (value !== undefined) Deno.env.set(key, value);
     else Deno.env.delete(key);
   }
+  // Hook getEnv() so process.env-first code paths also see overlay values
+  const restoreGetEnv = setGetEnvOverride((key) => Deno.env.get(key));
   return () => {
+    restoreGetEnv();
     _overlay = prev;
   };
 };

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -1,8 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  assignBuiltSite,
   buildSiteDataBlob,
   builtSitesCrudTable,
+  countAssignableSites,
+  getAssignableBuiltSites,
   getAllBuiltSites,
   insertBuiltSite,
   parseSiteDataBlob,
@@ -117,6 +120,9 @@ describeWithEnv("built-sites", { db: true }, () => {
         bunnyUrl: "test.bunny.run",
         dbUrl: "",
         dbToken: "",
+        assignable: false,
+        assignedAttendeeId: null,
+        assignedEventId: null,
         created: "2026-01-01",
       };
       const result = await builtSitesCrudTable.fromDb(site);
@@ -129,6 +135,7 @@ describeWithEnv("built-sites", { db: true }, () => {
         bunnyUrl: "test.bunny.run",
         dbUrl: "libsql://test.turso.io",
         dbToken: "tok123",
+        assignable: false,
       });
       expect(values.site_data).toBeTruthy();
       const parsed = parseSiteDataBlob(values.site_data as string);
@@ -144,6 +151,7 @@ describeWithEnv("built-sites", { db: true }, () => {
         bunnyUrl: "original.bunny.run",
         dbUrl: "",
         dbToken: "",
+        assignable: false,
       });
       const updated = await builtSitesCrudTable.update(site.id, {
         bunnyUrl: "new.bunny.run",
@@ -158,6 +166,7 @@ describeWithEnv("built-sites", { db: true }, () => {
         bunnyUrl: "original.bunny.run",
         dbUrl: "",
         dbToken: "",
+        assignable: false,
       });
       const updated = await builtSitesCrudTable.update(site.id, {
         name: "Updated",
@@ -172,6 +181,7 @@ describeWithEnv("built-sites", { db: true }, () => {
         bunnyUrl: "original.bunny.run",
         dbUrl: "libsql://db.turso.io",
         dbToken: "tok123",
+        assignable: false,
       });
       const updated = await builtSitesCrudTable.update(site.id, {
         name: "Updated",
@@ -192,6 +202,87 @@ describeWithEnv("built-sites", { db: true }, () => {
       const parsed = parseSiteDataBlob(values.site_data as string);
       expect(parsed.n).toBe("");
       expect(parsed.u).toBe("");
+    });
+  });
+
+  describe("assignable sites", () => {
+    test("insertBuiltSite with assignable flag", async () => {
+      await insertBuiltSite("Assignable Site", "a.b-cdn.net", "", "", true);
+      const sites = await getAllBuiltSites();
+      const site = sites.find((s) => s.name === "Assignable Site")!;
+      expect(site.assignable).toBe(true);
+    });
+
+    test("insertBuiltSite defaults to not assignable", async () => {
+      await insertBuiltSite("Default Site", "d.b-cdn.net");
+      const sites = await getAllBuiltSites();
+      const site = sites.find((s) => s.name === "Default Site")!;
+      expect(site.assignable).toBe(false);
+    });
+
+    test("countAssignableSites counts only assignable sites", async () => {
+      await insertBuiltSite("Site A", "a.b-cdn.net", "", "", true);
+      await insertBuiltSite("Site B", "b.b-cdn.net", "", "", true);
+      await insertBuiltSite("Site C", "c.b-cdn.net", "", "", false);
+      const count = await countAssignableSites();
+      expect(count).toBe(2);
+    });
+
+    test("countAssignableSites returns 0 when no assignable sites", async () => {
+      await insertBuiltSite("Site A", "a.b-cdn.net", "", "", false);
+      const count = await countAssignableSites();
+      expect(count).toBe(0);
+    });
+
+    test("getAssignableBuiltSites filters to assignable only", async () => {
+      await insertBuiltSite("Site A", "a.b-cdn.net", "", "", true);
+      await insertBuiltSite("Site B", "b.b-cdn.net", "", "", false);
+      await insertBuiltSite("Site C", "c.b-cdn.net", "", "", true);
+      const sites = await getAssignableBuiltSites();
+      expect(sites).toHaveLength(2);
+      expect(sites.every((s) => s.assignable)).toBe(true);
+    });
+
+    test("assignBuiltSite marks site as not assignable and stores IDs", async () => {
+      await insertBuiltSite("To Assign", "assign.b-cdn.net", "", "", true);
+      const sites = await getAllBuiltSites();
+      const site = sites.find((s) => s.name === "To Assign")!;
+
+      const updated = await assignBuiltSite(site.id, 42, 7);
+      expect(updated).not.toBeNull();
+      expect(updated!.assignable).toBe(false);
+      expect(updated!.assignedAttendeeId).toBe(42);
+      expect(updated!.assignedEventId).toBe(7);
+    });
+
+    test("assignBuiltSite returns null for non-existent site", async () => {
+      const result = await assignBuiltSite(999, 1, 1);
+      expect(result).toBeNull();
+    });
+
+    test("buildSiteDataBlob includes assignment IDs when provided", () => {
+      const blob = buildSiteDataBlob("Site", "s.b-cdn.net", "", "", 10, 5);
+      const parsed = parseSiteDataBlob(blob);
+      expect(parsed.ai).toBe(10);
+      expect(parsed.ei).toBe(5);
+    });
+
+    test("buildSiteDataBlob omits assignment IDs when not provided", () => {
+      const blob = buildSiteDataBlob("Site", "s.b-cdn.net");
+      const parsed = parseSiteDataBlob(blob);
+      expect(parsed.ai).toBeUndefined();
+      expect(parsed.ei).toBeUndefined();
+    });
+
+    test("parseSiteDataBlob handles legacy blobs without assignment fields", () => {
+      const legacyBlob = JSON.stringify({
+        v: 1,
+        n: "Old Site",
+        u: "old.b-cdn.net",
+      });
+      const parsed = parseSiteDataBlob(legacyBlob);
+      expect(parsed.ai).toBeUndefined();
+      expect(parsed.ei).toBeUndefined();
     });
   });
 });

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -243,7 +243,7 @@ describeWithEnv("built-sites", { db: true }, () => {
       expect(sites.every((s) => s.assignable)).toBe(true);
     });
 
-    test("assignBuiltSite marks site as not assignable and stores IDs", async () => {
+    test("assignBuiltSite marks site as not assignable and stores IDs in columns", async () => {
       await insertBuiltSite("To Assign", "assign.b-cdn.net", "", "", true);
       const sites = await getAllBuiltSites();
       const site = sites.find((s) => s.name === "To Assign")!;
@@ -260,29 +260,12 @@ describeWithEnv("built-sites", { db: true }, () => {
       expect(result).toBeNull();
     });
 
-    test("buildSiteDataBlob includes assignment IDs when provided", () => {
-      const blob = buildSiteDataBlob("Site", "s.b-cdn.net", "", "", 10, 5);
-      const parsed = parseSiteDataBlob(blob);
-      expect(parsed.ai).toBe(10);
-      expect(parsed.ei).toBe(5);
-    });
-
-    test("buildSiteDataBlob omits assignment IDs when not provided", () => {
-      const blob = buildSiteDataBlob("Site", "s.b-cdn.net");
-      const parsed = parseSiteDataBlob(blob);
-      expect(parsed.ai).toBeUndefined();
-      expect(parsed.ei).toBeUndefined();
-    });
-
-    test("parseSiteDataBlob handles legacy blobs without assignment fields", () => {
-      const legacyBlob = JSON.stringify({
-        v: 1,
-        n: "Old Site",
-        u: "old.b-cdn.net",
-      });
-      const parsed = parseSiteDataBlob(legacyBlob);
-      expect(parsed.ai).toBeUndefined();
-      expect(parsed.ei).toBeUndefined();
+    test("unassigned sites have null attendee and event IDs", async () => {
+      await insertBuiltSite("Unassigned", "u.b-cdn.net", "", "", true);
+      const sites = await getAllBuiltSites();
+      const site = sites.find((s) => s.name === "Unassigned")!;
+      expect(site.assignedAttendeeId).toBeNull();
+      expect(site.assignedEventId).toBeNull();
     });
   });
 });

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -5,8 +5,8 @@ import {
   buildSiteDataBlob,
   builtSitesCrudTable,
   countAssignableSites,
-  getAssignableBuiltSites,
   getAllBuiltSites,
+  getAssignableBuiltSites,
   insertBuiltSite,
   parseSiteDataBlob,
 } from "#lib/db/built-sites.ts";
@@ -202,6 +202,17 @@ describeWithEnv("built-sites", { db: true }, () => {
       const parsed = parseSiteDataBlob(values.site_data as string);
       expect(parsed.n).toBe("");
       expect(parsed.u).toBe("");
+    });
+
+    test("toDbValues sets assignable to 1 when true", async () => {
+      const values = await builtSitesCrudTable.toDbValues({
+        name: "Test",
+        bunnyUrl: "test.bunny.run",
+        dbUrl: "",
+        dbToken: "",
+        assignable: true,
+      });
+      expect(values.assignable).toBe(1);
     });
   });
 

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -343,6 +343,8 @@ describe("code quality", () => {
       // Route maps used by API documentation tests (production uses via dynamic import / createRouter)
       "routes/api.ts:apiRoutes",
       "routes/admin/api.ts:adminApiRoutes",
+      // Test env overlay hooks into getEnv() so process.env-first code paths see test values
+      "lib/env.ts:setGetEnvOverride",
     ];
 
     /**

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -343,8 +343,6 @@ describe("code quality", () => {
       // Route maps used by API documentation tests (production uses via dynamic import / createRouter)
       "routes/api.ts:apiRoutes",
       "routes/admin/api.ts:adminApiRoutes",
-      // Test env overlay hooks into getEnv() so process.env-first code paths see test values
-      "lib/env.ts:setGetEnvOverlay",
     ];
 
     /**

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -344,7 +344,7 @@ describe("code quality", () => {
       "routes/api.ts:apiRoutes",
       "routes/admin/api.ts:adminApiRoutes",
       // Test env overlay hooks into getEnv() so process.env-first code paths see test values
-      "lib/env.ts:setGetEnvOverride",
+      "lib/env.ts:setGetEnvOverlay",
     ];
 
     /**

--- a/test/lib/server-builder.test.ts
+++ b/test/lib/server-builder.test.ts
@@ -229,6 +229,23 @@ describeWithEnv(
         expect(sites[0]!.bunnyUrl).toBe("https://test-42.b-cdn.net");
         expect(sites[0]!.dbUrl).toBe("libsql://test.turso.io");
         expect(sites[0]!.dbToken).toBe("token123");
+        expect(sites[0]!.assignable).toBe(false);
+      });
+    });
+
+    test("POST /admin/builder passes assignable flag", async () => {
+      await withMocks(stubSuccessfulBuild, async () => {
+        const { response } = await adminFormPost("/admin/builder", {
+          site_name: "Assignable Site",
+          db_url: "libsql://test.turso.io",
+          db_token: "token123",
+          assignable: "1",
+        });
+
+        expectRedirect(response, "/admin/builder");
+        const sites = await getAllBuiltSites();
+        expect(sites).toHaveLength(1);
+        expect(sites[0]!.assignable).toBe(true);
       });
     });
 

--- a/test/lib/server-builder.test.ts
+++ b/test/lib/server-builder.test.ts
@@ -17,6 +17,7 @@ import {
   FLASH_TEST_ID,
   flashCookieHeader,
   mockRequest,
+  setTestEnv,
   testCookie,
   withMocks,
 } from "#test-utils";
@@ -85,10 +86,14 @@ describeWithEnv(
     });
 
     test("GET /admin/builder returns 404 when CAN_BUILD_SITES is not set", async () => {
-      Deno.env.delete("CAN_BUILD_SITES");
-      const cookie = await testCookie();
-      const response = await awaitTestRequest("/admin/builder", { cookie });
-      expect(response.status).toBe(404);
+      const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
+      try {
+        const cookie = await testCookie();
+        const response = await awaitTestRequest("/admin/builder", { cookie });
+        expect(response.status).toBe(404);
+      } finally {
+        restore();
+      }
     });
 
     test("GET /admin/builder redirects to login when not authenticated", async () => {
@@ -279,13 +284,17 @@ describeWithEnv(
     });
 
     test("POST /admin/builder returns 404 when CAN_BUILD_SITES is not set", async () => {
-      Deno.env.delete("CAN_BUILD_SITES");
-      const { response } = await adminFormPost("/admin/builder", {
-        site_name: "Test",
-        db_url: "libsql://test.turso.io",
-        db_token: "token",
-      });
-      expect(response.status).toBe(404);
+      const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
+      try {
+        const { response } = await adminFormPost("/admin/builder", {
+          site_name: "Test",
+          db_url: "libsql://test.turso.io",
+          db_token: "token",
+        });
+        expect(response.status).toBe(404);
+      } finally {
+        restore();
+      }
     });
 
     test("POST /admin/builder returns error when another task in progress", async () => {

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -51,6 +51,31 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
         `/admin/built-sites/${site.id}/delete`,
       );
     });
+
+    test("shows Not assignable status for default sites", async () => {
+      await createTestBuiltSite({ name: "Default Site" });
+      const { response } = await adminGet("/admin/built-sites");
+      await expectHtmlResponse(response, 200, "Not assignable");
+    });
+
+    test("shows Available status for assignable sites", async () => {
+      await createTestBuiltSite({ name: "Ready Site", assignable: true });
+      const { response } = await adminGet("/admin/built-sites");
+      await expectHtmlResponse(response, 200, "Available");
+    });
+
+    test("shows Assigned status for assigned sites", async () => {
+      const { insertBuiltSite, assignBuiltSite } = await import(
+        "#lib/db/built-sites.ts"
+      );
+      await insertBuiltSite("Taken Site", "https://taken.b-cdn.net", "", "", true);
+      const { getAllBuiltSites } = await import("#lib/db/built-sites.ts");
+      const sites = await getAllBuiltSites();
+      await assignBuiltSite(sites[0]!.id, 42, 7);
+
+      const { response } = await adminGet("/admin/built-sites");
+      await expectHtmlResponse(response, 200, "Assigned (attendee #42)");
+    });
   });
 
   describe("GET /admin/built-sites/new", () => {

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -68,7 +68,13 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
       const { insertBuiltSite, assignBuiltSite } = await import(
         "#lib/db/built-sites.ts"
       );
-      await insertBuiltSite("Taken Site", "https://taken.b-cdn.net", "", "", true);
+      await insertBuiltSite(
+        "Taken Site",
+        "https://taken.b-cdn.net",
+        "",
+        "",
+        true,
+      );
       const { getAllBuiltSites } = await import("#lib/db/built-sites.ts");
       const sites = await getAllBuiltSites();
       await assignBuiltSite(sites[0]!.id, 42, 7);

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -387,6 +387,7 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
       expect(values.bunny_url).toBe("");
       expect(values.db_url).toBe("");
       expect(values.db_token).toBe("");
+      expect(values.assignable).toBe("");
     });
 
     test("returns site values when site provided", async () => {
@@ -404,6 +405,16 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
       expect(values.bunny_url).toBe("https://test.b-cdn.net");
       expect(values.db_url).toBe("libsql://test.turso.io");
       expect(values.db_token).toBe("tok123");
+      expect(values.assignable).toBe("");
+    });
+
+    test("returns assignable=1 for assignable site", async () => {
+      const { builtSiteToFieldValues } = await import(
+        "#templates/admin/built-sites.tsx"
+      );
+      const site = testBuiltSite({ assignable: true });
+      const values = builtSiteToFieldValues(site);
+      expect(values.assignable).toBe("1");
     });
   });
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -30,6 +30,7 @@ import {
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
+  setTestEnv,
   setupEventAndLogin,
   submitTicketForm,
   testCookie,
@@ -3373,19 +3374,18 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
   describe("assign_built_site", () => {
     test("saves assign_built_site when CAN_BUILD_SITES is true", async () => {
-      Deno.env.set("CAN_BUILD_SITES", "true");
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       try {
         const event = await createTestEvent({ assignBuiltSite: true });
         const { getEventWithCount } = await import("#lib/db/events.ts");
         const saved = await getEventWithCount(event.id);
         expect(saved?.assign_built_site).toBe(true);
       } finally {
-        Deno.env.delete("CAN_BUILD_SITES");
+        restore();
       }
     });
 
     test("ignores assign_built_site when CAN_BUILD_SITES is not set", async () => {
-      Deno.env.delete("CAN_BUILD_SITES");
       const event = await createTestEvent({ assignBuiltSite: true });
       const { getEventWithCount } = await import("#lib/db/events.ts");
       const saved = await getEventWithCount(event.id);
@@ -3393,14 +3393,27 @@ describeWithEnv("server (admin events)", { db: true }, () => {
     });
 
     test("defaults to false even when CAN_BUILD_SITES is true", async () => {
-      Deno.env.set("CAN_BUILD_SITES", "true");
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       try {
         const event = await createTestEvent();
         const { getEventWithCount } = await import("#lib/db/events.ts");
         const saved = await getEventWithCount(event.id);
         expect(saved?.assign_built_site).toBe(false);
       } finally {
-        Deno.env.delete("CAN_BUILD_SITES");
+        restore();
+      }
+    });
+
+    test("updates event to enable assign_built_site", async () => {
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      try {
+        const event = await createTestEvent();
+        await updateTestEvent(event.id, { assignBuiltSite: true });
+        const { getEventWithCount } = await import("#lib/db/events.ts");
+        const updated = await getEventWithCount(event.id);
+        expect(updated?.assign_built_site).toBe(true);
+      } finally {
+        restore();
       }
     });
   });

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -3370,4 +3370,33 @@ describeWithEnv("server (admin events)", { db: true }, () => {
       );
     });
   });
+
+  describe("assign_built_site", () => {
+    test("saves assign_built_site when CAN_BUILD_SITES is true", async () => {
+      Deno.env.set("CAN_BUILD_SITES", "true");
+      try {
+        const event = await createTestEvent({ assignBuiltSite: true });
+        const { getEventWithCount } = await import("#lib/db/events.ts");
+        const saved = await getEventWithCount(event.id);
+        expect(saved?.assign_built_site).toBe(true);
+      } finally {
+        Deno.env.delete("CAN_BUILD_SITES");
+      }
+    });
+
+    test("ignores assign_built_site when CAN_BUILD_SITES is not set", async () => {
+      Deno.env.delete("CAN_BUILD_SITES");
+      const event = await createTestEvent({ assignBuiltSite: true });
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.assign_built_site).toBe(false);
+    });
+
+    test("defaults to false", async () => {
+      const event = await createTestEvent();
+      const { getEventWithCount } = await import("#lib/db/events.ts");
+      const saved = await getEventWithCount(event.id);
+      expect(saved?.assign_built_site).toBe(false);
+    });
+  });
 });

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -3392,11 +3392,16 @@ describeWithEnv("server (admin events)", { db: true }, () => {
       expect(saved?.assign_built_site).toBe(false);
     });
 
-    test("defaults to false", async () => {
-      const event = await createTestEvent();
-      const { getEventWithCount } = await import("#lib/db/events.ts");
-      const saved = await getEventWithCount(event.id);
-      expect(saved?.assign_built_site).toBe(false);
+    test("defaults to false even when CAN_BUILD_SITES is true", async () => {
+      Deno.env.set("CAN_BUILD_SITES", "true");
+      try {
+        const event = await createTestEvent();
+        const { getEventWithCount } = await import("#lib/db/events.ts");
+        const saved = await getEventWithCount(event.id);
+        expect(saved?.assign_built_site).toBe(false);
+      } finally {
+        Deno.env.delete("CAN_BUILD_SITES");
+      }
     });
   });
 });

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -3376,6 +3376,20 @@ describeWithEnv("server (admin events)", { db: true }, () => {
     test("saves assign_built_site when CAN_BUILD_SITES is true", async () => {
       const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       try {
+        // Debug: verify env overlay is working
+        const { getEnv } = await import("#lib/env.ts");
+        const { isBuilderEnabled } = await import(
+          "#routes/admin/builder.ts"
+        );
+        console.log("[DEBUG] Deno.env.get('CAN_BUILD_SITES'):", Deno.env.get("CAN_BUILD_SITES"));
+        console.log("[DEBUG] getEnv('CAN_BUILD_SITES'):", getEnv("CAN_BUILD_SITES"));
+        console.log("[DEBUG] isBuilderEnabled():", isBuilderEnabled());
+        console.log("[DEBUG] typeof process:", typeof globalThis.process);
+        if (globalThis.process?.env) {
+          console.log("[DEBUG] process.env.CAN_BUILD_SITES:", globalThis.process.env.CAN_BUILD_SITES);
+          console.log("[DEBUG] 'CAN_BUILD_SITES' in process.env:", "CAN_BUILD_SITES" in globalThis.process.env);
+        }
+
         const event = await createTestEvent({ assignBuiltSite: true });
         const { getEventWithCount } = await import("#lib/db/events.ts");
         const saved = await getEventWithCount(event.id);

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4760,7 +4760,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("built site availability check", () => {
     test("blocks registration when no assignable sites available", async () => {
-      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      Deno.env.set("CAN_BUILD_SITES", "true");
       try {
         const event = await createTestEvent({
           assignBuiltSite: true,
@@ -4774,12 +4774,12 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         expect(response.status).toBe(302);
         expectFlash(response, "not enough sites available", false);
       } finally {
-        restore();
+        Deno.env.delete("CAN_BUILD_SITES");
       }
     });
 
     test("allows registration when assignable sites are available", async () => {
-      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      Deno.env.set("CAN_BUILD_SITES", "true");
       try {
         const event = await createTestEvent({
           assignBuiltSite: true,
@@ -4792,7 +4792,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         });
         expectReservedRedirectWithTokens(response);
       } finally {
-        restore();
+        Deno.env.delete("CAN_BUILD_SITES");
       }
     });
 

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { addDays } from "#lib/dates.ts";
 import { createAttendeeAtomic } from "#lib/db/attendees.ts";
+import { insertBuiltSite } from "#lib/db/built-sites.ts";
 import {
   answersTable,
   getAttendeeAnswersBatch,
@@ -4754,6 +4755,59 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
       expect(response.status).toBe(302);
       expectFlash(response, expect.stringContaining("Please answer"), false);
+    });
+  });
+
+  describe("built site availability check", () => {
+    test("blocks registration when no assignable sites available", async () => {
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      try {
+        const event = await createTestEvent({
+          assignBuiltSite: true,
+          maxAttendees: 10,
+        });
+        // No assignable sites created
+        const response = await submitTicketForm(event.slug, {
+          name: "Test User",
+          email: "test@example.com",
+        });
+        expect(response.status).toBe(302);
+        expectFlash(response, "not enough sites available", false);
+      } finally {
+        restore();
+      }
+    });
+
+    test("allows registration when assignable sites are available", async () => {
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      try {
+        const event = await createTestEvent({
+          assignBuiltSite: true,
+          maxAttendees: 10,
+        });
+        await insertBuiltSite("Available", "avail.b-cdn.net", "", "", true);
+        const response = await submitTicketForm(event.slug, {
+          name: "Test User",
+          email: "test@example.com",
+        });
+        expectReservedRedirectWithTokens(response);
+      } finally {
+        restore();
+      }
+    });
+
+    test("skips check when CAN_BUILD_SITES is not set", async () => {
+      Deno.env.delete("CAN_BUILD_SITES");
+      const event = await createTestEvent({
+        assignBuiltSite: true,
+        maxAttendees: 10,
+      });
+      // Even without sites, booking should succeed when feature is disabled
+      const response = await submitTicketForm(event.slug, {
+        name: "Test User",
+        email: "test@example.com",
+      });
+      expectReservedRedirectWithTokens(response);
     });
   });
 });

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4797,12 +4797,14 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
 
     test("skips check when CAN_BUILD_SITES is not set", async () => {
-      Deno.env.delete("CAN_BUILD_SITES");
+      // Create event with flag enabled so assign_built_site is saved
+      Deno.env.set("CAN_BUILD_SITES", "true");
       const event = await createTestEvent({
         assignBuiltSite: true,
         maxAttendees: 10,
       });
-      // Even without sites, booking should succeed when feature is disabled
+      // Now disable the feature — booking should succeed despite no sites
+      Deno.env.delete("CAN_BUILD_SITES");
       const response = await submitTicketForm(event.slug, {
         name: "Test User",
         email: "test@example.com",

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4773,7 +4773,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
           email: "test@example.com",
         });
         expect(response.status).toBe(302);
-        expectFlash(response, "not enough sites available", false);
+        expectFlash(response, "Sorry, not enough sites available", false);
       } finally {
         restore();
       }

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4760,10 +4760,11 @@ describeWithEnv("server (public routes)", { db: true }, () => {
 
   describe("built site availability check", () => {
     test("blocks registration when no assignable sites available", async () => {
-      Deno.env.set("CAN_BUILD_SITES", "true");
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       try {
         const event = await createTestEvent({
           assignBuiltSite: true,
+          thankYouUrl: "",
           maxAttendees: 10,
         });
         // No assignable sites created
@@ -4774,15 +4775,16 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         expect(response.status).toBe(302);
         expectFlash(response, "not enough sites available", false);
       } finally {
-        Deno.env.delete("CAN_BUILD_SITES");
+        restore();
       }
     });
 
     test("allows registration when assignable sites are available", async () => {
-      Deno.env.set("CAN_BUILD_SITES", "true");
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       try {
         const event = await createTestEvent({
           assignBuiltSite: true,
+          thankYouUrl: "",
           maxAttendees: 10,
         });
         await insertBuiltSite("Available", "avail.b-cdn.net", "", "", true);
@@ -4792,19 +4794,20 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         });
         expectReservedRedirectWithTokens(response);
       } finally {
-        Deno.env.delete("CAN_BUILD_SITES");
+        restore();
       }
     });
 
     test("skips check when CAN_BUILD_SITES is not set", async () => {
       // Create event with flag enabled so assign_built_site is saved
-      Deno.env.set("CAN_BUILD_SITES", "true");
+      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       const event = await createTestEvent({
         assignBuiltSite: true,
+        thankYouUrl: "",
         maxAttendees: 10,
       });
-      // Now disable the feature — booking should succeed despite no sites
-      Deno.env.delete("CAN_BUILD_SITES");
+      restore();
+      // Now CAN_BUILD_SITES is not set — booking should succeed despite no sites
       const response = await submitTicketForm(event.slug, {
         name: "Test User",
         email: "test@example.com",

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -1,14 +1,15 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { insertBuiltSite } from "#lib/db/built-sites.ts";
 import {
-  assignSitesForEntries,
-  type SiteAssignmentEntry,
-} from "#lib/site-assignment.ts";
-import { describeWithEnv } from "#test-utils";
+  getAllBuiltSites,
+  insertBuiltSite,
+} from "#lib/db/built-sites.ts";
+import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
+import type { EmailEntry } from "#lib/email.ts";
+import { describeWithEnv, makeTestEntry } from "#test-utils";
 
-/** Build a minimal SiteAssignmentEntry for testing */
-const mockEntry = (
+/** Build an EmailEntry with assign_built_site for testing */
+const siteEntry = (
   overrides: {
     eventId?: number;
     eventName?: string;
@@ -17,79 +18,103 @@ const mockEntry = (
     quantity?: number;
     email?: string;
   } = {},
-): SiteAssignmentEntry => ({
-  event: {
-    id: overrides.eventId ?? 1,
-    name: overrides.eventName ?? "Test Event",
-    assign_built_site: overrides.assignBuiltSite ?? true,
-  },
-  attendee: {
-    id: overrides.attendeeId ?? 1,
-    email: overrides.email ?? "user@test.com",
-    quantity: overrides.quantity ?? 1,
-  },
-});
+): EmailEntry =>
+  makeTestEntry(
+    {
+      id: overrides.eventId,
+      name: overrides.eventName,
+      assign_built_site: overrides.assignBuiltSite ?? true,
+    },
+    {
+      id: overrides.attendeeId,
+      email: overrides.email,
+      quantity: overrides.quantity,
+    },
+  );
 
-describeWithEnv("site-assignment", { db: true }, () => {
-  describe("assignSitesForEntries", () => {
+describeWithEnv("site-assignment", {
+  db: true,
+  env: { CAN_BUILD_SITES: "true" },
+}, () => {
+  describe("assignAndNotifyBuiltSites", () => {
     test("assigns one site per ticket", async () => {
       await insertBuiltSite("Site A", "a.test.net", "", "", true);
       await insertBuiltSite("Site B", "b.test.net", "", "", true);
 
-      const entries = [mockEntry({ quantity: 2 })];
-      const assignments = await assignSitesForEntries(entries);
+      await assignAndNotifyBuiltSites([siteEntry({ quantity: 2 })]);
 
-      expect(assignments).toHaveLength(2);
-      expect(assignments[0]!.siteUrl).toBe("a.test.net");
-      expect(assignments[1]!.siteUrl).toBe("b.test.net");
+      const sites = await getAllBuiltSites();
+      const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+      expect(assigned).toHaveLength(2);
+      expect(assigned.every((s) => !s.assignable)).toBe(true);
     });
 
     test("skips events without assign_built_site", async () => {
       await insertBuiltSite("Site A", "a.test.net", "", "", true);
 
-      const entries = [mockEntry({ assignBuiltSite: false })];
-      const assignments = await assignSitesForEntries(entries);
+      await assignAndNotifyBuiltSites([
+        siteEntry({ assignBuiltSite: false }),
+      ]);
 
-      expect(assignments).toHaveLength(0);
+      const sites = await getAllBuiltSites();
+      expect(sites[0]!.assignable).toBe(true);
+      expect(sites[0]!.assignedAttendeeId).toBeNull();
     });
 
     test("assigns sites independently per event", async () => {
       await insertBuiltSite("Site A", "a.test.net", "", "", true);
       await insertBuiltSite("Site B", "b.test.net", "", "", true);
 
-      const entries = [
-        mockEntry({ eventId: 1, eventName: "Event 1", attendeeId: 10 }),
-        mockEntry({ eventId: 2, eventName: "Event 2", attendeeId: 10 }),
-      ];
-      const assignments = await assignSitesForEntries(entries);
+      await assignAndNotifyBuiltSites([
+        siteEntry({ eventId: 1, eventName: "Event 1", attendeeId: 10 }),
+        siteEntry({ eventId: 2, eventName: "Event 2", attendeeId: 10 }),
+      ]);
 
-      expect(assignments).toHaveLength(2);
-      expect(assignments[0]!.eventName).toBe("Event 1");
-      expect(assignments[1]!.eventName).toBe("Event 2");
+      const sites = await getAllBuiltSites();
+      const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+      expect(assigned).toHaveLength(2);
+      expect(assigned[0]!.assignedEventId).toBe(1);
+      expect(assigned[1]!.assignedEventId).toBe(2);
     });
 
-    test("returns empty when no assignable sites available", async () => {
+    test("does not assign when no assignable sites available", async () => {
       await insertBuiltSite("Site A", "a.test.net", "", "", false);
 
-      const entries = [mockEntry()];
-      const assignments = await assignSitesForEntries(entries);
+      await assignAndNotifyBuiltSites([siteEntry()]);
 
-      expect(assignments).toHaveLength(0);
+      const sites = await getAllBuiltSites();
+      expect(sites[0]!.assignedAttendeeId).toBeNull();
     });
 
-    test("returns empty for empty entries", async () => {
-      const assignments = await assignSitesForEntries([]);
-      expect(assignments).toHaveLength(0);
+    test("no-ops for empty entries", async () => {
+      await assignAndNotifyBuiltSites([]);
     });
 
     test("assigns only available sites when fewer than needed", async () => {
       await insertBuiltSite("Site A", "a.test.net", "", "", true);
 
-      const entries = [mockEntry({ quantity: 3 })];
-      const assignments = await assignSitesForEntries(entries);
+      await assignAndNotifyBuiltSites([siteEntry({ quantity: 3 })]);
 
-      expect(assignments).toHaveLength(1);
-      expect(assignments[0]!.siteUrl).toBe("a.test.net");
+      const sites = await getAllBuiltSites();
+      const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+      expect(assigned).toHaveLength(1);
+    });
+  });
+
+  describe("feature flag", () => {
+    test("no-ops when CAN_BUILD_SITES is disabled", async () => {
+      // Temporarily override to disabled
+      const original = Deno.env.get("CAN_BUILD_SITES");
+      Deno.env.delete("CAN_BUILD_SITES");
+      try {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        await assignAndNotifyBuiltSites([siteEntry()]);
+        const sites = await getAllBuiltSites();
+        expect(sites[0]!.assignable).toBe(true);
+        expect(sites[0]!.assignedAttendeeId).toBeNull();
+      } finally {
+        if (original) Deno.env.set("CAN_BUILD_SITES", original);
+      }
     });
   });
 });

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -5,10 +5,9 @@ import {
   insertBuiltSite,
 } from "#lib/db/built-sites.ts";
 import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
-import type { EmailEntry } from "#lib/email.ts";
-import { describeWithEnv, makeTestEntry } from "#test-utils";
+import { describeWithEnv, makeTestEntry, setTestEnv } from "#test-utils";
 
-/** Build an EmailEntry with assign_built_site for testing */
+/** Build an entry with assign_built_site for testing */
 const siteEntry = (
   overrides: {
     eventId?: number;
@@ -18,7 +17,7 @@ const siteEntry = (
     quantity?: number;
     email?: string;
   } = {},
-): EmailEntry =>
+) =>
   makeTestEntry(
     {
       id: overrides.eventId,
@@ -103,9 +102,7 @@ describeWithEnv("site-assignment", {
 
   describe("feature flag", () => {
     test("no-ops when CAN_BUILD_SITES is disabled", async () => {
-      // Temporarily override to disabled
-      const original = Deno.env.get("CAN_BUILD_SITES");
-      Deno.env.delete("CAN_BUILD_SITES");
+      const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
       try {
         await insertBuiltSite("Site A", "a.test.net", "", "", true);
         await assignAndNotifyBuiltSites([siteEntry()]);
@@ -113,7 +110,7 @@ describeWithEnv("site-assignment", {
         expect(sites[0]!.assignable).toBe(true);
         expect(sites[0]!.assignedAttendeeId).toBeNull();
       } finally {
-        if (original) Deno.env.set("CAN_BUILD_SITES", original);
+        restore();
       }
     });
   });

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -151,13 +151,21 @@ describeWithEnv("site-assignment", { db: true }, () => {
       expect(body.subject).toBe("Your new site is ready");
     });
 
-    test("includes reply-to when business email is set", async () => {
+    test("uses DB email config when available and includes reply-to", async () => {
+      // Configure email via DB settings (not host config) so getEmailConfig()
+      // returns non-null, covering the left branch of the ?? operator
       const { settings } = await import("#lib/db/settings.ts");
+      await settings.update.email.provider("resend");
+      await settings.update.email.apiKey("re_db_key");
+      await settings.update.email.fromAddress("db@example.com");
       await settings.update.businessEmail("biz@example.com");
+      resetHostEmailConfig();
+      setHostEmailConfigForTest(null);
 
       await insertBuiltSite("Site A", "a.test.net", "", "", true);
       await assignAndNotifyBuiltSites([siteEntry()]);
 
+      expect(fetchStub.calls.length).toBe(1);
       const body = JSON.parse(fetchStub.calls[0].args[1].body);
       expect(body.reply_to).toBe("biz@example.com");
     });

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -7,7 +7,7 @@ import {
 } from "#lib/db/built-sites.ts";
 import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
-import { describeWithEnv, makeTestEntry } from "#test-utils";
+import { describeWithEnv, makeTestEntry, setTestEnv } from "#test-utils";
 
 /** Build an entry with assign_built_site for testing */
 const siteEntry = (
@@ -35,13 +35,14 @@ const siteEntry = (
     },
   );
 
-describeWithEnv("site-assignment", { db: true }, () => {
+describeWithEnv("site-assignment", {
+  db: true,
+  env: { CAN_BUILD_SITES: "true" },
+}, () => {
   // deno-lint-ignore no-explicit-any
   let fetchStub: any;
 
   beforeEach(() => {
-    // Set directly (not via setTestEnv overlay) so process.env sees it
-    Deno.env.set("CAN_BUILD_SITES", "true");
     fetchStub = stub(globalThis, "fetch", () =>
       Promise.resolve(new Response()),
     );
@@ -53,7 +54,6 @@ describeWithEnv("site-assignment", { db: true }, () => {
   });
 
   afterEach(() => {
-    Deno.env.delete("CAN_BUILD_SITES");
     fetchStub.restore();
     resetHostEmailConfig();
   });
@@ -185,7 +185,7 @@ describeWithEnv("site-assignment", { db: true }, () => {
 
   describe("feature flag", () => {
     test("no-ops when CAN_BUILD_SITES is disabled", async () => {
-      Deno.env.delete("CAN_BUILD_SITES");
+      const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
       try {
         await insertBuiltSite("Site A", "a.test.net", "", "", true);
         await assignAndNotifyBuiltSites([siteEntry()]);
@@ -193,7 +193,7 @@ describeWithEnv("site-assignment", { db: true }, () => {
         expect(sites[0]!.assignable).toBe(true);
         expect(sites[0]!.assignedAttendeeId).toBeNull();
       } finally {
-        Deno.env.set("CAN_BUILD_SITES", "true");
+        restore();
       }
     });
   });

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -1,9 +1,11 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import {
   getAllBuiltSites,
   insertBuiltSite,
 } from "#lib/db/built-sites.ts";
+import { setHostEmailConfigForTest, resetHostEmailConfig } from "#lib/email.ts";
 import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
 import { describeWithEnv, makeTestEntry, setTestEnv } from "#test-utils";
 
@@ -35,8 +37,27 @@ describeWithEnv("site-assignment", {
   db: true,
   env: { CAN_BUILD_SITES: "true" },
 }, () => {
+  // deno-lint-ignore no-explicit-any
+  let fetchStub: any;
+
+  beforeEach(() => {
+    fetchStub = stub(globalThis, "fetch", () =>
+      Promise.resolve(new Response()),
+    );
+    setHostEmailConfigForTest({
+      provider: "resend",
+      apiKey: "re_test",
+      fromAddress: "test@example.com",
+    });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    resetHostEmailConfig();
+  });
+
   describe("assignAndNotifyBuiltSites", () => {
-    test("assigns one site per ticket", async () => {
+    test("assigns one site per ticket and sends email", async () => {
       await insertBuiltSite("Site A", "a.test.net", "", "", true);
       await insertBuiltSite("Site B", "b.test.net", "", "", true);
 
@@ -46,6 +67,7 @@ describeWithEnv("site-assignment", {
       const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
       expect(assigned).toHaveLength(2);
       expect(assigned.every((s) => !s.assignable)).toBe(true);
+      expect(fetchStub.calls.length).toBe(1);
     });
 
     test("skips events without assign_built_site", async () => {
@@ -58,6 +80,7 @@ describeWithEnv("site-assignment", {
       const sites = await getAllBuiltSites();
       expect(sites[0]!.assignable).toBe(true);
       expect(sites[0]!.assignedAttendeeId).toBeNull();
+      expect(fetchStub.calls.length).toBe(0);
     });
 
     test("assigns sites independently per event", async () => {
@@ -83,10 +106,12 @@ describeWithEnv("site-assignment", {
 
       const sites = await getAllBuiltSites();
       expect(sites[0]!.assignedAttendeeId).toBeNull();
+      expect(fetchStub.calls.length).toBe(0);
     });
 
     test("no-ops for empty entries", async () => {
       await assignAndNotifyBuiltSites([]);
+      expect(fetchStub.calls.length).toBe(0);
     });
 
     test("assigns only available sites when fewer than needed", async () => {
@@ -97,6 +122,43 @@ describeWithEnv("site-assignment", {
       const sites = await getAllBuiltSites();
       const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
       expect(assigned).toHaveLength(1);
+      expect(fetchStub.calls.length).toBe(1);
+    });
+
+    test("sends email with plural subject for multiple sites", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+      await insertBuiltSite("Site B", "b.test.net", "", "", true);
+
+      await assignAndNotifyBuiltSites([
+        siteEntry({ eventId: 1, eventName: "Event 1" }),
+        siteEntry({ eventId: 2, eventName: "Event 2" }),
+      ]);
+
+      expect(fetchStub.calls.length).toBe(1);
+      const body = JSON.parse(fetchStub.calls[0].args[1].body);
+      expect(body.subject).toContain("2 new sites");
+    });
+
+    test("sends email with singular subject for one site", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+      await assignAndNotifyBuiltSites([siteEntry()]);
+
+      expect(fetchStub.calls.length).toBe(1);
+      const body = JSON.parse(fetchStub.calls[0].args[1].body);
+      expect(body.subject).toBe("Your new site is ready");
+    });
+
+    test("skips email when no email config", async () => {
+      resetHostEmailConfig();
+      setHostEmailConfigForTest(null);
+
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+      await assignAndNotifyBuiltSites([siteEntry()]);
+
+      const sites = await getAllBuiltSites();
+      expect(sites[0]!.assignedAttendeeId).not.toBeNull();
+      expect(fetchStub.calls.length).toBe(0);
     });
   });
 

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -1,0 +1,111 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { insertBuiltSite } from "#lib/db/built-sites.ts";
+import { assignSitesForEntries } from "#lib/site-assignment.ts";
+import type { EmailEntry } from "#lib/email.ts";
+import { describeWithEnv } from "#test-utils";
+
+/** Build a minimal EmailEntry for testing */
+const mockEntry = (
+  overrides: {
+    eventId?: number;
+    eventName?: string;
+    assignBuiltSite?: boolean;
+    attendeeId?: number;
+    quantity?: number;
+    email?: string;
+  } = {},
+): EmailEntry =>
+  ({
+    event: {
+      id: overrides.eventId ?? 1,
+      name: overrides.eventName ?? "Test Event",
+      slug: "test",
+      webhook_url: "",
+      max_attendees: 100,
+      attendee_count: 0,
+      unit_price: 0,
+      can_pay_more: false,
+      date: "",
+      location: "",
+      purchase_only: false,
+      assign_built_site: overrides.assignBuiltSite ?? true,
+    },
+    attendee: {
+      id: overrides.attendeeId ?? 1,
+      name: "Test User",
+      email: overrides.email ?? "user@test.com",
+      phone: "",
+      address: "",
+      special_instructions: "",
+      quantity: overrides.quantity ?? 1,
+      payment_id: "",
+      price_paid: "0",
+      ticket_token: "tok123",
+      date: null,
+    },
+  }) as EmailEntry;
+
+describeWithEnv("site-assignment", { db: true }, () => {
+  describe("assignSitesForEntries", () => {
+    test("assigns one site per ticket", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+      await insertBuiltSite("Site B", "b.test.net", "", "", true);
+
+      const entries = [mockEntry({ quantity: 2 })];
+      const assignments = await assignSitesForEntries(entries);
+
+      expect(assignments).toHaveLength(2);
+      expect(assignments[0]!.siteUrl).toBe("a.test.net");
+      expect(assignments[1]!.siteUrl).toBe("b.test.net");
+    });
+
+    test("skips events without assign_built_site", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+      const entries = [mockEntry({ assignBuiltSite: false })];
+      const assignments = await assignSitesForEntries(entries);
+
+      expect(assignments).toHaveLength(0);
+    });
+
+    test("assigns sites independently per event", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+      await insertBuiltSite("Site B", "b.test.net", "", "", true);
+
+      const entries = [
+        mockEntry({ eventId: 1, eventName: "Event 1", attendeeId: 10 }),
+        mockEntry({ eventId: 2, eventName: "Event 2", attendeeId: 10 }),
+      ];
+      const assignments = await assignSitesForEntries(entries);
+
+      expect(assignments).toHaveLength(2);
+      expect(assignments[0]!.eventName).toBe("Event 1");
+      expect(assignments[1]!.eventName).toBe("Event 2");
+    });
+
+    test("returns empty when no assignable sites available", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", false);
+
+      const entries = [mockEntry()];
+      const assignments = await assignSitesForEntries(entries);
+
+      expect(assignments).toHaveLength(0);
+    });
+
+    test("returns empty for empty entries", async () => {
+      const assignments = await assignSitesForEntries([]);
+      expect(assignments).toHaveLength(0);
+    });
+
+    test("assigns only available sites when fewer than needed", async () => {
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+      const entries = [mockEntry({ quantity: 3 })];
+      const assignments = await assignSitesForEntries(entries);
+
+      expect(assignments).toHaveLength(1);
+      expect(assignments[0]!.siteUrl).toBe("a.test.net");
+    });
+  });
+});

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -1,10 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import {
-  getAllBuiltSites,
-  insertBuiltSite,
-} from "#lib/db/built-sites.ts";
+import { getAllBuiltSites, insertBuiltSite } from "#lib/db/built-sites.ts";
 import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
 import { describeWithEnv, makeTestEntry, setTestEnv } from "#test-utils";
@@ -35,166 +32,170 @@ const siteEntry = (
     },
   );
 
-describeWithEnv("site-assignment", {
-  db: true,
-  env: { CAN_BUILD_SITES: "true" },
-}, () => {
-  // deno-lint-ignore no-explicit-any
-  let fetchStub: any;
+describeWithEnv(
+  "site-assignment",
+  {
+    db: true,
+    env: { CAN_BUILD_SITES: "true" },
+  },
+  () => {
+    // deno-lint-ignore no-explicit-any
+    let fetchStub: any;
 
-  beforeEach(() => {
-    fetchStub = stub(globalThis, "fetch", () =>
-      Promise.resolve(new Response()),
-    );
-    setHostEmailConfigForTest({
-      provider: "resend",
-      apiKey: "re_test",
-      fromAddress: "test@example.com",
-    });
-  });
-
-  afterEach(() => {
-    fetchStub.restore();
-    resetHostEmailConfig();
-  });
-
-  describe("assignAndNotifyBuiltSites", () => {
-    test("assigns one site per ticket and sends email", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-      await insertBuiltSite("Site B", "b.test.net", "", "", true);
-
-      await assignAndNotifyBuiltSites([siteEntry({ quantity: 2 })]);
-
-      const sites = await getAllBuiltSites();
-      const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
-      expect(assigned).toHaveLength(2);
-      expect(assigned.every((s) => !s.assignable)).toBe(true);
-      expect(fetchStub.calls.length).toBe(1);
+    beforeEach(() => {
+      fetchStub = stub(globalThis, "fetch", () =>
+        Promise.resolve(new Response()),
+      );
+      setHostEmailConfigForTest({
+        provider: "resend",
+        apiKey: "re_test",
+        fromAddress: "test@example.com",
+      });
     });
 
-    test("skips events without assign_built_site", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-
-      await assignAndNotifyBuiltSites([
-        siteEntry({ assignBuiltSite: false }),
-      ]);
-
-      const sites = await getAllBuiltSites();
-      expect(sites[0]!.assignable).toBe(true);
-      expect(sites[0]!.assignedAttendeeId).toBeNull();
-      expect(fetchStub.calls.length).toBe(0);
-    });
-
-    test("assigns sites independently per event", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-      await insertBuiltSite("Site B", "b.test.net", "", "", true);
-
-      await assignAndNotifyBuiltSites([
-        siteEntry({ eventId: 1, eventName: "Event 1", attendeeId: 10 }),
-        siteEntry({ eventId: 2, eventName: "Event 2", attendeeId: 10 }),
-      ]);
-
-      const sites = await getAllBuiltSites();
-      const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
-      expect(assigned).toHaveLength(2);
-      expect(assigned[0]!.assignedEventId).toBe(1);
-      expect(assigned[1]!.assignedEventId).toBe(2);
-    });
-
-    test("does not assign when no assignable sites available", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", false);
-
-      await assignAndNotifyBuiltSites([siteEntry()]);
-
-      const sites = await getAllBuiltSites();
-      expect(sites[0]!.assignedAttendeeId).toBeNull();
-      expect(fetchStub.calls.length).toBe(0);
-    });
-
-    test("no-ops for empty entries", async () => {
-      await assignAndNotifyBuiltSites([]);
-      expect(fetchStub.calls.length).toBe(0);
-    });
-
-    test("assigns only available sites when fewer than needed", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-
-      await assignAndNotifyBuiltSites([siteEntry({ quantity: 3 })]);
-
-      const sites = await getAllBuiltSites();
-      const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
-      expect(assigned).toHaveLength(1);
-      expect(fetchStub.calls.length).toBe(1);
-    });
-
-    test("sends email with plural subject for multiple sites", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-      await insertBuiltSite("Site B", "b.test.net", "", "", true);
-
-      await assignAndNotifyBuiltSites([
-        siteEntry({ eventId: 1, eventName: "Event 1" }),
-        siteEntry({ eventId: 2, eventName: "Event 2" }),
-      ]);
-
-      expect(fetchStub.calls.length).toBe(1);
-      const body = JSON.parse(fetchStub.calls[0].args[1].body);
-      expect(body.subject).toContain("2 new sites");
-    });
-
-    test("sends email with singular subject for one site", async () => {
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-
-      await assignAndNotifyBuiltSites([siteEntry()]);
-
-      expect(fetchStub.calls.length).toBe(1);
-      const body = JSON.parse(fetchStub.calls[0].args[1].body);
-      expect(body.subject).toBe("Your new site is ready");
-    });
-
-    test("uses DB email config when available and includes reply-to", async () => {
-      // Configure email via DB settings (not host config) so getEmailConfig()
-      // returns non-null, covering the left branch of the ?? operator
-      const { settings } = await import("#lib/db/settings.ts");
-      await settings.update.email.provider("resend");
-      await settings.update.email.apiKey("re_db_key");
-      await settings.update.email.fromAddress("db@example.com");
-      await settings.update.businessEmail("biz@example.com");
+    afterEach(() => {
+      fetchStub.restore();
       resetHostEmailConfig();
-      setHostEmailConfigForTest(null);
-
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-      await assignAndNotifyBuiltSites([siteEntry()]);
-
-      expect(fetchStub.calls.length).toBe(1);
-      const body = JSON.parse(fetchStub.calls[0].args[1].body);
-      expect(body.reply_to).toBe("biz@example.com");
     });
 
-    test("skips email when no email config", async () => {
-      resetHostEmailConfig();
-      setHostEmailConfigForTest(null);
-
-      await insertBuiltSite("Site A", "a.test.net", "", "", true);
-      await assignAndNotifyBuiltSites([siteEntry()]);
-
-      const sites = await getAllBuiltSites();
-      expect(sites[0]!.assignedAttendeeId).not.toBeNull();
-      expect(fetchStub.calls.length).toBe(0);
-    });
-  });
-
-  describe("feature flag", () => {
-    test("no-ops when CAN_BUILD_SITES is disabled", async () => {
-      const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
-      try {
+    describe("assignAndNotifyBuiltSites", () => {
+      test("assigns one site per ticket and sends email", async () => {
         await insertBuiltSite("Site A", "a.test.net", "", "", true);
-        await assignAndNotifyBuiltSites([siteEntry()]);
+        await insertBuiltSite("Site B", "b.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([siteEntry({ quantity: 2 })]);
+
+        const sites = await getAllBuiltSites();
+        const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+        expect(assigned).toHaveLength(2);
+        expect(assigned.every((s) => !s.assignable)).toBe(true);
+        expect(fetchStub.calls.length).toBe(1);
+      });
+
+      test("skips events without assign_built_site", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([
+          siteEntry({ assignBuiltSite: false }),
+        ]);
+
         const sites = await getAllBuiltSites();
         expect(sites[0]!.assignable).toBe(true);
         expect(sites[0]!.assignedAttendeeId).toBeNull();
-      } finally {
-        restore();
-      }
+        expect(fetchStub.calls.length).toBe(0);
+      });
+
+      test("assigns sites independently per event", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        await insertBuiltSite("Site B", "b.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([
+          siteEntry({ eventId: 1, eventName: "Event 1", attendeeId: 10 }),
+          siteEntry({ eventId: 2, eventName: "Event 2", attendeeId: 10 }),
+        ]);
+
+        const sites = await getAllBuiltSites();
+        const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+        expect(assigned).toHaveLength(2);
+        expect(assigned[0]!.assignedEventId).toBe(1);
+        expect(assigned[1]!.assignedEventId).toBe(2);
+      });
+
+      test("does not assign when no assignable sites available", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", false);
+
+        await assignAndNotifyBuiltSites([siteEntry()]);
+
+        const sites = await getAllBuiltSites();
+        expect(sites[0]!.assignedAttendeeId).toBeNull();
+        expect(fetchStub.calls.length).toBe(0);
+      });
+
+      test("no-ops for empty entries", async () => {
+        await assignAndNotifyBuiltSites([]);
+        expect(fetchStub.calls.length).toBe(0);
+      });
+
+      test("assigns only available sites when fewer than needed", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([siteEntry({ quantity: 3 })]);
+
+        const sites = await getAllBuiltSites();
+        const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+        expect(assigned).toHaveLength(1);
+        expect(fetchStub.calls.length).toBe(1);
+      });
+
+      test("sends email with plural subject for multiple sites", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        await insertBuiltSite("Site B", "b.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([
+          siteEntry({ eventId: 1, eventName: "Event 1" }),
+          siteEntry({ eventId: 2, eventName: "Event 2" }),
+        ]);
+
+        expect(fetchStub.calls.length).toBe(1);
+        const body = JSON.parse(fetchStub.calls[0].args[1].body);
+        expect(body.subject).toContain("2 new sites");
+      });
+
+      test("sends email with singular subject for one site", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([siteEntry()]);
+
+        expect(fetchStub.calls.length).toBe(1);
+        const body = JSON.parse(fetchStub.calls[0].args[1].body);
+        expect(body.subject).toBe("Your new site is ready");
+      });
+
+      test("uses DB email config when available and includes reply-to", async () => {
+        // Configure email via DB settings (not host config) so getEmailConfig()
+        // returns non-null, covering the left branch of the ?? operator
+        const { settings } = await import("#lib/db/settings.ts");
+        await settings.update.email.provider("resend");
+        await settings.update.email.apiKey("re_db_key");
+        await settings.update.email.fromAddress("db@example.com");
+        await settings.update.businessEmail("biz@example.com");
+        resetHostEmailConfig();
+        setHostEmailConfigForTest(null);
+
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        await assignAndNotifyBuiltSites([siteEntry()]);
+
+        expect(fetchStub.calls.length).toBe(1);
+        const body = JSON.parse(fetchStub.calls[0].args[1].body);
+        expect(body.reply_to).toBe("biz@example.com");
+      });
+
+      test("skips email when no email config", async () => {
+        resetHostEmailConfig();
+        setHostEmailConfigForTest(null);
+
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        await assignAndNotifyBuiltSites([siteEntry()]);
+
+        const sites = await getAllBuiltSites();
+        expect(sites[0]!.assignedAttendeeId).not.toBeNull();
+        expect(fetchStub.calls.length).toBe(0);
+      });
     });
-  });
-});
+
+    describe("feature flag", () => {
+      test("no-ops when CAN_BUILD_SITES is disabled", async () => {
+        const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
+        try {
+          await insertBuiltSite("Site A", "a.test.net", "", "", true);
+          await assignAndNotifyBuiltSites([siteEntry()]);
+          const sites = await getAllBuiltSites();
+          expect(sites[0]!.assignable).toBe(true);
+          expect(sites[0]!.assignedAttendeeId).toBeNull();
+        } finally {
+          restore();
+        }
+      });
+    });
+  },
+);

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -22,14 +22,16 @@ const siteEntry = (
 ) =>
   makeTestEntry(
     {
-      id: overrides.eventId,
-      name: overrides.eventName,
       assign_built_site: overrides.assignBuiltSite ?? true,
+      ...(overrides.eventId !== undefined && { id: overrides.eventId }),
+      ...(overrides.eventName !== undefined && { name: overrides.eventName }),
     },
     {
-      id: overrides.attendeeId,
-      email: overrides.email,
-      quantity: overrides.quantity,
+      ...(overrides.attendeeId !== undefined && { id: overrides.attendeeId }),
+      ...(overrides.email !== undefined && { email: overrides.email }),
+      ...(overrides.quantity !== undefined && {
+        quantity: overrides.quantity,
+      }),
     },
   );
 

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -1,11 +1,13 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { insertBuiltSite } from "#lib/db/built-sites.ts";
-import { assignSitesForEntries } from "#lib/site-assignment.ts";
-import type { EmailEntry } from "#lib/email.ts";
+import {
+  assignSitesForEntries,
+  type SiteAssignmentEntry,
+} from "#lib/site-assignment.ts";
 import { describeWithEnv } from "#test-utils";
 
-/** Build a minimal EmailEntry for testing */
+/** Build a minimal SiteAssignmentEntry for testing */
 const mockEntry = (
   overrides: {
     eventId?: number;
@@ -15,36 +17,18 @@ const mockEntry = (
     quantity?: number;
     email?: string;
   } = {},
-): EmailEntry =>
-  ({
-    event: {
-      id: overrides.eventId ?? 1,
-      name: overrides.eventName ?? "Test Event",
-      slug: "test",
-      webhook_url: "",
-      max_attendees: 100,
-      attendee_count: 0,
-      unit_price: 0,
-      can_pay_more: false,
-      date: "",
-      location: "",
-      purchase_only: false,
-      assign_built_site: overrides.assignBuiltSite ?? true,
-    },
-    attendee: {
-      id: overrides.attendeeId ?? 1,
-      name: "Test User",
-      email: overrides.email ?? "user@test.com",
-      phone: "",
-      address: "",
-      special_instructions: "",
-      quantity: overrides.quantity ?? 1,
-      payment_id: "",
-      price_paid: "0",
-      ticket_token: "tok123",
-      date: null,
-    },
-  }) as EmailEntry;
+): SiteAssignmentEntry => ({
+  event: {
+    id: overrides.eventId ?? 1,
+    name: overrides.eventName ?? "Test Event",
+    assign_built_site: overrides.assignBuiltSite ?? true,
+  },
+  attendee: {
+    id: overrides.attendeeId ?? 1,
+    email: overrides.email ?? "user@test.com",
+    quantity: overrides.quantity ?? 1,
+  },
+});
 
 describeWithEnv("site-assignment", { db: true }, () => {
   describe("assignSitesForEntries", () => {

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -7,7 +7,7 @@ import {
 } from "#lib/db/built-sites.ts";
 import { setHostEmailConfigForTest, resetHostEmailConfig } from "#lib/email.ts";
 import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
-import { describeWithEnv, makeTestEntry, setTestEnv } from "#test-utils";
+import { describeWithEnv, makeTestEntry } from "#test-utils";
 
 /** Build an entry with assign_built_site for testing */
 const siteEntry = (
@@ -35,14 +35,13 @@ const siteEntry = (
     },
   );
 
-describeWithEnv("site-assignment", {
-  db: true,
-  env: { CAN_BUILD_SITES: "true" },
-}, () => {
+describeWithEnv("site-assignment", { db: true }, () => {
   // deno-lint-ignore no-explicit-any
   let fetchStub: any;
 
   beforeEach(() => {
+    // Set directly (not via setTestEnv overlay) so process.env sees it
+    Deno.env.set("CAN_BUILD_SITES", "true");
     fetchStub = stub(globalThis, "fetch", () =>
       Promise.resolve(new Response()),
     );
@@ -54,6 +53,7 @@ describeWithEnv("site-assignment", {
   });
 
   afterEach(() => {
+    Deno.env.delete("CAN_BUILD_SITES");
     fetchStub.restore();
     resetHostEmailConfig();
   });
@@ -166,7 +166,7 @@ describeWithEnv("site-assignment", {
 
   describe("feature flag", () => {
     test("no-ops when CAN_BUILD_SITES is disabled", async () => {
-      const restore = setTestEnv({ CAN_BUILD_SITES: undefined });
+      Deno.env.delete("CAN_BUILD_SITES");
       try {
         await insertBuiltSite("Site A", "a.test.net", "", "", true);
         await assignAndNotifyBuiltSites([siteEntry()]);
@@ -174,7 +174,7 @@ describeWithEnv("site-assignment", {
         expect(sites[0]!.assignable).toBe(true);
         expect(sites[0]!.assignedAttendeeId).toBeNull();
       } finally {
-        restore();
+        Deno.env.set("CAN_BUILD_SITES", "true");
       }
     });
   });

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -151,6 +151,17 @@ describeWithEnv("site-assignment", { db: true }, () => {
       expect(body.subject).toBe("Your new site is ready");
     });
 
+    test("includes reply-to when business email is set", async () => {
+      const { settings } = await import("#lib/db/settings.ts");
+      await settings.update.businessEmail("biz@example.com");
+
+      await insertBuiltSite("Site A", "a.test.net", "", "", true);
+      await assignAndNotifyBuiltSites([siteEntry()]);
+
+      const body = JSON.parse(fetchStub.calls[0].args[1].body);
+      expect(body.reply_to).toBe("biz@example.com");
+    });
+
     test("skips email when no email config", async () => {
       resetHostEmailConfig();
       setHostEmailConfigForTest(null);

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -5,7 +5,7 @@ import {
   getAllBuiltSites,
   insertBuiltSite,
 } from "#lib/db/built-sites.ts";
-import { setHostEmailConfigForTest, resetHostEmailConfig } from "#lib/email.ts";
+import { resetHostEmailConfig, setHostEmailConfigForTest } from "#lib/email.ts";
 import { assignAndNotifyBuiltSites } from "#lib/site-assignment.ts";
 import { describeWithEnv, makeTestEntry } from "#test-utils";
 

--- a/test/lib/stripe.test.ts
+++ b/test/lib/stripe.test.ts
@@ -25,6 +25,7 @@ import {
   installUrlHandler,
   resetDb,
   resetTestSlugCounter,
+  setTestEnv,
   testEvent,
   urlFromFetchInput,
   withFetchMock,
@@ -1225,17 +1226,40 @@ describeWithEnv(
 
     describe("getMockConfig", () => {
       test("returns undefined when STRIPE_MOCK_HOST not set", async () => {
-        Deno.env.delete("STRIPE_MOCK_HOST");
-        Deno.env.delete("STRIPE_MOCK_PORT");
-        resetStripeClient();
+        const restore = setTestEnv({
+          STRIPE_MOCK_HOST: undefined,
+          STRIPE_MOCK_PORT: undefined,
+        });
+        try {
+          resetStripeClient();
 
-        // The getMockConfig is a once() function, so we can't easily re-test it.
-        // But getStripeClient exercises the createStripeClient path
-        await settings.update.stripe.secretKey("sk_test_123");
-        // Without mock config, a real Stripe client would be created
-        // We just verify no crash occurs
-        const client = await getStripeClient();
-        expect(client).not.toBeNull();
+          // Without mock config, a real Stripe client is created (no mock server)
+          await settings.update.stripe.secretKey("sk_test_123");
+          const client = await getStripeClient();
+          expect(client).not.toBeNull();
+        } finally {
+          restore();
+          resetStripeClient();
+        }
+      });
+    });
+
+    describe("getMockConfig with default port", () => {
+      test("uses default port 12111 when STRIPE_MOCK_PORT not set", async () => {
+        const restore = setTestEnv({
+          STRIPE_MOCK_HOST: "localhost",
+          STRIPE_MOCK_PORT: undefined,
+        });
+        try {
+          resetStripeClient();
+          await settings.update.stripe.secretKey("sk_test_123");
+          // With STRIPE_MOCK_HOST set but no PORT, should use default 12111
+          const client = await getStripeClient();
+          expect(client).not.toBeNull();
+        } finally {
+          restore();
+          resetStripeClient();
+        }
       });
     });
 
@@ -2054,15 +2078,21 @@ describeWithEnv(
     describe("getMockConfig without STRIPE_MOCK_HOST", () => {
       test("creates client without mock config when STRIPE_MOCK_HOST not set", async () => {
         await settings.update.stripe.secretKey("sk_test_123");
-        Deno.env.delete("STRIPE_MOCK_HOST");
-        Deno.env.delete("STRIPE_MOCK_PORT");
+        const restore = setTestEnv({
+          STRIPE_MOCK_HOST: undefined,
+          STRIPE_MOCK_PORT: undefined,
+        });
+        try {
+          // resetStripeClient now also resets getMockConfig (lazyRef)
+          resetStripeClient();
 
-        // resetStripeClient now also resets getMockConfig (lazyRef)
-        resetStripeClient();
-
-        const client = await getStripeClient();
-        // Client is created using real Stripe (no mock) - returns non-null
-        expect(client !== undefined).toBe(true);
+          const client = await getStripeClient();
+          // Client is created using real Stripe (no mock) - returns non-null
+          expect(client !== undefined).toBe(true);
+        } finally {
+          restore();
+          resetStripeClient();
+        }
       });
     });
 

--- a/test/templates/admin/events.test.ts
+++ b/test/templates/admin/events.test.ts
@@ -1112,5 +1112,47 @@ describeWithEnv(
         });
       });
     });
+
+    describe("assign_built_site field", () => {
+      test("shows assign built site field when CAN_BUILD_SITES is true", () => {
+        Deno.env.set("CAN_BUILD_SITES", "true");
+        try {
+          const html = adminEventNewPage([], TEST_SESSION);
+          expect(html).toContain("assign_built_site");
+          expect(html).toContain("Assign a site on booking");
+        } finally {
+          Deno.env.delete("CAN_BUILD_SITES");
+        }
+      });
+
+      test("hides assign built site field when CAN_BUILD_SITES is not set", () => {
+        Deno.env.delete("CAN_BUILD_SITES");
+        const html = adminEventNewPage([], TEST_SESSION);
+        expect(html).not.toContain("assign_built_site");
+      });
+
+      test("shows on edit page when CAN_BUILD_SITES is true", () => {
+        Deno.env.set("CAN_BUILD_SITES", "true");
+        try {
+          const event = testEventWithCount({ assign_built_site: true });
+          const html = adminEventEditPage(event, [], TEST_SESSION);
+          expect(html).toContain("assign_built_site");
+          expect(html).toContain("checked");
+        } finally {
+          Deno.env.delete("CAN_BUILD_SITES");
+        }
+      });
+
+      test("shows on duplicate page when CAN_BUILD_SITES is true", () => {
+        Deno.env.set("CAN_BUILD_SITES", "true");
+        try {
+          const event = testEventWithCount({ assign_built_site: true });
+          const html = adminDuplicateEventPage(event, [], TEST_SESSION);
+          expect(html).toContain("assign_built_site");
+        } finally {
+          Deno.env.delete("CAN_BUILD_SITES");
+        }
+      });
+    });
   },
 );

--- a/test/templates/admin/events.test.ts
+++ b/test/templates/admin/events.test.ts
@@ -1069,12 +1069,17 @@ describeWithEnv(
     });
 
     describe("adminDuplicateEventPage image section", () => {
-      test("does not show image upload field even when storage enabled", () => {
-        const event = testEventWithCount({ image_url: "" });
-        const html = adminDuplicateEventPage(event, [], TEST_SESSION);
-        expect(html).not.toContain('type="file"');
-        expect(html).not.toContain('name="image"');
-        expect(html).toContain("multipart/form-data");
+      test("shows image upload field when storage enabled", () => {
+        runWithStorageConfig(
+          { zoneName: "testzone", zoneKey: "testkey" },
+          () => {
+            const event = testEventWithCount({ image_url: "" });
+            const html = adminDuplicateEventPage(event, [], TEST_SESSION);
+            expect(html).toContain('type="file"');
+            expect(html).toContain('name="image"');
+            expect(html).toContain("multipart/form-data");
+          },
+        );
       });
 
       test("does not show image field when storage is not enabled", () => {


### PR DESCRIPTION
## Summary
Implements automatic assignment of built sites to attendees when they purchase tickets for events with the `assign_built_site` flag enabled. Includes site availability validation, assignment tracking, and notification emails.

## Key Changes

### Core Assignment Logic
- Added `assignSitesForEntries()` function to assign available built sites to ticket quantities
- Added `sendSiteAssignmentEmail()` to notify attendees of their assigned site URLs
- Added `assignAndNotifyBuiltSites()` as the main entry point for pending work queue integration

### Database Schema & Operations
- Extended `built_sites` table with three new columns:
  - `assignable` (boolean flag for sites available for assignment)
  - `assigned_attendee_id` (tracks which attendee owns the site)
  - `assigned_event_id` (tracks which event the assignment is for)
- Added `assignBuiltSite()` function to mark a site as assigned and store attendee/event IDs
- Added `getAssignableBuiltSites()` and `countAssignableSites()` query functions
- Updated `insertBuiltSite()` to accept optional `assignable` parameter

### Event Configuration
- Added `assign_built_site` boolean field to events table and Event type
- Added UI field `assignBuiltSiteField` for event creation/editing (conditionally shown when builder is enabled)
- Updated event form handling to persist the flag

### Booking Validation
- Added `totalSitesNeeded()` helper to calculate required sites across events
- Added availability check in ticket submission to prevent overbooking sites
- Returns user-friendly error if insufficient sites available

### Admin UI
- Added "Assignable" checkbox field to built site creation form
- Added "Status" column to built sites table showing:
  - "Available" for unassigned assignable sites
  - "Assigned (attendee #X)" for assigned sites
  - "Not assignable" for sites marked as non-assignable
- Updated builder form with assignable checkbox

### Webhook Integration
- Integrated site assignment into webhook processing via `addPendingWork()`
- Sends assignment notification email after successful booking

### Testing
- Added comprehensive test suite for `assignSitesForEntries()` covering:
  - One site per ticket assignment
  - Event filtering (skips non-assign_built_site events)
  - Per-event assignment independence
  - Insufficient site availability handling
  - Edge cases (empty entries, fewer sites than needed)
- Added tests for new built-sites database operations

## Implementation Details
- Sites are assigned in order from the available pool, one per ticket quantity
- Assignment is atomic per site (marks as non-assignable immediately)
- Email notifications include event name and site URL for each assignment
- Gracefully handles race conditions where sites run out mid-assignment

https://claude.ai/code/session_01ChJyWjXrNq7LoNKqktoQJT