### PR TITLE
Keep scanner check-ins working past the 1-hour CSRF window

### DIFF
--- a/src/features/admin/scanner.ts
+++ b/src/features/admin/scanner.ts
@@ -8,9 +8,9 @@ import { filter, map, pipe } from "#fp";
 import { requirePrivateKey } from "#routes/admin/actions.ts";
 import { withEntityLoader } from "#routes/admin/entity-handlers.ts";
 import {
-  AUTH_JSON,
   getPrivateKey,
   requireSessionOr,
+  SCANNER_JSON,
   withAuth,
 } from "#routes/auth.ts";
 import type { IdRouteHandler } from "#routes/entity.ts";
@@ -144,7 +144,7 @@ const performCheckIn = async (
  * accidental check-outs from double-scans during rapid door check-in.
  */
 const handleScanPost: IdRouteHandler = (request, { id }) =>
-  withAuth(request, AUTH_JSON, async (session, body) => {
+  withAuth(request, SCANNER_JSON, async (session, body) => {
     if (typeof body.token !== "string") {
       return jsonResponse({ message: "Missing token", status: "error" }, 400);
     }

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -21,6 +21,7 @@ import { deleteSession, getSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
 import { decryptAdminLevel, getUserById } from "#shared/db/users.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { SCANNER_CSRF_MAX_AGE_S } from "#shared/limits.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
 import { nowMs } from "#shared/now.ts";
 import { getCachedSession, setCachedSession } from "#shared/session-context.ts";
@@ -218,6 +219,8 @@ export type AuthPolicy<T extends BodyMode = BodyMode> = {
   body: T;
   role?: AdminLevel;
   allowApiKey?: boolean;
+  /** Override the CSRF token max-age (seconds). Defaults to the standard 1 hour. */
+  csrfMaxAge?: number;
 };
 
 /** Auth policy presets — use with withAuth to avoid repeating policy objects */
@@ -228,10 +231,18 @@ export const OWNER_MULTIPART: AuthPolicy<"multipart"> = {
   body: "multipart",
   role: "owner",
 };
-export const AUTH_JSON: AuthPolicy<"json"> = { body: "json" };
 export const ADMIN_API: AuthPolicy<"json"> = {
   allowApiKey: true,
   body: "json",
+};
+/**
+ * Scanner check-in API: cookie-authenticated JSON with a CSRF max-age matching
+ * the session lifetime, so a logged-in admin can keep the scanner page open for
+ * a whole event without check-ins failing on CSRF expiry.
+ */
+export const SCANNER_JSON: AuthPolicy<"json"> = {
+  body: "json",
+  csrfMaxAge: SCANNER_CSRF_MAX_AGE_S,
 };
 
 /**
@@ -389,8 +400,9 @@ const parseJsonBody = async (
 const verifyCsrf = async (
   token: string,
   channel: AuthChannel,
+  maxAge?: number,
 ): Promise<Response | null> => {
-  if (await verifySignedCsrfToken(token)) return null;
+  if (await verifySignedCsrfToken(token, maxAge)) return null;
   if (channel === "json") {
     logError({ code: ErrorCode.AUTH_CSRF_MISMATCH, detail: "JSON API" });
   }
@@ -400,11 +412,13 @@ const verifyCsrf = async (
 /** Validate CSRF and parse body for the given mode.
  *
  * `skipCsrf` only applies to JSON bodies (used for API key auth). Form and
- * multipart bodies are always CSRF-checked because API key clients use JSON. */
+ * multipart bodies are always CSRF-checked because API key clients use JSON.
+ * `maxAge` overrides the CSRF token expiry window (seconds). */
 const parseCsrfBody = async (
   request: Request,
   mode: BodyMode,
   skipCsrf: boolean,
+  maxAge?: number,
 ): Promise<FormParams | FormData | Record<string, unknown> | Response> => {
   const channel = channelFor(mode);
   if (mode === "json") {
@@ -412,6 +426,7 @@ const parseCsrfBody = async (
       const err = await verifyCsrf(
         request.headers.get("x-csrf-token") ?? "",
         channel,
+        maxAge,
       );
       if (err) return err;
     }
@@ -419,13 +434,14 @@ const parseCsrfBody = async (
   }
   if (mode === "form") {
     const form = await parseFormData(request);
-    const err = await verifyCsrf(form.getString("csrf_token"), channel);
+    const err = await verifyCsrf(form.getString("csrf_token"), channel, maxAge);
     return err ?? form;
   }
   const fd = await request.formData();
   const err = await verifyCsrf(
     String(fd.get("csrf_token") ?? "").trim(),
     channel,
+    maxAge,
   );
   return err ?? fd;
 };
@@ -470,6 +486,7 @@ export async function withAuth<T extends BodyMode>(
     request,
     policy.body,
     auth.authKind === "apiKey",
+    policy.csrfMaxAge,
   );
   if (isResponse(body)) return body;
   return handler(auth.session, body as ParsedBody<T>, auth.authKind);

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -60,6 +60,18 @@ export const ATTACHMENT_URL_MAX_AGE_S = readLimit(
 /** Admin session cookie max-age in seconds (default: 86400 = 24 hours) */
 export const SESSION_MAX_AGE_S = readLimit("SESSION_MAX_AGE_S", 60 * 60 * 24);
 
+/**
+ * CSRF token validity for the scanner check-in API in seconds.
+ * Defaults to the session lifetime: admins keep the scanner page open for a
+ * whole event, so the embedded CSRF token should stay valid for as long as the
+ * session that authenticates them — otherwise check-ins fail on CSRF expiry
+ * while the admin is still logged in.
+ */
+export const SCANNER_CSRF_MAX_AGE_S = readLimit(
+  "SCANNER_CSRF_MAX_AGE_S",
+  SESSION_MAX_AGE_S,
+);
+
 /** Threshold for abandoned payment reservations in ms (default: 300000 = 5 min) */
 export const STALE_RESERVATION_MS = readLimit(
   "STALE_RESERVATION_MS",
@@ -250,6 +262,13 @@ export const LIMIT_ENTRIES: readonly LimitEntry[] = [
     defaultValue: 60 * 60 * 24,
     envKey: "SESSION_MAX_AGE_S",
     label: "Session max age",
+    unit: "seconds",
+  },
+  {
+    current: SCANNER_CSRF_MAX_AGE_S,
+    defaultValue: SESSION_MAX_AGE_S,
+    envKey: "SCANNER_CSRF_MAX_AGE_S",
+    label: "Scanner CSRF max age",
     unit: "seconds",
   },
   {

--- a/test/lib/limits.test.ts
+++ b/test/lib/limits.test.ts
@@ -20,6 +20,7 @@ import {
   PRUNE_SUMUP_RETENTION_HOURS,
   parsePositiveInt,
   readLimit,
+  SCANNER_CSRF_MAX_AGE_S,
   SESSION_MAX_AGE_S,
   STALE_RESERVATION_MS,
 } from "#shared/limits.ts";
@@ -95,6 +96,7 @@ describe("limits", () => {
         "MAX_ATTACHMENT_SIZE",
         "ATTACHMENT_URL_MAX_AGE_S",
         "SESSION_MAX_AGE_S",
+        "SCANNER_CSRF_MAX_AGE_S",
         "STALE_RESERVATION_MS",
         "MAX_LOGIN_ATTEMPTS",
         "LOGIN_LOCKOUT_MS",
@@ -123,6 +125,9 @@ describe("limits", () => {
         ATTACHMENT_URL_MAX_AGE_S,
       );
       expect(currentByKey.get("SESSION_MAX_AGE_S")).toBe(SESSION_MAX_AGE_S);
+      expect(currentByKey.get("SCANNER_CSRF_MAX_AGE_S")).toBe(
+        SCANNER_CSRF_MAX_AGE_S,
+      );
       expect(currentByKey.get("STALE_RESERVATION_MS")).toBe(
         STALE_RESERVATION_MS,
       );
@@ -155,6 +160,15 @@ describe("limits", () => {
         // Must end with a recognisable unit suffix — never just a bare number.
         expect(rendered).toMatch(/[A-Za-z]/);
       }
+    });
+  });
+
+  describe("SCANNER_CSRF_MAX_AGE_S", () => {
+    test("defaults to the session lifetime", () => {
+      // The scanner page stays open for a whole event, so its CSRF token must
+      // outlive the 1-hour default and remain valid for as long as the session
+      // that authenticates the admin.
+      expect(SCANNER_CSRF_MAX_AGE_S).toBe(SESSION_MAX_AGE_S);
     });
   });
 

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -6,8 +6,11 @@
 
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import { handleRequest } from "#routes";
 import { isJsonApiPath } from "#routes/middleware.ts";
+import { signCsrfToken, verifySignedCsrfToken } from "#shared/csrf.ts";
+import { SCANNER_CSRF_MAX_AGE_S } from "#shared/limits.ts";
 import {
   adminGet,
   assertJson,
@@ -475,6 +478,38 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       );
 
       expect(response.status).toBe(403);
+    });
+
+    test("accepts a CSRF token older than the 1-hour default", async () => {
+      // Admins keep the scanner page open for a whole event, so its CSRF token
+      // is given an extended window. A token well past the standard 1-hour
+      // expiry should still check attendees in.
+      const { event, token, session } = await setupScanTest(
+        "Aged",
+        "aged@test.com",
+      );
+      const time = new FakeTime();
+      try {
+        const agedToken = await signCsrfToken();
+        // Jump halfway into the scanner window — comfortably past the 1-hour
+        // default that every other endpoint enforces.
+        time.tick(Math.floor(SCANNER_CSRF_MAX_AGE_S / 2) * 1000);
+
+        // The standard CSRF window would already reject this token...
+        expect(await verifySignedCsrfToken(agedToken)).toBe(false);
+
+        // ...but the scanner endpoint still accepts it.
+        const result = await scanAndGetJson(
+          event.id,
+          { token },
+          session.cookie,
+          agedToken,
+        );
+        expect(result.status).toBe("checked_in");
+        expect(result.name).toBe("Aged");
+      } finally {
+        time.restore();
+      }
     });
 
     test("returns 400 for missing token in body", async () => {


### PR DESCRIPTION
## Problem

The scanner page (`/admin/event/:id/scan`) embeds a CSRF token at page load and reuses it for every check-in (camera scans and manual check-ins both POST it via the `x-csrf-token` header). Admins keep this page open for the whole length of an event, but CSRF tokens expire after the standard **1 hour** (`DEFAULT_MAX_AGE_S`). Once the page sat open past that, check-ins failed with `E_AUTH_CSRF_MISMATCH` — even though the admin's session is valid for **24 hours**.

## Fix

Make the CSRF expiry window configurable per auth policy, and give the scanner endpoint a window that matches the session lifetime — so check-ins keep working for as long as the logged-in session that authenticates the admin is valid.

- `AuthPolicy` gains an optional `csrfMaxAge` (seconds), threaded through `withAuth` → `parseCsrfBody` → `verifyCsrf` → `verifySignedCsrfToken`. Existing policies are unchanged and keep the 1-hour default.
- New `SCANNER_JSON` preset with `csrfMaxAge: SCANNER_CSRF_MAX_AGE_S`. The scan endpoint switches from `AUTH_JSON` to `SCANNER_JSON` (`AUTH_JSON` had no other users, so it was removed).
- New tunable `SCANNER_CSRF_MAX_AGE_S` in `limits.ts`, defaulting to `SESSION_MAX_AGE_S` (24h) and overridable via env var like the other limits. It also appears on the limits/debug page.

The change is scoped to the scanner — every other CSRF-protected endpoint keeps the standard 1-hour window.

## Notes

This is a deliberate, narrow relaxation: the session cookie still fully authenticates the request, the endpoint is one-way (check-in only), and the JSON API requires a custom header that browsers won't attach cross-origin. Extending the CSRF window for this one long-lived page doesn't change those protections.

## Tests

- `server-scanner.test.ts`: a CSRF token aged well past the 1-hour default (via `FakeTime`) is rejected by the standard window but still accepted by the scan endpoint and checks the attendee in.
- `limits.test.ts`: the new constant is registered in `LIMIT_ENTRIES` and defaults to the session lifetime.
- Typecheck, lint, code-quality (unused-export) and the affected test files all pass.

https://claude.ai/code/session_014aTsLYYsgGaSndkpRjhQKV

---
_Generated by [Claude Code](https://claude.ai/code/session_014aTsLYYsgGaSndkpRjhQKV)_