### PR TITLE
Show "Update In Progress" page during pre-migration backup

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -16,6 +16,7 @@ import {
 import {
   htmlResponse,
   jsonResponse,
+  migrationInProgressResponse,
   notFoundResponse,
   redirectResponse,
   siteNotActivatedResponse,
@@ -32,7 +33,11 @@ import {
   clearSessionCookie,
   parseFlashValue,
 } from "#shared/cookies.ts";
-import { initDb, MissingSettingsTableError } from "#shared/db/migrations.ts";
+import {
+  initDb,
+  MigrationInProgressError,
+  MissingSettingsTableError,
+} from "#shared/db/migrations.ts";
 import { maybeRunPrunes } from "#shared/db/prune.ts";
 import { runWithQueryLogContext } from "#shared/db/query-log.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -358,6 +363,9 @@ const initializeDatabaseForPath = async (
   } catch (error) {
     if (error instanceof MissingSettingsTableError) {
       return siteNotActivatedResponse();
+    }
+    if (error instanceof MigrationInProgressError) {
+      return migrationInProgressResponse();
     }
     throw error;
   }

--- a/src/features/response.ts
+++ b/src/features/response.ts
@@ -7,6 +7,7 @@ import { appendIframeParam, getIframeMode } from "#shared/iframe.ts";
 import { getRequestId } from "#shared/logger.ts";
 import { checkoutPopupPage, paymentErrorPage } from "#templates/payment.tsx";
 import {
+  migrationInProgressPage,
   notFoundPage,
   rateLimitedPage,
   siteNotActivatedPage,
@@ -66,6 +67,15 @@ export const temporaryErrorResponse = (): Response =>
  */
 export const siteNotActivatedResponse = (): Response =>
   htmlResponse(siteNotActivatedPage(), 503);
+
+/**
+ * Create "migration in progress" response, shown while another isolate runs a
+ * database migration and pre-migration backup. 503 with an auto-refresh, like
+ * temporaryErrorResponse, but with a message that explains the wait instead of
+ * presenting it as an error.
+ */
+export const migrationInProgressResponse = (): Response =>
+  htmlResponse(migrationInProgressPage(), 503);
 
 /**
  * Respond with checkout: popup page in iframe mode, 302 redirect otherwise.

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -523,6 +523,20 @@ export class MissingSettingsTableError extends Error {
   }
 }
 
+/**
+ * Thrown when another isolate holds the migration lock — i.e. a database
+ * migration (including its pre-migration backup) is already running. The
+ * request can be retried once the migration finishes, so callers surface a
+ * dedicated "migration in progress" page that auto-refreshes rather than the
+ * generic temporary-error page.
+ */
+export class MigrationInProgressError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationInProgressError";
+  }
+}
+
 const isMissingSettingsTableError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
   return /no such table:?\s*(\w+\.)?settings\b/i.test(message);
@@ -1003,7 +1017,7 @@ const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
   const acquired = await acquireMigrationLock(allowMissingSettings);
   if (!acquired) {
     void sendNtfyError(`E_DB_MIGRATION_LOCK ${getEnv("DB_URL") ?? "unknown"}`);
-    throw new Error(
+    throw new MigrationInProgressError(
       "Database migration is already in progress (migration_lock held). " +
         `The request can be retried; a crashed migration's lock is reclaimed automatically after ${
           MIGRATION_LOCK_TTL_MS / 60000

--- a/src/ui/templates/public.tsx
+++ b/src/ui/templates/public.tsx
@@ -411,6 +411,27 @@ export const temporaryErrorPage = (): string =>
   );
 
 /**
+ * Shown while another isolate is running a database migration (including its
+ * pre-migration backup). Auto-refreshes like the temporary error page, but
+ * with a reassuring message so the user knows work is happening rather than
+ * seeing a generic error. The backup can take a few seconds on larger
+ * databases, so refresh a little slower than the temporary error page.
+ */
+const MIGRATION_IN_PROGRESS_HEAD = `<meta http-equiv="refresh" content="5" />
+${ERROR_DIALOG_STYLE}`;
+
+export const migrationInProgressPage = (): string =>
+  String(
+    <Layout headExtra={MIGRATION_IN_PROGRESS_HEAD} title="Update In Progress">
+      <h1>Update In Progress</h1>
+      <p>
+        We&rsquo;re backing up and updating the database. This usually only
+        takes a few seconds. This page will reload automatically&hellip;
+      </p>
+    </Layout>,
+  );
+
+/**
  * Shown on non-setup routes when the site's database has not been set up
  * yet. No auto-refresh: retrying cannot succeed until someone completes
  * /setup, so an endlessly reloading error page would just be confusing.

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -16,6 +16,7 @@ import {
   LATEST_UPDATE,
   MIGRATION_IDS,
   MIGRATION_LOCK_TTL_MS,
+  MigrationInProgressError,
   MissingSettingsTableError,
   resetDatabase,
   SCHEMA_HASH,
@@ -656,6 +657,8 @@ describeWithEnv("db > migrations", { db: true }, () => {
         await setLock(new Date());
         invalidateInitDbCache();
 
+        await expect(initDb()).rejects.toThrow(MigrationInProgressError);
+        invalidateInitDbCache();
         await expect(initDb()).rejects.toThrow("migration_lock held");
 
         const ntfyCall = fetchStub.calls.find(
@@ -781,10 +784,7 @@ describe("db > migrations > schema change guard", () => {
   // migrations are pending").
   test("SCHEMA_HASH changes only alongside a new named migration", () => {
     expect({ migrationIds: MIGRATION_IDS, schemaHash: SCHEMA_HASH }).toEqual({
-      migrationIds: [
-        "2026-06-11_current_schema",
-        "2026-06-12_sumup_checkouts",
-      ],
+      migrationIds: ["2026-06-11_current_schema", "2026-06-12_sumup_checkouts"],
       schemaHash: "1a1d7bq",
     });
   });

--- a/test/lib/server-misc-routing.test.ts
+++ b/test/lib/server-misc-routing.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { getCleanUrl, handleRequest, isValidContentType } from "#routes";
 import {
+  migrationInProgressResponse,
   redirect,
   redirectResponse,
   siteNotActivatedResponse,
@@ -703,6 +704,62 @@ describeWithEnv("server (misc: security and routing)", { db: true }, () => {
       expect(response.headers.get("content-type")).toBe(
         "text/html; charset=utf-8",
       );
+    });
+
+    test("migrationInProgressResponse returns 503 styled HTML with auto-refresh", async () => {
+      const response = migrationInProgressResponse();
+      const html = await expectHtmlResponse(
+        response,
+        503,
+        "Update In Progress",
+        "backing up and updating the database",
+        'http-equiv="refresh"',
+      );
+      expect(html).not.toContain("Temporary Error");
+      expect(response.headers.get("content-type")).toBe(
+        "text/html; charset=utf-8",
+      );
+    });
+
+    test("serves the migration-in-progress page while a migration holds the lock", async () => {
+      const { getDb: getDbFn } = await import("#shared/db/client.ts");
+      const { invalidateInitDbCache, SCHEMA_HASH } = await import(
+        "#shared/db/migrations.ts"
+      );
+      const db = getDbFn();
+      // Stale schema hash makes initDb see a pending migration; a fresh lock
+      // makes it believe another isolate is already running that migration.
+      const fetchStub = stub(globalThis, "fetch", () =>
+        Promise.resolve(new Response()),
+      );
+      try {
+        await db.execute(
+          "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
+        );
+        await db.execute({
+          args: ["migration_lock", new Date().toISOString()],
+          sql: "INSERT INTO settings (key, value) VALUES (?, ?)",
+        });
+        invalidateInitDbCache();
+
+        const response = await handleRequest(mockRequest("/"));
+
+        const html = await expectHtmlResponse(
+          response,
+          503,
+          "Update In Progress",
+          'http-equiv="refresh"',
+        );
+        expect(html).not.toContain("Temporary Error");
+      } finally {
+        fetchStub.restore();
+        await db.execute("DELETE FROM settings WHERE key = 'migration_lock'");
+        await db.execute({
+          args: [SCHEMA_HASH],
+          sql: "UPDATE settings SET value = ? WHERE key = 'db_schema_hash'",
+        });
+        invalidateInitDbCache();
+      }
     });
 
     test("rethrows unhandled errors in test mode", async () => {

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -9,6 +9,7 @@ import type { EventWithCount } from "#shared/types.ts";
 import {
   buildOgTags,
   buildTicketEvent,
+  migrationInProgressPage,
   notFoundPage,
   renderEventImage,
   siteNotActivatedPage,
@@ -363,6 +364,23 @@ describe("temporaryErrorPage", () => {
     expect(html).toContain('content="2"');
     expect(html).toContain("<style>");
     expect(html).toContain("font-family:system-ui");
+  });
+});
+
+describe("migrationInProgressPage", () => {
+  test("renders update message with auto-refresh", () => {
+    const html = migrationInProgressPage();
+    expect(html).toContain("<h1>Update In Progress</h1>");
+    expect(html).toContain("backing up and updating the database");
+    expect(html).toContain('http-equiv="refresh"');
+    expect(html).toContain('content="5"');
+    expect(html).toContain("<style>");
+    expect(html).toContain("font-family:system-ui");
+  });
+
+  test("does not present itself as an error", () => {
+    const html = migrationInProgressPage();
+    expect(html).not.toContain("Error");
   });
 });
 


### PR DESCRIPTION
## Problem

When a request triggers a database migration whose lock is already held by another isolate (which happens while the pre-migration backup and migration run), the user saw the generic auto-refreshing **"Temporary Error"** page. That gives no insight that a backup/migration is underway — it just looks like something broke.

## Change

- Introduce a dedicated `MigrationInProgressError`, thrown from `initDbUncached` when the migration lock can't be acquired (replacing the generic `Error`).
- `initializeDatabaseForPath` catches it and returns a new `migrationInProgressResponse()`.
- New `migrationInProgressPage()` renders a reassuring **"Update In Progress"** page: _"We're backing up and updating the database. This usually only takes a few seconds. This page will reload automatically…"_
- It auto-refreshes every 5s (slightly slower than the temporary error page's 2s, since the backup can take a few seconds), so the request retries once the migration finishes.

The error message string is unchanged, so existing behaviour (ntfy notification, lock TTL self-healing, `rejects.toThrow("migration_lock held")`) is preserved.

## Tests

- `migrationInProgressPage` template test (message, auto-refresh, styling, not presented as an error).
- `migrationInProgressResponse` returns 503 with the styled auto-refresh HTML.
- Request-level integration test: a held migration lock + stale schema hash now serves the "Update In Progress" page rather than "Temporary Error".
- Asserted the lock-held path throws `MigrationInProgressError`.

Lint, typecheck, and the affected test files all pass.

https://claude.ai/code/session_01RCkeC2MtJAwFig69ZSBrJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkeC2MtJAwFig69ZSBrJ5)_