### PR TITLE
Suppress attendee import clone with jscpd:ignore, restore absolute ticket URL

### DIFF
--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -39,11 +39,14 @@ import {
   withAuth,
 } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
+/* jscpd:ignore-start */
 import { htmlResponse, notFoundResponse, redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { getSearchParam } from "#routes/url.ts";
+import { getEffectiveDomain } from "#shared/config.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
 import { getAttendeeActivityLog, logActivity } from "#shared/db/activityLog.ts";
+/* jscpd:ignore-end */
 import { getAllAttendeeStatuses } from "#shared/db/attendee-statuses.ts";
 import { getAttendeeOrderSummary } from "#shared/db/attendees/balance.ts";
 import {
@@ -261,6 +264,7 @@ const buildTemplateData = async (
   return {
     activityLog,
     allListings,
+    allowedDomain: getEffectiveDomain(),
     attendee,
     attendeeError: opts.attendeeError ?? null,
     availableDatesByListing,

--- a/src/ui/templates/admin/attendee-detail.tsx
+++ b/src/ui/templates/admin/attendee-detail.tsx
@@ -72,9 +72,11 @@ const PhoneCell = ({
  */
 export const AttendeeDetail = ({
   attendee,
+  allowedDomain,
   phonePrefix,
 }: {
   attendee: Attendee;
+  allowedDomain: string;
   phonePrefix: string;
 }): JSX.Element => {
   const rows = compact([
@@ -100,7 +102,9 @@ export const AttendeeDetail = ({
       </DetailTableRow>
     ) : null,
     <DetailTableRow label="Ticket">
-      <a href={`/t/${attendee.ticket_token}`}>{attendee.ticket_token}</a>
+      <a href={`https://${allowedDomain}/t/${attendee.ticket_token}`}>
+        {attendee.ticket_token}
+      </a>
     </DetailTableRow>,
     <DetailTableRow label="Registered">
       {formatDatetimeShort(attendee.created)}

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -93,6 +93,8 @@ export type AttendeeFormTemplateData = {
   /** Bulk-email contact history for the attendee's email (edit mode only;
    * null when there is no email on file or it has never been contacted). */
   emailStats?: EmailStats | null;
+  /** Public site domain, for the read-only ticket link (edit mode). */
+  allowedDomain: string;
   /** Country dialling code, for the read-only phone tel/WhatsApp links. */
   phonePrefix: string;
   /** This attendee's activity log entries, newest first (edit mode only). */
@@ -586,7 +588,11 @@ export const attendeeFormPage = (
       </div>
 
       {isEdit && a && (
-        <AttendeeDetail attendee={a} phonePrefix={data.phonePrefix} />
+        <AttendeeDetail
+          allowedDomain={data.allowedDomain}
+          attendee={a}
+          phonePrefix={data.phonePrefix}
+        />
       )}
 
       {isEdit && (

--- a/test/templates/admin/attendee-detail.test.ts
+++ b/test/templates/admin/attendee-detail.test.ts
@@ -9,8 +9,12 @@ import {
 } from "#templates/admin/attendee-detail.tsx";
 import { setupTestEncryptionKey, testAttendee } from "#test-utils";
 
+const ALLOWED_DOMAIN = "tickets.example.com";
+
 const renderDetail = (attendee = testAttendee(), phonePrefix = "44"): string =>
-  String(AttendeeDetail({ attendee, phonePrefix }));
+  String(
+    AttendeeDetail({ allowedDomain: ALLOWED_DOMAIN, attendee, phonePrefix }),
+  );
 
 beforeAll(() => {
   setupTestEncryptionKey();
@@ -23,7 +27,7 @@ describe("AttendeeDetail", () => {
     );
     expect(html).toContain('<th scope="row">Name</th>');
     expect(html).toContain("Jane Doe");
-    expect(html).toContain('href="/t/tok-123"');
+    expect(html).toContain(`https://${ALLOWED_DOMAIN}/t/tok-123`);
     expect(html).toContain("Registered");
   });
 


### PR DESCRIPTION
Follow-up to #1168.

That PR's attendee detail table linked the ticket with a relative `/t/<token>` URL purely to dodge a copy-paste-detection clone — the new `getEffectiveDomain` import created a run of identical import lines shared with `attendees-list.ts`, and the repo enforces a 0% duplication threshold. Removing the import sidestepped the symptom rather than addressing it.

This restores the proper approach:

- **Suppress the import clone with `/* jscpd:ignore-start */ … /* jscpd:ignore-end */`** around the import block, matching the convention already used in `dashboard.ts`, `questions.ts`, `calendar.ts`, etc.
- **Restore the absolute `https://<domain>/t/<token>` ticket link** (via `getEffectiveDomain` / `allowedDomain`), so the single-attendee detail table matches the absolute URLs the multi-attendee `AttendeeTable` renders.

## Verification

All CI steps reproduced locally:
- Typecheck, lint (Biome leaves the `jscpd:ignore` comments in place — no format diff)
- Copy-paste detection: **0 clones**
- Edge build
- Tests + coverage: **432 passed, 100% line and branch coverage**

https://claude.ai/code/session_01Q9pX7eJ4LG3UouLunqhMDQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9pX7eJ4LG3UouLunqhMDQ)_