### PR TITLE
Fix first-request SessionKeyError after initial setup

### DIFF
--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -441,6 +441,13 @@ const completeSetup = async (
   await writeRaw(CONFIG_KEYS.PUBLIC_KEY, publicKey);
   await writeRaw(CONFIG_KEYS.COUNTRY, country);
   await writeRaw(CONFIG_KEYS.SETUP_COMPLETE, "true");
+  // Keep the in-memory snapshot in sync with the freshly-written rows so the
+  // next request doesn't read stale defaults while the raw cache is still
+  // valid (loadAll short-circuits for up to SETTINGS_CACHE_TTL_MS).
+  setSnapshotField(CONFIG_KEYS.WRAPPED_PRIVATE_KEY, encryptedPrivateKey);
+  setSnapshotField(CONFIG_KEYS.PUBLIC_KEY, publicKey);
+  data.country = country;
+  applyCountryDerived(getCountry(country));
 };
 
 // ---------------------------------------------------------------------------

--- a/test/lib/db.test.ts
+++ b/test/lib/db.test.ts
@@ -476,6 +476,32 @@ describeWithEnv("db", { db: true }, () => {
       expect(settings.wrappedPrivateKey).toBeTruthy();
     });
 
+    test("completeSetup updates snapshot so wrappedPrivateKey is readable without invalidation", async () => {
+      // Regression: previously completeSetup only updated the raw entries
+      // cache, leaving the snapshot holding default "" values. Because
+      // loadAll() short-circuits while the 60s TTL is valid, the first
+      // GET /admin after setup would see settings.wrappedPrivateKey === ""
+      // and throw SessionKeyError ("Private key unavailable for session").
+      await getDb().execute("DELETE FROM users");
+      await getDb().execute("DELETE FROM settings");
+      // Prime the snapshot with a fresh loadAll so the cache is valid and
+      // contains default empty values for wrapped_private_key/public_key.
+      settings.invalidateCache();
+      await settings.loadAll();
+      expect(settings.wrappedPrivateKey).toBe("");
+      expect(settings.publicKey).toBe("");
+
+      await settings.setup.complete("setupuser", "mypassword", "US");
+
+      // Do NOT invalidate or reload — the snapshot should already reflect the
+      // values just written, since subsequent requests rely on loadAll() being
+      // a no-op while the cache is still valid.
+      expect(settings.wrappedPrivateKey).toBeTruthy();
+      expect(settings.publicKey).toBeTruthy();
+      expect(settings.country).toBe("US");
+      expect(settings.currency).toBe("USD");
+    });
+
     test("isComplete reloads cache when it has expired", async () => {
       settings.invalidateCache();
       // Cache is now invalid; isComplete should reload it from the DB


### PR DESCRIPTION
completeSetup wrote wrapped_private_key, public_key, and country via
writeRaw(), which only updates the raw-entries cache. The in-memory
snapshot that backs settings.wrappedPrivateKey (and friends) kept its
default "" value, and loadAll() short-circuits while the 60s TTL is
still valid — so the first GET /admin after setup saw an empty
wrappedPrivateKey, returned null from getPrivateKey(), and threw
SessionKeyError ("Private key unavailable for session"). The top-level
catch cleared the session cookie and redirected to /admin; only a later
request (after cache expiry or re-login) worked.

Mirror the update.* pattern: after writeRaw, also update the snapshot
fields directly so subsequent reads on the same cache generation see
the freshly-written values.