### PR TITLE
Consolidate question/answer load, parse, and save helpers

### DIFF
--- a/src/features/admin/actions.ts
+++ b/src/features/admin/actions.ts
@@ -22,13 +22,8 @@ import {
 import { logActivity } from "#shared/db/activityLog.ts";
 import { decryptAttendees } from "#shared/db/attendees.ts";
 import { getEventWithAttendeesRaw } from "#shared/db/events.ts";
-import {
-  getAttendeeAnswersBatch,
-  getQuestionsWithEventIds,
-} from "#shared/db/questions.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { Attendee, EventWithCount } from "#shared/types.ts";
-import type { TableQuestionData } from "#templates/attendee-table.tsx";
 
 /** Extract and validate ?date= query parameter. Returns null if absent or invalid. */
 export const getDateFilter = (request: Request): string | null => {
@@ -204,17 +199,4 @@ export const createActionHandler = <TSession = AuthSession>(
       );
       return redirect(redirectUrl, msg, true);
     });
-};
-
-/** Load question data for attendees across multiple events */
-export const loadQuestionData = async (
-  eventIds: number[],
-  attendeeIds: number[],
-): Promise<TableQuestionData | undefined> => {
-  if (attendeeIds.length === 0 || eventIds.length === 0) return undefined;
-  const [{ questions }, attendeeAnswerMap] = await Promise.all([
-    getQuestionsWithEventIds(eventIds),
-    getAttendeeAnswersBatch(attendeeIds),
-  ]);
-  return questions.length > 0 ? { attendeeAnswerMap, questions } : undefined;
 };

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -34,10 +34,9 @@ import { getAllEvents } from "#shared/db/events.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import {
-  getAttendeeAnswersBatch,
-  getQuestionsWithEventIds,
+  loadAttendeeQuestionData,
+  parseQuestionAnswers,
   type QuestionWithAnswers,
-  readQuestionAnswer,
   saveAttendeeAnswers,
 } from "#shared/db/questions.ts";
 import { getAvailableDates } from "#shared/dates.ts";
@@ -234,14 +233,11 @@ const loadQuestionsForExisting = async (
   existing: ExistingLine[],
 ): Promise<{ questions: QuestionWithAnswers[]; selectedAnswerIds: number[] }> => {
   const eventIds = unique(existing.map((e) => e.booking.event_id));
-  if (eventIds.length === 0) return { questions: [], selectedAnswerIds: [] };
-  const [{ questions }, answersMap] = await Promise.all([
-    getQuestionsWithEventIds(eventIds),
-    getAttendeeAnswersBatch([attendeeId]),
-  ]);
+  const data = await loadAttendeeQuestionData(eventIds, [attendeeId]);
+  if (!data) return { questions: [], selectedAnswerIds: [] };
   return {
-    questions,
-    selectedAnswerIds: answersMap.get(attendeeId) ?? [],
+    questions: data.questions,
+    selectedAnswerIds: data.attendeeAnswerMap.get(attendeeId) ?? [],
   };
 };
 
@@ -476,7 +472,8 @@ const handleSubmitInner = async (
       parsed,
       attendee!,
       questions,
-      parseQuestionAnswers(form, questions),
+      // Admin edit treats answers as optional — keep only the valid ones.
+      parseQuestionAnswers({ optional: true })(form, questions).answerIds,
     );
   if (outcome.ok) return outcome.response;
   // In-place re-render (no redirect): show the failure inside the form, the
@@ -512,20 +509,6 @@ const savedRedirect = (
   message: string,
 ): Response =>
   redirect(`${attendeePath(id, returnUrl)}#${ATTENDEE_FORM_ID}`, message, true);
-
-/** Read submitted question answers from the form, filtered to valid options. */
-const parseQuestionAnswers = (
-  form: FormParams,
-  questions: QuestionWithAnswers[],
-): number[] => {
-  const answerIds: number[] = [];
-  for (const q of questions) {
-    // Admin edit treats answers as optional — keep only the valid ones.
-    const answer = readQuestionAnswer(form, q);
-    if (answer.status === "ok") answerIds.push(answer.answerId);
-  }
-  return answerIds;
-};
 
 /** Run the atomic create flow. All-or-nothing: `ensureAllBookings` rolls the
  * attendee back unless every submitted line fits, so a partial booking never
@@ -605,7 +588,7 @@ const applyEdit = async (
 
   // Save question answers (atomic delete + insert) when the event has any.
   if (questions.length > 0) {
-    await saveAttendeeAnswers([attendeeId], answerIds);
+    await saveAttendeeAnswers(new Map([[attendeeId, answerIds]]));
   }
 
   const firstEventId = desired[0]?.eventId;

--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -3,11 +3,8 @@
  */
 
 import { filter, flatMap, map, pipe, reduce, sort, unique } from "#fp";
-import {
-  csvResponse,
-  getDateFilter,
-  loadQuestionData,
-} from "#routes/admin/actions.ts";
+import { csvResponse, getDateFilter } from "#routes/admin/actions.ts";
+import { loadAttendeeQuestionData } from "#shared/db/questions.ts";
 import { getPrivateKey, requireSessionOr } from "#routes/auth.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
@@ -216,7 +213,7 @@ const handleAdminCalendarGet = (request: Request) =>
       standardCtx.standardEvents,
       holidays,
     );
-    const questionData = await loadQuestionData(
+    const questionData = await loadAttendeeQuestionData(
       attendees.map((a) => a.eventId),
       attendees.map((a) => a.id),
     );

--- a/src/features/admin/groups.ts
+++ b/src/features/admin/groups.ts
@@ -3,7 +3,8 @@
  */
 
 import { map } from "#fp";
-import { loadQuestionData, requirePrivateKey } from "#routes/admin/actions.ts";
+import { requirePrivateKey } from "#routes/admin/actions.ts";
+import { loadAttendeeQuestionData } from "#shared/db/questions.ts";
 import { createCrudHandlers } from "#routes/admin/owner-crud.ts";
 import { requireSessionOr } from "#routes/auth.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
@@ -188,7 +189,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
       }
       const allowedDomain = getEffectiveDomain();
       const successMessage = getFlash().success;
-      const questionData = await loadQuestionData(
+      const questionData = await loadAttendeeQuestionData(
         eventIds,
         attendees.map((a) => a.id),
       );

--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -56,7 +56,7 @@ import {
   type ProcessedPayment,
   reserveSession,
 } from "#shared/db/processed-payments.ts";
-import { saveEventAnswers } from "#shared/db/questions.ts";
+import { groupEventAnswers, saveAttendeeAnswers } from "#shared/db/questions.ts";
 import { ErrorCode, logDebug, logError } from "#shared/logger.ts";
 import {
   type BookingItem,
@@ -630,7 +630,9 @@ const processPaymentSession = async (
   const createdEntries = created.entries;
 
   if (intent.eventAnswerIds) {
-    await saveEventAnswers(createdEntries, intent.eventAnswerIds);
+    await saveAttendeeAnswers(
+      groupEventAnswers(createdEntries, intent.eventAnswerIds),
+    );
   }
 
   const firstAttendee = createdEntries[0]!;

--- a/src/features/public/ticket-form.ts
+++ b/src/features/public/ticket-form.ts
@@ -9,7 +9,6 @@ import { validatePrice } from "#shared/currency.ts";
 import {
   type QuestionEventMap,
   type QuestionWithAnswers,
-  readQuestionAnswer,
 } from "#shared/db/questions.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { EventFields } from "#shared/types.ts";
@@ -43,26 +42,6 @@ export const formatAtomicError = capacityErrorFormatter({
   generic: "Sorry, not enough spots available",
   withName: (name) => `Sorry, ${name} no longer has enough spots available`,
 });
-
-/** Parse and validate answers for custom questions from form data.
- * Returns answer IDs if valid, or an error message if any required question is unanswered. */
-export const parseQuestionAnswers = (
-  form: URLSearchParams,
-  questions: QuestionWithAnswers[],
-): { ok: true; answerIds: number[] } | { ok: false; error: string } => {
-  const answerIds: number[] = [];
-  for (const q of questions) {
-    const answer = readQuestionAnswer(form, q);
-    if (answer.status === "missing") {
-      return { error: `Please answer: ${q.text}`, ok: false };
-    }
-    if (answer.status === "invalid") {
-      return { error: `Invalid answer for: ${q.text}`, ok: false };
-    }
-    answerIds.push(answer.answerId);
-  }
-  return { answerIds, ok: true };
-};
 
 /** Build a per-event answer map from parsed answers and the question-event mapping.
  * Each event gets only the answer IDs for questions assigned to it. */

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -7,7 +7,11 @@ import { applyFlash, withCsrfForm } from "#routes/csrf.ts";
 import { errorRedirect, redirectResponse } from "#routes/response.ts";
 import { getBaseUrl } from "#routes/url.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
-import { saveEventAnswers } from "#shared/db/questions.ts";
+import {
+  groupEventAnswers,
+  parseQuestionAnswers,
+  saveAttendeeAnswers,
+} from "#shared/db/questions.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#shared/demo.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { verifyQrBookToken } from "#shared/qr-token.ts";
@@ -26,7 +30,6 @@ import {
   getTicketFieldsSetting,
   parseCustomPrice,
   parseQuantities,
-  parseQuestionAnswers,
   ticketFormErrorResponse,
   ticketResponse,
   validateSubmittedDate,
@@ -208,7 +211,7 @@ const handleFreePath = async (params: PathParams): Promise<Response> => {
       ctx.questionEventMap,
       info.selectedEventIds,
     );
-    await saveEventAnswers(result.entries, eventAnswerMap);
+    await saveAttendeeAnswers(groupEventAnswers(result.entries, eventAnswerMap));
   }
 
   if (ctx.events.length === 1) {
@@ -252,7 +255,10 @@ const processSubmission = async (
     const eventIds = ctx.questionEventMap.get(q.id);
     return !eventIds || eventIds.some((eid) => selectedEventIds.has(eid));
   });
-  const answersResult = parseQuestionAnswers(form, activeQuestions);
+  const answersResult = parseQuestionAnswers({ optional: false })(
+    form,
+    activeQuestions,
+  );
   if (!answersResult.ok) {
     return ticketFormErrorResponse(ctx)(answersResult.error);
   }

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -291,12 +291,6 @@ export const setEventQuestions = async (
   await executeBatch(statements);
 };
 
-const answerInsert = (attendeeId: number, answerId: number) =>
-  insert("attendee_answers", {
-    answer_id: answerId,
-    attendee_id: attendeeId,
-  });
-
 /** Read and validate one question's submitted answer from form data.
  * `"missing"` = no value; `"invalid"` = the value isn't one of the question's
  * options; otherwise the matched answer id. Shared by the public (required)
@@ -317,61 +311,106 @@ export const readQuestionAnswer = (
   return { answerId, status: "ok" };
 };
 
-/** Replace all answers for one or more attendees in a single atomic batch.
- * Deletes existing answers first, then inserts the new ones. */
-export const saveAttendeeAnswers = async (
-  attendeeIds: number[],
-  answerIds: number[],
-): Promise<void> => {
-  if (attendeeIds.length === 0) return;
-  const deletes = attendeeIds.map((attendeeId) => ({
-    args: [attendeeId],
-    sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
-  }));
-  const inserts =
-    answerIds.length === 0
-      ? []
-      : attendeeIds.flatMap((attendeeId) =>
-          answerIds.map((answerId) => answerInsert(attendeeId, answerId)),
-        );
-  await executeBatch([...deletes, ...inserts]);
-};
+/** Outcome of parsing a form's submitted answers. */
+export type ParsedQuestionAnswers =
+  | { ok: true; answerIds: number[] }
+  | { ok: false; error: string };
 
 /**
- * Save per-event question answers for a batch of attendee/event pairs.
- * Collects all deletes and inserts into a single executeBatch call.
+ * Curried answer parser shared by the public and admin flows. The loop and
+ * per-answer lookup/validation live here once (over `readQuestionAnswer`);
+ * the `optional` flag is the only policy difference between the two callers:
+ *
+ * - `{ optional: false }` (public booking) — every question must be answered
+ *   with a valid option; the first missing/invalid one returns `ok: false`.
+ * - `{ optional: true }` (admin edit) — unanswered or invalid questions are
+ *   skipped, so the result is always `ok: true` with the valid answers found.
  */
-export const saveEventAnswers = async (
-  entries: { attendee: { id: number }; event: { id: number } }[],
-  eventAnswerIds: Record<string, number[]>,
-): Promise<void> => {
-  // Collect all answer IDs per attendee (one attendee may span multiple events)
-  const answersByAttendee = new Map<number, number[]>();
-  for (const { attendee, event } of entries) {
-    const answers = eventAnswerIds[String(event.id)];
-    if (answers && answers.length > 0) {
-      const existing = answersByAttendee.get(attendee.id) ?? [];
-      existing.push(...answers);
-      answersByAttendee.set(attendee.id, existing);
+export function parseQuestionAnswers(
+  opts: { optional: true },
+): (
+  form: URLSearchParams,
+  questions: QuestionWithAnswers[],
+) => { ok: true; answerIds: number[] };
+export function parseQuestionAnswers(
+  opts: { optional: false },
+): (
+  form: URLSearchParams,
+  questions: QuestionWithAnswers[],
+) => ParsedQuestionAnswers;
+export function parseQuestionAnswers(opts: { optional: boolean }) {
+  return (
+    form: URLSearchParams,
+    questions: QuestionWithAnswers[],
+  ): ParsedQuestionAnswers => {
+    const answerIds: number[] = [];
+    for (const q of questions) {
+      const answer = readQuestionAnswer(form, q);
+      if (answer.status === "ok") {
+        answerIds.push(answer.answerId);
+        continue;
+      }
+      if (opts.optional) continue;
+      const lead = answer.status === "missing"
+        ? "Please answer"
+        : "Invalid answer for";
+      return { error: `${lead}: ${q.text}`, ok: false };
     }
-  }
+    return { answerIds, ok: true };
+  };
+}
 
+/**
+ * Replace every listed attendee's answers in one atomic batch: each attendee's
+ * existing answers are deleted, then their new answer set inserted. The
+ * `Map<attendeeId, answerIds>` is the single shape every save situation reduces
+ * to — one answer set shared across attendees, a by-question selection, or the
+ * per-event grouping from `groupEventAnswers` — so callers build the map and
+ * this builds the SQL. `INSERT OR IGNORE` tolerates an answer set that repeats
+ * an id (e.g. an attendee whose booked events share a question), which the
+ * unique `(attendee_id, answer_id)` index would otherwise reject.
+ */
+export const saveAttendeeAnswers = async (
+  answersByAttendee: Map<number, number[]>,
+): Promise<void> => {
   const statements: { sql: string; args: InValue[] }[] = [];
-  for (const [attendeeId, answers] of answersByAttendee) {
+  for (const [attendeeId, answerIds] of answersByAttendee) {
     statements.push({
       args: [attendeeId],
       sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
     });
-    const placeholders = answers.map(() => "(?, ?)").join(", ");
-    const args = answers.flatMap((id) => [attendeeId, id]);
-    statements.push({
-      args,
-      sql: `INSERT OR IGNORE INTO attendee_answers (attendee_id, answer_id) VALUES ${placeholders}`,
-    });
+    if (answerIds.length > 0) {
+      const placeholders = answerIds.map(() => "(?, ?)").join(", ");
+      statements.push({
+        args: answerIds.flatMap((id) => [attendeeId, id]),
+        sql: `INSERT OR IGNORE INTO attendee_answers (attendee_id, answer_id) VALUES ${placeholders}`,
+      });
+    }
   }
   if (statements.length > 0) {
     await executeBatch(statements);
   }
+};
+
+/**
+ * Reduce per-event answer selections to one answer set per attendee. An
+ * attendee booking several events in the same submission accumulates every
+ * event's answers; events with no answers contribute nothing. Feeds the map
+ * straight into `saveAttendeeAnswers`.
+ */
+export const groupEventAnswers = (
+  entries: { attendee: { id: number }; event: { id: number } }[],
+  eventAnswerIds: Record<string, number[]>,
+): Map<number, number[]> => {
+  const answersByAttendee = new Map<number, number[]>();
+  for (const { attendee, event } of entries) {
+    const answers = eventAnswerIds[String(event.id)];
+    if (!answers || answers.length === 0) continue;
+    const existing = answersByAttendee.get(attendee.id) ?? [];
+    existing.push(...answers);
+    answersByAttendee.set(attendee.id, existing);
+  }
+  return answersByAttendee;
 };
 
 /** Get answers for multiple attendees in a single query */
@@ -398,6 +437,31 @@ export const getAttendeeAnswersBatch = async (
     },
     new Map(),
   )(rows);
+};
+
+/** Questions across a set of events plus each attendee's selected answers —
+ * the shape the attendee table, calendar, groups and edit form all render. */
+export type AttendeeQuestionData = {
+  questions: QuestionWithAnswers[];
+  attendeeAnswerMap: Map<number, number[]>;
+};
+
+/**
+ * Load the questions for a set of events together with each attendee's chosen
+ * answers, in parallel. Returns `undefined` when there's nothing to render —
+ * no events, no attendees, or no questions assigned — so callers can skip the
+ * answers UI without an extra emptiness check.
+ */
+export const loadAttendeeQuestionData = async (
+  eventIds: number[],
+  attendeeIds: number[],
+): Promise<AttendeeQuestionData | undefined> => {
+  if (attendeeIds.length === 0 || eventIds.length === 0) return undefined;
+  const [{ questions }, attendeeAnswerMap] = await Promise.all([
+    getQuestionsWithEventIds(eventIds),
+    getAttendeeAnswersBatch(attendeeIds),
+  ]);
+  return questions.length > 0 ? { attendeeAnswerMap, questions } : undefined;
 };
 
 /** Get attendee answers mapped by question ID.
@@ -431,24 +495,6 @@ export const getAttendeeAnswersByQuestion = async (
     });
   }
   return result;
-};
-
-/** Save attendee answers by question ID mapping.
- * Replaces all answers for the given attendee. */
-export const saveAttendeeAnswersByQuestion = async (
-  attendeeId: number,
-  questionToAnswer: Map<number, number>,
-): Promise<void> => {
-  const statements: { sql: string; args: InValue[] }[] = [
-    {
-      args: [attendeeId],
-      sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
-    },
-    ...Array.from(questionToAnswer.values()).map((answerId) =>
-      answerInsert(attendeeId, answerId),
-    ),
-  ];
-  await executeBatch(statements);
 };
 
 /** Delete a question and all related data in a single batch.

--- a/src/shared/merge/attendee-merge.ts
+++ b/src/shared/merge/attendee-merge.ts
@@ -13,7 +13,7 @@ import { invalidateEventsCache } from "#shared/db/events.ts";
 import type { QuestionWithAnswers } from "#shared/db/questions.ts";
 import {
   getAttendeeAnswersByQuestion,
-  saveAttendeeAnswersByQuestion,
+  saveAttendeeAnswers,
 } from "#shared/db/questions.ts";
 import type {
   ApplyAttendeeMergeInput,
@@ -523,8 +523,8 @@ export const applyAttendeeMerge = async (
     { args: [sourceId], sql: "DELETE FROM attendees WHERE id = ?" },
   ]);
 
-  // Save merged answers for target
-  await saveAttendeeAnswersByQuestion(targetId, finalAnswers);
+  // Save merged answers for target (one answer per question → flat id list).
+  await saveAttendeeAnswers(new Map([[targetId, [...finalAnswers.values()]]]));
 
   invalidateEventsCache();
 

--- a/src/ui/templates/attendee-table.tsx
+++ b/src/ui/templates/attendee-table.tsx
@@ -22,7 +22,11 @@ import {
   ATTENDEE_DEFAULT_ORDER,
   ATTENDEE_TABLE_COLUMNS,
 } from "#shared/columns/attendee-columns.ts";
-import type { Answer, QuestionWithAnswers } from "#shared/db/questions.ts";
+import type {
+  Answer,
+  AttendeeQuestionData,
+  QuestionWithAnswers,
+} from "#shared/db/questions.ts";
 import { settings } from "#shared/db/settings.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { Attendee, AttendeeTableRow } from "#shared/types.ts";
@@ -31,11 +35,10 @@ import { escapeHtml } from "#templates/layout.tsx";
 export { formatAddressInline } from "#shared/columns/attendee-columns.ts";
 export type { AttendeeTableRow } from "#shared/types.ts";
 
-/** Question data for displaying answers in the attendee table */
-export type TableQuestionData = {
-  questions: QuestionWithAnswers[];
-  attendeeAnswerMap: Map<number, number[]>;
-};
+/** Question data for displaying answers in the attendee table.
+ * Canonical shape lives in the questions module; aliased here so existing
+ * importers keep their `TableQuestionData` reference. */
+export type TableQuestionData = AttendeeQuestionData;
 
 /** Options passed to attendee column cell renderers */
 export type AttendeeColumnOpts = {

--- a/test/lib/attendee-merge.test.ts
+++ b/test/lib/attendee-merge.test.ts
@@ -247,8 +247,8 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const target = await createAttendee(event.id, "Alice");
       const source = await createAttendee(event.id, "Bob");
 
-      await saveAttendeeAnswers([target.id], [answers[0]!.id]); // Red
-      await saveAttendeeAnswers([source.id], [answers[1]!.id]); // Blue
+      await saveAttendeeAnswers(new Map([[target.id, [answers[0]!.id]]])); // Red
+      await saveAttendeeAnswers(new Map([[source.id, [answers[1]!.id]]])); // Blue
 
       const targetBookings = await getBookings(target.id);
       const sourceBookings = await getBookings(source.id);
@@ -298,7 +298,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const source = await createAttendee(event.id, "Bob");
 
       // Only source has an answer
-      await saveAttendeeAnswers([source.id], [answers[1]!.id]);
+      await saveAttendeeAnswers(new Map([[source.id, [answers[1]!.id]]]));
 
       const targetBookings = await getBookings(target.id);
       const sourceBookings = await getBookings(source.id);
@@ -429,7 +429,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
 
     const target = await createAttendee(event.id, "Alice", "alice@test.com");
     const source = await createAttendee(event.id, "Bob", "bob@test.com");
-    await saveAttendeeAnswers([source.id], [a1.id]);
+    await saveAttendeeAnswers(new Map([[source.id, [a1.id]]]));
 
     const targetBookings = await getBookings(target.id);
     const sourceBookings = await getBookings(source.id);
@@ -690,8 +690,8 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const target = await createAttendee(event1.id, "Alice", "alice@test.com");
       const source = await createAttendee(event2.id, "Bob", "bob@test.com");
 
-      await saveAttendeeAnswers([target.id], [answers[0]!.id]); // Red
-      await saveAttendeeAnswers([source.id], [answers[1]!.id]); // Blue
+      await saveAttendeeAnswers(new Map([[target.id, [answers[0]!.id]]])); // Red
+      await saveAttendeeAnswers(new Map([[source.id, [answers[1]!.id]]])); // Blue
 
       const targetBookings = await getBookings(target.id);
       const sourceBookings = await getBookings(source.id);
@@ -791,8 +791,8 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const target = await createAttendee(event.id, "Alice");
       const source = await createAttendee(event2.id, "Bob");
 
-      await saveAttendeeAnswers([target.id], [answers[0]!.id]);
-      await saveAttendeeAnswers([source.id], [answers[1]!.id]);
+      await saveAttendeeAnswers(new Map([[target.id, [answers[0]!.id]]]));
+      await saveAttendeeAnswers(new Map([[source.id, [answers[1]!.id]]]));
 
       const targetBookings = await getBookings(target.id);
       const sourceBookings = await getBookings(source.id);
@@ -870,7 +870,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const source = await createAttendee(event2.id, "Bob");
 
       // Only source has answer
-      await saveAttendeeAnswers([source.id], [answers[1]!.id]);
+      await saveAttendeeAnswers(new Map([[source.id, [answers[1]!.id]]]));
 
       const targetBookings = await getBookings(target.id);
       const sourceBookings = await getBookings(source.id);

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -63,7 +63,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       await setEventQuestions(event.id, [q.id]);
 
       const attendee = await createAttendee(event.id);
-      await saveAttendeeAnswers([attendee.id], [a.id]);
+      await saveAttendeeAnswers(new Map([[attendee.id, [a.id]]]));
 
       await deleteQuestion(q.id);
 
@@ -306,7 +306,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       const event = await createTestEvent();
       const attendee = await createAttendee(event.id);
 
-      await saveAttendeeAnswers([attendee.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
       const batch = await getAttendeeAnswersBatch([attendee.id]);
       expect(batch.get(attendee.id)).toEqual([a1.id]);
@@ -329,8 +329,8 @@ describeWithEnv("custom questions", { db: true }, () => {
       const att1 = await createAttendee(event.id, "Alice");
       const att2 = await createAttendee(event.id, "Bob");
 
-      await saveAttendeeAnswers([att1.id], [a1.id]);
-      await saveAttendeeAnswers([att2.id], [a2.id]);
+      await saveAttendeeAnswers(new Map([[att1.id, [a1.id]]]));
+      await saveAttendeeAnswers(new Map([[att2.id, [a2.id]]]));
 
       const batch = await getAttendeeAnswersBatch([att1.id, att2.id]);
       expect(batch.get(att1.id)).toEqual([a1.id]);
@@ -342,14 +342,14 @@ describeWithEnv("custom questions", { db: true }, () => {
       expect(batch.size).toBe(0);
     });
 
-    test("saveAttendeeAnswers does nothing for empty attendeeIds", async () => {
-      await saveAttendeeAnswers([], [1]);
-      // No error thrown, no rows inserted
+    test("saveAttendeeAnswers does nothing for an empty map", async () => {
+      await saveAttendeeAnswers(new Map());
+      // No error thrown, no batch executed
     });
 
-    test("saveAttendeeAnswers does nothing for empty answerIds", async () => {
-      await saveAttendeeAnswers([1], []);
-      // No error thrown, no rows inserted
+    test("saveAttendeeAnswers skips inserts for an answerless attendee", async () => {
+      await saveAttendeeAnswers(new Map([[1, []]]));
+      // No error thrown, no rows inserted (delete-only path)
     });
 
     test("saveAttendeeAnswers replaces existing answers atomically", async () => {
@@ -367,12 +367,12 @@ describeWithEnv("custom questions", { db: true }, () => {
 
       const event = await createTestEvent();
       const att = await createAttendee(event.id);
-      await saveAttendeeAnswers([att.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[att.id, [a1.id]]]));
 
       const before = await getAttendeeAnswersBatch([att.id]);
       expect(before.get(att.id)).toEqual([a1.id]);
 
-      await saveAttendeeAnswers([att.id], [a2.id]);
+      await saveAttendeeAnswers(new Map([[att.id, [a2.id]]]));
 
       const after = await getAttendeeAnswersBatch([att.id]);
       expect(after.get(att.id)).toEqual([a2.id]);
@@ -388,9 +388,9 @@ describeWithEnv("custom questions", { db: true }, () => {
 
       const event = await createTestEvent();
       const att = await createAttendee(event.id);
-      await saveAttendeeAnswers([att.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[att.id, [a1.id]]]));
 
-      await saveAttendeeAnswers([att.id], []);
+      await saveAttendeeAnswers(new Map([[att.id, []]]));
 
       const after = await getAttendeeAnswersBatch([att.id]);
       expect(after.get(att.id)).toBeUndefined();
@@ -475,8 +475,8 @@ describeWithEnv("custom questions", { db: true }, () => {
       });
       const att1 = await createAttendee(event.id, "Alice");
       const att2 = await createAttendee(event.id, "Bob");
-      await saveAttendeeAnswers([att1.id], [a1.id]);
-      await saveAttendeeAnswers([att2.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[att1.id, [a1.id]]]));
+      await saveAttendeeAnswers(new Map([[att2.id, [a1.id]]]));
       const counts = await getAnswerCountsForQuestion(q.id);
       expect(counts.get(a1.id)).toBe(2);
       expect(counts.get(a2.id)).toBe(0);

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -61,6 +61,18 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
     });
   });
 
+  describe("edit route (/admin/attendees/:id) requires auth", () => {
+    // The edit GET/POST share the same session guards as /new. Assert them on
+    // the edit endpoints directly so an unauthenticated request can never reach
+    // (or mutate) an existing attendee. Auth is checked before the attendee is
+    // loaded, so a placeholder id is fine.
+    testRequiresAuth("/admin/attendees/1");
+    testRequiresAuth("/admin/attendees/1", {
+      body: { line_count: "1", name: "X" },
+      method: "POST",
+    });
+  });
+
   describe("POST /admin/attendees/new", () => {
     testRequiresAuth("/admin/attendees/new", {
       body: { line_count: "1", name: "X" },
@@ -850,6 +862,76 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       );
       expect(saved.has(aA.id)).toBe(true);
       expect(saved.has(aB.id)).toBe(true);
+    });
+
+    test("never persists an answer id the admin didn't have as an option", async () => {
+      const { aA, attendeeId, qA, qB } = await setupMultiEventQuestions();
+
+      // Valid answer for qA; a bogus id for qB that isn't one of its options.
+      const form = await buildAttendeeEditForm(attendeeId, {
+        extra: {
+          [`question_${qA.id}`]: String(aA.id),
+          [`question_${qB.id}`]: "99999",
+        },
+        name: "Multi",
+      });
+      const { response } = await adminFormPost(
+        `/admin/attendees/${attendeeId}`,
+        form,
+      );
+      expect(response.status).toBe(302);
+
+      const saved = new Set(
+        (await getAttendeeAnswersBatch([attendeeId])).get(attendeeId) ?? [],
+      );
+      // The bogus id is silently dropped (admin answers are optional), never
+      // written — so the form can't inject an arbitrary answer row.
+      expect(saved.has(aA.id)).toBe(true);
+      expect(saved.has(99999)).toBe(false);
+    });
+
+    test("editing one attendee's answers leaves another attendee's untouched", async () => {
+      const event = await createTestEvent({ maxAttendees: 10, name: "Shared" });
+      const q = await questionsTable.insert({ text: "Size?" });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        sortOrder: 0,
+        text: "S",
+      });
+      const a2 = await answersTable.insert({
+        questionId: q.id,
+        sortOrder: 1,
+        text: "L",
+      });
+      await setEventQuestions(event.id, [q.id]);
+
+      const makeAttendee = async (name: string, email: string) => {
+        const result = await createAttendeeAtomic({
+          bookings: [{ eventId: event.id, quantity: 1 }],
+          email,
+          name,
+        });
+        if (!result.success) throw new Error("setup");
+        return result.attendees[0]!.id;
+      };
+      const alice = await makeAttendee("Alice", "alice@example.com");
+      const bob = await makeAttendee("Bob", "bob@example.com");
+      await saveAttendeeAnswers(new Map([[alice, [a1.id]]]));
+      await saveAttendeeAnswers(new Map([[bob, [a2.id]]]));
+
+      // Edit Alice's answer; her save must not touch Bob's row.
+      const form = await buildAttendeeEditForm(alice, {
+        extra: { [`question_${q.id}`]: String(a2.id) },
+        name: "Alice",
+      });
+      const { response } = await adminFormPost(
+        `/admin/attendees/${alice}`,
+        form,
+      );
+      expect(response.status).toBe(302);
+
+      const bobAnswers = (await getAttendeeAnswersBatch([bob])).get(bob) ?? [];
+      expect(bobAnswers).toEqual([a2.id]);
     });
   });
 });

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -813,7 +813,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       });
       if (!created.success) throw new Error("setup");
       const attendeeId = created.attendees[0]!.id;
-      await saveAttendeeAnswers([attendeeId], [aA.id, aB.id]);
+      await saveAttendeeAnswers(new Map([[attendeeId, [aA.id, aB.id]]]));
       return { aA, aB, attendeeId, qA, qB };
     };
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -2076,7 +2076,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
     test("pre-selects existing answer on edit page", async () => {
       const { attendee, a1 } = await setupQuestionAndAttendee();
       const { saveAttendeeAnswers } = await import("#shared/db/questions.ts");
-      await saveAttendeeAnswers([attendee.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
       const response = await awaitTestRequest(
         `/admin/attendees/${attendee.id}`,
@@ -2127,7 +2127,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const { saveAttendeeAnswers, getAttendeeAnswersBatch } = await import(
         "#shared/db/questions.ts"
       );
-      await saveAttendeeAnswers([attendee.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
       const form = await buildAttendeeEditForm(attendee.id, {
         email: "john@example.com",
@@ -2149,7 +2149,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const { saveAttendeeAnswers, getAttendeeAnswersBatch } = await import(
         "#shared/db/questions.ts"
       );
-      await saveAttendeeAnswers([attendee.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
       const form = await buildAttendeeEditForm(attendee.id, {
         email: "john@example.com",
@@ -3163,11 +3163,11 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const { saveAttendeeAnswers: save } = await import(
         "#shared/db/questions.ts"
       );
-      await save([target.id], [a1.id]);
+      await save(new Map([[target.id, [a1.id]]]));
       // Need source attendee ID
       const { getAttendeesByTokens } = await import("#shared/db/attendees.ts");
       const [sourceData] = await getAttendeesByTokens([sourceToken]);
-      await save([sourceData!.id], [a2.id]);
+      await save(new Map([[sourceData!.id, [a2.id]]]));
 
       const response = await awaitTestRequest(
         `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
@@ -3218,8 +3218,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         await import("#shared/db/questions.ts");
       const { getAttendeesByTokens } = await import("#shared/db/attendees.ts");
       const [sourceData] = await getAttendeesByTokens([sourceToken]);
-      await save([target.id], [a1.id]); // Small
-      await save([sourceData!.id], [a2.id]); // Large
+      await save(new Map([[target.id, [a1.id]]])); // Small
+      await save(new Map([[sourceData!.id, [a2.id]]])); // Large
 
       // Get merge version from preview page
       const previewPage = await awaitTestRequest(
@@ -3356,8 +3356,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         await import("#shared/db/questions.ts");
       const { getAttendeesByTokens } = await import("#shared/db/attendees.ts");
       const [sourceData] = await getAttendeesByTokens([sourceToken]);
-      await save([target.id], [a1.id]);
-      await save([sourceData!.id], [a2.id]);
+      await save(new Map([[target.id, [a1.id]]]));
+      await save(new Map([[sourceData!.id, [a2.id]]]));
 
       const mergeVersion = await getMergeVersion(target.id, sourceToken);
 
@@ -3410,8 +3410,8 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         await import("#shared/db/questions.ts");
       const { getAttendeesByTokens } = await import("#shared/db/attendees.ts");
       const [sourceData] = await getAttendeesByTokens([sourceToken]);
-      await save([target.id], [a1.id]);
-      await save([sourceData!.id], [a2.id]);
+      await save(new Map([[target.id, [a1.id]]]));
+      await save(new Map([[sourceData!.id, [a2.id]]]));
 
       const mergeVersion = await getMergeVersion(target.id, sourceToken);
 
@@ -3460,7 +3460,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         await import("#shared/db/questions.ts");
       const { getAttendeesByTokens } = await import("#shared/db/attendees.ts");
       const [sourceData] = await getAttendeesByTokens([sourceToken]);
-      await save([sourceData!.id], [a1.id]);
+      await save(new Map([[sourceData!.id, [a1.id]]]));
 
       const mergeVersion = await getMergeVersion(target.id, sourceToken);
 
@@ -3506,7 +3506,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       // Only target has an answer — no conflict
       const { saveAttendeeAnswers: save, getAttendeeAnswersByQuestion } =
         await import("#shared/db/questions.ts");
-      await save([target.id], [a1.id]);
+      await save(new Map([[target.id, [a1.id]]]));
 
       const mergeVersion = await getMergeVersion(target.id, sourceToken);
 

--- a/test/lib/server-events.test.ts
+++ b/test/lib/server-events.test.ts
@@ -708,7 +708,7 @@ describeWithEnv("server (admin events)", { db: true }, () => {
         text: "Large",
       });
       await setEventQuestions(event.id, [q.id]);
-      await saveAttendeeAnswers([attendee.id], [a1.id]);
+      await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
       const response = await awaitTestRequest(
         `/admin/event/${event.id}/export`,

--- a/test/lib/server-misc-admin-handlers.test.ts
+++ b/test/lib/server-misc-admin-handlers.test.ts
@@ -583,20 +583,26 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       expect(body).toBe("name,email\nJohn,john@test.com");
     });
 
-    test("loadQuestionData returns undefined for empty attendeeIds", async () => {
-      const { loadQuestionData } = await import("#routes/admin/actions.ts");
+    test("loadAttendeeQuestionData returns undefined for empty attendeeIds", async () => {
+      const { loadAttendeeQuestionData } = await import(
+        "#shared/db/questions.ts"
+      );
 
-      expect(await loadQuestionData([1, 2], [])).toBeUndefined();
+      expect(await loadAttendeeQuestionData([1, 2], [])).toBeUndefined();
     });
 
-    test("loadQuestionData returns undefined for empty eventIds", async () => {
-      const { loadQuestionData } = await import("#routes/admin/actions.ts");
+    test("loadAttendeeQuestionData returns undefined for empty eventIds", async () => {
+      const { loadAttendeeQuestionData } = await import(
+        "#shared/db/questions.ts"
+      );
 
-      expect(await loadQuestionData([], [1, 2])).toBeUndefined();
+      expect(await loadAttendeeQuestionData([], [1, 2])).toBeUndefined();
     });
 
-    test("loadQuestionData returns undefined when no questions exist", async () => {
-      const { loadQuestionData } = await import("#routes/admin/actions.ts");
+    test("loadAttendeeQuestionData returns undefined when no questions exist", async () => {
+      const { loadAttendeeQuestionData } = await import(
+        "#shared/db/questions.ts"
+      );
       const { createTestAttendeeDirect } = await import("#test-utils");
 
       const event = await createTestEvent({ maxAttendees: 10 });
@@ -606,12 +612,14 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
         "test@test.com",
       );
 
-      const result = await loadQuestionData([event.id], [attendee.id]);
+      const result = await loadAttendeeQuestionData([event.id], [attendee.id]);
       expect(result).toBeUndefined();
     });
 
-    test("loadQuestionData returns question data when questions exist", async () => {
-      const { loadQuestionData } = await import("#routes/admin/actions.ts");
+    test("loadAttendeeQuestionData returns question data when questions exist", async () => {
+      const { loadAttendeeQuestionData } = await import(
+        "#shared/db/questions.ts"
+      );
       const { createTestAttendeeDirect } = await import("#test-utils");
       const { answersTable, eventQuestionsTable, questionsTable } =
         await import("#shared/db/questions.ts");
@@ -634,7 +642,7 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
         "has-question@test.com",
       );
 
-      const result = await loadQuestionData([event.id], [attendee.id]);
+      const result = await loadAttendeeQuestionData([event.id], [attendee.id]);
       expect(result).toBeDefined();
       expect(result!.questions.length).toBe(1);
       expect(result!.questions[0]!.id).toBe(question.id);


### PR DESCRIPTION
## Why

Looking at the edit-attendee form, several pieces of question/answer handling
reinvented logic that already existed elsewhere — loading questions for a range
of events, parsing submitted answers, and saving an attendee's answers. This
routes them all through shared helpers in `src/shared/db/questions.ts` and
removes the duplicates.

## What changed

**1. `loadAttendeeQuestionData` — one loader instead of four**

The `getQuestionsWithEventIds` + `getAttendeeAnswersBatch` pair was hand-rolled
in four places (admin `actions.ts`, `calendar.ts`, `groups.ts`, and the edit
form's `loadQuestionsForExisting`). The canonical loader now lives in
`questions.ts`; the edit form and the calendar/groups callers reuse it.
`TableQuestionData` is now an alias of the canonical `AttendeeQuestionData`
shape so there's a single source of truth.

**2. `parseQuestionAnswers` — one curried parser instead of two**

The public (required) and admin (optional) answer parsers were duplicate loops
over `readQuestionAnswer`. They're replaced by a single curried, overloaded
helper whose only policy knob is `{ optional }`:
- `{ optional: false }` (public booking) errors on the first missing/invalid answer
- `{ optional: true }` (admin edit) skips them and always succeeds

**3. `saveAttendeeAnswers` — one save method instead of three**

`saveAttendeeAnswers`, `saveAttendeeAnswersByQuestion`, and `saveEventAnswers`
all did delete-then-insert in slightly different shapes. They collapse into a
single method taking `Map` that builds the SQL once.
`groupEventAnswers` reduces the per-event public-flow shape into that map.
`INSERT OR IGNORE` tolerates an answer set that repeats an id (e.g. an attendee
whose booked events share a question), which the unique `(attendee_id,
answer_id)` index would otherwise reject.

## Behaviour & security

No behaviour change — pure consolidation. Authorization is unchanged (it lives
in the route handlers, untouched) and the answer-belongs-to-question check stays
in `readQuestionAnswer`. The only attendee-writable path (public booking) still
writes only the freshly-created attendee ids from that same request, so there's
no way for one attendee to edit another's answers.

A second commit adds regression tests locking those edges: the edit route
rejects unauthenticated GET/POST, an admin-submitted answer id that isn't one of
the question's options is dropped rather than written, and editing one
attendee's answers never touches another's rows.

`deno task typecheck`, `deno task lint`, and the full test suite pass, with 100%
coverage maintained on the enforced files.

## Follow-up (separate PR)

Custom-question ordering is currently **per event** (`event_questions.sort_order`
on each `(event_id, question_id)` row), but the multi-event read path
(`getQuestionsWithEventIds`) already ignores it (orders by `a.sort_order`),
while the single-event path (`getQuestionsForEvent`) honours it. For a buyer
purchasing across multiple events in one go there's no coherent per-event order
to follow, so the two flows disagree. A **single global order per question**
would make them consistent — and would unblock folding the remaining duplicated
load in `features/admin/events.ts` (×2) into `loadAttendeeQuestionData`, which
this PR left alone precisely because the two queries order differently. Tracking
here since repo Issues are disabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3NpmERqJibLQDA6ftTeVY)_