### PR TITLE
Remove April 6-12 quantity bug warning from admin dashboard

### DIFF
--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -221,17 +221,6 @@ export const adminDashboardPage = (
 
       <Flash success={successMessage} error={imageError} />
 
-      <p class="notice warning">
-        <strong>Note from Stef:</strong> A bug on this system between April 6th
-        and 12th meant that editing attendee data (eg to change their name,
-        email, or phone number) could reset their ticket quantities to one -
-        even if they originally bought more. If you&apos;ve edited attendee
-        records in this period, please check their quantities against your email
-        receipts. Sorry! Please{" "}
-        <a href="mailto:hello@chobble.com">contact me</a> if you have further
-        questions.
-      </p>
-
       {!isReadOnly() && (
         <p>
           <a href="/admin/event/new">Add Event</a>

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -47,13 +47,6 @@ describe("adminDashboardPage", () => {
     expect(html).toContain("Add Event");
   });
 
-  test("renders admin notice about April 6-12 quantity bug", () => {
-    const html = adminDashboardPage([], TEST_SESSION);
-    expect(html).toContain("Note from Stef");
-    expect(html).toContain("April 6th");
-    expect(html).toContain("hello@chobble.com");
-  });
-
   test("includes logout link", () => {
     const html = adminDashboardPage([], TEST_SESSION);
     expect(html).toContain("/admin/logout");


### PR DESCRIPTION
Everyone who needed to see it has, so we can remove the notice.