### PR TITLE
Extract cachedTable and SettingsSection shared units

### DIFF
--- a/src/shared/db/attendee-statuses.ts
+++ b/src/shared/db/attendee-statuses.ts
@@ -8,12 +8,10 @@
  * the human-readable `name` is encrypted at rest.
  */
 
-import { registerCache } from "#shared/cache-registry.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { executeBatch, getDb, queryAll } from "#shared/db/client.ts";
 import { queryAndMap, swapSortOrder } from "#shared/db/query.ts";
-import { col, defineTable, withCacheInvalidation } from "#shared/db/table.ts";
-import { requestCache } from "#shared/request-cache.ts";
+import { cachedTable, col, defineTable } from "#shared/db/table.ts";
 
 /** Name of the status seeded on first run so there is always at least one. */
 export const DEFAULT_ATTENDEE_STATUS_NAME = "Confirmed";
@@ -61,27 +59,22 @@ const queryStatuses = queryAndMap<AttendeeStatus, AttendeeStatus>((row) =>
   rawAttendeeStatusesTable.fromDb(row),
 );
 
-const statusesCache = requestCache(() =>
-  queryStatuses(
-    "SELECT * FROM attendee_statuses ORDER BY sort_order ASC, id ASC",
-  ),
-);
-
-registerCache(() => ({
-  entries: statusesCache.size(),
+const statusesCache = cachedTable({
+  fetchAll: () =>
+    queryStatuses(
+      "SELECT * FROM attendee_statuses ORDER BY sort_order ASC, id ASC",
+    ),
   name: "attendee_statuses",
-}));
+  table: rawAttendeeStatusesTable,
+});
+
+/** Attendee statuses table — writes auto-invalidate the cache. */
+export const attendeeStatusesTable = statusesCache.table;
 
 /** Invalidate the statuses cache (for testing or after writes). */
 export const invalidateAttendeeStatusesCache = (): void => {
   statusesCache.invalidate();
 };
-
-/** Attendee statuses table — writes auto-invalidate the cache. */
-export const attendeeStatusesTable = withCacheInvalidation(
-  rawAttendeeStatusesTable,
-  invalidateAttendeeStatusesCache,
-);
 
 /** Get all statuses, decrypted, ordered by sort_order then id (from cache). */
 export const getAllAttendeeStatuses = (): Promise<AttendeeStatus[]> =>

--- a/src/shared/db/built-sites.ts
+++ b/src/shared/db/built-sites.ts
@@ -4,13 +4,11 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { registerCache } from "#shared/cache-registry.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { queryAll } from "#shared/db/client.ts";
 import type { ColumnDef, Table } from "#shared/db/table.ts";
-import { col, defineTable, withCacheInvalidation } from "#shared/db/table.ts";
+import { cachedTable, col, defineTable } from "#shared/db/table.ts";
 import { nowIso } from "#shared/now.ts";
-import { requestCache } from "#shared/request-cache.ts";
 
 /** Encrypted site-data blob version */
 export const SITE_DATA_BLOB_VERSION = 1;
@@ -164,16 +162,12 @@ const rowToBuiltSite = (row: BuiltSiteRow): BuiltSite => {
   };
 };
 
-const builtSitesCache = requestCache(() =>
-  queryAndDecrypt("SELECT * FROM built_sites ORDER BY created DESC"),
-);
-
-registerCache(() => ({ entries: builtSitesCache.size(), name: "built_sites" }));
-
-/** Invalidate the built sites cache */
-export const invalidateBuiltSitesCache = (): void => {
-  builtSitesCache.invalidate();
-};
+const builtSitesCache = cachedTable({
+  fetchAll: () =>
+    queryAndDecrypt("SELECT * FROM built_sites ORDER BY created DESC"),
+  name: "built_sites",
+  table: rawBuiltSitesTable,
+});
 
 /** Query and decrypt built site rows */
 const queryAndDecrypt = async (sql: string): Promise<BuiltSite[]> => {
@@ -187,10 +181,7 @@ const queryAndDecrypt = async (sql: string): Promise<BuiltSite[]> => {
 };
 
 /** Raw table with cache invalidation on writes */
-export const builtSitesTable = withCacheInvalidation(
-  rawBuiltSitesTable,
-  invalidateBuiltSitesCache,
-);
+export const builtSitesTable = builtSitesCache.table;
 
 /**
  * CRUD-compatible table adapter that presents BuiltSite (with individual fields)

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -10,12 +10,10 @@ import {
   defineIdTable,
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
-  registerCache,
 } from "#shared/db/common-schema.ts";
 import { invalidateListingsCache, listingsTable } from "#shared/db/listings.ts";
 import { queryAndMap } from "#shared/db/query.ts";
-import { col, withCacheInvalidation } from "#shared/db/table.ts";
-import { requestCache } from "#shared/request-cache.ts";
+import { cachedTable, col } from "#shared/db/table.ts";
 import type {
   Group,
   Listing,
@@ -53,22 +51,19 @@ const queryGroups = queryAndMap<Group, Group>((row) =>
   rawGroupsTable.fromDb(row),
 );
 
-const groupsCache = requestCache(() =>
-  queryGroups("SELECT * FROM groups ORDER BY id ASC"),
-);
+const groupsCache = cachedTable({
+  fetchAll: () => queryGroups("SELECT * FROM groups ORDER BY id ASC"),
+  name: "groups",
+  table: rawGroupsTable,
+});
 
-registerCache(() => ({ entries: groupsCache.size(), name: "groups" }));
+/** Groups table with CRUD operations — writes auto-invalidate the cache */
+export const groupsTable = groupsCache.table;
 
 /** Invalidate the groups cache (for testing or after writes). */
 export const invalidateGroupsCache = (): void => {
   groupsCache.invalidate();
 };
-
-/** Groups table with CRUD operations — writes auto-invalidate the cache */
-export const groupsTable = withCacheInvalidation(
-  rawGroupsTable,
-  invalidateGroupsCache,
-);
 
 /**
  * Get all groups, decrypted, ordered by id (from cache)

--- a/src/shared/db/holidays.ts
+++ b/src/shared/db/holidays.ts
@@ -3,12 +3,10 @@
  */
 
 import { filter } from "#fp";
-import { registerCache } from "#shared/cache-registry.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { queryAndMap } from "#shared/db/query.ts";
 import { settings } from "#shared/db/settings.ts";
-import { col, defineTable, withCacheInvalidation } from "#shared/db/table.ts";
-import { requestCache } from "#shared/request-cache.ts";
+import { cachedTable, col, defineTable } from "#shared/db/table.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { Holiday } from "#shared/types.ts";
 
@@ -36,22 +34,20 @@ const queryHolidays = queryAndMap<Holiday, Holiday>((row) =>
   rawHolidaysTable.fromDb(row),
 );
 
-const holidaysCache = requestCache(() =>
-  queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC"),
-);
+const holidaysCache = cachedTable({
+  fetchAll: () =>
+    queryHolidays("SELECT * FROM holidays ORDER BY start_date ASC"),
+  name: "holidays",
+  table: rawHolidaysTable,
+});
 
-registerCache(() => ({ entries: holidaysCache.size(), name: "holidays" }));
+/** Holidays table with CRUD operations — writes auto-invalidate the cache */
+export const holidaysTable = holidaysCache.table;
 
 /** Invalidate the holidays cache (for testing or after writes). */
 export const invalidateHolidaysCache = (): void => {
   holidaysCache.invalidate();
 };
-
-/** Holidays table with CRUD operations — writes auto-invalidate the cache */
-export const holidaysTable = withCacheInvalidation(
-  rawHolidaysTable,
-  invalidateHolidaysCache,
-);
 
 /**
  * Get all holidays, decrypted, ordered by start_date (from cache)

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -24,12 +24,10 @@ import {
   defineIdTable,
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
-  registerCache,
 } from "#shared/db/common-schema.ts";
-import { col, withCacheInvalidation } from "#shared/db/table.ts";
+import { cachedTable, col } from "#shared/db/table.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
 import { nowIso } from "#shared/now.ts";
-import { requestCache } from "#shared/request-cache.ts";
 import {
   type Attendee,
   type DayPrices,
@@ -191,9 +189,14 @@ const rawListingsTable = defineIdTable<Listing, ListingInput>("listings", {
   webhook_url: col.encryptedText(encrypt, decrypt),
 });
 
-export const listingsTable = withCacheInvalidation(rawListingsTable, () =>
-  invalidateListingsCache(),
-);
+const listingsCache = cachedTable({
+  fetchAll: () => queryListingsWithCounts(),
+  name: "listings",
+  table: rawListingsTable,
+});
+
+/** Listings table with CRUD operations — writes auto-invalidate the cache */
+export const listingsTable = listingsCache.table;
 
 /** Find a cached listing by ID */
 const findCachedListingById = async (
@@ -299,10 +302,6 @@ const queryListingsWithCounts = async (
     rows.map((row) => decryptAndAttachCount(row, row.attendee_count)),
   );
 };
-
-const listingsCache = requestCache(() => queryListingsWithCounts());
-
-registerCache(() => ({ entries: listingsCache.size(), name: "listings" }));
 
 /** Invalidate the listings cache (for testing or after writes). */
 export const invalidateListingsCache = (): void => {

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -10,7 +10,9 @@
 
 import type { InValue } from "@libsql/client";
 import { compact, filter, mapParallel, reduce } from "#fp";
+import { registerCache } from "#shared/cache-registry.ts";
 import { getDb, queryAll, queryOne } from "#shared/db/client.ts";
+import { requestCache } from "#shared/request-cache.ts";
 
 /**
  * Column definition for a table
@@ -402,6 +404,38 @@ export const withCacheInvalidation = <Row, Input>(
     return result;
   },
 });
+
+/**
+ * Bundle a request-scoped cache around a table.
+ *
+ * Wires together the three pieces every cached table used to repeat by hand:
+ *  - a {@link requestCache} over `fetchAll` (the decrypted/mapped rows),
+ *  - registration with the cache-stats registry under `name`, and
+ *  - a `table` wrapped via {@link withCacheInvalidation} so writes clear it.
+ *
+ * `fetchAll` may resolve a richer row type than the table's own `Row`
+ * (e.g. listings cached with attendee counts), captured by `Cached`.
+ */
+export const cachedTable = <Row, Input, Cached = Row>(config: {
+  fetchAll: () => Promise<Cached[]>;
+  name: string;
+  table: Table<Row, Input>;
+}): {
+  getAll: () => Promise<Cached[]>;
+  invalidate: () => void;
+  table: Table<Row, Input>;
+} => {
+  const cache = requestCache(config.fetchAll);
+  registerCache(() => ({ entries: cache.size(), name: config.name }));
+  const invalidate = (): void => {
+    cache.invalidate();
+  };
+  return {
+    getAll: () => cache.getAll(),
+    invalidate,
+    table: withCacheInvalidation(config.table, invalidate),
+  };
+};
 
 /** Transform function type for column read/write */
 type ColumnTransform<T> = (v: T) => Promise<T> | T;

--- a/src/ui/templates/admin/settings/apple-wallet.tsx
+++ b/src/ui/templates/admin/settings/apple-wallet.tsx
@@ -3,14 +3,13 @@
  */
 
 import { MASK_SENTINEL } from "#shared/db/settings.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
-  <CsrfForm action="/admin/settings/apple-wallet" id="settings-apple-wallet">
-    <div class="prose">
-      <h2>Apple Wallet</h2>
+  <SettingsSection
+    action="/admin/settings/apple-wallet"
+    description={
       <p>
         Configure Apple Wallet pass signing to show an &ldquo;Add to Apple
         Wallet&rdquo; button on ticket pages.{" "}
@@ -21,7 +20,11 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
             ? ` Overriding: ${s.hostAppleWalletLabel}.`
             : ""}
       </p>
-    </div>
+    }
+    id="settings-apple-wallet"
+    submitLabel="Save Apple Wallet Settings"
+    title="Apple Wallet"
+  >
     <label>
       Pass Type ID
       <input
@@ -72,6 +75,5 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
         {s.appleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>
     </label>
-    <SubmitButton icon="save">Save Apple Wallet Settings</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/apple-wallet.tsx
+++ b/src/ui/templates/admin/settings/apple-wallet.tsx
@@ -21,7 +21,6 @@ export const AppleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
             : ""}
       </p>
     }
-    id="settings-apple-wallet"
     submitLabel="Save Apple Wallet Settings"
     title="Apple Wallet"
   >

--- a/src/ui/templates/admin/settings/business-email.tsx
+++ b/src/ui/templates/admin/settings/business-email.tsx
@@ -14,7 +14,6 @@ export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
         reply-to address for automated emails.
       </p>
     }
-    id="settings-business-email"
     submitLabel="Save Business Email"
     title="Business Email"
   >

--- a/src/ui/templates/admin/settings/business-email.tsx
+++ b/src/ui/templates/admin/settings/business-email.tsx
@@ -2,22 +2,22 @@
  * Business Email form for settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/business-email"
-    id="settings-business-email"
-  >
-    <div class="prose">
-      <h2>Business Email</h2>
+    description={
       <p>
         This email will be included in webhook notifications and used as the
         reply-to address for automated emails.
       </p>
-    </div>
+    }
+    id="settings-business-email"
+    submitLabel="Save Business Email"
+    title="Business Email"
+  >
     <label>
       Business Email
       <input
@@ -28,6 +28,5 @@ export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
         value={s.businessEmail}
       />
     </label>
-    <SubmitButton icon="save">Save Business Email</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/change-password.tsx
+++ b/src/ui/templates/admin/settings/change-password.tsx
@@ -2,18 +2,21 @@
  * Change Password form for settings
  */
 
-import { CsrfForm, renderFields } from "#shared/forms.tsx";
+import { renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 import { changePasswordFields } from "#templates/fields.ts";
 
 export const ChangePasswordForm = (): JSX.Element => (
-  <CsrfForm action="/admin/settings" id="settings-password">
-    <div class="prose">
-      <h2>Change Password</h2>
+  <SettingsSection
+    action="/admin/settings"
+    description={
       <p>Changing your password will log you out of all sessions.</p>
-    </div>
+    }
+    id="settings-password"
+    submitLabel="Change Password"
+    title="Change Password"
+  >
     <Raw html={renderFields(changePasswordFields)} />
-    <SubmitButton icon="save">Change Password</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/column-order.tsx
+++ b/src/ui/templates/admin/settings/column-order.tsx
@@ -15,9 +15,8 @@ import {
   LISTING_DEFAULT_ORDER,
   LISTING_TABLE_COLUMNS,
 } from "#shared/columns/listing-columns.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 const listingDefault = buildDefaultTemplate(LISTING_DEFAULT_ORDER);
 const attendeeDefault = buildDefaultTemplate(ATTENDEE_DEFAULT_ORDER);
@@ -39,19 +38,20 @@ const AvailableTags = ({
 export const ListingColumnOrderForm = (
   s: AdvancedSettingsPageState,
 ): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/listing-column-order"
-    id="settings-listing-column-order"
-  >
-    <div class="prose">
-      <h2>Listing Table Columns</h2>
+    description={
       <p>
         Control which columns appear on the Listings table and in what order.
         Use Liquid-style tags separated by commas. See the{" "}
         <a href="/admin/guide#column-order">Column Order guide</a> for full
         details including custom date and currency formatting.
       </p>
-    </div>
+    }
+    id="settings-listing-column-order"
+    submitLabel="Save Listing Columns"
+    title="Listing Table Columns"
+  >
     <label>
       Column order
       <input
@@ -65,19 +65,15 @@ export const ListingColumnOrderForm = (
     <p>
       <AvailableTags columns={LISTING_TABLE_COLUMNS} />
     </p>
-    <SubmitButton icon="save">Save Listing Columns</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );
 
 export const AttendeeColumnOrderForm = (
   s: AdvancedSettingsPageState,
 ): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/attendee-column-order"
-    id="settings-attendee-column-order"
-  >
-    <div class="prose">
-      <h2>Attendee Table Columns</h2>
+    description={
       <p>
         Control which columns appear on Attendee tables and in what order. Use
         Liquid-style tags separated by commas. Columns referencing absent data
@@ -85,7 +81,11 @@ export const AttendeeColumnOrderForm = (
         the <a href="/admin/guide#column-order">Column Order guide</a> for full
         details including custom date and currency formatting.
       </p>
-    </div>
+    }
+    id="settings-attendee-column-order"
+    submitLabel="Save Attendee Columns"
+    title="Attendee Table Columns"
+  >
     <label>
       Column order
       <input
@@ -99,6 +99,5 @@ export const AttendeeColumnOrderForm = (
     <p>
       <AvailableTags columns={ATTENDEE_TABLE_COLUMNS} />
     </p>
-    <SubmitButton icon="save">Save Attendee Columns</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/column-order.tsx
+++ b/src/ui/templates/admin/settings/column-order.tsx
@@ -48,7 +48,6 @@ export const ListingColumnOrderForm = (
         details including custom date and currency formatting.
       </p>
     }
-    id="settings-listing-column-order"
     submitLabel="Save Listing Columns"
     title="Listing Table Columns"
   >
@@ -82,7 +81,6 @@ export const AttendeeColumnOrderForm = (
         details including custom date and currency formatting.
       </p>
     }
-    id="settings-attendee-column-order"
     submitLabel="Save Attendee Columns"
     title="Attendee Table Columns"
   >

--- a/src/ui/templates/admin/settings/country.tsx
+++ b/src/ui/templates/admin/settings/country.tsx
@@ -3,16 +3,17 @@
  */
 
 import { COUNTRIES, type CountryData } from "#shared/countries.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const CountryForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm action="/admin/settings/country" id="settings-country">
-    <div class="prose">
-      <h2>Your Country</h2>
-      <p>Sets your timezone, currency, and phone prefix.</p>
-    </div>
+  <SettingsSection
+    action="/admin/settings/country"
+    description={<p>Sets your timezone, currency, and phone prefix.</p>}
+    id="settings-country"
+    submitLabel="Save Country"
+    title="Your Country"
+  >
     <label>
       Country
       <select name="country" required>
@@ -25,6 +26,5 @@ export const CountryForm = (s: SettingsPageState): JSX.Element => (
         )}
       </select>
     </label>
-    <SubmitButton icon="save">Save Country</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/country.tsx
+++ b/src/ui/templates/admin/settings/country.tsx
@@ -10,7 +10,6 @@ export const CountryForm = (s: SettingsPageState): JSX.Element => (
   <SettingsSection
     action="/admin/settings/country"
     description={<p>Sets your timezone, currency, and phone prefix.</p>}
-    id="settings-country"
     submitLabel="Save Country"
     title="Your Country"
   >

--- a/src/ui/templates/admin/settings/email-tpl-admin.tsx
+++ b/src/ui/templates/admin/settings/email-tpl-admin.tsx
@@ -2,27 +2,27 @@
  * Admin Notification Email Template form for advanced settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 
 export const AdminEmailTemplateForm = (
   s: AdvancedSettingsPageState,
 ): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/email-templates/admin"
-    id="settings-email-tpl-admin"
-  >
-    <div class="prose">
-      <h2>Admin Notification Email Template</h2>
+    description={
       <p>
         Customise the notification email sent to the business email when a
         registration comes in (
         <a href="/admin/guide#email-templates">template guide</a>). Leave blank
         to use the default template.
       </p>
-    </div>
+    }
+    id="settings-email-tpl-admin"
+    submitLabel="Save Admin Notification Template"
+    title="Admin Notification Email Template"
+  >
     <label>
       Subject
       <input
@@ -64,6 +64,5 @@ export const AdminEmailTemplateForm = (
       <small>Edit default template</small>
     </a>
     <br />
-    <SubmitButton icon="save">Save Admin Notification Template</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/email-tpl-confirmation.tsx
+++ b/src/ui/templates/admin/settings/email-tpl-confirmation.tsx
@@ -2,20 +2,16 @@
  * Confirmation Email Template form for advanced settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 
 export const ConfirmationEmailTemplateForm = (
   s: AdvancedSettingsPageState,
 ): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/email-templates/confirmation"
-    id="settings-email-tpl-confirmation"
-  >
-    <div class="prose">
-      <h2>Confirmation Email Template</h2>
+    description={
       <p>
         Customise the registration confirmation email sent to attendees (
         <a href="/admin/guide#email-templates">template guide</a>). Uses{" "}
@@ -24,7 +20,11 @@ export const ConfirmationEmailTemplateForm = (
         </a>{" "}
         template syntax. Leave blank to use the default template.
       </p>
-    </div>
+    }
+    id="settings-email-tpl-confirmation"
+    submitLabel="Save Confirmation Template"
+    title="Confirmation Email Template"
+  >
     <details>
       <summary>Available variables</summary>
       <table>
@@ -155,6 +155,5 @@ export const ConfirmationEmailTemplateForm = (
       <small>Edit default template</small>
     </a>
     <br />
-    <SubmitButton icon="save">Save Confirmation Template</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/email.tsx
+++ b/src/ui/templates/admin/settings/email.tsx
@@ -7,19 +7,24 @@ import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#shared/email.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const EmailNotificationsForm = (
   s: AdvancedSettingsPageState,
 ): JSX.Element => (
   <>
-    <CsrfForm action="/admin/settings/email" id="settings-email">
-      <div class="prose">
-        <h2>Email Notifications</h2>
+    <SettingsSection
+      action="/admin/settings/email"
+      description={
         <p>
           Send confirmation emails to attendees and admin notifications when
           registrations come in. <a href="/admin/guide#email">Setup guide</a>.
         </p>
-      </div>
+      }
+      id="settings-email"
+      submitLabel="Save Email Settings"
+      title="Email Notifications"
+    >
       <label>
         Email Provider
         <select name="email_provider">
@@ -53,8 +58,7 @@ export const EmailNotificationsForm = (
           value={s.emailFromAddress}
         />
       </label>
-      <SubmitButton icon="save">Save Email Settings</SubmitButton>
-    </CsrfForm>
+    </SettingsSection>
     {s.emailProvider && (
       <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
         <SubmitButton class="secondary" icon="arrow-right">

--- a/src/ui/templates/admin/settings/email.tsx
+++ b/src/ui/templates/admin/settings/email.tsx
@@ -21,7 +21,6 @@ export const EmailNotificationsForm = (
           registrations come in. <a href="/admin/guide#email">Setup guide</a>.
         </p>
       }
-      id="settings-email"
       submitLabel="Save Email Settings"
       title="Email Notifications"
     >

--- a/src/ui/templates/admin/settings/embed-hosts.tsx
+++ b/src/ui/templates/admin/settings/embed-hosts.tsx
@@ -14,7 +14,6 @@ export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
         blank to allow embedding from any site.
       </p>
     }
-    id="settings-embed-hosts"
     submitLabel="Save Embed Hosts"
     title="Only allow embedding on these hosts"
   >

--- a/src/ui/templates/admin/settings/embed-hosts.tsx
+++ b/src/ui/templates/admin/settings/embed-hosts.tsx
@@ -2,19 +2,22 @@
  * Embed Hosts form for settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm action="/admin/settings/embed-hosts" id="settings-embed-hosts">
-    <div class="prose">
-      <h2>Only allow embedding on these hosts</h2>
+  <SettingsSection
+    action="/admin/settings/embed-hosts"
+    description={
       <p>
         Restrict which websites can embed your booking forms in an iframe. Leave
         blank to allow embedding from any site.
       </p>
-    </div>
+    }
+    id="settings-embed-hosts"
+    submitLabel="Save Embed Hosts"
+    title="Only allow embedding on these hosts"
+  >
     <label>
       Hosts (comma-separated)
       <input
@@ -31,6 +34,5 @@ export const EmbedHostsForm = (s: SettingsPageState): JSX.Element => (
         the booking page are always allowed.
       </small>
     </p>
-    <SubmitButton icon="save">Save Embed Hosts</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/google-wallet.tsx
+++ b/src/ui/templates/admin/settings/google-wallet.tsx
@@ -3,14 +3,13 @@
  */
 
 import { MASK_SENTINEL } from "#shared/db/settings.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
-  <CsrfForm action="/admin/settings/google-wallet" id="settings-google-wallet">
-    <div class="prose">
-      <h2>Google Wallet</h2>
+  <SettingsSection
+    action="/admin/settings/google-wallet"
+    description={
       <p>
         Configure Google Wallet to show an &ldquo;Add to Google Wallet&rdquo;
         button on ticket pages. Requires a Google Cloud service account with the
@@ -22,7 +21,11 @@ export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
             ? ` Overriding: ${s.hostGoogleWalletLabel}.`
             : ""}
       </p>
-    </div>
+    }
+    id="settings-google-wallet"
+    submitLabel="Save Google Wallet Settings"
+    title="Google Wallet"
+  >
     <label>
       Issuer ID
       <input
@@ -53,6 +56,5 @@ export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
         {s.googleWalletConfigured ? MASK_SENTINEL : ""}
       </textarea>
     </label>
-    <SubmitButton icon="save">Save Google Wallet Settings</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/google-wallet.tsx
+++ b/src/ui/templates/admin/settings/google-wallet.tsx
@@ -22,7 +22,6 @@ export const GoogleWalletForm = (s: AdvancedSettingsPageState): JSX.Element => (
             : ""}
       </p>
     }
-    id="settings-google-wallet"
     submitLabel="Save Google Wallet Settings"
     title="Google Wallet"
   >

--- a/src/ui/templates/admin/settings/header-image.tsx
+++ b/src/ui/templates/admin/settings/header-image.tsx
@@ -36,7 +36,6 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
           </p>
         }
         enctype="multipart/form-data"
-        id="settings-header-image"
         submitLabel="Upload"
         title="Header Image"
       >

--- a/src/ui/templates/admin/settings/header-image.tsx
+++ b/src/ui/templates/admin/settings/header-image.tsx
@@ -7,6 +7,7 @@ import { formatBytes, MAX_IMAGE_SIZE } from "#shared/limits.ts";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
   s.storageEnabled ? (
@@ -26,18 +27,19 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
           </CsrfForm>
         </div>
       )}
-      <CsrfForm
+      <SettingsSection
         action="/admin/settings/header-image"
-        enctype="multipart/form-data"
-        id="settings-header-image"
-      >
-        <div class="prose">
-          <h2>Header Image</h2>
+        description={
           <p>
             An optional image displayed at the top of every page. JPEG, PNG,
             GIF, or WebP — max {formatBytes(MAX_IMAGE_SIZE)}.
           </p>
-        </div>
+        }
+        enctype="multipart/form-data"
+        id="settings-header-image"
+        submitLabel="Upload"
+        title="Header Image"
+      >
         <label>
           {s.headerImageUrl ? "Replace Image" : "Upload Image"}
           <input
@@ -46,7 +48,6 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
             type="file"
           />
         </label>
-        <SubmitButton icon="save">Upload</SubmitButton>
-      </CsrfForm>
+      </SettingsSection>
     </div>
   ) : null;

--- a/src/ui/templates/admin/settings/public-api.tsx
+++ b/src/ui/templates/admin/settings/public-api.tsx
@@ -2,23 +2,23 @@
  * Public API toggle form for advanced settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/show-public-api"
-    id="settings-show-public-api"
-  >
-    <div class="prose">
-      <h2>Enable public API?</h2>
+    description={
       <p>
         Exposes a JSON API for listing listings, checking availability, and
         creating bookings. See the <a href="/admin/guide#api">API guide</a> for
         details.
       </p>
-    </div>
+    }
+    id="settings-show-public-api"
+    submitLabel="Save"
+    title="Enable public API?"
+  >
     <fieldset class="radios">
       <label>
         <input
@@ -39,6 +39,5 @@ export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
         No
       </label>
     </fieldset>
-    <SubmitButton icon="save">Save</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/public-api.tsx
+++ b/src/ui/templates/admin/settings/public-api.tsx
@@ -15,7 +15,6 @@ export const PublicApiForm = (s: AdvancedSettingsPageState): JSX.Element => (
         details.
       </p>
     }
-    id="settings-show-public-api"
     submitLabel="Save"
     title="Enable public API?"
   >

--- a/src/ui/templates/admin/settings/public-site.tsx
+++ b/src/ui/templates/admin/settings/public-site.tsx
@@ -14,7 +14,6 @@ export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
         for Home, Listings, T&amp;Cs and Contact pages.
       </p>
     }
-    id="settings-show-public-site"
     submitLabel="Save"
     title="Show public site?"
   >

--- a/src/ui/templates/admin/settings/public-site.tsx
+++ b/src/ui/templates/admin/settings/public-site.tsx
@@ -2,22 +2,22 @@
  * Show Public Site form for settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm
+  <SettingsSection
     action="/admin/settings/show-public-site"
-    id="settings-show-public-site"
-  >
-    <div class="prose">
-      <h2>Show public site?</h2>
+    description={
       <p>
         When enabled, the homepage will show a public website with navigation
         for Home, Listings, T&amp;Cs and Contact pages.
       </p>
-    </div>
+    }
+    id="settings-show-public-site"
+    submitLabel="Save"
+    title="Show public site?"
+  >
     <fieldset class="radios">
       <label>
         <input
@@ -38,6 +38,5 @@ export const PublicSiteForm = (s: SettingsPageState): JSX.Element => (
         No
       </label>
     </fieldset>
-    <SubmitButton icon="save">Save</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/terms.tsx
+++ b/src/ui/templates/admin/settings/terms.tsx
@@ -2,19 +2,22 @@
  * Terms and Conditions form for settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 import { FORMATTING_HINT } from "#templates/fields.ts";
 
 export const TermsForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm action="/admin/settings/terms" id="settings-terms">
-    <div class="prose">
-      <h2>Terms and Conditions</h2>
+  <SettingsSection
+    action="/admin/settings/terms"
+    description={
       <p>If set, users must agree to these terms before reserving tickets.</p>
-    </div>
+    }
+    id="settings-terms"
+    submitLabel="Save Terms"
+    title="Terms and Conditions"
+  >
     <label>
       Terms and Conditions
       <p>
@@ -31,6 +34,5 @@ export const TermsForm = (s: SettingsPageState): JSX.Element => (
         {s.termsAndConditions}
       </textarea>
     </label>
-    <SubmitButton icon="save">Save Terms</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/terms.tsx
+++ b/src/ui/templates/admin/settings/terms.tsx
@@ -14,7 +14,6 @@ export const TermsForm = (s: SettingsPageState): JSX.Element => (
     description={
       <p>If set, users must agree to these terms before reserving tickets.</p>
     }
-    id="settings-terms"
     submitLabel="Save Terms"
     title="Terms and Conditions"
   >

--- a/src/ui/templates/admin/settings/theme.tsx
+++ b/src/ui/templates/admin/settings/theme.tsx
@@ -2,16 +2,19 @@
  * Site Theme form for settings
  */
 
-import { CsrfForm } from "#shared/forms.tsx";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const ThemeForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm action="/admin/settings/theme" id="settings-theme">
-    <div class="prose">
-      <h2>Site Theme</h2>
+  <SettingsSection
+    action="/admin/settings/theme"
+    description={
       <p>Choose between light and dark themes for the site interface.</p>
-    </div>
+    }
+    id="settings-theme"
+    submitLabel="Save Theme"
+    title="Site Theme"
+  >
     <fieldset class="radios">
       <label>
         <input
@@ -32,6 +35,5 @@ export const ThemeForm = (s: SettingsPageState): JSX.Element => (
         Dark
       </label>
     </fieldset>
-    <SubmitButton icon="save">Save Theme</SubmitButton>
-  </CsrfForm>
+  </SettingsSection>
 );

--- a/src/ui/templates/admin/settings/theme.tsx
+++ b/src/ui/templates/admin/settings/theme.tsx
@@ -11,7 +11,6 @@ export const ThemeForm = (s: SettingsPageState): JSX.Element => (
     description={
       <p>Choose between light and dark themes for the site interface.</p>
     }
-    id="settings-theme"
     submitLabel="Save Theme"
     title="Site Theme"
   >

--- a/src/ui/templates/components/settings-section.tsx
+++ b/src/ui/templates/components/settings-section.tsx
@@ -15,6 +15,13 @@ import type { Child } from "#jsx/jsx-runtime.ts";
 import { CsrfForm } from "#shared/forms.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
 
+/**
+ * Derive a settings form's id from its POST target, since each settings
+ * endpoint hosts exactly one form: `/admin/settings/foo` -> `settings-foo`.
+ */
+const formIdFromAction = (action: string): string =>
+  `settings-${action.replace("/admin/settings/", "")}`;
+
 export const SettingsSection = ({
   action,
   description,
@@ -29,12 +36,21 @@ export const SettingsSection = ({
   description?: Child;
   /** Set for forms that upload files (e.g. `multipart/form-data`). */
   enctype?: string;
-  id: string;
+  /**
+   * Form id — also the flash-message target and page anchor. Defaults to the
+   * id derived from `action`; pass explicitly only when the id can't be derived
+   * from the post target (e.g. a form posting to the base settings endpoint).
+   */
+  id?: string;
   submitLabel: string;
   title: string;
   children?: Child;
 }): JSX.Element => (
-  <CsrfForm action={action} enctype={enctype} id={id}>
+  <CsrfForm
+    action={action}
+    enctype={enctype}
+    id={id ?? formIdFromAction(action)}
+  >
     <div class="prose">
       <h2>{title}</h2>
       {description}

--- a/src/ui/templates/components/settings-section.tsx
+++ b/src/ui/templates/components/settings-section.tsx
@@ -1,0 +1,45 @@
+/**
+ * Shared wrapper for an admin settings section.
+ *
+ * Every settings form is the same shell: a CSRF-protected POST form whose
+ * heading and intro sit in a `.prose` block, the section's own fields in the
+ * middle, and a single save button at the foot. This captures that skeleton so
+ * each section only declares its `action`, `id`, copy, and fields — passing the
+ * intro paragraph as `description` and the fields as children.
+ *
+ * Sections that don't share the shape (a bare `<h2>`, a button mid-form, a
+ * secondary action in a `<footer>`) keep using {@link CsrfForm} directly.
+ */
+
+import type { Child } from "#jsx/jsx-runtime.ts";
+import { CsrfForm } from "#shared/forms.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
+
+export const SettingsSection = ({
+  action,
+  description,
+  enctype,
+  id,
+  submitLabel,
+  title,
+  children,
+}: {
+  action: string;
+  /** Intro paragraph(s) shown under the heading, inside the `.prose` block. */
+  description?: Child;
+  /** Set for forms that upload files (e.g. `multipart/form-data`). */
+  enctype?: string;
+  id: string;
+  submitLabel: string;
+  title: string;
+  children?: Child;
+}): JSX.Element => (
+  <CsrfForm action={action} enctype={enctype} id={id}>
+    <div class="prose">
+      <h2>{title}</h2>
+      {description}
+    </div>
+    {children}
+    <SubmitButton icon="save">{submitLabel}</SubmitButton>
+  </CsrfForm>
+);

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -535,6 +535,11 @@ describe("code quality", () => {
       "features/utils.ts:withCookie",
       // Reset cache registry between tests
       "shared/cache-registry.ts:resetCacheRegistry",
+      // Request-cache invalidators kept for test cleanup only; in production
+      // writes auto-invalidate through cachedTable's wrapped table, so these
+      // have no production caller (groups/holidays have no raw-SQL writers).
+      "shared/db/groups.ts:invalidateGroupsCache",
+      "shared/db/holidays.ts:invalidateHolidaysCache",
       // Reset cached effective domain between tests
       "shared/config.ts:resetEffectiveDomain",
       "shared/config.ts:setEffectiveDomainForTest",


### PR DESCRIPTION
## What

A pass of large-scale tidying that pulls two repeated patterns into cohesive shared units. No behavioural change — rendered HTML and cache semantics are identical, and precommit (lint, typecheck, cpd, build:edge, **100% coverage**) passes.

## 1. `cachedTable` — DB cache factory

Every cached entity table repeated the same four-step ritual by hand:

```ts
const xCache = requestCache(() => queryX(...));
registerCache(() => ({ entries: xCache.size(), name: "x" }));
export const invalidateXCache = (): void => { xCache.invalidate(); };
export const xTable = withCacheInvalidation(rawXTable, invalidateXCache);
```

`cachedTable` (in `shared/db/table.ts`, alongside `withCacheInvalidation`) bundles all of it:

```ts
const xCache = cachedTable({ fetchAll: () => queryX(...), name: "x", table: rawXTable });
export const xTable = xCache.table;          // writes auto-invalidate
export const getAllX = () => xCache.getAll();
```

`fetchAll` may resolve a richer row type than the table's own row (e.g. listings cached with attendee counts), captured by a `Cached` type param.

Applied to **listings, groups, holidays, attendee-statuses, built-sites**. (`users.ts` keeps its hand-rolled cache — it has no `defineTable`/`withCacheInvalidation` table to wrap.)

Fallout handled honestly:
- `invalidateBuiltSitesCache` had no caller left once the table auto-invalidates, so it's **removed** (dead code).
- `invalidateGroupsCache` / `invalidateHolidaysCache` are still called by `test-utils` for cleanup, so they're kept and added to the `code-quality` test's existing test-hook allowlist (next to `resetCacheRegistry`, `resetSessionCache`, …).

## 2. `SettingsSection` — settings-form wrapper

Every settings form was the same shell — a CSRF POST form with a `.prose` heading/intro and a single save button, only the fields differing:

```tsx
<CsrfForm action=… id=…>
  <div class="prose"><h2>Title</h2><p>Intro…</p></div>
  {/* fields */}
  <SubmitButton icon="save">Save…</SubmitButton>
</CsrfForm>
```

New `templates/components/settings-section.tsx` captures that skeleton; each section now declares only its `action`, `id`, `title`, `description` and fields.

Applied to the **15 sections that share the shape**: country, business-email, terms, theme, public-api, public-site, embed-hosts, change-password, both email templates, both column-order forms, the email main form, the (multipart) header-image upload, and the Apple/Google wallet forms.

Sections with a genuinely different shape (a bare `<h2>`, a button mid-form, a secondary action in a `<footer>`) — superuser, subdomain, custom-domain, payment — keep using `CsrfForm` directly.

## Testing

`deno task precommit` passes end to end:

```
lint … ✓   typecheck … ✓   cpd … ✓   build:edge … ✓   test:coverage … ✓ (100%)
```

https://claude.ai/code/session_01MistCSZBng7hj442P8qcGb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MistCSZBng7hj442P8qcGb)_