### PR TITLE
Update custom price label from "Your Price" to "Price per ticket"

### DIFF
--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -251,8 +251,8 @@ const renderPayMoreInput = (
   const maxPrice = event.max_price;
   const rangeHint =
     minPrice > 0
-      ? `Your Price (${formatCurrency(minPrice)} minimum)`
-      : `Your Price (optional, up to ${formatCurrency(maxPrice)})`;
+      ? `Price per ticket (${formatCurrency(minPrice)} minimum)`
+      : `Price per ticket (optional, up to ${formatCurrency(maxPrice)})`;
   return (
     `<label>${rangeHint}` +
     `<input type="text" inputmode="decimal" name="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}" pattern="\\d+(\\.\\d{1,2})?" title="A non-negative number (e.g. 10.00)"${minPrice > 0 ? " required" : ""} /></label>`

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3942,7 +3942,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       const html = await response.text();
       expect(html).toMatch(/name="custom_price(_\d+)?"/);
 
-      expect(html).toContain("Your Price (£10 minimum)");
+      expect(html).toContain("Price per ticket (£10 minimum)");
       expect(html).toContain('value="10.00"');
       expect(html).toContain("required");
     });
@@ -3967,7 +3967,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       const html = await response.text();
       expect(html).toMatch(/name="custom_price(_\d+)?"/);
 
-      expect(html).toContain("Your Price (optional, up to £100)");
+      expect(html).toContain("Price per ticket (optional, up to £100)");
       expect(html).toContain('min="0.00"');
     });
 
@@ -3979,7 +3979,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       const html = await response.text();
       expect(html).toMatch(/name="custom_price(_\d+)?"/);
 
-      expect(html).toContain("Your Price (optional, up to £100)");
+      expect(html).toContain("Price per ticket (optional, up to £100)");
       expect(html).toContain('value="0.00" min="0.00" max="100.00"');
     });
 


### PR DESCRIPTION
## Summary
Updated the label text for custom price input fields to use more inclusive and accurate terminology.

## Changes
- Changed label text from "Your Price" to "Price per ticket" in the pay-more input rendering logic
- Updated both minimum price and optional price variants:
  - "Your Price (£X minimum)" → "Price per ticket (£X minimum)"
  - "Your Price (optional, up to £X)" → "Price per ticket (optional, up to £X)"
- Updated corresponding test expectations to match the new label text

## Details
The change improves clarity by using "Price per ticket" instead of "Your Price", which better describes what the input field represents and is more appropriate for group purchases or multiple ticket scenarios. The implementation change is in `src/templates/public.tsx` in the `renderPayMoreInput` function, with test updates in `test/lib/server-public.test.ts` to verify the new label appears correctly in the rendered HTML.

https://claude.ai/code/session_015LvycvY9HsMW88WPDgXPME