### PR TITLE
Use proper nav structure on group detail page

### DIFF
--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -260,17 +260,27 @@ export const adminGroupDetailPage = (
     <Layout title={group.name}>
       <AdminNav session={session} active="/admin/groups" />
       <Flash success={successMessage} />
-      <p>
-        {!isReadOnly() && (
-          <>
-            <a href={`/admin/groups/${group.id}/edit`}>Edit Group</a>{" "}
-            <a href={`/admin/groups/${group.id}/bulk-actions`}>
-              Bulk Actions
-            </a>{" "}
-          </>
-        )}
-        <a href={`/admin/groups/${group.id}/delete`}>Delete Group</a>
-      </p>
+      <nav>
+        <ul>
+          {!isReadOnly() && (
+            <>
+              <li>
+                <a href={`/admin/groups/${group.id}/edit`}>Edit Group</a>
+              </li>
+              <li>
+                <a href={`/admin/groups/${group.id}/bulk-actions`}>
+                  Bulk Actions
+                </a>
+              </li>
+            </>
+          )}
+          <li>
+            <a href={`/admin/groups/${group.id}/delete`} class="danger">
+              Delete Group
+            </a>
+          </li>
+        </ul>
+      </nav>
 
       <article>
         <div class="table-scroll">


### PR DESCRIPTION
## Summary
- Replace the inline `<p>` of action links on the group detail page with a semantic `<nav><ul><li>` structure, matching the `EventActionNav` pattern used on the event detail page.
- Apply `class="danger"` to the Delete Group link for consistency with the event action nav.

## Test plan
- [ ] Load `/admin/groups/:id` and confirm the Edit Group / Bulk Actions / Delete Group links render as a nav list styled like the event detail page.
- [ ] Confirm read-only mode still hides Edit Group and Bulk Actions.
- [ ] `deno task precommit` passes.