### PR TITLE
Expand multi-day booking plan: deep-dive, group handling, reconciliation and UI guidance

### DIFF
--- a/DURATION_PLAN.md
+++ b/DURATION_PLAN.md
@@ -6,6 +6,16 @@ Let admins mark a daily event as a fixed-length multi-day booking (e.g. a 3-day 
 
 This is deliberately a **small, low-risk step** that (a) delivers a new capability to existing users (multi-day courses/retreats/rentals), and (b) lays the plumbing for a later "customer picks their own end date" feature by making the whole stack multi-day-aware.
 
+## Codebase findings (April 2026 deep-dive)
+
+These findings come from reading the current implementation and should guide scope decisions:
+
+- There is no persistent "booking group" object after checkout. The payment/session path carries `items` + optional `date`; attendee writes are just `attendees` + `event_attendees` rows. Group context is not stored on attendee bookings.
+- "Groups" in this codebase are event collections (`events.group_id`) used for discovery, shared public pages, and optional aggregate capacity limits — not a long-lived booking container.
+- Group capacity checks happen dynamically by event membership (`events.group_id`) during availability/insert checks, not via any attendee-side group foreign key.
+- Public event headers already render a single `Date:` line for dated events; duration display should therefore be implemented as a date-range label there (not as a separate "duration" field).
+- Range copy decision: use an **en dash (`–`)** in rendered ranges.
+
 ## Semantics (decisions)
 
 - `duration_days INTEGER NOT NULL DEFAULT 1` on `events`.
@@ -17,13 +27,13 @@ This is deliberately a **small, low-risk step** that (a) delivers a new capabili
 - Customer still picks a **single start date**. The system extends the end automatically.
 - Price: `unit_price × quantity × duration_days`.
 - Start dates are only offered when **every day in the resulting range** is bookable (not a holiday, within the `bookable_days` weekday mask, and within `minimum_days_before` / `maximum_days_after`).
+- `duration_days` is always editable for daily events. On save, we also update existing `event_attendees.end_at` ranges for that event so stored bookings stay consistent with the event's current duration policy.
 
 ## Non-goals (explicitly out of scope)
 
 - Customer-chosen end date (phase 2 — this plan's infra supports it).
 - Per-day pricing tiers / discounts.
 - Partial cancellation/refund of days.
-- Admin edit of duration on existing bookings rewriting their ranges retroactively (new bookings pick up new duration; existing rows keep their stored range).
 - Calendar UI spreading a booking across multiple day cells (phase 2).
 - CSV export end-date column (phase 2).
 
@@ -63,10 +73,15 @@ This is the core correctness phase. Everything else rides on it.
   - `dateToStartEnd(date, durationDays)` — thread duration through.
   - `EventBooking` type (in `attendee-types.ts`): add `durationDays?: number` (default 1).
   - `buildCapacityCheckedInsert(booking, ...)` — pass `booking.durationDays` into `dateToStartEnd` so `end_at` is correct. The capacity-check SQL (overlap: `ea2.start_at < ? AND ea2.end_at > ?`) works unchanged for range-vs-range overlap.
+  - Add a reconciliation helper for duration edits (e.g. `recomputeEventBookingRanges(eventId, durationDays)`):
+    - Updates `end_at` for existing rows where `event_id = ?` and `start_at IS NOT NULL`.
+    - Formula: `end_at = datetime(start_at, '+' || durationDays || ' days')` (or equivalent UTC-safe expression).
+    - Runs in same transaction as event update when duration changes.
   - `getDateAttendeeCount(eventId, date)` — unchanged; still checks a single day's load (this is what makes multi-day checks accurate).
 - `src/lib/db/attendees.ts → checkBatchAvailability`
   - **Accuracy fix**: for each daily event in the batch, if `duration_days > 1` expand to per-day checks.
   - Implementation: enumerate every day in `[startDate, startDate + duration_days)` and run the existing single-day capacity query for each. Fail if any day is over capacity.
+  - Apply the same per-day expansion to **group capacity** checks (`groups.max_attendees`) so multi-day products cannot overflow group occupancy on later days in the range.
   - Parallelize with `Promise.all` across days × events.
   - Why per-day vs. a single overlap-sum: when two existing bookings each cover a subset of the requested range but don't overlap each other, overlap-sum double-counts them on days they don't both occupy, producing false "sold out" errors. Per-day iteration is exact and short (typical ranges ≤14 days).
 - `src/lib/db/attendees.ts → buildCapacityCondition`
@@ -79,7 +94,9 @@ This is the core correctness phase. Everything else rides on it.
   - `dateToRange("2026-04-15", 3)` → 2026-04-15..2026-04-18
   - `checkBatchAvailability` rejects when **any** day in a multi-day range is at capacity (even if adjacent days have space)
   - `checkBatchAvailability` accepts when all days have room
+  - Group max-attendees per-day enforcement: Saturday/Sunday/combo scenario never exceeds day occupancy of 100
   - `createAttendeeAtomic` stores `end_at = start_at + duration × 86_400_000 ms` for a duration-3 event
+  - duration edit reconciliation updates existing rows' `end_at` for that event
 
 ---
 
@@ -92,12 +109,23 @@ This is the core correctness phase. Everything else rides on it.
   - Hide/disable when `event_type !== 'daily'` — can piggyback on existing daily-only field visibility logic.
 - `src/routes/admin/events.ts`
   - `extractCommonFields` / `extractEventUpdateInput` — parse `duration_days` (clamp ≥1), alongside `minimum_days_before`.
+  - On event edit save: if `duration_days` changed and event is daily, call the DB reconciliation helper in the same transaction.
 - `src/templates/admin/events.tsx`
-  - Event detail view: show duration alongside min/max days.
+  - Admin event detail view: show duration alongside min/max days so staff can verify booking behavior.
+  - Event edit form JS warning flow:
+    - If duration value differs from persisted value, show warning label:
+      `"Changing booking duration will update existing bookings for this event."`
+    - Show a confirmation input/checkbox gate before enabling Save.
+    - Keep warning hidden when duration is unchanged.
+- `src/templates/admin/attendees.tsx` / `src/templates/admin/attendee-table.tsx` / attendee edit template
+  - When editing attendee event links for daily bookings, show both start and end dates (or compact range) to make duration-impacted edits explicit.
+  - When admin changes a booking date manually, recompute and persist end date using current event duration.
 
 **Tests**
 - `test/lib/forms/event-fields.test.ts` — parse/validate `duration_days` (reject 0, negative, non-integer).
 - `test/admin-api-events.test.ts` / `test/templates/admin/events.test.ts` — create a daily event with duration 3 and confirm it persists.
+- `test/templates/admin/events.test.ts` — warning/confirmation UI appears only when duration value changes.
+- `test/admin-attendee-edit.test.ts` (or equivalent) — attendee edit view renders date ranges and persists recomputed end date.
 
 ---
 
@@ -116,6 +144,7 @@ This is the core correctness phase. Everything else rides on it.
   - `parseCustomPrice` / pay-more validation — the customer-entered price is **per-day**. Multiply by `duration_days` when validating against `max_price`? Or treat `max_price` as already-per-day? **Decision**: `unit_price` and `max_price` are per-day values; UI labels reflect that. Validation checks the per-day value as today; the final charge is `customPrice × duration_days × quantity`.
 - `src/templates/public.tsx`
   - Near price display for daily events with duration>1, show "£X/day × N days = £Y".
+  - On event detail pages, if the event has a concrete start date (or is a daily event where booking resolves a concrete range), show a single date-range line as `<from> to <to>`.
   - `renderPayMoreInput` — label hint: "Price per day…" when duration>1.
 
 **Tests**
@@ -130,7 +159,16 @@ This is the core correctness phase. Everything else rides on it.
 ### Phase 5 — Display: confirmation page, email, admin views
 
 **Files**
-- `src/lib/dates.ts` — add `formatDateRangeLabel(startIso, endIso)` → `"Mon 15 Apr – Wed 17 Apr"`. Single-day collapses to `formatDateLabel`.
+- `src/lib/dates.ts`
+  - Add `formatDateRangeLabel(startIso, endIso)` for booking records, returning a human range; single-day collapses to `formatDateLabel`.
+  - Add English-only compact date-range formatter for event/ticket display (for now), using **en dash** style rules:
+    - Same day: `2 February 2027`
+    - Same month + same year: `2–3 February 2027`
+    - Different month + same year: `2 February – 3 March 2027`
+    - Different year: `2 February 2027 – 3 February 2028` (no dedupe across years)
+  - Keep this as a dedicated helper (e.g. `formatDateRangeLabelCompactEn`) so i18n can later replace locale behavior cleanly.
+- `src/templates/public.tsx`
+  - Reuse the compact formatter for the public event/date line so UI shows an explicit range when available, with en dash-separated labels.
 - `src/templates/tickets.tsx` — `attendeeDateHtml` (~line 57–59): render range when `attendee.end_at - attendee.start_at > 1 day`. Keep existing behaviour for single-day.
 - `src/lib/email-renderer.ts` — template data exposes `dateRangeLabel` alongside `date` (kept for backward compatibility).
 - `src/templates/admin/attendees.tsx` / `attendee-table.tsx` — date column shows range when multi-day (small visual tweak; row still sorts by start).
@@ -138,6 +176,7 @@ This is the core correctness phase. Everything else rides on it.
 
 **Tests**
 - `test/lib/dates.test.ts` — `formatDateRangeLabel` for 1-day and multi-day cases.
+- `test/lib/dates.test.ts` — compact English formatter coverage for same-day / same-month / same-year-different-month / cross-year cases.
 - `test/templates/...` — snapshot/render tests update where dates appear.
 
 ---
@@ -149,12 +188,91 @@ This is the core correctness phase. Everything else rides on it.
 
 ---
 
+## Group bookings interaction plan (deep-dive)
+
+This feature intersects with group behavior in ways that are easy to miss. We should treat this as first-class planning work, not a follow-up.
+
+### Group semantics to lock in
+
+- `duration_days` is **event-scoped**, not attendee-scoped: all tickets in one checkout for a daily event inherit the same date range from the selected start date.
+- Capacity is checked against **total attendee quantity per day** across the full range, regardless of whether tickets are bought as a group or individually.
+- Group identity is `events.group_id` membership, not attendee booking linkage: changing duration on the event affects only future attendee rows via future inserts.
+
+### DB + atomicity details for multi-event/group-page checkouts
+
+- For one checkout that creates multiple `event_attendees` rows:
+  - Compute a single `{ start_at, end_at }` from `date + duration_days` for each daily event booking being inserted.
+  - Keep the existing overlap predicate (`ea2.start_at < ? AND ea2.end_at > ?`) for atomic safety.
+  - Run preflight per-day availability for the **full requested quantity** before insert to avoid partial success outcomes where some booking rows insert and others fail.
+- If current implementation inserts one attendee at a time, verify ordering/rollback behavior:
+  - Prefer all-or-nothing transaction semantics for multi-row booking writes.
+  - Ensure payment finalization does not leave orphaned partial attendee links when capacity races occur.
+
+### Availability math with groups (nitty-gritty cases)
+
+For each day in range `D = [start, start + duration)`:
+
+- Effective demand added by booking = `quantity`.
+- Day is valid iff `existingAttendeesForDay + quantity <= max_quantity`.
+- Reject booking if **any** day fails this predicate.
+- For groups with `max_attendees > 0`, apply the same predicate to **group-day occupancy**:
+  - `existingGroupAttendeesForDay + requestedInGroupForDay <= group.max_attendees`
+  - This must be evaluated for each day in the booking range, not only the selected start date.
+
+Edge cases to explicitly test:
+
+1. Day 1 has room, Day 2 is full, Day 3 has room → entire checkout booking for that event must fail.
+2. Two concurrent checkouts for same range near capacity → only one should commit.
+3. Existing long booking overlaps only tail of requested range; another overlaps head; per-day checks should accept/reject correctly without overlap-sum false positives.
+4. Mixed cart with multiple daily events (different durations) and at least one grouped quantity >1.
+5. Group-level day cap with mixed products (single-day + combo) rejects any booking that would push either day over the group limit.
+
+### Concrete occupancy scenario to verify (must pass)
+
+Group setup:
+
+- One group with `group.max_attendees = 100`.
+- Three daily events in that group, each with `event.max_attendees = 100`:
+  1. Saturday session (`duration_days = 1`)
+  2. Sunday session (`duration_days = 1`)
+  3. Saturday+Sunday combo (`duration_days = 2`, start on Saturday)
+
+Expected behavior:
+
+- Booking Saturday-only should consume Saturday occupancy only.
+- Booking Sunday-only should consume Sunday occupancy only.
+- Booking combo should consume both Saturday and Sunday occupancy.
+- At any time, neither day's group occupancy can exceed 100.
+
+Implementation requirement:
+
+- During availability + atomic insert safety checks, compute per-day occupancy for:
+  - event-level caps, and
+  - group-level caps
+  across the entire requested range.
+- If any day in range would exceed 100 at group level, reject the booking even if event-level cap for the chosen product appears available.
+
+### UX/content implications for group flows
+
+- Public event page: show explicit date range text when a concrete range can be determined, using en dash style.
+- Ticket/checkout summaries should still make total pricing transparent (`per-day × duration × quantity`) so group organizers can reconcile totals.
+- Confirmation/email should show the resolved date range once booked; that is sufficient for group participants.
+
+### Suggested implementation placement
+
+- Phase 2: include group-aware per-day capacity checks (event + group limits) at DB/service layer.
+- Phase 4: include mixed-cart + grouped-quantity pricing checks.
+- Phase 6: e2e scenario should use `quantity > 1` to validate true group path, not only single-ticket happy path; include Saturday/Sunday/combo occupancy assertions.
+
+---
+
 ## Risk register
 
 | Risk | Mitigation |
 |---|---|
 | Over-rejection from overlap-sum in atomic insert (race window) | JS-side per-day check in `checkBatchAvailability` is primary; SQL overlap-sum is safety net. Document. |
 | Existing events silently change behaviour | Default `duration_days = 1` is a strict no-op for every existing row. |
+| Editing duration rewrites historical/future ranges unexpectedly | Require explicit UI warning + confirmation before save; run update in one transaction and log admin action. |
 | Price regression for existing paid daily events | Multiplier only applies when `duration_days > 1`; 1 × price is a no-op. Covered by test. |
 | Webhook/provider metadata `date` field is single-date | No change — still stores start date. Duration re-read from event at finalize time (duration is event-scoped, not booking-scoped). |
 | Admin accidentally sets duration on `standard` event | Ignored by booking logic. Optional: hide field in admin UI for standard events. |
@@ -173,11 +291,12 @@ This is the core correctness phase. Everything else rides on it.
 
 Roughly **8–10 source files**, **5–7 test files**.
 
-## Open questions (to resolve during implementation, not now)
+## Resolved decisions (April 2026)
 
-1. Should `duration_days` be editable after a daily event has bookings? (Default: yes, but existing bookings keep their stored ranges; new bookings use the new value.)
-2. Max value — 90 (current `maximum_days_after` default) or 365? Probably 90.
-3. Should the event detail page on the public ticket URL show the duration? (Yes — "3-day course" context is useful.)
+1. `duration_days` is always editable for daily events, and saving a changed value updates existing bookings for that event.
+2. Maximum `duration_days` is **90**.
+3. Admin UI must show explicit warning + confirmation when duration is changed.
+4. Because duration edits rewrite booking ranges, attendee-edit surfaces should show start/end (range) rather than start-only for daily bookings.
 
 ## Phase 2 kickoff
 


### PR DESCRIPTION
### Motivation

- Flesh out the multi-day `duration_days` design with implementation notes and codebase findings to guide safe rollout.  
- Surface interactions with group-level capacity, admin edits, and booking atomicity that affect correctness and UX.  
- Lock down decisions (editable duration, max 90 days, admin warning/confirmation) so implementation phases can proceed deterministically.

### Description

- Add a `Codebase findings` deep-dive and a `Group bookings interaction plan` that explain current data model constraints and how `events.group_id` is used for capacity checks.  
- Specify schema and runtime behavior for `duration_days`, inclusive range semantics, price multiplier, and the new `recomputeEventBookingRanges` reconciliation helper to update `end_at` when duration changes.  
- Describe per-day availability checks (including group-day caps), threading `duration_days` through `dateToRange`/`dateToStartEnd`, booking insert behavior, and where to apply JS-side and SQL safety checks.  
- Add admin UX requirements including the new form field, edit-time warning + confirmation gate, attendee edit UX to surface end dates, and compact date-range formatting helpers using an en dash style.

### Testing

- No automated tests were run as part of this documentation-only change; the document enumerates the test files and behaviors to add (for example `test/lib/db.test.ts`, `test/lib/dates.test.ts`, and various admin and e2e tests) to be executed during implementation phases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3265558c832dae48081287eb9a41)