### PR TITLE
Hide Booking Duration field for standard events

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1129,7 +1129,9 @@ form:has(select[name="event_type"] option[value="standard"]:checked)
 form:has(select[name="event_type"] option[value="standard"]:checked)
   > label:has([name="minimum_days_before"]),
 form:has(select[name="event_type"] option[value="standard"]:checked)
-  > label:has([name="maximum_days_after"]) {
+  > label:has([name="maximum_days_after"]),
+form:has(select[name="event_type"] option[value="standard"]:checked)
+  > label:has([name="duration_days"]) {
   display: none;
 }
 


### PR DESCRIPTION
## Problem

The **Booking Duration (days)** field's hint says "Only applies to daily events", but the field was still visible when editing a standard event.

## Cause

Daily-only fields are hidden for standard events via a CSS `:has()` rule in `src/ui/static/mvp.css`. The rule covered `bookable_days`, `minimum_days_before`, and `maximum_days_after`, but `duration_days` was never added to it.

## Fix

Add `duration_days` to the existing selector so it's hidden alongside the other daily-only fields when `event_type` is `standard`.

https://claude.ai/code/session_01KtHhvuJ2TM4ottB2tw7vH5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtHhvuJ2TM4ottB2tw7vH5)_