### PR TITLE
Hide scroll nav only after scrolling past it

### DIFF
--- a/src/ui/client/admin/scroll-hide-nav.ts
+++ b/src/ui/client/admin/scroll-hide-nav.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
-/** Scroll-hide nav: hide sticky main nav on scroll down, show on scroll up or at top. */
+/** Scroll-hide nav: hide sticky main nav on scroll down once it has been
+ * scrolled past, show on scroll up or while still within its natural area. */
 export const initScrollHideNav = (): void => {
   const nav = document.querySelector<HTMLElement>("#main-nav");
   if (!nav) return;
@@ -19,7 +20,11 @@ export const initScrollHideNav = (): void => {
       ticking = true;
       requestAnimationFrame(() => {
         const y = scrollY;
-        nav.classList.toggle("nav-hidden", y > 0 && y > lastY);
+        // Only hide once scrolled past the nav's natural position, so it
+        // slides away while already off-screen rather than visibly flying
+        // off the top while the user is still near the top of the page.
+        const navBottom = nav.offsetTop + nav.offsetHeight;
+        nav.classList.toggle("nav-hidden", y > navBottom && y > lastY);
         lastY = y;
         ticking = false;
       });


### PR DESCRIPTION
## Problem

The sticky admin nav (`#main-nav`, `position: sticky; top: 1rem` on desktop) flew off the top of the screen as soon as you started scrolling down, even when it was still fully visible near the top of the page.

The cause was in `scroll-hide-nav.ts`, which hid the nav on any downward scroll past a single pixel:

```js
nav.classList.toggle("nav-hidden", y > 0 && y > lastY);
```

Because the nav is sticky and pinned at the top, hiding it that early produced a jarring "fly off" while it was still in view.

## Fix

Gate hiding on the scroll position having passed the nav's natural bottom edge in document coordinates (`nav.offsetTop + nav.offsetHeight`):

```js
const navBottom = nav.offsetTop + nav.offsetHeight;
nav.classList.toggle("nav-hidden", y > navBottom && y > lastY);
```

Now the nav stays put while you're still within its natural area, and only slides away on continued downward scrolling once it would already be out of view — while still reappearing on scroll up, as before.

`main` is statically positioned, so the nav's `offsetParent` is `<body>` (margin/padding `0`), making `offsetTop` a true document-top offset. Sticky positioning is a paint-time shift and doesn't affect `offsetTop`/`offsetHeight`, so the threshold stays correct as you scroll.

## Verification

- `deno task typecheck` — passes
- Biome `check` on the changed file — clean
- `deno task build:static` — bundles successfully (new logic present in `admin.js`)

This module is browser-only client code (DOM globals) and is not imported by any test, so it falls outside the coverage-enforced set, consistent with the other `src/ui/client/admin/*` behaviors.

https://claude.ai/code/session_01AscKmrcXWzQwWgYETMXZJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AscKmrcXWzQwWgYETMXZJV)_