### PR TITLE
Add bookAttendee test helper for single-booking setup

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -929,11 +929,13 @@ const createDirectAdminSession = async (): Promise<{
   const { nowMs } = await import("#lib/now.ts");
 
   const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-  if (!user?.wrapped_data_key)
+  if (!user?.wrapped_data_key) {
     throw new Error("Admin user not found after setup");
+  }
   const passwordHash = await verifyUserPassword(user, TEST_ADMIN_PASSWORD);
-  if (!passwordHash)
+  if (!passwordHash) {
     throw new Error("Admin password verification failed after setup");
+  }
   const kek = await deriveKEK(passwordHash);
   const dataKey = await unwrapKey(user.wrapped_data_key, kek);
 
@@ -2378,6 +2380,47 @@ export const deleteTestBuiltSite = async (siteId: number): Promise<void> => {
 
 export type { BuiltSiteFormInput };
 
+import type {
+  CreateAttendeeResult,
+  EventBooking,
+} from "#lib/db/attendee-types.ts";
+
+export type BookAttendeeOpts = Partial<Omit<EventBooking, "eventId">> & {
+  name?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  special_instructions?: string;
+  paymentId?: string;
+};
+
+/**
+ * Book a single attendee onto an event via createAttendeeAtomic.
+ * One-liner wrapper for the common test pattern with sensible defaults
+ * (name "X", email "x@example.com").
+ */
+export const bookAttendee = async (
+  event: Pick<Event, "id">,
+  opts: BookAttendeeOpts = {},
+): Promise<CreateAttendeeResult> => {
+  const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+  const booking: EventBooking = { eventId: event.id };
+  if (opts.date !== undefined) booking.date = opts.date;
+  if (opts.quantity !== undefined) booking.quantity = opts.quantity;
+  if (opts.pricePaid !== undefined) booking.pricePaid = opts.pricePaid;
+  return createAttendeeAtomic({
+    bookings: [booking],
+    email: opts.email ?? "x@example.com",
+    name: opts.name ?? "X",
+    ...(opts.phone !== undefined && { phone: opts.phone }),
+    ...(opts.address !== undefined && { address: opts.address }),
+    ...(opts.special_instructions !== undefined && {
+      special_instructions: opts.special_instructions,
+    }),
+    ...(opts.paymentId !== undefined && { paymentId: opts.paymentId }),
+  });
+};
+
 /**
  * Create an attendee directly using createAttendeeAtomic (bypasses HTTP layer).
  * Returns the plaintext token just like production code receives it.
@@ -2627,8 +2670,9 @@ export const createTestManagerSession = async (
   const passwordHash = await verifyUserPassword(user, TEST_ADMIN_PASSWORD);
   if (!passwordHash) throw new Error("Admin password verification failed");
   const kek = await deriveKEK(passwordHash);
-  if (!user.wrapped_data_key)
+  if (!user.wrapped_data_key) {
     throw new Error("Admin user has no wrapped data key");
+  }
   const dataKey = await unwrapKey(user.wrapped_data_key, kek);
 
   // Create manager user with a properly wrapped data key

--- a/test/lib/attendee-merge.test.ts
+++ b/test/lib/attendee-merge.test.ts
@@ -23,7 +23,7 @@ import type {
   AttendeeMergeDecisionInput,
   AttendeeMergeDiff,
 } from "#lib/merge/attendee-merge-types.ts";
-import { createTestEvent, describeWithEnv } from "#test-utils";
+import { bookAttendee, createTestEvent, describeWithEnv } from "#test-utils";
 
 /** Create a test attendee directly via the DB */
 const createAttendee = async (
@@ -37,8 +37,9 @@ const createAttendee = async (
     email: email ?? `${name.toLowerCase()}@test.com`,
     name,
   });
-  if (!result.success)
+  if (!result.success) {
     throw new Error(`Failed to create attendee: ${result.reason}`);
+  }
   return result.attendees[0]!;
 };
 
@@ -345,11 +346,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const target = await createAttendee(event1.id, "Alice");
       const source = await createAttendee(event1.id, "Bob");
       // Add source to event2 as well
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event2.id }],
-        email: "bob@test.com",
-        name: "Bob",
-      });
+      await bookAttendee(event2, { email: "bob@test.com", name: "Bob" });
       // But for this test, let's use direct attendees
       // target is on event1, source is on event1 (duplicate) and event2 (moveable)
 

--- a/test/lib/db/attendees/check-batch-availability.test.ts
+++ b/test/lib/db/attendees/check-batch-availability.test.ts
@@ -1,63 +1,57 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import {
-  checkBatchAvailability,
-  createAttendeeAtomic,
-} from "#lib/db/attendees.ts";
-import { createTestEvent, describeWithEnv } from "#test-utils";
+import { checkBatchAvailability } from "#lib/db/attendees.ts";
+import { bookAttendee, createTestEvent, describeWithEnv } from "#test-utils";
 
-describeWithEnv(
-  "db > attendees > checkBatchAvailability",
-  { db: true },
-  () => {
-    test("returns true for empty items", async () => {
-      expect(await checkBatchAvailability([])).toBe(true);
+describeWithEnv("db > attendees > checkBatchAvailability", { db: true }, () => {
+  test("returns true for empty items", async () => {
+    expect(await checkBatchAvailability([])).toBe(true);
+  });
+
+  test("returns false when event not found", async () => {
+    expect(await checkBatchAvailability([{ eventId: 999, quantity: 1 }])).toBe(
+      false,
+    );
+  });
+
+  test("checks per-date capacity for daily events", async () => {
+    const event = await createTestEvent({
+      bookableDays: [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+      ],
+      eventType: "daily",
+      maxAttendees: 2,
+      maximumDaysAfter: 14,
+      minimumDaysBefore: 0,
     });
 
-    test("returns false when event not found", async () => {
-      expect(
-        await checkBatchAvailability([{ eventId: 999, quantity: 1 }]),
-      ).toBe(false);
+    await bookAttendee(event, {
+      date: "2026-05-01",
+      email: "filled@example.com",
+      name: "Filled",
+      quantity: 2,
     });
 
-    test("checks per-date capacity for daily events", async () => {
-      const event = await createTestEvent({
-        bookableDays: [
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-          "Sunday",
-        ],
-        eventType: "daily",
-        maxAttendees: 2,
-        maximumDaysAfter: 14,
-        minimumDaysBefore: 0,
-      });
+    // Same date is full
+    expect(
+      await checkBatchAvailability(
+        [{ eventId: event.id, quantity: 1 }],
+        "2026-05-01",
+      ),
+    ).toBe(false);
 
-      await createAttendeeAtomic({
-        bookings: [{ date: "2026-05-01", eventId: event.id, quantity: 2 }],
-        email: "filled@example.com",
-        name: "Filled",
-      });
-
-      // Same date is full
-      expect(
-        await checkBatchAvailability(
-          [{ eventId: event.id, quantity: 1 }],
-          "2026-05-01",
-        ),
-      ).toBe(false);
-
-      // Different date has room
-      expect(
-        await checkBatchAvailability(
-          [{ eventId: event.id, quantity: 2 }],
-          "2026-05-02",
-        ),
-      ).toBe(true);
-    });
-  },
-);
+    // Different date has room
+    expect(
+      await checkBatchAvailability(
+        [{ eventId: event.id, quantity: 2 }],
+        "2026-05-02",
+      ),
+    ).toBe(true);
+  });
+});

--- a/test/lib/db/attendees/decrypt-attendees.test.ts
+++ b/test/lib/db/attendees/decrypt-attendees.test.ts
@@ -1,12 +1,9 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import {
-  createAttendeeAtomic,
-  decryptAttendees,
-  getAttendeesRaw,
-} from "#lib/db/attendees.ts";
+import { decryptAttendees, getAttendeesRaw } from "#lib/db/attendees.ts";
 import { getDb } from "#lib/db/client.ts";
 import {
+  bookAttendee,
   createTestAttendee,
   createTestEvent,
   describeWithEnv,
@@ -57,11 +54,11 @@ describeWithEnv("db > attendees > decryptAttendees", { db: true }, () => {
       thankYouUrl: "https://example.com",
     });
 
-    const result = await createAttendeeAtomic({
-      bookings: [{ eventId: event.id, quantity: 1 }],
+    const result = await bookAttendee(event, {
       email: "phone@example.com",
       name: "Phone Person",
       phone: "+44 7700 900000",
+      quantity: 1,
     });
 
     expect(result.success).toBe(true);
@@ -83,12 +80,12 @@ describeWithEnv("db > attendees > decryptAttendees", { db: true }, () => {
       thankYouUrl: "https://example.com",
     });
 
-    const result = await createAttendeeAtomic({
+    const result = await bookAttendee(event, {
       address: "",
-      bookings: [{ eventId: event.id, quantity: 1 }],
       email: "",
       name: "NoContact Person",
       phone: "",
+      quantity: 1,
       special_instructions: "",
     });
 
@@ -116,10 +113,10 @@ describeWithEnv("db > attendees > decryptAttendees", { db: true }, () => {
       thankYouUrl: "https://example.com",
     });
 
-    const result = await createAttendeeAtomic({
-      bookings: [{ eventId: event.id, quantity: 1 }],
+    const result = await bookAttendee(event, {
       email: "inst@example.com",
       name: "Instructions Person",
+      quantity: 1,
       special_instructions: "No nuts please\nAllergic to dairy",
     });
 
@@ -139,11 +136,11 @@ describeWithEnv("db > attendees > decryptAttendees", { db: true }, () => {
       thankYouUrl: "https://example.com",
     });
 
-    const result = await createAttendeeAtomic({
+    const result = await bookAttendee(event, {
       address: "123 Main St\nSpringfield\nIL 62701",
-      bookings: [{ eventId: event.id, quantity: 1 }],
       email: "addr@example.com",
       name: "Address Person",
+      quantity: 1,
     });
 
     expect(result.success).toBe(true);

--- a/test/lib/db/attendees/get-date-attendee-count.test.ts
+++ b/test/lib/db/attendees/get-date-attendee-count.test.ts
@@ -1,10 +1,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import {
-  createAttendeeAtomic,
-  getDateAttendeeCount,
-} from "#lib/db/attendees.ts";
-import { createTestEvent, describeWithEnv } from "#test-utils";
+import { getDateAttendeeCount } from "#lib/db/attendees.ts";
+import { bookAttendee, createTestEvent, describeWithEnv } from "#test-utils";
 
 describeWithEnv("db > attendees > getDateAttendeeCount", { db: true }, () => {
   const dailyOpts = {
@@ -37,15 +34,17 @@ describeWithEnv("db > attendees > getDateAttendeeCount", { db: true }, () => {
       ...dailyOpts,
     });
 
-    await createAttendeeAtomic({
-      bookings: [{ date: "2026-02-10", eventId: event.id, quantity: 2 }],
+    await bookAttendee(event, {
+      date: "2026-02-10",
       email: "u1@example.com",
       name: "User 1",
+      quantity: 2,
     });
-    await createAttendeeAtomic({
-      bookings: [{ date: "2026-02-10", eventId: event.id, quantity: 3 }],
+    await bookAttendee(event, {
+      date: "2026-02-10",
       email: "u2@example.com",
       name: "User 2",
+      quantity: 3,
     });
 
     const count = await getDateAttendeeCount(event.id, "2026-02-10");
@@ -58,15 +57,17 @@ describeWithEnv("db > attendees > getDateAttendeeCount", { db: true }, () => {
       ...dailyOpts,
     });
 
-    await createAttendeeAtomic({
-      bookings: [{ date: "2026-02-10", eventId: event.id, quantity: 2 }],
+    await bookAttendee(event, {
+      date: "2026-02-10",
       email: "u1@example.com",
       name: "User 1",
+      quantity: 2,
     });
-    await createAttendeeAtomic({
-      bookings: [{ date: "2026-02-11", eventId: event.id, quantity: 1 }],
+    await bookAttendee(event, {
+      date: "2026-02-11",
       email: "u2@example.com",
       name: "User 2",
+      quantity: 1,
     });
 
     expect(await getDateAttendeeCount(event.id, "2026-02-10")).toBe(2);

--- a/test/lib/db/attendees/has-available-spots.test.ts
+++ b/test/lib/db/attendees/has-available-spots.test.ts
@@ -1,10 +1,8 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { hasAvailableSpots } from "#lib/db/attendees.ts";
 import {
-  createAttendeeAtomic,
-  hasAvailableSpots,
-} from "#lib/db/attendees.ts";
-import {
+  bookAttendee,
   createTestAttendee,
   createTestEvent,
   describeWithEnv,
@@ -65,8 +63,8 @@ describeWithEnv("db > attendees > hasAvailableSpots", { db: true }, () => {
       minimumDaysBefore: 0,
     });
 
-    await createAttendeeAtomic({
-      bookings: [{ date: "2026-02-10", eventId: event.id }],
+    await bookAttendee(event, {
+      date: "2026-02-10",
       email: "day@example.com",
       name: "Day User",
     });

--- a/test/lib/db/attendees/update-event-link.test.ts
+++ b/test/lib/db/attendees/update-event-link.test.ts
@@ -1,19 +1,16 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import {
-  createAttendeeAtomic,
-  getAttendeesRaw,
-} from "#lib/db/attendees.ts";
-import { createTestEvent, describeWithEnv } from "#test-utils";
+import { getAttendeesRaw } from "#lib/db/attendees.ts";
+import { bookAttendee, createTestEvent, describeWithEnv } from "#test-utils";
 
 describeWithEnv("db > attendees > updateEventLink", { db: true }, () => {
   test("updates quantity with capacity guard", async () => {
     const { updateEventLink } = await import("#lib/db/attendees.ts");
     const event = await createTestEvent({ maxAttendees: 5 });
-    const result = await createAttendeeAtomic({
-      bookings: [{ eventId: event.id, quantity: 2 }],
+    const result = await bookAttendee(event, {
       email: "link@test.com",
       name: "Link",
+      quantity: 2,
     });
     expect(result.success).toBe(true);
     if (!result.success) return;
@@ -31,10 +28,10 @@ describeWithEnv("db > attendees > updateEventLink", { db: true }, () => {
   test("rejects update that would exceed capacity", async () => {
     const { updateEventLink } = await import("#lib/db/attendees.ts");
     const event = await createTestEvent({ maxAttendees: 3 });
-    const result = await createAttendeeAtomic({
-      bookings: [{ eventId: event.id, quantity: 2 }],
+    const result = await bookAttendee(event, {
       email: "cap@test.com",
       name: "Cap",
+      quantity: 2,
     });
     expect(result.success).toBe(true);
     if (!result.success) return;
@@ -52,8 +49,8 @@ describeWithEnv("db > attendees > updateEventLink", { db: true }, () => {
       eventType: "daily",
       maxAttendees: 10,
     });
-    const result = await createAttendeeAtomic({
-      bookings: [{ date: "2026-04-07", eventId: event.id }],
+    const result = await bookAttendee(event, {
+      date: "2026-04-07",
       email: "daily@test.com",
       name: "Daily",
     });

--- a/test/lib/db/auth.test.ts
+++ b/test/lib/db/auth.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { decryptWithKey } from "#lib/crypto/encryption.ts";
 import { deriveKEK, importPrivateKey, unwrapKey } from "#lib/crypto/keys.ts";
-import { createAttendeeAtomic, getAttendee } from "#lib/db/attendees.ts";
+import { getAttendee } from "#lib/db/attendees.ts";
 import { getDb, insert } from "#lib/db/client.ts";
 import {
   clearLoginAttempts,
@@ -13,6 +13,7 @@ import { createSession, getSession } from "#lib/db/sessions.ts";
 import { settings } from "#lib/db/settings.ts";
 import { getUserByUsername, verifyUserPassword } from "#lib/db/users.ts";
 import {
+  bookAttendee,
   createTestEvent,
   describeWithEnv,
   TEST_ADMIN_PASSWORD,
@@ -93,8 +94,7 @@ describeWithEnv("db > auth", { db: true }, () => {
       });
 
       // Create an attendee BEFORE password change
-      const beforeResult = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      const beforeResult = await bookAttendee(event, {
         email: "alice@example.com",
         name: "Alice Before",
         paymentId: "pi_before_change",
@@ -117,8 +117,7 @@ describeWithEnv("db > auth", { db: true }, () => {
       expect(changeSuccess).toBe(true);
 
       // Create an attendee AFTER password change
-      const afterResult = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      const afterResult = await bookAttendee(event, {
         email: "bob@example.com",
         name: "Bob After",
         paymentId: "pi_after_change",

--- a/test/lib/db/events.test.ts
+++ b/test/lib/db/events.test.ts
@@ -32,6 +32,7 @@ import {
   reserveSession,
 } from "#lib/db/processed-payments.ts";
 import {
+  bookAttendee,
   createTestAttendee,
   createTestEvent,
   describeWithEnv,
@@ -394,8 +395,7 @@ describeWithEnv("db > events", { db: true }, () => {
     test("deletes orphaned attendee", async () => {
       const { unlinkAttendeeFromEvent } = await import("#lib/db/attendees.ts");
       const event = await createTestEvent({ maxAttendees: 50 });
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      const result = await bookAttendee(event, {
         email: "orphan@example.com",
         name: "Orphan",
       });

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -16,7 +16,12 @@ import {
   isGroupSlugTaken,
   resetGroupEvents,
 } from "#lib/db/groups.ts";
-import { createTestEvent, createTestGroup, describeWithEnv } from "#test-utils";
+import {
+  bookAttendee,
+  createTestEvent,
+  createTestGroup,
+  describeWithEnv,
+} from "#test-utils";
 
 describeWithEnv("db > groups", { db: true }, () => {
   describe("CRUD", () => {
@@ -101,10 +106,10 @@ describeWithEnv("db > groups", { db: true }, () => {
         sql: "UPDATE events SET active = 0 WHERE id = ?",
       });
 
-      const attendee = await createAttendeeAtomic({
-        bookings: [{ eventId: e1.id, quantity: 3 }],
+      const attendee = await bookAttendee(e1, {
         email: "a@example.com",
         name: "A",
+        quantity: 3,
       });
       if (!attendee.success) throw new Error("Failed to create attendee");
 

--- a/test/lib/db/processed-payments.test.ts
+++ b/test/lib/db/processed-payments.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { getDb, insert } from "#lib/db/client.ts";
 import {
   finalizeSession as finalizePaymentSession,
@@ -9,7 +8,7 @@ import {
   STALE_RESERVATION_MS,
 } from "#lib/db/processed-payments.ts";
 import { nowMs } from "#lib/now.ts";
-import { createTestEvent, describeWithEnv } from "#test-utils";
+import { bookAttendee, createTestEvent, describeWithEnv } from "#test-utils";
 
 describeWithEnv("db > processed payments", { db: true }, () => {
   describe("reserveSession", () => {
@@ -23,8 +22,7 @@ describeWithEnv("db > processed payments", { db: true }, () => {
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
       });
-      const attendeeResult = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      const attendeeResult = await bookAttendee(event, {
         email: "test@example.com",
         name: "Test",
       });

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -15,6 +15,7 @@ import {
   adminFormPost,
   assertAdminHtml,
   awaitTestRequest,
+  bookAttendee,
   createPaidTestAttendee,
   createTestAttendee,
   createTestAttendeeDirect,
@@ -966,13 +967,12 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
     test("shows edit form with prefilled attendee data", async () => {
       const event = await createTestEvent({ maxAttendees: 100 });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
+      const result = await bookAttendee(event, {
         address: "123 Main St",
-        bookings: [{ eventId: event.id, quantity: 1 }],
         email: "john@example.com",
         name: "John Doe",
         phone: "555-1234",
+        quantity: 1,
         special_instructions: "VIP guest",
       });
       if (!result.success) throw new Error("Failed to create attendee");
@@ -1095,9 +1095,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         maxAttendees: 100,
         name: "Daily Dates Event",
       });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ date: "2026-04-07", eventId: event.id }],
+      const result = await bookAttendee(event, {
+        date: "2026-04-07",
         email: "daily@example.com",
         name: "Daily User",
       });
@@ -1443,11 +1442,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         maxAttendees: 100,
         name: "Event 2",
       });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event1.id, quantity: 1 }],
+      const result = await bookAttendee(event1, {
         email: "john@example.com",
         name: "John Doe",
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create attendee");
       const attendee = result.attendees[0]!;
@@ -1467,11 +1465,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
     test("shows edit form with empty email field", async () => {
       const event = await createTestEvent({ maxAttendees: 100 });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, quantity: 1 }],
+      const result = await bookAttendee(event, {
         email: "",
         name: "John Doe",
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create attendee");
       const attendee = result.attendees[0]!;
@@ -1489,11 +1486,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         name: "Inactive Event",
       });
 
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: inactiveEvent.id, quantity: 1 }],
+      const result = await bookAttendee(inactiveEvent, {
         email: "john@example.com",
         name: "John Doe",
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create attendee");
       const attendee = result.attendees[0]!;
@@ -1520,11 +1516,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
     test("updates attendee with empty email", async () => {
       const event = await createTestEvent({ maxAttendees: 100 });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, quantity: 1 }],
+      const result = await bookAttendee(event, {
         email: "john@example.com",
         name: "John Doe",
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create attendee");
       const attendee = result.attendees[0]!;
@@ -1545,13 +1540,12 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
     test("updates attendee with all non-empty fields", async () => {
       const event = await createTestEvent({ maxAttendees: 100 });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
+      const result = await bookAttendee(event, {
         address: "123 Main St",
-        bookings: [{ eventId: event.id, quantity: 1 }],
         email: "john@example.com",
         name: "John Doe",
         phone: "555-1234",
+        quantity: 1,
         special_instructions: "VIP",
       });
       if (!result.success) throw new Error("Failed to create attendee");
@@ -1683,13 +1677,12 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         unitPrice: 1000,
       });
 
-      // Create attendee with price_paid using createAttendeeAtomic
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, pricePaid: 1000, quantity: 1 }],
+      const result = await bookAttendee(event, {
         email: "jane@example.com",
         name: "Jane Paid",
         paymentId: "pi_test",
+        pricePaid: 1000,
+        quantity: 1,
       });
 
       if (!result.success) {
@@ -1697,7 +1690,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       }
 
       const response = await awaitTestRequest(
-        `/admin/event/${event.id}/attendee/${result.attendees[0]!.id}/resend-notification`,
+        `/admin/event/${event.id}/attendee/${
+          result.attendees[0]!.id
+        }/resend-notification`,
         { cookie: await testCookie() },
       );
       await expectHtmlResponse(
@@ -1824,12 +1819,12 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         maxAttendees: 100,
         unitPrice: 1000,
       });
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, pricePaid: 1000, quantity: 1 }],
+      const result = await bookAttendee(event, {
         email: "paid@example.com",
         name: "Paid User",
         paymentId: "pi_test_123",
+        pricePaid: 1000,
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create attendee");
       const response = await awaitTestRequest(
@@ -1851,14 +1846,13 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         maxAttendees: 100,
         unitPrice: 1000,
       });
-      const { createAttendeeAtomic, markRefunded } = await import(
-        "#lib/db/attendees.ts"
-      );
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, pricePaid: 1000, quantity: 1 }],
+      const { markRefunded } = await import("#lib/db/attendees.ts");
+      const result = await bookAttendee(event, {
         email: "refunded@example.com",
         name: "Refunded User",
         paymentId: "pi_refunded_123",
+        pricePaid: 1000,
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create attendee");
       await markRefunded(result.attendees[0]!.id, event.id);
@@ -1881,7 +1875,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const response = await awaitTestRequest(
         `/admin/attendees/${attendee.id}?flash=${FLASH_TEST_ID}`,
         {
-          cookie: `${cookie}; ${flashCookieHeader("Payment status is up to date")}`,
+          cookie: `${cookie}; ${flashCookieHeader(
+            "Payment status is up to date",
+          )}`,
         },
       );
       await expectHtmlResponse(response, 200, "Payment status is up to date");
@@ -2525,11 +2521,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         eventType: "daily",
         maxAttendees: 50,
       });
-      const { createAttendeeAtomic: create } = await import(
-        "#lib/db/attendees.ts"
-      );
-      const result = await create({
-        bookings: [{ date: "2026-04-07", eventId: event.id }],
+      const result = await bookAttendee(event, {
+        date: "2026-04-07",
         email: "dnd@test.com",
         name: "Daily NoDate",
       });
@@ -2547,11 +2540,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         eventType: "daily",
         maxAttendees: 50,
       });
-      const { createAttendeeAtomic: create } = await import(
-        "#lib/db/attendees.ts"
-      );
-      const result = await create({
-        bookings: [{ date: "2026-04-07", eventId: event.id }],
+      const result = await bookAttendee(event, {
+        date: "2026-04-07",
         email: "du@test.com",
         name: "Daily Upd",
       });
@@ -2651,7 +2641,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "john@example.com",
       );
       const response = await awaitTestRequest(
-        `/admin/attendees/${attendee.id}/merge?token=${encodeURIComponent(token)}`,
+        `/admin/attendees/${attendee.id}/merge?token=${encodeURIComponent(
+          token,
+        )}`,
         { cookie: await testCookie() },
       );
       await expectHtmlResponse(
@@ -2674,7 +2666,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "john@example.com",
       );
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       await expectHtmlResponse(
@@ -2694,7 +2688,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     sourceToken: string,
   ): Promise<string> => {
     const page = await awaitTestRequest(
-      `/admin/attendees/${targetId}/merge?token=${encodeURIComponent(sourceToken)}`,
+      `/admin/attendees/${targetId}/merge?token=${encodeURIComponent(
+        sourceToken,
+      )}`,
       { cookie: await testCookie() },
     );
     const html = await page.text();
@@ -2985,7 +2981,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "Gluten free",
       );
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       // Multiline fields (address, special_instructions) differ — exercises renderFieldValue(val, true) with same=false
@@ -3009,7 +3007,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "john@example.com",
       );
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       await expectHtmlResponse(response, 200, "Merge Preview");
@@ -3030,7 +3030,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "",
       );
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       await expectHtmlResponse(response, 200, "Merge Preview");
@@ -3048,10 +3050,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         maxAttendees: 50,
         name: "Daily E",
       });
-      // Create source via createAttendeeAtomic with a daily event date
-      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
-      const result = await createAttendeeAtomic({
-        bookings: [{ date: "2026-05-01", eventId: dailyEvent.id }],
+      const result = await bookAttendee(dailyEvent, {
+        date: "2026-05-01",
         email: "john@example.com",
         name: "John Smith",
       });
@@ -3059,7 +3059,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const sourceToken = result.attendees[0]!.ticket_token;
 
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       // start_at is set for daily events — exercises the b.start_at ? `— date` : "" branch
@@ -3082,7 +3084,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
 
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       // All bookings are moveable (different events) — no Decision column rendered
@@ -3104,7 +3108,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
 
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       // Same event, same qty/price/checked_in/refunded — classified as "duplicate"
@@ -3155,7 +3161,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       await save([sourceData!.id], [a2.id]);
 
       const response = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       await expectHtmlResponse(
@@ -3206,7 +3214,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
       // Get merge version from preview page
       const previewPage = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       const previewHtml = await previewPage.text();
@@ -3248,7 +3258,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
       // Get merge version
       const previewPage = await awaitTestRequest(
-        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+        `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+          sourceToken,
+        )}`,
         { cookie: await testCookie() },
       );
       const html = await previewPage.text();

--- a/test/lib/server-checkin.test.ts
+++ b/test/lib/server-checkin.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { formatDateLabel } from "#lib/dates.ts";
-import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { handleRequest } from "#routes";
 import {
   adminGet,
   awaitTestRequest,
+  bookAttendee,
   createDailyTestAttendee,
   createTestAttendeeWithToken,
   createTestEvent,
@@ -219,8 +219,7 @@ describeWithEnv("check-in (/checkin/:tokens)", { db: true }, () => {
 
     test("renders empty email and phone for attendee without contact details", async () => {
       const event = await createTestEvent({ maxAttendees: 10 });
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      const result = await bookAttendee(event, {
         email: "",
         name: "NoContact",
       });

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
-import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
   assertPublicHtml,
   awaitTestRequest,
+  bookAttendee,
   createTestEvent,
   deactivateTestEvent,
   describeWithEnv,
@@ -186,8 +186,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
 
       // Fill the event with another attendee (using atomic to simulate production flow)
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      await bookAttendee(event, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
@@ -693,8 +692,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
 
       // Create attendee as if payment was already processed (using atomic to simulate production flow)
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      await bookAttendee(event, {
         email: "john@example.com",
         name: "John",
         paymentId: "pi_test_123",
@@ -794,8 +792,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
 
       // Fill the event (using atomic to simulate production flow)
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      await bookAttendee(event, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
@@ -1062,8 +1059,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
 
       // Fill the event
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      await bookAttendee(event, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
@@ -1116,8 +1112,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
 
       // Fill event2
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event2.id }],
+      await bookAttendee(event2, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
@@ -1455,11 +1450,11 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
 
       // Create attendee directly (simulates post-payment state)
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, pricePaid: 500 }],
+      const result = await bookAttendee(event, {
         email: "buyer@example.com",
         name: "Email Test",
         paymentId: "pi_email_notice",
+        pricePaid: 500,
       });
       if (!result.success) throw new Error("Failed to create attendee");
 
@@ -1472,7 +1467,9 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       try {
         const response = await handleRequest(
           mockRequest(
-            `/payment/success?tokens=${encodeURIComponent(result.attendees[0]!.ticket_token)}`,
+            `/payment/success?tokens=${encodeURIComponent(
+              result.attendees[0]!.ticket_token,
+            )}`,
           ),
         );
         const html = await expectHtmlResponse(response, 200, "Junk/Spam");

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { addDays } from "#lib/dates.ts";
-import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import { insertBuiltSite } from "#lib/db/built-sites.ts";
 import {
   answersTable,
@@ -20,6 +19,7 @@ import {
   assertJson,
   assertPublicHtml,
   awaitTestRequest,
+  bookAttendee,
   createTestEvent,
   createTestGroup,
   createTestHoliday,
@@ -324,10 +324,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         maxAttendees: 1,
         name: "Full Event",
       });
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, quantity: 1 }],
+      await bookAttendee(event, {
         email: "a@test.com",
         name: "Attendee",
+        quantity: 1,
       });
       const html = await assertPublicHtml("/events", "Sold Out");
       expect(html).not.toContain(`href="/ticket/${event.slug}"`);
@@ -1494,10 +1494,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         name: "Multi Full",
       });
       // Fill up event2
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event2.id, quantity: 1 }],
+      await bookAttendee(event2, {
         email: "john@example.com",
         name: "John",
+        quantity: 1,
       });
 
       await assertPublicHtml(
@@ -1517,10 +1517,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         maxAttendees: 1,
         name: "Multi Full Desc",
       });
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event2.id, quantity: 1 }],
+      await bookAttendee(event2, {
         email: "jane@example.com",
         name: "Jane",
+        quantity: 1,
       });
 
       await assertPublicHtml(
@@ -2158,10 +2158,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
 
       // Fill up event1 to make it sold out
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event1.id, quantity: 1 }],
+      await bookAttendee(event1, {
         email: "first@example.com",
         name: "First",
+        quantity: 1,
       });
 
       // GET the ticket page (sold-out event will show Sold Out label)
@@ -2249,8 +2249,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
 
       // Fill event1
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event1.id }],
+      await bookAttendee(event1, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
@@ -2573,10 +2572,10 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
 
       // Fill event1 to capacity
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event1.id, quantity: 1 }],
+      await bookAttendee(event1, {
         email: "first@example.com",
         name: "First",
+        quantity: 1,
       });
 
       const path = `/ticket/${event1.slug}+${event2.slug}`;

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
-import { createAttendeeAtomic } from "#lib/db/attendees.ts";
 import {
   answersTable,
   getAttendeeAnswersBatch,
@@ -13,6 +12,7 @@ import { resetStripeClient, stripeApi } from "#lib/stripe.ts";
 import { handleRequest } from "#routes";
 import {
   assertJson,
+  bookAttendee,
   createTestEvent,
   deactivateTestEvent,
   describeWithEnv,
@@ -456,8 +456,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
       });
 
       // Fill the event
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event.id }],
+      await bookAttendee(event, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
@@ -1153,11 +1152,11 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         unitPrice: 500,
       });
       // Create attendee directly (not via public form which redirects to Stripe for paid events)
-      const result = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, quantity: 1 }],
+      const result = await bookAttendee(event, {
         email: "already@example.com",
         name: "Already Done",
         paymentId: "pi_already_done",
+        quantity: 1,
       });
       if (!result.success) throw new Error("Failed to create test attendee");
       const attendee = result.attendees[0]!;
@@ -1298,11 +1297,11 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         name: "Multi WH Full",
         unitPrice: 500,
       });
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event2.id, quantity: 1 }],
+      await bookAttendee(event2, {
         email: "first@example.com",
         name: "First",
         paymentId: "pi_first",
+        quantity: 1,
       });
 
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
@@ -1602,10 +1601,10 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
       });
 
       // Fill event2 to capacity
-      await createAttendeeAtomic({
-        bookings: [{ eventId: event2.id, quantity: 1 }],
+      await bookAttendee(event2, {
         email: "existing@example.com",
         name: "Existing",
+        quantity: 1,
       });
 
       const { stripePaymentProvider } = await import("#lib/stripe-provider.ts");
@@ -1671,11 +1670,11 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         name: "WH Del Evt",
         unitPrice: 500,
       });
-      const attResult = await createAttendeeAtomic({
-        bookings: [{ eventId: event.id, quantity: 1 }],
+      const attResult = await bookAttendee(event, {
         email: "whdel@example.com",
         name: "WH Del",
         paymentId: "pi_del",
+        quantity: 1,
       });
       if (!attResult.success) throw new Error("Failed to create attendee");
 


### PR DESCRIPTION
## Summary

- Adds a `bookAttendee(event, opts)` helper in `#test-utils` that wraps `createAttendeeAtomic` for the common single-booking test pattern with sensible defaults (name `"X"`, email `"x@example.com"`).
- Refactors ~25 existing call sites across the recently-split test files (`test/lib/db/attendees/*`, `test/lib/server-*.test.ts`, a few others) to use the new helper.
- Keeps all multi-booking and `createAttendeeAtomic`-subject tests unchanged.

Before:
```ts
await createAttendeeAtomic({
  bookings: [{ eventId: event.id, quantity }],
  email: "x@example.com",
  name: "X",
});
```

After:
```ts
await bookAttendee(event, { quantity });
```

## Test plan
- [x] `deno task precommit` (typecheck, lint, cpd, build:edge, test:coverage) passes locally.
