### PR TITLE
Adopt valibot's slug() validator; allow underscores in slugs

### DIFF
--- a/src/features/middleware.ts
+++ b/src/features/middleware.ts
@@ -88,8 +88,8 @@ export const getSecurityHeaders = (
   "content-security-policy": buildCspHeader(embeddable),
 });
 
-/** Single slug: alphanumeric segments joined by hyphens (e.g. "a1b2" or "my-listing") */
-const SLUG = "[a-z0-9]+(?:-[a-z0-9]+)*";
+/** Single slug: alphanumeric segments joined by single hyphens or underscores (e.g. "a1b2", "my-listing", "my_listing") */
+const SLUG = "[a-z0-9]+(?:[-_][a-z0-9]+)*";
 
 /** Matches /ticket/ with one or more slugs separated by + */
 const EMBEDDABLE_PATH = new RegExp(`^/ticket/${SLUG}(?:\\+${SLUG})*$`);

--- a/src/features/router.ts
+++ b/src/features/router.ts
@@ -71,8 +71,8 @@ const isNumericParam = (name: string): boolean =>
 const getParamPattern = (name: string): string => {
   // Params ending in Id match digits only (e.g., listingId, attendeeId)
   if (isNumericParam(name)) return "(\\d+)";
-  // Slugs match lowercase alphanumeric with hyphens and + (for multi-listing URLs)
-  if (name === "slug") return "([a-z0-9]+(?:[-+][a-z0-9]+)*)";
+  // Slugs match lowercase alphanumeric with hyphens/underscores and + (for multi-listing URLs)
+  if (name === "slug") return "([a-z0-9]+(?:[-_+][a-z0-9]+)*)";
   // Default: match any non-slash characters
   return "([^/]+)";
 };

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -43,13 +43,16 @@ export const generateSlug = (): string => {
 export const normalizeSlug = (input: string): string =>
   input.trim().toLowerCase().replace(/\s+/g, "-");
 
-/** Valid slug schema: non-empty, lowercase alphanumeric and hyphens only */
+/**
+ * Valid slug schema: non-empty, lowercase alphanumeric segments joined by
+ * single hyphens or underscores (valibot's canonical slug form). The same
+ * shape gates URL routing (router.ts) and embeddable paths (middleware.ts).
+ */
 const SlugSchema = v.pipe(
   v.string(),
   v.nonEmpty("Slug is required"),
-  v.regex(
-    /^[a-z0-9-]+$/,
-    "Slug may only contain lowercase letters, numbers, and hyphens",
+  v.slug(
+    "Slug must be lowercase letters and numbers separated by single hyphens or underscores",
   ),
 );
 

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -763,12 +763,12 @@ export const attachmentField: Field = {
 
 /** Slug field for listing/group edit pages */
 export const slugField: Field = {
-  hint: "URL-friendly identifier (lowercase letters, numbers, and hyphens). Changing this will break any existing links, embeds, or QR codes that point to this page. Only change if you know what you're doing.",
+  hint: "URL-friendly identifier (lowercase letters, numbers, hyphens, and underscores). Changing this will break any existing links, embeds, or QR codes that point to this page. Only change if you know what you're doing.",
   label: "Slug",
   name: "slug",
-  pattern: "[a-z0-9-]+",
+  pattern: "[a-z0-9_-]+",
   required: true,
-  title: "Lowercase letters, numbers, and hyphens only",
+  title: "Lowercase letters, numbers, hyphens, and underscores only",
   type: "text",
   validate: (value: string) => validateSlug(normalizeSlug(value)),
 };

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -1114,7 +1114,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       await expectHtmlResponse(
         response,
         400,
-        "Slug may only contain lowercase letters, numbers, and hyphens",
+        "Slug must be lowercase letters and numbers separated by single hyphens or underscores",
       );
     });
 

--- a/test/lib/slug.test.ts
+++ b/test/lib/slug.test.ts
@@ -74,6 +74,9 @@ describe("slug", () => {
   });
 
   describe("validateSlug", () => {
+    const INVALID_SLUG_MESSAGE =
+      "Slug must be lowercase letters and numbers separated by single hyphens or underscores";
+
     test("returns null for valid slug", () => {
       expect(validateSlug("my-listing-123")).toBeNull();
     });
@@ -90,26 +93,36 @@ describe("slug", () => {
       expect(validateSlug("my-listing")).toBeNull();
     });
 
+    test("returns null for slug with underscores", () => {
+      expect(validateSlug("my_listing")).toBeNull();
+    });
+
     test("returns error for empty slug", () => {
       expect(validateSlug("")).toBe("Slug is required");
     });
 
     test("returns error for slug with uppercase letters", () => {
-      expect(validateSlug("My-Listing")).toBe(
-        "Slug may only contain lowercase letters, numbers, and hyphens",
-      );
+      expect(validateSlug("My-Listing")).toBe(INVALID_SLUG_MESSAGE);
     });
 
     test("returns error for slug with spaces", () => {
-      expect(validateSlug("my listing")).toBe(
-        "Slug may only contain lowercase letters, numbers, and hyphens",
-      );
+      expect(validateSlug("my listing")).toBe(INVALID_SLUG_MESSAGE);
     });
 
     test("returns error for slug with special characters", () => {
-      expect(validateSlug("my_listing!")).toBe(
-        "Slug may only contain lowercase letters, numbers, and hyphens",
-      );
+      expect(validateSlug("my-listing!")).toBe(INVALID_SLUG_MESSAGE);
+    });
+
+    test("returns error for slug with a leading hyphen", () => {
+      expect(validateSlug("-my-listing")).toBe(INVALID_SLUG_MESSAGE);
+    });
+
+    test("returns error for slug with a trailing hyphen", () => {
+      expect(validateSlug("my-listing-")).toBe(INVALID_SLUG_MESSAGE);
+    });
+
+    test("returns error for slug with consecutive separators", () => {
+      expect(validateSlug("my--listing")).toBe(INVALID_SLUG_MESSAGE);
     });
   });
 });


### PR DESCRIPTION
## Summary

Replaces the hand-rolled slug regex with valibot's built-in `v.slug()`, and widens the URL-matching patterns so slugs stay routable.

`v.slug()` validates the **canonical** slug form — lowercase alphanumeric segments joined by single hyphens or underscores, with no leading, trailing, or repeated separators (`^[\da-z]+(?:[-_][\da-z]+)*$`). Compared to the old `[a-z0-9-]+` rule this is:

- **stricter** in one direction — rejects malformed hyphen placement (`-abc`, `abc-`, `a--b`), which the old rule accepted but which the routing/embedding pattern already rejected (a latent mismatch);
- **looser** in another — now accepts underscores (`my_listing`).

Because `v.slug()` permits underscores, the patterns that gate slug URLs are widened so an accepted slug is always reachable end to end:

| Location | Before | After |
| --- | --- | --- |
| `router.ts` slug route param | `[a-z0-9]+(?:[-+][a-z0-9]+)*` | `[a-z0-9]+(?:[-_+][a-z0-9]+)*` |
| `middleware.ts` embeddable-path `SLUG` | `[a-z0-9]+(?:-[a-z0-9]+)*` | `[a-z0-9]+(?:[-_][a-z0-9]+)*` |
| `fields.ts` slug field HTML `pattern` | `[a-z0-9-]+` | `[a-z0-9_-]+` |

The routing changes only *widen* the existing character classes, so nothing that matched before stops matching — only the validator became stricter about hyphen placement.

## Behaviour change

For **new** slug submissions only (existing slugs are unaffected — validation runs on create/edit): underscores are now accepted, and slugs with leading/trailing/consecutive separators are now rejected. The slug field's hint/title copy and the validation error message are updated to match.

## Tests

- `validateSlug` tests updated: underscores now valid; leading hyphen, trailing hyphen, and consecutive separators now rejected; new error message asserted.
- `server-listings.test.ts` invalid-slug assertion updated to the new message.
- Full precommit green (lint, typecheck, cpd, build:edge, tests + 100% coverage).

https://claude.ai/code/session_01XsQJTsW29zPhW5kazWyn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsQJTsW29zPhW5kazWyn7c)_