### PR TITLE
Cover deleteFile override branch deterministically

### DIFF
--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -22,6 +22,7 @@ import {
   validateAttachment,
   validateImage,
 } from "#lib/storage.ts";
+import { setDeleteOverrideForTest } from "#lib/test-overrides.ts";
 import {
   describeWithEnv,
   installUrlHandler,
@@ -85,6 +86,19 @@ describeWithEnv(
           await expect(deleteFile("test.jpg")).rejects.toThrow(
             "Storage is not configured",
           );
+        });
+      });
+
+      test("throws the configured override error before touching storage", async () => {
+        await withLocalStorageEnabled(async () => {
+          setDeleteOverrideForTest(new Error("forced delete failure"));
+          try {
+            await expect(deleteFile("any-file.jpg")).rejects.toThrow(
+              "forced delete failure",
+            );
+          } finally {
+            setDeleteOverrideForTest(null);
+          }
         });
       });
     });


### PR DESCRIPTION
## Summary

- `src/lib/storage.ts:357` (`if (override) throw override;` in `deleteFile`) was flaky in coverage — about half of CI runs reported it uncovered.
- The only tests exercising that branch live in `test/routes/backup.test.ts`, and they trigger it through `cleanupStalePendingFiles().catch(() => {})` — a fire-and-forget promise kicked off inside `GET /admin/backup`.
- Those tests set `setDeleteOverrideForTest(...)` then clear it in `finally` after `handleRequest` resolves. Because the cleanup promise runs in the background, the `finally` races the `deleteFile` call: if the override is cleared before `deleteFile` reads it, line 357 is never executed.
- Added a direct test in `test/lib/storage.test.ts` that sets the override, awaits `deleteFile` itself, and asserts it rejects with the forced error. This hits the branch deterministically on every run.

## Test plan

- [ ] `deno task test:coverage` reports 100% line and branch coverage on `src/lib/storage.ts` across multiple runs.
- [ ] `deno task precommit` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YziiVLhDMEQTqh5LLu781)_