### PR TITLE
Guard contact form against owner self-spoof Reply-To

### DIFF
--- a/src/shared/contact-form.ts
+++ b/src/shared/contact-form.ts
@@ -27,19 +27,37 @@ export const isContactFormActive = (): boolean =>
  * Botpoison is not configured, in which case no widget is shown. */
 export const contactFormPublicKey = (): string => getBotpoisonPublicKey();
 
-/** Build the owner-notification email body (plain text + escaped HTML). */
+/** Case-insensitive comparison of two email addresses. */
+const sameEmail = (a: string, b: string): boolean =>
+  a.trim().toLowerCase() === b.trim().toLowerCase();
+
+/** Bold warning prepended when the submitter claimed the owner's own address. */
+const SPOOF_WARNING =
+  "It looks like this sender entered your own business email address — they may be attempting to spoof you.";
+
+/**
+ * Build the owner-notification email body (plain text + escaped HTML).
+ * When `spoofed` is set, a bold warning is prepended: the submitter used the
+ * owner's own business email, which we no longer trust as a Reply-To target.
+ */
 const buildMessageBody = (
   email: string,
   message: string,
+  spoofed: boolean,
 ): { subject: string; text: string; html: string } => {
   const domain = getEffectiveDomain();
+  const warningHtml = spoofed
+    ? `<p><strong>${escapeHtml(SPOOF_WARNING)}</strong></p>`
+    : "";
+  const warningText = spoofed ? `${SPOOF_WARNING}\n\n` : "";
   return {
     html:
+      warningHtml +
       `<p>You have received a message via the ${escapeHtml(domain)} contact form.</p>` +
       `<p><strong>From:</strong> ${escapeHtml(email)}</p>` +
       `<p><strong>Message:</strong></p><p>${escapeHtml(message).replace(/\n/g, "<br>")}</p>`,
     subject: `Contact form message from ${email}`,
-    text: `You have received a message via the ${domain} contact form.\n\nFrom: ${email}\n\nMessage:\n${message}`,
+    text: `${warningText}You have received a message via the ${domain} contact form.\n\nFrom: ${email}\n\nMessage:\n${message}`,
   };
 };
 
@@ -68,10 +86,15 @@ export const sendContactMessage = async (
   const businessEmail = settings.businessEmail;
   if (!businessEmail) return false;
 
-  const { subject, text, html } = buildMessageBody(email, message);
+  // Anti-spoof: when the submitter claims the owner's own address, a
+  // Reply-To of that address makes the message look self-sent and receiving
+  // mailboxes munge the visible sender (e.g. noreply@invalid.invalid). Fall
+  // back to the normal from address and flag it in the body instead.
+  const spoofed = sameEmail(email, businessEmail);
+  const { subject, text, html } = buildMessageBody(email, message, spoofed);
   const status = await sendEmail(config, {
     html,
-    replyTo: email,
+    replyTo: spoofed ? config.fromAddress : email,
     subject,
     text,
     to: businessEmail,

--- a/test/lib/contact-form.test.ts
+++ b/test/lib/contact-form.test.ts
@@ -160,6 +160,27 @@ describe("sendContactMessage", () => {
     expect(String(captured.body.html)).toContain("Hello there");
   });
 
+  test("uses the from address as Reply-To and warns when the submitter claims the owner's own email", async () => {
+    settings.setForTest({
+      business_email: "owner@example.com",
+      email_api_key: "re_test_key",
+      email_from_address: "sender@example.com",
+      email_provider: "resend",
+    });
+    const captured = { body: {} as Record<string, unknown> };
+    stubFetch((_url, init) => {
+      captured.body = JSON.parse(String(init?.body));
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+
+    const result = await sendContactMessage("OWNER@example.com", "Hi me");
+
+    expect(result).toBe(true);
+    expect(captured.body.reply_to).toBe("sender@example.com");
+    expect(String(captured.body.html)).toContain("spoof");
+    expect(String(captured.body.text)).toContain("spoof");
+  });
+
   test("returns false when the email provider responds with an error", async () => {
     configureEmail();
     stubFetch(() => Promise.resolve(new Response("nope", { status: 422 })));


### PR DESCRIPTION
## What

When a contact-form submitter enters the site's **own business email** as their address, the notification email arrives with a munged sender such as `noreply@invalid.invalid`.

## Why

The contact form always sends `From: <your sending address>` and puts the submitter's address in `Reply-To`. When the submitter's address is your own business email, the message both comes from and replies-to your own address — it looks self-sent. Receiving mailboxes (and masked-forwarding services) rewrite the visible sender to a reserved placeholder like `noreply@invalid.invalid` as anti-spoofing protection. This is correct behaviour for real visitors (who use their own address); it only bites the owner's own self-test, but it's confusing.

## Change

In `sendContactMessage`, when the submitter's email matches the business email (case-insensitive):

- Set `Reply-To` to the normal **from address** instead of the submitter's address, so the message no longer looks self-sent.
- Prepend a **bold warning** to the email body (HTML + plain text): "It looks like this sender entered your own business email address — they may be attempting to spoof you."

For all other submissions, behaviour is unchanged (`Reply-To` is the submitter, no warning).

## Tests

- Added a case asserting the spoof path uses the from address as `Reply-To` and includes the warning in both HTML and text bodies.
- Existing tests cover the normal (non-spoof) path.
- `contact-form.test.ts` and `server-contact.test.ts` pass; `deno check` and lint clean.

https://claude.ai/code/session_01NKnreCiBmyT8vWTRvCRtgu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKnreCiBmyT8vWTRvCRtgu)_