### PR TITLE
Create releases with empty notes instead of generated ones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,5 +42,5 @@ jobs:
           git push origin "$TAG"
           gh release create "$TAG" \
             --title "$TITLE" \
-            --generate-notes \
+            --notes "" \
             bunny-script.ts


### PR DESCRIPTION
The "Create Release" workflow fails when the auto-generated release notes from `--generate-notes` exceed GitHub's body length limit. Releases are now created with an empty body (`--notes ""` — `gh` requires an explicit notes flag in non-interactive CI), and notes will be written manually via the GitHub interface.

https://claude.ai/code/session_01GjGtvQRxo3KuRbhkULK6Rx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjGtvQRxo3KuRbhkULK6Rx)_