### PR TITLE
Hardcode EU storage region for Bunny DB provisioning

### DIFF
--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read --allow-sys --allow-ffi
+/**
+ * One-off CLI: provision a new Tickets site on Bunny via the existing
+ * builder pipeline (Bunny database + edge script + secrets + publish).
+ *
+ * Reuses `builderApi.buildSite` from src/shared/builder.ts so the script
+ * stays in sync with the admin /admin/builder flow.
+ *
+ * Usage: BUNNY_API_KEY=... deno run --allow-net --allow-env --allow-read \
+ *          --allow-sys --allow-ffi scripts/build-site.ts "My Event Site"
+ */
+
+import { builderApi } from "#shared/builder.ts";
+
+const [siteName] = Deno.args;
+if (!siteName) {
+  console.error("Usage: build-site.ts <site-name>");
+  Deno.exit(1);
+}
+
+if (!Deno.env.get("BUNNY_API_KEY")) {
+  console.error("BUNNY_API_KEY env var is required");
+  Deno.exit(1);
+}
+
+console.log(`Building site "${siteName}"…`);
+const result = await builderApi.buildSite({ siteName });
+
+if (!result.ok) {
+  console.error(`Build failed: ${result.error}`);
+  Deno.exit(1);
+}
+
+console.log("Site built successfully:");
+console.log(`  hostname:  https://${result.defaultHostname}`);
+console.log(`  scriptId:  ${result.scriptId}`);
+console.log(`  dbUrl:     ${result.dbUrl}`);
+console.log(`  dbToken:   ${result.dbToken}`);

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -1,13 +1,15 @@
-#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read --allow-sys --allow-ffi
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi
 /**
  * One-off CLI: provision a new Tickets site on Bunny via the existing
- * builder pipeline (Bunny database + edge script + secrets + publish).
+ * builder pipeline (Bunny database + edge script + secrets + publish),
+ * deploying a fresh local bundle instead of the latest GitHub release.
  *
- * Reuses `builderApi.buildSite` from src/shared/builder.ts so the script
- * stays in sync with the admin /admin/builder flow.
+ * Reuses `builderApi.buildSite` from src/shared/builder.ts. The admin
+ * /admin/builder route continues to use the GitHub release path; only
+ * this CLI passes the locally-built bundle via the `code` parameter.
  *
- * Usage: BUNNY_API_KEY=... deno run --allow-net --allow-env --allow-read \
- *          --allow-sys --allow-ffi scripts/build-site.ts "My Event Site"
+ * Usage:
+ *   BUNNY_API_KEY=... deno run --allow-all scripts/build-site.ts "My Event Site"
  */
 
 import { builderApi } from "#shared/builder.ts";
@@ -23,8 +25,25 @@ if (!Deno.env.get("BUNNY_API_KEY")) {
   Deno.exit(1);
 }
 
-console.log(`Building site "${siteName}"…`);
-const result = await builderApi.buildSite({ siteName });
+const repoRoot = new URL("..", import.meta.url).pathname;
+const bundlePath = `${repoRoot}bunny-script.ts`;
+
+console.log("Building edge bundle…");
+const build = await new Deno.Command(Deno.execPath(), {
+  args: ["task", "build:edge"],
+  cwd: repoRoot,
+  stderr: "inherit",
+  stdout: "inherit",
+}).output();
+if (!build.success) {
+  console.error("build:edge failed");
+  Deno.exit(build.code);
+}
+
+const code = await Deno.readTextFile(bundlePath);
+console.log(`Bundle ready (${code.length} bytes). Provisioning site "${siteName}"…`);
+
+const result = await builderApi.buildSite({ code, siteName });
 
 if (!result.ok) {
   console.error(`Build failed: ${result.error}`);

--- a/scripts/bunny-regions.ts
+++ b/scripts/bunny-regions.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env
+/**
+ * Diagnostic script: prints the storage zones and database regions that
+ * Bunny will accept when creating a libSQL database.
+ *
+ * Hits the same endpoint the `bunny db create` CLI uses internally
+ * (GET /database/v1/config) so the values match what the API will
+ * actually accept in a create-database request body.
+ *
+ * Usage: BUNNY_API_KEY=... deno run --allow-net --allow-env scripts/bunny-regions.ts
+ */
+
+interface BunnyRegion {
+  id: string;
+  name: string;
+  group: string;
+}
+
+interface BunnyConfig {
+  storage_region_available: BunnyRegion[];
+  primary_regions: BunnyRegion[];
+  replica_regions: BunnyRegion[];
+}
+
+const apiKey = Deno.env.get("BUNNY_API_KEY");
+if (!apiKey) {
+  console.error("BUNNY_API_KEY is required");
+  Deno.exit(1);
+}
+
+const res = await fetch("https://api.bunny.net/database/v1/config", {
+  headers: { AccessKey: apiKey },
+});
+
+if (!res.ok) {
+  console.error(`Bunny config endpoint failed: ${res.status}`);
+  console.error(await res.text());
+  Deno.exit(1);
+}
+
+const config: BunnyConfig = await res.json();
+
+const fmt = (rs: BunnyRegion[]) =>
+  rs.map((r) => `  ${r.id.padEnd(12)} ${r.group.padEnd(6)} ${r.name}`).join(
+    "\n",
+  );
+
+console.log("Storage zones (use the id as `storage_region`):");
+console.log(fmt(config.storage_region_available));
+console.log("\nPrimary regions:");
+console.log(fmt(config.primary_regions));
+console.log("\nReplica regions:");
+console.log(fmt(config.replica_regions));
+
+const eu = (r: BunnyRegion) => r.group === "EU";
+console.log("\nEuropean storage zone ids:");
+console.log(config.storage_region_available.filter(eu).map((r) => r.id));
+console.log("European primary region ids:");
+console.log(config.primary_regions.filter(eu).map((r) => r.id));
+console.log("European replica region ids:");
+console.log(config.replica_regions.filter(eu).map((r) => r.id));

--- a/src/shared/builder.ts
+++ b/src/shared/builder.ts
@@ -45,6 +45,12 @@ export type BuildSiteInput = {
   dbUrl?: string;
   /** Leave blank to auto-provision a new Bunny database via the API. */
   dbToken?: string;
+  /**
+   * Pre-built bundle source to deploy. When omitted, the latest GitHub
+   * release asset is fetched (used by /admin/builder). The CLI builder
+   * passes a freshly-built local bundle here.
+   */
+  code?: string;
 };
 
 export type BuildSiteResult =
@@ -93,26 +99,30 @@ export const buildSite = async (
 ): Promise<BuildSiteResult> => {
   const fullName = `Tickets - ${input.siteName}`;
 
-  // 1. Fetch latest release code
+  // 1. Source the bundle code: caller-supplied or latest GitHub release
   let code: string;
-  try {
-    const release = await fetchLatestRelease();
-    if (!release.assetUrl) {
-      return { error: "No release asset found on GitHub", ok: false };
-    }
-    const assetResponse = await fetchText(release.assetUrl);
-    if (!assetResponse.ok) {
+  if (input.code !== undefined) {
+    code = input.code;
+  } else {
+    try {
+      const release = await fetchLatestRelease();
+      if (!release.assetUrl) {
+        return { error: "No release asset found on GitHub", ok: false };
+      }
+      const assetResponse = await fetchText(release.assetUrl);
+      if (!assetResponse.ok) {
+        return {
+          error: `Failed to download release: ${assetResponse.status}`,
+          ok: false,
+        };
+      }
+      code = assetResponse.text;
+    } catch (e) {
       return {
-        error: `Failed to download release: ${assetResponse.status}`,
+        error: `Failed to fetch release: ${(e as Error).message}`,
         ok: false,
       };
     }
-    code = assetResponse.text;
-  } catch (e) {
-    return {
-      error: `Failed to fetch release: ${(e as Error).message}`,
-      ok: false,
-    };
   }
 
   // 1b. Auto-provision database if credentials not supplied

--- a/src/shared/bunny-db.ts
+++ b/src/shared/bunny-db.ts
@@ -6,16 +6,38 @@
  * Auth: AccessKey header (same BUNNY_API_KEY as CDN API)
  */
 
-import { map } from "#fp";
 import { parseBunnyError } from "#shared/bunny-cdn.ts";
 import { getBunnyApiKey } from "#shared/config.ts";
 import { fetchText } from "#shared/fetch.ts";
 
 const DB_API_BASE = "https://api.bunny.net/database";
-const CDN_PROBE_URL = "https://bunny.net/index.html";
-const CONFIG_API_BASE = "https://api.bunny.net";
 
-type DbApiResult<T> = { ok: true } & T | { ok: false; error: string };
+/**
+ * Storage region for new databases. Bunny only exposes two storage zones —
+ * `eu-west-1` (EU) and `us-east-1` (NA) — confirmed via
+ * `GET /database/v1/config`. See scripts/bunny-regions.ts.
+ */
+export const STORAGE_REGION = "eu-west-1";
+
+/** All European Bunny database node IDs. */
+export const EUROPEAN_REGIONS = [
+  "AMS",
+  "AT",
+  "BU",
+  "CZ",
+  "DE",
+  "DK",
+  "ES",
+  "FR",
+  "GR",
+  "HR",
+  "IT",
+  "PL",
+  "SE",
+  "UK",
+];
+
+type DbApiResult<T> = ({ ok: true } & T) | { ok: false; error: string };
 
 interface CreateDbResponse {
   db_id: string;
@@ -33,12 +55,6 @@ interface GenerateTokenResponse {
   token: string;
 }
 
-interface OptimalConfig {
-  primary_regions?: Array<{ id: string }>;
-  replica_regions?: Array<{ id: string }>;
-  storage_region?: { id: string };
-}
-
 export interface CreateDatabaseResult {
   dbId: string;
   dbUrl: string;
@@ -51,34 +67,6 @@ const dbApiHeaders = (): Record<string, string> => ({
   "Content-Type": "application/json",
 });
 
-const mapId = map((r: { id: string }) => r.id);
-
-/** Detect optimal regions via CDN location probe, returning empty arrays on failure. */
-const getOptimalRegions = async (): Promise<{
-  primaryRegions: string[];
-  replicasRegions: string[];
-  storageRegion: string | undefined;
-}> => {
-  const probeRes = await fetch(CDN_PROBE_URL, { method: "HEAD" });
-  const cdnToken = probeRes.headers.get("server") ?? "";
-
-  const optimalRes = await fetchText(
-    `${CONFIG_API_BASE}/v1/config/optimal?cdn_server_token=${encodeURIComponent(cdnToken)}`,
-    { headers: dbApiHeaders() },
-  );
-
-  if (!optimalRes.ok) {
-    return { primaryRegions: [], replicasRegions: [], storageRegion: undefined };
-  }
-
-  const data: OptimalConfig = JSON.parse(optimalRes.text);
-  return {
-    primaryRegions: mapId(data.primary_regions ?? []),
-    replicasRegions: mapId(data.replica_regions ?? []),
-    storageRegion: data.storage_region?.id,
-  };
-};
-
 /**
  * Create a new Bunny database with the given name.
  * Returns the database URL and a full-access token.
@@ -86,16 +74,13 @@ const getOptimalRegions = async (): Promise<{
 const createDatabaseImpl = async (
   name: string,
 ): Promise<DbApiResult<CreateDatabaseResult>> => {
-  const { primaryRegions, replicasRegions, storageRegion } =
-    await getOptimalRegions();
-
-  // 1. Create the database
+  // 1. Create the database with all European nodes as primaries and replicas
   const createRes = await fetchText(`${DB_API_BASE}/v2/databases`, {
     body: JSON.stringify({
       name,
-      primary_regions: primaryRegions,
-      replicas_regions: replicasRegions,
-      storage_region: storageRegion,
+      primary_regions: EUROPEAN_REGIONS,
+      replicas_regions: EUROPEAN_REGIONS,
+      storage_region: STORAGE_REGION,
     }),
     headers: dbApiHeaders(),
     method: "POST",

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -757,6 +757,55 @@ describeWithEnv(
       );
     });
 
+    test("buildSite uses provided code without fetching from GitHub", async () => {
+      const fetchedUrls: string[] = [];
+      const deployedCode: string[] = [];
+
+      await withMocks(
+        () => ({
+          createDbStub: stub(builderApi, "createDatabase", () =>
+            Promise.resolve(MOCK_DB_RESULT),
+          ),
+          createStub: stub(
+            bunnyCdnApi,
+            "createEdgeScript",
+            (_name: string, code: string) => {
+              deployedCode.push(code);
+              return Promise.resolve({
+                defaultHostname: "https://test.b-cdn.net",
+                ok: true as const,
+                pullZoneId: 1,
+                scriptId: 1,
+              });
+            },
+          ),
+          encKeyStub: stub(builderApi, "generateEncryptionKey", () => "key=="),
+          fetchStub: stub(globalThis, "fetch", (input: string | URL | Request) => {
+            fetchedUrls.push(String(input));
+            return Promise.resolve(new Response("should-not-be-called", { status: 500 }));
+          }),
+          publishStub: stub(bunnyCdnApi, "publishEdgeScript", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          secretStub: stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+          updatePzStub: stub(bunnyCdnApi, "updatePullZone", () =>
+            Promise.resolve({ ok: true as const }),
+          ),
+        }),
+        async () => {
+          const result = await builderApi.buildSite({
+            code: "console.log('local-bundle')",
+            siteName: "Local",
+          });
+          expect(result.ok).toBe(true);
+          expect(fetchedUrls.some((u) => u.includes("github"))).toBe(false);
+          expect(deployedCode).toEqual(["console.log('local-bundle')"]);
+        },
+      );
+    });
+
     test("buildSite uses empty string dbToken when dbUrl provided without dbToken", async () => {
       const secretsSet: [string, string][] = [];
 

--- a/test/lib/bunny-db.test.ts
+++ b/test/lib/bunny-db.test.ts
@@ -1,423 +1,268 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { bunnyDbApi } from "#shared/bunny-db.ts";
+import {
+  bunnyDbApi,
+  EUROPEAN_REGIONS,
+  STORAGE_REGION,
+} from "#shared/bunny-db.ts";
 import { describeWithEnv, withMocks } from "#test-utils";
 
-/** Stub a successful CDN probe returning a server token and optimal region response. */
-const stubOptimalRegions = (
-  fetchStub: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
-  probeServerHeader: string | null,
-  optimal: object | null,
-) =>
-  (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
-    if (init?.method === "HEAD") {
-      return Promise.resolve(
-        new Response("", {
-          headers: probeServerHeader ? { server: probeServerHeader } : undefined,
-          status: 200,
-        }),
-      );
-    }
-    if (String(input).includes("/v1/config/optimal")) {
-      if (optimal === null) {
-        return Promise.resolve(new Response("error", { status: 503 }));
-      }
-      return Promise.resolve(
-        new Response(JSON.stringify(optimal), { status: 200 }),
-      );
-    }
-    return fetchStub(input, init);
-  };
+describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
+  test("createDatabase calls create, get, and token endpoints", async () => {
+    const fetchCalls: string[] = [];
 
-describeWithEnv(
-  "bunny-db",
-  { env: { BUNNY_API_KEY: "test-api-key" } },
-  () => {
-    test("createDatabase calls create, get, and token endpoints", async () => {
-      const fetchCalls: string[] = [];
+    await withMocks(
+      () =>
+        stub(globalThis, "fetch", (input: string | URL | Request) => {
+          const url = String(input);
+          fetchCalls.push(url);
 
-      await withMocks(
-        () =>
-          stub(
-            globalThis,
-            "fetch",
-            stubOptimalRegions(
-              (input: string | URL | Request) => {
-                const url = String(input);
-                fetchCalls.push(url);
-
-                if (url.endsWith("/v2/databases") && !url.includes("/auth")) {
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ db_id: "db_test123" }), {
-                      status: 200,
-                    }),
-                  );
-                }
-
-                if (
-                  url.includes("/v2/databases/db_test123") &&
-                  !url.includes("/auth")
-                ) {
-                  return Promise.resolve(
-                    new Response(
-                      JSON.stringify({
-                        db: {
-                          db_id: "db_test123",
-                          name: "My Site",
-                          url: "libsql://my-site.lite.bunnydb.net",
-                        },
-                      }),
-                      { status: 200 },
-                    ),
-                  );
-                }
-
-                if (url.includes("/auth/generate")) {
-                  return Promise.resolve(
-                    new Response(
-                      JSON.stringify({ expires_at: null, token: "bny_token_abc" }),
-                      { status: 200 },
-                    ),
-                  );
-                }
-
-                return Promise.resolve(new Response("unexpected", { status: 500 }));
-              },
-              "cdn-token",
-              { primary_regions: [{ id: "DE" }], replica_regions: [], storage_region: { id: "DE" } },
-            ),
-          ),
-        async () => {
-          const result = await bunnyDbApi.createDatabase("My Site");
-
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            expect(result.dbUrl).toBe("libsql://my-site.lite.bunnydb.net");
-            expect(result.dbToken).toBe("bny_token_abc");
-            expect(result.dbId).toBe("db_test123");
-          }
-
-          expect(fetchCalls.length).toBe(3);
-        },
-      );
-    });
-
-    test("createDatabase sends detected optimal regions in create request body", async () => {
-      let createBody: unknown;
-
-      await withMocks(
-        () =>
-          stub(
-            globalThis,
-            "fetch",
-            stubOptimalRegions(
-              (input: string | URL | Request, init?: RequestInit) => {
-                const url = String(input);
-
-                if (url.endsWith("/v2/databases")) {
-                  createBody = JSON.parse(init?.body as string);
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ db_id: "db_abc" }), {
-                      status: 200,
-                    }),
-                  );
-                }
-
-                if (
-                  url.includes("/v2/databases/db_abc") &&
-                  !url.includes("/auth")
-                ) {
-                  return Promise.resolve(
-                    new Response(
-                      JSON.stringify({
-                        db: { db_id: "db_abc", name: "Test", url: "libsql://x.bunnydb.net" },
-                      }),
-                      { status: 200 },
-                    ),
-                  );
-                }
-
-                if (url.includes("/auth/generate")) {
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
-                  );
-                }
-
-                return Promise.resolve(new Response("unexpected", { status: 500 }));
-              },
-              "cdn-location-xyz",
-              {
-                primary_regions: [{ id: "NY" }, { id: "LA" }],
-                replica_regions: [{ id: "SG" }],
-                storage_region: { id: "NY" },
-              },
-            ),
-          ),
-        async () => {
-          await bunnyDbApi.createDatabase("Test");
-
-          expect(createBody).toEqual({
-            name: "Test",
-            primary_regions: ["NY", "LA"],
-            replicas_regions: ["SG"],
-            storage_region: "NY",
-          });
-        },
-      );
-    });
-
-    test("createDatabase sends empty regions when optimal region detection is unavailable", async () => {
-      let createBody: unknown;
-
-      await withMocks(
-        () =>
-          stub(
-            globalThis,
-            "fetch",
-            stubOptimalRegions(
-              (input: string | URL | Request, init?: RequestInit) => {
-                const url = String(input);
-
-                if (url.endsWith("/v2/databases")) {
-                  createBody = JSON.parse(init?.body as string);
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ db_id: "db_fb" }), {
-                      status: 200,
-                    }),
-                  );
-                }
-
-                if (
-                  url.includes("/v2/databases/db_fb") &&
-                  !url.includes("/auth")
-                ) {
-                  return Promise.resolve(
-                    new Response(
-                      JSON.stringify({
-                        db: { db_id: "db_fb", name: "FB", url: "libsql://fb.bunnydb.net" },
-                      }),
-                      { status: 200 },
-                    ),
-                  );
-                }
-
-                if (url.includes("/auth/generate")) {
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
-                  );
-                }
-
-                return Promise.resolve(new Response("unexpected", { status: 500 }));
-              },
-              null,
-              null,
-            ),
-          ),
-        async () => {
-          await bunnyDbApi.createDatabase("FB");
-
-          expect(createBody).toEqual({
-            name: "FB",
-            primary_regions: [],
-            replicas_regions: [],
-            storage_region: undefined,
-          });
-        },
-      );
-    });
-
-    test("createDatabase handles partial optimal config response", async () => {
-      let createBody: unknown;
-
-      await withMocks(
-        () =>
-          stub(
-            globalThis,
-            "fetch",
-            stubOptimalRegions(
-              (input: string | URL | Request, init?: RequestInit) => {
-                const url = String(input);
-
-                if (url.endsWith("/v2/databases")) {
-                  createBody = JSON.parse(init?.body as string);
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ db_id: "db_part" }), {
-                      status: 200,
-                    }),
-                  );
-                }
-
-                if (
-                  url.includes("/v2/databases/db_part") &&
-                  !url.includes("/auth")
-                ) {
-                  return Promise.resolve(
-                    new Response(
-                      JSON.stringify({
-                        db: { db_id: "db_part", name: "Part", url: "libsql://part.bunnydb.net" },
-                      }),
-                      { status: 200 },
-                    ),
-                  );
-                }
-
-                if (url.includes("/auth/generate")) {
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
-                  );
-                }
-
-                return Promise.resolve(new Response("unexpected", { status: 500 }));
-              },
-              null,
-              {},
-            ),
-          ),
-        async () => {
-          await bunnyDbApi.createDatabase("Part");
-
-          expect(createBody).toEqual({
-            name: "Part",
-            primary_regions: [],
-            replicas_regions: [],
-            storage_region: undefined,
-          });
-        },
-      );
-    });
-
-    test("createDatabase uses AccessKey header", async () => {
-      const headers: string[] = [];
-
-      await withMocks(
-        () =>
-          stub(
-            globalThis,
-            "fetch",
-            stubOptimalRegions(
-              (input: string | URL | Request, init?: RequestInit) => {
-                const url = String(input);
-                const accessKey = (init?.headers as Record<string, string>)?.[
-                  "AccessKey"
-                ];
-                if (accessKey) headers.push(accessKey);
-
-                if (url.endsWith("/v2/databases")) {
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ db_id: "db_hdr" }), { status: 200 }),
-                  );
-                }
-                if (
-                  url.includes("/v2/databases/db_hdr") &&
-                  !url.includes("/auth")
-                ) {
-                  return Promise.resolve(
-                    new Response(
-                      JSON.stringify({
-                        db: { db_id: "db_hdr", name: "H", url: "libsql://h.net" },
-                      }),
-                      { status: 200 },
-                    ),
-                  );
-                }
-                if (url.includes("/auth/generate")) {
-                  return Promise.resolve(
-                    new Response(JSON.stringify({ token: "t" }), { status: 200 }),
-                  );
-                }
-                return Promise.resolve(new Response("", { status: 500 }));
-              },
-              "cdn-token",
-              { primary_regions: [{ id: "DE" }], replica_regions: [], storage_region: { id: "DE" } },
-            ),
-          ),
-        async () => {
-          await bunnyDbApi.createDatabase("H");
-          expect(headers.every((h) => h === "test-api-key")).toBe(true);
-          expect(headers.length).toBeGreaterThan(0);
-        },
-      );
-    });
-
-    test("createDatabase returns error when create endpoint fails", async () => {
-      await withMocks(
-        () =>
-          stub(globalThis, "fetch", () =>
-            Promise.resolve(new Response("Forbidden", { status: 403 })),
-          ),
-        async () => {
-          const result = await bunnyDbApi.createDatabase("Bad");
-          expect(result.ok).toBe(false);
-          if (!result.ok) {
-            expect(result.error).toContain("Create database failed (403)");
-          }
-        },
-      );
-    });
-
-    test("createDatabase returns error when get database endpoint fails with JSON Message", async () => {
-      await withMocks(
-        () =>
-          stub(globalThis, "fetch", (input: string | URL | Request) => {
-            const url = String(input);
-            if (url.endsWith("/v2/databases")) {
-              return Promise.resolve(
-                new Response(JSON.stringify({ db_id: "db_err" }), { status: 200 }),
-              );
-            }
+          if (url.endsWith("/v2/databases") && !url.includes("/auth")) {
             return Promise.resolve(
-              new Response(JSON.stringify({ Message: "Database not found" }), {
-                status: 404,
+              new Response(JSON.stringify({ db_id: "db_test123" }), {
+                status: 200,
               }),
             );
-          }),
-        async () => {
-          const result = await bunnyDbApi.createDatabase("Err");
-          expect(result.ok).toBe(false);
-          if (!result.ok) {
-            expect(result.error).toContain("Get database failed (404)");
-            expect(result.error).toContain("Database not found");
           }
-        },
-      );
-    });
 
-    test("createDatabase returns error when token generation fails with JSON body", async () => {
-      await withMocks(
-        () =>
-          stub(globalThis, "fetch", (input: string | URL | Request) => {
+          if (
+            url.includes("/v2/databases/db_test123") &&
+            !url.includes("/auth")
+          ) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  db: {
+                    db_id: "db_test123",
+                    name: "My Site",
+                    url: "libsql://my-site.lite.bunnydb.net",
+                  },
+                }),
+                { status: 200 },
+              ),
+            );
+          }
+
+          if (url.includes("/auth/generate")) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ expires_at: null, token: "bny_token_abc" }),
+                { status: 200 },
+              ),
+            );
+          }
+
+          return Promise.resolve(new Response("unexpected", { status: 500 }));
+        }),
+      async () => {
+        const result = await bunnyDbApi.createDatabase("My Site");
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.dbUrl).toBe("libsql://my-site.lite.bunnydb.net");
+          expect(result.dbToken).toBe("bny_token_abc");
+          expect(result.dbId).toBe("db_test123");
+        }
+
+        expect(fetchCalls.length).toBe(3);
+      },
+    );
+  });
+
+  test("createDatabase sends EU storage region with all European primaries and replicas", async () => {
+    let createBody: unknown;
+
+    await withMocks(
+      () =>
+        stub(
+          globalThis,
+          "fetch",
+          (input: string | URL | Request, init?: RequestInit) => {
             const url = String(input);
+
             if (url.endsWith("/v2/databases")) {
+              createBody = JSON.parse(init?.body as string);
               return Promise.resolve(
-                new Response(JSON.stringify({ db_id: "db_tok" }), { status: 200 }),
+                new Response(JSON.stringify({ db_id: "db_abc" }), {
+                  status: 200,
+                }),
               );
             }
+
             if (
-              url.includes("/v2/databases/db_tok") &&
+              url.includes("/v2/databases/db_abc") &&
               !url.includes("/auth")
             ) {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({
-                    db: { db_id: "db_tok", name: "T", url: "libsql://t.net" },
+                    db: {
+                      db_id: "db_abc",
+                      name: "Test",
+                      url: "libsql://x.bunnydb.net",
+                    },
                   }),
                   { status: 200 },
                 ),
               );
             }
+
+            if (url.includes("/auth/generate")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
+              );
+            }
+
+            return Promise.resolve(new Response("unexpected", { status: 500 }));
+          },
+        ),
+      async () => {
+        await bunnyDbApi.createDatabase("Test");
+
+        expect(createBody).toEqual({
+          name: "Test",
+          primary_regions: EUROPEAN_REGIONS,
+          replicas_regions: EUROPEAN_REGIONS,
+          storage_region: STORAGE_REGION,
+        });
+      },
+    );
+  });
+
+  test("createDatabase uses AccessKey header", async () => {
+    const headers: string[] = [];
+
+    await withMocks(
+      () =>
+        stub(
+          globalThis,
+          "fetch",
+          (input: string | URL | Request, init?: RequestInit) => {
+            const url = String(input);
+            const accessKey = (init?.headers as Record<string, string>)?.[
+              "AccessKey"
+            ];
+            if (accessKey) headers.push(accessKey);
+
+            if (url.endsWith("/v2/databases")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ db_id: "db_hdr" }), {
+                  status: 200,
+                }),
+              );
+            }
+            if (
+              url.includes("/v2/databases/db_hdr") &&
+              !url.includes("/auth")
+            ) {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    db: { db_id: "db_hdr", name: "H", url: "libsql://h.net" },
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            if (url.includes("/auth/generate")) {
+              return Promise.resolve(
+                new Response(JSON.stringify({ token: "t" }), { status: 200 }),
+              );
+            }
+            return Promise.resolve(new Response("", { status: 500 }));
+          },
+        ),
+      async () => {
+        await bunnyDbApi.createDatabase("H");
+        expect(headers.every((h) => h === "test-api-key")).toBe(true);
+        expect(headers.length).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  test("createDatabase returns error when create endpoint fails", async () => {
+    await withMocks(
+      () =>
+        stub(
+          globalThis,
+          "fetch",
+          () => Promise.resolve(new Response("Forbidden", { status: 403 })),
+        ),
+      async () => {
+        const result = await bunnyDbApi.createDatabase("Bad");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toContain("Create database failed (403)");
+        }
+      },
+    );
+  });
+
+  test("createDatabase returns error when get database endpoint fails with JSON Message", async () => {
+    await withMocks(
+      () =>
+        stub(globalThis, "fetch", (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.endsWith("/v2/databases")) {
             return Promise.resolve(
-              new Response(JSON.stringify({ code: 401 }), { status: 401 }),
+              new Response(JSON.stringify({ db_id: "db_err" }), {
+                status: 200,
+              }),
             );
-          }),
-        async () => {
-          const result = await bunnyDbApi.createDatabase("T");
-          expect(result.ok).toBe(false);
-          if (!result.ok) {
-            expect(result.error).toContain("Generate database token failed (401)");
           }
-        },
-      );
-    });
-  },
-);
+          return Promise.resolve(
+            new Response(JSON.stringify({ Message: "Database not found" }), {
+              status: 404,
+            }),
+          );
+        }),
+      async () => {
+        const result = await bunnyDbApi.createDatabase("Err");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toContain("Get database failed (404)");
+          expect(result.error).toContain("Database not found");
+        }
+      },
+    );
+  });
+
+  test("createDatabase returns error when token generation fails with JSON body", async () => {
+    await withMocks(
+      () =>
+        stub(globalThis, "fetch", (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.endsWith("/v2/databases")) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ db_id: "db_tok" }), {
+                status: 200,
+              }),
+            );
+          }
+          if (url.includes("/v2/databases/db_tok") && !url.includes("/auth")) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  db: { db_id: "db_tok", name: "T", url: "libsql://t.net" },
+                }),
+                { status: 200 },
+              ),
+            );
+          }
+          return Promise.resolve(
+            new Response(JSON.stringify({ code: 401 }), { status: 401 }),
+          );
+        }),
+      async () => {
+        const result = await bunnyDbApi.createDatabase("T");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toContain(
+            "Generate database token failed (401)",
+          );
+        }
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The CDN-probe `getOptimalRegions` flow (PR #1090) returns
`storage_region: undefined` when the probe fails, and the Bunny API
rejects database creation without a valid storage region — so
`storage_region: null` (as proposed in PR #1091) also doesn't work.

This PR replaces the probe with hardcoded values:

- `storage_region: "eu-west-1"` — the only EU storage zone Bunny exposes
- `primary_regions` / `replicas_regions`: all 14 EU node IDs

Values verified via `GET /database/v1/config` (the endpoint the Bunny
CLI uses internally for `bunny db create`):

```
storage_region_available: [
  { id: "eu-west-1", group: "EU" },
  { id: "us-east-1", group: "NA" },
]
```

`scripts/bunny-regions.ts` is added as a diagnostic helper to re-query
the config endpoint and print available storage zones / regions.

## Test plan

- [x] `deno test test/lib/bunny-db.test.ts` — all 6 cases pass
- [x] `deno task lint` — clean (one pre-existing unrelated error in
      `bulk-actions.tsx`)
- [ ] Create a new built site in staging and confirm the Bunny database
      provisions successfully

https://claude.ai/code/session_01Wb6BEgu2jXxtfrsLqLAsgP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6BEgu2jXxtfrsLqLAsgP)_