### PR TITLE
tests(storage): add direct tests for Bunny CDN raw upload and download

### DIFF
--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -601,10 +601,73 @@ describeWithEnv(
         },
       },
       () => {
-        // uploadRaw and downloadRaw Bunny branches are covered indirectly:
-        // existing tests call uploadImage/downloadImage which delegate to
-        // uploadRaw/downloadRaw via encryptAndUpload/downloadImage wrappers.
-        // Only listFiles is a wholly new Bunny codepath that needs direct testing.
+        test("uploadRaw uploads bytes to Bunny CDN", async () => {
+          await runWithStorageConfig(
+            { zoneKey: "testkey", zoneName: "testzone" },
+            () =>
+              withFetchMock(async (originalFetch) => {
+                const uploadRequests: Array<{
+                  body: Uint8Array;
+                  contentType: string | null;
+                  method: string;
+                  url: string;
+                }> = [];
+
+                installUrlHandler(originalFetch, (url, init) => {
+                  if (url.includes("storage.bunnycdn.com")) {
+                    return (async () => {
+                      const request = new Request(url, init);
+                      uploadRequests.push({
+                        body: new Uint8Array(await request.arrayBuffer()),
+                        contentType: request.headers.get("content-type"),
+                        method: request.method,
+                        url,
+                      });
+                      return new Response(JSON.stringify({ HttpCode: 201 }), {
+                        status: 201,
+                      });
+                    })();
+                  }
+                  return null;
+                });
+
+                const raw = new Uint8Array([1, 2, 3, 4]);
+                const filename = await uploadRaw(raw, "raw-upload.bin");
+
+                expect(filename).toBe("raw-upload.bin");
+                expect(uploadRequests).toHaveLength(1);
+                const uploadRequest = uploadRequests[0];
+                if (uploadRequest === undefined) {
+                  throw new Error("Expected upload request to be captured");
+                }
+                expect(uploadRequest.method).toBe("PUT");
+                expect(uploadRequest.url).toContain("/raw-upload.bin");
+                expect(uploadRequest.contentType).toBe(
+                  "application/octet-stream",
+                );
+                expect(uploadRequest.body).toEqual(raw);
+              }),
+          );
+        });
+
+        test("downloadRaw returns null when Bunny reports missing file", async () => {
+          await runWithStorageConfig(
+            { zoneKey: "testkey", zoneName: "testzone" },
+            () =>
+              withFetchMock(async (originalFetch) => {
+                installUrlHandler(originalFetch, (url) => {
+                  if (url.includes("storage.bunnycdn.com")) {
+                    return Promise.resolve(new Response("File not found", {
+                      status: 404,
+                    }));
+                  }
+                  return null;
+                });
+
+                await expect(downloadRaw("missing.bin")).resolves.toBeNull();
+              }),
+          );
+        });
 
         test("listFiles lists files from Bunny CDN matching prefix", async () => {
           await runWithStorageConfig(


### PR DESCRIPTION
### Motivation

- Ensure direct coverage of the Bunny CDN raw codepaths (`uploadRaw` and `downloadRaw`) which were previously exercised only indirectly. 
- Verify that `uploadRaw` sends the correct HTTP method, URL, headers, and body when uploading raw bytes. 
- Verify that `downloadRaw` correctly returns `null` when the CDN reports a missing file.

### Description

- Added tests in `test/lib/storage.test.ts` that mock fetch requests for Bunny CDN and capture upload request details. 
- Implemented a test `uploadRaw uploads bytes to Bunny CDN` that asserts the upload uses `PUT`, includes the filename in the URL, sets `Content-Type: application/octet-stream`, and sends the expected bytes. 
- Implemented a test `downloadRaw returns null when Bunny reports missing file` that mocks a `404` response and asserts `downloadRaw` resolves to `null`. 
- Kept the existing `listFiles lists files from Bunny CDN matching prefix` test to ensure listing behavior remains covered.

### Testing

- Ran the unit test suite via `npm test` and verified the updated test file `test/lib/storage.test.ts` executes. 
- All tests including the new `uploadRaw` and `downloadRaw` tests passed. 
- No additional automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5c33a148832dad4f0d95a9dfeee9)