### PR TITLE
Strengthen migration tests and document backfill error-swallowing

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -632,7 +632,10 @@ export const initDb = async (): Promise<void> => {
 
   // 4. Backfill event_attendees from existing attendees data (idempotent)
   // Convert attendees.date ("YYYY-MM-DD") to start_at/end_at (full-day UTC range)
-  // Also copies per-event status columns to event_attendees
+  // Also copies per-event status columns to event_attendees.
+  // NOTE: On DBs where event_id was already dropped (intermediate state),
+  // this SELECT fails with "no such column" — runMigration swallows that
+  // error, making the backfill a safe no-op before dropDeprecatedAttendeeColumns.
   logDebug("Migration", "Step 3: backfilling event_attendees...");
   await runMigration(
     `INSERT OR IGNORE INTO event_attendees (event_id, attendee_id, start_at, end_at, quantity, checked_in, refunded, price_paid, attachment_downloads)

--- a/test/lib/db/legacy-migration.test.ts
+++ b/test/lib/db/legacy-migration.test.ts
@@ -322,6 +322,17 @@ describe("db > event_attendees migration from legacy schema", () => {
       price_paid TEXT
     )`);
 
+    await client.execute(
+      insert("attendees", {
+        created: "2024-03-01T00:00:00Z",
+        email: "alice@example.com",
+        id: 1,
+        name: "Alice",
+        pii_blob: "encrypted-data",
+        ticket_token_index: "tok_abc",
+      }),
+    );
+
     await initDb();
 
     const cols = await client.execute("PRAGMA table_info(attendees)");
@@ -333,5 +344,47 @@ describe("db > event_attendees migration from legacy schema", () => {
     expect(colNames).not.toContain("payment_id");
     expect(colNames).toContain("pii_blob");
     expect(colNames).toContain("ticket_token_index");
+
+    const rows = await client.execute("SELECT * FROM attendees WHERE id = 1");
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0]!.created).toBe("2024-03-01T00:00:00Z");
+    expect(rows.rows[0]!.pii_blob).toBe("encrypted-data");
+    expect(rows.rows[0]!.ticket_token_index).toBe("tok_abc");
+  });
+
+  test("skips table recreation when attendees already matches schema", async () => {
+    setupTestEncryptionKey();
+    const client = createClient({ url: ":memory:" });
+    setDb(client);
+
+    // Run initDb on a fresh DB so everything is created and up to date
+    await initDb();
+
+    // Insert a row so we can verify it's untouched (not lost to a spurious recreation)
+    await client.execute(
+      insert("attendees", {
+        created: "2024-05-01T00:00:00Z",
+        id: 1,
+        pii_blob: "blob-data",
+        ticket_token_index: "tok_skip",
+      }),
+    );
+
+    // Force a re-run by clearing the version marker
+    await client.execute(
+      "DELETE FROM settings WHERE key IN ('latest_db_update', 'db_schema_hash')",
+    );
+    await initDb();
+
+    const cols = await client.execute("PRAGMA table_info(attendees)");
+    const colNames = cols.rows.map((r) => r.name);
+    expect(colNames).toContain("id");
+    expect(colNames).toContain("pii_blob");
+    expect(colNames).toContain("created");
+
+    const rows = await client.execute("SELECT * FROM attendees WHERE id = 1");
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0]!.pii_blob).toBe("blob-data");
+    expect(rows.rows[0]!.ticket_token_index).toBe("tok_skip");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1015 — addresses three gaps identified during review of the `dropDeprecatedAttendeeColumns` change:

- **Data preservation test for intermediate state**: The test that exercises the partial-migration path (event_id already dropped, PII columns remaining) now inserts a row before migration and verifies `created`, `pii_blob`, and `ticket_token_index` survive the table recreation
- **Skip-path test**: New test verifies that when attendees already matches the schema, re-running `initDb` does not spuriously recreate the table — data inserted between runs remains intact
- **Document error-swallowing backfill**: Added a comment explaining that the event_attendees backfill SELECT intentionally fails with "no such column" on intermediate-state DBs, relying on `runMigration`'s error-swallowing for control flow

## Test plan

- [ ] `deno test --no-check --allow-all test/lib/db/legacy-migration.test.ts` — all three tests pass
- [ ] `deno task precommit` — full suite passes

https://claude.ai/code/session_01LEJLLcjQtd9vxDQrMSZQ1f