### PR TITLE
Fix docs workflow referencing non-existent events.ts module

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           src/docs/payments.ts
           src/docs/email.ts
           src/docs/tickets.ts
-          src/docs/events.ts
+          src/docs/listings.ts
           src/docs/config.ts
           src/docs/utilities.ts
           src/docs/embed.ts


### PR DESCRIPTION
## Problem

The docs deployment workflow failed with:

```
error: Module not found "file:///home/runner/work/tickets/tickets/src/docs/events.ts".
```

The `deno doc` invocation in `.github/workflows/docs.yml` listed `src/docs/events.ts`, which does not exist in the repository, while omitting `src/docs/listings.ts`, which does exist and is exported from `src/doc.ts`.

## Fix

Replaced the non-existent `src/docs/events.ts` with the real `src/docs/listings.ts` in the docs workflow. This now matches the modules listed and exported in `src/doc.ts`.

https://claude.ai/code/session_016miKYzrcFPS1opLsecxenS

---
_Generated by [Claude Code](https://claude.ai/code/session_016miKYzrcFPS1opLsecxenS)_