### PR TITLE
Prevent "x days ago" badge from wrapping

### DIFF
--- a/src/static/mvp.css
+++ b/src/static/mvp.css
@@ -950,6 +950,7 @@ input[type="submit"].danger:hover {
   margin-right: 1rem;
   padding: 0.2rem 0.5rem;
   border-radius: 999px;
+  white-space: nowrap;
 }
 
 [data-theme="dark"] .password-warning {


### PR DESCRIPTION
## Summary
- Add `white-space: nowrap` to `.badge-alert` so the past-event "x days ago" indicator stays on a single line.

## Test plan
- [ ] Visit a single-event ticket page for a past event at a narrow viewport and confirm the red badge next to the date does not wrap.
