### PR TITLE
Add icons to admin form submit buttons

### DIFF
--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -7,6 +7,7 @@ import { type Child, Raw } from "#jsx/jsx-runtime.ts";
 import { getCurrentCsrfToken } from "#shared/csrf.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { appendIframeParam } from "#shared/iframe.ts";
+import { Icon } from "#templates/components/actions.tsx";
 
 const escapeHtml = (str: string): string =>
   str
@@ -643,7 +644,8 @@ export const ConfirmForm = ({
       />
     </label>
     <button class={danger ? "danger" : undefined} type="submit">
-      {buttonText}
+      <Icon name={danger ? "trash-2" : "check"} />
+      <span>{buttonText}</span>
     </button>
   </CsrfForm>
 );

--- a/src/ui/static/icons.svg
+++ b/src/ui/static/icons.svg
@@ -1,9 +1,166 @@
-<svg xmlns="http://www.w3.org/2000/svg"><defs>
-<symbol id="plus" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14m-7-7v14"/></symbol>
-<symbol id="book-open" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 7v14m-9-3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4a4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3a3 3 0 0 0-3-3z"/></symbol>
-<symbol id="user-plus" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M19 8v6m3-3h-6"/></g></symbol>
-<symbol id="arrow-right" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14m-7-7l7 7l-7 7"/></symbol>
-<symbol id="credit-card" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="20" height="14" x="2" y="5" rx="2"/><path d="M2 10h20"/></g></symbol>
-<symbol id="hammer" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="m15 12l-9.373 9.373a1 1 0 0 1-3.001-3L12 9m6 6l4-4"/><path d="m21.5 11.5l-1.914-1.914A2 2 0 0 1 19 8.172v-.344a2 2 0 0 0-.586-1.414l-1.657-1.657A6 6 0 0 0 12.516 3H9l1.243 1.243A6 6 0 0 1 12 8.485V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5"/></g></symbol>
-<symbol id="rotate-ccw" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9a9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></g></symbol>
-</defs></svg>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Icons are from Lucide (https://lucide.dev), ISC licensed. Each <symbol>
+     id matches its Lucide icon name and is referenced via <use href="/icons.svg#id">
+     by the Icon component in src/ui/templates/components/actions.tsx. -->
+    <symbol id="plus" viewBox="0 0 24 24">
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M5 12h14m-7-7v14"
+      />
+    </symbol>
+    <symbol id="book-open" viewBox="0 0 24 24">
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M12 7v14m-9-3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4a4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3a3 3 0 0 0-3-3z"
+      />
+    </symbol>
+    <symbol id="user-plus" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M19 8v6m3-3h-6" />
+      </g>
+    </symbol>
+    <symbol id="arrow-right" viewBox="0 0 24 24">
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M5 12h14m-7-7l7 7l-7 7"
+      />
+    </symbol>
+    <symbol id="credit-card" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <rect width="20" height="14" x="2" y="5" rx="2" />
+        <path d="M2 10h20" />
+      </g>
+    </symbol>
+    <symbol id="hammer" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path d="m15 12l-9.373 9.373a1 1 0 0 1-3.001-3L12 9m6 6l4-4" />
+        <path
+          d="m21.5 11.5l-1.914-1.914A2 2 0 0 1 19 8.172v-.344a2 2 0 0 0-.586-1.414l-1.657-1.657A6 6 0 0 0 12.516 3H9l1.243 1.243A6 6 0 0 1 12 8.485V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5"
+        />
+      </g>
+    </symbol>
+    <symbol id="rotate-ccw" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path d="M3 12a9 9 0 1 0 9-9a9.75 9.75 0 0 0-6.74 2.74L3 8" />
+        <path d="M3 3v5h5" />
+      </g>
+    </symbol>
+    <symbol id="save" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path
+          d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"
+        />
+        <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+        <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+      </g>
+    </symbol>
+    <symbol id="check" viewBox="0 0 24 24">
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M20 6L9 17l-5-5"
+      />
+    </symbol>
+    <symbol id="search" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21l-4.3-4.3" />
+      </g>
+    </symbol>
+    <symbol id="trash-2" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path d="M3 6h18" />
+        <path
+          d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+        />
+        <path d="M10 11v6m4-6v6" />
+      </g>
+    </symbol>
+    <symbol id="log-in" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+        <path d="m10 17l5-5l-5-5" />
+        <path d="M15 12H3" />
+      </g>
+    </symbol>
+    <symbol id="log-out" viewBox="0 0 24 24">
+      <g
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      >
+        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+        <path d="m16 17l5-5l-5-5" />
+        <path d="M21 12H9" />
+      </g>
+    </symbol>
+  </defs>
+</svg>

--- a/src/ui/templates/admin/api-keys.tsx
+++ b/src/ui/templates/admin/api-keys.tsx
@@ -9,6 +9,7 @@ import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 type ApiKeyDisplay = {
@@ -97,7 +98,7 @@ export const adminApiKeysPage = (
       <CsrfForm action="/admin/api-keys">
         <h2>Create API key</h2>
         <Raw html={apiKeyForm.render()} />
-        <button type="submit">Create key</button>
+        <SubmitButton icon="plus">Create key</SubmitButton>
       </CsrfForm>
     </Layout>,
   );

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -22,6 +22,7 @@ import type {
   ListingWithCount,
 } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /**
@@ -183,7 +184,7 @@ const PaymentDetails = ({ attendee }: { attendee: Attendee }): string => {
         action={`/admin/attendees/${attendee.id}/refresh-payment`}
         class="inline"
       >
-        <button type="submit">Refresh payment status</button>
+        <SubmitButton icon="rotate-ccw">Refresh payment status</SubmitButton>
       </CsrfForm>
     </article>,
   );
@@ -316,7 +317,7 @@ export const adminEditAttendeePage = (
 
         <Raw html={renderEditQuestions(questions, selectedAnswerIds)} />
 
-        <button type="submit">Save Contact Info</button>
+        <SubmitButton icon="save">Save Contact Info</SubmitButton>
       </CsrfForm>
 
       {/* Listing Links Section */}
@@ -394,7 +395,7 @@ export const adminEditAttendeePage = (
           <Raw html={linkListingForm.field("date").render()} />
         </div>
 
-        <button type="submit">Add to Listing</button>
+        <SubmitButton icon="plus">Add to Listing</SubmitButton>
       </CsrfForm>
 
       {/* Available dates JSON for client-side date picker filtering (read by admin.ts) */}
@@ -423,7 +424,7 @@ export const adminEditAttendeePage = (
             type="text"
           />
         </label>
-        <button type="submit">Search</button>
+        <SubmitButton icon="search">Search</SubmitButton>
       </form>
     </Layout>,
   );
@@ -689,7 +690,7 @@ export const adminMergeAttendeePage = (
             value={searchToken || ""}
           />
         </label>
-        <button type="submit">Search</button>
+        <SubmitButton icon="search">Search</SubmitButton>
       </form>
 
       {source && mergeDiff && (
@@ -758,9 +759,9 @@ export const adminMergeAttendeePage = (
               <strong>Warning:</strong> This will permanently delete the source
               attendee. This action cannot be undone.
             </p>
-            <button class="danger" type="submit">
+            <SubmitButton class="danger" icon="trash-2">
               Merge and Delete Source Attendee
-            </button>
+            </SubmitButton>
           </CsrfForm>
         </div>
       )}

--- a/src/ui/templates/admin/backup.tsx
+++ b/src/ui/templates/admin/backup.tsx
@@ -5,7 +5,7 @@
 import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
-import { GuideLink } from "#templates/components/actions.tsx";
+import { GuideLink, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 export type BackupEntry = {
@@ -108,7 +108,7 @@ export const adminBackupPage = (
               class="no-bg"
               id="backup-create"
             >
-              <button type="submit">Create Backup Now</button>
+              <SubmitButton icon="plus">Create Backup Now</SubmitButton>
             </CsrfForm>
           </section>
 
@@ -165,7 +165,7 @@ export const adminBackupPage = (
                 Backup file (.zip)
                 <input accept=".zip" name="backup_file" required type="file" />
               </label>
-              <button type="submit">Upload &amp; Review</button>
+              <SubmitButton icon="rotate-ccw">Upload &amp; Review</SubmitButton>
             </CsrfForm>
           </section>
         </>

--- a/src/ui/templates/admin/builder.tsx
+++ b/src/ui/templates/admin/builder.tsx
@@ -7,6 +7,7 @@ import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 export type BuiltSiteDisplay = {
@@ -37,7 +38,7 @@ const BuilderForm = (): JSX.Element => (
           purchased
         </small>
       </fieldset>
-      <button type="submit">Build Site</button>
+      <SubmitButton icon="hammer">Build Site</SubmitButton>
     </CsrfForm>
   </section>
 );

--- a/src/ui/templates/admin/built-sites.tsx
+++ b/src/ui/templates/admin/built-sites.tsx
@@ -16,7 +16,11 @@ import { formatDeadlineLabel, isProvisioned } from "#shared/renewal-helpers.ts";
 import { renewalUrlFor } from "#shared/site-assignment.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { ActionButton } from "#templates/components/actions.tsx";
+import {
+  ActionButton,
+  Icon,
+  SubmitButton,
+} from "#templates/components/actions.tsx";
 import { builtSiteFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -174,7 +178,7 @@ export const adminBuiltSiteNewPage = (
         <h1>Add Built Site</h1>
         <Flash error={error} />
         <Raw html={renderFields(builtSiteFields)} />
-        <button type="submit">Create Built Site</button>
+        <SubmitButton icon="plus">Create Built Site</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -235,24 +239,25 @@ const ProvisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => {
           onclick="return confirm('The old URL will stop working. Continue?')"
           type="submit"
         >
-          Rotate token
+          <Icon name="rotate-ccw" />
+          <span>Rotate token</span>
         </button>
       </RenewalActionForm>
 
       <RenewalActionForm action="bump-deadline" siteId={site.id}>
         <label for="bump_months">Bump deadline by months</label>
         <MonthsInput id="bump_months" />
-        <button type="submit">Bump</button>
+        <SubmitButton icon="save">Bump</SubmitButton>
       </RenewalActionForm>
 
       <RenewalActionForm action="override-deadline" siteId={site.id}>
         <label for="override_date">Override deadline</label>
         <input id="override_date" name="date" type="date" />
-        <button type="submit">Override</button>
+        <SubmitButton icon="save">Override</SubmitButton>
       </RenewalActionForm>
 
       <RenewalActionForm action="re-sync-deadline" siteId={site.id}>
-        <button type="submit">Re-sync deadline</button>
+        <SubmitButton icon="rotate-ccw">Re-sync deadline</SubmitButton>
       </RenewalActionForm>
     </div>
   );
@@ -269,19 +274,19 @@ const UnprovisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => (
     <RenewalActionForm action="provision-renewal" siteId={site.id}>
       <label for="provision_months">Initial months</label>
       <MonthsInput id="provision_months" />
-      <button type="submit">Provision</button>
+      <SubmitButton icon="hammer">Provision</SubmitButton>
     </RenewalActionForm>
 
     <h3>Bump deadline</h3>
     <RenewalActionForm action="bump-deadline" siteId={site.id}>
       <MonthsInput />
-      <button type="submit">Bump</button>
+      <SubmitButton icon="save">Bump</SubmitButton>
     </RenewalActionForm>
 
     <h3>Override deadline</h3>
     <RenewalActionForm action="override-deadline" siteId={site.id}>
       <input name="date" type="date" />
-      <button type="submit">Override</button>
+      <SubmitButton icon="save">Override</SubmitButton>
     </RenewalActionForm>
   </div>
 );
@@ -306,7 +311,7 @@ export const adminBuiltSiteEditPage = (
         <Raw
           html={renderFields(builtSiteFields, builtSiteToFieldValues(site))}
         />
-        <button type="submit">Save Changes</button>
+        <SubmitButton icon="save">Save Changes</SubmitButton>
       </CsrfForm>
 
       <h2>Renewal</h2>

--- a/src/ui/templates/admin/bulk-actions.tsx
+++ b/src/ui/templates/admin/bulk-actions.tsx
@@ -19,6 +19,7 @@ import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, Group, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Form field values for the duplicate-group action */
@@ -238,7 +239,7 @@ export const adminDuplicateGroupPage = (
           <Raw html={listingsJson} />
         </script>
 
-        <button type="submit">Duplicate Group</button>
+        <SubmitButton icon="plus">Duplicate Group</SubmitButton>
       </CsrfForm>
     </Layout>,
   );

--- a/src/ui/templates/admin/database-reset.tsx
+++ b/src/ui/templates/admin/database-reset.tsx
@@ -4,6 +4,7 @@
  */
 
 import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Confirmation phrase that must be typed to reset the database */
@@ -44,9 +45,9 @@ export const ResetDatabaseForm = ({
       required
       type="text"
     />
-    <button class="danger" type="submit">
+    <SubmitButton class="danger" icon="trash-2">
       Reset Database
-    </button>
+    </SubmitButton>
   </CsrfForm>
 );
 

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -38,7 +38,7 @@ import {
   type AttendeeTableRow,
   type TableQuestionData,
 } from "#templates/attendee-table.tsx";
-import { ActionButton } from "#templates/components/actions.tsx";
+import { ActionButton, SubmitButton } from "#templates/components/actions.tsx";
 import { groupCreateFields, groupFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -122,7 +122,7 @@ export const adminGroupNewPage = (
         <h1>Add Group</h1>
         <Flash error={error} />
         <Raw html={renderFields(groupCreateFields, groupToFieldValues())} />
-        <button type="submit">Create Group</button>
+        <SubmitButton icon="plus">Create Group</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -142,7 +142,7 @@ export const adminGroupEditPage = (
         <h1>Edit Group</h1>
         <Flash error={error} />
         <Raw html={renderFields(groupFields, groupToFieldValues(group))} />
-        <button type="submit">Save Changes</button>
+        <SubmitButton icon="save">Save Changes</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -407,7 +407,7 @@ export const adminGroupDetailPage = (
                 </label>
               ))}
             </fieldset>
-            <button type="submit">Add Selected Listings</button>
+            <SubmitButton icon="plus">Add Selected Listings</SubmitButton>
           </CsrfForm>
         </>
       )}

--- a/src/ui/templates/admin/holidays.tsx
+++ b/src/ui/templates/admin/holidays.tsx
@@ -12,7 +12,11 @@ import {
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, Holiday } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { ActionButton, GuideLink } from "#templates/components/actions.tsx";
+import {
+  ActionButton,
+  GuideLink,
+  SubmitButton,
+} from "#templates/components/actions.tsx";
 import { holidayFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -88,7 +92,7 @@ export const adminHolidayNewPage = (
         <h1>Add Holiday</h1>
         <Flash error={error} />
         <Raw html={renderFields(holidayFields)} />
-        <button type="submit">Create Holiday</button>
+        <SubmitButton icon="plus">Create Holiday</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -110,7 +114,7 @@ export const adminHolidayEditPage = (
         <Raw
           html={renderFields(holidayFields, holidayToFieldValues(holiday))}
         />
-        <button type="submit">Save Changes</button>
+        <SubmitButton icon="save">Save Changes</SubmitButton>
       </CsrfForm>
     </Layout>,
   );

--- a/src/ui/templates/admin/listing-qr.tsx
+++ b/src/ui/templates/admin/listing-qr.tsx
@@ -14,6 +14,7 @@ import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { QR_TOKEN_MAX_AGE_S } from "#shared/qr-token.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const EXPIRY_LABEL = `${Math.round(QR_TOKEN_MAX_AGE_S / 60)} minutes`;
@@ -198,7 +199,7 @@ export const adminListingQrPage = ({
             />
           </label>
           {isDaily && <DateSelect dates={bookableDates} value={values.date} />}
-          <button type="submit">Generate QR code</button>
+          <SubmitButton icon="plus">Generate QR code</SubmitButton>
         </CsrfForm>
         {result && (
           <QrResultPanel

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -43,6 +43,7 @@ import {
   type AttendeeTableRow,
   type TableQuestionData,
 } from "#templates/attendee-table.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import {
   assignBuiltSiteField,
   attachmentField,
@@ -553,9 +554,9 @@ const ListingDetailsTable = ({
           <tr>
             <th>Public URL</th>
             <td>
-              <a
-                href={ticketUrl}
-              >{`${allowedDomain}/ticket/${listing.slug}`}</a>
+              <a href={ticketUrl}>
+                {`${allowedDomain}/ticket/${listing.slug}`}
+              </a>
               <small>
                 {" "}
                 (<a href={`/ticket/${listing.slug}/qr`}>QR Code</a>)
@@ -789,7 +790,7 @@ const AddAttendeeSection = ({
           ),
         )}
       />
-      <button type="submit">Add Attendee</button>
+      <SubmitButton icon="plus">Add Attendee</SubmitButton>
     </CsrfForm>
   </article>
 );
@@ -1002,7 +1003,7 @@ export const adminListingNewPage = (
         <Flash error={error} />
         <Raw html={renderFields(fields)} />
         <ListingGroupSelect groups={groups} selectedGroupId={0} />
-        <button type="submit">Create Listing</button>
+        <SubmitButton icon="plus">Create Listing</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -1041,7 +1042,7 @@ export const adminDuplicateListingPage = (
           groups={groups}
           selectedGroupId={listing.group_id}
         />
-        <button type="submit">Create Listing</button>
+        <SubmitButton icon="plus">Create Listing</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -1096,15 +1097,15 @@ export const adminListingEditPage = (
             <input id="duration-warning-confirm" type="checkbox" />I understand
           </label>
         </div>
-        <button id="listing-edit-submit" type="submit">
+        <SubmitButton icon="save" id="listing-edit-submit">
           Save Changes
-        </button>
+        </SubmitButton>
       </CsrfForm>
       {storageEnabled && listing.image_url && (
         <CsrfForm action={`/admin/listing/${listing.id}/image/delete`}>
-          <button class="secondary" type="submit">
+          <SubmitButton class="secondary" icon="trash-2">
             Remove Image
-          </button>
+          </SubmitButton>
         </CsrfForm>
       )}
       {storageEnabled && listing.attachment_name && (
@@ -1113,9 +1114,9 @@ export const adminListingEditPage = (
             Current attachment: <strong>{listing.attachment_name}</strong>
           </p>
           <CsrfForm action={`/admin/listing/${listing.id}/attachment/delete`}>
-            <button class="secondary" type="submit">
+            <SubmitButton class="secondary" icon="trash-2">
               Remove Attachment
-            </button>
+            </SubmitButton>
           </CsrfForm>
         </div>
       )}

--- a/src/ui/templates/admin/login.tsx
+++ b/src/ui/templates/admin/login.tsx
@@ -5,6 +5,7 @@
 import { isDemoMode } from "#shared/demo.ts";
 import { CsrfForm, Flash, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { loginFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -17,7 +18,7 @@ export const adminLoginPage = (error?: string): string =>
       <Flash error={error} />
       <CsrfForm action="/admin/login">
         <Raw html={renderFields(loginFields)} />
-        <button type="submit">Login</button>
+        <SubmitButton icon="log-in">Login</SubmitButton>
       </CsrfForm>
       {isDemoMode() && (
         <p>

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -14,6 +14,7 @@ import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { SettingsNagBanner } from "#templates/admin/settings-nag-banner.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 /** Render read-only or warning banner with optional renewal URL */
 const renderReadOnlyBanner = (
@@ -90,7 +91,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
         {navLink("/admin/guide", "Guide", active)}
         <li>
           <CsrfForm action="/admin/logout" class="inline">
-            <button type="submit">Logout</button>
+            <SubmitButton icon="log-out">Logout</SubmitButton>
           </CsrfForm>
         </li>
       </ul>

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -9,7 +9,7 @@ import type { Answer, QuestionWithAnswers } from "#shared/db/questions.ts";
 import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { GuideLink } from "#templates/components/actions.tsx";
+import { GuideLink, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** List all questions */
@@ -30,7 +30,7 @@ export const adminQuestionsPage = (
 
       <CsrfForm action="/admin/questions" id="new-question">
         <Raw html={questionTextForm.render()} />
-        <button type="submit">Add Question</button>
+        <SubmitButton icon="plus">Add Question</SubmitButton>
       </CsrfForm>
 
       {questions.length === 0 ? (
@@ -71,7 +71,7 @@ export const adminQuestionPage = (
 
       <CsrfForm action={`/admin/questions/${question.id}/edit`}>
         <Raw html={questionTextForm.render({ text: question.text })} />
-        <button type="submit">Update</button>
+        <SubmitButton icon="save">Update</SubmitButton>
       </CsrfForm>
 
       <h2>Answer Options</h2>
@@ -80,7 +80,7 @@ export const adminQuestionPage = (
         id="add-answer"
       >
         <Raw html={answerTextForm.render()} />
-        <button type="submit">Add Answer</button>
+        <SubmitButton icon="plus">Add Answer</SubmitButton>
       </CsrfForm>
 
       {question.answers.length === 0 ? (
@@ -149,7 +149,7 @@ export const adminQuestionPage = (
               </label>
             ))(allListings)}
           </fieldset>
-          <button type="submit">Save Listings</button>
+          <SubmitButton icon="save">Save Listings</SubmitButton>
         </CsrfForm>
       )}
 
@@ -265,7 +265,7 @@ export const adminListingQuestionsPage = (
               </label>
             ))(allQuestions)}
           </fieldset>
-          <button type="submit">Save</button>
+          <SubmitButton icon="save">Save</SubmitButton>
         </CsrfForm>
       )}
       <p>

--- a/src/ui/templates/admin/scanner.tsx
+++ b/src/ui/templates/admin/scanner.tsx
@@ -6,7 +6,7 @@ import { SCANNER_JS_PATH } from "#shared/asset-paths.ts";
 import { getCurrentCsrfToken } from "#shared/csrf.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { GuideLink } from "#templates/components/actions.tsx";
+import { GuideLink, SubmitButton } from "#templates/components/actions.tsx";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
 
 /** Ticket option for the manual check-in autocomplete */
@@ -129,7 +129,7 @@ export const adminScannerPage = (
             </div>
           </div>
           <div class="hidden" id="manual-checkin-status"></div>
-          <button type="submit">Check In</button>
+          <SubmitButton icon="check">Check In</SubmitButton>
         </form>
       </article>
     </Layout>,

--- a/src/ui/templates/admin/seeds.tsx
+++ b/src/ui/templates/admin/seeds.tsx
@@ -7,6 +7,7 @@ import { seedsForm } from "#routes/admin/seeds.ts";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Seed data admin page */
@@ -26,7 +27,7 @@ export const adminSeedsPage = (
         </p>
         <Flash error={error} success={success} />
         <Raw html={seedsForm.render()} />
-        <button type="submit">Create Seed Data</button>
+        <SubmitButton icon="plus">Create Seed Data</SubmitButton>
       </CsrfForm>
 
       <p>

--- a/src/ui/templates/admin/sessions.tsx
+++ b/src/ui/templates/admin/sessions.tsx
@@ -8,7 +8,7 @@ import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, Session } from "#shared/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
-import { GuideLink } from "#templates/components/actions.tsx";
+import { GuideLink, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const SessionRow = ({
@@ -80,9 +80,9 @@ export const adminSessionsPage = (
           <br />
 
           <CsrfForm action="/admin/sessions" class="one-button">
-            <button class="danger" type="submit">
+            <SubmitButton class="danger" icon="log-out">
               Log out of all other sessions ({otherSessionCount})
-            </button>
+            </SubmitButton>
           </CsrfForm>
         </>
       )}

--- a/src/ui/templates/admin/settings/apple-wallet.tsx
+++ b/src/ui/templates/admin/settings/apple-wallet.tsx
@@ -5,6 +5,7 @@
 import { MASK_SENTINEL } from "#shared/db/settings.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/apple-wallet" id="settings-apple-wallet">
@@ -69,6 +70,6 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
         {s.appleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>
     </label>
-    <button type="submit">Save Apple Wallet Settings</button>
+    <SubmitButton icon="save">Save Apple Wallet Settings</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/business-email.tsx
+++ b/src/ui/templates/admin/settings/business-email.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm
@@ -25,6 +26,6 @@ export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
         value={s.businessEmail}
       />
     </label>
-    <button type="submit">Save Business Email</button>
+    <SubmitButton icon="save">Save Business Email</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/change-password.tsx
+++ b/src/ui/templates/admin/settings/change-password.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { changePasswordFields } from "#templates/fields.ts";
 
 export const ChangePasswordForm = (): JSX.Element => (
@@ -11,6 +12,6 @@ export const ChangePasswordForm = (): JSX.Element => (
     <h2>Change Password</h2>
     <p>Changing your password will log you out of all sessions.</p>
     <Raw html={renderFields(changePasswordFields)} />
-    <button type="submit">Change Password</button>
+    <SubmitButton icon="save">Change Password</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/column-order.tsx
+++ b/src/ui/templates/admin/settings/column-order.tsx
@@ -17,6 +17,7 @@ import {
 } from "#shared/columns/listing-columns.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 const listingDefault = buildDefaultTemplate(LISTING_DEFAULT_ORDER);
 const attendeeDefault = buildDefaultTemplate(ATTENDEE_DEFAULT_ORDER);
@@ -62,7 +63,7 @@ export const ListingColumnOrderForm = (
     <p>
       <AvailableTags columns={LISTING_TABLE_COLUMNS} />
     </p>
-    <button type="submit">Save Listing Columns</button>
+    <SubmitButton icon="save">Save Listing Columns</SubmitButton>
   </CsrfForm>
 );
 
@@ -94,6 +95,6 @@ export const AttendeeColumnOrderForm = (
     <p>
       <AvailableTags columns={ATTENDEE_TABLE_COLUMNS} />
     </p>
-    <button type="submit">Save Attendee Columns</button>
+    <SubmitButton icon="save">Save Attendee Columns</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/country.tsx
+++ b/src/ui/templates/admin/settings/country.tsx
@@ -5,6 +5,7 @@
 import { COUNTRIES, type CountryData } from "#shared/countries.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const CountryForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/country" id="settings-country">
@@ -22,6 +23,6 @@ export const CountryForm = (s: SettingsPageState): JSX.Element => (
         )}
       </select>
     </label>
-    <button type="submit">Save Country</button>
+    <SubmitButton icon="save">Save Country</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/custom-domain.tsx
+++ b/src/ui/templates/admin/settings/custom-domain.tsx
@@ -5,6 +5,7 @@
 import { CsrfForm } from "#shared/forms.tsx";
 import { DomainPaymentWebhookWarning } from "#templates/admin/settings/domain-payment-warning.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const CustomDomainForm = (
   s: AdvancedSettingsPageState,
@@ -32,7 +33,7 @@ export const CustomDomainForm = (
             value={s.customDomain}
           />
         </label>
-        <button type="submit">Save Custom Domain</button>
+        <SubmitButton icon="save">Save Custom Domain</SubmitButton>
         <DomainPaymentWebhookWarning paymentProvider={s.paymentProvider} />
       </CsrfForm>
 
@@ -82,7 +83,7 @@ export const CustomDomainForm = (
               <small>Last validated: {s.customDomainLastValidated}</small>
             </p>
           )}
-          <button type="submit">Validate Custom Domain</button>
+          <SubmitButton icon="check">Validate Custom Domain</SubmitButton>
         </CsrfForm>
       )}
     </div>

--- a/src/ui/templates/admin/settings/email-tpl-admin.tsx
+++ b/src/ui/templates/admin/settings/email-tpl-admin.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 
 export const AdminEmailTemplateForm = (
@@ -61,6 +62,6 @@ export const AdminEmailTemplateForm = (
       <small>Edit default template</small>
     </a>
     <br />
-    <button type="submit">Save Admin Notification Template</button>
+    <SubmitButton icon="save">Save Admin Notification Template</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/email-tpl-confirmation.tsx
+++ b/src/ui/templates/admin/settings/email-tpl-confirmation.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 
 export const ConfirmationEmailTemplateForm = (
@@ -152,6 +153,6 @@ export const ConfirmationEmailTemplateForm = (
       <small>Edit default template</small>
     </a>
     <br />
-    <button type="submit">Save Confirmation Template</button>
+    <SubmitButton icon="save">Save Confirmation Template</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/email.tsx
+++ b/src/ui/templates/admin/settings/email.tsx
@@ -6,6 +6,7 @@ import { MASK_SENTINEL } from "#shared/db/settings.ts";
 import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#shared/email.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const EmailNotificationsForm = (
   s: AdvancedSettingsPageState,
@@ -50,13 +51,13 @@ export const EmailNotificationsForm = (
           value={s.emailFromAddress}
         />
       </label>
-      <button type="submit">Save Email Settings</button>
+      <SubmitButton icon="save">Save Email Settings</SubmitButton>
     </CsrfForm>
     {s.emailProvider && (
       <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
-        <button class="secondary" type="submit">
+        <SubmitButton class="secondary" icon="arrow-right">
           Send Test Email
-        </button>
+        </SubmitButton>
       </CsrfForm>
     )}
   </>

--- a/src/ui/templates/admin/settings/embed-hosts.tsx
+++ b/src/ui/templates/admin/settings/embed-hosts.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/embed-hosts" id="settings-embed-hosts">
@@ -28,6 +29,6 @@ export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
         the booking page are always allowed.
       </small>
     </p>
-    <button type="submit">Save Embed Hosts</button>
+    <SubmitButton icon="save">Save Embed Hosts</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/google-wallet.tsx
+++ b/src/ui/templates/admin/settings/google-wallet.tsx
@@ -5,6 +5,7 @@
 import { MASK_SENTINEL } from "#shared/db/settings.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/google-wallet" id="settings-google-wallet">
@@ -50,6 +51,6 @@ export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
         {s.googleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>
     </label>
-    <button type="submit">Save Google Wallet Settings</button>
+    <SubmitButton icon="save">Save Google Wallet Settings</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/header-image.tsx
+++ b/src/ui/templates/admin/settings/header-image.tsx
@@ -6,6 +6,7 @@ import { CsrfForm } from "#shared/forms.tsx";
 import { formatBytes, MAX_IMAGE_SIZE } from "#shared/limits.ts";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
   s.storageEnabled ? (
@@ -21,7 +22,7 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
             action="/admin/settings/header-image/delete"
             id="settings-header-image-delete"
           >
-            <button type="submit">Remove Image</button>
+            <SubmitButton icon="trash-2">Remove Image</SubmitButton>
           </CsrfForm>
         </div>
       )}
@@ -43,7 +44,7 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
             type="file"
           />
         </label>
-        <button type="submit">Upload</button>
+        <SubmitButton icon="save">Upload</SubmitButton>
       </CsrfForm>
     </div>
   ) : null;

--- a/src/ui/templates/admin/settings/payment.tsx
+++ b/src/ui/templates/admin/settings/payment.tsx
@@ -6,6 +6,7 @@ import { MASK_SENTINEL } from "#shared/db/settings.ts";
 import { CsrfForm, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import {
   squareAccessTokenFields,
   squareWebhookFields,
@@ -58,7 +59,7 @@ export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
         SumUp
       </label>
     </fieldset>
-    <button type="submit">Save Payment Provider</button>
+    <SubmitButton icon="save">Save Payment Provider</SubmitButton>
   </CsrfForm>
 );
 
@@ -115,7 +116,7 @@ export const StripeForm = (s: SettingsPageState): JSX.Element | null =>
         )}
       />
       <footer>
-        <button type="submit">Update Stripe Key</button>
+        <SubmitButton icon="save">Update Stripe Key</SubmitButton>
         {s.stripeKeyConfigured && (
           <button class="secondary" id="stripe-test-btn" type="button">
             Test Connection
@@ -155,7 +156,7 @@ export const SquareForm = (s: SettingsPageState): JSX.Element | null =>
         Sandbox mode (use Square's test environment)
       </label>
       <footer>
-        <button type="submit">Update Square Credentials</button>
+        <SubmitButton icon="save">Update Square Credentials</SubmitButton>
         {s.squareTokenConfigured && (
           <button class="secondary" id="square-test-btn" type="button">
             Test Connection
@@ -221,7 +222,7 @@ export const SquareWebhookForm = (s: SettingsPageState): JSX.Element | null =>
             : {},
         )}
       />
-      <button type="submit">Update Webhook Key</button>
+      <SubmitButton icon="save">Update Webhook Key</SubmitButton>
     </CsrfForm>
   ) : null;
 
@@ -249,7 +250,7 @@ export const SumUpForm = (s: SettingsPageState): JSX.Element | null =>
         )}
       />
       <footer>
-        <button type="submit">Update SumUp Credentials</button>
+        <SubmitButton icon="save">Update SumUp Credentials</SubmitButton>
         {s.sumupKeyConfigured && (
           <button class="secondary" id="sumup-test-btn" type="button">
             Test Connection
@@ -280,6 +281,6 @@ export const BookingFeeForm = (s: SettingsPageState): JSX.Element | null =>
           value={s.bookingFee}
         />
       </label>
-      <button type="submit">Save Booking Fee</button>
+      <SubmitButton icon="save">Save Booking Fee</SubmitButton>
     </CsrfForm>
   ) : null;

--- a/src/ui/templates/admin/settings/public-api.tsx
+++ b/src/ui/templates/admin/settings/public-api.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
   <CsrfForm
@@ -36,6 +37,6 @@ export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
         No
       </label>
     </fieldset>
-    <button type="submit">Save</button>
+    <SubmitButton icon="save">Save</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/public-site.tsx
+++ b/src/ui/templates/admin/settings/public-site.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm
@@ -35,6 +36,6 @@ export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
         No
       </label>
     </fieldset>
-    <button type="submit">Save</button>
+    <SubmitButton icon="save">Save</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/subdomain.tsx
+++ b/src/ui/templates/admin/settings/subdomain.tsx
@@ -6,6 +6,7 @@ import type { SafeHtml } from "#jsx/jsx-runtime";
 import { CsrfForm } from "#shared/forms.tsx";
 import { DomainPaymentWebhookWarning } from "#templates/admin/settings/domain-payment-warning.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 const SubdomainIntroProse = (): SafeHtml => (
   <div class="prose">
@@ -49,7 +50,7 @@ const SubdomainFormContent = (s: AdvancedSettingsPageState): SafeHtml => {
           (cannot be undone)
         </label>
         <footer>
-          <button type="submit">Register Subdomain</button>
+          <SubmitButton icon="plus">Register Subdomain</SubmitButton>
           <a
             class="btn secondary"
             href="/admin/settings-advanced#settings-host-subdomain"
@@ -75,9 +76,9 @@ const SubdomainFormContent = (s: AdvancedSettingsPageState): SafeHtml => {
         <span class="muted">{s.bunnyDnsSubdomainSuffix}</span>
       </label>
       <DomainPaymentWebhookWarning paymentProvider={s.paymentProvider} />
-      <button type="submit">
+      <SubmitButton icon="search">
         Check Availability &amp; Preview Complete Domain
-      </button>
+      </SubmitButton>
     </>
   );
 };

--- a/src/ui/templates/admin/settings/superuser.tsx
+++ b/src/ui/templates/admin/settings/superuser.tsx
@@ -1,5 +1,6 @@
 import { CsrfForm } from "#shared/forms.tsx";
 import type { SuperuserState } from "#shared/superuser.ts";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const SuperuserForm = (s: {
   superuser: SuperuserState;
@@ -60,7 +61,7 @@ export const SuperuserForm = (s: {
             </span>
           </label>
 
-          <button type="submit">Save</button>
+          <SubmitButton icon="save">Save</SubmitButton>
         </>
       )}
     </CsrfForm>

--- a/src/ui/templates/admin/settings/terms.tsx
+++ b/src/ui/templates/admin/settings/terms.tsx
@@ -6,6 +6,7 @@ import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { FORMATTING_HINT } from "#templates/fields.ts";
 
 export const TermsForm = (s: SettingsPageState): JSX.Element => (
@@ -27,6 +28,6 @@ export const TermsForm = (s: SettingsPageState): JSX.Element => (
         {s.termsAndConditions}
       </textarea>
     </label>
-    <button type="submit">Save Terms</button>
+    <SubmitButton icon="save">Save Terms</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/settings/theme.tsx
+++ b/src/ui/templates/admin/settings/theme.tsx
@@ -4,6 +4,7 @@
 
 import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const ThemeForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/theme" id="settings-theme">
@@ -29,6 +30,6 @@ export const ThemeForm = (s: SettingsPageState): JSX.Element => (
         Dark
       </label>
     </fieldset>
-    <button type="submit">Save Theme</button>
+    <SubmitButton icon="save">Save Theme</SubmitButton>
   </CsrfForm>
 );

--- a/src/ui/templates/admin/site.tsx
+++ b/src/ui/templates/admin/site.tsx
@@ -7,6 +7,7 @@ import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Sub-navigation for site editor pages */
@@ -49,7 +50,7 @@ export const adminSiteHomePage = (
             website_title: websiteTitle,
           })}
         />
-        <button type="submit">Save</button>
+        <SubmitButton icon="save">Save</SubmitButton>
       </CsrfForm>
     </Layout>,
   );
@@ -78,7 +79,7 @@ export const adminSiteContactPage = (
             contact_page_text: contactPageText,
           })}
         />
-        <button type="submit">Save</button>
+        <SubmitButton icon="save">Save</SubmitButton>
       </CsrfForm>
     </Layout>,
   );

--- a/src/ui/templates/admin/update.tsx
+++ b/src/ui/templates/admin/update.tsx
@@ -6,6 +6,7 @@ import { CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
 import { GITHUB_RELEASES_URL } from "#shared/update.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 export type UpdatePageState = {
@@ -37,7 +38,7 @@ const CurrentVersion = ({ state }: { state: UpdatePageState }): JSX.Element => (
 /** Check for updates form */
 const CheckForUpdates = (): JSX.Element => (
   <CsrfForm action="/admin/update/check" id="update-check">
-    <button type="submit">Check for Updates</button>
+    <SubmitButton icon="rotate-ccw">Check for Updates</SubmitButton>
   </CsrfForm>
 );
 
@@ -57,7 +58,7 @@ const UpdateAvailable = ({
     </div>
     {state.bunnyConfigured ? (
       <CsrfForm action="/admin/update" class="no-bg" id="update-deploy">
-        <button type="submit">Update Now</button>
+        <SubmitButton icon="rotate-ccw">Update Now</SubmitButton>
       </CsrfForm>
     ) : (
       <p>

--- a/src/ui/templates/admin/users.tsx
+++ b/src/ui/templates/admin/users.tsx
@@ -6,7 +6,11 @@ import { ConfirmForm, CsrfForm, Flash, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminLevel, AdminSession } from "#shared/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
-import { ActionButton, GuideLink } from "#templates/components/actions.tsx";
+import {
+  ActionButton,
+  GuideLink,
+  SubmitButton,
+} from "#templates/components/actions.tsx";
 import { inviteUserFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -93,7 +97,7 @@ export const adminUsersPage = (
                       action={`/admin/users/${user.id}/activate`}
                       class="inline"
                     >
-                      <button type="submit">Activate</button>
+                      <SubmitButton icon="check">Activate</SubmitButton>
                     </CsrfForm>
                   )}
                 </td>
@@ -158,7 +162,7 @@ export const adminUserNewPage = (
         <h1>Invite User</h1>
         <Flash error={error} />
         <Raw html={renderFields(inviteUserFields)} />
-        <button type="submit">Create Invite</button>
+        <SubmitButton icon="user-plus">Create Invite</SubmitButton>
       </CsrfForm>
     </Layout>,
   );

--- a/src/ui/templates/components/actions.tsx
+++ b/src/ui/templates/components/actions.tsx
@@ -10,7 +10,10 @@
 import type { Child, SafeHtml } from "#jsx/jsx-runtime.ts";
 import { ICONS_PATH } from "#shared/asset-paths.ts";
 
-/** Icon ids available in the sprite (src/ui/static/icons.svg) */
+/**
+ * Icon ids available in the sprite (src/ui/static/icons.svg).
+ * Names match their source icons in Lucide (https://lucide.dev).
+ */
 export type IconName =
   | "plus"
   | "book-open"
@@ -18,7 +21,13 @@ export type IconName =
   | "arrow-right"
   | "credit-card"
   | "hammer"
-  | "rotate-ccw";
+  | "rotate-ccw"
+  | "save"
+  | "check"
+  | "search"
+  | "trash-2"
+  | "log-in"
+  | "log-out";
 
 /** Visual variants for a button-styled link */
 export type BtnVariant = "primary" | "outline" | "secondary";
@@ -49,6 +58,29 @@ export const ActionButton = ({
     {icon ? <Icon name={icon} /> : null}
     <span>{children}</span>
   </a>
+);
+
+/**
+ * A form submit button with a leading icon. Mirrors {@link ActionButton} for
+ * the primary action of a form (e.g. "Save", "Create Listing"). Pass `class`
+ * to layer on the existing button modifiers (`secondary`, `danger`, …) and an
+ * optional `id` for buttons targeted by client scripts.
+ */
+export const SubmitButton = ({
+  icon,
+  class: className,
+  id,
+  children,
+}: {
+  icon: IconName;
+  class?: string;
+  id?: string;
+  children?: Child;
+}): SafeHtml => (
+  <button class={className} id={id} type="submit">
+    <Icon name={icon} />
+    <span>{children}</span>
+  </button>
 );
 
 /**

--- a/test/templates/components/actions.test.ts
+++ b/test/templates/components/actions.test.ts
@@ -5,6 +5,7 @@ import {
   ActionButton,
   GuideLink,
   Icon,
+  SubmitButton,
 } from "#templates/components/actions.tsx";
 
 describe("Icon", () => {
@@ -54,6 +55,38 @@ describe("ActionButton", () => {
       ActionButton({ children: "Try again", href: "/x", variant: "outline" }),
     );
     expect(html).toContain('class="btn outline"');
+  });
+});
+
+describe("SubmitButton", () => {
+  test("renders a submit button with a leading icon and label", () => {
+    const html = String(SubmitButton({ children: "Save Theme", icon: "save" }));
+    expect(html).toContain('type="submit"');
+    expect(html).toContain(`href="${ICONS_PATH}#save"`);
+    expect(html).toContain("<span>Save Theme</span>");
+  });
+
+  test("passes through a class for button modifiers", () => {
+    const html = String(
+      SubmitButton({
+        children: "Reset Database",
+        class: "danger",
+        icon: "trash-2",
+      }),
+    );
+    expect(html).toContain('class="danger"');
+    expect(html).toContain(`href="${ICONS_PATH}#trash-2"`);
+  });
+
+  test("passes through an id for script-targeted buttons", () => {
+    const html = String(
+      SubmitButton({
+        children: "Save Changes",
+        icon: "save",
+        id: "listing-edit-submit",
+      }),
+    );
+    expect(html).toContain('id="listing-edit-submit"');
   });
 });
 


### PR DESCRIPTION
Extends the icon system from #1137 (action buttons / guide links) to the **form submit buttons across the admin side**, so saving and other primary form actions match the same visual language without changing the public-facing pages.

## What changed

- **New reusable `SubmitButton` component** in `src/ui/templates/components/actions.tsx` (alongside `ActionButton`/`GuideLink`). It renders a `<button type="submit">` with a leading sprite icon and passes through `class`/`id`, so existing modifiers (`danger`, `secondary`) and script-targeted ids (e.g. `listing-edit-submit`) keep working.
- **`ConfirmForm` now carries an icon** too — `trash-2` for destructive confirms, `check` otherwise — which covers every admin delete/confirm flow in one place.
- **Six new icons added to the static sprite** (`save`, `check`, `search`, `trash-2`, `log-in`, `log-out`). These come from [Lucide](https://lucide.dev), the same set as the previous commit; this is now noted explicitly in `icons.svg` and in the `IconName` type, since the source wasn't otherwise discoverable.

## Icon vocabulary

Kept deliberately small and reused across all admin submit buttons:

| Icon | Used for |
| --- | --- |
| `save` | Save / Update / Set / Override / Bump |
| `plus` | Add / Create / Register / Generate / Duplicate |
| `user-plus` | Create Invite |
| `hammer` | Build Site / Provision |
| `rotate-ccw` | Check for Updates / Re-sync / Refresh / Restore / Rotate token |
| `check` | Check In / Activate / Validate |
| `search` | Search / availability checks |
| `trash-2` | Remove / Reset / destructive confirms |
| `log-in` | Login |
| `log-out` | Logout |

## Scope

- Every button-styled submit button on admin pages gets an icon.
- Inline `link-button` table actions (styled as plain text links) are intentionally left as-is, matching #1137 which only iconised real buttons and `.btn` links.
- The public-facing forms keep their plain buttons; per the request, only the admin **login** button gets an icon.

## Tests / checks

- Added unit tests for `SubmitButton` (icon + label, class pass-through, id pass-through).
- Full `deno task precommit` passes: biome, typecheck, lint, cpd, build:edge, and `test:coverage` (100% coverage maintained).

https://claude.ai/code/session_01Fc6cVMGrFZapjJrssGXw9i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc6cVMGrFZapjJrssGXw9i)_