### PR TITLE
Enable noBannedTypes biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,6 @@
     "enabled": true,
     "rules": {
       "complexity": {
-        "noBannedTypes": "off",
         "noStaticOnlyClass": "error",
         "noThisInStatic": "error",
         "noUselessThisAlias": "error",

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -246,8 +246,7 @@ export function defineRoutes<T extends string>(
 // Implementation accepts any function-valued record; the overload signature
 // above enforces type safety at call sites.
 export function defineRoutes(
-  // deno-lint-ignore ban-types
-  routes: Record<string, Function>,
+  routes: Record<string, (...args: never) => unknown>,
 ): Record<string, RouteHandlerFn> {
   return routes as Record<string, RouteHandlerFn>;
 }


### PR DESCRIPTION
## Summary
- Remove the `noBannedTypes: "off"` override from `biome.json` so the rule runs at its default level
- Fix the sole resulting violation in `src/routes/router.ts` by replacing `Function` with the safe top-type `(...args: never) => unknown`, which drops the `deno-lint-ignore ban-types` escape hatch

## Test plan
- [ ] `deno task biome:check` reports no `lint/complexity/noBannedTypes` errors
- [ ] `deno task typecheck` passes
- [ ] `deno task lint` passes

https://claude.ai/code/session_01WhpwoN4WJUDkRkxoBzsNT9