### PR TITLE
Add gap between event rows on group ticket pages

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1083,6 +1083,12 @@ fieldset {
   padding: 0 1rem;
 }
 
+.ticket-events {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+}
+
 .checkbox-group {
   border: 0;
   padding: 0;


### PR DESCRIPTION
## Summary

- `.ticket-events` (the fieldset wrapping multiple events on `/ticket/<group-slug>`) had no layout rules, so the `.ticket-row` items stacked flush against each other.
- Added a flex column with `gap: var(--space-s)` (0.5rem) using the same `display: flex; flex-direction: column; gap: var(--space-…)` pattern already used by `main`, `.stack`, `form`, etc.

## Test plan

- [ ] Visit `/ticket/<group-slug>` and confirm a small gap appears between event rows.
- [ ] Single-event pages (`/ticket/<event-slug>`) are unaffected — they don't render the `.ticket-events` fieldset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR4HWV8fCknyxHoqDbsWbS)_