### PR TITLE
Fix multi-day booking capacity checks with per-day validation

### DIFF
--- a/src/lib/booking.ts
+++ b/src/lib/booking.ts
@@ -46,7 +46,12 @@ export const processBooking = async (
     (customUnitPrice !== undefined && customUnitPrice > 0 && paymentsEnabled);
 
   if (needsPayment) {
-    const available = await hasAvailableSpots(event.id, quantity, date);
+    const available = await hasAvailableSpots(
+      event.id,
+      quantity,
+      date,
+      event.duration_days,
+    );
     if (!available) return { type: "sold_out" };
 
     // Provider is guaranteed to exist when isPaymentsEnabled() is true
@@ -71,8 +76,9 @@ export const processBooking = async (
       baseUrl,
     );
     if (!result) return { type: "checkout_failed" };
-    if ("error" in result)
+    if ("error" in result) {
       return { error: result.error, type: "checkout_failed" };
+    }
 
     return { checkoutUrl: result.checkoutUrl, type: "checkout" };
   }
@@ -80,11 +86,19 @@ export const processBooking = async (
   // Free event — create attendee atomically
   const result = await createAttendeeAtomic({
     ...contact,
-    bookings: [{ date, eventId: event.id, quantity }],
+    bookings: [
+      {
+        date,
+        durationDays: event.duration_days,
+        eventId: event.id,
+        quantity,
+      },
+    ],
   });
 
-  if (!result.success)
+  if (!result.success) {
     return { reason: result.reason, type: "creation_failed" };
+  }
 
   await logAndNotifyRegistration([{ attendee: result.attendees[0]!, event }]);
   return { attendee: result.attendees[0]!, type: "success" };

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -449,27 +449,37 @@ export const recomputeEventBookingRanges = async (
   const duration = Math.max(1, Math.floor(durationDays));
   await getDb().execute({
     // datetime(start_at, '+N days') keeps same time-of-day; start_at is always
-    // "YYYY-MM-DDT00:00:00Z" so the result is "YYYY-MM-DD 00:00:00". Normalize
-    // back to ISO with a T separator + Z suffix so SQL text comparisons against
-    // other end_at values stay consistent.
+    // "YYYY-MM-DDT00:00:00Z" so the result is "YYYY-MM-DD 00:00:00" (no millis,
+    // no Z). We stitch the ISO suffix ".000Z" back on so stored end_at values
+    // exactly match what fresh inserts produce via `new Date(...).toISOString()`
+    // — prevents scuzzy mixed formats in raw-row dumps and locks lexical
+    // comparisons to a single shape.
     args: [duration, eventId],
     sql: `UPDATE event_attendees
-           SET end_at = REPLACE(datetime(start_at, '+' || ? || ' days'), ' ', 'T') || 'Z'
+           SET end_at = REPLACE(datetime(start_at, '+' || ? || ' days'), ' ', 'T') || '.000Z'
            WHERE event_id = ? AND start_at IS NOT NULL`,
   });
   invalidateEventsCache();
 };
 
-/** Get the total attendee quantity for a specific event + date */
+/**
+ * Get the total attendee quantity for a specific event + date, optionally
+ * excluding one attendee (used when an admin edits their own booking so the
+ * row being updated doesn't fight itself in the capacity check).
+ */
 export const getDateAttendeeCount = async (
   eventId: number,
   date: string,
+  excludeAttendeeId?: number,
 ): Promise<number> => {
   const { startAt, endAt } = dateToRange(date);
-  const rows = await queryAll<{ count: number }>(
-    "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ? AND start_at < ? AND end_at > ?",
-    [eventId, endAt, startAt],
-  );
+  const sql = excludeAttendeeId
+    ? "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ? AND attendee_id != ? AND start_at < ? AND end_at > ?"
+    : "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ? AND start_at < ? AND end_at > ?";
+  const args: InValue[] = excludeAttendeeId
+    ? [eventId, excludeAttendeeId, endAt, startAt]
+    : [eventId, endAt, startAt];
+  const rows = await queryAll<{ count: number }>(sql, args);
   return rows[0]!.count;
 };
 
@@ -485,46 +495,168 @@ const getGroupMaxAttendees = async (groupId: number): Promise<number> => {
 /**
  * Count total attendees across all events in a group.
  * Date-aware: standard events always count, daily events only count matching date.
+ * Optional `excludeAttendeeId` skips rows belonging to that attendee — used by
+ * self-excluding admin edits so a booking being moved doesn't fight itself.
  */
 const getGroupAttendeeCount = async (
   groupId: number,
   date: string | null,
+  excludeAttendeeId?: number,
 ): Promise<number> => {
   const range = date ? dateToRange(date) : null;
+  const excludeClause = excludeAttendeeId ? " AND ea.attendee_id != ?" : "";
+  const args: InValue[] = excludeAttendeeId
+    ? [
+        groupId,
+        excludeAttendeeId,
+        date,
+        range?.endAt ?? null,
+        range?.startAt ?? null,
+      ]
+    : [groupId, date, range?.endAt ?? null, range?.startAt ?? null];
   const rows = await queryAll<{ count: number }>(
     `SELECT COALESCE(SUM(ea.quantity), 0) as count
      FROM event_attendees ea
      JOIN events e ON e.id = ea.event_id
-     WHERE e.group_id = ?
+     WHERE e.group_id = ?${excludeClause}
        AND (? IS NULL OR e.event_type != 'daily' OR (ea.start_at < ? AND ea.end_at > ?))`,
-    [groupId, date, range?.endAt ?? null, range?.startAt ?? null],
+    args,
   );
   return rows[0]!.count;
 };
 
 /**
- * Build the WHERE clause for capacity checking on event_attendees.
- * @param excludeAttendeeId - If set, excludes this attendee's rows from the count (for updates)
+ * Accurate per-day availability check for a single-event booking, shared by
+ * `hasAvailableSpots` (customer JSON API), `addEventLink`, and `updateEventLink`.
+ *
+ * Walks every day in `[date, date + durationDays)` and checks:
+ *   - event's own max_attendees against existing per-day load
+ *   - group's max_attendees (if any) against existing per-day group load
+ *
+ * Correct by construction — no overlap-sum false-rejection. The atomic SQL
+ * insert/update still runs its own WHERE-guarded check as a race-free safety
+ * net; this preflight ensures we don't fail rows that actually have room.
  */
-const buildCapacityCondition = (
+/** Enumerate every day in [date, date + durationDays) for per-day checks,
+ * or a single [null] for non-daily / date-less bookings. */
+const capacityCheckDays = (
+  isDaily: boolean,
+  date: string | null | undefined,
+  durationDays: number,
+): (string | null)[] => {
+  if (!isDaily || !date) return [null];
+  const duration = Math.max(1, Math.floor(durationDays));
+  return Array.from({ length: duration }, (_, i) => addDaysStr(date, i));
+};
+
+/** Existing event-level load for one day (null day = total). Self-excluding
+ * so admin edits to their own booking don't fight themselves. */
+const loadForDay = async (
   eventId: number,
-  qty: number,
-  date: string | null,
+  day: string | null,
+  excludeAttendeeId: number | undefined,
+  attendeeCount: number,
+): Promise<number> => {
+  if (day) return getDateAttendeeCount(eventId, day, excludeAttendeeId);
+  if (!excludeAttendeeId) return attendeeCount;
+  const row = await queryOne<{ count: number }>(
+    "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ? AND attendee_id != ?",
+    [eventId, excludeAttendeeId],
+  );
+  return row?.count ?? 0;
+};
+
+const checkEventCapForDays = async (
+  eventId: number,
+  quantity: number,
+  days: (string | null)[],
+  excludeAttendeeId: number | undefined,
+  event: { max_attendees: number; attendee_count: number },
+): Promise<boolean> => {
+  for (const day of days) {
+    const load = await loadForDay(
+      eventId,
+      day,
+      excludeAttendeeId,
+      event.attendee_count,
+    );
+    if (load + quantity > event.max_attendees) return false;
+  }
+  return true;
+};
+
+const checkGroupCapForDays = async (
+  groupId: number,
+  quantity: number,
+  days: (string | null)[],
+  excludeAttendeeId: number | undefined,
+): Promise<boolean> => {
+  const groupLimit = await getGroupMaxAttendees(groupId);
+  if (groupLimit <= 0) return true;
+  for (const day of days) {
+    const groupCount = await getGroupAttendeeCount(
+      groupId,
+      day,
+      excludeAttendeeId,
+    );
+    if (groupCount + quantity > groupLimit) return false;
+  }
+  return true;
+};
+
+const checkEventAvailability = async (
+  eventId: number,
+  quantity: number,
+  date: string | null | undefined,
   excludeAttendeeId?: number,
   durationDays = 1,
-): { sql: string; args: InValue[] } => {
-  const range = date ? dateToRange(date, durationDays) : null;
-  const endAt = range?.endAt ?? null;
-  const startAt = range?.startAt ?? null;
+): Promise<boolean> => {
+  if (quantity <= 0) return true;
+  const event = await getEventWithCount(eventId);
+  if (!event) return false;
 
+  const days = capacityCheckDays(
+    event.event_type === "daily",
+    date,
+    durationDays,
+  );
+
+  const eventOk = await checkEventCapForDays(
+    eventId,
+    quantity,
+    days,
+    excludeAttendeeId,
+    event,
+  );
+  if (!eventOk) return false;
+
+  if (event.group_id <= 0) return true;
+  return checkGroupCapForDays(
+    event.group_id,
+    quantity,
+    days,
+    excludeAttendeeId,
+  );
+};
+
+/**
+ * Build a single-day capacity clause (event-cap + optional group-cap).
+ * `dayRange` is null for non-daily bookings (date-less total check).
+ */
+const buildDayCapacitySql = (
+  eventId: number,
+  qty: number,
+  dayRange: { startAt: string; endAt: string } | null,
+  excludeAttendeeId?: number,
+): { sql: string; args: InValue[] } => {
   const excludeClause = excludeAttendeeId ? " AND ea2.attendee_id != ?" : "";
-  const capacityFilter = date
+  const capacityFilter = dayRange
     ? `SELECT COALESCE(SUM(ea2.quantity), 0) FROM event_attendees ea2 WHERE ea2.event_id = ?${excludeClause} AND ea2.start_at < ? AND ea2.end_at > ?`
     : `SELECT COALESCE(SUM(ea2.quantity), 0) FROM event_attendees ea2 WHERE ea2.event_id = ?${excludeClause}`;
-  const capacityArgs: InValue[] = date
+  const capacityArgs: InValue[] = dayRange
     ? excludeAttendeeId
-      ? [eventId, excludeAttendeeId, endAt, startAt]
-      : [eventId, endAt, startAt]
+      ? [eventId, excludeAttendeeId, dayRange.endAt, dayRange.startAt]
+      : [eventId, dayRange.endAt, dayRange.startAt]
     : excludeAttendeeId
       ? [eventId, excludeAttendeeId]
       : [eventId];
@@ -550,14 +682,76 @@ const buildCapacityCondition = (
             LEFT JOIN groups g ON g.id = ev.group_id
             WHERE ev.id = ?
           ) = 1`;
+  const dayDate = dayRange?.startAt.slice(0, 10) ?? null;
   const groupCapacityArgs: InValue[] = excludeAttendeeId
-    ? [excludeAttendeeId, date, endAt, startAt, qty, eventId]
-    : [date, endAt, startAt, qty, eventId];
+    ? [
+        excludeAttendeeId,
+        dayDate,
+        dayRange?.endAt ?? null,
+        dayRange?.startAt ?? null,
+        qty,
+        eventId,
+      ]
+    : [
+        dayDate,
+        dayRange?.endAt ?? null,
+        dayRange?.startAt ?? null,
+        qty,
+        eventId,
+      ];
 
   return {
     args: [...capacityArgs, qty, eventId, ...groupCapacityArgs],
     sql: `(${capacityFilter}) + ? <= (SELECT max_attendees FROM events WHERE id = ?)${groupCapacityCheck}`,
   };
+};
+
+/**
+ * Build the WHERE clause for capacity checking on event_attendees.
+ *
+ * Multi-day daily bookings emit one clause per day, AND'd together, so the
+ * SQL safety-net matches the per-day accuracy of the JS preflight. A single
+ * overlap-sum clause is strictly conservative — it's safe in the sense that
+ * it never under-rejects, but it false-rejects admin edits whose range
+ * contains existing non-overlapping bookings. Per-day expansion eliminates
+ * that UX hazard; range length is bounded (≤90 via form validation) so the
+ * SQL stays cheap.
+ *
+ * @param excludeAttendeeId - If set, excludes this attendee's rows from the count (for updates)
+ */
+const buildCapacityCondition = (
+  eventId: number,
+  qty: number,
+  date: string | null,
+  excludeAttendeeId?: number,
+  durationDays = 1,
+): { sql: string; args: InValue[] } => {
+  if (!date) {
+    return buildDayCapacitySql(eventId, qty, null, excludeAttendeeId);
+  }
+  const duration = Math.max(1, Math.floor(durationDays));
+  if (duration === 1) {
+    return buildDayCapacitySql(
+      eventId,
+      qty,
+      dateToRange(date, 1),
+      excludeAttendeeId,
+    );
+  }
+  const clauses: string[] = [];
+  const args: InValue[] = [];
+  for (let i = 0; i < duration; i++) {
+    const day = addDaysStr(date, i);
+    const daily = buildDayCapacitySql(
+      eventId,
+      qty,
+      dateToRange(day, 1),
+      excludeAttendeeId,
+    );
+    clauses.push(`(${daily.sql})`);
+    args.push(...daily.args);
+  }
+  return { args, sql: clauses.join(" AND ") };
 };
 
 /**
@@ -613,6 +807,11 @@ export const attendeesApi = {
     date?: string | null,
   ): Promise<boolean> => {
     if (items.length === 0) return true;
+    // Reject negative quantities outright — treating them as "no demand"
+    // would let a caller bypass capacity by offsetting positive rows with
+    // negative ones. Form validation clamps to ≥1 upstream, but a defensive
+    // check here is cheap insurance.
+    if (items.some((i) => i.quantity < 0)) return false;
     const eventIds = items.map((i) => i.eventId);
 
     const eventRows = await queryAll<{
@@ -748,6 +947,24 @@ export const attendeesApi = {
     if (bookings.length === 0) {
       return { reason: "capacity_exceeded", success: false };
     }
+    // Reject negative quantities outright — the atomic insert would happily
+    // store a negative row and skew future capacity sums.
+    if (bookings.some((b) => (b.quantity ?? 1) < 0)) {
+      return { reason: "capacity_exceeded", success: false };
+    }
+    // Reject duplicate (event_id, date) pairs in a single cart. The
+    // event_attendees unique index is on (event_id, attendee_id, start_at),
+    // so two rows with the same tuple would violate it — silently dropping
+    // one insert and delivering a half-fulfilled booking. Force the caller
+    // to merge quantities upstream rather than paper over the conflict.
+    const seenKeys = new Set<string>();
+    for (const b of bookings) {
+      const key = `${b.eventId}|${b.date ?? ""}`;
+      if (seenKeys.has(key)) {
+        return { reason: "capacity_exceeded", success: false };
+      }
+      seenKeys.add(key);
+    }
 
     const contactInfo = { address, email, name, phone, special_instructions };
     // Use first booking's pricePaid for encryption (PII blob is shared)
@@ -826,33 +1043,22 @@ export const attendeesApi = {
     invalidateEventsCache();
     return { attendees: successfulBookings, success: true };
   },
-  /** Check if an event has available spots for the requested quantity */
-  hasAvailableSpots: async (
+  /**
+   * Check if an event has available spots for the requested quantity on the
+   * given date. Duration-aware: for daily events with `durationDays > 1`,
+   * every day in `[date, date + durationDays)` must have room (both event cap
+   * and group cap). Without this expansion the customer-facing JSON API
+   * (`/api/events/:slug/availability`) and `processBooking` would only inspect
+   * the start day and hand back a misleading "available" for a range whose
+   * middle or tail is full.
+   */
+  hasAvailableSpots: (
     eventId: number,
     quantity = 1,
     date?: string | null,
-  ): Promise<boolean> => {
-    const event = await getEventWithCount(eventId);
-    if (!event) return false;
-    if (date) {
-      const dateCount = await getDateAttendeeCount(eventId, date);
-      if (dateCount + quantity > event.max_attendees) return false;
-    } else {
-      if (event.attendee_count + quantity > event.max_attendees) return false;
-    }
-    // Check group capacity if event belongs to a group with a limit
-    if (event.group_id > 0) {
-      const groupLimit = await getGroupMaxAttendees(event.group_id);
-      if (groupLimit > 0) {
-        const groupCount = await getGroupAttendeeCount(
-          event.group_id,
-          date ?? null,
-        );
-        if (groupCount + quantity > groupLimit) return false;
-      }
-    }
-    return true;
-  },
+    durationDays = 1,
+  ): Promise<boolean> =>
+    checkEventAvailability(eventId, quantity, date, undefined, durationDays),
 };
 
 /** Wrapper for test mocking - delegates to attendeesApi at runtime */
@@ -899,7 +1105,9 @@ export const getAttendeesByTokens = async (
   };
   const attendeeRows = await queryAll<AttendeeBase>(
     `SELECT id, created, ticket_token_index, pii_blob
-     FROM attendees WHERE ticket_token_index IN (${inPlaceholders(tokenIndexes)})`,
+     FROM attendees WHERE ticket_token_index IN (${inPlaceholders(
+       tokenIndexes,
+     )})`,
     tokenIndexes,
   );
 
@@ -1027,10 +1235,11 @@ export const updateAttendeePII = async (
  * Update a single event link's quantity and date with atomic capacity check.
  * Excludes this attendee's current row from the capacity calculation so
  * no-op edits (same quantity) don't self-fail.
- */
-/**
- * Update a single event link's quantity and date with atomic capacity check.
- * Excludes this attendee's current row from the capacity calculation.
+ *
+ * Runs a per-day preflight (accurate) before the atomic SQL UPDATE. Without
+ * the preflight, the SQL overlap-sum guard would false-reject multi-day edits
+ * whose target range contains existing non-overlapping bookings on separate
+ * days — the atomic SQL still runs as a race-free safety net.
  */
 export const updateEventLink = async (
   attendeeId: number,
@@ -1038,6 +1247,17 @@ export const updateEventLink = async (
   input: UpdateEventLinkInput,
 ): Promise<UpdateEventLinkResult> => {
   const { quantity: qty, date, durationDays = 1 } = input;
+  if (qty < 0) return CAPACITY_EXCEEDED;
+
+  const preflight = await checkEventAvailability(
+    eventId,
+    qty,
+    date,
+    attendeeId,
+    durationDays,
+  );
+  if (!preflight) return CAPACITY_EXCEEDED;
+
   const { startAt, endAt } = dateToStartEnd(date, durationDays);
   const condition = buildCapacityCondition(
     eventId,
@@ -1068,11 +1288,27 @@ const checkCapacityResult = (result: {
 /**
  * Add a new event link for an existing attendee with atomic capacity check.
  * Does NOT create a new attendee or touch PII — just inserts an event_attendees row.
+ *
+ * Runs a per-day preflight so multi-day events aren't false-rejected by the
+ * SQL overlap-sum safety net. Self-exclusion isn't needed (new row).
  */
 export const addEventLink = async (
   attendeeId: number,
   booking: EventBooking,
-): Promise<UpdateEventLinkResult> =>
-  checkCapacityResult(
+): Promise<UpdateEventLinkResult> => {
+  const qty = booking.quantity ?? 1;
+  if (qty < 0) return CAPACITY_EXCEEDED;
+
+  const preflight = await checkEventAvailability(
+    booking.eventId,
+    qty,
+    booking.date ?? null,
+    undefined,
+    booking.durationDays ?? 1,
+  );
+  if (!preflight) return CAPACITY_EXCEEDED;
+
+  return checkCapacityResult(
     await getDb().execute(buildCapacityCheckedInsert(booking, "?", attendeeId)),
   );
+};

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -174,7 +174,12 @@ const handleCheckAvailability = withActiveEvent(async (request, event) => {
   const quantity = Math.max(1, Number.isNaN(parsed) ? 1 : parsed);
   const date = url.searchParams.get("date") || undefined;
   return apiResponse({
-    available: await hasAvailableSpots(event.id, quantity, date),
+    available: await hasAvailableSpots(
+      event.id,
+      quantity,
+      date,
+      event.duration_days,
+    ),
   });
 });
 

--- a/test/integration/duration-days.test.ts
+++ b/test/integration/duration-days.test.ts
@@ -110,8 +110,9 @@ describeWithEnv("integration: duration_days", { db: true }, () => {
         args: [event.id],
         sql: "SELECT end_at FROM event_attendees WHERE event_id = ?",
       });
-      // start=2026-06-12 + 4 days → 2026-06-16 00:00:00Z
-      expect(String(row.rows[0]!.end_at)).toBe("2026-06-16T00:00:00Z");
+      // start=2026-06-12 + 4 days → 2026-06-16 00:00:00.000Z (matches the
+      // ISO format that fresh inserts produce via toISOString()).
+      expect(String(row.rows[0]!.end_at)).toBe("2026-06-16T00:00:00.000Z");
 
       // Event metadata itself still needs updating separately; verify the
       // event can be read and has the original duration (reconciliation only

--- a/test/lib/db/attendees.test.ts
+++ b/test/lib/db/attendees.test.ts
@@ -1485,5 +1485,320 @@ describeWithEnv("db > attendees", { db: true }, () => {
         ),
       ).toBe(true);
     });
+
+    test("hasAvailableSpots returns false when a later day in a multi-day range is full", async () => {
+      // Customer-path availability endpoint must not report "available" for
+      // a multi-day booking whose tail or middle day is at capacity.
+      const event = await createTestEvent({
+        durationDays: 3,
+        eventType: "daily",
+        maxAttendees: 2,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+
+      // Fill day 3 with a separate 1-day booking of qty=2.
+      await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-05-03",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 2,
+          },
+        ],
+        email: "tail@example.com",
+        name: "Tail",
+      });
+
+      // Start day (2026-05-01) is empty, but day 3 is full.
+      expect(await hasAvailableSpots(event.id, 1, "2026-05-01", 3)).toBe(false);
+      // Without duration (single-day check), same start day returns true.
+      expect(await hasAvailableSpots(event.id, 1, "2026-05-01", 1)).toBe(true);
+    });
+
+    test("hasAvailableSpots enforces group cap per day for multi-day ranges", async () => {
+      const { createTestGroup } = await import("#test-utils");
+      const group = await createTestGroup({ maxAttendees: 2 });
+      const event = await createTestEvent({
+        durationDays: 2,
+        eventType: "daily",
+        groupId: group.id,
+        maxAttendees: 100,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+      const sibling = await createTestEvent({
+        durationDays: 1,
+        eventType: "daily",
+        groupId: group.id,
+        maxAttendees: 100,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+
+      // Fill the group cap on day 2 via a sibling event in the same group.
+      await createAttendeeAtomic({
+        bookings: [{ date: "2026-05-02", eventId: sibling.id, quantity: 2 }],
+        email: "sib@example.com",
+        name: "Sib",
+      });
+
+      // A 2-day booking starting 2026-05-01 covers day 2 where the group cap
+      // is already exhausted. Must report unavailable even though the event's
+      // own max_attendees=100 has room.
+      expect(await hasAvailableSpots(event.id, 1, "2026-05-01", 2)).toBe(false);
+    });
+
+    test("checkBatchAvailability rejects negative quantities", async () => {
+      const event = await createTestEvent({ maxAttendees: 5 });
+      expect(
+        await checkBatchAvailability([{ eventId: event.id, quantity: -1 }]),
+      ).toBe(false);
+      // Mixed positive + negative must also reject, even if net demand would
+      // fit — preventing capacity bypass via offsetting rows.
+      expect(
+        await checkBatchAvailability([
+          { eventId: event.id, quantity: 10 },
+          { eventId: event.id, quantity: -8 },
+        ]),
+      ).toBe(false);
+    });
+
+    test("createAttendeeAtomic rejects negative quantities", async () => {
+      const event = await createTestEvent({ maxAttendees: 5 });
+      const result = await createAttendeeAtomic({
+        bookings: [{ eventId: event.id, quantity: -1 }],
+        email: "neg@example.com",
+        name: "Neg",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test("createAttendeeAtomic rejects duplicate (event, date) rows in one cart", async () => {
+      // Two rows with the same (event_id, attendee_id, start_at) would violate
+      // the unique index — silently dropping one insert and delivering a
+      // half-fulfilled booking. Reject upfront so the caller merges qty.
+      const event = await createTestEvent({
+        durationDays: 1,
+        eventType: "daily",
+        maxAttendees: 10,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+      const result = await createAttendeeAtomic({
+        bookings: [
+          { date: "2026-05-01", eventId: event.id, quantity: 1 },
+          { date: "2026-05-01", eventId: event.id, quantity: 1 },
+        ],
+        email: "dup@example.com",
+        name: "Dup",
+      });
+      expect(result.success).toBe(false);
+
+      // Same event on different dates is fine.
+      const ok = await createAttendeeAtomic({
+        bookings: [
+          { date: "2026-05-01", eventId: event.id, quantity: 1 },
+          { date: "2026-05-02", eventId: event.id, quantity: 1 },
+        ],
+        email: "diffdates@example.com",
+        name: "Different dates",
+      });
+      expect(ok.success).toBe(true);
+    });
+
+    test("recomputeEventBookingRanges produces .000Z formatted end_at", async () => {
+      // Stored end_at must match the format that fresh inserts produce via
+      // toISOString() — avoids scuzzy mixed formats in raw-row dumps.
+      const event = await createTestEvent({
+        durationDays: 1,
+        eventType: "daily",
+        maxAttendees: 5,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+      await createAttendeeAtomic({
+        bookings: [{ date: "2026-05-01", eventId: event.id, quantity: 1 }],
+        email: "fmt@example.com",
+        name: "Fmt",
+      });
+      const { recomputeEventBookingRanges } = await import(
+        "#lib/db/attendees.ts"
+      );
+      await recomputeEventBookingRanges(event.id, 3);
+      const row = await getDb().execute({
+        args: [event.id],
+        sql: "SELECT end_at FROM event_attendees WHERE event_id = ?",
+      });
+      expect(String(row.rows[0]!.end_at)).toBe("2026-05-04T00:00:00.000Z");
+    });
+
+    test("year-boundary range stores end_at correctly", async () => {
+      // A 7-day booking starting 2026-12-30 ends 2027-01-06. Crosses both
+      // month and year; covers any time-of-day math confusion around lex vs
+      // numeric comparisons.
+      const event = await createTestEvent({
+        durationDays: 7,
+        eventType: "daily",
+        maxAttendees: 2,
+        maximumDaysAfter: 400,
+        minimumDaysBefore: 0,
+      });
+      const result = await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-12-30",
+            durationDays: 7,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "ny@example.com",
+        name: "NewYear",
+      });
+      expect(result.success).toBe(true);
+      const row = await getDb().execute({
+        args: [event.id],
+        sql: "SELECT start_at, end_at FROM event_attendees WHERE event_id = ?",
+      });
+      expect(String(row.rows[0]!.start_at)).toBe("2026-12-30T00:00:00Z");
+      expect(String(row.rows[0]!.end_at)).toBe("2027-01-06T00:00:00.000Z");
+    });
+
+    test("addEventLink admits multi-day update whose range contains non-overlapping existing bookings", async () => {
+      // Exercises the per-day SQL path: overlap-sum would over-reject
+      // because two existing 1-day bookings both fall inside the new 3-day
+      // range, but neither overlaps the other's specific day. Per-day
+      // expansion lets the update through.
+      const { addEventLink } = await import("#lib/db/attendees.ts");
+      const event = await createTestEvent({
+        durationDays: 3,
+        eventType: "daily",
+        maxAttendees: 2,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+
+      // Existing occupant A: 1-day booking on day 1, qty=1.
+      await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-05-01",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "a@example.com",
+        name: "A",
+      });
+      // Existing occupant B: 1-day booking on day 3, qty=1.
+      await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-05-03",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "b@example.com",
+        name: "B",
+      });
+
+      // Anchor attendee we'll attach the 3-day booking to via addEventLink.
+      // Start them on an unrelated date so addEventLink does the work.
+      const base = await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-05-20",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "base@example.com",
+        name: "Base",
+      });
+      expect(base.success).toBe(true);
+      if (!base.success) return;
+
+      // Add a 3-day booking covering days 1-3 at qty=1. Per-day demand:
+      //   day 1: existing 1 + new 1 = 2 (== cap of 2) → ok
+      //   day 2: existing 0 + new 1 = 1 → ok
+      //   day 3: existing 1 + new 1 = 2 → ok
+      // Overlap-sum would see 2 existing in the 3-day window + 1 new = 3 > cap
+      // and false-reject without per-day expansion.
+      const link = await addEventLink(base.attendees[0]!.id, {
+        date: "2026-05-01",
+        durationDays: 3,
+        eventId: event.id,
+        quantity: 1,
+      });
+      expect(link.success).toBe(true);
+    });
+
+    test("updateEventLink admits multi-day update whose range contains non-overlapping existing bookings", async () => {
+      const { updateEventLink } = await import("#lib/db/attendees.ts");
+      const event = await createTestEvent({
+        durationDays: 3,
+        eventType: "daily",
+        maxAttendees: 2,
+        maximumDaysAfter: 30,
+        minimumDaysBefore: 0,
+      });
+
+      // Two existing non-overlapping 1-day occupants at days 1 and 3.
+      await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-06-01",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "x@example.com",
+        name: "X",
+      });
+      await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-06-03",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "y@example.com",
+        name: "Y",
+      });
+
+      // Target attendee originally booked on a disjoint day.
+      const target = await createAttendeeAtomic({
+        bookings: [
+          {
+            date: "2026-06-20",
+            durationDays: 1,
+            eventId: event.id,
+            quantity: 1,
+          },
+        ],
+        email: "t@example.com",
+        name: "T",
+      });
+      expect(target.success).toBe(true);
+      if (!target.success) return;
+
+      // Move target to a 3-day range 2026-06-01..2026-06-03 at qty=1.
+      // Per-day demand stays within cap=2 on every day.
+      const moved = await updateEventLink(target.attendees[0]!.id, event.id, {
+        date: "2026-06-01",
+        durationDays: 3,
+        quantity: 1,
+      });
+      expect(moved.success).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in capacity checking for multi-day daily events. The previous overlap-sum SQL approach would false-reject valid bookings whose date range contained non-overlapping existing bookings on separate days. The fix introduces per-day preflight validation that accurately checks capacity for each day in a multi-day range.

## Key Changes

- **Per-day capacity validation**: Added `checkEventAvailability()` function that walks every day in a multi-day booking range and validates both event and group capacity independently for each day, eliminating false rejections from overlap-sum logic.

- **Refactored capacity SQL generation**: Split `buildCapacityCondition()` into `buildDayCapacitySql()` for single-day checks and updated the main function to emit per-day AND'd clauses for multi-day ranges, keeping the atomic SQL safety net aligned with JS preflight logic.

- **Enhanced `hasAvailableSpots()` API**: Now accepts `durationDays` parameter to properly validate multi-day bookings. Updated all call sites in `processBooking()` and the availability API endpoint to pass event duration.

- **Negative quantity rejection**: Added defensive checks in `checkBatchAvailability()`, `createAttendeeAtomic()`, `addEventLink()`, and `updateEventLink()` to reject negative quantities upfront, preventing capacity bypass via offsetting rows.

- **Duplicate booking detection**: Added validation in `createAttendeeAtomic()` to reject duplicate `(event_id, date)` pairs in a single cart, preventing silent partial fulfillment from unique index violations.

- **ISO format standardization**: Fixed `recomputeEventBookingRanges()` to produce `.000Z` formatted `end_at` values matching `toISOString()` output, ensuring consistent formatting in raw-row dumps and reliable lexical comparisons.

- **Self-excluding capacity checks**: Enhanced `getDateAttendeeCount()` and `getGroupAttendeeCount()` with optional `excludeAttendeeId` parameter so admin edits to their own bookings don't self-fail on capacity checks.

## Implementation Details

- Per-day expansion is bounded by form validation (≤90 days) so SQL remains performant
- The atomic SQL UPDATE/INSERT still runs its own WHERE-guarded capacity check as a race-free safety net
- Multi-day daily bookings now emit one capacity clause per day, AND'd together, matching the accuracy of the JS preflight
- Year-boundary ranges (e.g., Dec 30 → Jan 6) are correctly handled with proper date arithmetic

https://claude.ai/code/session_014KWu2U7wFv8Xb8btKUVVYP