### PR TITLE
Document multi-day booking rollout plan and group-booking details

### DIFF
--- a/DURATION_PLAN.md
+++ b/DURATION_PLAN.md
@@ -6,6 +6,16 @@ Let admins mark a daily event as a fixed-length multi-day booking (e.g. a 3-day 
 
 This is deliberately a **small, low-risk step** that (a) delivers a new capability to existing users (multi-day courses/retreats/rentals), and (b) lays the plumbing for a later "customer picks their own end date" feature by making the whole stack multi-day-aware.
 
+## Codebase findings (April 2026 deep-dive)
+
+These findings come from reading the current implementation and should guide scope decisions:
+
+- There is no persistent "booking group" object after checkout. The payment/session path carries `items` + optional `date`; attendee writes are just `attendees` + `event_attendees` rows. Group context is not stored on attendee bookings.
+- "Groups" in this codebase are event collections (`events.group_id`) used for discovery, shared public pages, and optional aggregate capacity limits — not a long-lived booking container.
+- Group capacity checks happen dynamically by event membership (`events.group_id`) during availability/insert checks, not via any attendee-side group foreign key.
+- Public event headers already render a single `Date:` line for dated events; duration display should therefore be implemented as a date-range label there (not as a separate "duration" field).
+- Range copy decision: use an **en dash (`–`)** in rendered ranges.
+
 ## Semantics (decisions)
 
 - `duration_days INTEGER NOT NULL DEFAULT 1` on `events`.
@@ -131,15 +141,16 @@ This is the core correctness phase. Everything else rides on it.
 ### Phase 5 — Display: confirmation page, email, admin views
 
 **Files**
-- `src/lib/dates.ts` — add `formatDateRangeLabel(startIso, endIso)` → `"Mon 15 Apr – Wed 17 Apr"`. Single-day collapses to `formatDateLabel`.
-  - Add English-only compact range formatter for event/ticket display (for now), with these rules:
+- `src/lib/dates.ts`
+  - Add `formatDateRangeLabel(startIso, endIso)` for booking records, returning a human range; single-day collapses to `formatDateLabel`.
+  - Add English-only compact date-range formatter for event/ticket display (for now), using **en dash** style rules:
     - Same day: `2 February 2027`
     - Same month + same year: `2–3 February 2027`
     - Different month + same year: `2 February – 3 March 2027`
     - Different year: `2 February 2027 – 3 February 2028` (no dedupe across years)
-  - Keep this as a dedicated helper (e.g. `formatDateRangeLabelCompactEn`) so i18n can later swap locale-specific behavior without rewriting booking logic.
+  - Keep this as a dedicated helper (e.g. `formatDateRangeLabelCompactEn`) so i18n can later replace locale behavior cleanly.
 - `src/templates/public.tsx`
-  - Reuse the compact formatter for the public event/date line so UI shows `<from> to <to>` semantics without awkward repeated month/year text.
+  - Reuse the compact formatter for the public event/date line so UI shows an explicit range when available, with en dash-separated labels.
 - `src/templates/tickets.tsx` — `attendeeDateHtml` (~line 57–59): render range when `attendee.end_at - attendee.start_at > 1 day`. Keep existing behaviour for single-day.
 - `src/lib/email-renderer.ts` — template data exposes `dateRangeLabel` alongside `date` (kept for backward compatibility).
 - `src/templates/admin/attendees.tsx` / `attendee-table.tsx` — date column shows range when multi-day (small visual tweak; row still sorts by start).
@@ -165,38 +176,38 @@ This feature intersects with group behavior in ways that are easy to miss. We sh
 
 ### Group semantics to lock in
 
-- `duration_days` is **event-scoped**, not attendee-scoped: all tickets in a group booking inherit the same date range from the selected start date.
+- `duration_days` is **event-scoped**, not attendee-scoped: all tickets in one checkout for a daily event inherit the same date range from the selected start date.
 - Capacity is checked against **total attendee quantity per day** across the full range, regardless of whether tickets are bought as a group or individually.
-- Group identity (`group_id` or equivalent linkage) remains orthogonal to duration: changing duration on the event affects only future bookings, not existing group rows.
+- Group identity is `events.group_id` membership, not attendee booking linkage: changing duration on the event affects only future attendee rows via future inserts.
 
-### DB + atomicity details for grouped inserts
+### DB + atomicity details for multi-event/group-page checkouts
 
-- For grouped purchases that create multiple attendee rows in one transaction:
-  - Compute a single `{ start_at, end_at }` from `date + duration_days` and reuse it for every row in the group.
+- For one checkout that creates multiple `event_attendees` rows:
+  - Compute a single `{ start_at, end_at }` from `date + duration_days` for each daily event booking being inserted.
   - Keep the existing overlap predicate (`ea2.start_at < ? AND ea2.end_at > ?`) for atomic safety.
-  - Run preflight per-day availability for the **full requested quantity** before insert to avoid split-brain outcomes where some group members insert and others fail.
+  - Run preflight per-day availability for the **full requested quantity** before insert to avoid partial success outcomes where some booking rows insert and others fail.
 - If current implementation inserts one attendee at a time, verify ordering/rollback behavior:
-  - Prefer all-or-nothing transaction semantics for group booking writes.
-  - Ensure payment finalization does not leave orphaned partial groups when capacity races occur.
+  - Prefer all-or-nothing transaction semantics for multi-row booking writes.
+  - Ensure payment finalization does not leave orphaned partial attendee links when capacity races occur.
 
 ### Availability math with groups (nitty-gritty cases)
 
 For each day in range `D = [start, start + duration)`:
 
-- Effective demand added by booking = `quantity` (group size).
+- Effective demand added by booking = `quantity`.
 - Day is valid iff `existingAttendeesForDay + quantity <= max_quantity`.
 - Reject booking if **any** day fails this predicate.
 
 Edge cases to explicitly test:
 
-1. Day 1 has room, Day 2 is full, Day 3 has room → entire group booking must fail.
-2. Two concurrent group checkouts for same range near capacity → only one should commit.
+1. Day 1 has room, Day 2 is full, Day 3 has room → entire checkout booking for that event must fail.
+2. Two concurrent checkouts for same range near capacity → only one should commit.
 3. Existing long booking overlaps only tail of requested range; another overlaps head; per-day checks should accept/reject correctly without overlap-sum false positives.
 4. Mixed cart with multiple daily events (different durations) and at least one grouped quantity >1.
 
 ### UX/content implications for group flows
 
-- Public event page: show explicit date range text (`<from> to <to>`) when a concrete range can be determined.
+- Public event page: show explicit date range text when a concrete range can be determined, using en dash style.
 - Ticket/checkout summaries should still make total pricing transparent (`per-day × duration × quantity`) so group organizers can reconcile totals.
 - Confirmation/email should show the resolved date range once booked; that is sufficient for group participants.
 
@@ -236,8 +247,7 @@ Roughly **8–10 source files**, **5–7 test files**.
 
 1. Should `duration_days` be editable after a daily event has bookings? (Default: yes, but existing bookings keep their stored ranges; new bookings use the new value.)
 2. Max value — 90 (current `maximum_days_after` default) or 365? Probably 90.
-3. Should we add explicit guardrails around editing duration when there are existing group bookings to reduce admin confusion?
-4. Should the public event page use an en dash (`–`) vs literal `to` in the rendered range, and should this vary by template/context?
+3. Should we add explicit guardrails around editing duration when there are many existing future attendee rows to reduce admin confusion?
 
 ## Phase 2 kickoff
 

--- a/DURATION_PLAN.md
+++ b/DURATION_PLAN.md
@@ -27,13 +27,13 @@ These findings come from reading the current implementation and should guide sco
 - Customer still picks a **single start date**. The system extends the end automatically.
 - Price: `unit_price × quantity × duration_days`.
 - Start dates are only offered when **every day in the resulting range** is bookable (not a holiday, within the `bookable_days` weekday mask, and within `minimum_days_before` / `maximum_days_after`).
+- `duration_days` is always editable for daily events. On save, we also update existing `event_attendees.end_at` ranges for that event so stored bookings stay consistent with the event's current duration policy.
 
 ## Non-goals (explicitly out of scope)
 
 - Customer-chosen end date (phase 2 — this plan's infra supports it).
 - Per-day pricing tiers / discounts.
 - Partial cancellation/refund of days.
-- Admin edit of duration on existing bookings rewriting their ranges retroactively (new bookings pick up new duration; existing rows keep their stored range).
 - Calendar UI spreading a booking across multiple day cells (phase 2).
 - CSV export end-date column (phase 2).
 
@@ -73,6 +73,10 @@ This is the core correctness phase. Everything else rides on it.
   - `dateToStartEnd(date, durationDays)` — thread duration through.
   - `EventBooking` type (in `attendee-types.ts`): add `durationDays?: number` (default 1).
   - `buildCapacityCheckedInsert(booking, ...)` — pass `booking.durationDays` into `dateToStartEnd` so `end_at` is correct. The capacity-check SQL (overlap: `ea2.start_at < ? AND ea2.end_at > ?`) works unchanged for range-vs-range overlap.
+  - Add a reconciliation helper for duration edits (e.g. `recomputeEventBookingRanges(eventId, durationDays)`):
+    - Updates `end_at` for existing rows where `event_id = ?` and `start_at IS NOT NULL`.
+    - Formula: `end_at = datetime(start_at, '+' || durationDays || ' days')` (or equivalent UTC-safe expression).
+    - Runs in same transaction as event update when duration changes.
   - `getDateAttendeeCount(eventId, date)` — unchanged; still checks a single day's load (this is what makes multi-day checks accurate).
 - `src/lib/db/attendees.ts → checkBatchAvailability`
   - **Accuracy fix**: for each daily event in the batch, if `duration_days > 1` expand to per-day checks.
@@ -90,6 +94,7 @@ This is the core correctness phase. Everything else rides on it.
   - `checkBatchAvailability` rejects when **any** day in a multi-day range is at capacity (even if adjacent days have space)
   - `checkBatchAvailability` accepts when all days have room
   - `createAttendeeAtomic` stores `end_at = start_at + duration × 86_400_000 ms` for a duration-3 event
+  - duration edit reconciliation updates existing rows' `end_at` for that event
 
 ---
 
@@ -102,12 +107,23 @@ This is the core correctness phase. Everything else rides on it.
   - Hide/disable when `event_type !== 'daily'` — can piggyback on existing daily-only field visibility logic.
 - `src/routes/admin/events.ts`
   - `extractCommonFields` / `extractEventUpdateInput` — parse `duration_days` (clamp ≥1), alongside `minimum_days_before`.
+  - On event edit save: if `duration_days` changed and event is daily, call the DB reconciliation helper in the same transaction.
 - `src/templates/admin/events.tsx`
   - Admin event detail view: show duration alongside min/max days so staff can verify booking behavior.
+  - Event edit form JS warning flow:
+    - If duration value differs from persisted value, show warning label:
+      `"Changing booking duration will update existing bookings for this event."`
+    - Show a confirmation input/checkbox gate before enabling Save.
+    - Keep warning hidden when duration is unchanged.
+- `src/templates/admin/attendees.tsx` / `src/templates/admin/attendee-table.tsx` / attendee edit template
+  - When editing attendee event links for daily bookings, show both start and end dates (or compact range) to make duration-impacted edits explicit.
+  - When admin changes a booking date manually, recompute and persist end date using current event duration.
 
 **Tests**
 - `test/lib/forms/event-fields.test.ts` — parse/validate `duration_days` (reject 0, negative, non-integer).
 - `test/admin-api-events.test.ts` / `test/templates/admin/events.test.ts` — create a daily event with duration 3 and confirm it persists.
+- `test/templates/admin/events.test.ts` — warning/confirmation UI appears only when duration value changes.
+- `test/admin-attendee-edit.test.ts` (or equivalent) — attendee edit view renders date ranges and persists recomputed end date.
 
 ---
 
@@ -225,6 +241,7 @@ Edge cases to explicitly test:
 |---|---|
 | Over-rejection from overlap-sum in atomic insert (race window) | JS-side per-day check in `checkBatchAvailability` is primary; SQL overlap-sum is safety net. Document. |
 | Existing events silently change behaviour | Default `duration_days = 1` is a strict no-op for every existing row. |
+| Editing duration rewrites historical/future ranges unexpectedly | Require explicit UI warning + confirmation before save; run update in one transaction and log admin action. |
 | Price regression for existing paid daily events | Multiplier only applies when `duration_days > 1`; 1 × price is a no-op. Covered by test. |
 | Webhook/provider metadata `date` field is single-date | No change — still stores start date. Duration re-read from event at finalize time (duration is event-scoped, not booking-scoped). |
 | Admin accidentally sets duration on `standard` event | Ignored by booking logic. Optional: hide field in admin UI for standard events. |
@@ -243,11 +260,12 @@ Edge cases to explicitly test:
 
 Roughly **8–10 source files**, **5–7 test files**.
 
-## Open questions (to resolve during implementation, not now)
+## Resolved decisions (April 2026)
 
-1. Should `duration_days` be editable after a daily event has bookings? (Default: yes, but existing bookings keep their stored ranges; new bookings use the new value.)
-2. Max value — 90 (current `maximum_days_after` default) or 365? Probably 90.
-3. Should we add explicit guardrails around editing duration when there are many existing future attendee rows to reduce admin confusion?
+1. `duration_days` is always editable for daily events, and saving a changed value updates existing bookings for that event.
+2. Maximum `duration_days` is **90**.
+3. Admin UI must show explicit warning + confirmation when duration is changed.
+4. Because duration edits rewrite booking ranges, attendee-edit surfaces should show start/end (range) rather than start-only for daily bookings.
 
 ## Phase 2 kickoff
 

--- a/DURATION_PLAN.md
+++ b/DURATION_PLAN.md
@@ -93,7 +93,7 @@ This is the core correctness phase. Everything else rides on it.
 - `src/routes/admin/events.ts`
   - `extractCommonFields` / `extractEventUpdateInput` — parse `duration_days` (clamp ≥1), alongside `minimum_days_before`.
 - `src/templates/admin/events.tsx`
-  - Event detail view: show duration alongside min/max days.
+  - Admin event detail view: show duration alongside min/max days so staff can verify booking behavior.
 
 **Tests**
 - `test/lib/forms/event-fields.test.ts` — parse/validate `duration_days` (reject 0, negative, non-integer).
@@ -116,6 +116,7 @@ This is the core correctness phase. Everything else rides on it.
   - `parseCustomPrice` / pay-more validation — the customer-entered price is **per-day**. Multiply by `duration_days` when validating against `max_price`? Or treat `max_price` as already-per-day? **Decision**: `unit_price` and `max_price` are per-day values; UI labels reflect that. Validation checks the per-day value as today; the final charge is `customPrice × duration_days × quantity`.
 - `src/templates/public.tsx`
   - Near price display for daily events with duration>1, show "£X/day × N days = £Y".
+  - On event detail pages, if the event has a concrete start date (or is a daily event where booking resolves a concrete range), show a single date-range line as `<from> to <to>`.
   - `renderPayMoreInput` — label hint: "Price per day…" when duration>1.
 
 **Tests**
@@ -131,6 +132,14 @@ This is the core correctness phase. Everything else rides on it.
 
 **Files**
 - `src/lib/dates.ts` — add `formatDateRangeLabel(startIso, endIso)` → `"Mon 15 Apr – Wed 17 Apr"`. Single-day collapses to `formatDateLabel`.
+  - Add English-only compact range formatter for event/ticket display (for now), with these rules:
+    - Same day: `2 February 2027`
+    - Same month + same year: `2–3 February 2027`
+    - Different month + same year: `2 February – 3 March 2027`
+    - Different year: `2 February 2027 – 3 February 2028` (no dedupe across years)
+  - Keep this as a dedicated helper (e.g. `formatDateRangeLabelCompactEn`) so i18n can later swap locale-specific behavior without rewriting booking logic.
+- `src/templates/public.tsx`
+  - Reuse the compact formatter for the public event/date line so UI shows `<from> to <to>` semantics without awkward repeated month/year text.
 - `src/templates/tickets.tsx` — `attendeeDateHtml` (~line 57–59): render range when `attendee.end_at - attendee.start_at > 1 day`. Keep existing behaviour for single-day.
 - `src/lib/email-renderer.ts` — template data exposes `dateRangeLabel` alongside `date` (kept for backward compatibility).
 - `src/templates/admin/attendees.tsx` / `attendee-table.tsx` — date column shows range when multi-day (small visual tweak; row still sorts by start).
@@ -138,6 +147,7 @@ This is the core correctness phase. Everything else rides on it.
 
 **Tests**
 - `test/lib/dates.test.ts` — `formatDateRangeLabel` for 1-day and multi-day cases.
+- `test/lib/dates.test.ts` — compact English formatter coverage for same-day / same-month / same-year-different-month / cross-year cases.
 - `test/templates/...` — snapshot/render tests update where dates appear.
 
 ---
@@ -146,6 +156,55 @@ This is the core correctness phase. Everything else rides on it.
 
 **Files**
 - `test/e2e/*` / `test/integration/*` — add one end-to-end flow: create daily event with duration=3, customer books start date, confirm stored range, confirm email + confirmation page show range, confirm capacity blocks a second overlapping booking when max reached.
+
+---
+
+## Group bookings interaction plan (deep-dive)
+
+This feature intersects with group behavior in ways that are easy to miss. We should treat this as first-class planning work, not a follow-up.
+
+### Group semantics to lock in
+
+- `duration_days` is **event-scoped**, not attendee-scoped: all tickets in a group booking inherit the same date range from the selected start date.
+- Capacity is checked against **total attendee quantity per day** across the full range, regardless of whether tickets are bought as a group or individually.
+- Group identity (`group_id` or equivalent linkage) remains orthogonal to duration: changing duration on the event affects only future bookings, not existing group rows.
+
+### DB + atomicity details for grouped inserts
+
+- For grouped purchases that create multiple attendee rows in one transaction:
+  - Compute a single `{ start_at, end_at }` from `date + duration_days` and reuse it for every row in the group.
+  - Keep the existing overlap predicate (`ea2.start_at < ? AND ea2.end_at > ?`) for atomic safety.
+  - Run preflight per-day availability for the **full requested quantity** before insert to avoid split-brain outcomes where some group members insert and others fail.
+- If current implementation inserts one attendee at a time, verify ordering/rollback behavior:
+  - Prefer all-or-nothing transaction semantics for group booking writes.
+  - Ensure payment finalization does not leave orphaned partial groups when capacity races occur.
+
+### Availability math with groups (nitty-gritty cases)
+
+For each day in range `D = [start, start + duration)`:
+
+- Effective demand added by booking = `quantity` (group size).
+- Day is valid iff `existingAttendeesForDay + quantity <= max_quantity`.
+- Reject booking if **any** day fails this predicate.
+
+Edge cases to explicitly test:
+
+1. Day 1 has room, Day 2 is full, Day 3 has room → entire group booking must fail.
+2. Two concurrent group checkouts for same range near capacity → only one should commit.
+3. Existing long booking overlaps only tail of requested range; another overlaps head; per-day checks should accept/reject correctly without overlap-sum false positives.
+4. Mixed cart with multiple daily events (different durations) and at least one grouped quantity >1.
+
+### UX/content implications for group flows
+
+- Public event page: show explicit date range text (`<from> to <to>`) when a concrete range can be determined.
+- Ticket/checkout summaries should still make total pricing transparent (`per-day × duration × quantity`) so group organizers can reconcile totals.
+- Confirmation/email should show the resolved date range once booked; that is sufficient for group participants.
+
+### Suggested implementation placement
+
+- Phase 2: include group-aware per-day capacity tests at DB/service layer.
+- Phase 4: include mixed-cart + grouped-quantity pricing checks.
+- Phase 6: e2e scenario should use `quantity > 1` to validate true group path, not only single-ticket happy path.
 
 ---
 
@@ -177,7 +236,8 @@ Roughly **8–10 source files**, **5–7 test files**.
 
 1. Should `duration_days` be editable after a daily event has bookings? (Default: yes, but existing bookings keep their stored ranges; new bookings use the new value.)
 2. Max value — 90 (current `maximum_days_after` default) or 365? Probably 90.
-3. Should the event detail page on the public ticket URL show the duration? (Yes — "3-day course" context is useful.)
+3. Should we add explicit guardrails around editing duration when there are existing group bookings to reduce admin confusion?
+4. Should the public event page use an en dash (`–`) vs literal `to` in the rendered range, and should this vary by template/context?
 
 ## Phase 2 kickoff
 


### PR DESCRIPTION
### Motivation
- Capture a phased rollout plan to add multi-day bookings via an `duration_days` event setting and to coordinate UI, DB, and booking-flow changes.
- Surface edge cases and race conditions around capacity checks, pricing, and group bookings to ensure safe atomic inserts and correct availability math.
- Provide a single source of truth for required code changes, tests, and risks so implementation phases can be executed incrementally.

### Description
- Expand `DURATION_PLAN.md` with a six-phase implementation plan covering schema and DB changes, admin form fields, booking flow updates (date filtering and price multiplication), display/formatting changes, and regression/integration tests.
- Add a dedicated section detailing group-booking semantics, transaction/atomicity requirements, and per-day capacity math for grouped inserts.
- Specify a compact English date-range formatter behaviour, UI copy changes (e.g. "price per day"), and where to persist `duration_days` in booking objects and payment items.
- Update the risk register, file-change summary, and a list of automated tests to add for each phase, plus a set of open questions to resolve during implementation.

### Testing
- This is a documentation-only change, so no automated tests were run as part of this update.
- The plan lists specific tests to add during implementation (unit tests for date ranges, availability checks, pricing, templates, and e2e scenarios) but those tests are not executed here.
- CI and existing test suites are unaffected by this documentation update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3265558c832dae48081287eb9a41)