### PR TITLE
Refactor to reduce cognitive complexity across routes and templates

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -477,6 +477,56 @@ for (const ta of document.querySelectorAll<HTMLTextAreaElement>(
       statusEl.classList.add("checkin-status", `checkin-status-${type}`);
     };
 
+    const handleCheckedIn = (
+      result: { name: string; quantity?: unknown },
+      token: string,
+      idVerified: boolean,
+    ) => {
+      const qty = Number.isFinite(result.quantity)
+        ? (result.quantity as number)
+        : 1;
+      const idNote = idVerified ? " — verify their ID" : "";
+      showCheckinStatus(
+        `${result.name} checked in (${qty} ticket${qty === 1 ? "" : "s"})${idNote}`,
+        "success",
+      );
+      for (const opt of allOptions()) {
+        if (opt.dataset.token === token) {
+          opt.remove();
+          break;
+        }
+      }
+      tokenInput.value = "";
+      input.value = "";
+    };
+
+    const dispatchScanResult = (
+      result: {
+        status?: string;
+        name?: string;
+        message?: string;
+        quantity?: unknown;
+      },
+      token: string,
+      idVerified: boolean,
+    ) => {
+      if (result.status === "checked_in") {
+        handleCheckedIn(
+          result as { name: string; quantity?: unknown },
+          token,
+          idVerified,
+        );
+      } else if (result.status === "already_checked_in") {
+        showCheckinStatus(`${result.name} already checked in`, "warning");
+      } else if (result.status === "refunded") {
+        showCheckinStatus(`${result.name} has been refunded`, "error");
+      } else if (result.status === "not_found") {
+        showCheckinStatus("Ticket not found", "error");
+      } else {
+        showCheckinStatus(result.message ?? "Error", "error");
+      }
+    };
+
     form.addEventListener("submit", async (e) => {
       e.preventDefault();
       const token = tokenInput.value.trim();
@@ -510,30 +560,7 @@ for (const ta of document.querySelectorAll<HTMLTextAreaElement>(
           result = await postScan({ id_verified: true, token });
         }
 
-        if (result.status === "checked_in") {
-          const qty = Number.isFinite(result.quantity) ? result.quantity : 1;
-          const idNote = idVerified ? " — verify their ID" : "";
-          showCheckinStatus(
-            `${result.name} checked in (${qty} ticket${qty === 1 ? "" : "s"})${idNote}`,
-            "success",
-          );
-          for (const opt of allOptions()) {
-            if (opt.dataset.token === token) {
-              opt.remove();
-              break;
-            }
-          }
-          tokenInput.value = "";
-          input.value = "";
-        } else if (result.status === "already_checked_in") {
-          showCheckinStatus(`${result.name} already checked in`, "warning");
-        } else if (result.status === "refunded") {
-          showCheckinStatus(`${result.name} has been refunded`, "error");
-        } else if (result.status === "not_found") {
-          showCheckinStatus("Ticket not found", "error");
-        } else {
-          showCheckinStatus(result.message ?? "Error", "error");
-        }
+        dispatchScanResult(result, token, idVerified);
       } catch {
         showCheckinStatus("Network error", "error");
       }

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -116,54 +116,72 @@ const splitDatetime = (value: string): { date: string; time: string } => {
   return { date, time };
 };
 
+/** Render the input element for a field based on its type */
+const renderFieldInput = (field: Field, value: string): JSX.Element => {
+  if (field.type === "textarea") {
+    return (
+      <textarea
+        name={field.name}
+        required={field.required}
+        placeholder={field.placeholder}
+        maxlength={field.maxlength}
+        autocomplete={field.autocomplete}
+      >
+        <Raw html={escapeHtml(value)} />
+      </textarea>
+    );
+  }
+  if (field.type === "select" && field.options) {
+    return (
+      <Raw
+        html={`<select name="${escapeHtml(field.name)}" id="${escapeHtml(field.name)}">${renderSelectOptions(field.options, value)}</select>`}
+      />
+    );
+  }
+  if (field.type === "checkbox-group" && field.options) {
+    return (
+      <Raw
+        html={renderCheckboxGroup(
+          field.name,
+          field.options,
+          new Set(value ? value.split(",").map((v) => v.trim()) : []),
+        )}
+      />
+    );
+  }
+  if (field.type === "datetime") {
+    return (
+      <Raw html={renderDatetimeInputs(field.name, splitDatetime(value))} />
+    );
+  }
+  if (field.type === "file") {
+    return <input type="file" name={field.name} accept={field.accept} />;
+  }
+  return (
+    <input
+      type={field.type}
+      name={field.name}
+      value={value || undefined}
+      required={field.required}
+      placeholder={field.placeholder}
+      min={field.min}
+      max={field.max}
+      minlength={field.minlength}
+      inputmode={field.inputmode}
+      maxlength={field.maxlength}
+      pattern={field.pattern}
+      title={field.title}
+      autofocus={field.autofocus}
+      autocomplete={field.autocomplete}
+    />
+  );
+};
+
 export const renderField = (field: Field, value: string = ""): string =>
   String(
     <label>
       {field.label}
-      {field.type === "textarea" ? (
-        <textarea
-          name={field.name}
-          required={field.required}
-          placeholder={field.placeholder}
-          maxlength={field.maxlength}
-          autocomplete={field.autocomplete}
-        >
-          <Raw html={escapeHtml(value)} />
-        </textarea>
-      ) : field.type === "select" && field.options ? (
-        <Raw
-          html={`<select name="${escapeHtml(field.name)}" id="${escapeHtml(field.name)}">${renderSelectOptions(field.options, value)}</select>`}
-        />
-      ) : field.type === "checkbox-group" && field.options ? (
-        <Raw
-          html={renderCheckboxGroup(
-            field.name,
-            field.options,
-            new Set(value ? value.split(",").map((v) => v.trim()) : []),
-          )}
-        />
-      ) : field.type === "datetime" ? (
-        <Raw html={renderDatetimeInputs(field.name, splitDatetime(value))} />
-      ) : field.type === "file" ? (
-        <input type="file" name={field.name} accept={field.accept} />
-      ) : (
-        <input
-          type={field.type}
-          name={field.name}
-          value={value || undefined}
-          required={field.required}
-          placeholder={field.placeholder}
-          min={field.min}
-          max={field.max}
-          minlength={field.minlength}
-          inputmode={field.inputmode}
-          maxlength={field.maxlength}
-          pattern={field.pattern}
-          title={field.title}
-          autofocus={field.autofocus}
-          autocomplete={field.autocomplete}
-        />
-      )}
+      {renderFieldInput(field, value)}
       {field.hint && <small>{field.hint}</small>}
       {field.hintHtml && (
         <small>
@@ -208,6 +226,35 @@ const parseFieldValue = (
     : trimmed;
 
 /**
+ * Collect the raw trimmed value for a field from the form data.
+ * Returns the string value, or a FieldValidationResult for early exit
+ * (e.g. datetime partial error or empty-but-not-required datetime).
+ */
+const collectFieldValue = (
+  form: FormParams,
+  field: Field,
+): string | FieldValidationResult => {
+  if (field.type === "datetime") {
+    const result = getDatetimeValue(form, field.name);
+    if (result === null) return { error: DATETIME_PARTIAL_ERROR, valid: false };
+    if (!result) {
+      if (field.required)
+        return { error: `${field.label} is required`, valid: false };
+      return { valid: true, value: null };
+    }
+    return result;
+  }
+  if (field.type === "checkbox-group") {
+    return form
+      .getAll(field.name)
+      .map((v) => v.trim())
+      .filter((v) => v)
+      .join(",");
+  }
+  return form.getString(field.name);
+};
+
+/**
  * Validate a single field and return its parsed value.
  * For checkbox-group fields, collects all checked values via getAll()
  * and joins them as a comma-separated string.
@@ -219,26 +266,10 @@ const validateSingleField = (
   // File fields are handled separately via FormData, not URLSearchParams
   if (field.type === "file") return { valid: true, value: null };
 
-  let trimmed: string;
+  const collected = collectFieldValue(form, field);
+  if (typeof collected !== "string") return collected;
 
-  if (field.type === "datetime") {
-    const result = getDatetimeValue(form, field.name);
-    if (result === null) return { error: DATETIME_PARTIAL_ERROR, valid: false };
-    if (!result) {
-      if (field.required)
-        return { error: `${field.label} is required`, valid: false };
-      return { valid: true, value: null };
-    }
-    trimmed = result;
-  } else if (field.type === "checkbox-group") {
-    trimmed = form
-      .getAll(field.name)
-      .map((v) => v.trim())
-      .filter((v) => v)
-      .join(",");
-  } else {
-    trimmed = form.getString(field.name);
-  }
+  let trimmed = collected;
 
   if (!trimmed && field.defaultValue) {
     trimmed = field.defaultValue;

--- a/src/lib/merge/attendee-merge.ts
+++ b/src/lib/merge/attendee-merge.ts
@@ -317,6 +317,15 @@ const applyPiiDecisions = (
 };
 
 /** Apply an answer decision item; returns counter deltas */
+const takeSourceAnswer = (
+  finalAnswers: Map<number, number>,
+  qid: number,
+  sourceAnswerId: number,
+): { kept: number; taken: number; cleared: number } => {
+  finalAnswers.set(qid, sourceAnswerId);
+  return { cleared: 0, kept: 0, taken: 1 };
+};
+
 const applyAnswerDecision = (
   item: AttendeeMergeDiffAnswerItem,
   decision: AttendeeMergeDecisionInput,
@@ -327,8 +336,7 @@ const applyAnswerDecision = (
 
   if (item.conflict) {
     if (choice === "source" && item.sourceAnswerId !== null) {
-      finalAnswers.set(qid, item.sourceAnswerId);
-      return { cleared: 0, kept: 0, taken: 1 };
+      return takeSourceAnswer(finalAnswers, qid, item.sourceAnswerId);
     }
     if (choice === "clear") {
       finalAnswers.delete(qid);
@@ -339,8 +347,7 @@ const applyAnswerDecision = (
   }
   if (item.sourceAnswerId !== null && item.targetAnswerId === null) {
     // Source has answer, target doesn't — adopt source answer
-    finalAnswers.set(qid, item.sourceAnswerId);
-    return { cleared: 0, kept: 0, taken: 1 };
+    return takeSourceAnswer(finalAnswers, qid, item.sourceAnswerId);
   }
   if (item.targetAnswerId !== null) {
     return { cleared: 0, kept: 1, taken: 0 };

--- a/src/lib/merge/attendee-merge.ts
+++ b/src/lib/merge/attendee-merge.ts
@@ -294,13 +294,15 @@ export const validateAttendeeMergeDecision = (
 // applyAttendeeMerge
 // ---------------------------------------------------------------------------
 
-/** Apply a validated merge with explicit decisions */
-export const applyAttendeeMerge = async (
-  input: ApplyAttendeeMergeInput,
-): Promise<AttendeeMergeApplyResult> => {
-  const { targetId, sourceId, targetPii, sourcePii, diff, decision } = input;
+type BatchStatement = { sql: string; args: (number | string | null)[] };
 
-  // --- 1. Apply PII decisions ---
+/** Apply PII decisions — mutates mergedPii and returns fields taken from source */
+const applyPiiDecisions = (
+  diff: AttendeeMergeDiff,
+  decision: AttendeeMergeDecisionInput,
+  targetPii: Record<string, unknown>,
+  sourcePii: Record<string, unknown>,
+): { mergedPii: Record<string, unknown>; piiFieldsFromSource: string[] } => {
   const piiFieldsFromSource: string[] = [];
   const mergedPii = { ...targetPii };
   for (const field of diff.piiFields) {
@@ -311,13 +313,53 @@ export const applyAttendeeMerge = async (
       piiFieldsFromSource.push(field.field);
     }
   }
+  return { mergedPii, piiFieldsFromSource };
+};
 
-  // --- 2. Apply answer decisions ---
+/** Apply an answer decision item; returns counter deltas */
+const applyAnswerDecision = (
+  item: AttendeeMergeDiffAnswerItem,
+  decision: AttendeeMergeDecisionInput,
+  finalAnswers: Map<number, number>,
+): { kept: number; taken: number; cleared: number } => {
+  const qid = item.questionId;
+  const choice = decision.answers[String(qid)];
+
+  if (item.conflict) {
+    if (choice === "source" && item.sourceAnswerId !== null) {
+      finalAnswers.set(qid, item.sourceAnswerId);
+      return { cleared: 0, kept: 0, taken: 1 };
+    }
+    if (choice === "clear") {
+      finalAnswers.delete(qid);
+      return { cleared: 1, kept: 0, taken: 0 };
+    }
+    // "target" or default — keep target
+    return { cleared: 0, kept: 1, taken: 0 };
+  }
+  if (item.sourceAnswerId !== null && item.targetAnswerId === null) {
+    // Source has answer, target doesn't — adopt source answer
+    finalAnswers.set(qid, item.sourceAnswerId);
+    return { cleared: 0, kept: 0, taken: 1 };
+  }
+  if (item.targetAnswerId !== null) {
+    return { cleared: 0, kept: 1, taken: 0 };
+  }
+  return { cleared: 0, kept: 0, taken: 0 };
+};
+
+/** Apply all answer decisions — returns final answer map and summary counts */
+const applyAnswerDecisions = async (
+  targetId: number,
+  diff: AttendeeMergeDiff,
+  decision: AttendeeMergeDecisionInput,
+): Promise<{
+  finalAnswers: Map<number, number>;
+  answersKept: number;
+  answersTakenFromSource: number;
+  answersCleared: number;
+}> => {
   const targetAnswers = await getAttendeeAnswersByQuestion(targetId);
-
-  let answersKept = 0;
-  let answersTakenFromSource = 0;
-  let answersCleared = 0;
 
   // Start with target's answers as the base
   const finalAnswers = new Map<number, number>();
@@ -325,61 +367,63 @@ export const applyAttendeeMerge = async (
     finalAnswers.set(qid, answerId);
   }
 
-  // Process each answer item from the diff
-  for (const item of diff.answerItems) {
-    const qid = item.questionId;
-    const choice = decision.answers[String(qid)];
+  let answersKept = 0;
+  let answersTakenFromSource = 0;
+  let answersCleared = 0;
 
-    if (item.conflict) {
-      // Conflicting — must have an explicit decision
-      if (choice === "source" && item.sourceAnswerId !== null) {
-        finalAnswers.set(qid, item.sourceAnswerId);
-        answersTakenFromSource++;
-      } else if (choice === "clear") {
-        finalAnswers.delete(qid);
-        answersCleared++;
-      } else {
-        // "target" or default — keep target
-        answersKept++;
-      }
-    } else if (item.sourceAnswerId !== null && item.targetAnswerId === null) {
-      // Source has answer, target doesn't — adopt source answer
-      finalAnswers.set(qid, item.sourceAnswerId);
-      answersTakenFromSource++;
-    } else if (item.targetAnswerId !== null) {
-      answersKept++;
-    }
+  for (const item of diff.answerItems) {
+    const delta = applyAnswerDecision(item, decision, finalAnswers);
+    answersKept += delta.kept;
+    answersTakenFromSource += delta.taken;
+    answersCleared += delta.cleared;
   }
 
-  // --- 3. Apply booking decisions ---
+  return { answersCleared, answersKept, answersTakenFromSource, finalAnswers };
+};
+
+/** Build an INSERT statement to copy a source booking to the target */
+const bookingInsertStatement = (
+  targetId: number,
+  booking: EventAttendeeRow,
+): BatchStatement =>
+  insert("event_attendees", {
+    attachment_downloads: booking.attachment_downloads,
+    attendee_id: targetId,
+    checked_in: booking.checked_in,
+    end_at: booking.end_at,
+    event_id: booking.event_id,
+    price_paid: booking.price_paid,
+    quantity: booking.quantity,
+    refunded: booking.refunded,
+    start_at: booking.start_at,
+  }) as BatchStatement;
+
+/** Apply all booking decisions — returns pending SQL statements and counts */
+const applyBookingDecisions = (
+  targetId: number,
+  diff: AttendeeMergeDiff,
+  decision: AttendeeMergeDecisionInput,
+): {
+  insertStatements: BatchStatement[];
+  deleteTargetBookingStatements: BatchStatement[];
+  bookingsMoved: number;
+  bookingsSkipped: number;
+  bookingsReplacedTarget: number;
+} => {
+  const insertStatements: BatchStatement[] = [];
+  const deleteTargetBookingStatements: BatchStatement[] = [];
   let bookingsMoved = 0;
   let bookingsSkipped = 0;
   let bookingsReplacedTarget = 0;
-
-  type BatchStatement = { sql: string; args: (number | string | null)[] };
-  const insertStatements: BatchStatement[] = [];
-  const deleteTargetBookingStatements: BatchStatement[] = [];
-
-  /** Build an INSERT statement to copy a source booking to the target */
-  const bookingInsert = (booking: EventAttendeeRow): BatchStatement =>
-    insert("event_attendees", {
-      attachment_downloads: booking.attachment_downloads,
-      attendee_id: targetId,
-      checked_in: booking.checked_in,
-      end_at: booking.end_at,
-      event_id: booking.event_id,
-      price_paid: booking.price_paid,
-      quantity: booking.quantity,
-      refunded: booking.refunded,
-      start_at: booking.start_at,
-    }) as BatchStatement;
 
   for (const item of diff.bookingItems) {
     const choice = decision.bookings[itemBookingKey(item)];
 
     if (item.conflictClass === "moveable") {
       // No conflict — move source booking to target
-      insertStatements.push(bookingInsert(item.sourceBooking));
+      insertStatements.push(
+        bookingInsertStatement(targetId, item.sourceBooking),
+      );
       bookingsMoved++;
     } else if (choice === "take_source" && item.targetBooking) {
       // Replace target booking with source booking
@@ -389,13 +433,51 @@ export const applyAttendeeMerge = async (
               WHERE attendee_id = ? AND event_id = ?
               AND (start_at IS ? OR start_at = ?)`,
       });
-      insertStatements.push(bookingInsert(item.sourceBooking));
+      insertStatements.push(
+        bookingInsertStatement(targetId, item.sourceBooking),
+      );
       bookingsReplacedTarget++;
     } else {
       // keep_target or skip_source — do nothing for this booking
       bookingsSkipped++;
     }
   }
+
+  return {
+    bookingsMoved,
+    bookingsReplacedTarget,
+    bookingsSkipped,
+    deleteTargetBookingStatements,
+    insertStatements,
+  };
+};
+
+/** Apply a validated merge with explicit decisions */
+export const applyAttendeeMerge = async (
+  input: ApplyAttendeeMergeInput,
+): Promise<AttendeeMergeApplyResult> => {
+  const { targetId, sourceId, targetPii, sourcePii, diff, decision } = input;
+
+  // --- 1. Apply PII decisions ---
+  const { piiFieldsFromSource } = applyPiiDecisions(
+    diff,
+    decision,
+    targetPii as Record<string, unknown>,
+    sourcePii as Record<string, unknown>,
+  );
+
+  // --- 2. Apply answer decisions ---
+  const { finalAnswers, answersKept, answersTakenFromSource, answersCleared } =
+    await applyAnswerDecisions(targetId, diff, decision);
+
+  // --- 3. Apply booking decisions ---
+  const {
+    insertStatements,
+    deleteTargetBookingStatements,
+    bookingsMoved,
+    bookingsSkipped,
+    bookingsReplacedTarget,
+  } = applyBookingDecisions(targetId, diff, decision);
 
   // --- 4. Execute all DB changes atomically ---
   await executeBatch([

--- a/src/lib/merge/attendee-merge.ts
+++ b/src/lib/merge/attendee-merge.ts
@@ -349,10 +349,9 @@ const applyAnswerDecision = (
     // Source has answer, target doesn't — adopt source answer
     return takeSourceAnswer(finalAnswers, qid, item.sourceAnswerId);
   }
-  if (item.targetAnswerId !== null) {
-    return { cleared: 0, kept: 1, taken: 0 };
-  }
-  return { cleared: 0, kept: 0, taken: 0 };
+  // Target has an answer (diff items require at least one side non-null and
+  // the conflict/source-only branches are exhausted).
+  return { cleared: 0, kept: 1, taken: 0 };
 };
 
 /** Apply all answer decisions — returns final answer map and summary counts */

--- a/src/lib/sort-events.ts
+++ b/src/lib/sort-events.ts
@@ -19,6 +19,27 @@ const eventTier = (event: Event): number => {
   return event.date === "" ? 0 : 1;
 };
 
+/** Tier 1: dated standard — sort by date ASC, then name */
+const compareDatedStandard = (a: Event, b: Event): number => {
+  const cmp = a.date.localeCompare(b.date);
+  return cmp !== 0 ? cmp : a.name.localeCompare(b.name);
+};
+
+/** Tier 2: daily — sort by next bookable date ASC, then name */
+const compareDaily = (
+  nextDates: Map<number, string | null>,
+  a: Event,
+  b: Event,
+): number => {
+  const dateA = nextDates.get(a.id) ?? "";
+  const dateB = nextDates.get(b.id) ?? "";
+  if (dateA === "" && dateB === "") return a.name.localeCompare(b.name);
+  if (dateA === "") return 1;
+  if (dateB === "") return -1;
+  const cmp = dateA.localeCompare(dateB);
+  return cmp !== 0 ? cmp : a.name.localeCompare(b.name);
+};
+
 /**
  * Create a comparator that uses pre-computed next-bookable-dates for daily events.
  */
@@ -28,24 +49,9 @@ const compareEvents =
     const tierA = eventTier(a);
     const tierB = eventTier(b);
     if (tierA !== tierB) return tierA - tierB;
-
-    // Tier 0: no-date standard — sort by name only
     if (tierA === 0) return a.name.localeCompare(b.name);
-
-    // Tier 1: dated standard — sort by date ASC, then name
-    if (tierA === 1) {
-      const cmp = a.date.localeCompare(b.date);
-      return cmp !== 0 ? cmp : a.name.localeCompare(b.name);
-    }
-
-    // Tier 2: daily — sort by next bookable date ASC, then name
-    const dateA = nextDates.get(a.id) ?? "";
-    const dateB = nextDates.get(b.id) ?? "";
-    if (dateA === "" && dateB === "") return a.name.localeCompare(b.name);
-    if (dateA === "") return 1;
-    if (dateB === "") return -1;
-    const cmp = dateA.localeCompare(dateB);
-    return cmp !== 0 ? cmp : a.name.localeCompare(b.name);
+    if (tierA === 1) return compareDatedStandard(a, b);
+    return compareDaily(nextDates, a, b);
   };
 
 /**

--- a/src/routes/admin/attendee-refunds.ts
+++ b/src/routes/admin/attendee-refunds.ts
@@ -194,13 +194,18 @@ const processRefundBatch = async (
   return counts;
 };
 
+type RefundResponseCtx = {
+  event: EventWithCount;
+  refundAllUrl: string;
+  counts: RefundCounts;
+  remaining: number;
+};
+
 /** Build the error response branch of a bulk refund (some refunds failed). */
 const buildRefundProblemResponse = async (
-  event: EventWithCount,
-  refundAllUrl: string,
-  counts: RefundCounts,
-  remaining: number,
+  ctx: RefundResponseCtx,
 ): Promise<Response> => {
+  const { event, refundAllUrl, counts, remaining } = ctx;
   const { refundedCount, failedCount, errorCount } = counts;
   const problemCount = failedCount + errorCount;
   const errorNote =
@@ -220,17 +225,19 @@ const buildRefundProblemResponse = async (
 
 /** Build the final response for a bulk refund based on tallied results. */
 const buildRefundAllResponse = async (
-  event: EventWithCount,
-  refundAllUrl: string,
-  counts: RefundCounts,
-  totalRefundable: number,
-  remaining: number,
+  ctx: RefundResponseCtx & { totalRefundable: number },
 ): Promise<Response> => {
-  const { refundedCount, failedCount, errorCount } = counts;
-  const problemCount = failedCount + errorCount;
+  const { counts, event, refundAllUrl, totalRefundable, remaining } = ctx;
+  const refundedCount = counts.refundedCount;
+  const hasProblems = counts.failedCount + counts.errorCount > 0;
 
-  if (problemCount > 0) {
-    return buildRefundProblemResponse(event, refundAllUrl, counts, remaining);
+  if (hasProblems) {
+    return buildRefundProblemResponse({
+      counts,
+      event,
+      refundAllUrl,
+      remaining,
+    });
   }
 
   if (remaining > 0) {
@@ -276,13 +283,13 @@ const processRefundAll = async (
   const batch = refundable.slice(0, REFUND_BATCH_LIMIT);
   const remaining = refundable.length - batch.length;
   const counts = await processRefundBatch(provider, batch, event.id);
-  return buildRefundAllResponse(
+  return buildRefundAllResponse({
+    counts,
     event,
     refundAllUrl,
-    counts,
-    refundable.length,
     remaining,
-  );
+    totalRefundable: refundable.length,
+  });
 };
 
 /** Handle POST /admin/event/:id/refund-all */

--- a/src/routes/admin/attendee-refunds.ts
+++ b/src/routes/admin/attendee-refunds.ts
@@ -133,6 +133,125 @@ const handleAdminRefundAllGet = (
       : htmlResponse(adminRefundAllAttendeesPage(event, count, session));
   });
 
+type RefundResult = "ok" | "failed" | "errored";
+type RefundCounts = {
+  refundedCount: number;
+  failedCount: number;
+  errorCount: number;
+};
+
+/** Refund a single attendee, returning a typed result. */
+const refundOneAttendee = async (
+  provider: NonNullable<Awaited<ReturnType<typeof getActivePaymentProvider>>>,
+  attendee: Attendee,
+  eventId: number,
+): Promise<RefundResult> => {
+  try {
+    const refunded = await provider.refundPayment(attendee.payment_id);
+    if (refunded) {
+      await markRefunded(attendee.id, eventId);
+      return "ok";
+    }
+    logError({
+      code: ErrorCode.PAYMENT_REFUND,
+      detail: `Admin bulk refund failed for attendee ${attendee.id}, payment ${attendee.payment_id}`,
+      eventId,
+    });
+    return "failed";
+  } catch (err) {
+    const msg = String(err);
+    logError({
+      code: ErrorCode.PAYMENT_REFUND,
+      detail: `Admin bulk refund errored for attendee ${attendee.id}, payment ${attendee.payment_id}: ${msg}`,
+      eventId,
+    });
+    return "errored";
+  }
+};
+
+/** Process a batch of refundable attendees and tally results. */
+const processRefundBatch = async (
+  provider: NonNullable<Awaited<ReturnType<typeof getActivePaymentProvider>>>,
+  batch: Attendee[],
+  eventId: number,
+): Promise<RefundCounts> => {
+  const REFUND_CHUNK_SIZE = 5;
+  const counts: RefundCounts = {
+    errorCount: 0,
+    failedCount: 0,
+    refundedCount: 0,
+  };
+  for (const group of chunk(REFUND_CHUNK_SIZE)(batch)) {
+    const results = await Promise.all(
+      group.map((attendee) => refundOneAttendee(provider, attendee, eventId)),
+    );
+    for (const result of results) {
+      if (result === "ok") counts.refundedCount++;
+      else if (result === "errored") counts.errorCount++;
+      else counts.failedCount++;
+    }
+  }
+  return counts;
+};
+
+/** Build the error response branch of a bulk refund (some refunds failed). */
+const buildRefundProblemResponse = async (
+  event: EventWithCount,
+  refundAllUrl: string,
+  counts: RefundCounts,
+  remaining: number,
+): Promise<Response> => {
+  const { refundedCount, failedCount, errorCount } = counts;
+  const problemCount = failedCount + errorCount;
+  const errorNote =
+    errorCount > 0
+      ? ` (${errorCount} errored — check the activity log for details)`
+      : "";
+  const msg =
+    remaining > 0
+      ? `${refundedCount} refund(s) succeeded, ${problemCount} failed${errorNote}. ${remaining} remaining — submit again to continue.`
+      : `${refundedCount} refund(s) succeeded, ${problemCount} failed${errorNote}. Some payments may have already been refunded.`;
+  await logActivity(
+    `Bulk refund: ${refundedCount} succeeded, ${problemCount} failed for '${event.name}'`,
+    event.id,
+  );
+  return errorRedirect(refundAllUrl, msg);
+};
+
+/** Build the final response for a bulk refund based on tallied results. */
+const buildRefundAllResponse = async (
+  event: EventWithCount,
+  refundAllUrl: string,
+  counts: RefundCounts,
+  totalRefundable: number,
+  remaining: number,
+): Promise<Response> => {
+  const { refundedCount, failedCount, errorCount } = counts;
+  const problemCount = failedCount + errorCount;
+
+  if (problemCount > 0) {
+    return buildRefundProblemResponse(event, refundAllUrl, counts, remaining);
+  }
+
+  if (remaining > 0) {
+    await logActivity(
+      `Bulk refund: ${refundedCount} of ${totalRefundable} refunded for '${event.name}'`,
+      event.id,
+    );
+    return redirect(
+      refundAllUrl,
+      `${refundedCount} attendee(s) refunded. ${remaining} remaining — submit again to continue.`,
+      true,
+    );
+  }
+
+  await logActivity(
+    `Bulk refund: all ${refundedCount} attendee(s) refunded for '${event.name}'`,
+    event.id,
+  );
+  return redirect(`/admin/event/${event.id}`, "All attendees refunded", true);
+};
+
 /** Process bulk refund for all refundable attendees */
 const processRefundAll = async (
   event: EventWithCount,
@@ -154,80 +273,16 @@ const processRefundAll = async (
     return errorRedirect(refundAllUrl, NO_PROVIDER_ERROR);
   }
 
-  const REFUND_CHUNK_SIZE = 5;
   const batch = refundable.slice(0, REFUND_BATCH_LIMIT);
   const remaining = refundable.length - batch.length;
-
-  let refundedCount = 0;
-  let failedCount = 0;
-  let errorCount = 0;
-  for (const group of chunk(REFUND_CHUNK_SIZE)(batch)) {
-    const results = await Promise.all(
-      group.map(async (attendee) => {
-        try {
-          const refunded = await provider.refundPayment(attendee.payment_id);
-          if (refunded) {
-            await markRefunded(attendee.id, event.id);
-            return "ok" as const;
-          }
-          logError({
-            code: ErrorCode.PAYMENT_REFUND,
-            detail: `Admin bulk refund failed for attendee ${attendee.id}, payment ${attendee.payment_id}`,
-            eventId: event.id,
-          });
-          return "failed" as const;
-        } catch (err) {
-          const msg = String(err);
-          logError({
-            code: ErrorCode.PAYMENT_REFUND,
-            detail: `Admin bulk refund errored for attendee ${attendee.id}, payment ${attendee.payment_id}: ${msg}`,
-            eventId: event.id,
-          });
-          return "errored" as const;
-        }
-      }),
-    );
-    for (const result of results) {
-      if (result === "ok") refundedCount++;
-      else if (result === "errored") errorCount++;
-      else failedCount++;
-    }
-  }
-  const problemCount = failedCount + errorCount;
-
-  if (problemCount > 0) {
-    const errorNote =
-      errorCount > 0
-        ? ` (${errorCount} errored — check the activity log for details)`
-        : "";
-    const msg =
-      remaining > 0
-        ? `${refundedCount} refund(s) succeeded, ${problemCount} failed${errorNote}. ${remaining} remaining — submit again to continue.`
-        : `${refundedCount} refund(s) succeeded, ${problemCount} failed${errorNote}. Some payments may have already been refunded.`;
-    await logActivity(
-      `Bulk refund: ${refundedCount} succeeded, ${problemCount} failed for '${event.name}'`,
-      event.id,
-    );
-    return errorRedirect(refundAllUrl, msg);
-  }
-
-  if (remaining > 0) {
-    await logActivity(
-      `Bulk refund: ${refundedCount} of ${refundable.length} refunded for '${event.name}'`,
-      event.id,
-    );
-    return redirect(
-      refundAllUrl,
-      `${refundedCount} attendee(s) refunded. ${remaining} remaining — submit again to continue.`,
-      true,
-    );
-  }
-
-  await logActivity(
-    `Bulk refund: all ${refundedCount} attendee(s) refunded for '${event.name}'`,
-    event.id,
+  const counts = await processRefundBatch(provider, batch, event.id);
+  return buildRefundAllResponse(
+    event,
+    refundAllUrl,
+    counts,
+    refundable.length,
+    remaining,
   );
-  return redirect(`/admin/event/${event.id}`, "All attendees refunded", true);
 };
 
 /** Handle POST /admin/event/:id/refund-all */

--- a/src/routes/admin/attendees.ts
+++ b/src/routes/admin/attendees.ts
@@ -301,6 +301,43 @@ const handleAttendeeCheckin = attendeeFormAction(
   },
 );
 
+/** Build create-attendee input from validated form values */
+const buildCreateAttendeeInput = (
+  values: AddAttendeeFormValues,
+  eventId: number,
+  isDaily: boolean,
+) => {
+  const { name, email, phone, address, special_instructions, quantity, date } =
+    values;
+  return {
+    address: address || "",
+    bookings: [{ date: isDaily ? date : null, eventId, quantity }],
+    email: email || "",
+    name,
+    phone: phone || "",
+    special_instructions: special_instructions || "",
+  };
+};
+
+/** Convert a failed createAttendeeAtomic result into a redirect response */
+const handleCreateAttendeeFailure = (
+  result: { success: false; reason: string },
+  eventId: number,
+): Response => {
+  if (result.reason === "encryption_error") {
+    logError({
+      code: ErrorCode.ENCRYPT_FAILED,
+      detail: "manual add attendee",
+      eventId,
+    });
+  }
+  const errorMsg =
+    result.reason === "capacity_exceeded"
+      ? "Not enough spots available"
+      : "Encryption error — check that DB_ENCRYPTION_KEY is configured";
+  return redirect(`/admin/event/${eventId}`, errorMsg, false);
+};
+
 /** Handle POST /admin/event/:eventId/attendee (add attendee manually) */
 const handleAddAttendee = (
   request: Request,
@@ -319,40 +356,15 @@ const handleAddAttendee = (
       return redirect(`/admin/event/${eventId}`, validation.error, false);
     }
 
-    const {
-      name,
-      email,
-      phone,
-      address,
-      special_instructions,
-      quantity,
-      date,
-    } = validation.values;
-
-    const result = await createAttendeeAtomic({
-      address: address || "",
-      bookings: [{ date: isDaily ? date : null, eventId, quantity }],
-      email: email || "",
-      name,
-      phone: phone || "",
-      special_instructions: special_instructions || "",
-    });
+    const result = await createAttendeeAtomic(
+      buildCreateAttendeeInput(validation.values, eventId, isDaily),
+    );
 
     if (!result.success) {
-      if (result.reason === "encryption_error") {
-        logError({
-          code: ErrorCode.ENCRYPT_FAILED,
-          detail: "manual add attendee",
-          eventId,
-        });
-      }
-      const errorMsg =
-        result.reason === "capacity_exceeded"
-          ? "Not enough spots available"
-          : "Encryption error — check that DB_ENCRYPTION_KEY is configured";
-      return redirect(`/admin/event/${eventId}`, errorMsg, false);
+      return handleCreateAttendeeFailure(result, eventId);
     }
 
+    const { name } = validation.values;
     await logActivity(`Attendee '${name}' added manually`, eventId);
     return redirect(`/admin/event/${eventId}`, `Added ${name}`, true);
   });
@@ -844,41 +856,74 @@ const collectEventIds = (
   return [...ids];
 };
 
-/** Parse merge decision form data into AttendeeMergeDecisionInput */
-const parseMergeDecisionForm = (
+/** Parse PII decisions from form (each field: "source" or "target") */
+const parsePiiDecisions = (
   form: FormParams,
   diff: AttendeeMergeDiff,
-): AttendeeMergeDecisionInput => {
+): Record<string, MergeValueChoice> => {
   const pii: Record<string, MergeValueChoice> = {};
   for (const field of diff.piiFields) {
     const val = form.getString(`pii_${field.field}`);
     pii[field.field] = val === "source" ? "source" : "target";
   }
+  return pii;
+};
 
+/** Normalize a raw answer choice string into a MergeAnswerChoice */
+const toAnswerChoice = (raw: string): MergeAnswerChoice => {
+  if (raw === "source") return "source";
+  if (raw === "clear") return "clear";
+  return "target";
+};
+
+/** Parse answer decisions from form (only conflicting items) */
+const parseAnswerDecisions = (
+  form: FormParams,
+  diff: AttendeeMergeDiff,
+): Record<string, MergeAnswerChoice> => {
   const answers: Record<string, MergeAnswerChoice> = {};
   for (const item of diff.answerItems) {
     if (item.conflict) {
       const val = form.getString(`answer_${item.questionId}`);
-      if (val === "source") answers[String(item.questionId)] = "source";
-      else if (val === "clear") answers[String(item.questionId)] = "clear";
-      else answers[String(item.questionId)] = "target";
+      answers[String(item.questionId)] = toAnswerChoice(val);
     }
   }
+  return answers;
+};
 
+/** Normalize a raw booking choice string into a MergeBookingChoice */
+const toBookingChoice = (raw: string): MergeBookingChoice => {
+  if (raw === "take_source") return "take_source";
+  if (raw === "skip_source") return "skip_source";
+  return "keep_target";
+};
+
+/** Parse booking decisions from form (only non-moveable items) */
+const parseBookingDecisions = (
+  form: FormParams,
+  diff: AttendeeMergeDiff,
+): Record<string, MergeBookingChoice> => {
   const bookings: Record<string, MergeBookingChoice> = {};
   for (const item of diff.bookingItems) {
     if (item.conflictClass !== "moveable") {
       const key = bookingKey(item.eventId, item.startAt);
       const val = form.getString(`booking_${key}`);
-      if (val === "take_source") bookings[key] = "take_source";
-      else if (val === "skip_source") bookings[key] = "skip_source";
-      else bookings[key] = "keep_target";
+      bookings[key] = toBookingChoice(val);
     }
   }
-
-  const version = form.getString("merge_version");
-  return { answers, bookings, pii, version };
+  return bookings;
 };
+
+/** Parse merge decision form data into AttendeeMergeDecisionInput */
+const parseMergeDecisionForm = (
+  form: FormParams,
+  diff: AttendeeMergeDiff,
+): AttendeeMergeDecisionInput => ({
+  answers: parseAnswerDecisions(form, diff),
+  bookings: parseBookingDecisions(form, diff),
+  pii: parsePiiDecisions(form, diff),
+  version: form.getString("merge_version"),
+});
 
 /* jscpd:ignore-start — merge handlers share structural patterns with other route handlers */
 /** Handle GET /admin/attendees/:attendeeId/merge — analyze + render decisions */
@@ -965,6 +1010,207 @@ const handleMergeGet = (
     }),
   );
 
+type MergeSource = NonNullable<Awaited<ReturnType<typeof loadMergeSource>>>;
+type MergeSummary = Awaited<ReturnType<typeof applyAttendeeMerge>>["summary"];
+
+/** Extract PII subset for merge diff/apply input */
+const extractSourcePii = (source: MergeSource) => ({
+  address: source.address,
+  email: source.email,
+  name: source.name,
+  phone: source.phone,
+  special_instructions: source.special_instructions,
+});
+
+const extractTargetPii = (target: Attendee) => ({
+  address: target.address,
+  email: target.email,
+  name: target.name,
+  phone: target.phone,
+  special_instructions: target.special_instructions,
+});
+
+/** Build merge diff from source + target */
+const buildMergeDiffFor = async (
+  target: Attendee,
+  source: MergeSource,
+  attendeeId: number,
+): Promise<AttendeeMergeDiff> => {
+  const targetBookings = await loadAttendeeBookings(attendeeId);
+  const allEventIds = collectEventIds(targetBookings, source.bookings);
+  const { questions } = await getQuestionsWithEventIds(allEventIds);
+
+  return buildAttendeeMergeDiff(
+    {
+      sourceBookings: source.bookings,
+      sourceId: source.id,
+      sourcePii: extractSourcePii(source),
+      targetBookings,
+      targetId: attendeeId,
+      targetPii: extractTargetPii(target),
+    },
+    questions,
+  );
+};
+
+/** Resolve the (possibly-source) value of a PII field based on decision */
+const pickPiiField = <K extends keyof MergeSource>(
+  decision: AttendeeMergeDecisionInput,
+  field: K & string,
+  source: MergeSource,
+  target: Attendee,
+): string => {
+  const decisionChoice = decision.pii[field];
+  const sourceVal = source[field] as unknown as string;
+  const targetVal = target[field as keyof Attendee] as unknown as string;
+  return decisionChoice === "source" ? sourceVal : targetVal;
+};
+
+/** Update target attendee PII based on merge decisions */
+const updateTargetPiiFromDecision = (
+  attendeeId: number,
+  decision: AttendeeMergeDecisionInput,
+  source: MergeSource,
+  target: Attendee,
+): Promise<unknown> =>
+  updateAttendeePII(attendeeId, {
+    address: pickPiiField(decision, "address", source, target),
+    email: pickPiiField(decision, "email", source, target),
+    name: pickPiiField(decision, "name", source, target),
+    payment_id: target.payment_id,
+    phone: pickPiiField(decision, "phone", source, target),
+    special_instructions: pickPiiField(
+      decision,
+      "special_instructions",
+      source,
+      target,
+    ),
+    ticket_token: target.ticket_token,
+  });
+
+/** Build activity log message parts for a merge summary */
+const buildMergeLogParts = (
+  summary: MergeSummary,
+  sourceName: string,
+  mergedPiiName: string,
+): string[] =>
+  compact([
+    `Attendee '${sourceName}' merged into '${mergedPiiName}'`,
+    summary.bookingsMoved > 0
+      ? `${summary.bookingsMoved} booking(s) moved`
+      : null,
+    summary.bookingsSkipped > 0
+      ? `${summary.bookingsSkipped} booking(s) skipped`
+      : null,
+    summary.bookingsReplacedTarget > 0
+      ? `${summary.bookingsReplacedTarget} booking(s) replaced`
+      : null,
+    summary.answersTakenFromSource > 0
+      ? `${summary.answersTakenFromSource} answer(s) from source`
+      : null,
+    summary.answersCleared > 0
+      ? `${summary.answersCleared} answer(s) cleared`
+      : null,
+  ]);
+
+/** Build flash message parts for a merge */
+const buildMergeFlashParts = (
+  summary: MergeSummary,
+  sourceName: string,
+  mergedPiiName: string,
+): string[] => {
+  const parts = [`Merged ${sourceName} into ${mergedPiiName}`];
+  if (summary.bookingsMoved > 0) {
+    parts.push(`${summary.bookingsMoved} booking(s) moved`);
+  }
+  if (summary.bookingsSkipped > 0) {
+    parts.push(`${summary.bookingsSkipped} booking(s) skipped`);
+  }
+  return parts;
+};
+
+/** Validate merge POST preconditions, returning an error Response or the source */
+const validateMergePostInput = async (
+  attendeeId: number,
+  form: FormParams,
+  session: AuthSession,
+): Promise<
+  | { ok: true; source: MergeSource; sourceToken: string }
+  | { ok: false; response: Response }
+> => {
+  const sourceToken = form.getString("source_token");
+  if (!sourceToken) {
+    return {
+      ok: false,
+      response: errorRedirect(
+        `/admin/attendees/${attendeeId}/merge`,
+        "Source token is required",
+      ),
+    };
+  }
+
+  const source = await loadMergeSource(sourceToken, session);
+  if (!source) {
+    return {
+      ok: false,
+      response: errorRedirect(
+        `/admin/attendees/${attendeeId}/merge?token=${encodeURIComponent(sourceToken)}`,
+        "Ticket token not found",
+      ),
+    };
+  }
+
+  if (source.id === attendeeId) {
+    return {
+      ok: false,
+      response: errorRedirect(
+        `/admin/attendees/${attendeeId}/merge`,
+        "Cannot merge an attendee with themselves",
+      ),
+    };
+  }
+
+  return { ok: true, source, sourceToken };
+};
+
+/** Apply merge decisions and return the success redirect response */
+const applyMergeDecisions = async (
+  attendeeId: number,
+  target: Attendee,
+  source: MergeSource,
+  diff: AttendeeMergeDiff,
+  decision: AttendeeMergeDecisionInput,
+): Promise<Response> => {
+  const result = await applyAttendeeMerge({
+    decision,
+    diff,
+    sourceId: source.id,
+    sourcePii: extractSourcePii(source),
+    targetId: attendeeId,
+    targetPii: {
+      ...extractTargetPii(target),
+      payment_id: target.payment_id,
+      ticket_token: target.ticket_token,
+    },
+  });
+
+  const mergedPiiName =
+    decision.pii.name === "source" ? source.name : target.name;
+  await updateTargetPiiFromDecision(attendeeId, decision, source, target);
+
+  const { summary } = result;
+  await logActivity(
+    buildMergeLogParts(summary, source.name, mergedPiiName).join(". "),
+    target.event_id,
+  );
+
+  return redirect(
+    `/admin/attendees/${attendeeId}`,
+    buildMergeFlashParts(summary, source.name, mergedPiiName).join(". "),
+    true,
+  );
+};
+
 /** Handle POST /admin/attendees/:attendeeId/merge — validate + apply decisions */
 const handleMergePost = (
   request: Request,
@@ -972,58 +1218,11 @@ const handleMergePost = (
 ): Promise<Response> =>
   withAuth(request, AUTH_FORM, (session, form) =>
     withMergeTarget(session, attendeeId, async (target) => {
-      const sourceToken = form.getString("source_token");
-      if (!sourceToken) {
-        return errorRedirect(
-          `/admin/attendees/${attendeeId}/merge`,
-          "Source token is required",
-        );
-      }
+      const input = await validateMergePostInput(attendeeId, form, session);
+      if (!input.ok) return input.response;
+      const { source, sourceToken } = input;
 
-      const source = await loadMergeSource(sourceToken, session);
-      if (!source) {
-        return errorRedirect(
-          `/admin/attendees/${attendeeId}/merge?token=${encodeURIComponent(sourceToken)}`,
-          "Ticket token not found",
-        );
-      }
-
-      if (source.id === attendeeId) {
-        return errorRedirect(
-          `/admin/attendees/${attendeeId}/merge`,
-          "Cannot merge an attendee with themselves",
-        );
-      }
-
-      // Rebuild the diff to validate against
-      const targetBookings = await loadAttendeeBookings(attendeeId);
-      const allEventIds = collectEventIds(targetBookings, source.bookings);
-      const { questions } = await getQuestionsWithEventIds(allEventIds);
-
-      const diff = await buildAttendeeMergeDiff(
-        {
-          sourceBookings: source.bookings,
-          sourceId: source.id,
-          sourcePii: {
-            address: source.address,
-            email: source.email,
-            name: source.name,
-            phone: source.phone,
-            special_instructions: source.special_instructions,
-          },
-          targetBookings,
-          targetId: attendeeId,
-          targetPii: {
-            address: target.address,
-            email: target.email,
-            name: target.name,
-            phone: target.phone,
-            special_instructions: target.special_instructions,
-          },
-        },
-        questions,
-      );
-
+      const diff = await buildMergeDiffFor(target, source, attendeeId);
       const decision = parseMergeDecisionForm(form, diff);
       const validation = validateAttendeeMergeDecision(diff, decision);
 
@@ -1040,81 +1239,7 @@ const handleMergePost = (
         );
       }
 
-      const result = await applyAttendeeMerge({
-        decision,
-        diff,
-        sourceId: source.id,
-        sourcePii: {
-          address: source.address,
-          email: source.email,
-          name: source.name,
-          phone: source.phone,
-          special_instructions: source.special_instructions,
-        },
-        targetId: attendeeId,
-        targetPii: {
-          address: target.address,
-          email: target.email,
-          name: target.name,
-          payment_id: target.payment_id,
-          phone: target.phone,
-          special_instructions: target.special_instructions,
-          ticket_token: target.ticket_token,
-        },
-      });
-
-      // Update target PII based on decisions
-      const mergedPiiName =
-        decision.pii.name === "source" ? source.name : target.name;
-      await updateAttendeePII(attendeeId, {
-        address:
-          decision.pii.address === "source" ? source.address : target.address,
-        email: decision.pii.email === "source" ? source.email : target.email,
-        name: decision.pii.name === "source" ? source.name : target.name,
-        payment_id: target.payment_id,
-        phone: decision.pii.phone === "source" ? source.phone : target.phone,
-        special_instructions:
-          decision.pii.special_instructions === "source"
-            ? source.special_instructions
-            : target.special_instructions,
-        ticket_token: target.ticket_token,
-      });
-
-      // Log structured summary
-      const { summary } = result;
-      const parts = compact([
-        `Attendee '${source.name}' merged into '${mergedPiiName}'`,
-        summary.bookingsMoved > 0
-          ? `${summary.bookingsMoved} booking(s) moved`
-          : null,
-        summary.bookingsSkipped > 0
-          ? `${summary.bookingsSkipped} booking(s) skipped`
-          : null,
-        summary.bookingsReplacedTarget > 0
-          ? `${summary.bookingsReplacedTarget} booking(s) replaced`
-          : null,
-        summary.answersTakenFromSource > 0
-          ? `${summary.answersTakenFromSource} answer(s) from source`
-          : null,
-        summary.answersCleared > 0
-          ? `${summary.answersCleared} answer(s) cleared`
-          : null,
-      ]);
-      await logActivity(parts.join(". "), target.event_id);
-
-      const flashParts = [`Merged ${source.name} into ${mergedPiiName}`];
-      if (summary.bookingsMoved > 0) {
-        flashParts.push(`${summary.bookingsMoved} booking(s) moved`);
-      }
-      if (summary.bookingsSkipped > 0) {
-        flashParts.push(`${summary.bookingsSkipped} booking(s) skipped`);
-      }
-
-      return redirect(
-        `/admin/attendees/${attendeeId}`,
-        flashParts.join(". "),
-        true,
-      );
+      return applyMergeDecisions(attendeeId, target, source, diff, decision);
     }),
   );
 /* jscpd:ignore-end */

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -202,6 +202,21 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
     }),
   );
 
+/** Validate that all event types match the group; returns error message or null */
+const validateEventTypesForGroup = async (
+  groupId: number,
+  eventIds: number[],
+): Promise<string | null> => {
+  for (const eventId of eventIds) {
+    const event = await getEvent(eventId);
+    if (event) {
+      const typeError = await validateGroupEventType(groupId, event.event_type);
+      if (typeError) return typeError;
+    }
+  }
+  return null;
+};
+
 /** Handle POST /admin/groups/:id/add-events - assign ungrouped events to group */
 const handleAddEventsToGroup: TypedRouteHandler<
   "POST /admin/groups/:id/add-events"
@@ -213,18 +228,9 @@ const handleAddEventsToGroup: TypedRouteHandler<
         .map(Number)
         .filter((n) => n > 0);
       if (eventIds.length > 0) {
-        // Validate event types match the group's existing events
-        for (const eventId of eventIds) {
-          const event = await getEvent(eventId);
-          if (event) {
-            const typeError = await validateGroupEventType(
-              id,
-              event.event_type,
-            );
-            if (typeError) {
-              return redirect(`/admin/groups/${id}`, typeError, false);
-            }
-          }
+        const typeError = await validateEventTypesForGroup(id, eventIds);
+        if (typeError) {
+          return redirect(`/admin/groups/${id}`, typeError, false);
         }
         await assignEventsToGroup(eventIds, id);
         await logActivity(

--- a/src/routes/admin/scanner.ts
+++ b/src/routes/admin/scanner.ts
@@ -63,6 +63,80 @@ const resolveTokenEntries = async (
   return entries.length === 0 ? [] : decryptTokenEntries(entries, privateKey);
 };
 
+/** Get the attendee name from decrypted entries, falling back to raw decrypt */
+const resolveAttendeeName = async (
+  allEntries: TokenEntry[],
+  awb: AttendeeWithBookings,
+  privateKey: CryptoKey,
+): Promise<string> => {
+  const fromEntry = allEntries[0]?.attendee.name;
+  if (fromEntry) return fromEntry;
+  const decrypted = await decryptAttendees(
+    [{ pii_blob: awb.pii_blob } as Attendee],
+    privateKey,
+  );
+  return decrypted[0]!.name;
+};
+
+/** Build a wrong_event response when scanned token doesn't match the event */
+const wrongEventResponse = (
+  allEntries: TokenEntry[],
+  attendeeName: string,
+): Response => {
+  const eventNames =
+    allEntries.length > 0
+      ? allEntries.map((e) => e.event.name).join(", ")
+      : "Unknown event";
+  return jsonResponse({
+    eventName: eventNames,
+    name: attendeeName,
+    status: "wrong_event",
+  });
+};
+
+/** Check attendee state (refunded/checked_in/verify_id); return response or null */
+const checkAttendeeState = (
+  entry: TokenEntry,
+  attendeeName: string,
+  idVerified: boolean,
+): Response | null => {
+  if (entry.attendee.refunded) {
+    return jsonResponse({ name: attendeeName, status: "refunded" });
+  }
+  if (entry.attendee.checked_in) {
+    return jsonResponse({
+      name: attendeeName,
+      quantity: entry.attendee.quantity,
+      status: "already_checked_in",
+    });
+  }
+  if (entry.event.non_transferable && !idVerified) {
+    return jsonResponse({
+      name: attendeeName,
+      quantity: entry.attendee.quantity,
+      status: "verify_id",
+    });
+  }
+  return null;
+};
+
+/** Perform the actual check-in (database update + activity log) */
+const performCheckIn = async (
+  entry: TokenEntry,
+  attendeeName: string,
+): Promise<Response> => {
+  await updateCheckedIn(entry.attendee.id, entry.event.id, true);
+  await logActivity(
+    `Attendee checked in via scanner for '${entry.event.name}'`,
+    entry.event.id,
+  );
+  return jsonResponse({
+    name: attendeeName,
+    quantity: entry.attendee.quantity,
+    status: "checked_in",
+  });
+};
+
 /**
  * Handle POST /admin/event/:id/scan - JSON check-in API.
  * Scanner is intentionally one-way (check-in only, no check-out) to prevent
@@ -97,32 +171,12 @@ const handleScanPost: IdRouteHandler = (request, { id }) =>
     }
 
     const allEntries = await resolveTokenEntries(awb, privateKey);
-
-    // Find the entry matching the scanned event
     const matchingEntry = allEntries.find((e) => e.event.id === id);
-
-    // Decrypt name from first available entry, or from raw attendee if all events deleted
-    // Get name from resolved entries, or decrypt directly if all events were deleted
-    const attendeeName =
-      allEntries[0]?.attendee.name ??
-      (
-        await decryptAttendees(
-          [{ pii_blob: awb.pii_blob } as Attendee],
-          privateKey,
-        )
-      )[0]!.name;
+    const attendeeName = await resolveAttendeeName(allEntries, awb, privateKey);
 
     // Wrong event — attendee not registered for the scanned event
     if (!matchingEntry && !force) {
-      const eventNames =
-        allEntries.length > 0
-          ? allEntries.map((e) => e.event.name).join(", ")
-          : "Unknown event";
-      return jsonResponse({
-        eventName: eventNames,
-        name: attendeeName,
-        status: "wrong_event",
-      });
+      return wrongEventResponse(allEntries, attendeeName);
     }
 
     // When force=true, use the first entry if no match (cross-event check-in)
@@ -131,44 +185,10 @@ const handleScanPost: IdRouteHandler = (request, { id }) =>
       return jsonResponse({ status: "not_found" }, 404);
     }
 
-    // Refunded - cannot check in
-    if (entry.attendee.refunded) {
-      return jsonResponse({
-        name: attendeeName,
-        status: "refunded",
-      });
-    }
+    const stateResponse = checkAttendeeState(entry, attendeeName, idVerified);
+    if (stateResponse) return stateResponse;
 
-    // Already checked in
-    if (entry.attendee.checked_in) {
-      return jsonResponse({
-        name: attendeeName,
-        quantity: entry.attendee.quantity,
-        status: "already_checked_in",
-      });
-    }
-
-    // Non-transferable event - require ID verification before check-in
-    if (entry.event.non_transferable && !idVerified) {
-      return jsonResponse({
-        name: attendeeName,
-        quantity: entry.attendee.quantity,
-        status: "verify_id",
-      });
-    }
-
-    // Check them in for the specific event
-    await updateCheckedIn(entry.attendee.id, entry.event.id, true);
-    await logActivity(
-      `Attendee checked in via scanner for '${entry.event.name}'`,
-      entry.event.id,
-    );
-
-    return jsonResponse({
-      name: attendeeName,
-      quantity: entry.attendee.quantity,
-      status: "checked_in",
-    });
+    return performCheckIn(entry, attendeeName);
   });
 
 /** Pattern matching scan API paths (used by middleware for content-type validation) */

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -1144,25 +1144,38 @@ const handleAppleWalletPost = settingsHandler<AppleWalletFormData>({
     if (isAllCleared(d)) return null;
     if (!d.passTypeId) return "Pass Type ID is required";
     if (!d.teamId) return "Team ID is required";
-    if (!settings.appleWallet.hasDbConfig) {
-      if (d.cert.action !== "provided") {
-        return "Signing certificate is required";
-      }
-      if (d.key.action !== "provided") return "Signing private key is required";
-      if (d.wwdr.action !== "provided") return "WWDR certificate is required";
-    }
-    if (d.cert.action === "provided" && !isValidPemCertificate(d.cert.value)) {
-      return "Signing certificate is not a valid PEM certificate";
-    }
-    if (d.key.action === "provided" && !isValidPemPrivateKey(d.key.value)) {
-      return "Signing private key is not a valid PEM private key";
-    }
-    if (d.wwdr.action === "provided" && !isValidPemCertificate(d.wwdr.value)) {
-      return "WWDR certificate is not a valid PEM certificate";
-    }
-    return null;
+    const requiredError = validateAppleWalletRequiredSecrets(d);
+    if (requiredError) return requiredError;
+    return validateAppleWalletPemFields(d);
   },
 });
+
+/** Ensure required secrets are provided when no DB config exists */
+const validateAppleWalletRequiredSecrets = (
+  d: AppleWalletFormData,
+): string | null => {
+  if (settings.appleWallet.hasDbConfig) return null;
+  if (d.cert.action !== "provided") return "Signing certificate is required";
+  if (d.key.action !== "provided") return "Signing private key is required";
+  if (d.wwdr.action !== "provided") return "WWDR certificate is required";
+  return null;
+};
+
+/** Validate PEM structure of provided Apple Wallet secret fields */
+const validateAppleWalletPemFields = (
+  d: AppleWalletFormData,
+): string | null => {
+  if (d.cert.action === "provided" && !isValidPemCertificate(d.cert.value)) {
+    return "Signing certificate is not a valid PEM certificate";
+  }
+  if (d.key.action === "provided" && !isValidPemPrivateKey(d.key.value)) {
+    return "Signing private key is not a valid PEM private key";
+  }
+  if (d.wwdr.action === "provided" && !isValidPemCertificate(d.wwdr.value)) {
+    return "WWDR certificate is not a valid PEM certificate";
+  }
+  return null;
+};
 
 /**
  * Handle POST /admin/settings/google-wallet - owner only

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -1144,8 +1144,10 @@ const handleAppleWalletPost = settingsHandler<AppleWalletFormData>({
     if (isAllCleared(d)) return null;
     if (!d.passTypeId) return "Pass Type ID is required";
     if (!d.teamId) return "Team ID is required";
-    const requiredError = validateAppleWalletRequiredSecrets(d);
-    if (requiredError) return requiredError;
+    if (!settings.appleWallet.hasDbConfig) {
+      const requiredError = validateAppleWalletRequiredSecrets(d);
+      if (requiredError) return requiredError;
+    }
     return validateAppleWalletPemFields(d);
   },
 });
@@ -1154,7 +1156,6 @@ const handleAppleWalletPost = settingsHandler<AppleWalletFormData>({
 const validateAppleWalletRequiredSecrets = (
   d: AppleWalletFormData,
 ): string | null => {
-  if (settings.appleWallet.hasDbConfig) return null;
   if (d.cert.action !== "provided") return "Signing certificate is required";
   if (d.key.action !== "provided") return "Signing private key is required";
   if (d.wwdr.action !== "provided") return "WWDR certificate is required";

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -392,151 +392,193 @@ const logAndReturn = (
 };
 
 /**
- * Handle incoming requests with security headers and domain validation
+ * Buffer POST bodies BEFORE entering async context wrappers. The Bunny Edge
+ * runtime can garbage-collect the underlying request body resource during
+ * awaits, so we must capture it while the resource is still alive.
+ * This applies to webhook bodies (JSON) and multipart form uploads (file
+ * data backed by Blob resources that are especially prone to GC).
+ * Use normalizePath on the raw pathname so trailing-slash variants like
+ * /payment/webhook/ are correctly detected (the router normalizes later,
+ * but by then the body resource may already be garbage-collected).
  */
-export const handleRequest = async (
-  request: Request,
-  server?: ServerContext,
-): Promise<Response> => {
-  // Buffer POST bodies BEFORE entering async context wrappers. The Bunny Edge
-  // runtime can garbage-collect the underlying request body resource during
-  // awaits, so we must capture it while the resource is still alive.
-  // This applies to webhook bodies (JSON) and multipart form uploads (file
-  // data backed by Blob resources that are especially prone to GC).
-  // Use normalizePath on the raw pathname so trailing-slash variants like
-  // /payment/webhook/ are correctly detected (the router normalizes later,
-  // but by then the body resource may already be garbage-collected).
+const bufferRequestIfNeeded = async (request: Request): Promise<Request> => {
   const { pathname } = new URL(request.url);
   const contentType = request.headers.get("content-type") ?? "";
   const needsBodyBuffer =
     request.method === "POST" &&
     (isWebhookPath(normalizePath(pathname)) ||
       contentType.startsWith("multipart/form-data"));
-  const bufferedBody = needsBodyBuffer
-    ? new Uint8Array(await request.arrayBuffer())
-    : undefined;
-  const effectiveRequest = bufferedBody
-    ? new Request(request.url, {
-        body: bufferedBody,
-        headers: request.headers,
-        method: request.method,
-      })
-    : request;
+  if (!needsBodyBuffer) return request;
+  const bufferedBody = new Uint8Array(await request.arrayBuffer());
+  return new Request(request.url, {
+    body: bufferedBody,
+    headers: request.headers,
+    method: request.method,
+  });
+};
+
+/**
+ * If the GET URL contains tracking parameters (fbclid, utm_*, etc.), return a
+ * 301 redirect to a clean URL so the CDN can cache it.
+ */
+const trackingParamRedirect = (url: URL, method: string): Response | null => {
+  if (method !== "GET") return null;
+  const cleanUrl = getCleanUrl(url);
+  if (!cleanUrl) return null;
+  return new Response(null, {
+    headers: { location: cleanUrl },
+    status: 301,
+  });
+};
+
+/**
+ * Populate flash context from keyed cookie (flash ID in URL).
+ * Returns flashId when a flash was set so the caller can clear the cookie later.
+ */
+const applyFlashFromCookie = (request: Request): string | null => {
+  const flashId = new URL(request.url).searchParams.get("flash");
+  const flashRaw = flashId
+    ? parseCookies(request).get(`flash_${flashId}`)
+    : null;
+  const flash = flashRaw ? parseFlashValue(flashRaw) : null;
+  if (flash) setFlashContext(flash);
+  return flash ? flashId : null;
+};
+
+/**
+ * Run settings load, schedule pruning, resolve effective domain.
+ * These are per-request setup tasks that must happen before routing.
+ */
+const prepareRequestEnvironment = async (request: Request): Promise<void> => {
+  // Ensure settings cache is populated before reading custom domain.
+  // loadAll() is a no-op when the cache is still valid (60 s TTL).
+  await settings.loadAll();
+
+  // Schedule DB pruning as fire-and-forget pending work. Each
+  // prune task self-guards via its last_pruned_* timestamp, so
+  // this is near-free on most requests.
+  addPendingWork(maybeRunPrunes());
+
+  // Load effective domain (custom_domain from DB if set, else request hostname)
+  loadEffectiveDomain(request.url);
+};
+
+/** Route the request and attach security headers / flash cookie clearing */
+const routeAndFinalize = async (
+  request: Request,
+  path: string,
+  method: string,
+  server: ServerContext | undefined,
+): Promise<Response> => {
+  const embeddable = isEmbeddablePath(path);
+  const consumedFlashId = applyFlashFromCookie(request);
+
+  const response = await handleRequestInternal(request, path, method, server);
+
+  // Clear keyed flash cookie if one was consumed
+  if (consumedFlashId && hasFlash()) {
+    withCookie(response, clearFlashCookie(consumedFlashId));
+  }
+
+  return applySecurityHeaders(response, embeddable);
+};
+
+/**
+ * Convert a thrown error from the routing pipeline into a response, honoring
+ * the test rethrow flag and SessionKeyError special case.
+ */
+const handleRoutingError = (
+  error: unknown,
+  method: string,
+  path: string,
+): Response => {
+  logError({
+    code: ErrorCode.CDN_REQUEST,
+    detail: formatRequestError(method, path, error),
+  });
+  // In tests, surface the real error instead of swallowing it
+  // behind a generic "Temporary Error" page
+  if (
+    getRethrowErrors() &&
+    !(error instanceof SessionKeyError) &&
+    !Deno.env.get("TEST_EXPECT_ERROR")
+  ) {
+    throw error;
+  }
+  if (error instanceof SessionKeyError) {
+    return redirectResponse("/admin", clearSessionCookie());
+  }
+  return temporaryErrorResponse();
+};
+
+/**
+ * The core request pipeline that runs inside all async context wrappers.
+ * Performs parsing, early redirects, content-type validation, routing,
+ * error handling, and logging.
+ */
+const processRequest = async (
+  effectiveRequest: Request,
+  server: ServerContext | undefined,
+): Promise<Response> => {
+  const { url, path, method } = parseRequest(effectiveRequest);
+  const getElapsed = createRequestTimer();
+  detectIframeMode(effectiveRequest.url);
+  clearSavedFormData();
+
+  try {
+    const trackingRedirect = trackingParamRedirect(url, method);
+    if (trackingRedirect) {
+      return logAndReturn(trackingRedirect, method, path, getElapsed);
+    }
+
+    await prepareRequestEnvironment(effectiveRequest);
+
+    // Content-Type validation: reject POST requests without proper Content-Type
+    // (webhook endpoints accept JSON, all others require form-urlencoded)
+    if (!isValidContentType(effectiveRequest, path)) {
+      return logAndReturn(
+        contentTypeRejectionResponse(),
+        method,
+        path,
+        getElapsed,
+      );
+    }
+
+    try {
+      const response = await routeAndFinalize(
+        effectiveRequest,
+        path,
+        method,
+        server,
+      );
+      return logAndReturn(response, method, path, getElapsed);
+    } catch (error) {
+      return logAndReturn(
+        handleRoutingError(error, method, path),
+        method,
+        path,
+        getElapsed,
+      );
+    }
+  } finally {
+    await flushPendingWork();
+  }
+};
+
+/**
+ * Handle incoming requests with security headers and domain validation
+ */
+export const handleRequest = async (
+  request: Request,
+  server?: ServerContext,
+): Promise<Response> => {
+  const effectiveRequest = await bufferRequestIfNeeded(request);
 
   return runWithRequestId(() =>
     runWithRequestCache(() =>
       runWithQueryLogContext(() =>
         runWithFlashContext(() =>
-          runWithSessionContext(async () => {
-            const { url, path, method } = parseRequest(effectiveRequest);
-            const getElapsed = createRequestTimer();
-            detectIframeMode(effectiveRequest.url);
-            clearSavedFormData();
-
-            try {
-              // Strip tracking parameters (fbclid, utm_*, etc.) to avoid CDN caching issues
-              if (method === "GET") {
-                const cleanUrl = getCleanUrl(url);
-                if (cleanUrl) {
-                  return logAndReturn(
-                    new Response(null, {
-                      headers: { location: cleanUrl },
-                      status: 301,
-                    }),
-                    method,
-                    path,
-                    getElapsed,
-                  );
-                }
-              }
-
-              // Ensure settings cache is populated before reading custom domain.
-              // loadAll() is a no-op when the cache is still valid (60 s TTL).
-              await settings.loadAll();
-
-              // Schedule DB pruning as fire-and-forget pending work. Each
-              // prune task self-guards via its last_pruned_* timestamp, so
-              // this is near-free on most requests.
-              addPendingWork(maybeRunPrunes());
-
-              // Load effective domain (custom_domain from DB if set, else request hostname)
-              loadEffectiveDomain(effectiveRequest.url);
-
-              const embeddable = isEmbeddablePath(path);
-
-              // Content-Type validation: reject POST requests without proper Content-Type
-              // (webhook endpoints accept JSON, all others require form-urlencoded)
-              if (!isValidContentType(effectiveRequest, path)) {
-                return logAndReturn(
-                  contentTypeRejectionResponse(),
-                  method,
-                  path,
-                  getElapsed,
-                );
-              }
-
-              try {
-                // Populate flash context from keyed cookie (flash ID in URL)
-                const flashId = new URL(effectiveRequest.url).searchParams.get(
-                  "flash",
-                );
-                const flashRaw = flashId
-                  ? parseCookies(effectiveRequest).get(`flash_${flashId}`)
-                  : null;
-                const flash = flashRaw ? parseFlashValue(flashRaw) : null;
-                if (flash) setFlashContext(flash);
-
-                const response = await handleRequestInternal(
-                  effectiveRequest,
-                  path,
-                  method,
-                  server,
-                );
-
-                // Clear keyed flash cookie if one was consumed
-                if (flashId && flash && hasFlash()) {
-                  withCookie(response, clearFlashCookie(flashId));
-                }
-
-                return logAndReturn(
-                  await applySecurityHeaders(response, embeddable),
-                  method,
-                  path,
-                  getElapsed,
-                );
-              } catch (error) {
-                logError({
-                  code: ErrorCode.CDN_REQUEST,
-                  detail: formatRequestError(method, path, error),
-                });
-                // In tests, surface the real error instead of swallowing it
-                // behind a generic "Temporary Error" page
-                if (
-                  getRethrowErrors() &&
-                  !(error instanceof SessionKeyError) &&
-                  !Deno.env.get("TEST_EXPECT_ERROR")
-                ) {
-                  throw error;
-                }
-                if (error instanceof SessionKeyError) {
-                  return logAndReturn(
-                    redirectResponse("/admin", clearSessionCookie()),
-                    method,
-                    path,
-                    getElapsed,
-                  );
-                }
-                return logAndReturn(
-                  temporaryErrorResponse(),
-                  method,
-                  path,
-                  getElapsed,
-                );
-              }
-            } finally {
-              await flushPendingWork();
-            }
-          }),
+          runWithSessionContext(() => processRequest(effectiveRequest, server)),
         ),
       ),
     ),

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -165,16 +165,20 @@ const computeEventAnswerMap = (
       )
     : undefined;
 
+type PathParams = {
+  ctx: TicketCtx;
+  quantities: Map<number, number>;
+  date: string | null;
+  contact: ReturnType<typeof extractContact>;
+  info: AnswerInfo;
+};
+
 /** Handle the paid registration path */
 const handlePaidPath = async (
   request: Request,
-  ctx: TicketCtx,
-  quantities: Map<number, number>,
-  date: string | null,
-  contact: ReturnType<typeof extractContact>,
-  items: ReturnType<typeof buildRegistrationItems>,
-  info: AnswerInfo,
+  params: PathParams & { items: ReturnType<typeof buildRegistrationItems> },
 ): Promise<Response> => {
+  const { ctx, quantities, date, contact, items, info } = params;
   const available = await checkAvailability(ctx.events, quantities, date);
   if (!available) {
     return ticketFormErrorResponse(ctx)(
@@ -187,13 +191,8 @@ const handlePaidPath = async (
 };
 
 /** Handle the free registration path */
-const handleFreePath = async (
-  ctx: TicketCtx,
-  quantities: Map<number, number>,
-  date: string | null,
-  contact: ReturnType<typeof extractContact>,
-  info: AnswerInfo,
-): Promise<Response> => {
+const handleFreePath = async (params: PathParams): Promise<Response> => {
+  const { ctx, quantities, date, contact, info } = params;
   const result = await processFreeReservation(
     ctx.events,
     quantities,
@@ -278,9 +277,16 @@ const processSubmission = async (
   };
 
   if (await anyRequiresPayment(items)) {
-    return handlePaidPath(request, ctx, quantities, date, contact, items, info);
+    return handlePaidPath(request, {
+      contact,
+      ctx,
+      date,
+      info,
+      items,
+      quantities,
+    });
   }
-  return handleFreePath(ctx, quantities, date, contact, info);
+  return handleFreePath({ contact, ctx, date, info, quantities });
 };
 
 /** Handle POST for ticket registration */

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -7,6 +7,7 @@ import { signCsrfToken } from "#lib/csrf.ts";
 import { countAssignableSites } from "#lib/db/built-sites.ts";
 import { saveEventAnswers } from "#lib/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
+import type { FormParams } from "#lib/form-data.ts";
 import { isPaidEvent } from "#lib/types.ts";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import {
@@ -16,7 +17,10 @@ import {
   redirectResponse,
   withCsrfForm,
 } from "#routes/utils.ts";
-import { tryValidateTicketFields } from "#templates/fields.ts";
+import {
+  type TicketFormValues,
+  tryValidateTicketFields,
+} from "#templates/fields.ts";
 import type { TicketEvent } from "#templates/public.tsx";
 import {
   buildEventAnswerMap,
@@ -60,193 +64,233 @@ const totalSitesNeeded = (
   return total;
 };
 
+/** Validate fields, terms and event availability. Returns Response on error, or parsed field values. */
+const validateFormAndAvailability = (
+  form: FormParams,
+  ctx: TicketCtx,
+): Response | TicketFormValues => {
+  const errorResponse = ticketFormErrorResponse(ctx);
+  const anyPaid = ctx.events.some((e) => isPaidEvent(e.event));
+  const fieldResult = tryValidateTicketFields(
+    form,
+    getTicketFieldsSetting(ctx.events),
+    errorResponse,
+    anyPaid,
+  );
+  if (fieldResult instanceof Response) return fieldResult;
+
+  if (ctx.terms && form.get("agree_terms") !== "1") {
+    return errorResponse("You must agree to the terms and conditions");
+  }
+
+  const allUnavailable = ctx.events.every((e) => e.isSoldOut || e.isClosed);
+  if (allUnavailable) {
+    const allClosed = ctx.events.every((e) => e.isClosed);
+    return errorResponse(
+      allClosed
+        ? REGISTRATION_CLOSED_SUBMIT_MESSAGE
+        : "Sorry, not enough spots available",
+    );
+  }
+
+  for (const { event, isClosed } of ctx.events) {
+    const selectedQty = Number.parseInt(
+      form.get(`quantity_${event.id}`) || "0",
+      10,
+    );
+    if (isClosed && selectedQty > 0) {
+      return errorResponse(REGISTRATION_CLOSED_SUBMIT_MESSAGE);
+    }
+  }
+  return fieldResult;
+};
+
+/** Parse custom prices for pay-more events. Returns Response on validation error. */
+const parseCustomPrices = (
+  form: FormParams,
+  ctx: TicketCtx,
+  quantities: Map<number, number>,
+): Response | Map<number, number> => {
+  const errorResponse = ticketFormErrorResponse(ctx);
+  const customPrices = new Map<number, number>();
+  for (const { event } of ctx.events) {
+    if (!event.can_pay_more) continue;
+    const qty = quantities.get(event.id) ?? 0;
+    if (qty <= 0) continue;
+    const priceResult = parseCustomPrice(
+      form,
+      `custom_price_${event.id}`,
+      event.unit_price,
+      event.max_price,
+    );
+    if (!priceResult.ok) {
+      return errorResponse(`${event.name}: ${priceResult.error}`);
+    }
+    customPrices.set(event.id, priceResult.price);
+  }
+  return customPrices;
+};
+
+/** Verify built site availability when the builder feature is enabled */
+const checkBuiltSiteAvailability = async (
+  ctx: TicketCtx,
+  quantities: Map<number, number>,
+): Promise<Response | null> => {
+  const sitesNeeded = totalSitesNeeded(ctx.events, quantities);
+  if (sitesNeeded <= 0 || !isBuilderEnabled()) return null;
+  const availableSites = await countAssignableSites();
+  if (availableSites < sitesNeeded) {
+    return ticketFormErrorResponse(ctx)("Sorry, not enough sites available");
+  }
+  return null;
+};
+
+type AnswerInfo = {
+  activeQuestions: TicketCtx["questions"];
+  answerIds: number[];
+  selectedEventIds: Set<number>;
+};
+
+/** Compute event-answer map if answers exist */
+const computeEventAnswerMap = (
+  ctx: TicketCtx,
+  info: AnswerInfo,
+): Record<string, number[]> | undefined =>
+  info.answerIds.length > 0
+    ? buildEventAnswerMap(
+        info.activeQuestions,
+        info.answerIds,
+        ctx.questionEventMap,
+        info.selectedEventIds,
+      )
+    : undefined;
+
+/** Handle the paid registration path */
+const handlePaidPath = async (
+  request: Request,
+  ctx: TicketCtx,
+  quantities: Map<number, number>,
+  date: string | null,
+  contact: ReturnType<typeof extractContact>,
+  items: ReturnType<typeof buildRegistrationItems>,
+  info: AnswerInfo,
+): Promise<Response> => {
+  const available = await checkAvailability(ctx.events, quantities, date);
+  if (!available) {
+    return ticketFormErrorResponse(ctx)(
+      "Sorry, some tickets are no longer available",
+    );
+  }
+  const eventAnswerIds = computeEventAnswerMap(ctx, info);
+  const intent = { ...contact, date, eventAnswerIds, items };
+  return handlePaymentFlow(request, intent, ctx);
+};
+
+/** Handle the free registration path */
+const handleFreePath = async (
+  ctx: TicketCtx,
+  quantities: Map<number, number>,
+  date: string | null,
+  contact: ReturnType<typeof extractContact>,
+  info: AnswerInfo,
+): Promise<Response> => {
+  const result = await processFreeReservation(
+    ctx.events,
+    quantities,
+    contact,
+    date,
+  );
+  if (!result.success) return ticketFormErrorResponse(ctx)(result.error);
+
+  if (info.answerIds.length > 0) {
+    const eventAnswerMap = buildEventAnswerMap(
+      info.activeQuestions,
+      info.answerIds,
+      ctx.questionEventMap,
+      info.selectedEventIds,
+    );
+    await saveEventAnswers(result.entries, eventAnswerMap);
+  }
+
+  if (ctx.events.length === 1) {
+    const thankYouUrl = ctx.events[0]!.event.thank_you_url;
+    if (thankYouUrl) return redirectResponse(thankYouUrl);
+  }
+  const token = encodeURIComponent(result.token);
+  return redirectResponse(`/ticket/reserved?tokens=${token}`);
+};
+
+/** Process submitted form after CSRF and demo overrides. */
+const processSubmission = async (
+  request: Request,
+  ctx: TicketCtx,
+  form: FormParams,
+): Promise<Response> => {
+  const errorResponse = ticketFormErrorResponse(ctx);
+
+  const validated = validateFormAndAvailability(form, ctx);
+  if (validated instanceof Response) return validated;
+  const values = validated;
+
+  const quantities = parseQuantities(form, ctx.events);
+  const totalQuantity = reduce(
+    (sum: number, qty: number) => sum + qty,
+    0,
+  )(Array.from(quantities.values()));
+  if (totalQuantity === 0) {
+    return errorResponse("Please select at least one ticket");
+  }
+
+  const selectedEventIds = new Set(quantities.keys());
+  const activeQuestions = ctx.questions.filter((q) => {
+    const eventIds = ctx.questionEventMap.get(q.id);
+    return !eventIds || eventIds.some((eid) => selectedEventIds.has(eid));
+  });
+  const answersResult = parseQuestionAnswers(form, activeQuestions);
+  if (!answersResult.ok) {
+    return ticketFormErrorResponse(ctx)(answersResult.error);
+  }
+
+  const contact = extractContact(values);
+
+  let date: string | null = null;
+  if (ctx.dates.length > 0) {
+    date = validateSubmittedDate(form, ctx.dates);
+    if (!date) return errorResponse("Please select a valid date");
+  }
+
+  const customPricesResult = parseCustomPrices(form, ctx, quantities);
+  if (customPricesResult instanceof Response) return customPricesResult;
+
+  const items = buildRegistrationItems(
+    ctx.events,
+    quantities,
+    customPricesResult,
+  );
+
+  const siteCheckError = await checkBuiltSiteAvailability(ctx, quantities);
+  if (siteCheckError) return siteCheckError;
+
+  const info: AnswerInfo = {
+    activeQuestions,
+    answerIds: answersResult.answerIds,
+    selectedEventIds,
+  };
+
+  if (await anyRequiresPayment(items)) {
+    return handlePaidPath(request, ctx, quantities, date, contact, items, info);
+  }
+  return handleFreePath(ctx, quantities, date, contact, info);
+};
+
 /** Handle POST for ticket registration */
 const submitTicket = (request: Request, ctx: TicketCtx): Promise<Response> =>
   withCsrfForm(
     request,
     (message) => errorRedirect(`/ticket/${ctx.slugs.join("+")}`, message),
-    async (form) => {
-      const { dates, terms } = ctx;
-
+    (form) => {
       applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
-
-      // Validate fields based on merged event settings
-      const errorResponse = ticketFormErrorResponse(ctx);
-      const anyPaid = ctx.events.some((e) => isPaidEvent(e.event));
-      const fieldResult = tryValidateTicketFields(
-        form,
-        getTicketFieldsSetting(ctx.events),
-        errorResponse,
-        anyPaid,
-      );
-      if (fieldResult instanceof Response) return fieldResult;
-      const values = fieldResult;
-
-      // Validate terms and conditions acceptance if configured
-      if (terms && form.get("agree_terms") !== "1") {
-        return errorResponse("You must agree to the terms and conditions");
-      }
-
-      // Re-check registration status: events may have closed or sold out
-      // since the form was rendered
-      const allUnavailable = ctx.events.every((e) => e.isSoldOut || e.isClosed);
-      if (allUnavailable) {
-        const allClosed = ctx.events.every((e) => e.isClosed);
-        return ticketFormErrorResponse(ctx)(
-          allClosed
-            ? REGISTRATION_CLOSED_SUBMIT_MESSAGE
-            : "Sorry, not enough spots available",
-        );
-      }
-
-      // Check if any event the user selected is now closed
-      for (const { event, isClosed } of ctx.events) {
-        const selectedQty = Number.parseInt(
-          form.get(`quantity_${event.id}`) || "0",
-          10,
-        );
-        if (isClosed && selectedQty > 0) {
-          return ticketFormErrorResponse(ctx)(
-            REGISTRATION_CLOSED_SUBMIT_MESSAGE,
-          );
-        }
-      }
-
-      // Parse quantities
-      const quantities = parseQuantities(form, ctx.events);
-
-      // Check at least one ticket selected
-      const totalQuantity = reduce(
-        (sum: number, qty: number) => sum + qty,
-        0,
-      )(Array.from(quantities.values()));
-      if (totalQuantity === 0) {
-        return ticketFormErrorResponse(ctx)(
-          "Please select at least one ticket",
-        );
-      }
-
-      // Validate custom question answers (only for selected events)
-      const selectedEventIds = new Set(quantities.keys());
-      const activeQuestions = ctx.questions.filter((q) => {
-        const eventIds = ctx.questionEventMap.get(q.id);
-        return !eventIds || eventIds.some((eid) => selectedEventIds.has(eid));
-      });
-      const answersResult = parseQuestionAnswers(form, activeQuestions);
-      if (!answersResult.ok) {
-        return errorResponse(answersResult.error);
-      }
-
-      const contact = extractContact(values);
-
-      // For daily events, validate the submitted date
-      let date: string | null = null;
-      if (dates.length > 0) {
-        date = validateSubmittedDate(form, dates);
-        if (!date) {
-          return ticketFormErrorResponse(ctx)("Please select a valid date");
-        }
-      }
-
-      // Parse custom prices for pay-more events
-      const customPrices = new Map<number, number>();
-      for (const { event } of ctx.events) {
-        if (event.can_pay_more) {
-          const qty = quantities.get(event.id) ?? 0;
-          if (qty > 0) {
-            const priceResult = parseCustomPrice(
-              form,
-              `custom_price_${event.id}`,
-              event.unit_price,
-              event.max_price,
-            );
-            if (!priceResult.ok) {
-              return ticketFormErrorResponse(ctx)(
-                `${event.name}: ${priceResult.error}`,
-              );
-            }
-            customPrices.set(event.id, priceResult.price);
-          }
-        }
-      }
-
-      // Build registration items
-      const items = buildRegistrationItems(
-        ctx.events,
-        quantities,
-        customPrices,
-      );
-
-      // Check built site availability for assign_built_site events
-      // Only runs when the builder feature is enabled
-      const sitesNeeded = totalSitesNeeded(ctx.events, quantities);
-      if (sitesNeeded > 0 && isBuilderEnabled()) {
-        const availableSites = await countAssignableSites();
-        if (availableSites < sitesNeeded) {
-          return ticketFormErrorResponse(ctx)(
-            "Sorry, not enough sites available",
-          );
-        }
-      }
-
-      // Check if payment required
-      if (await anyRequiresPayment(items)) {
-        const available = await checkAvailability(ctx.events, quantities, date);
-        if (!available) {
-          return ticketFormErrorResponse(ctx)(
-            "Sorry, some tickets are no longer available",
-          );
-        }
-
-        const eventAnswerIds =
-          answersResult.answerIds.length > 0
-            ? buildEventAnswerMap(
-                activeQuestions,
-                answersResult.answerIds,
-                ctx.questionEventMap,
-                selectedEventIds,
-              )
-            : undefined;
-        const intent = {
-          ...contact,
-          date,
-          eventAnswerIds,
-          items,
-        };
-        return handlePaymentFlow(request, intent, ctx);
-      }
-
-      // Free registration
-      const result = await processFreeReservation(
-        ctx.events,
-        quantities,
-        contact,
-        date,
-      );
-
-      if (!result.success) {
-        return ticketFormErrorResponse(ctx)(result.error);
-      }
-
-      // Save per-event answers for each attendee
-      if (answersResult.answerIds.length > 0) {
-        const eventAnswerMap = buildEventAnswerMap(
-          activeQuestions,
-          answersResult.answerIds,
-          ctx.questionEventMap,
-          selectedEventIds,
-        );
-        await saveEventAnswers(result.entries, eventAnswerMap);
-      }
-
-      // For single-event bookings, respect the event's custom thank-you URL
-      if (ctx.events.length === 1) {
-        const thankYouUrl = ctx.events[0]!.event.thank_you_url;
-        if (thankYouUrl) return redirectResponse(thankYouUrl);
-      }
-
-      const token = encodeURIComponent(result.token);
-      return redirectResponse(`/ticket/reserved?tokens=${token}`);
+      return processSubmission(request, ctx, form);
     },
   );
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -745,43 +745,63 @@ const verifyCsrf = async (
   return authFailure(channel, "invalid-csrf");
 };
 
+/** Parse a form-encoded body with optional CSRF check */
+const parseCsrfForm = async (
+  request: Request,
+  skipCsrf: boolean,
+  channel: AuthChannel,
+): Promise<FormParams | Response> => {
+  const form = await parseFormData(request);
+  if (skipCsrf) return form;
+  const err = await verifyCsrf(form.getString("csrf_token"), channel);
+  return err ?? form;
+};
+
+/** Parse a multipart body with optional CSRF check */
+const parseCsrfMultipart = async (
+  request: Request,
+  skipCsrf: boolean,
+  channel: AuthChannel,
+): Promise<FormData | Response> => {
+  const fd = await request.formData();
+  if (skipCsrf) return fd;
+  const err = await verifyCsrf(
+    String(fd.get("csrf_token") ?? "").trim(),
+    channel,
+  );
+  return err ?? fd;
+};
+
+/** Parse a JSON body with optional CSRF check (via header) */
+const parseCsrfJson = async (
+  request: Request,
+  skipCsrf: boolean,
+  channel: AuthChannel,
+): Promise<Record<string, unknown> | Response> => {
+  if (!skipCsrf) {
+    const err = await verifyCsrf(
+      request.headers.get("x-csrf-token") ?? "",
+      channel,
+    );
+    if (err) return err;
+  }
+  return parseJsonBody(request);
+};
+
 /** Validate CSRF and parse body for the given mode */
-const parseCsrfBody = async (
+const parseCsrfBody = (
   request: Request,
   mode: BodyMode,
   skipCsrf: boolean,
 ): Promise<FormParams | FormData | Record<string, unknown> | Response> => {
   const channel = channelFor(mode);
   switch (mode) {
-    case "form": {
-      const form = await parseFormData(request);
-      if (!skipCsrf) {
-        const err = await verifyCsrf(form.getString("csrf_token"), channel);
-        if (err) return err;
-      }
-      return form;
-    }
-    case "multipart": {
-      const fd = await request.formData();
-      if (!skipCsrf) {
-        const err = await verifyCsrf(
-          String(fd.get("csrf_token") ?? "").trim(),
-          channel,
-        );
-        if (err) return err;
-      }
-      return fd;
-    }
-    case "json": {
-      if (!skipCsrf) {
-        const err = await verifyCsrf(
-          request.headers.get("x-csrf-token") ?? "",
-          channel,
-        );
-        if (err) return err;
-      }
-      return parseJsonBody(request);
-    }
+    case "form":
+      return parseCsrfForm(request, skipCsrf, channel);
+    case "multipart":
+      return parseCsrfMultipart(request, skipCsrf, channel);
+    case "json":
+      return parseCsrfJson(request, skipCsrf, channel);
   }
 };
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -745,64 +745,37 @@ const verifyCsrf = async (
   return authFailure(channel, "invalid-csrf");
 };
 
-/** Parse a form-encoded body with optional CSRF check */
-const parseCsrfForm = async (
-  request: Request,
-  skipCsrf: boolean,
-  channel: AuthChannel,
-): Promise<FormParams | Response> => {
-  const form = await parseFormData(request);
-  if (skipCsrf) return form;
-  const err = await verifyCsrf(form.getString("csrf_token"), channel);
-  return err ?? form;
-};
-
-/** Parse a multipart body with optional CSRF check */
-const parseCsrfMultipart = async (
-  request: Request,
-  skipCsrf: boolean,
-  channel: AuthChannel,
-): Promise<FormData | Response> => {
-  const fd = await request.formData();
-  if (skipCsrf) return fd;
-  const err = await verifyCsrf(
-    String(fd.get("csrf_token") ?? "").trim(),
-    channel,
-  );
-  return err ?? fd;
-};
-
-/** Parse a JSON body with optional CSRF check (via header) */
-const parseCsrfJson = async (
-  request: Request,
-  skipCsrf: boolean,
-  channel: AuthChannel,
-): Promise<Record<string, unknown> | Response> => {
-  if (!skipCsrf) {
-    const err = await verifyCsrf(
-      request.headers.get("x-csrf-token") ?? "",
-      channel,
-    );
-    if (err) return err;
-  }
-  return parseJsonBody(request);
-};
-
-/** Validate CSRF and parse body for the given mode */
-const parseCsrfBody = (
+/** Validate CSRF and parse body for the given mode.
+ *
+ * `skipCsrf` only applies to JSON bodies (used for API key auth). Form and
+ * multipart bodies are always CSRF-checked because API key clients use JSON. */
+const parseCsrfBody = async (
   request: Request,
   mode: BodyMode,
   skipCsrf: boolean,
 ): Promise<FormParams | FormData | Record<string, unknown> | Response> => {
   const channel = channelFor(mode);
-  switch (mode) {
-    case "form":
-      return parseCsrfForm(request, skipCsrf, channel);
-    case "multipart":
-      return parseCsrfMultipart(request, skipCsrf, channel);
-    case "json":
-      return parseCsrfJson(request, skipCsrf, channel);
+  if (mode === "json") {
+    if (!skipCsrf) {
+      const err = await verifyCsrf(
+        request.headers.get("x-csrf-token") ?? "",
+        channel,
+      );
+      if (err) return err;
+    }
+    return parseJsonBody(request);
   }
+  if (mode === "form") {
+    const form = await parseFormData(request);
+    const err = await verifyCsrf(form.getString("csrf_token"), channel);
+    return err ?? form;
+  }
+  const fd = await request.formData();
+  const err = await verifyCsrf(
+    String(fd.get("csrf_token") ?? "").trim(),
+    channel,
+  );
+  return err ?? fd;
 };
 
 /** Derive the auth channel (html vs json) from the body mode */

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -404,50 +404,38 @@ const priceMismatchRefund = async (
   return { detail, error: PRICE_CHANGED_MESSAGE, refunded, success: false };
 };
 
-/**
- * Core attendee creation logic shared between redirect and webhook handlers.
- * Handles all bookings uniformly — a single-item checkout is just an
- * items array with one entry.
- *
- * Uses two-phase locking to prevent duplicate attendee creation:
- * 1. Reserve session (claims the lock)
- * 2. Validate events and create attendees atomically (with rollback on failure)
- * 3. Finalize session (records attendee ID)
- */
-const processPaymentSession = async (
-  sessionId: string,
-  data: ValidatedSession,
-  options?: { storeTokens?: boolean },
-): Promise<PaymentResult> => {
-  const { session, intent } = data;
-  // Phase 1: Reserve the session (claim the lock)
-  const reservation = await reserveSession(sessionId);
+type ValidatedItem = {
+  item: BookingItem;
+  event: EventWithCount;
+  expectedPrice: number;
+};
 
-  if (!reservation.reserved) {
-    if (reservation.existing.attendee_id !== null) {
-      return alreadyProcessedResult(intent.items[0]!.e, {
-        ...reservation.existing,
-        attendee_id: reservation.existing.attendee_id,
-      });
-    }
-
-    // Session reserved but not finalized — another request is processing
-    return {
-      error: "Payment is being processed. Please wait a moment and refresh.",
-      status: 409,
-      success: false,
-    };
+/** Handle the "already reserved" branch of reserveSession */
+const handleReservationConflict = (
+  intent: BookingIntent,
+  existing: ProcessedPayment,
+): Promise<PaymentResult> | PaymentResult => {
+  if (existing.attendee_id !== null) {
+    return alreadyProcessedResult(intent.items[0]!.e, {
+      ...existing,
+      attendee_id: existing.attendee_id,
+    });
   }
+  // Session reserved but not finalized — another request is processing
+  return {
+    error: "Payment is being processed. Please wait a moment and refresh.",
+    status: 409,
+    success: false,
+  };
+};
 
-  // Phase 2: Validate events and create attendees atomically
+/** Validate all booking items and return per-item pricing info or a failure result. */
+const validateAllItems = async (
+  session: ValidatedPaymentSession,
+  intent: BookingIntent,
+): Promise<{ ok: true; items: ValidatedItem[] } | PaymentResult> => {
   const includeEventName = intent.items.length > 1;
-
-  const validatedItems: {
-    item: BookingItem;
-    event: EventWithCount;
-    expectedPrice: number;
-  }[] = [];
-
+  const validatedItems: ValidatedItem[] = [];
   for (const item of intent.items) {
     const vp = await validateAndPrice(
       { eventId: item.e, quantity: item.q },
@@ -460,41 +448,60 @@ const processPaymentSession = async (
       item,
     });
   }
+  return { items: validatedItems, ok: true };
+};
 
-  // Price validation — items always carry per-item prices (p field).
-  // Free events have p=0 and skip validation.
+/** Verify per-item and total prices for paid sessions. Returns null on success. */
+const verifyPaidPricing = async (
+  session: ValidatedPaymentSession,
+  intent: BookingIntent,
+  validatedItems: ValidatedItem[],
+): Promise<PaymentResult | null> => {
   const hasPaidItems = intent.items.some((item) => item.p > 0);
-  const bookingFeePercent = getBookingFee();
+  if (!hasPaidItems) return null;
 
-  if (hasPaidItems) {
-    // Per-item prices are ticket-only (no fee), so validate without booking fee
-    for (const { item, event, expectedPrice } of validatedItems) {
-      if (hasPriceMismatch(item.p, expectedPrice, event, 0, item.q)) {
-        return priceMismatchRefund(
-          session,
-          `Per-item price mismatch for event ${event.id}: metadata p=${item.p} but expected ${expectedPrice} (can_pay_more=${event.can_pay_more})`,
-          event.id,
-        );
-      }
-    }
-
-    // Total must equal sum of per-item prices + booking fee
-    const metadataTotal = validatedItems.reduce(
-      (sum, { item }) => sum + item.p,
-      0,
-    );
-    const expectedTotal =
-      metadataTotal + calculateBookingFee(metadataTotal, bookingFeePercent);
-    if (session.amountTotal !== expectedTotal) {
-      return priceMismatchRefund(
+  // Per-item prices are ticket-only (no fee), so validate without booking fee
+  for (const { item, event, expectedPrice } of validatedItems) {
+    if (hasPriceMismatch(item.p, expectedPrice, event, 0, item.q)) {
+      return await priceMismatchRefund(
         session,
-        `Total mismatch: provider charged ${session.amountTotal} but expected ${expectedTotal}`,
-        validatedItems[0]!.event.id,
+        `Per-item price mismatch for event ${event.id}: metadata p=${item.p} but expected ${expectedPrice} (can_pay_more=${event.can_pay_more})`,
+        event.id,
       );
     }
   }
 
-  // Create one attendee with all event bookings in a single atomic operation
+  // Total must equal sum of per-item prices + booking fee
+  const bookingFeePercent = getBookingFee();
+  const metadataTotal = validatedItems.reduce(
+    (sum, { item }) => sum + item.p,
+    0,
+  );
+  const expectedTotal =
+    metadataTotal + calculateBookingFee(metadataTotal, bookingFeePercent);
+  if (session.amountTotal !== expectedTotal) {
+    return await priceMismatchRefund(
+      session,
+      `Total mismatch: provider charged ${session.amountTotal} but expected ${expectedTotal}`,
+      validatedItems[0]!.event.id,
+    );
+  }
+  return null;
+};
+
+type CreatedAttendee = Extract<
+  Awaited<ReturnType<typeof createAttendeeAtomic>>,
+  { success: true }
+>["attendees"][number];
+
+type CreatedEntry = { attendee: CreatedAttendee; event: EventWithCount };
+
+/** Create the attendee plus per-event bookings atomically. */
+const createAttendeeForSession = async (
+  session: ValidatedPaymentSession,
+  intent: BookingIntent,
+  validatedItems: ValidatedItem[],
+): Promise<{ ok: true; entries: CreatedEntry[] } | PaymentResult> => {
   const bookings = validatedItems.map(({ item, event }) => ({
     date: event.event_type === "daily" ? intent.date : null,
     eventId: item.e,
@@ -526,12 +533,50 @@ const processPaymentSession = async (
     };
   }
   const created = result as Extract<typeof result, { success: true }>;
-
-  // Build entries: pair each attendee result with its event
-  const createdEntries = created.attendees.map((attendee, i) => ({
+  const entries = created.attendees.map((attendee, i) => ({
     attendee,
     event: validatedItems[i]!.event,
   }));
+  return { entries, ok: true };
+};
+
+/**
+ * Core attendee creation logic shared between redirect and webhook handlers.
+ * Handles all bookings uniformly — a single-item checkout is just an
+ * items array with one entry.
+ *
+ * Uses two-phase locking to prevent duplicate attendee creation:
+ * 1. Reserve session (claims the lock)
+ * 2. Validate events and create attendees atomically (with rollback on failure)
+ * 3. Finalize session (records attendee ID)
+ */
+const processPaymentSession = async (
+  sessionId: string,
+  data: ValidatedSession,
+  options?: { storeTokens?: boolean },
+): Promise<PaymentResult> => {
+  const { session, intent } = data;
+  // Phase 1: Reserve the session (claim the lock)
+  const reservation = await reserveSession(sessionId);
+  if (!reservation.reserved) {
+    return handleReservationConflict(intent, reservation.existing);
+  }
+
+  // Phase 2: Validate events and create attendees atomically
+  const validated = await validateAllItems(session, intent);
+  if ("success" in validated) return validated;
+  const validatedItems = validated.items;
+
+  const pricingError = await verifyPaidPricing(session, intent, validatedItems);
+  if (pricingError) return pricingError;
+
+  const created = await createAttendeeForSession(
+    session,
+    intent,
+    validatedItems,
+  );
+  if ("success" in created) return created;
+  const createdEntries = created.entries;
 
   if (intent.eventAnswerIds) {
     await saveEventAnswers(createdEntries, intent.eventAnswerIds);

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -63,7 +63,9 @@ export const adminBuiltSitesPage = (
                     </td>
                     <td>
                       <a href={`/admin/built-sites/${site.id}/edit`}>Edit</a>{" "}
-                      <a href={`/admin/built-sites/${site.id}/delete`}>Delete</a>
+                      <a href={`/admin/built-sites/${site.id}/delete`}>
+                        Delete
+                      </a>
                     </td>
                   </tr>
                 ))}

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -73,6 +73,364 @@ const StatusBadge = ({ ok }: { ok: boolean }): JSX.Element =>
     <span class="badge-missing">Not configured</span>
   );
 
+const BuildSection = ({
+  build,
+}: {
+  build: DebugPageState["build"];
+}): JSX.Element => (
+  <article>
+    <h2>Build</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>Timestamp</td>
+          <td>{build.timestamp || "—"}</td>
+        </tr>
+        <tr>
+          <td>Commit</td>
+          <td>{build.commit || "—"}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const AppleWalletSection = ({
+  appleWallet,
+}: {
+  appleWallet: DebugPageState["appleWallet"];
+}): JSX.Element => (
+  <article>
+    <h2>Apple Wallet</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>DB config</td>
+          <td>
+            <StatusBadge ok={appleWallet.dbConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Env var config</td>
+          <td>
+            <StatusBadge ok={appleWallet.envConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Active source</td>
+          <td>{appleWallet.source || "None"}</td>
+        </tr>
+        <tr>
+          <td>Pass Type ID</td>
+          <td>{appleWallet.passTypeId || "—"}</td>
+        </tr>
+        <tr>
+          <td>Signing certificate</td>
+          <td>{appleWallet.certValidation.signingCert}</td>
+        </tr>
+        <tr>
+          <td>Signing key</td>
+          <td>{appleWallet.certValidation.signingKey}</td>
+        </tr>
+        <tr>
+          <td>WWDR certificate</td>
+          <td>{appleWallet.certValidation.wwdrCert}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const GoogleWalletSection = ({
+  googleWallet,
+}: {
+  googleWallet: DebugPageState["googleWallet"];
+}): JSX.Element => (
+  <article>
+    <h2>Google Wallet</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>DB config</td>
+          <td>
+            <StatusBadge ok={googleWallet.dbConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Env var config</td>
+          <td>
+            <StatusBadge ok={googleWallet.envConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Active source</td>
+          <td>{googleWallet.source || "None"}</td>
+        </tr>
+        <tr>
+          <td>Issuer ID</td>
+          <td>{googleWallet.issuerId || "—"}</td>
+        </tr>
+        <tr>
+          <td>Private key</td>
+          <td>{googleWallet.privateKeyValid}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const PaymentsSection = ({
+  payment,
+}: {
+  payment: DebugPageState["payment"];
+}): JSX.Element => (
+  <article>
+    <h2>Payments</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>Provider</td>
+          <td>{payment.provider || "None"}</td>
+        </tr>
+        <tr>
+          <td>API key</td>
+          <td>
+            <StatusBadge ok={payment.keyConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Webhook</td>
+          <td>
+            <StatusBadge ok={payment.webhookConfigured} />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const EmailSection = ({
+  email,
+}: {
+  email: DebugPageState["email"];
+}): JSX.Element => (
+  <article>
+    <h2>Email</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>Provider (DB)</td>
+          <td>{email.provider || "None"}</td>
+        </tr>
+        <tr>
+          <td>API key</td>
+          <td>
+            <StatusBadge ok={email.apiKeyConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>From address</td>
+          <td>{email.fromAddress || "—"}</td>
+        </tr>
+        <tr>
+          <td>Host provider (env)</td>
+          <td>{email.hostProvider || "None"}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const NtfySection = ({
+  ntfy,
+}: {
+  ntfy: DebugPageState["ntfy"];
+}): JSX.Element => (
+  <article>
+    <h2>Notifications (ntfy)</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>NTFY URL</td>
+          <td>
+            <StatusBadge ok={ntfy.configured} />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const StorageBackendBadge = ({
+  backend,
+}: {
+  backend: DebugPageState["bunny"]["storageBackend"];
+}): JSX.Element => {
+  if (backend === "bunny") return <span class="badge-ok">Bunny CDN</span>;
+  if (backend === "local")
+    return <span class="badge-ok">Local filesystem</span>;
+  return <span class="badge-missing">Not configured</span>;
+};
+
+const BunnySection = ({
+  bunny,
+}: {
+  bunny: DebugPageState["bunny"];
+}): JSX.Element => (
+  <article>
+    <h2>Bunny</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>File storage (images)</td>
+          <td>
+            <StorageBackendBadge backend={bunny.storageBackend} />
+          </td>
+        </tr>
+        <tr>
+          <td>CDN management</td>
+          <td>
+            <StatusBadge ok={bunny.cdnEnabled} />
+          </td>
+        </tr>
+        <tr>
+          <td>CDN hostname</td>
+          <td>{bunny.cdnHostname || "—"}</td>
+        </tr>
+        <tr>
+          <td>Custom domain</td>
+          <td>{bunny.customDomain || "—"}</td>
+        </tr>
+        <tr>
+          <td>DNS subdomain</td>
+          <td>
+            <StatusBadge ok={bunny.dnsEnabled} />
+          </td>
+        </tr>
+        <tr>
+          <td>Subdomain suffix</td>
+          <td>{bunny.subdomainSuffix || "—"}</td>
+        </tr>
+        <tr>
+          <td>Registered subdomain</td>
+          <td>{bunny.registeredSubdomain || "—"}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const DatabaseDomainSection = ({
+  database,
+  domain,
+}: {
+  database: DebugPageState["database"];
+  domain: string;
+}): JSX.Element => (
+  <article>
+    <h2>Database &amp; Domain</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>DB_URL</td>
+          <td>
+            <StatusBadge ok={database.hostConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Effective domain</td>
+          <td>{domain}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const LimitValueCell = ({
+  limit,
+}: {
+  limit: DebugPageState["limits"][number];
+}): JSX.Element =>
+  limit.current === limit.defaultValue ? (
+    <span>{formatLimitValue(limit.current, limit.unit)}</span>
+  ) : (
+    <strong>{formatLimitValue(limit.current, limit.unit)} (overridden)</strong>
+  );
+
+const LimitsSection = ({
+  limits,
+}: {
+  limits: DebugPageState["limits"];
+}): JSX.Element => (
+  <article>
+    <h2>Limits</h2>
+    <p>
+      Override any limit with the corresponding environment variable. Values
+      must be positive integers.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Setting</th>
+          <th>Env var</th>
+          <th>Default</th>
+          <th>Current</th>
+        </tr>
+      </thead>
+      <tbody>
+        {limits.map((l) => (
+          <tr>
+            <td>{l.label}</td>
+            <td>
+              <code>{l.envKey}</code>
+            </td>
+            <td>{formatLimitValue(l.defaultValue, l.unit)}</td>
+            <td>
+              <LimitValueCell limit={l} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </article>
+);
+
+const PruneSection = ({
+  prune,
+}: {
+  prune: DebugPageState["prune"];
+}): JSX.Element => (
+  <article>
+    <h2>Database pruning</h2>
+    <p>
+      Automatic cleanup of short-lived rows. Runs in the background on incoming
+      requests; frequency controlled by <code>PRUNE_INTERVAL_HOURS</code>.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Table</th>
+          <th>Last pruned (UTC)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>processed_payments</td>
+          <td>{prune.payments}</td>
+        </tr>
+        <tr>
+          <td>sessions</td>
+          <td>{prune.sessions}</td>
+        </tr>
+        <tr>
+          <td>login_attempts</td>
+          <td>{prune.logins}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
 /**
  * Admin debug page
  */
@@ -91,291 +449,15 @@ export const adminDebugPage = (
         are shown.
       </p>
 
-      <article>
-        <h2>Build</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>Timestamp</td>
-              <td>{s.build.timestamp || "—"}</td>
-            </tr>
-            <tr>
-              <td>Commit</td>
-              <td>{s.build.commit || "—"}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Apple Wallet</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>DB config</td>
-              <td>
-                <StatusBadge ok={s.appleWallet.dbConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>Env var config</td>
-              <td>
-                <StatusBadge ok={s.appleWallet.envConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>Active source</td>
-              <td>{s.appleWallet.source || "None"}</td>
-            </tr>
-            <tr>
-              <td>Pass Type ID</td>
-              <td>{s.appleWallet.passTypeId || "—"}</td>
-            </tr>
-            <tr>
-              <td>Signing certificate</td>
-              <td>{s.appleWallet.certValidation.signingCert}</td>
-            </tr>
-            <tr>
-              <td>Signing key</td>
-              <td>{s.appleWallet.certValidation.signingKey}</td>
-            </tr>
-            <tr>
-              <td>WWDR certificate</td>
-              <td>{s.appleWallet.certValidation.wwdrCert}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Google Wallet</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>DB config</td>
-              <td>
-                <StatusBadge ok={s.googleWallet.dbConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>Env var config</td>
-              <td>
-                <StatusBadge ok={s.googleWallet.envConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>Active source</td>
-              <td>{s.googleWallet.source || "None"}</td>
-            </tr>
-            <tr>
-              <td>Issuer ID</td>
-              <td>{s.googleWallet.issuerId || "—"}</td>
-            </tr>
-            <tr>
-              <td>Private key</td>
-              <td>{s.googleWallet.privateKeyValid}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Payments</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>Provider</td>
-              <td>{s.payment.provider || "None"}</td>
-            </tr>
-            <tr>
-              <td>API key</td>
-              <td>
-                <StatusBadge ok={s.payment.keyConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>Webhook</td>
-              <td>
-                <StatusBadge ok={s.payment.webhookConfigured} />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Email</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>Provider (DB)</td>
-              <td>{s.email.provider || "None"}</td>
-            </tr>
-            <tr>
-              <td>API key</td>
-              <td>
-                <StatusBadge ok={s.email.apiKeyConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>From address</td>
-              <td>{s.email.fromAddress || "—"}</td>
-            </tr>
-            <tr>
-              <td>Host provider (env)</td>
-              <td>{s.email.hostProvider || "None"}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Notifications (ntfy)</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>NTFY URL</td>
-              <td>
-                <StatusBadge ok={s.ntfy.configured} />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Bunny</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>File storage (images)</td>
-              <td>
-                {s.bunny.storageBackend === "bunny" ? (
-                  <span class="badge-ok">Bunny CDN</span>
-                ) : s.bunny.storageBackend === "local" ? (
-                  <span class="badge-ok">Local filesystem</span>
-                ) : (
-                  <span class="badge-missing">Not configured</span>
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td>CDN management</td>
-              <td>
-                <StatusBadge ok={s.bunny.cdnEnabled} />
-              </td>
-            </tr>
-            <tr>
-              <td>CDN hostname</td>
-              <td>{s.bunny.cdnHostname || "—"}</td>
-            </tr>
-            <tr>
-              <td>Custom domain</td>
-              <td>{s.bunny.customDomain || "—"}</td>
-            </tr>
-            <tr>
-              <td>DNS subdomain</td>
-              <td>
-                <StatusBadge ok={s.bunny.dnsEnabled} />
-              </td>
-            </tr>
-            <tr>
-              <td>Subdomain suffix</td>
-              <td>{s.bunny.subdomainSuffix || "—"}</td>
-            </tr>
-            <tr>
-              <td>Registered subdomain</td>
-              <td>{s.bunny.registeredSubdomain || "—"}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Database &amp; Domain</h2>
-        <table>
-          <tbody>
-            <tr>
-              <td>DB_URL</td>
-              <td>
-                <StatusBadge ok={s.database.hostConfigured} />
-              </td>
-            </tr>
-            <tr>
-              <td>Effective domain</td>
-              <td>{s.domain}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Limits</h2>
-        <p>
-          Override any limit with the corresponding environment variable. Values
-          must be positive integers.
-        </p>
-        <table>
-          <thead>
-            <tr>
-              <th>Setting</th>
-              <th>Env var</th>
-              <th>Default</th>
-              <th>Current</th>
-            </tr>
-          </thead>
-          <tbody>
-            {s.limits.map((l) => (
-              <tr>
-                <td>{l.label}</td>
-                <td>
-                  <code>{l.envKey}</code>
-                </td>
-                <td>{formatLimitValue(l.defaultValue, l.unit)}</td>
-                <td>
-                  {l.current === l.defaultValue ? (
-                    <span>{formatLimitValue(l.current, l.unit)}</span>
-                  ) : (
-                    <strong>
-                      {formatLimitValue(l.current, l.unit)} (overridden)
-                    </strong>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </article>
-
-      <article>
-        <h2>Database pruning</h2>
-        <p>
-          Automatic cleanup of short-lived rows. Runs in the background on
-          incoming requests; frequency controlled by{" "}
-          <code>PRUNE_INTERVAL_HOURS</code>.
-        </p>
-        <table>
-          <thead>
-            <tr>
-              <th>Table</th>
-              <th>Last pruned (UTC)</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>processed_payments</td>
-              <td>{s.prune.payments}</td>
-            </tr>
-            <tr>
-              <td>sessions</td>
-              <td>{s.prune.sessions}</td>
-            </tr>
-            <tr>
-              <td>login_attempts</td>
-              <td>{s.prune.logins}</td>
-            </tr>
-          </tbody>
-        </table>
-      </article>
+      <BuildSection build={s.build} />
+      <AppleWalletSection appleWallet={s.appleWallet} />
+      <GoogleWalletSection googleWallet={s.googleWallet} />
+      <PaymentsSection payment={s.payment} />
+      <EmailSection email={s.email} />
+      <NtfySection ntfy={s.ntfy} />
+      <BunnySection bunny={s.bunny} />
+      <DatabaseDomainSection database={s.database} domain={s.domain} />
+      <LimitsSection limits={s.limits} />
+      <PruneSection prune={s.prune} />
     </Layout>,
   );

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -224,6 +224,519 @@ export type AdminEventPageOptions = {
   questionData?: TableQuestionData;
 };
 
+/** Top action nav for the event detail page */
+const EventActionNav = ({
+  event,
+  dateFilter,
+  hasPaidEvent,
+}: {
+  event: EventWithCount;
+  dateFilter: string | null;
+  hasPaidEvent: boolean;
+}): JSX.Element => {
+  const readOnly = isReadOnly();
+  return (
+    <nav>
+      <ul>
+        {!readOnly && (
+          <li>
+            <a href={`/admin/event/${event.id}/edit`}>Edit</a>
+          </li>
+        )}
+        {!readOnly && (
+          <li>
+            <a href={`/admin/event/${event.id}/duplicate`}>Duplicate</a>
+          </li>
+        )}
+        <li>
+          <a href={`/admin/event/${event.id}/log`}>Log</a>
+        </li>
+        {!event.purchase_only && (
+          <li>
+            <a href={`/admin/event/${event.id}/scanner`}>Scanner</a>
+          </li>
+        )}
+        <li>
+          <a href={`/admin/event/${event.id}/questions`}>Questions</a>
+        </li>
+        <li>
+          <a
+            href={`/admin/event/${event.id}/export${dateFilter ? `?date=${dateFilter}` : ""}`}
+          >
+            Export CSV
+          </a>
+        </li>
+        {hasPaidEvent && (
+          <li>
+            <a href={`/admin/event/${event.id}/refund-all`} class="danger">
+              Refund All
+            </a>
+          </li>
+        )}
+        {event.active ? (
+          <li>
+            <a href={`/admin/event/${event.id}/deactivate`} class="danger">
+              Deactivate
+            </a>
+          </li>
+        ) : (
+          <li>
+            <a href={`/admin/event/${event.id}/reactivate`}>Reactivate</a>
+          </li>
+        )}
+        <li>
+          <a href={`/admin/event/${event.id}/delete`} class="danger">
+            Delete
+          </a>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+/** Daily-specific schedule rows (bookable days, booking window) */
+const DailyScheduleRows = ({
+  event,
+}: {
+  event: EventWithCount;
+}): JSX.Element => (
+  <>
+    <tr>
+      <th>Bookable Days</th>
+      <td>{formatBookableDays(event.bookable_days)}</td>
+    </tr>
+    <tr>
+      <th>Booking Window</th>
+      <td>
+        {event.minimum_days_before} to{" "}
+        {event.maximum_days_after === 0
+          ? "unlimited"
+          : event.maximum_days_after}{" "}
+        days from today
+      </td>
+    </tr>
+  </>
+);
+
+/** Attendee count cell content (varies by daily/date-filter state) */
+const AttendeeCountDisplay = ({
+  event,
+  isDaily,
+  dateFilter,
+  adjustedCount,
+  completeQuantitySum,
+}: {
+  event: EventWithCount;
+  isDaily: boolean;
+  dateFilter: string | null;
+  adjustedCount: number;
+  completeQuantitySum: number;
+}): JSX.Element => {
+  if (isDaily && dateFilter) {
+    const overCap = completeQuantitySum >= event.max_attendees;
+    return (
+      <span class={overCap ? "danger-text" : ""}>
+        {completeQuantitySum} / {event.max_attendees} &mdash;{" "}
+        {event.max_attendees - completeQuantitySum} remain
+      </span>
+    );
+  }
+  const nearCap = adjustedCount >= event.max_attendees * 0.9;
+  return (
+    <span class={nearCap ? "danger-text" : ""}>
+      {adjustedCount}
+      {!isDaily && (
+        <>
+          {" "}
+          / {event.max_attendees} &mdash; {event.max_attendees - adjustedCount}{" "}
+          remain
+        </>
+      )}
+    </span>
+  );
+};
+
+/** Attendees row (header + count summary + daily capacity note) */
+const AttendeesSummaryRow = ({
+  event,
+  isDaily,
+  dateFilter,
+  dailySuffix,
+  adjustedCount,
+  completeQuantitySum,
+}: {
+  event: EventWithCount;
+  isDaily: boolean;
+  dateFilter: string | null;
+  dailySuffix: string;
+  adjustedCount: number;
+  completeQuantitySum: number;
+}): JSX.Element => (
+  <tr>
+    <th>Attendees{dailySuffix}</th>
+    <td>
+      <AttendeeCountDisplay
+        event={event}
+        isDaily={isDaily}
+        dateFilter={dateFilter}
+        adjustedCount={adjustedCount}
+        completeQuantitySum={completeQuantitySum}
+      />
+      {isDaily && !dateFilter && (
+        <>
+          {" "}
+          <small>Capacity of {event.max_attendees} applies per date</small>
+        </>
+      )}
+    </td>
+  </tr>
+);
+
+/** Event details table - all event metadata rows */
+const EventDetailsTable = ({
+  event,
+  allowedDomain,
+  ticketUrl,
+  embedScriptCode,
+  embedIframeCode,
+  isDaily,
+  dateFilter,
+  dailySuffix,
+  adjustedCount,
+  completeQuantitySum,
+  sharedRowsHtml,
+}: {
+  event: EventWithCount;
+  allowedDomain: string;
+  ticketUrl: string;
+  embedScriptCode: string;
+  embedIframeCode: string;
+  isDaily: boolean;
+  dateFilter: string | null;
+  dailySuffix: string;
+  adjustedCount: number;
+  completeQuantitySum: number;
+  sharedRowsHtml: string;
+}): JSX.Element => (
+  <article>
+    <div class="table-scroll">
+      <table class="event-details-table">
+        <tbody>
+          <tr>
+            <th colspan="2">{event.name}</th>
+          </tr>
+          {event.date && (
+            <tr>
+              <th>Event Date</th>
+              <td>
+                <span>
+                  <a href={`/admin/calendar?date=${event.date.slice(0, 10)}`}>
+                    {formatDatetimeLabel(event.date)}
+                  </a>{" "}
+                  <small>
+                    <em>({formatCountdown(event.date)})</em>
+                  </small>
+                </span>
+              </td>
+            </tr>
+          )}
+          {event.location && (
+            <tr>
+              <th>Location</th>
+              <td>{event.location}</td>
+            </tr>
+          )}
+          <tr>
+            <th>Event Type</th>
+            <td>{event.event_type === "daily" ? "Daily" : "Standard"}</td>
+          </tr>
+          {event.non_transferable && (
+            <tr>
+              <th>Non-Transferable</th>
+              <td>Yes &mdash; ID verification required at entry</td>
+            </tr>
+          )}
+          {event.hidden && (
+            <tr>
+              <th>Hidden</th>
+              <td>Yes &mdash; not shown in public events list</td>
+            </tr>
+          )}
+          {event.event_type === "daily" && <DailyScheduleRows event={event} />}
+          <tr>
+            <th>Registration Closes</th>
+            <td>
+              {event.closes_at ? (
+                <span>
+                  {formatDatetimeLabel(event.closes_at)}{" "}
+                  <small>
+                    <em>({formatCountdown(event.closes_at)})</em>
+                  </small>
+                </span>
+              ) : (
+                <em>No deadline</em>
+              )}
+            </td>
+          </tr>
+          <tr>
+            <th>Public URL</th>
+            <td>
+              <a href={ticketUrl}>{`${allowedDomain}/ticket/${event.slug}`}</a>
+              <small>
+                {" "}
+                (<a href={`/ticket/${event.slug}/qr`}>QR Code</a>)
+              </small>
+            </td>
+          </tr>
+          {event.thank_you_url && (
+            <tr>
+              <th>
+                <label for={`thank-you-url-${event.id}`}>Thank You URL</label>
+              </th>
+              <td>
+                <input
+                  type="text"
+                  id={`thank-you-url-${event.id}`}
+                  value={event.thank_you_url}
+                  readonly
+                  data-select-on-click
+                />
+              </td>
+            </tr>
+          )}
+          {event.webhook_url && (
+            <tr>
+              <th>
+                <label for={`webhook-url-${event.id}`}>Webhook URL</label>
+              </th>
+              <td>
+                <input
+                  type="text"
+                  id={`webhook-url-${event.id}`}
+                  value={event.webhook_url}
+                  readonly
+                  data-select-on-click
+                />
+              </td>
+            </tr>
+          )}
+          <tr>
+            <th>
+              <label for={`embed-script-${event.id}`}>Embed Script</label>
+            </th>
+            <td>
+              <input
+                type="text"
+                id={`embed-script-${event.id}`}
+                value={embedScriptCode}
+                readonly
+                data-select-on-click
+              />
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <label for={`embed-iframe-${event.id}`}>Embed Iframe</label>
+            </th>
+            <td>
+              <input
+                type="text"
+                id={`embed-iframe-${event.id}`}
+                value={embedIframeCode}
+                readonly
+                data-select-on-click
+              />
+            </td>
+          </tr>
+          <AttendeesSummaryRow
+            event={event}
+            isDaily={isDaily}
+            dateFilter={dateFilter}
+            dailySuffix={dailySuffix}
+            adjustedCount={adjustedCount}
+            completeQuantitySum={completeQuantitySum}
+          />
+          <Raw html={sharedRowsHtml} />
+        </tbody>
+      </table>
+    </div>
+  </article>
+);
+
+/** Attendees filter links (All / Checked In / Checked Out) */
+const AttendeesFilterLinks = ({
+  basePath,
+  dateQs,
+  activeFilter,
+}: {
+  basePath: string;
+  dateQs: string;
+  activeFilter: AttendeeFilter;
+}): JSX.Element => (
+  <p>
+    <Raw
+      html={FilterLink({
+        active: activeFilter === "all",
+        href: `${basePath}${dateQs}#attendees`,
+        label: "All",
+      })}
+    />
+    {" / "}
+    <Raw
+      html={FilterLink({
+        active: activeFilter === "in",
+        href: `${basePath}/in${dateQs}#attendees`,
+        label: "Checked In",
+      })}
+    />
+    {" / "}
+    <Raw
+      html={FilterLink({
+        active: activeFilter === "out",
+        href: `${basePath}/out${dateQs}#attendees`,
+        label: "Checked Out",
+      })}
+    />
+  </p>
+);
+
+/** Attendees article section (header, optional check-in flash, filters, table) */
+const AttendeesSection = ({
+  allowedDomain,
+  checkinMessage,
+  isDaily,
+  availableDates,
+  activeFilter,
+  dateFilter,
+  basePath,
+  dateQs,
+  returnUrl,
+  tableRows,
+  questionData,
+  phonePrefix,
+}: {
+  allowedDomain: string;
+  checkinMessage: CheckinMessage | undefined;
+  isDaily: boolean;
+  availableDates: DateOption[];
+  activeFilter: AttendeeFilter;
+  dateFilter: string | null;
+  basePath: string;
+  dateQs: string;
+  returnUrl: string;
+  tableRows: AttendeeTableRow[];
+  questionData: TableQuestionData | undefined;
+  phonePrefix: string | undefined;
+}): JSX.Element => {
+  const checkedInLabel = checkinMessage?.status === "in" ? "in" : "out";
+  const checkedInClass =
+    checkinMessage?.status === "in"
+      ? "checkin-message-in"
+      : "checkin-message-out";
+  return (
+    <article>
+      <h2 id="attendees">Attendees</h2>
+      {checkinMessage && (
+        <p id="message" class={checkedInClass}>
+          Checked {checkinMessage.name} {checkedInLabel}
+        </p>
+      )}
+      {isDaily && availableDates.length > 0 && (
+        <Raw
+          html={DateSelector({
+            activeFilter,
+            basePath,
+            dateFilter,
+            dates: availableDates,
+          })}
+        />
+      )}
+      <AttendeesFilterLinks
+        basePath={basePath}
+        dateQs={dateQs}
+        activeFilter={activeFilter}
+      />
+      <div class="table-scroll">
+        <Raw
+          html={AttendeeTable({
+            activeFilter,
+            allowedDomain,
+            phonePrefix,
+            questionData,
+            returnUrl,
+            rows: tableRows,
+            showDate: isDaily,
+            showEvent: false,
+          })}
+        />
+      </div>
+    </article>
+  );
+};
+
+/** Failed payments article (only rendered when there are incomplete attendees) */
+const FailedPaymentsSection = ({
+  attendees,
+  eventId,
+}: {
+  attendees: Attendee[];
+  eventId: number;
+}): JSX.Element => (
+  <article>
+    <h2 id="failed-payments">Failed Payments</h2>
+    <p>{attendees.length} attendee(s) with unresolved payments</p>
+    <div class="table-scroll">
+      <Raw html={FailedPaymentsTable({ attendees, eventId })} />
+    </div>
+  </article>
+);
+
+/** Add attendee form article (only rendered in writable mode) */
+const AddAttendeeSection = ({
+  event,
+}: {
+  event: EventWithCount;
+}): JSX.Element => (
+  <article>
+    <h2 id="add-attendee">Add Attendee</h2>
+    <CsrfForm action={`/admin/event/${event.id}/attendee`}>
+      <Raw
+        html={renderFields(
+          getAddAttendeeFields(event.fields, event.event_type === "daily"),
+        )}
+      />
+      <button type="submit">Add Attendee</button>
+    </CsrfForm>
+  </article>
+);
+
+/** Compute derived attendee stats needed by the detail page */
+const computeAttendeeStats = (
+  event: EventWithCount,
+  attendees: Attendee[],
+  hasPaidEvent: boolean,
+): {
+  incompleteAttendees: Attendee[];
+  completeAttendees: Attendee[];
+  adjustedCount: number;
+  completeQuantitySum: number;
+} => {
+  const incompleteAttendees = hasPaidEvent
+    ? filter((a: Attendee) => isIncompletePayment(a, true))(attendees)
+    : [];
+  const completeAttendees = hasPaidEvent
+    ? filter((a: Attendee) => !isIncompletePayment(a, true))(attendees)
+    : attendees;
+  const adjustedCount = event.attendee_count - sumQuantity(incompleteAttendees);
+  const completeQuantitySum = sumQuantity(completeAttendees);
+  return {
+    adjustedCount,
+    completeAttendees,
+    completeQuantitySum,
+    incompleteAttendees,
+  };
+};
+
 export const adminEventPage = ({
   event,
   attendees,
@@ -244,16 +757,12 @@ export const adminEventPage = ({
   const isDaily = event.event_type === "daily";
   const hasPaidEvent = isPaidEvent(event);
 
-  // Separate attendees with incomplete/failed payments from the main list
-  const incompleteAttendees = hasPaidEvent
-    ? filter((a: Attendee) => isIncompletePayment(a, true))(attendees)
-    : [];
-  const completeAttendees = hasPaidEvent
-    ? filter((a: Attendee) => !isIncompletePayment(a, true))(attendees)
-    : attendees;
-  const incompleteQuantitySum = sumQuantity(incompleteAttendees);
-  const adjustedCount = event.attendee_count - incompleteQuantitySum;
-  const completeQuantitySum = sumQuantity(completeAttendees);
+  const {
+    incompleteAttendees,
+    completeAttendees,
+    adjustedCount,
+    completeQuantitySum,
+  } = computeAttendeeStats(event, attendees, hasPaidEvent);
 
   const filteredAttendees = filterAttendees(completeAttendees, activeFilter);
   const dailySuffix = isDaily
@@ -284,374 +793,55 @@ export const adminEventPage = ({
     ),
   )(filteredAttendees);
 
-  const checkedInLabel = checkinMessage?.status === "in" ? "in" : "out";
-  const checkedInClass =
-    checkinMessage?.status === "in"
-      ? "checkin-message-in"
-      : "checkin-message-out";
-
   return String(
     <Layout title={`Event: ${event.name}`}>
       <AdminNav session={session} active="/admin/" />
-
-      <nav>
-        <ul>
-          {!isReadOnly() && (
-            <li>
-              <a href={`/admin/event/${event.id}/edit`}>Edit</a>
-            </li>
-          )}
-          {!isReadOnly() && (
-            <li>
-              <a href={`/admin/event/${event.id}/duplicate`}>Duplicate</a>
-            </li>
-          )}
-          <li>
-            <a href={`/admin/event/${event.id}/log`}>Log</a>
-          </li>
-          {!event.purchase_only && (
-            <li>
-              <a href={`/admin/event/${event.id}/scanner`}>Scanner</a>
-            </li>
-          )}
-          <li>
-            <a href={`/admin/event/${event.id}/questions`}>Questions</a>
-          </li>
-          <li>
-            <a
-              href={`/admin/event/${event.id}/export${dateFilter ? `?date=${dateFilter}` : ""}`}
-            >
-              Export CSV
-            </a>
-          </li>
-          {hasPaidEvent && (
-            <li>
-              <a href={`/admin/event/${event.id}/refund-all`} class="danger">
-                Refund All
-              </a>
-            </li>
-          )}
-          {event.active ? (
-            <li>
-              <a href={`/admin/event/${event.id}/deactivate`} class="danger">
-                Deactivate
-              </a>
-            </li>
-          ) : (
-            <li>
-              <a href={`/admin/event/${event.id}/reactivate`}>Reactivate</a>
-            </li>
-          )}
-          <li>
-            <a href={`/admin/event/${event.id}/delete`} class="danger">
-              Delete
-            </a>
-          </li>
-        </ul>
-      </nav>
-
+      <EventActionNav
+        event={event}
+        dateFilter={dateFilter}
+        hasPaidEvent={hasPaidEvent}
+      />
       <Flash success={successMessage} />
-
       {!event.active && (
         <div class="error" role="alert">
           This event is deactivated and cannot be booked
         </div>
       )}
-
       <Flash error={errorMessage} />
-
-      <article>
-        <div class="table-scroll">
-          <table class="event-details-table">
-            <tbody>
-              <tr>
-                <th colspan="2">{event.name}</th>
-              </tr>
-              {event.date && (
-                <tr>
-                  <th>Event Date</th>
-                  <td>
-                    <span>
-                      <a
-                        href={`/admin/calendar?date=${event.date.slice(0, 10)}`}
-                      >
-                        {formatDatetimeLabel(event.date)}
-                      </a>{" "}
-                      <small>
-                        <em>({formatCountdown(event.date)})</em>
-                      </small>
-                    </span>
-                  </td>
-                </tr>
-              )}
-              {event.location && (
-                <tr>
-                  <th>Location</th>
-                  <td>{event.location}</td>
-                </tr>
-              )}
-              <tr>
-                <th>Event Type</th>
-                <td>{event.event_type === "daily" ? "Daily" : "Standard"}</td>
-              </tr>
-              {event.non_transferable && (
-                <tr>
-                  <th>Non-Transferable</th>
-                  <td>Yes &mdash; ID verification required at entry</td>
-                </tr>
-              )}
-              {event.hidden && (
-                <tr>
-                  <th>Hidden</th>
-                  <td>Yes &mdash; not shown in public events list</td>
-                </tr>
-              )}
-              {event.event_type === "daily" && (
-                <tr>
-                  <th>Bookable Days</th>
-                  <td>{formatBookableDays(event.bookable_days)}</td>
-                </tr>
-              )}
-              {event.event_type === "daily" && (
-                <tr>
-                  <th>Booking Window</th>
-                  <td>
-                    {event.minimum_days_before} to{" "}
-                    {event.maximum_days_after === 0
-                      ? "unlimited"
-                      : event.maximum_days_after}{" "}
-                    days from today
-                  </td>
-                </tr>
-              )}
-              <tr>
-                <th>Registration Closes</th>
-                <td>
-                  {event.closes_at ? (
-                    <span>
-                      {formatDatetimeLabel(event.closes_at)}{" "}
-                      <small>
-                        <em>({formatCountdown(event.closes_at)})</em>
-                      </small>
-                    </span>
-                  ) : (
-                    <em>No deadline</em>
-                  )}
-                </td>
-              </tr>
-              <tr>
-                <th>Public URL</th>
-                <td>
-                  <a
-                    href={ticketUrl}
-                  >{`${allowedDomain}/ticket/${event.slug}`}</a>
-                  <small>
-                    {" "}
-                    (<a href={`/ticket/${event.slug}/qr`}>QR Code</a>)
-                  </small>
-                </td>
-              </tr>
-              {event.thank_you_url && (
-                <tr>
-                  <th>
-                    <label for={`thank-you-url-${event.id}`}>
-                      Thank You URL
-                    </label>
-                  </th>
-                  <td>
-                    <input
-                      type="text"
-                      id={`thank-you-url-${event.id}`}
-                      value={event.thank_you_url}
-                      readonly
-                      data-select-on-click
-                    />
-                  </td>
-                </tr>
-              )}
-              {event.webhook_url && (
-                <tr>
-                  <th>
-                    <label for={`webhook-url-${event.id}`}>Webhook URL</label>
-                  </th>
-                  <td>
-                    <input
-                      type="text"
-                      id={`webhook-url-${event.id}`}
-                      value={event.webhook_url}
-                      readonly
-                      data-select-on-click
-                    />
-                  </td>
-                </tr>
-              )}
-              <tr>
-                <th>
-                  <label for={`embed-script-${event.id}`}>Embed Script</label>
-                </th>
-                <td>
-                  <input
-                    type="text"
-                    id={`embed-script-${event.id}`}
-                    value={embedScriptCode}
-                    readonly
-                    data-select-on-click
-                  />
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <label for={`embed-iframe-${event.id}`}>Embed Iframe</label>
-                </th>
-                <td>
-                  <input
-                    type="text"
-                    id={`embed-iframe-${event.id}`}
-                    value={embedIframeCode}
-                    readonly
-                    data-select-on-click
-                  />
-                </td>
-              </tr>
-              <tr>
-                <th>Attendees{dailySuffix}</th>
-                <td>
-                  {isDaily && dateFilter ? (
-                    <span
-                      class={
-                        completeQuantitySum >= event.max_attendees
-                          ? "danger-text"
-                          : ""
-                      }
-                    >
-                      {completeQuantitySum} / {event.max_attendees} &mdash;{" "}
-                      {event.max_attendees - completeQuantitySum} remain
-                    </span>
-                  ) : (
-                    <span
-                      class={
-                        adjustedCount >= event.max_attendees * 0.9
-                          ? "danger-text"
-                          : ""
-                      }
-                    >
-                      {adjustedCount}
-                      {!isDaily && (
-                        <>
-                          {" "}
-                          / {event.max_attendees} &mdash;{" "}
-                          {event.max_attendees - adjustedCount} remain
-                        </>
-                      )}
-                    </span>
-                  )}
-                  {isDaily && !dateFilter && (
-                    <>
-                      {" "}
-                      <small>
-                        Capacity of {event.max_attendees} applies per date
-                      </small>
-                    </>
-                  )}
-                </td>
-              </tr>
-              <Raw html={renderDetailRows(sharedRows)} />
-            </tbody>
-          </table>
-        </div>
-      </article>
-
-      <article>
-        <h2 id="attendees">Attendees</h2>
-        {checkinMessage && (
-          <p id="message" class={checkedInClass}>
-            Checked {checkinMessage.name} {checkedInLabel}
-          </p>
-        )}
-        {isDaily && availableDates.length > 0 && (
-          <Raw
-            html={DateSelector({
-              activeFilter,
-              basePath,
-              dateFilter,
-              dates: availableDates,
-            })}
-          />
-        )}
-        <p>
-          <Raw
-            html={FilterLink({
-              active: activeFilter === "all",
-              href: `${basePath}${dateQs}#attendees`,
-              label: "All",
-            })}
-          />
-          {" / "}
-          <Raw
-            html={FilterLink({
-              active: activeFilter === "in",
-              href: `${basePath}/in${dateQs}#attendees`,
-              label: "Checked In",
-            })}
-          />
-          {" / "}
-          <Raw
-            html={FilterLink({
-              active: activeFilter === "out",
-              href: `${basePath}/out${dateQs}#attendees`,
-              label: "Checked Out",
-            })}
-          />
-        </p>
-        <div class="table-scroll">
-          <Raw
-            html={AttendeeTable({
-              activeFilter,
-              allowedDomain,
-              phonePrefix,
-              questionData,
-              returnUrl,
-              rows: tableRows,
-              showDate: isDaily,
-              showEvent: false,
-            })}
-          />
-        </div>
-      </article>
-
+      <EventDetailsTable
+        event={event}
+        allowedDomain={allowedDomain}
+        ticketUrl={ticketUrl}
+        embedScriptCode={embedScriptCode}
+        embedIframeCode={embedIframeCode}
+        isDaily={isDaily}
+        dateFilter={dateFilter}
+        dailySuffix={dailySuffix}
+        adjustedCount={adjustedCount}
+        completeQuantitySum={completeQuantitySum}
+        sharedRowsHtml={renderDetailRows(sharedRows)}
+      />
+      <AttendeesSection
+        allowedDomain={allowedDomain}
+        checkinMessage={checkinMessage}
+        isDaily={isDaily}
+        availableDates={availableDates}
+        activeFilter={activeFilter}
+        dateFilter={dateFilter}
+        basePath={basePath}
+        dateQs={dateQs}
+        returnUrl={returnUrl}
+        tableRows={tableRows}
+        questionData={questionData}
+        phonePrefix={phonePrefix}
+      />
       {incompleteAttendees.length > 0 && (
-        <article>
-          <h2 id="failed-payments">Failed Payments</h2>
-          <p>
-            {incompleteAttendees.length} attendee(s) with unresolved payments
-          </p>
-          <div class="table-scroll">
-            <Raw
-              html={FailedPaymentsTable({
-                attendees: incompleteAttendees,
-                eventId: event.id,
-              })}
-            />
-          </div>
-        </article>
+        <FailedPaymentsSection
+          attendees={incompleteAttendees}
+          eventId={event.id}
+        />
       )}
-
-      {!isReadOnly() && (
-        <article>
-          <h2 id="add-attendee">Add Attendee</h2>
-          <CsrfForm action={`/admin/event/${event.id}/attendee`}>
-            <Raw
-              html={renderFields(
-                getAddAttendeeFields(
-                  event.fields,
-                  event.event_type === "daily",
-                ),
-              )}
-            />
-            <button type="submit">Add Attendee</button>
-          </CsrfForm>
-        </article>
-      )}
+      {!isReadOnly() && <AddAttendeeSection event={event} />}
     </Layout>,
   );
 };

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -441,6 +441,103 @@ export type TicketPageOptions = {
   groupDescription?: string;
 };
 
+/** Unavailability message shown when all events are sold out or closed */
+const unavailableMessage = (
+  allClosed: boolean,
+  isSingleEvent: boolean,
+): string => {
+  if (isReadOnly() || allClosed) return "Registration closed.";
+  return isSingleEvent
+    ? "Sorry, this event is full."
+    : "Sorry, all events are sold out.";
+};
+
+/** Header block shown above the form with event/group details */
+const TicketPageHeader = ({
+  headerName,
+  headerDescription,
+  singleEvent,
+  pastDays,
+}: {
+  headerName: string;
+  headerDescription: string | null | undefined;
+  singleEvent: EventWithCount | null;
+  pastDays: number | null;
+}): JSX.Element => (
+  <>
+    {singleEvent && <Raw html={renderEventImage(singleEvent)} />}
+    <div class="prose">
+      <h1>{headerName}</h1>
+      {headerDescription && (
+        <div class="description">
+          <Raw html={renderMarkdown(headerDescription)} />
+        </div>
+      )}
+      {singleEvent?.date && (
+        <p>
+          <strong>Date:</strong> {formatDatetimeLabel(singleEvent.date)}
+          {pastDays !== null && (
+            <span class="badge-alert">
+              {" "}
+              {pastDays} {pastDays === 1 ? "day" : "days"} ago
+            </span>
+          )}
+        </p>
+      )}
+      {singleEvent?.location && (
+        <p>
+          <strong>Location:</strong> {singleEvent.location}
+        </p>
+      )}
+    </div>
+  </>
+);
+
+/** Form body with fields, date selector, event rows, questions, terms, and submit */
+const TicketPageForm = ({
+  slugs,
+  fields,
+  hasDaily,
+  dates,
+  eventRows,
+  hideQuantity,
+  isSingleEvent,
+  questions,
+  questionEventMap,
+  terms,
+}: {
+  slugs: string[];
+  fields: Field[];
+  hasDaily: boolean;
+  dates: string[] | undefined;
+  eventRows: string;
+  hideQuantity: boolean;
+  isSingleEvent: boolean;
+  questions: QuestionWithAnswers[] | undefined;
+  questionEventMap: QuestionEventMap | undefined;
+  terms: string | null | undefined;
+}): JSX.Element => (
+  <CsrfForm action={`/ticket/${slugs.join("+")}`}>
+    <Raw html={renderFields(fields)} />
+    {hasDaily && dates && <Raw html={renderDateSelector(dates)} />}
+
+    {hideQuantity || isSingleEvent ? (
+      <Raw html={eventRows} />
+    ) : (
+      <fieldset class="ticket-events">
+        <legend>Select Tickets</legend>
+        <Raw html={eventRows} />
+      </fieldset>
+    )}
+
+    {questions && questions.length > 0 && (
+      <Raw html={renderQuestions(questions, questionEventMap)} />
+    )}
+    {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
+    <button type="submit">Continue</button>
+  </CsrfForm>
+);
+
 /**
  * Ticket page - register for one or more events
  * Single events show rich details (image, description, date, location).
@@ -486,7 +583,6 @@ export const ticketPage = ({
   const title = headerName || "Reserve Tickets";
   const headExtra =
     singleEvent && baseUrl ? buildOgTags(singleEvent, baseUrl) : undefined;
-  const buttonText = "Continue";
 
   return String(
     <Layout
@@ -495,64 +591,32 @@ export const ticketPage = ({
       headExtra={headExtra}
     >
       {headerName && !inIframe && (
-        <>
-          {singleEvent && <Raw html={renderEventImage(singleEvent)} />}
-          <div class="prose">
-            <h1>{headerName}</h1>
-            {headerDescription && (
-              <div class="description">
-                <Raw html={renderMarkdown(headerDescription)} />
-              </div>
-            )}
-            {singleEvent?.date && (
-              <p>
-                <strong>Date:</strong> {formatDatetimeLabel(singleEvent.date)}
-                {pastDays !== null && (
-                  <span class="badge-alert">
-                    {" "}
-                    {pastDays} {pastDays === 1 ? "day" : "days"} ago
-                  </span>
-                )}
-              </p>
-            )}
-            {singleEvent?.location && (
-              <p>
-                <strong>Location:</strong> {singleEvent.location}
-              </p>
-            )}
-          </div>
-        </>
+        <TicketPageHeader
+          headerName={headerName}
+          headerDescription={headerDescription}
+          singleEvent={singleEvent}
+          pastDays={pastDays}
+        />
       )}
       <Flash error={error} />
 
       {allUnavailable || isReadOnly() ? (
         <div class="error" role="alert">
-          {isReadOnly() || allClosed
-            ? "Registration closed."
-            : isSingleEvent
-              ? "Sorry, this event is full."
-              : "Sorry, all events are sold out."}
+          {unavailableMessage(allClosed, isSingleEvent)}
         </div>
       ) : (
-        <CsrfForm action={`/ticket/${slugs.join("+")}`}>
-          <Raw html={renderFields(fields)} />
-          {hasDaily && dates && <Raw html={renderDateSelector(dates)} />}
-
-          {hideQuantity || isSingleEvent ? (
-            <Raw html={eventRows} />
-          ) : (
-            <fieldset class="ticket-events">
-              <legend>Select Tickets</legend>
-              <Raw html={eventRows} />
-            </fieldset>
-          )}
-
-          {questions && questions.length > 0 && (
-            <Raw html={renderQuestions(questions, questionEventMap)} />
-          )}
-          {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
-          <button type="submit">{buttonText}</button>
-        </CsrfForm>
+        <TicketPageForm
+          slugs={slugs}
+          fields={fields}
+          hasDaily={hasDaily}
+          dates={dates}
+          eventRows={eventRows}
+          hideQuantity={hideQuantity}
+          isSingleEvent={isSingleEvent}
+          questions={questions}
+          questionEventMap={questionEventMap}
+          terms={terms}
+        />
       )}
     </Layout>,
   );

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1106,6 +1106,53 @@ const authenticatedMultipartFormRequest = <T>(
     errorContext,
   );
 
+/** Format a boolean form field ("1" when truthy, "" otherwise) */
+const bool = (v: unknown): string => (v ? "1" : "");
+
+/** Format an optional numeric form field (stringified, or "" when nullish) */
+const optionalNumber = (v: number | null | undefined): string =>
+  v != null ? String(v) : "";
+
+/** Format an optional price field (major units string, or "" when nullish) */
+const optionalPrice = (v: number | null | undefined): string =>
+  v != null ? priceFormValue(v) : "";
+
+/** Build the form data body for creating an event */
+const buildCreateEventForm = (
+  input: Omit<EventInput, "slug" | "slugIndex">,
+): Record<string, string> => {
+  const closesAtParts = splitClosesAt(input.closesAt, null);
+  const dateParts = splitClosesAt(input.date, null);
+  return {
+    assign_built_site: bool(input.assignBuiltSite),
+    bookable_days: input.bookableDays
+      ? formatBookableDaysForForm(input.bookableDays)
+      : "",
+    can_pay_more: bool(input.canPayMore),
+    closes_at_date: closesAtParts.date,
+    closes_at_time: closesAtParts.time,
+    date_date: dateParts.date,
+    date_time: dateParts.time,
+    description: input.description ?? "",
+    event_type: input.eventType ?? "",
+    fields: input.fields ?? "email",
+    group_id: String(input.groupId ?? 0),
+    hidden: bool(input.hidden),
+    location: input.location ?? "",
+    max_attendees: String(input.maxAttendees),
+    max_price: priceFormValue(input.maxPrice),
+    max_quantity: String(input.maxQuantity ?? 1),
+    maximum_days_after: optionalNumber(input.maximumDaysAfter),
+    minimum_days_before: optionalNumber(input.minimumDaysBefore),
+    name: input.name,
+    non_transferable: bool(input.nonTransferable),
+    purchase_only: bool(input.purchaseOnly),
+    thank_you_url: input.thankYouUrl ?? "",
+    unit_price: optionalPrice(input.unitPrice),
+    webhook_url: input.webhookUrl ?? "",
+  };
+};
+
 /**
  * Create an event via the REST API
  * This is the preferred way to create test events as it exercises production code.
@@ -1115,43 +1162,9 @@ export const createTestEvent = (
   overrides: Partial<Omit<EventInput, "slug" | "slugIndex">> = {},
 ): Promise<Event> => {
   const input = testEventInput(overrides);
-
-  const closesAtParts = splitClosesAt(input.closesAt, null);
-  const dateParts = splitClosesAt(input.date, null);
-
   return authenticatedMultipartFormRequest(
     "/admin/event",
-    {
-      assign_built_site: input.assignBuiltSite ? "1" : "",
-      bookable_days: input.bookableDays
-        ? formatBookableDaysForForm(input.bookableDays)
-        : "",
-      can_pay_more: input.canPayMore ? "1" : "",
-      closes_at_date: closesAtParts.date,
-      closes_at_time: closesAtParts.time,
-      date_date: dateParts.date,
-      date_time: dateParts.time,
-      description: input.description ?? "",
-      event_type: input.eventType ?? "",
-      fields: input.fields ?? "email",
-      group_id: String(input.groupId ?? 0),
-      hidden: input.hidden ? "1" : "",
-      location: input.location ?? "",
-      max_attendees: String(input.maxAttendees),
-      max_price: priceFormValue(input.maxPrice),
-      max_quantity: String(input.maxQuantity ?? 1),
-      maximum_days_after:
-        input.maximumDaysAfter != null ? String(input.maximumDaysAfter) : "",
-      minimum_days_before:
-        input.minimumDaysBefore != null ? String(input.minimumDaysBefore) : "",
-      name: input.name,
-      non_transferable: input.nonTransferable ? "1" : "",
-      purchase_only: input.purchaseOnly ? "1" : "",
-      thank_you_url: input.thankYouUrl ?? "",
-      unit_price:
-        input.unitPrice != null ? priceFormValue(input.unitPrice) : "",
-      webhook_url: input.webhookUrl ?? "",
-    },
+    buildCreateEventForm(input),
     async () => {
       // Get the most recently created event (302 redirect guarantees creation succeeded)
       const { getAllEvents } = await import("#lib/db/events.ts");
@@ -1201,6 +1214,82 @@ const splitClosesAt = (
   return { date, time };
 };
 
+/** Pick a field from updates, falling back to an existing value */
+const pickField = <T>(update: T | undefined, existing: T): T =>
+  update !== undefined ? update : existing;
+
+/** Build boolean form fields for updating an event */
+const buildUpdateBoolFields = (
+  updates: Partial<EventInput>,
+  existing: EventWithCount,
+): Record<string, string> => ({
+  assign_built_site: bool(
+    pickField(updates.assignBuiltSite, existing.assign_built_site),
+  ),
+  can_pay_more: bool(pickField(updates.canPayMore, existing.can_pay_more)),
+  hidden: bool(pickField(updates.hidden, existing.hidden)),
+  non_transferable: bool(
+    pickField(updates.nonTransferable, existing.non_transferable),
+  ),
+  purchase_only: bool(pickField(updates.purchaseOnly, existing.purchase_only)),
+});
+
+/** Build numeric form fields for updating an event */
+const buildUpdateNumericFields = (
+  updates: Partial<EventInput>,
+  existing: EventWithCount,
+): Record<string, string> => ({
+  group_id: String(pickField(updates.groupId, existing.group_id)),
+  max_attendees: String(
+    pickField(updates.maxAttendees, existing.max_attendees),
+  ),
+  max_price: priceFormValue(pickField(updates.maxPrice, existing.max_price)),
+  max_quantity: String(pickField(updates.maxQuantity, existing.max_quantity)),
+  maximum_days_after: String(
+    pickField(updates.maximumDaysAfter, existing.maximum_days_after),
+  ),
+  minimum_days_before: String(
+    pickField(updates.minimumDaysBefore, existing.minimum_days_before),
+  ),
+  unit_price: formatPrice(updates.unitPrice, existing.unit_price),
+});
+
+/** Build string form fields for updating an event */
+const buildUpdateStringFields = (
+  updates: Partial<EventInput>,
+  existing: EventWithCount,
+): Record<string, string> => ({
+  bookable_days: formatBookableDaysForForm(
+    pickField(updates.bookableDays, existing.bookable_days),
+  ),
+  description: pickField(updates.description, existing.description),
+  event_type: pickField(updates.eventType, existing.event_type),
+  fields: pickField(updates.fields, existing.fields),
+  location: pickField(updates.location, existing.location),
+  name: pickField(updates.name, existing.name),
+  slug: pickField(updates.slug, existing.slug),
+  thank_you_url: formatOptional(updates.thankYouUrl, existing.thank_you_url),
+  webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
+});
+
+/** Build the form data body for updating an event, merging updates with existing values */
+const buildUpdateEventForm = (
+  updates: Partial<EventInput>,
+  existing: EventWithCount,
+): Record<string, string> => {
+  const closesAtParts = splitClosesAt(updates.closesAt, existing.closes_at);
+  const dateParts = splitClosesAt(updates.date, existing.date);
+  return {
+    ...buildUpdateBoolFields(updates, existing),
+    ...buildUpdateNumericFields(updates, existing),
+    ...buildUpdateStringFields(updates, existing),
+    closes_at_date: closesAtParts.date,
+    closes_at_time: closesAtParts.time,
+    date_date: dateParts.date,
+    date_time: dateParts.time,
+  };
+};
+
 /**
  * Update an event via the REST API
  */
@@ -1212,51 +1301,9 @@ export const updateTestEvent = async (
   if (!existing) {
     throw new Error(`Event not found: ${eventId}`);
   }
-
-  const closesAtParts = splitClosesAt(updates.closesAt, existing.closes_at);
-  const dateParts = splitClosesAt(updates.date, existing.date);
-
   return authenticatedMultipartFormRequest(
     `/admin/event/${eventId}/edit`,
-    {
-      assign_built_site:
-        (updates.assignBuiltSite ?? existing.assign_built_site) ? "1" : "",
-      bookable_days: updates.bookableDays
-        ? formatBookableDaysForForm(updates.bookableDays)
-        : formatBookableDaysForForm(existing.bookable_days),
-      can_pay_more: (updates.canPayMore ?? existing.can_pay_more) ? "1" : "",
-      closes_at_date: closesAtParts.date,
-      closes_at_time: closesAtParts.time,
-      date_date: dateParts.date,
-      date_time: dateParts.time,
-      description: updates.description ?? existing.description,
-      event_type: updates.eventType ?? existing.event_type,
-      fields: updates.fields ?? existing.fields,
-      group_id: String(updates.groupId ?? existing.group_id),
-      hidden: (updates.hidden ?? existing.hidden) ? "1" : "",
-      location: updates.location ?? existing.location,
-      max_attendees: String(updates.maxAttendees ?? existing.max_attendees),
-      max_price: priceFormValue(updates.maxPrice ?? existing.max_price),
-      max_quantity: String(updates.maxQuantity ?? existing.max_quantity),
-      maximum_days_after: String(
-        updates.maximumDaysAfter ?? existing.maximum_days_after,
-      ),
-      minimum_days_before: String(
-        updates.minimumDaysBefore ?? existing.minimum_days_before,
-      ),
-      name: updates.name ?? existing.name,
-      non_transferable:
-        (updates.nonTransferable ?? existing.non_transferable) ? "1" : "",
-      purchase_only:
-        (updates.purchaseOnly ?? existing.purchase_only) ? "1" : "",
-      slug: updates.slug ?? existing.slug,
-      thank_you_url: formatOptional(
-        updates.thankYouUrl,
-        existing.thank_you_url,
-      ),
-      unit_price: formatPrice(updates.unitPrice, existing.unit_price),
-      webhook_url: formatOptional(updates.webhookUrl, existing.webhook_url),
-    },
+    buildUpdateEventForm(updates, existing),
     async () => (await getEventWithCount(eventId)) as EventWithCount,
     "update event",
   );


### PR DESCRIPTION
## Summary

Biome's `noExcessiveCognitiveComplexity` rule (max 15) was flagging 21 functions across the codebase. This PR refactors each one by extracting cohesive helpers while preserving exact behavior and public signatures.

### Highlights

- **`src/routes/index.ts` `handleRequest`** (66 → <15): split request buffering, tracking-param redirect, flash handling, environment prep, routing, and error handling into named helpers.
- **`src/routes/public/ticket-submit.ts`** (64 → <15): decomposed into validation, availability checks, answer-map building, and paid/free submission paths.
- **`src/routes/admin/attendees.ts` `handleMergePost`** (51 → <15): separated input validation, diff rebuild, PII extraction, decision parsing, and merge application.
- **`src/templates/admin/events.tsx`** (42 → <15): pulled large JSX blocks into sub-components (`EventActionNav`, `EventDetailsTable`, `AttendeesSection`, etc).
- **`src/templates/admin/debug.tsx`** (17 → <15): split each config section into dedicated sub-components.

Smaller-scale helper extractions in: `forms.tsx`, `attendee-merge.ts`, `sort-events.ts`, `attendee-refunds.ts`, `groups.ts`, `scanner.ts`, `settings.ts`, `utils.ts`, `webhooks.ts`, `public.tsx`, `test-utils`, and `client/admin.ts`.

Also includes a formatting fix for `src/templates/admin/built-sites.tsx` (pre-existing, applied by biome).

### Verification

- `deno task biome:check`: zero complexity warnings remain
- `deno task lint`: passes
- `deno task typecheck`: passes
- Targeted tests pass for all refactored modules (forms, attendee-merge, sort-events, attendee-table, server-attendees, server-tickets, server-settings, webhook, routes, test-utils, events template, public template)

The pre-existing `noGlobalIsNan` errors and `useTemplate` warnings in `scripts/safe-upgrade.ts`, `src/lib/column-order.ts`, and `test/lib/payment-crypto.test.ts` are **not** complexity warnings and were intentionally left alone.

## Test plan

- [ ] Verify `deno task biome:check` reports no complexity warnings
- [ ] Verify `deno task typecheck` passes
- [ ] Verify `deno task test` passes (full suite — some local envs may OOM; run targeted suites instead)
- [ ] Spot-check high-traffic paths: ticket submission, webhooks (Stripe), admin attendee merge, event page rendering

https://claude.ai/code/session_01Wco4Vvcq3hSuHRkKntois9