### PR TITLE
Add duration_days column, types, and multi-day date helpers

### DIFF
--- a/src/shared/api-example.ts
+++ b/src/shared/api-example.ts
@@ -24,6 +24,7 @@ export const API_EXAMPLE_EVENT: EventWithCount = {
   date: "Sat 20 Aug 2025, 10:00 AM",
   description:
     "A hands-on workshop covering watercolours and sketching techniques. All materials provided.",
+  duration_days: 1,
   event_type: "standard",
   fields: "email",
   group_id: 0,

--- a/src/shared/band-name-generator.ts
+++ b/src/shared/band-name-generator.ts
@@ -36,7 +36,7 @@ import { VENUE_TYPES } from "#shared/band-name-generator/venue-types.ts";
 import { WEIRD_VENUES } from "#shared/band-name-generator/weird-venues.ts";
 
 // Re-export every pool so existing call sites and tests can keep using
-// `import { BAND_ADJECTIVES } from "#lib/band-name-generator.ts"`.
+// `import { BAND_ADJECTIVES } from "#shared/band-name-generator.ts"`.
 export {
   AGE_NOTES,
   AUDIENCE_OUTCOMES,

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -97,8 +97,30 @@ const isBookable = (
   bookableDays.includes(getDayName(dateStr)) && !isHoliday(dateStr, holidays);
 
 /**
+ * Check if every day in a multi-day booking starting at `start` is bookable.
+ * All days in `[start, start + durationDays)` must pass `isBookable` and
+ * stay within `endLimit` (inclusive).
+ */
+const isRangeBookable = (
+  start: string,
+  durationDays: number,
+  bookableDays: string[],
+  holidays: Holiday[],
+  endLimit: string,
+): boolean => {
+  for (let i = 0; i < durationDays; i++) {
+    const day = addDays(start, i);
+    if (day > endLimit) return false;
+    if (!isBookable(day, bookableDays, holidays)) return false;
+  }
+  return true;
+};
+
+/**
  * Compute available booking dates for a daily event.
  * Filters by bookable days of the week and excludes holidays.
+ * For events with `duration_days > 1`, excludes start dates whose full range
+ * would hit a non-bookable day or extend past the booking window.
  * Returns sorted array of YYYY-MM-DD strings.
  */
 export const getAvailableDates = (
@@ -106,9 +128,10 @@ export const getAvailableDates = (
   holidays: Holiday[],
 ): string[] => {
   const range = bookableRange(event);
-  return filter((d: string) => isBookable(d, range.bookableDays, holidays))(
-    dateRange(range.start, range.end),
-  );
+  const duration = Math.max(1, event.duration_days);
+  return filter((d: string) =>
+    isRangeBookable(d, duration, range.bookableDays, holidays, range.end),
+  )(dateRange(range.start, range.end));
 };
 
 /**
@@ -122,10 +145,21 @@ export const getNextBookableDate = (
 ): string | null => {
   const range = bookableRange(event);
   if (range.bookableDays.length === 0) return null;
+  const duration = Math.max(1, event.duration_days);
 
   let current = range.start;
   while (current <= range.end) {
-    if (isBookable(current, range.bookableDays, holidays)) return current;
+    if (
+      isRangeBookable(
+        current,
+        duration,
+        range.bookableDays,
+        holidays,
+        range.end,
+      )
+    ) {
+      return current;
+    }
     current = addDays(current, 1);
   }
   return null;

--- a/src/shared/db/attendee-types.ts
+++ b/src/shared/db/attendee-types.ts
@@ -49,6 +49,8 @@ export type EventBooking = {
   quantity?: number;
   pricePaid?: number;
   date?: string | null;
+  /** Booking duration in days (defaults to 1 for 1-day bookings). Only meaningful when date is set. */
+  durationDays?: number;
 };
 
 /** Input for creating an attendee atomically (one or more events) */
@@ -82,7 +84,12 @@ export type AttendeeWithBookings = {
 };
 
 /** Item for batch availability check */
-export type BatchAvailabilityItem = { eventId: number; quantity: number };
+export type BatchAvailabilityItem = {
+  eventId: number;
+  quantity: number;
+  /** Duration in days for multi-day bookings (defaults to 1 when absent). */
+  durationDays?: number;
+};
 
 /** Input for updating attendee PII (shared across events) */
 export type UpdateAttendeePIIInput = {
@@ -101,6 +108,8 @@ export type UpdateAttendeePIIInput = {
 export type UpdateEventLinkInput = {
   quantity: number;
   date: string | null;
+  /** Duration in days (defaults to 1). Only meaningful when date is set. */
+  durationDays?: number;
 };
 
 /** Result of updating an event link */

--- a/src/shared/db/events.ts
+++ b/src/shared/db/events.ts
@@ -71,6 +71,7 @@ export type EventInput = {
   hidden?: boolean;
   purchaseOnly?: boolean;
   assignBuiltSite?: boolean;
+  durationDays?: number;
 };
 
 /** Compute slug index from slug for blind index lookup */
@@ -155,6 +156,7 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
   created: col.withDefault(() => nowIso()),
   date: { default: () => "", read: decryptDatetime, write: writeEventDate },
   description: col.encryptedText(encrypt, decrypt),
+  duration_days: col.withDefault(() => 1),
   event_type: col.withDefault<EventType>(() => "standard"),
   fields: col.withDefault<EventFields>(() => "email"),
   group_id: col.withDefault(() => 0),

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -86,6 +86,7 @@ const SCHEMA: [name: string, table: Table][] = [
         ["purchase_only", "INTEGER NOT NULL DEFAULT 0"],
         ["assign_built_site", "INTEGER NOT NULL DEFAULT 0"],
         ["max_price", "INTEGER NOT NULL DEFAULT 0"],
+        ["duration_days", "INTEGER NOT NULL DEFAULT 1"],
       ],
       indexes: [
         {

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -34,7 +34,7 @@ type Table = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "add token rate-limit table with window_start/last_attempt";
+  "add duration_days to events";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,6 +102,7 @@ export interface Event {
   thank_you_url: string;
   unit_price: number;
   webhook_url: string;
+  duration_days: number;
 }
 
 export interface Attendee extends ContactInfo {

--- a/src/test-utils/factories.ts
+++ b/src/test-utils/factories.ts
@@ -31,6 +31,7 @@ export const testEvent = (overrides: Partial<Event> = {}): Event => ({
   created: "2024-01-01T00:00:00Z",
   date: "",
   description: "",
+  duration_days: 1,
   event_type: "standard",
   fields: "email",
   group_id: 0,

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -167,6 +167,32 @@ describeWithEnv("dates", { db: true }, () => {
       const dates = getAvailableDates(event, []);
       expect(dates).toEqual([]);
     });
+
+    test("excludes multi-day start dates whose range covers a holiday", () => {
+      const holidayStart = addDays(today(), 3);
+      const holidays = [
+        {
+          end_date: holidayStart,
+          id: 1,
+          name: "Conflict",
+          start_date: holidayStart,
+        },
+      ];
+      const event = testEvent({
+        bookable_days: [...VALID_DAY_NAMES],
+        duration_days: 3,
+        event_type: "daily",
+        maximum_days_after: 14,
+        minimum_days_before: 0,
+      });
+      const dates = getAvailableDates(event, holidays);
+      // day+1 start → covers day 1,2,3 → contains holidayStart → excluded
+      expect(dates).not.toContain(addDays(today(), 1));
+      // day+3 start is the holiday itself → excluded
+      expect(dates).not.toContain(holidayStart);
+      // day+4 start → covers day 4,5,6 → no holiday → included
+      expect(dates).toContain(addDays(today(), 4));
+    });
   });
 
   describe("getNextBookableDate", () => {


### PR DESCRIPTION
## Summary

- Add `duration_days INTEGER NOT NULL DEFAULT 1` to events table
- Add `duration_days` to Event interface, EventInput, and type definitions
- Add `durationDays?` to EventBooking, BatchAvailabilityItem, UpdateEventLinkInput
- Add `isRangeBookable` helper: validates every day in a multi-day range is bookable
- Update `getAvailableDates`/`getNextBookableDate` to respect duration (excludes start dates whose full range would hit non-bookable days or extend past window)

**Zero behavior change**: all existing events have `duration_days=1`, which preserves single-day semantics throughout.

## PR Stack

1. **This PR** — schema + types + date helpers
2. `duration-days/2-backend-engine` — capacity engine + booking flow (depends on this)
3. `duration-days/3-admin-ui` — admin UI + display (depends on #2)

## Test plan

- [x] Typecheck passes
- [x] Lint clean (546 files)
- [x] Full test suite passes (324 files, 5974 steps, 0 failures)
- [x] New tests in `test/lib/dates.test.ts` cover multi-day range exclusion

---
_Generated by [Claude Code](https://claude.ai/code/session_014KWu2U7wFv8Xb8btKUVVYP)_