### PR TITLE
Add admin notice about April 6-12 attendee data editing bug

### DIFF
--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -221,6 +221,17 @@ export const adminDashboardPage = (
 
       <Flash success={successMessage} error={imageError} />
 
+      <p class="notice warning">
+        <strong>Note from Stef:</strong> A bug on this system between April 6th
+        and 12th meant that editing attendee data (eg to change their name,
+        email, or phone number) could reset their ticket quantities to one -
+        even if they originally bought more. If you&apos;ve edited attendee
+        records in this period, please check their quantities against your email
+        receipts. Sorry! Please{" "}
+        <a href="mailto:hello@chobble.com">contact me</a> if you have further
+        questions.
+      </p>
+
       {!isReadOnly() && (
         <p>
           <a href="/admin/event/new">Add Event</a>

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -47,6 +47,13 @@ describe("adminDashboardPage", () => {
     expect(html).toContain("Add Event");
   });
 
+  test("renders admin notice about April 6-12 quantity bug", () => {
+    const html = adminDashboardPage([], TEST_SESSION);
+    expect(html).toContain("Note from Stef");
+    expect(html).toContain("April 6th");
+    expect(html).toContain("hello@chobble.com");
+  });
+
   test("includes logout link", () => {
     const html = adminDashboardPage([], TEST_SESSION);
     expect(html).toContain("/admin/logout");


### PR DESCRIPTION
## Summary
This PR adds a prominent notice to the admin dashboard informing administrators about a bug that occurred between April 6th and 12th, which could reset attendee ticket quantities to one when editing attendee records.

## Changes
- Added a warning notice to the admin dashboard template explaining the bug and its impact
- Included guidance for administrators to verify ticket quantities against email receipts
- Provided a contact email (hello@chobble.com) for administrators with questions
- Added test coverage to verify the notice is rendered with key information

## Implementation Details
- The notice is displayed as a styled warning message using the existing `notice warning` CSS classes
- The message is positioned prominently after the Flash messages and before the main dashboard content
- Test validates that the notice contains the key identifiers: "Note from Stef", "April 6th", and the contact email

https://claude.ai/code/session_01FNG8MhmQmFCv4wjwYedaH1