### PR TITLE
Harden attendee add/edit form: server-side contact validation + line-count cap

### DIFF
--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -23,8 +23,15 @@ import {
   addDays,
   getAvailableDates,
 } from "#shared/dates.ts";
+import { MAX_FORM_LINES } from "#shared/limits.ts";
 import type { Holiday } from "#shared/types.ts";
 import type { EventWithCount } from "#shared/types.ts";
+import {
+  validateAddress,
+  validateEmail,
+  validatePhone,
+  validateSpecialInstructions,
+} from "#templates/fields.ts";
 
 // ---------------------------------------------------------------------------
 // Field-name constants — single source of truth for template + parser
@@ -189,7 +196,7 @@ export const parseAttendeeForm = (
 ): ParsedAttendeeForm => {
   const lineCountRaw = Number.parseInt(form.getString(LINE_COUNT_FIELD), 10);
   const lineCount = Number.isInteger(lineCountRaw) && lineCountRaw > 0
-    ? lineCountRaw
+    ? Math.min(lineCountRaw, MAX_FORM_LINES)
     : 1;
 
   const lines: AttendeeFormLine[] = [];
@@ -280,6 +287,29 @@ const validateAttendeeBlock = (
 ): AttendeeFieldError | null => {
   if (!parsed.name.trim()) {
     return { field: "name", message: "Name is required" };
+  }
+  // Email and phone are optional on this form, but a provided value must be
+  // well-formed. The browser enforces this via type=email / pattern, so only a
+  // no-JS or hand-crafted POST reaches the server with a malformed value —
+  // validating here keeps bad contact data out of the encrypted PII blob.
+  // Reuse the same validators the public ticket form uses so both paths agree.
+  if (parsed.email) {
+    const emailError = validateEmail(parsed.email);
+    if (emailError) return { field: "email", message: emailError };
+  }
+  if (parsed.phone) {
+    const phoneError = validatePhone(parsed.phone);
+    if (phoneError) return { field: "phone", message: phoneError };
+  }
+  // Length caps backstop the HTML maxlength and keep these fields within the
+  // size the payment-metadata path elsewhere relies on.
+  const addressError = validateAddress(parsed.address);
+  if (addressError) return { field: "address", message: addressError };
+  const instructionsError = validateSpecialInstructions(
+    parsed.special_instructions,
+  );
+  if (instructionsError) {
+    return { field: "special_instructions", message: instructionsError };
   }
   return null;
 };

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -54,6 +54,19 @@ export const MAX_BACKUPS = readLimit("MAX_BACKUPS", 30);
 /** Maximum textarea content length in characters (default: 10240 = 10KB) */
 export const MAX_TEXTAREA_LENGTH = readLimit("MAX_TEXTAREA_LENGTH", 10_240);
 
+/**
+ * Maximum number of line items one attendee-form submission may declare
+ * (default: 1000).
+ *
+ * The attendee add/edit form reads its repeated event-registration rows from
+ * an operator-controlled `line_count`, looping once per declared line. Without
+ * a ceiling a hand-crafted POST with `line_count=1e9` would spin the edge
+ * worker allocating millions of blank line objects — a cheap denial of
+ * service. The cap sits far above any realistic number of registrations on a
+ * single attendee, so it never truncates a legitimate form.
+ */
+export const MAX_FORM_LINES = readLimit("MAX_FORM_LINES", 1000);
+
 // ---------------------------------------------------------------------------
 // Timing limits
 // ---------------------------------------------------------------------------
@@ -242,6 +255,13 @@ export const LIMIT_ENTRIES: readonly LimitEntry[] = [
     envKey: "MAX_TEXTAREA_LENGTH",
     label: "Max textarea length",
     unit: "chars",
+  },
+  {
+    current: MAX_FORM_LINES,
+    defaultValue: 1000,
+    envKey: "MAX_FORM_LINES",
+    label: "Max attendee-form line items",
+    unit: "lines",
   },
   {
     current: MAX_IMAGE_SIZE,

--- a/test/lib/attendee-form-model.test.ts
+++ b/test/lib/attendee-form-model.test.ts
@@ -12,6 +12,7 @@ import {
 } from "#routes/admin/attendee-form-model.ts";
 import type { Holiday } from "#shared/types.ts";
 import { FormParams } from "#shared/form-data.ts";
+import { MAX_FORM_LINES } from "#shared/limits.ts";
 import { testEventWithCount } from "#test-utils";
 import type { EventAttendeeRow } from "#shared/db/attendee-types.ts";
 
@@ -166,6 +167,16 @@ describe("parseAttendeeForm", () => {
     expect(parseAttendeeForm(form, new Map()).lines).toHaveLength(1);
   });
 
+  test("clamps an abusive line_count to MAX_FORM_LINES", () => {
+    const form = makeForm({
+      line_count: String(MAX_FORM_LINES + 50),
+      name: "X",
+    });
+    expect(parseAttendeeForm(form, new Map()).lines).toHaveLength(
+      MAX_FORM_LINES,
+    );
+  });
+
   test("attaches existing booking rows by key", () => {
     const booking = bookingRow({ event_id: 5, quantity: 3 });
     const form = makeForm({
@@ -307,6 +318,93 @@ describe("validateParsedForm", () => {
     );
     const trimmed = { ...parsed, lines: trimTrailingBlankLines(parsed.lines) };
     const result = validateParsedForm(trimmed, []);
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a malformed email even though it is optional", () => {
+    const event = testEventWithCount({ id: 1, active: true, max_quantity: 5 });
+    const parsed = parseAttendeeForm(
+      makeForm({
+        email: "not-an-email",
+        line_count: "1",
+        line_event_id_0: "1",
+        line_quantity_0: "1",
+        name: "Jane",
+      }),
+      new Map([[1, event]]),
+    );
+    const result = validateParsedForm(parsed, []);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.attendeeError?.field).toBe("email");
+  });
+
+  test("rejects a malformed phone even though it is optional", () => {
+    const event = testEventWithCount({ id: 1, active: true, max_quantity: 5 });
+    const parsed = parseAttendeeForm(
+      makeForm({
+        line_count: "1",
+        line_event_id_0: "1",
+        line_quantity_0: "1",
+        name: "Jane",
+        phone: "not a phone",
+      }),
+      new Map([[1, event]]),
+    );
+    const result = validateParsedForm(parsed, []);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.attendeeError?.field).toBe("phone");
+  });
+
+  test("rejects an address that exceeds the length cap", () => {
+    const event = testEventWithCount({ id: 1, active: true, max_quantity: 5 });
+    const parsed = parseAttendeeForm(
+      makeForm({
+        address: "x".repeat(251),
+        line_count: "1",
+        line_event_id_0: "1",
+        line_quantity_0: "1",
+        name: "Jane",
+      }),
+      new Map([[1, event]]),
+    );
+    const result = validateParsedForm(parsed, []);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.attendeeError?.field).toBe("address");
+  });
+
+  test("rejects special instructions that exceed the length cap", () => {
+    const event = testEventWithCount({ id: 1, active: true, max_quantity: 5 });
+    const parsed = parseAttendeeForm(
+      makeForm({
+        line_count: "1",
+        line_event_id_0: "1",
+        line_quantity_0: "1",
+        name: "Jane",
+        special_instructions: "x".repeat(251),
+      }),
+      new Map([[1, event]]),
+    );
+    const result = validateParsedForm(parsed, []);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.attendeeError?.field).toBe("special_instructions");
+    }
+  });
+
+  test("accepts well-formed optional email and phone", () => {
+    const event = testEventWithCount({ id: 1, active: true, max_quantity: 5 });
+    const parsed = parseAttendeeForm(
+      makeForm({
+        email: "jane@example.com",
+        line_count: "1",
+        line_event_id_0: "1",
+        line_quantity_0: "1",
+        name: "Jane",
+        phone: "+1 (555) 123-4567",
+      }),
+      new Map([[1, event]]),
+    );
+    const result = validateParsedForm(parsed, []);
     expect(result.valid).toBe(true);
   });
 

--- a/test/lib/limits.test.ts
+++ b/test/lib/limits.test.ts
@@ -93,6 +93,7 @@ describe("limits", () => {
     test("entries match the set of exported tunable constants", () => {
       const exportedKeys = [
         "MAX_TEXTAREA_LENGTH",
+        "MAX_FORM_LINES",
         "MAX_IMAGE_SIZE",
         "MAX_ATTACHMENT_SIZE",
         "MAX_BACKUPS",

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -635,6 +635,28 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       expect(html).toContain("Valid Name");
     });
 
+    test("create rejects a malformed email and saves nothing", async () => {
+      const event = await createTestEvent({
+        maxAttendees: 100,
+        maxQuantity: 5,
+      });
+      const { response } = await adminFormPost("/admin/attendees/new", {
+        email: "not-an-email",
+        line_count: "1",
+        line_event_id_0: String(event.id),
+        line_quantity_0: "1",
+        name: "Valid Name",
+      });
+      // Re-renders in place (200) with the field error; the browser's
+      // type=email guard is bypassed by a no-JS / crafted POST, so the server
+      // is the only thing standing between bad data and the PII blob.
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Please enter a valid email address");
+      expect(html).toContain("Valid Name");
+      expect((await getAttendeesRaw(event.id)).length).toBe(0);
+    });
+
     test("edit remove_line drops the line from the form without deleting until save", async () => {
       const event = await createTestEvent({ maxAttendees: 100 });
       const attendee = await createTestAttendee(


### PR DESCRIPTION
## Defensive sweep of the add / edit attendee form

The unified `/admin/attendees/new` and `/admin/attendees/:id` form looked solid, but its server-side validation only checked that **name** was non-empty. Everything else leaned entirely on HTML attributes — which a no-JS browser or a hand-crafted POST bypasses completely. Notably, the `AttendeeFieldError` type already enumerated `name | email | phone | address | special_instructions`, so validating all of them was clearly the original intent — only `name` ever got wired up.

### What this changes

**1. Server-side contact-field validation** (`validateAttendeeBlock`)
- **Email** format — backstops `type=email`
- **Phone** format — backstops the `pattern` attribute
- **Address** / **special instructions** length — backstops `maxlength=250`

These reuse the exact validators the public ticket form already uses (`validateEmail`, `validatePhone`, `validateAddress`, `validateSpecialInstructions` from `#templates/fields.ts`), so the admin and public paths agree and there's no duplicated logic. Email/phone stay optional — only a *provided* value is checked. Without this, malformed contact data could land in the encrypted PII blob.

**2. `line_count` DoS guard** (new `MAX_FORM_LINES` limit)
The parser loops once per operator-controlled `line_count`. There was no upper bound, so a crafted `line_count=1000000000` would spin the edge worker allocating millions of blank line objects. The new cap (in `#shared/limits.ts`, env-overridable like every other limit) sits far above any realistic number of registrations on one attendee, so it never truncates a legitimate form — it only defuses abuse.

### Deliberately *not* changed
No name-length validation was added: no `validateName`/length cap exists anywhere in the codebase (the public `nameField` is `required`-only), so inventing one here would diverge from the established convention.

### Tests
- Unit tests for every new validation branch (malformed email, malformed phone, over-length address, over-length special instructions, the valid-passes case) and the `line_count` clamp.
- A server-level test proving a malformed-email POST re-renders in place with the field error and **saves nothing**.
- `MAX_FORM_LINES` added to the `limits.ts` consistency tests.

All gates pass locally: typecheck, lint, cpd (0 clones), `build:edge`, and `test:coverage` — **100% line and branch coverage maintained**.

https://claude.ai/code/session_01RXBBshFWaJY3QxLbiQJsTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXBBshFWaJY3QxLbiQJsTr)_