### PR TITLE
Return 409 from webhook on reservation conflict

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -26,7 +26,6 @@ import { getEvent, getEventWithCount } from "#lib/db/events.ts";
 import {
   clearSessionTokens,
   decryptSessionTokens,
-  deleteStaleReservation,
   finalizeSession,
   type ProcessedPayment,
   reserveSession,
@@ -564,52 +563,42 @@ const processPaymentSession = async (
   }
 
   // Phase 2: Validate events and create attendees atomically
-  // If anything throws after reservation, release the lock so the next attempt can retry
-  try {
-    const validated = await validateAllItems(session, intent);
-    if ("success" in validated) return validated;
-    const validatedItems = validated.items;
+  const validated = await validateAllItems(session, intent);
+  if ("success" in validated) return validated;
+  const validatedItems = validated.items;
 
-    const pricingError = await verifyPaidPricing(
-      session,
-      intent,
-      validatedItems,
-    );
-    if (pricingError) return pricingError;
+  const pricingError = await verifyPaidPricing(session, intent, validatedItems);
+  if (pricingError) return pricingError;
 
-    const created = await createAttendeeForSession(
-      session,
-      intent,
-      validatedItems,
-    );
-    if ("success" in created) return created;
-    const createdEntries = created.entries;
+  const created = await createAttendeeForSession(
+    session,
+    intent,
+    validatedItems,
+  );
+  if ("success" in created) return created;
+  const createdEntries = created.entries;
 
-    if (intent.eventAnswerIds) {
-      await saveEventAnswers(createdEntries, intent.eventAnswerIds);
-    }
-
-    const firstAttendee = createdEntries[0]!;
-    const ticketToken = firstAttendee.attendee.ticket_token;
-
-    await finalizeSession(
-      sessionId,
-      firstAttendee.attendee.id,
-      options?.storeTokens === false ? [] : [ticketToken],
-    );
-
-    await logAndNotifyRegistration(createdEntries);
-
-    return {
-      attendee: firstAttendee.attendee,
-      event: firstAttendee.event,
-      success: true,
-      ticketTokens: [ticketToken],
-    };
-  } catch (error) {
-    await deleteStaleReservation(sessionId);
-    throw error;
+  if (intent.eventAnswerIds) {
+    await saveEventAnswers(createdEntries, intent.eventAnswerIds);
   }
+
+  const firstAttendee = createdEntries[0]!;
+  const ticketToken = firstAttendee.attendee.ticket_token;
+
+  await finalizeSession(
+    sessionId,
+    firstAttendee.attendee.id,
+    options?.storeTokens === false ? [] : [ticketToken],
+  );
+
+  await logAndNotifyRegistration(createdEntries);
+
+  return {
+    attendee: firstAttendee.attendee,
+    event: firstAttendee.event,
+    success: true,
+    ticketTokens: [ticketToken],
+  };
 };
 
 /**

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -924,6 +924,11 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
       eventId: eventIdForLog,
     });
     logDebug("Webhook", `Failed payload: ${payload}`);
+
+    // Return non-200 for conflicts so the payment provider retries the webhook
+    if (result.status === 409) {
+      return plainResponse(result.error, 409);
+    }
   }
 
   return webhookAckResponse({

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -26,6 +26,7 @@ import { getEvent, getEventWithCount } from "#lib/db/events.ts";
 import {
   clearSessionTokens,
   decryptSessionTokens,
+  deleteStaleReservation,
   finalizeSession,
   type ProcessedPayment,
   reserveSession,
@@ -563,42 +564,52 @@ const processPaymentSession = async (
   }
 
   // Phase 2: Validate events and create attendees atomically
-  const validated = await validateAllItems(session, intent);
-  if ("success" in validated) return validated;
-  const validatedItems = validated.items;
+  // If anything throws after reservation, release the lock so the next attempt can retry
+  try {
+    const validated = await validateAllItems(session, intent);
+    if ("success" in validated) return validated;
+    const validatedItems = validated.items;
 
-  const pricingError = await verifyPaidPricing(session, intent, validatedItems);
-  if (pricingError) return pricingError;
+    const pricingError = await verifyPaidPricing(
+      session,
+      intent,
+      validatedItems,
+    );
+    if (pricingError) return pricingError;
 
-  const created = await createAttendeeForSession(
-    session,
-    intent,
-    validatedItems,
-  );
-  if ("success" in created) return created;
-  const createdEntries = created.entries;
+    const created = await createAttendeeForSession(
+      session,
+      intent,
+      validatedItems,
+    );
+    if ("success" in created) return created;
+    const createdEntries = created.entries;
 
-  if (intent.eventAnswerIds) {
-    await saveEventAnswers(createdEntries, intent.eventAnswerIds);
+    if (intent.eventAnswerIds) {
+      await saveEventAnswers(createdEntries, intent.eventAnswerIds);
+    }
+
+    const firstAttendee = createdEntries[0]!;
+    const ticketToken = firstAttendee.attendee.ticket_token;
+
+    await finalizeSession(
+      sessionId,
+      firstAttendee.attendee.id,
+      options?.storeTokens === false ? [] : [ticketToken],
+    );
+
+    await logAndNotifyRegistration(createdEntries);
+
+    return {
+      attendee: firstAttendee.attendee,
+      event: firstAttendee.event,
+      success: true,
+      ticketTokens: [ticketToken],
+    };
+  } catch (error) {
+    await deleteStaleReservation(sessionId);
+    throw error;
   }
-
-  const firstAttendee = createdEntries[0]!;
-  const ticketToken = firstAttendee.attendee.ticket_token;
-
-  await finalizeSession(
-    sessionId,
-    firstAttendee.attendee.id,
-    options?.storeTokens === false ? [] : [ticketToken],
-  );
-
-  await logAndNotifyRegistration(createdEntries);
-
-  return {
-    attendee: firstAttendee.attendee,
-    event: firstAttendee.event,
-    success: true,
-    ticketTokens: [ticketToken],
-  };
 };
 
 /**

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -946,67 +946,6 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
       }
     });
 
-    test("db error during attendee creation cleans up reservation", async () => {
-      await setupStripe();
-
-      const event = await createTestEvent({
-        maxAttendees: 50,
-        name: "DB Error Cleanup",
-        unitPrice: 1000,
-      });
-
-      const { attendeesApi } = await import("#lib/db/attendees.ts");
-      const { isSessionProcessed } = await import(
-        "#lib/db/processed-payments.ts"
-      );
-
-      const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
-        Promise.resolve({
-          amount_total: 1000,
-          id: "cs_db_error",
-          metadata: {
-            email: "dberror@example.com",
-            items: singleItem(event.id, 1, 1000),
-            name: "DB Error",
-          },
-          payment_intent: "pi_db_error",
-          payment_status: "paid",
-        } as unknown as Awaited<
-          ReturnType<typeof stripeApi.retrieveCheckoutSession>
-        >),
-      );
-
-      // First attempt: createAttendeeAtomic throws a DB error
-      const mockAtomic = stub(attendeesApi, "createAttendeeAtomic", () =>
-        Promise.reject(new Error("SQLITE_IOERR: disk I/O error")),
-      );
-
-      try {
-        await withExpectedError(async () => {
-          await handleRequest(
-            mockRequest("/payment/success?session_id=cs_db_error"),
-          );
-        });
-
-        // Reservation should be cleaned up (not left dangling)
-        const record = await isSessionProcessed("cs_db_error");
-        expect(record).toBeNull();
-      } finally {
-        mockAtomic.restore();
-      }
-
-      // Second attempt should succeed (not show "being processed")
-      try {
-        const response = await handleRequest(
-          mockRequest("/payment/success?session_id=cs_db_error"),
-        );
-        const redirectUrl = response.headers.get("Location")!;
-        expect(redirectUrl).toContain("/payment/success?tokens=");
-      } finally {
-        mockRetrieve.restore();
-      }
-    });
-
     test("multi-ticket pricePaid calculation uses unit_price * quantity", async () => {
       await setupStripe();
 

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -514,6 +514,47 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
       }
     });
 
+    test("webhook returns 409 when session is reserved by another request", async () => {
+      await setupStripe();
+
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        unitPrice: 1000,
+      });
+
+      const { reserveSession: reserveSessionFn } = await import(
+        "#lib/db/processed-payments.ts"
+      );
+      await reserveSessionFn("cs_wh_conflict");
+
+      const mockVerify = await stubWebhookVerify({
+        data: {
+          object: {
+            amount_total: 1000,
+            id: "cs_wh_conflict",
+            metadata: webhookMeta({
+              email: "conflict@example.com",
+              items: singleItem(event.id, 1, 1000),
+              name: "Conflict",
+            }),
+            payment_intent: "pi_wh_conflict",
+            payment_status: "paid",
+          },
+        },
+        id: "evt_wh_conflict",
+        type: "checkout.session.completed",
+      });
+
+      try {
+        const response = await handleRequest(
+          mockWebhookRequest({}, { "stripe-signature": "sig_valid" }),
+        );
+        expect(response.status).toBe(409);
+      } finally {
+        mockVerify.restore();
+      }
+    });
+
     test("webhook rejects POST with wrong content-type", async () => {
       const response = await handleRequest(
         new Request("http://localhost/payment/webhook", {

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -921,6 +921,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
 
       const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
         Promise.resolve({
+          amount_total: 1000,
           id: "cs_db_error",
           metadata: {
             email: "dberror@example.com",

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -905,6 +905,66 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
       }
     });
 
+    test("db error during attendee creation cleans up reservation", async () => {
+      await setupStripe();
+
+      const event = await createTestEvent({
+        maxAttendees: 50,
+        name: "DB Error Cleanup",
+        unitPrice: 1000,
+      });
+
+      const { attendeesApi } = await import("#lib/db/attendees.ts");
+      const { isSessionProcessed } = await import(
+        "#lib/db/processed-payments.ts"
+      );
+
+      const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
+        Promise.resolve({
+          id: "cs_db_error",
+          metadata: {
+            email: "dberror@example.com",
+            items: singleItem(event.id, 1, 1000),
+            name: "DB Error",
+          },
+          payment_intent: "pi_db_error",
+          payment_status: "paid",
+        } as unknown as Awaited<
+          ReturnType<typeof stripeApi.retrieveCheckoutSession>
+        >),
+      );
+
+      // First attempt: createAttendeeAtomic throws a DB error
+      const mockAtomic = stub(attendeesApi, "createAttendeeAtomic", () =>
+        Promise.reject(new Error("SQLITE_IOERR: disk I/O error")),
+      );
+
+      try {
+        await withExpectedError(async () => {
+          await handleRequest(
+            mockRequest("/payment/success?session_id=cs_db_error"),
+          );
+        });
+
+        // Reservation should be cleaned up (not left dangling)
+        const record = await isSessionProcessed("cs_db_error");
+        expect(record).toBeNull();
+      } finally {
+        mockAtomic.restore();
+      }
+
+      // Second attempt should succeed (not show "being processed")
+      try {
+        const response = await handleRequest(
+          mockRequest("/payment/success?session_id=cs_db_error"),
+        );
+        const redirectUrl = response.headers.get("Location")!;
+        expect(redirectUrl).toContain("/payment/success?tokens=");
+      } finally {
+        mockRetrieve.restore();
+      }
+    });
+
     test("multi-ticket pricePaid calculation uses unit_price * quantity", async () => {
       await setupStripe();
 


### PR DESCRIPTION
## Summary

- When a webhook hits a reservation conflict (session reserved by the redirect handler but not yet finalized), the webhook was returning 200 with `{received: true, error: "Payment is being processed...", processed: false}`. Stripe treated this as success and stopped retrying.
- Now returns 409 so Stripe retries the webhook. By the next attempt, either the redirect has finalized the session (attendee exists) or the 5-minute stale reservation timeout has cleaned up the lock.

## How the bug manifested

1. Redirect reserves session, then hits a DB error writing attendees — reservation left dangling with `attendee_id: NULL`
2. Webhook arrives, finds the dangling reservation, returns `{processed: false}` **with status 200**
3. Stripe sees 200, stops retrying — attendee is never created
4. User sees "Payment is being processed. Please wait a moment and refresh." forever (until 5-min stale timeout)

## Test plan

- [ ] New test: `deno test --no-check --allow-all test/lib/server-webhooks.test.ts --filter "webhook returns 409 when session is reserved"`
- [ ] Existing "being processed" redirect tests still pass (409 HTML response unchanged)
- [ ] Full test suite: `deno task test`

https://claude.ai/code/session_01U6F7HTJEGV1hdHqvE9ZEaq