### PR TITLE
Show "not activated" page for pre-setup sites; link assignment emails to /setup

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -18,6 +18,7 @@ import {
   jsonResponse,
   notFoundResponse,
   redirectResponse,
+  siteNotActivatedResponse,
   temporaryErrorResponse,
   withCookie,
 } from "#routes/response.ts";
@@ -31,7 +32,7 @@ import {
   clearSessionCookie,
   parseFlashValue,
 } from "#shared/cookies.ts";
-import { initDb } from "#shared/db/migrations.ts";
+import { initDb, MissingSettingsTableError } from "#shared/db/migrations.ts";
 import { maybeRunPrunes } from "#shared/db/prune.ts";
 import { runWithQueryLogContext } from "#shared/db/query-log.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -334,7 +335,7 @@ const handleRequestInternal = async (
   if (!(await settings.setup.isComplete())) {
     return isSetupPath(path)
       ? redirectResponse("/setup")
-      : temporaryErrorResponse();
+      : siteNotActivatedResponse();
   }
 
   return (await routeMainApp(request, path, method, server))!;
@@ -343,8 +344,23 @@ const handleRequestInternal = async (
 const isSetupPath = (path: string): boolean =>
   path === "/setup" || path.startsWith("/setup/");
 
-const initializeDatabaseForPath = async (path: string): Promise<void> => {
-  await initDb({ allowMissingSettings: isSetupPath(path) });
+/**
+ * Run per-request DB init. Returns the "not activated" page when the
+ * database has never been set up (missing or uninitialized settings table);
+ * setup paths instead bootstrap the schema via allowMissingSettings.
+ */
+const initializeDatabaseForPath = async (
+  path: string,
+): Promise<Response | null> => {
+  try {
+    await initDb({ allowMissingSettings: isSetupPath(path) });
+    return null;
+  } catch (error) {
+    if (error instanceof MissingSettingsTableError) {
+      return siteNotActivatedResponse();
+    }
+    throw error;
+  }
 };
 
 /** Log request and return response */
@@ -509,7 +525,10 @@ const processRequest = async (
       );
     }
 
-    await initializeDatabaseForPath(path);
+    const notActivated = await initializeDatabaseForPath(path);
+    if (notActivated) {
+      return logAndReturn(notActivated, method, path, getElapsed);
+    }
 
     const trackingRedirect = trackingParamRedirect(url, method);
     if (trackingRedirect) {

--- a/src/features/response.ts
+++ b/src/features/response.ts
@@ -9,6 +9,7 @@ import { checkoutPopupPage, paymentErrorPage } from "#templates/payment.tsx";
 import {
   notFoundPage,
   rateLimitedPage,
+  siteNotActivatedPage,
   temporaryErrorPage,
 } from "#templates/public.tsx";
 
@@ -57,6 +58,14 @@ export const paymentErrorResponse = (message: string, status = 400): Response =>
  */
 export const temporaryErrorResponse = (): Response =>
   htmlResponse(temporaryErrorPage(), 503);
+
+/**
+ * Create "site not activated" response for sites whose database has not
+ * been set up yet. 503 like temporaryErrorResponse, but without the
+ * auto-refresh — the state only changes once someone completes /setup.
+ */
+export const siteNotActivatedResponse = (): Response =>
+  htmlResponse(siteNotActivatedPage(), 503);
 
 /**
  * Respond with checkout: popup page in iframe mode, 302 redirect otherwise.

--- a/src/shared/site-assignment.ts
+++ b/src/shared/site-assignment.ts
@@ -376,6 +376,12 @@ const assignSitesForEntries = async (
   return assignments;
 };
 
+/** Absolute /setup/ link for a site — bunnyUrl may be a bare hostname. */
+const siteSetupUrl = (siteUrl: string): string => {
+  const base = /^https?:\/\//.test(siteUrl) ? siteUrl : `https://${siteUrl}`;
+  return `${base.replace(/\/+$/, "")}/setup/`;
+};
+
 /** Send site assignment notification email */
 const sendSiteAssignmentEmail = async (
   to: string,
@@ -384,31 +390,33 @@ const sendSiteAssignmentEmail = async (
   const config = getEmailConfig() ?? getHostEmailConfig();
   if (!config) return;
 
-  const subject =
-    assignments.length === 1
-      ? "Your new site is ready"
-      : `Your ${assignments.length} new sites are ready`;
+  const plural = assignments.length > 1;
+  const subject = plural
+    ? `Your ${assignments.length} new sites are ready`
+    : "Your new site is ready";
 
-  const greeting = `Your new site${
-    assignments.length > 1 ? "s are" : " is"
-  } ready!`;
+  const greeting = `Your new site${plural ? "s are" : " is"} ready!`;
+  const activationNote = plural
+    ? "Visit the setup links below to activate your sites:"
+    : "Visit the setup link below to activate your site:";
 
   const htmlList = assignments
-    .map(
-      (a) => `<li>${a.eventName}: <a href="${a.siteUrl}">${a.siteUrl}</a></li>`,
-    )
+    .map((a) => {
+      const url = siteSetupUrl(a.siteUrl);
+      return `<li>${a.eventName}: <a href="${url}">${url}</a></li>`;
+    })
     .join("");
 
   const textList = assignments
-    .map((a) => `- ${a.eventName}: ${a.siteUrl}`)
+    .map((a) => `- ${a.eventName}: ${siteSetupUrl(a.siteUrl)}`)
     .join("\n");
 
   const replyTo = settings.businessEmail || undefined;
   await sendEmail(config, {
-    html: `<p>${greeting}</p><ul>${htmlList}</ul>`,
+    html: `<p>${greeting}</p><p>${activationNote}</p><ul>${htmlList}</ul>`,
     replyTo,
     subject,
-    text: `${greeting}\n\n${textList}`,
+    text: `${greeting}\n\n${activationNote}\n\n${textList}`,
     to,
   });
 };

--- a/src/ui/templates/public.tsx
+++ b/src/ui/templates/public.tsx
@@ -374,17 +374,23 @@ export const rateLimitedPage = (): string =>
   );
 
 /**
- * Temporary error page with auto-refresh
- * Used when a transient CDN or network error occurs
+ * Inline styles for error dialog pages — self-contained so the page renders
+ * correctly even when the database or CDN assets are unavailable
  */
-const TEMPORARY_ERROR_HEAD = `<meta http-equiv="refresh" content="2" />
-<style>
+const ERROR_DIALOG_STYLE = `<style>
 body{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;background:#f8fafc;color:#0f172a}
 main{max-width:36rem;margin:18vh auto 0;padding:0 1.5rem}
 h1{font-size:1.875rem;line-height:1.2;margin:0 0 .75rem}
 p{line-height:1.5;margin:.75rem 0}
 a{color:#0369a1}
 </style>`;
+
+/**
+ * Temporary error page with auto-refresh
+ * Used when a transient CDN or network error occurs
+ */
+const TEMPORARY_ERROR_HEAD = `<meta http-equiv="refresh" content="2" />
+${ERROR_DIALOG_STYLE}`;
 
 export const temporaryErrorPage = (): string =>
   String(
@@ -401,6 +407,19 @@ export const temporaryErrorPage = (): string =>
           </strong>
         </small>
       </p>
+    </Layout>,
+  );
+
+/**
+ * Shown on non-setup routes when the site's database has not been set up
+ * yet. No auto-refresh: retrying cannot succeed until someone completes
+ * /setup, so an endlessly reloading error page would just be confusing.
+ */
+export const siteNotActivatedPage = (): string =>
+  String(
+    <Layout headExtra={ERROR_DIALOG_STYLE} title="Not Activated">
+      <h1>Not Activated</h1>
+      <p>This site has not been activated yet.</p>
     </Layout>,
   );
 

--- a/test/lib/payment-helpers.test.ts
+++ b/test/lib/payment-helpers.test.ts
@@ -502,33 +502,45 @@ describe("payment-helpers", () => {
 });
 
 // hmacHash needs the encryption key configured, which describeWithEnv handles.
-describeWithEnv("buildItemsMetadata site-token hashing", {}, () => {
-  const baseIntent = (siteToken?: string): CheckoutIntent => ({
-    address: "",
-    date: null,
-    email: "renew@example.com",
-    items: [{ eventId: 1, name: "Tier", quantity: 1, slug: "t", unitPrice: 0 }],
-    name: "Renewer",
-    phone: "",
-    special_instructions: "",
-    ...(siteToken ? { siteToken } : {}),
-  });
+describeWithEnv(
+  "buildItemsMetadata site-token hashing",
+  { encryptionKey: true },
+  () => {
+    const baseIntent = (siteToken?: string): CheckoutIntent => ({
+      address: "",
+      date: null,
+      email: "renew@example.com",
+      items: [
+        {
+          eventId: 1,
+          name: "Tier",
+          quantity: 1,
+          slug: "t",
+          unitPrice: 0,
+        },
+      ],
+      name: "Renewer",
+      phone: "",
+      special_instructions: "",
+      ...(siteToken ? { siteToken } : {}),
+    });
 
-  test("emits site_token_index as the HMAC of the plain token", async () => {
-    const metadata = await buildItemsMetadata(baseIntent("plain-token-xyz"));
-    const expected = await hmacHash("plain-token-xyz");
-    expect(metadata.site_token_index).toBe(expected);
-  });
+    test("emits site_token_index as the HMAC of the plain token", async () => {
+      const metadata = await buildItemsMetadata(baseIntent("plain-token-xyz"));
+      const expected = await hmacHash("plain-token-xyz");
+      expect(metadata.site_token_index).toBe(expected);
+    });
 
-  test("plain token never appears in metadata", async () => {
-    const metadata = await buildItemsMetadata(baseIntent("plain-token-xyz"));
-    for (const value of Object.values(metadata)) {
-      expect(value.includes("plain-token-xyz")).toBe(false);
-    }
-  });
+    test("plain token never appears in metadata", async () => {
+      const metadata = await buildItemsMetadata(baseIntent("plain-token-xyz"));
+      for (const value of Object.values(metadata)) {
+        expect(value.includes("plain-token-xyz")).toBe(false);
+      }
+    });
 
-  test("omits site_token_index when siteToken is absent", async () => {
-    const metadata = await buildItemsMetadata(baseIntent());
-    expect("site_token_index" in metadata).toBe(false);
-  });
-});
+    test("omits site_token_index when siteToken is absent", async () => {
+      const metadata = await buildItemsMetadata(baseIntent());
+      expect("site_token_index" in metadata).toBe(false);
+    });
+  },
+);

--- a/test/lib/server-misc-routing.test.ts
+++ b/test/lib/server-misc-routing.test.ts
@@ -5,6 +5,7 @@ import { getCleanUrl, handleRequest, isValidContentType } from "#routes";
 import {
   redirect,
   redirectResponse,
+  siteNotActivatedResponse,
   temporaryErrorResponse,
 } from "#routes/response.ts";
 import {
@@ -686,6 +687,19 @@ describeWithEnv("server (misc: security and routing)", { db: true }, () => {
         "Retrying automatically",
         'http-equiv="refresh"',
       );
+      expect(response.headers.get("content-type")).toBe(
+        "text/html; charset=utf-8",
+      );
+    });
+
+    test("siteNotActivatedResponse returns 503 styled HTML without auto-refresh", async () => {
+      const response = siteNotActivatedResponse();
+      const html = await expectHtmlResponse(
+        response,
+        503,
+        "This site has not been activated yet",
+      );
+      expect(html).not.toContain('http-equiv="refresh"');
       expect(response.headers.get("content-type")).toBe(
         "text/html; charset=utf-8",
       );

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { getDb } from "#shared/db/client.ts";
-import { resetDatabase } from "#shared/db/migrations.ts";
+import { invalidateInitDbCache, resetDatabase } from "#shared/db/migrations.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   assertJson,
@@ -93,58 +93,51 @@ describeWithEnv("server (setup)", { db: true }, () => {
         await createTestDb();
       });
 
-      test("returns temporary status page for home when setup is incomplete", async () => {
+      test("returns not-activated page for home when setup is incomplete", async () => {
         const response = await handleRequest(mockRequest("/"));
         await expectHtmlResponse(
           response,
           503,
-          "Temporary Error",
-          "status.bunny.net",
+          "This site has not been activated yet",
         );
       });
 
-      test("returns temporary status page without bootstrapping a missing settings table", async () => {
+      test("returns not-activated page without bootstrapping a missing settings table", async () => {
         await resetToBrandNewDatabase();
 
-        await withExpectedError(async () => {
-          const response = await handleRequest(mockRequest("/"));
-          await expectHtmlResponse(
-            response,
-            503,
-            "Temporary Error",
-            "status.bunny.net",
-          );
-        });
+        const response = await handleRequest(mockRequest("/"));
+        const html = await expectHtmlResponse(
+          response,
+          503,
+          "This site has not been activated yet",
+        );
+        expect(html).not.toContain('http-equiv="refresh"');
 
         expect(await settingsTableExists()).toBe(false);
       });
 
-      test("returns temporary status page without bootstrapping an empty settings table", async () => {
+      test("returns not-activated page without bootstrapping an empty settings table", async () => {
         await resetToBrandNewDatabase();
         await createEmptySettingsTable();
 
-        await withExpectedError(async () => {
-          const response = await handleRequest(mockRequest("/"));
-          await expectHtmlResponse(
-            response,
-            503,
-            "Temporary Error",
-            "status.bunny.net",
-          );
-        });
+        const response = await handleRequest(mockRequest("/"));
+        await expectHtmlResponse(
+          response,
+          503,
+          "This site has not been activated yet",
+        );
 
         expect(await settingsTableExists()).toBe(true);
         expect(await tableExists("events")).toBe(false);
         expect(await schemaMarkerKeys()).toEqual([]);
       });
 
-      test("returns temporary status page for admin when setup is incomplete", async () => {
+      test("returns not-activated page for admin when setup is incomplete", async () => {
         const response = await handleRequest(mockRequest("/admin/"));
         await expectHtmlResponse(
           response,
           503,
-          "Temporary Error",
-          "status.bunny.net",
+          "This site has not been activated yet",
         );
       });
 
@@ -198,6 +191,9 @@ describeWithEnv("server (setup)", { db: true }, () => {
 
       test("returns the temporary status page when settings DB cannot be read", async () => {
         const { stub } = await import("@std/testing/mock");
+        // Drop the per-isolate "ready" cache so initDb really runs and the
+        // generic DB failure propagates through initializeDatabaseForPath.
+        invalidateInitDbCache();
         const executeStub = stub(getDb(), "execute", () =>
           Promise.reject(new Error("db unavailable")),
         );

--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -254,6 +254,27 @@ describeWithEnv(
         expect(body.subject).toBe("Your new site is ready");
       });
 
+      test("email links to the assigned site's /setup/ page", async () => {
+        await insertBuiltSite("Site A", "a.test.net", "", "", true);
+
+        await assignAndNotifyBuiltSites([siteEntry()]);
+
+        const body = JSON.parse(fetchStub.calls[0].args[1].body);
+        expect(body.html).toContain('href="https://a.test.net/setup/"');
+        expect(body.html).toContain("activate your site");
+        expect(body.text).toContain("https://a.test.net/setup/");
+      });
+
+      test("email setup link keeps the scheme when the site URL already has one", async () => {
+        await insertBuiltSite("Site C", "https://c.test.net/", "", "", true);
+
+        await assignAndNotifyBuiltSites([siteEntry()]);
+
+        const body = JSON.parse(fetchStub.calls[0].args[1].body);
+        expect(body.html).toContain('href="https://c.test.net/setup/"');
+        expect(body.text).toContain("https://c.test.net/setup/");
+      });
+
       test("uses DB email config when available and includes reply-to", async () => {
         // Configure email via DB settings (not host config) so getEmailConfig()
         // returns non-null, covering the left branch of the ?? operator

--- a/test/templates/admin/built-sites.test.ts
+++ b/test/templates/admin/built-sites.test.ts
@@ -5,11 +5,16 @@ import {
   adminBuiltSiteEditPage,
   adminBuiltSitesPage,
 } from "#templates/admin/built-sites.tsx";
-import { testBuiltSite, testEventWithCount } from "#test-utils";
+import {
+  setupTestEncryptionKey,
+  testBuiltSite,
+  testEventWithCount,
+} from "#test-utils";
 
 const TEST_SESSION = { adminLevel: "owner" as const };
 
 beforeAll(async () => {
+  setupTestEncryptionKey();
   await signCsrfToken();
 });
 

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -11,6 +11,7 @@ import {
   buildTicketEvent,
   notFoundPage,
   renderEventImage,
+  siteNotActivatedPage,
   temporaryErrorPage,
   ticketPage,
 } from "#templates/public.tsx";
@@ -362,6 +363,21 @@ describe("temporaryErrorPage", () => {
     expect(html).toContain('content="2"');
     expect(html).toContain("<style>");
     expect(html).toContain("font-family:system-ui");
+  });
+});
+
+describe("siteNotActivatedPage", () => {
+  test("renders not-activated message in the error dialog style", () => {
+    const html = siteNotActivatedPage();
+    expect(html).toContain("<h1>Not Activated</h1>");
+    expect(html).toContain("This site has not been activated yet.");
+    expect(html).toContain("<style>");
+    expect(html).toContain("font-family:system-ui");
+  });
+
+  test("does not auto-refresh", () => {
+    const html = siteNotActivatedPage();
+    expect(html).not.toContain('http-equiv="refresh"');
   });
 });
 


### PR DESCRIPTION
## What

**1. "This site has not been activated yet" page for pre-setup sites**

Sites whose database has never been set up (missing or uninitialized `settings` table), or where `/setup` was started but never completed, used to serve the auto-refreshing "Temporary Error" page on every public route — an endless reload loop that looked like an outage. They now get a clear, styled "This site has not been activated yet" page (same inline error-dialog style, 503, **no** meta refresh, since retrying can't succeed until someone completes `/setup`).

- The missing-database case (`MissingSettingsTableError`) is caught around the per-request `initDb` call, so unactivated sites no longer log `E_CDN_REQUEST` on every visit. Any other DB error still rethrows into the existing temporary-error path.
- The "tables exist but setup incomplete" branch returns the same page.
- Setup paths are unaffected: visiting `/setup` still bootstraps the schema and activates the site.

**2. Site-assignment emails link to each new site's `/setup/` page**

The "your new site is ready" email linked to the bare site hostname (`a.test.net`) — a broken relative href in HTML, and even fixed up it would land buyers on the unactivated-site page from change 1. Links now point at `https://<site>/setup/` with a note that this is where you activate, tolerating stored site URLs with or without a scheme.

**3. Fix two order-dependent test files (pre-existing flake)**

`payment-helpers.test.ts` (site-token hashing suite) and `templates/admin/built-sites.test.ts` relied on another file in the same parallel test worker having already set `DB_ENCRYPTION_KEY`, and failed when scheduled first. They now configure the key explicitly and pass standalone.

## Testing

- `deno task precommit` passes: typecheck, lint, cpd, edge build, full test suite with 100% line + branch coverage.
- New/updated tests cover: not-activated page for missing settings table, empty settings table, and incomplete setup (asserting no auto-refresh); generic DB errors still reaching the temporary-error path; email `/setup/` links for bare-hostname and scheme-prefixed site URLs.

https://claude.ai/code/session_01Nk6B8XKTwi9LUZPFTJzFin

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk6B8XKTwi9LUZPFTJzFin)_