### PR TITLE
Wrap heading+paragraph blocks in prose, style "Back to …" links as small buttons

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -521,6 +521,13 @@ input[type="submit"],
   color: var(--color-link);
 }
 
+/* Compact button, e.g. for "Back to …" navigation links */
+.btn.small {
+  font-size: small;
+  font-weight: normal;
+  padding: 0.1rem var(--space-s);
+}
+
 /* Inline SVG icons from the sprite, sized to the current text */
 .icon {
   flex: none;

--- a/src/ui/templates/admin/api-keys.tsx
+++ b/src/ui/templates/admin/api-keys.tsx
@@ -181,11 +181,13 @@ export const adminApiDocsPage = (
       <UsersSubNav />
 
       <div class="stack-md column">
-        <h3>Authentication</h3>
-        <p>
-          Admin API endpoints require authentication via API key or session
-          cookie:
-        </p>
+        <div class="prose">
+          <h3>Authentication</h3>
+          <p>
+            Admin API endpoints require authentication via API key or session
+            cookie:
+          </p>
+        </div>
         <pre>
           <code>Authorization: Bearer YOUR_API_KEY</code>
         </pre>
@@ -196,16 +198,20 @@ export const adminApiDocsPage = (
       </div>
 
       <div class="stack-md column">
-        <h3>Public API</h3>
-        <p>No API key required. All endpoints support CORS.</p>
+        <div class="prose">
+          <h3>Public API</h3>
+          <p>No API key required. All endpoints support CORS.</p>
+        </div>
         <Raw html={EndpointList({ endpoints: publicEndpoints })} />
       </div>
 
       <div class="stack-md column">
-        <h3>Admin API</h3>
-        <p>
-          Requires <code>Authorization: Bearer YOUR_API_KEY</code> header.
-        </p>
+        <div class="prose">
+          <h3>Admin API</h3>
+          <p>
+            Requires <code>Authorization: Bearer YOUR_API_KEY</code> header.
+          </p>
+        </div>
         <Raw html={EndpointList({ endpoints: adminEndpoints })} />
       </div>
     </Layout>,

--- a/src/ui/templates/admin/attendee-balance.tsx
+++ b/src/ui/templates/admin/attendee-balance.tsx
@@ -10,6 +10,7 @@ import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import type { OrderSummary } from "#shared/db/attendees/balance.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { BackButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 export type AttendeeBalanceView = {
@@ -30,40 +31,46 @@ export const attendeeBalancePage = (view: AttendeeBalanceView): string => {
     <Layout title="Attendee balance">
       <AdminNav active="/admin/" session={view.session} />
       <p>
-        <a href={`/admin/attendees/${view.attendeeId}`}>← Back to attendee</a>
+        <BackButton href={`/admin/attendees/${view.attendeeId}`}>
+          Back to attendee
+        </BackButton>
       </p>
-      <h1>Reservation balance</h1>
-
-      <p>
-        <strong>Status:</strong> {status ? status.name : "—"}
-      </p>
-      <p>
-        <strong>Full order price:</strong> {formatCurrency(summary.fullPrice)}
-      </p>
-      <p>
-        <strong>Paid so far:</strong> {formatCurrency(summary.depositPaid)}
-      </p>
-      {status?.is_reservation && (
+      <div class="prose">
+        <h1>Reservation balance</h1>
         <p>
-          <strong>Reservation deposit ({status.reservation_amount}):</strong>{" "}
-          {formatCurrency(deposit)}
+          <strong>Status:</strong> {status ? status.name : "—"}
         </p>
-      )}
-      <p>
-        <strong>Balance outstanding:</strong> {formatCurrency(remainingBalance)}
-      </p>
+        <p>
+          <strong>Full order price:</strong> {formatCurrency(summary.fullPrice)}
+        </p>
+        <p>
+          <strong>Paid so far:</strong> {formatCurrency(summary.depositPaid)}
+        </p>
+        {status?.is_reservation && (
+          <p>
+            <strong>Reservation deposit ({status.reservation_amount}):</strong>{" "}
+            {formatCurrency(deposit)}
+          </p>
+        )}
+        <p>
+          <strong>Balance outstanding:</strong>{" "}
+          {formatCurrency(remainingBalance)}
+        </p>
+      </div>
 
       {outstanding ? (
         <article>
-          <h2>Customer payment link</h2>
-          <p>
-            Send this secure link to the customer to collect the balance. It
-            contains no personal details and is valid for about 90 days;
-            generate a fresh one any time by reloading this page.
-          </p>
-          <p>
-            <input class="copyable" readonly type="text" value={link} />
-          </p>
+          <div class="prose">
+            <h2>Customer payment link</h2>
+            <p>
+              Send this secure link to the customer to collect the balance. It
+              contains no personal details and is valid for about 90 days;
+              generate a fresh one any time by reloading this page.
+            </p>
+            <p>
+              <input class="copyable" readonly type="text" value={link} />
+            </p>
+          </div>
         </article>
       ) : (
         <p>This booking is fully paid.</p>

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -281,11 +281,13 @@ const EmailHistory = ({
 /** Render the "Merge Attendee" section (edit mode only). */
 const MergeSection = ({ attendee }: { attendee: Attendee }): JSX.Element => (
   <article>
-    <h3>Merge Attendee</h3>
-    <p>
-      Search for another attendee by their ticket token and merge their listing
-      registrations into this attendee.
-    </p>
+    <div class="prose">
+      <h3>Merge Attendee</h3>
+      <p>
+        Search for another attendee by their ticket token and merge their
+        listing registrations into this attendee.
+      </p>
+    </div>
     <form
       action={`/admin/attendees/${attendee.id}/merge`}
       class="inline-row"

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -22,7 +22,7 @@ import type {
   ListingWithCount,
 } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { BackButton, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /**
@@ -50,23 +50,25 @@ export const adminDeleteAttendeePage = (
           <strong>Warning:</strong> This will permanently remove this attendee
           from the listing and delete any associated payment records.
         </p>
-        <h2>Attendee Details</h2>
-        <p>
-          <strong>Name:</strong> {attendee.name}
-        </p>
-        <p>
-          <strong>Email:</strong> {attendee.email}
-        </p>
-        <p>
-          <strong>Quantity:</strong> {attendee.quantity}
-        </p>
-        <p>
-          <strong>Registered:</strong> {formatDatetimeShort(attendee.created)}
-        </p>
-        <p>
-          To delete this attendee, type their name "{attendee.name}" into the
-          box below:
-        </p>
+        <div class="prose">
+          <h2>Attendee Details</h2>
+          <p>
+            <strong>Name:</strong> {attendee.name}
+          </p>
+          <p>
+            <strong>Email:</strong> {attendee.email}
+          </p>
+          <p>
+            <strong>Quantity:</strong> {attendee.quantity}
+          </p>
+          <p>
+            <strong>Registered:</strong> {formatDatetimeShort(attendee.created)}
+          </p>
+          <p>
+            To delete this attendee, type their name "{attendee.name}" into the
+            box below:
+          </p>
+        </div>
       </ConfirmForm>
     </Layout>,
   );
@@ -96,28 +98,31 @@ export const adminRefundAttendeePage = (
           <strong>Warning:</strong> This will issue a full refund for this
           attendee's payment. The attendee will remain registered.
         </p>
-        <h2>Attendee Details</h2>
-        <p>
-          <strong>Name:</strong> {attendee.name}
-        </p>
-        <p>
-          <strong>Email:</strong> {attendee.email}
-        </p>
-        <p>
-          <strong>Quantity:</strong> {attendee.quantity}
-        </p>
-        {Number.parseInt(attendee.price_paid, 10) > 0 && (
+        <div class="prose">
+          <h2>Attendee Details</h2>
           <p>
-            <strong>Amount Paid:</strong> {formatCurrency(attendee.price_paid)}
+            <strong>Name:</strong> {attendee.name}
           </p>
-        )}
-        <p>
-          <strong>Registered:</strong> {formatDatetimeShort(attendee.created)}
-        </p>
-        <p>
-          To refund this attendee, type their name "{attendee.name}" into the
-          box below:
-        </p>
+          <p>
+            <strong>Email:</strong> {attendee.email}
+          </p>
+          <p>
+            <strong>Quantity:</strong> {attendee.quantity}
+          </p>
+          {Number.parseInt(attendee.price_paid, 10) > 0 && (
+            <p>
+              <strong>Amount Paid:</strong>{" "}
+              {formatCurrency(attendee.price_paid)}
+            </p>
+          )}
+          <p>
+            <strong>Registered:</strong> {formatDatetimeShort(attendee.created)}
+          </p>
+          <p>
+            To refund this attendee, type their name "{attendee.name}" into the
+            box below:
+          </p>
+        </div>
       </ConfirmForm>
     </Layout>,
   );
@@ -169,39 +174,41 @@ export const PaymentDetails = ({
 
   return String(
     <article>
-      <h3>Payment Details</h3>
-      <p>
-        <strong>Payment ID:</strong>{" "}
-        {dashboardUrl ? (
-          <a href={dashboardUrl} rel="noopener" target="_blank">
-            {attendee.payment_id}
-          </a>
-        ) : (
-          attendee.payment_id
-        )}
-      </p>
-      {pricePaid > 0 && (
+      <div class="prose">
+        <h3>Payment Details</h3>
         <p>
-          <strong>Amount Paid:</strong> {formatCurrency(attendee.price_paid)}
+          <strong>Payment ID:</strong>{" "}
+          {dashboardUrl ? (
+            <a href={dashboardUrl} rel="noopener" target="_blank">
+              {attendee.payment_id}
+            </a>
+          ) : (
+            attendee.payment_id
+          )}
         </p>
-      )}
-      <p>
-        <strong>Refund Status:</strong>{" "}
-        {isRefunded ? (
-          <span class="badge-alert">Refunded</span>
-        ) : (
-          "Not refunded"
+        {pricePaid > 0 && (
+          <p>
+            <strong>Amount Paid:</strong> {formatCurrency(attendee.price_paid)}
+          </p>
         )}
-      </p>
-      {attendee.remaining_balance > 0 && (
         <p>
-          <strong>Balance outstanding:</strong>{" "}
-          {formatCurrency(attendee.remaining_balance)} —{" "}
-          <a href={`/admin/attendees/${attendee.id}/balance`}>
-            view balance &amp; payment link
-          </a>
+          <strong>Refund Status:</strong>{" "}
+          {isRefunded ? (
+            <span class="badge-alert">Refunded</span>
+          ) : (
+            "Not refunded"
+          )}
         </p>
-      )}
+        {attendee.remaining_balance > 0 && (
+          <p>
+            <strong>Balance outstanding:</strong>{" "}
+            {formatCurrency(attendee.remaining_balance)} —{" "}
+            <a href={`/admin/attendees/${attendee.id}/balance`}>
+              view balance &amp; payment link
+            </a>
+          </p>
+        )}
+      </div>
       <CsrfForm
         action={`/admin/attendees/${attendee.id}/refresh-payment`}
         class="inline"
@@ -479,7 +486,9 @@ export const adminMergeAttendeePage = (
 
       <h2>Merge Attendee</h2>
       <p>
-        <a href={`/admin/attendees/${target.id}`}>← Back to {target.name}</a>
+        <BackButton href={`/admin/attendees/${target.id}`}>
+          Back to {target.name}
+        </BackButton>
       </p>
 
       {/* Token search form */}
@@ -506,11 +515,13 @@ export const adminMergeAttendeePage = (
 
       {source && mergeDiff && (
         <div>
-          <h3>Merge Preview</h3>
-          <p>
-            Choose which value to keep for each field. Resolve any conflicts
-            below. The source attendee will then be deleted.
-          </p>
+          <div class="prose">
+            <h3>Merge Preview</h3>
+            <p>
+              Choose which value to keep for each field. Resolve any conflicts
+              below. The source attendee will then be deleted.
+            </p>
+          </div>
 
           <CsrfForm action={`/admin/attendees/${target.id}/merge`}>
             <input
@@ -605,28 +616,31 @@ export const adminResendNotificationPage = (
           <strong>Note:</strong> This will re-send the registration notification
           for this attendee.
         </p>
-        <h2>Attendee Details</h2>
-        <p>
-          <strong>Name:</strong> {attendee.name}
-        </p>
-        <p>
-          <strong>Email:</strong> {attendee.email}
-        </p>
-        <p>
-          <strong>Quantity:</strong> {attendee.quantity}
-        </p>
-        {Number.parseInt(attendee.price_paid, 10) > 0 && (
+        <div class="prose">
+          <h2>Attendee Details</h2>
           <p>
-            <strong>Amount Paid:</strong> {formatCurrency(attendee.price_paid)}
+            <strong>Name:</strong> {attendee.name}
           </p>
-        )}
-        <p>
-          <strong>Registered:</strong> {formatDatetimeShort(attendee.created)}
-        </p>
-        <p>
-          To re-send the notification, type their name "{attendee.name}" into
-          the box below:
-        </p>
+          <p>
+            <strong>Email:</strong> {attendee.email}
+          </p>
+          <p>
+            <strong>Quantity:</strong> {attendee.quantity}
+          </p>
+          {Number.parseInt(attendee.price_paid, 10) > 0 && (
+            <p>
+              <strong>Amount Paid:</strong>{" "}
+              {formatCurrency(attendee.price_paid)}
+            </p>
+          )}
+          <p>
+            <strong>Registered:</strong> {formatDatetimeShort(attendee.created)}
+          </p>
+          <p>
+            To re-send the notification, type their name "{attendee.name}" into
+            the box below:
+          </p>
+        </div>
       </ConfirmForm>
     </Layout>,
   );

--- a/src/ui/templates/admin/backup.tsx
+++ b/src/ui/templates/admin/backup.tsx
@@ -59,10 +59,12 @@ export const adminBackupPage = (
     <Layout title="Database Backup">
       <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
-      <h1>Database Backup &amp; Restore</h1>
-      <p class="actions">
-        <GuideLink href="/admin/guide#backups">Backup guide</GuideLink>
-      </p>
+      <div class="prose">
+        <h1>Database Backup &amp; Restore</h1>
+        <p class="actions">
+          <GuideLink href="/admin/guide#backups">Backup guide</GuideLink>
+        </p>
+      </div>
       <Flash error={error} success={success} />
 
       {!state.isRemote && (
@@ -84,11 +86,13 @@ export const adminBackupPage = (
       )}
 
       <section>
-        <h2>Encryption Key</h2>
-        <p>
-          You will need this key to restore a backup to a different site. Store
-          it securely — it cannot be recovered.
-        </p>
+        <div class="prose">
+          <h2>Encryption Key</h2>
+          <p>
+            You will need this key to restore a backup to a different site.
+            Store it securely — it cannot be recovered.
+          </p>
+        </div>
         <pre>
           <code>{state.encryptionKey}</code>
         </pre>
@@ -97,12 +101,14 @@ export const adminBackupPage = (
       {state.storageEnabled && (
         <>
           <section>
-            <h2>Create Backup</h2>
-            <p>
-              Creates a .zip archive containing a .sql file for each database
-              table. Backups are not encrypted (the sensitive contents are
-              already encrypted at the field level).
-            </p>
+            <div class="prose">
+              <h2>Create Backup</h2>
+              <p>
+                Creates a .zip archive containing a .sql file for each database
+                table. Backups are not encrypted (the sensitive contents are
+                already encrypted at the field level).
+              </p>
+            </div>
             <CsrfForm
               action="/admin/backup/create"
               class="no-bg"
@@ -151,11 +157,13 @@ export const adminBackupPage = (
           </section>
 
           <section>
-            <h2>Restore from Backup</h2>
-            <p>
-              <strong>Warning:</strong> Restoring will delete all current data
-              and replace it with the backup contents. This cannot be undone.
-            </p>
+            <div class="prose">
+              <h2>Restore from Backup</h2>
+              <p>
+                <strong>Warning:</strong> Restoring will delete all current data
+                and replace it with the backup contents. This cannot be undone.
+              </p>
+            </div>
             <CsrfForm
               action="/admin/backup/restore"
               enctype="multipart/form-data"

--- a/src/ui/templates/admin/bulk-actions.tsx
+++ b/src/ui/templates/admin/bulk-actions.tsx
@@ -49,11 +49,13 @@ export const adminBulkActionsPage = (
       <p>
         <a href={`/admin/groups/${group.id}`}>&larr; {group.name}</a>
       </p>
-      <h1>Bulk Actions</h1>
-      <p>
-        Apply an operation across all {listings.length} listing
-        {listings.length === 1 ? "" : "s"} in <strong>{group.name}</strong>.
-      </p>
+      <div class="prose">
+        <h1>Bulk Actions</h1>
+        <p>
+          Apply an operation across all {listings.length} listing
+          {listings.length === 1 ? "" : "s"} in <strong>{group.name}</strong>.
+        </p>
+      </div>
 
       <ul>
         <li>
@@ -139,13 +141,15 @@ export const adminDuplicateGroupPage = (
           &larr; Bulk Actions
         </a>
       </p>
-      <h1>Duplicate Group</h1>
-      <p>
-        Creating a new group based on <strong>{group.name}</strong>. Each
-        listing in the group will be duplicated into the new group with the same
-        settings. Use the fields below to apply a name replacement and/or a date
-        shift across all duplicates.
-      </p>
+      <div class="prose">
+        <h1>Duplicate Group</h1>
+        <p>
+          Creating a new group based on <strong>{group.name}</strong>. Each
+          listing in the group will be duplicated into the new group with the
+          same settings. Use the fields below to apply a name replacement and/or
+          a date shift across all duplicates.
+        </p>
+      </div>
       <Flash error={error} />
 
       <CsrfForm

--- a/src/ui/templates/admin/database-reset.tsx
+++ b/src/ui/templates/admin/database-reset.tsx
@@ -4,7 +4,7 @@
  */
 
 import { CsrfForm, Flash } from "#shared/forms.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { BackButton, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Confirmation phrase that must be typed to reset the database */
@@ -60,7 +60,7 @@ export const demoResetPage = (error?: string): string =>
       <Flash error={error} />
       <ResetDatabaseForm action="/demo/reset" />
       <p>
-        <a href="/admin">Back to login</a>
+        <BackButton href="/admin">Back to login</BackButton>
       </p>
     </Layout>,
   );

--- a/src/ui/templates/admin/debug.tsx
+++ b/src/ui/templates/admin/debug.tsx
@@ -364,11 +364,13 @@ const LimitsSection = ({
   limits: DebugPageState["limits"];
 }): JSX.Element => (
   <article>
-    <h2>Limits</h2>
-    <p>
-      Override any limit with the corresponding environment variable. Values
-      must be positive integers.
-    </p>
+    <div class="prose">
+      <h2>Limits</h2>
+      <p>
+        Override any limit with the corresponding environment variable. Values
+        must be positive integers.
+      </p>
+    </div>
     <table>
       <thead>
         <tr>
@@ -402,11 +404,14 @@ const PruneSection = ({
   prune: DebugPageState["prune"];
 }): JSX.Element => (
   <article>
-    <h2>Database pruning</h2>
-    <p>
-      Automatic cleanup of short-lived rows. Runs in the background on incoming
-      requests; frequency controlled by <code>PRUNE_INTERVAL_HOURS</code>.
-    </p>
+    <div class="prose">
+      <h2>Database pruning</h2>
+      <p>
+        Automatic cleanup of short-lived rows. Runs in the background on
+        incoming requests; frequency controlled by{" "}
+        <code>PRUNE_INTERVAL_HOURS</code>.
+      </p>
+    </div>
     <table>
       <thead>
         <tr>
@@ -444,11 +449,13 @@ export const adminDebugPage = (
       <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
 
-      <h1>Debug Info</h1>
-      <p>
-        Configuration status overview for troubleshooting. No secrets or keys
-        are shown.
-      </p>
+      <div class="prose">
+        <h1>Debug Info</h1>
+        <p>
+          Configuration status overview for troubleshooting. No secrets or keys
+          are shown.
+        </p>
+      </div>
 
       <BuildSection build={s.build} />
       <AppleWalletSection appleWallet={s.appleWallet} />

--- a/src/ui/templates/admin/guide.tsx
+++ b/src/ui/templates/admin/guide.tsx
@@ -94,12 +94,14 @@ export const adminGuidePage = (
     <Layout bodyClass="guide" title="Guide">
       <AdminNav active="/admin/guide" session={adminSession} />
 
-      <h2>Guide</h2>
+      <div class="prose">
+        <h2>Guide</h2>
 
-      <p class="search-hint">
-        Press <kbd>Ctrl</kbd>+<kbd>F</kbd> (or <kbd>&#8984;</kbd>+<kbd>F</kbd>{" "}
-        on Mac) to search this page.
-      </p>
+        <p class="search-hint">
+          Press <kbd>Ctrl</kbd>+<kbd>F</kbd> (or <kbd>&#8984;</kbd>+<kbd>F</kbd>{" "}
+          on Mac) to search this page.
+        </p>
+      </div>
 
       <Section title="Getting Started">
         <Q q="How do I create a listing?">

--- a/src/ui/templates/admin/listing-qr.tsx
+++ b/src/ui/templates/admin/listing-qr.tsx
@@ -162,19 +162,21 @@ export const adminListingQrPage = ({
     <Layout title={`QR Code: ${listing.name}`}>
       <AdminNav active="/admin/" session={session} />
       <article>
-        <h1>
-          Booking QR code &mdash;{" "}
-          <a href={`/admin/listing/${listing.id}`}>{listing.name}</a>
-        </h1>
-        <p>
-          Generate a signed link that pre-fills the booking form. If name and
-          price are both set and the listing has no extra required fields{" "}
-          <span class={canDirectCheckout ? "success-text" : "danger-text"}>
-            (this <strong>{canDirectCheckout ? "is" : "is not"}</strong> the
-            case)
-          </span>
-          , the scanner is taken straight to payment.
-        </p>
+        <div class="prose">
+          <h1>
+            Booking QR code &mdash;{" "}
+            <a href={`/admin/listing/${listing.id}`}>{listing.name}</a>
+          </h1>
+          <p>
+            Generate a signed link that pre-fills the booking form. If name and
+            price are both set and the listing has no extra required fields{" "}
+            <span class={canDirectCheckout ? "success-text" : "danger-text"}>
+              (this <strong>{canDirectCheckout ? "is" : "is not"}</strong> the
+              case)
+            </span>
+            , the scanner is taken straight to payment.
+          </p>
+        </div>
         <Flash error={error} />
         <CsrfForm action={formAction}>
           <label>

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -763,12 +763,14 @@ const AttendeesSection = ({
       : "checkin-message-out";
   return (
     <article>
-      <h2 id="attendees">Attendees</h2>
-      {checkinMessage && (
-        <p class={checkedInClass} id="message">
-          Checked {checkinMessage.name} {checkedInLabel}
-        </p>
-      )}
+      <div class="prose">
+        <h2 id="attendees">Attendees</h2>
+        {checkinMessage && (
+          <p class={checkedInClass} id="message">
+            Checked {checkinMessage.name} {checkedInLabel}
+          </p>
+        )}
+      </div>
       {isDaily && availableDates.length > 0 && (
         <Raw
           html={DateSelector({
@@ -811,8 +813,10 @@ const FailedPaymentsSection = ({
   listingId: number;
 }): JSX.Element => (
   <article>
-    <h2 id="failed-payments">Failed Payments</h2>
-    <p>{attendees.length} attendee(s) with unresolved payments</p>
+    <div class="prose">
+      <h2 id="failed-payments">Failed Payments</h2>
+      <p>{attendees.length} attendee(s) with unresolved payments</p>
+    </div>
     <div class="table-scroll">
       <Raw html={FailedPaymentsTable({ attendees, listingId })} />
     </div>
@@ -1119,10 +1123,12 @@ export const adminDuplicateListingPage = (
   return String(
     <Layout title={`Duplicate: ${listing.name}`}>
       <AdminNav active="/admin/" session={session} />
-      <h2>Duplicate Listing</h2>
-      <p>
-        Creating a new listing based on <strong>{listing.name}</strong>.
-      </p>
+      <div class="prose">
+        <h2>Duplicate Listing</h2>
+        <p>
+          Creating a new listing based on <strong>{listing.name}</strong>.
+        </p>
+      </div>
       <CsrfForm action="/admin/listing" enctype="multipart/form-data">
         <Raw html={renderFields(dupFields, values)} />
         <Raw html={renderDayPricesFieldset(listing)} />

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -22,10 +22,12 @@ export const adminQuestionsPage = (
     <Layout title="Custom Questions">
       <AdminNav active="/admin/questions" session={session} />
 
-      <h1>Custom Questions</h1>
-      <p class="actions">
-        <GuideLink href="/admin/guide#questions">Questions guide</GuideLink>
-      </p>
+      <div class="prose">
+        <h1>Custom Questions</h1>
+        <p class="actions">
+          <GuideLink href="/admin/guide#questions">Questions guide</GuideLink>
+        </p>
+      </div>
       <Flash error={error} />
 
       <CsrfForm action="/admin/questions" id="new-question">

--- a/src/ui/templates/admin/scanner.tsx
+++ b/src/ui/templates/admin/scanner.tsx
@@ -30,11 +30,13 @@ export const adminScannerPage = (
       title={`Scanner: ${listing.name}`}
     >
       <AdminNav active="/admin/" session={session} />
-      <h1>Scanner</h1>
-      <p class="actions">
-        <a href={`/admin/listing/${listing.id}`}>&larr; {listing.name}</a>
-        <GuideLink href="/admin/guide#checkin">Scanner help</GuideLink>
-      </p>
+      <div class="prose">
+        <h1>Scanner</h1>
+        <p class="actions">
+          <a href={`/admin/listing/${listing.id}`}>&larr; {listing.name}</a>
+          <GuideLink href="/admin/guide#checkin">Scanner help</GuideLink>
+        </p>
+      </div>
 
       <article>
         <div id="scanner-container">

--- a/src/ui/templates/admin/seeds.tsx
+++ b/src/ui/templates/admin/seeds.tsx
@@ -7,7 +7,7 @@ import { seedsForm } from "#routes/admin/seeds.ts";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { BackButton, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Seed data admin page */
@@ -20,18 +20,20 @@ export const adminSeedsPage = (
     <Layout title="Seed Data">
       <AdminNav active="" session={session} />
       <CsrfForm action="/admin/seeds">
-        <h1>Seed Data</h1>
-        <p>
-          Create sample listings and attendees from demo data. Useful for
-          testing and development.
-        </p>
+        <div class="prose">
+          <h1>Seed Data</h1>
+          <p>
+            Create sample listings and attendees from demo data. Useful for
+            testing and development.
+          </p>
+        </div>
         <Flash error={error} success={success} />
         <Raw html={seedsForm.render()} />
         <SubmitButton icon="plus">Create Seed Data</SubmitButton>
       </CsrfForm>
 
       <p>
-        <a href="/admin">&larr; Back to dashboard</a>
+        <BackButton href="/admin">Back to dashboard</BackButton>
       </p>
     </Layout>,
   );

--- a/src/ui/templates/admin/settings-statuses.tsx
+++ b/src/ui/templates/admin/settings-statuses.tsx
@@ -59,14 +59,16 @@ export const adminAttendeeStatusesPage = (
     <Layout title="Attendee Statuses">
       <AdminNav active="/admin/settings" session={session} />
       <SettingsSubNav />
-      <h1>Attendee Statuses</h1>
-      <p>
-        Statuses track where an attendee is in your workflow. The{" "}
-        <strong>public default</strong> is the status new public bookings start
-        in; if it is a <strong>reservation</strong>, bookings pay a deposit now
-        and the balance later. When a balance is paid the attendee moves to the{" "}
-        <strong>paid</strong> status.
-      </p>
+      <div class="prose">
+        <h1>Attendee Statuses</h1>
+        <p>
+          Statuses track where an attendee is in your workflow. The{" "}
+          <strong>public default</strong> is the status new public bookings
+          start in; if it is a <strong>reservation</strong>, bookings pay a
+          deposit now and the balance later. When a balance is paid the attendee
+          moves to the <strong>paid</strong> status.
+        </p>
+      </div>
       <Flash error={error} success={success} />
       <p class="actions">
         <ActionButton href={`${LIST_PATH}/new`} icon="plus">

--- a/src/ui/templates/admin/settings/apple-wallet.tsx
+++ b/src/ui/templates/admin/settings/apple-wallet.tsx
@@ -9,17 +9,19 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/apple-wallet" id="settings-apple-wallet">
-    <h2>Apple Wallet</h2>
-    <p>
-      Configure Apple Wallet pass signing to show an &ldquo;Add to Apple
-      Wallet&rdquo; button on ticket pages.{" "}
-      <a href="/admin/guide#apple-wallet">Setup guide</a>.
-      {s.hostAppleWalletLabel && !s.appleWalletConfigured
-        ? ` Currently using: ${s.hostAppleWalletLabel}. Override below or leave empty to keep using host config.`
-        : s.hostAppleWalletLabel && s.appleWalletConfigured
-          ? ` Overriding: ${s.hostAppleWalletLabel}.`
-          : ""}
-    </p>
+    <div class="prose">
+      <h2>Apple Wallet</h2>
+      <p>
+        Configure Apple Wallet pass signing to show an &ldquo;Add to Apple
+        Wallet&rdquo; button on ticket pages.{" "}
+        <a href="/admin/guide#apple-wallet">Setup guide</a>.
+        {s.hostAppleWalletLabel && !s.appleWalletConfigured
+          ? ` Currently using: ${s.hostAppleWalletLabel}. Override below or leave empty to keep using host config.`
+          : s.hostAppleWalletLabel && s.appleWalletConfigured
+            ? ` Overriding: ${s.hostAppleWalletLabel}.`
+            : ""}
+      </p>
+    </div>
     <label>
       Pass Type ID
       <input

--- a/src/ui/templates/admin/settings/business-email.tsx
+++ b/src/ui/templates/admin/settings/business-email.tsx
@@ -11,11 +11,13 @@ export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
     action="/admin/settings/business-email"
     id="settings-business-email"
   >
-    <h2>Business Email</h2>
-    <p>
-      This email will be included in webhook notifications and used as the
-      reply-to address for automated emails.
-    </p>
+    <div class="prose">
+      <h2>Business Email</h2>
+      <p>
+        This email will be included in webhook notifications and used as the
+        reply-to address for automated emails.
+      </p>
+    </div>
     <label>
       Business Email
       <input

--- a/src/ui/templates/admin/settings/change-password.tsx
+++ b/src/ui/templates/admin/settings/change-password.tsx
@@ -9,8 +9,10 @@ import { changePasswordFields } from "#templates/fields.ts";
 
 export const ChangePasswordForm = (): JSX.Element => (
   <CsrfForm action="/admin/settings" id="settings-password">
-    <h2>Change Password</h2>
-    <p>Changing your password will log you out of all sessions.</p>
+    <div class="prose">
+      <h2>Change Password</h2>
+      <p>Changing your password will log you out of all sessions.</p>
+    </div>
     <Raw html={renderFields(changePasswordFields)} />
     <SubmitButton icon="save">Change Password</SubmitButton>
   </CsrfForm>

--- a/src/ui/templates/admin/settings/column-order.tsx
+++ b/src/ui/templates/admin/settings/column-order.tsx
@@ -43,13 +43,15 @@ export const ListingColumnOrderForm = (
     action="/admin/settings/listing-column-order"
     id="settings-listing-column-order"
   >
-    <h2>Listing Table Columns</h2>
-    <p>
-      Control which columns appear on the Listings table and in what order. Use
-      Liquid-style tags separated by commas. See the{" "}
-      <a href="/admin/guide#column-order">Column Order guide</a> for full
-      details including custom date and currency formatting.
-    </p>
+    <div class="prose">
+      <h2>Listing Table Columns</h2>
+      <p>
+        Control which columns appear on the Listings table and in what order.
+        Use Liquid-style tags separated by commas. See the{" "}
+        <a href="/admin/guide#column-order">Column Order guide</a> for full
+        details including custom date and currency formatting.
+      </p>
+    </div>
     <label>
       Column order
       <input
@@ -74,14 +76,16 @@ export const AttendeeColumnOrderForm = (
     action="/admin/settings/attendee-column-order"
     id="settings-attendee-column-order"
   >
-    <h2>Attendee Table Columns</h2>
-    <p>
-      Control which columns appear on Attendee tables and in what order. Use
-      Liquid-style tags separated by commas. Columns referencing absent data
-      (e.g. email when no attendees have one) are hidden automatically. See the{" "}
-      <a href="/admin/guide#column-order">Column Order guide</a> for full
-      details including custom date and currency formatting.
-    </p>
+    <div class="prose">
+      <h2>Attendee Table Columns</h2>
+      <p>
+        Control which columns appear on Attendee tables and in what order. Use
+        Liquid-style tags separated by commas. Columns referencing absent data
+        (e.g. email when no attendees have one) are hidden automatically. See
+        the <a href="/admin/guide#column-order">Column Order guide</a> for full
+        details including custom date and currency formatting.
+      </p>
+    </div>
     <label>
       Column order
       <input

--- a/src/ui/templates/admin/settings/country.tsx
+++ b/src/ui/templates/admin/settings/country.tsx
@@ -9,8 +9,10 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const CountryForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/country" id="settings-country">
-    <h2>Your Country</h2>
-    <p>Sets your timezone, currency, and phone prefix.</p>
+    <div class="prose">
+      <h2>Your Country</h2>
+      <p>Sets your timezone, currency, and phone prefix.</p>
+    </div>
     <label>
       Country
       <select name="country" required>

--- a/src/ui/templates/admin/settings/custom-domain.tsx
+++ b/src/ui/templates/admin/settings/custom-domain.tsx
@@ -16,13 +16,15 @@ export const CustomDomainForm = (
         action="/admin/settings/custom-domain"
         id="settings-custom-domain"
       >
-        <h2>Custom Domain</h2>
-        <p>
-          Set a custom domain for your tickets site.{" "}
-          <a href="/admin/guide#custom-domain">Setup guide</a>.
-          {s.bunnySubdomain &&
-            " Your host subdomain can be active at the same time as a custom domain."}
-        </p>
+        <div class="prose">
+          <h2>Custom Domain</h2>
+          <p>
+            Set a custom domain for your tickets site.{" "}
+            <a href="/admin/guide#custom-domain">Setup guide</a>.
+            {s.bunnySubdomain &&
+              " Your host subdomain can be active at the same time as a custom domain."}
+          </p>
+        </div>
         <label>
           Domain
           <input

--- a/src/ui/templates/admin/settings/email-tpl-admin.tsx
+++ b/src/ui/templates/admin/settings/email-tpl-admin.tsx
@@ -14,13 +14,15 @@ export const AdminEmailTemplateForm = (
     action="/admin/settings/email-templates/admin"
     id="settings-email-tpl-admin"
   >
-    <h2>Admin Notification Email Template</h2>
-    <p>
-      Customise the notification email sent to the business email when a
-      registration comes in (
-      <a href="/admin/guide#email-templates">template guide</a>). Leave blank to
-      use the default template.
-    </p>
+    <div class="prose">
+      <h2>Admin Notification Email Template</h2>
+      <p>
+        Customise the notification email sent to the business email when a
+        registration comes in (
+        <a href="/admin/guide#email-templates">template guide</a>). Leave blank
+        to use the default template.
+      </p>
+    </div>
     <label>
       Subject
       <input

--- a/src/ui/templates/admin/settings/email-tpl-confirmation.tsx
+++ b/src/ui/templates/admin/settings/email-tpl-confirmation.tsx
@@ -14,15 +14,17 @@ export const ConfirmationEmailTemplateForm = (
     action="/admin/settings/email-templates/confirmation"
     id="settings-email-tpl-confirmation"
   >
-    <h2>Confirmation Email Template</h2>
-    <p>
-      Customise the registration confirmation email sent to attendees (
-      <a href="/admin/guide#email-templates">template guide</a>). Uses{" "}
-      <a href="https://liquidjs.com/" rel="noopener" target="_blank">
-        Liquid
-      </a>{" "}
-      template syntax. Leave blank to use the default template.
-    </p>
+    <div class="prose">
+      <h2>Confirmation Email Template</h2>
+      <p>
+        Customise the registration confirmation email sent to attendees (
+        <a href="/admin/guide#email-templates">template guide</a>). Uses{" "}
+        <a href="https://liquidjs.com/" rel="noopener" target="_blank">
+          Liquid
+        </a>{" "}
+        template syntax. Leave blank to use the default template.
+      </p>
+    </div>
     <details>
       <summary>Available variables</summary>
       <table>

--- a/src/ui/templates/admin/settings/email.tsx
+++ b/src/ui/templates/admin/settings/email.tsx
@@ -13,11 +13,13 @@ export const EmailNotificationsForm = (
 ): JSX.Element => (
   <>
     <CsrfForm action="/admin/settings/email" id="settings-email">
-      <h2>Email Notifications</h2>
-      <p>
-        Send confirmation emails to attendees and admin notifications when
-        registrations come in. <a href="/admin/guide#email">Setup guide</a>.
-      </p>
+      <div class="prose">
+        <h2>Email Notifications</h2>
+        <p>
+          Send confirmation emails to attendees and admin notifications when
+          registrations come in. <a href="/admin/guide#email">Setup guide</a>.
+        </p>
+      </div>
       <label>
         Email Provider
         <select name="email_provider">

--- a/src/ui/templates/admin/settings/embed-hosts.tsx
+++ b/src/ui/templates/admin/settings/embed-hosts.tsx
@@ -8,11 +8,13 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/embed-hosts" id="settings-embed-hosts">
-    <h2>Only allow embedding on these hosts</h2>
-    <p>
-      Restrict which websites can embed your booking forms in an iframe. Leave
-      blank to allow embedding from any site.
-    </p>
+    <div class="prose">
+      <h2>Only allow embedding on these hosts</h2>
+      <p>
+        Restrict which websites can embed your booking forms in an iframe. Leave
+        blank to allow embedding from any site.
+      </p>
+    </div>
     <label>
       Hosts (comma-separated)
       <input

--- a/src/ui/templates/admin/settings/google-wallet.tsx
+++ b/src/ui/templates/admin/settings/google-wallet.tsx
@@ -9,18 +9,20 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/google-wallet" id="settings-google-wallet">
-    <h2>Google Wallet</h2>
-    <p>
-      Configure Google Wallet to show an &ldquo;Add to Google Wallet&rdquo;
-      button on ticket pages. Requires a Google Cloud service account with the
-      Google Wallet API enabled.{" "}
-      <a href="/admin/guide#google-wallet">Setup guide</a>.
-      {s.hostGoogleWalletLabel && !s.googleWalletConfigured
-        ? ` Currently using: ${s.hostGoogleWalletLabel}. Override below or leave empty to keep using host config.`
-        : s.hostGoogleWalletLabel && s.googleWalletConfigured
-          ? ` Overriding: ${s.hostGoogleWalletLabel}.`
-          : ""}
-    </p>
+    <div class="prose">
+      <h2>Google Wallet</h2>
+      <p>
+        Configure Google Wallet to show an &ldquo;Add to Google Wallet&rdquo;
+        button on ticket pages. Requires a Google Cloud service account with the
+        Google Wallet API enabled.{" "}
+        <a href="/admin/guide#google-wallet">Setup guide</a>.
+        {s.hostGoogleWalletLabel && !s.googleWalletConfigured
+          ? ` Currently using: ${s.hostGoogleWalletLabel}. Override below or leave empty to keep using host config.`
+          : s.hostGoogleWalletLabel && s.googleWalletConfigured
+            ? ` Overriding: ${s.hostGoogleWalletLabel}.`
+            : ""}
+      </p>
+    </div>
     <label>
       Issuer ID
       <input

--- a/src/ui/templates/admin/settings/header-image.tsx
+++ b/src/ui/templates/admin/settings/header-image.tsx
@@ -31,11 +31,13 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
         enctype="multipart/form-data"
         id="settings-header-image"
       >
-        <h2>Header Image</h2>
-        <p>
-          An optional image displayed at the top of every page. JPEG, PNG, GIF,
-          or WebP — max {formatBytes(MAX_IMAGE_SIZE)}.
-        </p>
+        <div class="prose">
+          <h2>Header Image</h2>
+          <p>
+            An optional image displayed at the top of every page. JPEG, PNG,
+            GIF, or WebP — max {formatBytes(MAX_IMAGE_SIZE)}.
+          </p>
+        </div>
         <label>
           {s.headerImageUrl ? "Replace Image" : "Upload Image"}
           <input

--- a/src/ui/templates/admin/settings/payment.tsx
+++ b/src/ui/templates/admin/settings/payment.tsx
@@ -19,8 +19,10 @@ export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
     action="/admin/settings/payment-provider"
     id="settings-payment-provider"
   >
-    <h2>Payment Provider</h2>
-    <p>Choose which payment provider to use for paid listings.</p>
+    <div class="prose">
+      <h2>Payment Provider</h2>
+      <p>Choose which payment provider to use for paid listings.</p>
+    </div>
     <fieldset class="radios">
       <label>
         <input
@@ -95,12 +97,14 @@ const ApiKeyModeNotice = ({
 export const StripeForm = (s: SettingsPageState): JSX.Element | null =>
   s.paymentProvider === "stripe" ? (
     <CsrfForm action="/admin/settings/stripe" id="settings-stripe">
-      <h2>Stripe Settings</h2>
-      <p>
-        {s.stripeKeyConfigured
-          ? "A Stripe secret key is currently configured. Enter a new key below to replace it."
-          : "No Stripe key is configured. Enter your Stripe secret key to enable Stripe payments."}
-      </p>
+      <div class="prose">
+        <h2>Stripe Settings</h2>
+        <p>
+          {s.stripeKeyConfigured
+            ? "A Stripe secret key is currently configured. Enter a new key below to replace it."
+            : "No Stripe key is configured. Enter your Stripe secret key to enable Stripe payments."}
+        </p>
+      </div>
       {s.stripeKeyConfigured && (
         <ApiKeyModeNotice mode={s.stripeKeyMode} provider="Stripe" />
       )}
@@ -130,17 +134,19 @@ export const StripeForm = (s: SettingsPageState): JSX.Element | null =>
 export const SquareForm = (s: SettingsPageState): JSX.Element | null =>
   s.paymentProvider === "square" ? (
     <CsrfForm action="/admin/settings/square" id="settings-square">
-      <h2>Square Settings</h2>
-      <p>
-        {s.squareTokenConfigured
-          ? "A Square access token is currently configured. Enter new credentials below to replace them."
-          : "No Square access token is configured. Enter your Square credentials to enable Square payments."}
-      </p>
-      <p>
-        <small>
-          <a href="/admin/guide#payment-setup">Where do I find these?</a>
-        </small>
-      </p>
+      <div class="prose">
+        <h2>Square Settings</h2>
+        <p>
+          {s.squareTokenConfigured
+            ? "A Square access token is currently configured. Enter new credentials below to replace them."
+            : "No Square access token is configured. Enter your Square credentials to enable Square payments."}
+        </p>
+        <p>
+          <small>
+            <a href="/admin/guide#payment-setup">Where do I find these?</a>
+          </small>
+        </p>
+      </div>
       <Raw
         html={renderFields(
           squareAccessTokenFields,
@@ -173,10 +179,12 @@ export const SquareWebhookForm = (s: SettingsPageState): JSX.Element | null =>
       action="/admin/settings/square-webhook"
       id="settings-square-webhook"
     >
-      <h2>Square Webhook</h2>
-      <p>
-        <a href="/admin/guide#payment-setup">See the full setup guide</a>
-      </p>
+      <div class="prose">
+        <h2>Square Webhook</h2>
+        <p>
+          <a href="/admin/guide#payment-setup">See the full setup guide</a>
+        </p>
+      </div>
       <article>
         <aside>
           <p>
@@ -229,12 +237,14 @@ export const SquareWebhookForm = (s: SettingsPageState): JSX.Element | null =>
 export const SumUpForm = (s: SettingsPageState): JSX.Element | null =>
   s.paymentProvider === "sumup" ? (
     <CsrfForm action="/admin/settings/sumup" id="settings-sumup">
-      <h2>SumUp Settings</h2>
-      <p>
-        {s.sumupKeyConfigured
-          ? "A SumUp API key is currently configured. Enter new credentials below to replace them."
-          : "No SumUp API key is configured. Enter your SumUp credentials to enable SumUp payments."}
-      </p>
+      <div class="prose">
+        <h2>SumUp Settings</h2>
+        <p>
+          {s.sumupKeyConfigured
+            ? "A SumUp API key is currently configured. Enter new credentials below to replace them."
+            : "No SumUp API key is configured. Enter your SumUp credentials to enable SumUp payments."}
+        </p>
+      </div>
       {s.sumupKeyConfigured && (
         <ApiKeyModeNotice mode={s.sumupKeyMode} provider="SumUp" />
       )}
@@ -264,11 +274,13 @@ export const SumUpForm = (s: SettingsPageState): JSX.Element | null =>
 export const BookingFeeForm = (s: SettingsPageState): JSX.Element | null =>
   s.paymentProvider ? (
     <CsrfForm action="/admin/settings/booking-fee" id="settings-booking-fee">
-      <h2>Booking Fee</h2>
-      <p>
-        Percentage fee added at checkout (e.g. 1.5 for 1.5%). Set to 0 to
-        disable. Max 10.
-      </p>
+      <div class="prose">
+        <h2>Booking Fee</h2>
+        <p>
+          Percentage fee added at checkout (e.g. 1.5 for 1.5%). Set to 0 to
+          disable. Max 10.
+        </p>
+      </div>
       <label>
         Booking Fee (%)
         <input

--- a/src/ui/templates/admin/settings/public-api.tsx
+++ b/src/ui/templates/admin/settings/public-api.tsx
@@ -11,12 +11,14 @@ export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
     action="/admin/settings/show-public-api"
     id="settings-show-public-api"
   >
-    <h2>Enable public API?</h2>
-    <p>
-      Exposes a JSON API for listing listings, checking availability, and
-      creating bookings. See the <a href="/admin/guide#api">API guide</a> for
-      details.
-    </p>
+    <div class="prose">
+      <h2>Enable public API?</h2>
+      <p>
+        Exposes a JSON API for listing listings, checking availability, and
+        creating bookings. See the <a href="/admin/guide#api">API guide</a> for
+        details.
+      </p>
+    </div>
     <fieldset class="radios">
       <label>
         <input

--- a/src/ui/templates/admin/settings/public-site.tsx
+++ b/src/ui/templates/admin/settings/public-site.tsx
@@ -11,11 +11,13 @@ export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
     action="/admin/settings/show-public-site"
     id="settings-show-public-site"
   >
-    <h2>Show public site?</h2>
-    <p>
-      When enabled, the homepage will show a public website with navigation for
-      Home, Listings, T&amp;Cs and Contact pages.
-    </p>
+    <div class="prose">
+      <h2>Show public site?</h2>
+      <p>
+        When enabled, the homepage will show a public website with navigation
+        for Home, Listings, T&amp;Cs and Contact pages.
+      </p>
+    </div>
     <fieldset class="radios">
       <label>
         <input

--- a/src/ui/templates/admin/settings/terms.tsx
+++ b/src/ui/templates/admin/settings/terms.tsx
@@ -11,8 +11,10 @@ import { FORMATTING_HINT } from "#templates/fields.ts";
 
 export const TermsForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/terms" id="settings-terms">
-    <h2>Terms and Conditions</h2>
-    <p>If set, users must agree to these terms before reserving tickets.</p>
+    <div class="prose">
+      <h2>Terms and Conditions</h2>
+      <p>If set, users must agree to these terms before reserving tickets.</p>
+    </div>
     <label>
       Terms and Conditions
       <p>

--- a/src/ui/templates/admin/settings/theme.tsx
+++ b/src/ui/templates/admin/settings/theme.tsx
@@ -8,8 +8,10 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 
 export const ThemeForm = (s: SettingsPageState): JSX.Element => (
   <CsrfForm action="/admin/settings/theme" id="settings-theme">
-    <h2>Site Theme</h2>
-    <p>Choose between light and dark themes for the site interface.</p>
+    <div class="prose">
+      <h2>Site Theme</h2>
+      <p>Choose between light and dark themes for the site interface.</p>
+    </div>
     <fieldset class="radios">
       <label>
         <input

--- a/src/ui/templates/admin/site.tsx
+++ b/src/ui/templates/admin/site.tsx
@@ -92,17 +92,19 @@ const ContactFormToggle = ({
   botpoisonEnabled,
 }: ContactFormState): JSX.Element => (
   <CsrfForm action="/admin/site/contact/form">
-    <h2>Contact Form</h2>
-    <p>
-      Add a contact form to the public contact page. Visitors enter their email
-      address and a message, which is sent to your business email.
-    </p>
-    {!hasBusinessEmail && (
-      <p class="error" role="alert">
-        Set a business email on the Settings page to receive contact form
-        messages.
+    <div class="prose">
+      <h2>Contact Form</h2>
+      <p>
+        Add a contact form to the public contact page. Visitors enter their
+        email address and a message, which is sent to your business email.
       </p>
-    )}
+      {!hasBusinessEmail && (
+        <p class="error" role="alert">
+          Set a business email on the Settings page to receive contact form
+          messages.
+        </p>
+      )}
+    </div>
     <SpamProtectionNote botpoisonEnabled={botpoisonEnabled} />
     <label>
       <input

--- a/src/ui/templates/checkin.tsx
+++ b/src/ui/templates/checkin.tsx
@@ -75,7 +75,9 @@ export const checkinAdminPage = (
 export const checkinPublicPage = (): string =>
   String(
     <Layout title="Check-in">
-      <h1>Check-in</h1>
-      <p>Please show this QR code to an listing administrator to check in.</p>
+      <div class="prose">
+        <h1>Check-in</h1>
+        <p>Please show this QR code to an listing administrator to check in.</p>
+      </div>
     </Layout>,
   );

--- a/src/ui/templates/components/actions.tsx
+++ b/src/ui/templates/components/actions.tsx
@@ -86,6 +86,25 @@ export const SubmitButton = ({
 );
 
 /**
+ * A compact, button-styled "Back to …" navigation link. Renders a leading
+ * arrow-left icon followed by the label (e.g. "Back to attendee"). Pair the
+ * `href` with the destination and pass the label as children — omit the arrow
+ * glyph, the icon supplies it.
+ */
+export const BackButton = ({
+  href,
+  children,
+}: {
+  href: string;
+  children?: Child;
+}): SafeHtml => (
+  <a class="btn small" href={href}>
+    <Icon name="arrow-left" />
+    <span>{children}</span>
+  </a>
+);
+
+/**
  * A consistent, understated link to a help/guide section. Renders a book icon
  * followed by the label in muted text.
  */

--- a/src/ui/templates/join.tsx
+++ b/src/ui/templates/join.tsx
@@ -18,8 +18,10 @@ export const joinPage = (
   String(
     <Layout title="Set Your Password">
       <CsrfForm action={`/join/${code}`}>
-        <h1>Welcome, {username}</h1>
-        <p>Set your password to complete your account setup.</p>
+        <div class="prose">
+          <h1>Welcome, {username}</h1>
+          <p>Set your password to complete your account setup.</p>
+        </div>
         <Flash error={error} />
         <Raw html={joinForm.render()} />
         <button type="submit">Set Password</button>

--- a/src/ui/templates/payment.tsx
+++ b/src/ui/templates/payment.tsx
@@ -73,17 +73,19 @@ export const successPage = ({
         data-payment-result={paid ? "success" : undefined}
         data-scroll-into-view={inIframe || undefined}
       >
-        <h1>Thank you for your order.</h1>
-        {fromEmail ? (
-          <p>
-            <small>
-              <i>
-                Your ticket will be sent from {fromEmail} &mdash; please check
-                your Junk/Spam folder.
-              </i>
-            </small>
-          </p>
-        ) : null}
+        <div class="prose">
+          <h1>Thank you for your order.</h1>
+          {fromEmail ? (
+            <p>
+              <small>
+                <i>
+                  Your ticket will be sent from {fromEmail} &mdash; please check
+                  your Junk/Spam folder.
+                </i>
+              </small>
+            </p>
+          ) : null}
+        </div>
         {ticketUrl ? (
           <p>
             <a href={ticketUrl} rel="noopener" target="_blank">
@@ -114,10 +116,13 @@ export const paymentCancelPage = (
   String(
     <Layout title="Payment Cancelled">
       <div data-payment-result="cancel">
-        <h1>Payment Cancelled</h1>
-        <p>
-          Your payment was cancelled. Your ticket reservation has been removed.
-        </p>
+        <div class="prose">
+          <h1>Payment Cancelled</h1>
+          <p>
+            Your payment was cancelled. Your ticket reservation has been
+            removed.
+          </p>
+        </div>
         <p>
           <a class="btn outline" href={ticketUrl}>
             <Icon name="rotate-ccw" />

--- a/src/ui/templates/public.tsx
+++ b/src/ui/templates/public.tsx
@@ -477,14 +477,16 @@ export const notFoundPage = (): string =>
 export const qrBookErrorPage = (slug: string): string =>
   String(
     <Layout title="QR code expired">
-      <h1>QR code expired or invalid</h1>
-      <p>
-        This QR code has expired or the link has been tampered with. Ask the
-        organiser to generate a new one, or use the normal booking page below.
-      </p>
-      <p>
-        <a href={`/ticket/${escapeHtml(slug)}`}>Go to booking page</a>
-      </p>
+      <div class="prose">
+        <h1>QR code expired or invalid</h1>
+        <p>
+          This QR code has expired or the link has been tampered with. Ask the
+          organiser to generate a new one, or use the normal booking page below.
+        </p>
+        <p>
+          <a href={`/ticket/${escapeHtml(slug)}`}>Go to booking page</a>
+        </p>
+      </div>
     </Layout>,
   );
 
@@ -494,11 +496,13 @@ export const qrBookErrorPage = (slug: string): string =>
 export const rateLimitedPage = (): string =>
   String(
     <Layout title="Too Many Requests">
-      <h1>Too Many Requests</h1>
-      <p>
-        You've hit too many invalid ticket links. Please wait a few minutes and
-        try again.
-      </p>
+      <div class="prose">
+        <h1>Too Many Requests</h1>
+        <p>
+          You've hit too many invalid ticket links. Please wait a few minutes
+          and try again.
+        </p>
+      </div>
     </Layout>,
   );
 
@@ -524,18 +528,20 @@ ${ERROR_DIALOG_STYLE}`;
 export const temporaryErrorPage = (): string =>
   String(
     <Layout headExtra={TEMPORARY_ERROR_HEAD} title="Temporary Error">
-      <h1>Temporary Error</h1>
-      <p>
-        Something went wrong loading this page. Retrying automatically&hellip;
-      </p>
-      <p>
-        <small>
-          Check{" "}
-          <strong>
-            <a href="https://status.bunny.net/">status.bunny.net</a>
-          </strong>
-        </small>
-      </p>
+      <div class="prose">
+        <h1>Temporary Error</h1>
+        <p>
+          Something went wrong loading this page. Retrying automatically&hellip;
+        </p>
+        <p>
+          <small>
+            Check{" "}
+            <strong>
+              <a href="https://status.bunny.net/">status.bunny.net</a>
+            </strong>
+          </small>
+        </p>
+      </div>
     </Layout>,
   );
 
@@ -552,11 +558,13 @@ ${ERROR_DIALOG_STYLE}`;
 export const migrationInProgressPage = (): string =>
   String(
     <Layout headExtra={MIGRATION_IN_PROGRESS_HEAD} title="Update In Progress">
-      <h1>Update In Progress</h1>
-      <p>
-        We&rsquo;re backing up and updating the database. This usually only
-        takes a few seconds. This page will reload automatically&hellip;
-      </p>
+      <div class="prose">
+        <h1>Update In Progress</h1>
+        <p>
+          We&rsquo;re backing up and updating the database. This usually only
+          takes a few seconds. This page will reload automatically&hellip;
+        </p>
+      </div>
     </Layout>,
   );
 
@@ -568,8 +576,10 @@ export const migrationInProgressPage = (): string =>
 export const siteNotActivatedPage = (): string =>
   String(
     <Layout headExtra={ERROR_DIALOG_STYLE} title="Not Activated">
-      <h1>Not Activated</h1>
-      <p>This site has not been activated yet.</p>
+      <div class="prose">
+        <h1>Not Activated</h1>
+        <p>This site has not been activated yet.</p>
+      </div>
     </Layout>,
   );
 

--- a/src/ui/templates/public/balance.tsx
+++ b/src/ui/templates/public/balance.tsx
@@ -18,8 +18,10 @@ export const balancePaymentPage = (
 ): string =>
   String(
     <Layout title="Pay your balance">
-      <h1>Pay your balance</h1>
-      <p>Here's a summary of your booking. No personal details are shown.</p>
+      <div class="prose">
+        <h1>Pay your balance</h1>
+        <p>Here's a summary of your booking. No personal details are shown.</p>
+      </div>
       <table>
         <thead>
           <tr>
@@ -54,8 +56,10 @@ export const balancePaymentPage = (
 export const balanceSettledPage = (): string =>
   String(
     <Layout title="Nothing to pay">
-      <h1>Nothing to pay</h1>
-      <p>This booking has no outstanding balance. Thank you!</p>
+      <div class="prose">
+        <h1>Nothing to pay</h1>
+        <p>This booking has no outstanding balance. Thank you!</p>
+      </div>
     </Layout>,
   );
 
@@ -63,10 +67,12 @@ export const balanceSettledPage = (): string =>
 export const balanceInvalidPage = (): string =>
   String(
     <Layout title="Link not valid">
-      <h1>This payment link is not valid</h1>
-      <p>
-        The link may have expired or been mistyped. Please ask the organiser for
-        a new one.
-      </p>
+      <div class="prose">
+        <h1>This payment link is not valid</h1>
+        <p>
+          The link may have expired or been mistyped. Please ask the organiser
+          for a new one.
+        </p>
+      </div>
     </Layout>,
   );

--- a/src/ui/templates/setup.tsx
+++ b/src/ui/templates/setup.tsx
@@ -66,8 +66,10 @@ export const setupPage = (error?: string): string =>
   String(
     <Layout title="Setup">
       <CsrfForm action="/setup/">
-        <h1>Initial Setup</h1>
-        <p>Welcome! Please configure your ticket reservation system.</p>
+        <div class="prose">
+          <h1>Initial Setup</h1>
+          <p>Welcome! Please configure your ticket reservation system.</p>
+        </div>
         <Flash error={error} />
         <Raw html={renderFields(setupFields)} />
         <div class="field">

--- a/test/templates/components/actions.test.ts
+++ b/test/templates/components/actions.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { ICONS_PATH } from "#shared/asset-paths.ts";
 import {
   ActionButton,
+  BackButton,
   GuideLink,
   Icon,
   SubmitButton,
@@ -87,6 +88,18 @@ describe("SubmitButton", () => {
       }),
     );
     expect(html).toContain('id="listing-edit-submit"');
+  });
+});
+
+describe("BackButton", () => {
+  test("renders a compact button-styled link with a back-arrow icon", () => {
+    const html = String(
+      BackButton({ children: "Back to attendee", href: "/admin/attendees/7" }),
+    );
+    expect(html).toContain('class="btn small"');
+    expect(html).toContain('href="/admin/attendees/7"');
+    expect(html).toContain(`href="${ICONS_PATH}#arrow-left"`);
+    expect(html).toContain("<span>Back to attendee</span>");
   });
 });
 


### PR DESCRIPTION
## What

Two related template polish changes:

### 1. Prose-wrap heading + paragraph blocks

Starting with the **Reservation balance** panel, every heading that is immediately followed by one or more paragraphs is now grouped inside a `<div class="prose">`, so the shared first/last-child margin reset (`.prose > :first-child`/`:last-child`) applies consistently. This was swept across all templates that have headings.

The rule applied:
- A prose block starts at a heading (`<h1>`–`<h6>`) and includes the consecutive `<p>` siblings that immediately follow it (including `{cond && <p>…</p>}` conditionals).
- The block stops at the first non-paragraph sibling (form, list, table, `<article>`, components like `<Flash>`/`<Raw>`/`<CsrfForm>`, or a conditional that may render non-paragraph content).
- Headings with no paragraph immediately after them are left unwrapped.
- Blocks already inside a `prose` div were left untouched (no double-wrapping).

66 prose wrappers added across 38 templates; no nested/double prose divs.

### 2. "Back to …" links as compact buttons

Added a `BackButton` component — a compact `.btn.small` (smaller font/padding, normal weight) with a leading `arrow-left` icon — and used it for the four "Back to …" navigation links:

- Attendee balance → "Back to attendee"
- Seed data → "Back to dashboard"
- Merge attendee → "Back to {name}"
- Demo reset → "Back to login"

The arrow glyph that used to be inline in the text is now supplied by the icon.

## Testing

- `deno task precommit` passes: lint, typecheck, cpd, build:edge, and `test:coverage` (100% coverage maintained).
- Added a `BackButton` test in `test/templates/components/actions.test.ts`.
- The booking e2e flow (which clicks "Back to dashboard") still passes — the test browser matches the link by its span text.

https://claude.ai/code/session_01Tx3JwhYPAztL4U7SafqPPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tx3JwhYPAztL4U7SafqPPu)_