### PR TITLE
Add Table.rowToInput to eliminate manual snake_case→camelCase spreads

### DIFF
--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -205,6 +205,20 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
   },
   name: "built_sites",
   primaryKey: "id",
+  // The CRUD adapter is a façade over the raw table — the built-site blob
+  // is always reconstructed from BuiltSiteFormInput, so rowToInput just picks
+  // the exposed camelCase fields off an already-decrypted BuiltSite.
+  rowToInput: (
+    row: BuiltSite,
+    _exclude?: readonly string[],
+  ): Partial<BuiltSiteFormInput> => ({
+    assignable: row.assignable,
+    bunnyScriptId: row.bunnyScriptId,
+    bunnyUrl: row.bunnyUrl,
+    dbToken: row.dbToken,
+    dbUrl: row.dbUrl,
+    name: row.name,
+  }),
   schema: {
     assignable: {} as ColumnDef<boolean>,
     assignedAttendeeId: {} as ColumnDef<number | null>,

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -150,6 +150,14 @@ export interface Table<Row, Input> {
   toDbValues: (
     input: Input | Partial<Input>,
   ) => Promise<Record<string, InValue>>;
+
+  /**
+   * Build an Input object from an existing Row by copying the input-eligible
+   * columns and translating keys through `inputKeyMap`. Lets callers spread
+   * a row into a new insert without restating every field. Columns named in
+   * `exclude` are skipped — useful for auto-stamped fields like `created`.
+   */
+  rowToInput: (row: Row, exclude?: readonly string[]) => Partial<Input>;
 }
 
 /** Get value for a column with default applied */
@@ -338,6 +346,28 @@ export const defineTable = <Row, Input = Row>(config: {
     return mapParallel(fromDb)(rows);
   };
 
+  // Row → Input: copy input-eligible columns from a row, translating
+  // snake_case DB column names to camelCase input keys via inputKeyMap.
+  // `exclude` lets callers drop columns that shouldn't carry forward
+  // (e.g. auto-stamped `created` timestamps when duplicating a row).
+  const rowToInput = (
+    row: Row,
+    exclude: readonly string[] = [],
+  ): Partial<Input> => {
+    const skip = new Set<string>(exclude);
+    return reduce(
+      (acc: Record<string, unknown>, col: string) => {
+        if (skip.has(col)) return acc;
+        const value = (row as Record<string, unknown>)[col];
+        if (value !== undefined) {
+          acc[inputKeyMap[col] as string] = value;
+        }
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    )(inputColumns) as Partial<Input>;
+  };
+
   return {
     deleteById,
     findAll,
@@ -347,6 +377,7 @@ export const defineTable = <Row, Input = Row>(config: {
     insert,
     name,
     primaryKey,
+    rowToInput,
     schema,
     toDbValues,
     update,

--- a/src/lib/events-actions.ts
+++ b/src/lib/events-actions.ts
@@ -79,52 +79,24 @@ export const performEventDelete = async (
 /**
  * Build an `EventInput` from an existing event, with optional overrides.
  *
- * Produces a fresh unique slug (so the returned input is safe to insert).
- * Image and attachment URLs are cleared by default: they reference files
- * owned by the source event and would break if the original were deleted.
+ * Uses the table's `rowToInput` to carry every column across — no manual
+ * snake_case→camelCase translation. A fresh unique slug is generated so
+ * the returned input is safe to insert. Image and attachment URLs are
+ * cleared because they reference files owned by the source event.
  * Callers can override any field (e.g. `name`, `date`, `groupId`) via
  * `overrides`.
- *
- * Used by both the per-event duplicate form and the group-bulk duplicate
- * flow so the set of carried-over fields stays in one place.
  */
 export const buildDuplicateEventInput = async (
   source: Event,
   overrides: Partial<EventInput> = {},
-): Promise<EventInput> => {
-  const { slug, slugIndex } = await generateUniqueEventSlug();
-  const base: EventInput = {
-    active: source.active,
-    assignBuiltSite: source.assign_built_site,
-    attachmentName: "",
-    attachmentUrl: "",
-    bookableDays: [...source.bookable_days],
-    canPayMore: source.can_pay_more,
-    closesAt: source.closes_at ?? "",
-    date: source.date,
-    description: source.description,
-    eventType: source.event_type,
-    fields: source.fields,
-    groupId: source.group_id,
-    hidden: source.hidden,
-    imageUrl: "",
-    location: source.location,
-    maxAttendees: source.max_attendees,
-    maximumDaysAfter: source.maximum_days_after,
-    maxPrice: source.max_price,
-    maxQuantity: source.max_quantity,
-    minimumDaysBefore: source.minimum_days_before,
-    name: source.name,
-    nonTransferable: source.non_transferable,
-    purchaseOnly: source.purchase_only,
-    slug,
-    slugIndex,
-    thankYouUrl: source.thank_you_url,
-    unitPrice: source.unit_price,
-    webhookUrl: source.webhook_url,
-  };
-  return { ...base, ...overrides };
-};
+): Promise<EventInput> => ({
+  ...(eventsTable.rowToInput(source, ["created"]) as EventInput),
+  ...(await generateUniqueEventSlug()),
+  attachmentName: "",
+  attachmentUrl: "",
+  imageUrl: "",
+  ...overrides,
+});
 
 /**
  * Toggle event active state, log activity, and return the updated event.

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -170,6 +170,29 @@ describeWithEnv("built-sites", { db: true }, () => {
       expect(result).toEqual(site);
     });
 
+    test("rowToInput exposes form-input fields for reuse", () => {
+      const site = {
+        assignable: true,
+        assignedAttendeeId: null,
+        assignedEventId: null,
+        bunnyScriptId: "script-123",
+        bunnyUrl: "example.bunny.run",
+        created: "2026-01-01",
+        dbToken: "token",
+        dbUrl: "libsql://db",
+        id: 42,
+        name: "Mirror",
+      };
+      expect(builtSitesCrudTable.rowToInput(site)).toEqual({
+        assignable: true,
+        bunnyScriptId: "script-123",
+        bunnyUrl: "example.bunny.run",
+        dbToken: "token",
+        dbUrl: "libsql://db",
+        name: "Mirror",
+      });
+    });
+
     test("toDbValues builds encrypted blob from input", async () => {
       const values = await builtSitesCrudTable.toDbValues({
         assignable: false,

--- a/test/lib/db/table.test.ts
+++ b/test/lib/db/table.test.ts
@@ -247,6 +247,53 @@ describeWithEnv("db > table utilities", { db: true }, () => {
     expect(map.max_attendees).toBe("maxAttendees");
   });
 
+  test("rowToInput maps snake_case row columns to camelCase input keys", async () => {
+    const event = await createTestEvent({
+      maxAttendees: 42,
+      name: "Row To Input",
+      thankYouUrl: "https://example.com",
+    });
+    const input = eventsTable.rowToInput(event);
+    expect(input.name).toBe("Row To Input");
+    expect(input.maxAttendees).toBe(42);
+    expect(input.thankYouUrl).toBe("https://example.com");
+    // Generated columns are excluded so the output is safe to re-insert
+    expect("id" in input).toBe(false);
+  });
+
+  test("rowToInput excludes columns named in the exclude list", async () => {
+    const event = await createTestEvent({
+      maxAttendees: 10,
+      name: "Excluded",
+      thankYouUrl: "https://example.com",
+    });
+    const input = eventsTable.rowToInput(event, ["created"]);
+    expect("created" in input).toBe(false);
+    expect(input.name).toBe("Excluded");
+  });
+
+  test("rowToInput skips undefined row fields", async () => {
+    const { col, defineTable } = await import("#lib/db/table.ts");
+    type Row = { id: number; max_attendees: number; thank_you_url: string };
+    type Input = { maxAttendees: number; thankYouUrl?: string };
+    const table = defineTable<Row, Input>({
+      name: "events",
+      primaryKey: "id",
+      schema: {
+        id: col.generated<number>(),
+        max_attendees: col.simple<number>(),
+        thank_you_url: col.withDefault(() => "default-url"),
+      },
+    });
+    const input = table.rowToInput({
+      id: 1,
+      max_attendees: 5,
+      thank_you_url: undefined as unknown as string,
+    });
+    expect(input.maxAttendees).toBe(5);
+    expect("thankYouUrl" in input).toBe(false);
+  });
+
   test("getProvidedColumns uses inputKeyMap fallback for single-word keys", async () => {
     const event = await createTestEvent({
       maxAttendees: 10,


### PR DESCRIPTION
## Summary

Expose a `rowToInput(row, exclude?)` method on every `Table`. It copies every input-eligible column off a row, translates snake_case DB column names to camelCase input keys through the table's existing `inputKeyMap`, and skips anything in `exclude`. It works on the auto-generated tables (events, groups, holidays, built-sites, activity-log, questions) and on the manual `builtSitesCrudTable` façade.

The motivating caller — `buildDuplicateEventInput` — used to enumerate all 28 `EventInput` fields by hand (`assignBuiltSite: source.assign_built_site`, `bookableDays: [...source.bookable_days]`, etc). With `rowToInput` it collapses to a single spread:

```diff
 export const buildDuplicateEventInput = async (
   source: Event,
   overrides: Partial<EventInput> = {},
-): Promise<EventInput> => {
-  const { slug, slugIndex } = await generateUniqueEventSlug();
-  const base: EventInput = {
-    active: source.active,
-    assignBuiltSite: source.assign_built_site,
-    attachmentName: "",
-    …28 more field assignments…
-    webhookUrl: source.webhook_url,
-  };
-  return { ...base, ...overrides };
-};
+): Promise<EventInput> => ({
+  ...(eventsTable.rowToInput(source, ["created"]) as EventInput),
+  ...(await generateUniqueEventSlug()),
+  attachmentName: "",
+  attachmentUrl: "",
+  imageUrl: "",
+  ...overrides,
+});
```

## Why not rename `EventInput` to snake_case outright?

Exploring that path showed the case mismatch is concentrated in exactly one function. A global rename touches ~40 fields across 5 `*Input` types plus every construction site and test fixture, and it breaks the boundary between *DB column* naming (snake_case) and the rest of the codebase's *TypeScript convention* (camelCase) — including unrelated shapes like `CheckoutItem.unitPrice` that happen to share field names. The table abstraction already tracks the mapping, so routing `rowToInput` through it gives us the simplification without the churn.

## Test plan

- [x] `deno task typecheck` passes
- [x] `deno task lint` passes
- [x] `deno task cpd` passes (0 clones)
- [x] `deno task build:edge` passes
- [x] `deno task test:coverage` passes (100% line + branch)
- [x] New `rowToInput` has its own tests in `test/lib/db/table.test.ts` and `test/lib/built-sites.test.ts`
- [x] Existing `buildDuplicateEventInput` coverage (group duplicate in PR #1004, per-event duplicate) still passes

## Base branch

Targets `claude/bulk-group-actions-mUAVq` (PR #1004) because it's the caller this refactor directly benefits. Will rebase onto `main` once #1004 lands.

https://claude.ai/code/session_0126HMvdfPF9s44xpDgjB36E