### PR TITLE
Match test concurrency to host CPU cores

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -124,7 +124,6 @@ const runTests = async (useCoverage: boolean): Promise<number> => {
     cwd: projectRoot,
     env: {
       ...Deno.env.toObject(),
-      DENO_JOBS: Deno.env.get("DENO_JOBS") ?? "15",
       NO_PROXY: "localhost,127.0.0.1,::1",
       no_proxy: "localhost,127.0.0.1,::1",
       STRIPE_MOCK_HOST: "localhost",


### PR DESCRIPTION
## Summary

- `scripts/run-tests.ts` was hardcoding `DENO_JOBS=15` as the fallback for `deno test --parallel`. CI runs on `ubicloud-standard-8` (8 cores), and dev machines vary — in both cases 15 oversubscribes the CPU.
- Drop the fallback so `--parallel` uses `navigator.hardwareConcurrency` by default. An explicit `DENO_JOBS` env var still overrides (it passes through via `...Deno.env.toObject()`).

## Test plan

- [ ] `deno task test` passes locally and finishes in a reasonable time
- [ ] `DENO_JOBS=2 deno task test` still takes effect (override path still works)
- [ ] CI run on `ubicloud-standard-8` uses 8 jobs instead of 15

---
_Generated by [Claude Code](https://claude.ai/code/session_01VW633xMKK9VMG5Fm8SaBsv)_