### PR TITLE
Narrow --width-content to 800px on public-facing pages

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -32,6 +32,11 @@
   /* Breakpoint: desktop ≥ 769px, mobile ≤ 768px (use in @media rules) */
 }
 
+/* Public-facing pages (no admin nav) get a narrower reading width */
+body:not(:has(#main-nav)) {
+  --width-content: 800px;
+}
+
 :root[data-theme="dark"] {
   --color-accent: #0097fc4f;
   --color-bg: #01001c;


### PR DESCRIPTION
## Summary

- Adds a single CSS rule in `src/static/mvp.css` that overrides `--width-content` to `800px` on any page that does not render the admin nav.
- Uses `body:not(:has(#main-nav))` — no template changes required. Admin pages keep their 1300px width; public flows (events listing, ticket reservation, setup, join, payment, checkin, wallet, etc.) get a more readable 800px.

## Test plan

- [ ] Visit a public page (e.g. `/`, `/ticket/...`) and confirm `main` is capped at 800px
- [ ] Visit `/admin/` and confirm the dashboard still uses the full 1300px layout
- [ ] Confirm iframe embeds of the ticket flow still render correctly

https://claude.ai/code/session_01WvjAnZW5XMy1DZQmgoN82r