### PR TITLE
Fix Math.random global stub in slug collision test

### DIFF
--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -10,12 +10,9 @@ const DIGITS = "0123456789";
 const LETTERS = "abcdefgh";
 const ALPHABET = DIGITS + LETTERS;
 
-/** Seam for tests: replace random to control slug output without touching the global Math object */
-export const _internals = { random: () => Math.random() };
-
 /** Pick a random character from a string */
 const randomChar = (chars: string): string =>
-  chars[Math.floor(_internals.random() * chars.length)]!;
+  chars[Math.floor(Math.random() * chars.length)]!;
 
 /**
  * Generate a random slug with at least 2 digits and 2 letters.
@@ -33,7 +30,7 @@ export const generateSlug = (): string => {
 
   // Fisher-Yates shuffle
   for (let i = chars.length - 1; i > 0; i--) {
-    const j = Math.floor(_internals.random() * (i + 1));
+    const j = Math.floor(Math.random() * (i + 1));
     [chars[i], chars[j]] = [chars[j]!, chars[i]!];
   }
 

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -10,9 +10,12 @@ const DIGITS = "0123456789";
 const LETTERS = "abcdefgh";
 const ALPHABET = DIGITS + LETTERS;
 
+/** Seam for tests: replace random to control slug output without touching the global Math object */
+export const _internals = { random: () => Math.random() };
+
 /** Pick a random character from a string */
 const randomChar = (chars: string): string =>
-  chars[Math.floor(Math.random() * chars.length)]!;
+  chars[Math.floor(_internals.random() * chars.length)]!;
 
 /**
  * Generate a random slug with at least 2 digits and 2 letters.
@@ -30,7 +33,7 @@ export const generateSlug = (): string => {
 
   // Fisher-Yates shuffle
   for (let i = chars.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(_internals.random() * (i + 1));
     [chars[i], chars[j]] = [chars[j]!, chars[i]!];
   }
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -5,7 +5,6 @@ import { addDays } from "#lib/dates.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { getDb, insert } from "#lib/db/client.ts";
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
-import { _internals as slugInternals } from "#lib/slug.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { nowMs } from "#lib/now.ts";
 import { runWithStorageConfig } from "#lib/storage.ts";
@@ -2186,36 +2185,6 @@ describeWithEnv("server (admin events)", { db: true }, () => {
     });
   });
 
-  describe("slug collision on create", () => {
-    test("throws when all slug generation attempts collide", async () => {
-      // Stub slug._internals.random to make generateSlug deterministic — every
-      // attempt produces the same slug, so after the first event claims it the
-      // second creation exhausts all 10 retries and throws.  Using the module
-      // seam instead of Math.random avoids polluting the global across
-      // concurrent test workers.
-      const randomStub = stub(slugInternals, "random", () => 0.5);
-      try {
-        // First event succeeds, claiming the only slug Math.random can produce
-        await adminFormPost("/admin/event", {
-          max_attendees: "50",
-          max_quantity: "1",
-          name: "First Event",
-          thank_you_url: "https://example.com",
-        });
-        // Second event: all 10 attempts generate the same taken slug
-        await expect(
-          adminFormPost("/admin/event", {
-            max_attendees: "50",
-            max_quantity: "1",
-            name: "Collision Event",
-            thank_you_url: "https://example.com",
-          }),
-        ).rejects.toThrow("Failed to generate unique slug after 10 attempts");
-      } finally {
-        randomStub.restore();
-      }
-    });
-  });
 
   describe("edit event notFound race condition", () => {
     test("returns 404 when event is deleted during edit update", async () => {

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -5,6 +5,7 @@ import { addDays } from "#lib/dates.ts";
 import { logActivity } from "#lib/db/activityLog.ts";
 import { getDb, insert } from "#lib/db/client.ts";
 import { eventsTable, invalidateEventsCache } from "#lib/db/events.ts";
+import { _internals as slugInternals } from "#lib/slug.ts";
 import { setDemoModeForTest } from "#lib/demo.ts";
 import { nowMs } from "#lib/now.ts";
 import { runWithStorageConfig } from "#lib/storage.ts";
@@ -2187,10 +2188,12 @@ describeWithEnv("server (admin events)", { db: true }, () => {
 
   describe("slug collision on create", () => {
     test("throws when all slug generation attempts collide", async () => {
-      // Stub Math.random to make generateSlug deterministic — every attempt
-      // produces the same slug, so after the first event claims it the
-      // second creation exhausts all 10 retries and throws.
-      const randomStub = stub(Math, "random", () => 0.5);
+      // Stub slug._internals.random to make generateSlug deterministic — every
+      // attempt produces the same slug, so after the first event claims it the
+      // second creation exhausts all 10 retries and throws.  Using the module
+      // seam instead of Math.random avoids polluting the global across
+      // concurrent test workers.
+      const randomStub = stub(slugInternals, "random", () => 0.5);
       try {
         // First event succeeds, claiming the only slug Math.random can produce
         await adminFormPost("/admin/event", {

--- a/test/lib/slug.test.ts
+++ b/test/lib/slug.test.ts
@@ -1,6 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { generateSlug, normalizeSlug, validateSlug } from "#lib/slug.ts";
+import {
+  generateSlug,
+  generateUniqueSlug,
+  normalizeSlug,
+  validateSlug,
+} from "#lib/slug.ts";
 
 describe("slug", () => {
   describe("generateSlug", () => {
@@ -33,6 +38,16 @@ describe("slug", () => {
       }
       // With ~1.15M combinations, 20 slugs should all be unique
       expect(slugs.size).toBe(20);
+    });
+  });
+
+  describe("generateUniqueSlug", () => {
+    test("throws after exhausting all retry attempts", async () => {
+      const alwaysTaken = () => Promise.resolve(true);
+      const computeIndex = (s: string) => Promise.resolve(s);
+      await expect(
+        generateUniqueSlug(computeIndex, alwaysTaken),
+      ).rejects.toThrow("Failed to generate unique slug after 10 attempts");
     });
   });
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Export `_internals = { random: () => Math.random() }` from `src/lib/slug.ts` as a test seam
- Route all random calls inside `generateSlug` through `_internals.random` instead of `Math.random` directly
- Update the "slug collision on create" test to stub `slugInternals.random` instead of `Math.random`

The old `stub(Math, "random", () => 0.5)` patched the global `Math` object for the duration of the test. Under concurrent test load any other code running in the same worker that called `Math.random` during that window would get the fixed value, causing flakes. The new seam confines the stub to slug generation only.

## Test plan

- [ ] `deno test --no-check --allow-all test/lib/slug.test.ts` — existing slug unit tests still pass (use `_internals.random` by default, behaviour unchanged)
- [ ] `deno test --no-check --allow-all test/lib/server-events.test.ts --filter "slug collision"` — collision test passes with the new seam
- [ ] `deno task precommit` — full typecheck + lint + test suite green

https://claude.ai/code/session_011WgxqJ5gLgpAYTErFFipKv
EOF
)