### PR TITLE
Extract buildCapacityCondition into src/lib/db/capacity.ts

### DIFF
--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -20,6 +20,7 @@ import type {
   EncryptedAttendeeData,
   EncryptInput,
 } from "#lib/db/attendee-types.ts";
+import { buildCapacityCondition, dateToRange } from "#lib/db/capacity.ts";
 import {
   executeBatch,
   executeBatchWithResults,
@@ -414,15 +415,6 @@ const dateToStartEnd = (
   return { endAt: range.endAt, startAt: range.startAt };
 };
 
-/** Convert a date string ("YYYY-MM-DD") to start_at/end_at pair for full-day range */
-export const dateToRange = (
-  date: string,
-): { startAt: string; endAt: string } => {
-  const ms = new Date(`${date}T00:00:00Z`).getTime();
-  const nextDay = new Date(ms + 86_400_000).toISOString();
-  return { endAt: nextDay, startAt: `${date}T00:00:00Z` };
-};
-
 /** Get the total attendee quantity for a specific event + date */
 export const getDateAttendeeCount = async (
   eventId: number,
@@ -465,67 +457,6 @@ const getGroupAttendeeCount = async (
   return rows[0]!.count;
 };
 
-/**
- * Build the WHERE clause for capacity checking on event_attendees.
- * @param excludeAttendeeId - If set, excludes this attendee's rows from the count (for updates)
- */
-const buildCapacityCondition = (
-  eventId: number,
-  qty: number,
-  date: string | null,
-  excludeAttendeeId?: number,
-): { sql: string; args: InValue[] } => {
-  const range = date ? dateToRange(date) : null;
-  const endAt = range?.endAt ?? null;
-  const startAt = range?.startAt ?? null;
-
-  const excludeClause = excludeAttendeeId ? " AND ea2.attendee_id != ?" : "";
-  const capacityFilter = date
-    ? `SELECT COALESCE(SUM(ea2.quantity), 0) FROM event_attendees ea2 WHERE ea2.event_id = ?${excludeClause} AND ea2.start_at < ? AND ea2.end_at > ?`
-    : `SELECT COALESCE(SUM(ea2.quantity), 0) FROM event_attendees ea2 WHERE ea2.event_id = ?${excludeClause}`;
-  const capacityArgs: InValue[] = date
-    ? excludeAttendeeId
-      ? [eventId, excludeAttendeeId, endAt, startAt]
-      : [eventId, endAt, startAt]
-    : excludeAttendeeId
-      ? [eventId, excludeAttendeeId]
-      : [eventId];
-
-  const groupExclude = excludeAttendeeId
-    ? "AND ea3.attendee_id != ?\n                  "
-    : "";
-  const groupCapacityCheck = `
-          AND (
-            SELECT CASE
-              WHEN ev.group_id = 0 THEN 1
-              WHEN COALESCE(g.max_attendees, 0) = 0 THEN 1
-              WHEN (
-                SELECT COALESCE(SUM(ea3.quantity), 0)
-                FROM event_attendees ea3
-                JOIN events e2 ON e2.id = ea3.event_id
-                WHERE e2.group_id = ev.group_id
-                  ${groupExclude}AND (? IS NULL OR e2.event_type != 'daily' OR (ea3.start_at < ? AND ea3.end_at > ?))
-              ) + ? <= g.max_attendees THEN 1
-              ELSE 0
-            END
-            FROM events ev
-            LEFT JOIN groups g ON g.id = ev.group_id
-            WHERE ev.id = ?
-          ) = 1`;
-  const groupCapacityArgs: InValue[] = excludeAttendeeId
-    ? [excludeAttendeeId, date, endAt, startAt, qty, eventId]
-    : [date, endAt, startAt, qty, eventId];
-
-  return {
-    args: [...capacityArgs, qty, eventId, ...groupCapacityArgs],
-    sql: `(${capacityFilter}) + ? <= (SELECT max_attendees FROM events WHERE id = ?)${groupCapacityCheck}`,
-  };
-};
-
-/**
- * Build a capacity-checked INSERT INTO event_attendees for a single booking.
- * Uses last_insert_rowid() to reference the attendee created in step 1 of the batch.
- */
 /**
  * Build a capacity-checked INSERT into event_attendees.
  * @param attendeeIdExpr - SQL expression for attendee_id (e.g. "last_insert_rowid()" or "?")

--- a/src/lib/db/capacity.ts
+++ b/src/lib/db/capacity.ts
@@ -1,0 +1,77 @@
+/**
+ * SQL builders for event capacity checks.
+ *
+ * The WHERE clause produced by `buildCapacityCondition` is embedded inside
+ * atomic INSERT/UPDATE statements on `event_attendees` so that capacity is
+ * enforced in the same statement that mutates the row (no read-modify-write
+ * race). It currently handles the single-day case: for daily events we overlap
+ * on `start_at`/`end_at` derived from the booking date.
+ */
+
+import type { InValue } from "@libsql/client";
+
+/** Convert a date string ("YYYY-MM-DD") to start_at/end_at pair for full-day range */
+export const dateToRange = (
+  date: string,
+): { startAt: string; endAt: string } => {
+  const ms = new Date(`${date}T00:00:00Z`).getTime();
+  const nextDay = new Date(ms + 86_400_000).toISOString();
+  return { endAt: nextDay, startAt: `${date}T00:00:00Z` };
+};
+
+/**
+ * Build the WHERE clause for capacity checking on event_attendees.
+ * @param excludeAttendeeId - If set, excludes this attendee's rows from the count (for updates)
+ */
+export const buildCapacityCondition = (
+  eventId: number,
+  qty: number,
+  date: string | null,
+  excludeAttendeeId?: number,
+): { sql: string; args: InValue[] } => {
+  const range = date ? dateToRange(date) : null;
+  const endAt = range?.endAt ?? null;
+  const startAt = range?.startAt ?? null;
+
+  const excludeClause = excludeAttendeeId ? " AND ea2.attendee_id != ?" : "";
+  const capacityFilter = date
+    ? `SELECT COALESCE(SUM(ea2.quantity), 0) FROM event_attendees ea2 WHERE ea2.event_id = ?${excludeClause} AND ea2.start_at < ? AND ea2.end_at > ?`
+    : `SELECT COALESCE(SUM(ea2.quantity), 0) FROM event_attendees ea2 WHERE ea2.event_id = ?${excludeClause}`;
+  const capacityArgs: InValue[] = date
+    ? excludeAttendeeId
+      ? [eventId, excludeAttendeeId, endAt, startAt]
+      : [eventId, endAt, startAt]
+    : excludeAttendeeId
+      ? [eventId, excludeAttendeeId]
+      : [eventId];
+
+  const groupExclude = excludeAttendeeId
+    ? "AND ea3.attendee_id != ?\n                  "
+    : "";
+  const groupCapacityCheck = `
+          AND (
+            SELECT CASE
+              WHEN ev.group_id = 0 THEN 1
+              WHEN COALESCE(g.max_attendees, 0) = 0 THEN 1
+              WHEN (
+                SELECT COALESCE(SUM(ea3.quantity), 0)
+                FROM event_attendees ea3
+                JOIN events e2 ON e2.id = ea3.event_id
+                WHERE e2.group_id = ev.group_id
+                  ${groupExclude}AND (? IS NULL OR e2.event_type != 'daily' OR (ea3.start_at < ? AND ea3.end_at > ?))
+              ) + ? <= g.max_attendees THEN 1
+              ELSE 0
+            END
+            FROM events ev
+            LEFT JOIN groups g ON g.id = ev.group_id
+            WHERE ev.id = ?
+          ) = 1`;
+  const groupCapacityArgs: InValue[] = excludeAttendeeId
+    ? [excludeAttendeeId, date, endAt, startAt, qty, eventId]
+    : [date, endAt, startAt, qty, eventId];
+
+  return {
+    args: [...capacityArgs, qty, eventId, ...groupCapacityArgs],
+    sql: `(${capacityFilter}) + ? <= (SELECT max_attendees FROM events WHERE id = ?)${groupCapacityCheck}`,
+  };
+};

--- a/src/lib/db/events.ts
+++ b/src/lib/db/events.ts
@@ -9,8 +9,8 @@ import { hmacHash } from "#lib/crypto/hashing.ts";
 import {
   ATTENDEE_JOIN_SELECT,
   ATTENDEE_LEFT_JOIN_SELECT,
-  dateToRange,
 } from "#lib/db/attendees.ts";
+import { dateToRange } from "#lib/db/capacity.ts";
 import {
   executeBatch,
   getDb,


### PR DESCRIPTION
## Summary

- Move `buildCapacityCondition` (and the `dateToRange` date-range helper it depends on) out of `src/lib/db/attendees.ts` into a new standalone `src/lib/db/capacity.ts` module
- `attendees.ts` imports both back in; `events.ts` updated to import `dateToRange` directly from the new module
- No behaviour change — pure refactor to give the capacity-check logic a clear home before multi-day booking work lands

## Why

`attendees.ts` was ~956 lines with the single-day capacity SQL builder sitting in the middle of unrelated PII/attendee code. Giving it its own file lets a future multi-day capacity implementation grow in a dedicated module instead of rewriting a +300 chunk of `attendees.ts`.

## Test plan

- [ ] `deno task precommit` passes (typecheck + lint + tests) — could not run locally in this environment; CI will verify
- [ ] Existing capacity tests (`test/lib/db/attendees/has-available-spots.test.ts`, `check-batch-availability.test.ts`, `update-event-link.test.ts`, `create-attendee-atomic.test.ts`) still pass
- [ ] No callers outside `attendees.ts` / `events.ts` referenced the moved symbols

https://claude.ai/code/session_018fjyb8fjgDjRodF2WhKLgn