### PR TITLE
Strengthen limits tests; document debug page limits in guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1844,6 +1844,15 @@ export const adminGuidePage = (
             setup issues &mdash; you can quickly see which services are
             configured and which are missing.
           </p>
+          <p>
+            The page also lists every tunable system limit (file-size caps,
+            session and URL expiry windows, login lockout, database pruning
+            retention) alongside its default and current value. Any limit can
+            be overridden by setting the matching environment variable to a
+            positive integer; overridden values are highlighted. A
+            &quot;Database pruning&quot; table at the bottom shows when each
+            short-lived table was last cleaned up.
+          </p>
         </Q>
       </Section>
 

--- a/test/lib/limits.test.ts
+++ b/test/lib/limits.test.ts
@@ -1,16 +1,58 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import {
+  ATTACHMENT_URL_MAX_AGE_S,
   formatBytes,
   formatLimitValue,
   formatMs,
   formatSeconds,
   LIMIT_ENTRIES,
+  LOGIN_LOCKOUT_MS,
+  MAX_ATTACHMENT_SIZE,
+  MAX_IMAGE_SIZE,
+  MAX_LOGIN_ATTEMPTS,
+  MAX_TEXTAREA_LENGTH,
+  parsePositiveInt,
+  PRUNE_INTERVAL_HOURS,
+  PRUNE_INTERVAL_MS,
+  PRUNE_LOGINS_RETENTION_DAYS,
+  PRUNE_PAYMENTS_RETENTION_DAYS,
+  PRUNE_SESSIONS_RETENTION_DAYS,
   readLimit,
+  SESSION_MAX_AGE_S,
+  STALE_RESERVATION_MS,
 } from "#lib/limits.ts";
 import { setTestEnv } from "#test-utils";
 
 describe("limits", () => {
+  describe("parsePositiveInt", () => {
+    test("parses a positive integer string", () => {
+      expect(parsePositiveInt("42", 1)).toBe(42);
+    });
+
+    test("falls back for empty string", () => {
+      expect(parsePositiveInt("", 99)).toBe(99);
+    });
+
+    test("falls back for zero (rejects non-positive)", () => {
+      expect(parsePositiveInt("0", 99)).toBe(99);
+    });
+
+    test("falls back for negative numbers", () => {
+      expect(parsePositiveInt("-5", 99)).toBe(99);
+    });
+
+    test("falls back for non-numeric input", () => {
+      expect(parsePositiveInt("abc", 99)).toBe(99);
+    });
+
+    test("truncates fractional part (parseInt behaviour)", () => {
+      // parseInt("3.9") === 3. This documents observed behaviour — callers
+      // passing a float string get the floor, not a rounded value.
+      expect(parsePositiveInt("3.9", 99)).toBe(3);
+    });
+  });
+
   describe("readLimit", () => {
     let restoreEnv: () => void;
 
@@ -22,54 +64,94 @@ describe("limits", () => {
       expect(readLimit("NONEXISTENT_LIMIT_VAR", 42)).toBe(42);
     });
 
-    test("returns env var value when set to valid positive integer", () => {
+    test("uses env var value when set to a positive integer", () => {
       restoreEnv = setTestEnv({ TEST_LIMIT: "100" });
       expect(readLimit("TEST_LIMIT", 42)).toBe(100);
     });
 
-    test("returns default when env var is not a number", () => {
-      restoreEnv = setTestEnv({ TEST_LIMIT: "abc" });
-      expect(readLimit("TEST_LIMIT", 42)).toBe(42);
-    });
-
-    test("returns default when env var is zero", () => {
-      restoreEnv = setTestEnv({ TEST_LIMIT: "0" });
-      expect(readLimit("TEST_LIMIT", 42)).toBe(42);
-    });
-
-    test("returns default when env var is negative", () => {
-      restoreEnv = setTestEnv({ TEST_LIMIT: "-5" });
-      expect(readLimit("TEST_LIMIT", 42)).toBe(42);
-    });
-
-    test("returns default when env var is empty string", () => {
-      restoreEnv = setTestEnv({ TEST_LIMIT: "" });
-      expect(readLimit("TEST_LIMIT", 42)).toBe(42);
-    });
-
-    test("parses integer from string with trailing text", () => {
-      restoreEnv = setTestEnv({ TEST_LIMIT: "100abc" });
-      expect(readLimit("TEST_LIMIT", 42)).toBe(100);
+    test("falls back to default for invalid env values", () => {
+      // Covers all rejection cases in one table-driven test: bad values never
+      // override the default regardless of how they're malformed.
+      const invalid = ["", "abc", "0", "-5"];
+      for (const value of invalid) {
+        restoreEnv?.();
+        restoreEnv = setTestEnv({ TEST_LIMIT: value });
+        expect(readLimit("TEST_LIMIT", 42)).toBe(42);
+      }
     });
   });
 
   describe("LIMIT_ENTRIES", () => {
-    test("contains an entry for every exported limit", () => {
-      const envKeys = LIMIT_ENTRIES.map((e) => e.envKey);
-      expect(envKeys).toContain("MAX_IMAGE_SIZE");
-      expect(envKeys).toContain("MAX_ATTACHMENT_SIZE");
-      expect(envKeys).toContain("ATTACHMENT_URL_MAX_AGE_S");
-      expect(envKeys).toContain("SESSION_MAX_AGE_S");
-      expect(envKeys).toContain("STALE_RESERVATION_MS");
-      expect(envKeys).toContain("MAX_LOGIN_ATTEMPTS");
-      expect(envKeys).toContain("LOGIN_LOCKOUT_MS");
+    /**
+     * Keeps the debug-page display honest: every exported tunable limit must
+     * appear in LIMIT_ENTRIES so admins can see its configured value. If a
+     * new constant is added to limits.ts without an entry, this test fails.
+     */
+    test("entries match the set of exported tunable constants", () => {
+      const exportedKeys = [
+        "MAX_TEXTAREA_LENGTH",
+        "MAX_IMAGE_SIZE",
+        "MAX_ATTACHMENT_SIZE",
+        "ATTACHMENT_URL_MAX_AGE_S",
+        "SESSION_MAX_AGE_S",
+        "STALE_RESERVATION_MS",
+        "MAX_LOGIN_ATTEMPTS",
+        "LOGIN_LOCKOUT_MS",
+        "PRUNE_PAYMENTS_RETENTION_DAYS",
+        "PRUNE_SESSIONS_RETENTION_DAYS",
+        "PRUNE_LOGINS_RETENTION_DAYS",
+        "PRUNE_INTERVAL_HOURS",
+      ].sort();
+      const entryKeys = LIMIT_ENTRIES.map((e) => e.envKey).sort();
+      expect(entryKeys).toEqual(exportedKeys);
     });
 
-    test("every entry has a non-empty label and unit", () => {
+    test("each entry's current value matches its exported constant", () => {
+      const currentByKey = new Map(
+        LIMIT_ENTRIES.map((e) => [e.envKey, e.current]),
+      );
+      expect(currentByKey.get("MAX_TEXTAREA_LENGTH")).toBe(MAX_TEXTAREA_LENGTH);
+      expect(currentByKey.get("MAX_IMAGE_SIZE")).toBe(MAX_IMAGE_SIZE);
+      expect(currentByKey.get("MAX_ATTACHMENT_SIZE")).toBe(MAX_ATTACHMENT_SIZE);
+      expect(currentByKey.get("ATTACHMENT_URL_MAX_AGE_S")).toBe(
+        ATTACHMENT_URL_MAX_AGE_S,
+      );
+      expect(currentByKey.get("SESSION_MAX_AGE_S")).toBe(SESSION_MAX_AGE_S);
+      expect(currentByKey.get("STALE_RESERVATION_MS")).toBe(
+        STALE_RESERVATION_MS,
+      );
+      expect(currentByKey.get("MAX_LOGIN_ATTEMPTS")).toBe(MAX_LOGIN_ATTEMPTS);
+      expect(currentByKey.get("LOGIN_LOCKOUT_MS")).toBe(LOGIN_LOCKOUT_MS);
+      expect(currentByKey.get("PRUNE_PAYMENTS_RETENTION_DAYS")).toBe(
+        PRUNE_PAYMENTS_RETENTION_DAYS,
+      );
+      expect(currentByKey.get("PRUNE_SESSIONS_RETENTION_DAYS")).toBe(
+        PRUNE_SESSIONS_RETENTION_DAYS,
+      );
+      expect(currentByKey.get("PRUNE_LOGINS_RETENTION_DAYS")).toBe(
+        PRUNE_LOGINS_RETENTION_DAYS,
+      );
+      expect(currentByKey.get("PRUNE_INTERVAL_HOURS")).toBe(
+        PRUNE_INTERVAL_HOURS,
+      );
+    });
+
+    test("every entry renders to a non-empty string via formatLimitValue", () => {
+      // Guards the debug page: if a new unit is introduced that
+      // formatLimitValue can't render, an entry could slip through with a
+      // blank or nonsensical label.
       for (const entry of LIMIT_ENTRIES) {
-        expect(entry.label.length).toBeGreaterThan(0);
-        expect(entry.unit.length).toBeGreaterThan(0);
+        const rendered = formatLimitValue(entry.current, entry.unit);
+        expect(rendered.length).toBeGreaterThan(0);
+        // Must end with a recognisable unit suffix — never just a bare number.
+        expect(rendered).toMatch(/[A-Za-z]/);
       }
+    });
+  });
+
+  describe("PRUNE_INTERVAL_MS", () => {
+    test("is derived from PRUNE_INTERVAL_HOURS in ms", () => {
+      expect(PRUNE_INTERVAL_MS).toBe(PRUNE_INTERVAL_HOURS * 60 * 60 * 1000);
     });
   });
 
@@ -78,8 +160,16 @@ describe("limits", () => {
       expect(formatBytes(512)).toBe("512B");
     });
 
+    test("uses KB at the 1024 boundary", () => {
+      expect(formatBytes(1024)).toBe("1KB");
+    });
+
     test("formats kilobytes", () => {
       expect(formatBytes(256 * 1024)).toBe("256KB");
+    });
+
+    test("uses MB at the 1MB boundary", () => {
+      expect(formatBytes(1024 * 1024)).toBe("1MB");
     });
 
     test("formats megabytes", () => {
@@ -97,12 +187,16 @@ describe("limits", () => {
       expect(formatMs(500)).toBe("500ms");
     });
 
-    test("formats seconds", () => {
-      expect(formatMs(5000)).toBe("5s");
+    test("uses seconds at the 1000ms boundary", () => {
+      expect(formatMs(1000)).toBe("1s");
     });
 
     test("formats minutes", () => {
       expect(formatMs(5 * 60 * 1000)).toBe("5min");
+    });
+
+    test("uses hours at the 1h boundary", () => {
+      expect(formatMs(60 * 60 * 1000)).toBe("1h");
     });
 
     test("formats hours", () => {
@@ -119,15 +213,15 @@ describe("limits", () => {
       expect(formatSeconds(30)).toBe("30s");
     });
 
-    test("formats minutes", () => {
-      expect(formatSeconds(300)).toBe("5min");
+    test("uses minutes at the 60s boundary", () => {
+      expect(formatSeconds(60)).toBe("1min");
     });
 
-    test("formats hours", () => {
+    test("uses hours at the 3600s boundary", () => {
       expect(formatSeconds(3600)).toBe("1h");
     });
 
-    test("formats days", () => {
+    test("uses days at the 86400s boundary", () => {
       expect(formatSeconds(86400)).toBe("1d");
     });
 
@@ -147,6 +241,18 @@ describe("limits", () => {
 
     test("delegates to formatSeconds for seconds unit", () => {
       expect(formatLimitValue(3600, "seconds")).toBe("1h");
+    });
+
+    test("appends 'chars' suffix for chars unit", () => {
+      expect(formatLimitValue(10_240, "chars")).toBe("10240 chars");
+    });
+
+    test("appends 'days' suffix for days unit", () => {
+      expect(formatLimitValue(90, "days")).toBe("90 days");
+    });
+
+    test("appends 'hours' suffix for hours unit", () => {
+      expect(formatLimitValue(24, "hours")).toBe("24 hours");
     });
 
     test("returns value with unit for unknown units", () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -350,6 +350,16 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       }
     });
 
+    test("documents the debug page including tunable limits", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "/admin/debug",
+        "tunable system limit",
+        "environment variable",
+        "Database pruning",
+      );
+    });
+
     test("contains admin API section with auth and endpoint info", async () => {
       await assertAdminHtml(
         "/admin/guide",


### PR DESCRIPTION
## Summary

**Test-quality fixes in `test/lib/limits.test.ts`**

Audited the file against our test quality standards (tests production code, not reimplementations; not tautological; clear failure semantics) and found three concrete gaps:

- `parsePositiveInt` is exported from `#lib/limits.ts` but was never tested directly — only indirectly through `readLimit`. Added focused tests for its behaviour, including the observed parseInt floor-truncation of fractional strings.
- `formatLimitValue`'s `chars` / `days` / `hours` branches were untested. These branches are live on the admin debug page (`MAX_TEXTAREA_LENGTH`, retention days, `PRUNE_INTERVAL_HOURS`) so an accidental regression would silently ship. Added a test per branch.
- The `LIMIT_ENTRIES` test labelled "contains an entry for every exported limit" only checked 7 of 13 envKeys. Replaced it with an exact-equality check, plus a new test that every entry's `current` value matches the corresponding exported constant (keeps the debug page honest).

Also consolidated the weaker `readLimit` edge-case tests (`""`, `"abc"`, `"0"`, `"-5"`) into a single table-driven test and removed "parses integer from string with trailing text", which was effectively asserting `Number.parseInt` behaviour rather than ours. Added boundary tests at each unit threshold in `formatBytes` / `formatMs` / `formatSeconds`.

**Guide deep-dive update**

The `/admin/guide` FAQ for the debug page described the configuration-status sections but never mentioned the **Limits** table or the **Database pruning** table that the page actually renders (see `src/templates/admin/debug.tsx`). Extended the FAQ to document both, and the fact that any listed limit can be overridden via the matching environment variable. Added a `server-guide.test.ts` case asserting the new content so the guide and system stay in sync.

## Test plan

- [x] `deno test --no-check --allow-all test/lib/limits.test.ts` — 45 steps pass
- [x] `deno test --no-check --allow-all test/lib/server-guide.test.ts` — 43 steps pass (new debug-page test included)
- [x] `deno lint` on touched files — clean
- [x] `deno check` on touched files — clean
- [x] Confirmed pre-existing `deno fmt` findings in `guide.tsx` are unrelated to the new lines

https://claude.ai/code/session_01A4BdEHgv82TzzeH6Pgt9YD