### PR TITLE
Attendee form: separate Save from Add Event Line, show save result in the form

### DIFF
--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -41,6 +41,10 @@ export const SAVE_ACTION = "save";
 export const ADD_LINE_ACTION = "add_line";
 export const REMOVE_LINE_ACTION_PREFIX = "remove_line_";
 
+/** DOM id of the add/edit form, also used as the post-save scroll anchor
+ * (`#attendee-form`) so the operator lands on the form after a save. */
+export const ATTENDEE_FORM_ID = "attendee-form";
+
 // ---------------------------------------------------------------------------
 // Domain types
 // ---------------------------------------------------------------------------

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -61,6 +61,7 @@ import { getSearchParam } from "#routes/url.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { Attendee, EventWithCount, Holiday } from "#shared/types.ts";
 import {
+  ATTENDEE_FORM_ID,
   defaultNewDailyDate,
   type AttendeeFormLine,
   type DailyDefaults,
@@ -250,7 +251,8 @@ const renderForm = (
   data: AttendeeFormTemplateData,
 ): Response => htmlResponse(attendeeFormPage(data, session));
 
-/** Apply the flash cookie and render the attendee form page (GET handlers). */
+/** Render a GET of the form, surfacing any post-save flash (cookie) inside the
+ * form so the operator lands on it after the redirect. */
 const renderAttendeeFormPage = (
   request: Request,
   data: AttendeeFormTemplateData,
@@ -477,6 +479,8 @@ const handleSubmitInner = async (
       parseQuestionAnswers(form, questions),
     );
   if (outcome.ok) return outcome.response;
+  // In-place re-render (no redirect): show the failure inside the form, the
+  // same place a saved success lands, while preserving the entered data.
   return renderForm(session, {
     ...dataForRerender,
     flashError: outcome.flashError,
@@ -492,6 +496,22 @@ type SaveOutcome =
 
 /** Shown when a submission has no usable event lines. */
 const NO_LINES_ERROR = "Add at least one event line before saving";
+
+/** The edit page for an attendee, carrying the return_url through so the
+ * "Back without saving" link still works after a save. */
+const attendeePath = (id: number, returnUrl: string): string =>
+  returnUrl
+    ? `/admin/attendees/${id}?return_url=${encodeURIComponent(returnUrl)}`
+    : `/admin/attendees/${id}`;
+
+/** Redirect back to the saved attendee's own form, scrolling to it via the
+ * `#attendee-form` anchor; the flash cookie then shows the success inside it. */
+const savedRedirect = (
+  id: number,
+  returnUrl: string,
+  message: string,
+): Response =>
+  redirect(`${attendeePath(id, returnUrl)}#${ATTENDEE_FORM_ID}`, message, true);
 
 /** Read submitted question answers from the form, filtered to valid options. */
 const parseQuestionAnswers = (
@@ -535,8 +555,11 @@ const applyCreate = async (
   const firstEventId = parsed.lines.find((line) => line.eventId > 0)!.eventId;
   await logActivity(`Attendee '${parsed.name}' added manually`, firstEventId);
 
-  const target = parsed.returnUrl || `/admin/attendees/${attendees[0]!.id}`;
-  return { ok: true, response: redirect(target, `Added ${parsed.name}`, true) };
+  const newId = attendees[0]!.id;
+  return {
+    ok: true,
+    response: savedRedirect(newId, parsed.returnUrl, `Added ${parsed.name}`),
+  };
 };
 
 /** Run the atomic edit flow. */
@@ -587,8 +610,10 @@ const applyEdit = async (
 
   const firstEventId = desired[0]?.eventId;
   await logActivity(`Attendee '${parsed.name}' updated`, firstEventId);
-  const target = parsed.returnUrl || `/admin/attendees/${attendeeId}`;
-  return { ok: true, response: redirect(target, `Updated ${parsed.name}`, true) };
+  return {
+    ok: true,
+    response: savedRedirect(attendeeId, parsed.returnUrl, `Updated ${parsed.name}`),
+  };
 };
 
 // ---------------------------------------------------------------------------

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -12,6 +12,7 @@
 import {
   ACTION_FIELD,
   ADD_LINE_ACTION,
+  ATTENDEE_FORM_ID,
   type AttendeeFormLine,
   type DailyDefaults,
   type ParsedAttendeeForm,
@@ -48,7 +49,8 @@ export type AttendeeFormTemplateData = {
   dailyDefaults: DailyDefaults;
   /** Attendee-level error (e.g. "Name is required"). */
   attendeeError: string | null;
-  /** Generic page-level error/success flash (e.g. capacity lost to race). */
+  /** Save outcome shown inside the form (success after a save, or a recoverable
+   * failure like capacity lost to a race). */
   flashError?: string;
   flashSuccess?: string;
   /** Custom questions for the first existing event (edit mode only). */
@@ -326,7 +328,6 @@ export const attendeeFormPage = (
   return String(
     <Layout title={pageTitle(data)}>
       <AdminNav active="/admin/" session={session} />
-      <Flash error={data.flashError} success={data.flashSuccess} />
 
       <h2>{pageTitle(data)}</h2>
 
@@ -340,7 +341,8 @@ export const attendeeFormPage = (
 
       <Raw html={renderMixedTimingAlert(data)} />
 
-      <CsrfForm action={formAction} id="attendee-form">
+      <CsrfForm action={formAction} id={ATTENDEE_FORM_ID}>
+        <Flash error={data.flashError} success={data.flashSuccess} />
         {data.returnUrl && (
           <input name="return_url" type="hidden" value={data.returnUrl} />
         )}
@@ -411,7 +413,6 @@ export const attendeeFormPage = (
 
         <h3>Event Registrations</h3>
         <Raw html={renderLineEditor(data)} />
-
         <p>
           <button
             formnovalidate
@@ -421,14 +422,22 @@ export const attendeeFormPage = (
           >
             Add Event Line
           </button>
-          <button class="primary" type="submit" name={ACTION_FIELD} value={SAVE_ACTION}>
+        </p>
+
+        <hr />
+
+        <p class="form-actions">
+          <button
+            class="primary"
+            type="submit"
+            name={ACTION_FIELD}
+            value={SAVE_ACTION}
+          >
             {isEdit ? "Save Attendee" : "Create Attendee"}
           </button>
-          {data.returnUrl ? (
-            <a class="button" href={data.returnUrl}>Cancel</a>
-          ) : (
-            <a class="button" href="/admin/">Back</a>
-          )}
+          <a class="button" href={data.returnUrl || "/admin/"}>
+            Back without saving
+          </a>
         </p>
       </CsrfForm>
 

--- a/test/e2e/ticket-editing.test.ts
+++ b/test/e2e/ticket-editing.test.ts
@@ -151,23 +151,17 @@ describe("e2e: ticket editing flow", () => {
       },
       "Save Attendee",
     );
-    // Redirects to edit page with flash message
+    // 4. Save returns to the same edit form, with the flash shown inside it.
     expect(browser.containsText("Updated Alice Johnson")).toBe(true);
-
-    // 4. Verify edited details appear on the event page
     expect(browser.containsText("Alice Johnson")).toBe(true);
     expect(browser.containsText("Alice Smith")).toBe(false);
 
-    // 5. Navigate back to Alice's edit page to verify all fields were saved
-    //    and booking properties are intact
-    await visitFirstAttendeeEditPage(browser);
-    expect(browser.containsText("Alice Johnson")).toBe(true);
-    // Verify saved contact fields appear in the form
+    // 5. The edit form shows the saved fields and the preserved booking.
     expect(browser.currentHtml).toContain("alice.johnson@example.com");
     expect(browser.currentHtml).toContain("+449876543210");
     expect(browser.currentHtml).toContain("42 Oak Street");
     expect(browser.currentHtml).toContain("Needs wheelchair access");
-    // Verify booking preserved: quantity still 2 and still checked in
+    // Booking preserved: quantity still 2 and still checked in
     expect(browser.currentHtml).toContain('value="2"');
     expect(browser.currentHtml).toContain("Checked in");
 
@@ -205,16 +199,10 @@ describe("e2e: ticket editing flow", () => {
     );
     expect(browser.containsText("Updated Robert Jones")).toBe(true);
 
-    // 8. Verify Bob's edit was saved and his booking is intact
+    // 8. Save returns to Bob's edit form; his renamed details and intact
+    //    booking are shown there directly.
     expect(browser.containsText("Robert Jones")).toBe(true);
     expect(browser.containsText("Bob Jones")).toBe(false);
-
-    // Navigate to Bob's edit page to verify fields and booking
-    const bobEditLinks = browser.links.filter((l) =>
-      l.href.includes("/admin/attendees/"),
-    );
-    // Bob (Robert Jones) should be the second attendee link
-    await browser.visit(bobEditLinks[1]!.href);
     expect(browser.currentHtml).toContain("robert@example.com");
     expect(browser.currentHtml).toContain("+441111222333");
     expect(browser.currentHtml).toContain("7 Pine Avenue");
@@ -327,11 +315,10 @@ describe("e2e: ticket editing flow", () => {
       },
       "Save Attendee",
     );
-    // Flash confirms the save (the return_url bounces back to the event page).
+    // Save returns to the same edit form, with the flash shown inside it.
     expect(browser.containsText("Updated Alice Smith")).toBe(true);
 
-    // Verify both events are now registered by re-opening the edit page.
-    await visitFirstAttendeeEditPage(browser);
+    // Both events are now registered — visible in the form's line editor.
     expect(browser.containsText("Morning Workshop")).toBe(true);
     expect(browser.containsText("Evening Seminar")).toBe(true);
 
@@ -376,8 +363,7 @@ describe("e2e: ticket editing flow", () => {
     );
     expect(browser.containsText("Updated Bob Jones")).toBe(true);
 
-    // Verify both events are registered by re-opening the edit page.
-    await visitFirstAttendeeEditPage(browser);
+    // Both events are registered — visible in the form's line editor.
     expect(browser.containsText("Morning Workshop")).toBe(true);
     expect(browser.containsText("Evening Seminar")).toBe(true);
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1270,7 +1270,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       expect(response.status).toBe(302);
       expectRedirectWithFlash(
-        `/admin/attendees/${attendee.id}`,
+        `/admin/attendees/${attendee.id}#attendee-form`,
         "Updated Jane Doe",
       )(response);
 
@@ -1288,7 +1288,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       expect(html).toContain("Wheelchair access");
     });
 
-    test("appends success message to return_url after edit", async () => {
+    test("returns to the edit form after edit, preserving return_url", async () => {
       const event = await createTestEvent({ maxAttendees: 100 });
       const attendee = await createTestAttendee(
         event.id,
@@ -1307,11 +1307,13 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         `/admin/attendees/${attendee.id}`,
         form,
       );
+      // Save returns to the same form (anchored), carrying return_url through
+      // so the "Back without saving" link still points where the user came from.
       expectRedirect(
         response,
-        "/admin/calendar",
-        "date=2026-03-15",
-        "#attendees",
+        `/admin/attendees/${attendee.id}`,
+        `return_url=${encodeURIComponent(returnUrl)}`,
+        "#attendee-form",
       );
       expectFlash(response, expect.stringContaining("John Doe"));
     });
@@ -1337,7 +1339,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       expect(response.status).toBe(302);
       expectRedirectWithFlash(
-        `/admin/attendees/${attendee.id}`,
+        `/admin/attendees/${attendee.id}#attendee-form`,
         "Updated Jane Smith",
       )(response);
     });
@@ -1529,7 +1531,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       );
       expect(response.status).toBe(302);
       expectRedirectWithFlash(
-        `/admin/attendees/${attendee.id}`,
+        `/admin/attendees/${attendee.id}#attendee-form`,
         "Updated Jane Smith",
       )(response);
     });


### PR DESCRIPTION
Two UX fixes for the unified add/edit attendee form.

## 1. Button layout

The old action row crammed three unrelated buttons together — `Add Event Line` / `Save Attendee` / `Cancel` — which made it unclear what "Cancel" cancelled.

- **`Add Event Line`** now sits directly under the Event Registrations table it acts on (it's a sub-action of that section, not a peer of Save).
- A horizontal rule separates the **final action row**: just the primary **Save Attendee / Create Attendee** button and a **`Back without saving`** link. That replaces the vague `Cancel`/`Back` with a label that says what it does.

## 2. Save result shown inside the form

Saving now **redirects back to the same form** via the `#attendee-form` anchor and shows the success (or recoverable failure) **inside the form**, reusing the same PRG + flash-cookie pattern the settings forms use.

- `applyCreate`/`applyEdit` now redirect to the attendee's own edit page (`#attendee-form`), carrying `return_url` through so the `Back without saving` link still points where the operator came from.
- The `Flash` moved from the page top into the `CsrfForm`, fed by the flash cookie. A recoverable in-place failure (capacity lost to a race, no lines) renders in the same spot, so success and failure land consistently.
- Because the flash is read from the cookie (not a form-scoped store), **every** redirect to the edit page surfaces its message in the form — including the existing `refresh-payment` and link-error redirects — with no regression and no cross-request state to leak.

### Why not the form-scoped `CsrfForm` flash store?
That store is module-level and keyed by a `?form=` param, which would (a) hide messages from the other flows that redirect here without that param, and (b) risk stale messages leaking across requests. Driving the in-form `Flash` from template data avoids both.

## Tests
- Updated `server-attendees` redirect assertions for the new self-redirect + `#attendee-form` anchor, and rewrote the old "redirect to return_url" test to assert the form now returns to itself while preserving `return_url`.
- Updated the `ticket-editing` e2e flow: after a save the operator stays on the edit form, so the saved fields/booking are asserted there directly instead of re-navigating from the event page.
- CI-enforced checks pass locally: `typecheck`, `lint`, `cpd` (0 clones), `build:edge`; plus `server-attendee-form`, `server-attendees`, `ticket-editing`/`duration-days` e2e, `read-only`, `attendees-links`, and the template suite.

https://claude.ai/code/session_01YE2g6JDYcvhntbvFNVSMtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YE2g6JDYcvhntbvFNVSMtr)_