### PR TITLE
Drop stale attendee PII columns when event_id already gone

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -34,7 +34,7 @@ type Table = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "drop PII columns from attendees (now in pii_blob)";
+  "drop any legacy columns from attendees (event_id + pre-pii_blob PII)";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 
@@ -489,17 +489,28 @@ const recreateTable = async (tableName: string): Promise<void> => {
   await createIndexesForTable(tableName, tableSchema[1].indexes ?? []);
 };
 
+/** Get the set of columns declared by SCHEMA for a given table */
+const getSchemaColumns = (tableName: string): Set<string> =>
+  new Set(
+    SCHEMA.find(([n]) => n === tableName)![1].columns.map(([c]) => c),
+  );
+
 /**
- * Drop event_id, date, quantity from attendees table.
- * SQLite can't DROP COLUMN when a FK references the column, so we recreate the table.
- * Only runs if the old columns still exist (idempotent).
+ * Drop any legacy columns from attendees that aren't in the current schema
+ * (event_id, date, quantity, and the pre-pii_blob PII columns: name, email,
+ * phone, address, payment_id, etc).
+ *
+ * SQLite can't DROP COLUMN when a FK references the column, so we recreate
+ * the table. Idempotent: if every existing column matches the schema, skip.
  */
 const dropDeprecatedAttendeeColumns = async (): Promise<void> => {
   const cols = await getExistingColumns("attendees");
-  if (!cols.has("event_id")) {
+  const expected = getSchemaColumns("attendees");
+  const hasLegacy = [...cols].some((c) => !expected.has(c));
+  if (!hasLegacy) {
     logDebug(
       "Migration",
-      "attendees.event_id already dropped, skipping table recreation",
+      "attendees has no legacy columns, skipping table recreation",
     );
     return;
   }

--- a/test/lib/db/legacy-migration.test.ts
+++ b/test/lib/db/legacy-migration.test.ts
@@ -284,11 +284,54 @@ describe("db > event_attendees migration from legacy schema", () => {
     expect(colNames).not.toContain("event_id");
     expect(colNames).not.toContain("date");
     expect(colNames).not.toContain("quantity");
+    expect(colNames).not.toContain("name");
+    expect(colNames).not.toContain("email");
+    expect(colNames).not.toContain("phone");
+    expect(colNames).not.toContain("address");
+    expect(colNames).not.toContain("payment_id");
     expect(colNames).toContain("id");
     expect(colNames).toContain("pii_blob");
 
     const payments = await client.execute("SELECT * FROM processed_payments");
     expect(payments.rows.length).toBe(1);
     expect(payments.rows[0]!.attendee_id).toBe(1);
+  });
+
+  test("drops PII columns when event_id was dropped in a prior partial run", async () => {
+    setupTestEncryptionKey();
+    const client = createClient({ url: ":memory:" });
+    setDb(client);
+
+    // Simulate a DB in the intermediate state: event_id and its relatives
+    // have already been dropped (e.g. by a partial earlier migration), but
+    // the pre-pii_blob PII columns are still present with NOT NULL.
+    await client.execute(
+      "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+    );
+    await client.execute(`CREATE TABLE attendees (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL,
+      phone TEXT NOT NULL DEFAULT '',
+      address TEXT NOT NULL DEFAULT '',
+      payment_id TEXT,
+      created TEXT NOT NULL,
+      ticket_token_index TEXT,
+      pii_blob TEXT NOT NULL DEFAULT '',
+      checked_in TEXT NOT NULL DEFAULT '',
+      price_paid TEXT
+    )`);
+
+    await initDb();
+
+    const cols = await client.execute("PRAGMA table_info(attendees)");
+    const colNames = cols.rows.map((r) => r.name);
+    expect(colNames).not.toContain("name");
+    expect(colNames).not.toContain("email");
+    expect(colNames).not.toContain("phone");
+    expect(colNames).not.toContain("address");
+    expect(colNames).not.toContain("payment_id");
+    expect(colNames).toContain("pii_blob");
+    expect(colNames).toContain("ticket_token_index");
   });
 });


### PR DESCRIPTION
## Summary

Fixes `SQLITE_CONSTRAINT: NOT NULL constraint failed: attendees.name` at the payment webhook boundary (reported after an Apple Pay purchase, but the payment method is incidental — any attendee insert fails).

Root cause: `dropDeprecatedAttendeeColumns` only recreated the `attendees` table when the legacy `event_id` column was still present. A DB that reached an intermediate state — `event_id` dropped but the pre-`pii_blob` PII columns (`name`, `email`, `phone`, `address`, `payment_id`) still present with `NOT NULL` — bypassed the recreation. New inserts only set `pii_blob` / `created` / `ticket_token_index`, so any lingering `attendees.name TEXT NOT NULL` fails every insert.

## Fix

- `dropDeprecatedAttendeeColumns` now detects **any** column on `attendees` that isn't in the current `SCHEMA` and triggers recreation whenever one remains.
- Bump `LATEST_UPDATE` so existing deployments re-run the migration pass.
- New test covers the intermediate state (event_id dropped but PII columns remain).

## Test plan

- [x] `deno test test/lib/db/legacy-migration.test.ts` — both scenarios pass
- [x] `deno test test/lib/db/migrations.test.ts` — all 13 steps pass
- [x] `deno test test/lib/db/attendees/` — 13 passed / 45 steps
- [x] `deno task typecheck` clean
- [x] `deno task lint` clean

https://claude.ai/code/session_01SV2RgpUGkmRN47U5TzYZtR