### PR TITLE
Seed effective domain from request host before DB init

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -26,7 +26,10 @@ import { createRouter, defineRoutes } from "#routes/router.ts";
 import { routeStatic } from "#routes/static.ts";
 import type { ServerContext } from "#routes/types.ts";
 import { normalizePath, parseCookies, parseRequest } from "#routes/url.ts";
-import { loadEffectiveDomain } from "#shared/config.ts";
+import {
+  loadEffectiveDomain,
+  seedEffectiveDomainHost,
+} from "#shared/config.ts";
 import {
   clearFlashCookie,
   clearSessionCookie,
@@ -524,6 +527,12 @@ const processRequest = async (
         getElapsed,
       );
     }
+
+    // Seed the effective domain from the request host before touching the
+    // database, so errors during migration (e.g. on the first request after a
+    // cold boot) identify the real site instead of falling back to "localhost".
+    // prepareRequestEnvironment() refines this once settings are loaded.
+    seedEffectiveDomainHost(url.href);
 
     const notActivated = await initializeDatabaseForPath(path);
     if (notActivated) {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -46,6 +46,20 @@ export const loadEffectiveDomain = (requestUrl: string): string => {
   return effectiveDomainState.domain;
 };
 
+/**
+ * Seed the effective domain from the request's own hostname.
+ *
+ * loadEffectiveDomain() runs late in the request (after settings are loaded),
+ * so anything that fails before it — most notably database migrations on the
+ * first request after a cold boot — would otherwise read the bare "localhost"
+ * fallback in error notifications. Seeding the request host early makes those
+ * notifications (e.g. ntfy titles) identify the real site. The value is
+ * refined later by loadEffectiveDomain() once the custom domain is known.
+ */
+export const seedEffectiveDomainHost = (requestUrl: string): void => {
+  effectiveDomainState.domain = new URL(requestUrl).hostname;
+};
+
 /** Get the effective domain synchronously (must call loadEffectiveDomain first). */
 export const getEffectiveDomain = (): string =>
   effectiveDomainState.domain ?? "localhost";

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -7,6 +7,7 @@ import {
   isPaymentsEnabled,
   loadEffectiveDomain,
   resetEffectiveDomain,
+  seedEffectiveDomainHost,
   setEffectiveDomainForTest,
 } from "#shared/config.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -90,6 +91,21 @@ describeWithEnv("getEffectiveDomain", { db: true }, () => {
 
   test("returns 'localhost' before loadEffectiveDomain has been called", () => {
     expect(getEffectiveDomain()).toBe("localhost");
+  });
+
+  test("seedEffectiveDomainHost sets the request hostname before settings load", () => {
+    seedEffectiveDomainHost("https://event.example.com/ticket/abc");
+    expect(getEffectiveDomain()).toBe("event.example.com");
+  });
+
+  test("loadEffectiveDomain refines the seeded host with the validated custom domain", async () => {
+    await settings.update.customDomain("tickets.example.com");
+    await settings.update.customDomainLastValidated();
+    seedEffectiveDomainHost("https://mysite.bunny.run/");
+    expect(getEffectiveDomain()).toBe("mysite.bunny.run");
+
+    loadEffectiveDomain("https://mysite.bunny.run/");
+    expect(getEffectiveDomain()).toBe("tickets.example.com");
   });
 
   test("loadEffectiveDomain falls back to the request hostname when nothing is configured", () => {


### PR DESCRIPTION
## Problem

ntfy error notifications for database-lock issues always showed `localhost` in the title, making them impossible to trace to a site:

```
⚠️ localhost error
E_DB_MIGRATION_LOCK libsql://...
```

## Root cause

In the edge runtime every execution is request-triggered, but `loadEffectiveDomain()` runs late in `processRequest` — inside `prepareRequestEnvironment()`, *after* `initializeDatabaseForPath()`. `effectiveDomainState.domain` is a module global that persists across requests, so `getEffectiveDomain()` only falls back to the `"localhost"` sentinel on the **first request after a cold boot** — which is exactly when migrations run and `E_DB_MIGRATION_LOCK` / `E_CDN_REQUEST` fire. At that point the request host hadn't been read yet.

## Fix

Seed the effective domain from the request hostname right before `initializeDatabaseForPath()`, so errors during migration identify the real site. `prepareRequestEnvironment()` still refines the value with the custom domain / bunny subdomain once settings are loaded, so normal request behaviour is unchanged. The seed is placed *after* the static-asset short-circuit, leaving static responses untouched.

## Testing

- New unit tests for `seedEffectiveDomainHost` (sets request host; refined by `loadEffectiveDomain`).
- Full suite passes (361 files), lint + typecheck clean.

https://claude.ai/code/session_01SJRfjBWiPFN9gVQkjrkN75

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJRfjBWiPFN9gVQkjrkN75)_