### PR TITLE
Link attendee payment ID to provider dashboard

### DIFF
--- a/src/shared/payment-dashboard.ts
+++ b/src/shared/payment-dashboard.ts
@@ -1,0 +1,36 @@
+/**
+ * Deep links to view a payment on the configured provider's dashboard.
+ *
+ * The attendee record only stores the provider's payment reference
+ * (e.g. a Stripe payment intent id), not which provider produced it.
+ * The active provider — and whether it is in test/sandbox mode — comes
+ * from settings, so the link is built against the currently configured
+ * provider.
+ */
+
+import { settings } from "#shared/db/settings.ts";
+import type { PaymentProviderType } from "#shared/types.ts";
+
+/** Build a provider dashboard URL for a single payment reference. */
+const urlBuilders: Record<PaymentProviderType, (id: string) => string> = {
+  square: (id) =>
+    `https://${
+      settings.square.sandbox ? "squareupsandbox.com" : "squareup.com"
+    }/dashboard/sales/transactions/${id}`,
+  stripe: (id) =>
+    `https://dashboard.stripe.com/${
+      settings.stripe.keyMode === "test" ? "test/" : ""
+    }payments/${id}`,
+  sumup: (id) => `https://me.sumup.com/sales/transactions/${id}`,
+};
+
+/**
+ * Build a link to view a payment on the configured provider's dashboard.
+ * Returns null when there is no payment id or no provider is configured.
+ */
+export const paymentDashboardUrl = (paymentId: string): string | null => {
+  if (!paymentId) return null;
+  const provider = settings.paymentProvider;
+  if (!provider) return null;
+  return urlBuilders[provider](encodeURIComponent(paymentId));
+};

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -15,6 +15,7 @@ import {
   nonConflictAnswerLabel,
 } from "#shared/merge/attendee-merge.ts";
 import type { AttendeeMergeDiff } from "#shared/merge/attendee-merge-types.ts";
+import { paymentDashboardUrl } from "#shared/payment-dashboard.ts";
 import type {
   AdminSession,
   Attendee,
@@ -164,12 +165,20 @@ export const PaymentDetails = ({
   if (!attendee.payment_id) return "";
   const pricePaid = Number.parseInt(attendee.price_paid, 10);
   const isRefunded = attendee.refunded;
+  const dashboardUrl = paymentDashboardUrl(attendee.payment_id);
 
   return String(
     <article>
       <h3>Payment Details</h3>
       <p>
-        <strong>Payment ID:</strong> {attendee.payment_id}
+        <strong>Payment ID:</strong>{" "}
+        {dashboardUrl ? (
+          <a href={dashboardUrl} rel="noopener" target="_blank">
+            {attendee.payment_id}
+          </a>
+        ) : (
+          attendee.payment_id
+        )}
       </p>
       {pricePaid > 0 && (
         <p>

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -8,6 +8,7 @@ import {
   questionsTable,
   setListingQuestions,
 } from "#shared/db/questions.ts";
+import { settings } from "#shared/db/settings.ts";
 import { paymentsApi } from "#shared/payments.ts";
 import {
   adminAttendeeAction,
@@ -1816,6 +1817,39 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "Not refunded",
         "Refresh payment status",
       );
+    });
+
+    test("links the payment id to the configured provider dashboard", async () => {
+      settings.setForTest({
+        payment_provider: "stripe",
+        stripe_secret_key: "sk_live_abc",
+      });
+      try {
+        const listing = await createTestListing({
+          maxAttendees: 100,
+          unitPrice: 1000,
+        });
+        const result = await bookAttendee(listing, {
+          email: "linked@example.com",
+          name: "Linked User",
+          paymentId: "pi_linked_123",
+          pricePaid: 1000,
+          quantity: 1,
+        });
+        if (!result.success) throw new Error("Failed to create attendee");
+        const response = await awaitTestRequest(
+          `/admin/attendees/${result.attendees[0]!.id}`,
+          { cookie: await testCookie() },
+        );
+        await expectHtmlResponse(
+          response,
+          200,
+          'href="https://dashboard.stripe.com/payments/pi_linked_123"',
+          'target="_blank"',
+        );
+      } finally {
+        settings.clearTestOverrides();
+      }
     });
 
     test("shows refunded status for refunded attendee", async () => {

--- a/test/shared/payment-dashboard.test.ts
+++ b/test/shared/payment-dashboard.test.ts
@@ -1,0 +1,77 @@
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { settings } from "#shared/db/settings.ts";
+import { paymentDashboardUrl } from "#shared/payment-dashboard.ts";
+
+describe("paymentDashboardUrl", () => {
+  afterEach(() => {
+    settings.clearTestOverrides();
+  });
+
+  test("returns null when payment id is empty", () => {
+    settings.setForTest({ payment_provider: "stripe" });
+    expect(paymentDashboardUrl("")).toBe(null);
+  });
+
+  test("returns null when no provider is configured", () => {
+    settings.setForTest({ payment_provider: null });
+    expect(paymentDashboardUrl("pi_123")).toBe(null);
+  });
+
+  test("links to the live Stripe dashboard for a live key", () => {
+    settings.setForTest({
+      payment_provider: "stripe",
+      stripe_secret_key: "sk_live_abc",
+    });
+    expect(paymentDashboardUrl("pi_123")).toBe(
+      "https://dashboard.stripe.com/payments/pi_123",
+    );
+  });
+
+  test("links to the test Stripe dashboard for a test key", () => {
+    settings.setForTest({
+      payment_provider: "stripe",
+      stripe_secret_key: "sk_test_abc",
+    });
+    expect(paymentDashboardUrl("pi_123")).toBe(
+      "https://dashboard.stripe.com/test/payments/pi_123",
+    );
+  });
+
+  test("links to the production Square dashboard", () => {
+    settings.setForTest({
+      payment_provider: "square",
+      square_sandbox: false,
+    });
+    expect(paymentDashboardUrl("pay_1")).toBe(
+      "https://squareup.com/dashboard/sales/transactions/pay_1",
+    );
+  });
+
+  test("links to the sandbox Square dashboard", () => {
+    settings.setForTest({
+      payment_provider: "square",
+      square_sandbox: true,
+    });
+    expect(paymentDashboardUrl("pay_1")).toBe(
+      "https://squareupsandbox.com/dashboard/sales/transactions/pay_1",
+    );
+  });
+
+  test("links to the SumUp dashboard", () => {
+    settings.setForTest({ payment_provider: "sumup" });
+    expect(paymentDashboardUrl("tx_1")).toBe(
+      "https://me.sumup.com/sales/transactions/tx_1",
+    );
+  });
+
+  test("encodes the payment id", () => {
+    settings.setForTest({
+      payment_provider: "stripe",
+      stripe_secret_key: "sk_live_abc",
+    });
+    expect(paymentDashboardUrl("pi/with space")).toBe(
+      "https://dashboard.stripe.com/payments/pi%2Fwith%20space",
+    );
+  });
+});


### PR DESCRIPTION
## What

When viewing an attendee with a payment, the **Payment ID** in the Payment Details section is now a link that opens the payment on the configured provider's dashboard in a new tab (`target="_blank" rel="noopener"`).

## How

- Adds `src/shared/payment-dashboard.ts` with `paymentDashboardUrl(paymentId)`, which builds a deep link against the **currently configured** payment provider (the attendee record only stores the provider's payment reference, not which provider produced it):
  - **Stripe** → `https://dashboard.stripe.com/payments/{id}` (or `/test/payments/{id}` for a `sk_test_` key)
  - **Square** → `https://squareup.com/dashboard/sales/transactions/{id}` (or `squareupsandbox.com` in sandbox mode)
  - **SumUp** → `https://me.sumup.com/sales/transactions/{id}`
  - Returns `null` when there's no payment id or no provider configured — in that case the ID renders as plain text as before.
- Updates `PaymentDetails` in `attendees.tsx` to render the anchor when a URL is available.

## Tests

- `test/shared/payment-dashboard.test.ts` — unit tests for each provider, test/live + sandbox modes, the no-provider/empty-id null cases, and id encoding.
- Adds an integration test to `server-attendees.test.ts` asserting the rendered link/`target="_blank"` on the edit page.

https://claude.ai/code/session_01EVethgEQ5vzmRNJvjT1QUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVethgEQ5vzmRNJvjT1QUb)_