### PR TITLE
Add dark mode table styles with purple gradient

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -38,7 +38,7 @@ body:not(:has(#main-nav)) {
 }
 
 :root[data-theme="dark"] {
-  --color-accent: #0097fc4f;
+  --color-accent: #451c6e;
   --color-bg: #01001c;
   --color-bg-secondary: #460066;
   --color-link: #95d5ff;
@@ -96,6 +96,13 @@ html[data-theme="dark"] {
 }
 [data-theme="dark"] table {
   border-width: 2px;
+}
+[data-theme="dark"] table tr:nth-child(2n) {
+  background: linear-gradient(45deg, #460066 0%, #430e79 50%, #460066 100%);
+}
+[data-theme="dark"] table thead {
+  background-color: #290738;
+  color: #FFF;
 }
 
 @keyframes btn-glow-pulse {


### PR DESCRIPTION
## Summary

- Override `--color-accent` in dark mode to `#451c6e` (solid purple, replacing the semi-transparent blue)
- Add dark mode alternating row gradient: `linear-gradient(45deg, #460066 → #430e79 → #460066)`
- Add dark mode `thead` style: deep purple `#290738` background with white text

https://claude.ai/code/session_01KUPoRuZbEHEibqy9p2j4Ye