### PR TITLE
Fix dark mode overriding .inline and .one-button form resets

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -77,12 +77,6 @@ html[data-theme="dark"] {
   box-shadow: 0 0 12px rgba(189, 147, 249, 0.3),
               0 0 24px rgba(189, 147, 249, 0.15);
 }
-[data-theme="dark"] .inline,
-[data-theme="dark"] .inline button,
-[data-theme="dark"] .one-button {
-  box-shadow: none;
-  border: none;
-}
 [data-theme="dark"] input[type="text"],
 [data-theme="dark"] input[type="password"],
 [data-theme="dark"] input[type="email"],
@@ -540,8 +534,8 @@ form {
 }
 
 form.one-button {
-  border: none;
-  box-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
   padding-left: 0;
   padding-right: 0;
 }
@@ -1004,9 +998,9 @@ button.bulk-checkout:hover {
 
 .inline {
   display: inline;
-  box-shadow: none;
+  box-shadow: none !important;
   padding: 0;
-  border: none;
+  border: none !important;
 }
 
 .inline button {
@@ -1014,9 +1008,9 @@ button.bulk-checkout:hover {
   color: var(--color-link);
   text-decoration: underline;
   padding: 0;
-  border: none;
+  border: none !important;
   margin: 0;
-  box-shadow: none;
+  box-shadow: none !important;
 }
 
 button.link-button {

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -536,8 +536,8 @@ form {
 form.one-button {
   border: none !important;
   box-shadow: none !important;
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
 form.no-bg {
@@ -999,7 +999,7 @@ button.bulk-checkout:hover {
 .inline {
   display: inline;
   box-shadow: none !important;
-  padding: 0;
+  padding: 0 !important;
   border: none !important;
 }
 
@@ -1007,7 +1007,7 @@ button.bulk-checkout:hover {
   background-color: transparent;
   color: var(--color-link);
   text-decoration: underline;
-  padding: 0;
+  padding: 0 !important;
   border: none !important;
   margin: 0;
   box-shadow: none !important;

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -77,6 +77,12 @@ html[data-theme="dark"] {
   box-shadow: 0 0 12px rgba(189, 147, 249, 0.3),
               0 0 24px rgba(189, 147, 249, 0.15);
 }
+[data-theme="dark"] .inline,
+[data-theme="dark"] .inline button,
+[data-theme="dark"] .one-button {
+  box-shadow: none;
+  border: none;
+}
 [data-theme="dark"] input[type="text"],
 [data-theme="dark"] input[type="password"],
 [data-theme="dark"] input[type="email"],
@@ -1010,7 +1016,7 @@ button.bulk-checkout:hover {
   padding: 0;
   border: none;
   margin: 0;
-  box-shadow: none !important;
+  box-shadow: none;
 }
 
 button.link-button {


### PR DESCRIPTION
## Summary

- The `[data-theme="dark"] form` rule (specificity 0-1-1) was overriding `.inline` and `.one-button` resets (specificity 0-1-0), causing dark mode box-shadow/border to bleed through on inline forms
- Added `[data-theme="dark"] .inline`, `[data-theme="dark"] .inline button`, and `[data-theme="dark"] .one-button` overrides (specificity 0-2-0) to properly win without `!important`
- Removed the existing `!important` on `.inline button` since it's no longer needed

## Test plan

- [ ] Toggle dark mode on and verify `.inline` forms have no box-shadow or border
- [ ] Verify `.one-button` forms also have no shadow/border in dark mode
- [ ] Verify regular forms still have the purple glow in dark mode

https://claude.ai/code/session_0152cYKk4rRpRUA8SCtyZiZp