### PR TITLE
Add rawEventRange helper to test-utils

### DIFF
--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -23,7 +23,7 @@ import { generateSecureToken } from "#lib/crypto/utils.ts";
 import { signCsrfToken } from "#lib/csrf.ts";
 import { toMajorUnits } from "#lib/currency.ts";
 import { createApiKey } from "#lib/db/api-keys.ts";
-import { getDb, insert, setDb } from "#lib/db/client.ts";
+import { getDb, insert, queryOne, setDb } from "#lib/db/client.ts";
 import {
   type EventInput,
   getEventWithCount,
@@ -1409,6 +1409,24 @@ export const createTestAttendee = async (
  * This is used in production by getAttendees, so not a test-only export
  */
 export { getAttendeesRaw };
+
+/** Range fields from event_attendees that aren't on the Attendee type. */
+export type RawEventRange = {
+  start_at: string | null;
+  end_at: string | null;
+  quantity: number;
+};
+
+/**
+ * Fetch raw start_at/end_at/quantity for the first event_attendees row
+ * matching an event. Useful for tests that need the full timestamps
+ * (getAttendeesRaw only exposes the truncated `date` field).
+ */
+export const rawEventRange = (eventId: number): Promise<RawEventRange | null> =>
+  queryOne<RawEventRange>(
+    "SELECT start_at, end_at, quantity FROM event_attendees WHERE event_id = ? ORDER BY attendee_id LIMIT 1",
+    [eventId],
+  );
 
 // ---------------------------------------------------------------------------
 // FP-style curried assertion helpers

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -37,6 +37,7 @@ import {
   mockRequest,
   mockWebhookRequest,
   randomString,
+  rawEventRange,
   requireJoinCsrfToken,
   resetDb,
   resetTestSession,
@@ -696,6 +697,35 @@ describe("test-utils", () => {
       await expect(
         createTestAttendeeDirect(event.id, "Second", "second@example.com"),
       ).rejects.toThrow("Failed to create attendee");
+    });
+  });
+
+  describe("rawEventRange", () => {
+    beforeEach(async () => {
+      await createTestDbWithSetup();
+    });
+
+    test("returns start_at/end_at/quantity for the first booking", async () => {
+      const { createDailyTestEvent } = await import("#test-utils");
+      const { createAttendeeAtomic } = await import("#lib/db/attendees.ts");
+      const event = await createDailyTestEvent({ maxAttendees: 10 });
+      const result = await createAttendeeAtomic({
+        bookings: [{ date: "2026-05-01", eventId: event.id, quantity: 3 }],
+        email: "alice@test.com",
+        name: "Alice",
+      });
+      if (!result.success) throw new Error("create failed");
+
+      const range = await rawEventRange(event.id);
+      expect(range).not.toBeNull();
+      expect(range!.start_at).toBe("2026-05-01T00:00:00Z");
+      expect(range!.end_at).toBe("2026-05-02T00:00:00.000Z");
+      expect(range!.quantity).toBe(3);
+    });
+
+    test("returns null when no bookings exist for the event", async () => {
+      const event = await createTestEvent();
+      expect(await rawEventRange(event.id)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `rawEventRange(eventId)` helper in `src/test-utils/index.ts` that returns `{start_at, end_at, quantity}` from the first `event_attendees` row for an event.
- `getAttendeesRaw` only exposes a truncated `date` field (via `SUBSTR(ea.start_at, 1, 10)`), so tests needing the full timestamps previously had to run their own `SELECT` against `event_attendees`.
- Includes unit tests for the new helper: one asserting it returns the correct `start_at`/`end_at`/`quantity` for a booking, and one asserting it returns `null` when no bookings exist.

## Test plan

- [x] `deno task precommit` passes locally (typecheck, lint, biome, cpd, build:edge, test:coverage)
- [x] New tests pass in `test/lib/test-utils.test.ts`

https://claude.ai/code/session_01PheQNue9QohDA1bfxynbHD