### PR TITLE
Add Biome sorted-* rules and fix attribute-order test fallout

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,22 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "files": {
-    "includes": ["**/*.js", "**/*.ts", "**/*.tsx"],
+    "includes": [
+      "**/*.js",
+      "**/*.ts",
+      "**/*.tsx",
+      "!src/static/**",
+      "!src/client/scanner.js"
+    ],
     "ignoreUnknown": true
   },
   "assist": {
     "actions": {
       "source": {
-        "useSortedKeys": "on"
+        "useSortedAttributes": "on",
+        "useSortedInterfaceMembers": "on",
+        "useSortedKeys": "on",
+        "useSortedProperties": "on"
       }
     }
   },
@@ -19,6 +28,9 @@
   "linter": {
     "enabled": true,
     "rules": {
+      "nursery": {
+        "useSortedClasses": "error"
+      },
       "complexity": {
         "noStaticOnlyClass": "error",
         "noThisInStatic": "error",

--- a/scripts/build-tag.ts
+++ b/scripts/build-tag.ts
@@ -13,7 +13,7 @@
 export const isoToTag = (iso: string): string => {
   const d = new Date(iso);
   const pad = (n: number) => String(n).padStart(2, "0");
-  return `v${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${
-    pad(d.getUTCDate())
-  }-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`;
+  return `v${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(
+    d.getUTCDate(),
+  )}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`;
 };

--- a/scripts/precommit.ts
+++ b/scripts/precommit.ts
@@ -14,9 +14,9 @@ const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 const write = (s: string) => Deno.stdout.writeSync(encoder.encode(s));
 
 interface Step {
-  name: string;
   cmd: string[];
   filterOutput?: (stdout: string, stderr: string) => string;
+  name: string;
 }
 
 /** True when a line starts an ERRORS or FAILURES section or is a summary line */

--- a/scripts/profile-cold-boot.ts
+++ b/scripts/profile-cold-boot.ts
@@ -9,8 +9,8 @@ import { createClient } from "@libsql/client";
 import { setupTestEncryptionKey } from "#test-utils";
 
 interface Timing {
-  name: string;
   duration: number;
+  name: string;
 }
 
 const timings: Timing[] = [];

--- a/scripts/safe-upgrade.ts
+++ b/scripts/safe-upgrade.ts
@@ -14,19 +14,19 @@ const DEFAULT_MIN_AGE_DAYS = 14;
 const DENO_JSON_PATH = new URL("../deno.json", import.meta.url).pathname;
 
 interface VersionInfo {
-  version: string;
   publishedAt: Date;
+  version: string;
 }
 
 interface UpgradeResult {
-  name: string;
-  registry: "npm" | "jsr";
   currentSpec: string;
   currentVersion: string | null;
-  newVersion: string | null;
-  newPublishedAt: Date | null;
-  skippedNewer: string | null;
   error: string | null;
+  name: string;
+  newPublishedAt: Date | null;
+  newVersion: string | null;
+  registry: "npm" | "jsr";
+  skippedNewer: string | null;
 }
 
 function parseArgs(): { dryRun: boolean; minAgeDays: number } {

--- a/src/lib/bulk-replace.ts
+++ b/src/lib/bulk-replace.ts
@@ -8,32 +8,32 @@
 
 /** Inputs describing a single find/replace pass over a group's events */
 export interface DuplicateReplacements {
-  /** Substring to find inside event names (empty → no name change) */
-  nameFind: string;
-  /** Substring to substitute for `nameFind` */
-  nameReplace: string;
   /** Reference date (YYYY-MM-DD). Empty → no date shift. */
   dateFind: string;
   /** Target date (YYYY-MM-DD). Empty → no date shift. */
   dateReplace: string;
+  /** Substring to find inside event names (empty → no name change) */
+  nameFind: string;
+  /** Substring to substitute for `nameFind` */
+  nameReplace: string;
 }
 
 /** Preview of what a single event becomes after replacements are applied */
 export interface DuplicatePreviewRow {
   id: number;
-  originalName: string;
+  /** Shifted UTC ISO datetime, or empty string for events with no date */
+  newDate: string;
   newName: string;
   /** Original UTC ISO datetime, or empty string for events with no date */
   originalDate: string;
-  /** Shifted UTC ISO datetime, or empty string for events with no date */
-  newDate: string;
+  originalName: string;
 }
 
 /** Event data needed to compute a preview row */
 export interface PreviewableEvent {
+  date: string;
   id: number;
   name: string;
-  date: string;
 }
 
 const MS_PER_DAY = 86_400_000;

--- a/src/lib/bunny-cdn.ts
+++ b/src/lib/bunny-cdn.ts
@@ -27,14 +27,14 @@ type CdnHostnameResult =
 const HOSTNAME_ALREADY_REGISTERED = "pullzone.hostname_already_registered";
 
 interface EdgeScriptLinkedPullZone {
+  DefaultHostname: string;
   Id: number;
   PullZoneName: string;
-  DefaultHostname: string;
 }
 
 interface EdgeScriptResponse {
-  Id: number;
   DefaultHostname: string;
+  Id: number;
   LinkedPullZones: EdgeScriptLinkedPullZone[];
 }
 
@@ -215,14 +215,14 @@ const validateCustomDomainImpl = async (
 
 interface BunnyDnsRecord {
   Id: number;
-  Type: number;
   Name: string;
+  Type: number;
   Value: string;
 }
 
 interface BunnyDnsZone {
-  Id: number;
   Domain: string;
+  Id: number;
   Records: BunnyDnsRecord[];
 }
 
@@ -439,10 +439,10 @@ const publishScript = async (
 // ---------------------------------------------------------------------------
 
 interface CreateEdgeScriptResult {
-  ok: true;
-  scriptId: number;
-  pullZoneId: number;
   defaultHostname: string;
+  ok: true;
+  pullZoneId: number;
+  scriptId: number;
 }
 
 /**

--- a/src/lib/db/activityLog.ts
+++ b/src/lib/db/activityLog.ts
@@ -14,9 +14,9 @@ import type { Event, EventWithCount } from "#lib/types.ts";
 
 /** Activity log entry */
 export interface ActivityLogEntry {
-  id: number;
   created: string;
   event_id: number | null;
+  id: number;
   message: string;
 }
 

--- a/src/lib/db/built-sites.ts
+++ b/src/lib/db/built-sites.ts
@@ -14,27 +14,27 @@ import { requestCache } from "#lib/request-cache.ts";
 
 /** Encrypted site data blob shape */
 export interface SiteDataBlob {
-  v: 1;
-  /** Site name */
-  n: string;
-  /** Bunny URL (default hostname) */
-  u: string;
   /** Database URL (optional, absent in older blobs) */
   d?: string;
-  /** Database token (optional, absent in older blobs) */
-  t?: string;
+  /** Site name */
+  n: string;
   /** Bunny edge script ID (optional, absent in older blobs) */
   s?: string;
+  /** Database token (optional, absent in older blobs) */
+  t?: string;
+  /** Bunny URL (default hostname) */
+  u: string;
+  v: 1;
 }
 
 /** Built site row as stored in the database */
 export interface BuiltSiteRow {
-  id: number;
-  site_data: string;
   assignable: number;
   assigned_attendee_id: number | null;
   assigned_event_id: number | null;
   created: string;
+  id: number;
+  site_data: string;
 }
 
 /** Built site input for creating a new row */
@@ -47,16 +47,16 @@ export type BuiltSiteInput = {
 
 /** Decrypted built site for display */
 export interface BuiltSite {
-  id: number;
-  name: string;
-  bunnyUrl: string;
-  dbUrl: string;
-  dbToken: string;
-  bunnyScriptId: string;
   assignable: boolean;
   assignedAttendeeId: number | null;
   assignedEventId: number | null;
+  bunnyScriptId: string;
+  bunnyUrl: string;
   created: string;
+  dbToken: string;
+  dbUrl: string;
+  id: number;
+  name: string;
 }
 
 /** Form input for CRUD operations */

--- a/src/lib/db/questions.ts
+++ b/src/lib/db/questions.ts
@@ -30,23 +30,23 @@ export interface Question {
 export interface Answer {
   id: number;
   question_id: number;
-  text: string; // encrypted
   sort_order: number;
+  text: string; // encrypted
 }
 
 /** Link between event and question (ordering by sort_order) */
 export interface EventQuestion {
-  id: number;
   event_id: number;
+  id: number;
   question_id: number;
   sort_order: number;
 }
 
 /** Link between attendee and selected answer */
 export interface AttendeeAnswer {
-  id: number;
-  attendee_id: number;
   answer_id: number;
+  attendee_id: number;
+  id: number;
 }
 
 /** Question with its answer options (decrypted) */

--- a/src/lib/db/table.ts
+++ b/src/lib/db/table.ts
@@ -123,33 +123,23 @@ export const buildInputKeyMap = (columns: string[]): Record<string, string> =>
  * Table definition with CRUD operations
  */
 export interface Table<Row, Input> {
-  name: string;
-  primaryKey: keyof Row & string;
-  schema: TableSchema<Row>;
-  inputKeyMap: Record<string, string>;
-
-  /** Insert a new row, returns the created row */
-  insert: (input: Input) => Promise<Row>;
-
-  /** Update a row by primary key, returns updated row or null if not found */
-  update: (id: InValue, input: Partial<Input>) => Promise<Row | null>;
-
-  /** Find a row by primary key */
-  findById: (id: InValue) => Promise<Row | null>;
-
   /** Delete a row by primary key */
   deleteById: (id: InValue) => Promise<void>;
 
   /** Find all rows */
   findAll: () => Promise<Row[]>;
 
+  /** Find a row by primary key */
+  findById: (id: InValue) => Promise<Row | null>;
+
   /** Transform a row from DB (apply read transforms) */
   fromDb: (row: Row) => Promise<Row>;
+  inputKeyMap: Record<string, string>;
 
-  /** Transform input to DB values (apply write transforms and defaults) */
-  toDbValues: (
-    input: Input | Partial<Input>,
-  ) => Promise<Record<string, InValue>>;
+  /** Insert a new row, returns the created row */
+  insert: (input: Input) => Promise<Row>;
+  name: string;
+  primaryKey: keyof Row & string;
 
   /**
    * Build an Input object from an existing Row by copying the input-eligible
@@ -158,6 +148,15 @@ export interface Table<Row, Input> {
    * `exclude` are skipped — useful for auto-stamped fields like `created`.
    */
   rowToInput: (row: Row, exclude?: readonly string[]) => Partial<Input>;
+  schema: TableSchema<Row>;
+
+  /** Transform input to DB values (apply write transforms and defaults) */
+  toDbValues: (
+    input: Input | Partial<Input>,
+  ) => Promise<Record<string, InValue>>;
+
+  /** Update a row by primary key, returns updated row or null if not found */
+  update: (id: InValue, input: Partial<Input>) => Promise<Row | null>;
 }
 
 /** Get value for a column with default applied */

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -29,26 +29,26 @@ export type FieldType =
   | "file";
 
 export interface Field {
-  name: string;
-  label: string;
-  type: FieldType;
-  required?: boolean;
-  placeholder?: string;
+  accept?: string;
+  autocomplete?: string;
+  autofocus?: boolean;
+  defaultValue?: string;
   hint?: string;
   hintHtml?: string;
-  min?: number;
-  max?: number;
-  minlength?: number;
   inputmode?: string;
+  label: string;
+  max?: number;
   maxlength?: number;
-  pattern?: string;
-  title?: string;
-  accept?: string;
-  autofocus?: boolean;
-  autocomplete?: string;
-  defaultValue?: string;
-  validate?: (value: string) => string | null;
+  min?: number;
+  minlength?: number;
+  name: string;
   options?: { value: string; label: string }[];
+  pattern?: string;
+  placeholder?: string;
+  required?: boolean;
+  title?: string;
+  type: FieldType;
+  validate?: (value: string) => string | null;
 }
 
 export interface FieldValues {
@@ -121,11 +121,11 @@ const renderFieldInput = (field: Field, value: string): JSX.Element => {
   if (field.type === "textarea") {
     return (
       <textarea
-        name={field.name}
-        required={field.required}
-        placeholder={field.placeholder}
-        maxlength={field.maxlength}
         autocomplete={field.autocomplete}
+        maxlength={field.maxlength}
+        name={field.name}
+        placeholder={field.placeholder}
+        required={field.required}
       >
         <Raw html={escapeHtml(value)} />
       </textarea>
@@ -155,24 +155,24 @@ const renderFieldInput = (field: Field, value: string): JSX.Element => {
     );
   }
   if (field.type === "file") {
-    return <input type="file" name={field.name} accept={field.accept} />;
+    return <input accept={field.accept} name={field.name} type="file" />;
   }
   return (
     <input
-      type={field.type}
-      name={field.name}
-      value={value || undefined}
-      required={field.required}
-      placeholder={field.placeholder}
-      min={field.min}
-      max={field.max}
-      minlength={field.minlength}
-      inputmode={field.inputmode}
-      maxlength={field.maxlength}
-      pattern={field.pattern}
-      title={field.title}
-      autofocus={field.autofocus}
       autocomplete={field.autocomplete}
+      autofocus={field.autofocus}
+      inputmode={field.inputmode}
+      max={field.max}
+      maxlength={field.maxlength}
+      min={field.min}
+      minlength={field.minlength}
+      name={field.name}
+      pattern={field.pattern}
+      placeholder={field.placeholder}
+      required={field.required}
+      title={field.title}
+      type={field.type}
+      value={value || undefined}
     />
   );
 };
@@ -429,8 +429,8 @@ export const CsrfForm = ({
   class?: string;
   enctype?: string;
 } & { [key: `data-${string}`]: string | boolean }): JSX.Element => (
-  <form method="POST" action={appendIframeParam(action)} {...rest}>
-    <input type="hidden" name="csrf_token" value={getCurrentCsrfToken()} />
+  <form action={appendIframeParam(action)} method="POST" {...rest}>
+    <input name="csrf_token" type="hidden" value={getCurrentCsrfToken()} />
     {rest.id && rest.id === _successStore.formId && (
       <Flash success={_successStore.message} />
     )}
@@ -479,22 +479,22 @@ export const ConfirmForm = ({
 }): JSX.Element => (
   <CsrfForm action={action} id={id}>
     {children && <div class="prose">{children}</div>}
-    {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
+    {returnUrl && <input name="return_url" type="hidden" value={returnUrl} />}
     {hiddenFields &&
       Object.entries(hiddenFields).map(([fieldName, value]) => (
-        <input type="hidden" name={fieldName} value={value} />
+        <input name={fieldName} type="hidden" value={value} />
       ))}
     <label>
       {label}
       <input
-        type="text"
+        autocomplete="off"
         name="confirm_identifier"
         placeholder={name}
-        autocomplete="off"
         required
+        type="text"
       />
     </label>
-    <button type="submit" class={danger ? "danger" : undefined}>
+    <button class={danger ? "danger" : undefined} type="submit">
       {buttonText}
     </button>
   </CsrfForm>

--- a/src/lib/jsx/jsx-runtime.ts
+++ b/src/lib/jsx/jsx-runtime.ts
@@ -26,38 +26,38 @@ export type Child =
 
 /** HTML attribute types */
 interface HtmlAttributes {
+  action?: string;
+  alt?: string;
+  charset?: string;
+  checked?: boolean;
   children?: Child;
   class?: string;
-  style?: string;
+  cols?: string | number;
+  colspan?: string | number;
+  content?: string;
+  disabled?: boolean;
+  for?: string;
+  href?: string;
   // Common HTML attributes
   id?: string;
+  lang?: string;
+  max?: number | string;
+  method?: string;
+  min?: number | string;
   name?: string;
+  pattern?: string;
+  placeholder?: string;
+  readonly?: boolean;
+  rel?: string;
+  required?: boolean;
+  rows?: string | number;
+  rowspan?: string | number;
+  src?: string;
+  style?: string;
+  target?: string;
+  title?: string;
   type?: string;
   value?: string | number;
-  href?: string;
-  src?: string;
-  alt?: string;
-  title?: string;
-  placeholder?: string;
-  required?: boolean;
-  disabled?: boolean;
-  checked?: boolean;
-  readonly?: boolean;
-  min?: number | string;
-  max?: number | string;
-  pattern?: string;
-  rows?: string | number;
-  cols?: string | number;
-  for?: string;
-  method?: string;
-  action?: string;
-  target?: string;
-  rel?: string;
-  colspan?: string | number;
-  rowspan?: string | number;
-  lang?: string;
-  charset?: string;
-  content?: string;
   // Allow any other attributes
   [key: string]: Child | string | number | boolean | null | undefined;
 }

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -137,8 +137,8 @@ export type WebhookSetupResult =
  * Routes call these methods without knowing which provider is active.
  */
 export interface PaymentProvider {
-  /** Provider identifier */
-  readonly type: PaymentProviderType;
+  /** The webhook event type name that indicates a completed checkout */
+  readonly checkoutCompletedEventType: string;
 
   /**
    * Create a checkout session for one or more events.
@@ -150,41 +150,6 @@ export interface PaymentProvider {
   ): Promise<CheckoutSessionResult>;
 
   /**
-   * Retrieve and validate a completed checkout session by ID.
-   * Returns the validated session or null if not found / invalid.
-   */
-  retrieveSession(sessionId: string): Promise<ValidatedPaymentSession | null>;
-
-  /**
-   * Verify a webhook request's signature and parse the event payload.
-   * @param webhookUrl - The webhook endpoint URL derived from the incoming request
-   * @param payloadBytes - Raw body bytes from request.arrayBuffer()
-   */
-  verifyWebhookSignature(
-    payload: string,
-    signature: string,
-    webhookUrl: string,
-    payloadBytes: Uint8Array,
-  ): Promise<WebhookVerifyResult>;
-
-  /**
-   * Refund a completed payment.
-   * @param paymentReference - provider-specific payment reference (e.g. Stripe payment_intent ID)
-   * @returns true if refund succeeded, false otherwise
-   */
-  refundPayment(paymentReference: string): Promise<boolean>;
-
-  /**
-   * Set up a webhook endpoint for this provider.
-   * Some providers (e.g. Stripe) support programmatic creation.
-   */
-  setupWebhookEndpoint(
-    secretKey: string,
-    webhookUrl: string,
-    existingEndpointId?: string | null,
-  ): Promise<WebhookSetupResult>;
-
-  /**
    * Check if a payment has been refunded via the provider API.
    * Used to refresh refund status from the edit attendee page.
    * @param paymentReference - provider-specific payment reference
@@ -192,8 +157,12 @@ export interface PaymentProvider {
    */
   isPaymentRefunded(paymentReference: string): Promise<boolean>;
 
-  /** The webhook event type name that indicates a completed checkout */
-  readonly checkoutCompletedEventType: string;
+  /**
+   * Refund a completed payment.
+   * @param paymentReference - provider-specific payment reference (e.g. Stripe payment_intent ID)
+   * @returns true if refund succeeded, false otherwise
+   */
+  refundPayment(paymentReference: string): Promise<boolean>;
 
   /**
    * Resolve a validated session from a webhook event.
@@ -206,6 +175,36 @@ export interface PaymentProvider {
   resolveWebhookSession(
     event: WebhookEvent,
   ): Promise<ValidatedPaymentSession | "skip" | null>;
+
+  /**
+   * Retrieve and validate a completed checkout session by ID.
+   * Returns the validated session or null if not found / invalid.
+   */
+  retrieveSession(sessionId: string): Promise<ValidatedPaymentSession | null>;
+
+  /**
+   * Set up a webhook endpoint for this provider.
+   * Some providers (e.g. Stripe) support programmatic creation.
+   */
+  setupWebhookEndpoint(
+    secretKey: string,
+    webhookUrl: string,
+    existingEndpointId?: string | null,
+  ): Promise<WebhookSetupResult>;
+  /** Provider identifier */
+  readonly type: PaymentProviderType;
+
+  /**
+   * Verify a webhook request's signature and parse the event payload.
+   * @param webhookUrl - The webhook endpoint URL derived from the incoming request
+   * @param payloadBytes - Raw body bytes from request.arrayBuffer()
+   */
+  verifyWebhookSignature(
+    payload: string,
+    signature: string,
+    webhookUrl: string,
+    payloadBytes: Uint8Array,
+  ): Promise<WebhookVerifyResult>;
 }
 
 /**

--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -3,10 +3,10 @@
  * Uses uqr (zero-dep, ESM, ~4KB)
  */
 
+import { renderSVG } from "uqr";
 import { getQuestionsForEvent } from "#lib/db/questions.ts";
 import { parseEventFields } from "#lib/event-fields.ts";
 import type { EventWithCount } from "#lib/types.ts";
-import { renderSVG } from "uqr";
 
 /**
  * Generate an SVG string for a QR code encoding the given text.

--- a/src/lib/rest/crud-api.ts
+++ b/src/lib/rest/crud-api.ts
@@ -104,14 +104,28 @@ export const parseUpdateName = (
 
 /** Configuration for defineCrudApi */
 export interface CrudApiConfig<Row, Input, FullRow extends Row = Row> {
-  /** Resource name (lowercase plural, used in routes and log messages) */
-  name: string;
-  /** Singular display name for activity log (e.g. "Holiday") */
-  singular: string;
-  /** Table with CRUD operations */
-  table: Table<Row, Input>;
+  /** Extra route entries to merge in (can also override generated routes) */
+  extraRoutes?: Record<string, RouteHandlerFn>;
   /** Fetch all rows (from cache) — may return a richer row type than the table (e.g. joined counts) */
   getAll: () => Promise<FullRow[]>;
+  /** When true, activity log entries for create/update are linked to the row's id as event_id */
+  linkActivityToRow?: boolean;
+  /** Extra keys added to the list response alongside the row array (e.g. admin_level) */
+  listExtras?: (session: AdminSession) => Record<string, unknown>;
+  /** Custom single-row lookup (e.g. to include joined counts). Defaults to table.findById. */
+  lookup?: (id: number) => Promise<FullRow | null>;
+  /** Resource name (lowercase plural, used in routes and log messages) */
+  name: string;
+  /** Field on Row that holds the display name (for delete confirmation) */
+  nameField: keyof FullRow & string;
+  /** Custom delete logic (e.g. cascade). If not provided, uses table.deleteById */
+  onDelete?: (id: InValue) => Promise<void>;
+  /** Singular display name for activity log (e.g. "Holiday") */
+  singular: string;
+  /** Keys to strip from response (e.g. "slug_index") */
+  stripKeys?: string[];
+  /** Table with CRUD operations */
+  table: Table<Row, Input>;
   /** Convert JSON body to Input for create */
   toCreateInput: (
     body: Record<string, unknown>,
@@ -123,20 +137,6 @@ export interface CrudApiConfig<Row, Input, FullRow extends Row = Row> {
   ) => ParseResult<Input> | Promise<ParseResult<Input>>;
   /** Optional validation (return error message or null) */
   validate?: (input: Input, id?: number) => Promise<string | null>;
-  /** Field on Row that holds the display name (for delete confirmation) */
-  nameField: keyof FullRow & string;
-  /** Keys to strip from response (e.g. "slug_index") */
-  stripKeys?: string[];
-  /** Custom delete logic (e.g. cascade). If not provided, uses table.deleteById */
-  onDelete?: (id: InValue) => Promise<void>;
-  /** Custom single-row lookup (e.g. to include joined counts). Defaults to table.findById. */
-  lookup?: (id: number) => Promise<FullRow | null>;
-  /** Extra keys added to the list response alongside the row array (e.g. admin_level) */
-  listExtras?: (session: AdminSession) => Record<string, unknown>;
-  /** When true, activity log entries for create/update are linked to the row's id as event_id */
-  linkActivityToRow?: boolean;
-  /** Extra route entries to merge in (can also override generated routes) */
-  extraRoutes?: Record<string, RouteHandlerFn>;
 }
 
 /** Callback receiving an entity row plus auth context */

--- a/src/lib/rest/handlers.ts
+++ b/src/lib/rest/handlers.ts
@@ -34,12 +34,13 @@ type OnRowSuccess<R> = (row: R, session: AuthSession) => MaybeAsync<Response>;
 
 /** Options for create handler */
 export interface CreateHandlerOptions<R> {
-  onSuccess: OnRowSuccess<R>;
   onError: OnError;
+  onSuccess: OnRowSuccess<R>;
 }
 
 /** Options for delete handler */
 export interface DeleteHandlerOptions<R> {
+  onNotFound: () => MaybeAsync<Response>;
   onSuccess: (session: AuthSession) => MaybeAsync<Response>;
   /** Called when name verification fails - receives id so you can fetch extended data */
   onVerifyFailed?: (
@@ -48,7 +49,6 @@ export interface DeleteHandlerOptions<R> {
     session: AuthSession,
     form: FormParams,
   ) => MaybeAsync<Response>;
-  onNotFound: () => MaybeAsync<Response>;
 }
 
 /** Handler taking request and ID */

--- a/src/lib/rest/resource.ts
+++ b/src/lib/rest/resource.ts
@@ -59,13 +59,13 @@ export interface Resource<
   Input,
   _Values extends FieldValues = FieldValues,
 > {
-  readonly table: Table<Row, Input>;
+  create: (form: FormParams) => Promise<CreateResult<Row>>;
+  delete: (id: InValue) => Promise<DeleteResult>;
   readonly fields: Field[];
   parseInput: (form: FormParams) => Promise<ParseResult<Input>>;
   parsePartialInput: (form: FormParams) => Promise<ParseResult<Partial<Input>>>;
-  create: (form: FormParams) => Promise<CreateResult<Row>>;
+  readonly table: Table<Row, Input>;
   update: (id: InValue, form: FormParams) => Promise<UpdateResult<Row>>;
-  delete: (id: InValue) => Promise<DeleteResult>;
   verifyName?: (row: Row, confirmName: string) => boolean;
 }
 
@@ -78,12 +78,12 @@ export interface ResourceConfig<
   Id = InValue,
   Values extends FieldValues = FieldValues,
 > {
-  table: Table<Row, Input>;
   fields: Field[];
-  toInput: (values: Values) => Input | Promise<Input>;
   nameField?: keyof Row & string;
   /** Custom delete function (e.g., to delete related records first) */
   onDelete?: (id: InValue) => Promise<void>;
+  table: Table<Row, Input>;
+  toInput: (values: Values) => Input | Promise<Input>;
   /** Custom validation (e.g., check uniqueness). Return error message or null. */
   validate?: ValidateFn<Input, Id>;
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -21,10 +21,10 @@ import { ErrorCode, logError } from "#lib/logger.ts";
 // ---------------------------------------------------------------------------
 
 interface StorageConfig {
-  zoneName: string;
-  zoneKey: string;
   /** Override local storage path for tests. "" = disabled, undefined = use env var. */
   localPath?: string;
+  zoneKey: string;
+  zoneName: string;
 }
 
 const storageConfigStore = new AsyncLocalStorage<StorageConfig>();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,52 +72,52 @@ export const isPaidEvent = (
 ): boolean => event.unit_price > 0 || event.can_pay_more;
 
 export interface Event {
-  id: number;
-  name: string;
-  description: string;
+  active: boolean;
+  assign_built_site: boolean;
+  attachment_name: string;
+  attachment_url: string;
+  bookable_days: string[];
+  can_pay_more: boolean;
+  closes_at: string | null;
+  created: string;
   date: string; // encrypted UTC ISO datetime or empty string
+  description: string;
+  event_type: EventType;
+  fields: EventFields;
+  group_id: number;
+  hidden: boolean;
+  id: number;
+  image_url: string;
   location: string; // encrypted or empty string
+  max_attendees: number;
+  max_price: number;
+  max_quantity: number;
+  maximum_days_after: number;
+  minimum_days_before: number;
+  name: string;
+  non_transferable: boolean;
+  purchase_only: boolean;
   slug: string;
   slug_index: string;
-  group_id: number;
-  created: string;
-  max_attendees: number;
   thank_you_url: string;
   unit_price: number;
-  max_quantity: number;
   webhook_url: string;
-  active: boolean;
-  fields: EventFields;
-  closes_at: string | null;
-  event_type: EventType;
-  bookable_days: string[];
-  minimum_days_before: number;
-  maximum_days_after: number;
-  image_url: string;
-  attachment_url: string;
-  attachment_name: string;
-  non_transferable: boolean;
-  can_pay_more: boolean;
-  max_price: number;
-  hidden: boolean;
-  purchase_only: boolean;
-  assign_built_site: boolean;
 }
 
 export interface Attendee extends ContactInfo {
-  id: number;
-  event_id: number;
-  created: string;
-  payment_id: string;
-  quantity: number;
-  price_paid: string;
+  attachment_downloads: number;
   checked_in: boolean;
+  created: string;
+  date: string | null;
+  event_id: number;
+  id: number;
+  payment_id: string;
+  pii_blob: string;
+  price_paid: string;
+  quantity: number;
   refunded: boolean;
   ticket_token: string;
   ticket_token_index: string;
-  date: string | null;
-  attachment_downloads: number;
-  pii_blob: string;
 }
 
 /** Short keys used in the PII blob JSON to minimize encrypted payload size */
@@ -138,11 +138,11 @@ export interface Settings {
 }
 
 export interface Session {
-  token: string; // Contains the hashed token for DB storage
   csrf_token: string;
   expires: number;
-  wrapped_data_key: string | null;
+  token: string; // Contains the hashed token for DB storage
   user_id: number;
+  wrapped_data_key: string | null;
 }
 
 /** Admin role levels */
@@ -160,42 +160,42 @@ export type AdminSession = {
 };
 
 export interface User {
-  id: number;
-  username_hash: string; // encrypted at rest, decrypted to display
-  username_index: string; // HMAC hash for lookups
-  password_hash: string; // PBKDF2 hash encrypted at rest
-  wrapped_data_key: string | null; // wrapped with user's KEK
   admin_level: string; // encrypted "owner" or "manager"
+  id: number;
   invite_code_hash: string | null; // encrypted SHA-256 of invite token, null after password set
   invite_expiry: string | null; // encrypted ISO 8601, null after password set
+  password_hash: string; // PBKDF2 hash encrypted at rest
+  username_hash: string; // encrypted at rest, decrypted to display
+  username_index: string; // HMAC hash for lookups
+  wrapped_data_key: string | null; // wrapped with user's KEK
 }
 
 export interface ApiKey {
-  id: number;
-  user_id: number;
-  key_index: string; // HMAC hash for lookup
-  wrapped_data_key: string; // DATA_KEY wrapped with the API key token
-  name: string; // encrypted label
   created: string;
+  id: number;
+  key_index: string; // HMAC hash for lookup
   last_used: string; // ISO 8601 or empty string
+  name: string; // encrypted label
+  user_id: number;
+  wrapped_data_key: string; // DATA_KEY wrapped with the API key token
 }
 
 export interface Holiday {
+  end_date: string;
   id: number;
   name: string;
   start_date: string;
-  end_date: string;
 }
 
 export interface Group {
+  description: string;
+  hidden: boolean;
   id: number;
+  max_attendees: number;
+  name: string;
   slug: string;
   slug_index: string;
-  name: string;
-  description: string;
   terms_and_conditions: string;
-  max_attendees: number;
-  hidden: boolean;
 }
 
 export interface EventWithCount extends Event {

--- a/src/routes/admin/event-qr.ts
+++ b/src/routes/admin/event-qr.ts
@@ -28,9 +28,9 @@ import {
   withAuth,
 } from "#routes/utils.ts";
 import {
-  adminEventQrPage,
   type AdminEventQrResult,
   type AdminEventQrValues,
+  adminEventQrPage,
 } from "#templates/admin/event-qr.tsx";
 
 const EMPTY_VALUES: AdminEventQrValues = {
@@ -85,10 +85,10 @@ const extractValues = (
 ):
   | { ok: true; parsed: ParsedValues; values: AdminEventQrValues }
   | {
-    ok: false;
-    error: string;
-    values: AdminEventQrValues;
-  } => {
+      ok: false;
+      error: string;
+      values: AdminEventQrValues;
+    } => {
   const values: AdminEventQrValues = {
     customerName: form.getString("customer_name").trim(),
     date: form.getString("date").trim(),
@@ -151,9 +151,9 @@ type ParsedValues = {
 /** Build the absolute URL the QR encodes */
 const buildQrUrl = (slug: string, token: string): string => {
   const domain = getEffectiveDomain();
-  return `https://${domain}/ticket/${slug}/qr-book?t=${
-    encodeURIComponent(token)
-  }`;
+  return `https://${domain}/ticket/${slug}/qr-book?t=${encodeURIComponent(
+    token,
+  )}`;
 };
 
 /** Sign a fresh token for the given event and render its QR SVG */
@@ -184,18 +184,15 @@ const handlePost: TypedRouteHandler<"POST /admin/event/:id/qr"> = (
   request,
   { id },
 ) =>
-  withAuth(
-    request,
-    AUTH_FORM,
-    (session, form) =>
-      orNotFound(Promise.resolve(getEventWithCount(id)), (event) => {
-        const extracted = extractValues(form, event);
-        return extracted.ok
-          ? generateAndRender(id, session, event, extracted)
-          : renderPage(id, session, extracted.values, {
+  withAuth(request, AUTH_FORM, (session, form) =>
+    orNotFound(Promise.resolve(getEventWithCount(id)), (event) => {
+      const extracted = extractValues(form, event);
+      return extracted.ok
+        ? generateAndRender(id, session, event, extracted)
+        : renderPage(id, session, extracted.values, {
             error: extracted.error,
           });
-      }),
+    }),
   );
 
 /**

--- a/src/routes/public/qr-book.ts
+++ b/src/routes/public/qr-book.ts
@@ -17,8 +17,8 @@ import type { EventWithCount } from "#lib/types.ts";
 import { htmlResponse, isRegistrationClosed } from "#routes/utils.ts";
 import {
   buildTicketEvent,
-  qrBookErrorPage,
   type QrPrefill,
+  qrBookErrorPage,
   type TicketPrefill,
 } from "#templates/public.tsx";
 import { getTicketContext, runCheckoutFlow } from "./ticket-payment.ts";

--- a/src/templates/admin/activityLog.tsx
+++ b/src/templates/admin/activityLog.tsx
@@ -37,7 +37,7 @@ export const adminEventActivityLogPage = (
 ): string =>
   String(
     <Layout title={`Log: ${event.name}`}>
-      <AdminNav session={session} active="/admin/log" />
+      <AdminNav active="/admin/log" session={session} />
       <p>
         <a href={`/admin/event/${event.id}`}>&larr; {event.name}</a>
         {" | "}
@@ -69,7 +69,7 @@ export const adminGlobalActivityLogPage = (
 ): string =>
   String(
     <Layout title="Log">
-      <AdminNav session={session} active="/admin/log" />
+      <AdminNav active="/admin/log" session={session} />
       <p>
         <a href="/admin/guide#activity-log">Activity log guide</a>
       </p>

--- a/src/templates/admin/api-keys.tsx
+++ b/src/templates/admin/api-keys.tsx
@@ -28,7 +28,7 @@ const ApiKeyRow = ({ apiKey }: { apiKey: ApiKeyDisplay }): string =>
           : "Never"}
       </td>
       <td>
-        <a href={`/admin/api-keys/${apiKey.id}/delete`} class="danger small">
+        <a class="danger small" href={`/admin/api-keys/${apiKey.id}/delete`}>
           Delete
         </a>
       </td>
@@ -53,7 +53,7 @@ export const adminApiKeysPage = (
 
   return String(
     <Layout title="API Keys">
-      <AdminNav session={adminSession} active="/admin/users" />
+      <AdminNav active="/admin/users" session={adminSession} />
       <UsersSubNav />
 
       <Flash error={opts.error} success={opts.success} />
@@ -98,11 +98,11 @@ export const adminApiKeysPage = (
         <label>
           Name
           <input
-            type="text"
+            maxLength={100}
             name="name"
             placeholder="e.g. CI Pipeline"
             required
-            maxLength={100}
+            type="text"
           />
         </label>
         <button type="submit">Create key</button>
@@ -120,13 +120,13 @@ export const adminDeleteApiKeyPage = (
 ): string =>
   String(
     <Layout title={`Delete: ${apiKey.name}`}>
-      <AdminNav session={session} active="/admin/users" />
+      <AdminNav active="/admin/users" session={session} />
 
       <ConfirmForm
         action={`/admin/api-keys/${apiKey.id}/delete`}
-        name={apiKey.name}
-        label="API key name"
         buttonText="Delete API Key"
+        label="API key name"
+        name={apiKey.name}
       >
         <p>
           <strong>Warning:</strong> This will permanently delete this API key.
@@ -184,7 +184,7 @@ export const adminApiDocsPage = (
 ): string =>
   String(
     <Layout title="API Documentation">
-      <AdminNav session={session} active="/admin/users" />
+      <AdminNav active="/admin/users" session={session} />
       <UsersSubNav />
 
       <div class="stack-md column">

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -30,14 +30,14 @@ export const adminDeleteAttendeePage = (
 ): string =>
   String(
     <Layout title={`Delete Attendee: ${attendee.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/attendee/${attendee.id}/delete`}
-        name={attendee.name}
-        label="Attendee name"
         buttonText="Delete Attendee"
+        label="Attendee name"
+        name={attendee.name}
         returnUrl={returnUrl}
       >
         <p>
@@ -76,14 +76,14 @@ export const adminRefundAttendeePage = (
 ): string =>
   String(
     <Layout title={`Refund Attendee: ${attendee.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/attendee/${attendee.id}/refund`}
-        name={attendee.name}
-        label="Attendee name"
         buttonText="Refund Attendee"
+        label="Attendee name"
+        name={attendee.name}
         returnUrl={returnUrl}
       >
         <p>
@@ -127,14 +127,14 @@ export const adminRefundAllAttendeesPage = (
 ): string =>
   String(
     <Layout title={`Refund All: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/refund-all`}
-        name={event.name}
-        label="Event name"
         buttonText="Refund All Attendees"
+        label="Event name"
+        name={event.name}
       >
         <p>
           <strong>Warning:</strong> This will issue a full refund for all{" "}
@@ -237,8 +237,8 @@ export const adminEditAttendeePage = (
 ): string =>
   String(
     <Layout title={`Edit Attendee: ${attendee.name}`}>
-      <AdminNav session={session} active="/admin/" />
-      <Flash success={success} error={error} />
+      <AdminNav active="/admin/" session={session} />
+      <Flash error={error} success={success} />
 
       <h2>Edit Attendee</h2>
 
@@ -248,27 +248,27 @@ export const adminEditAttendeePage = (
       <h3>Contact Information</h3>
       <CsrfForm action={`/admin/attendees/${attendee.id}`}>
         {returnUrl && (
-          <input type="hidden" name="return_url" value={returnUrl} />
+          <input name="return_url" type="hidden" value={returnUrl} />
         )}
 
         <label for="name">
           Name
           <input
-            type="text"
+            autofocus
             id="name"
             name="name"
-            value={attendee.name}
             required
-            autofocus
+            type="text"
+            value={attendee.name}
           />
         </label>
 
         <label for="email">
           Email
           <input
-            type="email"
             id="email"
             name="email"
+            type="email"
             value={attendee.email || ""}
           />
         </label>
@@ -276,18 +276,18 @@ export const adminEditAttendeePage = (
         <label for="phone">
           Phone
           <input
-            type="text"
             id="phone"
             name="phone"
-            value={attendee.phone || ""}
             pattern="[+\d][\d\s\-()]{5,}"
             title="Phone number (digits, spaces, hyphens, parentheses, optional leading +)"
+            type="text"
+            value={attendee.phone || ""}
           />
         </label>
 
         <label for="address">
           Address
-          <textarea id="address" name="address" rows={3} maxlength={250}>
+          <textarea id="address" maxlength={250} name="address" rows={3}>
             {attendee.address || ""}
           </textarea>
         </label>
@@ -296,9 +296,9 @@ export const adminEditAttendeePage = (
           Special Instructions
           <textarea
             id="special_instructions"
+            maxlength={250}
             name="special_instructions"
             rows={3}
-            maxlength={250}
           >
             {attendee.special_instructions || ""}
           </textarea>
@@ -335,14 +335,14 @@ export const adminEditAttendeePage = (
                     class="inline"
                   >
                     <input
-                      type="number"
-                      name="quantity"
-                      value={String(booking.quantity)}
-                      min="1"
                       max={String(evt.max_quantity)}
+                      min="1"
+                      name="quantity"
                       style="width:4em"
+                      type="number"
+                      value={String(booking.quantity)}
                     />
-                    <button type="submit" class="link-button">
+                    <button class="link-button" type="submit">
                       Update
                     </button>
                   </CsrfForm>
@@ -360,7 +360,7 @@ export const adminEditAttendeePage = (
                     action={`/admin/attendees/${attendee.id}/unlink/${evt.id}`}
                     class="inline"
                   >
-                    <button type="submit" class="link-button danger">
+                    <button class="link-button danger" type="submit">
                       Remove
                     </button>
                   </CsrfForm>
@@ -381,7 +381,7 @@ export const adminEditAttendeePage = (
             {allEvents
               .filter((e) => e.active)
               .map((e) => (
-                <option value={String(e.id)} data-event-type={e.event_type}>
+                <option data-event-type={e.event_type} value={String(e.id)}>
                   {e.name}
                 </option>
               ))}
@@ -391,16 +391,16 @@ export const adminEditAttendeePage = (
         <label for="add_quantity">
           Quantity
           <input
-            type="number"
             id="add_quantity"
-            name="quantity"
-            value="1"
             min="1"
+            name="quantity"
             required
+            type="number"
+            value="1"
           />
         </label>
 
-        <label for="add_date" class="daily-date-field" style="display:none">
+        <label class="daily-date-field" for="add_date" style="display:none">
           Date
           <select id="add_date" name="date">
             <option value="">Select date...</option>
@@ -411,7 +411,7 @@ export const adminEditAttendeePage = (
       </CsrfForm>
 
       {/* Available dates JSON for client-side date picker filtering (read by admin.ts) */}
-      <script type="application/json" id="available-dates-data">
+      <script id="available-dates-data" type="application/json">
         <Raw html={JSON.stringify(availableDatesByEvent)} />
       </script>
 
@@ -423,17 +423,17 @@ export const adminEditAttendeePage = (
       </p>
       <form
         action={`/admin/attendees/${attendee.id}/merge`}
-        method="get"
         class="inline-row"
+        method="get"
       >
         <label for="merge_token">
           Ticket token
           <input
-            type="text"
             id="merge_token"
             name="token"
             placeholder="Enter ticket token…"
             required
+            type="text"
           />
         </label>
         <button type="submit">Search</button>
@@ -480,7 +480,7 @@ const MergePiiField = ({
       <th scope="row">{label}</th>
       <td>
         <label>
-          <input type="radio" name={name} value="target" checked />{" "}
+          <input checked name={name} type="radio" value="target" />{" "}
           <Raw html={renderFieldValue(targetValue, multiline)} />
         </label>
       </td>
@@ -489,7 +489,7 @@ const MergePiiField = ({
           <span class="muted">(same)</span>
         ) : (
           <label>
-            <input type="radio" name={name} value="source" />{" "}
+            <input name={name} type="radio" value="source" />{" "}
             <Raw html={renderFieldValue(sourceValue, multiline)} />
           </label>
         )}
@@ -546,19 +546,19 @@ const MergeAnswersDecisionTable = ({
                   <th scope="row">{item.questionText}</th>
                   <td>
                     <label>
-                      <input type="radio" name={name} value="target" checked />{" "}
+                      <input checked name={name} type="radio" value="target" />{" "}
                       {targetLabel}
                     </label>
                   </td>
                   <td>
                     <label>
-                      <input type="radio" name={name} value="source" />{" "}
+                      <input name={name} type="radio" value="source" />{" "}
                       {sourceLabel}
                     </label>
                   </td>
                   <td>
                     <label>
-                      <input type="radio" name={name} value="clear" /> None
+                      <input name={name} type="radio" value="clear" /> None
                     </label>
                   </td>
                 </tr>
@@ -631,21 +631,21 @@ const MergeBookingsDecisionTable = ({
                   <td>
                     <label>
                       <input
-                        type="radio"
-                        name={name}
-                        value="keep_target"
                         checked
+                        name={name}
+                        type="radio"
+                        value="keep_target"
                       />{" "}
                       Keep target
                     </label>
                     <br />
                     <label>
-                      <input type="radio" name={name} value="take_source" />{" "}
+                      <input name={name} type="radio" value="take_source" />{" "}
                       Replace with source
                     </label>
                     <br />
                     <label>
-                      <input type="radio" name={name} value="skip_source" />{" "}
+                      <input name={name} type="radio" value="skip_source" />{" "}
                       Skip source
                     </label>
                   </td>
@@ -672,7 +672,7 @@ export const adminMergeAttendeePage = (
 ): string =>
   String(
     <Layout title={`Merge Attendee: ${target.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <h2>Merge Attendee</h2>
@@ -684,19 +684,19 @@ export const adminMergeAttendeePage = (
       <h3>Search by Ticket Token</h3>
       <form
         action={`/admin/attendees/${target.id}/merge`}
-        method="get"
         class="inline-row"
+        method="get"
       >
         <label for="token">
           Ticket token to merge from
           <input
-            type="text"
+            autofocus={!source}
             id="token"
             name="token"
-            value={searchToken || ""}
             placeholder="Enter ticket token…"
             required
-            autofocus={!source}
+            type="text"
+            value={searchToken || ""}
           />
         </label>
         <button type="submit">Search</button>
@@ -712,13 +712,13 @@ export const adminMergeAttendeePage = (
 
           <CsrfForm action={`/admin/attendees/${target.id}/merge`}>
             <input
-              type="hidden"
               name="source_token"
+              type="hidden"
               value={source.ticket_token}
             />
             <input
-              type="hidden"
               name="merge_version"
+              type="hidden"
               value={mergeDiff.version}
             />
 
@@ -768,7 +768,7 @@ export const adminMergeAttendeePage = (
               <strong>Warning:</strong> This will permanently delete the source
               attendee. This action cannot be undone.
             </p>
-            <button type="submit" class="danger">
+            <button class="danger" type="submit">
               Merge and Delete Source Attendee
             </button>
           </CsrfForm>
@@ -788,15 +788,15 @@ export const adminResendNotificationPage = (
 ): string =>
   String(
     <Layout title={`Re-send Notification: ${attendee.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/attendee/${attendee.id}/resend-notification`}
-        name={attendee.name}
-        label="Attendee name"
         buttonText="Re-send Notification"
         danger={false}
+        label="Attendee name"
+        name={attendee.name}
         returnUrl={returnUrl}
       >
         <p>

--- a/src/templates/admin/backup.tsx
+++ b/src/templates/admin/backup.tsx
@@ -27,7 +27,7 @@ export const adminBackupPage = (
 ): string =>
   String(
     <Layout title="Database Backup">
-      <AdminNav session={session} active="/admin/settings" />
+      <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
       <h1>Database Backup &amp; Restore</h1>
       <p>
@@ -75,8 +75,8 @@ export const adminBackupPage = (
             </p>
             <CsrfForm
               action="/admin/backup/create"
-              id="backup-create"
               class="no-bg"
+              id="backup-create"
             >
               <button type="submit">Create Backup Now</button>
             </CsrfForm>
@@ -120,12 +120,12 @@ export const adminBackupPage = (
             </p>
             <CsrfForm
               action="/admin/backup/restore"
-              id="backup-restore"
               enctype="multipart/form-data"
+              id="backup-restore"
             >
               <label>
                 Backup file (.zip)
-                <input type="file" name="backup_file" accept=".zip" required />
+                <input accept=".zip" name="backup_file" required type="file" />
               </label>
               <button type="submit">Upload &amp; Review</button>
             </CsrfForm>
@@ -147,16 +147,16 @@ export const adminRestoreConfirmPage = (
 ): string =>
   String(
     <Layout title="Confirm Restore">
-      <AdminNav session={session} active="/admin/settings" />
+      <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
 
       <ConfirmForm
         action="/admin/backup/restore/confirm"
-        id="backup-restore-confirm"
-        name={RESTORE_CONFIRM_PHRASE}
-        label="Confirmation phrase"
         buttonText="Restore Database"
         hiddenFields={{ backup_filename: filename }}
+        id="backup-restore-confirm"
+        label="Confirmation phrase"
+        name={RESTORE_CONFIRM_PHRASE}
       >
         <h1>Confirm Database Restore</h1>
         <Flash error={error} />

--- a/src/templates/admin/builder.tsx
+++ b/src/templates/admin/builder.tsx
@@ -27,38 +27,38 @@ const BuilderForm = (): JSX.Element => (
       <label for="site_name">
         Site Name
         <input
-          type="text"
           id="site_name"
-          name="site_name"
-          required
-          placeholder="My Event Site"
-          minlength={1}
           maxlength={64}
+          minlength={1}
+          name="site_name"
+          placeholder="My Event Site"
+          required
+          type="text"
         />
       </label>
       <label for="db_url">
         Database URL
         <input
-          type="url"
           id="db_url"
           name="db_url"
-          required
           placeholder="libsql://your-db.turso.io"
+          required
+          type="url"
         />
       </label>
       <label for="db_token">
         Database Token
         <input
-          type="password"
           id="db_token"
           name="db_token"
-          required
           placeholder="Token for the database"
+          required
+          type="password"
         />
       </label>
       <fieldset>
         <label>
-          <input type="checkbox" name="assignable" value="1" />
+          <input name="assignable" type="checkbox" value="1" />
           Available for assignment
         </label>
         <small>
@@ -95,7 +95,7 @@ const BuiltSitesTable = ({
           <tr>
             <td>{site.name}</td>
             <td>
-              <a href={site.bunnyUrl} target="_blank" rel="noopener">
+              <a href={site.bunnyUrl} rel="noopener" target="_blank">
                 {site.bunnyUrl}
               </a>
             </td>
@@ -114,7 +114,7 @@ export const adminBuilderPage = (
 ): string =>
   String(
     <Layout title="Site Builder">
-      <AdminNav session={session} active="/admin/settings" />
+      <AdminNav active="/admin/settings" session={session} />
 
       <Flash error={error} success={success} />
 

--- a/src/templates/admin/built-sites.tsx
+++ b/src/templates/admin/built-sites.tsx
@@ -25,7 +25,7 @@ export const adminBuiltSitesPage = (
 
   return String(
     <Layout title="Built Sites">
-      <AdminNav session={session} active="/admin/built-sites" />
+      <AdminNav active="/admin/built-sites" session={session} />
       <Flash success={successMessage} />
       <p>
         <a href="/admin/built-sites/new">Add Built Site</a>{" "}
@@ -50,7 +50,7 @@ export const adminBuiltSitesPage = (
                   <tr>
                     <td>{site.name}</td>
                     <td>
-                      <a href={site.bunnyUrl} target="_blank" rel="noopener">
+                      <a href={site.bunnyUrl} rel="noopener" target="_blank">
                         {site.bunnyUrl}
                       </a>
                     </td>
@@ -102,7 +102,7 @@ export const adminBuiltSiteNewPage = (
 ): string =>
   String(
     <Layout title="Add Built Site">
-      <AdminNav session={session} active="/admin/built-sites" />
+      <AdminNav active="/admin/built-sites" session={session} />
       <CsrfForm action="/admin/built-sites">
         <h1>Add Built Site</h1>
         <Flash error={error} />
@@ -122,7 +122,7 @@ export const adminBuiltSiteEditPage = (
 ): string =>
   String(
     <Layout title="Edit Built Site">
-      <AdminNav session={session} active="/admin/built-sites" />
+      <AdminNav active="/admin/built-sites" session={session} />
       <CsrfForm action={`/admin/built-sites/${site.id}/edit`}>
         <h1>Edit Built Site</h1>
         <Flash error={error} />
@@ -144,13 +144,13 @@ export const adminBuiltSiteDeletePage = (
 ): string =>
   String(
     <Layout title="Delete Built Site">
-      <AdminNav session={session} active="/admin/built-sites" />
+      <AdminNav active="/admin/built-sites" session={session} />
       <ConfirmForm
         action={`/admin/built-sites/${site.id}/delete`}
-        name={site.name}
-        label="Site name"
         buttonText="Delete Built Site"
         danger={false}
+        label="Site name"
+        name={site.name}
       >
         <h1>Delete Built Site</h1>
         <Flash error={error} />

--- a/src/templates/admin/bulk-actions.tsx
+++ b/src/templates/admin/bulk-actions.tsx
@@ -23,11 +23,11 @@ import { Layout } from "#templates/layout.tsx";
 
 /** Form field values for the duplicate-group action */
 export interface DuplicateGroupFormValues {
-  newName: string;
-  nameFind: string;
-  nameReplace: string;
   dateFind: string;
   dateReplace: string;
+  nameFind: string;
+  nameReplace: string;
+  newName: string;
 }
 
 /** Embed JSON safely inside a <script type="application/json"> tag */
@@ -44,7 +44,7 @@ export const adminBulkActionsPage = (
   const allDeactivated = events.length > 0 && !hasActive;
   return String(
     <Layout title={`Bulk Actions: ${group.name}`}>
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <p>
         <a href={`/admin/groups/${group.id}`}>&larr; {group.name}</a>
       </p>
@@ -132,7 +132,7 @@ export const adminDuplicateGroupPage = (
 
   return String(
     <Layout title={`Duplicate Group: ${group.name}`}>
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <p>
         <a href={`/admin/groups/${group.id}/bulk-actions`}>
           &larr; Bulk Actions
@@ -149,38 +149,38 @@ export const adminDuplicateGroupPage = (
 
       <CsrfForm
         action={`/admin/groups/${group.id}/bulk-actions/duplicate`}
-        id="duplicate-group-form"
         data-duplicate-preview
         data-timezone={tz}
+        id="duplicate-group-form"
       >
         <label>
           New group name
           <input
-            type="text"
-            name="new_name"
-            value={values.newName}
-            required
             autofocus
             data-duplicate-field
+            name="new_name"
+            required
+            type="text"
+            value={values.newName}
           />
         </label>
         <label>
           Find in event names
           <input
-            type="text"
-            name="name_find"
-            value={values.nameFind || undefined}
-            placeholder="(leave blank to keep names unchanged)"
             data-duplicate-field="name_find"
+            name="name_find"
+            placeholder="(leave blank to keep names unchanged)"
+            type="text"
+            value={values.nameFind || undefined}
           />
         </label>
         <label>
           Replace with
           <input
-            type="text"
-            name="name_replace"
-            value={values.nameReplace || undefined}
             data-duplicate-field="name_replace"
+            name="name_replace"
+            type="text"
+            value={values.nameReplace || undefined}
           />
         </label>
         <p>
@@ -193,19 +193,19 @@ export const adminDuplicateGroupPage = (
         <label>
           Reference date
           <input
-            type="date"
-            name="date_find"
-            value={values.dateFind || undefined}
             data-duplicate-field="date_find"
+            name="date_find"
+            type="date"
+            value={values.dateFind || undefined}
           />
         </label>
         <label>
           Target date
           <input
-            type="date"
-            name="date_replace"
-            value={values.dateReplace || undefined}
             data-duplicate-field="date_replace"
+            name="date_replace"
+            type="date"
+            value={values.dateReplace || undefined}
           />
         </label>
 
@@ -234,7 +234,7 @@ export const adminDuplicateGroupPage = (
           </div>
         )}
 
-        <script type="application/json" id="duplicate-preview-events">
+        <script id="duplicate-preview-events" type="application/json">
           <Raw html={eventsJson} />
         </script>
 
@@ -254,7 +254,7 @@ export const adminDeactivateGroupPage = (
   const activeCount = events.filter((e) => e.active).length;
   return String(
     <Layout title={`Deactivate Group: ${group.name}`}>
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <p>
         <a href={`/admin/groups/${group.id}/bulk-actions`}>
           &larr; Bulk Actions
@@ -264,9 +264,9 @@ export const adminDeactivateGroupPage = (
 
       <ConfirmForm
         action={`/admin/groups/${group.id}/bulk-actions/deactivate`}
-        name={group.name}
-        label="Group name"
         buttonText="Deactivate Group"
+        label="Group name"
+        name={group.name}
       >
         <p>
           <strong>Warning:</strong> Deactivating this group will deactivate{" "}
@@ -298,7 +298,7 @@ export const adminReactivateGroupPage = (
   const inactiveCount = events.filter((e) => !e.active).length;
   return String(
     <Layout title={`Reactivate Group: ${group.name}`}>
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <p>
         <a href={`/admin/groups/${group.id}/bulk-actions`}>
           &larr; Bulk Actions
@@ -308,10 +308,10 @@ export const adminReactivateGroupPage = (
 
       <ConfirmForm
         action={`/admin/groups/${group.id}/bulk-actions/reactivate`}
-        name={group.name}
-        label="Group name"
         buttonText="Reactivate Group"
         danger={false}
+        label="Group name"
+        name={group.name}
       >
         <p>
           Reactivating this group will reactivate {inactiveCount} event

--- a/src/templates/admin/calendar.tsx
+++ b/src/templates/admin/calendar.tsx
@@ -101,7 +101,7 @@ export const adminCalendarPage = (
 
   return String(
     <Layout title="Calendar">
-      <AdminNav session={session} active="/admin/calendar" />
+      <AdminNav active="/admin/calendar" session={session} />
 
       <p>
         <a href="/admin/guide#calendar">Calendar guide</a>

--- a/src/templates/admin/dashboard.tsx
+++ b/src/templates/admin/dashboard.tsx
@@ -56,9 +56,9 @@ const MultiBookingCheckbox = ({ e }: { e: EventWithCount }): string =>
     <li>
       <label>
         <input
-          type="checkbox"
-          data-multi-booking-slug={e.slug}
           data-fields={e.fields}
+          data-multi-booking-slug={e.slug}
+          type="checkbox"
         />
         {` ${e.name}`}
       </label>
@@ -81,31 +81,31 @@ const multiBookingSection = (activeEvents: EventWithCount[]): string => {
       </ul>
       <label for="multi-booking-url">Booking link</label>
       <input
-        type="text"
-        id="multi-booking-url"
-        readonly
-        data-select-on-click
-        data-multi-booking-url
         data-domain={getEffectiveDomain()}
+        data-multi-booking-url
+        data-select-on-click
+        id="multi-booking-url"
         placeholder="Select two or more events"
+        readonly
+        type="text"
       />
       <label for="multi-booking-embed-script">Embed Script</label>
       <input
-        type="text"
-        id="multi-booking-embed-script"
-        readonly
-        data-select-on-click
         data-multi-booking-embed-script
+        data-select-on-click
+        id="multi-booking-embed-script"
         placeholder="Select two or more events"
+        readonly
+        type="text"
       />
       <label for="multi-booking-embed-iframe">Embed Iframe</label>
       <input
-        type="text"
-        id="multi-booking-embed-iframe"
-        readonly
-        data-select-on-click
         data-multi-booking-embed-iframe
+        data-select-on-click
+        id="multi-booking-embed-iframe"
         placeholder="Select two or more events"
+        readonly
+        type="text"
       />
     </details>,
   );
@@ -217,9 +217,9 @@ export const adminDashboardPage = (
 
   return String(
     <Layout title="Events">
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
 
-      <Flash success={successMessage} error={imageError} />
+      <Flash error={imageError} success={successMessage} />
 
       {!isReadOnly() && (
         <p>

--- a/src/templates/admin/database-reset.tsx
+++ b/src/templates/admin/database-reset.tsx
@@ -38,13 +38,13 @@ export const ResetDatabaseForm = ({
     </p>
     <label for="confirm_phrase">Confirmation phrase</label>
     <input
-      type="text"
+      autocomplete="off"
       id="confirm_phrase"
       name="confirm_phrase"
-      autocomplete="off"
       required
+      type="text"
     />
-    <button type="submit" class="danger">
+    <button class="danger" type="submit">
       Reset Database
     </button>
   </CsrfForm>

--- a/src/templates/admin/debug.tsx
+++ b/src/templates/admin/debug.tsx
@@ -439,8 +439,8 @@ export const adminDebugPage = (
   s: DebugPageState,
 ): string =>
   String(
-    <Layout title="Debug Info" theme={s.theme}>
-      <AdminNav session={session} active="/admin/settings" />
+    <Layout theme={s.theme} title="Debug Info">
+      <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
 
       <h1>Debug Info</h1>

--- a/src/templates/admin/event-qr.tsx
+++ b/src/templates/admin/event-qr.tsx
@@ -53,26 +53,26 @@ const PriceInput = ({
   value: string;
 }): JSX.Element => {
   const hint = event.can_pay_more
-    ? `Minimum ${formatCurrency(event.unit_price)}, maximum ${
-      formatCurrency(event.max_price)
-    }`
-    : `Overrides the ticket price of ${
-      formatCurrency(event.unit_price)
-    } for this booking`;
+    ? `Minimum ${formatCurrency(event.unit_price)}, maximum ${formatCurrency(
+        event.max_price,
+      )}`
+    : `Overrides the ticket price of ${formatCurrency(
+        event.unit_price,
+      )} for this booking`;
   const min = event.can_pay_more ? toMajorUnits(event.unit_price) : "0";
   const max = event.can_pay_more ? toMajorUnits(event.max_price) : undefined;
   return (
     <label>
       Price
       <input
-        type="text"
-        name="value"
         inputmode="decimal"
+        max={max}
+        min={min}
+        name="value"
         pattern="\d+(\.\d{1,2})?"
         title="A non-negative number (e.g. 10.00)"
+        type="text"
         value={value}
-        min={min}
-        max={max}
       />
       <small>{hint}</small>
     </label>
@@ -92,7 +92,7 @@ const DateSelect = ({
     <select name="date" required>
       <option value="">— Select a date —</option>
       {dates.map((d) => (
-        <option value={d} selected={d === value}>
+        <option selected={d === value} value={d}>
           {formatDateLabel(d)}
         </option>
       ))}
@@ -132,11 +132,11 @@ const QrResultPanel = ({
     <label>
       Link
       <input
+        data-qr-link
+        data-select-on-click
+        readonly
         type="text"
         value={result.url}
-        readonly
-        data-select-on-click
-        data-qr-link
       />
     </label>
   </article>
@@ -157,7 +157,7 @@ export const adminEventQrPage = ({
   const refreshUrl = `/admin/event/${event.id}/qr.json`;
   return String(
     <Layout title={`QR Code: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <article>
         <h1>
           Booking QR code &mdash;{" "}
@@ -177,8 +177,8 @@ export const adminEventQrPage = ({
           <label>
             Customer name
             <input
-              type="text"
               name="customer_name"
+              type="text"
               value={values.customerName}
             />
             <small>Optional &mdash; pre-fills the name field.</small>
@@ -187,12 +187,12 @@ export const adminEventQrPage = ({
           <label>
             Quantity
             <input
-              type="number"
-              name="quantity"
-              min="1"
               max={event.max_quantity}
-              value={values.quantity}
+              min="1"
+              name="quantity"
               required
+              type="number"
+              value={values.quantity}
             />
           </label>
           {isDaily && <DateSelect dates={bookableDates} value={values.date} />}
@@ -200,9 +200,9 @@ export const adminEventQrPage = ({
         </CsrfForm>
         {result && (
           <QrResultPanel
-            result={result}
-            refreshUrl={refreshUrl}
             formAction={formAction}
+            refreshUrl={refreshUrl}
+            result={result}
           />
         )}
       </article>

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -115,7 +115,7 @@ const FailedPaymentRow = ({
           action={`/admin/event/${eventId}/attendee/${attendee.id}/delete-incomplete`}
           class="inline"
         >
-          <button type="submit" class="link-button danger">
+          <button class="link-button danger" type="submit">
             Delete
           </button>
         </CsrfForm>
@@ -273,14 +273,14 @@ const EventActionNav = ({
         </li>
         {hasPaidEvent && (
           <li>
-            <a href={`/admin/event/${event.id}/refund-all`} class="danger">
+            <a class="danger" href={`/admin/event/${event.id}/refund-all`}>
               Refund All
             </a>
           </li>
         )}
         {event.active ? (
           <li>
-            <a href={`/admin/event/${event.id}/deactivate`} class="danger">
+            <a class="danger" href={`/admin/event/${event.id}/deactivate`}>
               Deactivate
             </a>
           </li>
@@ -290,7 +290,7 @@ const EventActionNav = ({
           </li>
         )}
         <li>
-          <a href={`/admin/event/${event.id}/delete`} class="danger">
+          <a class="danger" href={`/admin/event/${event.id}/delete`}>
             Delete
           </a>
         </li>
@@ -381,11 +381,11 @@ const AttendeesSummaryRow = ({
     <th>Attendees{dailySuffix}</th>
     <td>
       <AttendeeCountDisplay
-        event={event}
-        isDaily={isDaily}
-        dateFilter={dateFilter}
         adjustedCount={adjustedCount}
         completeQuantitySum={completeQuantitySum}
+        dateFilter={dateFilter}
+        event={event}
+        isDaily={isDaily}
       />
       {isDaily && !dateFilter && (
         <>
@@ -500,11 +500,11 @@ const EventDetailsTable = ({
               </th>
               <td>
                 <input
-                  type="text"
-                  id={`thank-you-url-${event.id}`}
-                  value={event.thank_you_url}
-                  readonly
                   data-select-on-click
+                  id={`thank-you-url-${event.id}`}
+                  readonly
+                  type="text"
+                  value={event.thank_you_url}
                 />
               </td>
             </tr>
@@ -516,11 +516,11 @@ const EventDetailsTable = ({
               </th>
               <td>
                 <input
-                  type="text"
-                  id={`webhook-url-${event.id}`}
-                  value={event.webhook_url}
-                  readonly
                   data-select-on-click
+                  id={`webhook-url-${event.id}`}
+                  readonly
+                  type="text"
+                  value={event.webhook_url}
                 />
               </td>
             </tr>
@@ -531,11 +531,11 @@ const EventDetailsTable = ({
             </th>
             <td>
               <input
-                type="text"
-                id={`embed-script-${event.id}`}
-                value={embedScriptCode}
-                readonly
                 data-select-on-click
+                id={`embed-script-${event.id}`}
+                readonly
+                type="text"
+                value={embedScriptCode}
               />
             </td>
           </tr>
@@ -545,21 +545,21 @@ const EventDetailsTable = ({
             </th>
             <td>
               <input
-                type="text"
-                id={`embed-iframe-${event.id}`}
-                value={embedIframeCode}
-                readonly
                 data-select-on-click
+                id={`embed-iframe-${event.id}`}
+                readonly
+                type="text"
+                value={embedIframeCode}
               />
             </td>
           </tr>
           <AttendeesSummaryRow
-            event={event}
-            isDaily={isDaily}
-            dateFilter={dateFilter}
-            dailySuffix={dailySuffix}
             adjustedCount={adjustedCount}
             completeQuantitySum={completeQuantitySum}
+            dailySuffix={dailySuffix}
+            dateFilter={dateFilter}
+            event={event}
+            isDaily={isDaily}
           />
           <Raw html={sharedRowsHtml} />
         </tbody>
@@ -642,7 +642,7 @@ const AttendeesSection = ({
     <article>
       <h2 id="attendees">Attendees</h2>
       {checkinMessage && (
-        <p id="message" class={checkedInClass}>
+        <p class={checkedInClass} id="message">
           Checked {checkinMessage.name} {checkedInLabel}
         </p>
       )}
@@ -657,9 +657,9 @@ const AttendeesSection = ({
         />
       )}
       <AttendeesFilterLinks
+        activeFilter={activeFilter}
         basePath={basePath}
         dateQs={dateQs}
-        activeFilter={activeFilter}
       />
       <div class="table-scroll">
         <Raw
@@ -800,10 +800,10 @@ export const adminEventPage = ({
 
   return String(
     <Layout title={`Event: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <EventActionNav
-        event={event}
         dateFilter={dateFilter}
+        event={event}
         hasPaidEvent={hasPaidEvent}
       />
       <Flash success={successMessage} />
@@ -814,31 +814,31 @@ export const adminEventPage = ({
       )}
       <Flash error={errorMessage} />
       <EventDetailsTable
-        event={event}
-        allowedDomain={allowedDomain}
-        ticketUrl={ticketUrl}
-        embedScriptCode={embedScriptCode}
-        embedIframeCode={embedIframeCode}
-        isDaily={isDaily}
-        dateFilter={dateFilter}
-        dailySuffix={dailySuffix}
         adjustedCount={adjustedCount}
+        allowedDomain={allowedDomain}
         completeQuantitySum={completeQuantitySum}
+        dailySuffix={dailySuffix}
+        dateFilter={dateFilter}
+        embedIframeCode={embedIframeCode}
+        embedScriptCode={embedScriptCode}
+        event={event}
+        isDaily={isDaily}
         sharedRowsHtml={renderDetailRows(sharedRows)}
+        ticketUrl={ticketUrl}
       />
       <AttendeesSection
-        allowedDomain={allowedDomain}
-        checkinMessage={checkinMessage}
-        isDaily={isDaily}
-        availableDates={availableDates}
         activeFilter={activeFilter}
-        dateFilter={dateFilter}
+        allowedDomain={allowedDomain}
+        availableDates={availableDates}
         basePath={basePath}
+        checkinMessage={checkinMessage}
+        dateFilter={dateFilter}
         dateQs={dateQs}
+        isDaily={isDaily}
+        phonePrefix={phonePrefix}
+        questionData={questionData}
         returnUrl={returnUrl}
         tableRows={tableRows}
-        questionData={questionData}
-        phonePrefix={phonePrefix}
       />
       {incompleteAttendees.length > 0 && (
         <FailedPaymentsSection
@@ -907,7 +907,7 @@ export const adminEventNewPage = (
   ];
   return String(
     <Layout title="Add Event">
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
 
       <CsrfForm action="/admin/event" enctype="multipart/form-data">
         <h1>Add Event</h1>
@@ -940,7 +940,7 @@ export const adminDuplicateEventPage = (
 
   return String(
     <Layout title={`Duplicate: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <h2>Duplicate Event</h2>
       <p>
         Creating a new event based on <strong>{event.name}</strong>.
@@ -972,7 +972,7 @@ export const adminEventEditPage = (
   ];
   return String(
     <Layout title={`Edit: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
       <CsrfForm
         action={`/admin/event/${event.id}/edit`}
@@ -988,7 +988,7 @@ export const adminEventEditPage = (
       </CsrfForm>
       {storageEnabled && event.image_url && (
         <CsrfForm action={`/admin/event/${event.id}/image/delete`}>
-          <button type="submit" class="secondary">
+          <button class="secondary" type="submit">
             Remove Image
           </button>
         </CsrfForm>
@@ -999,7 +999,7 @@ export const adminEventEditPage = (
             Current attachment: <strong>{event.attachment_name}</strong>
           </p>
           <CsrfForm action={`/admin/event/${event.id}/attachment/delete`}>
-            <button type="submit" class="secondary">
+            <button class="secondary" type="submit">
               Remove Attachment
             </button>
           </CsrfForm>
@@ -1019,14 +1019,14 @@ export const adminDeleteEventPage = (
 ): string =>
   String(
     <Layout title={`Delete: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/delete`}
-        name={event.name}
-        label="Event name"
         buttonText="Delete Event"
+        label="Event name"
+        name={event.name}
       >
         <p>
           <strong>Warning:</strong> This will permanently delete the event, all{" "}
@@ -1050,14 +1050,14 @@ export const adminDeactivateEventPage = (
 ): string =>
   String(
     <Layout title={`Deactivate: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/deactivate`}
-        name={event.name}
-        label="Event name"
         buttonText="Deactivate Event"
+        label="Event name"
+        name={event.name}
       >
         <p>
           <strong>Warning:</strong> Deactivating this event will:
@@ -1086,15 +1086,15 @@ export const adminReactivateEventPage = (
 ): string =>
   String(
     <Layout title={`Reactivate: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/event/${event.id}/reactivate`}
-        name={event.name}
-        label="Event name"
         buttonText="Reactivate Event"
         danger={false}
+        label="Event name"
+        name={event.name}
       >
         <p>
           Reactivating this event will make it available for registrations

--- a/src/templates/admin/group-select.tsx
+++ b/src/templates/admin/group-select.tsx
@@ -18,12 +18,12 @@ export const EventGroupSelect = ({
   return (
     <label>
       Group
-      <select name="group_id" id="group_id">
-        <option value="0" selected={selectedGroupId === 0}>
+      <select id="group_id" name="group_id">
+        <option selected={selectedGroupId === 0} value="0">
           No Group
         </option>
         {groups.map((g) => (
-          <option value={String(g.id)} selected={g.id === selectedGroupId}>
+          <option selected={g.id === selectedGroupId} value={String(g.id)}>
             {g.name}
           </option>
         ))}

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -44,7 +44,7 @@ export const adminGroupsPage = (
 ): string =>
   String(
     <Layout title="Groups">
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <Flash success={successMessage} />
       {!isReadOnly() && (
         <p>
@@ -118,7 +118,7 @@ export const adminGroupNewPage = (
 ): string =>
   String(
     <Layout title="Add Group">
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <CsrfForm action="/admin/groups">
         <h1>Add Group</h1>
         <Flash error={error} />
@@ -138,7 +138,7 @@ export const adminGroupEditPage = (
 ): string =>
   String(
     <Layout title="Edit Group">
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <CsrfForm action={`/admin/groups/${group.id}/edit`}>
         <h1>Edit Group</h1>
         <Flash error={error} />
@@ -158,13 +158,13 @@ export const adminGroupDeletePage = (
 ): string =>
   String(
     <Layout title="Delete Group">
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <ConfirmForm
         action={`/admin/groups/${group.id}/delete`}
-        name={group.name}
-        label="Group name"
         buttonText="Delete Group"
         danger={false}
+        label="Group name"
+        name={group.name}
       >
         <h1>Delete Group</h1>
         <Flash error={error} />
@@ -258,7 +258,7 @@ export const adminGroupDetailPage = (
 
   return String(
     <Layout title={group.name}>
-      <AdminNav session={session} active="/admin/groups" />
+      <AdminNav active="/admin/groups" session={session} />
       <Flash success={successMessage} />
       <nav>
         <ul>
@@ -275,7 +275,7 @@ export const adminGroupDetailPage = (
             </>
           )}
           <li>
-            <a href={`/admin/groups/${group.id}/delete`} class="danger">
+            <a class="danger" href={`/admin/groups/${group.id}/delete`}>
               Delete Group
             </a>
           </li>
@@ -307,11 +307,11 @@ export const adminGroupDetailPage = (
                 </th>
                 <td>
                   <input
-                    type="text"
-                    id={`embed-script-${group.id}`}
-                    value={embedScriptCode}
-                    readonly
                     data-select-on-click
+                    id={`embed-script-${group.id}`}
+                    readonly
+                    type="text"
+                    value={embedScriptCode}
                   />
                 </td>
               </tr>
@@ -321,11 +321,11 @@ export const adminGroupDetailPage = (
                 </th>
                 <td>
                   <input
-                    type="text"
-                    id={`embed-iframe-${group.id}`}
-                    value={embedIframeCode}
-                    readonly
                     data-select-on-click
+                    id={`embed-iframe-${group.id}`}
+                    readonly
+                    type="text"
+                    value={embedIframeCode}
                   />
                 </td>
               </tr>
@@ -369,7 +369,7 @@ export const adminGroupDetailPage = (
           <CsrfForm action={`/admin/groups/${group.id}/add-events`}>
             {ungroupedEvents.map((e) => (
               <label>
-                <input type="checkbox" name="event_ids" value={String(e.id)} />
+                <input name="event_ids" type="checkbox" value={String(e.id)} />
                 {` ${e.name}`}
               </label>
             ))}

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -91,14 +91,13 @@ export const adminGuidePage = (
   hostConfig?: GuideHostConfig,
 ): string =>
   String(
-    <Layout title="Guide" bodyClass="guide">
-      <AdminNav session={adminSession} active="/admin/guide" />
+    <Layout bodyClass="guide" title="Guide">
+      <AdminNav active="/admin/guide" session={adminSession} />
 
       <h2>Guide</h2>
 
       <p class="search-hint">
-        Press <kbd>Ctrl</kbd>+<kbd>F</kbd> (or <kbd>&#8984;</kbd>+<kbd>F</kbd>
-        {" "}
+        Press <kbd>Ctrl</kbd>+<kbd>F</kbd> (or <kbd>&#8984;</kbd>+<kbd>F</kbd>{" "}
         on Mac) to search this page.
       </p>
 
@@ -117,11 +116,10 @@ export const adminGuidePage = (
 
         <Q q="How do I set up payments?">
           <p>
-            Go to <strong>Settings</strong>{" "}
-            and choose Stripe or Square as your payment provider. Paste in your
-            API key and save. For Stripe, the webhook is configured
-            automatically. For Square, you'll need to copy the webhook URL shown
-            and add it in your Square Developer Dashboard.
+            Go to <strong>Settings</strong> and choose Stripe or Square as your
+            payment provider. Paste in your API key and save. For Stripe, the
+            webhook is configured automatically. For Square, you'll need to copy
+            the webhook URL shown and add it in your Square Developer Dashboard.
           </p>
         </Q>
       </Section>
@@ -129,12 +127,11 @@ export const adminGuidePage = (
       <Section title="Dashboard">
         <Q q="What is the dashboard?">
           <p>
-            The <strong>Events</strong>{" "}
-            page is your dashboard. It lists all your events with attendee
-            counts, booking links, and quick actions. At the top, the{" "}
-            <strong>Active Event Statistics</strong>{" "}
-            section shows totals across all active events: total income, number
-            of ticket rows, and total attendee quantity. Click the heading to
+            The <strong>Events</strong> page is your dashboard. It lists all
+            your events with attendee counts, booking links, and quick actions.
+            At the top, the <strong>Active Event Statistics</strong> section
+            shows totals across all active events: total income, number of
+            ticket rows, and total attendee quantity. Click the heading to
             expand or collapse it.
           </p>
         </Q>
@@ -156,9 +153,9 @@ export const adminGuidePage = (
             This project is early in development (started January 2026) and bugs
             are expected. If you find something that doesn&apos;t work
             correctly, please email{" "}
-            <a href="mailto:hello@chobble.com">hello@chobble.com</a>{" "}
-            with a description of what happened and what you expected. The more
-            detail you can provide, the faster it can be fixed.
+            <a href="mailto:hello@chobble.com">hello@chobble.com</a> with a
+            description of what happened and what you expected. The more detail
+            you can provide, the faster it can be fixed.
           </p>
         </Q>
       </Section>
@@ -166,12 +163,11 @@ export const adminGuidePage = (
       <Section title="Events">
         <Q q="What's the difference between standard and daily events?">
           <p>
-            A <strong>standard event</strong>{" "}
-            is a one-off &mdash; attendees book a place and the capacity applies
-            to the whole event. A <strong>daily event</strong>{" "}
-            lets attendees pick a specific date when booking. The capacity limit
-            applies separately to each date, so you can run the same event every
-            day with a fresh allocation.
+            A <strong>standard event</strong> is a one-off &mdash; attendees
+            book a place and the capacity applies to the whole event. A{" "}
+            <strong>daily event</strong> lets attendees pick a specific date
+            when booking. The capacity limit applies separately to each date, so
+            you can run the same event every day with a fresh allocation.
           </p>
         </Q>
 
@@ -188,25 +184,23 @@ export const adminGuidePage = (
             admin, they appear as one attendee linked to multiple events.
           </p>
           <p>
-            To generate the link, open the <strong>Multi-booking link</strong>
-            {" "}
-            section on the <strong>Events</strong>{" "}
-            page and tick the events you want to combine. The link updates as
-            you select, and events appear in the order you tick them.
+            To generate the link, open the <strong>Multi-booking link</strong>{" "}
+            section on the <strong>Events</strong> page and tick the events you
+            want to combine. The link updates as you select, and events appear
+            in the order you tick them.
           </p>
         </Q>
 
         <Q q="What are groups?">
           <p>
             Groups let you bundle related events under a single URL. Create a
-            group from the <strong>Groups</strong>{" "}
-            page, then assign events to it using the group dropdown on the event
-            form. Share <code>/ticket/your-group-slug</code>{" "}
-            and attendees see all active events in the group on one page. You
-            can optionally set a maximum attendee limit on the group to cap
-            total bookings across all events in it. If you add terms and
-            conditions to a group, they replace the global T&amp;Cs for that
-            page.
+            group from the <strong>Groups</strong> page, then assign events to
+            it using the group dropdown on the event form. Share{" "}
+            <code>/ticket/your-group-slug</code> and attendees see all active
+            events in the group on one page. You can optionally set a maximum
+            attendee limit on the group to cap total bookings across all events
+            in it. If you add terms and conditions to a group, they replace the
+            global T&amp;Cs for that page.
           </p>
         </Q>
 
@@ -234,22 +228,20 @@ export const adminGuidePage = (
           <p>
             When enabled, attendees can choose their own price instead of paying
             a fixed amount. The ticket price becomes a minimum. You can set a
-            maximum price using the "Maximum Price" field — it must be at least
-            {" "}
-            {formatCurrency(100)}{" "}
-            more than the ticket price. If the ticket price is zero, it becomes
-            a pay-what-you-want event where attendees can optionally enter any
-            amount up to the configured maximum.
+            maximum price using the "Maximum Price" field — it must be at least{" "}
+            {formatCurrency(100)} more than the ticket price. If the ticket
+            price is zero, it becomes a pay-what-you-want event where attendees
+            can optionally enter any amount up to the configured maximum.
           </p>
         </Q>
 
         <Q q="What is 'Purchase Only' mode?">
           <p>
-            When you enable <strong>Purchase Only</strong>{" "}
-            on an event, it becomes a non-attendance purchase &mdash; ideal for
-            raffles, fundraisers, donations, or merchandise. The booking button
-            changes from &ldquo;Reserve&rdquo; to &ldquo;Buy now&rdquo;, and
-            after purchase attendees see &ldquo;Your Purchase&rdquo; instead of
+            When you enable <strong>Purchase Only</strong> on an event, it
+            becomes a non-attendance purchase &mdash; ideal for raffles,
+            fundraisers, donations, or merchandise. The booking button changes
+            from &ldquo;Reserve&rdquo; to &ldquo;Buy now&rdquo;, and after
+            purchase attendees see &ldquo;Your Purchase&rdquo; instead of
             &ldquo;Your Tickets&rdquo;.
           </p>
           <p>
@@ -271,26 +263,23 @@ export const adminGuidePage = (
 
         <Q q="How do I embed the booking form on my website?">
           <p>
-            You only need <strong>one</strong>{" "}
-            of the two embed codes shown on your event page &mdash; not both:
+            You only need <strong>one</strong> of the two embed codes shown on
+            your event page &mdash; not both:
           </p>
           <ul>
             <li>
-              <strong>Embed Script</strong> (recommended) &mdash; paste a single
-              {" "}
-              <code>&lt;script&gt;</code>{" "}
-              tag and it creates the iframe for you with automatic resizing.
+              <strong>Embed Script</strong> (recommended) &mdash; paste a single{" "}
+              <code>&lt;script&gt;</code> tag and it creates the iframe for you
+              with automatic resizing.
             </li>
             <li>
-              <strong>Embed Iframe</strong>{" "}
-              &mdash; use this if your hosting platform blocks third-party
-              scripts or if you want full control over the iframe styling
-              yourself.
+              <strong>Embed Iframe</strong> &mdash; use this if your hosting
+              platform blocks third-party scripts or if you want full control
+              over the iframe styling yourself.
             </li>
           </ul>
           <p>
-            In{" "}
-            <strong>Settings</strong>, add your website's domain to the embed
+            In <strong>Settings</strong>, add your website's domain to the embed
             hosts list to restrict which sites can embed your forms. If no hosts
             are listed, embedding is allowed from any site.
           </p>
@@ -346,43 +335,39 @@ export const adminGuidePage = (
 
         <Q q="Where can I find the event QR code?">
           <p>
-            On the admin event page, click the <strong>QR code</strong>{" "}
-            link next to the public URL. This opens an SVG image of the QR code
-            that links to your event's registration page. You can save or print
-            it for posters, flyers, or other materials.
+            On the admin event page, click the <strong>QR code</strong> link
+            next to the public URL. This opens an SVG image of the QR code that
+            links to your event's registration page. You can save or print it
+            for posters, flyers, or other materials.
           </p>
         </Q>
 
         <Q q="How do I duplicate an event?">
           <p>
-            Open the event and click{" "}
-            <strong>Duplicate</strong>. This creates a new event pre-filled with
-            the same capacity, price, fields, group, and other settings so you
-            can adjust what you need without starting from scratch. The name is
-            left blank for you to fill in, and the image, attachment, and
-            assigned questions are not copied.
+            Open the event and click <strong>Duplicate</strong>. This creates a
+            new event pre-filled with the same capacity, price, fields, group,
+            and other settings so you can adjust what you need without starting
+            from scratch. The name is left blank for you to fill in, and the
+            image, attachment, and assigned questions are not copied.
           </p>
         </Q>
 
         <Q q="How do I deactivate an event?">
           <p>
-            Open the event and click{" "}
-            <strong>Deactivate</strong>. Deactivated events no longer accept
-            bookings and are hidden from the public events listing, but all
-            existing attendee data is kept. Click <strong>Reactivate</strong>
-            {" "}
-            to make the event bookable again.
+            Open the event and click <strong>Deactivate</strong>. Deactivated
+            events no longer accept bookings and are hidden from the public
+            events listing, but all existing attendee data is kept. Click{" "}
+            <strong>Reactivate</strong> to make the event bookable again.
           </p>
         </Q>
 
         <Q q="What are non-transferable tickets?">
           <p>
-            When you enable <strong>Non-Transferable</strong>{" "}
-            on an event, attendees see a notice on their ticket saying
-            "Non-transferable — ID required at entry". At check-in, the QR
-            scanner prompts door staff to verify the attendee's ID matches the
-            name on the ticket before completing check-in. This helps prevent
-            ticket touting.
+            When you enable <strong>Non-Transferable</strong> on an event,
+            attendees see a notice on their ticket saying "Non-transferable — ID
+            required at entry". At check-in, the QR scanner prompts door staff
+            to verify the attendee's ID matches the name on the ticket before
+            completing check-in. This helps prevent ticket touting.
           </p>
         </Q>
 
@@ -393,21 +378,20 @@ export const adminGuidePage = (
           </p>
           <ul>
             <li>
-              <strong>Contact Information</strong>{" "}
-              &mdash; name, email, phone, address, special instructions, and
-              custom question answers. These are shared across all the
-              attendee's event registrations.
+              <strong>Contact Information</strong> &mdash; name, email, phone,
+              address, special instructions, and custom question answers. These
+              are shared across all the attendee's event registrations.
             </li>
             <li>
-              <strong>Event Registrations</strong>{" "}
-              &mdash; a table showing each event the attendee is registered for,
-              with their quantity, check-in status, and refund status. You can
-              update the quantity per event or remove a registration.
+              <strong>Event Registrations</strong> &mdash; a table showing each
+              event the attendee is registered for, with their quantity,
+              check-in status, and refund status. You can update the quantity
+              per event or remove a registration.
             </li>
             <li>
-              <strong>Add to Event</strong>{" "}
-              &mdash; link the attendee to an additional event. For daily
-              events, you also pick a date. Capacity is checked when adding.
+              <strong>Add to Event</strong> &mdash; link the attendee to an
+              additional event. For daily events, you also pick a date. Capacity
+              is checked when adding.
             </li>
           </ul>
         </Q>
@@ -415,10 +399,9 @@ export const adminGuidePage = (
         <Q q="How do I add an attendee to another event?">
           <p>
             Open the attendee's edit page and use the{" "}
-            <strong>Add to Event</strong>{" "}
-            section at the bottom. Select the event, choose a quantity, and for
-            daily events pick a date. If the event has enough capacity the
-            attendee is linked immediately.
+            <strong>Add to Event</strong> section at the bottom. Select the
+            event, choose a quantity, and for daily events pick a date. If the
+            event has enough capacity the attendee is linked immediately.
           </p>
         </Q>
 
@@ -434,18 +417,17 @@ export const adminGuidePage = (
 
         <Q q="How do I delete an attendee?">
           <p>
-            Open the event's attendee list and click <strong>Delete</strong>
-            {" "}
+            Open the event's attendee list and click <strong>Delete</strong>{" "}
             next to the attendee. You'll see a confirmation page showing their
             name, email, quantity, and registration date. Type the attendee's
-            exact name to confirm, then click{" "}
-            <strong>Delete Attendee</strong>. This permanently removes the
-            attendee and any associated payment records.
+            exact name to confirm, then click <strong>Delete Attendee</strong>.
+            This permanently removes the attendee and any associated payment
+            records.
           </p>
           <p>
-            If the attendee has paid, <strong>refund them first</strong>{" "}
-            before deleting &mdash; once deleted, there is no payment record to
-            refund against. See the <strong>Refunds</strong> section below.
+            If the attendee has paid, <strong>refund them first</strong> before
+            deleting &mdash; once deleted, there is no payment record to refund
+            against. See the <strong>Refunds</strong> section below.
           </p>
         </Q>
 
@@ -453,8 +435,8 @@ export const adminGuidePage = (
           <p>
             If the same person booked separately and ended up with two attendee
             records, you can merge them. Open one attendee's edit page and find
-            the <strong>Merge</strong>{" "}
-            section. Enter the other attendee's ticket token to start the merge.
+            the <strong>Merge</strong> section. Enter the other attendee's
+            ticket token to start the merge.
           </p>
           <p>
             You'll see a comparison of their contact details, custom question
@@ -469,19 +451,17 @@ export const adminGuidePage = (
         <Q q="How do I resend a confirmation email?">
           <p>
             In the event's attendee list, click{" "}
-            <strong>Re-send Notification</strong>{" "}
-            next to the attendee. You'll be asked to type their name to confirm.
-            This re-sends both the attendee confirmation email (with their
-            ticket link) and the admin notification email. If email is not
-            configured or the attendee has no email address, the action
-            completes silently without sending.
+            <strong>Re-send Notification</strong> next to the attendee. You'll
+            be asked to type their name to confirm. This re-sends both the
+            attendee confirmation email (with their ticket link) and the admin
+            notification email. If email is not configured or the attendee has
+            no email address, the action completes silently without sending.
           </p>
         </Q>
 
         <Q q="How do I add terms and conditions?">
           <p>
-            In{" "}
-            <strong>Settings</strong>, enter your terms in the "Terms and
+            In <strong>Settings</strong>, enter your terms in the "Terms and
             Conditions" box. When set, attendees must tick an agreement checkbox
             before they can reserve tickets. Clear the box to remove the
             requirement.
@@ -501,13 +481,11 @@ export const adminGuidePage = (
 
         <Q q="How do I create a question?">
           <p>
-            Open any event and click <strong>Questions</strong>{" "}
-            in the event menu, then follow the <strong>Manage Questions</strong>
-            {" "}
-            link. Type your question text and click{" "}
-            <strong>Add Question</strong>. Then open the question and add your
-            answer options. You can reorder answers using the move-up and
-            move-down buttons.
+            Open any event and click <strong>Questions</strong> in the event
+            menu, then follow the <strong>Manage Questions</strong> link. Type
+            your question text and click <strong>Add Question</strong>. Then
+            open the question and add your answer options. You can reorder
+            answers using the move-up and move-down buttons.
           </p>
         </Q>
 
@@ -553,9 +531,9 @@ export const adminGuidePage = (
             <a href="https://developers.facebook.com/tools/debug/">
               Facebook Sharing Debugger
             </a>{" "}
-            and click <strong>Scrape Again</strong>{" "}
-            if the result looks wrong. Once Facebook has successfully scraped
-            the URL, future shares should work normally.
+            and click <strong>Scrape Again</strong> if the result looks wrong.
+            Once Facebook has successfully scraped the URL, future shares should
+            work normally.
           </p>
         </Q>
       </Section>
@@ -563,37 +541,35 @@ export const adminGuidePage = (
       <Section title="Public Site">
         <Q q="What is the public site?">
           <p>
-            When enabled in{" "}
-            <strong>Settings</strong>, your domain shows a public website with
-            navigation for Home and Events, plus T&amp;Cs and Contact links if
-            you've set those up. The <strong>Events</strong>{" "}
-            page lists all active events with booking links. Visitors can browse
-            event details and book directly. If the public site is disabled,
-            visitors can still book via direct ticket links.
+            When enabled in <strong>Settings</strong>, your domain shows a
+            public website with navigation for Home and Events, plus T&amp;Cs
+            and Contact links if you've set those up. The{" "}
+            <strong>Events</strong> page lists all active events with booking
+            links. Visitors can browse event details and book directly. If the
+            public site is disabled, visitors can still book via direct ticket
+            links.
           </p>
         </Q>
 
         <Q q="Can I hide an event from the public list?">
           <p>
-            Yes. When editing an event, tick the <strong>Hidden Event</strong>
-            {" "}
+            Yes. When editing an event, tick the <strong>Hidden Event</strong>{" "}
             checkbox. Hidden events won&apos;t appear on the public Events page
             and their ticket pages will be marked as{" "}
-            <code>noindex, nofollow</code>{" "}
-            for search engines. The event is still fully bookable via its direct
-            link or when embedded in an iframe.
+            <code>noindex, nofollow</code> for search engines. The event is
+            still fully bookable via its direct link or when embedded in an
+            iframe.
           </p>
         </Q>
 
         <Q q="How do I edit the homepage and contact page?">
           <p>
-            Enable the public site in <strong>Settings</strong>, then open the
-            {" "}
-            <strong>Site</strong>{" "}
-            section from the admin navigation. The homepage editor lets you set
-            a website title (shown as the heading on all public pages) and
-            homepage text. The contact page editor lets you set contact
-            information. Both fields support Markdown formatting.
+            Enable the public site in <strong>Settings</strong>, then open the{" "}
+            <strong>Site</strong> section from the admin navigation. The
+            homepage editor lets you set a website title (shown as the heading
+            on all public pages) and homepage text. The contact page editor lets
+            you set contact information. Both fields support Markdown
+            formatting.
           </p>
         </Q>
       </Section>
@@ -603,19 +579,17 @@ export const adminGuidePage = (
           <p>
             Event descriptions, terms and conditions, homepage text, and contact
             page text all support{" "}
-            <a href="https://www.markdownguide.org/cheat-sheet/">Markdown</a>
-            {" "}
+            <a href="https://www.markdownguide.org/cheat-sheet/">Markdown</a>{" "}
             formatting.
           </p>
         </Q>
 
         <Q q="What formatting can I use?">
           <p>
-            <strong>Bold</strong> with <code>**bold**</code>, <em>italic</em>
-            {" "}
+            <strong>Bold</strong> with <code>**bold**</code>, <em>italic</em>{" "}
             with <code>*italic*</code>, links with{" "}
-            <code>[text](https://...)</code>, and lists with <code>-</code>{" "}
-            at the start of a line. See the{" "}
+            <code>[text](https://...)</code>, and lists with <code>-</code> at
+            the start of a line. See the{" "}
             <a href="https://www.markdownguide.org/cheat-sheet/">
               Markdown cheat sheet
             </a>{" "}
@@ -627,9 +601,9 @@ export const adminGuidePage = (
       <Section title="Payments">
         <Q q="Which payment providers are supported?">
           <p>
-            <strong>Stripe</strong> and{" "}
-            <strong>Square</strong>. Choose one in Settings and enter your API
-            credentials. You can switch between them at any time.
+            <strong>Stripe</strong> and <strong>Square</strong>. Choose one in
+            Settings and enter your API credentials. You can switch between them
+            at any time.
           </p>
         </Q>
 
@@ -672,9 +646,8 @@ export const adminGuidePage = (
 
         <Q q="How do refunds work?">
           <p>
-            See the <strong>Refunds</strong>{" "}
-            section below for full details on automatic refunds, admin-issued
-            refunds, and bulk refunds.
+            See the <strong>Refunds</strong> section below for full details on
+            automatic refunds, admin-issued refunds, and bulk refunds.
           </p>
         </Q>
 
@@ -687,11 +660,10 @@ export const adminGuidePage = (
           </p>
           <p>
             Configure it in <a href="/admin/settings">Settings</a> under{" "}
-            <strong>Booking Fee</strong>{" "}
-            (only visible when a payment provider is set up). Enter a percentage
-            between 0 and 10. Set it to 0 or leave it blank to disable. The fee
-            is calculated on the subtotal and added automatically during
-            checkout.
+            <strong>Booking Fee</strong> (only visible when a payment provider
+            is set up). Enter a percentage between 0 and 10. Set it to 0 or
+            leave it blank to disable. The fee is calculated on the subtotal and
+            added automatically during checkout.
           </p>
         </Q>
       </Section>
@@ -714,8 +686,8 @@ export const adminGuidePage = (
               <strong>Secret key</strong> row and click <strong>Reveal</strong>
             </li>
             <li>
-              Copy the key &mdash; it starts with <code>sk_live_</code>{" "}
-              for live mode or <code>sk_test_</code> for test mode
+              Copy the key &mdash; it starts with <code>sk_live_</code> for live
+              mode or <code>sk_test_</code> for test mode
             </li>
             <li>
               Paste it into the Stripe Secret Key field on the{" "}
@@ -723,9 +695,9 @@ export const adminGuidePage = (
             </li>
           </ol>
           <p>
-            <strong>Tip:</strong> Use a <code>sk_test_</code>{" "}
-            key first to verify everything works before switching to your live
-            key. Test mode lets you make bookings without real charges.
+            <strong>Tip:</strong> Use a <code>sk_test_</code> key first to
+            verify everything works before switching to your live key. Test mode
+            lets you make bookings without real charges.
           </p>
         </Q>
 
@@ -735,8 +707,8 @@ export const adminGuidePage = (
             <a href="/admin/settings">Settings</a>, the system automatically
             creates a webhook endpoint in your Stripe account and stores the
             signing secret. You can verify it's working by clicking the{" "}
-            <strong>Test Connection</strong>{" "}
-            button that appears after saving your key.
+            <strong>Test Connection</strong> button that appears after saving
+            your key.
           </p>
         </Q>
 
@@ -758,8 +730,7 @@ export const adminGuidePage = (
               Click the <strong>+</strong> button to create a new application
             </li>
             <li>
-              Give it a name (e.g. your organisation or event name) and click
-              {" "}
+              Give it a name (e.g. your organisation or event name) and click{" "}
               <strong>Save</strong>
             </li>
           </ol>
@@ -782,9 +753,8 @@ export const adminGuidePage = (
               Open the <strong>Credentials</strong> page
             </li>
             <li>
-              Copy the <strong>Access token</strong>{" "}
-              for the environment you want (Sandbox for testing, Production for
-              real payments)
+              Copy the <strong>Access token</strong> for the environment you
+              want (Sandbox for testing, Production for real payments)
             </li>
             <li>
               Paste it into the Square Access Token field on the{" "}
@@ -806,14 +776,13 @@ export const adminGuidePage = (
               Open the <strong>Locations</strong> page in the sidebar
             </li>
             <li>
-              Copy the <strong>Location ID</strong>{" "}
-              for the location you want to accept payments at
+              Copy the <strong>Location ID</strong> for the location you want to
+              accept payments at
             </li>
           </ol>
           <p>
             You can also find your location ID in the main{" "}
-            <a href="https://squareup.com/dashboard">Square Dashboard</a> under
-            {" "}
+            <a href="https://squareup.com/dashboard">Square Dashboard</a> under{" "}
             <strong>Account &amp; Settings</strong> &rarr;{" "}
             <strong>Business information</strong> &rarr;{" "}
             <strong>Locations</strong>.
@@ -840,9 +809,8 @@ export const adminGuidePage = (
               Click <strong>Add Subscription</strong>
             </li>
             <li>
-              Set the <strong>Notification URL</strong>{" "}
-              to the webhook URL shown on your{" "}
-              <a href="/admin/settings">Settings</a> page
+              Set the <strong>Notification URL</strong> to the webhook URL shown
+              on your <a href="/admin/settings">Settings</a> page
             </li>
             <li>
               Subscribe to the <strong>payment.updated</strong> event
@@ -887,8 +855,8 @@ export const adminGuidePage = (
           </ul>
           <p>
             The system detects which mode you are in based on the key prefix and
-            shows it on the <a href="/admin/settings">Settings</a>{" "}
-            page. Only keys with a valid prefix (<code>sk_test_</code> or{" "}
+            shows it on the <a href="/admin/settings">Settings</a> page. Only
+            keys with a valid prefix (<code>sk_test_</code> or{" "}
             <code>sk_live_</code>) are accepted.
           </p>
         </Q>
@@ -906,15 +874,13 @@ export const adminGuidePage = (
               <a href="https://docs.stripe.com/testing#cards">
                 Stripe&apos;s test card numbers
               </a>
-              . The Settings page will show a <strong>Test mode</strong>{" "}
-              badge so you always know which environment is active.
+              . The Settings page will show a <strong>Test mode</strong> badge
+              so you always know which environment is active.
             </li>
             <li>
-              <strong>Square:</strong>{" "}
-              Use your Sandbox access token and location, and tick the{" "}
-              <strong>Sandbox mode</strong>{" "}
-              checkbox on the Settings page. You can make test payments with
-              {" "}
+              <strong>Square:</strong> Use your Sandbox access token and
+              location, and tick the <strong>Sandbox mode</strong> checkbox on
+              the Settings page. You can make test payments with{" "}
               <a href="https://developer.squareup.com/docs/devtools/sandbox/payments">
                 Square&apos;s sandbox test values
               </a>
@@ -961,11 +927,11 @@ export const adminGuidePage = (
 
         <Q q="How do I refund all attendees for an event?">
           <p>
-            On the event page, click <strong>Refund All</strong>{" "}
-            in the navigation bar. Type the event name to confirm. Each attendee
-            with a recorded payment is refunded one by one. If some refunds fail
-            (e.g. a payment was already refunded via the provider dashboard),
-            you'll see a summary of how many succeeded and how many failed.
+            On the event page, click <strong>Refund All</strong> in the
+            navigation bar. Type the event name to confirm. Each attendee with a
+            recorded payment is refunded one by one. If some refunds fail (e.g.
+            a payment was already refunded via the provider dashboard), you'll
+            see a summary of how many succeeded and how many failed.
           </p>
         </Q>
 
@@ -979,11 +945,10 @@ export const adminGuidePage = (
 
         <Q q="What happens to the attendee after a refund?">
           <p>
-            The attendee{" "}
-            <strong>remains registered</strong>. A refund only clears their
-            payment record &mdash; it does not remove them from the event. If
-            you also want to remove them, delete the attendee separately after
-            refunding.
+            The attendee <strong>remains registered</strong>. A refund only
+            clears their payment record &mdash; it does not remove them from the
+            event. If you also want to remove them, delete the attendee
+            separately after refunding.
           </p>
           <p>
             Refunds are per-event. If the attendee is registered for multiple
@@ -1042,9 +1007,9 @@ export const adminGuidePage = (
         <Q q="What are holidays?">
           <p>
             Holidays are date ranges when no daily events can be booked. Add
-            them from the <strong>Holidays</strong>{" "}
-            page. Any dates falling within a holiday range are removed from the
-            booking calendar for all daily events.
+            them from the <strong>Holidays</strong> page. Any dates falling
+            within a holiday range are removed from the booking calendar for all
+            daily events.
           </p>
         </Q>
       </Section>
@@ -1077,10 +1042,10 @@ export const adminGuidePage = (
         <Q q="How do I use the QR scanner?">
           <p>
             Open an event and click <strong>Scanner</strong>. Tap{" "}
-            <strong>Start Camera</strong>{" "}
-            to begin (grants camera permission on first use). Point the camera
-            at an attendee's QR code and check-in happens automatically. The
-            scanner works best with the rear camera on mobile devices.
+            <strong>Start Camera</strong> to begin (grants camera permission on
+            first use). Point the camera at an attendee's QR code and check-in
+            happens automatically. The scanner works best with the rear camera
+            on mobile devices.
           </p>
         </Q>
 
@@ -1105,32 +1070,28 @@ export const adminGuidePage = (
 
         <Q q="What do the scanner status messages mean?">
           <p>
-            <strong>Checked in</strong>{" "}
-            &mdash; shows the attendee's name and ticket count (e.g. "Jo checked
-            in (2 tickets)"). <strong>Already checked in</strong>{" "}
-            &mdash; they were already marked as arrived.{" "}
-            <strong>Refunded</strong>{" "}
-            &mdash; the attendee has been refunded and cannot be checked in.
-            {" "}
-            <strong>Ticket not found</strong>{" "}
+            <strong>Checked in</strong> &mdash; shows the attendee's name and
+            ticket count (e.g. "Jo checked in (2 tickets)").{" "}
+            <strong>Already checked in</strong> &mdash; they were already marked
+            as arrived. <strong>Refunded</strong> &mdash; the attendee has been
+            refunded and cannot be checked in. <strong>Ticket not found</strong>{" "}
             &mdash; the QR code doesn't match any registration.{" "}
-            <strong>Different event</strong>{" "}
-            &mdash; a confirmation dialogue asks whether to check them in
-            anyway. <strong>ID verification</strong>{" "}
-            &mdash; for non-transferable events, staff are asked to confirm the
-            attendee's ID matches the ticket name before check-in proceeds.
+            <strong>Different event</strong> &mdash; a confirmation dialogue
+            asks whether to check them in anyway.{" "}
+            <strong>ID verification</strong> &mdash; for non-transferable
+            events, staff are asked to confirm the attendee's ID matches the
+            ticket name before check-in proceeds.
           </p>
         </Q>
 
         <Q q="What if someone doesn't have their QR code?">
           <p>
             Below the camera on the Scanner page there is a{" "}
-            <strong>Manual Check-in</strong>{" "}
-            section. Start typing the attendee's name or ticket token and a
-            dropdown shows matching tickets that haven't been checked in yet.
-            Select the right person and click{" "}
-            <strong>Check In</strong>. This is useful for walk-ins or when an
-            attendee can't pull up their ticket on their phone.
+            <strong>Manual Check-in</strong> section. Start typing the
+            attendee's name or ticket token and a dropdown shows matching
+            tickets that haven't been checked in yet. Select the right person
+            and click <strong>Check In</strong>. This is useful for walk-ins or
+            when an attendee can't pull up their ticket on their phone.
           </p>
         </Q>
 
@@ -1151,12 +1112,11 @@ export const adminGuidePage = (
         <Q q="What is Apple Wallet integration?">
           <p>
             When configured, attendees see an{" "}
-            <strong>Add to Apple Wallet</strong>{" "}
-            button on their ticket page. Tapping it downloads a{" "}
-            <code>.pkpass</code>{" "}
-            file that adds the ticket to their iPhone Wallet and Apple Watch.
-            The pass shows the event name, date, location, ticket quantity,
-            price paid, and a QR code for check-in.
+            <strong>Add to Apple Wallet</strong> button on their ticket page.
+            Tapping it downloads a <code>.pkpass</code> file that adds the
+            ticket to their iPhone Wallet and Apple Watch. The pass shows the
+            event name, date, location, ticket quantity, price paid, and a QR
+            code for check-in.
           </p>
         </Q>
 
@@ -1167,16 +1127,15 @@ export const adminGuidePage = (
               using pass type{" "}
               <code>{hostConfig.hostAppleWalletPassTypeId}</code>. The Add to
               Apple Wallet button should appear automatically on all ticket
-              pages. You can override this by entering your own credentials in
-              {" "}
+              pages. You can override this by entering your own credentials in{" "}
               <a href="/admin/settings">Settings</a>.
             </p>
           )}
           <p>
             Go to <a href="/admin/settings">Settings</a>, click{" "}
             <strong>Advanced Settings</strong>, and find the{" "}
-            <strong>Apple Wallet</strong>{" "}
-            section. You need five values from your Apple Developer account:
+            <strong>Apple Wallet</strong> section. You need five values from
+            your Apple Developer account:
           </p>
           <ol>
             <li>
@@ -1187,17 +1146,16 @@ export const adminGuidePage = (
               <strong>Team ID</strong> &mdash; your Apple Developer Team ID
             </li>
             <li>
-              <strong>Signing Certificate</strong>{" "}
-              &mdash; PEM-encoded certificate for your Pass Type ID
+              <strong>Signing Certificate</strong> &mdash; PEM-encoded
+              certificate for your Pass Type ID
             </li>
             <li>
-              <strong>Signing Key</strong>{" "}
-              &mdash; PEM-encoded private key for the certificate
+              <strong>Signing Key</strong> &mdash; PEM-encoded private key for
+              the certificate
             </li>
             <li>
-              <strong>WWDR Certificate</strong>{" "}
-              &mdash; Apple's intermediate certificate (download from the Apple
-              Developer portal)
+              <strong>WWDR Certificate</strong> &mdash; Apple's intermediate
+              certificate (download from the Apple Developer portal)
             </li>
           </ol>
           <p>
@@ -1222,11 +1180,10 @@ export const adminGuidePage = (
         <Q q="What is Google Wallet integration?">
           <p>
             When configured, attendees see an{" "}
-            <strong>Add to Google Wallet</strong>{" "}
-            button on their ticket page. Tapping it adds the ticket to their
-            Android device's Google Wallet app. The pass shows the event name,
-            date, location, ticket quantity, price paid, and a QR code for
-            check-in.
+            <strong>Add to Google Wallet</strong> button on their ticket page.
+            Tapping it adds the ticket to their Android device's Google Wallet
+            app. The pass shows the event name, date, location, ticket quantity,
+            price paid, and a QR code for check-in.
           </p>
         </Q>
 
@@ -1243,8 +1200,8 @@ export const adminGuidePage = (
           <p>
             Go to <a href="/admin/settings">Settings</a>, click{" "}
             <strong>Advanced Settings</strong>, and find the{" "}
-            <strong>Google Wallet</strong>{" "}
-            section. You need three values from your Google Cloud account:
+            <strong>Google Wallet</strong> section. You need three values from
+            your Google Cloud account:
           </p>
           <ol>
             <li>
@@ -1254,13 +1211,12 @@ export const adminGuidePage = (
               </a>
             </li>
             <li>
-              <strong>Service Account Email</strong>{" "}
-              &mdash; a Google Cloud service account with the Google Wallet API
-              enabled
+              <strong>Service Account Email</strong> &mdash; a Google Cloud
+              service account with the Google Wallet API enabled
             </li>
             <li>
-              <strong>Service Account Private Key</strong>{" "}
-              &mdash; PEM-encoded RSA private key for the service account
+              <strong>Service Account Private Key</strong> &mdash; PEM-encoded
+              RSA private key for the service account
             </li>
           </ol>
           <p>
@@ -1284,21 +1240,19 @@ export const adminGuidePage = (
       <Section id="user-classes" title="Users &amp; Permissions">
         <Q q="What's the difference between an owner and a manager?">
           <p>
-            <strong>Owners</strong>{" "}
-            have full access: events, calendar, groups, questions, holidays,
-            users, site pages, settings, API keys, sessions, and the activity
-            log. <strong>Managers</strong>{" "}
-            can manage events, view the calendar, manage groups, issue refunds,
-            and view the activity log. They cannot change settings, manage
-            users, manage questions or holidays, create API keys, edit site
-            pages, or view sessions.
+            <strong>Owners</strong> have full access: events, calendar, groups,
+            questions, holidays, users, site pages, settings, API keys,
+            sessions, and the activity log. <strong>Managers</strong> can manage
+            events, view the calendar, manage groups, issue refunds, and view
+            the activity log. They cannot change settings, manage users, manage
+            questions or holidays, create API keys, edit site pages, or view
+            sessions.
           </p>
         </Q>
 
         <Q q="How do I invite another admin?">
           <p>
-            Go to{" "}
-            <strong>Users</strong>, enter a username and choose their role
+            Go to <strong>Users</strong>, enter a username and choose their role
             (owner or manager). You'll receive an invite link to send them. They
             use the link to set their password and activate their account.
           </p>
@@ -1306,9 +1260,9 @@ export const adminGuidePage = (
 
         <Q q="How long do invite links last?">
           <p>
-            Invite links expire after{" "}
-            <strong>7 days</strong>. If the link expires before the person uses
-            it, you'll need to delete the pending user and create a new invite.
+            Invite links expire after <strong>7 days</strong>. If the link
+            expires before the person uses it, you'll need to delete the pending
+            user and create a new invite.
           </p>
         </Q>
       </Section>
@@ -1316,8 +1270,8 @@ export const adminGuidePage = (
       <Section id="login-security" title="Login &amp; Security">
         <Q q="What happens if I enter the wrong password?">
           <p>
-            After <strong>5 failed login attempts</strong>{" "}
-            from the same IP address, the system locks out that IP for{" "}
+            After <strong>5 failed login attempts</strong> from the same IP
+            address, the system locks out that IP for{" "}
             <strong>15 minutes</strong>. During the lockout, all login attempts
             from that IP are rejected &mdash; even with the correct password.
             Wait for the lockout period to pass and try again.
@@ -1335,24 +1289,22 @@ export const adminGuidePage = (
 
         <Q q="Is there a way to recover a lost password?">
           <p>
-            No. There is <strong>no password recovery</strong>{" "}
-            mechanism. All attendee data is encrypted with keys derived from
-            admin passwords, so a reset would make existing data unreadable. If
-            you lose your password, another owner can delete your account and
-            send a fresh invite &mdash; all existing attendee data remains
-            accessible to other admins. Keep your password somewhere safe.
+            No. There is <strong>no password recovery</strong> mechanism. All
+            attendee data is encrypted with keys derived from admin passwords,
+            so a reset would make existing data unreadable. If you lose your
+            password, another owner can delete your account and send a fresh
+            invite &mdash; all existing attendee data remains accessible to
+            other admins. Keep your password somewhere safe.
           </p>
         </Q>
 
         <Q q="How are admin sessions secured?">
           <p>
             Sessions use HttpOnly cookies that cannot be read by JavaScript.
-            Each session expires after{" "}
-            <strong>24 hours</strong>, after which you must log in again. You
-            can view all active sessions and log out all other sessions from the
-            {" "}
-            <strong>Sessions</strong>{" "}
-            page if you suspect your account has been compromised.
+            Each session expires after <strong>24 hours</strong>, after which
+            you must log in again. You can view all active sessions and log out
+            all other sessions from the <strong>Sessions</strong> page if you
+            suspect your account has been compromised.
           </p>
         </Q>
       </Section>
@@ -1370,11 +1322,10 @@ export const adminGuidePage = (
 
         <Q q="What happens if I lose my password?">
           <p>
-            There is{" "}
-            <strong>no password recovery</strong>. If you lose your password,
-            you cannot log in or decrypt any data. Keep your password safe.
-            Another owner can delete your account and send a fresh invite, and
-            all existing attendee data remains accessible to other admins.
+            There is <strong>no password recovery</strong>. If you lose your
+            password, you cannot log in or decrypt any data. Keep your password
+            safe. Another owner can delete your account and send a fresh invite,
+            and all existing attendee data remains accessible to other admins.
           </p>
         </Q>
 
@@ -1392,12 +1343,11 @@ export const adminGuidePage = (
 
         <Q q="What does 'reset database' do?">
           <p>
-            It permanently deletes{" "}
-            <strong>everything</strong>: all events, attendees, groups,
-            questions, users, holidays, API keys, activity logs, payment
-            configuration, and sessions. The system returns to its initial setup
-            state. You must type a confirmation phrase to proceed. This cannot
-            be undone.
+            It permanently deletes <strong>everything</strong>: all events,
+            attendees, groups, questions, users, holidays, API keys, activity
+            logs, payment configuration, and sessions. The system returns to its
+            initial setup state. You must type a confirmation phrase to proceed.
+            This cannot be undone.
           </p>
         </Q>
       </Section>
@@ -1431,12 +1381,9 @@ export const adminGuidePage = (
           </pre>
           <p>
             Prices are in the smallest currency unit (e.g. pence for GBP, cents
-            for USD). The <code>ticket_url</code>{" "}
-            links to the attendee's ticket page. For multi-event bookings the
-            {" "}
-            <code>tickets</code>{" "}
-            array contains one entry per event, all sharing the same ticket
-            token.
+            for USD). The <code>ticket_url</code> links to the attendee's ticket
+            page. For multi-event bookings the <code>tickets</code> array
+            contains one entry per event, all sharing the same ticket token.
           </p>
         </Q>
       </Section>
@@ -1452,8 +1399,7 @@ export const adminGuidePage = (
 
         <Q q="What happens when I change my password?">
           <p>
-            Changing your password <strong>ends every active session</strong>
-            {" "}
+            Changing your password <strong>ends every active session</strong>{" "}
             for your account &mdash; you and anyone else signed in as you will
             be logged out and must sign in again with the new password.
           </p>
@@ -1466,19 +1412,18 @@ export const adminGuidePage = (
 
         <Q q="How do I log out other users?">
           <p>
-            On the <strong>Sessions</strong>{" "}
-            page, click "Log out of all other sessions". This ends every session
-            except your own, forcing all other admins to log in again. Useful if
-            you suspect an account has been compromised.
+            On the <strong>Sessions</strong> page, click "Log out of all other
+            sessions". This ends every session except your own, forcing all
+            other admins to log in again. Useful if you suspect an account has
+            been compromised.
           </p>
         </Q>
 
         <Q q="What happens after too many failed login attempts?">
           <p>
             The login form is protected by per-IP rate limiting. After{" "}
-            <strong>{MAX_LOGIN_ATTEMPTS} failed attempts</strong>{" "}
-            from the same IP address, further login attempts from that IP are
-            blocked for{" "}
+            <strong>{MAX_LOGIN_ATTEMPTS} failed attempts</strong> from the same
+            IP address, further login attempts from that IP are blocked for{" "}
             <strong>{LOGIN_LOCKOUT_MS / 60_000} minutes</strong>. A successful
             login clears the counter immediately. This defends against password
             guessing and credential stuffing.
@@ -1497,11 +1442,11 @@ export const adminGuidePage = (
       <Section id="calendar" title="Calendar">
         <Q q="What is the calendar page?">
           <p>
-            The <strong>Calendar</strong>{" "}
-            page lets you pick a date and see every attendee booked across all
-            events on that day. This is especially useful for daily events. You
-            can export a CSV of the day's attendees and manage check-ins, edits,
-            and deletions from the same view.
+            The <strong>Calendar</strong> page lets you pick a date and see
+            every attendee booked across all events on that day. This is
+            especially useful for daily events. You can export a CSV of the
+            day's attendees and manage check-ins, edits, and deletions from the
+            same view.
           </p>
         </Q>
       </Section>
@@ -1509,12 +1454,11 @@ export const adminGuidePage = (
       <Section id="activity-log" title="Activity Log">
         <Q q="What is the activity log?">
           <p>
-            The <strong>Log</strong>{" "}
-            page shows a chronological list of admin actions such as event
-            creation, event updates, attendee changes, and question changes.
-            Both owners and managers can view the log. Each event also has its
-            own log, accessible from the event page, showing only actions
-            related to that event.
+            The <strong>Log</strong> page shows a chronological list of admin
+            actions such as event creation, event updates, attendee changes, and
+            question changes. Both owners and managers can view the log. Each
+            event also has its own log, accessible from the event page, showing
+            only actions related to that event.
           </p>
         </Q>
       </Section>
@@ -1523,13 +1467,12 @@ export const adminGuidePage = (
         <Q q="What are email notifications?">
           <p>
             When configured, the system can send up to two emails after each
-            successful registration: a <strong>confirmation email</strong>{" "}
-            to the attendee (if they provided an email address) with their
-            ticket details and link, and a <strong>notification email</strong>
-            {" "}
-            to the business email address (if one is set) letting you know
-            someone has booked. Emails are sent in the background and won't
-            delay the booking process.
+            successful registration: a <strong>confirmation email</strong> to
+            the attendee (if they provided an email address) with their ticket
+            details and link, and a <strong>notification email</strong> to the
+            business email address (if one is set) letting you know someone has
+            booked. Emails are sent in the background and won't delay the
+            booking process.
           </p>
         </Q>
 
@@ -1565,10 +1508,8 @@ export const adminGuidePage = (
         <Q q="How do I set up email?">
           {hostConfig?.hostEmailProvider && (
             <p>
-              Email is already configured by your server administrator using
-              {" "}
-              <strong>{hostConfig.hostEmailProvider}</strong> with from address
-              {" "}
+              Email is already configured by your server administrator using{" "}
+              <strong>{hostConfig.hostEmailProvider}</strong> with from address{" "}
               <code>{hostConfig.hostEmailFromAddress}</code>. You can override
               this by entering your own provider and API key in{" "}
               <a href="/admin/settings">Settings</a>. If you provide your own
@@ -1582,14 +1523,13 @@ export const adminGuidePage = (
             </li>
             <li>Choose your email provider from the dropdown</li>
             <li>
-              Paste your provider's API key into the <strong>API Key</strong>
-              {" "}
+              Paste your provider's API key into the <strong>API Key</strong>{" "}
               field
             </li>
             <li>
-              Enter a <strong>From Address</strong>{" "}
-              &mdash; this is the sender address that appears on outgoing
-              emails. If left blank, the business email address is used instead
+              Enter a <strong>From Address</strong> &mdash; this is the sender
+              address that appears on outgoing emails. If left blank, the
+              business email address is used instead
             </li>
             <li>Save the settings</li>
           </ol>
@@ -1602,8 +1542,7 @@ export const adminGuidePage = (
 
         <Q q="How do I test that email is working?">
           <p>
-            After saving your email settings, a <strong>Send Test Email</strong>
-            {" "}
+            After saving your email settings, a <strong>Send Test Email</strong>{" "}
             button appears. Click it to send a test email to your business email
             address. If the test fails, you'll see an error with the HTTP status
             code from your provider &mdash; check that your API key is correct
@@ -1625,11 +1564,11 @@ export const adminGuidePage = (
             price paid, and a clickable link to their ticket page. Each email
             also includes an SVG ticket image as an attachment &mdash; one per
             event, with a QR code for check-in. For{" "}
-            <strong>Purchase Only</strong>{" "}
-            events the QR code is omitted since there is no check-in. For
-            multi-event bookings, all events are listed in a single email with
-            numbered ticket attachments. The business email is set as the
-            reply-to address so attendees can reply directly to you.
+            <strong>Purchase Only</strong> events the QR code is omitted since
+            there is no check-in. For multi-event bookings, all events are
+            listed in a single email with numbered ticket attachments. The
+            business email is set as the reply-to address so attendees can reply
+            directly to you.
           </p>
         </Q>
 
@@ -1646,26 +1585,23 @@ export const adminGuidePage = (
       <Section id="email-templates" title="Email Templates">
         <Q q="Can I customise the emails that are sent?">
           <p>
-            Yes. In{" "}
-            <a href="/admin/settings">Settings</a>, scroll to the email template
-            sections. You can customise both the{" "}
-            <strong>confirmation email</strong> (sent to the attendee) and the
-            {" "}
-            <strong>admin notification email</strong>{" "}
-            (sent to you). Each has three parts: subject line, HTML body, and
-            plain text body.
+            Yes. In <a href="/admin/settings">Settings</a>, scroll to the email
+            template sections. You can customise both the{" "}
+            <strong>confirmation email</strong> (sent to the attendee) and the{" "}
+            <strong>admin notification email</strong> (sent to you). Each has
+            three parts: subject line, HTML body, and plain text body.
           </p>
           <p>
-            Templates use <a href="https://liquidjs.com/">Liquid</a>{" "}
-            syntax. Clear any field to revert to the built-in default.
+            Templates use <a href="https://liquidjs.com/">Liquid</a> syntax.
+            Clear any field to revert to the built-in default.
           </p>
         </Q>
 
         <Q q="What variables can I use in templates?">
           <ul>
             <li>
-              <code>{"{{ event_names }}"}</code>{" "}
-              &mdash; all event names joined with &ldquo;and&rdquo;
+              <code>{"{{ event_names }}"}</code> &mdash; all event names joined
+              with &ldquo;and&rdquo;
             </li>
             <li>
               <code>{"{{ ticket_url }}"}</code> &mdash; link to view tickets
@@ -1688,10 +1624,8 @@ export const adminGuidePage = (
           </ul>
           <p>
             For multi-event bookings, loop through the <code>entries</code>{" "}
-            array: <code>{"{% for entry in entries %}"}</code>. Each entry has
-            {" "}
-            <code>entry.event.name</code>, <code>entry.attendee.quantity</code>,
-            {" "}
+            array: <code>{"{% for entry in entries %}"}</code>. Each entry has{" "}
+            <code>entry.event.name</code>, <code>entry.attendee.quantity</code>,{" "}
             <code>entry.attendee.date</code>, etc. The quantity and date are
             per-event &mdash; each entry shows the values for that specific
             event registration.
@@ -1702,8 +1636,8 @@ export const adminGuidePage = (
           <p>Two custom filters are built in:</p>
           <ul>
             <li>
-              <code>{"{{ amount | currency }}"}</code>{" "}
-              &mdash; formats a number as currency (e.g. &pound;15.00)
+              <code>{"{{ amount | currency }}"}</code> &mdash; formats a number
+              as currency (e.g. &pound;15.00)
             </li>
             <li>
               <code>{'{{ count | pluralize: "ticket", "tickets" }}'}</code>{" "}
@@ -1730,8 +1664,7 @@ export const adminGuidePage = (
               my-business
               {hostConfig?.bunnyDnsSubdomainSuffix || ".example.com"}
             </code>
-            ) instead of using the default CDN hostname. The option appears in
-            {" "}
+            ) instead of using the default CDN hostname. The option appears in{" "}
             <strong>Advanced Settings</strong> under{" "}
             <strong>Host Subdomain</strong>.
           </p>
@@ -1740,9 +1673,8 @@ export const adminGuidePage = (
         <Q q="How do I register a subdomain?">
           <ol>
             <li>
-              Go to <a href="/admin/settings-advanced">Advanced Settings</a>
-              {" "}
-              and find the <strong>Host Subdomain</strong> section
+              Go to <a href="/admin/settings-advanced">Advanced Settings</a> and
+              find the <strong>Host Subdomain</strong> section
             </li>
             <li>
               Enter your preferred subdomain name (lowercase letters, numbers,
@@ -1750,8 +1682,7 @@ export const adminGuidePage = (
             </li>
             <li>
               Click{" "}
-              <strong>Check Availability &amp; Preview Complete Domain</strong>
-              {" "}
+              <strong>Check Availability &amp; Preview Complete Domain</strong>{" "}
               to see the full URL and verify it's available
             </li>
             <li>
@@ -1777,15 +1708,13 @@ export const adminGuidePage = (
       <Section id="custom-domain" title="Custom Domain">
         <Q q="How do I set up a custom domain?">
           <p>
-            If your site runs on Bunny CDN and the <code>BUNNY_API_KEY</code>
-            {" "}
-            and <code>BUNNY_SCRIPT_ID</code>{" "}
-            environment variables are configured, you'll see a{" "}
-            <strong>Custom Domain</strong> section in{" "}
+            If your site runs on Bunny CDN and the <code>BUNNY_API_KEY</code>{" "}
+            and <code>BUNNY_SCRIPT_ID</code> environment variables are
+            configured, you'll see a <strong>Custom Domain</strong> section in{" "}
             <a href="/admin/settings-advanced">Advanced Settings</a>. Enter your
-            domain (e.g.{" "}
-            <code>tickets.yourdomain.com</code>) and save, then follow the CNAME
-            instructions shown and click <strong>Validate</strong>.
+            domain (e.g. <code>tickets.yourdomain.com</code>) and save, then
+            follow the CNAME instructions shown and click{" "}
+            <strong>Validate</strong>.
           </p>
         </Q>
 
@@ -1803,8 +1732,8 @@ export const adminGuidePage = (
             it fails &mdash; usually because DNS hasn't propagated yet &mdash;
             your domain is still saved and you'll see a warning. Create the
             CNAME record shown on the page, wait a few minutes for DNS to
-            propagate, then click <strong>Validate Custom Domain</strong>{" "}
-            to try again.
+            propagate, then click <strong>Validate Custom Domain</strong> to try
+            again.
           </p>
         </Q>
       </Section>
@@ -1816,37 +1745,36 @@ export const adminGuidePage = (
           </p>
           <ul>
             <li>
-              <strong>Country</strong>{" "}
-              &mdash; sets your timezone, currency, and phone prefix in one step
+              <strong>Country</strong> &mdash; sets your timezone, currency, and
+              phone prefix in one step
             </li>
             <li>
-              <strong>Business email</strong>{" "}
-              &mdash; receives admin notification emails, used as reply-to on
-              attendee confirmations, and included in webhook payloads
+              <strong>Business email</strong> &mdash; receives admin
+              notification emails, used as reply-to on attendee confirmations,
+              and included in webhook payloads
             </li>
             <li>
               <strong>Payment provider</strong> &mdash; Stripe, Square, or none
             </li>
             <li>
-              <strong>Booking fee</strong>{" "}
-              &mdash; percentage-based fee added to ticket prices (requires a
-              payment provider)
+              <strong>Booking fee</strong> &mdash; percentage-based fee added to
+              ticket prices (requires a payment provider)
             </li>
             <li>
-              <strong>Header image</strong>{" "}
-              &mdash; upload a logo or banner shown at the top of every page
+              <strong>Header image</strong> &mdash; upload a logo or banner
+              shown at the top of every page
             </li>
             <li>
-              <strong>Embed hosts</strong>{" "}
-              &mdash; restrict which websites can embed your booking forms
+              <strong>Embed hosts</strong> &mdash; restrict which websites can
+              embed your booking forms
             </li>
             <li>
-              <strong>Terms and conditions</strong>{" "}
-              &mdash; attendees must agree before booking
+              <strong>Terms and conditions</strong> &mdash; attendees must agree
+              before booking
             </li>
             <li>
-              <strong>Show public site</strong>{" "}
-              &mdash; enable or disable the public-facing website
+              <strong>Show public site</strong> &mdash; enable or disable the
+              public-facing website
             </li>
             <li>
               <strong>Site theme</strong> &mdash; light or dark
@@ -1859,86 +1787,79 @@ export const adminGuidePage = (
 
         <Q q="How does the header image work?">
           <p>
-            Upload a logo or banner from <strong>Settings</strong>{" "}
-            and it appears at the top of every admin and public page. The image
-            is encrypted and served through the{" "}
-            <code>/image/</code>{" "}
-            proxy with long-lived immutable cache headers, so browsers only
-            download it once.
+            Upload a logo or banner from <strong>Settings</strong> and it
+            appears at the top of every admin and public page. The image is
+            encrypted and served through the <code>/image/</code> proxy with
+            long-lived immutable cache headers, so browsers only download it
+            once.
           </p>
           <p>
             Supported formats are JPEG, PNG, GIF, and WebP, up to 256&nbsp;KB.
             Uploading a new image automatically deletes the old one, and the{" "}
             <strong>Remove Image</strong> button clears it completely. If image
             storage isn't configured the section is hidden &mdash; see{" "}
-            <strong>Advanced Settings</strong>{" "}
-            to set up a Bunny storage zone.
+            <strong>Advanced Settings</strong> to set up a Bunny storage zone.
           </p>
         </Q>
 
         <Q q="What are Advanced Settings?">
           <p>
             The main Settings page has a link to{" "}
-            <strong>Advanced Settings</strong>{" "}
-            for less common configuration. Advanced settings include:
+            <strong>Advanced Settings</strong> for less common configuration.
+            Advanced settings include:
           </p>
           <ul>
             <li>
-              <strong>Public API</strong>{" "}
-              &mdash; enable the JSON API for external integrations
+              <strong>Public API</strong> &mdash; enable the JSON API for
+              external integrations
             </li>
             <li>
-              <strong>Apple Wallet</strong>{" "}
-              &mdash; configure pass signing certificates for Add to Apple
-              Wallet
+              <strong>Apple Wallet</strong> &mdash; configure pass signing
+              certificates for Add to Apple Wallet
             </li>
             <li>
-              <strong>Google Wallet</strong>{" "}
-              &mdash; configure service account credentials for Add to Google
-              Wallet
+              <strong>Google Wallet</strong> &mdash; configure service account
+              credentials for Add to Google Wallet
             </li>
             <li>
-              <strong>Email provider</strong>{" "}
-              &mdash; choose and configure your email sending service
+              <strong>Email provider</strong> &mdash; choose and configure your
+              email sending service
             </li>
             <li>
-              <strong>Email templates</strong>{" "}
-              &mdash; customise confirmation and admin notification emails using
-              Liquid syntax
+              <strong>Email templates</strong> &mdash; customise confirmation
+              and admin notification emails using Liquid syntax
             </li>
             <li>
-              <strong>Host subdomain</strong>{" "}
-              &mdash; register a pretty subdomain for your site (when enabled by
-              server administrator)
+              <strong>Host subdomain</strong> &mdash; register a pretty
+              subdomain for your site (when enabled by server administrator)
             </li>
             <li>
-              <strong>Custom domain</strong>{" "}
-              &mdash; set up a custom domain for your site (Bunny CDN only)
+              <strong>Custom domain</strong> &mdash; set up a custom domain for
+              your site (Bunny CDN only)
             </li>
             <li>
-              <strong>Backups</strong>{" "}
-              &mdash; create, download, and restore full database backups
-              (requires CDN storage)
+              <strong>Backups</strong> &mdash; create, download, and restore
+              full database backups (requires CDN storage)
             </li>
             <li>
-              <strong>Software updates</strong>{" "}
-              &mdash; check for and install new versions
+              <strong>Software updates</strong> &mdash; check for and install
+              new versions
             </li>
             <li>
-              <strong>Database reset</strong>{" "}
-              &mdash; permanently delete all data
+              <strong>Database reset</strong> &mdash; permanently delete all
+              data
             </li>
           </ul>
         </Q>
 
         <Q q="What is the debug page?">
           <p>
-            The debug page at <code>/admin/debug</code>{" "}
-            shows the configuration status of all integrated services (payments,
-            email, Apple Wallet, Google Wallet, storage, CDN, notifications,
-            database) without revealing any secrets or API keys. It's useful for
-            troubleshooting setup issues &mdash; you can quickly see which
-            services are configured and which are missing.
+            The debug page at <code>/admin/debug</code> shows the configuration
+            status of all integrated services (payments, email, Apple Wallet,
+            Google Wallet, storage, CDN, notifications, database) without
+            revealing any secrets or API keys. It's useful for troubleshooting
+            setup issues &mdash; you can quickly see which services are
+            configured and which are missing.
           </p>
           <p>
             The page also lists every tunable system limit (file-size caps,
@@ -1978,23 +1899,22 @@ export const adminGuidePage = (
         <Section id="built-sites" title="Built Sites">
           <Q q="What are built sites?">
             <p>
-              The <strong>Built Sites</strong>{" "}
-              page (owners only) keeps a registry of Tickets instances you've
-              deployed. Each entry records the site name and its Bunny CDN URL.
-              You can add, edit, and delete entries to keep track of all the
-              instances you manage.
+              The <strong>Built Sites</strong> page (owners only) keeps a
+              registry of Tickets instances you've deployed. Each entry records
+              the site name and its Bunny CDN URL. You can add, edit, and delete
+              entries to keep track of all the instances you manage.
             </p>
           </Q>
 
           <Q q="How do I create a new Tickets instance?">
             <p>
-              Visit <code>/admin/builder</code>{" "}
-              to deploy a new instance. Enter a site name, database URL (libsql
-              format), and database token. The builder will fetch the latest
-              release code from GitHub, create a Bunny edge script, configure
-              secrets (including a generated encryption key), test the database
-              connection, and publish the site. Host-level configuration such as
-              email, wallet, and storage settings are copied automatically.
+              Visit <code>/admin/builder</code> to deploy a new instance. Enter
+              a site name, database URL (libsql format), and database token. The
+              builder will fetch the latest release code from GitHub, create a
+              Bunny edge script, configure secrets (including a generated
+              encryption key), test the database connection, and publish the
+              site. Host-level configuration such as email, wallet, and storage
+              settings are copied automatically.
             </p>
           </Q>
 
@@ -2002,17 +1922,17 @@ export const adminGuidePage = (
             <p>
               You need a libsql database (e.g. from{" "}
               <a href="https://turso.tech">Turso</a>) with its URL and auth
-              token. The server must have <code>BUNNY_API_KEY</code>{" "}
-              configured. The builder is owner-only.
+              token. The server must have <code>BUNNY_API_KEY</code> configured.
+              The builder is owner-only.
             </p>
           </Q>
 
           <Q q="Can I add a site record without using the builder?">
             <p>
               Yes. On the <strong>Built Sites</strong> page, click{" "}
-              <strong>Add Built Site</strong>{" "}
-              to manually record a site name and URL. This is useful for
-              tracking instances you deployed by other means.
+              <strong>Add Built Site</strong> to manually record a site name and
+              URL. This is useful for tracking instances you deployed by other
+              means.
             </p>
           </Q>
         </Section>
@@ -2027,13 +1947,11 @@ export const adminGuidePage = (
           <ul>
             <li>
               <strong>ICS calendar</strong> &mdash;{" "}
-              <code>/feeds/events.ics</code>{" "}
-              &mdash; subscribe from any calendar app (Google Calendar, Apple
-              Calendar, Thunderbird, etc.)
+              <code>/feeds/events.ics</code> &mdash; subscribe from any calendar
+              app (Google Calendar, Apple Calendar, Thunderbird, etc.)
             </li>
             <li>
-              <strong>RSS feed</strong> &mdash; <code>/feeds/events.rss</code>
-              {" "}
+              <strong>RSS feed</strong> &mdash; <code>/feeds/events.rss</code>{" "}
               &mdash; subscribe from any RSS reader
             </li>
           </ul>
@@ -2046,9 +1964,9 @@ export const adminGuidePage = (
 
         <Q q="How do I connect to Mobilizon?">
           <p>
-            <a href="https://mobilizon.org/">Mobilizon</a>{" "}
-            is a federated event platform. You can use its built-in importer to
-            pull events from your ICS feed:
+            <a href="https://mobilizon.org/">Mobilizon</a> is a federated event
+            platform. You can use its built-in importer to pull events from your
+            ICS feed:
           </p>
           <ol>
             <li>
@@ -2061,8 +1979,8 @@ export const adminGuidePage = (
               <code>https://{getEffectiveDomain()}/feeds/events.ics</code>
             </li>
             <li>
-              Set <strong>joinMode</strong> to <strong>external</strong>{" "}
-              so the &ldquo;Join&rdquo; button on Mobilizon links back to your
+              Set <strong>joinMode</strong> to <strong>external</strong> so the
+              &ldquo;Join&rdquo; button on Mobilizon links back to your
               registration page
             </li>
           </ol>
@@ -2080,8 +1998,7 @@ export const adminGuidePage = (
             booking functionality as the web interface. It lets you build custom
             frontends, integrate with other services, or automate bookings. The
             public endpoints below need no authentication. There is also an
-            admin API for managing events, groups, and holidays &mdash; see the
-            {" "}
+            admin API for managing events, groups, and holidays &mdash; see the{" "}
             <a href="#admin-api">Admin API</a> section below for details.
           </p>
         </Q>
@@ -2094,13 +2011,12 @@ export const adminGuidePage = (
           </p>
           <ul>
             <li>
-              <code>GET /api/events</code>{" "}
-              &mdash; list all active, non-hidden events
+              <code>GET /api/events</code> &mdash; list all active, non-hidden
+              events
             </li>
             <li>
-              <code>GET /api/events/:slug</code>{" "}
-              &mdash; get a single event by its slug (hidden events are
-              accessible if you know the slug)
+              <code>GET /api/events/:slug</code> &mdash; get a single event by
+              its slug (hidden events are accessible if you know the slug)
             </li>
             <li>
               <code>
@@ -2125,8 +2041,8 @@ export const adminGuidePage = (
           </pre>
           <p>
             Prices are in the smallest currency unit (e.g. pence for GBP, cents
-            for USD). <code>maxPurchasable</code>{" "}
-            is 0 when the event is sold out or registration is closed.
+            for USD). <code>maxPurchasable</code> is 0 when the event is sold
+            out or registration is closed.
           </p>
         </Q>
 
@@ -2135,10 +2051,9 @@ export const adminGuidePage = (
             <code>{`GET /api/events/summer-workshop\n\nResponse:\n${API_SINGLE_EXAMPLE_JSON}`}</code>
           </pre>
           <p>
-            The <code>availableDates</code>{" "}
-            field is only included for daily events. Returns{" "}
-            <code>{'{ "error": "Event not found" }'}</code>{" "}
-            with status 404 if the event doesn&apos;t exist or is inactive.
+            The <code>availableDates</code> field is only included for daily
+            events. Returns <code>{'{ "error": "Event not found" }'}</code> with
+            status 404 if the event doesn&apos;t exist or is inactive.
           </p>
         </Q>
 
@@ -2147,9 +2062,8 @@ export const adminGuidePage = (
             <code>{`GET /api/events/summer-workshop/availability?quantity=2\n\nResponse:\n${API_AVAILABILITY_EXAMPLE_JSON}`}</code>
           </pre>
           <p>
-            For daily events, add <code>&amp;date=YYYY-MM-DD</code>{" "}
-            to check a specific date. The <code>quantity</code>{" "}
-            parameter defaults to 1.
+            For daily events, add <code>&amp;date=YYYY-MM-DD</code> to check a
+            specific date. The <code>quantity</code> parameter defaults to 1.
           </p>
         </Q>
 
@@ -2158,12 +2072,11 @@ export const adminGuidePage = (
             <code>{`POST /api/events/summer-workshop/book\nContent-Type: application/json\n\n${API_BOOK_REQUEST_JSON}`}</code>
           </pre>
           <p>
-            Which fields are required depends on the event's field settings. The
-            {" "}
-            <code>name</code> field is always required. <code>date</code>{" "}
-            is required for daily events (use a date from{" "}
-            <code>availableDates</code>). <code>customPrice</code>{" "}
-            is for pay-more events only (in major currency units, e.g. 10.00 for
+            Which fields are required depends on the event's field settings. The{" "}
+            <code>name</code> field is always required. <code>date</code> is
+            required for daily events (use a date from{" "}
+            <code>availableDates</code>). <code>customPrice</code> is for
+            pay-more events only (in major currency units, e.g. 10.00 for
             &pound;10).
           </p>
           <p>
@@ -2179,29 +2092,28 @@ export const adminGuidePage = (
             <code>{API_BOOK_PAID_EXAMPLE_JSON}</code>
           </pre>
           <p>
-            Redirect the user to <code>checkoutUrl</code>{" "}
-            to complete payment. Possible error responses: 400 (validation error
-            or registration closed), 404 (event not found), 409 (not enough
-            spots available).
+            Redirect the user to <code>checkoutUrl</code> to complete payment.
+            Possible error responses: 400 (validation error or registration
+            closed), 404 (event not found), 409 (not enough spots available).
           </p>
         </Q>
 
         <Q q="What data does the API expose?">
           <p>
-            The API exposes <strong>exactly the same data</strong>{" "}
-            as the public booking pages &mdash; no more. Internal fields like
-            capacity limits, attendee counts, close times, and webhook URLs are
-            never included. The <code>isSoldOut</code>,{" "}
-            <code>isClosed</code>, and <code>maxPurchasable</code>{" "}
-            fields are derived values, not raw database fields.
+            The API exposes <strong>exactly the same data</strong> as the public
+            booking pages &mdash; no more. Internal fields like capacity limits,
+            attendee counts, close times, and webhook URLs are never included.
+            The <code>isSoldOut</code>, <code>isClosed</code>, and{" "}
+            <code>maxPurchasable</code> fields are derived values, not raw
+            database fields.
           </p>
         </Q>
 
         <Q q="Where can I find the full API reference?">
           <p>
-            The <a href="/admin/api-keys/docs">API documentation page</a>{" "}
-            has a complete reference for both public and admin API endpoints,
-            with example request and response payloads for each.
+            The <a href="/admin/api-keys/docs">API documentation page</a> has a
+            complete reference for both public and admin API endpoints, with
+            example request and response payloads for each.
           </p>
         </Q>
       </Section>
@@ -2220,32 +2132,31 @@ export const adminGuidePage = (
         <Q q="How do I create an API key?">
           <p>
             Open <a href="/admin/api-keys">API Keys</a> (under{" "}
-            <strong>Users</strong>{" "}
-            in the navigation), enter a descriptive name for the key (e.g. "CI
-            pipeline" or "Zapier integration"), and click{" "}
+            <strong>Users</strong> in the navigation), enter a descriptive name
+            for the key (e.g. "CI pipeline" or "Zapier integration"), and click{" "}
             <strong>Create key</strong>.
           </p>
           <p>
-            <strong>The full key is shown only once.</strong>{" "}
-            Copy it immediately and store it somewhere secure &mdash; once you
-            leave the page there is no way to retrieve it again. If you lose a
-            key, delete it and create a new one.
+            <strong>The full key is shown only once.</strong> Copy it
+            immediately and store it somewhere secure &mdash; once you leave the
+            page there is no way to retrieve it again. If you lose a key, delete
+            it and create a new one.
           </p>
         </Q>
 
         <Q q="How do I authenticate?">
           <p>
-            Send the key in the <code>Authorization</code>{" "}
-            header on every request:
+            Send the key in the <code>Authorization</code> header on every
+            request:
           </p>
           <pre>
             <code>Authorization: Bearer YOUR_API_KEY</code>
           </pre>
           <p>
             Bearer-authenticated requests do not need a CSRF token. Send JSON
-            request bodies with{" "}
-            <code>Content-Type: application/json</code>. Requests without a
-            valid key receive a <code>401 Invalid API key</code> response.
+            request bodies with <code>Content-Type: application/json</code>.
+            Requests without a valid key receive a{" "}
+            <code>401 Invalid API key</code> response.
           </p>
         </Q>
 
@@ -2280,30 +2191,27 @@ export const adminGuidePage = (
             </li>
           </ul>
           <p>
-            Delete requests must include a <code>confirm_identifier</code>{" "}
-            field that matches the resource name &mdash; the same way the web UI
+            Delete requests must include a <code>confirm_identifier</code> field
+            that matches the resource name &mdash; the same way the web UI
             requires you to type the name to confirm a delete. The{" "}
-            <a href="/admin/api-keys/docs">API documentation page</a>{" "}
-            shows the full request and response shape for every endpoint.
+            <a href="/admin/api-keys/docs">API documentation page</a> shows the
+            full request and response shape for every endpoint.
           </p>
         </Q>
 
         <Q q="How do I revoke an API key?">
           <p>
-            Open{" "}
-            <a href="/admin/api-keys">API Keys</a>, find the key in the list,
-            and click{" "}
-            <strong>Delete</strong>. You'll be asked to type the key's name to
-            confirm. Revocation is immediate &mdash; any integration using that
-            key will start receiving <code>401 Invalid API key</code>{" "}
-            on its next request, so switch integrations over to a new key before
-            deleting the old one.
+            Open <a href="/admin/api-keys">API Keys</a>, find the key in the
+            list, and click <strong>Delete</strong>. You'll be asked to type the
+            key's name to confirm. Revocation is immediate &mdash; any
+            integration using that key will start receiving{" "}
+            <code>401 Invalid API key</code> on its next request, so switch
+            integrations over to a new key before deleting the old one.
           </p>
           <p>
-            The <strong>Last used</strong>{" "}
-            column on the API Keys page shows when each key was most recently
-            accepted. Use it to spot keys that are no longer in use before
-            deleting them.
+            The <strong>Last used</strong> column on the API Keys page shows
+            when each key was most recently accepted. Use it to spot keys that
+            are no longer in use before deleting them.
           </p>
         </Q>
 
@@ -2311,11 +2219,10 @@ export const adminGuidePage = (
           <p>
             Each API key is tied to the owner who created it, because the key
             wraps that owner's data encryption key. When you delete an owner
-            from the <strong>Users</strong>{" "}
-            page, all of their API keys are deleted at the same time and any
-            integration using one of those keys will stop working immediately.
-            If a previous owner had keys in use, create new keys under another
-            owner before removing the old account.
+            from the <strong>Users</strong> page, all of their API keys are
+            deleted at the same time and any integration using one of those keys
+            will stop working immediately. If a previous owner had keys in use,
+            create new keys under another owner before removing the old account.
           </p>
         </Q>
       </Section>
@@ -2346,28 +2253,27 @@ export const adminGuidePage = (
             On the Backups page, upload a .zip backup file using the restore
             form. You'll see a summary of how many SQL statements it contains
             and whether the schema version matches. Type the full confirmation
-            phrase to proceed. <strong>Warning:</strong>{" "}
-            restoring drops all existing tables and replaces them with the
-            backup contents. This cannot be undone.
+            phrase to proceed. <strong>Warning:</strong> restoring drops all
+            existing tables and replaces them with the backup contents. This
+            cannot be undone.
           </p>
         </Q>
 
         <Q q="What is the encryption key shown on the backup page?">
           <p>
             The encryption key is needed if you ever restore a backup to a{" "}
-            <strong>different</strong>{" "}
-            site. All personal data in the database is encrypted at the field
-            level, so you need the same encryption key to read it. Store this
-            key securely &mdash; it cannot be recovered if lost.
+            <strong>different</strong> site. All personal data in the database
+            is encrypted at the field level, so you need the same encryption key
+            to read it. Store this key securely &mdash; it cannot be recovered
+            if lost.
           </p>
         </Q>
 
         <Q q="Do backups require any special configuration?">
           <p>
             Yes. Backups require CDN storage to be configured (
-            <code>STORAGE_ZONE_NAME</code> and{" "}
-            <code>STORAGE_ZONE_KEY</code>). The feature is designed for remote
-            databases (<code>libsql://</code>
+            <code>STORAGE_ZONE_NAME</code> and <code>STORAGE_ZONE_KEY</code>).
+            The feature is designed for remote databases (<code>libsql://</code>
             ). If storage is not configured, the backup page will show a message
             explaining this.
           </p>
@@ -2391,11 +2297,10 @@ export const adminGuidePage = (
       <Section title="Software Updates">
         <Q q="How do I check for updates?">
           <p>
-            Go to <code>/admin/update</code>{" "}
-            to see your current build date and commit. Click{" "}
-            <strong>Check for Updates</strong>{" "}
-            to query GitHub for the latest release. If a newer version is
-            available, you'll see its name and version number.
+            Go to <code>/admin/update</code> to see your current build date and
+            commit. Click <strong>Check for Updates</strong> to query GitHub for
+            the latest release. If a newer version is available, you'll see its
+            name and version number.
           </p>
         </Q>
 
@@ -2415,11 +2320,10 @@ export const adminGuidePage = (
           <p>
             If an update is available and your server has{" "}
             <code>BUNNY_API_KEY</code> and <code>BUNNY_SCRIPT_ID</code>{" "}
-            configured, an <strong>Update Now</strong>{" "}
-            button appears. Click it to download and deploy the new version
-            automatically via Bunny CDN. The update is logged in the activity
-            log. If the Bunny environment variables are not set, you'll need to
-            deploy the update manually.
+            configured, an <strong>Update Now</strong> button appears. Click it
+            to download and deploy the new version automatically via Bunny CDN.
+            The update is logged in the activity log. If the Bunny environment
+            variables are not set, you'll need to deploy the update manually.
           </p>
         </Q>
 
@@ -2450,10 +2354,9 @@ export const adminGuidePage = (
 
         <Q q="Can you customise it for me?">
           <p>
-            Yes. I offer customisation at a transparent flat rate &mdash; see
-            {" "}
-            <a href="https://chobble.com/prices">chobble.com/prices</a>{" "}
-            for current pricing. I can help you with custom features, branding,
+            Yes. I offer customisation at a transparent flat rate &mdash; see{" "}
+            <a href="https://chobble.com/prices">chobble.com/prices</a> for
+            current pricing. I can help you with custom features, branding,
             event image design, hosting setup, or whatever you need. You'll own
             the code outright, and I can show you how to maintain it yourself or
             handle updates for you. Over 20 years building web systems means I
@@ -2470,14 +2373,14 @@ export const adminGuidePage = (
           </p>
         </Q>
       </Section>
-      <Section title="Column Order" id="column-order">
+      <Section id="column-order" title="Column Order">
         <Q q="How do I customise which columns appear in tables?">
           <p>
             Go to <strong>Advanced Settings</strong> and find the{" "}
             <strong>Event Table Columns</strong> or{" "}
-            <strong>Attendee Table Columns</strong>{" "}
-            section. Enter a comma-separated list of Liquid-style tags to
-            control which columns appear and in what order.
+            <strong>Attendee Table Columns</strong> section. Enter a
+            comma-separated list of Liquid-style tags to control which columns
+            appear and in what order.
           </p>
           <p>
             For example, to show only the name and status on the events table:
@@ -2505,8 +2408,7 @@ export const adminGuidePage = (
             <code>{buildDefaultTemplate(ATTENDEE_DEFAULT_ORDER)}</code>
           </p>
           <p>
-            Columns referencing absent data (e.g. <code>{"{{email}}"}</code>
-            {" "}
+            Columns referencing absent data (e.g. <code>{"{{email}}"}</code>{" "}
             when no attendees have an email) are hidden automatically even when
             included in the template.
           </p>
@@ -2540,8 +2442,8 @@ export const adminGuidePage = (
               <code>%B</code> full month name, <code>%b</code> abbreviated
             </li>
             <li>
-              <code>%d</code> zero-padded day, <code>%e</code>{" "}
-              day without padding
+              <code>%d</code> zero-padded day, <code>%e</code> day without
+              padding
             </li>
             <li>
               <code>%A</code> full weekday, <code>%a</code> abbreviated
@@ -2552,14 +2454,12 @@ export const adminGuidePage = (
             </li>
           </ul>
           <p>
-            The <code>currency</code>{" "}
-            filter formats a number as your configured currency (e.g.{" "}
-            <code>2500</code> &rarr; &pound;25.00).
+            The <code>currency</code> filter formats a number as your configured
+            currency (e.g. <code>2500</code> &rarr; &pound;25.00).
           </p>
           <p>
-            Columns without a <code>rawValue</code>{" "}
-            (like name or email) ignore filters &mdash; they always render their
-            default content.
+            Columns without a <code>rawValue</code> (like name or email) ignore
+            filters &mdash; they always render their default content.
           </p>
         </Q>
       </Section>

--- a/src/templates/admin/holidays.tsx
+++ b/src/templates/admin/holidays.tsx
@@ -19,7 +19,7 @@ export const adminHolidaysPage = (
 ): string =>
   String(
     <Layout title="Holidays">
-      <AdminNav session={session} active="/admin/holidays" />
+      <AdminNav active="/admin/holidays" session={session} />
       <Flash success={successMessage} />
       <p>
         <a href="/admin/holidays/new">Add Holiday</a>
@@ -78,7 +78,7 @@ export const adminHolidayNewPage = (
 ): string =>
   String(
     <Layout title="Add Holiday">
-      <AdminNav session={session} active="/admin/holidays" />
+      <AdminNav active="/admin/holidays" session={session} />
       <CsrfForm action="/admin/holidays">
         <h1>Add Holiday</h1>
         <Flash error={error} />
@@ -98,7 +98,7 @@ export const adminHolidayEditPage = (
 ): string =>
   String(
     <Layout title="Edit Holiday">
-      <AdminNav session={session} active="/admin/holidays" />
+      <AdminNav active="/admin/holidays" session={session} />
       <CsrfForm action={`/admin/holidays/${holiday.id}/edit`}>
         <h1>Edit Holiday</h1>
         <Flash error={error} />
@@ -120,13 +120,13 @@ export const adminHolidayDeletePage = (
 ): string =>
   String(
     <Layout title="Delete Holiday">
-      <AdminNav session={session} active="/admin/holidays" />
+      <AdminNav active="/admin/holidays" session={session} />
       <ConfirmForm
         action={`/admin/holidays/${holiday.id}/delete`}
-        name={holiday.name}
-        label="Holiday name"
         buttonText="Delete Holiday"
         danger={false}
+        label="Holiday name"
+        name={holiday.name}
       >
         <h1>Delete Holiday</h1>
         <Flash error={error} />

--- a/src/templates/admin/nav.tsx
+++ b/src/templates/admin/nav.tsx
@@ -14,13 +14,13 @@ export const READ_ONLY_BANNER =
   '<div class="read-only-banner">This site is in read-only mode</div>';
 
 interface AdminNavProps {
-  session: AdminSession;
   active: string;
+  session: AdminSession;
 }
 
 const navLink = (href: string, label: string, active: string): JSX.Element => (
   <li>
-    <a href={href} class={href === active ? "active" : undefined}>
+    <a class={href === active ? "active" : undefined} href={href}>
       {label}
     </a>
   </li>

--- a/src/templates/admin/questions.tsx
+++ b/src/templates/admin/questions.tsx
@@ -17,7 +17,7 @@ export const adminQuestionsPage = (
 ): string =>
   String(
     <Layout title="Custom Questions">
-      <AdminNav session={session} active="/admin/questions" />
+      <AdminNav active="/admin/questions" session={session} />
 
       <h1>Custom Questions</h1>
       <p>
@@ -29,10 +29,10 @@ export const adminQuestionsPage = (
         <label>
           New Question
           <input
-            type="text"
             name="text"
-            required
             placeholder="e.g. What is your T-shirt size?"
+            required
+            type="text"
           />
         </label>
         <button type="submit">Add Question</button>
@@ -67,7 +67,7 @@ export const adminQuestionPage = (
 ): string =>
   String(
     <Layout title={`Question: ${question.text}`}>
-      <AdminNav session={session} active="/admin/questions" />
+      <AdminNav active="/admin/questions" session={session} />
 
       <h1>{question.text}</h1>
       <Flash error={error} />
@@ -75,7 +75,7 @@ export const adminQuestionPage = (
       <CsrfForm action={`/admin/questions/${question.id}/edit`}>
         <label>
           Question Text
-          <input type="text" name="text" required value={question.text} />
+          <input name="text" required type="text" value={question.text} />
         </label>
         <button type="submit">Update</button>
       </CsrfForm>
@@ -87,7 +87,7 @@ export const adminQuestionPage = (
       >
         <label>
           New Answer
-          <input type="text" name="text" required placeholder="e.g. Medium" />
+          <input name="text" placeholder="e.g. Medium" required type="text" />
         </label>
         <button type="submit">Add Answer</button>
       </CsrfForm>
@@ -107,7 +107,7 @@ export const adminQuestionPage = (
                   action={`/admin/questions/${question.id}/answers/${a.id}/move-up`}
                   class="inline"
                 >
-                  <button type="submit" class="link-button small">
+                  <button class="link-button small" type="submit">
                     &#9650;
                   </button>
                 </CsrfForm>
@@ -118,15 +118,15 @@ export const adminQuestionPage = (
                   action={`/admin/questions/${question.id}/answers/${a.id}/move-down`}
                   class="inline"
                 >
-                  <button type="submit" class="link-button small">
+                  <button class="link-button small" type="submit">
                     &#9660;
                   </button>
                 </CsrfForm>
               )}
               {i < question.answers.length - 1 && " "}
               <a
-                href={`/admin/questions/${question.id}/answers/${a.id}/delete`}
                 class="danger small"
+                href={`/admin/questions/${question.id}/answers/${a.id}/delete`}
               >
                 Delete
               </a>
@@ -136,7 +136,7 @@ export const adminQuestionPage = (
       )}
 
       <p>
-        <a href={`/admin/questions/${question.id}/delete`} class="danger">
+        <a class="danger" href={`/admin/questions/${question.id}/delete`}>
           Delete Question
         </a>
       </p>
@@ -151,13 +151,13 @@ export const adminQuestionDeletePage = (
 ): string =>
   String(
     <Layout title="Delete Question">
-      <AdminNav session={session} active="/admin/questions" />
+      <AdminNav active="/admin/questions" session={session} />
 
       <ConfirmForm
         action={`/admin/questions/${question.id}/delete`}
-        name={question.text}
-        label="Question text"
         buttonText="Delete Question"
+        label="Question text"
+        name={question.text}
       >
         <h1>Delete Question</h1>
         <Flash error={error} />
@@ -182,13 +182,13 @@ export const adminAnswerDeletePage = (
 ): string =>
   String(
     <Layout title="Delete Answer">
-      <AdminNav session={session} active="/admin/questions" />
+      <AdminNav active="/admin/questions" session={session} />
 
       <ConfirmForm
         action={`/admin/questions/${question.id}/answers/${answer.id}/delete`}
-        name={answer.text}
-        label="Answer text"
         buttonText="Delete Answer"
+        label="Answer text"
+        name={answer.text}
       >
         <h1>Delete Answer</h1>
         <Flash error={error} />
@@ -214,7 +214,7 @@ export const adminEventQuestionsPage = (
 ): string =>
   String(
     <Layout title={`Questions: ${event.name}`}>
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
 
       <h1>Questions for {event.name}</h1>
       <Flash error={error} />
@@ -229,10 +229,10 @@ export const adminEventQuestionsPage = (
           {map((q: QuestionWithAnswers) => (
             <label>
               <input
-                type="checkbox"
-                name="question_ids"
-                value={String(q.id)}
                 checked={assignedIds.has(q.id) || undefined}
+                name="question_ids"
+                type="checkbox"
+                value={String(q.id)}
               />
               {` ${q.text}`}
               <small>

--- a/src/templates/admin/scanner.tsx
+++ b/src/templates/admin/scanner.tsx
@@ -10,9 +10,9 @@ import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /** Ticket option for the manual check-in autocomplete */
 export interface TicketOption {
-  token: string;
   name: string;
   quantity: number;
+  token: string;
 }
 
 /**
@@ -25,10 +25,10 @@ export const adminScannerPage = (
 ): string =>
   String(
     <Layout
-      title={`Scanner: ${event.name}`}
       headExtra={`<meta name="csrf-token" content="${getCurrentCsrfToken()}" /><script src="${SCANNER_JS_PATH}" defer></script>`}
+      title={`Scanner: ${event.name}`}
     >
-      <AdminNav session={session} active="/admin/" />
+      <AdminNav active="/admin/" session={session} />
       <h1>Scanner</h1>
       <p>
         <a href={`/admin/event/${event.id}`}>&larr; {event.name}</a>
@@ -39,20 +39,20 @@ export const adminScannerPage = (
       <article>
         <div id="scanner-container">
           <video
-            id="scanner-video"
-            data-event-id={String(event.id)}
-            playsinline
-            muted
             class="hidden"
+            data-event-id={String(event.id)}
+            id="scanner-video"
+            muted
+            playsinline
           ></video>
-          <div id="scanner-status" class="hidden"></div>
-          <div id="scanner-confirm" class="hidden">
+          <div class="hidden" id="scanner-status"></div>
+          <div class="hidden" id="scanner-confirm">
             <div id="scanner-confirm-backdrop"></div>
             <div id="scanner-confirm-box">
               <button
+                aria-label="Close"
                 id="scanner-confirm-close"
                 type="button"
-                aria-label="Close"
               >
                 &times;
               </button>
@@ -77,56 +77,56 @@ export const adminScannerPage = (
       <article>
         <h2>Manual Check-in</h2>
         <form
+          action={`/admin/event/${event.id}/scan`}
+          data-event-id={String(event.id)}
+          data-manual-checkin
           id="manual-checkin"
           method="POST"
-          action={`/admin/event/${event.id}/scan`}
-          data-manual-checkin
-          data-event-id={String(event.id)}
         >
           <input
-            type="hidden"
             name="csrf_token"
+            type="hidden"
             value={getCurrentCsrfToken()}
           />
           <label for="manual-checkin-input">
             Search by name or ticket token
           </label>
           <div class="combobox">
-            <input type="hidden" name="token" id="manual-checkin-token" />
+            <input id="manual-checkin-token" name="token" type="hidden" />
             <input
-              id="manual-checkin-input"
-              type="text"
-              role="combobox"
-              autocomplete="off"
               aria-autocomplete="list"
-              aria-expanded="false"
               aria-controls="ticket-options"
+              aria-expanded="false"
+              autocomplete="off"
+              id="manual-checkin-input"
               placeholder={
                 uncheckedIn.length > 0
                   ? `${uncheckedIn.length} tickets available`
                   : "No tickets to check in"
               }
               required
+              role="combobox"
+              type="text"
             />
             <div
+              class="combobox-list hidden"
               id="ticket-options"
               role="listbox"
-              class="combobox-list hidden"
             >
               {uncheckedIn.map((t) => (
                 <div
-                  role="option"
-                  tabIndex={0}
-                  data-token={t.token}
                   data-name={escapeHtml(t.name)}
                   data-quantity={String(t.quantity)}
+                  data-token={t.token}
+                  role="option"
+                  tabIndex={0}
                 >
                   {`${escapeHtml(t.name)} (${t.quantity} attendee${t.quantity === 1 ? "" : "s"}) — ${t.token}`}
                 </div>
               ))}
             </div>
           </div>
-          <div id="manual-checkin-status" class="hidden"></div>
+          <div class="hidden" id="manual-checkin-status"></div>
           <button type="submit">Check In</button>
         </form>
       </article>

--- a/src/templates/admin/seeds.tsx
+++ b/src/templates/admin/seeds.tsx
@@ -16,7 +16,7 @@ export const adminSeedsPage = (
 ): string =>
   String(
     <Layout title="Seed Data">
-      <AdminNav session={session} active="" />
+      <AdminNav active="" session={session} />
       <CsrfForm action="/admin/seeds">
         <h1>Seed Data</h1>
         <p>
@@ -26,24 +26,24 @@ export const adminSeedsPage = (
         <Flash error={error} success={success} />
         <label for="event_count">Number of events</label>
         <input
-          type="number"
           id="event_count"
-          name="event_count"
-          value="5"
-          min="1"
           max="30"
+          min="1"
+          name="event_count"
           required
+          type="number"
+          value="5"
         />
 
         <label for="attendees_per_event">Attendees per event</label>
         <input
-          type="number"
           id="attendees_per_event"
-          name="attendees_per_event"
-          value="10"
-          min="0"
           max={String(SEED_MAX_ATTENDEES)}
+          min="0"
+          name="attendees_per_event"
           required
+          type="number"
+          value="10"
         />
 
         <button type="submit">Create Seed Data</button>

--- a/src/templates/admin/sessions.tsx
+++ b/src/templates/admin/sessions.tsx
@@ -50,7 +50,7 @@ export const adminSessionsPage = (
 
   return String(
     <Layout title="Sessions">
-      <AdminNav session={adminSession} active="/admin/users" />
+      <AdminNav active="/admin/users" session={adminSession} />
       <UsersSubNav />
 
       <Flash success={success} />
@@ -79,7 +79,7 @@ export const adminSessionsPage = (
           <br />
 
           <CsrfForm action="/admin/sessions" class="one-button">
-            <button type="submit" class="danger">
+            <button class="danger" type="submit">
               Log out of all other sessions ({otherSessionCount})
             </button>
           </CsrfForm>

--- a/src/templates/admin/settings-advanced.tsx
+++ b/src/templates/admin/settings-advanced.tsx
@@ -63,8 +63,8 @@ export const adminAdvancedSettingsPage = (
   s: AdvancedSettingsPageState,
 ): string =>
   String(
-    <Layout title="Advanced Settings" theme={s.theme}>
-      <AdminNav session={session} active="/admin/settings" />
+    <Layout theme={s.theme} title="Advanced Settings">
+      <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
 
       <article>

--- a/src/templates/admin/settings.tsx
+++ b/src/templates/admin/settings.tsx
@@ -59,8 +59,8 @@ export const adminSettingsPage = (
   s: SettingsPageState,
 ): string =>
   String(
-    <Layout title="Settings" theme={s.theme}>
-      <AdminNav session={session} active="/admin/settings" />
+    <Layout theme={s.theme} title="Settings">
+      <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
 
       {CountryForm(s)}

--- a/src/templates/admin/settings/apple-wallet.tsx
+++ b/src/templates/admin/settings/apple-wallet.tsx
@@ -22,29 +22,29 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
     <label>
       Pass Type ID
       <input
-        type="text"
+        autocomplete="off"
         name="apple_wallet_pass_type_id"
         placeholder="pass.com.example.tickets"
+        type="text"
         value={s.appleWalletPassTypeId}
-        autocomplete="off"
       />
     </label>
     <label>
       Team ID
       <input
-        type="text"
+        autocomplete="off"
         name="apple_wallet_team_id"
         placeholder="ABC1234567"
+        type="text"
         value={s.appleWalletTeamId}
-        autocomplete="off"
       />
     </label>
     <label>
       Signing Certificate (PEM)
       <textarea
         name="apple_wallet_signing_cert"
-        rows={4}
         placeholder="-----BEGIN CERTIFICATE-----"
+        rows={4}
       >
         {s.appleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>
@@ -53,8 +53,8 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
       Signing Private Key (PEM)
       <textarea
         name="apple_wallet_signing_key"
-        rows={4}
         placeholder="-----BEGIN PRIVATE KEY-----"
+        rows={4}
       >
         {s.appleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>
@@ -63,8 +63,8 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
       WWDR Certificate (PEM)
       <textarea
         name="apple_wallet_wwdr_cert"
-        rows={4}
         placeholder="-----BEGIN CERTIFICATE-----"
+        rows={4}
       >
         {s.appleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>

--- a/src/templates/admin/settings/business-email.tsx
+++ b/src/templates/admin/settings/business-email.tsx
@@ -18,11 +18,11 @@ export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
     <label>
       Business Email
       <input
-        type="email"
+        autocomplete="email"
         name="business_email"
         placeholder="contact@example.com"
+        type="email"
         value={s.businessEmail}
-        autocomplete="email"
       />
     </label>
     <button type="submit">Save Business Email</button>

--- a/src/templates/admin/settings/column-order.tsx
+++ b/src/templates/admin/settings/column-order.tsx
@@ -52,11 +52,11 @@ export const EventColumnOrderForm = (
     <label>
       Column order
       <input
-        type="text"
-        name="column_order"
-        value={s.eventColumnOrder || eventDefault}
-        placeholder={eventDefault}
         autocomplete="off"
+        name="column_order"
+        placeholder={eventDefault}
+        type="text"
+        value={s.eventColumnOrder || eventDefault}
       />
     </label>
     <p>
@@ -84,11 +84,11 @@ export const AttendeeColumnOrderForm = (
     <label>
       Column order
       <input
-        type="text"
-        name="column_order"
-        value={s.attendeeColumnOrder || attendeeDefault}
-        placeholder={attendeeDefault}
         autocomplete="off"
+        name="column_order"
+        placeholder={attendeeDefault}
+        type="text"
+        value={s.attendeeColumnOrder || attendeeDefault}
       />
     </label>
     <p>

--- a/src/templates/admin/settings/country.tsx
+++ b/src/templates/admin/settings/country.tsx
@@ -15,7 +15,7 @@ export const CountryForm = (s: SettingsPageState): JSX.Element => (
       <select name="country" required>
         {Object.entries(COUNTRIES).map(
           ([code, data]: [string, CountryData]) => (
-            <option value={code} selected={code === s.country}>
+            <option selected={code === s.country} value={code}>
               {data.name} ({data.currency}, +{data.phonePrefix})
             </option>
           ),

--- a/src/templates/admin/settings/custom-domain.tsx
+++ b/src/templates/admin/settings/custom-domain.tsx
@@ -24,11 +24,11 @@ export const CustomDomainForm = (
         <label>
           Domain
           <input
-            type="text"
+            autocomplete="off"
             name="custom_domain"
             placeholder="tickets.yourdomain.com"
+            type="text"
             value={s.customDomain}
-            autocomplete="off"
           />
         </label>
         <button type="submit">Save Custom Domain</button>

--- a/src/templates/admin/settings/email-tpl-admin.tsx
+++ b/src/templates/admin/settings/email-tpl-admin.tsx
@@ -23,41 +23,41 @@ export const AdminEmailTemplateForm = (
     <label>
       Subject
       <input
-        type="text"
+        autocomplete="off"
         name="subject"
         placeholder={DEFAULT_TEMPLATES.admin.subject}
+        type="text"
         value={s.adminTemplates.subject}
-        autocomplete="off"
       />
     </label>
     <label>
       HTML Body
       <textarea
+        data-default-tpl={DEFAULT_TEMPLATES.admin.html}
         id="admin_html"
         name="html"
-        rows="8"
         placeholder="Leave blank to use default template"
-        data-default-tpl={DEFAULT_TEMPLATES.admin.html}
+        rows="8"
       >
         {s.adminTemplates.html}
       </textarea>
     </label>
-    <a href="#" data-fill-default="admin_html">
+    <a data-fill-default="admin_html" href="#">
       <small>Edit default template</small>
     </a>
     <label>
       Plain Text Body
       <textarea
+        data-default-tpl={DEFAULT_TEMPLATES.admin.text}
         id="admin_text"
         name="text"
-        rows="6"
         placeholder="Leave blank to use default template"
-        data-default-tpl={DEFAULT_TEMPLATES.admin.text}
+        rows="6"
       >
         {s.adminTemplates.text}
       </textarea>
     </label>
-    <a href="#" data-fill-default="admin_text">
+    <a data-fill-default="admin_text" href="#">
       <small>Edit default template</small>
     </a>
     <br />

--- a/src/templates/admin/settings/email-tpl-confirmation.tsx
+++ b/src/templates/admin/settings/email-tpl-confirmation.tsx
@@ -17,7 +17,7 @@ export const ConfirmationEmailTemplateForm = (
     <p>
       Customise the registration confirmation email sent to attendees (
       <a href="/admin/guide#email-templates">template guide</a>). Uses{" "}
-      <a href="https://liquidjs.com/" target="_blank" rel="noopener">
+      <a href="https://liquidjs.com/" rel="noopener" target="_blank">
         Liquid
       </a>{" "}
       template syntax. Leave blank to use the default template.
@@ -114,41 +114,41 @@ export const ConfirmationEmailTemplateForm = (
     <label>
       Subject
       <input
-        type="text"
+        autocomplete="off"
         name="subject"
         placeholder={DEFAULT_TEMPLATES.confirmation.subject}
+        type="text"
         value={s.confirmationTemplates.subject}
-        autocomplete="off"
       />
     </label>
     <label>
       HTML Body
       <textarea
+        data-default-tpl={DEFAULT_TEMPLATES.confirmation.html}
         id="confirmation_html"
         name="html"
-        rows="8"
         placeholder="Leave blank to use default template"
-        data-default-tpl={DEFAULT_TEMPLATES.confirmation.html}
+        rows="8"
       >
         {s.confirmationTemplates.html}
       </textarea>
     </label>
-    <a href="#" data-fill-default="confirmation_html">
+    <a data-fill-default="confirmation_html" href="#">
       <small>Edit default template</small>
     </a>
     <label>
       Plain Text Body
       <textarea
+        data-default-tpl={DEFAULT_TEMPLATES.confirmation.text}
         id="confirmation_text"
         name="text"
-        rows="6"
         placeholder="Leave blank to use default template"
-        data-default-tpl={DEFAULT_TEMPLATES.confirmation.text}
+        rows="6"
       >
         {s.confirmationTemplates.text}
       </textarea>
     </label>
-    <a href="#" data-fill-default="confirmation_text">
+    <a data-fill-default="confirmation_text" href="#">
       <small>Edit default template</small>
     </a>
     <br />

--- a/src/templates/admin/settings/email.tsx
+++ b/src/templates/admin/settings/email.tsx
@@ -20,11 +20,11 @@ export const EmailNotificationsForm = (
       <label>
         Email Provider
         <select name="email_provider">
-          <option value="" selected={!s.emailProvider}>
+          <option selected={!s.emailProvider} value="">
             {s.hostEmailLabel || "None (disabled)"}
           </option>
           {Array.from(VALID_EMAIL_PROVIDERS).map((p) => (
-            <option value={p} selected={s.emailProvider === p}>
+            <option selected={s.emailProvider === p} value={p}>
               {EMAIL_PROVIDER_LABELS[p]}
             </option>
           ))}
@@ -33,28 +33,28 @@ export const EmailNotificationsForm = (
       <label>
         API Key
         <input
-          type="password"
+          autocomplete="off"
           name="email_api_key"
           placeholder="Enter API key"
+          type="password"
           value={s.emailApiKeyConfigured ? MASK_SENTINEL : undefined}
-          autocomplete="off"
         />
       </label>
       <label>
         From Address
         <input
-          type="email"
+          autocomplete="off"
           name="email_from_address"
           placeholder={s.businessEmail || "tickets@yourdomain.com"}
+          type="email"
           value={s.emailFromAddress}
-          autocomplete="off"
         />
       </label>
       <button type="submit">Save Email Settings</button>
     </CsrfForm>
     {s.emailProvider && (
       <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
-        <button type="submit" class="secondary">
+        <button class="secondary" type="submit">
           Send Test Email
         </button>
       </CsrfForm>

--- a/src/templates/admin/settings/embed-hosts.tsx
+++ b/src/templates/admin/settings/embed-hosts.tsx
@@ -15,11 +15,11 @@ export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
     <label>
       Hosts (comma-separated)
       <input
-        type="text"
+        autocomplete="off"
         name="embed_hosts"
         placeholder="example.com, *.mysite.org"
+        type="text"
         value={s.embedHosts}
-        autocomplete="off"
       />
     </label>
     <p>

--- a/src/templates/admin/settings/google-wallet.tsx
+++ b/src/templates/admin/settings/google-wallet.tsx
@@ -23,29 +23,29 @@ export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
     <label>
       Issuer ID
       <input
-        type="text"
+        autocomplete="off"
         name="google_wallet_issuer_id"
         placeholder="3388000000012345678"
+        type="text"
         value={s.googleWalletIssuerId}
-        autocomplete="off"
       />
     </label>
     <label>
       Service Account Email
       <input
-        type="email"
+        autocomplete="off"
         name="google_wallet_service_account_email"
         placeholder="wallet@project.iam.gserviceaccount.com"
+        type="email"
         value={s.googleWalletServiceAccountEmail}
-        autocomplete="off"
       />
     </label>
     <label>
       Service Account Private Key (PEM)
       <textarea
         name="google_wallet_service_account_key"
-        rows={4}
         placeholder="-----BEGIN PRIVATE KEY-----"
+        rows={4}
       >
         {s.googleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>

--- a/src/templates/admin/settings/header-image.tsx
+++ b/src/templates/admin/settings/header-image.tsx
@@ -13,9 +13,9 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
       {s.headerImageUrl && (
         <div>
           <img
-            src={getImageProxyUrl(s.headerImageUrl)}
             alt="Header preview"
             class="event-image-preview"
+            src={getImageProxyUrl(s.headerImageUrl)}
           />
           <CsrfForm
             action="/admin/settings/header-image/delete"
@@ -38,9 +38,9 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
         <label>
           {s.headerImageUrl ? "Replace Image" : "Upload Image"}
           <input
-            type="file"
-            name="header_image"
             accept="image/jpeg,image/png,image/gif,image/webp"
+            name="header_image"
+            type="file"
           />
         </label>
         <button type="submit">Upload</button>

--- a/src/templates/admin/settings/payment.tsx
+++ b/src/templates/admin/settings/payment.tsx
@@ -21,28 +21,28 @@ export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
     <p>Choose which payment provider to use for paid events.</p>
     <label>
       <input
-        type="radio"
-        name="payment_provider"
-        value="none"
         checked={!s.paymentProvider}
+        name="payment_provider"
+        type="radio"
+        value="none"
       />
       None (payments disabled)
     </label>
     <label>
       <input
-        type="radio"
-        name="payment_provider"
-        value="stripe"
         checked={s.paymentProvider === "stripe"}
+        name="payment_provider"
+        type="radio"
+        value="stripe"
       />
       Stripe
     </label>
     <label>
       <input
-        type="radio"
-        name="payment_provider"
-        value="square"
         checked={s.paymentProvider === "square"}
+        name="payment_provider"
+        type="radio"
+        value="square"
       />
       Square
     </label>
@@ -87,12 +87,12 @@ export const StripeForm = (s: SettingsPageState): JSX.Element | null =>
       <footer>
         <button type="submit">Update Stripe Key</button>
         {s.stripeKeyConfigured && (
-          <button type="button" id="stripe-test-btn" class="secondary">
+          <button class="secondary" id="stripe-test-btn" type="button">
             Test Connection
           </button>
         )}
       </footer>
-      <div id="stripe-test-result" class="hidden"></div>
+      <div class="hidden" id="stripe-test-result"></div>
     </CsrfForm>
   ) : null;
 
@@ -118,21 +118,21 @@ export const SquareForm = (s: SettingsPageState): JSX.Element | null =>
       />
       <label>
         <input
-          type="checkbox"
-          name="square_sandbox"
           checked={s.squareSandbox}
+          name="square_sandbox"
+          type="checkbox"
         />
         Sandbox mode (use Square's test environment)
       </label>
       <footer>
         <button type="submit">Update Square Credentials</button>
         {s.squareTokenConfigured && (
-          <button type="button" id="square-test-btn" class="secondary">
+          <button class="secondary" id="square-test-btn" type="button">
             Test Connection
           </button>
         )}
       </footer>
-      <div id="square-test-result" class="hidden"></div>
+      <div class="hidden" id="square-test-result"></div>
     </CsrfForm>
   ) : null;
 
@@ -206,13 +206,13 @@ export const BookingFeeForm = (s: SettingsPageState): JSX.Element | null =>
       <label>
         Booking Fee (%)
         <input
-          type="number"
-          name="booking_fee"
-          step="0.1"
-          min="0"
           max="10"
-          value={s.bookingFee}
+          min="0"
+          name="booking_fee"
           required
+          step="0.1"
+          type="number"
+          value={s.bookingFee}
         />
       </label>
       <button type="submit">Save Booking Fee</button>

--- a/src/templates/admin/settings/public-api.tsx
+++ b/src/templates/admin/settings/public-api.tsx
@@ -17,19 +17,19 @@ export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
     </p>
     <label>
       <input
-        type="radio"
-        name="show_public_api"
-        value="true"
         checked={s.showPublicApi === true}
+        name="show_public_api"
+        type="radio"
+        value="true"
       />
       Yes
     </label>
     <label>
       <input
-        type="radio"
-        name="show_public_api"
-        value="false"
         checked={s.showPublicApi !== true}
+        name="show_public_api"
+        type="radio"
+        value="false"
       />
       No
     </label>

--- a/src/templates/admin/settings/public-site.tsx
+++ b/src/templates/admin/settings/public-site.tsx
@@ -17,19 +17,19 @@ export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
     </p>
     <label>
       <input
-        type="radio"
-        name="show_public_site"
-        value="true"
         checked={s.showPublicSite === true}
+        name="show_public_site"
+        type="radio"
+        value="true"
       />
       Yes
     </label>
     <label>
       <input
-        type="radio"
-        name="show_public_site"
-        value="false"
         checked={s.showPublicSite !== true}
+        name="show_public_site"
+        type="radio"
+        value="false"
       />
       No
     </label>

--- a/src/templates/admin/settings/subdomain.tsx
+++ b/src/templates/admin/settings/subdomain.tsx
@@ -41,16 +41,16 @@ const SubdomainFormContent = (s: AdvancedSettingsPageState): SafeHtml => {
         <p>
           <strong>{s.subdomainPreviewFullDomain}</strong> is available.
         </p>
-        <input type="hidden" name="subdomain" value={s.subdomainPreview} />
+        <input name="subdomain" type="hidden" value={s.subdomainPreview} />
         <label>
-          <input type="checkbox" name="save" value="1" /> Confirm registration
+          <input name="save" type="checkbox" value="1" /> Confirm registration
           (cannot be undone)
         </label>
         <footer>
           <button type="submit">Register Subdomain</button>
           <a
-            href="/admin/settings-advanced#settings-host-subdomain"
             class="secondary"
+            href="/admin/settings-advanced#settings-host-subdomain"
           >
             <strong>Cancel</strong>
           </a>
@@ -64,11 +64,11 @@ const SubdomainFormContent = (s: AdvancedSettingsPageState): SafeHtml => {
       <label>
         Subdomain
         <input
-          type="text"
-          name="subdomain"
-          placeholder="my-business-name"
           autocomplete="off"
+          name="subdomain"
           pattern="[a-z0-9]([a-z0-9-]{'{'}0,61{'}'}[a-z0-9])?"
+          placeholder="my-business-name"
+          type="text"
         />
         <span class="muted">{s.bunnyDnsSubdomainSuffix}</span>
       </label>

--- a/src/templates/admin/settings/terms.tsx
+++ b/src/templates/admin/settings/terms.tsx
@@ -20,8 +20,8 @@ export const TermsForm = (s: SettingsPageState): JSX.Element => (
         </small>
       </p>
       <textarea
-        name="terms_and_conditions"
         maxlength={MAX_TEXTAREA_LENGTH}
+        name="terms_and_conditions"
         placeholder="Enter terms and conditions that attendees must agree to before registering. Leave blank to disable."
       >
         {s.termsAndConditions}

--- a/src/templates/admin/settings/theme.tsx
+++ b/src/templates/admin/settings/theme.tsx
@@ -11,19 +11,19 @@ export const ThemeForm = (s: SettingsPageState): JSX.Element => (
     <p>Choose between light and dark themes for the site interface.</p>
     <label>
       <input
-        type="radio"
-        name="theme"
-        value="light"
         checked={s.theme === "light"}
+        name="theme"
+        type="radio"
+        value="light"
       />
       Light
     </label>
     <label>
       <input
-        type="radio"
-        name="theme"
-        value="dark"
         checked={s.theme === "dark"}
+        name="theme"
+        type="radio"
+        value="dark"
       />
       Dark
     </label>

--- a/src/templates/admin/site.tsx
+++ b/src/templates/admin/site.tsx
@@ -36,7 +36,7 @@ export const adminSiteHomePage = (
 ): string =>
   String(
     <Layout title="Site - Home">
-      <AdminNav session={session} active="/admin/site" />
+      <AdminNav active="/admin/site" session={session} />
       <SiteSubNav />
 
       <Flash error={error} success={success} />
@@ -52,12 +52,12 @@ export const adminSiteHomePage = (
           </small>
         </p>
         <input
-          type="text"
-          id="website_title"
-          name="website_title"
-          maxlength="128"
-          value={websiteTitle}
           autocomplete="off"
+          id="website_title"
+          maxlength="128"
+          name="website_title"
+          type="text"
+          value={websiteTitle}
         />
 
         <label for="homepage_text">Homepage Text</label>
@@ -69,8 +69,8 @@ export const adminSiteHomePage = (
         </p>
         <textarea
           id="homepage_text"
-          name="homepage_text"
           maxlength={MAX_TEXTAREA_LENGTH}
+          name="homepage_text"
           placeholder="Welcome to our site..."
         >
           {homepageText}
@@ -92,7 +92,7 @@ export const adminSiteContactPage = (
 ): string =>
   String(
     <Layout title="Site - Contact">
-      <AdminNav session={session} active="/admin/site" />
+      <AdminNav active="/admin/site" session={session} />
       <SiteSubNav />
 
       <Flash error={error} success={success} />
@@ -109,8 +109,8 @@ export const adminSiteContactPage = (
         </p>
         <textarea
           id="contact_page_text"
-          name="contact_page_text"
           maxlength={MAX_TEXTAREA_LENGTH}
+          name="contact_page_text"
           placeholder="Get in touch with us..."
         >
           {contactPageText}

--- a/src/templates/admin/update.tsx
+++ b/src/templates/admin/update.tsx
@@ -56,7 +56,7 @@ const UpdateAvailable = ({
       </p>
     </div>
     {state.bunnyConfigured ? (
-      <CsrfForm action="/admin/update" id="update-deploy" class="no-bg">
+      <CsrfForm action="/admin/update" class="no-bg" id="update-deploy">
         <button type="submit">Update Now</button>
       </CsrfForm>
     ) : (
@@ -92,7 +92,7 @@ export const adminUpdatePage = (
 ): string =>
   String(
     <Layout title="Update">
-      <AdminNav session={session} active="/admin/settings" />
+      <AdminNav active="/admin/settings" session={session} />
 
       <Flash error={error} success={success} />
 

--- a/src/templates/admin/users.tsx
+++ b/src/templates/admin/users.tsx
@@ -11,12 +11,12 @@ import { Layout } from "#templates/layout.tsx";
 
 /** Displayable user info (decrypted) */
 export interface DisplayUser {
-  id: number;
-  username: string;
   adminLevel: AdminLevel;
-  hasPassword: boolean;
   hasDataKey: boolean;
+  hasPassword: boolean;
+  id: number;
   inviteExpired: boolean;
+  username: string;
 }
 
 /** Status label for a user */
@@ -31,10 +31,10 @@ const userStatus = (user: DisplayUser): string => {
  * Admin user management page
  */
 export interface UsersPageOpts {
+  currentUserId: number;
+  error?: string;
   inviteLink: string;
   success?: string;
-  error?: string;
-  currentUserId: number;
 }
 
 export const adminUsersPage = (
@@ -44,7 +44,7 @@ export const adminUsersPage = (
 ): string =>
   String(
     <Layout title="Users">
-      <AdminNav session={session} active="/admin/users" />
+      <AdminNav active="/admin/users" session={session} />
       <UsersSubNav />
       <p>
         <a href="/admin/guide#user-classes">User roles and permissions</a>
@@ -85,8 +85,8 @@ export const adminUsersPage = (
                 <td>
                   {user.hasPassword && !user.hasDataKey && (
                     <CsrfForm
-                      class="inline"
                       action={`/admin/users/${user.id}/activate`}
+                      class="inline"
                     >
                       <button type="submit">Activate</button>
                     </CsrfForm>
@@ -115,13 +115,13 @@ export const adminUserDeletePage = (
 ): string =>
   String(
     <Layout title={`Delete User: ${user.username}`}>
-      <AdminNav session={session} active="/admin/users" />
+      <AdminNav active="/admin/users" session={session} />
 
       <ConfirmForm
         action={`/admin/users/${user.id}/delete`}
-        name={user.username}
-        label="Username"
         buttonText="Delete User"
+        label="Username"
+        name={user.username}
       >
         <h1>Delete User</h1>
         <Flash error={error} />
@@ -147,7 +147,7 @@ export const adminUserNewPage = (
 ): string =>
   String(
     <Layout title="Invite User">
-      <AdminNav session={session} active="/admin/users" />
+      <AdminNav active="/admin/users" session={session} />
 
       <CsrfForm action="/admin/users">
         <h1>Invite User</h1>

--- a/src/templates/attendee-table.tsx
+++ b/src/templates/attendee-table.tsx
@@ -208,9 +208,9 @@ const CheckinButton = ({
       action={`/admin/event/${eventId}/attendee/${a.id}/checkin`}
       class="inline"
     >
-      <input type="hidden" name="return_filter" value={activeFilter} />
-      {returnUrl && <input type="hidden" name="return_url" value={returnUrl} />}
-      <button type="submit" class={buttonClass}>
+      <input name="return_filter" type="hidden" value={activeFilter} />
+      {returnUrl && <input name="return_url" type="hidden" value={returnUrl} />}
+      <button class={buttonClass} type="submit">
         {label}
       </button>
     </CsrfForm>,
@@ -246,8 +246,8 @@ const createActionsRenderer =
       <>
         {isRefundable(row) && (
           <a
-            href={`/admin/event/${row.eventId}/attendee/${a.id}/refund${suffix}`}
             class="danger"
+            href={`/admin/event/${row.eventId}/attendee/${a.id}/refund${suffix}`}
           >
             Refund
           </a>
@@ -255,8 +255,8 @@ const createActionsRenderer =
         {isRefundable(row) && " "}
         <a href={`/admin/attendees/${a.id}${suffix}`}>Edit</a>{" "}
         <a
-          href={`/admin/event/${row.eventId}/attendee/${a.id}/delete${suffix}`}
           class="danger"
+          href={`/admin/event/${row.eventId}/attendee/${a.id}/delete${suffix}`}
         >
           Delete
         </a>{" "}

--- a/src/templates/checkin.tsx
+++ b/src/templates/checkin.tsx
@@ -48,8 +48,8 @@ export const checkinAdminPage = (
       <CsrfForm action={checkinPath}>
         <h1>Check-in</h1>
         <Flash success={message} />
-        <input type="hidden" name="check_in" value={nextValue} />
-        <button type="submit" class={buttonClass}>
+        <input name="check_in" type="hidden" value={nextValue} />
+        <button class={buttonClass} type="submit">
           {buttonLabel}
         </button>
       </CsrfForm>

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -22,11 +22,11 @@ export const escapeHtml = (str: string): string =>
     .replace(/"/g, "&quot;");
 
 interface LayoutProps {
-  title: string;
   bodyClass?: string;
-  headExtra?: string;
   children?: Child;
+  headExtra?: string;
   theme?: Theme;
+  title: string;
 }
 
 /**
@@ -45,28 +45,28 @@ export const Layout = ({
   return new SafeHtml(
     "<!DOCTYPE html>" +
     (
-      <html lang="en" data-theme={resolvedTheme}>
+      <html data-theme={resolvedTheme} lang="en">
         <head>
           <meta charset="UTF-8" />
           <meta
-            name="viewport"
             content="width=device-width, initial-scale=1.0"
+            name="viewport"
           />
           <title>{title}</title>
-          <link rel="stylesheet" href={CSS_PATH} />
+          <link href={CSS_PATH} rel="stylesheet" />
           {headExtra && <Raw html={headExtra} />}
         </head>
         <body class={bodyClass || undefined}>
-          <a href="#main-content" class="skip-nav">
+          <a class="skip-nav" href="#main-content">
             Skip to content
           </a>
           {isDemoMode() && <Raw html={DEMO_BANNER} />}
           <main id="main-content" tabindex="-1">
             {headerImage && (
               <img
-                src={getImageProxyUrl(headerImage)}
                 alt=""
                 class="header-image"
+                src={getImageProxyUrl(headerImage)}
               />
             )}
             {children}
@@ -74,7 +74,7 @@ export const Layout = ({
           {bodyClass?.includes("iframe") && (
             <script src={IFRAME_RESIZER_CHILD_JS_PATH}></script>
           )}
-          <script src={JS_PATH} defer></script>
+          <script defer src={JS_PATH}></script>
           <Raw html={renderDebugFooter()} />
         </body>
       </html>

--- a/src/templates/payment.tsx
+++ b/src/templates/payment.tsx
@@ -57,13 +57,13 @@ export const successPage = ({
   const inIframe = getIframeMode();
   return String(
     <Layout
-      title="Order Successful"
+      bodyClass={inIframe ? "iframe" : undefined}
       headExtra={
         thankYouUrl
           ? `<meta http-equiv="refresh" content="3;url=${escapeHtml(thankYouUrl)}">`
           : undefined
       }
-      bodyClass={inIframe ? "iframe" : undefined}
+      title="Order Successful"
     >
       <div
         data-payment-result={paid ? "success" : undefined}
@@ -82,7 +82,7 @@ export const successPage = ({
         ) : null}
         {ticketUrl ? (
           <p>
-            <a href={ticketUrl} target="_blank" rel="noopener">
+            <a href={ticketUrl} rel="noopener" target="_blank">
               Click here to view your ticket
             </a>
           </p>
@@ -142,15 +142,15 @@ export const paymentErrorPage = (message: string): string =>
  */
 export const checkoutPopupPage = (checkoutUrl: string): string =>
   String(
-    <Layout title="Complete Payment" bodyClass="iframe">
+    <Layout bodyClass="iframe" title="Complete Payment">
       <div data-checkout-popup={escapeHtml(checkoutUrl)} data-scroll-into-view>
         <p>Payment is processed in a new window.</p>
         <p>
           <a
-            href={checkoutUrl}
-            target="_blank"
             data-open-checkout
+            href={checkoutUrl}
             rel="noopener"
+            target="_blank"
           >
             <b>Pay Now</b>
           </a>
@@ -158,7 +158,7 @@ export const checkoutPopupPage = (checkoutUrl: string): string =>
         <div data-checkout-waiting hidden>
           <p>Completing payment in the other window...</p>
           <p>
-            <a href={checkoutUrl} target="_blank" rel="noopener">
+            <a href={checkoutUrl} rel="noopener" target="_blank">
               <small>Click here if the payment window didn't open</small>
             </a>
           </p>

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -83,7 +83,7 @@ export const publicSitePage = (
     : titles[pageType];
 
   return String(
-    <Layout title={pageTitle} headExtra={FEED_DISCOVERY_TAGS}>
+    <Layout headExtra={FEED_DISCOVERY_TAGS} title={pageTitle}>
       {websiteTitle && <h1>{websiteTitle}</h1>}
       <PublicNav {...navFlags()} />
       <div class="prose">
@@ -158,7 +158,7 @@ export const homepagePage = (
 
   if (events.length === 0 && groups.length === 0) {
     return String(
-      <Layout title={title} headExtra={FEED_DISCOVERY_TAGS}>
+      <Layout headExtra={FEED_DISCOVERY_TAGS} title={title}>
         {websiteTitle && <h1>{websiteTitle}</h1>}
         <PublicNav {...navFlags()} />
         <p>
@@ -182,7 +182,7 @@ export const homepagePage = (
   )(events);
 
   return String(
-    <Layout title={title} headExtra={FEED_DISCOVERY_TAGS}>
+    <Layout headExtra={FEED_DISCOVERY_TAGS} title={title}>
       {websiteTitle && <h1>{websiteTitle}</h1>}
       <PublicNav {...navFlags()} />
       <h2>All bookable events</h2>
@@ -348,8 +348,8 @@ export const rateLimitedPage = (): string =>
 export const temporaryErrorPage = (): string =>
   String(
     <Layout
-      title="Temporary Error"
       headExtra='<meta http-equiv="refresh" content="2" />'
+      title="Temporary Error"
     >
       <h1>Temporary Error</h1>
       <p>
@@ -600,7 +600,7 @@ const TicketPageForm = ({
   return (
     <CsrfForm action={`/ticket/${slugs.join("+")}`}>
       {qrPrefill && (
-        <input type="hidden" name="qr_token" value={qrPrefill.token} />
+        <input name="qr_token" type="hidden" value={qrPrefill.token} />
       )}
       <Raw html={renderFields(fields, fieldValues)} />
       {hasDaily && dates && (
@@ -678,16 +678,16 @@ export const ticketPage = ({
 
   return String(
     <Layout
-      title={title}
       bodyClass={inIframe ? "iframe" : undefined}
       headExtra={headExtra}
+      title={title}
     >
       {headerName && !inIframe && (
         <TicketPageHeader
-          headerName={headerName}
           headerDescription={headerDescription}
-          singleEvent={singleEvent}
+          headerName={headerName}
           pastDays={pastDays}
+          singleEvent={singleEvent}
         />
       )}
       <Flash error={error} />
@@ -698,17 +698,17 @@ export const ticketPage = ({
         </div>
       ) : (
         <TicketPageForm
-          slugs={slugs}
-          fields={fields}
-          hasDaily={hasDaily}
           dates={dates}
           eventRows={eventRows}
+          fields={fields}
+          hasDaily={hasDaily}
           hideQuantity={hideQuantity}
           isSingleEvent={isSingleEvent}
-          questions={questions}
-          questionEventMap={questionEventMap}
-          terms={terms}
           qrPrefill={qrPrefill}
+          questionEventMap={questionEventMap}
+          questions={questions}
+          slugs={slugs}
+          terms={terms}
         />
       )}
     </Layout>,

--- a/src/templates/setup.tsx
+++ b/src/templates/setup.tsx
@@ -51,7 +51,7 @@ const DataControllerAgreement = (): JSX.Element => (
     </p>
     <div class="field">
       <label>
-        <input type="checkbox" name="accept_agreement" value="yes" required />I
+        <input name="accept_agreement" required type="checkbox" value="yes" />I
         understand and accept these terms
       </label>
     </div>
@@ -74,7 +74,7 @@ export const setupPage = (error?: string): string =>
             Your Country
             <select name="country" required>
               {Object.entries(COUNTRIES).map(([code, data]) => (
-                <option value={code} selected={code === DEFAULT_COUNTRY}>
+                <option selected={code === DEFAULT_COUNTRY} value={code}>
                   {data.name} ({data.currency})
                 </option>
               ))}

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -683,6 +683,15 @@ export const hasCheckedInput = (
   );
 };
 
+/** True when `html` contains an `<option value="...">` with the `selected` attribute, in any attribute order. */
+export const hasSelectedOption = (html: string, value: string): boolean => {
+  const tags = html.match(/<option\b[^>]*>/gi) ?? [];
+  return tags.some(
+    (t) =>
+      t.includes(`value="${value}"`) && /\bselected(?=[\s/>])/.test(t),
+  );
+};
+
 /**
  * Extract admin login CSRF token from HTML body
  */

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -563,12 +563,12 @@ export const setTestEnv = (
 
 /** Options for {@link describeWithEnv}. */
 interface DescribeEnvOptions {
-  /** Environment variables to set before each test and restore after. */
-  env?: Record<string, string | undefined>;
   /** Reset slug counter, create test DB in beforeEach; resetDb in afterEach. */
   db?: boolean;
   /** Call setupTestEncryptionKey in beforeEach. */
   encryptionKey?: boolean;
+  /** Environment variables to set before each test and restore after. */
+  env?: Record<string, string | undefined>;
 }
 
 /**
@@ -646,8 +646,41 @@ export const getCsrfTokenFromCookie = async (
  */
 export const extractCsrfToken = (html: string | null): string | null => {
   if (!html) return null;
-  const match = html.match(/name="csrf_token"\s+value="([^"]+)"/);
-  return match?.[1] ?? null;
+  return extractInputValue(html, "csrf_token");
+};
+
+/** Extract the `value` of an `<input>` with the given `name`, regardless of attribute order. */
+export const extractInputValue = (
+  html: string,
+  name: string,
+): string | null => {
+  const tags = html.match(/<input\b[^>]*>/gi) ?? [];
+  const needle = `name="${name}"`;
+  const tag = tags.find((t) => t.includes(needle));
+  return tag?.match(/\bvalue="([^"]*)"/)?.[1] ?? null;
+};
+
+/** True when `html` contains an `<input>` with the given `name` and `value`, in any attribute order. */
+export const hasInputWithValue = (
+  html: string,
+  name: string,
+  value: string,
+): boolean => extractInputValue(html, name) === value;
+
+/** True when `html` contains a `checked` `<input>` with the given `name` and `value`. */
+export const hasCheckedInput = (
+  html: string,
+  name: string,
+  value: string,
+): boolean => {
+  const tags = html.match(/<input\b[^>]*>/gi) ?? [];
+  const needle = `name="${name}"`;
+  return tags.some(
+    (t) =>
+      t.includes(needle) &&
+      t.includes(`value="${value}"`) &&
+      /\bchecked(?=[\s/>])/.test(t),
+  );
 };
 
 /**
@@ -715,10 +748,10 @@ export const mockTicketFormRequest = (
 interface TestRequestOptions {
   /** Full cookie string (use when you have raw set-cookie value) */
   cookie?: string;
-  /** HTTP method (defaults to GET, or POST if data is provided) */
-  method?: string;
   /** Form data for POST requests */
   data?: Record<string, string>;
+  /** HTTP method (defaults to GET, or POST if data is provided) */
+  method?: string;
 }
 
 /**
@@ -1764,8 +1797,8 @@ export const errorResponse =
 // ---------------------------------------------------------------------------
 
 export interface FetchCall {
-  url: string;
   init: RequestInit | undefined;
+  url: string;
 }
 
 /** Stub fetch to return a JSON response with given body. */

--- a/test/e2e/ticket-editing.test.ts
+++ b/test/e2e/ticket-editing.test.ts
@@ -46,9 +46,10 @@ const extractEventIdFromSelect = (
   html: string,
   eventName: string,
 ): string | null => {
+  const escaped = eventName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = html.match(
     new RegExp(
-      `<option value="(\\d+)"[^>]*>\\s*${eventName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*<\\/option>`,
+      `<option[^>]*\\bvalue="(\\d+)"[^>]*>\\s*${escaped}\\s*<\\/option>`,
     ),
   );
   return match?.[1] ?? null;

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -9,7 +9,11 @@ import {
   sortAttendeeRows,
   type TableQuestionData,
 } from "#templates/attendee-table.tsx";
-import { setupTestEncryptionKey, testAttendee } from "#test-utils";
+import {
+  hasInputWithValue,
+  setupTestEncryptionKey,
+  testAttendee,
+} from "#test-utils";
 
 const ALLOWED_DOMAIN = "example.com";
 
@@ -312,7 +316,7 @@ describe("AttendeeTable", () => {
 
     test("includes activeFilter as return_filter", () => {
       const html = AttendeeTable(makeOpts({ activeFilter: "in" }));
-      expect(html).toContain('name="return_filter" value="in"');
+      expect(hasInputWithValue(html, "return_filter", "in")).toBe(true);
     });
   });
 
@@ -379,7 +383,7 @@ describe("AttendeeTable", () => {
 
     test("includes return_url as hidden form field in check-in form", () => {
       const html = AttendeeTable(makeOpts({ returnUrl: "/checkin/abc" }));
-      expect(html).toContain('name="return_url" value="/checkin/abc"');
+      expect(hasInputWithValue(html, "return_url", "/checkin/abc")).toBe(true);
     });
 
     test("does not include return_url when not provided", () => {

--- a/test/lib/forms/flash.test.ts
+++ b/test/lib/forms/flash.test.ts
@@ -10,7 +10,7 @@ import {
   setFormSuccess,
 } from "#lib/forms.tsx";
 import { detectIframeMode } from "#lib/iframe.ts";
-import { setupTestEncryptionKey } from "#test-utils";
+import { hasInputWithValue, setupTestEncryptionKey } from "#test-utils";
 
 beforeAll(async () => {
   setupTestEncryptionKey();
@@ -104,9 +104,10 @@ describe("CsrfForm", () => {
 
   test("renders POST form with action and CSRF token", () => {
     const html = String(CsrfForm({ action: "/submit" }));
-    expect(html).toContain('<form method="POST" action="/submit"');
-    expect(html).toContain(
-      `<input type="hidden" name="csrf_token" value="${getCurrentCsrfToken()}"`,
+    expect(html).toContain('action="/submit"');
+    expect(html).toContain('method="POST"');
+    expect(hasInputWithValue(html, "csrf_token", getCurrentCsrfToken())).toBe(
+      true,
     );
   });
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -29,6 +29,7 @@ import {
   FLASH_TEST_ID,
   flashCookieHeader,
   followRedirectWithFlash,
+  extractInputValue,
   getAttendeesRaw,
   mockFormRequest,
   mockProviderType,
@@ -2694,9 +2695,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       { cookie: await testCookie() },
     );
     const html = await page.text();
-    const match = html.match(/name="merge_version"\s+value="([^"]*)"/);
-    if (!match) throw new Error("merge_version not found in page");
-    return match[1]!;
+    const value = extractInputValue(html, "merge_version");
+    if (value === null) throw new Error("merge_version not found in page");
+    return value;
   };
 
   describe("POST /admin/attendees/:attendeeId/merge", () => {
@@ -3220,10 +3221,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         { cookie: await testCookie() },
       );
       const previewHtml = await previewPage.text();
-      const versionMatch = previewHtml.match(
-        /name="merge_version"\s+value="([^"]*)"/,
-      );
-      const mergeVersion = versionMatch![1]!;
+      const mergeVersion = extractInputValue(previewHtml, "merge_version")!;
 
       // Submit choosing source answer
       const { response } = await adminFormPost(
@@ -3264,8 +3262,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         { cookie: await testCookie() },
       );
       const html = await previewPage.text();
-      const match = html.match(/name="merge_version"\s+value="([^"]*)"/);
-      const mergeVersion = match![1]!;
+      const mergeVersion = extractInputValue(html, "merge_version")!;
 
       const bookingKey = `${event.id}:null`;
       const { response } = await adminFormPost(

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -14,6 +14,7 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirectWithFlash,
+  extractInputValue,
   FLASH_TEST_ID,
   flashCookieHeader,
   followRedirectWithFlash,
@@ -45,7 +46,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
     test("shows login page", async () => {
       const html = await assertPublicHtml("/admin/login", "Login");
       // Login page contains a signed CSRF token in the form
-      expect(html).toMatch(/name="csrf_token" value="s1\./);
+      expect(extractInputValue(html, "csrf_token")).toMatch(/^s1\./);
     });
 
     test("redirects to /admin when already authenticated", async () => {

--- a/test/lib/server-event-qr-admin.test.ts
+++ b/test/lib/server-event-qr-admin.test.ts
@@ -56,10 +56,20 @@ describeWithEnv("admin event-qr route", { db: true }, () => {
     });
 
     test("shows green indicator for event with no extra fields, red when extra fields required", async () => {
-      const noFields = await createTestEvent({ fields: "", maxAttendees: 10, unitPrice: 500 });
-      const withFields = await createTestEvent({ fields: "email", maxAttendees: 10, unitPrice: 500 });
+      const noFields = await createTestEvent({
+        fields: "",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
+      const withFields = await createTestEvent({
+        fields: "email",
+        maxAttendees: 10,
+        unitPrice: 500,
+      });
       const { response: r1 } = await adminGet(`/admin/event/${noFields.id}/qr`);
-      const { response: r2 } = await adminGet(`/admin/event/${withFields.id}/qr`);
+      const { response: r2 } = await adminGet(
+        `/admin/event/${withFields.id}/qr`,
+      );
       expect(await r1.text()).toContain('class="success-text"');
       expect(await r2.text()).toContain('class="danger-text"');
     });
@@ -219,7 +229,9 @@ describeWithEnv("admin event-qr route", { db: true }, () => {
     });
 
     test("returns 404 when the event does not exist", async () => {
-      const { response } = await adminGet("/admin/event/99999/qr.json?quantity=1");
+      const { response } = await adminGet(
+        "/admin/event/99999/qr.json?quantity=1",
+      );
       expect(response.status).toBe(404);
       response.body?.cancel();
     });

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -29,8 +29,9 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirect,
+  extractInputValue,
   getTicketCsrfToken,
-  matchGroup,
+  hasCheckedInput,
   mockFormRequest,
   mockRequest,
   setTestEnv,
@@ -904,7 +905,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       );
       const html = await response.text();
       // Signed tokens start with s1.
-      expect(html).toMatch(/name="csrf_token" value="s1\./);
+      expect(extractInputValue(html, "csrf_token")).toMatch(/^s1\./);
     });
 
     test("POST succeeds with signed token and no cookie", async () => {
@@ -914,7 +915,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`/ticket/${event.slug}`),
       );
       const html = await getResponse.text();
-      const signedToken = matchGroup(html, /name="csrf_token" value="([^"]+)"/);
+      const signedToken = extractInputValue(html, "csrf_token") ?? "";
       expect(signedToken.startsWith("s1.")).toBe(true);
 
       // POST without any cookie - signed tokens are the only CSRF mechanism
@@ -1621,7 +1622,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`/ticket/${event1.slug}+${event2.slug}?iframe=true`),
       );
       const html = await response.text();
-      expect(html).toMatch(/name="csrf_token" value="s1\./);
+      expect(extractInputValue(html, "csrf_token")).toMatch(/^s1\./);
     });
 
     test("ticket POST succeeds with signed token and no cookie", async () => {
@@ -1633,7 +1634,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         mockRequest(`${path}?iframe=true`),
       );
       const html = await getResponse.text();
-      const signedToken = matchGroup(html, /name="csrf_token" value="([^"]+)"/);
+      const signedToken = extractInputValue(html, "csrf_token") ?? "";
 
       const response = await handleRequest(
         mockFormRequest(`${path}?iframe=true`, {
@@ -4141,7 +4142,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
         cookie: await testCookie(),
       });
       const html = await response.text();
-      expect(html).toContain('name="can_pay_more" value="1" checked');
+      expect(hasCheckedInput(html, "can_pay_more", "1")).toBe(true);
     });
 
     test("admin edit page shows can_pay_more unchecked for disabled event", async () => {
@@ -4154,7 +4155,7 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       });
       const html = await response.text();
       expect(html).toContain('name="can_pay_more"');
-      expect(html).not.toContain('name="can_pay_more" value="1" checked');
+      expect(hasCheckedInput(html, "can_pay_more", "1")).toBe(false);
     });
 
     test("POST respects custom max_price", async () => {

--- a/test/lib/server-qr-book.test.ts
+++ b/test/lib/server-qr-book.test.ts
@@ -31,6 +31,7 @@ import {
   createTestEvent,
   describeWithEnv,
   getAttendeesRaw,
+  hasInputWithValue,
   mockProviderType,
   mockRequest,
   setupStripe,
@@ -42,10 +43,8 @@ const qrBookPath = (slug: string, token: string): string =>
 
 /** Stub Stripe as the active provider with a canned checkout URL */
 const stubStripe = (checkoutUrl = "https://stripe.example/checkout") => {
-  const providerStub = stub(
-    paymentsApi,
-    "getConfiguredProvider",
-    () => mockProviderType("stripe"),
+  const providerStub = stub(paymentsApi, "getConfiguredProvider", () =>
+    mockProviderType("stripe"),
   );
   const checkoutStub = stub(
     stripePaymentProvider,
@@ -179,7 +178,9 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
       );
       const response = await awaitTestRequest(qrBookPath(event.slug, token));
       const body = await response.text();
-      expect(body).toContain(`name="custom_price_${event.id}" value="25.00"`);
+      expect(hasInputWithValue(body, `custom_price_${event.id}`, "25.00")).toBe(
+        true,
+      );
     });
 
     test("pre-fills quantity for the event row", async () => {
@@ -250,10 +251,8 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
         event.slug,
         buildQrBookPayload({ name: "Ada", value: 1000 }),
       );
-      const providerStub = stub(
-        paymentsApi,
-        "getConfiguredProvider",
-        () => mockProviderType("stripe"),
+      const providerStub = stub(paymentsApi, "getConfiguredProvider", () =>
+        mockProviderType("stripe"),
       );
       const checkoutStub = stub(
         stripePaymentProvider,

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -648,7 +648,9 @@ describeWithEnv("QR Scanner", { db: true }, () => {
     test("nav contains guide link", async () => {
       const { response } = await adminGet("/admin/guide");
       const body = await response.text();
-      expect(body).toContain('/admin/guide" class="active">Guide</a>');
+      expect(body).toMatch(
+        /<a[^>]*\bclass="active"[^>]*\bhref="\/admin\/guide"[^>]*>\s*Guide\s*<\/a>/,
+      );
     });
   });
 });

--- a/test/scripts/build-tag.test.ts
+++ b/test/scripts/build-tag.test.ts
@@ -9,12 +9,12 @@
 
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { isoToTag } from "../../scripts/build-tag.ts";
 import {
   isNewerVersion,
   parseReleaseTag,
   setBuildTimestampForTest,
 } from "#lib/update.ts";
+import { isoToTag } from "../../scripts/build-tag.ts";
 
 const RELEASE_TAG_FORMAT = /^v\d{4}-\d{2}-\d{2}-\d{6}$/;
 

--- a/test/templates/admin/events.test.ts
+++ b/test/templates/admin/events.test.ts
@@ -14,6 +14,7 @@ import {
 import { eventFields } from "#templates/fields.ts";
 import {
   describeWithEnv,
+  hasSelectedOption,
   setupTestEncryptionKey,
   testAttendee,
   testEventWithCount,
@@ -38,8 +39,8 @@ describe("adminEventEditPage group select", () => {
     const event = testEventWithCount({ group_id: 2 });
     const html = adminEventEditPage(event, groups, TEST_SESSION);
     expect(html).toContain('name="group_id"');
-    expect(html).toContain('<option value="2" selected');
-    expect(html).not.toContain('<option value="0" selected');
+    expect(hasSelectedOption(html, "2")).toBe(true);
+    expect(hasSelectedOption(html, "0")).toBe(false);
   });
 });
 
@@ -442,8 +443,8 @@ describe("adminEventNewPage", () => {
     const groups = [testGroup({ id: 2, name: "My Group" })];
     const html = adminEventNewPage(groups, TEST_SESSION);
     expect(html).toContain('name="group_id"');
-    expect(html).toContain('<option value="0" selected>No Group</option>');
-    expect(html).toContain('<option value="2"');
+    expect(hasSelectedOption(html, "0")).toBe(true);
+    expect(html).toContain('value="2"');
     expect(html).toContain("My Group");
   });
 

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -17,6 +17,7 @@ import {
 import { ticketViewPage } from "#templates/tickets.tsx";
 import {
   describeWithEnv,
+  hasInputWithValue,
   setupTestEncryptionKey,
   testAttendee,
   testEventWithCount,
@@ -133,9 +134,7 @@ describe("ticketPage (single event)", () => {
   test("hides quantity selector when max_quantity is 1", () => {
     const html = renderTicket(event); // max_quantity is 1
     expect(html).not.toContain("Number of Tickets");
-    expect(html).toContain(
-      `type="hidden" name="quantity_${event.id}" value="1"`,
-    );
+    expect(hasInputWithValue(html, `quantity_${event.id}`, "1")).toBe(true);
     expect(html).toContain("Continue");
   });
 
@@ -522,7 +521,7 @@ describe("ticketPage", () => {
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
-    expect(html).toContain('name="quantity_1" value="1"');
+    expect(hasInputWithValue(html, "quantity_1", "1")).toBe(true);
     expect(html).not.toContain("<select");
     expect(html).not.toContain("Select Tickets");
   });
@@ -543,7 +542,7 @@ describe("ticketPage", () => {
     expect(html).toContain("<select");
     expect(html).toContain('name="quantity_1"');
     expect(html).toContain("Number of Tickets");
-    expect(html).not.toContain('name="quantity_1" value="1"');
+    expect(hasInputWithValue(html, "quantity_1", "1")).toBe(false);
   });
 
   test("shows quantity selector for multiple events even with max quantity 1", () => {
@@ -594,7 +593,7 @@ describe("ticketPage", () => {
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
-    expect(html).toContain('name="quantity_1" value="1"');
+    expect(hasInputWithValue(html, "quantity_1", "1")).toBe(true);
     expect(html).not.toContain("Select Tickets");
   });
 });


### PR DESCRIPTION
## Summary

- Enables `useSortedKeys`, `useSortedAttributes`, `useSortedInterfaceMembers`, `useSortedProperties`, and `useSortedClasses` in `biome.json`.
- Excludes vendored minified files (`src/static/**`, `src/client/scanner.js`) so biome doesn't rewrite bundled output.
- Adds `extractInputValue`, `hasInputWithValue`, and `hasCheckedInput` helpers in `src/test-utils/index.ts` so tests assert on form input values independent of attribute order.
- Auto-sorted object keys, JSX attributes, interface members, class orders, and CSS classes across ~70 source files; updated ~10 tests to use the new helpers / order-agnostic regexes.

## Test plan

- [x] `deno task biome:fix` passes clean
- [x] `deno task typecheck` passes
- [x] `deno task lint` passes
- [x] `deno task cpd` passes (0% threshold)
- [x] `deno task build:edge` passes
- [x] `deno task test` — 2935 tests pass, 0 failures (process exits 139 at cleanup; also reproduces on `main` so it's a pre-existing flake unrelated to this change)
