### PR TITLE
Auto-provision Bunny databases for built sites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,24 @@ jobs:
           STRIPE_MOCK_HOST: localhost
           STRIPE_MOCK_PORT: "12111"
           DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
-        run: deno task test:coverage
+        run: set -o pipefail && deno task test:coverage 2>&1 | tee test-output.log
+
+      - name: Surface test failures in step summary
+        if: failure()
+        run: |
+          {
+            echo "## Test failure diagnostics"
+            echo ""
+            echo "### Last 200 lines of test output"
+            echo '```'
+            tail -200 test-output.log || echo "(no test-output.log)"
+            echo '```'
+            echo ""
+            echo "### Lines matching FAILED / Error / AssertionError / uncovered"
+            echo '```'
+            grep -E "FAILED|error:|Error:|AssertionError|uncovered|coverage|Branch coverage|Line coverage" test-output.log | head -80 || echo "(no matches)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate HTML coverage report
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,24 +61,7 @@ jobs:
           STRIPE_MOCK_HOST: localhost
           STRIPE_MOCK_PORT: "12111"
           DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
-        run: set -o pipefail && deno task test:coverage 2>&1 | tee test-output.log
-
-      - name: Surface test failures in step summary
-        if: failure()
-        run: |
-          {
-            echo "## Test failure diagnostics"
-            echo ""
-            echo "### Last 200 lines of test output"
-            echo '```'
-            tail -200 test-output.log || echo "(no test-output.log)"
-            echo '```'
-            echo ""
-            echo "### Lines matching FAILED / Error / AssertionError / uncovered"
-            echo '```'
-            grep -E "FAILED|error:|Error:|AssertionError|uncovered|coverage|Branch coverage|Line coverage" test-output.log | head -80 || echo "(no matches)"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: deno task test:coverage
 
       - name: Generate HTML coverage report
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Environment variables are configured as **Bunny native secrets** in the Bunny Ed
 - `STORAGE_ZONE_KEY` - Bunny CDN storage zone access key (required for image uploads)
 - `BUNNY_DNS_ZONE_ID` - Bunny DNS zone ID for subdomain registration (enables subdomain feature when set with `BUNNY_API_KEY`)
 - `BUNNY_DNS_SUBDOMAIN_SUFFIX` - Suffix appended to user-chosen subdomain (e.g. `.tickets`)
+- `BUNNY_DB_REGION` - Bunny database region for auto-provisioned databases (defaults to `DE` for Frankfurt; e.g. `NY`, `LA`, `SG`)
 - `NTFY_URL` - Ntfy endpoint URL for error notifications (e.g. `https://ntfy.sh/your-topic`). Sends domain and error code only, no personal or encrypted data.
 - `APPLE_WALLET_PASS_TYPE_ID` - Apple Wallet Pass Type ID (e.g. `pass.com.example.tickets`)
 - `APPLE_WALLET_TEAM_ID` - Apple Developer Team ID (e.g. `ABC1234567`)

--- a/src/features/admin/builder.ts
+++ b/src/features/admin/builder.ts
@@ -104,8 +104,8 @@ const builderPost = createAuthedFormRoute({
 
     const result = await settings.withCurrentTask("builder", () =>
       builderApi.buildSite({
-        dbToken: values.db_token || undefined,
-        dbUrl: values.db_url || undefined,
+        dbToken: values.db_token ?? undefined,
+        dbUrl: values.db_url ?? undefined,
         siteName: values.site_name,
       }),
     );

--- a/src/features/admin/builder.ts
+++ b/src/features/admin/builder.ts
@@ -67,17 +67,17 @@ export const builderForm = defineForm({
       type: "text" as const,
     },
     {
+      hint: "Leave blank to auto-provision a new Bunny database",
       label: "Database URL",
       name: "db_url",
       placeholder: "libsql://your-db.turso.io",
-      required: true,
       type: "url" as const,
     },
     {
+      hint: "Leave blank to auto-provision a new Bunny database",
       label: "Database Token",
       name: "db_token",
       placeholder: "Token for the database",
-      required: true,
       type: "password" as const,
     },
   ] as const,
@@ -89,21 +89,23 @@ const builderPost = createAuthedFormRoute({
   form: builderForm,
   onInvalid: ({ error }) => errorRedirect(BUILDER_PATH, error),
   onValid: async ({ form, values }) => {
-    const dbTest = await builderApi.testDbConnection(
-      values.db_url,
-      values.db_token,
-    );
-    if (!dbTest.ok) {
-      return errorRedirect(
-        BUILDER_PATH,
-        `Database connection failed: ${dbTest.error}`,
+    if (values.db_url) {
+      const dbTest = await builderApi.testDbConnection(
+        values.db_url,
+        values.db_token ?? "",
       );
+      if (!dbTest.ok) {
+        return errorRedirect(
+          BUILDER_PATH,
+          `Database connection failed: ${dbTest.error}`,
+        );
+      }
     }
 
     const result = await settings.withCurrentTask("builder", () =>
       builderApi.buildSite({
-        dbToken: values.db_token,
-        dbUrl: values.db_url,
+        dbToken: values.db_token || undefined,
+        dbUrl: values.db_url || undefined,
         siteName: values.site_name,
       }),
     );
@@ -116,8 +118,8 @@ const builderPost = createAuthedFormRoute({
     await insertBuiltSite(
       values.site_name,
       buildResult.defaultHostname,
-      values.db_url,
-      values.db_token,
+      buildResult.dbUrl,
+      buildResult.dbToken,
       form.getString("assignable") === "1",
       String(buildResult.scriptId),
     );

--- a/src/shared/builder.ts
+++ b/src/shared/builder.ts
@@ -3,16 +3,16 @@
  *
  * Flow:
  * 1. Fetch latest release code from GitHub
+ * 1b. Auto-provision a Bunny database if dbUrl/dbToken not supplied
  * 2. Create a new Bunny edge script with the code
  * 3. Enable cookies on the linked pull zone (DisableCookies: false)
- * 4. Set secrets: user-provided (DB_URL, DB_TOKEN), generated (DB_ENCRYPTION_KEY),
- *    and copied from host (email, wallet, ntfy, storage, DNS config)
- * 5. Test database connection
- * 6. Publish the script
- * 7. Record the built site in the local database
+ * 4. Set secrets: DB credentials, generated DB_ENCRYPTION_KEY,
+ *    and host secrets copied from the host environment
+ * 5. Publish the script
  */
 
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
+import { bunnyDbApi, type CreateDatabaseResult } from "#shared/bunny-db.ts";
 import { toBase64 } from "#shared/crypto/utils.ts";
 import { getEnv } from "#shared/env.ts";
 import { fetchText } from "#shared/fetch.ts";
@@ -41,12 +41,14 @@ const HOST_SECRET_KEYS = [
 
 export type BuildSiteInput = {
   siteName: string;
-  dbUrl: string;
-  dbToken: string;
+  /** Leave blank to auto-provision a new Bunny database via the API. */
+  dbUrl?: string;
+  /** Leave blank to auto-provision a new Bunny database via the API. */
+  dbToken?: string;
 };
 
 export type BuildSiteResult =
-  | { ok: true; scriptId: number; defaultHostname: string }
+  | { ok: true; scriptId: number; defaultHostname: string; dbUrl: string; dbToken: string }
   | { ok: false; error: string };
 
 /** Generate a random 32-byte base64 encryption key */
@@ -113,6 +115,16 @@ export const buildSite = async (
     };
   }
 
+  // 1b. Auto-provision database if credentials not supplied
+  let dbCredentials: Pick<CreateDatabaseResult, "dbUrl" | "dbToken">;
+  if (input.dbUrl) {
+    dbCredentials = { dbToken: input.dbToken ?? "", dbUrl: input.dbUrl };
+  } else {
+    const dbResult = await builderApi.createDatabase(input.siteName);
+    if (!dbResult.ok) return dbResult;
+    dbCredentials = { dbToken: dbResult.dbToken, dbUrl: dbResult.dbUrl };
+  }
+
   // 2. Create edge script
   const createResult = await bunnyCdnApi.createEdgeScript(fullName, code);
   if (!createResult.ok) return createResult;
@@ -130,8 +142,8 @@ export const buildSite = async (
 
   // 5. Set secrets
   const secrets: [string, string][] = [
-    ["DB_URL", input.dbUrl],
-    ["DB_TOKEN", input.dbToken],
+    ["DB_URL", dbCredentials.dbUrl],
+    ["DB_TOKEN", dbCredentials.dbToken],
     ["DB_ENCRYPTION_KEY", encryptionKey],
     ["BUNNY_SCRIPT_ID", String(scriptId)],
   ];
@@ -151,12 +163,13 @@ export const buildSite = async (
   const publishResult = await bunnyCdnApi.publishEdgeScript(scriptId);
   if (!publishResult.ok) return publishResult;
 
-  return { defaultHostname, ok: true, scriptId };
+  return { dbToken: dbCredentials.dbToken, dbUrl: dbCredentials.dbUrl, defaultHostname, ok: true, scriptId };
 };
 
 /** Stubbable API for testing */
 export const builderApi = {
   buildSite,
+  createDatabase: bunnyDbApi.createDatabase,
   generateEncryptionKey,
   testDbConnection,
 };

--- a/src/shared/bunny-cdn.ts
+++ b/src/shared/bunny-cdn.ts
@@ -104,7 +104,7 @@ const okOrError = (response: FetchResult, label: string): BunnyApiResult =>
   response.ok ? { ok: true } : parseBunnyError(response, label);
 
 /** Parse a Bunny API error response into a BunnyApiResult. */
-const parseBunnyError = (
+export const parseBunnyError = (
   response: FetchResult,
   label: string,
 ): BunnyApiResult & { ok: false } => {

--- a/src/shared/bunny-db.ts
+++ b/src/shared/bunny-db.ts
@@ -1,0 +1,127 @@
+/**
+ * Bunny Database API client — creates and provisions libSQL databases.
+ * Used by the site builder to automatically provision a database for each new site.
+ *
+ * API base: https://api.bunny.net/database
+ * Auth: AccessKey header (same BUNNY_API_KEY as CDN API)
+ */
+
+import { getBunnyApiKey } from "#shared/config.ts";
+import { fetchText } from "#shared/fetch.ts";
+import { getEnv } from "#shared/env.ts";
+
+const DB_API_BASE = "https://api.bunny.net/database";
+
+/** Region to use when creating a new database (short Bunny region code). */
+export const getBunnyDbRegion = (): string =>
+  getEnv("BUNNY_DB_REGION") ?? "DE";
+
+type DbApiResult<T> = { ok: true } & T | { ok: false; error: string };
+
+interface CreateDbResponse {
+  db_id: string;
+}
+
+interface GetDbResponse {
+  db: {
+    db_id: string;
+    name: string;
+    url: string;
+  };
+}
+
+interface GenerateTokenResponse {
+  token: string;
+}
+
+export interface CreateDatabaseResult {
+  dbId: string;
+  dbUrl: string;
+  dbToken: string;
+}
+
+/** Headers for all Bunny Database API requests. */
+const dbApiHeaders = (): Record<string, string> => ({
+  AccessKey: getBunnyApiKey(),
+  "Content-Type": "application/json",
+});
+
+/** Parse a Bunny Database API error response. */
+const parseDbError = (
+  response: { status: number; text: string },
+  label: string,
+): { ok: false; error: string } => {
+  let message = response.text;
+  try {
+    const json = JSON.parse(response.text);
+    if (json.Message) message = json.Message;
+    else if (json.message) message = json.message;
+  } catch {
+    /* use raw text */
+  }
+  return { error: `${label} failed (${response.status}): ${message}`, ok: false };
+};
+
+/**
+ * Create a new Bunny database with the given name.
+ * Returns the database URL and a full-access token.
+ */
+const createDatabaseImpl = async (
+  name: string,
+): Promise<DbApiResult<CreateDatabaseResult>> => {
+  const region = getBunnyDbRegion();
+
+  // 1. Create the database
+  const createRes = await fetchText(`${DB_API_BASE}/v2/databases`, {
+    body: JSON.stringify({
+      name,
+      primary_regions: [region],
+      replicas_regions: [],
+      storage_region: region,
+    }),
+    headers: dbApiHeaders(),
+    method: "POST",
+  });
+
+  if (!createRes.ok) {
+    return parseDbError(createRes, "Create database");
+  }
+
+  const createData: CreateDbResponse = JSON.parse(createRes.text);
+  const dbId = createData.db_id;
+
+  // 2. Fetch database details to get the connection URL
+  const getRes = await fetchText(`${DB_API_BASE}/v2/databases/${encodeURIComponent(dbId)}`, {
+    headers: dbApiHeaders(),
+  });
+
+  if (!getRes.ok) {
+    return parseDbError(getRes, "Get database");
+  }
+
+  const getData: GetDbResponse = JSON.parse(getRes.text);
+  const dbUrl = getData.db.url;
+
+  // 3. Generate a full-access token
+  const tokenRes = await fetchText(
+    `${DB_API_BASE}/v2/databases/${encodeURIComponent(dbId)}/auth/generate`,
+    {
+      body: JSON.stringify({ authorization: "full-access", expires_at: null }),
+      headers: dbApiHeaders(),
+      method: "PUT",
+    },
+  );
+
+  if (!tokenRes.ok) {
+    return parseDbError(tokenRes, "Generate database token");
+  }
+
+  const tokenData: GenerateTokenResponse = JSON.parse(tokenRes.text);
+
+  return { dbId, dbToken: tokenData.token, dbUrl, ok: true };
+};
+
+/** Stubbable API for testing */
+export const bunnyDbApi = {
+  createDatabase: createDatabaseImpl,
+};

--- a/src/shared/bunny-db.ts
+++ b/src/shared/bunny-db.ts
@@ -55,7 +55,6 @@ const parseDbError = (
   try {
     const json = JSON.parse(response.text);
     if (json.Message) message = json.Message;
-    else if (json.message) message = json.message;
   } catch {
     /* use raw text */
   }

--- a/src/shared/bunny-db.ts
+++ b/src/shared/bunny-db.ts
@@ -6,6 +6,7 @@
  * Auth: AccessKey header (same BUNNY_API_KEY as CDN API)
  */
 
+import { parseBunnyError } from "#shared/bunny-cdn.ts";
 import { getBunnyApiKey } from "#shared/config.ts";
 import { fetchText } from "#shared/fetch.ts";
 import { getEnv } from "#shared/env.ts";
@@ -46,21 +47,6 @@ const dbApiHeaders = (): Record<string, string> => ({
   "Content-Type": "application/json",
 });
 
-/** Parse a Bunny Database API error response. */
-const parseDbError = (
-  response: { status: number; text: string },
-  label: string,
-): { ok: false; error: string } => {
-  let message = response.text;
-  try {
-    const json = JSON.parse(response.text);
-    if (json.Message) message = json.Message;
-  } catch {
-    /* use raw text */
-  }
-  return { error: `${label} failed (${response.status}): ${message}`, ok: false };
-};
-
 /**
  * Create a new Bunny database with the given name.
  * Returns the database URL and a full-access token.
@@ -83,7 +69,7 @@ const createDatabaseImpl = async (
   });
 
   if (!createRes.ok) {
-    return parseDbError(createRes, "Create database");
+    return parseBunnyError(createRes, "Create database");
   }
 
   const createData: CreateDbResponse = JSON.parse(createRes.text);
@@ -95,7 +81,7 @@ const createDatabaseImpl = async (
   });
 
   if (!getRes.ok) {
-    return parseDbError(getRes, "Get database");
+    return parseBunnyError(getRes, "Get database");
   }
 
   const getData: GetDbResponse = JSON.parse(getRes.text);
@@ -112,7 +98,7 @@ const createDatabaseImpl = async (
   );
 
   if (!tokenRes.ok) {
-    return parseDbError(tokenRes, "Generate database token");
+    return parseBunnyError(tokenRes, "Generate database token");
   }
 
   const tokenData: GenerateTokenResponse = JSON.parse(tokenRes.text);

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -774,27 +774,27 @@ describeWithEnv(
             }),
           ),
           encKeyStub: stub(builderApi, "generateEncryptionKey", () => "key=="),
-          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
-            const url = String(input);
-            if (url.includes("releases/latest")) {
+          fetchStub: stub(globalThis, "fetch", (_input: string | URL | Request) => {
+            const href = String(_input);
+            if (href.includes("releases/latest")) {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({
                     assets: [
                       {
-                        browser_download_url: "https://example.com/s.ts",
+                        browser_download_url: "https://example.com/notoken.ts",
                         name: "bunny-script.ts",
                       },
                     ],
-                    name: "T",
-                    published_at: "2026-01-01T00:00:00Z",
-                    tag_name: "v2026-01-01-000000",
+                    name: "NoToken",
+                    published_at: "2026-02-01T00:00:00Z",
+                    tag_name: "v2026-02-01-000000",
                   }),
                   { status: 200 },
                 ),
               );
             }
-            return Promise.resolve(new Response("code", { status: 200 }));
+            return Promise.resolve(new Response("/* notoken */", { status: 200 }));
           }),
           publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
             Promise.resolve({ ok: true as const }),

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -756,5 +756,68 @@ describeWithEnv(
         },
       );
     });
+
+    test("buildSite uses empty string dbToken when dbUrl provided without dbToken", async () => {
+      const secretsSet: [string, string][] = [];
+
+      await withMocks(
+        () => ({
+          createDbStub: stub(builderApi, "createDatabase", () =>
+            Promise.resolve(MOCK_DB_RESULT),
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              defaultHostname: "https://test.b-cdn.net",
+              ok: true as const,
+              pullZoneId: 1,
+              scriptId: 1,
+            }),
+          ),
+          encKeyStub: stub(builderApi, "generateEncryptionKey", () => "key=="),
+          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes("releases/latest")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    assets: [
+                      {
+                        browser_download_url: "https://example.com/s.ts",
+                        name: "bunny-script.ts",
+                      },
+                    ],
+                    name: "T",
+                    published_at: "2026-01-01T00:00:00Z",
+                    tag_name: "v2026-01-01-000000",
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            return Promise.resolve(new Response("code", { status: 200 }));
+          }),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          secretStub: stub(
+            bunnyCdnApi,
+            "setEdgeScriptSecret",
+            (_id: number, name: string, value: string) => {
+              secretsSet.push([name, value]);
+              return Promise.resolve({ ok: true as const });
+            },
+          ),
+          updatePzStub: stub(bunnyCdnApi, "updatePullZone", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+        }),
+        async ({ createDbStub }) => {
+          await builderApi.buildSite({ dbUrl: "libsql://provided.io", siteName: "NoToken" });
+          expect(createDbStub.calls.length).toBe(0);
+          const dbTokenSecret = secretsSet.find(([n]) => n === "DB_TOKEN");
+          expect(dbTokenSecret![1]).toBe("");
+        },
+      );
+    });
   },
 );

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -774,27 +774,27 @@ describeWithEnv(
             }),
           ),
           encKeyStub: stub(builderApi, "generateEncryptionKey", () => "key=="),
-          fetchStub: stub(globalThis, "fetch", (_input: string | URL | Request) => {
-            const href = String(_input);
-            if (href.includes("releases/latest")) {
+          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes("releases/latest")) {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({
                     assets: [
                       {
-                        browser_download_url: "https://example.com/notoken.ts",
+                        browser_download_url: "https://example.com/s.ts",
                         name: "bunny-script.ts",
                       },
                     ],
-                    name: "NoToken",
-                    published_at: "2026-02-01T00:00:00Z",
-                    tag_name: "v2026-02-01-000000",
+                    name: "T",
+                    published_at: "2026-01-01T00:00:00Z",
+                    tag_name: "v2026-01-01-000000",
                   }),
                   { status: 200 },
                 ),
               );
             }
-            return Promise.resolve(new Response("/* notoken */", { status: 200 }));
+            return Promise.resolve(new Response("code", { status: 200 }));
           }),
           publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
             Promise.resolve({ ok: true as const }),

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -5,6 +5,13 @@ import { builderApi } from "#shared/builder.ts";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { describeWithEnv, withMocks } from "#test-utils";
 
+const MOCK_DB_RESULT = {
+  dbId: "db_auto123",
+  dbToken: "auto-token",
+  dbUrl: "libsql://auto.lite.bunnydb.net",
+  ok: true as const,
+};
+
 describeWithEnv(
   "builder",
   { db: true, env: { NTFY_URL: "https://ntfy.example.com/test" } },
@@ -570,6 +577,182 @@ describeWithEnv(
           if (!result.ok) {
             expect(result.error).toContain("Publish edge script failed");
           }
+        },
+      );
+    });
+
+    test("buildSite auto-creates database when dbUrl is not provided", async () => {
+      const secretsSet: [string, string][] = [];
+
+      await withMocks(
+        () => ({
+          createDbStub: stub(
+            builderApi,
+            "createDatabase",
+            () => Promise.resolve(MOCK_DB_RESULT),
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              defaultHostname: "https://auto-42.b-cdn.net",
+              ok: true as const,
+              pullZoneId: 99,
+              scriptId: 42,
+            }),
+          ),
+          encKeyStub: stub(builderApi, "generateEncryptionKey", () => "dGVzdGtleQ=="),
+          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes("releases/latest")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    assets: [
+                      {
+                        browser_download_url: "https://example.com/script.ts",
+                        name: "bunny-script.ts",
+                      },
+                    ],
+                    name: "Test Release",
+                    published_at: "2026-01-01T00:00:00Z",
+                    tag_name: "v2026-01-01-000000",
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            if (url.includes("example.com/script.ts")) {
+              return Promise.resolve(new Response("console.log('code')", { status: 200 }));
+            }
+            return Promise.resolve(new Response("error", { status: 500 }));
+          }),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          secretStub: stub(
+            bunnyCdnApi,
+            "setEdgeScriptSecret",
+            (_id: number, name: string, value: string) => {
+              secretsSet.push([name, value]);
+              return Promise.resolve({ ok: true as const });
+            },
+          ),
+          updatePzStub: stub(bunnyCdnApi, "updatePullZone", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+        }),
+        async ({ createDbStub }) => {
+          const result = await builderApi.buildSite({ siteName: "Auto Site" });
+
+          expect(result.ok).toBe(true);
+          expect(createDbStub.calls.length).toBe(1);
+          expect(createDbStub.calls[0]!.args[0]).toBe("Auto Site");
+
+          if (result.ok) {
+            expect(result.dbUrl).toBe(MOCK_DB_RESULT.dbUrl);
+            expect(result.dbToken).toBe(MOCK_DB_RESULT.dbToken);
+          }
+
+          const dbUrlSecret = secretsSet.find(([n]) => n === "DB_URL");
+          expect(dbUrlSecret![1]).toBe(MOCK_DB_RESULT.dbUrl);
+          const dbTokenSecret = secretsSet.find(([n]) => n === "DB_TOKEN");
+          expect(dbTokenSecret![1]).toBe(MOCK_DB_RESULT.dbToken);
+        },
+      );
+    });
+
+    test("buildSite returns error when auto-create database fails", async () => {
+      await withMocks(
+        () => ({
+          createDbStub: stub(builderApi, "createDatabase", () =>
+            Promise.resolve({ error: "Create database failed (403): Forbidden", ok: false as const }),
+          ),
+          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes("releases/latest")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    assets: [
+                      {
+                        browser_download_url: "https://example.com/script.ts",
+                        name: "bunny-script.ts",
+                      },
+                    ],
+                    name: "Test",
+                    published_at: "2026-01-01T00:00:00Z",
+                    tag_name: "v2026-01-01-000000",
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            return Promise.resolve(new Response("code", { status: 200 }));
+          }),
+        }),
+        async () => {
+          const result = await builderApi.buildSite({ siteName: "Fail Site" });
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Create database failed");
+          }
+        },
+      );
+    });
+
+    test("buildSite uses provided dbUrl and dbToken without calling createDatabase", async () => {
+      await withMocks(
+        () => ({
+          createDbStub: stub(builderApi, "createDatabase", () =>
+            Promise.resolve(MOCK_DB_RESULT),
+          ),
+          createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
+            Promise.resolve({
+              defaultHostname: "https://test.b-cdn.net",
+              ok: true as const,
+              pullZoneId: 1,
+              scriptId: 1,
+            }),
+          ),
+          encKeyStub: stub(builderApi, "generateEncryptionKey", () => "key=="),
+          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes("releases/latest")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    assets: [
+                      {
+                        browser_download_url: "https://example.com/s.ts",
+                        name: "bunny-script.ts",
+                      },
+                    ],
+                    name: "T",
+                    published_at: "2026-01-01T00:00:00Z",
+                    tag_name: "v2026-01-01-000000",
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            return Promise.resolve(new Response("code", { status: 200 }));
+          }),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          secretStub: stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          updatePzStub: stub(bunnyCdnApi, "updatePullZone", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+        }),
+        async ({ createDbStub }) => {
+          await builderApi.buildSite({
+            dbToken: "provided-token",
+            dbUrl: "libsql://provided.io",
+            siteName: "Provided",
+          });
+          expect(createDbStub.calls.length).toBe(0);
         },
       );
     });

--- a/test/lib/bunny-db.test.ts
+++ b/test/lib/bunny-db.test.ts
@@ -215,14 +215,14 @@ describeWithEnv(
     test("createDatabase returns error when token generation fails with JSON body", async () => {
       await withMocks(
         () =>
-          stub(globalThis, "fetch", (input: string | URL | Request) => {
-            const url = String(input);
-            if (url.endsWith("/v2/databases")) {
+          stub(globalThis, "fetch", (_input: string | URL | Request) => {
+            const path = String(_input);
+            if (path.endsWith("/v2/databases")) {
               return Promise.resolve(
                 new Response(JSON.stringify({ db_id: "db_tok" }), { status: 200 }),
               );
             }
-            if (url.includes("/v2/databases/db_tok") && !url.includes("/auth")) {
+            if (path.includes("/v2/databases/db_tok") && !path.includes("/auth")) {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({ db: { db_id: "db_tok", name: "T", url: "libsql://t.net" } }),

--- a/test/lib/bunny-db.test.ts
+++ b/test/lib/bunny-db.test.ts
@@ -187,7 +187,7 @@ describeWithEnv(
       );
     });
 
-    test("createDatabase returns error when get database endpoint fails", async () => {
+    test("createDatabase returns error when get database endpoint fails with JSON Message", async () => {
       await withMocks(
         () =>
           stub(globalThis, "fetch", (input: string | URL | Request) => {
@@ -197,19 +197,22 @@ describeWithEnv(
                 new Response(JSON.stringify({ db_id: "db_err" }), { status: 200 }),
               );
             }
-            return Promise.resolve(new Response("Server Error", { status: 500 }));
+            return Promise.resolve(
+              new Response(JSON.stringify({ Message: "Database not found" }), { status: 404 }),
+            );
           }),
         async () => {
           const result = await bunnyDbApi.createDatabase("Err");
           expect(result.ok).toBe(false);
           if (!result.ok) {
-            expect(result.error).toContain("Get database failed (500)");
+            expect(result.error).toContain("Get database failed (404)");
+            expect(result.error).toContain("Database not found");
           }
         },
       );
     });
 
-    test("createDatabase returns error when token generation fails", async () => {
+    test("createDatabase returns error when token generation fails with JSON body", async () => {
       await withMocks(
         () =>
           stub(globalThis, "fetch", (input: string | URL | Request) => {
@@ -227,7 +230,9 @@ describeWithEnv(
                 ),
               );
             }
-            return Promise.resolve(new Response("Unauthorized", { status: 401 }));
+            return Promise.resolve(
+              new Response(JSON.stringify({ code: 401 }), { status: 401 }),
+            );
           }),
         async () => {
           const result = await bunnyDbApi.createDatabase("T");

--- a/test/lib/bunny-db.test.ts
+++ b/test/lib/bunny-db.test.ts
@@ -1,0 +1,242 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { bunnyDbApi, getBunnyDbRegion } from "#shared/bunny-db.ts";
+import { describeWithEnv, setTestEnv, withMocks } from "#test-utils";
+
+describeWithEnv(
+  "bunny-db",
+  { env: { BUNNY_API_KEY: "test-api-key" } },
+  () => {
+    test("getBunnyDbRegion returns BUNNY_DB_REGION env var when set", () => {
+      const restore = setTestEnv({ BUNNY_DB_REGION: "NY" });
+      try {
+        expect(getBunnyDbRegion()).toBe("NY");
+      } finally {
+        restore();
+      }
+    });
+
+    test("getBunnyDbRegion defaults to DE when BUNNY_DB_REGION is not set", () => {
+      const restore = setTestEnv({ BUNNY_DB_REGION: undefined });
+      try {
+        expect(getBunnyDbRegion()).toBe("DE");
+      } finally {
+        restore();
+      }
+    });
+
+    test("createDatabase calls create, get, and token endpoints", async () => {
+      const fetchCalls: string[] = [];
+
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            fetchCalls.push(url);
+
+            if (url.endsWith("/v2/databases") && !url.includes("/auth")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ db_id: "db_test123" }), {
+                  status: 200,
+                }),
+              );
+            }
+
+            if (url.includes("/v2/databases/db_test123") && !url.includes("/auth")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    db: {
+                      db_id: "db_test123",
+                      name: "My Site",
+                      url: "libsql://my-site.lite.bunnydb.net",
+                    },
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+
+            if (url.includes("/auth/generate")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({ expires_at: null, token: "bny_token_abc" }),
+                  { status: 200 },
+                ),
+              );
+            }
+
+            return Promise.resolve(new Response("unexpected", { status: 500 }));
+          }),
+        async () => {
+          const result = await bunnyDbApi.createDatabase("My Site");
+
+          expect(result.ok).toBe(true);
+          if (result.ok) {
+            expect(result.dbUrl).toBe("libsql://my-site.lite.bunnydb.net");
+            expect(result.dbToken).toBe("bny_token_abc");
+            expect(result.dbId).toBe("db_test123");
+          }
+
+          expect(fetchCalls.length).toBe(3);
+        },
+      );
+    });
+
+    test("createDatabase sends correct request body with region", async () => {
+      let createBody: unknown;
+
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", (input: string | URL | Request, init?: RequestInit) => {
+            const url = String(input);
+
+            if (url.endsWith("/v2/databases")) {
+              createBody = JSON.parse(init?.body as string);
+              return Promise.resolve(
+                new Response(JSON.stringify({ db_id: "db_abc" }), {
+                  status: 200,
+                }),
+              );
+            }
+
+            if (url.includes("/v2/databases/db_abc") && !url.includes("/auth")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    db: { db_id: "db_abc", name: "Test", url: "libsql://x.bunnydb.net" },
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+
+            if (url.includes("/auth/generate")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
+              );
+            }
+
+            return Promise.resolve(new Response("unexpected", { status: 500 }));
+          }),
+        async () => {
+          await bunnyDbApi.createDatabase("Test");
+
+          expect(createBody).toEqual({
+            name: "Test",
+            primary_regions: ["DE"],
+            replicas_regions: [],
+            storage_region: "DE",
+          });
+        },
+      );
+    });
+
+    test("createDatabase uses AccessKey header", async () => {
+      const headers: string[] = [];
+
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", (input: string | URL | Request, init?: RequestInit) => {
+            const url = String(input);
+            const accessKey = (init?.headers as Record<string, string>)?.["AccessKey"];
+            if (accessKey) headers.push(accessKey);
+
+            if (url.endsWith("/v2/databases")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ db_id: "db_hdr" }), { status: 200 }),
+              );
+            }
+            if (url.includes("/v2/databases/db_hdr") && !url.includes("/auth")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({ db: { db_id: "db_hdr", name: "H", url: "libsql://h.net" } }),
+                  { status: 200 },
+                ),
+              );
+            }
+            if (url.includes("/auth/generate")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ token: "t" }), { status: 200 }),
+              );
+            }
+            return Promise.resolve(new Response("", { status: 500 }));
+          }),
+        async () => {
+          await bunnyDbApi.createDatabase("H");
+          expect(headers.every((h) => h === "test-api-key")).toBe(true);
+          expect(headers.length).toBeGreaterThan(0);
+        },
+      );
+    });
+
+    test("createDatabase returns error when create endpoint fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Forbidden", { status: 403 })),
+          ),
+        async () => {
+          const result = await bunnyDbApi.createDatabase("Bad");
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Create database failed (403)");
+          }
+        },
+      );
+    });
+
+    test("createDatabase returns error when get database endpoint fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.endsWith("/v2/databases")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ db_id: "db_err" }), { status: 200 }),
+              );
+            }
+            return Promise.resolve(new Response("Server Error", { status: 500 }));
+          }),
+        async () => {
+          const result = await bunnyDbApi.createDatabase("Err");
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Get database failed (500)");
+          }
+        },
+      );
+    });
+
+    test("createDatabase returns error when token generation fails", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.endsWith("/v2/databases")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ db_id: "db_tok" }), { status: 200 }),
+              );
+            }
+            if (url.includes("/v2/databases/db_tok") && !url.includes("/auth")) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({ db: { db_id: "db_tok", name: "T", url: "libsql://t.net" } }),
+                  { status: 200 },
+                ),
+              );
+            }
+            return Promise.resolve(new Response("Unauthorized", { status: 401 }));
+          }),
+        async () => {
+          const result = await bunnyDbApi.createDatabase("T");
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("Generate database token failed (401)");
+          }
+        },
+      );
+    });
+  },
+);

--- a/test/lib/bunny-db.test.ts
+++ b/test/lib/bunny-db.test.ts
@@ -215,14 +215,14 @@ describeWithEnv(
     test("createDatabase returns error when token generation fails with JSON body", async () => {
       await withMocks(
         () =>
-          stub(globalThis, "fetch", (_input: string | URL | Request) => {
-            const path = String(_input);
-            if (path.endsWith("/v2/databases")) {
+          stub(globalThis, "fetch", (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.endsWith("/v2/databases")) {
               return Promise.resolve(
                 new Response(JSON.stringify({ db_id: "db_tok" }), { status: 200 }),
               );
             }
-            if (path.includes("/v2/databases/db_tok") && !path.includes("/auth")) {
+            if (url.includes("/v2/databases/db_tok") && !url.includes("/auth")) {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({ db: { db_id: "db_tok", name: "T", url: "libsql://t.net" } }),

--- a/test/lib/server-builder.test.ts
+++ b/test/lib/server-builder.test.ts
@@ -193,6 +193,24 @@ describeWithEnv(
       );
     });
 
+    test("POST /admin/builder passes empty token to testDbConnection when db_token omitted", async () => {
+      await withMocks(
+        () => ({
+          dbTestStub: stub(builderApi, "testDbConnection", () =>
+            Promise.resolve({ error: "no auth", ok: false as const }),
+          ),
+        }),
+        async ({ dbTestStub }) => {
+          await adminFormPost("/admin/builder", {
+            db_url: "libsql://test.turso.io",
+            site_name: "NoTokenSite",
+          });
+          expect(dbTestStub.calls).toHaveLength(1);
+          expect(dbTestStub.calls[0]!.args[1]).toBe("");
+        },
+      );
+    });
+
     test("POST /admin/builder creates site and records it on success with provided db", async () => {
       await withMocks(stubSuccessfulBuild, async () => {
         const { response } = await adminFormPost("/admin/builder", {

--- a/test/lib/server-builder.test.ts
+++ b/test/lib/server-builder.test.ts
@@ -5,6 +5,13 @@ import { builderApi } from "#shared/builder.ts";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { getAllBuiltSites } from "#shared/db/built-sites.ts";
 import { settings } from "#shared/db/settings.ts";
+
+const MOCK_DB_RESULT = {
+  dbId: "db_auto123",
+  dbToken: "auto-token",
+  dbUrl: "libsql://auto.lite.bunnydb.net",
+  ok: true as const,
+};
 import {
   adminFormPost,
   awaitTestRequest,
@@ -22,6 +29,9 @@ import {
 
 /** Stub all Bunny + GitHub APIs for a successful build */
 const stubSuccessfulBuild = () => ({
+  createDbStub: stub(builderApi, "createDatabase", () =>
+    Promise.resolve(MOCK_DB_RESULT),
+  ),
   createStub: stub(bunnyCdnApi, "createEdgeScript", () =>
     Promise.resolve({
       defaultHostname: "https://test-42.b-cdn.net",
@@ -158,35 +168,7 @@ describeWithEnv(
       );
     });
 
-    test("POST /admin/builder returns error when db_url is empty", async () => {
-      const { response } = await adminFormPost("/admin/builder", {
-        db_token: "token",
-        db_url: "",
-        site_name: "Test",
-      });
-      expectRedirect(response, "/admin/builder");
-      expectFlash(
-        response,
-        expect.stringContaining("Database URL is required"),
-        false,
-      );
-    });
-
-    test("POST /admin/builder returns error when db_token is empty", async () => {
-      const { response } = await adminFormPost("/admin/builder", {
-        db_token: "",
-        db_url: "libsql://test.turso.io",
-        site_name: "Test",
-      });
-      expectRedirect(response, "/admin/builder");
-      expectFlash(
-        response,
-        expect.stringContaining("Database Token is required"),
-        false,
-      );
-    });
-
-    test("POST /admin/builder returns error when db connection fails", async () => {
+    test("POST /admin/builder returns error when db connection fails with provided URL", async () => {
       await withMocks(
         () =>
           stub(builderApi, "testDbConnection", () =>
@@ -211,7 +193,7 @@ describeWithEnv(
       );
     });
 
-    test("POST /admin/builder creates site and records it on success", async () => {
+    test("POST /admin/builder creates site and records it on success with provided db", async () => {
       await withMocks(stubSuccessfulBuild, async () => {
         const { response } = await adminFormPost("/admin/builder", {
           db_token: "token123",
@@ -222,7 +204,7 @@ describeWithEnv(
         expectRedirect(response, "/admin/builder");
         expectFlash(response, expect.stringContaining("created successfully"));
 
-        // Verify site was recorded with db credentials
+        // Verify site was recorded with db credentials from buildResult
         const sites = await getAllBuiltSites();
         expect(sites).toHaveLength(1);
         expect(sites[0]!.name).toBe("My Test Site");
@@ -231,6 +213,24 @@ describeWithEnv(
         expect(sites[0]!.dbToken).toBe("token123");
         expect(sites[0]!.bunnyScriptId).toBe("42");
         expect(sites[0]!.assignable).toBe(false);
+      });
+    });
+
+    test("POST /admin/builder auto-creates database when db_url is blank", async () => {
+      await withMocks(stubSuccessfulBuild, async () => {
+        const { response } = await adminFormPost("/admin/builder", {
+          db_url: "",
+          site_name: "Auto DB Site",
+        });
+
+        expectRedirect(response, "/admin/builder");
+        expectFlash(response, expect.stringContaining("created successfully"));
+
+        const sites = await getAllBuiltSites();
+        expect(sites).toHaveLength(1);
+        expect(sites[0]!.name).toBe("Auto DB Site");
+        expect(sites[0]!.dbUrl).toBe(MOCK_DB_RESULT.dbUrl);
+        expect(sites[0]!.dbToken).toBe(MOCK_DB_RESULT.dbToken);
       });
     });
 
@@ -302,6 +302,8 @@ describeWithEnv(
         () => ({
           buildStub: stub(builderApi, "buildSite", () =>
             Promise.resolve({
+              dbToken: "tok",
+              dbUrl: "libsql://test.io",
               defaultHostname: "https://test.b-cdn.net",
               ok: true as const,
               scriptId: 1,


### PR DESCRIPTION
## Summary

- **New `src/shared/bunny-db.ts`**: Calls the Bunny Database REST API (`https://api.bunny.net/database`) to create a database, fetch its connection URL, and generate a full-access token — same `AccessKey` auth pattern as the existing CDN API
- **`BuildSiteInput.dbUrl`/`dbToken` are now optional**: when omitted, `buildSite` auto-provisions a fresh Bunny database before creating the edge script
- **Admin builder form**: `db_url` and `db_token` fields are now optional with hint text "Leave blank to auto-provision a new Bunny database"; connection test is skipped when no URL is supplied
- **`BUNNY_DB_REGION` env var** (optional, defaults to `DE`): controls which Bunny region the auto-created database is placed in

## How it works

The Bunny Database API flow (replacing the manual step):
1. `POST /v2/databases` — create the database
2. `GET /v2/databases/{db_id}` — fetch the connection URL
3. `PUT /v2/databases/{db_id}/auth/generate` — generate a full-access token

The resulting `dbUrl`/`dbToken` are passed through to the edge script secrets and stored in the built-site record exactly as before.

## Test plan

- [ ] New `test/lib/bunny-db.test.ts` covers create/get/token API calls, error paths, and `BUNNY_DB_REGION` fallback
- [ ] `test/lib/builder.test.ts`: auto-create path, error when auto-create fails, explicit credentials still skip auto-create
- [ ] `test/lib/server-builder.test.ts`: auto-create on blank `db_url`, explicit-db path stores correct credentials

https://claude.ai/code/session_01ThvA2q1LfWVREb931wGcB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThvA2q1LfWVREb931wGcB4)_