### PR TITLE
Stop markdown content wrapping mid-paragraph on hard line breaks

### DIFF
--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -35,6 +35,15 @@ const hasHref = (token: Token): token is Token & { href: string } =>
 
 const md = new Marked({
   renderer: {
+    // CommonMark turns a backslash or two-plus trailing spaces before a newline
+    // into a hard <br>. That lets stray trailing whitespace — from copy-paste,
+    // an editor reflowing a long line, or word-wrap — force a line break in the
+    // middle of a paragraph. Render every hard break as a plain space so authored
+    // content always flows as continuous prose. Real paragraph breaks (a blank
+    // line), lists, and headings are unaffected; code blocks never emit br.
+    br() {
+      return " ";
+    },
     html({ raw }) {
       return escapeHtml(raw);
     },

--- a/test/lib/markdown.test.ts
+++ b/test/lib/markdown.test.ts
@@ -30,6 +30,29 @@ describe("markdown", () => {
       expect(result).toContain("<p>para2</p>");
     });
 
+    test("flows trailing-space hard breaks instead of wrapping the line", () => {
+      // Two trailing spaces before a newline are a CommonMark hard break; we
+      // collapse them to a space so stray whitespace can't break a paragraph.
+      const result = renderMarkdown("variation on  \nwe carry on");
+      expect(result).not.toContain("<br>");
+      expect(result).toContain("<p>variation on we carry on</p>");
+    });
+
+    test("flows backslash hard breaks instead of wrapping the line", () => {
+      const result = renderMarkdown("variation on\\\nwe carry on");
+      expect(result).not.toContain("<br>");
+      expect(result).toContain("<p>variation on we carry on</p>");
+    });
+
+    test("still separates paragraphs split by a blank line", () => {
+      // Collapsing hard breaks must not merge genuine paragraphs: two opening
+      // <p> tags means the blank line still produced two distinct paragraphs.
+      const result = renderMarkdown("first para  \n\nsecond para");
+      expect(result).not.toContain("<br>");
+      expect(result).toContain("<p>first para");
+      expect(result).toContain("<p>second para</p>");
+    });
+
     test("renders unordered lists", () => {
       const result = renderMarkdown("- item1\n- item2");
       expect(result).toContain("<li>item1</li>");


### PR DESCRIPTION
## Problem

User-authored markdown content was showing unwanted line breaks in the middle of a paragraph — "a line break here because the markdown wraps".

The cause is CommonMark's **hard line break** rule: a backslash or **two-or-more trailing spaces** before a newline render as a `<br>`, even though our renderer has `breaks: false` (so ordinary single newlines already flow). That trailing whitespace sneaks in constantly — from copy-paste, an editor reflowing a long line, or word-wrapped source — and forces a break the author never intended.

This affects every field rendered through `renderMarkdown`: listing/group descriptions, terms & conditions, homepage/contact text, and bulk email bodies.

## Fix

Override the `marked` renderer's `br()` to emit a plain space, so a hard break flows as continuous prose instead of breaking the line.

```ts
br() {
  return " ";
}
```

It's deliberately surgical — only intra-paragraph hard breaks are affected:

- **Real paragraphs** (blank line → `\n\n`) stay separate.
- **Lists**, **headings**, **bold/italic/links** are untouched.
- **Code blocks** never emit a `br` token, so their whitespace is preserved exactly.

## Before / after

| Source | Before | After |
| --- | --- | --- |
| `variation on··\nwe carry on` (2 trailing spaces) | `variation on<br>we carry on` | `variation on we carry on` |
| `variation on\\\nwe carry on` (backslash) | `variation on<br>we carry on` | `variation on we carry on` |
| `para1\n\npara2` | two `<p>` | two `<p>` (unchanged) |

## Tests

Added three cases to `test/lib/markdown.test.ts` covering trailing-space breaks, backslash breaks, and that genuine paragraph splits are still preserved. Lint and typecheck pass.

https://claude.ai/code/session_017XwfqtvYUSoenrCnnt3HQe

---
_Generated by [Claude Code](https://claude.ai/code/session_017XwfqtvYUSoenrCnnt3HQe)_