### PR TITLE
Add a link-based month calendar to the date picker

### DIFF
--- a/src/features/admin/actions.ts
+++ b/src/features/admin/actions.ts
@@ -37,6 +37,13 @@ export const getDateFilter = (request: Request): string | null => {
   return date;
 };
 
+/** Extract and validate ?cal= month parameter (YYYY-MM). Returns null if absent or invalid. */
+export const getMonthFilter = (request: Request): string | null => {
+  const month = new URL(request.url).searchParams.get("cal");
+  if (!month || !/^\d{4}-\d{2}$/.test(month)) return null;
+  return month;
+};
+
 /** Build a CSV file download response */
 export const csvResponse = (csv: string, filename: string): Response =>
   new Response(encodeBody(csv), {

--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -6,6 +6,7 @@ import { filter, flatMap, map, pipe, reduce, sort, unique } from "#fp";
 import {
   csvResponse,
   getDateFilter,
+  getMonthFilter,
   loadQuestionData,
 } from "#routes/admin/actions.ts";
 import { getPrivateKey, requireSessionOr } from "#routes/auth.ts";
@@ -37,9 +38,9 @@ import {
 import {
   adminCalendarPage,
   type CalendarAttendeeRow,
-  type CalendarDateOption,
 } from "#templates/admin/calendar.tsx";
 import { type CalendarAttendee, generateCalendarCsv } from "#templates/csv.ts";
+import type { DatePickerDate } from "#templates/date-picker.tsx";
 
 /** Build a map of YYYY-MM-DD → event IDs for standard events that have a date */
 const buildStandardEventDateMap = (
@@ -67,7 +68,7 @@ const compileDateOptions = (
     start_date: string;
     end_date: string;
   }[],
-): CalendarDateOption[] => {
+): DatePickerDate[] => {
   const availableDates = pipe(
     flatMap((event: EventWithCount) => getAvailableDates(event, holidays)),
     (dates: string[]) => unique(dates),
@@ -93,8 +94,8 @@ const compileDateOptions = (
   );
 
   return map((d: string) => ({
-    hasBookings: attendeeDateSet.has(d) || standardDatesWithBookings.has(d),
     label: formatDateLabel(d),
+    selectable: attendeeDateSet.has(d) || standardDatesWithBookings.has(d),
     value: d,
   }))(allDates);
 };
@@ -231,6 +232,7 @@ const handleAdminCalendarGet = (request: Request) =>
         dateFilter,
         availableDates,
         todayInTz(settings.timezone),
+        getMonthFilter(request),
         settings.phonePrefix,
         questionData,
         hasPaidEvent,

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -234,6 +234,40 @@ export const formatDateLabel = (dateStr: string): string => {
 };
 
 /**
+ * Shift a YYYY-MM month string by `delta` months (negative goes backwards).
+ * Crosses year boundaries: shiftMonth("2026-12", 1) → "2027-01".
+ */
+export const shiftMonth = (month: string, delta: number): string => {
+  const d = new Date(`${month}-01T00:00:00Z`);
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + delta, 1))
+    .toISOString()
+    .slice(0, 7);
+};
+
+/**
+ * Format a YYYY-MM month string for display, e.g. "July 2026".
+ */
+export const formatMonthLabel = (month: string): string => {
+  const d = new Date(`${month}-01T00:00:00Z`);
+  return `${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+};
+
+/**
+ * Build the calendar grid for a YYYY-MM month as a flat list of YYYY-MM-DD
+ * strings. The grid is whole Monday→Sunday weeks spanning the month plus one
+ * extra full week on each side, so adjacent-month context is always visible.
+ */
+export const calendarGridDates = (month: string): string[] => {
+  const first = `${month}-01`;
+  const firstDow = new Date(`${first}T00:00:00Z`).getUTCDay();
+  const start = addDays(first, -(((firstDow + 6) % 7) + 7));
+  const last = addDays(`${shiftMonth(month, 1)}-01`, -1);
+  const lastDow = new Date(`${last}T00:00:00Z`).getUTCDay();
+  const end = addDays(last, ((7 - lastDow) % 7) + 7);
+  return dateRange(start, end);
+};
+
+/**
  * Compact English date-range formatter. Uses an en dash (`–`) for ranges.
  *
  * - Same day: `2 February 2027`

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -253,6 +253,21 @@ export const formatMonthLabel = (month: string): string => {
 };
 
 /**
+ * List every YYYY-MM month within `yearsEitherSide` years of the given month's
+ * year, in ascending order. e.g. monthsAround("2026-03", 5) runs from
+ * "2021-01" to "2031-12". Used to populate the calendar's month picker.
+ */
+export const monthsAround = (
+  month: string,
+  yearsEitherSide: number,
+): string[] => {
+  const year = new Date(`${month}-01T00:00:00Z`).getUTCFullYear();
+  const start = `${year - yearsEitherSide}-01`;
+  const count = (yearsEitherSide * 2 + 1) * 12;
+  return Array.from({ length: count }, (_, i) => shiftMonth(start, i));
+};
+
+/**
  * Build the calendar grid for a YYYY-MM month as a flat list of YYYY-MM-DD
  * strings. The grid is whole Monday→Sunday weeks spanning the month plus one
  * extra full week on each side, so adjacent-month context is always visible.

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1681,4 +1681,75 @@ button.secondary:hover {
   height: auto;
 }
 
+/* Link-based date picker calendar */
+.calendar {
+  max-width: 22rem;
+  margin-bottom: var(--space-m);
+}
+
+.calendar-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-s);
+  margin-bottom: var(--space-s);
+  font-weight: bold;
+}
+
+.calendar-nav a {
+  padding: 0 var(--space-s);
+  text-decoration: none;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  text-align: center;
+}
+
+.calendar-dow {
+  padding: 0.2rem 0;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.cal-day {
+  display: block;
+  padding: 0.35rem 0;
+  border-radius: var(--border-radius);
+  font-size: 0.9rem;
+}
+
+/* Selectable days are links; non-selectable days are plain greyed text */
+a.cal-day {
+  background: var(--color-accent);
+  text-decoration: none;
+}
+
+a.cal-day:hover {
+  background: var(--color-bg-secondary);
+}
+
+span.cal-day {
+  color: var(--color-text-secondary);
+}
+
+/* Days outside the displayed month (the extra week either side) */
+.cal-day-muted {
+  opacity: 0.45;
+}
+
+/* Today */
+.cal-day-today {
+  outline: 1px solid var(--color-link);
+}
+
+/* Currently selected date */
+.cal-day-selected,
+a.cal-day-selected:hover {
+  background: var(--color-link);
+  color: var(--color-bg);
+}
+
 /* Guide page */

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1701,6 +1701,29 @@ button.secondary:hover {
   text-decoration: none;
 }
 
+/* The month label is a <select> styled to read as plain text */
+.calendar-month-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: auto;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: bold;
+  color: inherit;
+  text-align: center;
+  cursor: pointer;
+}
+
+.calendar-month-select:hover {
+  text-decoration: underline;
+}
+
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);

--- a/src/ui/templates/admin/calendar.tsx
+++ b/src/ui/templates/admin/calendar.tsx
@@ -16,14 +16,8 @@ import {
   type AttendeeTableRow,
   type TableQuestionData,
 } from "#templates/attendee-table.tsx";
+import { DatePicker, type DatePickerDate } from "#templates/date-picker.tsx";
 import { Layout } from "#templates/layout.tsx";
-
-/** Calendar date option for the date filter dropdown */
-export type CalendarDateOption = {
-  value: string;
-  label: string;
-  hasBookings: boolean;
-};
 
 /** Attendee row with event context for display */
 export type CalendarAttendeeRow = Attendee & {
@@ -34,35 +28,6 @@ export type CalendarAttendeeRow = Attendee & {
   eventId: number;
 };
 
-/** Build date selector dropdown for calendar view */
-const CalendarDateSelector = ({
-  dateFilter,
-  dates,
-  today,
-}: {
-  dateFilter: string | null;
-  dates: CalendarDateOption[];
-  today: string;
-}): string => {
-  const selectOption = `<option value="/admin/calendar#attendees"${
-    !dateFilter ? " selected" : ""
-  }>Select a date</option>`;
-  const dateOptions = dates.map((d) =>
-    d.hasBookings
-      ? `<option value="/admin/calendar?date=${d.value}#attendees"${
-          dateFilter === d.value ? " selected" : ""
-        }>${d.label}</option>`
-      : `<option disabled>${d.label}</option>`,
-  );
-  // Insert "Select a date" before the first current/future date to split past from future
-  const splitIndex = dates.findIndex((d) => d.value >= today);
-  const insertAt = splitIndex === -1 ? dateOptions.length : splitIndex;
-  dateOptions.splice(insertAt, 0, selectOption);
-  return `<select data-nav-select aria-label="Select a date">${dateOptions.join(
-    "",
-  )}</select>`;
-};
-
 /**
  * Admin calendar page - shows attendees across all daily events for a selected date
  */
@@ -71,8 +36,9 @@ export const adminCalendarPage = (
   allowedDomain: string,
   session: AdminSession,
   dateFilter: string | null,
-  availableDates: CalendarDateOption[],
+  availableDates: DatePickerDate[],
   today: string,
+  viewMonth: string | null = null,
   phonePrefix?: string,
   questionData?: TableQuestionData,
   hasPaidEvent = false,
@@ -116,12 +82,19 @@ export const adminCalendarPage = (
 
       <article>
         <h2 id="attendees">Attendees by Date</h2>
-        <Raw
-          html={CalendarDateSelector({
-            dateFilter,
-            dates: availableDates,
-            today,
-          })}
+        <DatePicker
+          ariaLabel="Select a date"
+          clearHref="/admin/calendar#attendees"
+          dates={availableDates}
+          dayHref={(value) => `/admin/calendar?date=${value}#attendees`}
+          monthHref={(month) =>
+            `/admin/calendar?${
+              dateFilter ? `date=${dateFilter}&` : ""
+            }cal=${month}#calendar`
+          }
+          selected={dateFilter}
+          today={today}
+          viewMonth={viewMonth}
         />
         {dateFilter && (
           <p>

--- a/src/ui/templates/date-picker.tsx
+++ b/src/ui/templates/date-picker.tsx
@@ -13,6 +13,7 @@ import { compact, map, reduce } from "#fp";
 import {
   calendarGridDates,
   formatMonthLabel,
+  monthsAround,
   shiftMonth,
 } from "#shared/dates.ts";
 import type { SafeHtml } from "#shared/jsx/jsx-runtime.ts";
@@ -151,7 +152,19 @@ export const DatePicker = ({
           >
             ←
           </a>
-          <strong>{formatMonthLabel(month)}</strong>
+          <select
+            aria-label="Jump to month"
+            class="calendar-month-select"
+            data-nav-select
+          >
+            {map(
+              (ym: string): SafeHtml => (
+                <option selected={ym === month} value={monthHref(ym)}>
+                  {formatMonthLabel(ym)}
+                </option>
+              ),
+            )(monthsAround(month, 5))}
+          </select>
           <a aria-label="Next month" href={monthHref(shiftMonth(month, 1))}>
             →
           </a>

--- a/src/ui/templates/date-picker.tsx
+++ b/src/ui/templates/date-picker.tsx
@@ -1,0 +1,169 @@
+/**
+ * Reusable, link-based date picker: a small month calendar above a navigable
+ * dropdown of the same dates. Selectable dates render as links; non-selectable
+ * dates render as plain greyed text. Paging months only changes which month the
+ * grid displays — it never changes the current selection — so stepping through
+ * months never lands the viewer on an empty date.
+ *
+ * The component is metric-agnostic: callers decide which dates are selectable,
+ * so it works equally for bookings, availability, or any other rule.
+ */
+
+import { compact, map, reduce } from "#fp";
+import {
+  calendarGridDates,
+  formatMonthLabel,
+  shiftMonth,
+} from "#shared/dates.ts";
+import type { SafeHtml } from "#shared/jsx/jsx-runtime.ts";
+
+/** A single date offered by the picker. */
+export type DatePickerDate = {
+  /** ISO YYYY-MM-DD date. */
+  value: string;
+  /** Human-readable label for the dropdown, e.g. "Monday 15 March 2026". */
+  label: string;
+  /** Whether this date is a clickable link (vs. plain greyed text). */
+  selectable: boolean;
+};
+
+export type DatePickerProps = {
+  /** All known dates, sorted ascending by ISO `value`. */
+  dates: DatePickerDate[];
+  /** Currently selected date (drives highlight + dropdown), or null. */
+  selected: string | null;
+  /** Today as YYYY-MM-DD: default month, today marker, dropdown past/future split. */
+  today: string;
+  /** Month to display as YYYY-MM, or null to derive from `selected`/`today`. */
+  viewMonth: string | null;
+  /** Build the href for a selectable day. */
+  dayHref: (value: string) => string;
+  /** Href for the "clear selection" dropdown option. */
+  clearHref: string;
+  /** Build the href for paging to a different month (YYYY-MM). */
+  monthHref: (month: string) => string;
+  /** Accessible label for the dropdown. */
+  ariaLabel: string;
+};
+
+/** Monday-first weekday initials for the grid header. */
+const WEEKDAY_INITIALS = ["M", "T", "W", "T", "F", "S", "S"];
+
+/** Build the space-separated class list for a single day cell. */
+const dayClasses = (
+  value: string,
+  viewMonth: string,
+  selected: string | null,
+  today: string,
+): string =>
+  compact([
+    "cal-day",
+    value.slice(0, 7) === viewMonth ? null : "cal-day-muted",
+    value === today ? "cal-day-today" : null,
+    value === selected ? "cal-day-selected" : null,
+  ]).join(" ");
+
+/** Render one day: a link when selectable, plain text otherwise. */
+const renderDay =
+  (
+    byValue: Map<string, DatePickerDate>,
+    viewMonth: string,
+    selected: string | null,
+    today: string,
+    dayHref: (value: string) => string,
+  ) =>
+  (value: string): SafeHtml => {
+    const dayNum = new Date(`${value}T00:00:00Z`).getUTCDate();
+    const cls = dayClasses(value, viewMonth, selected, today);
+    return byValue.get(value)?.selectable ? (
+      <a
+        aria-current={value === selected ? "date" : undefined}
+        class={cls}
+        href={dayHref(value)}
+      >
+        {dayNum}
+      </a>
+    ) : (
+      <span class={cls}>{dayNum}</span>
+    );
+  };
+
+/** Render the dropdown, splitting past from future with a "Select a date" entry. */
+const renderSelect = (
+  dates: DatePickerDate[],
+  selected: string | null,
+  today: string,
+  dayHref: (value: string) => string,
+  clearHref: string,
+  ariaLabel: string,
+): SafeHtml => {
+  const options: SafeHtml[] = map(
+    (d: DatePickerDate): SafeHtml =>
+      d.selectable ? (
+        <option selected={selected === d.value} value={dayHref(d.value)}>
+          {d.label}
+        </option>
+      ) : (
+        <option disabled>{d.label}</option>
+      ),
+  )(dates);
+  const splitIndex = dates.findIndex((d) => d.value >= today);
+  const insertAt = splitIndex === -1 ? options.length : splitIndex;
+  options.splice(
+    insertAt,
+    0,
+    <option selected={!selected} value={clearHref}>
+      Select a date
+    </option>,
+  );
+  return (
+    <select aria-label={ariaLabel} data-nav-select>
+      {options}
+    </select>
+  );
+};
+
+/** A small month calendar plus an equivalent navigable dropdown. */
+export const DatePicker = ({
+  dates,
+  selected,
+  today,
+  viewMonth,
+  dayHref,
+  clearHref,
+  monthHref,
+  ariaLabel,
+}: DatePickerProps): SafeHtml => {
+  const byValue = reduce(
+    (acc: Map<string, DatePickerDate>, d: DatePickerDate) =>
+      acc.set(d.value, d),
+    new Map<string, DatePickerDate>(),
+  )(dates);
+  const month = viewMonth ?? (selected ?? today).slice(0, 7);
+  const day = renderDay(byValue, month, selected, today, dayHref);
+  return (
+    <>
+      <div class="calendar" id="calendar">
+        <div class="calendar-nav">
+          <a
+            aria-label="Previous month"
+            href={monthHref(shiftMonth(month, -1))}
+          >
+            ←
+          </a>
+          <strong>{formatMonthLabel(month)}</strong>
+          <a aria-label="Next month" href={monthHref(shiftMonth(month, 1))}>
+            →
+          </a>
+        </div>
+        <div class="calendar-grid">
+          {map((d: string): SafeHtml => <span class="calendar-dow">{d}</span>)(
+            WEEKDAY_INITIALS,
+          )}
+          {map(day)(calendarGridDates(month))}
+        </div>
+      </div>
+      {renderSelect(dates, selected, today, dayHref, clearHref, ariaLabel)}
+    </>
+  );
+};

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -15,6 +15,7 @@ import {
   formatMonthLabel,
   getAvailableDates,
   getNextBookableDate,
+  monthsAround,
   normalizeDatetime,
   shiftMonth,
 } from "#shared/dates.ts";
@@ -124,6 +125,26 @@ describeWithEnv("dates", { db: true }, () => {
 
     test("formats December", () => {
       expect(formatMonthLabel("2026-12")).toBe("December 2026");
+    });
+  });
+
+  describe("monthsAround", () => {
+    test("spans the requested years either side of the month's year", () => {
+      const months = monthsAround("2026-03", 5);
+      expect(months[0]).toBe("2021-01");
+      expect(months[months.length - 1]).toBe("2031-12");
+    });
+
+    test("returns twelve months for every year in range", () => {
+      expect(monthsAround("2026-03", 5)).toHaveLength(11 * 12);
+    });
+
+    test("centres on the year, ignoring the month part", () => {
+      expect(monthsAround("2026-12", 1)).toEqual(monthsAround("2026-01", 1));
+    });
+
+    test("includes the centre month itself", () => {
+      expect(monthsAround("2026-03", 5)).toContain("2026-03");
     });
   });
 

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   addDays,
   addMonthsIso,
+  calendarGridDates,
   DAY_NAMES,
   daysAgo,
   eventDateToCalendarDate,
@@ -11,9 +12,11 @@ import {
   formatDateRangeLabelCompactEn,
   formatDatetimeLabel,
   formatDatetimeShort,
+  formatMonthLabel,
   getAvailableDates,
   getNextBookableDate,
   normalizeDatetime,
+  shiftMonth,
 } from "#shared/dates.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import { VALID_DAY_NAMES } from "#templates/fields.ts";
@@ -85,6 +88,80 @@ describeWithEnv("dates", { db: true }, () => {
       expect(addMonthsIso("2026-01-15T14:30:45.123Z", 2)).toBe(
         "2026-03-15T14:30:45.123Z",
       );
+    });
+  });
+
+  describe("shiftMonth", () => {
+    test("advances to the next month", () => {
+      expect(shiftMonth("2026-07", 1)).toBe("2026-08");
+    });
+
+    test("steps back to the previous month", () => {
+      expect(shiftMonth("2026-07", -1)).toBe("2026-06");
+    });
+
+    test("crosses the year boundary forward", () => {
+      expect(shiftMonth("2026-12", 1)).toBe("2027-01");
+    });
+
+    test("crosses the year boundary backward", () => {
+      expect(shiftMonth("2026-01", -1)).toBe("2025-12");
+    });
+
+    test("shifts by several months at once", () => {
+      expect(shiftMonth("2026-07", 6)).toBe("2027-01");
+    });
+  });
+
+  describe("formatMonthLabel", () => {
+    test("formats a mid-year month", () => {
+      expect(formatMonthLabel("2026-07")).toBe("July 2026");
+    });
+
+    test("formats January", () => {
+      expect(formatMonthLabel("2026-01")).toBe("January 2026");
+    });
+
+    test("formats December", () => {
+      expect(formatMonthLabel("2026-12")).toBe("December 2026");
+    });
+  });
+
+  describe("calendarGridDates", () => {
+    test("starts on the Monday a full week before the month's first week", () => {
+      // 1 March 2026 is a Sunday; its Monday is 23 Feb, minus one week = 16 Feb.
+      expect(calendarGridDates("2026-03")[0]).toBe("2026-02-16");
+    });
+
+    test("ends on the Sunday a full week after the month's last week", () => {
+      const grid = calendarGridDates("2026-03");
+      expect(grid[grid.length - 1]).toBe("2026-04-12");
+    });
+
+    test("always spans whole weeks", () => {
+      expect(calendarGridDates("2026-03").length % 7).toBe(0);
+      expect(calendarGridDates("2026-07").length % 7).toBe(0);
+      expect(calendarGridDates("2024-02").length % 7).toBe(0);
+    });
+
+    test("begins on a Monday and ends on a Sunday", () => {
+      const grid = calendarGridDates("2026-07");
+      expect(DAY_NAMES[new Date(`${grid[0]}T00:00:00Z`).getUTCDay()]).toBe(
+        "Monday",
+      );
+      expect(
+        DAY_NAMES[new Date(`${grid[grid.length - 1]}T00:00:00Z`).getUTCDay()],
+      ).toBe("Sunday");
+    });
+
+    test("includes every day of the target month", () => {
+      const grid = calendarGridDates("2026-07");
+      expect(grid).toContain("2026-07-01");
+      expect(grid).toContain("2026-07-31");
+    });
+
+    test("includes the leap day in a leap February", () => {
+      expect(calendarGridDates("2024-02")).toContain("2024-02-29");
     });
   });
 

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -327,6 +327,42 @@ describeWithEnv(
         // The date should appear as a disabled option (no bookings)
         expect(html).toContain("<option disabled>Monday 15 June 2026</option>");
       });
+
+      test("renders the calendar grid", async () => {
+        const html = await fetchCalendarHtml();
+        expect(html).toContain('class="calendar"');
+        expect(html).toContain("calendar-grid");
+      });
+
+      test("the cal parameter sets the displayed month", async () => {
+        const html = await fetchCalendarHtml("/admin/calendar?cal=2027-03");
+        expect(html).toContain("<strong>March 2027</strong>");
+      });
+
+      test("invalid cal parameter is ignored", async () => {
+        // cal=bogus is rejected, so the month falls back to the selected date.
+        const html = await fetchCalendarHtml(
+          "/admin/calendar?date=2027-05-15&cal=bogus",
+        );
+        expect(html).toContain("<strong>May 2027</strong>");
+      });
+
+      test("a booked date is a clickable day link in the grid", async () => {
+        const { date } = await setupDailyBooking();
+        const html = await fetchCalendarHtml(`/admin/calendar?date=${date}`);
+        expect(html).toContain(`href="/admin/calendar?date=${date}#attendees"`);
+      });
+
+      test("paging months keeps the selected date's attendees", async () => {
+        const { date } = await setupDailyBooking();
+        // Page to a far-away month while a date is selected; the selection
+        // (and its attendees) must survive the month change.
+        const html = await fetchCalendarHtml(
+          `/admin/calendar?date=${date}&cal=2030-01`,
+        );
+        expect(html).toContain("User A");
+        expect(html).toContain("<strong>January 2030</strong>");
+      });
     });
 
     describe("GET /admin/calendar/export", () => {

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -336,7 +336,7 @@ describeWithEnv(
 
       test("the cal parameter sets the displayed month", async () => {
         const html = await fetchCalendarHtml("/admin/calendar?cal=2027-03");
-        expect(html).toContain("<strong>March 2027</strong>");
+        expect(html).toMatch(/<option selected[^>]*>March 2027<\/option>/);
       });
 
       test("invalid cal parameter is ignored", async () => {
@@ -344,7 +344,7 @@ describeWithEnv(
         const html = await fetchCalendarHtml(
           "/admin/calendar?date=2027-05-15&cal=bogus",
         );
-        expect(html).toContain("<strong>May 2027</strong>");
+        expect(html).toMatch(/<option selected[^>]*>May 2027<\/option>/);
       });
 
       test("a booked date is a clickable day link in the grid", async () => {
@@ -361,7 +361,7 @@ describeWithEnv(
           `/admin/calendar?date=${date}&cal=2030-01`,
         );
         expect(html).toContain("User A");
-        expect(html).toContain("<strong>January 2030</strong>");
+        expect(html).toMatch(/<option selected[^>]*>January 2030<\/option>/);
       });
     });
 

--- a/test/lib/server-misc-admin-handlers.test.ts
+++ b/test/lib/server-misc-admin-handlers.test.ts
@@ -565,6 +565,27 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       expect(getDateFilter(mockRequest("/test?date="))).toBeNull();
     });
 
+    test("getMonthFilter returns valid month", async () => {
+      const { getMonthFilter } = await import("#routes/admin/actions.ts");
+
+      expect(getMonthFilter(mockRequest("/test?cal=2026-07"))).toBe("2026-07");
+    });
+
+    test("getMonthFilter returns null for invalid format", async () => {
+      const { getMonthFilter } = await import("#routes/admin/actions.ts");
+
+      expect(getMonthFilter(mockRequest("/test?cal=2026-7"))).toBeNull();
+      expect(getMonthFilter(mockRequest("/test?cal=2026-07-01"))).toBeNull();
+      expect(getMonthFilter(mockRequest("/test?cal=not-a-month"))).toBeNull();
+    });
+
+    test("getMonthFilter returns null when absent", async () => {
+      const { getMonthFilter } = await import("#routes/admin/actions.ts");
+
+      expect(getMonthFilter(mockRequest("/test"))).toBeNull();
+      expect(getMonthFilter(mockRequest("/test?cal="))).toBeNull();
+    });
+
     test("csvResponse returns proper CSV response", async () => {
       const { csvResponse } = await import("#routes/admin/actions.ts");
 

--- a/test/templates/admin/calendar.test.ts
+++ b/test/templates/admin/calendar.test.ts
@@ -277,7 +277,9 @@ describe("adminCalendarPage", () => {
       dates,
       "2026-03-10",
     );
-    const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/)!;
+    const selectMatch = html.match(
+      /<select aria-label="Select a date"[^>]*>([\s\S]*?)<\/select>/,
+    )!;
     const optionTexts = [...selectMatch[1]!.matchAll(/>([^<]+)</g)].map(
       (m) => m[1],
     );
@@ -311,7 +313,9 @@ describe("adminCalendarPage", () => {
       dates,
       "2026-03-10",
     );
-    const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/)!;
+    const selectMatch = html.match(
+      /<select aria-label="Select a date"[^>]*>([\s\S]*?)<\/select>/,
+    )!;
     const optionTexts = [...selectMatch[1]!.matchAll(/>([^<]+)</g)].map(
       (m) => m[1],
     );
@@ -343,7 +347,9 @@ describe("adminCalendarPage", () => {
       dates,
       "2026-03-10",
     );
-    const selectMatch = html.match(/<select[^>]*>([\s\S]*?)<\/select>/)!;
+    const selectMatch = html.match(
+      /<select aria-label="Select a date"[^>]*>([\s\S]*?)<\/select>/,
+    )!;
     const optionTexts = [...selectMatch[1]!.matchAll(/>([^<]+)</g)].map(
       (m) => m[1],
     );
@@ -372,7 +378,7 @@ describe("adminCalendarPage", () => {
     expect(html).toContain('class="calendar"');
     expect(html).toContain("calendar-grid");
     expect(html.indexOf('class="calendar"')).toBeLessThan(
-      html.indexOf("<select"),
+      html.indexOf('aria-label="Select a date"'),
     );
   });
 
@@ -403,7 +409,7 @@ describe("adminCalendarPage", () => {
       [],
       "2026-01-10",
     );
-    expect(html).toContain("<strong>March 2026</strong>");
+    expect(html).toMatch(/<option selected[^>]*>March 2026<\/option>/);
   });
 
   test("calendar respects the view month parameter", () => {
@@ -416,7 +422,7 @@ describe("adminCalendarPage", () => {
       "2026-03-10",
       "2026-08",
     );
-    expect(html).toContain("<strong>August 2026</strong>");
+    expect(html).toMatch(/<option selected[^>]*>August 2026<\/option>/);
   });
 
   test("month navigation links preserve the selected date", () => {

--- a/test/templates/admin/calendar.test.ts
+++ b/test/templates/admin/calendar.test.ts
@@ -46,13 +46,13 @@ describe("adminCalendarPage", () => {
   test("renders date selector dropdown", () => {
     const dates = [
       {
-        hasBookings: true,
         label: "Sunday 15 March 2026",
+        selectable: true,
         value: "2026-03-15",
       },
       {
-        hasBookings: false,
         label: "Monday 16 March 2026",
+        selectable: false,
         value: "2026-03-16",
       },
     ];
@@ -72,8 +72,8 @@ describe("adminCalendarPage", () => {
   test("disables options for dates without bookings", () => {
     const dates = [
       {
-        hasBookings: false,
         label: "Sunday 15 March 2026",
+        selectable: false,
         value: "2026-03-15",
       },
     ];
@@ -91,8 +91,8 @@ describe("adminCalendarPage", () => {
   test("enables options for dates with bookings", () => {
     const dates = [
       {
-        hasBookings: true,
         label: "Sunday 15 March 2026",
+        selectable: true,
         value: "2026-03-15",
       },
     ];
@@ -249,23 +249,23 @@ describe("adminCalendarPage", () => {
   test("places Select a date between past and future dates", () => {
     const dates = [
       {
-        hasBookings: true,
         label: "Sunday 8 March 2026",
+        selectable: true,
         value: "2026-03-08",
       },
       {
-        hasBookings: true,
         label: "Monday 9 March 2026",
+        selectable: true,
         value: "2026-03-09",
       },
       {
-        hasBookings: true,
         label: "Sunday 15 March 2026",
+        selectable: true,
         value: "2026-03-15",
       },
       {
-        hasBookings: true,
         label: "Monday 16 March 2026",
+        selectable: true,
         value: "2026-03-16",
       },
     ];
@@ -293,13 +293,13 @@ describe("adminCalendarPage", () => {
   test("places Select a date at end when all dates are past", () => {
     const dates = [
       {
-        hasBookings: true,
         label: "Sunday 8 March 2026",
+        selectable: true,
         value: "2026-03-08",
       },
       {
-        hasBookings: true,
         label: "Monday 9 March 2026",
+        selectable: true,
         value: "2026-03-09",
       },
     ];
@@ -325,13 +325,13 @@ describe("adminCalendarPage", () => {
   test("places Select a date at start when all dates are future", () => {
     const dates = [
       {
-        hasBookings: true,
         label: "Sunday 15 March 2026",
+        selectable: true,
         value: "2026-03-15",
       },
       {
-        hasBookings: true,
         label: "Monday 16 March 2026",
+        selectable: true,
         value: "2026-03-16",
       },
     ];
@@ -352,6 +352,85 @@ describe("adminCalendarPage", () => {
       "Sunday 15 March 2026",
       "Monday 16 March 2026",
     ]);
+  });
+
+  test("renders the calendar grid above the dropdown", () => {
+    const html = adminCalendarPage(
+      [],
+      "localhost",
+      TEST_SESSION,
+      null,
+      [
+        {
+          label: "Sunday 15 March 2026",
+          selectable: true,
+          value: "2026-03-15",
+        },
+      ],
+      "2026-03-10",
+    );
+    expect(html).toContain('class="calendar"');
+    expect(html).toContain("calendar-grid");
+    expect(html.indexOf('class="calendar"')).toBeLessThan(
+      html.indexOf("<select"),
+    );
+  });
+
+  test("calendar day for a selectable date links to that date", () => {
+    const html = adminCalendarPage(
+      [],
+      "localhost",
+      TEST_SESSION,
+      null,
+      [
+        {
+          label: "Thursday 12 March 2026",
+          selectable: true,
+          value: "2026-03-12",
+        },
+      ],
+      "2026-03-10",
+    );
+    expect(html).toContain('href="/admin/calendar?date=2026-03-12#attendees"');
+  });
+
+  test("calendar shows the selected date's month", () => {
+    const html = adminCalendarPage(
+      [],
+      "localhost",
+      TEST_SESSION,
+      "2026-03-15",
+      [],
+      "2026-01-10",
+    );
+    expect(html).toContain("<strong>March 2026</strong>");
+  });
+
+  test("calendar respects the view month parameter", () => {
+    const html = adminCalendarPage(
+      [],
+      "localhost",
+      TEST_SESSION,
+      null,
+      [],
+      "2026-03-10",
+      "2026-08",
+    );
+    expect(html).toContain("<strong>August 2026</strong>");
+  });
+
+  test("month navigation links preserve the selected date", () => {
+    const html = adminCalendarPage(
+      [],
+      "localhost",
+      TEST_SESSION,
+      "2026-03-15",
+      [],
+      "2026-03-10",
+    );
+    // The selected date rides along on the month-paging links so paging
+    // months never clears the current selection.
+    expect(html).toContain("date=2026-03-15&amp;cal=");
   });
 });
 

--- a/test/templates/date-picker.test.ts
+++ b/test/templates/date-picker.test.ts
@@ -27,19 +27,55 @@ const date = (overrides: Partial<DatePickerDate>): DatePickerDate => ({
   ...overrides,
 });
 
+/** Option labels of the day dropdown only (excludes the month picker). */
+const daySelectOptions = (html: string): (string | undefined)[] => {
+  const inner = html.match(
+    /<select aria-label="Select a date"[^>]*>([\s\S]*?)<\/select>/,
+  )![1]!;
+  return [...inner.matchAll(/<option[^>]*>([^<]+)</g)].map((m) => m[1]);
+};
+
 describe("DatePicker month resolution", () => {
   test("defaults the displayed month to today's month", () => {
-    expect(render()).toContain("<strong>March 2026</strong>");
+    expect(render()).toMatch(/<option selected[^>]*>March 2026<\/option>/);
   });
 
   test("derives the displayed month from the selected date", () => {
     const html = render({ selected: "2026-07-15" });
-    expect(html).toContain("<strong>July 2026</strong>");
+    expect(html).toMatch(/<option selected[^>]*>July 2026<\/option>/);
   });
 
   test("an explicit view month overrides the selected date's month", () => {
     const html = render({ selected: "2026-07-15", viewMonth: "2026-09" });
-    expect(html).toContain("<strong>September 2026</strong>");
+    expect(html).toMatch(/<option selected[^>]*>September 2026<\/option>/);
+  });
+});
+
+describe("DatePicker month select", () => {
+  const monthSelect = (html: string): string =>
+    html.match(
+      /<select[^>]*calendar-month-select[^>]*>([\s\S]*?)<\/select>/,
+    )![1]!;
+
+  test("the month label is a nav-select that reads as plain text", () => {
+    const html = render();
+    expect(html).toContain('class="calendar-month-select"');
+    expect(monthSelect(html)).toBeDefined();
+    expect(html).toContain("data-nav-select");
+  });
+
+  test("lists every month from five years before to five years after", () => {
+    const labels = [
+      ...monthSelect(render()).matchAll(/>([^<]+)<\/option>/g),
+    ].map((m) => m[1]);
+    expect(labels[0]).toBe("January 2021");
+    expect(labels[labels.length - 1]).toBe("December 2031");
+    expect(labels).toHaveLength(11 * 12);
+  });
+
+  test("each month option navigates via monthHref", () => {
+    // April 2026 option carries the monthHref value (the arrows use href=).
+    expect(render()).toContain('value="/m/2026-04"');
   });
 });
 
@@ -164,10 +200,7 @@ describe("DatePicker dropdown", () => {
         date({ label: "Future", value: "2026-03-20" }),
       ],
     });
-    const options = [...html.matchAll(/<option[^>]*>([^<]+)</g)].map(
-      (m) => m[1],
-    );
-    expect(options).toEqual(["Past", "Select a date", "Future"]);
+    expect(daySelectOptions(html)).toEqual(["Past", "Select a date", "Future"]);
   });
 
   test("appends the clear option when every date is in the past", () => {
@@ -177,9 +210,10 @@ describe("DatePicker dropdown", () => {
         date({ label: "Past B", value: "2026-03-02" }),
       ],
     });
-    const options = [...html.matchAll(/<option[^>]*>([^<]+)</g)].map(
-      (m) => m[1],
-    );
-    expect(options).toEqual(["Past A", "Past B", "Select a date"]);
+    expect(daySelectOptions(html)).toEqual([
+      "Past A",
+      "Past B",
+      "Select a date",
+    ]);
   });
 });

--- a/test/templates/date-picker.test.ts
+++ b/test/templates/date-picker.test.ts
@@ -1,0 +1,185 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  DatePicker,
+  type DatePickerDate,
+  type DatePickerProps,
+} from "#templates/date-picker.tsx";
+
+const baseProps: DatePickerProps = {
+  ariaLabel: "Select a date",
+  clearHref: "/clear",
+  dates: [],
+  dayHref: (v) => `/go/${v}`,
+  monthHref: (m) => `/m/${m}`,
+  selected: null,
+  today: "2026-03-10",
+  viewMonth: null,
+};
+
+const render = (overrides: Partial<DatePickerProps> = {}): string =>
+  String(DatePicker({ ...baseProps, ...overrides }));
+
+const date = (overrides: Partial<DatePickerDate>): DatePickerDate => ({
+  label: "A date",
+  selectable: true,
+  value: "2026-03-12",
+  ...overrides,
+});
+
+describe("DatePicker month resolution", () => {
+  test("defaults the displayed month to today's month", () => {
+    expect(render()).toContain("<strong>March 2026</strong>");
+  });
+
+  test("derives the displayed month from the selected date", () => {
+    const html = render({ selected: "2026-07-15" });
+    expect(html).toContain("<strong>July 2026</strong>");
+  });
+
+  test("an explicit view month overrides the selected date's month", () => {
+    const html = render({ selected: "2026-07-15", viewMonth: "2026-09" });
+    expect(html).toContain("<strong>September 2026</strong>");
+  });
+});
+
+describe("DatePicker month navigation", () => {
+  test("links to the previous and next months", () => {
+    const html = render();
+    expect(html).toContain('href="/m/2026-02"');
+    expect(html).toContain('href="/m/2026-04"');
+  });
+
+  test("navigation arrows have accessible labels", () => {
+    const html = render();
+    expect(html).toContain('aria-label="Previous month"');
+    expect(html).toContain('aria-label="Next month"');
+  });
+
+  test("crosses the year boundary when paging forward from December", () => {
+    const html = render({ viewMonth: "2026-12" });
+    expect(html).toContain('href="/m/2027-01"');
+  });
+});
+
+describe("DatePicker grid", () => {
+  test("renders Monday-first weekday initials", () => {
+    const html = render();
+    const initials = [...html.matchAll(/calendar-dow">([^<]+)</g)].map(
+      (m) => m[1],
+    );
+    expect(initials).toEqual(["M", "T", "W", "T", "F", "S", "S"]);
+  });
+
+  test("renders selectable dates as links", () => {
+    const html = render({ dates: [date({ value: "2026-03-12" })] });
+    expect(html).toContain('href="/go/2026-03-12"');
+  });
+
+  test("renders non-selectable dates as plain text, not links", () => {
+    const html = render({
+      dates: [date({ selectable: false, value: "2026-03-12" })],
+    });
+    expect(html).toContain('<span class="cal-day">12</span>');
+    expect(html).not.toContain("/go/2026-03-12");
+  });
+
+  test("dates absent from the list are plain text", () => {
+    // 2026-03-12 is in the grid but not in `dates`, so it is not a link.
+    expect(render()).toContain('<span class="cal-day">12</span>');
+  });
+
+  test("marks today within the grid", () => {
+    expect(render()).toContain('class="cal-day cal-day-today">10</span>');
+  });
+
+  test("marks the selected date as a link with aria-current", () => {
+    const html = render({
+      dates: [date({ value: "2026-03-15" })],
+      selected: "2026-03-15",
+    });
+    expect(html).toContain('aria-current="date"');
+    expect(html).toContain("cal-day-selected");
+  });
+
+  test("selectable but unselected days omit aria-current", () => {
+    const html = render({ dates: [date({ value: "2026-03-12" })] });
+    expect(html).not.toContain("aria-current");
+  });
+
+  test("shows one extra week of adjacent-month context either side", () => {
+    // March 2026: grid runs Mon 16 Feb → Sun 12 Apr (whole weeks + a week each side).
+    const html = render();
+    expect(html).toContain('class="cal-day cal-day-muted">16</span>'); // 16 Feb
+    expect(html).toContain('class="cal-day cal-day-muted">12</span>'); // 12 Apr
+  });
+});
+
+describe("DatePicker dropdown", () => {
+  test("renders a navigable select with a clear option", () => {
+    const html = render();
+    expect(html).toContain("data-nav-select");
+    expect(html).toContain("Select a date");
+  });
+
+  test("the clear option is selected when nothing is chosen", () => {
+    const html = render();
+    expect(html).toContain('<option selected value="/clear">Select a date');
+  });
+
+  test("the clear option is not selected when a date is chosen", () => {
+    const html = render({
+      dates: [date({ label: "Pick", value: "2026-03-15" })],
+      selected: "2026-03-15",
+    });
+    expect(html).toContain('<option value="/clear">Select a date');
+  });
+
+  test("selectable dates are options linking to their day href", () => {
+    const html = render({
+      dates: [date({ label: "Pick me", value: "2026-03-15" })],
+    });
+    expect(html).toContain('<option value="/go/2026-03-15">Pick me</option>');
+  });
+
+  test("the chosen date's option is marked selected", () => {
+    const html = render({
+      dates: [date({ label: "Pick", value: "2026-03-15" })],
+      selected: "2026-03-15",
+    });
+    expect(html).toContain('<option selected value="/go/2026-03-15">Pick');
+  });
+
+  test("non-selectable dates are disabled options", () => {
+    const html = render({
+      dates: [date({ label: "Closed", selectable: false })],
+    });
+    expect(html).toContain("<option disabled>Closed</option>");
+  });
+
+  test("inserts the clear option between past and future dates", () => {
+    const html = render({
+      dates: [
+        date({ label: "Past", value: "2026-03-01" }),
+        date({ label: "Future", value: "2026-03-20" }),
+      ],
+    });
+    const options = [...html.matchAll(/<option[^>]*>([^<]+)</g)].map(
+      (m) => m[1],
+    );
+    expect(options).toEqual(["Past", "Select a date", "Future"]);
+  });
+
+  test("appends the clear option when every date is in the past", () => {
+    const html = render({
+      dates: [
+        date({ label: "Past A", value: "2026-03-01" }),
+        date({ label: "Past B", value: "2026-03-02" }),
+      ],
+    });
+    const options = [...html.matchAll(/<option[^>]*>([^<]+)</g)].map(
+      (m) => m[1],
+    );
+    expect(options).toEqual(["Past A", "Past B", "Select a date"]);
+  });
+});


### PR DESCRIPTION
## What

The calendar view's date dropdown is now paired with a small, link-only month calendar rendered **above** it:

```
| ←      March 2026      → |
---------------------------
 M  T  W  T  F  S  S
16 17 18 19 20 21 22   ← muted (previous month)
23 24 25 26 27 28  1
 2  3  4  5  6  7  8
 9 10 11 12 13 14 15   ← 15 is a link, 10 outlined as "today"
...
```

- **Selectable dates are links**; every other day is plain greyed text — exactly mirroring which options are enabled vs. disabled in the dropdown.
- **Paging months only changes the displayed grid** (via a `?cal=YYYY-MM` query param) and **preserves the current selection**, so stepping through months never bounces the viewer onto a date with nothing on. The attendee list below only changes when you click an actual day.
- Defaults to the same month the dropdown points at (today, or the selected date's month).

## How it meets the brief

- **No client JavaScript** — the calendar is pure `<a href>` links; month arrows are links carrying the selection forward.
- **Built-in date primitives** — `Date` / `Date.UTC` / `getUTCDay` / `toISOString`; no date library.
- **One reusable module** — the dropdown and calendar are now a single `DatePicker` component (`src/ui/templates/date-picker.tsx`). It's **metric-agnostic**: callers pass a `selectable` flag and inject the `dayHref` / `monthHref` / `clearHref` builders, so it can be dropped onto future pages whose dates are decided by some rule other than bookings (the old `hasBookings` field is now the generic `selectable`).
- **FP throughout** — `map` / `reduce` / `compact` from `#fp`.
- **No new database queries** — only reads the new query param.
- **One full week of context either side** — the grid spans whole Monday→Sunday weeks plus one extra week before and after the visible month.
- **Relies on ISO strings sorting alphabetically** — past/future split and in-grid checks use plain string comparison.
- **Minimal CSS** reusing the existing MVP.css variables; **no defensive code**.

## Changes

- `src/shared/dates.ts` — `shiftMonth`, `formatMonthLabel`, `calendarGridDates` helpers
- `src/ui/templates/date-picker.tsx` — new reusable `DatePicker` (calendar grid + dropdown)
- `src/ui/templates/admin/calendar.tsx` / `src/features/admin/calendar.ts` — use `DatePicker`, rename `hasBookings` → `selectable`
- `src/features/admin/actions.ts` — `getMonthFilter` validates `?cal=`
- `src/ui/static/mvp.css` — calendar styles

## Testing

- New `test/templates/date-picker.test.ts` plus additions to the dates, calendar, and admin-handler suites.
- **100% coverage** on every changed/new file; full `deno task precommit` passes (biome, typecheck, lint, cpd, build:edge, test:coverage).

https://claude.ai/code/session_01KBKbayoty5BvZqFeUfLyMC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBKbayoty5BvZqFeUfLyMC)_