### PR TITLE
Adopt valibot for remaining case-conversion, the email-provider guard, and test format checks

### DIFF
--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -9,6 +9,7 @@
  */
 
 import type { InValue } from "@libsql/client";
+import * as v from "valibot";
 import { compact, filter, mapParallel, reduce } from "#fp";
 import { registerCache } from "#shared/cache-registry.ts";
 import { getDb, queryAll, queryOne } from "#shared/db/client.ts";
@@ -96,17 +97,25 @@ export type InputFor<Row, Schema extends TableSchema<Row>> = {
   [K in OptionalInputKeys<Row, Schema>]?: Row[K];
 };
 
-/**
- * Convert snake_case to camelCase
- */
-export const toCamelCase = (s: string): string =>
-  s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+// Case conversion is delegated to valibot's `toCamelCase`/`toSnakeCase` actions
+// rather than bespoke regexes. The schemas are built once at module load and
+// reused on every call. valibot's word-splitting is more robust than a plain
+// regex (it handles digits and acronyms sensibly), and produces byte-identical
+// output to the previous implementation for every column name in the app's
+// table schemas, in both directions. These run only at table-definition time
+// (see `buildInputKeyMap` in `defineTable`), so the parse has no hot-path cost.
+const camelCaseSchema = v.pipe(v.string(), v.toCamelCase());
+const snakeCaseSchema = v.pipe(v.string(), v.toSnakeCase());
 
 /**
- * Convert camelCase to snake_case
+ * Convert snake_case to camelCase (e.g. `max_attendees` → `maxAttendees`).
  */
-export const toSnakeCase = (s: string): string =>
-  s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+export const toCamelCase = (s: string): string => v.parse(camelCaseSchema, s);
+
+/**
+ * Convert camelCase to snake_case (the inverse of {@link toCamelCase}).
+ */
+export const toSnakeCase = (s: string): string => v.parse(snakeCaseSchema, s);
 
 /**
  * Build input key mapping from DB columns

--- a/src/shared/email.ts
+++ b/src/shared/email.ts
@@ -3,6 +3,7 @@
  * Sends registration emails via HTTP email APIs (Resend, Postmark, SendGrid, Mailgun)
  */
 
+import * as v from "valibot";
 import { chunk, lazyRef, map } from "#fp";
 import { toBase64 } from "#shared/crypto/utils.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -232,14 +233,23 @@ const PROVIDERS = {
 /** Union of all supported email provider keys, derived from the PROVIDERS map */
 export type EmailProvider = keyof typeof PROVIDERS;
 
-/** Valid provider names, derived from the PROVIDERS map */
-export const VALID_EMAIL_PROVIDERS: ReadonlySet<EmailProvider> = new Set(
-  Object.keys(PROVIDERS) as EmailProvider[],
+/**
+ * Picklist schema for the supported email providers. Its options are derived
+ * from the PROVIDERS map so the two can never drift, and it mirrors the
+ * string-union picklists in types.ts (ContactFieldSchema, PaymentProviderSchema
+ * …) — `EmailProviderSchema.options` + `v.is` replace the previous hand-rolled
+ * Set + `.has()` guard.
+ */
+export const EmailProviderSchema = v.picklist(
+  Object.keys(PROVIDERS) as [EmailProvider, ...EmailProvider[]],
 );
+
+/** Valid provider names (the picklist options), derived from the PROVIDERS map */
+export const VALID_EMAIL_PROVIDERS = EmailProviderSchema.options;
 
 /** Type guard: checks if a string is a valid EmailProvider */
 export const isEmailProvider = (value: string): value is EmailProvider =>
-  (VALID_EMAIL_PROVIDERS as ReadonlySet<string>).has(value);
+  v.is(EmailProviderSchema, value);
 
 /** Display labels for email providers — keys must match EmailProvider */
 export const EMAIL_PROVIDER_LABELS: Record<EmailProvider, string> = {

--- a/src/ui/templates/admin/settings/email.tsx
+++ b/src/ui/templates/admin/settings/email.tsx
@@ -30,7 +30,7 @@ export const EmailNotificationsForm = (
           <option selected={!s.emailProvider} value="">
             {s.hostEmailLabel || "None (disabled)"}
           </option>
-          {Array.from(VALID_EMAIL_PROVIDERS).map((p) => (
+          {VALID_EMAIL_PROVIDERS.map((p) => (
             <option selected={s.emailProvider === p} value={p}>
               {EMAIL_PROVIDER_LABELS[p]}
             </option>

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import * as v from "valibot";
 import { decryptBytes, encryptBytes } from "#shared/crypto/encryption.ts";
 import {
   ATTACHMENT_ERROR_MESSAGES,
@@ -459,9 +460,13 @@ describeWithEnv(
     describe("generateAttachmentFilename", () => {
       test("generates filename with UUID prefix and original name", () => {
         const filename = generateAttachmentFilename("report.pdf");
-        expect(filename).toMatch(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-report\.pdf$/,
+        // The prefix is a real UUID (from crypto.randomUUID), validated with
+        // valibot's uuid() rather than a hand-rolled hex regex; the sanitized
+        // original name follows it.
+        expect(v.is(v.pipe(v.string(), v.uuid()), filename.slice(0, 36))).toBe(
+          true,
         );
+        expect(filename.slice(36)).toBe("-report.pdf");
       });
 
       test("sanitizes special characters in filename", () => {

--- a/test/lib/timezone.test.ts
+++ b/test/lib/timezone.test.ts
@@ -10,6 +10,7 @@ import {
   todayInTz,
   utcToLocalInput,
 } from "#shared/timezone.ts";
+import { isIsoDate } from "#shared/validation/date.ts";
 
 describe("timezone", () => {
   describe("DEFAULT_TIMEZONE", () => {
@@ -21,7 +22,10 @@ describe("timezone", () => {
   describe("todayInTz", () => {
     test("returns a YYYY-MM-DD string", () => {
       const result = todayInTz("Europe/London");
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      // Reuse the production calendar-date guard rather than a hand-rolled
+      // regex: it enforces the same YYYY-MM-DD shape and additionally that the
+      // value is a real calendar day, which today's date always is.
+      expect(isIsoDate(result)).toBe(true);
     });
 
     test("returns same date for same timezone", () => {


### PR DESCRIPTION
## What

Several focused swaps continuing the app's migration of hand-rolled validation/transform code onto valibot.

### 1. `toCamelCase` / `toSnakeCase` — `src/shared/db/table.ts`
Delegated the regex case-conversion helpers to valibot's `toCamelCase`/`toSnakeCase` actions (schemas built once at module load; only ever called at table-definition time, so no per-row cost). Verified byte-identical output to the old regexes for every column name in the schema, both directions.

### 2. Email-provider guard — `src/shared/email.ts`
Replaced the `VALID_EMAIL_PROVIDERS` Set + `.has()` guard with a valibot `picklist`, matching the string-union picklists already used throughout `types.ts`. Options derive from `Object.keys(PROVIDERS)` so the schema and the provider map can't drift; `isEmailProvider` delegates to `v.is`.

### 3. Test assertions — `test/lib/timezone.test.ts`, `test/lib/storage.test.ts`
Stop re-deriving formats that valibot (or a valibot-backed production guard) already expresses:
- `timezone.test.ts`: assert `todayInTz` output via the production `isIsoDate` guard instead of a `\d{4}-\d{2}-\d{2}` regex — reuses production validation (per the repo's "test production code, don't reimplement" rule) and is stricter (real calendar day).
- `storage.test.ts`: validate an attachment filename's UUID prefix with valibot's `uuid()` instead of a hand-rolled hex-group regex (the UUID comes from `crypto.randomUUID`, so there's no production guard to reuse).

## Scope note

Most general validators were **already** migrated to valibot, and the test suite already reuses production validators rather than reimplementing them. The remaining custom code was deliberately left as-is where valibot is not an equal-or-better fit — e.g. our URL checks must allow relative paths and enforce `https:` + SSRF blocking (valibot's `url()` accepts `javascript:`/`ftp:` and rejects relative paths); `isValidDatetime` validates real calendar dates via `@internationalized/date` (valibot's `isoDateTime` is format-only); `DOMAIN_PATTERN` is structurally reused via `.source` to build the wildcard host pattern; and the release-tag / backup-timestamp regexes are non-standard formats valibot's ISO validators don't match.

## Checks

`deno task precommit` passes: lint ✓, typecheck ✓, cpd ✓, build:edge ✓, test:coverage ✓ (100% coverage maintained).

https://claude.ai/code/session_01Yb2kAWx4pHWakmnjotpfTH