### PR TITLE
Tighten event-fields tests; document multi-event field merging in guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -184,6 +184,14 @@ export const adminGuidePage = (
             admin, they appear as one attendee linked to multiple events.
           </p>
           <p>
+            If the events have different contact-detail settings, the combined
+            form asks for the union of all selected fields &mdash; so pairing an
+            email-only event with one that also collects a phone number will
+            require both from every attendee. Fields always appear in the same
+            order (email, phone, address, special instructions) regardless of
+            which events are combined.
+          </p>
+          <p>
             To generate the link, open the <strong>Multi-booking link</strong>{" "}
             section on the <strong>Events</strong> page and tick the events you
             want to combine. The link updates as you select, and events appear

--- a/test/lib/event-fields.test.ts
+++ b/test/lib/event-fields.test.ts
@@ -5,6 +5,7 @@ import {
   parseEventFields,
   withRequiredEmail,
 } from "#lib/event-fields.ts";
+import { CONTACT_FIELDS } from "#lib/types.ts";
 
 describe("event-fields", () => {
   describe("parseEventFields", () => {
@@ -12,74 +13,64 @@ describe("event-fields", () => {
       expect(parseEventFields("")).toEqual([]);
     });
 
-    test("parses single field", () => {
-      expect(parseEventFields("email")).toEqual(["email"]);
-    });
-
-    test("parses comma-separated fields", () => {
-      expect(parseEventFields("email,phone")).toEqual(["email", "phone"]);
-    });
-
-    test("trims whitespace", () => {
+    test("parses and trims comma-separated fields", () => {
       expect(parseEventFields(" email , phone ")).toEqual(["email", "phone"]);
     });
 
-    test("filters invalid fields", () => {
-      expect(parseEventFields("email,bogus,phone")).toEqual(["email", "phone"]);
+    test("drops tokens that are not recognised contact fields", () => {
+      // Events render contactFieldMap[f] directly; an unrecognised token
+      // would produce undefined and crash form rendering.
+      expect(parseEventFields("email,<script>,phone,DROP TABLE")).toEqual([
+        "email",
+        "phone",
+      ]);
     });
 
-    test("parses all four contact fields", () => {
-      expect(
-        parseEventFields("email,phone,address,special_instructions"),
-      ).toEqual(["email", "phone", "address", "special_instructions"]);
+    test("preserves input order of valid fields", () => {
+      // Single-event rendering uses this order verbatim, so it must not
+      // silently re-sort.
+      expect(parseEventFields("phone,email")).toEqual(["phone", "email"]);
     });
   });
 
   describe("mergeEventFields", () => {
-    test("returns empty string for empty array", () => {
+    test("returns empty string when no settings are provided", () => {
       expect(mergeEventFields([])).toBe("");
     });
 
-    test("returns empty string when all events have empty fields", () => {
-      expect(mergeEventFields(["", ""])).toBe("");
+    test("returns fields in canonical order regardless of input order", () => {
+      // Multi-event booking must render fields consistently; the output
+      // order must match CONTACT_FIELDS, not any single event's order.
+      const reversed = [...CONTACT_FIELDS].reverse().join(",");
+      expect(mergeEventFields([reversed])).toBe(CONTACT_FIELDS.join(","));
     });
 
-    test("returns union of fields in canonical order", () => {
-      expect(mergeEventFields(["phone", "email"])).toBe("email,phone");
-    });
-
-    test("deduplicates across settings", () => {
-      expect(mergeEventFields(["email,phone", "email,phone"])).toBe(
-        "email,phone",
-      );
-    });
-
-    test("merges disjoint field sets", () => {
-      expect(mergeEventFields(["email", "phone,address"])).toBe(
+    test("returns union across settings without duplicates", () => {
+      expect(mergeEventFields(["email,phone", "phone,address"])).toBe(
         "email,phone,address",
       );
     });
 
-    test("returns single field from single setting", () => {
-      expect(mergeEventFields(["phone"])).toBe("phone");
+    test("ignores empty and unrecognised tokens while merging", () => {
+      expect(mergeEventFields(["", "email,bogus", "phone"])).toBe(
+        "email,phone",
+      );
     });
   });
 
   describe("withRequiredEmail", () => {
-    test("returns unchanged when email already present", () => {
-      expect(withRequiredEmail("email,phone")).toBe("email,phone");
-    });
-
     test("prepends email when missing", () => {
-      expect(withRequiredEmail("phone")).toBe("email,phone");
+      expect(withRequiredEmail("phone,address")).toBe("email,phone,address");
     });
 
-    test("returns email for empty fields", () => {
+    test("returns email alone for empty input", () => {
       expect(withRequiredEmail("")).toBe("email");
     });
 
-    test("prepends email when only non-email fields present", () => {
-      expect(withRequiredEmail("phone,address")).toBe("email,phone,address");
+    test("returns input unchanged when email is already present", () => {
+      // Idempotence matters: Square checkout calls this on every request.
+      const input = "email,phone";
+      expect(withRequiredEmail(input)).toBe(input);
     });
   });
 });


### PR DESCRIPTION
## Summary

The existing `test/lib/event-fields.test.ts` had several low-value tests that restated trivial base cases or duplicated coverage. This PR replaces them with tests pinned to behaviour the callers genuinely depend on, and fills a gap in `/admin/guide` that the rewritten tests surfaced.

## Test changes

Removed:
- `mergeEventFields(["", ""])` &mdash; same assertion as the empty-array test already exercises the "no fields" path.
- `mergeEventFields(["phone"])` &mdash; restates a base case already covered by the union and canonical-order tests.
- `parses single field` / `parses comma-separated fields` &mdash; subsumed by the whitespace-trimming test, which asserts the same parse + an additional behaviour.
- `parses all four contact fields` &mdash; only asserted that parsing four literal names returns the same four names; replaced with a proper canonical-order test that reverses the input.
- `deduplicates across settings` with identical settings &mdash; replaced with a disjoint-settings union test plus a mixed-noise test that covers dedup alongside invalid-token filtering.

Added / tightened:
- `drops tokens that are not recognised contact fields` &mdash; covers the real security-relevant behaviour (an unrecognised token would produce `undefined` via `contactFieldMap[f]` lookup in `getTicketFields` and crash form rendering). Uses adversarial tokens like `<script>` and `DROP TABLE` rather than a benign `bogus`.
- `preserves input order of valid fields` &mdash; documents that `parseEventFields` must not silently re-sort, because single-event form rendering uses the output order verbatim.
- `returns fields in canonical order regardless of input order` &mdash; uses `[...CONTACT_FIELDS].reverse()` to prove the merge enforces canonical order rather than echoing input order, which the previous two-field test couldn't verify.
- `ignores empty and unrecognised tokens while merging` &mdash; single test that exercises empty settings, invalid tokens, and union-in-canonical-order together.

Constants are imported from `#lib/types.ts` instead of hardcoded, per the "no magic strings" project standard.

## Guide change

The "How do I combine multiple events into one booking?" entry didn't explain what happens when the events have different contact-detail settings &mdash; an admin wouldn't know whether the combined form would show fields from the first event, the last event, or the union. The new paragraph documents that it's the union in canonical order (email, phone, address, special instructions), matching what `mergeEventFields` actually does and what the new canonical-order test enforces.

## Test plan

- [x] `deno test --no-check --allow-all test/lib/event-fields.test.ts` &mdash; 11 steps pass
- [x] `deno test --no-check --allow-all test/lib/server-guide.test.ts` &mdash; 44 steps pass (guide template unchanged behaviourally)
- [x] `deno lint` / `deno fmt --check` on both modified files &mdash; clean
- [x] `biome check` on `test/lib/event-fields.test.ts` &mdash; clean (pre-existing unrelated issues elsewhere left untouched)

https://claude.ai/code/session_01NNQChP7yBRV94ciQMGg1X8