### PR TITLE
Handle missing DB_URL in backup helpers

### DIFF
--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -82,7 +82,8 @@ export const splitStatements = (sql: string): string[] => {
 
 /** Check if DB_URL points to a remote database */
 export const isRemoteDatabase = (): boolean => {
-  const url = getEnv("DB_URL")!;
+  const url = getEnv("DB_URL");
+  if (!url) return false;
   return url.startsWith("libsql://") || url.startsWith("https://");
 };
 
@@ -92,7 +93,8 @@ export const isRemoteDatabase = (): boolean => {
  * Falls back to "local" for non-remote or unparseable URLs.
  */
 export const dbName = (): string => {
-  const url = getEnv("DB_URL")!;
+  const url = getEnv("DB_URL");
+  if (!url) return "local";
   let host: string;
   try {
     host = new URL(url).hostname;


### PR DESCRIPTION
### Motivation
- Tests and runtime routes were crashing with `TypeError` because `isRemoteDatabase()` and `dbName()` assumed `DB_URL` was always set and immediately called string methods on it, which is not true in local/test setups.

### Description
- Update `isRemoteDatabase()` to read `DB_URL` via `getEnv("DB_URL")` and return `false` when the variable is unset instead of calling `.startsWith()` on `undefined`.
- Update `dbName()` to return `"local"` when `DB_URL` is unset, preserving stable backup filename behavior in local/test environments.

### Testing
- Attempted to run targeted tests with `deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/lib/backup.test.ts test/lib/server-backup.test.ts test/e2e/full-booking-flow.test.ts`, but the test runner could not be executed in this environment because `deno` is not installed (tests were not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9acabed24832da7e6e79883f88e2e)