### PR TITLE
Display flash messages on attendee delete and resend notification pages

### DIFF
--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -210,9 +210,9 @@ export const verifiedAttendeeForm = (
 /** Handle GET /admin/event/:eventId/attendee/:attendeeId/delete */
 const handleAdminAttendeeDeleteGet = attendeeGetRoute(
   (data, session, request) => {
-    applyFlash(request);
+    const flash = applyFlash(request);
     return htmlResponse(
-      adminDeleteAttendeePage(data, session, getReturnUrl(request)),
+      adminDeleteAttendeePage(data, session, getReturnUrl(request), flash.error),
     );
   },
 );
@@ -556,9 +556,9 @@ const handleEditAttendeePost = editAttendeePost(editAttendeeHandler);
 /** Handle GET /admin/event/:eventId/attendee/:attendeeId/resend-notification */
 const handleAdminResendNotificationGet = attendeeGetRoute(
   (data, session, request) => {
-    applyFlash(request);
+    const flash = applyFlash(request);
     return htmlResponse(
-      adminResendNotificationPage(data, session, getReturnUrl(request)),
+      adminResendNotificationPage(data, session, getReturnUrl(request), flash.error),
     );
   },
 );

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -26,10 +26,12 @@ export const adminDeleteAttendeePage = (
   { event, attendee }: { event: EventWithCount; attendee: Attendee },
   session: AdminSession,
   returnUrl?: string,
+  error?: string,
 ): string =>
   String(
     <Layout title={`Delete Attendee: ${attendee.name}`}>
       <AdminNav session={session} active="/admin/" />
+      <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/attendee/${attendee.id}/delete`}
@@ -782,10 +784,12 @@ export const adminResendNotificationPage = (
   { event, attendee }: { event: EventWithCount; attendee: Attendee },
   session: AdminSession,
   returnUrl?: string,
+  error?: string,
 ): string =>
   String(
     <Layout title={`Re-send Notification: ${attendee.name}`}>
       <AdminNav session={session} active="/admin/" />
+      <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/attendee/${attendee.id}/resend-notification`}

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -2167,12 +2167,12 @@ export const adminGuidePage = (
         <Q q="Why does my site say it's in read-only mode?">
           <p>
             Read-only mode is switched on by the host (not from inside the
-            admin) and is used for two things: sites that have fallen behind
-            on billing, and sites undergoing maintenance. While it's on,
-            bookings are refused and the create/edit pages for events and
-            groups are blocked, but everything else stays viewable. If you
-            think your site shouldn't be in read-only mode, get in touch with
-            whoever hosts it for you.
+            admin) and is used for two things: sites that have fallen behind on
+            billing, and sites undergoing maintenance. While it's on, bookings
+            are refused and the create/edit pages for events and groups are
+            blocked, but everything else stays viewable. If you think your site
+            shouldn't be in read-only mode, get in touch with whoever hosts it
+            for you.
           </p>
         </Q>
       </Section>

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -26,10 +26,12 @@ import {
   expectRedirectWithFlash,
   FLASH_TEST_ID,
   flashCookieHeader,
+  followRedirectWithFlash,
   getAttendeesRaw,
   mockFormRequest,
   mockProviderType,
   mockRequest,
+  setupAdminTest,
   setupEventAndLogin,
   testCookie,
   testCsrfToken,
@@ -1378,7 +1380,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     });
 
     test("preserves quantity when editing contact info without quantity field", async () => {
-      const event = await createTestEvent({ maxAttendees: 100, maxQuantity: 5 });
+      const event = await createTestEvent({
+        maxAttendees: 100,
+        maxQuantity: 5,
+      });
       const { attendee } = await createTestAttendeeDirect(
         event.id,
         "John Doe",
@@ -1593,7 +1598,6 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       await expectHtmlResponse(response, 200, 'name="quantity"', 'max="5"');
     });
-
   });
 
   describe("GET /admin/event/:eventId/attendee/:attendeeId/resend-notification", () => {
@@ -1659,6 +1663,24 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         'name="return_url"',
         "/admin/calendar#attendees",
       );
+    });
+
+    test("shows error message when attendee name does not match", async () => {
+      const { event, attendee, cookie, csrfToken } = await setupAdminTest();
+      const postResponse = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/attendee/${attendee.id}/resend-notification`,
+          { csrf_token: csrfToken, confirm_identifier: "Wrong Name" },
+          cookie,
+        ),
+      );
+      const page = await followRedirectWithFlash(
+        postResponse,
+        handleRequest,
+        cookie,
+      );
+      const html = await page.text();
+      expect(html).toContain("does not match");
     });
 
     test("shows amount paid on resend notification page for paid attendee", async () => {


### PR DESCRIPTION
## Summary
This PR adds flash message support to the attendee delete and resend notification confirmation pages, allowing error messages to be displayed to users when actions fail.

## Key Changes
- **Test improvements**: Added new test case to verify error message display when attendee name doesn't match during resend notification
- **Route handlers**: Modified `handleAdminAttendeeDeleteGet` and `handleAdminResendNotificationGet` to capture flash messages from requests and pass them to their respective page templates
- **Template updates**: Updated `adminDeleteAttendeePage` and `adminResendNotificationPage` to accept an optional `error` parameter and render a `<Flash>` component to display error messages
- **Code formatting**: Fixed line wrapping in the admin guide template for improved readability
- **Test utilities**: Added imports for `followRedirectWithFlash` and `setupAdminTest` helper functions to support the new test case

## Implementation Details
The flash message handling follows the existing pattern in the codebase:
1. Extract flash data from the request using `applyFlash(request)`
2. Pass the error message to the page template
3. Render the `<Flash>` component in the template to display the message to users

This ensures users receive immediate feedback when confirmation actions fail, improving the user experience on these admin pages.

https://claude.ai/code/session_01RR8pWNshrMv8j1Z8F2tKTH