### PR TITLE
Expand /admin/debug with site, availability, payment mode, and schema info

### DIFF
--- a/src/features/admin/debug.ts
+++ b/src/features/admin/debug.ts
@@ -14,15 +14,24 @@ import { getCdnHostname } from "#shared/bunny-cdn.ts";
 import {
   getBunnyDnsSubdomainSuffix,
   getEffectiveDomain,
+  isBotpoisonEnabled,
   isBunnyCdnEnabled,
   isBunnyDnsEnabled,
   isPaymentsEnabled,
 } from "#shared/config.ts";
+import { SCHEMA_HASH } from "#shared/db/migrations.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getHostEmailConfig } from "#shared/email.ts";
-import { getEnv } from "#shared/env.ts";
+import {
+  getEnv,
+  getReadOnlyCutoffIso,
+  getRenewalUrl,
+  isReadOnly,
+  isReadOnlyWarning,
+} from "#shared/env.ts";
 import { isValidGooglePrivateKey } from "#shared/google-wallet.ts";
 import { LIMIT_ENTRIES } from "#shared/limits.ts";
+import { nowIso } from "#shared/now.ts";
 import { getRuntimeInfo } from "#shared/runtime.ts";
 import { getStorageBackend } from "#shared/storage.ts";
 import {
@@ -105,6 +114,32 @@ const webhookConfiguredFor = (provider: string | null): boolean => {
   return false;
 };
 
+/** Map a `sk_test_`/`sk_live_` key mode to a display label; "" if unrecognized. */
+const paymentModeLabel = (mode: "test" | "live" | null): string =>
+  mode === "live" ? "Live" : mode === "test" ? "Test" : "";
+
+/**
+ * Resolve the active payment provider's environment (Test/Live/Sandbox) for
+ * display. Derived from the key prefix (Stripe/SumUp) or the sandbox flag
+ * (Square) — never exposes the key itself.
+ */
+const resolvePaymentMode = (provider: string | null): string => {
+  if (provider === "stripe") return paymentModeLabel(settings.stripe.keyMode);
+  if (provider === "sumup") return paymentModeLabel(settings.sumup.keyMode);
+  if (provider === "square") {
+    return settings.square.sandbox ? "Sandbox" : "Live";
+  }
+  return "";
+};
+
+/** Resolve the site's write-access state from the read-only env flags. */
+const resolveAvailabilityState =
+  (): DebugPageState["availability"]["state"] => {
+    if (isReadOnly()) return "readonly";
+    if (isReadOnlyWarning()) return "warning";
+    return "active";
+  };
+
 /** Gather debug state concurrently */
 const getDebugPageState = async (): Promise<DebugPageState> => {
   const bunnyCdnEnabled = isBunnyCdnEnabled();
@@ -127,6 +162,12 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
         appleWalletEnvConfigured,
       ),
     },
+    availability: {
+      cutoff: getReadOnlyCutoffIso() ?? "",
+      renewalConfigured: getRenewalUrl() !== null,
+      serverTime: nowIso(),
+      state: resolveAvailabilityState(),
+    },
     build: {
       commit: BUILD_COMMIT,
       timestamp: BUILD_TIMESTAMP,
@@ -142,6 +183,8 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     },
     database: {
       hostConfigured: !!getEnv("DB_URL"),
+      schemaHash: SCHEMA_HASH,
+      schemaInSync: settings.getCachedRaw("db_schema_hash") === SCHEMA_HASH,
     },
     domain: getEffectiveDomain(),
     email: {
@@ -168,6 +211,7 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
     },
     payment: {
       keyConfigured: isPaymentsEnabled(),
+      mode: resolvePaymentMode(paymentProvider),
       provider: paymentProvider ?? "",
       webhookConfigured: webhookConfiguredFor(paymentProvider),
     },
@@ -177,6 +221,16 @@ const getDebugPageState = async (): Promise<DebugPageState> => {
       sessions: formatLastPruned(settings.lastPrunedSessions),
     },
     runtime: getRuntimeInfo(),
+    site: {
+      bookingFee: settings.bookingFee,
+      contactForm: settings.contactFormEnabled,
+      country: settings.country,
+      currency: settings.currency,
+      publicApi: settings.showPublicApi,
+      publicSite: settings.showPublicSite,
+      spamProtection: isBotpoisonEnabled(),
+      timezone: settings.timezone,
+    },
     theme: settings.theme,
   };
 };

--- a/src/ui/templates/admin/debug.tsx
+++ b/src/ui/templates/admin/debug.tsx
@@ -31,6 +31,23 @@ export type DebugPageState = {
     provider: string;
     keyConfigured: boolean;
     webhookConfigured: boolean;
+    mode: string;
+  };
+  site: {
+    publicSite: boolean;
+    publicApi: boolean;
+    contactForm: boolean;
+    spamProtection: boolean;
+    country: string;
+    currency: string;
+    timezone: string;
+    bookingFee: string;
+  };
+  availability: {
+    state: "active" | "warning" | "readonly";
+    cutoff: string;
+    renewalConfigured: boolean;
+    serverTime: string;
   };
   email: {
     provider: string;
@@ -52,6 +69,8 @@ export type DebugPageState = {
   };
   database: {
     hostConfigured: boolean;
+    schemaInSync: boolean;
+    schemaHash: string;
   };
   build: {
     timestamp: string;
@@ -73,6 +92,22 @@ const StatusBadge = ({ ok }: { ok: boolean }): JSX.Element =>
     <span class="badge-ok">Configured</span>
   ) : (
     <span class="badge-missing">Not configured</span>
+  );
+
+/** Badge with caller-chosen labels for a two-state (on/off) value. */
+const OnOffBadge = ({
+  on,
+  onLabel,
+  offLabel,
+}: {
+  on: boolean;
+  onLabel: string;
+  offLabel: string;
+}): JSX.Element =>
+  on ? (
+    <span class="badge-ok">{onLabel}</span>
+  ) : (
+    <span class="badge-missing">{offLabel}</span>
   );
 
 const BuildSection = ({
@@ -240,6 +275,10 @@ const PaymentsSection = ({
           <td>{payment.provider || "None"}</td>
         </tr>
         <tr>
+          <td>Mode</td>
+          <td>{payment.mode || "—"}</td>
+        </tr>
+        <tr>
           <td>API key</td>
           <td>
             <StatusBadge ok={payment.keyConfigured} />
@@ -302,6 +341,120 @@ const NtfySection = ({
           <td>
             <StatusBadge ok={ntfy.configured} />
           </td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const SiteSection = ({
+  site,
+}: {
+  site: DebugPageState["site"];
+}): JSX.Element => (
+  <article>
+    <h2>Site</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>Public site</td>
+          <td>
+            <OnOffBadge
+              offLabel="Hidden"
+              on={site.publicSite}
+              onLabel="Visible"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>Public API</td>
+          <td>
+            <OnOffBadge
+              offLabel="Disabled"
+              on={site.publicApi}
+              onLabel="Enabled"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>Contact form</td>
+          <td>
+            <OnOffBadge
+              offLabel="Disabled"
+              on={site.contactForm}
+              onLabel="Enabled"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>Spam protection</td>
+          <td>
+            <StatusBadge ok={site.spamProtection} />
+          </td>
+        </tr>
+        <tr>
+          <td>Country</td>
+          <td>{site.country || "—"}</td>
+        </tr>
+        <tr>
+          <td>Currency</td>
+          <td>{site.currency || "—"}</td>
+        </tr>
+        <tr>
+          <td>Timezone</td>
+          <td>{site.timezone || "—"}</td>
+        </tr>
+        <tr>
+          <td>Booking fee</td>
+          <td>{site.bookingFee}%</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+);
+
+const AvailabilityStateBadge = ({
+  state,
+}: {
+  state: DebugPageState["availability"]["state"];
+}): JSX.Element => {
+  if (state === "readonly") {
+    return <span class="badge-missing">Read-only</span>;
+  }
+  if (state === "warning") {
+    return <span class="badge-missing">Expiring soon</span>;
+  }
+  return <span class="badge-ok">Active</span>;
+};
+
+const AvailabilitySection = ({
+  availability,
+}: {
+  availability: DebugPageState["availability"];
+}): JSX.Element => (
+  <article>
+    <h2>Availability</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td>Write access</td>
+          <td>
+            <AvailabilityStateBadge state={availability.state} />
+          </td>
+        </tr>
+        <tr>
+          <td>Read-only from</td>
+          <td>{availability.cutoff || "—"}</td>
+        </tr>
+        <tr>
+          <td>Renewal URL</td>
+          <td>
+            <StatusBadge ok={availability.renewalConfigured} />
+          </td>
+        </tr>
+        <tr>
+          <td>Server time (UTC)</td>
+          <td>{availability.serverTime}</td>
         </tr>
       </tbody>
     </table>
@@ -388,6 +541,22 @@ const DatabaseDomainSection = ({
         <tr>
           <td>Effective domain</td>
           <td>{domain}</td>
+        </tr>
+        <tr>
+          <td>Schema status</td>
+          <td>
+            <OnOffBadge
+              offLabel="Out of sync"
+              on={database.schemaInSync}
+              onLabel="Up to date"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>Schema hash</td>
+          <td>
+            <code>{database.schemaHash}</code>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -506,6 +675,8 @@ export const adminDebugPage = (
 
       <BuildSection build={s.build} />
       <RuntimeSection runtime={s.runtime} />
+      <SiteSection site={s.site} />
+      <AvailabilitySection availability={s.availability} />
       <AppleWalletSection appleWallet={s.appleWallet} />
       <GoogleWalletSection googleWallet={s.googleWallet} />
       <PaymentsSection payment={s.payment} />

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
+import { SCHEMA_HASH } from "#shared/db/migrations.ts";
 import { settings } from "#shared/db/settings.ts";
 import { LIMIT_ENTRIES } from "#shared/limits.ts";
 import { getRuntimeInfo } from "#shared/runtime.ts";
@@ -20,6 +21,87 @@ import {
   generateGoogleTestCreds,
   generateTestCerts,
 } from "#test-utils/crypto.ts";
+
+/** Build a complete DebugPageState, overriding only the fields a test cares about. */
+const makeDebugState = (
+  overrides: Partial<DebugPageState> = {},
+): DebugPageState => ({
+  appleWallet: {
+    certValidation: {
+      signingCert: "Not set",
+      signingKey: "Not set",
+      wwdrCert: "Not set",
+    },
+    dbConfigured: false,
+    envConfigured: false,
+    passTypeId: "",
+    source: "",
+  },
+  availability: {
+    cutoff: "",
+    renewalConfigured: false,
+    serverTime: "1970-01-01T00:00:00.000Z",
+    state: "active",
+  },
+  build: { commit: "", timestamp: "" },
+  bunny: {
+    cdnEnabled: false,
+    cdnHostname: "",
+    customDomain: "",
+    dnsEnabled: false,
+    registeredSubdomain: "",
+    storageBackend: "none",
+    subdomainSuffix: "",
+  },
+  database: { hostConfigured: false, schemaHash: "", schemaInSync: false },
+  domain: "localhost",
+  email: {
+    apiKeyConfigured: false,
+    fromAddress: "",
+    hostProvider: "",
+    provider: "",
+  },
+  googleWallet: {
+    dbConfigured: false,
+    envConfigured: false,
+    issuerId: "",
+    privateKeyValid: "Not set",
+    source: "",
+  },
+  limits: [],
+  ntfy: { configured: false },
+  payment: {
+    keyConfigured: false,
+    mode: "",
+    provider: "",
+    webhookConfigured: false,
+  },
+  prune: { logins: "Never", payments: "Never", sessions: "Never" },
+  runtime: {
+    arch: "",
+    denoVersion: "",
+    nodeCompatVersion: "",
+    os: "",
+    runtime: "unknown",
+    typescriptVersion: "",
+    userAgent: "",
+    v8Version: "",
+  },
+  site: {
+    bookingFee: "0",
+    contactForm: false,
+    country: "",
+    currency: "",
+    publicApi: false,
+    publicSite: false,
+    spamProtection: false,
+    timezone: "",
+  },
+  theme: "light",
+  ...overrides,
+});
+
+const ownerSession = { adminLevel: "owner" as const };
 
 describeWithEnv("server (admin debug)", { db: true }, () => {
   describe("GET /admin/debug", () => {
@@ -156,6 +238,25 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
       });
       await assertAdminHtml("/admin/debug", "stripe", "Configured");
     });
+
+    test("shows Test mode for a test-prefixed key without leaking it", async () => {
+      await settings.update.paymentProvider("stripe");
+      await settings.update.stripe.secretKey("sk_test_fake");
+      const html = await assertAdminHtml("/admin/debug", "Mode", "Test");
+      expect(html).not.toContain("sk_test_fake");
+    });
+
+    test("shows Live mode for a live-prefixed key", async () => {
+      await settings.update.paymentProvider("stripe");
+      await settings.update.stripe.secretKey("sk_live_fake");
+      const html = await assertAdminHtml("/admin/debug", "Live");
+      expect(html).not.toContain("sk_live_fake");
+    });
+
+    test("shows an em dash for mode when no key is set", async () => {
+      await settings.update.paymentProvider("stripe");
+      await assertAdminHtml("/admin/debug", "stripe", "Mode", "—");
+    });
   });
 
   describe("GET /admin/debug with Square configured", () => {
@@ -163,6 +264,17 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
       await settings.update.paymentProvider("square");
       await settings.update.square.webhookSignatureKey("sig_fake");
       await assertAdminHtml("/admin/debug", "square");
+    });
+
+    test("shows Live mode when sandbox is disabled", async () => {
+      await settings.update.paymentProvider("square");
+      await assertAdminHtml("/admin/debug", "square", "Mode", "Live");
+    });
+
+    test("shows Sandbox mode when sandbox is enabled", async () => {
+      await settings.update.paymentProvider("square");
+      await settings.update.square.sandbox(true);
+      await assertAdminHtml("/admin/debug", "square", "Mode", "Sandbox");
     });
   });
 
@@ -172,6 +284,12 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
       await settings.update.sumup.apiKey("sk_test_fake");
       await settings.update.sumup.merchantCode("MC_fake");
       await assertAdminHtml("/admin/debug", "sumup", "Configured");
+    });
+
+    test("shows Test mode for a test-prefixed SumUp key", async () => {
+      await settings.update.paymentProvider("sumup");
+      await settings.update.sumup.apiKey("sk_test_fake");
+      await assertAdminHtml("/admin/debug", "sumup", "Mode", "Test");
     });
   });
 
@@ -382,19 +500,7 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     });
 
     test("shows registered subdomain when set", () => {
-      const state: DebugPageState = {
-        appleWallet: {
-          certValidation: {
-            signingCert: "Not set",
-            signingKey: "Not set",
-            wwdrCert: "Not set",
-          },
-          dbConfigured: false,
-          envConfigured: false,
-          passTypeId: "",
-          source: "",
-        },
-        build: { commit: "", timestamp: "" },
+      const state = makeDebugState({
         bunny: {
           cdnEnabled: false,
           cdnHostname: "",
@@ -404,45 +510,122 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
           storageBackend: "none",
           subdomainSuffix: ".tickets",
         },
-        database: { hostConfigured: false },
-        domain: "localhost",
-        email: {
-          apiKeyConfigured: false,
-          fromAddress: "",
-          hostProvider: "",
-          provider: "",
-        },
-        googleWallet: {
-          dbConfigured: false,
-          envConfigured: false,
-          issuerId: "",
-          privateKeyValid: "Not set",
-          source: "",
-        },
-        limits: [],
-        ntfy: { configured: false },
-        payment: {
-          keyConfigured: false,
-          provider: "",
-          webhookConfigured: false,
-        },
-        prune: { logins: "Never", payments: "Never", sessions: "Never" },
-        runtime: {
-          arch: "",
-          denoVersion: "",
-          nodeCompatVersion: "",
-          os: "",
-          runtime: "unknown",
-          typescriptVersion: "",
-          userAgent: "",
-          v8Version: "",
-        },
-        theme: "light",
-      };
-      const session = { adminLevel: "owner" as const };
-      const html = adminDebugPage(session, state);
+      });
+      const html = adminDebugPage(ownerSession, state);
       expect(html).toContain("mylisting.example.com");
       expect(html).toContain(".tickets");
+    });
+  });
+
+  describe("Site section", () => {
+    test("shows site configuration rows with values from setup", async () => {
+      await assertAdminHtml(
+        "/admin/debug",
+        "Site",
+        "Public site",
+        "Public API",
+        "Contact form",
+        "Spam protection",
+        "Country",
+        "Currency",
+        "Timezone",
+        "Booking fee",
+        "GBP",
+        "UTC",
+        "0%",
+      );
+    });
+
+    test("shows Hidden/Disabled badges when features are off", async () => {
+      await assertAdminHtml("/admin/debug", "Hidden", "Disabled");
+    });
+
+    test("shows Visible/Enabled badges and the booking fee when features are on", async () => {
+      await Promise.all([
+        settings.update.showPublicSite(true),
+        settings.update.showPublicApi(true),
+        settings.update.contactFormEnabled(true),
+        settings.update.bookingFee("2.5"),
+      ]);
+      await assertAdminHtml("/admin/debug", "Visible", "Enabled", "2.5%");
+    });
+  });
+
+  describe("Site section with spam protection configured", () => {
+    let restoreEnv: () => void;
+
+    afterEach(() => restoreEnv());
+
+    test("shows spam protection as configured when Botpoison keys are set", async () => {
+      restoreEnv = setTestEnv({
+        BOTPOISON_PUBLIC_KEY: "test-public",
+        BOTPOISON_SECRET_KEY: "test-secret",
+      });
+      await assertAdminHtml("/admin/debug", "Spam protection", "Configured");
+    });
+  });
+
+  describe("Availability section", () => {
+    test("shows Active write access by default", async () => {
+      await assertAdminHtml(
+        "/admin/debug",
+        "Availability",
+        "Write access",
+        "Active",
+        "Read-only from",
+        "Renewal URL",
+        "Server time (UTC)",
+      );
+    });
+  });
+
+  describe("Availability section with read-only mode", () => {
+    let restoreEnv: () => void;
+
+    afterEach(() => restoreEnv());
+
+    test("shows Read-only state, the cutoff, and the renewal badge", async () => {
+      restoreEnv = setTestEnv({
+        READ_ONLY_FROM: "2000-01-01T00:00:00Z",
+        RENEWAL_URL: "https://example.com/renew",
+      });
+      await assertAdminHtml(
+        "/admin/debug",
+        "Read-only",
+        "2000-01-01T00:00:00Z",
+        "Configured",
+      );
+    });
+
+    test("shows Expiring soon when within the warning window", async () => {
+      const soon = new Date(Date.now() + 3 * 86_400_000).toISOString();
+      restoreEnv = setTestEnv({ READ_ONLY_FROM: soon });
+      await assertAdminHtml("/admin/debug", "Expiring soon");
+    });
+  });
+
+  describe("Database schema section", () => {
+    test("shows the schema hash and an up-to-date status", async () => {
+      await assertAdminHtml(
+        "/admin/debug",
+        "Schema status",
+        "Up to date",
+        "Schema hash",
+        SCHEMA_HASH,
+      );
+    });
+
+    test("shows Out of sync and the hash when markers do not match", () => {
+      const state = makeDebugState({
+        database: {
+          hostConfigured: true,
+          schemaHash: "deadbeef",
+          schemaInSync: false,
+        },
+      });
+      const html = adminDebugPage(ownerSession, state);
+      expect(html).toContain("Out of sync");
+      expect(html).toContain("deadbeef");
     });
   });
 
@@ -469,43 +652,7 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
     });
 
     test("shows overridden indicator when current differs from default", () => {
-      const state: DebugPageState = {
-        appleWallet: {
-          certValidation: {
-            signingCert: "Not set",
-            signingKey: "Not set",
-            wwdrCert: "Not set",
-          },
-          dbConfigured: false,
-          envConfigured: false,
-          passTypeId: "",
-          source: "",
-        },
-        build: { commit: "", timestamp: "" },
-        bunny: {
-          cdnEnabled: false,
-          cdnHostname: "",
-          customDomain: "",
-          dnsEnabled: false,
-          registeredSubdomain: "",
-          storageBackend: "none",
-          subdomainSuffix: "",
-        },
-        database: { hostConfigured: false },
-        domain: "localhost",
-        email: {
-          apiKeyConfigured: false,
-          fromAddress: "",
-          hostProvider: "",
-          provider: "",
-        },
-        googleWallet: {
-          dbConfigured: false,
-          envConfigured: false,
-          issuerId: "",
-          privateKeyValid: "Not set",
-          source: "",
-        },
+      const state = makeDebugState({
         limits: [
           {
             current: 200,
@@ -515,27 +662,8 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
             unit: "bytes",
           },
         ],
-        ntfy: { configured: false },
-        payment: {
-          keyConfigured: false,
-          provider: "",
-          webhookConfigured: false,
-        },
-        prune: { logins: "Never", payments: "Never", sessions: "Never" },
-        runtime: {
-          arch: "",
-          denoVersion: "",
-          nodeCompatVersion: "",
-          os: "",
-          runtime: "unknown",
-          typescriptVersion: "",
-          userAgent: "",
-          v8Version: "",
-        },
-        theme: "light",
-      };
-      const session = { adminLevel: "owner" as const };
-      const html = adminDebugPage(session, state);
+      });
+      const html = adminDebugPage(ownerSession, state);
       expect(html).toContain("200B");
       expect(html).toContain("(overridden)");
     });


### PR DESCRIPTION
## Summary

Makes `/admin/debug` more useful for troubleshooting a live deployment, while keeping its "No secrets or keys are shown" guarantee intact. All additions are derived/boolean/identifier values — no keys, tokens, or full URLs.

### What's new

**Payments → Mode** — shows the active provider's environment: **Test / Live / Sandbox**, derived from the key prefix (Stripe/SumUp) or the Square sandbox flag. The key itself is never rendered. This is the most common payment misconfiguration (a test key left in production), previously invisible on the page.

**New "Site" section** — public-site visibility, public API, contact form, spam-protection (Botpoison) status, country, currency, timezone, and booking fee. These are all observable/public values, surfaced in one place for "why is X behaving oddly" questions (e.g. wrong timezone on bookings).

**New "Availability" section** — write-access state (Active / Expiring soon / Read-only), the read-only cutoff date, whether a renewal URL is configured, and the server's current UTC time. The renewal URL carries a per-site token, so only a **Configured/Not configured** badge is shown — never the URL. Server time pairs with the cutoff to debug clock/expiry issues.

**Database → schema status + hash** — confirms the live schema matches the deployed code, read from the already-loaded settings snapshot (zero extra queries).

### Why these are safe to show

| Field | Source | Sensitive? |
| --- | --- | --- |
| Payment mode | `sk_test_`/`sk_live_` prefix, Square sandbox flag | No — classification only, key not shown |
| Site config | public toggles, country/currency/timezone, booking fee | No — all publicly observable |
| Renewal URL | `getRenewalUrl() !== null` | No — badge only; URL (with token) withheld |
| Read-only cutoff / server time | dates | No |
| Schema hash | djb2 of the schema definition | No — code-level value |

### Tests

- Added integration coverage for every new section/branch (payment modes for Stripe/SumUp/Square incl. test/live/sandbox/unset, read-only & warning states, schema sync, site toggles, Botpoison).
- New assertions confirm the underlying key is **not** leaked when showing payment mode.
- Replaced the two large inline `DebugPageState` literals in the tests with a shared `makeDebugState` factory, so future fields only change one place.
- `deno task precommit` passes: lint, typecheck, cpd (0 clones), build:edge, and full `test:coverage` at 100% (debug source files 100% branch/function/line).

https://claude.ai/code/session_01GaRCae6YmU3adyq3kErVPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaRCae6YmU3adyq3kErVPR)_