### PR TITLE
Fix registration email logic to send admin notification without attendee email

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -305,29 +305,30 @@ export const sendRegistrationEmails = async (
   entries: EmailEntry[],
   currency: string,
 ): Promise<void> => {
-  const attendeeEmail = entries[0]?.attendee.email;
-  if (!attendeeEmail) return;
-
   const config = (await getEmailConfig()) ?? getHostEmailConfig();
   if (!config) return;
 
+  const attendeeEmail = entries[0]?.attendee.email;
   const businessEmail = settings.businessEmail;
   const ticketUrl = buildTicketUrl(entries);
-  const replyTo = businessEmail || undefined;
   const data = buildTemplateData(entries, currency, ticketUrl);
+  const promises: Promise<number | undefined>[] = [];
 
-  const [confirmation, attachments] = await Promise.all([
-    renderEmailContent("confirmation", data),
-    buildTicketAttachments(entries, currency),
-  ]);
-  const promises: Promise<number | undefined>[] = [
-    sendEmail(config, {
-      to: attendeeEmail,
-      ...confirmation,
-      replyTo,
-      attachments,
-    }),
-  ];
+  if (attendeeEmail) {
+    const replyTo = businessEmail || undefined;
+    const [confirmation, attachments] = await Promise.all([
+      renderEmailContent("confirmation", data),
+      buildTicketAttachments(entries, currency),
+    ]);
+    promises.push(
+      sendEmail(config, {
+        to: attendeeEmail,
+        ...confirmation,
+        replyTo,
+        attachments,
+      }),
+    );
+  }
 
   if (businessEmail) {
     const notification = await renderEmailContent("admin", data);
@@ -335,7 +336,7 @@ export const sendRegistrationEmails = async (
       sendEmail(config, {
         to: businessEmail,
         ...notification,
-        replyTo: attendeeEmail,
+        replyTo: attendeeEmail || undefined,
       }),
     );
   }

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -601,9 +601,19 @@ describeWithEnv("email", { db: true }, () => {
       },
     },
     () => {
-      test("skips when attendee has no email address", async () => {
+      test("skips all emails when attendee has no email and no business email set", async () => {
         await setupAndSendRegistration({}, [makeEntry({}, { email: "" })]);
         expect(fetchStub.calls.length).toBe(0);
+      });
+
+      test("sends admin notification when attendee has no email but business email is set", async () => {
+        await setupAndSendRegistration({ businessEmail: "admin@business.com" }, [
+          makeEntry({}, { email: "" }),
+        ]);
+
+        expect(fetchStub.calls.length).toBe(1);
+        const body = getFetchJsonBody();
+        expect(body.to).toEqual(["admin@business.com"]);
       });
 
       test("skips when email not configured", async () => {


### PR DESCRIPTION
## Summary
Refactored the registration email sending logic to properly handle cases where an attendee has no email address but a business email is configured. Previously, the function would skip all emails if the attendee lacked an email. Now it correctly sends the admin notification to the business email even when the attendee email is missing.

## Key Changes
- Moved the early return check for `attendeeEmail` to allow the function to continue when only a business email is available
- Wrapped the attendee confirmation email logic in a conditional block that only executes when `attendeeEmail` exists
- Updated the admin notification `replyTo` field to handle undefined attendee emails gracefully (`attendeeEmail || undefined`)
- Reordered operations to fetch email config before checking attendee email, ensuring config validation happens first

## Implementation Details
- The function now initializes an empty `promises` array and conditionally pushes email sending operations based on available email addresses
- Both email sending paths (attendee confirmation and admin notification) are now independent, allowing either to execute without the other
- Added test coverage for the new behavior: admin notifications are now sent when business email is configured, even if the attendee has no email address

https://claude.ai/code/session_01A6gLBKF98QS69wt5c7chs8