### PR TITLE
ci: run the full precommit battery in the Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,49 +21,26 @@ jobs:
         with:
           deno-version: v2.x
 
+      # stripe-mock is downloaded, started, and stopped by scripts/run-tests.ts
+      # (invoked via the test:coverage step inside precommit). Caching .bin just
+      # avoids re-downloading it on every run.
       - name: Cache stripe-mock
         uses: actions/cache@v4
         with:
           path: .bin
           key: stripe-mock-${{ env.STRIPE_MOCK_VERSION }}-linux-amd64
 
-      - name: Download stripe-mock
-        run: |
-          if [ ! -f .bin/stripe-mock ]; then
-            mkdir -p .bin
-            curl -sL "https://github.com/stripe/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" | tar -xz -C .bin
-            chmod +x .bin/stripe-mock
-          fi
-
       - name: Install dependencies
         run: deno install --allow-scripts
 
-      - name: Typecheck
-        run: deno task typecheck
-
-      - name: Lint
-        run: |
-          deno task lint
-          git diff --exit-code || (echo "::error::Code is not formatted/linted. Run 'deno task lint' locally and commit the result." && exit 1)
-
-      - name: Copy-paste detection
-        run: deno task cpd
-
-      - name: Build edge script
-        run: deno task build:edge
-
-      - name: Start stripe-mock
-        run: |
-          .bin/stripe-mock -http-port 12111 &
-          sleep 2
-          curl -s http://localhost:12111 > /dev/null && echo "stripe-mock is running"
-
-      - name: Run tests with coverage
+      # Runs the same battery as a local `deno task precommit` (lint, typecheck,
+      # cpd, build:edge, test:coverage) so CI and precommit can never drift. The
+      # --ci flag makes the lint step fail on unformatted code instead of
+      # silently fixing it.
+      - name: Run precommit checks
         env:
-          STRIPE_MOCK_HOST: localhost
-          STRIPE_MOCK_PORT: "12111"
           DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
-        run: deno task test:coverage
+        run: deno task precommit --ci
 
       - name: Generate HTML coverage report
         if: always()

--- a/scripts/precommit.ts
+++ b/scripts/precommit.ts
@@ -17,6 +17,8 @@ interface Step {
   cmd: string[];
   filterOutput?: (stdout: string, stderr: string) => string;
   name: string;
+  /** Runs after a successful command; return an error message to fail the step */
+  verify?: () => Promise<string | null>;
 }
 
 /** True when a line starts an ERRORS or FAILURES section or is a summary line */
@@ -46,9 +48,33 @@ const filterTestOutput = (stdout: string, stderr: string): string => {
   return output.join("\n").trim();
 };
 
-const getSteps = (): Step[] => {
+/** True when running in CI (the --ci flag or a CI env var is set) */
+const isCi = (): boolean =>
+  Deno.args.includes("--ci") || Boolean(Deno.env.get("CI"));
+
+/**
+ * In CI, `lint` (Biome `check --write`) silently fixes files and exits 0, so a
+ * passing lint step would hide unformatted code. After it runs, fail if the
+ * working tree changed — the same guard the CI workflow used to inline.
+ */
+const checkFormatted = async (): Promise<string | null> => {
+  const { success } = await new Deno.Command("git", {
+    args: ["diff", "--exit-code"],
+    stderr: "null",
+    stdout: "null",
+  }).output();
+  return success
+    ? null
+    : "Code is not formatted/linted. Run 'deno task lint' locally and commit the result.";
+};
+
+const getSteps = (ci: boolean): Step[] => {
   return [
-    { cmd: ["deno", "task", "lint"], name: "lint" },
+    {
+      cmd: ["deno", "task", "lint"],
+      name: "lint",
+      verify: ci ? checkFormatted : undefined,
+    },
     { cmd: ["deno", "task", "typecheck"], name: "typecheck" },
     { cmd: ["deno", "task", "cpd"], name: "cpd" },
     { cmd: ["deno", "task", "build:edge"], name: "build:edge" },
@@ -74,8 +100,14 @@ const runStep = async (step: Step): Promise<boolean> => {
   const elapsed = ((performance.now() - start) / 1000).toFixed(1);
 
   if (result.success) {
-    write(`${green("✓")} ${dim(`${elapsed}s`)}\n`);
-    return true;
+    const verifyError = step.verify ? await step.verify() : null;
+    if (!verifyError) {
+      write(`${green("✓")} ${dim(`${elapsed}s`)}\n`);
+      return true;
+    }
+    write(`${red("✗")} ${dim(`${elapsed}s`)}\n`);
+    console.log(verifyError);
+    return false;
   }
 
   write(`${red("✗")} ${dim(`${elapsed}s`)}\n`);
@@ -89,9 +121,10 @@ const runStep = async (step: Step): Promise<boolean> => {
 };
 
 const main = async (): Promise<void> => {
-  console.log(bold("precommit"));
+  const ci = isCi();
+  console.log(bold(ci ? "precommit (ci)" : "precommit"));
 
-  const steps = getSteps();
+  const steps = getSteps(ci);
   for (const step of steps) {
     const passed = await runStep(step);
     if (!passed) {


### PR DESCRIPTION
## What

The Test workflow (`.github/workflows/test.yml`) re-listed each check — typecheck, lint, cpd, build:edge, test:coverage — as its own step, duplicating the step list already defined in `scripts/precommit.ts`. The two could silently drift: adding a check to precommit didn't add it to CI, and vice-versa.

This makes `scripts/precommit.ts` the single source of truth. CI now runs one step: `deno task precommit --ci`.

## Changes

- **`scripts/precommit.ts`** — added a CI mode (`--ci` flag, or any truthy `CI` env var, which GitHub Actions sets automatically). The step list is unchanged; the only difference in CI is the lint step:
  - `lint` runs Biome `check --write` (same as before), which auto-fixes and exits `0`.
  - In CI, a `verify` hook then runs `git diff --exit-code` and **fails the step** if linting modified any tracked files — preserving the workflow's old "code is not formatted/linted" gate that a plain auto-fixing lint would otherwise hide. Locally (`deno task precommit`, no `--ci`) the behaviour is unchanged: lint just fixes in place.
- **`.github/workflows/test.yml`** — replaced the five separate check steps with a single `Run precommit checks` step (`deno task precommit --ci`). Removed the redundant *Download stripe-mock* and *Start stripe-mock* steps: `scripts/run-tests.ts` (invoked via `test:coverage`) already downloads, starts, and stops stripe-mock, and sets the `STRIPE_MOCK_*` env vars itself. The `.bin` cache is kept so stripe-mock isn't re-downloaded each run. The coverage HTML report + artifact upload steps are unchanged.

## Verification

`deno task precommit --ci` was run locally:

- Happy path (clean tree): `lint ✓ · typecheck ✓ · cpd ✓ · build:edge ✓ · test:coverage ✓` → `precommit passed`. The `test:coverage` step confirms `run-tests.ts` downloads/starts/stops stripe-mock on its own, which is what makes removing those workflow steps safe.
- Guard (unformatted tracked file): the lint step fails with `Code is not formatted/linted. Run 'deno task lint' locally and commit the result.`, matching the message the workflow used to emit inline.

https://claude.ai/code/session_01A1V1DJPHuXoPBWYcFGcNL7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1V1DJPHuXoPBWYcFGcNL7)_