### PR TITLE
Add groupSlug to public events API and expose GET /api/groups

### DIFF
--- a/src/lib/admin-api-example.ts
+++ b/src/lib/admin-api-example.ts
@@ -92,6 +92,20 @@ export const PUBLIC_API_ENDPOINTS: EndpointDoc[] = [
     response: json({ available: true }),
   },
   {
+    description: "List all non-hidden event groups",
+    method: "GET",
+    path: "/api/groups",
+    response: json({
+      groups: [
+        {
+          description: "Weekend workshop events",
+          name: "Workshops",
+          slug: "workshops",
+        },
+      ],
+    }),
+  },
+  {
     description: "Create a booking",
     method: "POST",
     path: "/api/events/:slug/book",

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -10,6 +10,7 @@ import { processBooking } from "#lib/booking.ts";
 import { getAvailableDates } from "#lib/dates.ts";
 import { hasAvailableSpots } from "#lib/db/attendees.ts";
 import { getAllEvents, getEventWithCountBySlug } from "#lib/db/events.ts";
+import { getAllGroups } from "#lib/db/groups.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { FormParams } from "#lib/form-data.ts";
 import { sortEvents } from "#lib/sort-events.ts";
@@ -64,6 +65,7 @@ export type PublicEvent = {
   nonTransferable: boolean;
   purchaseOnly: boolean;
   fields: string;
+  groupSlug: string | null;
   eventType: string;
   isSoldOut: boolean;
   isClosed: boolean;
@@ -71,11 +73,18 @@ export type PublicEvent = {
   availableDates?: string[];
 };
 
+export type PublicGroup = {
+  description: string;
+  name: string;
+  slug: string;
+};
+
 /** Serialize an event to the public API shape (same data the web UI renders) */
 export const toPublicEvent = (
   event: EventWithCount,
   closed = false,
   availableDates?: string[],
+  groupSlug: string | null = null,
 ): PublicEvent => {
   const spotsRemaining = event.max_attendees - event.attendee_count;
   const isSoldOut = spotsRemaining <= 0;
@@ -88,6 +97,7 @@ export const toPublicEvent = (
     description: event.description,
     eventType: event.event_type,
     fields: event.fields,
+    groupSlug,
     imageUrl: event.image_url || null,
     isClosed: closed,
     isSoldOut,
@@ -147,12 +157,23 @@ const withActiveEvent =
 
 /** GET /api/events — list active, non-hidden events */
 const handleListEvents = async (): Promise<Response> => {
-  const allEvents = await getAllEvents();
-  const holidays = await getActiveHolidays();
+  const [allEvents, allGroups, holidays] = await Promise.all([
+    getAllEvents(),
+    getAllGroups(),
+    getActiveHolidays(),
+  ]);
+  const groupSlugById = new Map(allGroups.map((g) => [g.id, g.slug]));
   const events = pipe(
     filter((e: EventWithCount) => e.active && !e.hidden),
     (active: EventWithCount[]) => sortEvents(active, holidays),
-    map((e: EventWithCount) => toPublicEvent(e, isRegistrationClosed(e))),
+    map((e: EventWithCount) =>
+      toPublicEvent(
+        e,
+        isRegistrationClosed(e),
+        undefined,
+        groupSlugById.get(e.group_id) ?? null,
+      ),
+    ),
   )(allEvents);
   return apiResponse({ events });
 };
@@ -160,11 +181,16 @@ const handleListEvents = async (): Promise<Response> => {
 /** GET /api/events/:slug — single event detail */
 const handleGetEvent = withActiveEvent(async (_request, event) => {
   const closed = isRegistrationClosed(event);
+  const allGroups = await getAllGroups();
+  const group = allGroups.find((g) => g.id === event.group_id);
+  const groupSlug = group?.slug ?? null;
   let availableDates: string[] | undefined;
   if (event.event_type === "daily") {
     availableDates = getAvailableDates(event, await getActiveHolidays());
   }
-  return apiResponse({ event: toPublicEvent(event, closed, availableDates) });
+  return apiResponse({
+    event: toPublicEvent(event, closed, availableDates, groupSlug),
+  });
 });
 
 /** GET /api/events/:slug/availability — check if spots are available */
@@ -279,6 +305,19 @@ const handleBook = withActiveEvent(async (request, event) => {
   );
 });
 
+/** GET /api/groups — list non-hidden event groups */
+const handleListGroups = async (): Promise<Response> => {
+  const allGroups = await getAllGroups();
+  const groups: PublicGroup[] = allGroups
+    .filter((g) => !g.hidden)
+    .map((g) => ({
+      description: g.description,
+      name: g.name,
+      slug: g.slug,
+    }));
+  return apiResponse({ groups });
+};
+
 // =============================================================================
 // Route definitions
 // =============================================================================
@@ -287,10 +326,12 @@ export const apiRoutes = defineRoutes({
   "GET /api/events": handleListEvents,
   "GET /api/events/:slug": handleGetEvent,
   "GET /api/events/:slug/availability": handleCheckAvailability,
+  "GET /api/groups": handleListGroups,
   "OPTIONS /api/events": handleOptions,
   "OPTIONS /api/events/:slug": handleOptions,
   "OPTIONS /api/events/:slug/availability": handleOptions,
   "OPTIONS /api/events/:slug/book": handleOptions,
+  "OPTIONS /api/groups": handleOptions,
   "POST /api/events/:slug/book": handleBook,
 });
 

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -8,6 +8,7 @@ import {
   createDailyTestEvent,
   createTestAttendeeDirect,
   createTestEvent,
+  createTestGroup,
   deactivateTestEvent,
   describeWithEnv,
   setupStripe,
@@ -186,6 +187,18 @@ describeWithEnv("Public API", { db: true }, () => {
       expect(event.isSoldOut).toBe(false);
       expect(event.isClosed).toBe(false);
       expect(typeof event.maxPurchasable).toBe("number");
+      // groupSlug is null for ungrouped events
+      expect(event.groupSlug).toBeNull();
+    });
+
+    test("includes groupSlug matching the event's group", async () => {
+      const group = await createTestGroup({
+        name: "Workshops",
+        slug: "workshops",
+      });
+      await createTestEvent({ groupId: group.id, name: "Workshop Event" });
+      const { events } = await fetchEventsList();
+      expect(events[0]!.groupSlug).toBe("workshops");
     });
 
     test("sets isSoldOut when event is at capacity", async () => {
@@ -208,7 +221,17 @@ describeWithEnv("Public API", { db: true }, () => {
       const apiEvent = body.event as Record<string, unknown>;
       expect(apiEvent.name).toBe("My Event");
       expect(apiEvent.description).toBe("Hello");
+      expect(apiEvent.groupSlug).toBeNull();
       expectCorsHeaders(response);
+    });
+
+    test("includes groupSlug for event with a group", async () => {
+      const group = await createTestGroup({ slug: "concerts" });
+      const event = await createTestEvent({ groupId: group.id });
+      const { body } = await fetchEventBySlug(event.slug);
+      expect((body.event as Record<string, unknown>).groupSlug).toBe(
+        "concerts",
+      );
     });
 
     test("returns 404 for non-existent event", async () => {
@@ -644,6 +667,58 @@ describeWithEnv("Public API", { db: true }, () => {
     });
   });
 
+  describe("GET /api/groups", () => {
+    /** Fetch the groups list and return parsed groups array */
+    const fetchGroupsList = async (): Promise<{
+      response: Response;
+      groups: Record<string, unknown>[];
+    }> => {
+      const response = await handleRequest(apiRequest("/api/groups"));
+      const body = (await response.json()) as Record<string, unknown>;
+      return { groups: body.groups as Record<string, unknown>[], response };
+    };
+
+    test("returns empty array when no groups exist", async () => {
+      const { response, groups } = await fetchGroupsList();
+      expect(response.status).toBe(200);
+      expect(groups).toEqual([]);
+      expectCorsHeaders(response);
+    });
+
+    test("returns non-hidden groups with name, slug, and description", async () => {
+      await createTestGroup({
+        description: "Weekend events",
+        name: "Workshops",
+        slug: "workshops",
+      });
+      const { response, groups } = await fetchGroupsList();
+      expect(response.status).toBe(200);
+      expect(groups.length).toBe(1);
+      expect(groups[0]!.name).toBe("Workshops");
+      expect(groups[0]!.slug).toBe("workshops");
+      expect(groups[0]!.description).toBe("Weekend events");
+    });
+
+    test("excludes hidden groups", async () => {
+      await createTestGroup({ hidden: false, name: "Visible Group" });
+      await createTestGroup({ hidden: true, name: "Hidden Group" });
+      const { groups } = await fetchGroupsList();
+      expect(groups.length).toBe(1);
+      expect(groups[0]!.name).toBe("Visible Group");
+    });
+
+    test("does not expose internal fields", async () => {
+      await createTestGroup({ name: "Test Group" });
+      const { groups } = await fetchGroupsList();
+      const group = groups[0]!;
+      expect(group.id).toBeUndefined();
+      expect(group.slug_index).toBeUndefined();
+      expect(group.hidden).toBeUndefined();
+      expect(group.max_attendees).toBeUndefined();
+      expect(group.terms_and_conditions).toBeUndefined();
+    });
+  });
+
   describe("OPTIONS /api/*", () => {
     test("returns 204 with CORS headers for events", async () => {
       const response = await handleRequest(
@@ -678,6 +753,14 @@ describeWithEnv("Public API", { db: true }, () => {
     test("returns 204 for book path", async () => {
       const response = await handleRequest(
         apiRequest("/api/events/test-slug/book", { method: "OPTIONS" }),
+      );
+      expect(response.status).toBe(204);
+      expectCorsHeaders(response);
+    });
+
+    test("returns 204 for groups path", async () => {
+      const response = await handleRequest(
+        apiRequest("/api/groups", { method: "OPTIONS" }),
       );
       expect(response.status).toBe(204);
       expectCorsHeaders(response);


### PR DESCRIPTION
## Summary

- Adds `groupSlug: string | null` to every event in `GET /api/events` and `GET /api/events/:slug` responses — `null` for ungrouped events, the group's slug otherwise
- Adds a new `GET /api/groups` endpoint listing all non-hidden groups with `name`, `slug`, and `description`
- Adds `OPTIONS /api/groups` for CORS preflight support

This enables chobble-template importers to create `categories/*.md` pages with `items` blocks filtered by `groupSlug`, listing the events (products) that belong to each group (category).

Example category page frontmatter an importer can now generate:

```yaml
blocks:
  - type: items
    collection: events
    filter:
      property: data.groupSlug
      equals: workshops
```

## Test plan

- [x] `GET /api/events` events include `groupSlug: null` for ungrouped events
- [x] `GET /api/events` events include correct `groupSlug` for events in a group
- [x] `GET /api/events/:slug` includes `groupSlug: null` for ungrouped events
- [x] `GET /api/events/:slug` includes correct `groupSlug` for grouped events
- [x] `GET /api/groups` returns empty array when no groups
- [x] `GET /api/groups` returns non-hidden groups with name, slug, description
- [x] `GET /api/groups` excludes hidden groups
- [x] `GET /api/groups` does not expose internal fields (id, slug_index, etc.)
- [x] `OPTIONS /api/groups` returns 204 with CORS headers
- [x] All documented API endpoint shape tests pass
- [x] `group_id` remains absent from public event responses

https://claude.ai/code/session_01UN3VAifQjwVBDUTjiJEnvT