### PR TITLE
Adopt valibot isoDate for YYYY-MM-DD validation

### DIFF
--- a/src/features/admin/actions.ts
+++ b/src/features/admin/actions.ts
@@ -24,12 +24,12 @@ import { decryptAttendees } from "#shared/db/attendees.ts";
 import { getListingWithAttendeesRaw } from "#shared/db/listings.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { Attendee, ListingWithCount } from "#shared/types.ts";
+import { isIsoDate } from "#shared/validation/date.ts";
 
 /** Extract and validate ?date= query parameter. Returns null if absent or invalid. */
 export const getDateFilter = (request: Request): string | null => {
   const date = new URL(request.url).searchParams.get("date");
-  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
-  return date;
+  return date && isIsoDate(date) ? date : null;
 };
 
 /** Extract and validate ?cal= month parameter (YYYY-MM). Returns null if absent or invalid. */

--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -34,6 +34,7 @@ import {
   type ListingWithCount,
   normalizeDurationDays,
 } from "#shared/types.ts";
+import { isIsoDate } from "#shared/validation/date.ts";
 import {
   validateAddress,
   validateEmail,
@@ -286,17 +287,6 @@ export const resolveStatusId = (
 // Validation
 // ---------------------------------------------------------------------------
 
-const isValidDateString = (value: string): boolean => {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-  // Reject rollover typos (e.g. 2026-02-30 → Mar 2) by requiring the parsed
-  // date to serialize back to the same string, not just be non-NaN.
-  const parsed = new Date(`${value}T00:00:00Z`);
-  return (
-    !Number.isNaN(parsed.getTime()) &&
-    parsed.toISOString().slice(0, 10) === value
-  );
-};
-
 /**
  * Validate the attendee block + each line independently.
  *
@@ -420,7 +410,7 @@ const validateLine = (
   const isDaily = line.listing.listing_type === "daily";
   if (isDaily) {
     if (!line.date) return "Date is required for daily listings";
-    if (!isValidDateString(line.date)) {
+    if (!isIsoDate(line.date)) {
       return "Date must be a valid YYYY-MM-DD value";
     }
     const lineError = validateDailyLine(line, line.listing, holidays);

--- a/src/features/admin/built-sites.ts
+++ b/src/features/admin/built-sites.ts
@@ -30,6 +30,7 @@ import {
   rotateRenewalToken,
   syncReadOnlyFrom,
 } from "#shared/site-assignment.ts";
+import { isIsoDate } from "#shared/validation/date.ts";
 import {
   adminBuiltSiteDeletePage,
   adminBuiltSiteEditPage,
@@ -106,23 +107,8 @@ const readClampedMonths = (form: {
   return Math.min(months, MAX_RENEWAL_MONTHS);
 };
 
-const parseDeadlineDate = (dateStr: string): string | null => {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return null;
-  const [year, month, day] = dateStr.split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const date = new Date(Date.UTC(year, month - 1, day, 23, 59, 59));
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
-    return null;
-  }
-  return `${dateStr}T23:59:59Z`;
-};
+const parseDeadlineDate = (dateStr: string): string | null =>
+  isIsoDate(dateStr) ? `${dateStr}T23:59:59Z` : null;
 
 type AdminForm = { getString: (key: string) => string };
 

--- a/src/shared/validation/date.ts
+++ b/src/shared/validation/date.ts
@@ -1,0 +1,26 @@
+import * as v from "valibot";
+
+/**
+ * Calendar-date validation — the single source of truth for "is this a real
+ * day" in `YYYY-MM-DD` form across the app. Format is delegated to valibot's
+ * `isoDate` action (a 4-digit year, month `01`–`12`, day `01`–`31`); the
+ * trailing `check` additionally rejects rollover typos that share the format
+ * but aren't real days — e.g. `2026-02-30`, which `Date` would silently roll
+ * forward to March 2. valibot's `isoDate` already excludes out-of-range parts
+ * (`2026-99-99`), so the round-tripped `Date` can never be invalid here.
+ *
+ * Mirrors the schema + isValidXxx shape of validation/email.ts as the rest of
+ * the app's validation migrates to valibot.
+ */
+export const IsoDateSchema = v.pipe(
+  v.string(),
+  v.isoDate(),
+  v.check(
+    (value) =>
+      new Date(`${value}T00:00:00Z`).toISOString().slice(0, 10) === value,
+    "Date is not a real calendar day",
+  ),
+);
+
+/** Whether a string is a real calendar date in strict `YYYY-MM-DD` form. */
+export const isIsoDate = (value: string): boolean => v.is(IsoDateSchema, value);

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -31,6 +31,7 @@ import {
   type ListingType,
   MAX_DURATION_DAYS,
 } from "#shared/types.ts";
+import { isIsoDate } from "#shared/validation/date.ts";
 import { EmailFormatSchema } from "#shared/validation/email.ts";
 
 // ---------------------------------------------------------------------------
@@ -653,14 +654,8 @@ export const initialSiteMonthsField: Field = {
 };
 
 /** Validate date format (YYYY-MM-DD) */
-export const validateDate = (value: string): string | null => {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return "Please enter a valid date (YYYY-MM-DD)";
-  }
-  const date = new Date(`${value}T00:00:00Z`);
-  if (Number.isNaN(date.getTime())) return "Please enter a valid date";
-  return null;
-};
+export const validateDate = (value: string): string | null =>
+  isIsoDate(value) ? null : "Please enter a valid date (YYYY-MM-DD)";
 
 /**
  * Holiday form field definitions

--- a/test/lib/forms/listing-fields.test.ts
+++ b/test/lib/forms/listing-fields.test.ts
@@ -410,27 +410,21 @@ describe("holidayFields", () => {
 });
 
 describe("validateDate", () => {
-  test("accepts valid dates including leap day", () => {
+  test("returns null for a valid date", () => {
     expect(validateDate("2026-12-25")).toBeNull();
     expect(validateDate("2028-02-29")).toBeNull();
   });
 
-  test("rejects wrong format", () => {
+  test("returns the error message for an invalid date", () => {
+    // Exhaustive format/calendar coverage lives in the isIsoDate unit test;
+    // this only verifies validateDate maps a rejection to its message.
     expect(validateDate("12/25/2026")).toBe(
       "Please enter a valid date (YYYY-MM-DD)",
     );
-    expect(validateDate("2026-12")).toBe(
-      "Please enter a valid date (YYYY-MM-DD)",
-    );
-    expect(validateDate("not-a-date")).toBe(
+    expect(validateDate("2026-02-30")).toBe(
       "Please enter a valid date (YYYY-MM-DD)",
     );
     expect(validateDate("")).toBe("Please enter a valid date (YYYY-MM-DD)");
-  });
-
-  test("rejects month 00 and month 13 as impossible dates", () => {
-    expect(validateDate("2026-00-01")).toBe("Please enter a valid date");
-    expect(validateDate("2026-13-01")).toBe("Please enter a valid date");
   });
 });
 

--- a/test/lib/server-misc-admin-handlers.test.ts
+++ b/test/lib/server-misc-admin-handlers.test.ts
@@ -550,11 +550,10 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       expect(getDateFilter(request)).toBe("2024-01-15");
     });
 
-    test("getDateFilter returns null for invalid format", async () => {
+    test("getDateFilter returns null for an invalid date", async () => {
+      // Exhaustive date-format coverage lives in the isIsoDate unit test.
       const { getDateFilter } = await import("#routes/admin/actions.ts");
 
-      expect(getDateFilter(mockRequest("/test?date=01-15-2024"))).toBeNull();
-      expect(getDateFilter(mockRequest("/test?date=2024/01/15"))).toBeNull();
       expect(getDateFilter(mockRequest("/test?date=not-a-date"))).toBeNull();
     });
 

--- a/test/lib/validation/date.test.ts
+++ b/test/lib/validation/date.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { isIsoDate } from "#shared/validation/date.ts";
+
+describe("isIsoDate", () => {
+  test("accepts real calendar dates including the leap day", () => {
+    expect(isIsoDate("2026-12-25")).toBe(true);
+    expect(isIsoDate("2026-01-01")).toBe(true);
+    expect(isIsoDate("2028-02-29")).toBe(true); // 2028 is a leap year
+  });
+
+  test("rejects wrong formats", () => {
+    expect(isIsoDate("12/25/2026")).toBe(false);
+    expect(isIsoDate("2026/01/15")).toBe(false);
+    expect(isIsoDate("2026-12")).toBe(false);
+    expect(isIsoDate("2026-1-1")).toBe(false); // single-digit month/day
+    expect(isIsoDate("not-a-date")).toBe(false);
+    expect(isIsoDate("")).toBe(false);
+  });
+
+  test("rejects out-of-range months and days", () => {
+    expect(isIsoDate("2026-00-01")).toBe(false);
+    expect(isIsoDate("2026-13-01")).toBe(false);
+    expect(isIsoDate("2026-01-00")).toBe(false);
+    expect(isIsoDate("2026-01-32")).toBe(false);
+  });
+
+  test("rejects well-formatted but impossible calendar dates", () => {
+    expect(isIsoDate("2026-02-30")).toBe(false); // February never has 30 days
+    expect(isIsoDate("2027-02-29")).toBe(false); // 2027 is not a leap year
+    expect(isIsoDate("2026-06-31")).toBe(false); // June has only 30 days
+  });
+});


### PR DESCRIPTION
## What

The `YYYY-MM-DD` format regex (`/^\d{4}-\d{2}-\d{2}$/`) was hand-rolled in **four** places, each reimplementing valibot's [`isoDate`](https://valibot.dev/api/isoDate/) action at differing levels of strictness:

| Site | Old behaviour |
| --- | --- |
| `validateDate` (`templates/fields.ts`) | regex + weak `new Date` check |
| `getDateFilter` (`admin/actions.ts`) | regex only — accepted `2026-99-99` |
| `parseDeadlineDate` (`admin/built-sites.ts`) | regex + 15-line `Date.UTC` round-trip |
| `isValidDateString` (`admin/attendee-form-model.ts`) | regex + `toISOString` round-trip |

This PR consolidates them into a single valibot-backed helper, `isIsoDate` (`src/shared/validation/date.ts`), mirroring the existing `validation/email.ts` shape:

- **`v.isoDate()`** owns the format check — and, unlike the old `\d{2}` regex, properly rejects out-of-range parts like `2026-99-99` / `2026-13-01`.
- A small **round-trip `check`** rejects well-formatted-but-impossible days such as `2026-02-30` (which `Date` would silently roll to March 2) — something valibot doesn't do, so it stays as custom logic.

All four call sites now share one correct, consistent rule. As discussed, valibot's rules differ slightly from the old hand-rolled ones (e.g. `validateDate` now returns a single message instead of two, and `getDateFilter` rejects impossible dates it previously let through) — both are improvements.

## Why

Rolling our own validation that a library already provides is exactly the duplication to remove. The codebase already delegates email, slug, phone, username and enum validation to valibot; this brings date validation in line and deletes ~50 lines of bespoke parsing.

## Tests

- New `test/lib/validation/date.test.ts` owns the exhaustive format / range / calendar coverage for `isIsoDate`.
- Removed now-redundant per-site assertions: the `validateDate` "month 00/13" sub-test (it asserted a two-message distinction that no longer exists) and the duplicated `getDateFilter` format variations.
- `deno task precommit` passes: lint, typecheck, cpd, build:edge, and **test:coverage at 100%**.

https://claude.ai/code/session_011L9DZ5DjSDgZmDUeVVN1cB

---
_Generated by [Claude Code](https://claude.ai/code/session_011L9DZ5DjSDgZmDUeVVN1cB)_