### PR TITLE
Add warning about email collection for ticket delivery

### DIFF
--- a/src/templates/fields.ts
+++ b/src/templates/fields.ts
@@ -388,6 +388,8 @@ export const eventFields: Field[] = [
     label: "Contact Fields",
     type: "checkbox-group",
     hint: "Which contact details to collect from attendees",
+    hintHtml:
+      "If you don't collect email addresses, <strong>attendees won't be emailed their ticket</strong>.",
     options: [
       { value: "email", label: "Email" },
       { value: "phone", label: "Phone Number" },

--- a/test/lib/email.test.ts
+++ b/test/lib/email.test.ts
@@ -607,9 +607,10 @@ describeWithEnv("email", { db: true }, () => {
       });
 
       test("sends admin notification when attendee has no email but business email is set", async () => {
-        await setupAndSendRegistration({ businessEmail: "admin@business.com" }, [
-          makeEntry({}, { email: "" }),
-        ]);
+        await setupAndSendRegistration(
+          { businessEmail: "admin@business.com" },
+          [makeEntry({}, { email: "" })],
+        );
 
         expect(fetchStub.calls.length).toBe(1);
         const body = getFetchJsonBody();

--- a/test/lib/forms/event-fields.test.ts
+++ b/test/lib/forms/event-fields.test.ts
@@ -104,6 +104,12 @@ describe("eventFields — contact fields setting", () => {
       expectValid(eventFields, eventForm({ fields: value }));
     }
   });
+
+  test("warns that attendees won't be emailed their ticket without email collection", () => {
+    const fieldsField = eventFields.find((f) => f.name === "fields")!;
+    expect(fieldsField.hintHtml).toContain("<strong>");
+    expect(fieldsField.hintHtml).toContain("emailed their ticket");
+  });
 });
 
 describe("eventFields — event_type", () => {


### PR DESCRIPTION
## Summary
Added a prominent warning to the event fields form to inform users that attendees won't receive their tickets via email if email collection is not enabled.

## Changes
- **src/templates/fields.ts**: Added `hintHtml` property to the "Contact Fields" field with a warning message that attendees won't be emailed their ticket if email addresses aren't collected
- **test/lib/forms/event-fields.test.ts**: Added test to verify the warning message is present in the hint HTML
- **test/lib/email.test.ts**: Reformatted function call for better readability (no functional change)

## Implementation Details
The warning is displayed as HTML-formatted hint text below the "Contact Fields" checkbox group, using `<strong>` tags to emphasize the critical information about ticket delivery via email.

https://claude.ai/code/session_01H7QqDM9uq1g7E2rhm76ma7