### PR TITLE
test: cover intra-cart group caps and all-or-nothing cart rollback

### DIFF
--- a/test/lib/db/attendees/create-attendee-atomic.test.ts
+++ b/test/lib/db/attendees/create-attendee-atomic.test.ts
@@ -11,6 +11,7 @@ import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
 import {
   createDailyTestEvent,
   createTestEvent,
+  createTestGroup,
   describeWithEnv,
   getTestPrivateKey,
 } from "#test-utils";
@@ -299,6 +300,134 @@ describeWithEnv("db > attendees > createAttendeeAtomic", { db: true }, () => {
       name: "Ok",
     });
     expect(ok.success).toBe(true);
+  });
+
+  test("intra-cart group cap: a sibling insert earlier in the same batch counts (no oversell)", async () => {
+    // Two events share a group capped at 3. A single cart asks for 2 + 2 = 4.
+    // The second INSERT's capacity check must see the first INSERT from the
+    // same atomic batch, so it is refused — booking the first line (2) and
+    // declining the second rather than overselling the group to 4. The
+    // all-or-nothing policy lives one layer up (ensureAllBookings); this layer
+    // fulfils greedily but must never exceed the cap.
+    const group = await createTestGroup({
+      maxAttendees: 3,
+      name: "cart-accum",
+      slug: "cart-accum",
+    });
+    const e1 = await createTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-accum-a",
+    });
+    const e2 = await createTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-accum-b",
+    });
+    const result = await createAttendeeAtomic({
+      bookings: [
+        { eventId: e1.id, quantity: 2 },
+        { eventId: e2.id, quantity: 2 },
+      ],
+      email: "cart@example.com",
+      name: "Cart",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.attendees.length).toBe(1);
+    expect((await getAttendeesRaw(e1.id))[0]!.quantity).toBe(2);
+    expect((await getAttendeesRaw(e2.id)).length).toBe(0);
+  });
+
+  test("intra-cart group cap: a cart that exactly fills the group across events succeeds", async () => {
+    const group = await createTestGroup({
+      maxAttendees: 3,
+      name: "cart-fill",
+      slug: "cart-fill",
+    });
+    const e1 = await createTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-fill-a",
+    });
+    const e2 = await createTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-fill-b",
+    });
+    const result = await createAttendeeAtomic({
+      bookings: [
+        { eventId: e1.id, quantity: 1 },
+        { eventId: e2.id, quantity: 2 },
+      ],
+      email: "fill@example.com",
+      name: "Fill",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.attendees.length).toBe(2);
+    expect((await getAttendeesRaw(e1.id))[0]!.quantity).toBe(1);
+    expect((await getAttendeesRaw(e2.id))[0]!.quantity).toBe(2);
+  });
+
+  test("intra-cart group cap is per-date for daily events booked on the same day", async () => {
+    const group = await createTestGroup({
+      maxAttendees: 3,
+      name: "cart-daily",
+      slug: "cart-daily",
+    });
+    const e1 = await createDailyTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-daily-a",
+    });
+    const e2 = await createDailyTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-daily-b",
+    });
+    const result = await createAttendeeAtomic({
+      bookings: [
+        { date: "2026-05-01", eventId: e1.id, quantity: 2 },
+        { date: "2026-05-01", eventId: e2.id, quantity: 2 },
+      ],
+      email: "daily-cart@example.com",
+      name: "DailyCart",
+    });
+    // 2 + 2 = 4 on the same date > cap 3: first fits, second refused.
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.attendees.length).toBe(1);
+    expect((await getAttendeesRaw(e1.id)).length).toBe(1);
+    expect((await getAttendeesRaw(e2.id)).length).toBe(0);
+  });
+
+  test("intra-cart daily group cap is independent across different dates", async () => {
+    const group = await createTestGroup({
+      maxAttendees: 3,
+      name: "cart-daily-dates",
+      slug: "cart-daily-dates",
+    });
+    const e1 = await createDailyTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-dates-a",
+    });
+    const e2 = await createDailyTestEvent({
+      groupId: group.id,
+      maxAttendees: 10,
+      name: "cart-dates-b",
+    });
+    // Each day independently holds 3; both lines sit exactly at the per-day cap.
+    const result = await createAttendeeAtomic({
+      bookings: [
+        { date: "2026-05-01", eventId: e1.id, quantity: 3 },
+        { date: "2026-05-02", eventId: e2.id, quantity: 3 },
+      ],
+      email: "spread@example.com",
+      name: "Spread",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.attendees.length).toBe(2);
+    expect((await getAttendeesRaw(e1.id))[0]!.quantity).toBe(3);
+    expect((await getAttendeesRaw(e2.id))[0]!.quantity).toBe(3);
   });
 
   test("dateToRange produces half-open [start, end) with 1-day default", () => {

--- a/test/routes/public/ticket-payment.test.ts
+++ b/test/routes/public/ticket-payment.test.ts
@@ -1,0 +1,170 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  ensureAllBookings,
+  processFreeReservation,
+} from "#routes/public/ticket-payment.ts";
+import { createAttendeeAtomic, getAttendeesRaw } from "#shared/db/attendees.ts";
+import { getEventWithCount } from "#shared/db/events.ts";
+import type { ContactInfo, EventWithCount } from "#shared/types.ts";
+import { buildTicketEvent, type TicketEvent } from "#templates/public.tsx";
+import { createTestEvent, createTestGroup, describeWithEnv } from "#test-utils";
+
+const contact: ContactInfo = {
+  address: "",
+  email: "buyer@example.com",
+  name: "Buyer",
+  phone: "",
+  special_instructions: "",
+};
+
+/** Fetch an event with its live attendee count and wrap it as a TicketEvent. */
+const ticketEventFor = async (eventId: number): Promise<TicketEvent> => {
+  const event = (await getEventWithCount(eventId)) as EventWithCount;
+  return buildTicketEvent(event, false, undefined);
+};
+
+describeWithEnv("routes > public > ticket-payment", { db: true }, () => {
+  describe("ensureAllBookings", () => {
+    test("ok when every booking in the cart succeeded", async () => {
+      const e1 = await createTestEvent({ maxAttendees: 10, name: "ok-a" });
+      const e2 = await createTestEvent({ maxAttendees: 10, name: "ok-b" });
+      const result = await createAttendeeAtomic({
+        bookings: [
+          { eventId: e1.id, quantity: 1 },
+          { eventId: e2.id, quantity: 1 },
+        ],
+        email: contact.email,
+        name: contact.name,
+      });
+      const check = await ensureAllBookings(result, 2);
+      expect(check.ok).toBe(true);
+      expect((await getAttendeesRaw(e1.id)).length).toBe(1);
+      expect((await getAttendeesRaw(e2.id)).length).toBe(1);
+    });
+
+    test("rolls back a partially-fulfilled cart and reports capacity_exceeded", async () => {
+      // Group cap 3 forces the second line to fail; createAttendeeAtomic books
+      // the first greedily, leaving a partial attendee. ensureAllBookings must
+      // delete it so the customer is never left with half a cart.
+      const group = await createTestGroup({
+        maxAttendees: 3,
+        name: "rollback",
+        slug: "rollback",
+      });
+      const e1 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "rollback-a",
+      });
+      const e2 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "rollback-b",
+      });
+      const result = await createAttendeeAtomic({
+        bookings: [
+          { eventId: e1.id, quantity: 2 },
+          { eventId: e2.id, quantity: 2 },
+        ],
+        email: contact.email,
+        name: contact.name,
+      });
+      // Sanity: the atomic layer fulfilled only the first line.
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.attendees.length).toBe(1);
+
+      const check = await ensureAllBookings(result, 2);
+      expect(check.ok).toBe(false);
+      if (!check.ok) expect(check.reason).toBe("capacity_exceeded");
+      // Full rollback: even the first line's row is gone.
+      expect((await getAttendeesRaw(e1.id)).length).toBe(0);
+      expect((await getAttendeesRaw(e2.id)).length).toBe(0);
+    });
+
+    test("propagates the failure reason when the whole cart failed", async () => {
+      const failure = {
+        reason: "encryption_error" as const,
+        success: false as const,
+      };
+      const check = await ensureAllBookings(failure, 1);
+      expect(check).toEqual({ ok: false, reason: "encryption_error" });
+    });
+  });
+
+  describe("processFreeReservation (all-or-nothing)", () => {
+    test("rejects the whole cart and persists nothing when a group cap is partially exceeded", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 3,
+        name: "free-rollback",
+        slug: "free-rollback",
+      });
+      const e1 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "free-a",
+      });
+      const e2 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "free-b",
+      });
+      const ticketEvents = [
+        await ticketEventFor(e1.id),
+        await ticketEventFor(e2.id),
+      ];
+      const quantities = new Map([
+        [e1.id, 2],
+        [e2.id, 2],
+      ]);
+      const result = await processFreeReservation(
+        ticketEvents,
+        quantities,
+        contact,
+        null,
+      );
+      expect(result.success).toBe(false);
+      // Nothing persists for either event — the partial booking is rolled back.
+      expect((await getAttendeesRaw(e1.id)).length).toBe(0);
+      expect((await getAttendeesRaw(e2.id)).length).toBe(0);
+    });
+
+    test("books the whole cart when the combined order fits the group cap", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 3,
+        name: "free-ok",
+        slug: "free-ok",
+      });
+      const e1 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "free-ok-a",
+      });
+      const e2 = await createTestEvent({
+        groupId: group.id,
+        maxAttendees: 10,
+        maxQuantity: 10,
+        name: "free-ok-b",
+      });
+      const ticketEvents = [
+        await ticketEventFor(e1.id),
+        await ticketEventFor(e2.id),
+      ];
+      const result = await processFreeReservation(
+        ticketEvents,
+        new Map([
+          [e1.id, 1],
+          [e2.id, 2],
+        ]),
+        contact,
+        null,
+      );
+      expect(result.success).toBe(true);
+      expect((await getAttendeesRaw(e1.id))[0]!.quantity).toBe(1);
+      expect((await getAttendeesRaw(e2.id))[0]!.quantity).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Following a review of how tickets, groups and availability interact, the existing suite turned out to be strong at most layers (per-date daily caps, multi-day ranges, self-exclusion on edits, concurrent inserts, group-cap-across-events, the display clamp, and the single-type group invariant across create/edit/assign routes). Two seams were genuinely under-covered, both around what happens when a **single cart** touches a shared group cap.

## What changed

**Intra-cart group-cap accumulation** (`create-attendee-atomic.test.ts`)
`createAttendeeAtomic` runs each booking as a separate capacity-guarded INSERT inside one atomic batch. A booking earlier in the batch must count toward the group cap for later bookings, otherwise a single cart could oversell a shared group. New tests lock this down:
- a cart of `2 + 2` against a group cap of `3` books only the first line (no oversell to 4);
- a cart that exactly fills the group across two events succeeds;
- the same accumulation is per-date for daily events on the same day;
- per-day independence holds for daily bookings on different dates within one cart.

**All-or-nothing layering** (`routes/public/ticket-payment.test.ts`)
The greedy/atomic primitive and the all-or-nothing policy live at different levels — easy to conflate, previously untested:
- `createAttendeeAtomic` fulfils greedily (its cleanup only drops an attendee that ended up with *zero* links);
- `ensureAllBookings` rolls a partially-fulfilled cart fully back and reports `capacity_exceeded`, and propagates the underlying reason when the whole cart failed;
- `processFreeReservation` therefore persists **nothing** for either event when a group cap is partially exceeded, and books the whole cart when it fits.

## Notes

No production code changed — these tests document and pin existing behaviour. They also confirmed the design decision (raised and approved) that carts are **all-or-nothing** when a cap is partially exceeded, and that group availability is always coherent because the app forbids mixed daily/standard groups.

All new tests pass; `deno fmt`, `deno lint`, and `deno check` are clean on the changed files.

https://claude.ai/code/session_01CS8qWoZZ1W8TWDjmsr7fdb

---
_Generated by [Claude Code](https://claude.ai/code/session_01CS8qWoZZ1W8TWDjmsr7fdb)_