### PR TITLE
Tighten config tests; document canonical-domain priority in guide

### DIFF
--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -1746,6 +1746,42 @@ export const adminGuidePage = (
             propagate, then click <strong>Validate Custom Domain</strong> to try
             again.
           </p>
+          <p>
+            Until validation succeeds, ticket links, redirect URLs, and emails
+            continue to use your host subdomain (or the Bunny.net address if you
+            haven't registered one). See{" "}
+            <strong>Which domain is used for ticket links and emails?</strong>{" "}
+            below.
+          </p>
+        </Q>
+
+        <Q q="Which domain is used for ticket links and emails?">
+          <p>
+            The system picks a single <strong>canonical</strong> domain for
+            every request and uses it for generated URLs (ticket links, QR
+            codes, redirects, webhook callbacks, and emails). It's chosen in
+            this order of priority:
+          </p>
+          <ol>
+            <li>
+              Your <strong>custom domain</strong>, but only once its{" "}
+              <strong>CNAME has been validated</strong>. Saving a domain is not
+              enough on its own.
+            </li>
+            <li>
+              Your registered <strong>host subdomain</strong> (e.g.{" "}
+              <code>mysite.tickets</code>), if one is set.
+            </li>
+            <li>
+              Otherwise the hostname from the incoming request (the Bunny.net
+              address).
+            </li>
+          </ol>
+          <p>
+            Both the host subdomain and a validated custom domain continue to
+            accept traffic at the CDN level, but only the higher-priority one is
+            used when the system generates links.
+          </p>
         </Q>
       </Section>
 

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -1,246 +1,182 @@
-import process from "node:process";
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, beforeEach, it as test } from "@std/testing/bdd";
 import {
   getBookingFee,
   getEffectiveDomain,
+  getEmbedHosts,
   isPaymentsEnabled,
   loadEffectiveDomain,
   resetEffectiveDomain,
   setEffectiveDomainForTest,
 } from "#lib/config.ts";
 import { settings } from "#lib/db/settings.ts";
-import { getEnv } from "#lib/env.ts";
-import { getActivePaymentProvider } from "#lib/payments.ts";
-import { createTestDb, resetDb, setTestEnv, setupStripe } from "#test-utils";
+import { describeWithEnv, setupStripe } from "#test-utils";
 
-describe("config", () => {
-  beforeEach(async () => {
-    await createTestDb();
+describeWithEnv("isPaymentsEnabled", { db: true }, () => {
+  test("returns false when no provider is configured", () => {
+    expect(isPaymentsEnabled()).toBe(false);
   });
 
-  afterEach(() => {
-    resetDb();
-  });
-
-  describe("isPaymentsEnabled", () => {
-    test("returns false when no provider set", async () => {
-      expect(await isPaymentsEnabled()).toBe(false);
-    });
-
-    test("returns false when provider set but no stripe key", async () => {
-      await settings.update.paymentProvider("stripe");
-      expect(await isPaymentsEnabled()).toBe(false);
-    });
-
-    test("returns false when stripe key set but no provider", async () => {
-      await settings.update.stripe.secretKey("sk_test_123");
-      expect(await isPaymentsEnabled()).toBe(false);
-    });
-
-    test("returns true when provider is stripe and key is set", async () => {
-      await setupStripe("sk_test_123");
-      expect(await isPaymentsEnabled()).toBe(true);
-    });
-
-    test("returns false when provider is square but no token", async () => {
-      await settings.update.paymentProvider("square");
-      expect(await isPaymentsEnabled()).toBe(false);
-    });
-
-    test("returns true when provider is square and token is set", async () => {
-      await settings.update.paymentProvider("square");
-      await settings.update.square.accessToken("EAAAl_test_123");
-      expect(await isPaymentsEnabled()).toBe(true);
-    });
-  });
-
-  describe("getEffectiveDomain", () => {
-    afterEach(() => {
-      resetEffectiveDomain();
-    });
-
-    test("returns request hostname when no custom domain is set", async () => {
-      const result = await loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(result).toBe("mysite.bunny.run");
-      expect(getEffectiveDomain()).toBe("mysite.bunny.run");
-    });
-
-    test("returns custom domain when set and validated in DB", async () => {
-      await settings.update.customDomain("tickets.example.com");
-      await settings.update.customDomainLastValidated();
-      settings.invalidateCache();
-      await settings.loadAll();
-      const result = await loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(result).toBe("tickets.example.com");
-      expect(getEffectiveDomain()).toBe("tickets.example.com");
-    });
-
-    test("falls back to request hostname when custom domain is set but not validated", async () => {
-      await settings.update.customDomain("tickets.example.com");
-      settings.invalidateCache();
-      const result = await loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(result).toBe("mysite.bunny.run");
-      expect(getEffectiveDomain()).toBe("mysite.bunny.run");
-    });
-
-    test("falls back to request hostname after custom domain is cleared", async () => {
-      await settings.update.customDomain("tickets.example.com");
-      await settings.update.customDomainLastValidated();
-      settings.invalidateCache();
-      await settings.loadAll();
-      await loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(getEffectiveDomain()).toBe("tickets.example.com");
-
-      await settings.update.customDomain("");
-      settings.invalidateCache();
-      await settings.loadAll();
-      await loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(getEffectiveDomain()).toBe("mysite.bunny.run");
-    });
-
-    test("returns localhost before loadEffectiveDomain is called", () => {
-      expect(getEffectiveDomain()).toBe("localhost");
-    });
-
-    test("setEffectiveDomainForTest overrides the cached value", () => {
-      setEffectiveDomainForTest("custom.example.com");
-      expect(getEffectiveDomain()).toBe("custom.example.com");
-    });
-
-    test("resetEffectiveDomain clears the cached value", async () => {
-      await settings.update.customDomain("tickets.example.com");
-      await settings.update.customDomainLastValidated();
-      settings.invalidateCache();
-      await settings.loadAll();
-      await loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(getEffectiveDomain()).toBe("tickets.example.com");
-
-      resetEffectiveDomain();
-      expect(getEffectiveDomain()).toBe("localhost");
-    });
-
-    test("returns bunny subdomain when set and no custom domain", async () => {
-      await settings.update.bunnySubdomain("myevent.tickets.example.com");
-      settings.invalidateCache();
-      await settings.loadAll();
-      const result = loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(result).toBe("myevent.tickets.example.com");
-      expect(getEffectiveDomain()).toBe("myevent.tickets.example.com");
-    });
-
-    test("custom domain takes priority over bunny subdomain", async () => {
-      await settings.update.bunnySubdomain("myevent.tickets.example.com");
-      await settings.update.customDomain("tickets.example.com");
-      await settings.update.customDomainLastValidated();
-      settings.invalidateCache();
-      await settings.loadAll();
-      const result = loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(result).toBe("tickets.example.com");
-    });
-
-    test("bunny subdomain used when custom domain set but not validated", async () => {
-      await settings.update.bunnySubdomain("myevent.tickets.example.com");
-      await settings.update.customDomain("tickets.example.com");
-      // Not validated
-      settings.invalidateCache();
-      await settings.loadAll();
-      const result = loadEffectiveDomain("https://mysite.bunny.run/");
-      expect(result).toBe("myevent.tickets.example.com");
-    });
-  });
-
-  describe("isPaymentsEnabled - non-stripe provider", () => {
-    test("returns false when provider is set to unknown value", async () => {
-      await settings.setRaw("payment_provider", "paypal");
-      await settings.update.stripe.secretKey("sk_test_123");
-      // Unknown provider doesn't match "stripe" or "square", so isPaymentsEnabled returns false
-      expect(await isPaymentsEnabled()).toBe(false);
-    });
-  });
-
-  describe("getBookingFee", () => {
-    test("returns 0 when not set", async () => {
-      expect(await getBookingFee()).toBe(0);
-    });
-
-    test("returns parsed value when set", async () => {
-      await settings.update.bookingFee("1.5");
-      expect(await getBookingFee()).toBe(1.5);
-    });
-
-    test("returns 0 for unparseable value", async () => {
-      await settings.update.bookingFee("abc");
-      expect(await getBookingFee()).toBe(0);
-    });
-  });
-});
-
-describe("env", () => {
-  test("getEnv returns undefined when variable is not set anywhere", () => {
-    const uniqueKey = "TOTALLY_NONEXISTENT_VAR_XYZ_123";
-    // Ensure it's not in process.env
-    delete process.env[uniqueKey];
-    const restore = setTestEnv({ [uniqueKey]: undefined });
-
-    const result = getEnv(uniqueKey);
-    expect(result).toBeUndefined();
-    restore();
-  });
-
-  test("getEnv reads from process.env when available", () => {
-    process.env.TEST_ENV_VAR_CONFIG = "from_process";
-    const result = getEnv("TEST_ENV_VAR_CONFIG");
-    expect(result).toBe("from_process");
-    delete process.env.TEST_ENV_VAR_CONFIG;
-  });
-
-  test("getEnv falls back to Deno.env when not in process.env", () => {
-    const key = "TEST_DENO_ONLY_VAR";
-    delete process.env[key];
-    const restore = setTestEnv({ [key]: "from_deno" });
-    const result = getEnv(key);
-    expect(result).toBe("from_deno");
-    restore();
-  });
-});
-
-describe("payments", () => {
-  beforeEach(async () => {
-    await createTestDb();
-  });
-
-  afterEach(() => {
-    resetDb();
-  });
-
-  test("getActivePaymentProvider returns null when no provider configured", async () => {
-    const provider = await getActivePaymentProvider();
-    expect(provider).toBeNull();
-  });
-
-  test("getActivePaymentProvider returns null for unknown provider type", async () => {
-    // Set a non-stripe provider type directly
-    await settings.setRaw("payment_provider", "unknown_provider");
-    const provider = await getActivePaymentProvider();
-    expect(provider).toBeNull();
-  });
-
-  test("getActivePaymentProvider returns stripe provider when configured", async () => {
+  test("returns false when provider is stripe but no secret key is set", async () => {
     await settings.update.paymentProvider("stripe");
-    const provider = await getActivePaymentProvider();
-    expect(provider).not.toBeNull();
-    expect(provider?.type).toBe("stripe");
+    expect(isPaymentsEnabled()).toBe(false);
   });
 
-  test("getActivePaymentProvider returns square provider when configured", async () => {
+  test("returns false when a stripe key is stored but no provider is selected", async () => {
+    await settings.update.stripe.secretKey("sk_test_123");
+    expect(isPaymentsEnabled()).toBe(false);
+  });
+
+  test("returns true when provider is stripe and a key is set", async () => {
+    await setupStripe("sk_test_123");
+    expect(isPaymentsEnabled()).toBe(true);
+  });
+
+  test("returns false when provider is square but no access token is set", async () => {
     await settings.update.paymentProvider("square");
-    const provider = await getActivePaymentProvider();
-    expect(provider).not.toBeNull();
-    expect(provider?.type).toBe("square");
+    expect(isPaymentsEnabled()).toBe(false);
   });
 
-  test("settings.timezone returns default timezone when cache is empty", () => {
-    expect(settings.timezone).toBe("Europe/London");
+  test("returns true when provider is square and a token is set", async () => {
+    await settings.update.paymentProvider("square");
+    await settings.update.square.accessToken("EAAAl_test_123");
+    expect(isPaymentsEnabled()).toBe(true);
+  });
+
+  test("returns false when the raw provider value is not stripe or square", async () => {
+    // setRaw bypasses the typed API; reload the snapshot so the getter sees it
+    await settings.setRaw("payment_provider", "paypal");
+    await settings.update.stripe.secretKey("sk_test_123");
+    settings.invalidateCache();
+    await settings.loadAll();
+    expect(isPaymentsEnabled()).toBe(false);
+  });
+});
+
+describeWithEnv("getBookingFee", { db: true }, () => {
+  test("returns 0 when no booking fee is configured", () => {
+    expect(getBookingFee()).toBe(0);
+  });
+
+  test("returns the parsed numeric value when configured", async () => {
+    await settings.update.bookingFee("1.5");
+    expect(getBookingFee()).toBe(1.5);
+  });
+
+  test("returns 0 when the stored value cannot be parsed as a number", async () => {
+    await settings.update.bookingFee("abc");
+    expect(getBookingFee()).toBe(0);
+  });
+});
+
+describeWithEnv("getEffectiveDomain", { db: true }, () => {
+  beforeEach(() => {
+    resetEffectiveDomain();
+  });
+  afterEach(() => {
+    resetEffectiveDomain();
+  });
+
+  test("returns 'localhost' before loadEffectiveDomain has been called", () => {
+    expect(getEffectiveDomain()).toBe("localhost");
+  });
+
+  test("loadEffectiveDomain falls back to the request hostname when nothing is configured", () => {
+    const result = loadEffectiveDomain("https://mysite.bunny.run/");
+    expect(result).toBe("mysite.bunny.run");
+    expect(getEffectiveDomain()).toBe("mysite.bunny.run");
+  });
+
+  test("returns the custom domain when it is set AND validated in the DB", async () => {
+    await settings.update.customDomain("tickets.example.com");
+    await settings.update.customDomainLastValidated();
+    expect(loadEffectiveDomain("https://mysite.bunny.run/")).toBe(
+      "tickets.example.com",
+    );
+  });
+
+  test("falls back to request hostname when custom domain is set but unvalidated", async () => {
+    await settings.update.customDomain("tickets.example.com");
+    expect(loadEffectiveDomain("https://mysite.bunny.run/")).toBe(
+      "mysite.bunny.run",
+    );
+  });
+
+  test("reflects clearing the custom domain after it was previously validated", async () => {
+    await settings.update.customDomain("tickets.example.com");
+    await settings.update.customDomainLastValidated();
+    loadEffectiveDomain("https://mysite.bunny.run/");
+    expect(getEffectiveDomain()).toBe("tickets.example.com");
+
+    await settings.update.customDomain("");
+    expect(loadEffectiveDomain("https://mysite.bunny.run/")).toBe(
+      "mysite.bunny.run",
+    );
+  });
+
+  test("uses the bunny subdomain when it is set and no custom domain is configured", async () => {
+    await settings.update.bunnySubdomain("myevent.tickets.example.com");
+    expect(loadEffectiveDomain("https://mysite.bunny.run/")).toBe(
+      "myevent.tickets.example.com",
+    );
+  });
+
+  test("validated custom domain takes priority over bunny subdomain", async () => {
+    await settings.update.bunnySubdomain("myevent.tickets.example.com");
+    await settings.update.customDomain("tickets.example.com");
+    await settings.update.customDomainLastValidated();
+    expect(loadEffectiveDomain("https://mysite.bunny.run/")).toBe(
+      "tickets.example.com",
+    );
+  });
+
+  test("bunny subdomain is used when custom domain is set but not validated", async () => {
+    await settings.update.bunnySubdomain("myevent.tickets.example.com");
+    await settings.update.customDomain("tickets.example.com");
+    expect(loadEffectiveDomain("https://mysite.bunny.run/")).toBe(
+      "myevent.tickets.example.com",
+    );
+  });
+
+  test("setEffectiveDomainForTest overrides the cached value", () => {
+    setEffectiveDomainForTest("custom.example.com");
+    expect(getEffectiveDomain()).toBe("custom.example.com");
+  });
+
+  test("resetEffectiveDomain clears the cached value back to 'localhost'", async () => {
+    await settings.update.customDomain("tickets.example.com");
+    await settings.update.customDomainLastValidated();
+    loadEffectiveDomain("https://mysite.bunny.run/");
+    expect(getEffectiveDomain()).toBe("tickets.example.com");
+
+    resetEffectiveDomain();
+    expect(getEffectiveDomain()).toBe("localhost");
+  });
+});
+
+describeWithEnv("getEmbedHosts", { db: true }, () => {
+  test("returns an empty array when no embed hosts are configured", async () => {
+    expect(await getEmbedHosts()).toEqual([]);
+  });
+
+  test("returns an empty array when the stored value is whitespace only", async () => {
+    await settings.update.embedHosts("   ");
+    expect(await getEmbedHosts()).toEqual([]);
+  });
+
+  test("parses a comma-separated list into normalized hostnames", async () => {
+    await settings.update.embedHosts("Example.COM, *.mysite.org");
+    expect(await getEmbedHosts()).toEqual(["example.com", "*.mysite.org"]);
+  });
+
+  test("reflects updates made after the first read", async () => {
+    await settings.update.embedHosts("one.example.com");
+    expect(await getEmbedHosts()).toEqual(["one.example.com"]);
+
+    await settings.update.embedHosts("two.example.com, three.example.com");
+    expect(await getEmbedHosts()).toEqual([
+      "two.example.com",
+      "three.example.com",
+    ]);
   });
 });

--- a/test/lib/payments.test.ts
+++ b/test/lib/payments.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { settings } from "#lib/db/settings.ts";
+import { getActivePaymentProvider } from "#lib/payments.ts";
+import { describeWithEnv } from "#test-utils";
+
+describeWithEnv("getActivePaymentProvider", { db: true }, () => {
+  test("returns null when no provider is configured", async () => {
+    expect(await getActivePaymentProvider()).toBeNull();
+  });
+
+  test("returns null for a provider type the module doesn't recognise", async () => {
+    // setRaw bypasses the typed API; reload so the snapshot reflects the raw value
+    await settings.setRaw("payment_provider", "unknown_provider");
+    settings.invalidateCache();
+    await settings.loadAll();
+    expect(await getActivePaymentProvider()).toBeNull();
+  });
+
+  test("returns the stripe provider when provider is set to stripe", async () => {
+    await settings.update.paymentProvider("stripe");
+    const provider = await getActivePaymentProvider();
+    expect(provider?.type).toBe("stripe");
+  });
+
+  test("returns the square provider when provider is set to square", async () => {
+    await settings.update.paymentProvider("square");
+    const provider = await getActivePaymentProvider();
+    expect(provider?.type).toBe("square");
+  });
+});

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -385,6 +385,15 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       );
     });
 
+    test("explains the canonical-domain priority order for generated links", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "Which domain is used for ticket links and emails?",
+        "CNAME has been validated",
+        "host subdomain",
+      );
+    });
+
     test("contains host subdomain in advanced settings list", async () => {
       await assertAdminHtml(
         "/admin/guide",


### PR DESCRIPTION
## Summary

**Test quality improvements to `test/lib/config.test.ts`**

The file had drifted into testing unrelated modules:

- A `describe("env", ...)` block duplicated tests already covered by `test/lib/env.test.ts`, and mutated `process.env` without the `describeWithEnv` overlay that protects concurrent test runs.
- A `describe("payments", ...)` block tested `getActivePaymentProvider` from `#lib/payments.ts` — not `#lib/config.ts`.
- A `settings.timezone` assertion was stranded inside the payments block, unrelated to its topic.
- `getEmbedHosts` (a public export of `config.ts`) had no coverage anywhere.
- `settings.invalidateCache() + settings.loadAll()` boilerplate was repeated six times even though the `settings.update.*` methods already mirror into the snapshot.

Changes:

- Moved `getActivePaymentProvider` tests to a new `test/lib/payments.test.ts`.
- Removed the duplicative env block and the misplaced timezone test.
- Added `getEmbedHosts` tests (default empty, whitespace-only, parsing, updates).
- Switched every block to `describeWithEnv({ db: true })` for consistent DB isolation.
- Fixed two `setRaw`-based tests that "passed" for the wrong reason — `setRaw` doesn't update the in-memory snapshot, so the tests were asserting the default, not the raw value. They now invalidate and reload so they actually exercise the unknown-provider branch.

**Admin guide update**

While reviewing `/admin/guide`, the Custom Domain section didn't explain which domain the system actually uses for generated URLs. `loadEffectiveDomain` picks between the custom domain, host subdomain, and request hostname in a specific order, and a custom domain is only used once its CNAME is validated — admins had no way to know that saving a domain doesn't immediately switch ticket links to it.

Added a new "Which domain is used for ticket links and emails?" entry that spells out the priority order, and updated the existing "What if validation fails?" answer to point at it. Covered the new section with a test in `test/lib/server-guide.test.ts`.

## Test plan
- [ ] `deno task precommit` passes (typecheck, lint, tests)
- [ ] `deno test --no-check --allow-all test/lib/config.test.ts` passes
- [ ] `deno test --no-check --allow-all test/lib/payments.test.ts` passes
- [ ] `deno test --no-check --allow-all test/lib/server-guide.test.ts` passes — the new canonical-domain test finds the added text
- [ ] Open `/admin/guide` locally and confirm the new "Which domain is used for ticket links and emails?" entry renders under Custom Domain

https://claude.ai/code/session_01AB2p6durmVie1cYoZa9uM5