### PR TITLE
Fix custom domain validation error handling in tests

### DIFF
--- a/test/lib/server-settings-advanced.test.ts
+++ b/test/lib/server-settings-advanced.test.ts
@@ -1327,16 +1327,18 @@ describeWithEnv("server (admin settings-advanced)", { db: true }, () => {
           bunnyCdnApi.validateCustomDomain = () => {
             throw new Error("network failure");
           };
-          Deno.env.set("TEST_EXPECT_ERROR", "1");
           try {
             await adminFormPost("/admin/settings/custom-domain", {
               custom_domain: "tickets.example.com",
             });
-            expect(settings.currentTask).toBe("");
+          } catch {
+            // The stubbed error may be rethrown by handleRequest's
+            // test guard — that's fine, we only care that current_task
+            // was cleared by the finally block in withCurrentTask.
           } finally {
-            Deno.env.delete("TEST_EXPECT_ERROR");
             bunnyCdnApi.validateCustomDomain = original;
           }
+          expect(settings.currentTask).toBe("");
         });
       });
     },


### PR DESCRIPTION
## Summary
Updated the custom domain validation test to properly handle stubbed errors without relying on environment variable guards, making the test more robust and clearer in intent.

## Key Changes
- Removed `TEST_EXPECT_ERROR` environment variable usage that was attempting to suppress expected errors
- Wrapped the `adminFormPost` call in a try-catch block to gracefully handle the stubbed network failure
- Moved the `currentTask` assertion outside the try-finally block to ensure it runs after error handling completes
- Added clarifying comment explaining that the stubbed error may be rethrown by `handleRequest`'s test guard, but the important verification is that `currentTask` was cleared by the `finally` block in `withCurrentTask`

## Implementation Details
The test now properly validates that even when a network error occurs during custom domain validation, the `currentTask` is correctly cleared by the finally block in `withCurrentTask`. This approach is more explicit about error handling expectations and doesn't rely on environment variable side effects.

https://claude.ai/code/session_017VVVUP5vDJMEck2bST5LKR