### PR TITLE
Add pre-filled booking QR codes

### DIFF
--- a/src/client/admin.ts
+++ b/src/client/admin.ts
@@ -20,6 +20,7 @@ import { initMultiBookingBuilder } from "./admin/multi-booking.ts";
 import { initNavSelect } from "./admin/nav-select.ts";
 import { initPaymentResultNotifier } from "./admin/payment-result.ts";
 import { initPaymentTestButtons } from "./admin/payment-test-buttons.ts";
+import { initQrRefresh } from "./admin/qr-refresh.ts";
 import { initScrollHideNav } from "./admin/scroll-hide-nav.ts";
 import { initSelectOnClick } from "./admin/select-on-click.ts";
 
@@ -33,6 +34,7 @@ initCheckoutPopup();
 initScrollHideNav();
 initPaymentResultNotifier();
 initPaymentTestButtons();
+initQrRefresh();
 initCharCounters();
 initManualCheckin();
 initFormSubmitDisable();

--- a/src/client/admin/qr-refresh.ts
+++ b/src/client/admin/qr-refresh.ts
@@ -1,0 +1,75 @@
+/// <reference lib="dom" />
+/** Auto-refresh the admin QR result panel every minute so stale links are
+ *  obvious to anyone watching the screen. Fades the old QR out (500ms), swaps
+ *  in the new SVG + URL, then fades the new one in (500ms). */
+
+const REFRESH_INTERVAL_MS = 60_000;
+const FADE_MS = 500;
+
+type RefreshResponseOk = { ok: true; url: string; svg: string };
+type RefreshResponseErr = { ok: false; error: string };
+type RefreshResponse = RefreshResponseOk | RefreshResponseErr;
+
+/** Build the refresh URL from the admin form's current values */
+const buildRefreshUrl = (endpoint: string, form: HTMLFormElement): string => {
+  const data = new FormData(form);
+  const params = new URLSearchParams();
+  for (const key of ["customer_name", "value", "quantity", "date"]) {
+    const v = data.get(key);
+    if (typeof v === "string" && v) params.set(key, v);
+  }
+  return `${endpoint}?${params.toString()}`;
+};
+
+/** Fade out → swap → fade in. Animates via inline opacity so the page
+ *  only needs a single `transition: opacity` CSS rule. */
+const swap = (
+  panel: HTMLElement,
+  svgContainer: HTMLElement,
+  linkInput: HTMLInputElement,
+  data: RefreshResponseOk,
+): Promise<void> => {
+  panel.style.opacity = "0";
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      svgContainer.innerHTML = data.svg;
+      linkInput.value = data.url;
+      panel.style.opacity = "1";
+      resolve();
+    }, FADE_MS);
+  });
+};
+
+/** Fetch a new token and swap the panel contents */
+const refresh = async (
+  endpoint: string,
+  form: HTMLFormElement,
+  panel: HTMLElement,
+  svgContainer: HTMLElement,
+  linkInput: HTMLInputElement,
+): Promise<void> => {
+  const response = await fetch(buildRefreshUrl(endpoint, form), {
+    credentials: "same-origin",
+  });
+  if (!response.ok) return;
+  const data = (await response.json()) as RefreshResponse;
+  if (data.ok) await swap(panel, svgContainer, linkInput, data);
+};
+
+/** Boot the refresher when the result panel is present on the page */
+export const initQrRefresh = (): void => {
+  const panel = document.querySelector<HTMLElement>("[data-qr-refresh]");
+  if (!panel) return;
+  const endpoint = panel.dataset.qrRefresh;
+  if (!endpoint) return;
+  const form = document.querySelector<HTMLFormElement>(
+    `form[action="${panel.dataset.qrRefreshForm}"]`,
+  );
+  const svgContainer = panel.querySelector<HTMLElement>("[data-qr-svg]");
+  const linkInput = panel.querySelector<HTMLInputElement>("[data-qr-link]");
+  if (!form || !svgContainer || !linkInput) return;
+  setInterval(
+    () => refresh(endpoint, form, panel, svgContainer, linkInput),
+    REFRESH_INTERVAL_MS,
+  );
+};

--- a/src/lib/qr-token.ts
+++ b/src/lib/qr-token.ts
@@ -1,0 +1,150 @@
+/**
+ * Signed tokens for QR-code pre-filled booking links.
+ *
+ * A token embeds a small JSON payload (customer name, price, quantity, date,
+ * expiry) and an HMAC signature over a domain-separated message so the
+ * signature can never collide with CSRF or any other signed token in the app.
+ *
+ * Format: qr1.{payloadB64url}.{hmacB64url}
+ * HMAC input: "qr-book:{slug}:{payloadB64url}"
+ */
+
+import { hmacHash } from "#lib/crypto/hashing.ts";
+import {
+  base64ToBase64Url,
+  constantTimeEqual,
+  fromBase64,
+  toBase64,
+} from "#lib/crypto/utils.ts";
+import { nowMs } from "#lib/now.ts";
+
+const PREFIX = "qr1.";
+const DOMAIN = "qr-book:";
+
+/** QR token expiry in seconds from generation */
+export const QR_TOKEN_MAX_AGE_S = 300;
+
+/** Payload carried inside a signed QR booking token */
+export type QrBookPayload = {
+  /** Customer name to pre-fill (empty string = not provided) */
+  n: string;
+  /** Price in minor units. -1 = not provided */
+  v: number;
+  /** Quantity to book (defaults to 1 when creating a token) */
+  q: number;
+  /** Date for daily events (YYYY-MM-DD). Empty string = not provided */
+  d: string;
+  /** Expiry as unix seconds */
+  e: number;
+};
+
+/** Encode bytes to base64url (no padding) */
+const bytesToBase64Url = (bytes: Uint8Array): string =>
+  base64ToBase64Url(toBase64(bytes));
+
+/** Decode a base64url string to bytes */
+const base64UrlToBytes = (s: string): Uint8Array => {
+  const padLen = (4 - (s.length % 4)) % 4;
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat(padLen);
+  return fromBase64(b64);
+};
+
+/** Encode payload JSON as base64url */
+const encodePayload = (payload: QrBookPayload): string => {
+  const json = JSON.stringify(payload);
+  return bytesToBase64Url(new TextEncoder().encode(json));
+};
+
+/** Decode payload JSON from base64url. Returns null on any decode failure. */
+const decodePayload = (encoded: string): QrBookPayload | null => {
+  try {
+    const bytes = base64UrlToBytes(encoded);
+    const parsed = JSON.parse(new TextDecoder().decode(bytes));
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      typeof parsed.n !== "string" ||
+      typeof parsed.v !== "number" ||
+      typeof parsed.q !== "number" ||
+      typeof parsed.d !== "string" ||
+      typeof parsed.e !== "number"
+    ) {
+      return null;
+    }
+    return parsed as QrBookPayload;
+  } catch {
+    return null;
+  }
+};
+
+/** Build the domain-separated HMAC input for a token */
+const buildMessage = (slug: string, encodedPayload: string): string =>
+  `${DOMAIN}${slug}:${encodedPayload}`;
+
+/**
+ * Build a payload ready for signing.
+ * Fills defaults and computes the expiry timestamp.
+ */
+export const buildQrBookPayload = (input: {
+  name?: string;
+  value?: number;
+  quantity?: number;
+  date?: string;
+  maxAgeSeconds?: number;
+}): QrBookPayload => {
+  const maxAge = input.maxAgeSeconds ?? QR_TOKEN_MAX_AGE_S;
+  return {
+    d: input.date ?? "",
+    e: Math.floor(nowMs() / 1000) + maxAge,
+    n: input.name ?? "",
+    q: input.quantity ?? 1,
+    v: input.value ?? -1,
+  };
+};
+
+/**
+ * Sign a QR booking payload for the given event slug.
+ * Returns the encoded token "qr1.{payload}.{hmac}".
+ */
+export const signQrBookToken = async (
+  slug: string,
+  payload: QrBookPayload,
+): Promise<string> => {
+  const encoded = encodePayload(payload);
+  const message = buildMessage(slug, encoded);
+  const hmac = base64ToBase64Url(await hmacHash(message));
+  return `${PREFIX}${encoded}.${hmac}`;
+};
+
+/**
+ * Verify a QR booking token for the given event slug.
+ * Checks the prefix, HMAC signature, expiry, and clock-skew bounds.
+ * Returns the decoded payload on success, or null on any failure.
+ */
+export const verifyQrBookToken = async (
+  slug: string,
+  token: string,
+): Promise<QrBookPayload | null> => {
+  if (!token.startsWith(PREFIX)) return null;
+  const rest = token.slice(PREFIX.length);
+  const dotIndex = rest.indexOf(".");
+  if (dotIndex <= 0 || dotIndex === rest.length - 1) return null;
+
+  const encoded = rest.slice(0, dotIndex);
+  const providedHmac = rest.slice(dotIndex + 1);
+
+  const expected = base64ToBase64Url(
+    await hmacHash(buildMessage(slug, encoded)),
+  );
+  if (!constantTimeEqual(expected, providedHmac)) return null;
+
+  const payload = decodePayload(encoded);
+  if (!payload) return null;
+
+  const nowS = Math.floor(nowMs() / 1000);
+  // Reject expired and future-dated tokens (60s clock skew tolerance)
+  if (payload.e < nowS) return null;
+  if (payload.e - nowS > QR_TOKEN_MAX_AGE_S + 60) return null;
+
+  return payload;
+};

--- a/src/routes/admin/event-qr.ts
+++ b/src/routes/admin/event-qr.ts
@@ -1,0 +1,188 @@
+/**
+ * Admin route for generating pre-filled booking QR codes for an event.
+ *
+ * GET renders the form, POST validates input, signs a URL, and re-renders
+ * the page with the generated QR beneath the form.
+ */
+
+import { getEffectiveDomain } from "#lib/config.ts";
+import { validatePrice } from "#lib/currency.ts";
+import { getAvailableDates } from "#lib/dates.ts";
+import { getEventWithCount } from "#lib/db/events.ts";
+import { getActiveHolidays } from "#lib/db/holidays.ts";
+import type { FormParams } from "#lib/form-data.ts";
+import { generateQrSvg } from "#lib/qr.ts";
+import { buildQrBookPayload, signQrBookToken } from "#lib/qr-token.ts";
+import type { AdminSession, EventWithCount } from "#lib/types.ts";
+import type { TypedRouteHandler } from "#routes/router.ts";
+import { defineRoutes } from "#routes/router.ts";
+import {
+  AUTH_FORM,
+  htmlResponse,
+  orNotFound,
+  requireSessionOr,
+  withAuth,
+} from "#routes/utils.ts";
+import {
+  adminEventQrPage,
+  type AdminEventQrResult,
+  type AdminEventQrValues,
+} from "#templates/admin/event-qr.tsx";
+
+const EMPTY_VALUES: AdminEventQrValues = {
+  customerName: "",
+  date: "",
+  quantity: "1",
+  value: "",
+};
+
+/** Load bookable dates for daily events (empty for standard events) */
+const loadBookableDates = async (event: EventWithCount): Promise<string[]> => {
+  if (event.event_type !== "daily") return [];
+  const holidays = await getActiveHolidays();
+  return getAvailableDates(event, holidays);
+};
+
+/** Render the QR admin page; 404 when the event is missing */
+const renderPage = (
+  eventId: number,
+  session: AdminSession,
+  values: AdminEventQrValues,
+  extras: { error?: string; result?: AdminEventQrResult } = {},
+): Promise<Response> =>
+  orNotFound(Promise.resolve(getEventWithCount(eventId)), async (event) => {
+    const bookableDates = await loadBookableDates(event);
+    return htmlResponse(
+      adminEventQrPage({
+        bookableDates,
+        event,
+        session,
+        values,
+        ...extras,
+      }),
+    );
+  });
+
+/** GET /admin/event/:id/qr */
+const handleGet: TypedRouteHandler<"GET /admin/event/:id/qr"> = (
+  request,
+  { id },
+) =>
+  requireSessionOr(request, (session) => renderPage(id, session, EMPTY_VALUES));
+
+/** Extract and validate form values. Returns a parsed shape or an error string. */
+const extractValues = (
+  form: FormParams,
+  event: EventWithCount,
+):
+  | { ok: true; parsed: ParsedValues; values: AdminEventQrValues }
+  | {
+    ok: false;
+    error: string;
+    values: AdminEventQrValues;
+  } => {
+  const values: AdminEventQrValues = {
+    customerName: form.getString("customer_name").trim(),
+    date: form.getString("date").trim(),
+    quantity: form.getString("quantity").trim() || "1",
+    value: form.getString("value").trim(),
+  };
+
+  const quantity = Number.parseInt(values.quantity, 10);
+  if (Number.isNaN(quantity) || quantity < 1) {
+    return { error: "Quantity must be at least 1", ok: false, values };
+  }
+  if (quantity > event.max_quantity) {
+    return {
+      error: `Quantity cannot exceed ${event.max_quantity}`,
+      ok: false,
+      values,
+    };
+  }
+
+  let valueMinor: number | undefined;
+  if (values.value) {
+    const minPrice = event.can_pay_more ? event.unit_price : 0;
+    const maxPrice = event.can_pay_more
+      ? event.max_price
+      : Number.MAX_SAFE_INTEGER;
+    const priceResult = validatePrice(values.value, minPrice, maxPrice);
+    if (!priceResult.ok) {
+      return { error: priceResult.error, ok: false, values };
+    }
+    valueMinor = priceResult.price;
+  }
+
+  if (event.event_type === "daily" && !values.date) {
+    return {
+      error: "Date is required for daily events",
+      ok: false,
+      values,
+    };
+  }
+
+  return {
+    ok: true,
+    parsed: {
+      date: values.date || undefined,
+      name: values.customerName || undefined,
+      quantity,
+      value: valueMinor,
+    },
+    values,
+  };
+};
+
+type ParsedValues = {
+  name?: string;
+  value?: number;
+  quantity: number;
+  date?: string;
+};
+
+/** Build the absolute URL the QR encodes */
+const buildQrUrl = (slug: string, token: string): string => {
+  const domain = getEffectiveDomain();
+  return `https://${domain}/ticket/${slug}/qr-book?t=${
+    encodeURIComponent(token)
+  }`;
+};
+
+/** Process a validated admin QR form submission and render the result panel */
+const generateAndRender = async (
+  id: number,
+  session: AdminSession,
+  event: EventWithCount,
+  extracted: Extract<ReturnType<typeof extractValues>, { ok: true }>,
+): Promise<Response> => {
+  const payload = buildQrBookPayload(extracted.parsed);
+  const token = await signQrBookToken(event.slug, payload);
+  const url = buildQrUrl(event.slug, token);
+  const svg = await generateQrSvg(url);
+  return renderPage(id, session, extracted.values, { result: { svg, url } });
+};
+
+/** POST /admin/event/:id/qr */
+const handlePost: TypedRouteHandler<"POST /admin/event/:id/qr"> = (
+  request,
+  { id },
+) =>
+  withAuth(
+    request,
+    AUTH_FORM,
+    (session, form) =>
+      orNotFound(Promise.resolve(getEventWithCount(id)), (event) => {
+        const extracted = extractValues(form, event);
+        return extracted.ok
+          ? generateAndRender(id, session, event, extracted)
+          : renderPage(id, session, extracted.values, {
+            error: extracted.error,
+          });
+      }),
+  );
+
+/** Exported admin routes for the QR generator */
+export const eventQrRoutes = defineRoutes({
+  "GET /admin/event/:id/qr": handleGet,
+  "POST /admin/event/:id/qr": handlePost,
+});

--- a/src/routes/admin/event-qr.ts
+++ b/src/routes/admin/event-qr.ts
@@ -3,6 +3,9 @@
  *
  * GET renders the form, POST validates input, signs a URL, and re-renders
  * the page with the generated QR beneath the form.
+ *
+ * GET /admin/event/:id/qr.json returns a fresh token as JSON so the page
+ * can refresh the QR client-side (every minute) without a full reload.
  */
 
 import { getEffectiveDomain } from "#lib/config.ts";
@@ -10,7 +13,7 @@ import { validatePrice } from "#lib/currency.ts";
 import { getAvailableDates } from "#lib/dates.ts";
 import { getEventWithCount } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
-import type { FormParams } from "#lib/form-data.ts";
+import { FormParams } from "#lib/form-data.ts";
 import { generateQrSvg } from "#lib/qr.ts";
 import { buildQrBookPayload, signQrBookToken } from "#lib/qr-token.ts";
 import type { AdminSession, EventWithCount } from "#lib/types.ts";
@@ -19,6 +22,7 @@ import { defineRoutes } from "#routes/router.ts";
 import {
   AUTH_FORM,
   htmlResponse,
+  jsonResponse,
   orNotFound,
   requireSessionOr,
   withAuth,
@@ -148,6 +152,18 @@ const buildQrUrl = (slug: string, token: string): string => {
   }`;
 };
 
+/** Sign a fresh token for the given event and render its QR SVG */
+const signAndRenderQr = async (
+  event: EventWithCount,
+  parsed: ParsedValues,
+): Promise<AdminEventQrResult> => {
+  const payload = buildQrBookPayload(parsed);
+  const token = await signQrBookToken(event.slug, payload);
+  const url = buildQrUrl(event.slug, token);
+  const svg = await generateQrSvg(url);
+  return { svg, url };
+};
+
 /** Process a validated admin QR form submission and render the result panel */
 const generateAndRender = async (
   id: number,
@@ -155,11 +171,8 @@ const generateAndRender = async (
   event: EventWithCount,
   extracted: Extract<ReturnType<typeof extractValues>, { ok: true }>,
 ): Promise<Response> => {
-  const payload = buildQrBookPayload(extracted.parsed);
-  const token = await signQrBookToken(event.slug, payload);
-  const url = buildQrUrl(event.slug, token);
-  const svg = await generateQrSvg(url);
-  return renderPage(id, session, extracted.values, { result: { svg, url } });
+  const result = await signAndRenderQr(event, extracted.parsed);
+  return renderPage(id, session, extracted.values, { result });
 };
 
 /** POST /admin/event/:id/qr */
@@ -181,8 +194,32 @@ const handlePost: TypedRouteHandler<"POST /admin/event/:id/qr"> = (
       }),
   );
 
+/**
+ * GET /admin/event/:id/qr.json
+ *
+ * Used by the admin page's client-side auto-refresh: it reads the current
+ * form values, calls this endpoint, and swaps the rendered QR every minute
+ * so stale links become obvious to any admin watching the screen.
+ */
+const handleJsonGet: TypedRouteHandler<"GET /admin/event/:id/qr.json"> = (
+  request,
+  { id },
+) =>
+  requireSessionOr(request, () =>
+    orNotFound(Promise.resolve(getEventWithCount(id)), async (event) => {
+      const form = new FormParams(new URL(request.url).searchParams);
+      const extracted = extractValues(form, event);
+      if (!extracted.ok) {
+        return jsonResponse({ error: extracted.error, ok: false }, 400);
+      }
+      const result = await signAndRenderQr(event, extracted.parsed);
+      return jsonResponse({ ok: true, ...result });
+    }),
+  );
+
 /** Exported admin routes for the QR generator */
 export const eventQrRoutes = defineRoutes({
   "GET /admin/event/:id/qr": handleGet,
+  "GET /admin/event/:id/qr.json": handleJsonGet,
   "POST /admin/event/:id/qr": handlePost,
 });

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -21,6 +21,7 @@ import { bulkActionsRoutes } from "#routes/admin/bulk-actions.ts";
 import { calendarRoutes } from "#routes/admin/calendar.ts";
 import { dashboardRoutes } from "#routes/admin/dashboard.ts";
 import { debugRoutes } from "#routes/admin/debug.ts";
+import { eventQrRoutes } from "#routes/admin/event-qr.ts";
 import { eventsRoutes } from "#routes/admin/events.ts";
 import { groupsRoutes } from "#routes/admin/groups.ts";
 import { guideRoutes } from "#routes/admin/guide.ts";
@@ -47,6 +48,7 @@ const adminRouteModules: Record<string, RouteHandlerFn>[] = [
   sessionsRoutes,
   calendarRoutes,
   eventsRoutes,
+  eventQrRoutes,
   attendeesRoutes,
   attendeeRefundRoutes,
   usersRoutes,

--- a/src/routes/public/qr-book.ts
+++ b/src/routes/public/qr-book.ts
@@ -1,0 +1,158 @@
+/**
+ * Scan handler for signed booking QR links.
+ *
+ * Verifies a signed token; on success, either skips straight to Stripe
+ * checkout (when the token carries a name + value and the event requires
+ * no extra fields, questions, or terms) or renders the normal booking page
+ * with the token's values pre-filled.
+ */
+
+import { getAvailableDates } from "#lib/dates.ts";
+import { getEventWithCountBySlug } from "#lib/db/events.ts";
+import { getActiveHolidays } from "#lib/db/holidays.ts";
+import { getQuestionsForEvent } from "#lib/db/questions.ts";
+import { settings } from "#lib/db/settings.ts";
+import { parseEventFields } from "#lib/event-fields.ts";
+import type { CheckoutIntent } from "#lib/payments.ts";
+import { type QrBookPayload, verifyQrBookToken } from "#lib/qr-token.ts";
+import type { EventWithCount } from "#lib/types.ts";
+import { htmlResponse, isRegistrationClosed } from "#routes/utils.ts";
+import {
+  buildTicketEvent,
+  qrBookErrorPage,
+  type QrPrefill,
+  type TicketPrefill,
+} from "#templates/public.tsx";
+import { getTicketContext, runCheckoutFlow } from "./ticket-payment.ts";
+import { handleTicket } from "./ticket-submit.ts";
+
+const errorResponse = (slug: string, status: number): Response =>
+  htmlResponse(qrBookErrorPage(slug), status);
+
+/** Build per-event prefill entries from a QR payload */
+const buildEventPrefills = (
+  event: EventWithCount,
+  payload: QrBookPayload,
+): Map<number, TicketPrefill> => {
+  const entry: TicketPrefill = { quantity: payload.q };
+  if (payload.v >= 0 && event.can_pay_more) {
+    entry.customPriceMinor = payload.v;
+  }
+  return new Map([[event.id, entry]]);
+};
+
+/** Build the QrPrefill context for the ticket page */
+const buildPrefill = (
+  event: EventWithCount,
+  payload: QrBookPayload,
+  token: string,
+): QrPrefill => ({
+  date: payload.d || undefined,
+  events: buildEventPrefills(event, payload),
+  name: payload.n || undefined,
+  token,
+});
+
+/** Check whether the scan should skip straight to Stripe checkout.
+ * Pre-requisites enforced by the caller: event is loaded, and for daily
+ * events the payload date has been validated against bookable dates. */
+const canSkipToCheckout = async (
+  event: EventWithCount,
+  payload: QrBookPayload,
+): Promise<boolean> => {
+  if (!payload.n || payload.v < 0) return false;
+  if (parseEventFields(event.fields).length > 0) return false;
+  if (settings.terms) return false;
+  const questions = await getQuestionsForEvent(event.id);
+  return questions.length === 0;
+};
+
+/** Validate a daily-event booking date against available dates (minus holidays) */
+const isDailyDateBookable = async (
+  event: EventWithCount,
+  date: string,
+): Promise<boolean> => {
+  if (!date) return false;
+  const holidays = await getActiveHolidays();
+  return getAvailableDates(event, holidays).includes(date);
+};
+
+/** Construct a CheckoutIntent for a single-event direct-to-Stripe booking */
+const buildCheckoutIntent = (
+  event: EventWithCount,
+  payload: QrBookPayload,
+): CheckoutIntent => ({
+  address: "",
+  date: event.event_type === "daily" ? payload.d : null,
+  email: "",
+  items: [
+    {
+      eventId: event.id,
+      name: event.name,
+      quantity: payload.q,
+      slug: event.slug,
+      unitPrice: payload.v,
+    },
+  ],
+  name: payload.n,
+  phone: "",
+  special_instructions: "",
+});
+
+/** Redirect directly to Stripe checkout using the signed values */
+const skipToCheckout = (
+  request: Request,
+  event: EventWithCount,
+  payload: QrBookPayload,
+): Promise<Response> => {
+  const intent = buildCheckoutIntent(event, payload);
+  return runCheckoutFlow(
+    `qr-book event=${event.id}`,
+    request,
+    (provider, baseUrl) => provider.createCheckoutSession(intent, baseUrl),
+    () => errorResponse(event.slug, 500),
+  );
+};
+
+/** Once the token is verified and the event loaded, render or redirect */
+const dispatchVerified = async (
+  request: Request,
+  slug: string,
+  token: string,
+  payload: QrBookPayload,
+  event: EventWithCount,
+): Promise<Response> => {
+  if (
+    event.event_type === "daily" &&
+    !(await isDailyDateBookable(event, payload.d))
+  ) {
+    return errorResponse(slug, 400);
+  }
+  if (await canSkipToCheckout(event, payload)) {
+    return skipToCheckout(request, event, payload);
+  }
+  const ticketEvent = buildTicketEvent(event, isRegistrationClosed(event));
+  const prefill = buildPrefill(event, payload, token);
+  return handleTicket(
+    request,
+    [slug],
+    [ticketEvent],
+    getTicketContext,
+    prefill,
+  );
+};
+
+/** GET /ticket/:slug/qr-book */
+export const handleQrBookGet = async (
+  request: Request,
+  params: { slug: string },
+): Promise<Response> => {
+  const { slug } = params;
+  const token = new URL(request.url).searchParams.get("t") ?? "";
+  if (!token) return errorResponse(slug, 400);
+  const payload = await verifyQrBookToken(slug, token);
+  if (!payload) return errorResponse(slug, 400);
+  const event = await getEventWithCountBySlug(slug);
+  if (!event || !event.active) return errorResponse(slug, 404);
+  return dispatchVerified(request, slug, token, payload, event);
+};

--- a/src/routes/public/ticket-routes.ts
+++ b/src/routes/public/ticket-routes.ts
@@ -11,6 +11,7 @@ import { createRouter, defineRoutes } from "#routes/router.ts";
 import { htmlResponse, notFoundResponse } from "#routes/utils.ts";
 import { successPage } from "#templates/payment.tsx";
 import { handleGroupTicketBySlug } from "./groups.ts";
+import { handleQrBookGet } from "./qr-book.ts";
 import { handleTicketBySlugs } from "./ticket-submit.ts";
 import { parseSlugs } from "./types.ts";
 
@@ -74,6 +75,7 @@ export const handleTicketQrGet = async (
 const publicRoutes = defineRoutes({
   "GET /ticket/:slug": handleTicketBySlug,
   "GET /ticket/:slug/qr": handleTicketQrGet,
+  "GET /ticket/:slug/qr-book": handleQrBookGet,
   "GET /ticket/reserved": handleReservedGet,
   "POST /ticket/:slug": handleTicketBySlug,
 });

--- a/src/routes/public/ticket-submit.ts
+++ b/src/routes/public/ticket-submit.ts
@@ -8,6 +8,7 @@ import { countAssignableSites } from "#lib/db/built-sites.ts";
 import { saveEventAnswers } from "#lib/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#lib/demo.ts";
 import type { FormParams } from "#lib/form-data.ts";
+import { verifyQrBookToken } from "#lib/qr-token.ts";
 import { isPaidEvent } from "#lib/types.ts";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import {
@@ -129,6 +130,29 @@ const parseCustomPrices = (
     customPrices.set(event.id, priceResult.price);
   }
   return customPrices;
+};
+
+/**
+ * Apply signed QR-token price overrides to the custom prices map.
+ *
+ * QR tokens can pre-set a price for a specific event. For can_pay_more events
+ * the user-submitted custom_price_{id} already populated the map in
+ * parseCustomPrices and wins. For fixed-price events the signed value
+ * overrides event.unit_price so admins can generate one-off bookings at any
+ * price. Tokens are re-verified here to prevent tampering of the hidden field.
+ */
+const applyQrTokenOverride = async (
+  form: FormParams,
+  ctx: TicketCtx,
+  customPrices: Map<number, number>,
+): Promise<void> => {
+  const token = form.getString("qr_token");
+  if (!token || ctx.slugs.length !== 1) return;
+  const payload = await verifyQrBookToken(ctx.slugs[0]!, token);
+  if (!payload || payload.v < 0) return;
+  for (const { event } of ctx.events) {
+    if (!event.can_pay_more) customPrices.set(event.id, payload.v);
+  }
 };
 
 /** Verify built site availability when the builder feature is enabled */
@@ -261,6 +285,8 @@ const processSubmission = async (
   const customPricesResult = parseCustomPrices(form, ctx, quantities);
   if (customPricesResult instanceof Response) return customPricesResult;
 
+  await applyQrTokenOverride(form, ctx, customPricesResult);
+
   const items = buildRegistrationItems(
     ctx.events,
     quantities,
@@ -306,6 +332,7 @@ export const handleTicket = async (
   actionSlugs: string[],
   activeEvents: TicketEvent[],
   getContext: TicketContextProvider,
+  qrPrefill?: TicketCtx["qrPrefill"],
 ): Promise<Response> => {
   const [sharedCtx] = await Promise.all([
     getContext(activeEvents),
@@ -316,6 +343,7 @@ export const handleTicket = async (
     events: activeEvents,
     slugs: actionSlugs,
     ...sharedCtx,
+    qrPrefill,
   };
   if (request.method === "GET") applyFlash(request);
   const response =

--- a/src/routes/public/types.ts
+++ b/src/routes/public/types.ts
@@ -9,7 +9,11 @@ import type {
 } from "#lib/db/questions.ts";
 import type { EventWithCount } from "#lib/types.ts";
 import { isRegistrationClosed } from "#routes/utils.ts";
-import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
+import {
+  buildTicketEvent,
+  type QrPrefill,
+  type TicketEvent,
+} from "#templates/public.tsx";
 
 /** Shared rendering context for ticket pages */
 export type TicketCtx = {
@@ -22,6 +26,7 @@ export type TicketCtx = {
   baseUrl?: string;
   groupName?: string;
   groupDescription?: string;
+  qrPrefill?: QrPrefill;
 };
 
 /** Possibly-async response handler */

--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -1601,4 +1601,9 @@ button.secondary:hover {
   outline: none;
 }
 
+/* QR result panel — fade transition for client-side auto-refresh */
+.qr-result {
+  transition: opacity 500ms ease-in-out;
+}
+
 /* Guide page */

--- a/src/templates/admin/event-qr.tsx
+++ b/src/templates/admin/event-qr.tsx
@@ -1,0 +1,176 @@
+/**
+ * Admin page for generating pre-filled booking QR codes.
+ *
+ * Admin enters (optional) customer name, price, quantity, and for daily events
+ * a date. The server signs a URL and renders the resulting QR inline so the
+ * admin can photograph, print, or share it. Links expire 5 minutes after
+ * generation.
+ */
+
+import { formatCurrency, toMajorUnits } from "#lib/currency.ts";
+import { formatDateLabel } from "#lib/dates.ts";
+import { CsrfForm, Flash } from "#lib/forms.tsx";
+import { Raw } from "#lib/jsx/jsx-runtime.ts";
+import { QR_TOKEN_MAX_AGE_S } from "#lib/qr-token.ts";
+import type { AdminSession, EventWithCount } from "#lib/types.ts";
+import { AdminNav } from "#templates/admin/nav.tsx";
+import { Layout } from "#templates/layout.tsx";
+
+const EXPIRY_LABEL = `${Math.round(QR_TOKEN_MAX_AGE_S / 60)} minutes`;
+
+/** Values the admin previously submitted, re-rendered on error/success */
+export type AdminEventQrValues = {
+  customerName: string;
+  value: string;
+  quantity: string;
+  date: string;
+};
+
+/** Result of generating a QR (shown alongside the form on success) */
+export type AdminEventQrResult = {
+  url: string;
+  svg: string;
+};
+
+/** Options for the admin event-QR page */
+export type AdminEventQrPageOptions = {
+  event: EventWithCount;
+  session: AdminSession;
+  bookableDates: string[];
+  values: AdminEventQrValues;
+  error?: string;
+  result?: AdminEventQrResult;
+};
+
+/** Render the price input. Can_pay_more events use the configured min/max;
+ *  fixed-price events have no upper bound so the admin can set any override. */
+const PriceInput = ({
+  event,
+  value,
+}: {
+  event: EventWithCount;
+  value: string;
+}): JSX.Element => {
+  const hint = event.can_pay_more
+    ? `Minimum ${formatCurrency(event.unit_price)}, maximum ${
+      formatCurrency(event.max_price)
+    }`
+    : `Overrides the ticket price of ${
+      formatCurrency(event.unit_price)
+    } for this booking`;
+  const min = event.can_pay_more ? toMajorUnits(event.unit_price) : "0";
+  const max = event.can_pay_more ? toMajorUnits(event.max_price) : undefined;
+  return (
+    <label>
+      Price
+      <input
+        type="text"
+        name="value"
+        inputmode="decimal"
+        pattern="\d+(\.\d{1,2})?"
+        title="A non-negative number (e.g. 10.00)"
+        value={value}
+        min={min}
+        max={max}
+      />
+      <small>{hint}</small>
+    </label>
+  );
+};
+
+/** Date dropdown for daily events (required) */
+const DateSelect = ({
+  dates,
+  value,
+}: {
+  dates: string[];
+  value: string;
+}): JSX.Element => (
+  <label>
+    Date
+    <select name="date" required>
+      <option value="">— Select a date —</option>
+      {dates.map((d) => (
+        <option value={d} selected={d === value}>
+          {formatDateLabel(d)}
+        </option>
+      ))}
+    </select>
+  </label>
+);
+
+/** Result panel: QR + copyable URL + expiry note */
+const QrResultPanel = ({
+  result,
+}: {
+  result: AdminEventQrResult;
+}): JSX.Element => (
+  <article>
+    <h2>QR code</h2>
+    <div class="qr-code">
+      <Raw html={result.svg} />
+    </div>
+    <p>
+      <small>Expires in {EXPIRY_LABEL} from generation.</small>
+    </p>
+    <label>
+      Link
+      <input type="text" value={result.url} readonly data-select-on-click />
+    </label>
+  </article>
+);
+
+/** Admin "generate booking QR code" page */
+export const adminEventQrPage = ({
+  event,
+  session,
+  bookableDates,
+  values,
+  error,
+  result,
+}: AdminEventQrPageOptions): string => {
+  const isDaily = event.event_type === "daily";
+  return String(
+    <Layout title={`QR Code: ${event.name}`}>
+      <AdminNav session={session} active="/admin/" />
+      <article>
+        <h1>
+          Booking QR code &mdash;{" "}
+          <a href={`/admin/event/${event.id}`}>{event.name}</a>
+        </h1>
+        <p>
+          Generate a signed link that pre-fills the booking form. If name and
+          price are both set and the event has no extra required fields, the
+          scanner is taken straight to payment.
+        </p>
+        <Flash error={error} />
+        <CsrfForm action={`/admin/event/${event.id}/qr`}>
+          <label>
+            Customer name
+            <input
+              type="text"
+              name="customer_name"
+              value={values.customerName}
+            />
+            <small>Optional &mdash; pre-fills the name field.</small>
+          </label>
+          <PriceInput event={event} value={values.value} />
+          <label>
+            Quantity
+            <input
+              type="number"
+              name="quantity"
+              min="1"
+              max={event.max_quantity}
+              value={values.quantity}
+              required
+            />
+          </label>
+          {isDaily && <DateSelect dates={bookableDates} value={values.date} />}
+          <button type="submit">Generate QR code</button>
+        </CsrfForm>
+        {result && <QrResultPanel result={result} />}
+      </article>
+    </Layout>,
+  );
+};

--- a/src/templates/admin/event-qr.tsx
+++ b/src/templates/admin/event-qr.tsx
@@ -99,23 +99,44 @@ const DateSelect = ({
   </label>
 );
 
-/** Result panel: QR + copyable URL + expiry note */
+/** Result panel: QR + copyable URL + expiry note.
+ *
+ * Data attributes drive client-side auto-refresh: the panel polls the
+ * `data-qr-refresh` endpoint every minute and fades the new SVG + URL
+ * in/out. See src/client/admin/qr-refresh.ts. */
 const QrResultPanel = ({
   result,
+  refreshUrl,
+  formAction,
 }: {
   result: AdminEventQrResult;
+  refreshUrl: string;
+  formAction: string;
 }): JSX.Element => (
-  <article>
+  <article
+    class="qr-result"
+    data-qr-refresh={refreshUrl}
+    data-qr-refresh-form={formAction}
+  >
     <h2>QR code</h2>
-    <div class="qr-code">
+    <div class="qr-code" data-qr-svg>
       <Raw html={result.svg} />
     </div>
     <p>
-      <small>Expires in {EXPIRY_LABEL} from generation.</small>
+      <small>
+        Refreshes every minute. Each code expires {EXPIRY_LABEL} after it was
+        generated.
+      </small>
     </p>
     <label>
       Link
-      <input type="text" value={result.url} readonly data-select-on-click />
+      <input
+        type="text"
+        value={result.url}
+        readonly
+        data-select-on-click
+        data-qr-link
+      />
     </label>
   </article>
 );
@@ -130,6 +151,8 @@ export const adminEventQrPage = ({
   result,
 }: AdminEventQrPageOptions): string => {
   const isDaily = event.event_type === "daily";
+  const formAction = `/admin/event/${event.id}/qr`;
+  const refreshUrl = `/admin/event/${event.id}/qr.json`;
   return String(
     <Layout title={`QR Code: ${event.name}`}>
       <AdminNav session={session} active="/admin/" />
@@ -144,7 +167,7 @@ export const adminEventQrPage = ({
           scanner is taken straight to payment.
         </p>
         <Flash error={error} />
-        <CsrfForm action={`/admin/event/${event.id}/qr`}>
+        <CsrfForm action={formAction}>
           <label>
             Customer name
             <input
@@ -169,7 +192,13 @@ export const adminEventQrPage = ({
           {isDaily && <DateSelect dates={bookableDates} value={values.date} />}
           <button type="submit">Generate QR code</button>
         </CsrfForm>
-        {result && <QrResultPanel result={result} />}
+        {result && (
+          <QrResultPanel
+            result={result}
+            refreshUrl={refreshUrl}
+            formAction={formAction}
+          />
+        )}
       </article>
     </Layout>,
   );

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -259,6 +259,11 @@ const EventActionNav = ({
         <li>
           <a href={`/admin/event/${event.id}/questions`}>Questions</a>
         </li>
+        {!readOnly && (
+          <li>
+            <a href={`/admin/event/${event.id}/qr`}>Booking QR</a>
+          </li>
+        )}
         <li>
           <a
             href={`/admin/event/${event.id}/export${dateFilter ? `?date=${dateFilter}` : ""}`}

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -419,12 +419,11 @@ const resolveQuantity = (
   return Math.max(0, Math.min(prefill.quantity, maxPurchasable));
 };
 
-/** Render quantity selector for an event row */
-const renderEventRow = (
-  info: TicketEvent,
-  hideQuantity = false,
-  prefill?: TicketPrefill,
-): string => {
+/** Render quantity selector for an event row.
+ *
+ * Note: QR pre-fills are single-event only and go through
+ * renderSingleEventControls, so this function has no prefill parameter. */
+const renderEventRow = (info: TicketEvent, hideQuantity = false): string => {
   const { event, isSoldOut, isClosed, maxPurchasable } = info;
   const fieldName = `quantity_${event.id}`;
   const imageHtml = renderEventImage(event);
@@ -450,10 +449,9 @@ const renderEventRow = (
     `;
   }
 
-  const prefilledQty = resolveQuantity(prefill, maxPurchasable);
   const quantityHtml = hideQuantity
     ? `<input type="hidden" name="${fieldName}" value="1" />`
-    : `<select name="${fieldName}">${quantityOptions(maxPurchasable, prefilledQty)}</select>`;
+    : `<select name="${fieldName}">${quantityOptions(maxPurchasable, 0)}</select>`;
 
   const showPayMore = event.can_pay_more;
   const priceFieldName = `custom_price_${event.id}`;
@@ -463,7 +461,7 @@ const renderEventRow = (
       ${imageHtml}
       <label>${escapeHtml(event.name)}${quantityHtml}</label>
       ${renderEventDescription(event.description)}
-      ${showPayMore ? renderPayMoreInput(event, priceFieldName, prefill?.customPriceMinor) : ""}
+      ${showPayMore ? renderPayMoreInput(event, priceFieldName) : ""}
     </div>
   `;
 };
@@ -477,12 +475,13 @@ const renderSingleEventControls = (
   const { event, maxPurchasable } = info;
   const fieldName = `quantity_${event.id}`;
   const prefilledQty = resolveQuantity(prefill, maxPurchasable);
+  const prefilledPrice = prefill ? prefill.customPriceMinor : undefined;
   const quantityHtml = hideQuantity
     ? `<input type="hidden" name="${fieldName}" value="1" />`
     : `<label>Number of Tickets<select name="${fieldName}">${quantityOptions(maxPurchasable, prefilledQty)}</select></label>`;
   const showPayMore = event.can_pay_more;
   const priceFieldName = `custom_price_${event.id}`;
-  return `${quantityHtml}${showPayMore ? renderPayMoreInput(event, priceFieldName, prefill?.customPriceMinor) : ""}`;
+  return `${quantityHtml}${showPayMore ? renderPayMoreInput(event, priceFieldName, prefilledPrice) : ""}`;
 };
 
 /**
@@ -661,17 +660,14 @@ export const ticketPage = ({
     availableEvents.length === 1 && availableEvents[0]?.maxPurchasable === 1;
 
   // For single events, render just the quantity/pay-more controls (event details are in the header).
-  // For multiple events, render full event rows with name, image, and description.
-  const eventPrefill = (id: number) => qrPrefill?.events.get(id);
+  // QR pre-fills only apply to single-event pages, so multi-event rows ignore them.
   const eventRows = isSingleEvent
     ? renderSingleEventControls(
         events[0]!,
         hideQuantity,
-        eventPrefill(events[0]!.event.id),
+        qrPrefill?.events.get(events[0]!.event.id),
       )
-    : events
-        .map((e) => renderEventRow(e, hideQuantity, eventPrefill(e.event.id)))
-        .join("");
+    : events.map((e) => renderEventRow(e, hideQuantity)).join("");
 
   // Unified header: single events use event details, groups use group metadata
   const headerName = singleEvent?.name ?? groupName;

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -230,13 +230,18 @@ export const buildOgTags = (
 };
 
 /** Render a date selector dropdown for daily events */
-const renderDateSelector = (dates: string[]): string =>
+const renderDateSelector = (dates: string[], selected = ""): string =>
   dates.length === 0
     ? `<div class="error" role="alert">No dates are currently available for booking.</div>`
     : `<label for="date">Select Date</label>
        <select name="date" id="date" required>
          <option value="">— Select a date —</option>
-         ${dates.map((d) => `<option value="${d}">${formatDateLabel(d)}</option>`).join("")}
+         ${dates
+           .map(
+             (d) =>
+               `<option value="${d}"${d === selected ? " selected" : ""}>${formatDateLabel(d)}</option>`,
+           )
+           .join("")}
        </select>`;
 
 /** Quantity values parsed from ticket form */
@@ -246,6 +251,7 @@ export type TicketQuantities = Map<number, number>;
 const renderPayMoreInput = (
   event: Pick<EventWithCount, "unit_price" | "max_price">,
   fieldName = "custom_price",
+  prefillMinor?: number,
 ): string => {
   const minPrice = event.unit_price;
   const maxPrice = event.max_price;
@@ -253,9 +259,13 @@ const renderPayMoreInput = (
     minPrice > 0
       ? `Price per ticket (${formatCurrency(minPrice)} minimum)`
       : `Price per ticket (optional, up to ${formatCurrency(maxPrice)})`;
+  const defaultValue =
+    prefillMinor !== undefined && prefillMinor >= minPrice
+      ? prefillMinor
+      : minPrice;
   return (
     `<label>${rangeHint}` +
-    `<input type="text" inputmode="decimal" name="${fieldName}" value="${escapeHtml(toMajorUnits(minPrice))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}" pattern="\\d+(\\.\\d{1,2})?" title="A non-negative number (e.g. 10.00)"${minPrice > 0 ? " required" : ""} /></label>`
+    `<input type="text" inputmode="decimal" name="${fieldName}" value="${escapeHtml(toMajorUnits(defaultValue))}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(toMajorUnits(maxPrice))}" pattern="\\d+(\\.\\d{1,2})?" title="A non-negative number (e.g. 10.00)"${minPrice > 0 ? " required" : ""} /></label>`
   );
 };
 
@@ -296,6 +306,24 @@ export const notFoundPage = (): string =>
   String(
     <Layout title="Not Found">
       <h1>Not Found</h1>
+    </Layout>,
+  );
+
+/**
+ * QR booking link error page shown when a signed link is invalid or expired.
+ * Always includes a fallback link to the normal event booking page.
+ */
+export const qrBookErrorPage = (slug: string): string =>
+  String(
+    <Layout title="QR code expired">
+      <h1>QR code expired or invalid</h1>
+      <p>
+        This QR code has expired or the link has been tampered with. Ask the
+        organiser to generate a new one, or use the normal booking page below.
+      </p>
+      <p>
+        <a href={`/ticket/${escapeHtml(slug)}`}>Go to booking page</a>
+      </p>
     </Layout>,
   );
 
@@ -366,8 +394,37 @@ const renderEventDescription = (description: string): string =>
     ? `<div class="description-compact">${renderMarkdown(description)}</div>`
     : "";
 
+/** Per-event pre-fill applied when scanning a signed QR link */
+export type TicketPrefill = {
+  quantity?: number;
+  /** Pre-fill the custom_price input for can_pay_more events (minor units) */
+  customPriceMinor?: number;
+};
+
+/** Render an <option> list for quantity selectors with the given default selected */
+const quantityOptions = (max: number, selected: number): string =>
+  Array.from({ length: max + 1 }, (_, i) => i)
+    .map(
+      (n) =>
+        `<option value="${n}"${n === selected ? " selected" : ""}>${n}</option>`,
+    )
+    .join("");
+
+/** Resolve the pre-filled quantity value, clamped to the allowed range */
+const resolveQuantity = (
+  prefill: TicketPrefill | undefined,
+  maxPurchasable: number,
+): number => {
+  if (!prefill?.quantity) return 0;
+  return Math.max(0, Math.min(prefill.quantity, maxPurchasable));
+};
+
 /** Render quantity selector for an event row */
-const renderEventRow = (info: TicketEvent, hideQuantity = false): string => {
+const renderEventRow = (
+  info: TicketEvent,
+  hideQuantity = false,
+  prefill?: TicketPrefill,
+): string => {
   const { event, isSoldOut, isClosed, maxPurchasable } = info;
   const fieldName = `quantity_${event.id}`;
   const imageHtml = renderEventImage(event);
@@ -393,14 +450,10 @@ const renderEventRow = (info: TicketEvent, hideQuantity = false): string => {
     `;
   }
 
+  const prefilledQty = resolveQuantity(prefill, maxPurchasable);
   const quantityHtml = hideQuantity
     ? `<input type="hidden" name="${fieldName}" value="1" />`
-    : (() => {
-        const options = Array.from({ length: maxPurchasable + 1 }, (_, i) => i)
-          .map((n) => `<option value="${n}">${n}</option>`)
-          .join("");
-        return `<select name="${fieldName}">${options}</select>`;
-      })();
+    : `<select name="${fieldName}">${quantityOptions(maxPurchasable, prefilledQty)}</select>`;
 
   const showPayMore = event.can_pay_more;
   const priceFieldName = `custom_price_${event.id}`;
@@ -410,7 +463,7 @@ const renderEventRow = (info: TicketEvent, hideQuantity = false): string => {
       ${imageHtml}
       <label>${escapeHtml(event.name)}${quantityHtml}</label>
       ${renderEventDescription(event.description)}
-      ${showPayMore ? renderPayMoreInput(event, priceFieldName) : ""}
+      ${showPayMore ? renderPayMoreInput(event, priceFieldName, prefill?.customPriceMinor) : ""}
     </div>
   `;
 };
@@ -419,20 +472,17 @@ const renderEventRow = (info: TicketEvent, hideQuantity = false): string => {
 const renderSingleEventControls = (
   info: TicketEvent,
   hideQuantity: boolean,
+  prefill?: TicketPrefill,
 ): string => {
   const { event, maxPurchasable } = info;
   const fieldName = `quantity_${event.id}`;
+  const prefilledQty = resolveQuantity(prefill, maxPurchasable);
   const quantityHtml = hideQuantity
     ? `<input type="hidden" name="${fieldName}" value="1" />`
-    : (() => {
-        const options = Array.from({ length: maxPurchasable + 1 }, (_, i) => i)
-          .map((n) => `<option value="${n}">${n}</option>`)
-          .join("");
-        return `<label>Number of Tickets<select name="${fieldName}">${options}</select></label>`;
-      })();
+    : `<label>Number of Tickets<select name="${fieldName}">${quantityOptions(maxPurchasable, prefilledQty)}</select></label>`;
   const showPayMore = event.can_pay_more;
   const priceFieldName = `custom_price_${event.id}`;
-  return `${quantityHtml}${showPayMore ? renderPayMoreInput(event, priceFieldName) : ""}`;
+  return `${quantityHtml}${showPayMore ? renderPayMoreInput(event, priceFieldName, prefill?.customPriceMinor) : ""}`;
 };
 
 /**
@@ -440,6 +490,18 @@ const renderSingleEventControls = (
  */
 const getTicketFieldsSetting = (events: TicketEvent[]): EventFields =>
   mergeEventFields(events.map((e) => e.event.fields));
+
+/** Pre-fill state derived from a signed QR booking link */
+export type QrPrefill = {
+  /** Opaque signed token re-submitted via a hidden input to verify price override */
+  token: string;
+  /** Pre-fill name input */
+  name?: string;
+  /** Pre-fill date selector (for daily events) */
+  date?: string;
+  /** Per-event pre-fill — keyed by event id */
+  events: Map<number, TicketPrefill>;
+};
 
 /** Options for the ticket page */
 export type TicketPageOptions = {
@@ -453,6 +515,7 @@ export type TicketPageOptions = {
   baseUrl?: string;
   groupName?: string;
   groupDescription?: string;
+  qrPrefill?: QrPrefill;
 };
 
 /** Unavailability message shown when all events are sold out or closed */
@@ -519,6 +582,7 @@ const TicketPageForm = ({
   questions,
   questionEventMap,
   terms,
+  qrPrefill,
 }: {
   slugs: string[];
   fields: Field[];
@@ -530,27 +594,37 @@ const TicketPageForm = ({
   questions: QuestionWithAnswers[] | undefined;
   questionEventMap: QuestionEventMap | undefined;
   terms: string | null | undefined;
-}): JSX.Element => (
-  <CsrfForm action={`/ticket/${slugs.join("+")}`}>
-    <Raw html={renderFields(fields)} />
-    {hasDaily && dates && <Raw html={renderDateSelector(dates)} />}
+  qrPrefill?: QrPrefill;
+}): JSX.Element => {
+  const fieldValues: Record<string, string> = {};
+  if (qrPrefill?.name) fieldValues.name = qrPrefill.name;
+  return (
+    <CsrfForm action={`/ticket/${slugs.join("+")}`}>
+      {qrPrefill && (
+        <input type="hidden" name="qr_token" value={qrPrefill.token} />
+      )}
+      <Raw html={renderFields(fields, fieldValues)} />
+      {hasDaily && dates && (
+        <Raw html={renderDateSelector(dates, qrPrefill?.date ?? "")} />
+      )}
 
-    {hideQuantity || isSingleEvent ? (
-      <Raw html={eventRows} />
-    ) : (
-      <fieldset class="ticket-events">
-        <legend>Select Tickets</legend>
+      {hideQuantity || isSingleEvent ? (
         <Raw html={eventRows} />
-      </fieldset>
-    )}
+      ) : (
+        <fieldset class="ticket-events">
+          <legend>Select Tickets</legend>
+          <Raw html={eventRows} />
+        </fieldset>
+      )}
 
-    {questions && questions.length > 0 && (
-      <Raw html={renderQuestions(questions, questionEventMap)} />
-    )}
-    {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
-    <button type="submit">Continue</button>
-  </CsrfForm>
-);
+      {questions && questions.length > 0 && (
+        <Raw html={renderQuestions(questions, questionEventMap)} />
+      )}
+      {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
+      <button type="submit">Continue</button>
+    </CsrfForm>
+  );
+};
 
 /**
  * Ticket page - register for one or more events
@@ -568,6 +642,7 @@ export const ticketPage = ({
   baseUrl,
   groupName,
   groupDescription,
+  qrPrefill,
 }: TicketPageOptions): string => {
   const inIframe = getIframeMode();
   const allUnavailable = events.every((e) => e.isSoldOut || e.isClosed);
@@ -587,9 +662,16 @@ export const ticketPage = ({
 
   // For single events, render just the quantity/pay-more controls (event details are in the header).
   // For multiple events, render full event rows with name, image, and description.
+  const eventPrefill = (id: number) => qrPrefill?.events.get(id);
   const eventRows = isSingleEvent
-    ? renderSingleEventControls(events[0]!, hideQuantity)
-    : events.map((e) => renderEventRow(e, hideQuantity)).join("");
+    ? renderSingleEventControls(
+        events[0]!,
+        hideQuantity,
+        eventPrefill(events[0]!.event.id),
+      )
+    : events
+        .map((e) => renderEventRow(e, hideQuantity, eventPrefill(e.event.id)))
+        .join("");
 
   // Unified header: single events use event details, groups use group metadata
   const headerName = singleEvent?.name ?? groupName;
@@ -630,6 +712,7 @@ export const ticketPage = ({
           questions={questions}
           questionEventMap={questionEventMap}
           terms={terms}
+          qrPrefill={qrPrefill}
         />
       )}
     </Layout>,

--- a/test/lib/qr-token.test.ts
+++ b/test/lib/qr-token.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for signed QR booking tokens.
+ *
+ * These tests guard the two invariants the whole feature relies on:
+ *  1. A token signed for one slug cannot be verified against another (domain
+ *     separation — prevents one event's QR working on another).
+ *  2. Any tampering with payload or signature fails verification; expired
+ *     tokens are rejected.
+ */
+
+import { expect } from "@std/expect";
+import { beforeEach, describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+import { hmacHash } from "#lib/crypto/hashing.ts";
+import { base64ToBase64Url, toBase64 } from "#lib/crypto/utils.ts";
+import {
+  buildQrBookPayload,
+  QR_TOKEN_MAX_AGE_S,
+  signQrBookToken,
+  verifyQrBookToken,
+} from "#lib/qr-token.ts";
+import { setupTestEncryptionKey } from "#test-utils";
+
+describe("qr-token", () => {
+  beforeEach(() => {
+    setupTestEncryptionKey();
+  });
+
+  describe("buildQrBookPayload", () => {
+    test("fills defaults for optional fields", () => {
+      const payload = buildQrBookPayload({});
+      expect(payload.n).toBe("");
+      expect(payload.v).toBe(-1);
+      expect(payload.q).toBe(1);
+      expect(payload.d).toBe("");
+    });
+
+    test("sets expiry to now plus default max age", () => {
+      const nowS = Math.floor(Date.now() / 1000);
+      const payload = buildQrBookPayload({});
+      expect(payload.e).toBeGreaterThanOrEqual(nowS + QR_TOKEN_MAX_AGE_S - 2);
+      expect(payload.e).toBeLessThanOrEqual(nowS + QR_TOKEN_MAX_AGE_S + 2);
+    });
+
+    test("carries supplied values into the payload", () => {
+      const payload = buildQrBookPayload({
+        date: "2026-05-01",
+        name: "Ada",
+        quantity: 3,
+        value: 1500,
+      });
+      expect(payload.n).toBe("Ada");
+      expect(payload.v).toBe(1500);
+      expect(payload.q).toBe(3);
+      expect(payload.d).toBe("2026-05-01");
+    });
+  });
+
+  describe("signQrBookToken", () => {
+    test("produces a token with the qr1. prefix and two dot-separated parts", async () => {
+      const token = await signQrBookToken("my-event", buildQrBookPayload({}));
+      expect(token.startsWith("qr1.")).toBe(true);
+      const rest = token.slice(4);
+      expect(rest.split(".").length).toBe(2);
+    });
+
+    test("produces the same token for the same slug and payload (determinism)", async () => {
+      const payload = buildQrBookPayload({ name: "Ada", value: 1000 });
+      const a = await signQrBookToken("slug", payload);
+      const b = await signQrBookToken("slug", payload);
+      expect(a).toBe(b);
+    });
+
+    test("produces different tokens for the same payload under different slugs", async () => {
+      const payload = buildQrBookPayload({ name: "Ada", value: 1000 });
+      const a = await signQrBookToken("slug-a", payload);
+      const b = await signQrBookToken("slug-b", payload);
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("verifyQrBookToken", () => {
+    test("accepts a freshly signed token and returns the original payload", async () => {
+      const original = buildQrBookPayload({
+        date: "2026-05-01",
+        name: "Ada",
+        quantity: 2,
+        value: 2500,
+      });
+      const token = await signQrBookToken("event-slug", original);
+      const result = await verifyQrBookToken("event-slug", token);
+      expect(result).toEqual(original);
+    });
+
+    test("rejects a token used for a different slug (domain separation)", async () => {
+      const token = await signQrBookToken(
+        "event-a",
+        buildQrBookPayload({ name: "Ada" }),
+      );
+      const result = await verifyQrBookToken("event-b", token);
+      expect(result).toBe(null);
+    });
+
+    test("rejects a token with tampered signature", async () => {
+      const token = await signQrBookToken(
+        "event",
+        buildQrBookPayload({ value: 500 }),
+      );
+      const tampered = `${token.slice(0, -4)}XXXX`;
+      expect(await verifyQrBookToken("event", tampered)).toBe(null);
+    });
+
+    test("rejects a token with tampered payload", async () => {
+      const token = await signQrBookToken(
+        "event",
+        buildQrBookPayload({ value: 500 }),
+      );
+      const rest = token.slice(4);
+      const dotIdx = rest.indexOf(".");
+      const hmac = rest.slice(dotIdx);
+      // Replace the payload with a different one (same length to look similar)
+      const otherPayload = buildQrBookPayload({ value: 999999 });
+      const otherToken = await signQrBookToken("event", otherPayload);
+      const otherEncoded = otherToken.slice(4).split(".")[0]!;
+      const forged = `qr1.${otherEncoded}${hmac}`;
+      expect(await verifyQrBookToken("event", forged)).toBe(null);
+    });
+
+    test("rejects a token whose payload cannot be base64-decoded", async () => {
+      expect(await verifyQrBookToken("event", "qr1.!!!not-base64!!!.sig")).toBe(
+        null,
+      );
+    });
+
+    test("rejects a token without the qr1. prefix", async () => {
+      const token = await signQrBookToken("event", buildQrBookPayload({}));
+      const stripped = token.slice(4);
+      expect(await verifyQrBookToken("event", stripped)).toBe(null);
+    });
+
+    test("rejects an empty string", async () => {
+      expect(await verifyQrBookToken("event", "")).toBe(null);
+    });
+
+    test("rejects a token missing the dot separator", async () => {
+      expect(await verifyQrBookToken("event", "qr1.nodot")).toBe(null);
+    });
+
+    test("rejects a token with empty signature", async () => {
+      expect(await verifyQrBookToken("event", "qr1.payload.")).toBe(null);
+    });
+
+    test("rejects an expired token", async () => {
+      const time = new FakeTime(1_700_000_000_000);
+      try {
+        const token = await signQrBookToken(
+          "event",
+          buildQrBookPayload({ name: "Ada", value: 100 }),
+        );
+        // Advance past the max-age window
+        time.tick((QR_TOKEN_MAX_AGE_S + 10) * 1000);
+        expect(await verifyQrBookToken("event", token)).toBe(null);
+      } finally {
+        time.restore();
+      }
+    });
+
+    test("accepts a token still within its validity window", async () => {
+      const time = new FakeTime(1_700_000_000_000);
+      try {
+        const token = await signQrBookToken(
+          "event",
+          buildQrBookPayload({ name: "Ada", value: 100 }),
+        );
+        // Advance by just under the max-age window
+        time.tick((QR_TOKEN_MAX_AGE_S - 10) * 1000);
+        const result = await verifyQrBookToken("event", token);
+        expect(result?.n).toBe("Ada");
+      } finally {
+        time.restore();
+      }
+    });
+
+    test("rejects a token with an unreasonably far-future expiry", async () => {
+      // Caller passes a huge maxAgeSeconds to try to bypass the max-age check
+      const payload = buildQrBookPayload({
+        maxAgeSeconds: QR_TOKEN_MAX_AGE_S * 100,
+        name: "Ada",
+      });
+      const token = await signQrBookToken("event", payload);
+      expect(await verifyQrBookToken("event", token)).toBe(null);
+    });
+
+    test("rejects a token whose signed payload fails shape validation", async () => {
+      // Construct a token where the HMAC is correctly computed over a
+      // non-conforming JSON payload. Guards the branch where signature
+      // passes but decodePayload rejects the shape.
+      const encoder = new TextEncoder();
+      const bogus = base64ToBase64Url(
+        toBase64(encoder.encode(JSON.stringify({ not: "a payload" }))),
+      );
+      const message = `qr-book:event:${bogus}`;
+      const hmac = base64ToBase64Url(await hmacHash(message));
+      const token = `qr1.${bogus}.${hmac}`;
+      expect(await verifyQrBookToken("event", token)).toBe(null);
+    });
+
+    test("rejects a token whose payload is signed but not valid base64", async () => {
+      // HMAC is computed over the literal "encoded" string regardless of
+      // whether it's valid base64, so we can get past the signature check
+      // with a payload that fails decoding. Guards the catch branch.
+      const encoded = "not-valid-base64-@@@";
+      const message = `qr-book:event:${encoded}`;
+      const hmac = base64ToBase64Url(await hmacHash(message));
+      expect(await verifyQrBookToken("event", `qr1.${encoded}.${hmac}`)).toBe(
+        null,
+      );
+    });
+  });
+});

--- a/test/lib/server-event-qr-admin.test.ts
+++ b/test/lib/server-event-qr-admin.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the admin "generate booking QR code" page.
+ *
+ * Exercises the end-to-end flow: form rendering, validation, token signing,
+ * and the embedded QR SVG. Auth, CSRF, and role checks are shared with other
+ * admin routes and tested there.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { verifyQrBookToken } from "#lib/qr-token.ts";
+import { handleRequest } from "#routes";
+import {
+  adminFormPost,
+  adminGet,
+  createDailyTestEvent,
+  createTestEvent,
+  describeWithEnv,
+  mockFormRequest,
+  mockRequest,
+  testCookie,
+} from "#test-utils";
+
+/** Extract the ?t= token from a generated QR booking link */
+const extractToken = (html: string): string | null => {
+  const match = html.match(/\/qr-book\?t=([^"\s&]+)/);
+  return match ? decodeURIComponent(match[1]!) : null;
+};
+
+describeWithEnv("admin event-qr route", { db: true }, () => {
+  describe("GET /admin/event/:id/qr", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      const response = await handleRequest(
+        mockRequest(`/admin/event/${event.id}/qr`),
+      );
+      expect(response.status).toBe(302);
+      response.body?.cancel();
+    });
+
+    test("returns 404 when the event does not exist", async () => {
+      const { response } = await adminGet("/admin/event/99999/qr");
+      expect(response.status).toBe(404);
+      response.body?.cancel();
+    });
+
+    test("renders the form with quantity defaulted to 1", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const { response } = await adminGet(`/admin/event/${event.id}/qr`);
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('name="customer_name"');
+      expect(body).toContain('name="value"');
+      expect(body).toContain('name="quantity"');
+      expect(body).toContain('value="1"');
+    });
+
+    test("shows a date selector for daily events", async () => {
+      const event = await createDailyTestEvent({ unitPrice: 500 });
+      const { response } = await adminGet(`/admin/event/${event.id}/qr`);
+      const body = await response.text();
+      expect(body).toContain('name="date"');
+    });
+
+    test("omits the date selector for standard events", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const { response } = await adminGet(`/admin/event/${event.id}/qr`);
+      const body = await response.text();
+      expect(body).not.toContain('name="date"');
+    });
+  });
+
+  describe("POST /admin/event/:id/qr", () => {
+    test("rejects invalid CSRF for an authenticated session", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/event/${event.id}/qr`,
+          { csrf_token: "invalid", quantity: "1" },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(403);
+      response.body?.cancel();
+    });
+
+    test("renders a validation error when quantity exceeds max", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 10,
+        maxQuantity: 2,
+        unitPrice: 500,
+      });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        quantity: "5",
+      });
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain("Quantity cannot exceed 2");
+      expect(body).not.toContain("/qr-book?t=");
+    });
+
+    test("renders a validation error when quantity is not a number", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        quantity: "abc",
+      });
+      const body = await response.text();
+      expect(body).toContain("Quantity must be at least 1");
+    });
+
+    test("renders a validation error when daily event is missing a date", async () => {
+      const event = await createDailyTestEvent({ unitPrice: 500 });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        customer_name: "Ada",
+        quantity: "1",
+        value: "5.00",
+      });
+      const body = await response.text();
+      expect(body).toContain("Date is required");
+    });
+
+    test("renders a validation error for pay-more price below minimum", async () => {
+      const event = await createTestEvent({
+        canPayMore: true,
+        maxAttendees: 10,
+        maxPrice: 10000,
+        unitPrice: 500,
+      });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        quantity: "1",
+        value: "1.00",
+      });
+      const body = await response.text();
+      expect(body).toContain("at least the minimum");
+    });
+
+    test("accepts any price for fixed-price events as a one-off override", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        customer_name: "Ada",
+        quantity: "1",
+        // Way above the event's unit_price; allowed for the override
+        value: "200.00",
+      });
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain("/qr-book?t=");
+      expect(body).toContain("<svg");
+    });
+
+    test("signed token embeds submitted values and matches the event slug", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 10,
+        maxQuantity: 5,
+        unitPrice: 500,
+      });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        customer_name: "Ada Lovelace",
+        quantity: "3",
+        value: "12.50",
+      });
+      const body = await response.text();
+      const token = extractToken(body);
+      expect(token).not.toBeNull();
+      const payload = await verifyQrBookToken(event.slug, token!);
+      expect(payload).not.toBeNull();
+      expect(payload!.n).toBe("Ada Lovelace");
+      expect(payload!.v).toBe(1250);
+      expect(payload!.q).toBe(3);
+    });
+
+    test("generates a token when customer_name is omitted, defaulting quantity to 1", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const { response } = await adminFormPost(`/admin/event/${event.id}/qr`, {
+        // No customer_name, no quantity, no value
+      });
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      const token = extractToken(body);
+      expect(token).not.toBeNull();
+      const payload = await verifyQrBookToken(event.slug, token!);
+      expect(payload!.n).toBe("");
+      expect(payload!.q).toBe(1);
+      expect(payload!.v).toBe(-1);
+    });
+
+    test("tokens are scoped to their event slug", async () => {
+      const a = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const b = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const { response } = await adminFormPost(`/admin/event/${a.id}/qr`, {
+        customer_name: "Ada",
+        quantity: "1",
+        value: "5.00",
+      });
+      const body = await response.text();
+      const token = extractToken(body)!;
+      expect(await verifyQrBookToken(b.slug, token)).toBeNull();
+    });
+  });
+});

--- a/test/lib/server-event-qr-admin.test.ts
+++ b/test/lib/server-event-qr-admin.test.ts
@@ -198,4 +198,82 @@ describeWithEnv("admin event-qr route", { db: true }, () => {
       expect(await verifyQrBookToken(b.slug, token)).toBeNull();
     });
   });
+
+  describe("GET /admin/event/:id/qr.json (client-side refresh)", () => {
+    test("redirects to login when not authenticated", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      const response = await handleRequest(
+        mockRequest(`/admin/event/${event.id}/qr.json?quantity=1`),
+      );
+      expect(response.status).toBe(302);
+      response.body?.cancel();
+    });
+
+    test("returns 404 when the event does not exist", async () => {
+      const { response } = await adminGet("/admin/event/99999/qr.json?quantity=1");
+      expect(response.status).toBe(404);
+      response.body?.cancel();
+    });
+
+    test("returns JSON with a fresh token matching submitted values", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 10,
+        maxQuantity: 5,
+        unitPrice: 500,
+      });
+      const { response } = await adminGet(
+        `/admin/event/${event.id}/qr.json?customer_name=Ada&value=7.50&quantity=2`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+      const body = (await response.json()) as {
+        ok: boolean;
+        url: string;
+        svg: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.svg).toContain("<svg");
+      const match = body.url.match(/\/qr-book\?t=([^&]+)/);
+      expect(match).not.toBeNull();
+      const token = decodeURIComponent(match![1]!);
+      const payload = await verifyQrBookToken(event.slug, token);
+      expect(payload!.n).toBe("Ada");
+      expect(payload!.v).toBe(750);
+      expect(payload!.q).toBe(2);
+    });
+
+    test("returns 400 JSON on validation failure", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 10,
+        maxQuantity: 2,
+        unitPrice: 500,
+      });
+      const { response } = await adminGet(
+        `/admin/event/${event.id}/qr.json?quantity=99`,
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as {
+        ok: boolean;
+        error?: string;
+      };
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain("Quantity cannot exceed");
+    });
+
+    test("signs a different token each minute (fresh expiry)", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const first = await adminGet(
+        `/admin/event/${event.id}/qr.json?customer_name=Ada&value=5.00&quantity=1`,
+      );
+      await new Promise((r) => setTimeout(r, 1100));
+      const second = await adminGet(
+        `/admin/event/${event.id}/qr.json?customer_name=Ada&value=5.00&quantity=1`,
+      );
+      const a = (await first.response.json()) as { url: string };
+      const b = (await second.response.json()) as { url: string };
+      expect(a.url).not.toBe(b.url);
+    });
+  });
 });

--- a/test/lib/server-qr-book.test.ts
+++ b/test/lib/server-qr-book.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Tests for the QR-book scan handler and its price-override plumbing.
+ *
+ * Covers three behaviours:
+ *  - Error paths (missing/invalid/expired token, unknown event)
+ *  - Pre-fill rendering when the event still needs user input
+ *  - Skip-to-Stripe when all required data is carried in the signed token
+ *  - Price override on POST for fixed-price events
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { FakeTime } from "@std/testing/time";
+import { toMinorUnits } from "#lib/currency.ts";
+import { addDays } from "#lib/dates.ts";
+import { eventsTable } from "#lib/db/events.ts";
+import { settings } from "#lib/db/settings.ts";
+import { paymentsApi } from "#lib/payments.ts";
+import {
+  buildQrBookPayload,
+  QR_TOKEN_MAX_AGE_S,
+  signQrBookToken,
+} from "#lib/qr-token.ts";
+import { stripePaymentProvider } from "#lib/stripe-provider.ts";
+import { todayInTz } from "#lib/timezone.ts";
+import { handleRequest } from "#routes";
+import {
+  awaitTestRequest,
+  createDailyTestEvent,
+  createTestEvent,
+  describeWithEnv,
+  getAttendeesRaw,
+  mockProviderType,
+  mockRequest,
+  setupStripe,
+  submitTicketForm,
+} from "#test-utils";
+
+const qrBookPath = (slug: string, token: string): string =>
+  `/ticket/${slug}/qr-book?t=${encodeURIComponent(token)}`;
+
+/** Stub Stripe as the active provider with a canned checkout URL */
+const stubStripe = (checkoutUrl = "https://stripe.example/checkout") => {
+  const providerStub = stub(
+    paymentsApi,
+    "getConfiguredProvider",
+    () => mockProviderType("stripe"),
+  );
+  const checkoutStub = stub(
+    stripePaymentProvider,
+    "createCheckoutSession",
+    () =>
+      Promise.resolve({
+        checkoutUrl,
+        sessionId: "cs_test_123",
+      }),
+  );
+  return {
+    checkoutStub,
+    restore: () => {
+      providerStub.restore();
+      checkoutStub.restore();
+    },
+  };
+};
+
+describeWithEnv("qr-book scan handler", { db: true }, () => {
+  describe("error paths", () => {
+    test("missing ?t= token renders the error page", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      const response = await handleRequest(
+        mockRequest(`/ticket/${event.slug}/qr-book`),
+      );
+      expect(response.status).toBe(400);
+      const body = await response.text();
+      expect(body).toContain("expired or invalid");
+      expect(body).toContain(`/ticket/${event.slug}`);
+    });
+
+    test("invalid signature renders the error page", async () => {
+      const event = await createTestEvent({ maxAttendees: 10 });
+      const response = await awaitTestRequest(
+        qrBookPath(event.slug, "qr1.not-a-real-token.signature"),
+      );
+      expect(response.status).toBe(400);
+      const body = await response.text();
+      expect(body).toContain("expired or invalid");
+    });
+
+    test("unknown event slug renders the error page", async () => {
+      const token = await signQrBookToken(
+        "unknown-slug",
+        buildQrBookPayload({ name: "Ada" }),
+      );
+      const response = await awaitTestRequest(
+        qrBookPath("unknown-slug", token),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("expired token renders the error page", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      const time = new FakeTime(1_700_000_000_000);
+      try {
+        const token = await signQrBookToken(
+          event.slug,
+          buildQrBookPayload({ name: "Ada", value: 500 }),
+        );
+        time.tick((QR_TOKEN_MAX_AGE_S + 30) * 1000);
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(400);
+      } finally {
+        time.restore();
+      }
+    });
+
+    test("deactivated event is treated like unknown (404)", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, unitPrice: 500 });
+      await eventsTable.update(event.id, { active: false });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      expect(response.status).toBe(404);
+    });
+
+    test("daily event with an un-bookable date is rejected", async () => {
+      const event = await createDailyTestEvent({ unitPrice: 500 });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ date: "1999-01-01", name: "Ada", value: 500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      expect(response.status).toBe(400);
+    });
+
+    test("daily event with no date in the token is rejected", async () => {
+      const event = await createDailyTestEvent({ unitPrice: 500 });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("pre-fill rendering", () => {
+    test("pre-fills the name input when the event still needs other fields", async () => {
+      const event = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada Lovelace", value: 500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('value="Ada Lovelace"');
+      expect(body).toContain('name="qr_token"');
+    });
+
+    test("pre-fills custom_price input for can_pay_more events", async () => {
+      const event = await createTestEvent({
+        canPayMore: true,
+        fields: "email",
+        maxAttendees: 10,
+        maxPrice: 10000,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 2500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      const body = await response.text();
+      expect(body).toContain(`name="custom_price_${event.id}" value="25.00"`);
+    });
+
+    test("pre-fills quantity for the event row", async () => {
+      const event = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        maxQuantity: 5,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", quantity: 3, value: 500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      const body = await response.text();
+      expect(body).toMatch(/<option value="3"\s+selected>/);
+    });
+
+    test("pre-fills the daily date selector", async () => {
+      const event = await createDailyTestEvent({
+        fields: "email",
+        unitPrice: 500,
+      });
+      const tomorrow = addDays(todayInTz(settings.timezone), 1);
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ date: tomorrow, name: "Ada", value: 500 }),
+      );
+      const response = await awaitTestRequest(qrBookPath(event.slug, token));
+      const body = await response.text();
+      expect(body).toMatch(new RegExp(`value="${tomorrow}"\\s+selected`));
+    });
+  });
+
+  describe("skip-to-Stripe", () => {
+    test("redirects straight to Stripe when name + value are both set and no extra fields are required", async () => {
+      const event = await createTestEvent({
+        fields: "",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 1000 }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toContain("stripe.example");
+        expect(stripe.checkoutStub.calls.length).toBe(1);
+        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(intent.name).toBe("Ada");
+        expect(intent.items[0]!.unitPrice).toBe(1000);
+        expect(intent.items[0]!.quantity).toBe(1);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("renders the error page when the provider cannot create a session", async () => {
+      const event = await createTestEvent({
+        fields: "",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 1000 }),
+      );
+      const providerStub = stub(
+        paymentsApi,
+        "getConfiguredProvider",
+        () => mockProviderType("stripe"),
+      );
+      const checkoutStub = stub(
+        stripePaymentProvider,
+        "createCheckoutSession",
+        () => Promise.resolve(null),
+      );
+      try {
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(500);
+        const body = await response.text();
+        expect(body).toContain("expired or invalid");
+      } finally {
+        checkoutStub.restore();
+        providerStub.restore();
+      }
+    });
+
+    test("falls through to the form when the event requires email", async () => {
+      const event = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 1000 }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(200);
+        expect(stripe.checkoutStub.calls.length).toBe(0);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("falls through when name is missing even though value is set", async () => {
+      const event = await createTestEvent({
+        fields: "",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ value: 1000 }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(200);
+        expect(stripe.checkoutStub.calls.length).toBe(0);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("daily event with a bookable date skips straight to Stripe with the date set", async () => {
+      const event = await createDailyTestEvent({
+        fields: "",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const tomorrow = addDays(todayInTz(settings.timezone), 1);
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ date: tomorrow, name: "Ada", value: 1000 }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(302);
+        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(intent.date).toBe(tomorrow);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("falls through when global terms are configured", async () => {
+      const event = await createTestEvent({
+        fields: "",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      await settings.update.terms("# Test terms");
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 1000 }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await awaitTestRequest(qrBookPath(event.slug, token));
+        expect(response.status).toBe(200);
+        expect(stripe.checkoutStub.calls.length).toBe(0);
+      } finally {
+        await settings.update.terms("");
+        stripe.restore();
+      }
+    });
+  });
+
+  describe("POST price override", () => {
+    test("fixed-price event: signed qr_token overrides unit_price for the booking", async () => {
+      await setupStripe();
+      const event = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const overridePrice = toMinorUnits(12.5);
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: overridePrice }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await submitTicketForm(event.slug, {
+          [`quantity_${event.id}`]: "1",
+          email: "ada@example.com",
+          name: "Ada",
+          qr_token: token,
+        });
+        // Response is a 302 redirect to Stripe
+        expect(response.status).toBe(302);
+        expect(stripe.checkoutStub.calls.length).toBe(1);
+        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(intent.items[0]!.unitPrice).toBe(overridePrice);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("tampered qr_token is ignored; original unit_price is used", async () => {
+      await setupStripe();
+      const event = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const stripe = stubStripe();
+      try {
+        const response = await submitTicketForm(event.slug, {
+          [`quantity_${event.id}`]: "1",
+          email: "ada@example.com",
+          name: "Ada",
+          qr_token: "qr1.forged.signature",
+        });
+        expect(response.status).toBe(302);
+        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(intent.items[0]!.unitPrice).toBe(500);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("can_pay_more event: user's custom_price wins over the qr_token value", async () => {
+      await setupStripe();
+      const event = await createTestEvent({
+        canPayMore: true,
+        fields: "email",
+        maxAttendees: 10,
+        maxPrice: 10000,
+        unitPrice: 500,
+      });
+      const token = await signQrBookToken(
+        event.slug,
+        buildQrBookPayload({ name: "Ada", value: 1000 }),
+      );
+      const stripe = stubStripe();
+      try {
+        const response = await submitTicketForm(event.slug, {
+          [`custom_price_${event.id}`]: "50.00",
+          [`quantity_${event.id}`]: "1",
+          email: "ada@example.com",
+          name: "Ada",
+          qr_token: token,
+        });
+        expect(response.status).toBe(302);
+        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(intent.items[0]!.unitPrice).toBe(5000);
+      } finally {
+        stripe.restore();
+      }
+    });
+
+    test("free booking path still works without a qr_token (no regression)", async () => {
+      const event = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        unitPrice: 0,
+      });
+      const response = await submitTicketForm(event.slug, {
+        [`quantity_${event.id}`]: "1",
+        email: "ada@example.com",
+        name: "Ada",
+      });
+      expect(response.status).toBe(302);
+      const attendees = await getAttendeesRaw(event.id);
+      expect(attendees.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Admins can generate a signed QR link at `/admin/event/:id/qr` that pre-fills the booking form with customer name, price, quantity, and (for daily events) a date. Links expire 5 minutes after generation.

When a scanner lands on `/ticket/:slug/qr-book` and the token carries both a name and a price — and the event has no other required fields, questions, or terms — the request redirects straight to Stripe checkout. Otherwise the normal booking page renders with the values pre-filled.

For fixed-price events the signed token's price overrides `unit_price` for the one booking. The token is carried through POST as a hidden input and re-verified before the override is applied, so a tampered hidden field is ignored and the event's configured price is used instead.

Tokens use HMAC-SHA256 via the existing `hmacHash` helper with a domain-separated message (`"qr-book:<slug>:<payload>"`) so the signature can never collide with CSRF or other signed tokens in the app.

## Files
- **New**: `src/lib/qr-token.ts` (sign/verify), `src/routes/admin/event-qr.ts` + `src/templates/admin/event-qr.tsx` (admin form), `src/routes/public/qr-book.ts` (scan handler)
- **Edited**: `src/routes/public/ticket-submit.ts` (price-override plumbing), `src/templates/public.tsx` (pre-fill state, error page), `src/routes/public/types.ts` (TicketCtx), `src/routes/admin/index.ts` + `src/routes/public/ticket-routes.ts` (route wiring), `src/templates/admin/events.tsx` (nav link)
- **Tests**: three new test files covering token sign/verify, admin form, scan handler, skip-to-Stripe, and POST price-override plumbing (64 new test steps, all passing; 100% line + branch coverage on new files)

## Test plan
- [ ] Visit `/admin/event/:id/qr` on a fixed-price event, generate a QR with a name + price, scan it — expect redirect straight to Stripe when the event has no other required fields
- [ ] Same but with `fields="email"` — expect the booking form with name pre-filled and a hidden `qr_token` input
- [ ] Same but with `can_pay_more: true` — expect `custom_price_{id}` pre-filled, user can edit, their value wins on submit
- [ ] For a daily event, generate with a required date; scan — expect the date pre-selected
- [ ] Scan a tampered or expired URL — expect the error page with a link back to `/ticket/:slug`
- [ ] Submit the form with a valid `qr_token` for a fixed-price event — expect Stripe intent to use the signed value, not `unit_price`
- [ ] Submit the form with a tampered `qr_token` — expect `unit_price` to be used

https://claude.ai/code/session_011pUWD21dcy1fxHNjU9jqXd