### PR TITLE
Rework edit attendee page around a read-only summary

### DIFF
--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -42,7 +42,6 @@ import { applyFlash } from "#routes/csrf.ts";
 import { htmlResponse, notFoundResponse, redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { getSearchParam } from "#routes/url.ts";
-import { getEffectiveDomain } from "#shared/config.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
 import { getAttendeeActivityLog, logActivity } from "#shared/db/activityLog.ts";
 import { getAllAttendeeStatuses } from "#shared/db/attendee-statuses.ts";
@@ -262,7 +261,6 @@ const buildTemplateData = async (
   return {
     activityLog,
     allListings,
-    allowedDomain: getEffectiveDomain(),
     attendee,
     attendeeError: opts.attendeeError ?? null,
     availableDatesByListing,

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -42,8 +42,9 @@ import { applyFlash } from "#routes/csrf.ts";
 import { htmlResponse, notFoundResponse, redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { getSearchParam } from "#routes/url.ts";
+import { getEffectiveDomain } from "#shared/config.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
-import { logActivity } from "#shared/db/activityLog.ts";
+import { getAttendeeActivityLog, logActivity } from "#shared/db/activityLog.ts";
 import { getAllAttendeeStatuses } from "#shared/db/attendee-statuses.ts";
 import { getAttendeeOrderSummary } from "#shared/db/attendees/balance.ts";
 import {
@@ -219,6 +220,10 @@ const buildEditFormFromAttendee = (
   };
 };
 
+/** How many of an attendee's activity-log entries to show on the edit page.
+ * High enough to be "all of them" for any real attendee. */
+const ATTENDEE_LOG_LIMIT = 1000;
+
 /** Build the template data for re-rendering the form. */
 const buildTemplateData = async (
   mode: "create" | "edit",
@@ -249,8 +254,15 @@ const buildTemplateData = async (
     summary?.fullPrice ?? 0,
     summary?.depositPaid ?? 0,
   );
+  // The read-only summary (detail table + activity log) is edit-only; create
+  // mode has no attendee to summarise yet.
+  const activityLog = attendee
+    ? await getAttendeeActivityLog(attendee.id, ATTENDEE_LOG_LIMIT)
+    : [];
   return {
+    activityLog,
     allListings,
+    allowedDomain: getEffectiveDomain(),
     attendee,
     attendeeError: opts.attendeeError ?? null,
     availableDatesByListing,
@@ -262,7 +274,8 @@ const buildTemplateData = async (
     flashSuccess: opts.flashSuccess,
     mode,
     parsed,
-    questions: opts.questions,
+    phonePrefix: settings.phonePrefix,
+    questions: opts.questions ?? [],
     returnUrl: opts.returnUrl,
     selectedAnswerIds: opts.selectedAnswerIds ?? [],
     statuses,
@@ -615,9 +628,13 @@ const applyCreate = async (
   // input.bookings is non-empty (guarded above) and every booking comes from a
   // fillable line, so its listing id is always present — no re-scan needed.
   const firstListingId = input.bookings[0]!.listingId;
-  await logActivity(`Attendee '${parsed.name}' added manually`, firstListingId);
-
   const newId = attendees[0]!.id;
+  await logActivity(
+    `Attendee '${parsed.name}' added manually`,
+    firstListingId,
+    newId,
+  );
+
   return {
     ok: true,
     response: savedRedirect(newId, parsed.returnUrl, `Added ${parsed.name}`),
@@ -675,7 +692,11 @@ const applyEdit = async (
   }
 
   const firstListingId = desired[0]?.listingId;
-  await logActivity(`Attendee '${parsed.name}' updated`, firstListingId);
+  await logActivity(
+    `Attendee '${parsed.name}' updated`,
+    firstListingId,
+    attendeeId,
+  );
   return {
     ok: true,
     response: savedRedirect(

--- a/src/shared/phone.ts
+++ b/src/shared/phone.ts
@@ -18,3 +18,25 @@ export const normalizePhone = (phone: string, prefix: string): string => {
   // Already has country code without leading zero: 44161... → +44161...
   return `+${digits}`;
 };
+
+/** A clickable phone number's `tel:` and WhatsApp (`wa.me`) hrefs. */
+export type PhoneLinks = { tel: string; whatsapp: string };
+
+/**
+ * Build `tel:` and `wa.me` hrefs for a phone number, or null when the number
+ * has no digits. The prefix is the country dialling code (e.g. "44"); a
+ * leading "+" is tolerated so a settings value of either "44" or "+44" works.
+ * WhatsApp's wa.me wants the international number with no leading "+".
+ */
+export const phoneLinks = (
+  phone: string,
+  prefix: string,
+): PhoneLinks | null => {
+  const normalized = normalizePhone(phone, prefix.replace(/^\+/, ""));
+  if (!normalized) return null;
+  return {
+    tel: `tel:${normalized}`,
+    // normalized always starts with "+", which wa.me must not include.
+    whatsapp: `https://wa.me/${normalized.slice(1)}`,
+  };
+};

--- a/src/ui/templates/admin/activityLog.tsx
+++ b/src/ui/templates/admin/activityLog.tsx
@@ -53,6 +53,31 @@ const activityLogRows = (entries: ActivityLogEntry[]): string =>
     : '<tr><td colspan="2">No activity recorded yet</td></tr>';
 
 /**
+ * The Time/Activity log table, scrollable on narrow screens. Shared by the
+ * listing and global log pages and the per-attendee log section so every
+ * activity log renders identically.
+ */
+export const ActivityLogTable = ({
+  entries,
+}: {
+  entries: ActivityLogEntry[];
+}): JSX.Element => (
+  <div class="table-scroll">
+    <table>
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Activity</th>
+        </tr>
+      </thead>
+      <tbody>
+        <Raw html={activityLogRows(entries)} />
+      </tbody>
+    </table>
+  </div>
+);
+
+/**
  * Admin activity log page for a specific listing
  */
 export const adminListingActivityLogPage = (
@@ -69,19 +94,7 @@ export const adminListingActivityLogPage = (
           Activity log guide
         </GuideLink>
       </p>
-      <div class="table-scroll">
-        <table>
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Activity</th>
-            </tr>
-          </thead>
-          <tbody>
-            <Raw html={activityLogRows(entries)} />
-          </tbody>
-        </table>
-      </div>
+      <ActivityLogTable entries={entries} />
     </Layout>,
   );
 
@@ -101,19 +114,7 @@ export const adminGlobalActivityLogPage = (
           Activity log guide
         </GuideLink>
       </p>
-      <div class="table-scroll">
-        <table>
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Activity</th>
-            </tr>
-          </thead>
-          <tbody>
-            <Raw html={activityLogRows(entries)} />
-          </tbody>
-        </table>
-      </div>
+      <ActivityLogTable entries={entries} />
       {truncated && <p>Showing the most recent 200 entries.</p>}
     </Layout>,
   );

--- a/src/ui/templates/admin/attendee-detail.tsx
+++ b/src/ui/templates/admin/attendee-detail.tsx
@@ -72,11 +72,9 @@ const PhoneCell = ({
  */
 export const AttendeeDetail = ({
   attendee,
-  allowedDomain,
   phonePrefix,
 }: {
   attendee: Attendee;
-  allowedDomain: string;
   phonePrefix: string;
 }): JSX.Element => {
   const rows = compact([
@@ -102,9 +100,7 @@ export const AttendeeDetail = ({
       </DetailTableRow>
     ) : null,
     <DetailTableRow label="Ticket">
-      <a href={`https://${allowedDomain}/t/${attendee.ticket_token}`}>
-        {attendee.ticket_token}
-      </a>
+      <a href={`/t/${attendee.ticket_token}`}>{attendee.ticket_token}</a>
     </DetailTableRow>,
     <DetailTableRow label="Registered">
       {formatDatetimeShort(attendee.created)}

--- a/src/ui/templates/admin/attendee-detail.tsx
+++ b/src/ui/templates/admin/attendee-detail.tsx
@@ -1,0 +1,173 @@
+/**
+ * Read-only attendee views shown at the top of the edit attendee page.
+ *
+ * `AttendeeDetail` is the single-attendee counterpart to the multi-attendee
+ * `AttendeeTable`: instead of one row per attendee it lays a single attendee's
+ * details out vertically as a key/value table. `AttendeeAnswersTable` renders
+ * the attendee's custom-question answers, and `AttendeeLogSection` wraps the
+ * shared activity-log table (filtered to this attendee) in a collapsed
+ * details/summary disclosure.
+ */
+
+import { compact } from "#fp";
+import { formatDatetimeShort } from "#shared/dates.ts";
+import type { ActivityLogEntry } from "#shared/db/activityLog.ts";
+import type { QuestionWithAnswers } from "#shared/db/questions.ts";
+import type { Child } from "#shared/jsx/jsx-runtime.ts";
+import { phoneLinks } from "#shared/phone.ts";
+import type { Attendee } from "#shared/types.ts";
+import { ActivityLogTable } from "#templates/admin/activityLog.tsx";
+
+/** One key/value row of a detail table. */
+const DetailTableRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: Child;
+}): JSX.Element => (
+  <tr>
+    <th scope="row">{label}</th>
+    <td>{children}</td>
+  </tr>
+);
+
+/** Preserve the author's line breaks for multi-line free text. */
+const Multiline = ({ text }: { text: string }): JSX.Element => (
+  <span style="white-space:pre-wrap">{text}</span>
+);
+
+/** The phone number followed by small `tel:` and WhatsApp links. The number is
+ * normalised (e.g. `07700 900000` → `+447700900000`) for the link hrefs while
+ * the display keeps whatever the attendee entered. */
+const PhoneCell = ({
+  phone,
+  phonePrefix,
+}: {
+  phone: string;
+  phonePrefix: string;
+}): JSX.Element => {
+  const links = phoneLinks(phone, phonePrefix);
+  return (
+    <>
+      {phone}
+      {links && (
+        <>
+          {" "}
+          <small>
+            <a href={links.tel}>tel</a>{" "}
+            <a href={links.whatsapp} rel="noopener" target="_blank">
+              whatsapp
+            </a>
+          </small>
+        </>
+      )}
+    </>
+  );
+};
+
+/**
+ * The main read-only details table for a single attendee. Optional contact
+ * fields are omitted when blank so the table only spells out what's on file.
+ */
+export const AttendeeDetail = ({
+  attendee,
+  allowedDomain,
+  phonePrefix,
+}: {
+  attendee: Attendee;
+  allowedDomain: string;
+  phonePrefix: string;
+}): JSX.Element => {
+  const rows = compact([
+    <DetailTableRow label="Name">{attendee.name}</DetailTableRow>,
+    attendee.email ? (
+      <DetailTableRow label="Email">
+        <a href={`mailto:${attendee.email}`}>{attendee.email}</a>
+      </DetailTableRow>
+    ) : null,
+    attendee.phone ? (
+      <DetailTableRow label="Phone">
+        <PhoneCell phone={attendee.phone} phonePrefix={phonePrefix} />
+      </DetailTableRow>
+    ) : null,
+    attendee.address ? (
+      <DetailTableRow label="Address">
+        <Multiline text={attendee.address} />
+      </DetailTableRow>
+    ) : null,
+    attendee.special_instructions ? (
+      <DetailTableRow label="Special Instructions">
+        <Multiline text={attendee.special_instructions} />
+      </DetailTableRow>
+    ) : null,
+    <DetailTableRow label="Ticket">
+      <a href={`https://${allowedDomain}/t/${attendee.ticket_token}`}>
+        {attendee.ticket_token}
+      </a>
+    </DetailTableRow>,
+    <DetailTableRow label="Registered">
+      {formatDatetimeShort(attendee.created)}
+    </DetailTableRow>,
+  ]);
+  return (
+    <div class="table-scroll">
+      <table class="listing-details-table">
+        <tbody>{rows}</tbody>
+      </table>
+    </div>
+  );
+};
+
+/**
+ * The attendee's answers to custom questions, one row per answered question.
+ * Returns null when the attendee has answered nothing, so the caller can drop
+ * the section entirely.
+ */
+export const AttendeeAnswersTable = ({
+  questions,
+  selectedAnswerIds,
+}: {
+  questions: QuestionWithAnswers[];
+  selectedAnswerIds: number[];
+}): JSX.Element | null => {
+  const selected = new Set(selectedAnswerIds);
+  const answered = compact(
+    questions.map((q) => {
+      const picks = q.answers.filter((a) => selected.has(a.id));
+      return picks.length > 0
+        ? { answer: picks.map((a) => a.text).join(", "), question: q.text }
+        : null;
+    }),
+  );
+  if (answered.length === 0) return null;
+  return (
+    <>
+      <h3>Answers</h3>
+      <div class="table-scroll">
+        <table class="listing-details-table">
+          <tbody>
+            {answered.map((row) => (
+              <DetailTableRow label={row.question}>{row.answer}</DetailTableRow>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+};
+
+/**
+ * The attendee's activity log, collapsed by default. Renders the same
+ * Time/Activity table the /admin/log pages use, filtered to this attendee.
+ */
+export const AttendeeLogSection = ({
+  entries,
+}: {
+  entries: ActivityLogEntry[];
+}): JSX.Element => (
+  <details>
+    <summary>Activity Log</summary>
+    <ActivityLogTable entries={entries} />
+  </details>
+);

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -32,6 +32,7 @@ import {
 } from "#routes/admin/attendee-form-model.ts";
 import { toMajorUnits } from "#shared/currency.ts";
 import { formatDateRangeLabel, formatDatetimeShort } from "#shared/dates.ts";
+import type { ActivityLogEntry } from "#shared/db/activityLog.ts";
 import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import type { EmailStats } from "#shared/db/email-preferences.ts";
 import type { QuestionWithAnswers } from "#shared/db/questions.ts";
@@ -43,6 +44,11 @@ import {
   availableDayCounts,
   type ListingWithCount,
 } from "#shared/types.ts";
+import {
+  AttendeeAnswersTable,
+  AttendeeDetail,
+  AttendeeLogSection,
+} from "#templates/admin/attendee-detail.tsx";
 import { EditQuestions, PaymentDetails } from "#templates/admin/attendees.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { Icon, SubmitButton } from "#templates/components/actions.tsx";
@@ -75,8 +81,9 @@ export type AttendeeFormTemplateData = {
    * failure like capacity lost to a race). */
   flashError?: string;
   flashSuccess?: string;
-  /** Custom questions for the first existing listing (edit mode only). */
-  questions?: QuestionWithAnswers[];
+  /** Custom questions across the attendee's booked listings; empty in create
+   * mode and when no listing has any. */
+  questions: QuestionWithAnswers[];
   /** Currently-selected answer ids for the rendered questions. */
   selectedAnswerIds: number[];
   /** Today's ISO date — used for the new-daily-line default. */
@@ -86,6 +93,12 @@ export type AttendeeFormTemplateData = {
   /** Bulk-email contact history for the attendee's email (edit mode only;
    * null when there is no email on file or it has never been contacted). */
   emailStats?: EmailStats | null;
+  /** Public site domain, for the read-only ticket link (edit mode). */
+  allowedDomain: string;
+  /** Country dialling code, for the read-only phone tel/WhatsApp links. */
+  phonePrefix: string;
+  /** This attendee's activity log entries, newest first (edit mode only). */
+  activityLog: ActivityLogEntry[];
 };
 
 /** Status badges for an existing booking — "Checked in" and/or "Refunded",
@@ -310,9 +323,23 @@ const MergeSection = ({ attendee }: { attendee: Attendee }): JSX.Element => (
 
 /** Page title for the layout. */
 const pageTitle = (data: AttendeeFormTemplateData): string =>
-  data.mode === "create"
-    ? "Add Attendee"
-    : `Edit Attendee: ${data.attendee!.name}`;
+  data.mode === "create" ? "Add Attendee" : `Attendee: ${data.attendee!.name}`;
+
+/**
+ * The attendee's current status as an `<h2>`, shown only when the site has more
+ * than one status configured (with a single status it carries no information).
+ */
+const StatusHeading = ({
+  data,
+}: {
+  data: AttendeeFormTemplateData;
+}): JSX.Element | null => {
+  if (data.mode !== "edit" || !data.attendee || data.statuses.length <= 1) {
+    return null;
+  }
+  const status = data.statuses.find((s) => s.id === data.attendee!.status_id);
+  return <h2>Status: {status ? status.name : "None"}</h2>;
+};
 
 /** Tiny progressive-enhancement script: hide the date field on non-daily
  * listings and populate defaults when a daily listing is first chosen. The
@@ -438,13 +465,146 @@ export const attendeeFormPage = (
   const isEdit = data.mode === "edit";
   const a = data.attendee;
 
+  // The whole editable form. Status & Balance sit right after the name and
+  // before the contact fields, per the agreed field order. In edit mode the
+  // read-only summary above is the primary view, so the form is tucked into a
+  // collapsed disclosure (see below); in create mode it is the page.
+  const editForm = (
+    <CsrfForm action={formAction} id={ATTENDEE_FORM_ID}>
+      <Flash error={data.flashError} success={data.flashSuccess} />
+      {data.returnUrl && (
+        <input name="return_url" type="hidden" value={data.returnUrl} />
+      )}
+
+      {!isEdit && <h3>Attendee Details</h3>}
+
+      <label for="name">
+        Name
+        <input
+          autofocus
+          id="name"
+          name="name"
+          required
+          type="text"
+          value={data.parsed.name}
+        />
+      </label>
+
+      <StatusAndBalanceFields data={data} />
+
+      <label for="email">
+        Email
+        <input
+          id="email"
+          name="email"
+          type="email"
+          value={data.parsed.email || ""}
+        />
+      </label>
+
+      <label for="phone">
+        Phone
+        <input
+          id="phone"
+          name="phone"
+          pattern="[+\d][\d\s\-()]{5,}"
+          title="Phone number (digits, spaces, hyphens, parentheses, optional leading +)"
+          type="text"
+          value={data.parsed.phone || ""}
+        />
+      </label>
+
+      <label for="address">
+        Address
+        <textarea id="address" maxlength={250} name="address" rows={3}>
+          {data.parsed.address || ""}
+        </textarea>
+      </label>
+
+      <label for="special_instructions">
+        Special Instructions
+        <textarea
+          id="special_instructions"
+          maxlength={250}
+          name="special_instructions"
+          rows={3}
+        >
+          {data.parsed.special_instructions || ""}
+        </textarea>
+      </label>
+
+      {data.questions.length > 0 && (
+        <>
+          <h3>Custom Questions</h3>
+          <EditQuestions
+            questions={data.questions}
+            selectedAnswerIds={data.selectedAnswerIds}
+          />
+        </>
+      )}
+
+      <h3>Listing Registrations</h3>
+      <LineEditor data={data} />
+      <p>
+        <button
+          formnovalidate
+          name={ACTION_FIELD}
+          type="submit"
+          value={ADD_LINE_ACTION}
+        >
+          <Icon name="plus" />
+          <span>Add Listing Line</span>
+        </button>
+      </p>
+
+      <hr />
+
+      <p class="form-actions">
+        <button
+          class="primary"
+          name={ACTION_FIELD}
+          type="submit"
+          value={SAVE_ACTION}
+        >
+          <Icon name="save" />
+          <span>{isEdit ? "Save Attendee" : "Create Attendee"}</span>
+        </button>
+        {!isEdit && (
+          <a class="button" href={data.returnUrl || "/admin/"}>
+            Back without saving
+          </a>
+        )}
+      </p>
+    </CsrfForm>
+  );
+
   return String(
     <Layout title={pageTitle(data)}>
       <AdminNav active="/admin/" session={session} />
 
-      <h2>{pageTitle(data)}</h2>
+      <div class="prose">
+        <h1>{pageTitle(data)}</h1>
+        <StatusHeading data={data} />
+      </div>
+
+      {isEdit && a && (
+        <AttendeeDetail
+          allowedDomain={data.allowedDomain}
+          attendee={a}
+          phonePrefix={data.phonePrefix}
+        />
+      )}
+
+      {isEdit && (
+        <AttendeeAnswersTable
+          questions={data.questions}
+          selectedAnswerIds={data.selectedAnswerIds}
+        />
+      )}
 
       {isEdit && a && <Raw html={PaymentDetails({ attendee: a })} />}
+
+      {isEdit && <AttendeeLogSection entries={data.activityLog} />}
 
       {data.attendeeError && (
         <div class="error" role="alert">
@@ -460,110 +620,14 @@ export const attendeeFormPage = (
         </output>
       )}
 
-      <CsrfForm action={formAction} id={ATTENDEE_FORM_ID}>
-        <Flash error={data.flashError} success={data.flashSuccess} />
-        {data.returnUrl && (
-          <input name="return_url" type="hidden" value={data.returnUrl} />
-        )}
-
-        <h3>Attendee Details</h3>
-
-        <label for="name">
-          Name
-          <input
-            autofocus
-            id="name"
-            name="name"
-            required
-            type="text"
-            value={data.parsed.name}
-          />
-        </label>
-
-        <label for="email">
-          Email
-          <input
-            id="email"
-            name="email"
-            type="email"
-            value={data.parsed.email || ""}
-          />
-        </label>
-
-        <label for="phone">
-          Phone
-          <input
-            id="phone"
-            name="phone"
-            pattern="[+\d][\d\s\-()]{5,}"
-            title="Phone number (digits, spaces, hyphens, parentheses, optional leading +)"
-            type="text"
-            value={data.parsed.phone || ""}
-          />
-        </label>
-
-        <label for="address">
-          Address
-          <textarea id="address" maxlength={250} name="address" rows={3}>
-            {data.parsed.address || ""}
-          </textarea>
-        </label>
-
-        <label for="special_instructions">
-          Special Instructions
-          <textarea
-            id="special_instructions"
-            maxlength={250}
-            name="special_instructions"
-            rows={3}
-          >
-            {data.parsed.special_instructions || ""}
-          </textarea>
-        </label>
-
-        <StatusAndBalanceFields data={data} />
-
-        {data.questions && data.questions.length > 0 && (
-          <>
-            <h3>Custom Questions</h3>
-            <EditQuestions
-              questions={data.questions}
-              selectedAnswerIds={data.selectedAnswerIds}
-            />
-          </>
-        )}
-
-        <h3>Listing Registrations</h3>
-        <LineEditor data={data} />
-        <p>
-          <button
-            formnovalidate
-            name={ACTION_FIELD}
-            type="submit"
-            value={ADD_LINE_ACTION}
-          >
-            <Icon name="plus" />
-            <span>Add Listing Line</span>
-          </button>
-        </p>
-
-        <hr />
-
-        <p class="form-actions">
-          <button
-            class="primary"
-            name={ACTION_FIELD}
-            type="submit"
-            value={SAVE_ACTION}
-          >
-            <Icon name="save" />
-            <span>{isEdit ? "Save Attendee" : "Create Attendee"}</span>
-          </button>
-          <a class="button" href={data.returnUrl || "/admin/"}>
-            Back without saving
-          </a>
-        </p>
-      </CsrfForm>
+      {isEdit ? (
+        <details>
+          <summary>Edit Attendee Details</summary>
+          {editForm}
+        </details>
+      ) : (
+        editForm
+      )}
 
       {isEdit && a && a.email && (
         <EmailHistory emailStats={data.emailStats ?? null} />

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -93,8 +93,6 @@ export type AttendeeFormTemplateData = {
   /** Bulk-email contact history for the attendee's email (edit mode only;
    * null when there is no email on file or it has never been contacted). */
   emailStats?: EmailStats | null;
-  /** Public site domain, for the read-only ticket link (edit mode). */
-  allowedDomain: string;
   /** Country dialling code, for the read-only phone tel/WhatsApp links. */
   phonePrefix: string;
   /** This attendee's activity log entries, newest first (edit mode only). */
@@ -588,11 +586,7 @@ export const attendeeFormPage = (
       </div>
 
       {isEdit && a && (
-        <AttendeeDetail
-          allowedDomain={data.allowedDomain}
-          attendee={a}
-          phonePrefix={data.phonePrefix}
-        />
+        <AttendeeDetail attendee={a} phonePrefix={data.phonePrefix} />
       )}
 
       {isEdit && (

--- a/test/lib/phone.test.ts
+++ b/test/lib/phone.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { normalizePhone } from "#shared/phone.ts";
+import { normalizePhone, phoneLinks } from "#shared/phone.ts";
 
 describe("normalizePhone", () => {
   test("strips non-numeric characters and adds prefix for leading zero", () => {
@@ -65,5 +65,40 @@ describe("normalizePhone", () => {
 
   test("normalizes 0161 1234567", () => {
     expect(normalizePhone("0161 1234567", "44")).toBe("+441611234567");
+  });
+});
+
+describe("phoneLinks", () => {
+  test("builds tel and wa.me hrefs from a local number", () => {
+    expect(phoneLinks("07700 900000", "44")).toEqual({
+      tel: "tel:+447700900000",
+      whatsapp: "https://wa.me/447700900000",
+    });
+  });
+
+  test("wa.me link omits the leading plus", () => {
+    expect(phoneLinks("07700 900000", "44")?.whatsapp).toBe(
+      "https://wa.me/447700900000",
+    );
+  });
+
+  test("tolerates a prefix that already includes a leading plus", () => {
+    // settings.phonePrefix can be "+44"; the helper must not double the code.
+    expect(phoneLinks("07700 900000", "+44")).toEqual({
+      tel: "tel:+447700900000",
+      whatsapp: "https://wa.me/447700900000",
+    });
+  });
+
+  test("uses the given dialling code for non-UK numbers", () => {
+    expect(phoneLinks("0234 567 8900", "1")).toEqual({
+      tel: "tel:+12345678900",
+      whatsapp: "https://wa.me/12345678900",
+    });
+  });
+
+  test("returns null when the number has no digits", () => {
+    expect(phoneLinks("", "44")).toBeNull();
+    expect(phoneLinks("not a phone", "44")).toBeNull();
   });
 });

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -848,7 +848,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       );
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Edit Attendee: Orphan");
+      expect(html).toContain("Attendee: Orphan");
     });
 
     test("POST edit for attendee with no bookings re-renders with no_lines error", async () => {
@@ -1141,6 +1141,27 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       expect(html).toContain('name="remaining_balance"');
       expect(html).not.toContain("still unpaid");
       expect(html).not.toContain("paid status but still owes");
+    });
+
+    test("edit page shows the attendee's status as a heading when multiple statuses exist", async () => {
+      const reservation = await newReservation();
+      const id = await seedAttendee(reservation.id, 900);
+      const html = await getEdit(id);
+      expect(html).toContain("<h2>Status: Reserved</h2>");
+    });
+
+    test("edit page status heading reads None when the attendee has no status", async () => {
+      await newReservation(); // a second status, so the heading is shown
+      const id = await seedAttendee(null, 0);
+      const html = await getEdit(id);
+      expect(html).toContain("<h2>Status: None</h2>");
+    });
+
+    test("edit page omits the status heading when only one status exists", async () => {
+      // Fresh installs seed a single status, which carries no information.
+      const id = await seedAttendee(null, 0);
+      const html = await getEdit(id);
+      expect(html).not.toContain("<h2>Status:");
     });
   });
 });

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1357,7 +1357,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         form,
       );
       // Save returns to the same form (anchored), carrying return_url through
-      // so the "Back without saving" link still points where the user came from.
+      // so a later save still round-trips the caller's origin.
       expectRedirect(
         response,
         `/admin/attendees/${attendee.id}`,

--- a/test/templates/admin/attendee-detail.test.ts
+++ b/test/templates/admin/attendee-detail.test.ts
@@ -9,12 +9,8 @@ import {
 } from "#templates/admin/attendee-detail.tsx";
 import { setupTestEncryptionKey, testAttendee } from "#test-utils";
 
-const ALLOWED_DOMAIN = "tickets.example.com";
-
 const renderDetail = (attendee = testAttendee(), phonePrefix = "44"): string =>
-  String(
-    AttendeeDetail({ allowedDomain: ALLOWED_DOMAIN, attendee, phonePrefix }),
-  );
+  String(AttendeeDetail({ attendee, phonePrefix }));
 
 beforeAll(() => {
   setupTestEncryptionKey();
@@ -27,7 +23,7 @@ describe("AttendeeDetail", () => {
     );
     expect(html).toContain('<th scope="row">Name</th>');
     expect(html).toContain("Jane Doe");
-    expect(html).toContain(`https://${ALLOWED_DOMAIN}/t/tok-123`);
+    expect(html).toContain('href="/t/tok-123"');
     expect(html).toContain("Registered");
   });
 

--- a/test/templates/admin/attendee-detail.test.ts
+++ b/test/templates/admin/attendee-detail.test.ts
@@ -1,0 +1,141 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import type { ActivityLogEntry } from "#shared/db/activityLog.ts";
+import type { QuestionWithAnswers } from "#shared/db/questions.ts";
+import {
+  AttendeeAnswersTable,
+  AttendeeDetail,
+  AttendeeLogSection,
+} from "#templates/admin/attendee-detail.tsx";
+import { setupTestEncryptionKey, testAttendee } from "#test-utils";
+
+const ALLOWED_DOMAIN = "tickets.example.com";
+
+const renderDetail = (attendee = testAttendee(), phonePrefix = "44"): string =>
+  String(
+    AttendeeDetail({ allowedDomain: ALLOWED_DOMAIN, attendee, phonePrefix }),
+  );
+
+beforeAll(() => {
+  setupTestEncryptionKey();
+});
+
+describe("AttendeeDetail", () => {
+  test("always shows name, ticket link and registered", () => {
+    const html = renderDetail(
+      testAttendee({ name: "Jane Doe", ticket_token: "tok-123" }),
+    );
+    expect(html).toContain('<th scope="row">Name</th>');
+    expect(html).toContain("Jane Doe");
+    expect(html).toContain(`https://${ALLOWED_DOMAIN}/t/tok-123`);
+    expect(html).toContain("Registered");
+  });
+
+  test("renders email as a mailto link when present", () => {
+    const html = renderDetail(testAttendee({ email: "jane@example.com" }));
+    expect(html).toContain('href="mailto:jane@example.com"');
+  });
+
+  test("omits the email row when there is no email", () => {
+    const html = renderDetail(testAttendee({ email: "" }));
+    expect(html).not.toContain("Email");
+  });
+
+  test("shows the phone number with small tel and whatsapp links", () => {
+    const html = renderDetail(testAttendee({ phone: "07700 900000" }));
+    expect(html).toContain("07700 900000");
+    expect(html).toContain('<a href="tel:+447700900000">tel</a>');
+    expect(html).toContain("https://wa.me/447700900000");
+    expect(html).toContain("<small>");
+  });
+
+  test("normalises the phone with the given dialling code", () => {
+    const html = renderDetail(testAttendee({ phone: "0234 567 8900" }), "1");
+    expect(html).toContain('href="tel:+12345678900"');
+    expect(html).toContain("https://wa.me/12345678900");
+  });
+
+  test("omits the phone row when there is no phone", () => {
+    const html = renderDetail(testAttendee({ phone: "" }));
+    expect(html).not.toContain("Phone");
+    expect(html).not.toContain("tel:");
+  });
+
+  test("preserves line breaks for address and special instructions", () => {
+    const html = renderDetail(
+      testAttendee({
+        address: "1 High St\nTownsville",
+        special_instructions: "Step free\nNut allergy",
+      }),
+    );
+    expect(html).toContain("white-space:pre-wrap");
+    expect(html).toContain("1 High St\nTownsville");
+    expect(html).toContain("Step free\nNut allergy");
+  });
+});
+
+describe("AttendeeAnswersTable", () => {
+  const questions: QuestionWithAnswers[] = [
+    {
+      answers: [
+        { id: 10, question_id: 1, sort_order: 0, text: "Small" },
+        { id: 11, question_id: 1, sort_order: 1, text: "Large" },
+      ],
+      id: 1,
+      text: "Shirt size?",
+    },
+    {
+      answers: [{ id: 20, question_id: 2, sort_order: 0, text: "Vegan" }],
+      id: 2,
+      text: "Meal?",
+    },
+  ];
+
+  test("lists only the questions the attendee answered", () => {
+    const html = String(
+      AttendeeAnswersTable({ questions, selectedAnswerIds: [11] }),
+    );
+    expect(html).toContain("Answers");
+    expect(html).toContain("Shirt size?");
+    expect(html).toContain("Large");
+    // Unanswered question and the unpicked option are absent.
+    expect(html).not.toContain("Meal?");
+    expect(html).not.toContain("Small");
+  });
+
+  test("returns null when the attendee answered no questions", () => {
+    // Null lets the caller drop the section entirely (JSX renders it as empty).
+    expect(
+      AttendeeAnswersTable({ questions, selectedAnswerIds: [] }),
+    ).toBeNull();
+  });
+});
+
+describe("AttendeeLogSection", () => {
+  const entries: ActivityLogEntry[] = [
+    {
+      attendee_id: 7,
+      created: "2026-01-15T10:30:00Z",
+      id: 1,
+      listing_id: 2,
+      message: "Attendee 'Jane Doe' updated",
+    },
+  ];
+
+  test("renders a collapsed details disclosure with the log table", () => {
+    const html = String(AttendeeLogSection({ entries }));
+    expect(html).toContain("<details>");
+    // Collapsed by default — no open attribute.
+    expect(html).not.toContain("<details open");
+    expect(html).toContain("<summary>Activity Log</summary>");
+    expect(html).toContain("Attendee 'Jane Doe' updated");
+    // Same Time/Activity columns as /admin/log.
+    expect(html).toContain("<th>Time</th>");
+    expect(html).toContain("<th>Activity</th>");
+  });
+
+  test("shows the empty state when the attendee has no log entries", () => {
+    const html = String(AttendeeLogSection({ entries: [] }));
+    expect(html).toContain("No activity recorded yet");
+  });
+});


### PR DESCRIPTION
Restructures the edit attendee page so the attendee's details are shown up front, read-only, with the editable form tucked into a collapsed disclosure beneath them.

## Changes

- **AttendeeDetail table** — a new single-attendee, key/value counterpart to the multi-attendee `AttendeeTable`, shown at the top of the page. Optional contact fields are omitted when blank.
- **Phone tel/WhatsApp links** — the phone row is followed by small `tel:` and WhatsApp (`wa.me`) links built from the normalised number (new `phoneLinks` helper).
- **Answers table** — the attendee's custom-question answers in a separate table after the details table, only when they've answered something.
- **Activity Log section** — a collapsed `details`/`summary` reusing the same table `/admin/log` renders, filtered to this attendee. Create/edit log entries are now tagged with the attendee id so the section reflects work done on the page (extracted a shared `ActivityLogTable`).
- **Title** — "Attendee: \<name\>" instead of "Edit Attendee: \<name\>".
- **Headings in `div.prose`** — the `h1`, plus a "Status: \<status\>" `h2` shown only when more than one attendee status is configured.
- **Field order** — Status & Balance moved directly after the name and before the contact fields.
- **Edit form collapsed** — tucked under an "Edit Attendee Details" `details`/`summary`, closed by default, with the now-redundant "Back without saving" link dropped in edit mode (kept for create).

Create mode (Add Attendee) is unchanged apart from the shared field-order tweak.

## Testing

- New unit tests for `phoneLinks` and the three new `attendee-detail` components.
- New integration tests for the status heading (shown/hidden, name vs "None").
- Full suite green (431 files, 7492 steps); lint, typecheck and 100% line + branch coverage all pass.

https://claude.ai/code/session_01Q9pX7eJ4LG3UouLunqhMDQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9pX7eJ4LG3UouLunqhMDQ)_