### PR TITLE
Tighten CSV custom-question tests; document in admin guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1334,7 +1334,10 @@ export const adminGuidePage = (
             Yes. On any event's attendee list, click <strong>Export CSV</strong>
             . The export includes name, email, phone, address, special
             instructions, quantity, registration date, amount paid, transaction
-            ID, check-in status, ticket token, and ticket URL. For daily events,
+            ID, check-in status, ticket token, and ticket URL. If the event has
+            custom booking questions, each question is appended as an
+            additional column (one per question, in the order assigned to the
+            event) with the attendee's selected answer text. For daily events,
             the attendee list has a date filter &mdash; select a date to see
             only that day's attendees, and the CSV export respects the same
             filter.

--- a/test/lib/csv-questions.test.ts
+++ b/test/lib/csv-questions.test.ts
@@ -1,116 +1,141 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import {
-  resetEffectiveDomain,
-  setEffectiveDomainForTest,
-} from "#lib/config.ts";
+import { describe, it as test } from "@std/testing/bdd";
 import type { QuestionWithAnswers } from "#lib/db/questions.ts";
-import type { Attendee } from "#lib/types.ts";
 import { generateAttendeesCsv } from "#templates/csv.ts";
+import { testAttendee } from "#test-utils";
 
-const makeAttendee = (id: number, name: string): Attendee => ({
-  address: "",
-  attachment_downloads: 0,
-  checked_in: false,
-  created: "2024-01-01T00:00:00Z",
-  date: null,
-  email: "test@test.com",
-  event_id: 1,
+/** Build a question with answers that each have a distinct numeric id. */
+const question = (
+  id: number,
+  text: string,
+  answers: { id: number; text: string }[],
+): QuestionWithAnswers => ({
+  answers: answers.map((a, i) => ({
+    id: a.id,
+    question_id: id,
+    sort_order: i,
+    text: a.text,
+  })),
   id,
-  name,
-  payment_id: "",
-  phone: "",
-  pii_blob: "",
-  price_paid: "0",
-  quantity: 1,
-  refunded: false,
-  special_instructions: "",
-  ticket_token: "ABC123",
-  ticket_token_index: "idx",
+  text,
 });
 
-const makeQuestions = (): QuestionWithAnswers[] => [
-  {
-    answers: [
-      { id: 10, question_id: 1, sort_order: 0, text: "Small" },
-      { id: 11, question_id: 1, sort_order: 1, text: "Large" },
-    ],
-    id: 1,
-    text: "T-shirt Size",
-  },
-  {
-    answers: [
-      { id: 20, question_id: 2, sort_order: 0, text: "None" },
-      { id: 21, question_id: 2, sort_order: 1, text: "Vegetarian" },
-    ],
-    id: 2,
-    text: "Dietary Requirements",
-  },
-];
+const SIZE_Q = question(1, "T-shirt Size", [
+  { id: 10, text: "Small" },
+  { id: 11, text: "Large" },
+]);
+
+const DIET_Q = question(2, "Dietary Requirements", [
+  { id: 20, text: "None" },
+  { id: 21, text: "Vegetarian" },
+]);
+
+const csvWithQuestions = (
+  attendees: Parameters<typeof generateAttendeesCsv>[0],
+  questions: QuestionWithAnswers[],
+  attendeeAnswerMap: Map<number, number[]>,
+): string[] =>
+  generateAttendeesCsv(attendees, false, undefined, {
+    attendeeAnswerMap,
+    questions,
+  }).split("\n");
 
 describe("CSV with custom questions", () => {
-  beforeEach(() => {
-    setEffectiveDomainForTest("example.com");
+  test("appends question text columns after the ticket URL column", () => {
+    const [header] = csvWithQuestions(
+      [testAttendee()],
+      [SIZE_Q, DIET_Q],
+      new Map(),
+    );
+    expect(header!.endsWith(",T-shirt Size,Dietary Requirements")).toBe(true);
   });
 
-  afterEach(() => {
-    resetEffectiveDomain();
+  test("renders the selected answer text in the column for its question", () => {
+    const alice = testAttendee({ id: 1, name: "Alice" });
+    const bob = testAttendee({ id: 2, name: "Bob" });
+    const [, aliceRow, bobRow] = csvWithQuestions(
+      [alice, bob],
+      [SIZE_Q, DIET_Q],
+      new Map([
+        [1, [10, 21]], // Alice: Small, Vegetarian
+        [2, [11, 20]], // Bob: Large, None
+      ]),
+    );
+    // Question columns are the last two: ...,<size>,<diet>
+    expect(aliceRow!.endsWith(",Small,Vegetarian")).toBe(true);
+    expect(bobRow!.endsWith(",Large,None")).toBe(true);
   });
 
-  test("includes question columns in header", () => {
-    const attendees = [makeAttendee(1, "Alice")];
-    const questions = makeQuestions();
-    const answerMap = new Map([[1, [10, 20]]]);
-
-    const csv = generateAttendeesCsv(attendees, false, undefined, {
-      attendeeAnswerMap: answerMap,
-      questions,
-    });
-
-    const header = csv.split("\n")[0]!;
-    expect(header).toContain("T-shirt Size");
-    expect(header).toContain("Dietary Requirements");
+  test("leaves the question column blank when the attendee did not answer it", () => {
+    const [, row] = csvWithQuestions(
+      [testAttendee({ id: 1 })],
+      [SIZE_Q, DIET_Q],
+      new Map([[1, [10]]]), // answered size only
+    );
+    // Expect the two trailing question cells to be "Small" and "" (blank)
+    expect(row!.endsWith(",Small,")).toBe(true);
   });
 
-  test("includes correct answer values per attendee", () => {
-    const attendees = [makeAttendee(1, "Alice"), makeAttendee(2, "Bob")];
-    const questions = makeQuestions();
-    const answerMap = new Map([
-      [1, [10, 21]], // Alice: Small, Vegetarian
-      [2, [11, 20]], // Bob: Large, None
+  test("leaves all question columns blank when the attendee map has no entry", () => {
+    const [, row] = csvWithQuestions(
+      [testAttendee({ id: 1 })],
+      [SIZE_Q, DIET_Q],
+      new Map(),
+    );
+    expect(row!.endsWith(",,")).toBe(true);
+  });
+
+  test("escapes commas in question text", () => {
+    const commaQuestion = question(3, "Name, as printed on ticket", [
+      { id: 30, text: "Y" },
     ]);
-
-    const csv = generateAttendeesCsv(attendees, false, undefined, {
-      attendeeAnswerMap: answerMap,
-      questions,
-    });
-
-    const lines = csv.split("\n");
-    expect(lines[1]).toContain("Small");
-    expect(lines[1]).toContain("Vegetarian");
-    expect(lines[2]).toContain("Large");
-    expect(lines[2]).toContain("None");
+    const [header] = csvWithQuestions(
+      [testAttendee({ id: 1 })],
+      [commaQuestion],
+      new Map([[1, [30]]]),
+    );
+    expect(header).toContain('"Name, as printed on ticket"');
   });
 
-  test("uses empty string for attendee with no answers", () => {
-    const attendees = [makeAttendee(1, "Alice")];
-    const questions = makeQuestions();
-    const answerMap = new Map<number, number[]>();
-
-    const csv = generateAttendeesCsv(attendees, false, undefined, {
-      attendeeAnswerMap: answerMap,
-      questions,
-    });
-
-    const lines = csv.split("\n");
-    // Last two values should be empty (no answers)
-    expect(lines[1]!.endsWith(",,")).toBe(true);
+  test("escapes commas in answer text", () => {
+    const q = question(4, "Allergies", [
+      { id: 40, text: "Nuts, dairy" },
+      { id: 41, text: "None" },
+    ]);
+    const [, row] = csvWithQuestions(
+      [testAttendee({ id: 1 })],
+      [q],
+      new Map([[1, [40]]]),
+    );
+    expect(row).toContain('"Nuts, dairy"');
   });
 
-  test("generates normal CSV when no questionData provided", () => {
-    const attendees = [makeAttendee(1, "Alice")];
-    const csv = generateAttendeesCsv(attendees);
-    const header = csv.split("\n")[0]!;
-    expect(header).not.toContain("T-shirt");
+  test("escapes quotes in answer text per RFC 4180", () => {
+    const q = question(5, "Quote", [{ id: 50, text: 'She said "hi"' }]);
+    const [, row] = csvWithQuestions(
+      [testAttendee({ id: 1 })],
+      [q],
+      new Map([[1, [50]]]),
+    );
+    expect(row).toContain('"She said ""hi"""');
+  });
+
+  test("ignores answer IDs that do not belong to any of the provided questions", () => {
+    const [, row] = csvWithQuestions(
+      [testAttendee({ id: 1 })],
+      [SIZE_Q],
+      new Map([[1, [999, 10]]]), // 999 is stale / unknown, 10 matches Small
+    );
+    // The unknown answer must not leak into the column or appear as "undefined"
+    expect(row!.endsWith(",Small")).toBe(true);
+    expect(row).not.toContain("undefined");
+  });
+
+  test("omits question columns entirely when questionData is not provided", () => {
+    const [header, row] = generateAttendeesCsv([testAttendee()]).split("\n");
+    // The header should end with "Ticket URL" — no trailing question columns
+    expect(header!.endsWith("Ticket URL")).toBe(true);
+    // And the data row should have the same number of cells (commas) as the header
+    expect(row!.split(",").length).toBe(header!.split(",").length);
   });
 });


### PR DESCRIPTION
## Summary

`test/lib/csv-questions.test.ts` violated several of the project's test quality criteria, and a behaviour it touches (custom-question CSV columns) wasn't mentioned in the admin guide. This PR fixes both.

### Test file rewrite (`test/lib/csv-questions.test.ts`)

Issues addressed in the original:
- **Reimplemented production helpers** — had a local `makeAttendee` instead of using the shared `testAttendee` from `#test-utils`.
- **Pollutes global state under concurrency** — called `setEffectiveDomainForTest` / `resetEffectiveDomain` even though none of the assertions check URLs, risking interference with other tests that read the effective domain.
- **Fragile assertions** — relied on `endsWith(",,")` with no context for what the trailing cells represent.
- **Sparse coverage** — only 4 tests, missing column ordering, CSV escaping (RFC 4180), and stale answer-ID handling.

Changes:
- Uses `testAttendee(overrides)` throughout (no more local factory).
- Removes effective-domain setup entirely.
- Introduces two small helpers (`question(...)`, `csvWithQuestions(...)`) to cut boilerplate without leaking production-logic into the test.
- Adds tests for:
  - header column ordering (question columns after `Ticket URL`),
  - per-attendee answer rendering across multiple questions,
  - blank cells for missing answers (with and without any map entry),
  - escaping of commas in question and answer text,
  - RFC 4180 escaping of embedded quotes,
  - stale/unknown answer IDs (must not emit `undefined`),
  - the no-`questionData` shape (header and row widths stay aligned).
- All 9 tests complete in ~27 ms, well under the 100 ms budget.

### Admin guide update (`src/templates/admin/guide.tsx`)

The "Can I export attendee data?" Q&A enumerated every CSV column except custom booking questions, which are appended after `Ticket URL` when the event has them. Extended that paragraph to describe the behaviour — directly aligned with the new `appends question text columns after the ticket URL column` test.

## Test plan

- [x] `deno test --no-check --allow-all test/lib/csv-questions.test.ts` — 9 passed, 0 failed in 27 ms
- [x] `deno test --no-check --allow-all test/templates/csv.test.ts` — still passes (unchanged behaviour)
- [x] `deno lint` — no issues on edited files
