### PR TITLE
style: apply biome formatting fixes

### DIFF
--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -326,12 +326,12 @@ export const questionsRoutes = {
     "POST /admin/event/:id/questions": handleEventQuestionsPost,
     "POST /admin/questions": handleQuestionsPost,
     "POST /admin/questions/:id/answers": handleAddAnswer,
-    "POST /admin/questions/:id/events": handleQuestionEvents,
     "POST /admin/questions/:id/answers/:answerId/delete":
       handleDeleteAnswerPost,
     "POST /admin/questions/:id/answers/:answerId/move-down":
       handleMoveAnswerDown,
     "POST /admin/questions/:id/answers/:answerId/move-up": handleMoveAnswerUp,
     "POST /admin/questions/:id/edit": handleQuestionEdit,
+    "POST /admin/questions/:id/events": handleQuestionEvents,
   }),
 };

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -11,7 +11,11 @@ import {
   localToUtc,
   todayInTz,
 } from "#shared/timezone.ts";
-import { type Event, type Holiday, normalizeDurationDays } from "#shared/types.ts";
+import {
+  type Event,
+  type Holiday,
+  normalizeDurationDays,
+} from "#shared/types.ts";
 
 /** Day name lookup from Date.getUTCDay() index (Sunday=0) */
 export const DAY_NAMES = [

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -267,8 +267,8 @@ const getGroupSpanLoad = async (
     row.event_type === "daily";
   return {
     base: pipe(
-      filter((row: IntervalRow & { event_type: EventType }) =>
-        !isDailyRow(row)
+      filter(
+        (row: IntervalRow & { event_type: EventType }) => !isDailyRow(row),
       ),
       sumQuantity,
     )(groupRows),
@@ -436,7 +436,8 @@ export const checkBatchAvailabilityImpl = async (
     const days = demandedDays(bucket);
     if (days) {
       const remaining = await getGroupRemainingPerDay(groupId, days);
-      const overCap = remaining &&
+      const overCap =
+        remaining &&
         [...bucket.perDay].some(
           ([day, qty]) => qty + bucket.total > remaining.get(day)!,
         );
@@ -451,4 +452,3 @@ export const checkBatchAvailabilityImpl = async (
   }
   return true;
 };
-

--- a/src/shared/db/attendees/update.ts
+++ b/src/shared/db/attendees/update.ts
@@ -3,7 +3,6 @@
  */
 
 import { filter, map, pipe, reduce, sort, unique } from "#fp";
-import { normalizeDurationDays } from "#shared/types.ts";
 import type {
   EventBooking,
   UpdateAttendeePIIInput,
@@ -20,6 +19,7 @@ import { buildCapacityCondition } from "#shared/db/capacity.ts";
 import { getDb, queryAll } from "#shared/db/client.ts";
 import { invalidateEventsCache } from "#shared/db/events.ts";
 import { settings } from "#shared/db/settings.ts";
+import { normalizeDurationDays } from "#shared/types.ts";
 
 /** Update a per-event status field on event_attendees */
 const updateEventAttendeeField =
@@ -140,9 +140,7 @@ export const checkGroupCapAfterDurationChange = async (
   // count (pre-daily legacy bookings), mirroring the SQL overlap predicate.
   type GroupRow = (typeof rows)[number];
   const isDailyWithRange = (row: GroupRow): boolean =>
-    row.event_type === "daily" &&
-    row.start_at !== null &&
-    row.end_at !== null;
+    row.event_type === "daily" && row.start_at !== null && row.end_at !== null;
   const toDayInterval = (row: GroupRow): DayInterval => ({
     end: row.end_at!.slice(0, 10),
     quantity: row.quantity,
@@ -178,7 +176,7 @@ export const checkGroupCapAfterDurationChange = async (
   // max end of this event's ranges that start at or before the candidate —
   // the candidate is inside this event's booked days iff that end is later.
   const sortedRanges = sort((a: DayInterval, b: DayInterval) =>
-    a.start < b.start ? -1 : 1
+    a.start < b.start ? -1 : 1,
   )(eventRanges);
   const startDays = unique(
     map((interval: DayInterval) => interval.start)(intervals),
@@ -186,7 +184,10 @@ export const checkGroupCapAfterDurationChange = async (
   let rangeIdx = 0;
   let maxEnd = "";
   for (const day of startDays) {
-    while (rangeIdx < sortedRanges.length && sortedRanges[rangeIdx]!.start <= day) {
+    while (
+      rangeIdx < sortedRanges.length &&
+      sortedRanges[rangeIdx]!.start <= day
+    ) {
       const end = sortedRanges[rangeIdx]!.end;
       if (end > maxEnd) maxEnd = end;
       rangeIdx++;

--- a/src/shared/db/events.ts
+++ b/src/shared/db/events.ts
@@ -5,8 +5,8 @@
 import type { ResultSet } from "@libsql/client";
 import { filter as fpFilter, reduce, sort, unique } from "#fp";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { addDays } from "#shared/dates.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
+import { addDays } from "#shared/dates.ts";
 import {
   ATTENDEE_JOIN_SELECT,
   ATTENDEE_LEFT_JOIN_SELECT,
@@ -181,9 +181,8 @@ const rawEventsTable = defineIdTable<Event, EventInput>("events", {
   webhook_url: col.encryptedText(encrypt, decrypt),
 });
 
-export const eventsTable = withCacheInvalidation(
-  rawEventsTable,
-  () => invalidateEventsCache(),
+export const eventsTable = withCacheInvalidation(rawEventsTable, () =>
+  invalidateEventsCache(),
 );
 
 /** Find a cached event by ID */
@@ -231,18 +230,15 @@ export const deleteEvent = async (eventId: number): Promise<void> => {
     // Delete orphaned attendees (no remaining event links) and their dependent data
     {
       args: [],
-      sql:
-        "DELETE FROM processed_payments WHERE attendee_id NOT IN (SELECT attendee_id FROM event_attendees)",
+      sql: "DELETE FROM processed_payments WHERE attendee_id NOT IN (SELECT attendee_id FROM event_attendees)",
     },
     {
       args: [],
-      sql:
-        "DELETE FROM attendee_answers WHERE attendee_id NOT IN (SELECT attendee_id FROM event_attendees)",
+      sql: "DELETE FROM attendee_answers WHERE attendee_id NOT IN (SELECT attendee_id FROM event_attendees)",
     },
     {
       args: [],
-      sql:
-        "DELETE FROM attendees WHERE id NOT IN (SELECT attendee_id FROM event_attendees)",
+      sql: "DELETE FROM attendees WHERE id NOT IN (SELECT attendee_id FROM event_attendees)",
     },
     { args: [eventId], sql: "DELETE FROM activity_log WHERE event_id = ?" },
     { args: [eventId], sql: "DELETE FROM events WHERE id = ?" },
@@ -471,8 +467,7 @@ export const getEventWithAttendeeRaw = async (
     },
     {
       args: [eventId],
-      sql:
-        "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ?",
+      sql: "SELECT COALESCE(SUM(quantity), 0) as count FROM event_attendees WHERE event_id = ?",
     },
   ]);
 

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -944,11 +944,6 @@ const settingsBase = {
         CONFIG_KEYS.SQUARE_WEBHOOK_SIGNATURE_KEY,
       ),
     },
-    // --- SumUp writes ---
-    sumup: {
-      apiKey: encryptedUpdate(CONFIG_KEYS.SUMUP_API_KEY),
-      merchantCode: plaintextUpdate(CONFIG_KEYS.SUMUP_MERCHANT_CODE),
-    },
     // --- Stripe writes ---
     stripe: {
       secretKey: encryptedUpdate(CONFIG_KEYS.STRIPE_SECRET_KEY),
@@ -967,6 +962,11 @@ const settingsBase = {
         data.stripe_webhook_secret = config.secret;
         data.stripe_webhook_endpoint_id = config.endpointId;
       },
+    },
+    // --- SumUp writes ---
+    sumup: {
+      apiKey: encryptedUpdate(CONFIG_KEYS.SUMUP_API_KEY),
+      merchantCode: plaintextUpdate(CONFIG_KEYS.SUMUP_MERCHANT_CODE),
     },
     superuserChoice: plaintextUpdate(CONFIG_KEYS.SUPERUSER_CHOICE) as (
       v: SuperuserChoice,

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -96,7 +96,11 @@ export type SessionMetadata = {
 
 /** Valid payment status values. "failed" is a terminal non-payment (declined
  * or expired checkout) — distinct from "unpaid", which may still complete. */
-export type PaymentStatus = "paid" | "unpaid" | "no_payment_required" | "failed";
+export type PaymentStatus =
+  | "paid"
+  | "unpaid"
+  | "no_payment_required"
+  | "failed";
 
 /** Runtime array of valid payment status values */
 const PAYMENT_STATUSES: readonly PaymentStatus[] = [

--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -37,7 +37,6 @@ import {
 /** Square payment provider implementation */
 export const squarePaymentProvider: PaymentProvider = {
   checkoutCompletedEventType: "payment.updated",
-  requiresWebhookSignature: true,
 
   createCheckoutSession(intent: CheckoutIntent, baseUrl: string) {
     return withCheckoutError(async () => {
@@ -55,6 +54,7 @@ export const squarePaymentProvider: PaymentProvider = {
   refundPayment(paymentReference: string): Promise<boolean> {
     return refundPayment(paymentReference);
   },
+  requiresWebhookSignature: true,
 
   async resolveWebhookSession(
     event: WebhookEvent,

--- a/src/shared/stripe-provider.ts
+++ b/src/shared/stripe-provider.ts
@@ -32,7 +32,6 @@ import {
 /** Stripe payment provider implementation */
 export const stripePaymentProvider: PaymentProvider = {
   checkoutCompletedEventType: "checkout.session.completed",
-  requiresWebhookSignature: true,
 
   createCheckoutSession: (intent: CheckoutIntent, baseUrl: string) =>
     withCheckoutError(async () => {
@@ -49,6 +48,7 @@ export const stripePaymentProvider: PaymentProvider = {
     const result = await stripeRefund(paymentReference);
     return result !== null;
   },
+  requiresWebhookSignature: true,
 
   resolveWebhookSession({
     data: { object: obj },

--- a/src/shared/stripe.ts
+++ b/src/shared/stripe.ts
@@ -17,8 +17,8 @@ import {
 } from "#shared/payment-crypto.ts";
 import {
   buildItemsMetadata,
-  cachedClientFactory,
   type CredentialCheck,
+  cachedClientFactory,
   createWithClient,
   enforceMetadataLimits,
   errorMessage,

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -12,7 +12,10 @@
  * - No webhook endpoint to set up (return_url is set per checkout)
  */
 
-import { getSumupCheckout, hasSumupCheckoutId } from "#shared/db/sumup-checkouts.ts";
+import {
+  getSumupCheckout,
+  hasSumupCheckoutId,
+} from "#shared/db/sumup-checkouts.ts";
 import {
   extractSessionMetadata,
   toCheckoutResult,
@@ -59,7 +62,6 @@ const buildValidatedSession = (
 /** SumUp payment provider implementation. */
 export const sumupPaymentProvider: PaymentProvider = {
   checkoutCompletedEventType: "CHECKOUT_STATUS_CHANGED",
-  requiresWebhookSignature: false,
 
   createCheckoutSession: (intent: CheckoutIntent, baseUrl: string) =>
     withCheckoutError(async () => {
@@ -74,6 +76,7 @@ export const sumupPaymentProvider: PaymentProvider = {
   refundPayment(paymentReference: string): Promise<boolean> {
     return refundTransaction(paymentReference);
   },
+  requiresWebhookSignature: false,
 
   async resolveWebhookSession(
     webhookEvent: WebhookEvent,
@@ -117,7 +120,10 @@ export const sumupPaymentProvider: PaymentProvider = {
     // resolveWebhookSession. We only parse the tiny payload
     // ({ event_type, id }) into the provider-agnostic event shape here.
     try {
-      const parsed = JSON.parse(payload) as { event_type?: string; id?: string };
+      const parsed = JSON.parse(payload) as {
+        event_type?: string;
+        id?: string;
+      };
       const id = parsed.id ?? "";
       return Promise.resolve({
         event: {

--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -15,8 +15,8 @@
  * decimal places (the shared currency helpers).
  */
 
-import { SumUp } from "@sumup/sdk";
 import type { CheckoutSuccess, Currency } from "@sumup/sdk";
+import { SumUp } from "@sumup/sdk";
 import { getBookingFeeAmount, itemsSubtotal } from "#shared/booking-fee.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { toMajorUnits, toMinorUnits } from "#shared/currency.ts";
@@ -168,7 +168,10 @@ export const sumupApi: {
       });
       const url = checkout.hosted_checkout_url;
       if (!checkout.id || !url) {
-        logDebug("SumUp", "Checkout response missing id or hosted_checkout_url");
+        logDebug(
+          "SumUp",
+          "Checkout response missing id or hosted_checkout_url",
+        );
         return null;
       }
       // Record the SumUp id so webhooks for this checkout pass the pre-filter
@@ -257,8 +260,7 @@ export const createCheckout = (i: CheckoutIntent, b: string) =>
   sumupApi.createCheckout(i, b);
 export const retrieveCheckoutById = (id: string) =>
   sumupApi.retrieveCheckoutById(id);
-export const refundTransaction = (id: string) =>
-  sumupApi.refundTransaction(id);
+export const refundTransaction = (id: string) => sumupApi.refundTransaction(id);
 export const getTransactionStatus = (id: string) =>
   sumupApi.getTransactionStatus(id);
 export const testSumupConnection = () => sumupApi.testSumupConnection();

--- a/test/e2e/duration-days.test.ts
+++ b/test/e2e/duration-days.test.ts
@@ -10,9 +10,8 @@
 
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
-import { getEventActivityLog } from "#shared/db/activityLog.ts";
-import { settings } from "#shared/db/settings.ts";
 import { addDays, getAvailableDates } from "#shared/dates.ts";
+import { getEventActivityLog } from "#shared/db/activityLog.ts";
 import {
   checkBatchAvailability,
   checkGroupCapAfterDurationChange,
@@ -23,6 +22,7 @@ import {
 } from "#shared/db/attendees.ts";
 import { getEvent, getEventWithCount } from "#shared/db/events.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
+import { settings } from "#shared/db/settings.ts";
 import { buildTemplateData } from "#shared/email-renderer.ts";
 import { MAX_DURATION_DAYS } from "#shared/types.ts";
 import { generateAttendeesCsv } from "#templates/csv.ts";
@@ -609,9 +609,9 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
         args: [sibling.id],
         sql: "UPDATE events SET event_type = 'standard' WHERE id = ?",
       });
-      expect(
-        await checkGroupCapAfterDurationChange(daily.id, group.id),
-      ).toBe("2026-10-01");
+      expect(await checkGroupCapAfterDurationChange(daily.id, group.id)).toBe(
+        "2026-10-01",
+      );
     });
 
     test("checkGroupCapAfterDurationChange returns null when the event has no bookings", async () => {
@@ -641,9 +641,7 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
       await bookAttendee(event, { date: "2026-10-01", quantity: 5 });
       // Simulate a legacy attendee with NULL start_at (pre-daily migration).
       const { getDb } = await import("#shared/db/client.ts");
-      const { createAttendeeAtomic } = await import(
-        "#shared/db/attendees.ts"
-      );
+      const { createAttendeeAtomic } = await import("#shared/db/attendees.ts");
       const legacy = await createAttendeeAtomic({
         bookings: [{ eventId: event.id, quantity: 5 }],
         email: "legacy@example.com",
@@ -889,9 +887,10 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
         `/admin/event/${event.id}/edit`,
         dailyEditForm(event, 2),
       );
-      expectRedirectWithFlash(`/admin/event/${event.id}`, "Event updated")(
-        response,
-      );
+      expectRedirectWithFlash(
+        `/admin/event/${event.id}`,
+        "Event updated",
+      )(response);
 
       const after = await rawEventRange(event.id);
       expect(after!.end_at).toBe(before!.end_at);
@@ -917,9 +916,10 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
           thank_you_url: "https://example.com",
         },
       );
-      expectRedirectWithFlash(`/admin/event/${event.id}`, "Event updated")(
-        response,
-      );
+      expectRedirectWithFlash(
+        `/admin/event/${event.id}`,
+        "Event updated",
+      )(response);
 
       // The value persists (inert until the event becomes daily)…
       expect((await getEvent(event.id))?.duration_days).toBe(7);

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -76,7 +76,9 @@ describe("AttendeeTable", () => {
     });
 
     test("links Name to the edit attendee page", () => {
-      const rows = [makeRow({ attendee: testAttendee({ id: 7, name: "Jane" }) })];
+      const rows = [
+        makeRow({ attendee: testAttendee({ id: 7, name: "Jane" }) }),
+      ];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).toContain('<a href="/admin/attendees/7">Jane</a>');
     });

--- a/test/lib/db/events.test.ts
+++ b/test/lib/db/events.test.ts
@@ -26,12 +26,12 @@ import {
   writeClosesAt,
   writeEventDate,
 } from "#shared/db/events.ts";
-import { MAX_DURATION_DAYS } from "#shared/types.ts";
 import {
   finalizeSession as finalizePaymentSession,
   isSessionProcessed,
   reserveSession,
 } from "#shared/db/processed-payments.ts";
+import { MAX_DURATION_DAYS } from "#shared/types.ts";
 import {
   bookAttendee,
   createTestAttendee,

--- a/test/lib/server-settings/sumup.test.ts
+++ b/test/lib/server-settings/sumup.test.ts
@@ -121,7 +121,10 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
   });
 
   describe("POST /admin/settings/sumup/test", () => {
-    testRequiresAuth("/admin/settings/sumup/test", { body: {}, method: "POST" });
+    testRequiresAuth("/admin/settings/sumup/test", {
+      body: {},
+      method: "POST",
+    });
 
     test("returns the connection test result as JSON", async () => {
       await withMocks(

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -2,13 +2,13 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
+import { setEffectiveDomainForTest } from "#shared/config.ts";
 import {
   answersTable,
   getAttendeeAnswersBatch,
   questionsTable,
   setEventQuestions,
 } from "#shared/db/questions.ts";
-import { setEffectiveDomainForTest } from "#shared/config.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   setSumupCheckoutId,
@@ -123,7 +123,9 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         expect((await response.json()).processed).toBe(true);
 
         // A retried webhook resolves to the already-created attendee
-        const retry = await handleRequest(mockWebhookRequest(sumupWebhookEvent));
+        const retry = await handleRequest(
+          mockWebhookRequest(sumupWebhookEvent),
+        );
         expect((await retry.json()).processed).toBe(true);
       } finally {
         restore.restore();

--- a/test/lib/sumup-provider.test.ts
+++ b/test/lib/sumup-provider.test.ts
@@ -38,8 +38,7 @@ const withFetched = (
   body: (calls: () => unknown[][]) => Promise<void>,
 ) =>
   withMocks(
-    () =>
-      stub(sumupApi, "retrieveCheckoutById", () => Promise.resolve(value)),
+    () => stub(sumupApi, "retrieveCheckoutById", () => Promise.resolve(value)),
     (mock) => body(() => mock.calls.map((c) => c.args)),
   );
 

--- a/test/lib/sumup.test.ts
+++ b/test/lib/sumup.test.ts
@@ -1,7 +1,7 @@
-import type { SumUp } from "@sumup/sdk";
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import type { SumUp } from "@sumup/sdk";
 import { setEffectiveDomainForTest } from "#shared/config.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getSumupCheckout } from "#shared/db/sumup-checkouts.ts";
@@ -178,9 +178,7 @@ describe("sumup", () => {
         expect(String(sentBody.redirect_url)).toContain(
           `session_id=${result!.reference}`,
         );
-        expect(sentBody.return_url).toBe(
-          "https://example.com/payment/webhook",
-        );
+        expect(sentBody.return_url).toBe("https://example.com/payment/webhook");
         // Metadata + SumUp id persisted under the generated reference
         const stored = await getSumupCheckout(result!.reference);
         expect(stored!.metadata.name).toBe("Alice");

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -177,7 +177,9 @@ describe("adminQuestionPage", () => {
       TEST_EVENTS,
       new Set([1]),
     );
-    expect(html).toContain('checked name="event_ids" type="checkbox" value="1"');
+    expect(html).toContain(
+      'checked name="event_ids" type="checkbox" value="1"',
+    );
     expect(html).not.toContain(
       'checked name="event_ids" type="checkbox" value="2"',
     );


### PR DESCRIPTION
## Summary

Runs `deno task precommit` and commits the mechanical formatting fixes that `biome:fix` applied. No behavior changes.

The changes are purely lint/format adjustments across `src/` and `test/`:
- **Import ordering** — alphabetised imports and grouped `type` imports
- **Object-key sorting** — sorted object/route-map keys and provider properties
- **Line-width reformatting** — re-wrapped long lines and collapsed lines that now fit

## Verification

Full `deno task precommit` suite passes against the formatted code:

| Step | Result |
| --- | --- |
| `biome:fix` | ✓ |
| `typecheck` | ✓ |
| `lint` | ✓ |
| `cpd` | ✓ |
| `build:edge` | ✓ |
| `test:coverage` | ✓ |

`biome:check` is idempotent after the fixes ("No fixes applied"). The 7 remaining biome warnings are pre-existing non-fatal complexity warnings, not introduced or resolved here, and do not fail the precommit.

https://claude.ai/code/session_01GwfGDjGYLukQTb3ctgE98H

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwfGDjGYLukQTb3ctgE98H)_