### PR TITLE
Add copyable recipient address list to bulk email preview

### DIFF
--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -259,6 +259,7 @@ const handlePreviewGet = ownerEmailPage(async (_request, session) => {
         canBulkSend && config ? EMAIL_PROVIDER_LABELS[config.provider] : "",
       recipientCount: recipients.length,
       sendableCount: sendable.length,
+      sendableEmails: sendable,
       skippedCount: skipped,
       targetLabel,
     }),

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -693,6 +693,13 @@ textarea[readonly] {
   background-color: var(--color-bg-secondary);
 }
 
+/* Recipient address list: wrap long emails so they never overflow a
+   narrow (mobile) screen. */
+.recipient-emails {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .char-counter {
   display: block;
   text-align: right;

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -169,6 +169,8 @@ export type BulkEmailPreviewState = {
   recipientCount: number;
   skippedCount: number;
   sendableCount: number;
+  /** The exact addresses that will be emailed, for copying. */
+  sendableEmails: string[];
   canBulkSend: boolean;
   disabledReason: string;
   /** Provider display name, e.g. "Resend" (only when canBulkSend). */
@@ -304,6 +306,24 @@ export const bulkEmailPreviewPage = (
           <a href={state.mailtoLink}>Open a BCC draft to {recipients}</a>
         </p>
       </div>
+
+      {state.sendableEmails.length > 0 && (
+        <>
+          <div class="prose">
+            <h2>Copy the address list</h2>
+            <p>
+              Every address that will be emailed, separated by commas. Copy
+              these into your own email tool if you'd rather send another way.
+            </p>
+          </div>
+          <label>
+            Recipient addresses
+            <textarea class="recipient-emails" readonly>
+              {state.sendableEmails.join(", ")}
+            </textarea>
+          </label>
+        </>
+      )}
     </Layout>,
   );
 };

--- a/test/lib/server-bulk-email.test.ts
+++ b/test/lib/server-bulk-email.test.ts
@@ -226,6 +226,24 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
       expect(html).toContain("via Resend");
       expect(html).toContain('action="/admin/emails/send"');
       expect(html).toContain("Transactional / service email");
+      expect(html).toContain('class="recipient-emails"');
+      expect(html).toContain("alice@example.com, bob@example.com");
+    });
+
+    test("omits the address list when there are no recipients", async () => {
+      useResend();
+      settings.setForTest({
+        bulk_email_draft: serializeDraft({
+          body: "Body",
+          marketing: false,
+          subject: "Subject",
+          target: { kind: "listing", listingId: 987654 },
+        }),
+      });
+      const html = await awaitTestRequest("/admin/emails/preview", {
+        cookie: await testCookie(),
+      }).then((r) => r.text());
+      expect(html).not.toContain('class="recipient-emails"');
     });
 
     test("disables sending and explains marketing when not sendable", async () => {


### PR DESCRIPTION
## Summary

On the **Preview bulk email** page, adds a read-only, scrolling textarea listing every address that will be emailed, comma-separated, so the owner can copy them into another tool if they prefer. It sits after the existing "Send through your email provider" and "Or send from your own email app" (BCC) sections.

- Matches the existing form/label/textarea styling already used on the page.
- New `.recipient-emails` CSS class applies `overflow-wrap: anywhere` / `word-break: break-word` so long addresses wrap and don't overflow narrow mobile screens.
- The list uses the already-computed `sendable` recipients (the exact addresses that will receive the email, after unsubscribes are skipped), so it stays consistent with the recipient count and BCC draft.
- The section is omitted entirely when there are no recipients.

## Testing

- `deno task typecheck`
- `deno test test/lib/server-bulk-email.test.ts` — added assertions covering the rendered address list (present with recipients, absent when none).

https://claude.ai/code/session_0128NLAhsS9M8zmdNEZJEyWi

---
_Generated by [Claude Code](https://claude.ai/code/session_0128NLAhsS9M8zmdNEZJEyWi)_