### PR TITLE
Narrow the bulk email body preview width

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -205,11 +205,13 @@ article > * {
   margin-bottom: 0;
 }
 
-/* Outlines a rendered email body so it reads as a preview, not page content. */
+/* Outlines a rendered email body so it reads as a preview, not page content.
+   Constrained to a typical email column width so it reads like a real email. */
 .email-preview {
   border: 1px dashed var(--color-text-secondary);
   border-radius: var(--border-radius);
   padding: var(--space-m);
+  max-width: 40rem;
 }
 
 hr {


### PR DESCRIPTION
On `/admin/emails`, the rendered email body preview (`.email-preview`) previously stretched to the full page width, which doesn't reflect how the email actually reads in an inbox.

This constrains the preview to a typical email column width (`max-width: 40rem`) so it reads more like a real email.

https://claude.ai/code/session_01Evj6evsyq2GEmVqx3XT1ib

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evj6evsyq2GEmVqx3XT1ib)_