### PR TITLE
Refine /admin/emails page, add listing-scoped email log and info flash

### DIFF
--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -33,6 +33,7 @@ import {
   parseDraft,
   resolveRecipientEmails,
   serializeDraft,
+  summarizeProviderResponse,
   targetQuery,
   validateDraftInput,
 } from "#shared/bulk-email.ts";
@@ -77,7 +78,7 @@ const getBulkAvailability = (): BulkAvailability => {
         canBulkSend: false,
         config: null,
         disabledReason:
-          "You haven't configured your own email provider, so the system won't send bulk email for you — sending marketing from a shared address risks the whole platform's deliverability. Add your provider under Settings → Advanced → Email Notifications.",
+          "You haven't configured your own email provider, so the system won't send bulk email for you. Sending marketing from a shared address risks the whole platform's deliverability.",
       };
 };
 
@@ -308,14 +309,19 @@ const handleSendPost = (request: Request): Promise<Response> =>
       privateKey,
     );
     await settings.update.bulkEmailDraft("");
+    const providerSummary = summarizeProviderResponse(result.responses);
+    const recipientLabel = `${result.attempted} recipient${
+      result.attempted === 1 ? "" : "s"
+    }`;
     await logActivity(
-      `Sent bulk email "${draft.subject}" to ${result.attempted} recipient(s)`,
+      `Sent bulk email "${draft.subject}" to ${recipientLabel}. ${providerSummary}`,
+      draft.target.kind === "listing" ? draft.target.listingId : null,
     );
     return ok(
       COMPOSE_PATH,
-      `Sent to ${result.attempted} recipient${
-        result.attempted === 1 ? "" : "s"
-      }.`,
+      `Sent to ${recipientLabel} via ${
+        EMAIL_PROVIDER_LABELS[config.provider]
+      }. ${providerSummary}`,
     );
   });
 

--- a/src/features/csrf.ts
+++ b/src/features/csrf.ts
@@ -93,7 +93,7 @@ export const withCsrfForm = async (
  */
 export const applyFlash = (
   request: Request,
-): { success?: string; error?: string; result?: string } => {
+): { success?: string; error?: string; info?: string; result?: string } => {
   const flash = getFlash();
   const formId = getSearchParam(request, "form");
   if (flash.success) setFormSuccess(formId, flash.success);

--- a/src/features/csrf.ts
+++ b/src/features/csrf.ts
@@ -8,7 +8,7 @@ import {
   signCsrfToken,
   verifySignedCsrfToken,
 } from "#shared/csrf.ts";
-import { getFlash } from "#shared/flash-context.ts";
+import { type Flash, getFlash } from "#shared/flash-context.ts";
 import { FormParams } from "#shared/form-data.ts";
 import {
   setFormError,
@@ -91,9 +91,7 @@ export const withCsrfForm = async (
  * per-request success/error stores so CsrfForm can display them.
  * Returns the flash object for callers that need additional logic.
  */
-export const applyFlash = (
-  request: Request,
-): { success?: string; error?: string; info?: string; result?: string } => {
+export const applyFlash = (request: Request): Flash => {
   const flash = getFlash();
   const formId = getSearchParam(request, "form");
   if (flash.success) setFormSuccess(formId, flash.success);

--- a/src/features/public/unsubscribe.ts
+++ b/src/features/public/unsubscribe.ts
@@ -7,7 +7,7 @@
  */
 
 import { applyFlash, withCsrfForm } from "#routes/csrf.ts";
-import { htmlResponse, redirect } from "#routes/response.ts";
+import { htmlResponse, infoRedirect, redirect } from "#routes/response.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
 import {
   isHashUnsubscribed,
@@ -31,6 +31,7 @@ export const handleUnsubscribeGet = async (
     unsubscribePage({
       error: flash.error,
       hash,
+      info: flash.info,
       success: flash.success,
       unsubscribed,
     }),
@@ -60,10 +61,9 @@ export const handleUnsubscribePost = (request: Request): Promise<Response> =>
         );
       }
       await unsubscribeHash(hash);
-      return redirect(
+      return infoRedirect(
         pagePath(hash),
         "You've unsubscribed from our marketing emails.",
-        true,
       );
     },
   );

--- a/src/features/response.ts
+++ b/src/features/response.ts
@@ -2,7 +2,7 @@
  * Response builder utilities for route handlers
  */
 
-import { buildFlashCookie } from "#shared/cookies.ts";
+import { buildFlashCookie, type FlashLevel } from "#shared/cookies.ts";
 import { appendIframeParam, getIframeMode } from "#shared/iframe.ts";
 import { getRequestId } from "#shared/logger.ts";
 import { checkoutPopupPage, paymentErrorPage } from "#templates/payment.tsx";
@@ -112,6 +112,8 @@ type RedirectOpts = {
   cookie?: string;
   form?: URLSearchParams;
   result?: string;
+  /** Override the flash level; defaults to success/error from `succeeded`. */
+  level?: FlashLevel;
 };
 
 /**
@@ -136,7 +138,13 @@ export const redirect = (
     u.searchParams.set("form", opts.formId);
     u.hash = opts.formId;
   }
-  const flash = buildFlashCookie(flashId, message, succeeded, opts?.result);
+  const flash = buildFlashCookie(
+    flashId,
+    message,
+    succeeded,
+    opts?.result,
+    opts?.level,
+  );
   const response = redirectResponse(u.pathname + u.search + u.hash, flash);
   if (opts?.cookie) withCookie(response, opts.cookie);
   return response;
@@ -151,6 +159,13 @@ export const errorRedirect = (
   message: string,
   formId?: string,
 ): Response => redirect(url, message, false, formId ? { formId } : undefined);
+
+/**
+ * Redirect with a neutral informational message (PRG pattern), e.g. confirming
+ * an opt-out. Rendered in the info style rather than success or error.
+ */
+export const infoRedirect = (url: string, message: string): Response =>
+  redirect(url, message, true, { level: "info" });
 
 /**
  * Create JSON response

--- a/src/shared/bulk-email.ts
+++ b/src/shared/bulk-email.ts
@@ -8,7 +8,7 @@
  * be added in one place without touching the routes or templates.
  */
 
-import { filter, map, pipe, sort, uniqueBy } from "#fp";
+import { filter, map, pipe, sort, unique, uniqueBy } from "#fp";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { decryptPiiBlob } from "#shared/db/attendees/pii.ts";
 import {
@@ -19,6 +19,7 @@ import { hashEmail } from "#shared/db/email-preferences.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import {
   BULK_UNSUBSCRIBE_PLACEHOLDER,
+  type BulkBatchResponse,
   type BulkEmailPayload,
   type BulkRecipient,
 } from "#shared/email.ts";
@@ -303,13 +304,47 @@ export const buildBulkPayload = async (params: {
 export const contactFrequencySummary = (counts: number[]): string => {
   if (counts.length === 0) return "";
   const total = counts.reduce((sum, n) => sum + n, 0);
-  if (total === 0) return "These attendees have never been contacted.";
+  if (total === 0) {
+    return "These attendees have never been contacted through this page.";
+  }
   const average = total / counts.length;
   return Number.isInteger(average)
-    ? `These attendees have been contacted ${average} times each.`
-    : `These attendees have been contacted an average of ${average.toFixed(
+    ? `These attendees have been contacted through this page ${average} times each.`
+    : `These attendees have been contacted through this page an average of ${average.toFixed(
         1,
       )} times each.`;
+};
+
+// ── Provider reply ──────────────────────────────────────────────────
+
+/** Cap on how much of a provider's reply we echo back, so a verbose body can't
+ * blow a flash cookie or flood the activity log. */
+const MAX_PROVIDER_REPLY_LENGTH = 300;
+
+/**
+ * One-line, human-readable summary of what the email provider said in reply to
+ * a bulk send. Providers acknowledge a batch with queued message IDs or, on
+ * failure, a reason — both worth surfacing to the sender and storing in the
+ * log. Distinct per-batch replies are de-duplicated and the result is
+ * length-capped.
+ */
+export const summarizeProviderResponse = (
+  responses: readonly BulkBatchResponse[],
+): string => {
+  if (responses.length === 0) return "The email provider sent no response.";
+  const parts = pipe(
+    map((r: BulkBatchResponse) => {
+      const body = r.body.trim();
+      return body ? `HTTP ${r.status}: ${body}` : `HTTP ${r.status}`;
+    }),
+    unique,
+  )(responses as BulkBatchResponse[]);
+  const joined = parts.join("; ");
+  const trimmed =
+    joined.length > MAX_PROVIDER_REPLY_LENGTH
+      ? `${joined.slice(0, MAX_PROVIDER_REPLY_LENGTH)}...`
+      : joined;
+  return `The email provider responded with ${trimmed}.`;
 };
 
 // ── mailto fallback ─────────────────────────────────────────────────

--- a/src/shared/cookies.ts
+++ b/src/shared/cookies.ts
@@ -1,4 +1,5 @@
 import { getEffectiveDomain } from "#shared/config.ts";
+import type { Flash } from "#shared/flash-context.ts";
 import { SESSION_MAX_AGE_S } from "#shared/limits.ts";
 
 export const isSecureMode = (): boolean => getEffectiveDomain() !== "localhost";
@@ -64,9 +65,7 @@ export const clearFlashCookie = (id: string): string =>
   )}=; HttpOnly${secureAttribute()}; SameSite=Strict; Path=/; Max-Age=0`;
 
 /** Parse a flash cookie value into type, message, and optional result */
-export const parseFlashValue = (
-  value: string,
-): { success?: string; error?: string; info?: string; result?: string } => {
+export const parseFlashValue = (value: string): Flash => {
   const decoded = decodeURIComponent(value);
   const obj = JSON.parse(decoded);
   return {

--- a/src/shared/cookies.ts
+++ b/src/shared/cookies.ts
@@ -27,14 +27,27 @@ const FLASH_COOKIE_PREFIX = "flash_";
 /** Build the cookie name for a keyed flash message */
 const flashCookieName = (id: string): string => `${FLASH_COOKIE_PREFIX}${id}`;
 
-/** Build a flash cookie containing a success or error message, keyed by ID */
+/** Visual level of a flash message: a positive result, a failure, or a
+ * neutral acknowledgement. */
+export type FlashLevel = "success" | "error" | "info";
+
+/** Single-char cookie tag for each flash level. */
+const FLASH_TYPE_CHAR: Record<FlashLevel, string> = {
+  error: "e",
+  info: "i",
+  success: "s",
+};
+
+/** Build a flash cookie containing a success, error, or info message, keyed by
+ * ID. `level` defaults to success/error from `succeeded`; pass it to override. */
 export const buildFlashCookie = (
   id: string,
   message: string,
   succeeded: boolean,
   result?: string,
+  level: FlashLevel = succeeded ? "success" : "error",
 ): string => {
-  const type = succeeded ? "s" : "e";
+  const type = FLASH_TYPE_CHAR[level];
   const payload = JSON.stringify(
     result ? { m: message, r: result, t: type } : { m: message, t: type },
   );
@@ -53,11 +66,12 @@ export const clearFlashCookie = (id: string): string =>
 /** Parse a flash cookie value into type, message, and optional result */
 export const parseFlashValue = (
   value: string,
-): { success?: string; error?: string; result?: string } => {
+): { success?: string; error?: string; info?: string; result?: string } => {
   const decoded = decodeURIComponent(value);
   const obj = JSON.parse(decoded);
   return {
     error: obj.t === "e" ? obj.m : undefined,
+    info: obj.t === "i" ? obj.m : undefined,
     result: obj.r,
     success: obj.t === "s" ? obj.m : undefined,
   };

--- a/src/shared/email.ts
+++ b/src/shared/email.ts
@@ -519,18 +519,30 @@ const BULK_PROVIDERS = {
   },
 } as const satisfies Record<EmailProvider, BulkProviderSpec>;
 
-/** Outcome of a bulk send: recipients attempted, batches sent, and recipients in failed batches. */
+/** What the provider returned for one batch: HTTP status, ok flag, and the raw
+ * response body. Providers reply with queued message IDs (or rejection
+ * reasons), so the body is kept to surface back to the sender and the log. */
+export type BulkBatchResponse = {
+  status: number;
+  ok: boolean;
+  body: string;
+};
+
+/** Outcome of a bulk send: recipients attempted, batches sent, recipients in
+ * failed batches, and the raw per-batch provider responses. */
 export type BulkSendResult = {
   attempted: number;
   batches: number;
   failed: number;
+  responses: BulkBatchResponse[];
 };
 
 /**
  * Send a bulk email via the configured provider. Every supported provider has a
  * batch endpoint, so this works for any `EmailConfig`. Chunks recipients to the
  * provider's batch limit and POSTs each chunk; logs (never throws) on a non-OK
- * batch, whose recipients then count as failed.
+ * batch, whose recipients then count as failed. Each batch's provider response
+ * is captured so the caller can relay it to the sender.
  */
 export const sendBulkEmails = async (
   config: EmailConfig,
@@ -539,11 +551,13 @@ export const sendBulkEmails = async (
   const spec = BULK_PROVIDERS[config.provider];
   const { recipients, ...template } = payload;
   const batches = chunk(spec.maxBatchSize)(recipients);
+  const responses: BulkBatchResponse[] = [];
   let failed = 0;
   for (const batch of batches) {
-    const { ok, status } = await sendRequest(
+    const { ok, status, text } = await sendRequest(
       spec.build(config, template, batch),
     );
+    responses.push({ body: text, ok, status });
     if (!ok) {
       failed += batch.length;
       logError({
@@ -552,7 +566,12 @@ export const sendBulkEmails = async (
       });
     }
   }
-  return { attempted: recipients.length, batches: batches.length, failed };
+  return {
+    attempted: recipients.length,
+    batches: batches.length,
+    failed,
+    responses,
+  };
 };
 
 /** Send a test email to the business email address. Returns HTTP status or undefined on non-HTTP errors. */

--- a/src/shared/flash-context.ts
+++ b/src/shared/flash-context.ts
@@ -7,7 +7,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 /** Flash message shape — fields are only present when a message exists */
-export type Flash = { success?: string; error?: string; result?: string };
+export type Flash = {
+  success?: string;
+  error?: string;
+  info?: string;
+  result?: string;
+};
 
 const flashStore = new AsyncLocalStorage<Flash>();
 
@@ -21,6 +26,7 @@ export const setFlashContext = (flash: Flash): void => {
   if (store) {
     store.success = flash.success;
     store.error = flash.error;
+    store.info = flash.info;
     store.result = flash.result;
   }
 };
@@ -30,6 +36,7 @@ export const getFlash = (): Flash => {
   const store = flashStore.getStore();
   return {
     error: store?.error,
+    info: store?.info,
     result: store?.result,
     success: store?.success,
   };
@@ -38,5 +45,9 @@ export const getFlash = (): Flash => {
 /** Whether the current request has a flash message */
 export const hasFlash = (): boolean => {
   const store = flashStore.getStore();
-  return store?.success !== undefined || store?.error !== undefined;
+  return (
+    store?.success !== undefined ||
+    store?.error !== undefined ||
+    store?.info !== undefined
+  );
 };

--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -124,7 +124,7 @@ const renderCheckboxGroup = (
   options: readonly { value: string; label: string }[],
   selectedValues: Set<string>,
 ): string =>
-  `<fieldset class="checkbox-group">${options
+  `<fieldset class="checkboxes">${options
     .map(
       (opt) =>
         `<label><input type="checkbox" name="${escapeHtml(name)}" value="${escapeHtml(
@@ -466,14 +466,21 @@ export const defineForm = <
 export const Flash = ({
   error,
   success,
+  info,
 }: {
   error?: string;
   success?: string;
+  info?: string;
 }): JSX.Element => (
   <>
     {success ? (
       <div class="success" role="alert">
         {success}
+      </div>
+    ) : null}
+    {info ? (
+      <div class="info" role="alert">
+        {info}
       </div>
     ) : null}
     {error ? (

--- a/src/ui/static/icons.svg
+++ b/src/ui/static/icons.svg
@@ -46,6 +46,16 @@
         d="M5 12h14m-7-7l7 7l-7 7"
       />
     </symbol>
+    <symbol id="arrow-left" viewBox="0 0 24 24">
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M19 12H5m7 7l-7-7l7-7"
+      />
+    </symbol>
     <symbol id="credit-card" viewBox="0 0 24 24">
       <g
         fill="none"

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -205,6 +205,13 @@ article > * {
   margin-bottom: 0;
 }
 
+/* Outlines a rendered email body so it reads as a preview, not page content. */
+.email-preview {
+  border: 1px dashed var(--color-text-secondary);
+  border-radius: var(--border-radius);
+  padding: var(--space-m);
+}
+
 hr {
   background-color: var(--color-bg-secondary);
   border: none;
@@ -421,6 +428,15 @@ pre samp {
 small,
 .muted {
   color: var(--color-text-secondary);
+}
+
+/* Small print as a paragraph modifier: shrinks the text and tightens the
+ * spacing so a note doesn't carry a full paragraph's worth of margin. */
+.small {
+  color: var(--color-text-secondary);
+  font-size: 0.85em;
+  line-height: 1.4;
+  margin: var(--space-s) 0;
 }
 
 sup {
@@ -928,6 +944,13 @@ article {
   padding: var(--space-m);
 }
 
+.info {
+  background: #eef4ff;
+  border-left: 4px solid #0066cc;
+  color: #0055aa;
+  padding: var(--space-m);
+}
+
 [data-theme="dark"] .error {
   background: #3c2020;
   color: #ff5555;
@@ -935,6 +958,10 @@ article {
 [data-theme="dark"] .success {
   background: #203c20;
   color: #50fa7b;
+}
+[data-theme="dark"] .info {
+  background: #1f2a3c;
+  color: #8ab4ff;
 }
 
 /* Danger elements */
@@ -1120,14 +1147,14 @@ fieldset {
   gap: var(--space-s);
 }
 
-.checkbox-group,
-.radio-group {
+.checkboxes,
+.radios {
   border: 0;
   padding: 0;
 }
 
-.checkbox-group label,
-.radio-group label {
+.checkboxes label,
+.radios label {
   display: inline-block;
   font-weight: normal;
   max-width: none;

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -15,9 +15,13 @@ import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { ActionButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const NAV_ACTIVE = "/admin/emails";
+
+/** Deep link to the Email Notifications form on the advanced settings page. */
+const EMAIL_SETTINGS_LINK = "/admin/settings-advanced#settings-email";
 
 export type BulkEmailComposeState = {
   target: BulkEmailTarget;
@@ -76,12 +80,14 @@ export const bulkEmailComposePage = (
       <AdminNav active={NAV_ACTIVE} session={session} />
       <Flash />
 
-      <h1>Send a bulk email</h1>
-      <p>
-        Email your attendees about an upcoming listing or other news. Choose who
-        receives it, write your message in Markdown, then preview before
-        sending.
-      </p>
+      <div class="prose">
+        <h1>Send a bulk email</h1>
+        <p>
+          Email your attendees about an upcoming listing or other news. Choose
+          who receives it, write your message in Markdown, then preview before
+          sending.
+        </p>
+      </div>
 
       {!state.canBulkSend && (
         <div class="prose">
@@ -89,6 +95,11 @@ export const bulkEmailComposePage = (
             <strong>Heads up:</strong> {state.disabledReason} You can still
             compose and preview, then use the BCC email-app option on the
             preview page.
+          </p>
+          <p class="small">
+            <a href={EMAIL_SETTINGS_LINK}>
+              Set up your email provider in advanced settings
+            </a>
           </p>
         </div>
       )}
@@ -115,24 +126,26 @@ export const bulkEmailComposePage = (
           </textarea>
         </label>
 
-        <label>
-          <input
-            checked={draft?.marketing ?? false}
-            name="marketing"
-            type="checkbox"
-            value="1"
-          />{" "}
-          This is a marketing email (adds an unsubscribe footer and skips
-          unsubscribed people)
-        </label>
+        <fieldset class="checkboxes">
+          <label>
+            <input
+              checked={draft?.marketing ?? false}
+              name="marketing"
+              type="checkbox"
+              value="1"
+            />{" "}
+            This is a marketing email (adds an unsubscribe footer and skips
+            unsubscribed people)
+          </label>
+        </fieldset>
 
         <div class="prose">
           <p>
             This selection currently reaches{" "}
             <strong>{state.recipientCount}</strong> recipient
-            {state.recipientCount === 1 ? "" : "s"} — everyone who gave an email
-            address, de-duplicated. Preview to confirm the exact list for your
-            final selection.
+            {state.recipientCount === 1 ? "" : "s"}. That's everyone who gave an
+            email address, de-duplicated. Preview to confirm the exact list for
+            your final selection.
           </p>
         </div>
 
@@ -173,9 +186,9 @@ const TypeExplainer = ({ marketing }: { marketing: boolean }): JSX.Element =>
   ) : (
     <p>
       <strong>Transactional / service email.</strong> Treated as essential
-      information about a listing someone booked — no unsubscribe footer is
-      added and unsubscribed people are still included. Only use this for
-      genuine listing info, never promotions.
+      information about a listing someone booked. No unsubscribe footer is added
+      and unsubscribed people are still included. Only use this for genuine
+      listing info, never promotions.
     </p>
   );
 
@@ -197,75 +210,95 @@ export const bulkEmailPreviewPage = (
       <AdminNav active={NAV_ACTIVE} session={session} />
       <Flash />
 
-      <h1>Preview bulk email</h1>
+      <div class="prose">
+        <h1>Preview bulk email</h1>
+      </div>
       <p>
-        <a href={`/admin/emails${targetQuery(draft.target)}`}>← Edit message</a>
+        <ActionButton
+          href={`/admin/emails${targetQuery(draft.target)}`}
+          icon="arrow-left"
+          variant="secondary"
+        >
+          Edit message
+        </ActionButton>
       </p>
 
       <div class="prose">
         <p>
-          <strong>To:</strong> {state.targetLabel} — {recipients}
+          <strong>To:</strong> {state.targetLabel} ({recipients}
           {state.skippedCount > 0
-            ? ` (${state.skippedCount} unsubscribed will be skipped)`
+            ? `, ${state.skippedCount} unsubscribed will be skipped`
             : ""}
+          )
         </p>
         {state.audienceDescription && (
-          <p>
-            <small>{state.audienceDescription}</small>
-          </p>
+          <p class="small">{state.audienceDescription}</p>
         )}
-        {state.contactSummary && (
-          <p>
-            <small>{state.contactSummary}</small>
-          </p>
-        )}
+        {state.contactSummary && <p class="small">{state.contactSummary}</p>}
         <p>
           <strong>Subject:</strong> {draft.subject}
         </p>
         <TypeExplainer marketing={draft.marketing} />
       </div>
 
-      <h2>Message preview</h2>
-      <article class="prose">
+      <div class="prose">
+        <h2>Message preview</h2>
+      </div>
+      <article class="prose email-preview">
         <Raw html={renderMarkdown(draft.body)} />
       </article>
       {draft.marketing && (
-        <p>
-          <small>
+        <div class="prose">
+          <p class="small">
             A personalized unsubscribe footer is appended to each marketing
             email.
-          </small>
-        </p>
+          </p>
+        </div>
       )}
 
-      <h2>Send through your email provider</h2>
+      <div class="prose">
+        <h2>Send through your email provider</h2>
+      </div>
       {state.canBulkSend ? (
-        <CsrfForm action="/admin/emails/send" id="bulk-email-send">
+        <CsrfForm
+          action="/admin/emails/send"
+          class="inline"
+          id="bulk-email-send"
+        >
           <button type="submit">
             Send to {recipients} via {state.providerLabel}
           </button>
         </CsrfForm>
       ) : (
         <>
-          <p>
-            <strong>Sending is disabled.</strong> {state.disabledReason}
-          </p>
+          <div class="prose">
+            <p>
+              <strong>Sending is disabled.</strong> {state.disabledReason}
+            </p>
+            <p class="small">
+              <a href={EMAIL_SETTINGS_LINK}>
+                Set up your email provider in advanced settings
+              </a>
+            </p>
+          </div>
           <button disabled type="button">
             Send to {recipients}
           </button>
         </>
       )}
 
-      <h2>Or send from your own email app</h2>
-      <p>
-        This opens your email app with everyone in BCC. It needs no provider
-        setup, but sending lots of mail this way — especially marketing — is a
-        quick way to get your account rate-limited or blocked. Best for small,
-        genuinely transactional messages.
-      </p>
-      <p>
-        <a href={state.mailtoLink}>Open a BCC draft to {recipients}</a>
-      </p>
+      <div class="prose">
+        <h2>Or send from your own email app</h2>
+        <p>
+          This opens your email app with everyone in BCC. It needs no provider
+          setup, but sending lots of mail this way, especially marketing, is a
+          quick way to get your account rate-limited or blocked. It's best for
+          small, genuinely transactional messages.
+        </p>
+        <p>
+          <a href={state.mailtoLink}>Open a BCC draft to {recipients}</a>
+        </p>
+      </div>
     </Layout>,
   );
 };

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -395,7 +395,7 @@ export const adminGroupDetailPage = (
         <>
           <h2>Add Listings to Group</h2>
           <CsrfForm action={`/admin/groups/${group.id}/add-listings`}>
-            <fieldset class="checkbox-group">
+            <fieldset class="checkboxes">
               {ungroupedListings.map((e) => (
                 <label>
                   <input

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -286,6 +286,11 @@ const ListingActionNav = ({
             <a href={`/admin/listing/${listing.id}/qr`}>Booking QR</a>
           </li>
         )}
+        {isOwner && (
+          <li>
+            <a href={`/admin/emails?listing=${listing.id}`}>Email</a>
+          </li>
+        )}
         <li>
           <a
             href={`/admin/listing/${listing.id}/export${
@@ -295,11 +300,6 @@ const ListingActionNav = ({
             Export CSV
           </a>
         </li>
-        {isOwner && (
-          <li>
-            <a href={`/admin/emails?listing=${listing.id}`}>Email Attendees</a>
-          </li>
-        )}
         {hasPaidListing && (
           <li>
             <a class="danger" href={`/admin/listing/${listing.id}/refund-all`}>

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -136,7 +136,7 @@ export const adminQuestionPage = (
           action={`/admin/questions/${question.id}/listings`}
           id="question-listings"
         >
-          <fieldset class="checkbox-group">
+          <fieldset class="checkboxes">
             {map((e: ListingWithCount) => (
               <label>
                 <input
@@ -244,7 +244,7 @@ export const adminListingQuestionsPage = (
         </p>
       ) : (
         <CsrfForm action={`/admin/listing/${listing.id}/questions`}>
-          <fieldset class="checkbox-group">
+          <fieldset class="checkboxes">
             {map((q: QuestionWithAnswers) => (
               <label>
                 <input

--- a/src/ui/templates/admin/settings/payment.tsx
+++ b/src/ui/templates/admin/settings/payment.tsx
@@ -21,7 +21,7 @@ export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
   >
     <h2>Payment Provider</h2>
     <p>Choose which payment provider to use for paid listings.</p>
-    <fieldset class="radio-group">
+    <fieldset class="radios">
       <label>
         <input
           checked={!s.paymentProvider}

--- a/src/ui/templates/admin/settings/public-api.tsx
+++ b/src/ui/templates/admin/settings/public-api.tsx
@@ -17,7 +17,7 @@ export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
       creating bookings. See the <a href="/admin/guide#api">API guide</a> for
       details.
     </p>
-    <fieldset class="radio-group">
+    <fieldset class="radios">
       <label>
         <input
           checked={s.showPublicApi === true}

--- a/src/ui/templates/admin/settings/public-site.tsx
+++ b/src/ui/templates/admin/settings/public-site.tsx
@@ -16,7 +16,7 @@ export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
       When enabled, the homepage will show a public website with navigation for
       Home, Listings, T&amp;Cs and Contact pages.
     </p>
-    <fieldset class="radio-group">
+    <fieldset class="radios">
       <label>
         <input
           checked={s.showPublicSite === true}

--- a/src/ui/templates/admin/settings/theme.tsx
+++ b/src/ui/templates/admin/settings/theme.tsx
@@ -10,7 +10,7 @@ export const ThemeForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/theme" id="settings-theme">
     <h2>Site Theme</h2>
     <p>Choose between light and dark themes for the site interface.</p>
-    <fieldset class="radio-group">
+    <fieldset class="radios">
       <label>
         <input
           checked={s.theme === "light"}

--- a/src/ui/templates/components/actions.tsx
+++ b/src/ui/templates/components/actions.tsx
@@ -19,6 +19,7 @@ export type IconName =
   | "book-open"
   | "user-plus"
   | "arrow-right"
+  | "arrow-left"
   | "credit-card"
   | "hammer"
   | "rotate-ccw"

--- a/src/ui/templates/public/unsubscribe.tsx
+++ b/src/ui/templates/public/unsubscribe.tsx
@@ -16,6 +16,7 @@ export type UnsubscribeState = {
   unsubscribed: boolean;
   success?: string;
   error?: string;
+  info?: string;
 };
 
 /** The toggle form — carries the hash and the action, never the address. */
@@ -28,7 +29,7 @@ const ToggleForm = ({
   action: "unsubscribe" | "resubscribe";
   label: string;
 }): JSX.Element => (
-  <CsrfForm action="/unsubscribe" id="unsubscribe">
+  <CsrfForm action="/unsubscribe" class="inline" id="unsubscribe">
     <input name="email" type="hidden" value={hash} />
     <input name="action" type="hidden" value={action} />
     <button type="submit">{label}</button>
@@ -42,7 +43,7 @@ export const unsubscribePage = (state: UnsubscribeState): string => {
   return String(
     <Layout title={title}>
       <h1>Email preferences</h1>
-      <Flash error={state.error} success={state.success} />
+      <Flash error={state.error} info={state.info} success={state.success} />
       {!state.hash ? (
         <div class="prose">
           <p>

--- a/test/lib/bulk-email.test.ts
+++ b/test/lib/bulk-email.test.ts
@@ -17,6 +17,7 @@ import {
   parseDraft,
   resolveRecipientEmails,
   serializeDraft,
+  summarizeProviderResponse,
   targetQuery,
   unsubscribeUrl,
   validateDraftInput,
@@ -180,20 +181,81 @@ describe("contactFrequencySummary", () => {
 
   test("reports never-contacted when all counts are zero", () => {
     expect(contactFrequencySummary([0, 0, 0])).toBe(
-      "These attendees have never been contacted.",
+      "These attendees have never been contacted through this page.",
     );
   });
 
   test("reports a whole number when the average is an integer", () => {
     expect(contactFrequencySummary([2, 2, 2])).toBe(
-      "These attendees have been contacted 2 times each.",
+      "These attendees have been contacted through this page 2 times each.",
     );
   });
 
   test("reports a one-decimal average otherwise", () => {
     expect(contactFrequencySummary([1, 2])).toBe(
-      "These attendees have been contacted an average of 1.5 times each.",
+      "These attendees have been contacted through this page an average of 1.5 times each.",
     );
+  });
+});
+
+describe("summarizeProviderResponse", () => {
+  test("notes when there were no responses at all", () => {
+    expect(summarizeProviderResponse([])).toBe(
+      "The email provider sent no response.",
+    );
+  });
+
+  test("reports just the status when the body is empty", () => {
+    expect(
+      summarizeProviderResponse([{ body: "", ok: true, status: 200 }]),
+    ).toBe("The email provider responded with HTTP 200.");
+  });
+
+  test("includes the provider's reply body when present", () => {
+    expect(
+      summarizeProviderResponse([
+        { body: '{"id":"abc-123"}', ok: true, status: 200 },
+      ]),
+    ).toBe('The email provider responded with HTTP 200: {"id":"abc-123"}.');
+  });
+
+  test("surfaces a failed batch's status and reason", () => {
+    expect(
+      summarizeProviderResponse([
+        { body: "rate limit exceeded", ok: false, status: 429 },
+      ]),
+    ).toBe("The email provider responded with HTTP 429: rate limit exceeded.");
+  });
+
+  test("de-duplicates identical replies across batches", () => {
+    expect(
+      summarizeProviderResponse([
+        { body: "queued", ok: true, status: 200 },
+        { body: "queued", ok: true, status: 200 },
+      ]),
+    ).toBe("The email provider responded with HTTP 200: queued.");
+  });
+
+  test("joins distinct per-batch replies", () => {
+    expect(
+      summarizeProviderResponse([
+        { body: "queued", ok: true, status: 200 },
+        { body: "rejected", ok: false, status: 422 },
+      ]),
+    ).toBe(
+      "The email provider responded with HTTP 200: queued; HTTP 422: rejected.",
+    );
+  });
+
+  test("truncates an over-long reply", () => {
+    const long = "x".repeat(1000);
+    const summary = summarizeProviderResponse([
+      { body: long, ok: true, status: 200 },
+    ]);
+    expect(summary).toContain("...");
+    // Capped well below the raw body, which is never echoed in full.
+    expect(summary.length).toBeLessThan(long.length);
+    expect(summary).not.toContain(long);
   });
 });
 

--- a/test/lib/cookies.test.ts
+++ b/test/lib/cookies.test.ts
@@ -153,6 +153,7 @@ describe("parseFlashValue", () => {
     const encoded = JSON.stringify({ m: "Listing created", t: "s" });
     expect(parseFlashValue(encoded)).toEqual({
       error: undefined,
+      info: undefined,
       result: undefined,
       success: "Listing created",
     });
@@ -162,6 +163,17 @@ describe("parseFlashValue", () => {
     const encoded = JSON.stringify({ m: "Something went wrong", t: "e" });
     expect(parseFlashValue(encoded)).toEqual({
       error: "Something went wrong",
+      info: undefined,
+      result: undefined,
+      success: undefined,
+    });
+  });
+
+  test("parses info flash value", () => {
+    const encoded = JSON.stringify({ m: "You've unsubscribed", t: "i" });
+    expect(parseFlashValue(encoded)).toEqual({
+      error: undefined,
+      info: "You've unsubscribed",
       result: undefined,
       success: undefined,
     });
@@ -173,6 +185,7 @@ describe("parseFlashValue", () => {
     );
     expect(parseFlashValue(encoded)).toEqual({
       error: undefined,
+      info: undefined,
       result: undefined,
       success: "Hello world",
     });
@@ -182,6 +195,7 @@ describe("parseFlashValue", () => {
     const encoded = JSON.stringify({ m: "Created", r: "abc123", t: "s" });
     expect(parseFlashValue(encoded)).toEqual({
       error: undefined,
+      info: undefined,
       result: "abc123",
       success: "Created",
     });

--- a/test/lib/email/send-bulk-email.test.ts
+++ b/test/lib/email/send-bulk-email.test.ts
@@ -25,13 +25,21 @@ const payload = (n: number): BulkEmailPayload => ({
   text: "Hi",
 });
 
+/** The stub fetch returns an empty 200, so each batch records this response. */
+const okBatch = { body: "", ok: true, status: 200 };
+
 describe("sendBulkEmails", () => {
   const fetch = useFetchStub();
 
   test("Resend posts one batch request with all recipients", async () => {
     const result = await sendBulkEmails(config, payload(3));
 
-    expect(result).toEqual({ attempted: 3, batches: 1, failed: 0 });
+    expect(result).toEqual({
+      attempted: 3,
+      batches: 1,
+      failed: 0,
+      responses: [okBatch],
+    });
     expect(fetch.callCount()).toBe(1);
     const [url] = fetch.getFetchArgs();
     expect(url).toBe("https://api.resend.com/emails/batch");
@@ -62,7 +70,12 @@ describe("sendBulkEmails", () => {
   test("Resend chunks recipients beyond the 100-per-batch limit", async () => {
     const result = await sendBulkEmails(config, payload(101));
 
-    expect(result).toEqual({ attempted: 101, batches: 2, failed: 0 });
+    expect(result).toEqual({
+      attempted: 101,
+      batches: 2,
+      failed: 0,
+      responses: [okBatch, okBatch],
+    });
     expect(fetch.callCount()).toBe(2);
     expect(fetch.getFetchJsonBody(0)).toHaveLength(100);
     expect(fetch.getFetchJsonBody(1)).toHaveLength(1);
@@ -74,7 +87,12 @@ describe("sendBulkEmails", () => {
       payload(2),
     );
 
-    expect(result).toEqual({ attempted: 2, batches: 1, failed: 0 });
+    expect(result).toEqual({
+      attempted: 2,
+      batches: 1,
+      failed: 0,
+      responses: [okBatch],
+    });
     const [url] = fetch.getFetchArgs();
     expect(url).toBe("https://api.postmarkapp.com/email/batch");
     expect(fetch.getFetchHeaders()["X-Postmark-Server-Token"]).toBe("re_key");
@@ -147,7 +165,12 @@ describe("sendBulkEmails", () => {
       },
     );
 
-    expect(result).toEqual({ attempted: 2, batches: 1, failed: 0 });
+    expect(result).toEqual({
+      attempted: 2,
+      batches: 1,
+      failed: 0,
+      responses: [okBatch],
+    });
     const [url] = fetch.getFetchArgs();
     expect(url).toBe("https://api.mailgun.net/v3/mg.example.com/messages");
     expect(fetch.getFetchHeaders().Authorization).toBe(
@@ -182,7 +205,12 @@ describe("sendBulkEmails", () => {
     const errorSpy = spy(console, "error");
     try {
       const result = await sendBulkEmails(config, payload(3));
-      expect(result).toEqual({ attempted: 3, batches: 1, failed: 3 });
+      expect(result).toEqual({
+        attempted: 3,
+        batches: 1,
+        failed: 3,
+        responses: [{ body: "nope", ok: false, status: 500 }],
+      });
       const logged = errorSpy.calls.some((c) =>
         String(c.args[0]).includes("E_EMAIL_SEND"),
       );
@@ -194,7 +222,12 @@ describe("sendBulkEmails", () => {
 
   test("sending no recipients makes no requests", async () => {
     const result = await sendBulkEmails(config, payload(0));
-    expect(result).toEqual({ attempted: 0, batches: 0, failed: 0 });
+    expect(result).toEqual({
+      attempted: 0,
+      batches: 0,
+      failed: 0,
+      responses: [],
+    });
     expect(fetch.callCount()).toBe(0);
   });
 });

--- a/test/lib/server-bulk-email.test.ts
+++ b/test/lib/server-bulk-email.test.ts
@@ -1,7 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { serializeDraft } from "#shared/bulk-email.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
+import {
+  getAllActivityLog,
+  getListingActivityLog,
+} from "#shared/db/activityLog.ts";
 import {
   getEmailStats,
   hashEmail,
@@ -129,7 +132,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
       ).then((r) => r.text());
       expect(html).toContain('value="Saved subject"');
       expect(html).toContain("checked");
-      expect(html).toContain("recipient — everyone");
+      expect(html).toContain("recipient. That's everyone");
       expect(html).not.toContain("recipients");
     });
 
@@ -334,12 +337,59 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
 
       expectRedirectWithFlash(
         "/admin/emails",
-        "Sent to 2 recipients.",
+        "Sent to 2 recipients via Resend. The email provider responded with HTTP 200.",
       )(response);
       expect(fetch.callCount()).toBe(1);
       expect(settings.bulkEmailDraft).toBe("");
       const log = await getAllActivityLog(10);
       expect(log.some((e) => e.message.includes("Sent bulk email"))).toBe(true);
+    });
+
+    test("relays the provider's reply in the flash and the listing log", async () => {
+      useResend();
+      const listing = await seedListingWithAttendees();
+      await adminFormPost("/admin/emails/preview", {
+        body: "Hello",
+        listing_id: String(listing.id),
+        subject: "Update",
+      });
+      // The provider acknowledges the batch with queued message IDs.
+      fetch.restubFetch(() =>
+        Promise.resolve(
+          new Response('{"data":[{"id":"msg_1"}]}', { status: 200 }),
+        ),
+      );
+
+      const { response } = await adminFormPost("/admin/emails/send", {});
+
+      expectRedirectWithFlash(
+        "/admin/emails",
+        'Sent to 2 recipients via Resend. The email provider responded with HTTP 200: {"data":[{"id":"msg_1"}]}.',
+      )(response);
+      // The reply is stored against this listing's log, not just the global one.
+      const listingLog = await getListingActivityLog(listing.id);
+      expect(
+        listingLog.some((e) => e.message.includes('{"data":[{"id":"msg_1"}]}')),
+      ).toBe(true);
+    });
+
+    test("logs an audience send against no specific listing", async () => {
+      useResend();
+      await seedListingWithAttendees();
+      await adminFormPost("/admin/emails/preview", {
+        audience: "active",
+        body: "Newsletter",
+        subject: "Monthly",
+      });
+
+      const { response } = await adminFormPost("/admin/emails/send", {});
+
+      expectRedirect(response, "/admin/emails");
+      const log = await getAllActivityLog(10);
+      const entry = log.find((e) =>
+        e.message.includes('Sent bulk email "Monthly"'),
+      );
+      expect(entry?.listing_id).toBe(null);
     });
 
     test("errors when the audience has no recipients", async () => {
@@ -399,13 +449,14 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
     });
   });
 
-  describe("listing page Email Attendees link", () => {
+  describe("listing page Email link", () => {
     test("owners see the link on the listing page", async () => {
       const listing = await seedListingWithAttendees();
       const html = await awaitTestRequest(`/admin/listing/${listing.id}`, {
         cookie: await testCookie(),
       }).then((r) => r.text());
       expect(html).toContain(`/admin/emails?listing=${listing.id}`);
+      expect(html).toContain(">Email</a>");
     });
 
     test("managers do not see the link", async () => {
@@ -462,7 +513,9 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
       useResend();
       const listing = await seedListingWithAttendees();
       const html = await previewListing(listing);
-      expect(html).toContain("These attendees have never been contacted.");
+      expect(html).toContain(
+        "These attendees have never been contacted through this page.",
+      );
     });
 
     test("a send records a contact, surfaced on the next preview", async () => {
@@ -485,7 +538,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
 
       const html = await previewListing(listing);
       expect(html).toContain(
-        "These attendees have been contacted 1 times each.",
+        "These attendees have been contacted through this page 1 times each.",
       );
     });
 

--- a/test/routes/unsubscribe.test.ts
+++ b/test/routes/unsubscribe.test.ts
@@ -93,14 +93,37 @@ describeWithEnv("routes (unsubscribe)", { db: true }, () => {
       expect(await isHashUnsubscribed(hash)).toBe(false);
     });
 
-    test("confirms with a flash message after unsubscribing", async () => {
+    test("confirms unsubscribing with an info flash", async () => {
       const hash = await hashEmail("confirm@example.com");
       const response = await postUnsubscribe({
         action: "unsubscribe",
         email: hash,
       });
       const followed = await followRedirectWithFlash(response, handleRequest);
-      await expectHtmlResponse(followed, 200, "You've unsubscribed");
+      const html = await expectHtmlResponse(
+        followed,
+        200,
+        "You've unsubscribed",
+      );
+      expect(html).toContain('class="info"');
+      expect(html).not.toContain('class="success"');
+    });
+
+    test("confirms resubscribing with a success flash", async () => {
+      const hash = await hashEmail("welcomeback@example.com");
+      await unsubscribeHash(hash);
+      const response = await postUnsubscribe({
+        action: "resubscribe",
+        email: hash,
+      });
+      const followed = await followRedirectWithFlash(response, handleRequest);
+      const html = await expectHtmlResponse(
+        followed,
+        200,
+        "You've resubscribed",
+      );
+      expect(html).toContain('class="success"');
+      expect(html).not.toContain('class="info"');
     });
 
     test("redirects with an error when the hash is missing", async () => {


### PR DESCRIPTION
## Summary

Polish for the bulk email (`/admin/emails`) compose & preview pages, plus a couple of related follow-ups.

### Compose / preview page
- **Prose wrapping** – the H1, intro paragraph, H2s and their paragraphs now sit inside `prose` divs for consistent typographic spacing.
- **Inline checkbox CSS** – the "This is a marketing email" checkbox now uses the inline checkbox styling. The classes were renamed `checkbox-group` → `checkboxes` and `radio-group` → `radios` (a single checkbox is no longer a "group"); all existing usages updated. The form-field *type* `checkbox-group` is unchanged — only the presentational class.
- **No em-dashes** – rewritten as full sentences ("It's best for small…", etc.).
- **Contact note** – "These attendees have never been contacted" now reads "…through this page".
- **Message preview box** – dashed border + small padding via a new `.email-preview` class.
- **`.small` paragraph modifier** – small print is now a `<p class="small">` (smaller font, tighter spacing) instead of `<p><small>`, which carried a full paragraph's margin.
- **Disabled-sending link** – "Sending is disabled" now links to the Email Notifications section of advanced settings.
- **Back link** – "Edit message" is now a `btn` with a back-facing arrow (new `arrow-left` icon).

### Provider replies
`sendBulkEmails` now captures each batch's provider response (status + body). After a send, the route relays a one-line summary to the sender (flash) and stores it in the activity log — against the **listing** when the send targets one, so the reply shows up in that listing's log.

### Listings
The per-listing email link is renamed **"Email Attendees" → "Email"** and moved to sit right after **Booking QR** in the listing subnav (still owner-only, still scoped to that listing with no audience selector).

### Single-button forms + unsubscribe flash
- The unsubscribe/resubscribe toggle and the bulk **Send** button live in single-button forms, so they now use the `inline` form class (no card border/padding).
- Added an **info** flash level. The visitor unsubscribe page now flashes an *info* message when you unsubscribe and a *success* message when you resubscribe.

### Note
The Email link points at `/admin/emails?listing=<id>` (the existing query convention used by `targetQuery`/`resolveComposeTarget`), not `?listing_id=`. Happy to switch the query param to `listing_id` to match the form field if preferred.

## Testing
- `deno task typecheck`, `deno task lint`, `deno task build:edge` — clean
- Full suite: **392 passed (7034 steps), 0 failed**
- Coverage: **100% line and branch**

https://claude.ai/code/session_01XGN2acbLqC7sXC7CmuqAYA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGN2acbLqC7sXC7CmuqAYA)_