### PR TITLE
Show uncovered lines/branches in coverage error output

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -138,6 +138,35 @@ const runTests = async (useCoverage: boolean): Promise<number> => {
   return result.code;
 };
 
+/** Extract uncovered line numbers from DA: entries in an lcov record */
+const extractUncoveredLines = (record: string): number[] => {
+  const matches = record.matchAll(/^DA:(\d+),0$/gm);
+  const lines: number[] = [];
+  for (const m of matches) lines.push(parseInt(m[1], 10));
+  return lines;
+};
+
+/** Extract uncovered branch line numbers from BRDA: entries, deduped */
+const extractUncoveredBranchLines = (record: string): number[] => {
+  const matches = record.matchAll(/^BRDA:(\d+),\d+,\d+,(-|0)$/gm);
+  const seen = new Set<number>();
+  const lines: number[] = [];
+  for (const m of matches) {
+    const line = parseInt(m[1], 10);
+    if (!seen.has(line)) {
+      seen.add(line);
+      lines.push(line);
+    }
+  }
+  return lines;
+};
+
+/** Format uncovered numbers as an indented suffix, or "" if none */
+const formatUncovered = (label: string, nums: number[]): string => {
+  if (nums.length === 0) return "";
+  return `\n      uncovered ${label}: ${nums.join(", ")}`;
+};
+
 /** Check a coverage metric (lines or branches) in an lcov record */
 const checkMetric = (
   record: string,
@@ -145,13 +174,16 @@ const checkMetric = (
   foundKey: string,
   file: string,
   label: string,
+  uncoveredSuffix: string,
 ): string | undefined => {
   const hitMatch = record.match(new RegExp(`${hitKey}:(\\d+)`));
   const foundMatch = record.match(new RegExp(`${foundKey}:(\\d+)`));
   if (!hitMatch || !foundMatch) return undefined;
   const hit = parseInt(hitMatch[1], 10);
   const found = parseInt(foundMatch[1], 10);
-  return hit < found ? `${file}: ${hit}/${found} ${label} covered` : undefined;
+  return hit < found
+    ? `${file}: ${hit}/${found} ${label} covered${uncoveredSuffix}`
+    : undefined;
 };
 
 // Files excluded from coverage enforcement
@@ -175,9 +207,21 @@ const checkRecord = (
   lineFailures: string[],
   branchFailures: string[],
 ): void => {
-  const lineFail = checkMetric(record, "LH", "LF", file, "lines");
+  const lineSuffix = formatUncovered("lines", extractUncoveredLines(record));
+  const branchSuffix = formatUncovered(
+    "branches (by line)",
+    extractUncoveredBranchLines(record),
+  );
+  const lineFail = checkMetric(record, "LH", "LF", file, "lines", lineSuffix);
   if (lineFail) lineFailures.push(lineFail);
-  const branchFail = checkMetric(record, "BRH", "BRF", file, "branches");
+  const branchFail = checkMetric(
+    record,
+    "BRH",
+    "BRF",
+    file,
+    "branches",
+    branchSuffix,
+  );
   if (branchFail) branchFailures.push(branchFail);
 };
 


### PR DESCRIPTION
## Summary

- When `deno task test:coverage` reports a file below 100%, also print the specific uncovered line numbers (and branch lines) under the file header, so you can jump straight to them without re-running `deno coverage` by hand.
- Parses `DA:<line>,0` and `BRDA:<line>,_,_,(-|0)` entries from the lcov data the script already fetches — no extra `deno coverage` invocation.
- Failure header string (`{file}: {hit}/{found} X covered`) stays byte-identical; suffix is only appended when there are uncovered entries to list.

Example new output:

```
Line coverage is not 100%:
  src/lib/storage.ts: 273/274 lines covered
      uncovered lines: 147

Branch coverage is not 100%:
  src/lib/storage.ts: 116/117 branches covered
      uncovered branches (by line): 147
```

## Test plan

- [ ] Temporarily introduce a known uncovered line/branch in a source file (e.g. wrap a statement in `if (false) { ... }` in `src/lib/storage.ts`).
- [ ] Run `deno task test:coverage` from the repo root.
- [ ] Confirm the output includes the indented `uncovered lines: <n>` and `uncovered branches (by line): <n>` lines under the file header.
- [ ] Cross-check reported numbers against `deno coverage coverage/ --detailed`.
- [ ] Revert the forced-uncovered change and re-run — expect the unchanged happy-path message `All files have 100% line and branch coverage`.
- [ ] Spot-check a file with no branches (pure re-export module) to confirm the absence of `BRDA:` entries doesn't break anything.

https://claude.ai/code/session_01W2DL7p6Fgd5s5gikaBRTWo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2DL7p6Fgd5s5gikaBRTWo)_