### PR TITLE
Clean up header-image tests; document header image in guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1857,6 +1857,25 @@ export const adminGuidePage = (
           </ul>
         </Q>
 
+        <Q q="How does the header image work?">
+          <p>
+            Upload a logo or banner from <strong>Settings</strong>{" "}
+            and it appears at the top of every admin and public page. The image
+            is encrypted and served through the{" "}
+            <code>/image/</code>{" "}
+            proxy with long-lived immutable cache headers, so browsers only
+            download it once.
+          </p>
+          <p>
+            Supported formats are JPEG, PNG, GIF, and WebP, up to 256&nbsp;KB.
+            Uploading a new image automatically deletes the old one, and the{" "}
+            <strong>Remove Image</strong> button clears it completely. If image
+            storage isn't configured the section is hidden &mdash; see{" "}
+            <strong>Advanced Settings</strong>{" "}
+            to set up a Bunny storage zone.
+          </p>
+        </Q>
+
         <Q q="What are Advanced Settings?">
           <p>
             The main Settings page has a link to{" "}

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2936,6 +2936,20 @@ export const withCdnProxy = (
     }),
   );
 
+/** Mock fetch where CDN requests reject (simulates network failure) */
+export const withCdnRejecting = (
+  error: Error,
+  fn: () => Promise<void>,
+): Promise<void> =>
+  runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, () =>
+    withFetchMock(async (originalFetch) => {
+      installUrlHandler(originalFetch, (url) =>
+        url.includes("storage.bunnycdn.com") ? Promise.reject(error) : null,
+      );
+      await fn();
+    }),
+  );
+
 /**
  * Run a callback with storage explicitly disabled (neither Bunny nor local).
  * Uses AsyncLocalStorage so concurrent tests cannot interfere.

--- a/test/lib/header-image.test.ts
+++ b/test/lib/header-image.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { encryptBytes } from "#lib/crypto/encryption.ts";
 import { settings } from "#lib/db/settings.ts";
 import { handleRequest } from "#routes";
@@ -14,36 +14,41 @@ import {
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,
+  PDF_BYTES,
   testCookie,
   testCsrfToken,
+  withCdnProxy,
+  withCdnRejecting,
   withStorageDisabled,
   withStorageEnabled,
   withStorageMock,
 } from "#test-utils";
 
+const HEADER_IMAGE_POST = "/admin/settings/header-image";
+const HEADER_IMAGE_DELETE = "/admin/settings/header-image/delete";
+const HEADER_IMAGE_FORM_REDIRECT =
+  "/admin/settings?form=settings-header-image#settings-header-image";
+const HEADER_IMAGE_DELETE_FORM_REDIRECT =
+  "/admin/settings?form=settings-header-image-delete#settings-header-image-delete";
+const PROXY_URL = "/image/abc123-def4-5678-9abc-def012345678.jpg";
+
 /** Submit a file to the header-image upload endpoint */
 const submitHeaderImage = async (
-  file: {
-    name: string;
-    data: Uint8Array;
-    contentType: string;
-  },
+  file: { name: string; data: Uint8Array; contentType: string },
   cookie?: string,
   csrfToken?: string,
 ): Promise<Response> => {
   const csrf = csrfToken ?? (await testCsrfToken());
   const ck = cookie ?? (await testCookie());
   return handleRequest(
-    mockMultipartRequest(
-      "/admin/settings/header-image",
-      { csrf_token: csrf },
-      ck,
-      { fieldName: "header_image", ...file },
-    ),
+    mockMultipartRequest(HEADER_IMAGE_POST, { csrf_token: csrf }, ck, {
+      fieldName: "header_image",
+      ...file,
+    }),
   );
 };
 
-/** Submit a JPEG to the header-image upload endpoint */
+/** Submit a valid JPEG to the header-image upload endpoint */
 const submitHeaderJpeg = (
   filename: string,
   cookie?: string,
@@ -56,360 +61,256 @@ const submitHeaderJpeg = (
   );
 
 /** Submit a POST to delete the header image */
-const submitHeaderImageDelete = async (
-  cookie?: string,
-  csrfToken?: string,
-): Promise<Response> => {
-  const csrf = csrfToken ?? (await testCsrfToken());
-  const ck = cookie ?? (await testCookie());
-  return handleRequest(
+const submitHeaderImageDelete = async (): Promise<Response> =>
+  handleRequest(
     mockFormRequest(
-      "/admin/settings/header-image/delete",
-      { csrf_token: csrf },
-      ck,
+      HEADER_IMAGE_DELETE,
+      { csrf_token: await testCsrfToken() },
+      await testCookie(),
     ),
   );
-};
 
-/** Assert response is a 302 redirect to /admin/settings */
+/** Assert a response redirects back to /admin/settings (success case) */
 const expectSettingsRedirect = (response: Response): void => {
   expect(response.status).toBe(302);
   expect(response.headers.get("location")).toContain("/admin/settings");
 };
 
-describeWithEnv("header image settings DB", { db: true }, () => {
-  test("getHeaderImageUrlFromDb returns empty string when not set", () => {
-    const url = settings.headerImageUrl;
-    expect(url).toBe("");
+describeWithEnv("server (header image settings)", { db: true }, () => {
+  describe("GET /admin/settings (header image section)", () => {
+    test("shows header image section when storage is enabled", async () => {
+      await withStorageEnabled(async () => {
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(response, 200, "Header Image");
+      });
+    });
+
+    test("hides header image section when storage is disabled", async () => {
+      await withStorageDisabled(async () => {
+        const html = await assertAdminHtml("/admin/settings");
+        expect(html).not.toContain("Header Image");
+      });
+    });
+
+    test("shows remove button and proxy URL when header image is set", async () => {
+      await withStorageEnabled(async () => {
+        await settings.update.headerImageUrl("existing.jpg");
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(
+          response,
+          200,
+          "Remove Image",
+          "/image/existing.jpg",
+        );
+      });
+    });
+
+    test("shows upload button when no header image exists", async () => {
+      await withStorageEnabled(async () => {
+        const { response } = await adminGet("/admin/settings");
+        await expectHtmlResponse(response, 200, "Upload Image");
+      });
+    });
   });
 
-  test("getHeaderImageUrlFromDb returns decrypted filename after update", async () => {
-    await settings.update.headerImageUrl("abc123.jpg");
-    const url = settings.headerImageUrl;
-    expect(url).toBe("abc123.jpg");
+  describe("POST /admin/settings/header-image", () => {
+    test("stores uploaded header image URL with .jpg extension", async () => {
+      await withStorageMock(async () => {
+        const response = await submitHeaderJpeg("logo.jpg");
+        expectSettingsRedirect(response);
+        expect(settings.headerImageUrl).toMatch(/\.jpg$/);
+      });
+    });
+
+    test("rejects non-image MIME type", async () => {
+      await withStorageMock(async () => {
+        const response = await submitHeaderImage({
+          contentType: "application/pdf",
+          data: PDF_BYTES,
+          name: "doc.pdf",
+        });
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          expect.stringContaining("JPEG, PNG, GIF, or WebP"),
+          false,
+        )(response);
+      });
+    });
+
+    test("rejects oversized image", async () => {
+      const oversized = new Uint8Array(257 * 1024);
+      oversized.set(JPEG_HEADER);
+
+      await withStorageMock(async () => {
+        const response = await submitHeaderImage({
+          contentType: "image/jpeg",
+          data: oversized,
+          name: "big.jpg",
+        });
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          expect.stringContaining("256KB"),
+          false,
+        )(response);
+      });
+    });
+
+    test("returns 403 for non-owner admin", async () => {
+      await withStorageEnabled(async () => {
+        const managerCookie = await createTestManagerSession(
+          "mgr-header-session",
+          "headerimgmgr",
+        );
+        const { signCsrfToken } = await import("#lib/csrf.ts");
+        const signedCsrf = await signCsrfToken();
+        const response = await submitHeaderJpeg(
+          "logo.jpg",
+          managerCookie,
+          signedCsrf,
+        );
+        expect(response.status).toBe(403);
+      });
+    });
+
+    test("rejects request with no file attached", async () => {
+      await withStorageEnabled(async () => {
+        const request = mockMultipartRequest(
+          HEADER_IMAGE_POST,
+          { csrf_token: await testCsrfToken() },
+          await testCookie(),
+        );
+        const response = await handleRequest(request);
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          expect.stringContaining("No image file provided"),
+          false,
+        )(response);
+      });
+    });
+
+    test("reports error when storage is not configured", async () => {
+      await withStorageDisabled(async () => {
+        const response = await submitHeaderJpeg("logo.jpg");
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          expect.stringContaining("Image storage is not configured"),
+          false,
+        )(response);
+      });
+    });
+
+    test("deletes old header image when uploading a new one", async () => {
+      await settings.update.headerImageUrl("old-header.jpg");
+
+      await withStorageMock(async (fetchCalls) => {
+        const response = await submitHeaderJpeg("new-logo.jpg");
+        expectSettingsRedirect(response);
+
+        const deleteCall = fetchCalls.find((url) =>
+          url.includes("old-header.jpg"),
+        );
+        expect(deleteCall).not.toBeUndefined();
+        expect(settings.headerImageUrl).not.toBe("old-header.jpg");
+      });
+    });
+
+    test("reports error when CDN upload fails", async () => {
+      await withCdnRejecting(new Error("CDN unreachable"), async () => {
+        const response = await submitHeaderJpeg("logo.jpg");
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          "Header image upload failed",
+          false,
+        )(response);
+      });
+    });
+
+    test("rejects bytes whose magic number does not match declared type", async () => {
+      await withStorageMock(async () => {
+        const response = await submitHeaderImage({
+          contentType: "image/jpeg",
+          data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+          name: "fake.jpg",
+        });
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          expect.stringContaining("valid image"),
+          false,
+        )(response);
+      });
+    });
   });
 
-  test("updateHeaderImageUrl with empty string clears the setting", async () => {
-    await settings.update.headerImageUrl("abc123.jpg");
-    await settings.update.headerImageUrl("");
-    const url = settings.headerImageUrl;
-    expect(url).toBe("");
+  describe("POST /admin/settings/header-image/delete", () => {
+    test("clears the stored header image URL", async () => {
+      await settings.update.headerImageUrl("to-delete.jpg");
+
+      await withStorageMock(async () => {
+        const response = await submitHeaderImageDelete();
+        expectSettingsRedirect(response);
+        expect(settings.headerImageUrl).toBe("");
+      });
+    });
+
+    test("reports error when there is no header image to remove", async () => {
+      await withStorageEnabled(async () => {
+        const response = await submitHeaderImageDelete();
+        expectRedirectWithFlash(
+          HEADER_IMAGE_FORM_REDIRECT,
+          expect.stringContaining("No header image to remove"),
+          false,
+        )(response);
+      });
+    });
+
+    test("keeps DB record when CDN delete fails", async () => {
+      await settings.update.headerImageUrl("failing.jpg");
+
+      await withCdnRejecting(new Error("CDN unreachable"), async () => {
+        const response = await submitHeaderImageDelete();
+        expectRedirectWithFlash(
+          HEADER_IMAGE_DELETE_FORM_REDIRECT,
+          "Header image removal failed",
+          false,
+        )(response);
+        expect(settings.headerImageUrl).toBe("failing.jpg");
+      });
+    });
+  });
+
+  describe("GET /image/:filename (header image proxy)", () => {
+    test("streams decrypted bytes with immutable cache headers", async () => {
+      const encrypted = await encryptBytes(JPEG_HEADER);
+
+      await withCdnProxy(
+        () => new Response(encrypted.buffer as BodyInit),
+        async () => {
+          const response = await handleRequest(mockRequest(PROXY_URL));
+          expect(response.status).toBe(200);
+          expect(response.headers.get("content-type")).toBe("image/jpeg");
+          expect(response.headers.get("cache-control")).toContain("immutable");
+          expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+            JPEG_HEADER,
+          );
+        },
+      );
+    });
+
+    test("returns 404 when storage is disabled", async () => {
+      await withStorageDisabled(async () => {
+        const response = await handleRequest(mockRequest(PROXY_URL));
+        expect(response.status).toBe(404);
+      });
+    });
+
+    test("returns 404 when CDN reports the object missing", async () => {
+      await withCdnProxy(
+        () => new Response(null, { status: 404 }),
+        async () => {
+          const response = await handleRequest(mockRequest(PROXY_URL));
+          expect(response.status).toBe(404);
+        },
+      );
+    });
   });
 });
-
-describeWithEnv(
-  "server (header image settings)",
-  {
-    db: true,
-  },
-  () => {
-    beforeEach(() => {
-      settings.clearTestOverride("header_image_url");
-    });
-
-    afterEach(() => {
-      settings.clearTestOverride("header_image_url");
-    });
-
-    describe("GET /admin/settings (header image section)", () => {
-      test("shows header image section when storage is enabled", async () => {
-        await withStorageEnabled(async () => {
-          const { response } = await adminGet("/admin/settings");
-          await expectHtmlResponse(response, 200, "Header Image");
-        });
-      });
-
-      describe("when storage is disabled", () => {
-        test("hides header image section", async () => {
-          await withStorageDisabled(async () => {
-            const html = await assertAdminHtml("/admin/settings");
-            expect(html).not.toContain("Header Image");
-          });
-        });
-      });
-
-      test("shows remove button when header image is set", async () => {
-        await withStorageEnabled(async () => {
-          await settings.update.headerImageUrl("existing.jpg");
-          const { response } = await adminGet("/admin/settings");
-          await expectHtmlResponse(
-            response,
-            200,
-            "Remove Image",
-            "/image/existing.jpg",
-          );
-        });
-      });
-
-      test("shows upload button when no header image exists", async () => {
-        await withStorageEnabled(async () => {
-          const { response } = await adminGet("/admin/settings");
-          await expectHtmlResponse(response, 200, "Upload Image");
-        });
-      });
-    });
-
-    describe("POST /admin/settings/header-image", () => {
-      test("uploads header image successfully", async () => {
-        await withStorageMock(async () => {
-          const response = await submitHeaderJpeg("logo.jpg");
-          expectSettingsRedirect(response);
-
-          const url = settings.headerImageUrl;
-          expect(url).not.toBeNull();
-          expect(url).toMatch(/\.jpg$/);
-        });
-      });
-
-      test("rejects invalid image type", async () => {
-        await withStorageMock(async () => {
-          const response = await submitHeaderImage({
-            contentType: "application/pdf",
-            data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
-            name: "doc.pdf",
-          });
-          expectRedirectWithFlash(
-            "/admin/settings?form=settings-header-image#settings-header-image",
-            expect.stringContaining("JPEG, PNG, GIF, or WebP"),
-            false,
-          )(response);
-        });
-      });
-
-      test("rejects oversized image", async () => {
-        const oversized = new Uint8Array(257 * 1024);
-        oversized[0] = 0xff;
-        oversized[1] = 0xd8;
-        oversized[2] = 0xff;
-
-        await withStorageMock(async () => {
-          const response = await submitHeaderImage({
-            contentType: "image/jpeg",
-            data: oversized,
-            name: "big.jpg",
-          });
-          expectRedirectWithFlash(
-            "/admin/settings?form=settings-header-image#settings-header-image",
-            expect.stringContaining("256KB"),
-            false,
-          )(response);
-        });
-      });
-
-      test("returns 403 for non-owner admin", async () => {
-        await withStorageEnabled(async () => {
-          const managerCookie = await createTestManagerSession(
-            "mgr-header-session",
-            "headerimgmgr",
-          );
-          const { signCsrfToken } = await import("#lib/csrf.ts");
-          const signedCsrf = await signCsrfToken();
-          const response = await submitHeaderJpeg(
-            "logo.jpg",
-            managerCookie,
-            signedCsrf,
-          );
-          expect(response.status).toBe(403);
-        });
-      });
-
-      test("rejects request with no file", async () => {
-        await withStorageEnabled(async () => {
-          const request = mockMultipartRequest(
-            "/admin/settings/header-image",
-            { csrf_token: await testCsrfToken() },
-            await testCookie(),
-          );
-          const response = await handleRequest(request);
-          expectRedirectWithFlash(
-            "/admin/settings?form=settings-header-image#settings-header-image",
-            expect.stringContaining("No image file provided"),
-            false,
-          )(response);
-        });
-      });
-
-      describe("when storage is not configured", () => {
-        test("returns error", async () => {
-          await withStorageDisabled(async () => {
-            const response = await submitHeaderJpeg("logo.jpg");
-            expectRedirectWithFlash(
-              "/admin/settings?form=settings-header-image#settings-header-image",
-              expect.stringContaining("Image storage is not configured"),
-              false,
-            )(response);
-          });
-        });
-      });
-
-      test("deletes old header image when uploading new one", async () => {
-        await settings.update.headerImageUrl("old-header.jpg");
-
-        await withStorageMock(async (fetchCalls) => {
-          const response = await submitHeaderJpeg("new-logo.jpg");
-          expectSettingsRedirect(response);
-
-          const deleteCall = fetchCalls.find((url) =>
-            url.includes("old-header.jpg"),
-          );
-          expect(deleteCall).not.toBeUndefined();
-
-          const url = settings.headerImageUrl;
-          expect(url).toMatch(/\.jpg$/);
-          expect(url).not.toBe("old-header.jpg");
-        });
-      });
-
-      test("reports error when upload fails", async () => {
-        await withStorageEnabled(async () => {
-          const originalFetch = globalThis.fetch;
-          globalThis.fetch = (): Promise<Response> => {
-            return Promise.reject(new Error("CDN unreachable"));
-          };
-
-          try {
-            const response = await submitHeaderJpeg("logo.jpg");
-            expectRedirectWithFlash(
-              "/admin/settings?form=settings-header-image#settings-header-image",
-              "Header image upload failed",
-              false,
-            )(response);
-          } finally {
-            globalThis.fetch = originalFetch;
-          }
-        });
-      });
-
-      test("rejects mismatched magic bytes", async () => {
-        await withStorageMock(async () => {
-          const response = await submitHeaderImage({
-            contentType: "image/jpeg",
-            data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
-            name: "fake.jpg",
-          });
-          expectRedirectWithFlash(
-            "/admin/settings?form=settings-header-image#settings-header-image",
-            expect.stringContaining("valid image"),
-            false,
-          )(response);
-        });
-      });
-    });
-
-    describe("POST /admin/settings/header-image/delete", () => {
-      test("removes header image", async () => {
-        await settings.update.headerImageUrl("to-delete.jpg");
-
-        await withStorageMock(async () => {
-          const response = await submitHeaderImageDelete();
-          expectSettingsRedirect(response);
-
-          const url = settings.headerImageUrl;
-          expect(url).toBe("");
-        });
-      });
-
-      test("returns error when no header image exists", async () => {
-        await withStorageEnabled(async () => {
-          const response = await submitHeaderImageDelete();
-          expectRedirectWithFlash(
-            "/admin/settings?form=settings-header-image#settings-header-image",
-            expect.stringContaining("No header image to remove"),
-            false,
-          )(response);
-        });
-      });
-
-      test("reports error when storage delete throws", async () => {
-        await withStorageEnabled(async () => {
-          await settings.update.headerImageUrl("failing.jpg");
-
-          const originalFetch = globalThis.fetch;
-          globalThis.fetch = (): Promise<Response> => {
-            return Promise.reject(new Error("CDN unreachable"));
-          };
-
-          try {
-            const response = await submitHeaderImageDelete();
-            expectRedirectWithFlash(
-              "/admin/settings?form=settings-header-image-delete#settings-header-image-delete",
-              "Header image removal failed",
-              false,
-            )(response);
-
-            // DB record should NOT be cleared when CDN delete fails
-            const url = settings.headerImageUrl;
-            expect(url).toBe("failing.jpg");
-          } finally {
-            globalThis.fetch = originalFetch;
-          }
-        });
-      });
-    });
-
-    describe("header image in layout", () => {
-      test("renders header image in page when set", async () => {
-        await withStorageEnabled(async () => {
-          await settings.update.headerImageUrl("my-header.jpg");
-          const { response } = await adminGet("/admin/settings");
-          await expectHtmlResponse(
-            response,
-            200,
-            'class="header-image"',
-            "/image/my-header.jpg",
-          );
-        });
-      });
-
-      test("does not render header image when not set", async () => {
-        await withStorageEnabled(async () => {
-          settings.clearTestOverride("header_image_url");
-          const html = await assertAdminHtml("/admin/settings");
-          expect(html).not.toContain('class="header-image"');
-        });
-      });
-    });
-
-    describe("header image proxy", () => {
-      test("serves header image via proxy route", async () => {
-        const encrypted = await encryptBytes(JPEG_HEADER);
-
-        await withStorageEnabled(async () => {
-          const originalFetch = globalThis.fetch;
-          globalThis.fetch = (
-            input: string | URL | Request,
-          ): Promise<Response> => {
-            const url =
-              typeof input === "string"
-                ? input
-                : input instanceof URL
-                  ? input.toString()
-                  : input.url;
-            if (url.includes("storage.bunnycdn.com")) {
-              return Promise.resolve(
-                // deno-lint-ignore no-explicit-any
-                new Response(encrypted as any, { status: 200 }),
-              );
-            }
-            return originalFetch(input);
-          };
-
-          try {
-            const response = await handleRequest(
-              mockRequest("/image/abc123-def4-5678-9abc-def012345678.jpg"),
-            );
-            expect(response.status).toBe(200);
-            const headers = response.headers;
-            expect(headers.get("content-type")).toBe("image/jpeg");
-            expect(headers.get("cache-control")).toContain("immutable");
-            expect(new Uint8Array(await response.arrayBuffer())).toEqual(
-              JPEG_HEADER,
-            );
-          } finally {
-            globalThis.fetch = originalFetch;
-          }
-        });
-      });
-    });
-  },
-);


### PR DESCRIPTION
## Summary

`test/lib/header-image.test.ts` had the clearest quality-criteria violations of any test file in the repo: three tests reassigned `globalThis.fetch` directly (try/finally with `originalFetch = globalThis.fetch`), even though `withFetchMock` and `installUrlHandler` already exist exactly to avoid that. It also duplicated coverage that already lives in `test/integration/header-image.test.ts` (layout rendering) and had a `describeWithEnv("header image settings DB", ...)` block whose three tests were round-tripping through the generic `encryptedUpdate`/`snap` machinery — not testing anything header-image-specific.

While refactoring I also noticed the admin guide never mentioned the header image feature beyond one bullet in the settings list.

### What changed

- **`test/lib/header-image.test.ts`** — dropped the settings-DB round-trip block and the duplicated layout block; replaced the three direct `globalThis.fetch` swaps with `withCdnRejecting` / `withCdnProxy`; deduped magic constants; added proxy-route tests for storage-disabled and CDN-reporting-404 (previously only the happy path was covered). File shrank from 415 to ~310 lines and every test now reaches production behavior through a shared helper.
- **`src/test-utils/index.ts`** — added `withCdnRejecting`, a sibling of `withCdnProxy` that rejects for Bunny CDN URLs so tests can model a network failure without touching `globalThis.fetch` directly.
- **`src/templates/admin/guide.tsx`** — added a "How does the header image work?" Q&A in the Settings Overview section, covering supported formats, the 256&nbsp;KB limit, the `/image/` proxy with immutable caching, auto-replace on upload, and the storage-zone requirement.

### Notes

- Ran lint + typecheck + `deno test test/lib/header-image.test.ts test/integration/header-image.test.ts test/lib/server-images.test.ts test/lib/server-guide.test.ts` — all green (77 steps passed).
- Full `deno task test` segfaults on exit in this environment on *main* too (exit 139 after all tests pass), so it's a pre-existing Deno/environment issue, not caused by this change.

## Test plan

- [x] `deno task lint`
- [x] `deno task typecheck`
- [x] Focused test run on touched files + neighbours
- [ ] CI green on full suite
- [ ] Visually confirm the new Q&A renders on `/admin/guide`

https://claude.ai/code/session_01Ht1s3rumjnaeXFEDTAEiGH