### PR TITLE
Use CSS classes instead of inline style for QR checkout indicator

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -936,6 +936,11 @@ input[type="submit"].danger:hover {
   font-weight: bold;
 }
 
+.success-text {
+  color: #006600;
+  font-weight: bold;
+}
+
 .badge-alert {
   font-size: 0.6rem;
   font-weight: bold;
@@ -952,6 +957,9 @@ input[type="submit"].danger:hover {
 }
 [data-theme="dark"] .danger-text {
   color: #ff5555;
+}
+[data-theme="dark"] .success-text {
+  color: #50fa7b;
 }
 [data-theme="dark"] .badge-alert {
   background-color: #991919;

--- a/src/templates/admin/event-qr.tsx
+++ b/src/templates/admin/event-qr.tsx
@@ -166,9 +166,7 @@ export const adminEventQrPage = ({
         <p>
           Generate a signed link that pre-fills the booking form. If name and
           price are both set and the event has no extra required fields{" "}
-          <span
-            style={`color:${canDirectCheckout ? "green" : "red"}`}
-          >
+          <span class={canDirectCheckout ? "success-text" : "danger-text"}>
             (this <strong>{canDirectCheckout ? "is" : "is not"}</strong> the
             case)
           </span>

--- a/test/lib/server-event-qr-admin.test.ts
+++ b/test/lib/server-event-qr-admin.test.ts
@@ -60,8 +60,8 @@ describeWithEnv("admin event-qr route", { db: true }, () => {
       const withFields = await createTestEvent({ fields: "email", maxAttendees: 10, unitPrice: 500 });
       const { response: r1 } = await adminGet(`/admin/event/${noFields.id}/qr`);
       const { response: r2 } = await adminGet(`/admin/event/${withFields.id}/qr`);
-      expect(await r1.text()).toContain("color:green");
-      expect(await r2.text()).toContain("color:red");
+      expect(await r1.text()).toContain('class="success-text"');
+      expect(await r2.text()).toContain('class="danger-text"');
     });
 
     test("shows a date selector for daily events", async () => {


### PR DESCRIPTION
## Summary
- Replace the inline `style="color:..."` on the direct-checkout indicator in the admin event-QR page with semantic `success-text` / `danger-text` classes (the inline style was rendering as empty in some environments).
- Add a matching `.success-text` CSS rule (plus dark-theme variant) alongside the existing `.danger-text`.
- Update the corresponding test to assert on the class name.

## Test plan
- [ ] `deno task precommit`
- [ ] Visit `/admin/event/:id/qr` for an event with no extra fields → indicator is green/bold.
- [ ] Visit `/admin/event/:id/qr` for an event with extra required fields → indicator is red/bold.