### PR TITLE
Dedupe authed-route factories and drop their jscpd:ignore blocks

### DIFF
--- a/src/features/admin/confirmation.ts
+++ b/src/features/admin/confirmation.ts
@@ -109,11 +109,9 @@ type VerifiedFormRouteConfig<TParams, TContext> = AuthedBase<
 export const createVerifiedFormRoute = <TParams, TContext>(
   config: VerifiedFormRouteConfig<TParams, TContext>,
 ) =>
-  /* jscpd:ignore-start */
   createAuthedHandler<TParams, TContext>({
-    auth: config.auth,
+    ...config,
     handle: async (args) => {
-      /* jscpd:ignore-end */
       const expected = await config.identifier(args.context, args.params);
       const error = verifyOrRedirect(
         args.form,
@@ -125,7 +123,6 @@ export const createVerifiedFormRoute = <TParams, TContext>(
       if (error) return error;
       return config.onConfirm(args);
     },
-    loadContext: config.loadContext,
   });
 
 /** Auth option: string shorthand or explicit guard pair */

--- a/src/shared/app-forms.ts
+++ b/src/shared/app-forms.ts
@@ -112,11 +112,9 @@ export const createAuthedFormRoute = <
 >(
   config: FormRouteConfig<TValues, TParams, TContext>,
 ) =>
-  /* jscpd:ignore-start */
   createAuthedHandler<TParams, TContext>({
-    auth: config.auth,
+    ...config,
     handle: ({ context, form, params, session }) => {
-      /* jscpd:ignore-end */
       config.preprocessForm?.(form, context);
       const validator =
         typeof config.form === "function" ? config.form(context) : config.form;
@@ -137,7 +135,6 @@ export const createAuthedFormRoute = <
             session,
           });
     },
-    loadContext: config.loadContext,
   });
 
 // ── createFormRoute: public CSRF-only (no auth) ───────────────────────


### PR DESCRIPTION
## What

`createAuthedFormRoute` (`src/shared/app-forms.ts`) and `createVerifiedFormRoute` (`src/features/admin/confirmation.ts`) both forwarded `auth` and `loadContext` into `createAuthedHandler` field-by-field:

```ts
createAuthedHandler<TParams, TContext>({
  auth: config.auth,
  handle: (...) => { ... },
  loadContext: config.loadContext,
});
```

That block was identical in both factories, so it had to be wrapped in `/* jscpd:ignore-start */` … `/* jscpd:ignore-end */` markers to keep the 0%-duplication `cpd` check green.

Both configs extend `AuthedBase` (which *is* `{ auth?, loadContext? }`), so the passthrough can just be a spread:

```ts
createAuthedHandler<TParams, TContext>({
  ...config,
  handle: (...) => { ... },
});
```

## Why this matches the brief

- **Enforces the de-dup standard by refactoring, not exclusions** — removes three `jscpd:ignore` suppressions rather than adding any.
- **Removes indirection** — the ignore comments were pure noise; nothing was added in their place (no new helper/wrapper).
- **Fewer lines** — net −6 (2 insertions, 8 deletions).
- **Simpler** — one spread reads more obviously "forward the config through" than two hand-copied fields, and it can't drift out of sync.

## Behaviour

Identical. `createAuthedHandler` only reads `auth`, `loadContext`, and `handle`; the extra config fields carried by the spread are ignored at runtime, and `handle` is still set explicitly after the spread.

## Checks

- `typecheck`, `deno lint`, `biome check` — clean
- `deno task cpd` — 0 clones (the markers are no longer needed)
- Tests through both factories pass: `test/templates/admin/questions.test.ts`, `test/lib/server-users-manage.test.ts`, `test/lib/server-misc-admin-handlers.test.ts`, `test/bulk-actions/` (incl. confirmation-mismatch paths)

https://claude.ai/code/session_01YE2g6JDYcvhntbvFNVSMtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YE2g6JDYcvhntbvFNVSMtr)_