### PR TITLE
Surface group capacity in public availability checks

### DIFF
--- a/src/lib/api-example.ts
+++ b/src/lib/api-example.ts
@@ -47,8 +47,12 @@ export const API_EXAMPLE_EVENT: EventWithCount = {
 };
 
 /** The example PublicEvent, produced by toPublicEvent */
-export const API_EXAMPLE_PUBLIC_EVENT: PublicEvent =
-  toPublicEvent(API_EXAMPLE_EVENT);
+export const API_EXAMPLE_PUBLIC_EVENT: PublicEvent = toPublicEvent(
+  API_EXAMPLE_EVENT,
+  false,
+  undefined,
+  undefined,
+);
 
 /** Example list response JSON */
 export const API_LIST_EXAMPLE_JSON: string = JSON.stringify(

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -42,6 +42,8 @@ export {
   getDateAttendeeCount,
   getGroupAttendeeCount,
   getGroupMaxAttendees,
+  getGroupRemainingByGroupId,
+  getGroupRemainingForEvents,
 } from "#lib/db/attendees/capacity.ts";
 export { buildAttendeeInsert } from "#lib/db/attendees/create.ts";
 export {

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -42,8 +42,9 @@ export {
   getDateAttendeeCount,
   getGroupAttendeeCount,
   getGroupMaxAttendees,
+  getGroupRemainingByEventId,
   getGroupRemainingByGroupId,
-  getGroupRemainingForEvents,
+  getGroupRemainingForEvent,
 } from "#lib/db/attendees/capacity.ts";
 export { buildAttendeeInsert } from "#lib/db/attendees/create.ts";
 export {

--- a/src/lib/db/attendees.ts
+++ b/src/lib/db/attendees.ts
@@ -40,8 +40,6 @@ export {
   checkCapacityResult,
   dateToStartEnd,
   getDateAttendeeCount,
-  getGroupAttendeeCount,
-  getGroupMaxAttendees,
   getGroupRemainingByEventId,
   getGroupRemainingByGroupId,
   getGroupRemainingForEvent,

--- a/src/lib/db/attendees/capacity.ts
+++ b/src/lib/db/attendees/capacity.ts
@@ -80,21 +80,13 @@ export const checkCapacityResult = (result: {
   return { success: true };
 };
 
-/** Map of remaining capacity keyed by group id or event id. */
 type RemainingMap = Map<number, number>;
 
 /**
- * Compute remaining group capacity (max_attendees − attendees) for the given
- * groups in a single query. Only groups with `max_attendees > 0` appear in
- * the result map.
- *
- * The date filter mirrors the booking-time SQL in `buildCapacityCondition`:
- * standard events always count, and daily-event groups count only attendees
- * matching the given date. When `date` is null, daily-event attendees are
- * counted across all dates — useful for booking-time enforcement when the
- * caller has already validated a date upstream, but a misleading aggregate
- * for display. Display callers (`getGroupRemainingByEventId`) skip daily
- * groups when no date is given.
+ * Per-group remaining capacity. Groups with `max_attendees <= 0` (no cap)
+ * are omitted from the map. With `date = null`, daily-event attendees count
+ * cumulatively — correct for booking-time enforcement after upstream date
+ * validation, misleading for display.
  */
 export const getGroupRemainingByGroupId = async (
   groupIds: number[],
@@ -123,7 +115,6 @@ export const getGroupRemainingByGroupId = async (
   );
 };
 
-/** Event shape required to look up group remaining for display. */
 type EventForGroupLookup = {
   id: number;
   group_id: number;
@@ -131,13 +122,9 @@ type EventForGroupLookup = {
 };
 
 /**
- * Look up group remaining capacity for a list of events. Returns a map keyed
- * by event id; only includes events whose group has a positive max_attendees.
- *
- * Daily events are skipped when no `date` is given because their group cap is
- * enforced per-date — surfacing a cumulative count would mislead the sold-out
- * display for dates that still have room. Pass a `date` (e.g. once the user
- * picks one) to get the remaining capacity for that specific date.
+ * Per-event view of group remaining capacity. Daily events are dropped when
+ * `date` is null — their cap is per-date, so a cumulative count would
+ * misreport spots that other dates still have.
  */
 export const getGroupRemainingByEventId = async (
   events: EventForGroupLookup[],
@@ -158,8 +145,8 @@ export const getGroupRemainingByEventId = async (
   return result;
 };
 
-/** Convenience wrapper for a single event. Returns undefined when no group
- * cap applies (no group, no limit, or daily event without a date). */
+/** Returns `undefined` when no group cap applies: ungrouped, uncapped
+ * group, or daily event without a `date`. */
 export const getGroupRemainingForEvent = async (
   event: EventForGroupLookup,
   date: string | null = null,
@@ -204,7 +191,6 @@ export const checkBatchAvailabilityImpl = async (
   });
   if (!eventOk) return false;
 
-  // Group capacity check: one query for all groups, then per-group sum.
   const groupIds = unique(
     rows.filter((r) => r.group_id > 0).map((r) => r.group_id),
   );

--- a/src/lib/db/attendees/capacity.ts
+++ b/src/lib/db/attendees/capacity.ts
@@ -111,9 +111,10 @@ export const checkCapacityResult = (result: {
  * with a non-zero max_attendees limit). Used by the public UI/API to surface
  * group-aware sold-out state when an event is bought outside the group URL.
  *
- * Note: counts attendees across all dates for daily-event groups too — same
- * total-based semantics as the per-event display already uses. Per-date
- * enforcement still happens at booking time via buildCapacityCondition.
+ * Note: this is a non-date-aware count, so it should only be used for groups
+ * containing standard events. Daily-event groups use per-date enforcement at
+ * booking time via buildCapacityCondition; surfacing a cumulative count here
+ * would falsely mark dates with room as sold out.
  */
 export const getGroupRemainingByGroupId = async (
   groupIds: number[],
@@ -139,21 +140,41 @@ export const getGroupRemainingByGroupId = async (
   );
 };
 
+/** Event shape required to look up group remaining for display. */
+type EventForGroupLookup = {
+  id: number;
+  group_id: number;
+  event_type: string;
+};
+
 /**
  * Look up group remaining capacity for a list of events. Returns a map keyed
- * by event id (only includes events whose group has a positive max_attendees).
+ * by event id; only includes standard events whose group has a positive
+ * max_attendees. Daily events are skipped because their group cap is enforced
+ * per date at booking time, and a cumulative count here would mislead the
+ * sold-out display for dates that still have room.
  */
-export const getGroupRemainingForEvents = async (
-  events: { id: number; group_id: number }[],
+export const getGroupRemainingByEventId = async (
+  events: EventForGroupLookup[],
 ): Promise<Map<number, number>> => {
-  const groupIds = events.map((e) => e.group_id);
+  const standard = events.filter((e) => e.event_type !== "daily");
+  const groupIds = standard.map((e) => e.group_id);
   const groupMap = await getGroupRemainingByGroupId(groupIds);
   const result = new Map<number, number>();
-  for (const event of events) {
+  for (const event of standard) {
     const remaining = groupMap.get(event.group_id);
     if (remaining !== undefined) result.set(event.id, remaining);
   }
   return result;
+};
+
+/** Convenience wrapper for a single event. Returns undefined when no group
+ * cap applies (no group, no limit, or daily event). */
+export const getGroupRemainingForEvent = async (
+  event: EventForGroupLookup,
+): Promise<number | undefined> => {
+  const map = await getGroupRemainingByEventId([event]);
+  return map.get(event.id);
 };
 
 /**

--- a/src/lib/db/attendees/capacity.ts
+++ b/src/lib/db/attendees/capacity.ts
@@ -9,7 +9,11 @@ import type {
   EventBooking,
   UpdateEventLinkResult,
 } from "#lib/db/attendee-types.ts";
-import { buildCapacityCondition, dateToRange } from "#lib/db/capacity.ts";
+import {
+  buildCapacityCondition,
+  buildGroupAttendeePredicate,
+  dateToRange,
+} from "#lib/db/capacity.ts";
 import { inPlaceholders, queryAll } from "#lib/db/client.ts";
 import { getEventWithCount, invalidateEventsCache } from "#lib/db/events.ts";
 import type { EventType } from "#lib/types.ts";
@@ -98,7 +102,7 @@ export const getGroupRemainingByGroupId = async (
 ): Promise<RemainingMap> => {
   const ids = unique(groupIds.filter((id) => id > 0));
   if (ids.length === 0) return new Map();
-  const range = date ? dateToRange(date) : null;
+  const predicate = buildGroupAttendeePredicate("e", "ea", date);
   const rows = await queryAll<{
     group_id: number;
     max_attendees: number;
@@ -109,10 +113,10 @@ export const getGroupRemainingByGroupId = async (
      FROM groups g
      LEFT JOIN events e ON e.group_id = g.id
      LEFT JOIN event_attendees ea ON ea.event_id = e.id
-       AND (? IS NULL OR e.event_type != 'daily' OR (ea.start_at < ? AND ea.end_at > ?))
+       AND ${predicate.sql}
      WHERE g.id IN (${inPlaceholders(ids)}) AND g.max_attendees > 0
      GROUP BY g.id`,
-    [date, range?.endAt ?? null, range?.startAt ?? null, ...ids],
+    [...predicate.args, ...ids],
   );
   return new Map(
     rows.map((r) => [r.group_id, Math.max(0, r.max_attendees - r.count)]),

--- a/src/lib/db/attendees/capacity.ts
+++ b/src/lib/db/attendees/capacity.ts
@@ -3,6 +3,7 @@
  */
 
 import type { InValue } from "@libsql/client";
+import { unique } from "#fp";
 import type {
   BatchAvailabilityItem,
   EventBooking,
@@ -103,6 +104,56 @@ export const checkCapacityResult = (result: {
   if (!result.rowsAffected) return CAPACITY_EXCEEDED;
   invalidateEventsCache();
   return { success: true };
+};
+
+/**
+ * Compute remaining group capacity for each given group id (only for groups
+ * with a non-zero max_attendees limit). Used by the public UI/API to surface
+ * group-aware sold-out state when an event is bought outside the group URL.
+ *
+ * Note: counts attendees across all dates for daily-event groups too — same
+ * total-based semantics as the per-event display already uses. Per-date
+ * enforcement still happens at booking time via buildCapacityCondition.
+ */
+export const getGroupRemainingByGroupId = async (
+  groupIds: number[],
+): Promise<Map<number, number>> => {
+  const ids = unique(groupIds.filter((id) => id > 0));
+  if (ids.length === 0) return new Map();
+  const rows = await queryAll<{
+    group_id: number;
+    max_attendees: number;
+    count: number;
+  }>(
+    `SELECT g.id as group_id, g.max_attendees,
+            COALESCE(SUM(ea.quantity), 0) as count
+     FROM groups g
+     LEFT JOIN events e ON e.group_id = g.id
+     LEFT JOIN event_attendees ea ON ea.event_id = e.id
+     WHERE g.id IN (${inPlaceholders(ids)}) AND g.max_attendees > 0
+     GROUP BY g.id`,
+    ids,
+  );
+  return new Map(
+    rows.map((r) => [r.group_id, Math.max(0, r.max_attendees - r.count)]),
+  );
+};
+
+/**
+ * Look up group remaining capacity for a list of events. Returns a map keyed
+ * by event id (only includes events whose group has a positive max_attendees).
+ */
+export const getGroupRemainingForEvents = async (
+  events: { id: number; group_id: number }[],
+): Promise<Map<number, number>> => {
+  const groupIds = events.map((e) => e.group_id);
+  const groupMap = await getGroupRemainingByGroupId(groupIds);
+  const result = new Map<number, number>();
+  for (const event of events) {
+    const remaining = groupMap.get(event.group_id);
+    if (remaining !== undefined) result.set(event.id, remaining);
+  }
+  return result;
 };
 
 /**

--- a/src/lib/db/attendees/capacity.ts
+++ b/src/lib/db/attendees/capacity.ts
@@ -12,6 +12,7 @@ import type {
 import { buildCapacityCondition, dateToRange } from "#lib/db/capacity.ts";
 import { inPlaceholders, queryAll, queryOne } from "#lib/db/client.ts";
 import { getEventWithCount, invalidateEventsCache } from "#lib/db/events.ts";
+import type { EventType } from "#lib/types.ts";
 
 /** Shared failure result for capacity-exceeded */
 export const CAPACITY_EXCEEDED = {
@@ -144,7 +145,7 @@ export const getGroupRemainingByGroupId = async (
 type EventForGroupLookup = {
   id: number;
   group_id: number;
-  event_type: string;
+  event_type: EventType;
 };
 
 /**

--- a/src/lib/db/attendees/capacity.ts
+++ b/src/lib/db/attendees/capacity.ts
@@ -10,7 +10,7 @@ import type {
   UpdateEventLinkResult,
 } from "#lib/db/attendee-types.ts";
 import { buildCapacityCondition, dateToRange } from "#lib/db/capacity.ts";
-import { inPlaceholders, queryAll, queryOne } from "#lib/db/client.ts";
+import { inPlaceholders, queryAll } from "#lib/db/client.ts";
 import { getEventWithCount, invalidateEventsCache } from "#lib/db/events.ts";
 import type { EventType } from "#lib/types.ts";
 
@@ -38,37 +38,6 @@ export const getDateAttendeeCount = async (
   const rows = await queryAll<{ count: number }>(
     "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ? AND start_at < ? AND end_at > ?",
     [eventId, endAt, startAt],
-  );
-  return rows[0]!.count;
-};
-
-/** Get a group's max_attendees limit (0 = no limit) */
-export const getGroupMaxAttendees = async (
-  groupId: number,
-): Promise<number> => {
-  const row = await queryOne<{ max_attendees: number }>(
-    "SELECT max_attendees FROM groups WHERE id = ?",
-    [groupId],
-  );
-  return row?.max_attendees ?? 0;
-};
-
-/**
- * Count total attendees across all events in a group.
- * Date-aware: standard events always count, daily events only count matching date.
- */
-export const getGroupAttendeeCount = async (
-  groupId: number,
-  date: string | null,
-): Promise<number> => {
-  const range = date ? dateToRange(date) : null;
-  const rows = await queryAll<{ count: number }>(
-    `SELECT COALESCE(SUM(ea.quantity), 0) as count
-     FROM event_attendees ea
-     JOIN events e ON e.id = ea.event_id
-     WHERE e.group_id = ?
-       AND (? IS NULL OR e.event_type != 'daily' OR (ea.start_at < ? AND ea.end_at > ?))`,
-    [groupId, date, range?.endAt ?? null, range?.startAt ?? null],
   );
   return rows[0]!.count;
 };
@@ -107,21 +76,29 @@ export const checkCapacityResult = (result: {
   return { success: true };
 };
 
+/** Map of remaining capacity keyed by group id or event id. */
+type RemainingMap = Map<number, number>;
+
 /**
- * Compute remaining group capacity for each given group id (only for groups
- * with a non-zero max_attendees limit). Used by the public UI/API to surface
- * group-aware sold-out state when an event is bought outside the group URL.
+ * Compute remaining group capacity (max_attendees − attendees) for the given
+ * groups in a single query. Only groups with `max_attendees > 0` appear in
+ * the result map.
  *
- * Note: this is a non-date-aware count, so it should only be used for groups
- * containing standard events. Daily-event groups use per-date enforcement at
- * booking time via buildCapacityCondition; surfacing a cumulative count here
- * would falsely mark dates with room as sold out.
+ * The date filter mirrors the booking-time SQL in `buildCapacityCondition`:
+ * standard events always count, and daily-event groups count only attendees
+ * matching the given date. When `date` is null, daily-event attendees are
+ * counted across all dates — useful for booking-time enforcement when the
+ * caller has already validated a date upstream, but a misleading aggregate
+ * for display. Display callers (`getGroupRemainingByEventId`) skip daily
+ * groups when no date is given.
  */
 export const getGroupRemainingByGroupId = async (
   groupIds: number[],
-): Promise<Map<number, number>> => {
+  date: string | null = null,
+): Promise<RemainingMap> => {
   const ids = unique(groupIds.filter((id) => id > 0));
   if (ids.length === 0) return new Map();
+  const range = date ? dateToRange(date) : null;
   const rows = await queryAll<{
     group_id: number;
     max_attendees: number;
@@ -132,9 +109,10 @@ export const getGroupRemainingByGroupId = async (
      FROM groups g
      LEFT JOIN events e ON e.group_id = g.id
      LEFT JOIN event_attendees ea ON ea.event_id = e.id
+       AND (? IS NULL OR e.event_type != 'daily' OR (ea.start_at < ? AND ea.end_at > ?))
      WHERE g.id IN (${inPlaceholders(ids)}) AND g.max_attendees > 0
      GROUP BY g.id`,
-    ids,
+    [date, range?.endAt ?? null, range?.startAt ?? null, ...ids],
   );
   return new Map(
     rows.map((r) => [r.group_id, Math.max(0, r.max_attendees - r.count)]),
@@ -150,19 +128,26 @@ type EventForGroupLookup = {
 
 /**
  * Look up group remaining capacity for a list of events. Returns a map keyed
- * by event id; only includes standard events whose group has a positive
- * max_attendees. Daily events are skipped because their group cap is enforced
- * per date at booking time, and a cumulative count here would mislead the
- * sold-out display for dates that still have room.
+ * by event id; only includes events whose group has a positive max_attendees.
+ *
+ * Daily events are skipped when no `date` is given because their group cap is
+ * enforced per-date — surfacing a cumulative count would mislead the sold-out
+ * display for dates that still have room. Pass a `date` (e.g. once the user
+ * picks one) to get the remaining capacity for that specific date.
  */
 export const getGroupRemainingByEventId = async (
   events: EventForGroupLookup[],
-): Promise<Map<number, number>> => {
-  const standard = events.filter((e) => e.event_type !== "daily");
-  const groupIds = standard.map((e) => e.group_id);
-  const groupMap = await getGroupRemainingByGroupId(groupIds);
-  const result = new Map<number, number>();
-  for (const event of standard) {
+  date: string | null = null,
+): Promise<RemainingMap> => {
+  const candidates = date
+    ? events
+    : events.filter((e) => e.event_type !== "daily");
+  const groupMap = await getGroupRemainingByGroupId(
+    candidates.map((e) => e.group_id),
+    date,
+  );
+  const result: RemainingMap = new Map();
+  for (const event of candidates) {
     const remaining = groupMap.get(event.group_id);
     if (remaining !== undefined) result.set(event.id, remaining);
   }
@@ -170,11 +155,12 @@ export const getGroupRemainingByEventId = async (
 };
 
 /** Convenience wrapper for a single event. Returns undefined when no group
- * cap applies (no group, no limit, or daily event). */
+ * cap applies (no group, no limit, or daily event without a date). */
 export const getGroupRemainingForEvent = async (
   event: EventForGroupLookup,
+  date: string | null = null,
 ): Promise<number | undefined> => {
-  const map = await getGroupRemainingByEventId([event]);
+  const map = await getGroupRemainingByEventId([event], date);
   return map.get(event.id);
 };
 
@@ -214,21 +200,20 @@ export const checkBatchAvailabilityImpl = async (
   });
   if (!eventOk) return false;
 
-  // Group capacity check: collect unique group IDs with limits
-  const groupIds = new Set<number>();
-  for (const row of rows) {
-    if (row.group_id > 0) groupIds.add(row.group_id);
-  }
-  for (const groupId of groupIds) {
-    const groupLimit = await getGroupMaxAttendees(groupId);
-    if (groupLimit <= 0) continue;
-    const groupCount = await getGroupAttendeeCount(groupId, date ?? null);
-    // Sum requested quantities for events in this group
+  // Group capacity check: one query for all groups, then per-group sum.
+  const groupIds = unique(
+    rows.filter((r) => r.group_id > 0).map((r) => r.group_id),
+  );
+  const remainingByGroupId = await getGroupRemainingByGroupId(
+    groupIds,
+    date ?? null,
+  );
+  for (const [groupId, remaining] of remainingByGroupId) {
     const requestedInGroup = items.reduce((sum, item) => {
       const row = counts.get(item.eventId);
       return row && row.group_id === groupId ? sum + item.quantity : sum;
     }, 0);
-    if (groupCount + requestedInGroup > groupLimit) return false;
+    if (requestedInGroup > remaining) return false;
   }
   return true;
 };
@@ -249,14 +234,12 @@ export const hasAvailableSpotsImpl = async (
   }
   // Check group capacity if event belongs to a group with a limit
   if (event.group_id > 0) {
-    const groupLimit = await getGroupMaxAttendees(event.group_id);
-    if (groupLimit > 0) {
-      const groupCount = await getGroupAttendeeCount(
-        event.group_id,
-        date ?? null,
-      );
-      if (groupCount + quantity > groupLimit) return false;
-    }
+    const remainingByGroupId = await getGroupRemainingByGroupId(
+      [event.group_id],
+      date ?? null,
+    );
+    const remaining = remainingByGroupId.get(event.group_id);
+    if (remaining !== undefined && quantity > remaining) return false;
   }
   return true;
 };

--- a/src/lib/db/capacity.ts
+++ b/src/lib/db/capacity.ts
@@ -10,6 +10,9 @@
 
 import type { InValue } from "@libsql/client";
 
+/** A reusable SQL fragment with its positional bind arguments. */
+export type SqlFragment = { sql: string; args: InValue[] };
+
 /** Convert a date string ("YYYY-MM-DD") to start_at/end_at pair for full-day range */
 export const dateToRange = (
   date: string,
@@ -17,6 +20,34 @@ export const dateToRange = (
   const ms = new Date(`${date}T00:00:00Z`).getTime();
   const nextDay = new Date(ms + 86_400_000).toISOString();
   return { endAt: nextDay, startAt: `${date}T00:00:00Z` };
+};
+
+/**
+ * SQL fragment deciding whether an `event_attendees` row counts toward a
+ * group's used capacity for a given date.
+ *
+ *   - Standard events always count.
+ *   - Daily events count only when their booking overlaps the date.
+ *   - When `date` is null, every row counts — callers that want per-date
+ *     scope pass a non-null date upstream.
+ *
+ * Used by both the booking-time SQL in `buildCapacityCondition` and the
+ * read-side SQL in `getGroupRemainingByGroupId` so the two never drift.
+ *
+ * Produces `(? IS NULL OR <eventAlias>.event_type != 'daily' OR
+ * (<attendeeAlias>.start_at < ? AND <attendeeAlias>.end_at > ?))` plus its
+ * three positional args `[date, endAt, startAt]`.
+ */
+export const buildGroupAttendeePredicate = (
+  eventAlias: string,
+  attendeeAlias: string,
+  date: string | null,
+): SqlFragment => {
+  const range = date ? dateToRange(date) : null;
+  return {
+    args: [date, range?.endAt ?? null, range?.startAt ?? null],
+    sql: `(? IS NULL OR ${eventAlias}.event_type != 'daily' OR (${attendeeAlias}.start_at < ? AND ${attendeeAlias}.end_at > ?))`,
+  };
 };
 
 /**
@@ -28,7 +59,7 @@ export const buildCapacityCondition = (
   qty: number,
   date: string | null,
   excludeAttendeeId?: number,
-): { sql: string; args: InValue[] } => {
+): SqlFragment => {
   const range = date ? dateToRange(date) : null;
   const endAt = range?.endAt ?? null;
   const startAt = range?.startAt ?? null;
@@ -48,6 +79,7 @@ export const buildCapacityCondition = (
   const groupExclude = excludeAttendeeId
     ? "AND ea3.attendee_id != ?\n                  "
     : "";
+  const groupPredicate = buildGroupAttendeePredicate("e2", "ea3", date);
   const groupCapacityCheck = `
           AND (
             SELECT CASE
@@ -58,7 +90,7 @@ export const buildCapacityCondition = (
                 FROM event_attendees ea3
                 JOIN events e2 ON e2.id = ea3.event_id
                 WHERE e2.group_id = ev.group_id
-                  ${groupExclude}AND (? IS NULL OR e2.event_type != 'daily' OR (ea3.start_at < ? AND ea3.end_at > ?))
+                  ${groupExclude}AND ${groupPredicate.sql}
               ) + ? <= g.max_attendees THEN 1
               ELSE 0
             END
@@ -67,8 +99,8 @@ export const buildCapacityCondition = (
             WHERE ev.id = ?
           ) = 1`;
   const groupCapacityArgs: InValue[] = excludeAttendeeId
-    ? [excludeAttendeeId, date, endAt, startAt, qty, eventId]
-    : [date, endAt, startAt, qty, eventId];
+    ? [excludeAttendeeId, ...groupPredicate.args, qty, eventId]
+    : [...groupPredicate.args, qty, eventId];
 
   return {
     args: [...capacityArgs, qty, eventId, ...groupCapacityArgs],

--- a/src/lib/db/capacity.ts
+++ b/src/lib/db/capacity.ts
@@ -10,7 +10,6 @@
 
 import type { InValue } from "@libsql/client";
 
-/** A reusable SQL fragment with its positional bind arguments. */
 export type SqlFragment = { sql: string; args: InValue[] };
 
 /** Convert a date string ("YYYY-MM-DD") to start_at/end_at pair for full-day range */
@@ -23,20 +22,12 @@ export const dateToRange = (
 };
 
 /**
- * SQL fragment deciding whether an `event_attendees` row counts toward a
- * group's used capacity for a given date.
+ * Whether an `event_attendees` row should count toward its group's cap on
+ * the given date. Standard events always count; daily events count only
+ * when their booking overlaps the date. With `date = null` every row
+ * counts — useful after upstream date validation, misleading for display.
  *
- *   - Standard events always count.
- *   - Daily events count only when their booking overlaps the date.
- *   - When `date` is null, every row counts — callers that want per-date
- *     scope pass a non-null date upstream.
- *
- * Used by both the booking-time SQL in `buildCapacityCondition` and the
- * read-side SQL in `getGroupRemainingByGroupId` so the two never drift.
- *
- * Produces `(? IS NULL OR <eventAlias>.event_type != 'daily' OR
- * (<attendeeAlias>.start_at < ? AND <attendeeAlias>.end_at > ?))` plus its
- * three positional args `[date, endAt, startAt]`.
+ * Args order: `[date, endAt, startAt]`.
  */
 export const buildGroupAttendeePredicate = (
   eventAlias: string,

--- a/src/routes/admin/events.ts
+++ b/src/routes/admin/events.ts
@@ -7,13 +7,14 @@ import { getEffectiveDomain } from "#lib/config.ts";
 import { toMinorUnits } from "#lib/currency.ts";
 import { formatDateLabel, normalizeDatetime } from "#lib/dates.ts";
 import { getEventWithActivityLog, logActivity } from "#lib/db/activityLog.ts";
+import { getGroupRemainingByGroupId } from "#lib/db/attendees.ts";
 import {
   computeSlugIndex,
   type EventInput,
   eventsTable,
   getEventWithCount,
 } from "#lib/db/events.ts";
-import { getAllGroups } from "#lib/db/groups.ts";
+import { getAllGroups, groupsTable } from "#lib/db/groups.ts";
 import { deleteAllStaleReservations } from "#lib/db/processed-payments.ts";
 import {
   getAttendeeAnswersBatch,
@@ -81,6 +82,7 @@ import {
   adminEventNewPage,
   adminEventPage,
   adminReactivateEventPage,
+  type GroupContext,
 } from "#templates/admin/events.tsx";
 import { type CsvQuestionData, generateAttendeesCsv } from "#templates/csv.ts";
 import type {
@@ -382,6 +384,22 @@ const applyDateFilter = (
   };
 };
 
+/** Fetch group + current usage when the event sits in a capped group, so the
+ * detail page can render a row for the shared cap. Returns undefined for
+ * ungrouped or uncapped groups. */
+const loadGroupContext = async (
+  event: EventWithCount,
+  dateFilter: string | null,
+): Promise<GroupContext | undefined> => {
+  if (event.group_id === 0) return undefined;
+  const group = await groupsTable.findById(event.group_id);
+  if (!group || group.max_attendees <= 0) return undefined;
+  const remainingMap = await getGroupRemainingByGroupId([group.id], dateFilter);
+  // group.max_attendees > 0 guarantees the helper returns an entry for it.
+  const remaining = remainingMap.get(group.id) as number;
+  return { attendeeCount: group.max_attendees - remaining, group };
+};
+
 /** Render event page with attendee list and optional filter */
 const renderEventPage = async (
   request: Request,
@@ -404,12 +422,13 @@ const renderEventPage = async (
           request,
         );
         const attendeeIds = filteredByDate.map((a) => a.id);
-        const [flash, phonePrefix, questions, attendeeAnswerMap] =
+        const [flash, phonePrefix, questions, attendeeAnswerMap, groupContext] =
           await Promise.all([
             Promise.resolve(getFlash()),
             Promise.resolve(settings.phonePrefix),
             getQuestionsForEvent(event.id),
             getAttendeeAnswersBatch(attendeeIds),
+            loadGroupContext(event, dateFilter),
           ]);
         const questionData =
           questions.length > 0 ? { attendeeAnswerMap, questions } : undefined;
@@ -423,6 +442,7 @@ const renderEventPage = async (
             dateFilter,
             errorMessage: flash.error,
             event,
+            groupContext,
             phonePrefix,
             questionData,
             session,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -9,7 +9,8 @@ import { filter, pipe } from "#fp";
 import { processBooking } from "#lib/booking.ts";
 import { getAvailableDates } from "#lib/dates.ts";
 import {
-  getGroupRemainingForEvents,
+  getGroupRemainingByEventId,
+  getGroupRemainingForEvent,
   hasAvailableSpots,
 } from "#lib/db/attendees.ts";
 import { getAllEvents, getEventWithCountBySlug } from "#lib/db/events.ts";
@@ -80,10 +81,13 @@ export const toPublicEvent = (
   event: EventWithCount,
   closed = false,
   availableDates?: string[],
-  groupRemaining = Number.POSITIVE_INFINITY,
+  groupRemaining?: number,
 ): PublicEvent => {
   const eventRemaining = event.max_attendees - event.attendee_count;
-  const spotsRemaining = Math.min(eventRemaining, groupRemaining);
+  const spotsRemaining =
+    groupRemaining === undefined
+      ? eventRemaining
+      : Math.min(eventRemaining, groupRemaining);
   const isSoldOut = spotsRemaining <= 0;
   const maxPurchasable =
     isSoldOut || closed ? 0 : Math.min(event.max_quantity, spotsRemaining);
@@ -159,7 +163,7 @@ const handleListEvents = async (): Promise<Response> => {
     filter((e: EventWithCount) => e.active && !e.hidden),
     (active: EventWithCount[]) => sortEvents(active, holidays),
   )(allEvents);
-  const groupRemaining = await getGroupRemainingForEvents(visibleEvents);
+  const groupRemaining = await getGroupRemainingByEventId(visibleEvents);
   const events = visibleEvents.map((e) =>
     toPublicEvent(
       e,
@@ -178,13 +182,12 @@ const handleGetEvent = withActiveEvent(async (_request, event) => {
   if (event.event_type === "daily") {
     availableDates = getAvailableDates(event, await getActiveHolidays());
   }
-  const groupRemaining = await getGroupRemainingForEvents([event]);
   return apiResponse({
     event: toPublicEvent(
       event,
       closed,
       availableDates,
-      groupRemaining.get(event.id),
+      await getGroupRemainingForEvent(event),
     ),
   });
 });

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -73,11 +73,8 @@ export type PublicEvent = {
   availableDates?: string[];
 };
 
-/** Serialize an event to the public API shape (same data the web UI renders).
- * Pass `groupRemaining` when the event belongs to a group with a
- * `max_attendees` limit so the API reports the group-aware sold-out state;
- * pass `undefined` when no group cap applies. `availableDates` is included
- * only for daily events. */
+/** `groupRemaining`, when defined, clamps the displayed sold-out state to
+ * the group's combined cap. */
 export const toPublicEvent = (
   event: EventWithCount,
   closed: boolean,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -74,14 +74,15 @@ export type PublicEvent = {
 };
 
 /** Serialize an event to the public API shape (same data the web UI renders).
- * When the event belongs to a group with a max_attendees limit, pass the
- * group's remaining capacity so the API reports the group-aware sold-out
- * state. */
+ * Pass `groupRemaining` when the event belongs to a group with a
+ * `max_attendees` limit so the API reports the group-aware sold-out state;
+ * pass `undefined` when no group cap applies. `availableDates` is included
+ * only for daily events. */
 export const toPublicEvent = (
   event: EventWithCount,
-  closed = false,
-  availableDates?: string[],
-  groupRemaining?: number,
+  closed: boolean,
+  availableDates: string[] | undefined,
+  groupRemaining: number | undefined,
 ): PublicEvent => {
   const eventRemaining = event.max_attendees - event.attendee_count;
   const spotsRemaining =

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -5,10 +5,13 @@
  * with the same data and validation as the web UI.
  */
 
-import { filter, map, pipe } from "#fp";
+import { filter, pipe } from "#fp";
 import { processBooking } from "#lib/booking.ts";
 import { getAvailableDates } from "#lib/dates.ts";
-import { hasAvailableSpots } from "#lib/db/attendees.ts";
+import {
+  getGroupRemainingForEvents,
+  hasAvailableSpots,
+} from "#lib/db/attendees.ts";
 import { getAllEvents, getEventWithCountBySlug } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import { FormParams } from "#lib/form-data.ts";
@@ -69,13 +72,18 @@ export type PublicEvent = {
   availableDates?: string[];
 };
 
-/** Serialize an event to the public API shape (same data the web UI renders) */
+/** Serialize an event to the public API shape (same data the web UI renders).
+ * When the event belongs to a group with a max_attendees limit, pass the
+ * group's remaining capacity so the API reports the group-aware sold-out
+ * state. */
 export const toPublicEvent = (
   event: EventWithCount,
   closed = false,
   availableDates?: string[],
+  groupRemaining = Number.POSITIVE_INFINITY,
 ): PublicEvent => {
-  const spotsRemaining = event.max_attendees - event.attendee_count;
+  const eventRemaining = event.max_attendees - event.attendee_count;
+  const spotsRemaining = Math.min(eventRemaining, groupRemaining);
   const isSoldOut = spotsRemaining <= 0;
   const maxPurchasable =
     isSoldOut || closed ? 0 : Math.min(event.max_quantity, spotsRemaining);
@@ -147,11 +155,19 @@ const withActiveEvent =
 const handleListEvents = async (): Promise<Response> => {
   const allEvents = await getAllEvents();
   const holidays = await getActiveHolidays();
-  const events = pipe(
+  const visibleEvents = pipe(
     filter((e: EventWithCount) => e.active && !e.hidden),
     (active: EventWithCount[]) => sortEvents(active, holidays),
-    map((e: EventWithCount) => toPublicEvent(e, isRegistrationClosed(e))),
   )(allEvents);
+  const groupRemaining = await getGroupRemainingForEvents(visibleEvents);
+  const events = visibleEvents.map((e) =>
+    toPublicEvent(
+      e,
+      isRegistrationClosed(e),
+      undefined,
+      groupRemaining.get(e.id),
+    ),
+  );
   return apiResponse({ events });
 };
 
@@ -162,7 +178,15 @@ const handleGetEvent = withActiveEvent(async (_request, event) => {
   if (event.event_type === "daily") {
     availableDates = getAvailableDates(event, await getActiveHolidays());
   }
-  return apiResponse({ event: toPublicEvent(event, closed, availableDates) });
+  const groupRemaining = await getGroupRemainingForEvents([event]);
+  return apiResponse({
+    event: toPublicEvent(
+      event,
+      closed,
+      availableDates,
+      groupRemaining.get(event.id),
+    ),
+  });
 });
 
 /** GET /api/events/:slug/availability — check if spots are available */

--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -29,7 +29,7 @@ const withActiveGroupEventsBySlug = async (
     getActiveEventsByGroupId(group.id),
     getActiveHolidays(),
   ]);
-  const activeEvents = getActiveEvents(sortEvents(events, holidays));
+  const activeEvents = await getActiveEvents(sortEvents(events, holidays));
   return activeEvents.length === 0
     ? notFoundResponse()
     : handler(group, activeEvents);

--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -12,7 +12,7 @@ import { sortEvents } from "#lib/sort-events.ts";
 import type { Group } from "#lib/types.ts";
 import { notFoundResponse } from "#routes/response.ts";
 import type { TicketEvent } from "#templates/public.tsx";
-import { buildTicketEventsForGroup } from "./ticket-events.ts";
+import { buildTicketEventsWithGroupCapacity } from "./ticket-events.ts";
 import { getTicketContext } from "./ticket-payment.ts";
 import { handleTicket } from "./ticket-submit.ts";
 import type { AsyncHandler } from "./types.ts";
@@ -30,8 +30,7 @@ const withActiveGroupEventsBySlug = async (
     getActiveEventsByGroupId(group.id),
     getActiveHolidays(),
   ]);
-  const activeEvents = buildTicketEventsForGroup(
-    group,
+  const activeEvents = await buildTicketEventsWithGroupCapacity(
     sortEvents(events, holidays),
   );
   return activeEvents.length === 0

--- a/src/routes/public/groups.ts
+++ b/src/routes/public/groups.ts
@@ -12,9 +12,10 @@ import { sortEvents } from "#lib/sort-events.ts";
 import type { Group } from "#lib/types.ts";
 import { notFoundResponse } from "#routes/response.ts";
 import type { TicketEvent } from "#templates/public.tsx";
+import { buildTicketEventsForGroup } from "./ticket-events.ts";
 import { getTicketContext } from "./ticket-payment.ts";
 import { handleTicket } from "./ticket-submit.ts";
-import { type AsyncHandler, getActiveEvents } from "./types.ts";
+import type { AsyncHandler } from "./types.ts";
 
 /** Load group by slug and its active events, return 404 if empty */
 const withActiveGroupEventsBySlug = async (
@@ -29,7 +30,10 @@ const withActiveGroupEventsBySlug = async (
     getActiveEventsByGroupId(group.id),
     getActiveHolidays(),
   ]);
-  const activeEvents = await getActiveEvents(sortEvents(events, holidays));
+  const activeEvents = buildTicketEventsForGroup(
+    group,
+    sortEvents(events, holidays),
+  );
   return activeEvents.length === 0
     ? notFoundResponse()
     : handler(group, activeEvents);

--- a/src/routes/public/pages.ts
+++ b/src/routes/public/pages.ts
@@ -16,7 +16,7 @@ import {
   type PublicPageType,
   publicSitePage,
 } from "#templates/public.tsx";
-import { buildTicketEventsWithGroupCapacity } from "./types.ts";
+import { buildTicketEventsWithGroupCapacity } from "./ticket-events.ts";
 
 /** Active+visible filter for public event listings */
 const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;

--- a/src/routes/public/pages.ts
+++ b/src/routes/public/pages.ts
@@ -6,18 +6,17 @@ import { getAllGroups } from "#lib/db/groups.ts";
 import { settings } from "#lib/db/settings.ts";
 import { loadSortedEvents } from "#lib/sort-events.ts";
 import type { EventWithCount, Group } from "#lib/types.ts";
-import { isRegistrationClosed } from "#routes/format.ts";
 import {
   htmlResponse,
   notFoundResponse,
   redirectResponse,
 } from "#routes/response.ts";
 import {
-  buildTicketEvent,
   homepagePage,
   type PublicPageType,
   publicSitePage,
 } from "#templates/public.tsx";
+import { buildTicketEventsWithGroupCapacity } from "./types.ts";
 
 /** Active+visible filter for public event listings */
 const isPublicEvent = (e: EventWithCount): boolean => e.active && !e.hidden;
@@ -55,9 +54,7 @@ export const handlePublicEvents = (): Response | Promise<Response> =>
       loadPublicGroups(),
       loadSortedEvents(isPublicEvent),
     ]);
-    const ticketEvents = events.map((e) =>
-      buildTicketEvent(e, isRegistrationClosed(e)),
-    );
+    const ticketEvents = await buildTicketEventsWithGroupCapacity(events);
     return htmlResponse(
       homepagePage(ticketEvents, settings.websiteTitle, groups),
     );

--- a/src/routes/public/qr-book.ts
+++ b/src/routes/public/qr-book.ts
@@ -8,7 +8,7 @@
  */
 
 import { getAvailableDates } from "#lib/dates.ts";
-import { getGroupRemainingForEvents } from "#lib/db/attendees.ts";
+import { getGroupRemainingForEvent } from "#lib/db/attendees.ts";
 import { getEventWithCountBySlug } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import type { CheckoutIntent } from "#lib/payments.ts";
@@ -128,11 +128,10 @@ const dispatchVerified = async (
   if (await canSkipToCheckout(event, payload)) {
     return skipToCheckout(request, event, payload);
   }
-  const groupRemaining = await getGroupRemainingForEvents([event]);
   const ticketEvent = buildTicketEvent(
     event,
     isRegistrationClosed(event),
-    groupRemaining.get(event.id),
+    await getGroupRemainingForEvent(event),
   );
   const prefill = buildPrefill(event, payload, token);
   return handleTicket(

--- a/src/routes/public/qr-book.ts
+++ b/src/routes/public/qr-book.ts
@@ -8,6 +8,7 @@
  */
 
 import { getAvailableDates } from "#lib/dates.ts";
+import { getGroupRemainingForEvents } from "#lib/db/attendees.ts";
 import { getEventWithCountBySlug } from "#lib/db/events.ts";
 import { getActiveHolidays } from "#lib/db/holidays.ts";
 import type { CheckoutIntent } from "#lib/payments.ts";
@@ -127,7 +128,12 @@ const dispatchVerified = async (
   if (await canSkipToCheckout(event, payload)) {
     return skipToCheckout(request, event, payload);
   }
-  const ticketEvent = buildTicketEvent(event, isRegistrationClosed(event));
+  const groupRemaining = await getGroupRemainingForEvents([event]);
+  const ticketEvent = buildTicketEvent(
+    event,
+    isRegistrationClosed(event),
+    groupRemaining.get(event.id),
+  );
   const prefill = buildPrefill(event, payload, token);
   return handleTicket(
     request,

--- a/src/routes/public/ticket-events.ts
+++ b/src/routes/public/ticket-events.ts
@@ -6,7 +6,7 @@
  */
 
 import { getGroupRemainingByEventId } from "#lib/db/attendees.ts";
-import type { EventWithCount, Group } from "#lib/types.ts";
+import type { EventWithCount } from "#lib/types.ts";
 import { isRegistrationClosed } from "#routes/format.ts";
 import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
 
@@ -17,29 +17,5 @@ export const buildTicketEventsWithGroupCapacity = async (
   const groupRemaining = await getGroupRemainingByEventId(events);
   return events.map((e) =>
     buildTicketEvent(e, isRegistrationClosed(e), groupRemaining.get(e.id)),
-  );
-};
-
-/**
- * Build ticket events for a single known group, computing remaining capacity
- * locally from the events' attendee counts instead of running another query.
- * Skips group-cap clamping for daily-event groups (per-date cap is enforced
- * at booking time, not displayed cumulatively).
- */
-export const buildTicketEventsForGroup = (
-  group: Group,
-  events: EventWithCount[],
-): TicketEvent[] => {
-  const isDailyGroup = events.some((e) => e.event_type === "daily");
-  const groupRemaining =
-    group.max_attendees > 0 && !isDailyGroup
-      ? Math.max(
-          0,
-          group.max_attendees -
-            events.reduce((sum, e) => sum + e.attendee_count, 0),
-        )
-      : undefined;
-  return events.map((e) =>
-    buildTicketEvent(e, isRegistrationClosed(e), groupRemaining),
   );
 };

--- a/src/routes/public/ticket-events.ts
+++ b/src/routes/public/ticket-events.ts
@@ -1,0 +1,45 @@
+/**
+ * Build TicketEvent values with group-aware sold-out / maxPurchasable values.
+ *
+ * Lives outside types.ts so the route modules can keep type-only imports
+ * separate from this DB-fetching helper.
+ */
+
+import { getGroupRemainingByEventId } from "#lib/db/attendees.ts";
+import type { EventWithCount, Group } from "#lib/types.ts";
+import { isRegistrationClosed } from "#routes/format.ts";
+import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
+
+/** Build ticket events with group-aware sold-out / maxPurchasable values. */
+export const buildTicketEventsWithGroupCapacity = async (
+  events: EventWithCount[],
+): Promise<TicketEvent[]> => {
+  const groupRemaining = await getGroupRemainingByEventId(events);
+  return events.map((e) =>
+    buildTicketEvent(e, isRegistrationClosed(e), groupRemaining.get(e.id)),
+  );
+};
+
+/**
+ * Build ticket events for a single known group, computing remaining capacity
+ * locally from the events' attendee counts instead of running another query.
+ * Skips group-cap clamping for daily-event groups (per-date cap is enforced
+ * at booking time, not displayed cumulatively).
+ */
+export const buildTicketEventsForGroup = (
+  group: Group,
+  events: EventWithCount[],
+): TicketEvent[] => {
+  const isDailyGroup = events.some((e) => e.event_type === "daily");
+  const groupRemaining =
+    group.max_attendees > 0 && !isDailyGroup
+      ? Math.max(
+          0,
+          group.max_attendees -
+            events.reduce((sum, e) => sum + e.attendee_count, 0),
+        )
+      : undefined;
+  return events.map((e) =>
+    buildTicketEvent(e, isRegistrationClosed(e), groupRemaining),
+  );
+};

--- a/src/routes/public/ticket-events.ts
+++ b/src/routes/public/ticket-events.ts
@@ -1,16 +1,8 @@
-/**
- * Build TicketEvent values with group-aware sold-out / maxPurchasable values.
- *
- * Lives outside types.ts so the route modules can keep type-only imports
- * separate from this DB-fetching helper.
- */
-
 import { getGroupRemainingByEventId } from "#lib/db/attendees.ts";
 import type { EventWithCount } from "#lib/types.ts";
 import { isRegistrationClosed } from "#routes/format.ts";
 import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
 
-/** Build ticket events with group-aware sold-out / maxPurchasable values. */
 export const buildTicketEventsWithGroupCapacity = async (
   events: EventWithCount[],
 ): Promise<TicketEvent[]> => {

--- a/src/routes/public/ticket-payment.ts
+++ b/src/routes/public/ticket-payment.ts
@@ -24,20 +24,20 @@ import {
 } from "#lib/payments.ts";
 import type { ContactInfo, Group } from "#lib/types.ts";
 import { logAndNotifyRegistration } from "#lib/webhook.ts";
-import { isRegistrationClosed } from "#routes/format.ts";
 import {
   checkoutResponse,
   errorRedirect,
   notFoundResponse,
 } from "#routes/response.ts";
 import { getBaseUrl } from "#routes/url.ts";
-import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
+import type { TicketEvent } from "#templates/public.tsx";
 import { eventsWithQuantity, formatAtomicError } from "./ticket-form.ts";
-import type {
-  AsyncHandler,
-  EventQty,
-  TicketCtx,
-  TicketSharedContext,
+import {
+  type AsyncHandler,
+  buildTicketEventsWithGroupCapacity,
+  type EventQty,
+  type TicketCtx,
+  type TicketSharedContext,
 } from "./types.ts";
 
 /** Try to redirect to checkout, or return error using provided handler.
@@ -247,9 +247,7 @@ export const withActiveEvents = async (
 ): Promise<Response> => {
   const events = await getEventsBySlugsBatch(slugs);
   const active = compact(events).filter((e) => e.active);
-  const activeEvents = active.map((e) =>
-    buildTicketEvent(e, isRegistrationClosed(e)),
-  );
+  const activeEvents = await buildTicketEventsWithGroupCapacity(active);
   return activeEvents.length === 0 ? notFoundResponse() : handler(activeEvents);
 };
 

--- a/src/routes/public/ticket-payment.ts
+++ b/src/routes/public/ticket-payment.ts
@@ -31,13 +31,13 @@ import {
 } from "#routes/response.ts";
 import { getBaseUrl } from "#routes/url.ts";
 import type { TicketEvent } from "#templates/public.tsx";
+import { buildTicketEventsWithGroupCapacity } from "./ticket-events.ts";
 import { eventsWithQuantity, formatAtomicError } from "./ticket-form.ts";
-import {
-  type AsyncHandler,
-  buildTicketEventsWithGroupCapacity,
-  type EventQty,
-  type TicketCtx,
-  type TicketSharedContext,
+import type {
+  AsyncHandler,
+  EventQty,
+  TicketCtx,
+  TicketSharedContext,
 } from "./types.ts";
 
 /** Try to redirect to checkout, or return error using provided handler.

--- a/src/routes/public/types.ts
+++ b/src/routes/public/types.ts
@@ -2,19 +2,12 @@
  * Shared types, constants, and tiny utilities for public ticket routes
  */
 
-import { compact } from "#fp";
-import { getGroupRemainingForEvents } from "#lib/db/attendees.ts";
 import type {
   QuestionEventMap,
   QuestionWithAnswers,
 } from "#lib/db/questions.ts";
 import type { EventWithCount } from "#lib/types.ts";
-import { isRegistrationClosed } from "#routes/format.ts";
-import {
-  buildTicketEvent,
-  type QrPrefill,
-  type TicketEvent,
-} from "#templates/public.tsx";
+import type { QrPrefill, TicketEvent } from "#templates/public.tsx";
 
 /** Shared rendering context for ticket pages */
 export type TicketCtx = {
@@ -60,22 +53,6 @@ export const REGISTRATION_CLOSED_SUBMIT_MESSAGE =
 /** Parse slugs from a slug string (may contain + separator for multiple events) */
 export const parseSlugs = (slug: string): string[] =>
   slug.split("+").filter((s) => s.length > 0);
-
-/** Build ticket events with group-aware sold-out / maxPurchasable values. */
-export const buildTicketEventsWithGroupCapacity = async (
-  events: EventWithCount[],
-): Promise<TicketEvent[]> => {
-  const groupRemaining = await getGroupRemainingForEvents(events);
-  return events.map((e) =>
-    buildTicketEvent(e, isRegistrationClosed(e), groupRemaining.get(e.id)),
-  );
-};
-
-/** Filter and transform events to active ticket events */
-export const getActiveEvents = (
-  events: (EventWithCount | null)[],
-): Promise<TicketEvent[]> =>
-  buildTicketEventsWithGroupCapacity(compact(events).filter((e) => e.active));
 
 /** Set noindex signal header on response for hidden events */
 export const applyHiddenNoindex = (

--- a/src/routes/public/types.ts
+++ b/src/routes/public/types.ts
@@ -2,7 +2,8 @@
  * Shared types, constants, and tiny utilities for public ticket routes
  */
 
-import { compact, filter, map, pipe } from "#fp";
+import { compact } from "#fp";
+import { getGroupRemainingForEvents } from "#lib/db/attendees.ts";
 import type {
   QuestionEventMap,
   QuestionWithAnswers,
@@ -60,14 +61,21 @@ export const REGISTRATION_CLOSED_SUBMIT_MESSAGE =
 export const parseSlugs = (slug: string): string[] =>
   slug.split("+").filter((s) => s.length > 0);
 
+/** Build ticket events with group-aware sold-out / maxPurchasable values. */
+export const buildTicketEventsWithGroupCapacity = async (
+  events: EventWithCount[],
+): Promise<TicketEvent[]> => {
+  const groupRemaining = await getGroupRemainingForEvents(events);
+  return events.map((e) =>
+    buildTicketEvent(e, isRegistrationClosed(e), groupRemaining.get(e.id)),
+  );
+};
+
 /** Filter and transform events to active ticket events */
 export const getActiveEvents = (
   events: (EventWithCount | null)[],
-): TicketEvent[] =>
-  pipe(
-    filter((e: EventWithCount) => e.active),
-    map((e: EventWithCount) => buildTicketEvent(e, isRegistrationClosed(e))),
-  )(compact(events));
+): Promise<TicketEvent[]> =>
+  buildTicketEventsWithGroupCapacity(compact(events).filter((e) => e.active));
 
 /** Set noindex signal header on response for hidden events */
 export const applyHiddenNoindex = (

--- a/src/templates/admin/events.tsx
+++ b/src/templates/admin/events.tsx
@@ -215,6 +215,14 @@ const DateSelector = ({
 };
 
 /** Options for rendering the admin event detail page */
+/** Group + current attendee count, supplied when the event is in a capped
+ * group so the detail page can show group-wide capacity beneath the
+ * event's own. Only the cap > 0 case needs surfacing. */
+export type GroupContext = {
+  group: Group;
+  attendeeCount: number;
+};
+
 export type AdminEventPageOptions = {
   event: EventWithCount;
   attendees: Attendee[];
@@ -228,6 +236,7 @@ export type AdminEventPageOptions = {
   phonePrefix?: string;
   successMessage?: string;
   questionData?: TableQuestionData;
+  groupContext?: GroupContext;
 };
 
 /** Top action nav for the event detail page */
@@ -386,7 +395,7 @@ const AttendeesSummaryRow = ({
   completeQuantitySum: number;
 }): JSX.Element => (
   <tr>
-    <th>Attendees{dailySuffix}</th>
+    <th>Event Attendees{dailySuffix}</th>
     <td>
       <AttendeeCountDisplay
         adjustedCount={adjustedCount}
@@ -405,6 +414,38 @@ const AttendeesSummaryRow = ({
   </tr>
 );
 
+/** Group capacity row shown below the event-attendees row when the event
+ * belongs to a capped group. The label makes the group source explicit so
+ * admins see why a not-yet-full event might still be sold out. */
+const GroupAttendeesRow = ({
+  group,
+  groupAttendeeCount,
+  dailySuffix,
+}: {
+  group: Group;
+  groupAttendeeCount: number;
+  dailySuffix: string;
+}): JSX.Element => {
+  const remaining = Math.max(0, group.max_attendees - groupAttendeeCount);
+  const overCap = groupAttendeeCount >= group.max_attendees;
+  const nearCap = groupAttendeeCount >= group.max_attendees * 0.9;
+  return (
+    <tr>
+      <th>Group Attendees{dailySuffix}</th>
+      <td>
+        <span class={overCap || nearCap ? "danger-text" : ""}>
+          {groupAttendeeCount} / {group.max_attendees} &mdash; {remaining}{" "}
+          remain
+        </span>{" "}
+        <small>
+          across all events in{" "}
+          <a href={`/admin/groups/${group.id}`}>{group.name}</a>
+        </small>
+      </td>
+    </tr>
+  );
+};
+
 /** Event details table - all event metadata rows */
 const EventDetailsTable = ({
   event,
@@ -417,6 +458,7 @@ const EventDetailsTable = ({
   dailySuffix,
   adjustedCount,
   completeQuantitySum,
+  groupContext,
   sharedRowsHtml,
 }: {
   event: EventWithCount;
@@ -429,6 +471,7 @@ const EventDetailsTable = ({
   dailySuffix: string;
   adjustedCount: number;
   completeQuantitySum: number;
+  groupContext: GroupContext | undefined;
   sharedRowsHtml: string;
 }): JSX.Element => (
   <article>
@@ -569,6 +612,13 @@ const EventDetailsTable = ({
             event={event}
             isDaily={isDaily}
           />
+          {groupContext && (
+            <GroupAttendeesRow
+              dailySuffix={dailySuffix}
+              group={groupContext.group}
+              groupAttendeeCount={groupContext.attendeeCount}
+            />
+          )}
           <Raw html={sharedRowsHtml} />
         </tbody>
       </table>
@@ -763,6 +813,7 @@ export const adminEventPage = ({
   phonePrefix,
   successMessage,
   questionData,
+  groupContext,
 }: AdminEventPageOptions): string => {
   const ticketUrl = `https://${allowedDomain}/ticket/${event.slug}`;
   const { script: embedScriptCode, iframe: embedIframeCode } =
@@ -830,6 +881,7 @@ export const adminEventPage = ({
         embedIframeCode={embedIframeCode}
         embedScriptCode={embedScriptCode}
         event={event}
+        groupContext={groupContext}
         isDaily={isDaily}
         sharedRowsHtml={renderDetailRows(sharedRows)}
         ticketUrl={ticketUrl}

--- a/src/templates/admin/groups.tsx
+++ b/src/templates/admin/groups.tsx
@@ -201,17 +201,46 @@ const buildAttendeeRows = (
   )(attendees);
 };
 
-/** Sum attendee_count across all events in the group */
 const totalAttendeeCount = reduce(
   (sum: number, e: EventWithCount) => sum + e.attendee_count,
   0,
 );
 
-/** Sum max_attendees across all events in the group */
-const totalMaxAttendees = reduce(
-  (sum: number, e: EventWithCount) => sum + e.max_attendees,
-  0,
-);
+/** Render the group-attendees row. The cap fragment is omitted when the
+ * group is uncapped so the displayed total isn't conflated with a fake
+ * limit. */
+const GroupAttendeesRow = ({
+  group,
+  attendeeCount,
+}: {
+  group: Group;
+  attendeeCount: number;
+}): JSX.Element => {
+  if (group.max_attendees <= 0) {
+    return (
+      <tr>
+        <th>Group Attendees</th>
+        <td>
+          {attendeeCount} <small>(no group cap)</small>
+        </td>
+      </tr>
+    );
+  }
+  const remaining = Math.max(0, group.max_attendees - attendeeCount);
+  const overCap = attendeeCount >= group.max_attendees;
+  const nearCap = attendeeCount >= group.max_attendees * 0.9;
+  return (
+    <tr>
+      <th>Group Attendees</th>
+      <td>
+        <span class={overCap || nearCap ? "danger-text" : ""}>
+          {attendeeCount} / {group.max_attendees} &mdash; {remaining} remain
+        </span>{" "}
+        <small>across all events in the group</small>
+      </td>
+    </tr>
+  );
+};
 
 /**
  * Admin group detail page - shows group info, events in group, and add-events form
@@ -246,14 +275,13 @@ export const adminGroupDetailPage = (
   const hasPaidEvent = events.some(isPaidEvent);
   const totalCount = totalAttendeeCount(events);
   const tableRows = buildAttendeeRows(attendees, events);
-  const effectiveCapacity =
-    group.max_attendees > 0 ? group.max_attendees : totalMaxAttendees(events);
   const sharedRows = buildSharedDetailRows({
     attendeeCount: totalCount,
     attendees,
     hasPaidEvent,
-    maxCapacity: effectiveCapacity,
+    maxCapacity: 0,
     questionData,
+    skipAttendees: true,
   });
 
   return String(
@@ -335,6 +363,7 @@ export const adminGroupDetailPage = (
                   <td>Yes &mdash; not shown in public events list</td>
                 </tr>
               )}
+              <GroupAttendeesRow attendeeCount={totalCount} group={group} />
               <Raw html={renderDetailRows(sharedRows)} />
             </tbody>
           </table>

--- a/src/templates/admin/guide.tsx
+++ b/src/templates/admin/guide.tsx
@@ -645,18 +645,18 @@ export const adminGuidePage = (
           </p>
           <p>
             Imagine if we <em>did</em> hold places during checkout. A sneaky
-            person could write a small program that opens the checkout page
-            over and over, grabbing every place, without ever paying. Real
-            visitors would see &ldquo;sold out&rdquo; even though nobody had
-            actually bought anything. When the holds expired, the program
-            could grab them all again. This is how ticket scalpers cause
-            problems on bigger sites.
+            person could write a small program that opens the checkout page over
+            and over, grabbing every place, without ever paying. Real visitors
+            would see &ldquo;sold out&rdquo; even though nobody had actually
+            bought anything. When the holds expired, the program could grab them
+            all again. This is how ticket scalpers cause problems on bigger
+            sites.
           </p>
           <p>
-            Because places only count once payment is finished, the only way
-            to &ldquo;hold&rdquo; a place is to actually pay for it. Real
-            money has to change hands &mdash; so the trick above doesn't
-            work, and real visitors get a fair chance at the tickets.
+            Because places only count once payment is finished, the only way to
+            &ldquo;hold&rdquo; a place is to actually pay for it. Real money has
+            to change hands &mdash; so the trick above doesn't work, and real
+            visitors get a fair chance at the tickets.
           </p>
           <p>
             The trade-off: very rarely, two people can finish paying for the
@@ -668,11 +668,11 @@ export const adminGuidePage = (
 
         <Q q="What if the event sells out while someone is paying?">
           <p>
-            If someone completes payment but the event has since sold out,
-            they are automatically refunded. They'll see a message explaining
-            the event is full and that their payment has been returned. This
-            is rare but possible &mdash; it's the trade-off described in the
-            previous question.
+            If someone completes payment but the event has since sold out, they
+            are automatically refunded. They'll see a message explaining the
+            event is full and that their payment has been returned. This is rare
+            but possible &mdash; it's the trade-off described in the previous
+            question.
           </p>
         </Q>
 

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -411,10 +411,13 @@ export type TicketEvent = {
 export const buildTicketEvent = (
   event: EventWithCount,
   closed = false,
-  groupRemaining = Number.POSITIVE_INFINITY,
+  groupRemaining?: number,
 ): TicketEvent => {
   const eventRemaining = event.max_attendees - event.attendee_count;
-  const spotsRemaining = Math.min(eventRemaining, groupRemaining);
+  const spotsRemaining =
+    groupRemaining === undefined
+      ? eventRemaining
+      : Math.min(eventRemaining, groupRemaining);
   const isSoldOut = spotsRemaining <= 0;
   const maxPurchasable =
     isSoldOut || closed ? 0 : Math.min(event.max_quantity, spotsRemaining);

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -405,13 +405,14 @@ export type TicketEvent = {
 };
 
 /** Build ticket event info from event.
- * When the event belongs to a group with a max_attendees limit, pass the
- * group's remaining capacity so the displayed sold-out state and purchasable
- * quantity reflect the smaller of the per-event and group-wide limits. */
+ * Pass `groupRemaining` when the event belongs to a group with a
+ * `max_attendees` limit so the displayed sold-out state and purchasable
+ * quantity reflect the smaller of the per-event and group-wide limits.
+ * Pass `undefined` when no group cap applies. */
 export const buildTicketEvent = (
   event: EventWithCount,
-  closed = false,
-  groupRemaining?: number,
+  closed: boolean,
+  groupRemaining: number | undefined,
 ): TicketEvent => {
   const eventRemaining = event.max_attendees - event.attendee_count;
   const spotsRemaining =

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -404,11 +404,8 @@ export type TicketEvent = {
   maxPurchasable: number;
 };
 
-/** Build ticket event info from event.
- * Pass `groupRemaining` when the event belongs to a group with a
- * `max_attendees` limit so the displayed sold-out state and purchasable
- * quantity reflect the smaller of the per-event and group-wide limits.
- * Pass `undefined` when no group cap applies. */
+/** `groupRemaining`, when defined, clamps the displayed sold-out state and
+ * `maxPurchasable` to the group's combined cap. */
 export const buildTicketEvent = (
   event: EventWithCount,
   closed: boolean,

--- a/src/templates/public.tsx
+++ b/src/templates/public.tsx
@@ -404,12 +404,17 @@ export type TicketEvent = {
   maxPurchasable: number;
 };
 
-/** Build ticket event info from event */
+/** Build ticket event info from event.
+ * When the event belongs to a group with a max_attendees limit, pass the
+ * group's remaining capacity so the displayed sold-out state and purchasable
+ * quantity reflect the smaller of the per-event and group-wide limits. */
 export const buildTicketEvent = (
   event: EventWithCount,
   closed = false,
+  groupRemaining = Number.POSITIVE_INFINITY,
 ): TicketEvent => {
-  const spotsRemaining = event.max_attendees - event.attendee_count;
+  const eventRemaining = event.max_attendees - event.attendee_count;
+  const spotsRemaining = Math.min(eventRemaining, groupRemaining);
   const isSoldOut = spotsRemaining <= 0;
   const maxPurchasable =
     isSoldOut || closed ? 0 : Math.min(event.max_quantity, spotsRemaining);

--- a/test/lib/admin-api-example.test.ts
+++ b/test/lib/admin-api-example.test.ts
@@ -52,7 +52,12 @@ describe("endpoint docs", () => {
       (e: EndpointDoc) => e.method === "GET" && e.path === "/api/events",
     )!;
     const parsed = JSON.parse(listEndpoint.response);
-    const realPublicEvent = toPublicEvent(ADMIN_API_EXAMPLE_EVENT);
+    const realPublicEvent = toPublicEvent(
+      ADMIN_API_EXAMPLE_EVENT,
+      false,
+      undefined,
+      undefined,
+    );
     const realKeys = Object.keys(realPublicEvent).sort();
     const exampleKeys = Object.keys(parsed.events[0]).sort();
     expect(exampleKeys).toEqual(realKeys);

--- a/test/lib/api-example.test.ts
+++ b/test/lib/api-example.test.ts
@@ -20,12 +20,22 @@ import { toPublicEvent } from "#routes/api.ts";
 
 describe("API example", () => {
   test("toPublicEvent output matches the documented example", () => {
-    const result = toPublicEvent(API_EXAMPLE_EVENT);
+    const result = toPublicEvent(
+      API_EXAMPLE_EVENT,
+      false,
+      undefined,
+      undefined,
+    );
     expect(result).toEqual(API_EXAMPLE_PUBLIC_EVENT);
   });
 
   test("example has all PublicEvent keys", () => {
-    const result = toPublicEvent(API_EXAMPLE_EVENT);
+    const result = toPublicEvent(
+      API_EXAMPLE_EVENT,
+      false,
+      undefined,
+      undefined,
+    );
     const resultKeys = Object.keys(result).sort();
     const exampleKeys = Object.keys(API_EXAMPLE_PUBLIC_EVENT).sort();
     expect(exampleKeys).toEqual(resultKeys);

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -383,6 +383,67 @@ describeWithEnv("db > groups", { db: true }, () => {
       expect(await hasAvailableSpots(event.id, 1)).toBe(false);
     });
 
+    test("checkBatchAvailability rejects when one group is full and another has room", async () => {
+      const { e1: fullGroupEvent } = await createCappedGroupWithEvents(
+        2,
+        "full-grp",
+      );
+      const { e1: openGroupEvent } = await createCappedGroupWithEvents(
+        10,
+        "open-grp",
+      );
+
+      await book(fullGroupEvent.id, 2);
+
+      expect(
+        await checkBatchAvailability([
+          { eventId: fullGroupEvent.id, quantity: 1 },
+          { eventId: openGroupEvent.id, quantity: 1 },
+        ]),
+      ).toBe(false);
+
+      expect(
+        await checkBatchAvailability([
+          { eventId: openGroupEvent.id, quantity: 1 },
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe("group remaining helpers", () => {
+    /** Build the same capped-group fixture used by the capacity tests. */
+    const createCappedGroupWithEvents = async (
+      groupMax: number,
+      slug: string,
+      overrides?: { eventType?: "standard" | "daily" },
+    ) => {
+      const group = await createTestGroup({
+        maxAttendees: groupMax,
+        name: slug,
+        slug,
+      });
+      const e1 = await createTestEvent({
+        eventType: overrides?.eventType,
+        groupId: group.id,
+        maxAttendees: 10,
+        name: `${slug}-a`,
+      });
+      const e2 = await createTestEvent({
+        eventType: overrides?.eventType,
+        groupId: group.id,
+        maxAttendees: 10,
+        name: `${slug}-b`,
+      });
+      return { e1, e2, group };
+    };
+
+    const book = (eventId: number, quantity: number, date?: string) =>
+      createAttendeeAtomic({
+        bookings: [{ date, eventId, quantity }],
+        email: `g${eventId}q${quantity}@example.com`,
+        name: `g-${eventId}-${quantity}`,
+      });
+
     test("getGroupRemainingByGroupId returns spots remaining for capped groups", async () => {
       const { e1, group } = await createCappedGroupWithEvents(5, "remaining");
       await book(e1.id, 2);
@@ -457,32 +518,6 @@ describeWithEnv("db > groups", { db: true }, () => {
         name: "no-group",
       });
       expect(await getGroupRemainingForEvent(ungrouped)).toBeUndefined();
-    });
-
-    test("checkBatchAvailability rejects when one group is full and another has room", async () => {
-      const { e1: fullGroupEvent } = await createCappedGroupWithEvents(
-        2,
-        "full-grp",
-      );
-      const { e1: openGroupEvent } = await createCappedGroupWithEvents(
-        10,
-        "open-grp",
-      );
-
-      await book(fullGroupEvent.id, 2);
-
-      expect(
-        await checkBatchAvailability([
-          { eventId: fullGroupEvent.id, quantity: 1 },
-          { eventId: openGroupEvent.id, quantity: 1 },
-        ]),
-      ).toBe(false);
-
-      expect(
-        await checkBatchAvailability([
-          { eventId: openGroupEvent.id, quantity: 1 },
-        ]),
-      ).toBe(true);
     });
   });
 });

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -411,7 +411,6 @@ describeWithEnv("db > groups", { db: true }, () => {
   });
 
   describe("group remaining helpers", () => {
-    /** Build the same capped-group fixture used by the capacity tests. */
     const createCappedGroupWithEvents = async (
       groupMax: number,
       slug: string,

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -3,6 +3,8 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   checkBatchAvailability,
   createAttendeeAtomic,
+  getGroupRemainingByGroupId,
+  getGroupRemainingForEvents,
   hasAvailableSpots,
 } from "#lib/db/attendees.ts";
 import { getDb } from "#lib/db/client.ts";
@@ -378,6 +380,53 @@ describeWithEnv("db > groups", { db: true }, () => {
 
       await book(event.id, 1);
       expect(await hasAvailableSpots(event.id, 1)).toBe(false);
+    });
+
+    test("getGroupRemainingByGroupId returns spots remaining for capped groups", async () => {
+      const { e1, group } = await createCappedGroupWithEvents(5, "remaining");
+      await book(e1.id, 2);
+
+      const map = await getGroupRemainingByGroupId([group.id]);
+      expect(map.get(group.id)).toBe(3);
+    });
+
+    test("getGroupRemainingByGroupId omits groups with no max set", async () => {
+      const group = await createTestGroup({
+        name: "unbounded",
+        slug: "unbounded",
+      });
+      const map = await getGroupRemainingByGroupId([group.id]);
+      expect(map.has(group.id)).toBe(false);
+    });
+
+    test("getGroupRemainingByGroupId returns empty map for empty input", async () => {
+      const map = await getGroupRemainingByGroupId([]);
+      expect(map.size).toBe(0);
+    });
+
+    test("getGroupRemainingByGroupId reports zero when group is exactly full", async () => {
+      const { e1, group } = await createCappedGroupWithEvents(2, "exact-fill");
+      await book(e1.id, 2);
+      const map = await getGroupRemainingByGroupId([group.id]);
+      expect(map.get(group.id)).toBe(0);
+    });
+
+    test("getGroupRemainingForEvents keys remaining by event id", async () => {
+      const { e1, e2 } = await createCappedGroupWithEvents(6, "for-events");
+      await book(e1.id, 4);
+
+      const map = await getGroupRemainingForEvents([e1, e2]);
+      expect(map.get(e1.id)).toBe(2);
+      expect(map.get(e2.id)).toBe(2);
+    });
+
+    test("getGroupRemainingForEvents skips ungrouped events", async () => {
+      const ungrouped = await createTestEvent({
+        maxAttendees: 50,
+        name: "loner",
+      });
+      const map = await getGroupRemainingForEvents([ungrouped]);
+      expect(map.has(ungrouped.id)).toBe(false);
     });
 
     test("checkBatchAvailability rejects when one group is full and another has room", async () => {

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -3,8 +3,9 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   checkBatchAvailability,
   createAttendeeAtomic,
+  getGroupRemainingByEventId,
   getGroupRemainingByGroupId,
-  getGroupRemainingForEvents,
+  getGroupRemainingForEvent,
   hasAvailableSpots,
 } from "#lib/db/attendees.ts";
 import { getDb } from "#lib/db/client.ts";
@@ -411,22 +412,51 @@ describeWithEnv("db > groups", { db: true }, () => {
       expect(map.get(group.id)).toBe(0);
     });
 
-    test("getGroupRemainingForEvents keys remaining by event id", async () => {
+    test("getGroupRemainingByEventId keys remaining by event id", async () => {
       const { e1, e2 } = await createCappedGroupWithEvents(6, "for-events");
       await book(e1.id, 4);
 
-      const map = await getGroupRemainingForEvents([e1, e2]);
+      const map = await getGroupRemainingByEventId([e1, e2]);
       expect(map.get(e1.id)).toBe(2);
       expect(map.get(e2.id)).toBe(2);
     });
 
-    test("getGroupRemainingForEvents skips ungrouped events", async () => {
+    test("getGroupRemainingByEventId skips ungrouped events", async () => {
       const ungrouped = await createTestEvent({
         maxAttendees: 50,
         name: "loner",
       });
-      const map = await getGroupRemainingForEvents([ungrouped]);
+      const map = await getGroupRemainingByEventId([ungrouped]);
       expect(map.has(ungrouped.id)).toBe(false);
+    });
+
+    test("getGroupRemainingByEventId skips daily events", async () => {
+      const { e1 } = await createCappedGroupWithEvents(3, "daily-skip", {
+        eventType: "daily",
+      });
+      const map = await getGroupRemainingByEventId([e1]);
+      expect(map.has(e1.id)).toBe(false);
+    });
+
+    test("getGroupRemainingForEvent returns remaining for standard event", async () => {
+      const { e1, e2 } = await createCappedGroupWithEvents(4, "single-evt");
+      await book(e1.id, 1);
+      expect(await getGroupRemainingForEvent(e2)).toBe(3);
+    });
+
+    test("getGroupRemainingForEvent returns undefined for daily event", async () => {
+      const { e1 } = await createCappedGroupWithEvents(3, "single-daily", {
+        eventType: "daily",
+      });
+      expect(await getGroupRemainingForEvent(e1)).toBeUndefined();
+    });
+
+    test("getGroupRemainingForEvent returns undefined when no group", async () => {
+      const ungrouped = await createTestEvent({
+        maxAttendees: 50,
+        name: "no-group",
+      });
+      expect(await getGroupRemainingForEvent(ungrouped)).toBeUndefined();
     });
 
     test("checkBatchAvailability rejects when one group is full and another has room", async () => {

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -519,5 +519,45 @@ describeWithEnv("db > groups", { db: true }, () => {
       });
       expect(await getGroupRemainingForEvent(ungrouped)).toBeUndefined();
     });
+
+    test("getGroupRemainingByGroupId is per-date for daily-event groups", async () => {
+      const { e1, group } = await createCappedGroupWithEvents(
+        4,
+        "by-id-daily",
+        {
+          eventType: "daily",
+        },
+      );
+      await book(e1.id, 3, "2026-09-01");
+      await book(e1.id, 1, "2026-09-02");
+
+      const onSep1 = await getGroupRemainingByGroupId([group.id], "2026-09-01");
+      const onSep2 = await getGroupRemainingByGroupId([group.id], "2026-09-02");
+      expect(onSep1.get(group.id)).toBe(1);
+      expect(onSep2.get(group.id)).toBe(3);
+    });
+
+    test("getGroupRemainingByEventId returns daily events when date is given", async () => {
+      const { e1, e2 } = await createCappedGroupWithEvents(4, "by-evt-daily", {
+        eventType: "daily",
+      });
+      await book(e1.id, 1, "2026-10-01");
+
+      const onOct1 = await getGroupRemainingByEventId([e1, e2], "2026-10-01");
+      expect(onOct1.get(e1.id)).toBe(3);
+      expect(onOct1.get(e2.id)).toBe(3);
+    });
+
+    test("getGroupRemainingForEvent returns per-date remaining for daily event", async () => {
+      const { e1, e2 } = await createCappedGroupWithEvents(
+        5,
+        "single-daily-date",
+        { eventType: "daily" },
+      );
+      await book(e1.id, 2, "2026-11-15");
+
+      expect(await getGroupRemainingForEvent(e2, "2026-11-15")).toBe(3);
+      expect(await getGroupRemainingForEvent(e2, "2026-11-16")).toBe(5);
+    });
   });
 });

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -309,6 +309,62 @@ describeWithEnv("server (admin events)", { db: true }, () => {
       expect(html).toContain(">Edit<");
     });
 
+    test("shows Group Attendees row when event is in a capped group", async () => {
+      const { event, cookie } = await setupEventAndLogin({
+        maxAttendees: 100,
+      });
+      const { bookAttendee, createTestEvent, createTestGroup } = await import(
+        "#test-utils"
+      );
+      const { eventsTable } = await import("#lib/db/events.ts");
+      const group = await createTestGroup({
+        maxAttendees: 20,
+        name: "Capped Group",
+        slug: "capped-grp",
+      });
+      await eventsTable.update(event.id, { groupId: group.id });
+      // Sibling event in the same group with bookings: proves the row's
+      // count is the group-wide total, not just the current event's.
+      const sibling = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 100,
+        name: "Sibling",
+      });
+      await bookAttendee(sibling, {
+        email: "a@test.com",
+        name: "A",
+        quantity: 4,
+      });
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+        cookie,
+      });
+      const html = await response.text();
+      expect(html).toContain("Group Attendees");
+      expect(html).toContain("4 / 20");
+      expect(html).toContain("16 remain");
+      expect(html).toContain(`href="/admin/groups/${group.id}"`);
+    });
+
+    test("omits Group Attendees row when group is uncapped", async () => {
+      const { event, cookie } = await setupEventAndLogin({
+        maxAttendees: 100,
+      });
+      const { createTestGroup } = await import("#test-utils");
+      const { eventsTable } = await import("#lib/db/events.ts");
+      const group = await createTestGroup({
+        name: "Uncapped",
+        slug: "uncapped-grp",
+      });
+      await eventsTable.update(event.id, { groupId: group.id });
+
+      const response = await awaitTestRequest(`/admin/event/${event.id}`, {
+        cookie,
+      });
+      const html = await response.text();
+      expect(html).not.toContain("Group Attendees");
+    });
+
     test("shows question answer summary when questions assigned", async () => {
       const { event, cookie } = await setupEventAndLogin({
         maxAttendees: 100,

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -963,27 +963,30 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
       expect(updated.max_attendees).toBe(30);
     });
 
-    test("detail page shows attendees with max when set", async () => {
+    test("detail page shows Group Attendees with cap when set", async () => {
       const group = await createTestGroup({
         maxAttendees: 100,
         name: "Detail Max",
         slug: "detail-max",
       });
 
-      await assertAdminHtml(`/admin/groups/${group.id}`, "0 / 100");
+      await assertAdminHtml(
+        `/admin/groups/${group.id}`,
+        "Group Attendees",
+        "0 / 100",
+      );
     });
 
-    test("detail page shows plain attendee count when no group max set", async () => {
+    test("detail page shows Group Attendees with no-cap note when uncapped", async () => {
       const group = await createTestGroup({
         name: "Detail No Max",
         slug: "detail-no-max",
       });
 
-      // Attendees row should show just "0" not "0 / X"
       await assertAdminHtml(
         `/admin/groups/${group.id}`,
-        "<th>Attendees</th>",
-        "<td>0</td>",
+        "Group Attendees",
+        "(no group cap)",
       );
     });
   });

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -237,9 +237,8 @@ describeWithEnv("Public API", { db: true }, () => {
       const sibling = await createTestEvent({
         groupId: group.id,
         maxAttendees: 10,
-        // Pick a maxQuantity strictly larger than the group remaining we
-        // expect (group cap 5 - 3 booked = 2) so the assertion proves the
-        // group clamp, not the per-event maxQuantity.
+        // Larger than expected group remaining (5 − 3 = 2) so the assertion
+        // proves the group clamp, not the per-event maxQuantity.
         maxQuantity: 10,
         name: "Sibling2",
       });

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -231,11 +231,15 @@ describeWithEnv("Public API", { db: true }, () => {
       const filler = await createTestEvent({
         groupId: group.id,
         maxAttendees: 10,
+        maxQuantity: 1,
         name: "Filler2",
       });
       const sibling = await createTestEvent({
         groupId: group.id,
         maxAttendees: 10,
+        // Pick a maxQuantity strictly larger than the group remaining we
+        // expect (group cap 5 - 3 booked = 2) so the assertion proves the
+        // group clamp, not the per-event maxQuantity.
         maxQuantity: 10,
         name: "Sibling2",
       });

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -8,6 +8,7 @@ import {
   createDailyTestEvent,
   createTestAttendeeDirect,
   createTestEvent,
+  createTestGroup,
   deactivateTestEvent,
   describeWithEnv,
   setupStripe,
@@ -194,6 +195,58 @@ describeWithEnv("Public API", { db: true }, () => {
       const { events } = await fetchEventsList();
       expect(events[0]!.isSoldOut).toBe(true);
       expect(events[0]!.maxPurchasable).toBe(0);
+    });
+
+    test("sets isSoldOut when sibling event has filled the group cap", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 2,
+        name: "shared-cap",
+        slug: "shared-cap",
+      });
+      const filler = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Filler",
+      });
+      const sibling = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Sibling",
+      });
+      await createTestAttendeeDirect(filler.id, "A", "a@test.com");
+      await createTestAttendeeDirect(filler.id, "B", "b@test.com");
+
+      const { events } = await fetchEventsList();
+      const siblingEvent = events.find((e) => e.slug === sibling.slug)!;
+      expect(siblingEvent.isSoldOut).toBe(true);
+      expect(siblingEvent.maxPurchasable).toBe(0);
+    });
+
+    test("clamps maxPurchasable to remaining group capacity", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 5,
+        name: "tight-cap",
+        slug: "tight-cap",
+      });
+      const filler = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Filler2",
+      });
+      const sibling = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "Sibling2",
+      });
+      await createTestAttendeeDirect(filler.id, "C", "c@test.com");
+      await createTestAttendeeDirect(filler.id, "D", "d@test.com");
+      await createTestAttendeeDirect(filler.id, "E", "e@test.com");
+
+      const { events } = await fetchEventsList();
+      const siblingEvent = events.find((e) => e.slug === sibling.slug)!;
+      expect(siblingEvent.isSoldOut).toBe(false);
+      expect(siblingEvent.maxPurchasable).toBe(2);
     });
   });
 

--- a/test/routes/public/ticket-events.test.ts
+++ b/test/routes/public/ticket-events.test.ts
@@ -82,8 +82,6 @@ describeWithEnv("routes > public > ticket-events", { db: true }, () => {
       await bookAttendee(inactive, { email: "q@test.com", name: "Q" });
       await deactivateTestEvent(inactive.id);
 
-      // Only the active event reaches the public group page, but the two
-      // attendees on the inactive event still consume two spots of group cap.
       const events = await getActiveEventsByGroupId(group.id);
       expect(events.map((e) => e.id)).toEqual([active.id]);
       const [ticketEvent] = await buildTicketEventsWithGroupCapacity(events);

--- a/test/routes/public/ticket-events.test.ts
+++ b/test/routes/public/ticket-events.test.ts
@@ -1,0 +1,150 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { getActiveEventsByGroupId } from "#lib/db/groups.ts";
+import {
+  buildTicketEventsForGroup,
+  buildTicketEventsWithGroupCapacity,
+} from "#routes/public/ticket-events.ts";
+import {
+  bookAttendee,
+  createTestEvent,
+  createTestGroup,
+  describeWithEnv,
+} from "#test-utils";
+
+describeWithEnv("routes > public > ticket-events", { db: true }, () => {
+  describe("buildTicketEventsWithGroupCapacity", () => {
+    test("clamps spots to group remaining for standard events", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 4,
+        name: "with-cap",
+        slug: "with-cap-1",
+      });
+      const e1 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "with-cap-a",
+      });
+      const e2 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "with-cap-b",
+      });
+      await bookAttendee(e1, { email: "x@test.com", name: "X" });
+
+      const events = await getActiveEventsByGroupId(group.id);
+      const ticketEvents = await buildTicketEventsWithGroupCapacity(events);
+      const eb = ticketEvents.find((t) => t.event.id === e2.id)!;
+      expect(eb.maxPurchasable).toBe(3);
+      expect(eb.isSoldOut).toBe(false);
+    });
+
+    test("does not clamp when group is daily", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 1,
+        name: "daily-no-clamp",
+        slug: "daily-no-clamp",
+      });
+      const e1 = await createTestEvent({
+        eventType: "daily",
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 5,
+        name: "daily-a",
+      });
+
+      const events = await getActiveEventsByGroupId(group.id);
+      const [ticketEvent] = await buildTicketEventsWithGroupCapacity(events);
+      expect(ticketEvent!.maxPurchasable).toBe(5);
+      expect(ticketEvent!.isSoldOut).toBe(false);
+      expect(ticketEvent!.event.id).toBe(e1.id);
+    });
+  });
+
+  describe("buildTicketEventsForGroup", () => {
+    test("clamps spots using group's max minus summed attendee counts", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 5,
+        name: "for-group",
+        slug: "for-group",
+      });
+      const e1 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "for-group-a",
+      });
+      const e2 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "for-group-b",
+      });
+      await bookAttendee(e1, { email: "y@test.com", name: "Y" });
+      await bookAttendee(e1, { email: "z@test.com", name: "Z" });
+
+      const events = await getActiveEventsByGroupId(group.id);
+      const ticketEvents = buildTicketEventsForGroup(group, events);
+      const ea = ticketEvents.find((t) => t.event.id === e1.id)!;
+      const eb = ticketEvents.find((t) => t.event.id === e2.id)!;
+      expect(ea.maxPurchasable).toBe(3);
+      expect(eb.maxPurchasable).toBe(3);
+    });
+
+    test("skips group cap when group is daily", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 1,
+        name: "for-group-daily",
+        slug: "for-group-daily",
+      });
+      await createTestEvent({
+        eventType: "daily",
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 4,
+        name: "for-group-daily-a",
+      });
+      const events = await getActiveEventsByGroupId(group.id);
+      const [ticketEvent] = buildTicketEventsForGroup(group, events);
+      expect(ticketEvent!.maxPurchasable).toBe(4);
+    });
+
+    test("skips group cap when group has no max set", async () => {
+      const group = await createTestGroup({
+        name: "for-group-uncapped",
+        slug: "for-group-uncapped",
+      });
+      await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 8,
+        maxQuantity: 8,
+        name: "for-group-uncapped-a",
+      });
+      const events = await getActiveEventsByGroupId(group.id);
+      const [ticketEvent] = buildTicketEventsForGroup(group, events);
+      expect(ticketEvent!.maxPurchasable).toBe(8);
+    });
+
+    test("clamps remaining at zero when overbooked", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 1,
+        name: "for-group-overbooked",
+        slug: "for-group-overbooked",
+      });
+      const event = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "for-group-overbooked-a",
+      });
+      await bookAttendee(event, { email: "aa@test.com", name: "AA" });
+
+      const events = await getActiveEventsByGroupId(group.id);
+      const [ticketEvent] = buildTicketEventsForGroup(group, events);
+      expect(ticketEvent!.isSoldOut).toBe(true);
+      expect(ticketEvent!.maxPurchasable).toBe(0);
+    });
+  });
+});

--- a/test/routes/public/ticket-events.test.ts
+++ b/test/routes/public/ticket-events.test.ts
@@ -1,14 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { getActiveEventsByGroupId } from "#lib/db/groups.ts";
-import {
-  buildTicketEventsForGroup,
-  buildTicketEventsWithGroupCapacity,
-} from "#routes/public/ticket-events.ts";
+import { buildTicketEventsWithGroupCapacity } from "#routes/public/ticket-events.ts";
 import {
   bookAttendee,
   createTestEvent,
   createTestGroup,
+  deactivateTestEvent,
   describeWithEnv,
 } from "#test-utils";
 
@@ -61,90 +59,35 @@ describeWithEnv("routes > public > ticket-events", { db: true }, () => {
       expect(ticketEvent!.isSoldOut).toBe(false);
       expect(ticketEvent!.event.id).toBe(e1.id);
     });
-  });
 
-  describe("buildTicketEventsForGroup", () => {
-    test("clamps spots using group's max minus summed attendee counts", async () => {
+    test("counts attendees on inactive sibling events toward group cap", async () => {
       const group = await createTestGroup({
-        maxAttendees: 5,
-        name: "for-group",
-        slug: "for-group",
+        maxAttendees: 4,
+        name: "inactive-sibling",
+        slug: "inactive-sibling",
       });
-      const e1 = await createTestEvent({
+      const inactive = await createTestEvent({
         groupId: group.id,
         maxAttendees: 10,
         maxQuantity: 10,
-        name: "for-group-a",
+        name: "inactive-event",
       });
-      const e2 = await createTestEvent({
+      const active = await createTestEvent({
         groupId: group.id,
         maxAttendees: 10,
         maxQuantity: 10,
-        name: "for-group-b",
+        name: "active-event",
       });
-      await bookAttendee(e1, { email: "y@test.com", name: "Y" });
-      await bookAttendee(e1, { email: "z@test.com", name: "Z" });
+      await bookAttendee(inactive, { email: "p@test.com", name: "P" });
+      await bookAttendee(inactive, { email: "q@test.com", name: "Q" });
+      await deactivateTestEvent(inactive.id);
 
+      // Only the active event reaches the public group page, but the two
+      // attendees on the inactive event still consume two spots of group cap.
       const events = await getActiveEventsByGroupId(group.id);
-      const ticketEvents = buildTicketEventsForGroup(group, events);
-      const ea = ticketEvents.find((t) => t.event.id === e1.id)!;
-      const eb = ticketEvents.find((t) => t.event.id === e2.id)!;
-      expect(ea.maxPurchasable).toBe(3);
-      expect(eb.maxPurchasable).toBe(3);
-    });
-
-    test("skips group cap when group is daily", async () => {
-      const group = await createTestGroup({
-        maxAttendees: 1,
-        name: "for-group-daily",
-        slug: "for-group-daily",
-      });
-      await createTestEvent({
-        eventType: "daily",
-        groupId: group.id,
-        maxAttendees: 10,
-        maxQuantity: 4,
-        name: "for-group-daily-a",
-      });
-      const events = await getActiveEventsByGroupId(group.id);
-      const [ticketEvent] = buildTicketEventsForGroup(group, events);
-      expect(ticketEvent!.maxPurchasable).toBe(4);
-    });
-
-    test("skips group cap when group has no max set", async () => {
-      const group = await createTestGroup({
-        name: "for-group-uncapped",
-        slug: "for-group-uncapped",
-      });
-      await createTestEvent({
-        groupId: group.id,
-        maxAttendees: 8,
-        maxQuantity: 8,
-        name: "for-group-uncapped-a",
-      });
-      const events = await getActiveEventsByGroupId(group.id);
-      const [ticketEvent] = buildTicketEventsForGroup(group, events);
-      expect(ticketEvent!.maxPurchasable).toBe(8);
-    });
-
-    test("clamps remaining at zero when overbooked", async () => {
-      const group = await createTestGroup({
-        maxAttendees: 1,
-        name: "for-group-overbooked",
-        slug: "for-group-overbooked",
-      });
-      const event = await createTestEvent({
-        groupId: group.id,
-        maxAttendees: 10,
-        maxQuantity: 10,
-        name: "for-group-overbooked-a",
-      });
-      await bookAttendee(event, { email: "aa@test.com", name: "AA" });
-
-      const events = await getActiveEventsByGroupId(group.id);
-      const [ticketEvent] = buildTicketEventsForGroup(group, events);
-      expect(ticketEvent!.isSoldOut).toBe(true);
-      expect(ticketEvent!.maxPurchasable).toBe(0);
+      expect(events.map((e) => e.id)).toEqual([active.id]);
+      const [ticketEvent] = await buildTicketEventsWithGroupCapacity(events);
+      expect(ticketEvent!.maxPurchasable).toBe(2);
     });
   });
 });

--- a/test/templates/admin/events.test.ts
+++ b/test/templates/admin/events.test.ts
@@ -64,9 +64,54 @@ describe("adminEventPage", () => {
       event,
       session: TEST_SESSION,
     });
-    expect(html).toContain("Attendees");
+    expect(html).toContain("Event Attendees");
     expect(html).toContain("2 / 100");
     expect(html).toContain("98 remain");
+  });
+
+  test("renders no Group Attendees row when groupContext is omitted", () => {
+    const html = adminEventPage({
+      allowedDomain: "localhost",
+      attendees: [],
+      event,
+      session: TEST_SESSION,
+    });
+    expect(html).not.toContain("Group Attendees");
+  });
+
+  test("shows Group Attendees row with count, cap, remaining, and link", () => {
+    const group = testGroup({
+      id: 7,
+      max_attendees: 50,
+      name: "Summer Festival",
+    });
+    const html = adminEventPage({
+      allowedDomain: "localhost",
+      attendees: [],
+      event,
+      groupContext: { attendeeCount: 30, group },
+      session: TEST_SESSION,
+    });
+    expect(html).toContain("Group Attendees");
+    expect(html).toContain("30 / 50");
+    expect(html).toContain("20 remain");
+    expect(html).toContain('href="/admin/groups/7"');
+    expect(html).toContain("Summer Festival");
+    expect(html).toContain("across all events");
+  });
+
+  test("Group Attendees row gets danger-text when at or near cap", () => {
+    const group = testGroup({ id: 8, max_attendees: 10 });
+    const html = adminEventPage({
+      allowedDomain: "localhost",
+      attendees: [],
+      event,
+      groupContext: { attendeeCount: 10, group },
+      session: TEST_SESSION,
+    });
+    expect(html).toContain("danger-text");
+    expect(html).toContain("10 / 10");
+    expect(html).toContain("0 remain");
   });
 
   test("shows checked in row with 0 of 0 when no attendees", () => {

--- a/test/templates/admin/groups.test.ts
+++ b/test/templates/admin/groups.test.ts
@@ -1,0 +1,78 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { signCsrfToken } from "#lib/csrf.ts";
+import { adminGroupDetailPage } from "#templates/admin/groups.tsx";
+import {
+  setupTestEncryptionKey,
+  testEventWithCount,
+  testGroup,
+} from "#test-utils";
+
+const TEST_SESSION = { adminLevel: "owner" as const };
+
+beforeAll(async () => {
+  setupTestEncryptionKey();
+  await signCsrfToken();
+});
+
+describe("adminGroupDetailPage", () => {
+  test("shows Group Attendees row with cap, count, and remaining", () => {
+    const group = testGroup({ max_attendees: 50, name: "Summer Festival" });
+    const events = [
+      testEventWithCount({ attendee_count: 12, group_id: group.id, id: 1 }),
+      testEventWithCount({ attendee_count: 8, group_id: group.id, id: 2 }),
+    ];
+    const html = adminGroupDetailPage(
+      group,
+      events,
+      [],
+      [],
+      TEST_SESSION,
+      "localhost",
+    );
+    expect(html).toContain("Group Attendees");
+    expect(html).toContain("20 / 50");
+    expect(html).toContain("30 remain");
+    expect(html).toContain("across all events");
+  });
+
+  test("Group Attendees row drops cap fragment when group is uncapped", () => {
+    const group = testGroup({ max_attendees: 0, name: "Open Group" });
+    const events = [
+      testEventWithCount({ attendee_count: 5, group_id: group.id }),
+    ];
+    const html = adminGroupDetailPage(
+      group,
+      events,
+      [],
+      [],
+      TEST_SESSION,
+      "localhost",
+    );
+    const groupRow = html.match(
+      /<th>Group Attendees<\/th><td>([\s\S]*?)<\/td>/,
+    );
+    expect(groupRow).not.toBeNull();
+    expect(groupRow![1]).toContain("(no group cap)");
+    expect(groupRow![1]).not.toContain("remain");
+    expect(groupRow![1]).not.toContain(" / ");
+  });
+
+  test("Group Attendees row gets danger-text when at cap", () => {
+    const group = testGroup({ max_attendees: 10 });
+    const events = [
+      testEventWithCount({ attendee_count: 10, group_id: group.id }),
+    ];
+    const html = adminGroupDetailPage(
+      group,
+      events,
+      [],
+      [],
+      TEST_SESSION,
+      "localhost",
+    );
+    expect(html).toContain("danger-text");
+    expect(html).toContain("10 / 10");
+    expect(html).toContain("0 remain");
+  });
+});

--- a/test/templates/layout.test.ts
+++ b/test/templates/layout.test.ts
@@ -81,7 +81,7 @@ describeWithEnv(
       const event = testEventWithCount({ attendee_count: 0 });
       const html = ticketPage({
         dates: [],
-        events: [buildTicketEvent(event)],
+        events: [buildTicketEvent(event, false, undefined)],
         slugs: [event.slug],
       });
       expect(html).toContain("Registration closed.");

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -61,7 +61,7 @@ describe("ticketPage (single event)", () => {
       baseUrl: opts?.baseUrl,
       dates: opts?.dates ?? [],
       error: opts?.error,
-      events: [buildTicketEvent(ev, opts?.isClosed)],
+      events: [buildTicketEvent(ev, opts?.isClosed ?? false, undefined)],
       questions: opts?.questions,
       slugs: [ev.slug],
       terms: opts?.terms,
@@ -374,6 +374,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
       buildTicketEvent(
         testEventWithCount({
@@ -383,6 +385,8 @@ describe("ticketPage", () => {
           name: "Event B",
           slug: "cd34e",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
@@ -399,6 +403,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({
@@ -420,6 +426,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const questions = [
@@ -451,6 +459,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
@@ -469,6 +479,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
@@ -485,6 +497,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
@@ -500,6 +514,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
@@ -518,6 +534,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
@@ -536,6 +554,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c"] });
@@ -555,6 +575,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
       buildTicketEvent(
         testEventWithCount({
@@ -564,6 +586,8 @@ describe("ticketPage", () => {
           name: "Event B",
           slug: "cd34e",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
@@ -581,6 +605,8 @@ describe("ticketPage", () => {
           name: "Event A",
           slug: "ab12c",
         }),
+        false,
+        undefined,
       ),
       buildTicketEvent(
         testEventWithCount({
@@ -590,6 +616,8 @@ describe("ticketPage", () => {
           name: "Event B",
           slug: "cd34e",
         }),
+        false,
+        undefined,
       ),
     ];
     const html = ticketPage({ events, slugs: ["ab12c", "cd34e"] });
@@ -604,7 +632,7 @@ describe("ticketPage event date and location", () => {
     else detectIframeMode("https://example.com/");
     return ticketPage({
       dates: [],
-      events: [buildTicketEvent(ev)],
+      events: [buildTicketEvent(ev, false, undefined)],
       slugs: [ev.slug],
     });
   };
@@ -921,7 +949,7 @@ describeWithEnv(
       const renderSingleEvent = (ev: EventWithCount) =>
         ticketPage({
           dates: [],
-          events: [buildTicketEvent(ev)],
+          events: [buildTicketEvent(ev, false, undefined)],
           slugs: [ev.slug],
           terms: null,
         });
@@ -957,6 +985,8 @@ describeWithEnv(
               image_url: "img-a.jpg",
               name: "Event A",
             }),
+            false,
+            undefined,
           ),
           buildTicketEvent(
             testEventWithCount({
@@ -964,6 +994,8 @@ describeWithEnv(
               image_url: "img-b.jpg",
               name: "Event B",
             }),
+            false,
+            undefined,
           ),
         ];
         const html = ticketPage({ events, slugs: ["slug-a", "slug-b"] });
@@ -975,6 +1007,8 @@ describeWithEnv(
         const events = [
           buildTicketEvent(
             testEventWithCount({ id: 1, image_url: "", name: "Event A" }),
+            false,
+            undefined,
           ),
         ];
         const html = ticketPage({ events, slugs: ["slug-a"] });


### PR DESCRIPTION
## Summary

When buying a ticket for an event that belongs to a group, the public UI and JSON API now reflect the group's combined capacity, not just the individual event's remaining quota. Previously, a visitor reaching an event by its own slug (rather than the group URL) could see "available" for an event whose group was already full and only learn at booking time that no spots remained — the atomic insert and `hasAvailableSpots` already enforced the group cap, but the displayed `isSoldOut` / `maxPurchasable` ignored it.

## Changes

- New `getGroupRemainingByGroupId` / `getGroupRemainingForEvents` helpers in `src/lib/db/attendees/capacity.ts` compute remaining group capacity in a single query.
- `buildTicketEvent` (`src/templates/public.tsx`) and `toPublicEvent` (`src/routes/api.ts`) take an optional `groupRemaining` and clamp the displayed remaining/sold-out state to the smaller of per-event and group-wide limits.
- New `buildTicketEventsWithGroupCapacity` helper in `src/routes/public/types.ts`, used by the public listing, group page, single-ticket page, QR book flow, and JSON API so all rendering paths apply the same group-aware logic.

## Test plan

- [x] `deno task precommit` (typecheck, lint, cpd, build:edge, test:coverage)
- [x] New tests for `getGroupRemainingByGroupId` / `getGroupRemainingForEvents` in `test/lib/db/groups.test.ts`
- [x] New API tests in `test/routes/api.test.ts` verifying `isSoldOut` and `maxPurchasable` reflect a sibling event filling the group cap


---
_Generated by [Claude Code](https://claude.ai/code/session_01M31ataNoGDvD7AkDzPfdrY)_