### PR TITLE
Dedupe plural greeting in site assignment email

### DIFF
--- a/src/lib/site-assignment.ts
+++ b/src/lib/site-assignment.ts
@@ -62,26 +62,28 @@ const sendSiteAssignmentEmail = async (
       ? "Your new site is ready"
       : `Your ${assignments.length} new sites are ready`;
 
-  const siteListHtml = assignments
+  const greeting = `Your new site${
+    assignments.length > 1 ? "s are" : " is"
+  } ready!`;
+
+  const htmlList = assignments
     .map(
       (a) => `<li>${a.eventName}: <a href="${a.siteUrl}">${a.siteUrl}</a></li>`,
     )
     .join("");
 
-  const html = `<p>Your new site${
-    assignments.length > 1 ? "s are" : " is"
-  } ready!</p><ul>${siteListHtml}</ul>`;
-
-  const siteListText = assignments
+  const textList = assignments
     .map((a) => `- ${a.eventName}: ${a.siteUrl}`)
     .join("\n");
 
-  const text = `Your new site${
-    assignments.length > 1 ? "s are" : " is"
-  } ready!\n\n${siteListText}`;
-
   const replyTo = settings.businessEmail || undefined;
-  await sendEmail(config, { html, replyTo, subject, text, to });
+  await sendEmail(config, {
+    html: `<p>${greeting}</p><ul>${htmlList}</ul>`,
+    replyTo,
+    subject,
+    text: `${greeting}\n\n${textList}`,
+    to,
+  });
 };
 
 /** Assign sites and send notification email. Designed to be called via addPendingWork.


### PR DESCRIPTION
## Summary

Small readability cleanup in `src/lib/site-assignment.ts` (`sendSiteAssignmentEmail`). The output strings are byte-identical to before — only the local variable shape changes.

### What changed
- Extract the "Your new site(s) is/are ready!" greeting into a single `greeting` variable instead of duplicating the same `length > 1 ? "s are" : " is"` ternary in both the HTML and plain-text bodies.
- Drop the intermediate `html` and `text` variables; the templates are short enough to read inline at the `sendEmail` call.
- Rename `siteListHtml` / `siteListText` to `htmlList` / `textList` to match the inlined call site.

### Why this is "obviously the same"
- The `subject` ternary is unchanged.
- The HTML body still produces `<p>Your new site… ready!</p><ul>…</ul>`, with the same plural decision (`length > 1`).
- The text body still produces `Your new site… ready!\n\n…`, with the same plural decision.
- The `<li>` and `- ` list rows are produced by the same two `.map(...).join(...)` calls as before.
- All 13 tests in `test/lib/site-assignment.test.ts` pass, including the singular- and plural-subject tests that pin down the exact strings.

### Diff size
1 file changed, 13 insertions(+), 11 deletions(-)

## Test plan
- [x] `deno test --no-check --allow-all test/lib/site-assignment.test.ts` — 13/13 pass
- [x] `deno task lint` — clean
- [x] `deno check src/lib/site-assignment.ts` — clean

https://claude.ai/code/session_012zocC5uj1miARgjNk8Ymfv

---
_Generated by [Claude Code](https://claude.ai/code/session_012zocC5uj1miARgjNk8Ymfv)_