### PR TITLE
Group the listing form into sections; reveal day prices under its toggle

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1291,27 +1291,70 @@ label.terms-agree {
   min-width: 0;
 }
 
-/* Hide daily-only fields when listing type is "standard" */
+/* Listing form sections: grouped <fieldset>s with a heading legend, and a
+   collapsible <details> for the technical/advanced fields. Field spacing inside
+   each section comes from the nested .stack; the form's gap spaces the sections
+   themselves. */
+.listing-section {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+
+.listing-section > legend {
+  display: block;
+  width: 100%;
+  margin-bottom: var(--space-m);
+  padding-bottom: var(--space-s);
+  border-bottom: 1px solid var(--color-bg-secondary);
+  font-weight: bold;
+  font-size: 1.05rem;
+}
+
+.listing-advanced > summary {
+  font-size: 1.05rem;
+}
+
+/* When expanded, the summary reads as a section heading like the legends. */
+.listing-advanced[open] > summary {
+  margin-bottom: var(--space-m);
+  padding-bottom: var(--space-s);
+  border-bottom: 1px solid var(--color-bg-secondary);
+}
+
+/* Daily-only scheduling fields are grouped in one section, hidden entirely for
+   standard listings (which book a single fixed date instead). */
 form:has(select[name="listing_type"] option[value="standard"]:checked)
-  > label:has([name="bookable_days"]),
-form:has(select[name="listing_type"] option[value="standard"]:checked)
-  > label:has([name="minimum_days_before"]),
-form:has(select[name="listing_type"] option[value="standard"]:checked)
-  > label:has([name="maximum_days_after"]),
-form:has(select[name="listing_type"] option[value="standard"]:checked)
-  > label:has([name="duration_days"]) {
+  .listing-section--daily {
   display: none;
 }
 
-/* Hide listing date field when listing type is "daily" */
+/* Booking duration applies to daily listings, or to any listing using
+   customisable day pricing (where it caps how many days a visitor may pick). */
+form:has(select[name="listing_type"] option[value="standard"]:checked):not(
+    :has(input[name="customisable_days"]:checked)
+  )
+  label:has([name="duration_days"]) {
+  display: none;
+}
+
+/* Hide listing date field when listing type is "daily" (dates are chosen per
+   booking instead). */
 form:has(select[name="listing_type"] option[value="daily"]:checked)
-  > label:has([name="date_date"]) {
+  label:has([name="date_date"]) {
+  display: none;
+}
+
+/* Day prices only apply when "Customisable Days" is enabled; revealed in place
+   right beneath the checkbox that controls them. */
+form:not(:has(input[name="customisable_days"]:checked)) #day-prices {
   display: none;
 }
 
 /* Hide max price field when "Allow Pay More" is not checked */
 form:not(:has(input[name="can_pay_more"]:checked))
-  > label:has([name="max_price"]) {
+  label:has([name="max_price"]) {
   display: none;
 }
 

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -141,10 +141,9 @@ const LineRow = ({
   const isCustomisable = Boolean(
     line.listing?.customisable_days && line.listing.listing_type === "daily",
   );
-  const dayCounts =
-    line.listing && line.listing.customisable_days
-      ? availableDayCounts(line.listing)
-      : [];
+  const dayCounts = line.listing?.customisable_days
+    ? availableDayCounts(line.listing)
+    : [];
   const selectedDayCount = isCustomisable ? lineDayCount(line) : 0;
   const removeLabel = line.existingBooking ? "Remove" : "Drop";
   return (
@@ -493,28 +492,23 @@ const StatusAndBalanceFields = ({
 };
 
 /**
- * Render the unified attendee form page (create or edit).
- *
- * The single CsrfForm wraps every input including the line editor, so the
- * add-line / remove-line / save buttons are all submitters of the same
- * form. The server distinguishes them by the `action` value.
+ * The editable attendee form: contact details, optional custom questions, and
+ * the listing-line editor, all inside one CsrfForm. Status & Balance sit right
+ * after the name and before the contact fields, per the agreed field order.
+ * The add-line / remove-line / save buttons are all submitters of this one
+ * form; the server distinguishes them by the `action` value.
  */
-export const attendeeFormPage = (
-  data: AttendeeFormTemplateData,
-  session: AdminSession,
-): string => {
+const AttendeeEditForm = ({
+  data,
+}: {
+  data: AttendeeFormTemplateData;
+}): JSX.Element => {
+  const isEdit = data.mode === "edit";
   const formAction =
     data.mode === "create"
       ? "/admin/attendees/new"
       : `/admin/attendees/${data.attendee!.id}`;
-  const isEdit = data.mode === "edit";
-  const a = data.attendee;
-
-  // The whole editable form. Status & Balance sit right after the name and
-  // before the contact fields, per the agreed field order. In edit mode the
-  // read-only summary above is the primary view, so the form is tucked into a
-  // collapsed disclosure (see below); in create mode it is the page.
-  const editForm = (
+  return (
     <CsrfForm action={formAction} id={ATTENDEE_FORM_ID}>
       <Flash error={data.flashError} success={data.flashSuccess} />
       {data.returnUrl && (
@@ -622,6 +616,25 @@ export const attendeeFormPage = (
       </p>
     </CsrfForm>
   );
+};
+
+/**
+ * Render the unified attendee form page (create or edit).
+ *
+ * The single CsrfForm wraps every input including the line editor, so the
+ * add-line / remove-line / save buttons are all submitters of the same
+ * form. The server distinguishes them by the `action` value.
+ */
+export const attendeeFormPage = (
+  data: AttendeeFormTemplateData,
+  session: AdminSession,
+): string => {
+  const isEdit = data.mode === "edit";
+  const a = data.attendee;
+
+  // In edit mode the read-only summary above is the primary view, so the form
+  // is tucked into a collapsed disclosure (below); in create mode it is the page.
+  const editForm = <AttendeeEditForm data={data} />;
 
   return String(
     <Layout title={pageTitle(data)}>

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -2,7 +2,7 @@
  * Admin listing page templates - detail, edit, delete
  */
 
-import { filter, joinStrings, map, pipe } from "#fp";
+import { compact, filter, joinStrings, map, pipe } from "#fp";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { formatCountdown } from "#routes/format.ts";
 import { targetQuery } from "#shared/bulk-email.ts";
@@ -23,7 +23,6 @@ import {
   entityToFieldValues,
   type FieldValues,
   Flash,
-  renderField,
   renderFields,
 } from "#shared/forms.tsx";
 import { escapeHtml, Raw } from "#shared/jsx/jsx-runtime.ts";
@@ -1091,6 +1090,191 @@ const listingFieldsWithAutofocus: Field[] = pipe(
   map((f: Field): Field => (f.name === "name" ? { ...f, autofocus: true } : f)),
 )(listingFields);
 
+// ---------------------------------------------------------------------------
+// Sectioned listing form
+//
+// The listing form is grouped into labelled <fieldset> sections plus a
+// collapsible Advanced <details> for the technical fields most owners never
+// touch. Each array below fixes the field order within its section; names
+// absent from the assembled field list (builder-only or storage-only fields,
+// or slug on the create form) are skipped. The "Booking Duration & Day Prices"
+// section is assembled inline because it interleaves the day-prices fieldset
+// and the edit-only duration-change warning.
+//
+// Conditional visibility (daily-only fields, day prices, max price) is handled
+// entirely in CSS via :has() — see the form rules in mvp.css. The day-prices
+// block sits right under the "Customisable Days" checkbox so enabling it
+// reveals the prices in place.
+// ---------------------------------------------------------------------------
+
+const BASICS_FIELDS = [
+  "name",
+  "listing_type",
+  "description",
+  "date",
+  "location",
+  "image",
+  "attachment",
+] as const;
+
+const TICKET_FIELDS = [
+  "max_attendees",
+  "max_quantity",
+  "closes_at",
+  "unit_price",
+  "can_pay_more",
+  "max_price",
+] as const;
+
+const DAILY_FIELDS = [
+  "bookable_days",
+  "minimum_days_before",
+  "maximum_days_after",
+] as const;
+
+const OPTION_FIELDS = [
+  "fields",
+  "non_transferable",
+  "purchase_only",
+  "hidden",
+] as const;
+
+const ADVANCED_FIELDS = [
+  "thank_you_url",
+  "webhook_url",
+  "months_per_unit",
+  "initial_site_months",
+  "assign_built_site",
+  "slug",
+] as const;
+
+/**
+ * Whether the Advanced section should render expanded. Open it when any of its
+ * fields already carries a value, so editors don't lose track of a configured
+ * webhook or renewal tier. Slug is deliberately excluded: it is always set, so
+ * counting it would force the section open on every edit. Builder-only fields
+ * only count when the builder is enabled (otherwise they aren't rendered).
+ */
+const advancedSectionHasValues = (
+  listing: ListingWithCount,
+  builderEnabled: boolean,
+): boolean => {
+  if (listing.thank_you_url || listing.webhook_url) return true;
+  return (
+    builderEnabled &&
+    (listing.months_per_unit > 0 ||
+      listing.initial_site_months > 0 ||
+      listing.assign_built_site)
+  );
+};
+
+/** Edit-only warning shown next to the booking-duration field: changing it
+ * rewrites end_at on every existing booking. Wired up by initDurationWarning. */
+const DurationWarning = ({
+  listing,
+}: {
+  listing: ListingWithCount;
+}): JSX.Element => (
+  <div
+    data-duration-original={listing.duration_days}
+    hidden
+    id="duration-warning"
+  >
+    <p>
+      <strong>Warning:</strong> Changing booking duration will update existing
+      bookings for this listing.
+    </p>
+    <label>
+      <input id="duration-warning-confirm" type="checkbox" />I understand
+    </label>
+  </div>
+);
+
+/**
+ * Render the body of a listing form (create, duplicate, or edit) as grouped
+ * sections. The surrounding <form>, page heading, and submit button differ per
+ * page and stay in the individual page functions.
+ */
+const ListingFormSections = ({
+  fields,
+  values,
+  groups,
+  selectedGroupId,
+  dayPricesListing,
+  durationWarning,
+  imagePreview,
+  advancedOpen,
+}: {
+  fields: Field[];
+  values: FieldValues;
+  groups: Group[];
+  selectedGroupId: number;
+  /** Listing whose duration sizes the day-price rows (absent on create). */
+  dayPricesListing?: ListingWithCount;
+  /** Pre-rendered edit-only duration-change warning ("" on create/duplicate). */
+  durationWarning: string;
+  /** Pre-rendered edit-only current-image preview ("" otherwise). */
+  imagePreview: string;
+  advancedOpen: boolean;
+}): JSX.Element => {
+  const fieldMap = new Map<string, Field>(fields.map((f) => [f.name, f]));
+  const sec = (names: readonly string[]): string =>
+    renderFields(compact(names.map((n) => fieldMap.get(n))), values);
+  return (
+    <>
+      <fieldset class="listing-section">
+        <legend>Basics</legend>
+        <div class="stack">
+          <Raw html={sec(BASICS_FIELDS)} />
+          {imagePreview && <Raw html={imagePreview} />}
+          <ListingGroupSelect
+            groups={groups}
+            selectedGroupId={selectedGroupId}
+          />
+        </div>
+      </fieldset>
+
+      <fieldset class="listing-section">
+        <legend>Tickets &amp; Pricing</legend>
+        <div class="stack">
+          <Raw html={sec(TICKET_FIELDS)} />
+        </div>
+      </fieldset>
+
+      <fieldset class="listing-section listing-section--daily">
+        <legend>Daily Scheduling</legend>
+        <div class="stack">
+          <Raw html={sec(DAILY_FIELDS)} />
+        </div>
+      </fieldset>
+
+      <fieldset class="listing-section">
+        <legend>Booking Duration &amp; Day Prices</legend>
+        <div class="stack">
+          <Raw html={sec(["duration_days"])} />
+          {durationWarning && <Raw html={durationWarning} />}
+          <Raw html={sec(["customisable_days"])} />
+          <Raw html={renderDayPricesFieldset(dayPricesListing)} />
+        </div>
+      </fieldset>
+
+      <fieldset class="listing-section">
+        <legend>Options &amp; Visibility</legend>
+        <div class="stack">
+          <Raw html={sec(OPTION_FIELDS)} />
+        </div>
+      </fieldset>
+
+      <details class="listing-advanced" open={advancedOpen}>
+        <summary>Advanced settings</summary>
+        <div class="stack">
+          <Raw html={sec(ADVANCED_FIELDS)} />
+        </div>
+      </details>
+    </>
+  );
+};
+
 /**
  * Admin listing create page
  */
@@ -1115,9 +1299,15 @@ export const adminListingNewPage = (
       <CsrfForm action="/admin/listing" enctype="multipart/form-data">
         <h1>Add Listing</h1>
         <Flash error={error} />
-        <Raw html={renderFields(fields)} />
-        <Raw html={renderDayPricesFieldset()} />
-        <ListingGroupSelect groups={groups} selectedGroupId={0} />
+        <ListingFormSections
+          advancedOpen={!!error}
+          durationWarning=""
+          fields={fields}
+          groups={groups}
+          imagePreview=""
+          selectedGroupId={0}
+          values={{}}
+        />
         <SubmitButton icon="plus">Create Listing</SubmitButton>
       </CsrfForm>
     </Layout>,
@@ -1154,11 +1344,15 @@ export const adminDuplicateListingPage = (
         </p>
       </div>
       <CsrfForm action="/admin/listing" enctype="multipart/form-data">
-        <Raw html={renderFields(dupFields, values)} />
-        <Raw html={renderDayPricesFieldset(listing)} />
-        <ListingGroupSelect
+        <ListingFormSections
+          advancedOpen={advancedSectionHasValues(listing, builderEnabled)}
+          dayPricesListing={listing}
+          durationWarning=""
+          fields={dupFields}
           groups={groups}
+          imagePreview=""
           selectedGroupId={listing.group_id}
+          values={values}
         />
         <SubmitButton icon="plus">Create Listing</SubmitButton>
       </CsrfForm>
@@ -1177,13 +1371,21 @@ export const adminListingEditPage = (
 ): string => {
   const storageEnabled = isStorageEnabled();
   const builderEnabled = isBuilderEnabled();
+  // Slug is editable only here (auto-generated on create), so it lives in the
+  // edit form's field list rather than the shared definitions.
   const fields = [
     ...listingFields,
     ...(builderEnabled
       ? [monthsPerUnitField, initialSiteMonthsField, assignBuiltSiteField]
       : []),
     ...(storageEnabled ? [imageField, attachmentField] : []),
+    slugField,
   ];
+  const imagePreview =
+    storageEnabled && listing.image_url
+      ? renderListingImage(listing, "listing-image-full")
+      : "";
+  const durationWarning = String(<DurationWarning listing={listing} />);
   return String(
     <Layout title={`Edit: ${listing.name}`}>
       <AdminNav active="/admin/" session={session} />
@@ -1193,29 +1395,18 @@ export const adminListingEditPage = (
         enctype="multipart/form-data"
         id="listing-edit-form"
       >
-        <Raw html={renderFields(fields, listingToFieldValues(listing))} />
-        <Raw html={renderDayPricesFieldset(listing)} />
-        <ListingGroupSelect
+        <ListingFormSections
+          advancedOpen={
+            advancedSectionHasValues(listing, builderEnabled) || !!error
+          }
+          dayPricesListing={listing}
+          durationWarning={durationWarning}
+          fields={fields}
           groups={groups}
+          imagePreview={imagePreview}
           selectedGroupId={listing.group_id}
+          values={listingToFieldValues(listing)}
         />
-        <Raw html={renderField(slugField, String(listing.slug))} />
-        {storageEnabled && listing.image_url && (
-          <Raw html={renderListingImage(listing, "listing-image-full")} />
-        )}
-        <div
-          data-duration-original={listing.duration_days}
-          hidden
-          id="duration-warning"
-        >
-          <p>
-            <strong>Warning:</strong> Changing booking duration will update
-            existing bookings for this listing.
-          </p>
-          <label>
-            <input id="duration-warning-confirm" type="checkbox" />I understand
-          </label>
-        </div>
         <SubmitButton icon="save" id="listing-edit-submit">
           Save Changes
         </SubmitButton>

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -88,6 +88,166 @@ describe("adminListingEditPage day prices", () => {
   });
 });
 
+describe("adminListingEditPage form sections", () => {
+  test("groups fields under section legends and an Advanced disclosure", () => {
+    const listing = testListingWithCount();
+    const html = adminListingEditPage(listing, [], TEST_SESSION);
+    expect(html).toContain("<legend>Basics</legend>");
+    expect(html).toContain("<legend>Tickets &amp; Pricing</legend>");
+    expect(html).toContain("<legend>Daily Scheduling</legend>");
+    expect(html).toContain(
+      "<legend>Booking Duration &amp; Day Prices</legend>",
+    );
+    expect(html).toContain("<legend>Options &amp; Visibility</legend>");
+    expect(html).toContain("<summary>Advanced settings</summary>");
+  });
+
+  test("renders the day-prices block immediately after the customisable-days checkbox", () => {
+    const listing = testListingWithCount({
+      customisable_days: true,
+      day_prices: { 1: 1000 },
+      duration_days: 1,
+    });
+    const html = adminListingEditPage(listing, [], TEST_SESSION);
+    const customisableIdx = html.indexOf('name="customisable_days"');
+    const dayPriceIdx = html.indexOf('name="day_price_1"');
+    const contactFieldsIdx = html.indexOf('name="fields"');
+    // The prices follow the checkbox, and both sit before the later Options
+    // section — i.e. no longer dumped at the bottom of the form.
+    expect(customisableIdx).toBeGreaterThan(-1);
+    expect(customisableIdx).toBeLessThan(dayPriceIdx);
+    expect(dayPriceIdx).toBeLessThan(contactFieldsIdx);
+  });
+
+  test("places the technical fields inside the Advanced disclosure", () => {
+    const listing = testListingWithCount();
+    const html = adminListingEditPage(listing, [], TEST_SESSION);
+    const advancedIdx = html.indexOf("<summary>Advanced settings</summary>");
+    expect(advancedIdx).toBeGreaterThan(-1);
+    expect(advancedIdx).toBeLessThan(html.indexOf('name="webhook_url"'));
+    expect(advancedIdx).toBeLessThan(html.indexOf('name="thank_you_url"'));
+    expect(advancedIdx).toBeLessThan(html.indexOf('name="slug"'));
+  });
+});
+
+describe("adminListingEditPage Advanced section auto-open", () => {
+  test("stays collapsed when only the slug is set", () => {
+    // Slug is always populated; on its own it must not force the section open.
+    const listing = testListingWithCount({
+      thank_you_url: "",
+      webhook_url: "",
+    });
+    const html = adminListingEditPage(listing, [], TEST_SESSION);
+    expect(html).toContain('<details class="listing-advanced">');
+    expect(html).not.toContain('<details class="listing-advanced" open>');
+  });
+
+  test("opens when a thank-you URL is set", () => {
+    const listing = testListingWithCount({
+      thank_you_url: "https://example.com/thanks",
+      webhook_url: "",
+    });
+    const html = adminListingEditPage(listing, [], TEST_SESSION);
+    expect(html).toContain('<details class="listing-advanced" open>');
+  });
+
+  test("opens when a webhook URL is set", () => {
+    const listing = testListingWithCount({
+      thank_you_url: "",
+      webhook_url: "https://hooks.example.com/notify",
+    });
+    const html = adminListingEditPage(listing, [], TEST_SESSION);
+    expect(html).toContain('<details class="listing-advanced" open>');
+  });
+
+  test("opens on a validation error so hidden fields stay reachable", () => {
+    const listing = testListingWithCount({
+      thank_you_url: "",
+      webhook_url: "",
+    });
+    const html = adminListingEditPage(listing, [], TEST_SESSION, "Bad input");
+    expect(html).toContain('<details class="listing-advanced" open>');
+  });
+});
+
+describe("adminListingNewPage Advanced section", () => {
+  test("renders collapsed by default", () => {
+    const html = adminListingNewPage([], TEST_SESSION);
+    expect(html).toContain('<details class="listing-advanced">');
+    expect(html).not.toContain('<details class="listing-advanced" open>');
+  });
+
+  test("opens when re-rendered with an error", () => {
+    const html = adminListingNewPage([], TEST_SESSION, "Something went wrong");
+    expect(html).toContain('<details class="listing-advanced" open>');
+  });
+});
+
+describe("adminListingEditPage Advanced section auto-open (builder fields)", () => {
+  const withBuilder = (fn: () => void): void => {
+    Deno.env.set("CAN_BUILD_SITES", "true");
+    try {
+      fn();
+    } finally {
+      Deno.env.delete("CAN_BUILD_SITES");
+    }
+  };
+
+  test("opens when a renewal tier (months per unit) is set", () => {
+    withBuilder(() => {
+      const listing = testListingWithCount({
+        months_per_unit: 3,
+        thank_you_url: "",
+        webhook_url: "",
+      });
+      const html = adminListingEditPage(listing, [], TEST_SESSION);
+      expect(html).toContain('<details class="listing-advanced" open>');
+    });
+  });
+
+  test("opens when initial site months is set", () => {
+    withBuilder(() => {
+      const listing = testListingWithCount({
+        initial_site_months: 6,
+        months_per_unit: 0,
+        thank_you_url: "",
+        webhook_url: "",
+      });
+      const html = adminListingEditPage(listing, [], TEST_SESSION);
+      expect(html).toContain('<details class="listing-advanced" open>');
+    });
+  });
+
+  test("opens when a built site is assigned on booking", () => {
+    withBuilder(() => {
+      const listing = testListingWithCount({
+        assign_built_site: true,
+        initial_site_months: 0,
+        months_per_unit: 0,
+        thank_you_url: "",
+        webhook_url: "",
+      });
+      const html = adminListingEditPage(listing, [], TEST_SESSION);
+      expect(html).toContain('<details class="listing-advanced" open>');
+    });
+  });
+
+  test("stays collapsed when no advanced field is set even with the builder enabled", () => {
+    withBuilder(() => {
+      const listing = testListingWithCount({
+        assign_built_site: false,
+        initial_site_months: 0,
+        months_per_unit: 0,
+        thank_you_url: "",
+        webhook_url: "",
+      });
+      const html = adminListingEditPage(listing, [], TEST_SESSION);
+      expect(html).toContain('<details class="listing-advanced">');
+      expect(html).not.toContain('<details class="listing-advanced" open>');
+    });
+  });
+});
+
 describe("adminListingPage duration display", () => {
   test("shows booking duration row for daily listings", () => {
     const listing = testListingWithCount({


### PR DESCRIPTION
## Why

The listing create/edit form was one long flat list of ~22 fields. Two problems:

- **"Day Prices (customisable days)" was easy to miss** — it rendered at the very bottom of the form, ~10 fields below the *Customisable Days* checkbox that controls it, and was shown even when that checkbox was off.
- **No grouping** — technical fields only a minority touch (webhook URL, thank-you page, slug) sat inline next to mandatory ones, and fields whose meaning depends on other selections weren't visually grouped.

## What changed

The three listing forms (create, duplicate, edit) now render through a shared `ListingFormSections` component that groups fields into labelled `<fieldset>` sections:

1. **Basics** — name, type, description, date, location, image/attachment, group
2. **Tickets & Pricing** — capacity, ticket limits, price, pay-more/max-price
3. **Daily Scheduling** — bookable days, notice windows *(hidden entirely for standard listings)*
4. **Booking Duration & Day Prices** — duration, the **Customisable Days** checkbox, and the day-prices block **right beneath it**
5. **Options & Visibility** — contact fields, non-transferable, purchase-only, hidden
6. **Advanced settings** — a collapsed `<details>` for the technical fields (thank-you URL, webhook URL, slug, renewal/built-site)

### Day prices appear where you'd expect
- Repositioned to render **immediately after** the Customisable Days checkbox.
- A CSS `:has()` rule reveals it only when the checkbox is ticked — reusing the project's existing JS-free conditional-field pattern (max price, daily-only fields). Booking duration now also stays visible for **standard** listings that use customisable day pricing.

### Advanced section auto-open
The Advanced disclosure opens automatically when any of its fields already has a value, so editors don't lose track of a configured webhook or renewal tier. **Slug is deliberately excluded** from this check (it's always set, so it would force the section open every time). It also opens after a validation error so a hidden invalid field stays reachable.

## No new JavaScript
All conditional visibility stays pure CSS. The existing `:has()` rules were rescoped from `> label` to descendant selectors so they keep working through the new section nesting.

## Also
- Extracted `AttendeeEditForm` out of `attendeeFormPage` to clear a pre-existing cognitive-complexity lint warning, and applied an optional-chain lint fix in the same file (good-citizen cleanup).

## Testing
- New template tests cover the section legends, day-prices placement, the Advanced disclosure contents, and the auto-open logic (including the slug-exclusion and the builder-field paths).
- `deno task precommit` passes: lint (0 warnings), typecheck, copy-paste detection, edge build, and `test:coverage` at 100%.

https://claude.ai/code/session_01Rchh1gjyGWotYJWS4Prar6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rchh1gjyGWotYJWS4Prar6)_