### PR TITLE
Streamline admin questions management

### DIFF
--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -21,7 +21,7 @@ import {
   createAuthedHandler,
 } from "#shared/app-forms.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
-import { getEventWithCount } from "#shared/db/events.ts";
+import { getAllEvents, getEventWithCount } from "#shared/db/events.ts";
 import {
   type Answer,
   answersTable,
@@ -31,10 +31,12 @@ import {
   getAnswerCountsForQuestion,
   getEventQuestionIds,
   getNextAnswerSortOrder,
+  getQuestionEventIds,
   getQuestionWithAnswers,
   type QuestionWithAnswers,
   questionsTable,
   setEventQuestions,
+  setQuestionEvents,
   swapAnswerOrder,
 } from "#shared/db/questions.ts";
 import { getFlash } from "#shared/flash-context.ts";
@@ -92,9 +94,13 @@ const handleQuestionsPost = createAuthedFormRoute({
   form: questionTextForm,
   onInvalid: ({ error }) => errorRedirect("/admin/questions", error),
   onValid: async ({ values: { text } }) => {
-    await questionsTable.insert({ text });
+    const question = await questionsTable.insert({ text });
     await logActivity(`Question '${text}' created`);
-    return redirect("/admin/questions", "Question created", true);
+    return redirect(
+      `/admin/questions/${question.id}`,
+      "Question created",
+      true,
+    );
   },
 });
 
@@ -103,9 +109,20 @@ const handleQuestionGet = ownerGetById(
   getQuestionWithAnswers,
   async (q, session) => {
     const flash = getFlash();
-    const answerCounts = await getAnswerCountsForQuestion(q.id);
+    const [answerCounts, allEvents, assignedEventIds] = await Promise.all([
+      getAnswerCountsForQuestion(q.id),
+      getAllEvents(),
+      getQuestionEventIds(q.id),
+    ]);
     return htmlResponse(
-      adminQuestionPage(q, session, flash.error, answerCounts),
+      adminQuestionPage(
+        q,
+        session,
+        flash.error,
+        answerCounts,
+        allEvents,
+        new Set(assignedEventIds),
+      ),
     );
   },
 );
@@ -131,6 +148,23 @@ const handleQuestionEdit = createAuthedFormRoute<
     await logActivity(`Question '${text}' updated`);
     return redirect(`/admin/questions/${params.id}`, "Question updated", true);
   },
+});
+
+/** Handle POST /admin/questions/:id/events (assign question to events) */
+const handleQuestionEvents = ownerFormById(async (id, _session, form) => {
+  const question = await getQuestionWithAnswers(id);
+  if (!question) return notFoundResponse();
+  const eventIds = form
+    .getAll("event_ids")
+    .map((v) => Number.parseInt(v, 10))
+    .filter((n) => !Number.isNaN(n));
+  await setQuestionEvents(id, eventIds);
+  await logActivity(
+    `Question '${question.text}' assigned to ${eventIds.length} event${
+      eventIds.length !== 1 ? "s" : ""
+    }`,
+  );
+  return redirect(`/admin/questions/${id}`, "Events updated", true);
 });
 
 /** Handle POST /admin/questions/:id/answers (add answer) */
@@ -298,6 +332,7 @@ export const questionsRoutes = {
     "POST /admin/event/:id/questions": handleEventQuestionsPost,
     "POST /admin/questions": handleQuestionsPost,
     "POST /admin/questions/:id/answers": handleAddAnswer,
+    "POST /admin/questions/:id/events": handleQuestionEvents,
     "POST /admin/questions/:id/answers/:answerId/delete":
       handleDeleteAnswerPost,
     "POST /admin/questions/:id/answers/:answerId/move-down":

--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -154,10 +154,7 @@ const handleQuestionEdit = createAuthedFormRoute<
 const handleQuestionEvents = ownerFormById(async (id, _session, form) => {
   const question = await getQuestionWithAnswers(id);
   if (!question) return notFoundResponse();
-  const eventIds = form
-    .getAll("event_ids")
-    .map((v) => Number.parseInt(v, 10))
-    .filter((n) => !Number.isNaN(n));
+  const eventIds = form.getNumberArray("event_ids");
   await setQuestionEvents(id, eventIds);
   await logActivity(
     `Question '${question.text}' assigned to ${eventIds.length} event${
@@ -307,10 +304,7 @@ const handleEventQuestionsGet = ownerGetById(
 const handleEventQuestionsPost = ownerFormById(async (id, _session, form) => {
   const event = await getEventWithCount(id);
   if (!event) return notFoundResponse();
-  const questionIds = form
-    .getAll("question_ids")
-    .map((v) => Number.parseInt(v, 10))
-    .filter((n) => !Number.isNaN(n));
+  const questionIds = form.getNumberArray("question_ids");
   await setEventQuestions(id, questionIds);
   await logActivity(
     `Questions updated for '${event.name}' (${questionIds.length} question${

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -228,6 +228,43 @@ export const getEventQuestionIds = async (eventId: number): Promise<number[]> =>
     ),
   );
 
+/** Get the IDs of the events a question is assigned to */
+export const getQuestionEventIds = async (
+  questionId: number,
+): Promise<number[]> =>
+  map((r: { event_id: number }) => r.event_id)(
+    await queryAll<{ event_id: number }>(
+      "SELECT event_id FROM event_questions WHERE question_id = ? ORDER BY event_id",
+      [questionId],
+    ),
+  );
+
+/** Set which events a question is assigned to.
+ * Adds the question to newly-checked events (appended after each event's
+ * existing questions) and removes it from unchecked ones, leaving the
+ * ordering of the other questions on each event untouched. */
+export const setQuestionEvents = async (
+  questionId: number,
+  eventIds: number[],
+): Promise<void> => {
+  const current = new Set(await getQuestionEventIds(questionId));
+  const target = new Set(eventIds);
+  const toRemove = [...current].filter((id) => !target.has(id));
+  const toAdd = eventIds.filter((id) => !current.has(id));
+  const statements = [
+    ...toRemove.map((eventId) => ({
+      args: [eventId, questionId],
+      sql: "DELETE FROM event_questions WHERE event_id = ? AND question_id = ?",
+    })),
+    ...toAdd.map((eventId) => ({
+      args: [eventId, questionId, eventId],
+      sql: `INSERT INTO event_questions (event_id, question_id, sort_order)
+            VALUES (?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM event_questions WHERE event_id = ?), 0))`,
+    })),
+  ];
+  if (statements.length > 0) await executeBatch(statements);
+};
+
 /** Map from question ID to the set of event IDs that use it */
 export type QuestionEventMap = Map<number, number[]>;
 

--- a/src/shared/form-data.ts
+++ b/src/shared/form-data.ts
@@ -9,4 +9,12 @@ export class FormParams extends URLSearchParams {
   getString(key: string): string {
     return this.get(key)?.trim() ?? "";
   }
+
+  /** All values for a repeated field parsed as integers, dropping non-numbers.
+   * Useful for checkbox lists that submit multiple values under one name. */
+  getNumberArray(key: string): number[] {
+    return this.getAll(key)
+      .map((v) => Number.parseInt(v, 10))
+      .filter((n) => !Number.isNaN(n));
+  }
 }

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -58,6 +58,8 @@ export const adminQuestionPage = (
   session: AdminSession,
   error?: string,
   answerCounts?: Map<number, number>,
+  allEvents: EventWithCount[] = [],
+  assignedEventIds: Set<number> = new Set(),
 ): string =>
   String(
     <Layout title={`Question: ${question.text}`}>
@@ -121,6 +123,31 @@ export const adminQuestionPage = (
             </li>
           ))}
         </ul>
+      )}
+
+      <h2>Assign to Events</h2>
+      {allEvents.length === 0 ? (
+        <p>
+          <em>No events yet.</em>
+        </p>
+      ) : (
+        <CsrfForm
+          action={`/admin/questions/${question.id}/events`}
+          id="question-events"
+        >
+          {map((e: EventWithCount) => (
+            <label>
+              <input
+                checked={assignedEventIds.has(e.id) || undefined}
+                name="event_ids"
+                type="checkbox"
+                value={String(e.id)}
+              />
+              {` ${e.name}`}
+            </label>
+          ))(allEvents)}
+          <button type="submit">Save Events</button>
+        </CsrfForm>
       )}
 
       <p>

--- a/test/e2e/booking.test.ts
+++ b/test/e2e/booking.test.ts
@@ -120,14 +120,15 @@ describe("e2e: full booking flow", () => {
     await browser.visit("/admin/questions");
     expect(browser.containsText("Custom Questions")).toBe(true);
 
+    // Creating a question redirects straight to its detail page so answers
+    // can be added immediately.
     await browser.submitForm(
       { text: "What is your t-shirt size?" },
       "Add Question",
     );
     expect(browser.containsText("What is your t-shirt size?")).toBe(true);
 
-    // Navigate to the question detail page and add answers
-    await browser.clickLink("What is your t-shirt size?");
+    // Add answers on the question detail page
     await browser.submitForm({ text: "Small" }, "Add Answer");
     await browser.submitForm({ text: "Medium" }, "Add Answer");
     await browser.submitForm({ text: "Large" }, "Add Answer");

--- a/test/lib/form-data.test.ts
+++ b/test/lib/form-data.test.ts
@@ -23,3 +23,26 @@ describe("FormParams.getString", () => {
     expect(form.getString("name")).toBe("");
   });
 });
+
+describe("FormParams.getNumberArray", () => {
+  test("parses all repeated values as integers", () => {
+    const form = new FormParams();
+    form.append("ids", "1");
+    form.append("ids", "2");
+    form.append("ids", "3");
+    expect(form.getNumberArray("ids")).toEqual([1, 2, 3]);
+  });
+
+  test("drops values that are not numbers", () => {
+    const form = new FormParams();
+    form.append("ids", "1");
+    form.append("ids", "abc");
+    form.append("ids", "4");
+    expect(form.getNumberArray("ids")).toEqual([1, 4]);
+  });
+
+  test("returns empty array when the key is absent", () => {
+    const form = new FormParams();
+    expect(form.getNumberArray("ids")).toEqual([]);
+  });
+});

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -10,12 +10,14 @@ import {
   getAttendeeAnswersBatch,
   getEventQuestionIds,
   getNextAnswerSortOrder,
+  getQuestionEventIds,
   getQuestionsForEvent,
   getQuestionsWithEventIds,
   getQuestionWithAnswers,
   questionsTable,
   saveAttendeeAnswers,
   setEventQuestions,
+  setQuestionEvents,
   swapAnswerOrder,
 } from "#shared/db/questions.ts";
 import { createTestEvent, describeWithEnv } from "#test-utils";
@@ -203,6 +205,92 @@ describeWithEnv("custom questions", { db: true }, () => {
     test("returns empty array for event with no questions", async () => {
       const event = await createTestEvent();
       expect(await getEventQuestionIds(event.id)).toEqual([]);
+    });
+  });
+
+  describe("getQuestionEventIds", () => {
+    test("returns the events a question is assigned to", async () => {
+      const q = await questionsTable.insert({ text: "Q" });
+      const event1 = await createTestEvent();
+      const event2 = await createTestEvent({ name: "Event 2" });
+      await setEventQuestions(event1.id, [q.id]);
+      await setEventQuestions(event2.id, [q.id]);
+
+      const ids = await getQuestionEventIds(q.id);
+      expect(ids.sort()).toEqual([event1.id, event2.id].sort());
+    });
+
+    test("returns empty array when assigned to no events", async () => {
+      const q = await questionsTable.insert({ text: "Lonely Q" });
+      expect(await getQuestionEventIds(q.id)).toEqual([]);
+    });
+  });
+
+  describe("setQuestionEvents", () => {
+    test("assigns a question to the selected events", async () => {
+      const q = await questionsTable.insert({ text: "Q" });
+      const event1 = await createTestEvent();
+      const event2 = await createTestEvent({ name: "Event 2" });
+
+      await setQuestionEvents(q.id, [event1.id, event2.id]);
+
+      expect((await getQuestionEventIds(q.id)).sort()).toEqual(
+        [event1.id, event2.id].sort(),
+      );
+    });
+
+    test("removes the question from unchecked events", async () => {
+      const q = await questionsTable.insert({ text: "Q" });
+      const event1 = await createTestEvent();
+      const event2 = await createTestEvent({ name: "Event 2" });
+      await setQuestionEvents(q.id, [event1.id, event2.id]);
+
+      await setQuestionEvents(q.id, [event1.id]);
+
+      expect(await getQuestionEventIds(q.id)).toEqual([event1.id]);
+    });
+
+    test("appends after an event's existing questions without reordering", async () => {
+      const existing = await questionsTable.insert({ text: "Existing" });
+      const added = await questionsTable.insert({ text: "Added" });
+      await answersTable.insert({
+        questionId: existing.id,
+        sortOrder: 0,
+        text: "A",
+      });
+      await answersTable.insert({
+        questionId: added.id,
+        sortOrder: 0,
+        text: "B",
+      });
+
+      const event = await createTestEvent();
+      await setEventQuestions(event.id, [existing.id]);
+
+      await setQuestionEvents(added.id, [event.id]);
+
+      const ids = await getEventQuestionIds(event.id);
+      expect(ids).toEqual([existing.id, added.id]);
+    });
+
+    test("does nothing when the assignment is unchanged", async () => {
+      const q = await questionsTable.insert({ text: "Q" });
+      const event = await createTestEvent();
+      await setQuestionEvents(q.id, [event.id]);
+
+      await setQuestionEvents(q.id, [event.id]);
+
+      expect(await getQuestionEventIds(q.id)).toEqual([event.id]);
+    });
+
+    test("clears all events when given an empty list", async () => {
+      const q = await questionsTable.insert({ text: "Q" });
+      const event = await createTestEvent();
+      await setQuestionEvents(q.id, [event.id]);
+
+      await setQuestionEvents(q.id, []);
+
+      expect(await getQuestionEventIds(q.id)).toEqual([]);
     });
   });
 

--- a/test/lib/server-questions.test.ts
+++ b/test/lib/server-questions.test.ts
@@ -83,6 +83,21 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       expect(id).toBeGreaterThan(0);
     });
 
+    test("redirects to the new question's detail page", async () => {
+      const { response } = await adminFormPost("/admin/questions", {
+        text: "Redirect target?",
+      });
+      const { getAllQuestionsWithAnswers } = await import(
+        "#shared/db/questions.ts"
+      );
+      const questions = await getAllQuestionsWithAnswers();
+      const found = questions.find((q) => q.text === "Redirect target?")!;
+      expectRedirectWithFlash(
+        `/admin/questions/${found.id}`,
+        "Question created",
+      )(response);
+    });
+
     test("rejects empty text", async () => {
       const { response } = await adminFormPost("/admin/questions", {
         text: "",
@@ -251,6 +266,83 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       expect(question!.answers[1]!.sort_order).toBe(1);
       expect(question!.answers[2]!.text).toBe("Third");
       expect(question!.answers[2]!.sort_order).toBe(2);
+    });
+  });
+
+  describe("POST /admin/questions/:id/events", () => {
+    testRequiresAuth("/admin/questions/1/events", {
+      body: { event_ids: "1" },
+      method: "POST",
+      setup: async () => {
+        await createQuestion("Events auth question");
+      },
+    });
+
+    test("returns 404 for non-existent question", async () => {
+      const event = await createTestEvent({ name: "Orphan event" });
+      const { response } = await adminFormPost("/admin/questions/999/events", {
+        event_ids: String(event.id),
+      });
+      expectStatus(404)(response);
+    });
+
+    test("assigns question to a single event and redirects", async () => {
+      const event = await createTestEvent({ name: "Target event" });
+      const qId = await createQuestion("Assign me?");
+
+      const { response } = await adminFormPost(
+        `/admin/questions/${qId}/events`,
+        { event_ids: String(event.id) },
+      );
+      expectRedirectWithFlash(
+        `/admin/questions/${qId}`,
+        "Events updated",
+      )(response);
+
+      const { getQuestionEventIds } = await import("#shared/db/questions.ts");
+      expect(await getQuestionEventIds(qId)).toEqual([event.id]);
+    });
+
+    test("removes question from unchecked events", async () => {
+      const event = await createTestEvent({ name: "Unassign event" });
+      const qId = await createQuestion("Unassign me?");
+
+      const { setQuestionEvents, getQuestionEventIds } = await import(
+        "#shared/db/questions.ts"
+      );
+      await setQuestionEvents(qId, [event.id]);
+
+      const { response } = await adminFormPost(
+        `/admin/questions/${qId}/events`,
+        {},
+      );
+      expectRedirectWithFlash(
+        `/admin/questions/${qId}`,
+        "Events updated",
+      )(response);
+      expect(await getQuestionEventIds(qId)).toEqual([]);
+    });
+
+    test("logs singular when assigned to one event", async () => {
+      const event = await createTestEvent({ name: "Singular event" });
+      const qId = await createQuestion("Singular events log");
+      await adminFormPost(`/admin/questions/${qId}/events`, {
+        event_ids: String(event.id),
+      });
+
+      const { response } = await adminGet("/admin/log");
+      const body = await response.text();
+      expect(body).toContain("assigned to 1 event");
+      expect(body).not.toContain("assigned to 1 events");
+    });
+
+    test("logs plural when assigned to zero events", async () => {
+      const qId = await createQuestion("Plural events log");
+      await adminFormPost(`/admin/questions/${qId}/events`, {});
+
+      const { response } = await adminGet("/admin/log");
+      const body = await response.text();
+      expect(body).toContain("assigned to 0 events");
     });
   });
 

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -14,6 +14,11 @@ import {
 } from "#templates/admin/questions.tsx";
 import { setupTestEncryptionKey, testEventWithCount } from "#test-utils";
 
+const TEST_EVENTS = [
+  testEventWithCount({ id: 1, name: "Spring Gig" }),
+  testEventWithCount({ id: 2, name: "Summer Gig" }),
+];
+
 const TEST_SESSION = { adminLevel: "owner" as const };
 
 beforeAll(async () => {
@@ -139,6 +144,43 @@ describe("adminQuestionPage", () => {
     const html = adminQuestionPage(q, TEST_SESSION);
     expect(html).toContain("/answers/11/move-up");
     expect(html).toContain("/answers/11/move-down");
+  });
+
+  test("renders empty state when no events exist", () => {
+    const html = adminQuestionPage(question, TEST_SESSION);
+    expect(html).toContain("Assign to Events");
+    expect(html).toContain("No events yet");
+  });
+
+  test("renders an event checkbox for each event", () => {
+    const html = adminQuestionPage(
+      question,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      TEST_EVENTS,
+    );
+    expect(html).toContain('action="/admin/questions/1/events"');
+    expect(html).toContain('name="event_ids"');
+    expect(html).toContain('value="1"');
+    expect(html).toContain('value="2"');
+    expect(html).toContain("Spring Gig");
+    expect(html).toContain("Summer Gig");
+  });
+
+  test("checks events the question is assigned to", () => {
+    const html = adminQuestionPage(
+      question,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      TEST_EVENTS,
+      new Set([1]),
+    );
+    expect(html).toContain('checked name="event_ids" type="checkbox" value="1"');
+    expect(html).not.toContain(
+      'checked name="event_ids" type="checkbox" value="2"',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Makes `/admin/questions` less clunky to work with by smoothing out two workflows, reusing the existing form / redirect / checkbox paradigms throughout.

### 1. Redirect to the new question after creating it
Creating a question previously bounced back to the questions list. It now redirects (PRG, via the existing `redirect()` helper) straight to the new question's detail page with a "Question created" flash, so you can add answers immediately.

### 2. Assign a question to events from the question page
The question detail page now has an **"Assign to Events"** checkbox list of every event. Tick/untick to add or remove the question across all events in one save, instead of editing each event's questions one at a time. This reuses the same `CsrfForm` + `name="event_ids"` checkbox pattern and `form.getAll(...)` handler pattern already used elsewhere (e.g. groups, and the existing per-event questions page, which is left in place).

Two new DB helpers back this:
- `getQuestionEventIds(questionId)` — events a question belongs to
- `setQuestionEvents(questionId, eventIds)` — adds/removes the question per event, appending new assignments after each event's existing questions so other questions' ordering is untouched

## Testing
- New unit tests for `getQuestionEventIds` / `setQuestionEvents` (add, remove, append-ordering, no-op, clear)
- New handler tests for `POST /admin/questions/:id/events` (auth, 404, assign, remove, singular/plural activity log) and the create-redirect target
- New template tests for the event checkbox section (empty state, rendering, checked state)
- Updated the e2e booking flow to reflect landing on the detail page after create
- `deno check`, `deno lint`, and the affected test files all pass; changed handler/template at 100% coverage

https://claude.ai/code/session_01EK7tniaYEHm13aiqaKpuFE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK7tniaYEHm13aiqaKpuFE)_