### PR TITLE
Scope TEST_EXPECT_ERROR to async context to fix flaky parallel tests

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,8 @@
  * Uses lazy loading to minimize startup time for edge scripts
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { lazyRef, once, reduce } from "#fp";
 import { loadEffectiveDomain } from "#lib/config.ts";
 import {
@@ -68,6 +70,27 @@ const [getRethrowErrors, setRethrowErrors] = lazyRef<boolean | null>(
 /** Explicitly enable/disable test error rethrowing without env var races */
 export const setRethrowErrorsForTest = (rethrow: boolean | null): void =>
   setRethrowErrors(rethrow);
+
+/**
+ * Per-async-context flag set by `runWithExpectedError` so a specific call site
+ * can opt out of the test rethrow guard without touching process-wide state
+ * (which would race with concurrent tests in other files).
+ */
+const expectedErrorContext = new AsyncLocalStorage<true>();
+
+/** True when the current async context is inside a `runWithExpectedError` scope. */
+const isExpectedErrorActive = (): boolean =>
+  expectedErrorContext.getStore() === true;
+
+/**
+ * Run a callback inside a scope where `handleRequest` treats thrown errors as
+ * responses (via `handleRoutingError`) instead of rethrowing them. Scope is
+ * per-async-context, so concurrent tests don't interfere.
+ */
+export const runWithExpectedError = <T>(
+  fn: () => T | Promise<T>,
+): Promise<T> =>
+  expectedErrorContext.run(true, async (): Promise<T> => await fn());
 
 /** Lazy-load admin routes (only needed for authenticated admin requests) */
 const loadAdminRoutes = once(async () => {
@@ -342,7 +365,7 @@ const routeMainApp: RouterFn = async (request, path, method, server) => {
   if (!Object.hasOwn(prefixHandlers, prefix)) return notFoundResponse();
   return (
     (await prefixHandlers[prefix]?.(request, path, method, server)) ??
-    notFoundResponse()
+      notFoundResponse()
   );
 };
 
@@ -404,8 +427,7 @@ const logAndReturn = (
 const bufferRequestIfNeeded = async (request: Request): Promise<Request> => {
   const { pathname } = new URL(request.url);
   const contentType = request.headers.get("content-type") ?? "";
-  const needsBodyBuffer =
-    request.method === "POST" &&
+  const needsBodyBuffer = request.method === "POST" &&
     (isWebhookPath(normalizePath(pathname)) ||
       contentType.startsWith("multipart/form-data"));
   if (!needsBodyBuffer) return request;
@@ -501,7 +523,7 @@ const handleRoutingError = (
   if (
     getRethrowErrors() &&
     !(error instanceof SessionKeyError) &&
-    !Deno.env.get("TEST_EXPECT_ERROR")
+    !isExpectedErrorActive()
   ) {
     throw error;
   }
@@ -578,9 +600,9 @@ export const handleRequest = async (
     runWithRequestCache(() =>
       runWithQueryLogContext(() =>
         runWithFlashContext(() =>
-          runWithSessionContext(() => processRequest(effectiveRequest, server)),
-        ),
-      ),
-    ),
+          runWithSessionContext(() => processRequest(effectiveRequest, server))
+        )
+      )
+    )
   );
 };

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -43,7 +43,10 @@ import { setSuppressDebugLogs, setSuppressRequestLogs } from "#lib/logger.ts";
 import { runWithStorageConfig } from "#lib/storage.ts";
 import type { Attendee, Event, EventWithCount, Group } from "#lib/types.ts";
 import { setSkipLoginDelayForTest } from "#routes/admin/auth.ts";
-import { setRethrowErrorsForTest } from "#routes/index.ts";
+import {
+  runWithExpectedError,
+  setRethrowErrorsForTest,
+} from "#routes/index.ts";
 
 /**
  * Default test admin username
@@ -361,17 +364,12 @@ export const urlFromFetchInput = (input: string | URL | Request): string =>
 
 /**
  * Run a callback that intentionally triggers an error caught by handleRequest.
- * Temporarily sets TEST_EXPECT_ERROR so the error is returned as a response
- * instead of being rethrown by the TEST_RETHROW_ERRORS guard.
+ * The scope is per-async-context (via AsyncLocalStorage inside the routes
+ * module), so concurrent tests in other files can't flip the flag mid-request.
  */
-export const withExpectedError = bracket(
-  () => {
-    Deno.env.set("TEST_EXPECT_ERROR", "1");
-  },
-  () => {
-    Deno.env.delete("TEST_EXPECT_ERROR");
-  },
-);
+export const withExpectedError = <T>(
+  fn: () => T | Promise<T>,
+): Promise<T> => runWithExpectedError(fn);
 
 /**
  * Swap globalThis.fetch for the duration of a callback, using bracket for safe restore.

--- a/test/lib/server-misc.test.ts
+++ b/test/lib/server-misc.test.ts
@@ -354,7 +354,7 @@ describeWithEnv("server (misc)", { db: true }, () => {
         const flashId = url.searchParams.get("flash")!;
         const cookies = response.headers.getSetCookie();
         const flashCookie = cookies.find((c) =>
-          c.startsWith(`flash_${flashId}=`),
+          c.startsWith(`flash_${flashId}=`)
         );
         expect(flashCookie).toBeDefined();
       }));
@@ -619,10 +619,6 @@ describeWithEnv("server (misc)", { db: true }, () => {
       // resolve from cache; the stub then only affects route-handler queries
       // inside the inner try/catch.
       await s.loadAll();
-      // Ensure TEST_EXPECT_ERROR is not set (concurrent tests may set it),
-      // otherwise handleRequest swallows the error instead of rethrowing.
-      const hadExpectError = Deno.env.get("TEST_EXPECT_ERROR");
-      Deno.env.delete("TEST_EXPECT_ERROR");
       const executeStub = stub(db, "execute", () => {
         throw new Error("synthetic db failure");
       });
@@ -632,7 +628,6 @@ describeWithEnv("server (misc)", { db: true }, () => {
         ).rejects.toThrow("synthetic db failure");
       } finally {
         executeStub.restore();
-        if (hadExpectError) Deno.env.set("TEST_EXPECT_ERROR", hadExpectError);
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure in `test/lib/server-misc.test.ts:612`
("rethrows unhandled errors in test mode") by replacing the process-wide
`TEST_EXPECT_ERROR` env var with an AsyncLocalStorage-scoped flag.

### The race

`withExpectedError` (in `src/test-utils/index.ts`) used to set/unset the
`TEST_EXPECT_ERROR` env var around a callback, and `handleRoutingError`
in `src/routes/index.ts` read it to decide whether to rethrow or swallow
route errors in test mode. Because the env var is process-wide, any
concurrent test in another file that entered a `withExpectedError`
scope could flip the flag while an unrelated `handleRequest` was
already mid-await. That's exactly what the "rethrows unhandled errors"
test tripped over — its await resolved to a swallowed Response instead
of a rethrown error. An inline comment on that test documents the
hazard, and PR #968 fixed a similar race for a different call site
(`current_task`).

### The fix

- Introduce `expectedErrorContext`, an `AsyncLocalStorage<true>` in
  `src/routes/index.ts`.
- Export a new `runWithExpectedError(fn)` helper that runs `fn` inside
  `expectedErrorContext.run(true, …)`. Awaits inside `fn` inherit the
  flag via AsyncHooks, but tests in other async contexts never see it.
- `handleRoutingError` checks `isExpectedErrorActive()` instead of
  `Deno.env.get("TEST_EXPECT_ERROR")`.
- `withExpectedError` in `src/test-utils/index.ts` now delegates to
  `runWithExpectedError` — same call-site API, no env mutation.
- Drop the defensive `Deno.env.get/delete/set("TEST_EXPECT_ERROR")`
  dance in `test/lib/server-misc.test.ts:612`; it was only there to
  paper over the race and is no longer needed.

No production behaviour changes — `runWithExpectedError` is only
entered from tests, and outside of it the rethrow guard behaves
identically to before.

## Test plan

- [x] Full suite: `277 passed, 0 failed`, 100% line and branch coverage
- [x] `deno task typecheck`, `deno task lint`, `deno task cpd`, `deno task build:edge`: clean
- [x] 5× parallel runs of the four test files that exercise
  `withExpectedError` (`server-misc`, `server-webhooks`,
  `server-setup`, `server-images`): all green, ~1s each

https://claude.ai/code/session_0138j8PvDmTBnL4NyZxUrKLm