### PR TITLE
Add typed form schemas and refactor attendee event-link handling; improve Deno installer

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,35 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "Installing Deno..."
-curl -fsSL https://deno.land/install.sh | sh
+INSTALL_SOURCES=(
+  "https://deno.land/install.sh"
+  "https://raw.githubusercontent.com/denoland/deno_install/main/install.sh"
+)
+
+install_success=false
+for source in "${INSTALL_SOURCES[@]}"; do
+  echo "  trying $source"
+  if curl -fsSL "$source" | sh; then
+    install_success=true
+    break
+  fi
+done
+
+if [ "$install_success" != true ]; then
+  echo "Failed to install Deno from known install sources." >&2
+  exit 1
+fi
 
 # Add Deno to PATH for this session
 export DENO_INSTALL="$HOME/.deno"
 export PATH="$DENO_INSTALL/bin:$PATH"
 export DENO_TLS_CA_STORE=system
+
+if ! command -v deno >/dev/null 2>&1; then
+  echo "Deno installer completed but deno binary was not found on PATH." >&2
+  exit 1
+fi
 
 echo ""
 echo "Deno installed successfully!"

--- a/src/client/admin/event-date-picker.ts
+++ b/src/client/admin/event-date-picker.ts
@@ -3,9 +3,13 @@
 export const initEventDatePicker = (): void => {
   const datesEl = document.getElementById("available-dates-data");
   const eventSelect =
-    document.querySelector<HTMLSelectElement>("#add_event_id");
+    document.querySelector<HTMLSelectElement>(
+      'select[name="event_id"], #add_event_id',
+    );
   const dateField = document.querySelector<HTMLElement>(".daily-date-field");
-  const dateSelect = document.querySelector<HTMLSelectElement>("#add_date");
+  const dateSelect = document.querySelector<HTMLSelectElement>(
+    'select[name="date"], #add_date',
+  );
   if (!datesEl || !eventSelect || !dateField || !dateSelect) return;
 
   const datesData: Record<string, string[]> = JSON.parse(

--- a/src/lib/form-schemas.ts
+++ b/src/lib/form-schemas.ts
@@ -1,0 +1,71 @@
+import { defineForm } from "#lib/forms.tsx";
+
+type EventLinkOption = {
+  active: boolean;
+  id: number;
+  name: string;
+};
+
+const eventOptionLabel = { label: "Select event...", value: "" };
+const dateOptionLabel = { label: "Select date...", value: "" };
+const defaultQuantityField = {
+  defaultValue: "1",
+  id: "add_quantity",
+  label: "Quantity",
+  min: 1,
+  name: "quantity",
+  required: true,
+  type: "number",
+  validate: (value: string) =>
+    Number(value) >= 1 ? null : "Quantity must be at least 1",
+} as const;
+const defaultDateField = {
+  id: "add_date",
+  label: "Date",
+  name: "date",
+  options: [dateOptionLabel],
+  type: "select",
+} as const;
+
+export const createLinkEventForm = (events: EventLinkOption[] = []) =>
+  defineForm({
+    fields: [
+      {
+        label: "Event",
+        name: "event_id",
+        id: "add_event_id",
+        options: [
+          eventOptionLabel,
+          ...events
+            .filter((event) => event.active)
+            .map((event) => ({ label: event.name, value: String(event.id) })),
+        ],
+        parse: (value) => Number.parseInt(value, 10),
+        required: true,
+        type: "select",
+        validate: (value) => {
+          const eventId = Number.parseInt(value, 10);
+          return eventId > 0 ? null : "Event is required";
+        },
+      },
+      defaultQuantityField,
+      defaultDateField,
+    ] as const,
+    id: "linkEvent",
+  });
+
+export const linkEventUpdateForm = defineForm({
+  fields: [defaultQuantityField, defaultDateField] as const,
+  id: "linkEventUpdate",
+});
+
+export const linkEventForm = createLinkEventForm();
+export type LinkEventValues = {
+  date: string | null;
+  event_id: number;
+  quantity: number;
+};
+export type LinkEventUpdateValues = {
+  date: string | null;
+  quantity: number;
+};

--- a/src/lib/forms.tsx
+++ b/src/lib/forms.tsx
@@ -35,6 +35,7 @@ export interface Field {
   defaultValue?: string;
   hint?: string;
   hintHtml?: string;
+  id?: string;
   inputmode?: string;
   label: string;
   max?: number;
@@ -42,7 +43,8 @@ export interface Field {
   min?: number;
   minlength?: number;
   name: string;
-  options?: { value: string; label: string }[];
+  options?: readonly { value: string; label: string }[];
+  parse?: (value: string) => string | number | null;
   pattern?: string;
   placeholder?: string;
   required?: boolean;
@@ -50,6 +52,44 @@ export interface Field {
   type: FieldType;
   validate?: (value: string) => string | null;
 }
+
+type FormFieldDefinition = Readonly<Field>;
+type FormFieldDefinitions = readonly FormFieldDefinition[];
+
+type ParsedFieldValue<F extends FormFieldDefinition> = F extends {
+  parse: (...args: never[]) => infer T;
+}
+  ? T
+  : F["type"] extends "number"
+    ? number | null
+    : string | null;
+
+type NormalizedFieldValue<F extends FormFieldDefinition> = F extends {
+  required: true;
+}
+  ? Exclude<ParsedFieldValue<F>, null>
+  : ParsedFieldValue<F>;
+
+export type FormValuesFor<TFields extends FormFieldDefinitions> = {
+  [F in TFields[number] as F["name"]]: NormalizedFieldValue<F>;
+};
+
+type FormFieldRenderHelper = { render: (value?: string) => string };
+
+export type FormDefinition<
+  TFields extends FormFieldDefinitions,
+  TContext = undefined,
+> = {
+  id: string;
+  fields: TFields;
+  render: (values?: Partial<FormValuesFor<TFields>>) => string;
+  renderFields: (values?: Partial<FormValuesFor<TFields>>) => string;
+  field: (name: TFields[number]["name"]) => FormFieldRenderHelper;
+  validate: (
+    form: FormParams,
+    context?: TContext,
+  ) => ValidationResult<FormValuesFor<TFields>>;
+};
 
 export interface FieldValues {
   [key: string]: string | number | null;
@@ -65,7 +105,7 @@ type FieldValidationResult =
 
 /** Render select options HTML */
 const renderSelectOptions = (
-  options: { value: string; label: string }[],
+  options: readonly { value: string; label: string }[],
   selectedValue: string,
 ): string =>
   options
@@ -78,7 +118,7 @@ const renderSelectOptions = (
 /** Render checkbox group HTML (multiple checkboxes with the same name) */
 const renderCheckboxGroup = (
   name: string,
-  options: { value: string; label: string }[],
+  options: readonly { value: string; label: string }[],
   selectedValues: Set<string>,
 ): string =>
   `<fieldset class="checkbox-group">${options
@@ -122,6 +162,7 @@ const renderFieldInput = (field: Field, value: string): JSX.Element => {
     return (
       <textarea
         autocomplete={field.autocomplete}
+        id={field.id}
         maxlength={field.maxlength}
         name={field.name}
         placeholder={field.placeholder}
@@ -134,7 +175,7 @@ const renderFieldInput = (field: Field, value: string): JSX.Element => {
   if (field.type === "select" && field.options) {
     return (
       <Raw
-        html={`<select name="${escapeHtml(field.name)}" id="${escapeHtml(field.name)}">${renderSelectOptions(field.options, value)}</select>`}
+        html={`<select name="${escapeHtml(field.name)}" id="${escapeHtml(field.id ?? field.name)}">${renderSelectOptions(field.options, value)}</select>`}
       />
     );
   }
@@ -161,6 +202,7 @@ const renderFieldInput = (field: Field, value: string): JSX.Element => {
     <input
       autocomplete={field.autocomplete}
       autofocus={field.autofocus}
+      id={field.id}
       inputmode={field.inputmode}
       max={field.max}
       maxlength={field.maxlength}
@@ -219,11 +261,13 @@ const parseFieldValue = (
   field: Field,
   trimmed: string,
 ): string | number | null =>
-  field.type === "number"
-    ? trimmed
-      ? Number.parseInt(trimmed, 10)
-      : null
-    : trimmed;
+  field.parse
+    ? field.parse(trimmed)
+    : field.type === "number"
+      ? trimmed
+        ? Number.parseInt(trimmed, 10)
+        : null
+      : trimmed;
 
 /**
  * Collect the raw trimmed value for a field from the form data.
@@ -308,6 +352,71 @@ export const validateForm = <T = FieldValues>(
   }
 
   return { valid: true, values: values as T };
+};
+
+const normalizeOptionalValue = (
+  field: Field,
+  value: string | number | null,
+): string | number | null => {
+  if (field.required) return value;
+  if (field.type === "number") return value;
+  return value === "" ? null : value;
+};
+
+/**
+ * Define a typed form schema that can render and validate from one source.
+ */
+export const defineForm = <
+  TFields extends FormFieldDefinitions,
+  TContext = undefined,
+>(config: {
+  id: string;
+  fields: TFields;
+  validate?: (
+    values: FormValuesFor<TFields>,
+    context: TContext,
+  ) => string | null;
+}): FormDefinition<TFields, TContext> => {
+  const fields = [...config.fields];
+  const fieldMap = new Map(fields.map((f) => [f.name, f] as const));
+
+  const validate = (
+    form: FormParams,
+    context?: TContext,
+  ): ValidationResult<FormValuesFor<TFields>> => {
+    const base = validateForm<Record<string, string | number | null>>(
+      form,
+      fields,
+    );
+    if (!base.valid) return base;
+
+    const values = Object.fromEntries(
+      fields.map((field) => [
+        field.name,
+        normalizeOptionalValue(field, base.values[field.name] ?? null),
+      ]),
+    ) as FormValuesFor<TFields>;
+
+    if (config.validate) {
+      const error = config.validate(values, context as TContext);
+      if (error) return { error, valid: false };
+    }
+    return { valid: true, values };
+  };
+
+  const render = (values: Partial<FormValuesFor<TFields>> = {}): string =>
+    renderFields(fields, values as FieldValues);
+
+  return {
+    field: (name) => ({
+      render: (value = "") => renderField(fieldMap.get(name)!, value),
+    }),
+    fields: config.fields,
+    id: config.id,
+    render,
+    renderFields: render,
+    validate,
+  };
 };
 
 /**

--- a/src/routes/admin/attendees-links.ts
+++ b/src/routes/admin/attendees-links.ts
@@ -11,6 +11,12 @@ import {
 import { queryOne } from "#lib/db/client.ts";
 import { getEventWithCount } from "#lib/db/events.ts";
 import type { FormParams } from "#lib/form-data.ts";
+import {
+  type LinkEventValues,
+  type LinkEventUpdateValues,
+  linkEventForm,
+  linkEventUpdateForm,
+} from "#lib/form-schemas.ts";
 import type { EventWithCount } from "#lib/types.ts";
 import { AUTH_FORM, errorRedirect, redirect, withAuth } from "#routes/utils.ts";
 
@@ -22,18 +28,24 @@ const parseQuantity = (value: string, max: number): number => {
 
 /** Parse quantity and date from form for an event link operation */
 const parseLinkFormFields = (
-  form: FormParams,
+  values: {
+    quantity: number;
+    date: string | null;
+  },
   event: EventWithCount,
 ): { quantity: number; date: string | null } => ({
-  date: event.event_type === "daily" ? form.getString("date") || null : null,
-  quantity: parseQuantity(form.get("quantity") || "1", event.max_quantity),
+  date: event.event_type === "daily" ? values.date : null,
+  quantity: parseQuantity(String(values.quantity), event.max_quantity),
 });
 
 /** Resolve event, parse form fields, run op, check capacity, redirect on success */
 const applyLinkOp = async (
   attendeeId: number,
   eventId: number,
-  form: FormParams,
+  values: {
+    quantity: number;
+    date: string | null;
+  },
   operate: (fields: {
     quantity: number;
     date: string | null;
@@ -43,7 +55,7 @@ const applyLinkOp = async (
   const event = await getEventWithCount(eventId);
   if (!event)
     return errorRedirect(`/admin/attendees/${attendeeId}`, "Event not found");
-  const result = await operate(parseLinkFormFields(form, event));
+  const result = await operate(parseLinkFormFields(values, event));
   return result.success
     ? onSuccess(event)
     : errorRedirect(
@@ -53,16 +65,53 @@ const applyLinkOp = async (
 };
 
 /* jscpd:ignore-start — route factories; inner signature matches editAttendeePost in attendees-edit.ts */
-/** Route handler factory for /admin/attendees/:attendeeId operations */
-const attendeeRoute =
-  (
-    fn: (attendeeId: number, form: FormParams) => Response | Promise<Response>,
+type FormSchema<TValues> = {
+  validate: (
+    form: FormParams,
+  ) => { valid: true; values: TValues } | { valid: false; error: string };
+};
+
+const attendeeRouteWithForm =
+  <TValues>(
+    schema: FormSchema<TValues>,
+    fn: (attendeeId: number, values: TValues) => Response | Promise<Response>,
   ) =>
   (
     request: Request,
     { attendeeId }: { attendeeId: number },
   ): Promise<Response> =>
-    withAuth(request, AUTH_FORM, (_session, form) => fn(attendeeId, form));
+    withAuth(request, AUTH_FORM, (_session, form) => {
+      const validation = schema.validate(form);
+      if (!validation.valid)
+        return errorRedirect(
+          `/admin/attendees/${attendeeId}`,
+          validation.error,
+        );
+      return fn(attendeeId, validation.values);
+    });
+
+const eventLinkRouteWithForm =
+  <TValues>(
+    schema: FormSchema<TValues>,
+    fn: (
+      attendeeId: number,
+      eventId: number,
+      values: TValues,
+    ) => Promise<Response>,
+  ) =>
+  (
+    request: Request,
+    { attendeeId, eventId }: { attendeeId: number; eventId: number },
+  ): Promise<Response> =>
+    withAuth(request, AUTH_FORM, (_session, form) => {
+      const validation = schema.validate(form);
+      if (!validation.valid)
+        return errorRedirect(
+          `/admin/attendees/${attendeeId}`,
+          validation.error,
+        );
+      return fn(attendeeId, eventId, validation.values);
+    });
 
 /** Route handler factory for /admin/attendees/:attendeeId/…/:eventId operations */
 const eventLinkRoute =
@@ -107,41 +156,44 @@ export const handleUnlinkEvent = eventLinkRoute(async (attendeeId, eventId) => {
 });
 
 /** Handle POST /admin/attendees/:attendeeId/event/:eventId — update per-event link */
-export const handleUpdateEventLink = eventLinkRoute(
-  (attendeeId, eventId, form) =>
-    applyLinkOp(
-      attendeeId,
-      eventId,
-      form,
-      (fields) => updateEventLink(attendeeId, eventId, fields),
-      (event) =>
-        Promise.resolve(
-          redirect(
-            `/admin/attendees/${attendeeId}`,
-            `Updated ${event.name}`,
-            true,
+export const handleUpdateEventLink =
+  eventLinkRouteWithForm<LinkEventUpdateValues>(
+    linkEventUpdateForm,
+    (attendeeId, eventId, values) =>
+      applyLinkOp(
+        attendeeId,
+        eventId,
+        values,
+        (fields) => updateEventLink(attendeeId, eventId, fields),
+        (event) =>
+          Promise.resolve(
+            redirect(
+              `/admin/attendees/${attendeeId}`,
+              `Updated ${event.name}`,
+              true,
+            ),
           ),
-        ),
-    ),
-);
+      ),
+  );
 
 /** Handle POST /admin/attendees/:attendeeId/link — add event link */
-export const handleAddEventLink = attendeeRoute((attendeeId, form) => {
-  const eventId = Number(form.get("event_id")) || 0;
-  if (!eventId)
-    return errorRedirect(`/admin/attendees/${attendeeId}`, "Event is required");
-  return applyLinkOp(
-    attendeeId,
-    eventId,
-    form,
-    (fields) => addEventLink(attendeeId, { eventId, ...fields }),
-    async (event) => {
-      await logActivity(`Attendee linked to '${event.name}'`, eventId);
-      return redirect(
-        `/admin/attendees/${attendeeId}`,
-        `Added to ${event.name}`,
-        true,
-      );
-    },
-  );
-});
+export const handleAddEventLink = attendeeRouteWithForm<LinkEventValues>(
+  linkEventForm,
+  (attendeeId, values) => {
+    const eventId = values.event_id;
+    return applyLinkOp(
+      attendeeId,
+      eventId,
+      values,
+      (fields) => addEventLink(attendeeId, { eventId, ...fields }),
+      async (event) => {
+        await logActivity(`Attendee linked to '${event.name}'`, eventId);
+        return redirect(
+          `/admin/attendees/${attendeeId}`,
+          `Added to ${event.name}`,
+          true,
+        );
+      },
+    );
+  },
+);

--- a/src/templates/admin/attendees.tsx
+++ b/src/templates/admin/attendees.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from "#lib/currency.ts";
 import { formatDateLabel, formatDatetimeShort } from "#lib/dates.ts";
 import type { EventAttendeeRow } from "#lib/db/attendee-types.ts";
 import type { QuestionWithAnswers } from "#lib/db/questions.ts";
+import { createLinkEventForm } from "#lib/form-schemas.ts";
 import { ConfirmForm, CsrfForm, Flash } from "#lib/forms.tsx";
 import { Raw } from "#lib/jsx/jsx-runtime.ts";
 import {
@@ -234,8 +235,9 @@ export const adminEditAttendeePage = (
   returnUrl?: string,
   success?: string,
   error?: string,
-): string =>
-  String(
+): string => {
+  const linkEventForm = createLinkEventForm(allEvents);
+  return String(
     <Layout title={`Edit Attendee: ${attendee.name}`}>
       <AdminNav active="/admin/" session={session} />
       <Flash error={error} success={success} />
@@ -374,38 +376,11 @@ export const adminEditAttendeePage = (
       {/* Add Event Link Section */}
       <h3>Add to Event</h3>
       <CsrfForm action={`/admin/attendees/${attendee.id}/link`}>
-        <label for="add_event_id">
-          Event
-          <select id="add_event_id" name="event_id" required>
-            <option value="">Select event...</option>
-            {allEvents
-              .filter((e) => e.active)
-              .map((e) => (
-                <option data-event-type={e.event_type} value={String(e.id)}>
-                  {e.name}
-                </option>
-              ))}
-          </select>
-        </label>
-
-        <label for="add_quantity">
-          Quantity
-          <input
-            id="add_quantity"
-            min="1"
-            name="quantity"
-            required
-            type="number"
-            value="1"
-          />
-        </label>
-
-        <label class="daily-date-field" for="add_date" style="display:none">
-          Date
-          <select id="add_date" name="date">
-            <option value="">Select date...</option>
-          </select>
-        </label>
+        <Raw html={linkEventForm.field("event_id").render()} />
+        <Raw html={linkEventForm.field("quantity").render()} />
+        <div class="daily-date-field" style="display:none">
+          <Raw html={linkEventForm.field("date").render()} />
+        </div>
 
         <button type="submit">Add to Event</button>
       </CsrfForm>
@@ -440,6 +415,7 @@ export const adminEditAttendeePage = (
       </form>
     </Layout>,
   );
+};
 
 /** Source attendee data for the merge preview page */
 type MergeSourceInfo = {


### PR DESCRIPTION
### Motivation
- Provide a single, typed source for form rendering and validation for event-link forms to reduce duplication and improve type safety.
- Refactor admin attendee event-link routes to validate and parse form data before handler logic to simplify handlers and avoid repeated parsing logic.
- Make the admin client date-picker more robust to different markup and improve the CI/dev bootstrap by making the Deno installer resilient to alternative install sources and stricter shell settings.

### Description
- Added `src/lib/form-schemas.ts` which defines `createLinkEventForm`, `linkEventForm`, `linkEventUpdateForm`, and exported `LinkEventValues`/`LinkEventUpdateValues` types for event-link forms.
- Extended `src/lib/forms.tsx` with richer typing, optional `id` on fields, `parse` support for custom parsing, preservation of field `id` in rendered inputs, a `defineForm` helper to create typed form definitions, and normalization logic for optional values.
- Updated client-side date picker `src/client/admin/event-date-picker.ts` to select event/date elements by either `name` or legacy `id` for better compatibility.
- Refactored routes in `src/routes/admin/attendees-links.ts` to use the new form schemas and added `attendeeRouteWithForm`/`eventLinkRouteWithForm` helpers; changed `applyLinkOp` and `parseLinkFormFields` to accept parsed values rather than raw `FormParams`.
- Updated admin template `src/templates/admin/attendees.tsx` to use the generated `linkEventForm` for rendering the add-event UI and adjusted the daily date field wrapper markup.
- Improved `setup.sh` to use `set -euo pipefail`, try multiple Deno install sources, verify the `deno` binary is on `PATH`, and provide clearer error messages on failure.

### Testing
- Ran the repository precommit task via `deno task precommit`, which includes type checks and linting, and it completed successfully.
- Verified form rendering and admin attendee add/update flows via the updated templates and route handlers through the project's automated checks invoked by precommit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9087c54e0832d882a13c9107628ae)