### PR TITLE
Auto-build a site on demand when a ticket needs one

### DIFF
--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -3,12 +3,10 @@
  */
 
 import { reduce } from "#fp";
-import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { applyFlash, withCsrfForm } from "#routes/csrf.ts";
 import { errorRedirect, redirectResponse } from "#routes/response.ts";
 import { getBaseUrl } from "#routes/url.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
-import { countAssignableSites } from "#shared/db/built-sites.ts";
 import { saveEventAnswers } from "#shared/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#shared/demo.ts";
 import type { FormParams } from "#shared/form-data.ts";
@@ -45,21 +43,6 @@ import {
   type TicketContextProvider,
   type TicketCtx,
 } from "./types.ts";
-
-/** Sum quantity needed across events with assign_built_site enabled */
-const totalSitesNeeded = (
-  events: TicketEvent[],
-  quantities: Map<number, number>,
-): number => {
-  let total = 0;
-  for (const { event } of events) {
-    if (event.assign_built_site) {
-      // quantities is always populated for every event by parseQuantities
-      total += quantities.get(event.id)!;
-    }
-  }
-  return total;
-};
 
 /** Validate fields, terms and event availability. Returns Response on error, or parsed field values. */
 const validateFormAndAvailability = (
@@ -149,20 +132,6 @@ const applyQrTokenOverride = async (
   for (const { event } of ctx.events) {
     if (!event.can_pay_more) customPrices.set(event.id, payload.v);
   }
-};
-
-/** Verify built site availability when the builder feature is enabled */
-const checkBuiltSiteAvailability = async (
-  ctx: TicketCtx,
-  quantities: Map<number, number>,
-): Promise<Response | null> => {
-  const sitesNeeded = totalSitesNeeded(ctx.events, quantities);
-  if (sitesNeeded <= 0 || !isBuilderEnabled()) return null;
-  const availableSites = await countAssignableSites();
-  if (availableSites < sitesNeeded) {
-    return ticketFormErrorResponse(ctx)("Sorry, not enough sites available");
-  }
-  return null;
 };
 
 type AnswerInfo = {
@@ -288,9 +257,6 @@ const processSubmission = async (
     quantities,
     customPricesResult,
   );
-
-  const siteCheckError = await checkBuiltSiteAvailability(ctx, quantities);
-  if (siteCheckError) return siteCheckError;
 
   const info: AnswerInfo = {
     activeQuestions,

--- a/src/shared/db/built-sites.ts
+++ b/src/shared/db/built-sites.ts
@@ -6,7 +6,7 @@
 import type { InValue } from "@libsql/client";
 import { registerCache } from "#shared/cache-registry.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { queryAll, queryOne } from "#shared/db/client.ts";
+import { queryAll } from "#shared/db/client.ts";
 import type { ColumnDef, Table } from "#shared/db/table.ts";
 import { col, defineTable, withCacheInvalidation } from "#shared/db/table.ts";
 import { nowIso } from "#shared/now.ts";
@@ -284,16 +284,6 @@ export const insertBuiltSite = (
 /** Get all built sites, decrypted and sorted by name */
 export const getAllBuiltSites = (): Promise<BuiltSite[]> =>
   builtSitesCache.getAll();
-
-/** Count assignable sites (fast SQL, no decryption) */
-export const countAssignableSites = async (): Promise<number> => {
-  // COUNT(*) always returns exactly one row
-  const row = (await queryOne<{ cnt: number }>(
-    "SELECT COUNT(*) as cnt FROM built_sites WHERE assignable = 1",
-    [],
-  ))!;
-  return row.cnt;
-};
 
 /** Get all assignable built sites */
 export const getAssignableBuiltSites = async (): Promise<BuiltSite[]> => {

--- a/src/shared/site-assignment.ts
+++ b/src/shared/site-assignment.ts
@@ -5,8 +5,12 @@
  */
 
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
+import { builderApi } from "#shared/builder.ts";
 import {
   assignBuiltSite,
+  type BuiltSite,
+  builtSitesCrudTable,
+  getAllBuiltSites,
   getAssignableBuiltSites,
 } from "#shared/db/built-sites.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -15,6 +19,7 @@ import {
   getHostEmailConfig,
   sendEmail,
 } from "#shared/email.ts";
+import { ErrorCode, logError } from "#shared/logger.ts";
 
 /** Entry with the fields needed for site assignment */
 type SiteAssignmentEntry = {
@@ -26,6 +31,31 @@ type SiteAssignmentEntry = {
 type SiteAssignment = {
   siteUrl: string;
   eventName: string;
+};
+
+/** Compute the next sequential site name based on total site count, zero-padded to 5 digits. */
+const nextSiteName = async (): Promise<string> =>
+  String((await getAllBuiltSites()).length + 1).padStart(5, "0");
+
+/** Build a new site on-demand and insert it as an assignable record. */
+const buildSiteForAssignment = async (): Promise<BuiltSite | null> => {
+  const name = await nextSiteName();
+  const result = await builderApi.buildSite({ siteName: name });
+  if (!result.ok) {
+    logError({
+      code: ErrorCode.CDN_REQUEST,
+      detail: `Failed to auto-build site '${name}': ${result.error}`,
+    });
+    return null;
+  }
+  return builtSitesCrudTable.insert({
+    assignable: true,
+    bunnyScriptId: String(result.scriptId),
+    bunnyUrl: result.defaultHostname,
+    dbToken: result.dbToken,
+    dbUrl: result.dbUrl,
+    name,
+  });
 };
 
 /** Assign built sites to entries that need them. Returns assigned URLs. */
@@ -42,8 +72,8 @@ const assignSitesForEntries = async (
   for (const { event, attendee } of needsSite) {
     const qty = attendee.quantity;
     for (let i = 0; i < qty; i++) {
-      const site = available[idx];
-      if (!site) break; // edge case: ran out (paid booking race)
+      const site = available[idx] ?? (await buildSiteForAssignment());
+      if (!site) break;
       await assignBuiltSite(site.id, attendee.id, event.id);
       assignments.push({ eventName: event.name, siteUrl: site.bunnyUrl });
       idx++;

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -4,7 +4,6 @@ import {
   assignBuiltSite,
   buildSiteDataBlob,
   builtSitesCrudTable,
-  countAssignableSites,
   getAllBuiltSites,
   getAssignableBuiltSites,
   insertBuiltSite,
@@ -329,20 +328,6 @@ describeWithEnv("built-sites", { db: true }, () => {
       const sites = await getAllBuiltSites();
       const site = sites.find((s) => s.name === "Default Site")!;
       expect(site.assignable).toBe(false);
-    });
-
-    test("countAssignableSites counts only assignable sites", async () => {
-      await insertBuiltSite("Site A", "a.b-cdn.net", "", "", true);
-      await insertBuiltSite("Site B", "b.b-cdn.net", "", "", true);
-      await insertBuiltSite("Site C", "c.b-cdn.net", "", "", false);
-      const count = await countAssignableSites();
-      expect(count).toBe(2);
-    });
-
-    test("countAssignableSites returns 0 when no assignable sites", async () => {
-      await insertBuiltSite("Site A", "a.b-cdn.net", "", "", false);
-      const count = await countAssignableSites();
-      expect(count).toBe(0);
     });
 
     test("getAssignableBuiltSites filters to assignable only", async () => {

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { capacityErrorFormatter } from "#routes/format.ts";
+import { builderApi } from "#shared/builder.ts";
 import { addDays } from "#shared/dates.ts";
 import { insertBuiltSite } from "#shared/db/built-sites.ts";
 import {
@@ -4609,28 +4610,31 @@ describeWithEnv("server (public routes)", { db: true }, () => {
     });
   });
 
-  describe("built site availability check", () => {
-    test("blocks registration when no assignable sites available", async () => {
+  describe("built site assignment", () => {
+    test("registration succeeds when no sites available — auto-build is attempted in the background", async () => {
       const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
+      const buildStub = stub(builderApi, "buildSite", () =>
+        Promise.resolve({ error: "stubbed", ok: false as const }),
+      );
       try {
         const event = await createTestEvent({
           assignBuiltSite: true,
           maxAttendees: 10,
           thankYouUrl: "",
         });
-        // No assignable sites created
         const response = await submitTicketForm(event.slug, {
           email: "test@example.com",
           name: "Test User",
         });
-        expect(response.status).toBe(302);
-        expectFlash(response, "Sorry, not enough sites available", false);
+        expectReservedRedirectWithTokens(response);
+        expect(buildStub.calls.length).toBe(1);
       } finally {
+        buildStub.restore();
         restore();
       }
     });
 
-    test("allows registration when assignable sites are available", async () => {
+    test("registration succeeds when assignable sites are available", async () => {
       const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
       try {
         const event = await createTestEvent({
@@ -4647,23 +4651,6 @@ describeWithEnv("server (public routes)", { db: true }, () => {
       } finally {
         restore();
       }
-    });
-
-    test("skips check when CAN_BUILD_SITES is not set", async () => {
-      // Create event with flag enabled so assign_built_site is saved
-      const restore = setTestEnv({ CAN_BUILD_SITES: "true" });
-      const event = await createTestEvent({
-        assignBuiltSite: true,
-        maxAttendees: 10,
-        thankYouUrl: "",
-      });
-      restore();
-      // Now CAN_BUILD_SITES is not set — booking should succeed despite no sites
-      const response = await submitTicketForm(event.slug, {
-        email: "test@example.com",
-        name: "Test User",
-      });
-      expectReservedRedirectWithTokens(response);
     });
   });
 });

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import { type BuildSiteInput, builderApi } from "#shared/builder.ts";
 import { getAllBuiltSites, insertBuiltSite } from "#shared/db/built-sites.ts";
 import {
   resetHostEmailConfig,
@@ -8,6 +9,26 @@ import {
 } from "#shared/email.ts";
 import { assignAndNotifyBuiltSites } from "#shared/site-assignment.ts";
 import { describeWithEnv, makeTestEntry, setTestEnv } from "#test-utils";
+
+const stubBuildSiteSuccess = (onCall?: (input: BuildSiteInput) => void) => {
+  let counter = 0;
+  return stub(builderApi, "buildSite", (input: BuildSiteInput) => {
+    counter++;
+    onCall?.(input);
+    return Promise.resolve({
+      dbToken: `token-${counter}`,
+      dbUrl: `libsql://auto-${counter}.test`,
+      defaultHostname: `auto-${counter}.b-cdn.net`,
+      ok: true as const,
+      scriptId: 1000 + counter,
+    });
+  });
+};
+
+const stubBuildSiteFailure = () =>
+  stub(builderApi, "buildSite", () =>
+    Promise.resolve({ error: "build failed", ok: false as const }),
+  );
 
 /** Build an entry with assign_built_site for testing */
 const siteEntry = (
@@ -104,14 +125,20 @@ describeWithEnv(
         expect(assigned[1]!.assignedEventId).toBe(2);
       });
 
-      test("does not assign when no assignable sites available", async () => {
+      test("does not assign when no sites available and buildSite fails", async () => {
         await insertBuiltSite("Site A", "a.test.net", "", "", false);
+        const buildStub = stubBuildSiteFailure();
+        try {
+          await assignAndNotifyBuiltSites([siteEntry()]);
 
-        await assignAndNotifyBuiltSites([siteEntry()]);
-
-        const sites = await getAllBuiltSites();
-        expect(sites[0]!.assignedAttendeeId).toBeNull();
-        expect(fetchStub.calls.length).toBe(0);
+          const sites = await getAllBuiltSites();
+          const existing = sites.find((s) => s.name === "Site A")!;
+          expect(existing.assignedAttendeeId).toBeNull();
+          expect(buildStub.calls.length).toBe(1);
+          expect(fetchStub.calls.length).toBe(0);
+        } finally {
+          buildStub.restore();
+        }
       });
 
       test("no-ops for empty entries", async () => {
@@ -119,15 +146,54 @@ describeWithEnv(
         expect(fetchStub.calls.length).toBe(0);
       });
 
-      test("assigns only available sites when fewer than needed", async () => {
+      test("auto-builds when no assignable sites are available", async () => {
+        const buildStub = stubBuildSiteSuccess();
+        try {
+          await assignAndNotifyBuiltSites([siteEntry()]);
+
+          const sites = await getAllBuiltSites();
+          expect(sites).toHaveLength(1);
+          expect(sites[0]!.bunnyUrl).toBe("auto-1.b-cdn.net");
+          expect(sites[0]!.assignedAttendeeId).not.toBeNull();
+          expect(buildStub.calls.length).toBe(1);
+          expect(fetchStub.calls.length).toBe(1);
+        } finally {
+          buildStub.restore();
+        }
+      });
+
+      test("auto-builds remaining sites when fewer assignable than needed", async () => {
         await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        const builtNames: string[] = [];
+        const buildStub = stubBuildSiteSuccess((input) => {
+          builtNames.push(input.siteName);
+        });
+        try {
+          await assignAndNotifyBuiltSites([siteEntry({ quantity: 3 })]);
 
-        await assignAndNotifyBuiltSites([siteEntry({ quantity: 3 })]);
+          const sites = await getAllBuiltSites();
+          const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
+          expect(assigned).toHaveLength(3);
+          expect(buildStub.calls.length).toBe(2);
+          expect(fetchStub.calls.length).toBe(1);
+        } finally {
+          buildStub.restore();
+        }
+      });
 
-        const sites = await getAllBuiltSites();
-        const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
-        expect(assigned).toHaveLength(1);
-        expect(fetchStub.calls.length).toBe(1);
+      test("uses sequential zero-padded names for auto-built sites", async () => {
+        await insertBuiltSite("Manual", "manual.b-cdn.net", "", "", false);
+        const builtNames: string[] = [];
+        const buildStub = stubBuildSiteSuccess((input) => {
+          builtNames.push(input.siteName);
+        });
+        try {
+          await assignAndNotifyBuiltSites([siteEntry({ quantity: 2 })]);
+
+          expect(builtNames).toEqual(["00002", "00003"]);
+        } finally {
+          buildStub.restore();
+        }
       });
 
       test("sends email with plural subject for multiple sites", async () => {


### PR DESCRIPTION
## Summary

- Purchasing a ticket for an event with `assign_built_site` enabled no longer blocks when no assignable sites are available
- Post-purchase assignment now auto-builds a site on the fly via `builderApi.buildSite` when the assignable pool runs out
- New sites get a 5-digit zero-padded name based on total site count (e.g. `00001`, `00002`, ...). A failed build is logged via `ErrorCode.CDN_REQUEST` and the ticket is left unassigned

## Changes

- `src/shared/site-assignment.ts`: add `nextSiteName` + `buildSiteForAssignment`; fall back to it in `assignSitesForEntries` when no assignable site is available
- `src/features/public/ticket-submit.ts`: remove the `checkBuiltSiteAvailability` pre-check (and now-unused `totalSitesNeeded`)
- `src/shared/db/built-sites.ts`: drop the now-unused `countAssignableSites`
- Tests updated to cover the new auto-build path (success, build failure, sequential naming) and to drop the obsolete "blocks registration when no sites" case

## Test plan

- [x] `deno task precommit` (typecheck, lint, build:edge, full test suite with 100% line/branch coverage)
- [x] `deno test --no-check --allow-all test/lib/site-assignment.test.ts`
- [x] `deno test --no-check --allow-all test/lib/server-public.test.ts` (the new `built site assignment` describe block)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MH6UK7HqXQnv4MqhgddGkc)_