### PR TITLE
Scale main horizontal padding fluidly with viewport

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -178,6 +178,10 @@ main {
   display: flex;
   flex-direction: column;
   gap: var(--space-xl);
+  /* Fluid horizontal padding: stays at the small --space-m floor on mobile,
+     eases through ~lg across tablet widths, and caps at the --space-xl
+     ceiling on desktop. Vertical padding stays as set by the base rule. */
+  padding-inline: clamp(var(--space-m), 4.5vw, var(--space-xl));
 }
 
 /* Stack reset: gap controls spacing, not browser default margins */


### PR DESCRIPTION
## What

Give the `main` content area horizontal padding that grows with the viewport — small on mobile, more on tablet, most on desktop — using a single fluid rule:

```css
main {
  padding-inline: clamp(var(--space-m), 4.5vw, var(--space-xl));
}
```

| Viewport | Horizontal padding |
| --- | --- |
| Mobile (small phones) | `--space-m` (1rem) — the clamp floor |
| Tablet (~768–1024px) | eases through ~`--space-lg` (2rem) |
| Desktop (≥ ~1440px) | `--space-xl` (4rem) — the clamp ceiling |

Vertical padding and the `header`/`footer` (which share the base rule) are unchanged — only `main`'s left/right padding scales.

## Why this approach (no new breakpoints)

The original idea used stepped `@media` queries, which would have meant inventing a new `1024px` tablet↔desktop breakpoint — the stylesheet only has a single real breakpoint (`768/769px`) plus two component one-offs (`650px`, `480px`), and no `1024px` tier anywhere. Rather than add a single-use breakpoint, this uses a fluid `clamp()`, which:

- **Adds zero breakpoints** — nothing new to keep in sync.
- **Matches existing idioms** — the stylesheet already uses `min()` (3×) and `padding-inline` (line 861) for responsive sizing without media queries; `clamp()` is the same family.
- Scales smoothly instead of snapping at hard cutoffs.

Trade-off vs. discrete steps: padding transitions smoothly, so a large phone gets slightly more than the bare minimum and a mid-size desktop sits just under the full `xl` cap — the cost of going fluid instead of stepped.

## Testing

- `deno task lint` (Biome) — passes, no reformatting.
- `deno test test/lib/server-public.test.ts` — `server (public routes)` suite passes (293 steps), including the `GET /mvp.css` serving tests.

https://claude.ai/code/session_01NBFngtviyybHM8ffDMj8Yw