### PR TITLE
Add a single global sort_order per question

### DIFF
--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -25,6 +25,7 @@ import { getAllEvents, getEventWithCount } from "#shared/db/events.ts";
 import {
   type Answer,
   answersTable,
+  assignNextQuestionSortOrder,
   deleteAnswer,
   deleteQuestion,
   getAllQuestionsWithAnswers,
@@ -38,6 +39,7 @@ import {
   setEventQuestions,
   setQuestionEvents,
   swapAnswerOrder,
+  swapQuestionOrder,
 } from "#shared/db/questions.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import { defineForm } from "#shared/forms.tsx";
@@ -95,6 +97,7 @@ const handleQuestionsPost = createAuthedFormRoute({
   onInvalid: ({ error }) => errorRedirect("/admin/questions", error),
   onValid: async ({ values: { text } }) => {
     const question = await questionsTable.insert({ text });
+    await assignNextQuestionSortOrder(question.id);
     await logActivity(`Question '${text}' created`);
     return redirect(
       `/admin/questions/${question.id}`,
@@ -281,6 +284,27 @@ const handleMoveAnswerUp = moveAnswerHandler(-1);
 /** Handle POST /admin/questions/:id/answers/:answerId/move-down */
 const handleMoveAnswerDown = moveAnswerHandler(1);
 
+/** Factory for question move-up/move-down handlers. Swaps the question's
+ * global sort_order with its neighbour in the ordered list. */
+const moveQuestionHandler = (direction: -1 | 1) =>
+  createAuthedHandler<QuestionIdParams, QuestionWithAnswers>({
+    auth: OWNER_FORM,
+    handle: async ({ context: question }) => {
+      const all = await getAllQuestionsWithAnswers();
+      const idx = all.findIndex((q) => q.id === question.id);
+      const neighbor = all[idx + direction];
+      if (neighbor) await swapQuestionOrder(question.id, neighbor.id);
+      return redirect("/admin/questions", "Question moved", true);
+    },
+    loadContext: ({ id }) => getQuestionWithAnswers(id),
+  });
+
+/** Handle POST /admin/questions/:id/move-up */
+const handleMoveQuestionUp = moveQuestionHandler(-1);
+
+/** Handle POST /admin/questions/:id/move-down */
+const handleMoveQuestionDown = moveQuestionHandler(1);
+
 /** Handle GET /admin/event/:id/questions */
 const handleEventQuestionsGet = ownerGetById(
   getEventWithCount,
@@ -333,5 +357,7 @@ export const questionsRoutes = {
       handleMoveAnswerDown,
     "POST /admin/questions/:id/answers/:answerId/move-up": handleMoveAnswerUp,
     "POST /admin/questions/:id/edit": handleQuestionEdit,
+    "POST /admin/questions/:id/move-down": handleMoveQuestionDown,
+    "POST /admin/questions/:id/move-up": handleMoveQuestionUp,
   }),
 };

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -38,7 +38,7 @@ type Table = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "reorder event_attendees overlap index to (event_id, end_at, start_at)";
+  "add a global sort_order column to questions for unified ordering";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 
@@ -372,6 +372,7 @@ const SCHEMA: [name: string, table: Table][] = [
       columns: [
         ["id", "INTEGER PRIMARY KEY AUTOINCREMENT"],
         ["text", "TEXT NOT NULL"],
+        ["sort_order", "INTEGER NOT NULL DEFAULT 0"],
       ],
     },
   ],
@@ -855,6 +856,21 @@ const MIGRATIONS: Migration[] = [
     id: "2026-06-13_event_attendees_overlap_index",
     up: syncIndexes,
     verify: verifyOverlapIndex,
+  },
+  {
+    description:
+      "Add a single global sort_order per question (replacing per-event ordering); backfill existing questions from their row id to preserve creation order",
+    id: "2026-06-14_question_sort_order",
+    up: async () => {
+      await applySchemaChanges();
+      // One-time backfill: existing rows all default to 0, so seed each from
+      // its id (distinct, creation-ordered). New questions are assigned a
+      // non-zero sort_order on creation, so this never re-touches them.
+      await getDb().execute(
+        "UPDATE questions SET sort_order = id WHERE sort_order = 0",
+      );
+    },
+    verify: verifyCurrentAppSchema,
   },
 ];
 

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -34,7 +34,9 @@ export interface Answer {
   text: string; // encrypted
 }
 
-/** Link between event and question (ordering by sort_order) */
+/** Link between event and question. Membership only — display order comes
+ * from the question's own `sort_order`, not from this row. The `sort_order`
+ * column is retained but unused (legacy per-event ordering). */
 export interface EventQuestion {
   event_id: number;
   id: number;
@@ -196,11 +198,11 @@ export const getAllQuestionsWithAnswers = async (): Promise<
 > =>
   groupJoinedRows(
     await queryAll<JoinedRow>(
-      `SELECT ${QA_COLS} FROM ${QA_JOIN} ORDER BY q.id, a.sort_order`,
+      `SELECT ${QA_COLS} FROM ${QA_JOIN} ORDER BY q.sort_order, q.id, a.sort_order`,
     ),
   );
 
-/** Get questions assigned to an event, ordered by sort_order.
+/** Get questions assigned to an event, in the global question order.
  * Questions with no answers are excluded (nothing useful to ask). */
 export const getQuestionsForEvent = async (
   eventId: number,
@@ -213,17 +215,21 @@ export const getQuestionsForEvent = async (
        JOIN questions q ON q.id = eq.question_id
        LEFT JOIN answers a ON a.question_id = q.id
        WHERE eq.event_id = ?
-       ORDER BY eq.sort_order, a.sort_order`,
+       ORDER BY q.sort_order, q.id, a.sort_order`,
         [eventId],
       ),
     ),
   );
 
-/** Get just the assigned question IDs for an event (no joins/decryption) */
+/** Get the assigned question IDs for an event, in the global question order. */
 export const getEventQuestionIds = async (eventId: number): Promise<number[]> =>
   map((r: { question_id: number }) => r.question_id)(
     await queryAll<{ question_id: number }>(
-      "SELECT question_id FROM event_questions WHERE event_id = ? ORDER BY sort_order",
+      `SELECT eq.question_id
+       FROM event_questions eq
+       JOIN questions q ON q.id = eq.question_id
+       WHERE eq.event_id = ?
+       ORDER BY q.sort_order, q.id`,
       [eventId],
     ),
   );
@@ -239,10 +245,9 @@ export const getQuestionEventIds = async (
     ),
   );
 
-/** Set which events a question is assigned to.
- * Adds the question to newly-checked events (appended after each event's
- * existing questions) and removes it from unchecked ones, leaving the
- * ordering of the other questions on each event untouched. */
+/** Set which events a question is assigned to: add it to newly-checked events
+ * and remove it from unchecked ones. Membership only — display order is the
+ * question's global `sort_order`, so no per-event ordering is written. */
 export const setQuestionEvents = async (
   questionId: number,
   eventIds: number[],
@@ -257,9 +262,8 @@ export const setQuestionEvents = async (
       sql: "DELETE FROM event_questions WHERE event_id = ? AND question_id = ?",
     })),
     ...toAdd.map((eventId) => ({
-      args: [eventId, questionId, eventId],
-      sql: `INSERT INTO event_questions (event_id, question_id, sort_order)
-            VALUES (?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM event_questions WHERE event_id = ?), 0))`,
+      args: [eventId, questionId],
+      sql: "INSERT INTO event_questions (event_id, question_id) VALUES (?, ?)",
     })),
   ];
   if (statements.length > 0) await executeBatch(statements);
@@ -317,11 +321,10 @@ export const setEventQuestions = async (
 ): Promise<void> => {
   const statements = [
     { args: [eventId], sql: "DELETE FROM event_questions WHERE event_id = ?" },
-    ...questionIds.map((qid, i) =>
+    ...questionIds.map((qid) =>
       insert("event_questions", {
         event_id: eventId,
         question_id: qid,
-        sort_order: i,
       }),
     ),
   ];
@@ -624,4 +627,47 @@ export const getNextAnswerSortOrder = async (
     [questionId],
   );
   return row!.next_order;
+};
+
+/** Swap the global sort_order of two questions, reading their current values
+ * so callers only need the ids. A no-op visually when both share a value
+ * (e.g. legacy rows still at 0 before the id backfill). Callers pass two
+ * existing question ids (the move handler takes them from the rendered list). */
+export const swapQuestionOrder = async (
+  questionId1: number,
+  questionId2: number,
+): Promise<void> => {
+  const rows = await queryAll<{ id: number; sort_order: number }>(
+    "SELECT id, sort_order FROM questions WHERE id IN (?, ?)",
+    [questionId1, questionId2],
+  );
+  const orderById = new Map(rows.map((r) => [r.id, r.sort_order]));
+  await executeBatch([
+    {
+      args: [orderById.get(questionId2)!, questionId1],
+      sql: "UPDATE questions SET sort_order = ? WHERE id = ?",
+    },
+    {
+      args: [orderById.get(questionId1)!, questionId2],
+      sql: "UPDATE questions SET sort_order = ? WHERE id = ?",
+    },
+  ]);
+};
+
+/** Assign a freshly-created question the next global sort_order (max + 1).
+ * Always >= 1 so new questions never collide with the one-time id-backfill of
+ * legacy rows, which only seeds rows still at sort_order 0. */
+export const assignNextQuestionSortOrder = async (
+  questionId: number,
+): Promise<void> => {
+  await executeBatch([
+    {
+      args: [questionId, questionId],
+      sql: `UPDATE questions
+            SET sort_order = COALESCE(
+              (SELECT MAX(sort_order) FROM questions WHERE id != ?), 0
+            ) + 1
+            WHERE id = ?`,
+    },
+  ]);
 };

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -38,15 +38,36 @@ export const adminQuestionsPage = (
         </p>
       ) : (
         <ul class="question-list">
-          {map((q: QuestionWithAnswers) => (
+          {questions.map((q, i) => (
             <li>
               <a href={`/admin/questions/${q.id}`}>{q.text}</a>
               <small>
                 {" "}
                 ({q.answers.length} answer{q.answers.length !== 1 ? "s" : ""})
-              </small>
+              </small>{" "}
+              {i > 0 && (
+                <CsrfForm
+                  action={`/admin/questions/${q.id}/move-up`}
+                  class="inline"
+                >
+                  <button class="link-button small" type="submit">
+                    &#9650;
+                  </button>
+                </CsrfForm>
+              )}
+              {i > 0 && " "}
+              {i < questions.length - 1 && (
+                <CsrfForm
+                  action={`/admin/questions/${q.id}/move-down`}
+                  class="inline"
+                >
+                  <button class="link-button small" type="submit">
+                    &#9660;
+                  </button>
+                </CsrfForm>
+              )}
             </li>
-          ))(questions)}
+          ))}
         </ul>
       )}
     </Layout>,

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -788,8 +788,9 @@ describe("db > migrations > schema change guard", () => {
         "2026-06-11_current_schema",
         "2026-06-12_sumup_checkouts",
         "2026-06-13_event_attendees_overlap_index",
+        "2026-06-14_question_sort_order",
       ],
-      schemaHash: "3htq2e",
+      schemaHash: "zdatc0",
     });
   });
 });

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { createAttendeeAtomic } from "#shared/db/attendees.ts";
 import {
   answersTable,
+  assignNextQuestionSortOrder,
   deleteAnswer,
   deleteQuestion,
   getAllQuestionsWithAnswers,
@@ -19,6 +20,7 @@ import {
   setEventQuestions,
   setQuestionEvents,
   swapAnswerOrder,
+  swapQuestionOrder,
 } from "#shared/db/questions.ts";
 import { createTestEvent, describeWithEnv } from "#test-utils";
 
@@ -134,13 +136,33 @@ describeWithEnv("custom questions", { db: true }, () => {
       });
 
       const event = await createTestEvent();
+      // Assign in reverse; the event ignores assignment order and uses the
+      // global question order (here creation/id order, since both are at the
+      // default sort_order 0).
       await setEventQuestions(event.id, [q2.id, q1.id]);
 
       const questions = await getQuestionsForEvent(event.id);
       expect(questions).toHaveLength(2);
-      // Order should match the order provided
-      expect(questions[0]!.text).toBe("Q2");
-      expect(questions[1]!.text).toBe("Q1");
+      expect(questions[0]!.text).toBe("Q1");
+      expect(questions[1]!.text).toBe("Q2");
+    });
+
+    test("orders event questions by the global sort_order, not assignment order", async () => {
+      const q1 = await questionsTable.insert({ text: "Q1" });
+      await assignNextQuestionSortOrder(q1.id);
+      const q2 = await questionsTable.insert({ text: "Q2" });
+      await assignNextQuestionSortOrder(q2.id);
+      await answersTable.insert({ questionId: q1.id, sortOrder: 0, text: "A1" });
+      await answersTable.insert({ questionId: q2.id, sortOrder: 0, text: "A2" });
+
+      // Put q2 ahead of q1 globally.
+      await swapQuestionOrder(q1.id, q2.id);
+
+      const event = await createTestEvent();
+      await setEventQuestions(event.id, [q1.id, q2.id]);
+
+      const questions = await getQuestionsForEvent(event.id);
+      expect(questions.map((q) => q.text)).toEqual(["Q2", "Q1"]);
     });
 
     test("replaces event questions on re-assignment", async () => {
@@ -198,8 +220,9 @@ describeWithEnv("custom questions", { db: true }, () => {
       const event = await createTestEvent();
       await setEventQuestions(event.id, [q2.id, q1.id]);
 
+      // Returned in the global question order, not the assignment order.
       const ids = await getEventQuestionIds(event.id);
-      expect(ids).toEqual([q2.id, q1.id]);
+      expect(ids).toEqual([q1.id, q2.id]);
     });
 
     test("returns empty array for event with no questions", async () => {
@@ -250,7 +273,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       expect(await getQuestionEventIds(q.id)).toEqual([event1.id]);
     });
 
-    test("appends after an event's existing questions without reordering", async () => {
+    test("lists an event's assigned questions in the global question order", async () => {
       const existing = await questionsTable.insert({ text: "Existing" });
       const added = await questionsTable.insert({ text: "Added" });
       await answersTable.insert({
@@ -589,6 +612,37 @@ describeWithEnv("custom questions", { db: true }, () => {
       // After swap, "Second" should come first (sort_order 0) and "First" second (sort_order 1)
       expect(updated!.answers[0]!.text).toBe("Second");
       expect(updated!.answers[1]!.text).toBe("First");
+    });
+  });
+
+  describe("question ordering", () => {
+    test("assignNextQuestionSortOrder gives sequential non-zero orders", async () => {
+      const q1 = await questionsTable.insert({ text: "Q1" });
+      const q2 = await questionsTable.insert({ text: "Q2" });
+      await answersTable.insert({ questionId: q1.id, sortOrder: 0, text: "A" });
+      await answersTable.insert({ questionId: q2.id, sortOrder: 0, text: "B" });
+
+      await assignNextQuestionSortOrder(q1.id);
+      await assignNextQuestionSortOrder(q2.id);
+
+      // Both are >= 1 (never 0, so they survive the legacy id-backfill) and q1
+      // precedes q2 in the global list.
+      const all = await getAllQuestionsWithAnswers();
+      expect(all.map((q) => q.text)).toEqual(["Q1", "Q2"]);
+    });
+
+    test("swapQuestionOrder reorders the global question list", async () => {
+      const q1 = await questionsTable.insert({ text: "Q1" });
+      await assignNextQuestionSortOrder(q1.id);
+      const q2 = await questionsTable.insert({ text: "Q2" });
+      await assignNextQuestionSortOrder(q2.id);
+      await answersTable.insert({ questionId: q1.id, sortOrder: 0, text: "A" });
+      await answersTable.insert({ questionId: q2.id, sortOrder: 0, text: "B" });
+
+      await swapQuestionOrder(q1.id, q2.id);
+
+      const all = await getAllQuestionsWithAnswers();
+      expect(all.map((q) => q.text)).toEqual(["Q2", "Q1"]);
     });
   });
 });

--- a/test/lib/server-questions.test.ts
+++ b/test/lib/server-questions.test.ts
@@ -896,4 +896,61 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       expect(body).toContain("(0)");
     });
   });
+
+  describe("POST /admin/questions/:id/move-up and move-down", () => {
+    testRequiresAuth("/admin/questions/1/move-up", {
+      body: {},
+      method: "POST",
+    });
+
+    /** Read the current global question order as a list of texts. */
+    const questionOrder = async (): Promise<string[]> => {
+      const { getAllQuestionsWithAnswers } = await import(
+        "#shared/db/questions.ts"
+      );
+      return (await getAllQuestionsWithAnswers()).map((q) => q.text);
+    };
+
+    test("move-down then move-up reorders the global list", async () => {
+      const firstId = await createQuestion("First");
+      await createQuestion("Second");
+      expect(await questionOrder()).toEqual(["First", "Second"]);
+
+      const down = await adminFormPost(
+        `/admin/questions/${firstId}/move-down`,
+        {},
+      );
+      expectRedirectWithFlash("/admin/questions", "Question moved")(
+        down.response,
+      );
+      expect(await questionOrder()).toEqual(["Second", "First"]);
+
+      const up = await adminFormPost(
+        `/admin/questions/${firstId}/move-up`,
+        {},
+      );
+      expect(up.response.status).toBe(302);
+      expect(await questionOrder()).toEqual(["First", "Second"]);
+    });
+
+    test("moving the last question down is a no-op", async () => {
+      await createQuestion("Alpha");
+      const lastId = await createQuestion("Beta");
+
+      const { response } = await adminFormPost(
+        `/admin/questions/${lastId}/move-down`,
+        {},
+      );
+      expect(response.status).toBe(302);
+      expect(await questionOrder()).toEqual(["Alpha", "Beta"]);
+    });
+
+    test("returns 404 for a non-existent question", async () => {
+      const { response } = await adminFormPost(
+        "/admin/questions/999/move-up",
+        {},
+      );
+      expectStatus(404)(response);
+    });
+  });
 });

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -65,6 +65,30 @@ describe("adminQuestionsPage", () => {
     expect(html).not.toContain("1 answers");
   });
 
+  test("renders reorder controls: down on the first, up on the last", () => {
+    const html = adminQuestionsPage(
+      [
+        {
+          answers: [{ id: 10, question_id: 1, sort_order: 0, text: "A" }],
+          id: 1,
+          text: "First Q",
+        },
+        {
+          answers: [{ id: 20, question_id: 2, sort_order: 0, text: "B" }],
+          id: 2,
+          text: "Second Q",
+        },
+      ],
+      TEST_SESSION,
+    );
+    // First question: down button, but no up button.
+    expect(html).toContain("/admin/questions/1/move-down");
+    expect(html).not.toContain("/admin/questions/1/move-up");
+    // Last question: up button, but no down button.
+    expect(html).toContain("/admin/questions/2/move-up");
+    expect(html).not.toContain("/admin/questions/2/move-down");
+  });
+
   test("renders error message when provided", () => {
     const html = adminQuestionsPage([], TEST_SESSION, "Something went wrong");
     expect(html).toContain("Something went wrong");


### PR DESCRIPTION
Custom-question ordering was per-event (event_questions.sort_order), but the multi-event read path (getQuestionsWithEventIds) already ignored it, so the two flows disagreed and per-event order was meaningless for multi-event purchases. Replace it with one global order per question.

- Migration: add questions.sort_order (INTEGER NOT NULL DEFAULT 0) and a one-time backfill seeding each existing row from its id (creation order).
- Every question query now orders by q.sort_order, q.id — getQuestionsForEvent, getQuestionsWithEventIds, getAllQuestionsWithAnswers, getEventQuestionIds.
- event_questions assignment is membership-only now; setEventQuestions / setQuestionEvents no longer write the vestigial per-event sort_order.
- New questions get the next global order (assignNextQuestionSortOrder); the /admin/questions list gains move up/down controls (swapQuestionOrder), mirroring how answers already reorder.

Behaviour: question order is now consistent across the event page, the public booking form, and the admin attendee-edit form. Tests updated to assert global order; added coverage for the new helpers, the reorder routes, and the list controls.