### PR TITLE
Flex/gap layout for checkbox & radio groups, legend & dark-mode tweaks

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -834,6 +834,10 @@ label > small {
   width: 100%;
 }
 
+[data-theme="dark"] label > small {
+  color: #b1aeae;
+}
+
 label > select,
 label > input {
   flex: 1;
@@ -1259,6 +1263,10 @@ fieldset {
 .checkboxes,
 .radios {
   border: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-m);
+  margin: 0;
   padding: 0;
 }
 
@@ -1267,7 +1275,6 @@ fieldset {
   display: inline-block;
   font-weight: normal;
   max-width: none;
-  margin: 0 var(--space-m) var(--space-m) 0;
 }
 
 label.terms-agree {
@@ -1305,6 +1312,7 @@ label.terms-agree {
 .listing-section > legend {
   display: block;
   width: 100%;
+  margin-top: var(--space-lg);
   margin-bottom: var(--space-m);
   padding-bottom: var(--space-s);
   border-bottom: 1px solid var(--color-bg-secondary);


### PR DESCRIPTION
## Summary

CSS-only adjustments to `src/ui/static/mvp.css`:

- **`.checkboxes` / `.radios`** now lay out with `display: flex`, `flex-wrap: wrap`, and `gap: var(--space-m)`, with `margin: 0` and `padding: 0`. The per-label `margin: 0 var(--space-m) var(--space-m) 0` that previously handled spacing is removed so the new `gap` is the single source of spacing (no double-spacing). `flex-wrap: wrap` preserves the original inline-flow wrapping for groups with many options.
- **`.listing-section > legend`** gains `margin-top: var(--space-lg)` for more separation above each section heading.
- **Dark mode**: `label > small` now uses `#b1aeae` for better contrast (added a co-located `[data-theme="dark"]` override).

## Testing

- `deno task lint` (Biome `check --write`) — checked 652 files, no fixes applied (changes already conform to formatting).

The CSS is read directly from source at both runtime and build time (no committed bundle to regenerate).

https://claude.ai/code/session_017EvA6DJ3N5DTSyDg231Tre

---
_Generated by [Claude Code](https://claude.ai/code/session_017EvA6DJ3N5DTSyDg231Tre)_