### PR TITLE
Drop redundant type annotations in favor of inference

### DIFF
--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -375,7 +375,7 @@ export const getAttendeeAnswersBatch = async (
       acc.set(attendee_id, list);
       return acc;
     },
-    new Map<number, number[]>(),
+    new Map(),
   )(rows);
 };
 
@@ -488,7 +488,7 @@ export const getAnswerCountsForQuestion = async (
       acc.set(answer_id, cnt);
       return acc;
     },
-    new Map<number, number>(),
+    new Map(),
   )(rows);
 };
 

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -111,13 +111,10 @@ export const toSnakeCase = (s: string): string =>
  * snake_case DB column → camelCase input key
  */
 export const buildInputKeyMap = (columns: string[]): Record<string, string> =>
-  reduce(
-    (acc: Record<string, string>, col: string) => {
-      acc[col] = toCamelCase(col);
-      return acc;
-    },
-    {} as Record<string, string>,
-  )(columns);
+  reduce((acc: Record<string, string>, col: string) => {
+    acc[col] = toCamelCase(col);
+    return acc;
+  }, {})(columns);
 
 /**
  * Table definition with CRUD operations
@@ -354,18 +351,15 @@ export const defineTable = <Row, Input = Row>(config: {
     row: Row,
     exclude: readonly string[] = [],
   ): Partial<Input> => {
-    const skip = new Set<string>(exclude);
-    return reduce(
-      (acc: Record<string, unknown>, col: string) => {
-        if (skip.has(col)) return acc;
-        const value = (row as Record<string, unknown>)[col];
-        if (value !== undefined) {
-          acc[inputKeyMap[col] as string] = value;
-        }
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    )(inputColumns) as Partial<Input>;
+    const skip = new Set(exclude);
+    return reduce((acc: Record<string, unknown>, col: string) => {
+      if (skip.has(col)) return acc;
+      const value = (row as Record<string, unknown>)[col];
+      if (value !== undefined) {
+        acc[inputKeyMap[col] as string] = value;
+      }
+      return acc;
+    }, {})(inputColumns) as Partial<Input>;
   };
 
   return {

--- a/src/lib/merge/attendee-merge.ts
+++ b/src/lib/merge/attendee-merge.ts
@@ -213,7 +213,7 @@ const buildBookingDiffItems = (
       acc.set(bookingKey(b.event_id, b.start_at), b);
       return acc;
     },
-    new Map<string, EventAttendeeRow>(),
+    new Map(),
   )(targetBookings);
 
   return map((sb: EventAttendeeRow): AttendeeMergeDiffBookingItem => {

--- a/src/routes/admin/calendar.ts
+++ b/src/routes/admin/calendar.ts
@@ -53,7 +53,7 @@ const buildStandardEventDateMap = (
       acc.set(calDate, ids);
     }
     return acc;
-  }, new Map<string, number[]>())(events);
+  }, new Map())(events);
 
 /** Compile all possible dates from events (available + existing attendee dates + standard event dates) */
 const compileDateOptions = (
@@ -109,7 +109,7 @@ const buildCalendarAttendees = (
       acc.set(e.id, e);
       return acc;
     },
-    new Map<number, EventWithCount>(),
+    new Map(),
   )(events);
 
   return map((a: Attendee): CalendarAttendeeRow => {

--- a/src/routes/admin/groups.ts
+++ b/src/routes/admin/groups.ts
@@ -198,7 +198,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
       const successMessage = getFlash().success;
       const questionData = await loadQuestionData(
         eventIds,
-        attendees.map((a: Attendee) => a.id),
+        attendees.map((a) => a.id),
       );
 
       return htmlResponse(

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -290,7 +290,7 @@ const publicPageHandlers = reduce(
     };
     return acc;
   },
-  {} as Record<string, RouterFn>,
+  {},
 )(PUBLIC_GET_PAGES);
 
 /** Prefix dispatch table — O(1) lookup replaces the sequential ?? chain */

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -159,7 +159,7 @@ const compileRoutes = (
       compiled.set(method, methodRoutes);
       return compiled;
     },
-    new Map<string, CompiledRoute[]>(),
+    new Map(),
   )(sortedEntries);
 };
 

--- a/src/templates/admin/detail-rows.tsx
+++ b/src/templates/admin/detail-rows.tsx
@@ -113,7 +113,7 @@ const countAnswers = (answerMap: Map<number, number[]>): Map<number, number> =>
   reduce((counts: Map<number, number>, ids: number[]) => {
     for (const id of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
     return counts;
-  }, new Map<number, number>())([...answerMap.values()]);
+  }, new Map())([...answerMap.values()]);
 
 /** Format answers as "text (count), text (count), ..." */
 const formatAnswerSummary = (

--- a/src/templates/admin/questions.tsx
+++ b/src/templates/admin/questions.tsx
@@ -98,7 +98,7 @@ export const adminQuestionPage = (
         </p>
       ) : (
         <ul class="answer-list">
-          {question.answers.map((a: Answer, i: number) => (
+          {question.answers.map((a, i) => (
             <li>
               {a.text}
               {answerCounts && <small> ({answerCounts.get(a.id)})</small>}{" "}

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -162,7 +162,7 @@ const buildAnswerTextMap = (
     reduce((m: Map<number, string>, a: Answer) => {
       m.set(a.id, a.text);
       return m;
-    }, new Map<number, string>()),
+    }, new Map()),
   )(questions);
 
 /** Build answer question map (answer ID → question text) */


### PR DESCRIPTION
## Summary

Cuts a bit of type noise by letting TypeScript infer what it already knows:

- Drop generic args on `new Map<K, V>()` / `new Set<T>(...)` and `{} as Record<...>` casts when they're passed as the `initial` argument to the curried `reduce()` from `#fp` — the reducer function's accumulator param already pins the type, so the generic on `initial` is redundant.
- Drop explicit callback param types on `.map((x: T) => ...)` where the receiver array is already typed.

No behavior change. Scope was deliberately narrow; left in place:

- Standalone `const m = new Map<K, V>()` (dropping the generic would widen to `Map<any, any>`).
- Empty `const xs: T[] = []` before `.push()` (otherwise inferred as `never[]`).
- Explicit `Promise<T>` on exported async functions (serves as API documentation).
- `.reduce()` accumulator types (inference often gets them wrong).

## Test plan
- [x] `deno task typecheck` passes
- [x] `deno task lint` passes
- [x] `deno task test` passes

Note: `deno task test:coverage` exits with SIGSEGV (139) on this environment on both this branch and `main` — pre-existing, unrelated.

https://claude.ai/code/session_01NknZtsrvMuqp7r8WW5fYRy