### PR TITLE
Add Runtime section to /admin/debug

### DIFF
--- a/src/features/admin/debug.ts
+++ b/src/features/admin/debug.ts
@@ -23,6 +23,7 @@ import { getHostEmailConfig } from "#shared/email.ts";
 import { getEnv } from "#shared/env.ts";
 import { isValidGooglePrivateKey } from "#shared/google-wallet.ts";
 import { LIMIT_ENTRIES } from "#shared/limits.ts";
+import { getRuntimeInfo } from "#shared/runtime.ts";
 import { getStorageBackend } from "#shared/storage.ts";
 import {
   adminDebugPage,
@@ -175,6 +176,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
       payments: formatLastPruned(settings.lastPrunedPayments),
       sessions: formatLastPruned(settings.lastPrunedSessions),
     },
+    runtime: getRuntimeInfo(),
     theme: settings.theme,
   };
 };

--- a/src/shared/runtime.ts
+++ b/src/shared/runtime.ts
@@ -1,0 +1,76 @@
+/**
+ * Runtime introspection — collects non-secret details about the JavaScript
+ * runtime the app is executing on (Deno version, V8, OS/arch, etc.).
+ *
+ * The app runs in three environments, each exposing different globals:
+ * - Local dev / tests: Deno (`Deno.version`, `Deno.build`)
+ * - Bunny Edge (production): Deno-based, with a `Bunny` global injected
+ * - Node: not used in production, but detected for completeness
+ *
+ * Every global is probed defensively because availability varies between
+ * runtimes, and we only ever read version/platform metadata — never secrets.
+ */
+
+/** Shape of the runtime globals we probe. All optional — presence varies. */
+export type RuntimeGlobals = {
+  Bunny?: unknown;
+  Deno?: {
+    version?: { deno?: string; v8?: string; typescript?: string };
+    build?: { os?: string; arch?: string };
+  };
+  process?: { versions?: Record<string, string | undefined> };
+  navigator?: { userAgent?: string };
+};
+
+/** Non-secret runtime/platform metadata for the debug page. */
+export type RuntimeInfo = {
+  /** Detected host runtime. */
+  runtime: "bunny" | "deno" | "node" | "unknown";
+  /** Operating system (e.g. "linux", "darwin"), or "" if unknown. */
+  os: string;
+  /** CPU architecture (e.g. "x86_64", "aarch64"), or "" if unknown. */
+  arch: string;
+  /** Deno version (e.g. "2.8.3"), or "" on non-Deno runtimes. */
+  denoVersion: string;
+  /** V8 engine version, or "" if unknown. */
+  v8Version: string;
+  /** Bundled TypeScript version, or "" if unknown. */
+  typescriptVersion: string;
+  /** Node.js compatibility version (process.versions.node), or "" if unset. */
+  nodeCompatVersion: string;
+  /** navigator.userAgent (runtime identity), or "" if unavailable. */
+  userAgent: string;
+};
+
+/**
+ * Detect the host runtime. Mirrors the Bunny SDK's own detection order: the
+ * production edge injects a `Bunny` global (and is Deno-based underneath), so
+ * it must be checked before Deno.
+ */
+const detectRuntime = (g: RuntimeGlobals): RuntimeInfo["runtime"] => {
+  if (typeof g.Bunny !== "undefined") return "bunny";
+  if (g.Deno?.build != null) return "deno";
+  if (g.process?.versions?.node != null) return "node";
+  return "unknown";
+};
+
+/** Build a RuntimeInfo from a (possibly partial) set of runtime globals. */
+export const buildRuntimeInfo = (g: RuntimeGlobals): RuntimeInfo => {
+  const version = g.Deno?.version;
+  const build = g.Deno?.build;
+  const processVersions = g.process?.versions;
+  return {
+    arch: build?.arch ?? "",
+    denoVersion: version?.deno ?? "",
+    nodeCompatVersion: processVersions?.node ?? "",
+    os: build?.os ?? "",
+    runtime: detectRuntime(g),
+    typescriptVersion: version?.typescript ?? "",
+    userAgent: g.navigator?.userAgent ?? "",
+    v8Version: version?.v8 ?? processVersions?.v8 ?? "",
+  };
+};
+
+/** Collect runtime info from the current global scope. */
+export const getRuntimeInfo = (): RuntimeInfo =>
+  buildRuntimeInfo(globalThis as unknown as RuntimeGlobals);

--- a/src/ui/templates/admin/debug.tsx
+++ b/src/ui/templates/admin/debug.tsx
@@ -3,6 +3,7 @@
  */
 
 import { formatLimitValue, type LIMIT_ENTRIES } from "#shared/limits.ts";
+import type { RuntimeInfo } from "#shared/runtime.ts";
 import type { AdminSession, Theme } from "#shared/types.ts";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
@@ -56,6 +57,7 @@ export type DebugPageState = {
     timestamp: string;
     commit: string;
   };
+  runtime: RuntimeInfo;
   domain: string;
   limits: typeof LIMIT_ENTRIES;
   prune: {
@@ -89,6 +91,51 @@ const BuildSection = ({
         <tr>
           <td>Commit</td>
           <td>{build.commit || "—"}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const RuntimeSection = ({
+  runtime,
+}: {
+  runtime: DebugPageState["runtime"];
+}): JSX.Element => (
+  <article>
+    <h2>Runtime</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>Host runtime</td>
+          <td>{runtime.runtime}</td>
+        </tr>
+        <tr>
+          <td>Deno version</td>
+          <td>{runtime.denoVersion || "—"}</td>
+        </tr>
+        <tr>
+          <td>V8 version</td>
+          <td>{runtime.v8Version || "—"}</td>
+        </tr>
+        <tr>
+          <td>TypeScript version</td>
+          <td>{runtime.typescriptVersion || "—"}</td>
+        </tr>
+        <tr>
+          <td>Node compatibility</td>
+          <td>{runtime.nodeCompatVersion || "—"}</td>
+        </tr>
+        <tr>
+          <td>OS / architecture</td>
+          <td>
+            {runtime.os || "—"}
+            {runtime.arch ? ` / ${runtime.arch}` : ""}
+          </td>
+        </tr>
+        <tr>
+          <td>User agent</td>
+          <td>{runtime.userAgent || "—"}</td>
         </tr>
       </tbody>
     </table>
@@ -458,6 +505,7 @@ export const adminDebugPage = (
       </div>
 
       <BuildSection build={s.build} />
+      <RuntimeSection runtime={s.runtime} />
       <AppleWalletSection appleWallet={s.appleWallet} />
       <GoogleWalletSection googleWallet={s.googleWallet} />
       <PaymentsSection payment={s.payment} />

--- a/test/lib/runtime.test.ts
+++ b/test/lib/runtime.test.ts
@@ -1,0 +1,89 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  buildRuntimeInfo,
+  getRuntimeInfo,
+  type RuntimeGlobals,
+} from "#shared/runtime.ts";
+
+describe("runtime", () => {
+  describe("getRuntimeInfo (live globals)", () => {
+    test("detects the Deno runtime the tests execute on", () => {
+      expect(getRuntimeInfo().runtime).toBe("deno");
+    });
+
+    test("reports a concrete Deno version", () => {
+      expect(getRuntimeInfo().denoVersion).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    test("reports a Deno user agent", () => {
+      expect(getRuntimeInfo().userAgent).toContain("Deno");
+    });
+  });
+
+  describe("buildRuntimeInfo runtime detection", () => {
+    test("reports bunny when the Bunny global is present", () => {
+      const g: RuntimeGlobals = { Bunny: {}, Deno: { build: { os: "linux" } } };
+      expect(buildRuntimeInfo(g).runtime).toBe("bunny");
+    });
+
+    test("reports deno when Deno.build is present", () => {
+      const g: RuntimeGlobals = { Deno: { build: { os: "linux" } } };
+      expect(buildRuntimeInfo(g).runtime).toBe("deno");
+    });
+
+    test("reports node when only process.versions.node is present", () => {
+      const g: RuntimeGlobals = { process: { versions: { node: "20.11.0" } } };
+      expect(buildRuntimeInfo(g).runtime).toBe("node");
+    });
+
+    test("reports unknown when no runtime globals are present", () => {
+      expect(buildRuntimeInfo({}).runtime).toBe("unknown");
+    });
+  });
+
+  describe("buildRuntimeInfo field extraction", () => {
+    test("extracts every field from a fully-populated Deno global", () => {
+      const g: RuntimeGlobals = {
+        Deno: {
+          build: { arch: "aarch64", os: "darwin" },
+          version: { deno: "2.8.3", typescript: "5.9.0", v8: "13.1.0" },
+        },
+        navigator: { userAgent: "Deno/2.8.3" },
+      };
+      expect(buildRuntimeInfo(g)).toEqual({
+        arch: "aarch64",
+        denoVersion: "2.8.3",
+        nodeCompatVersion: "",
+        os: "darwin",
+        runtime: "deno",
+        typescriptVersion: "5.9.0",
+        userAgent: "Deno/2.8.3",
+        v8Version: "13.1.0",
+      });
+    });
+
+    test("falls back to process.versions.v8 when Deno has no version", () => {
+      const g: RuntimeGlobals = {
+        process: { versions: { node: "20.11.0", v8: "11.3.244" } },
+      };
+      const info = buildRuntimeInfo(g);
+      expect(info.v8Version).toBe("11.3.244");
+      expect(info.nodeCompatVersion).toBe("20.11.0");
+    });
+
+    test("defaults all metadata to empty strings when globals are bare", () => {
+      const g: RuntimeGlobals = { Deno: { build: {}, version: {} } };
+      expect(buildRuntimeInfo(g)).toEqual({
+        arch: "",
+        denoVersion: "",
+        nodeCompatVersion: "",
+        os: "",
+        runtime: "deno",
+        typescriptVersion: "",
+        userAgent: "",
+        v8Version: "",
+      });
+    });
+  });
+});

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { settings } from "#shared/db/settings.ts";
 import { LIMIT_ENTRIES } from "#shared/limits.ts";
+import { getRuntimeInfo } from "#shared/runtime.ts";
 import {
   adminDebugPage,
   type DebugPageState,
@@ -39,6 +40,26 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
 
     test("shows Build section", async () => {
       await assertAdminHtml("/admin/debug", "Build", "Timestamp", "Commit");
+    });
+
+    test("shows Runtime section with version rows", async () => {
+      await assertAdminHtml(
+        "/admin/debug",
+        "Runtime",
+        "Host runtime",
+        "Deno version",
+        "V8 version",
+        "TypeScript version",
+        "Node compatibility",
+        "OS / architecture",
+        "User agent",
+      );
+    });
+
+    test("shows the actual Deno version it is running on", async () => {
+      const { denoVersion } = getRuntimeInfo();
+      const html = await assertAdminHtml("/admin/debug", "Deno version");
+      expect(html).toContain(denoVersion);
     });
 
     test("shows Apple Wallet section", async () => {
@@ -406,6 +427,16 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
           webhookConfigured: false,
         },
         prune: { logins: "Never", payments: "Never", sessions: "Never" },
+        runtime: {
+          arch: "",
+          denoVersion: "",
+          nodeCompatVersion: "",
+          os: "",
+          runtime: "unknown",
+          typescriptVersion: "",
+          userAgent: "",
+          v8Version: "",
+        },
         theme: "light",
       };
       const session = { adminLevel: "owner" as const };
@@ -491,6 +522,16 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
           webhookConfigured: false,
         },
         prune: { logins: "Never", payments: "Never", sessions: "Never" },
+        runtime: {
+          arch: "",
+          denoVersion: "",
+          nodeCompatVersion: "",
+          os: "",
+          runtime: "unknown",
+          typescriptVersion: "",
+          userAgent: "",
+          v8Version: "",
+        },
         theme: "light",
       };
       const session = { adminLevel: "owner" as const };


### PR DESCRIPTION
## What

Adds a **Runtime** section to the owner-only `/admin/debug` page showing the Deno version we're running on, plus other non-secret runtime/platform metadata.

The section renders rows for:

| Row | Example (local dev) |
| --- | --- |
| Host runtime | `deno` (will be `bunny` in production) |
| Deno version | `2.8.3` |
| V8 version | `14.9.207.2-rusty` |
| TypeScript version | `6.0.3` |
| Node compatibility | `24.15.0` |
| OS / architecture | `linux / x86_64` |
| User agent | `Deno/2.8.3` |

It sits right under the existing **Build** section.

## How

- New `#shared/runtime.ts` module:
  - `getRuntimeInfo()` reads the current global scope.
  - `buildRuntimeInfo(globals)` is a pure helper that probes each runtime global **defensively** — the Bunny Edge runtime (`Bunny` global, Deno-based), local Deno, and Node each expose different things, and any field that's unavailable falls back to an empty string (rendered as `—`).
  - Runtime detection mirrors the Bunny SDK's own order (`Bunny` → `Deno` → `process` → `unknown`).
- `src/features/admin/debug.ts` adds `runtime: getRuntimeInfo()` to the page state.
- `src/ui/templates/admin/debug.tsx` adds the `RuntimeSection` and a `RuntimeInfo` field on `DebugPageState`.

## Secrets

No secrets are read or displayed — only version strings and platform names. The page's existing "No secrets or keys are shown" guarantee still holds.

## Tests

- New `test/lib/runtime.test.ts` — covers live detection plus all `buildRuntimeInfo` branches (bunny/deno/node/unknown, full extraction, `process.versions.v8` fallback, empty-global defaults).
- `test/lib/server-debug.test.ts` — asserts the Runtime section renders and that the page reflects the actual Deno version returned by `getRuntimeInfo()`.
- 100% branch/line coverage on both `runtime.ts` and `debug.tsx`; full typecheck, lint, and code-quality checks pass.

https://claude.ai/code/session_01EzkQ52vQESypSYuQTMwJV6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzkQ52vQESypSYuQTMwJV6)_