### PR TITLE
Show runtime uptime in the admin debug footer

### DIFF
--- a/src/shared/uptime.ts
+++ b/src/shared/uptime.ts
@@ -1,0 +1,15 @@
+/**
+ * Tracks how long the current runtime instance has been alive.
+ *
+ * `startMs` is captured when this module is first evaluated. On Bunny Edge
+ * Scripting that happens at isolate boot (and at process start in local dev).
+ * Because module-level state lives for the whole lifetime of the isolate, the
+ * reported value grows across every request the same isolate serves and only
+ * resets to zero when a fresh isolate starts — making it a cheap, direct
+ * measure of how long edge isolates actually live.
+ */
+
+const startMs = Date.now();
+
+/** Seconds the current runtime instance has been alive. */
+export const getUptimeSeconds = (): number => (Date.now() - startMs) / 1000;

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -10,12 +10,14 @@ import {
   isQueryLogEnabled,
   type QueryLogEntry,
 } from "#shared/db/query-log.ts";
+import { getUptimeSeconds } from "#shared/uptime.ts";
 
 /** Data passed to the footer renderer */
 export type DebugFooterData = {
   readonly renderTimeMs: number;
   readonly queries: QueryLogEntry[];
   readonly cacheStats: CacheStat[];
+  readonly uptimeSeconds: number;
 };
 
 const sumDurations = reduce(
@@ -33,7 +35,7 @@ const renderCacheStat = (stat: CacheStat): string =>
 
 /** Render the admin debug footer as an HTML string for injection before </body> */
 export const debugFooterHtml = (data: DebugFooterData): string => {
-  const { renderTimeMs, queries, cacheStats } = data;
+  const { renderTimeMs, queries, cacheStats, uptimeSeconds } = data;
   const totalSqlMs = sumDurations(queries);
   const otherMs = renderTimeMs - totalSqlMs;
   const totalCacheEntries = reduce(
@@ -49,7 +51,8 @@ export const debugFooterHtml = (data: DebugFooterData): string => {
     ` &middot; ${queries.length} quer${queries.length === 1 ? "y" : "ies"} ${totalSqlMs.toFixed(
       0,
     )}ms` +
-    ` &middot; ${totalCacheEntries} cached</summary>` +
+    ` &middot; ${totalCacheEntries} cached` +
+    ` &middot; up ${uptimeSeconds.toFixed(0)}s</summary>` +
     `<p>Render: ${renderTimeMs.toFixed(1)}ms` +
     ` (sql ${totalSqlMs.toFixed(1)}ms + other ${otherMs.toFixed(1)}ms)</p>` +
     (queries.length > 0
@@ -85,6 +88,7 @@ export const renderDebugFooter = (): string =>
         cacheStats: getAllCacheStats(),
         queries: getQueryLog(),
         renderTimeMs: performance.now() - getQueryLogStartTime(),
+        uptimeSeconds: getUptimeSeconds(),
       })
     : "";
 

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -15,6 +15,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 42.7,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("43ms");
   });
@@ -24,6 +25,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).toContain('href="https://github.com/chobbledotcom/tickets"');
     expect(html).toContain("Chobble Tickets</a>");
@@ -34,6 +36,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("<details>");
     expect(html).toContain("<summary>");
@@ -46,6 +49,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("<footer");
     expect(html).toContain("</footer>");
@@ -56,6 +60,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).toContain('class="debug-footer"');
   });
@@ -68,6 +73,7 @@ describe("debugFooterHtml", () => {
         { durationMs: 3.1, sql: "SELECT * FROM users WHERE id = ?" },
       ],
       renderTimeMs: 20,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("SELECT * FROM listings");
     expect(html).toContain("5.2ms");
@@ -80,6 +86,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [{ durationMs: 1.0, sql: "SELECT '<script>' FROM t" }],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
@@ -90,6 +97,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 5,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("0 queries");
     expect(html).not.toContain("SQL queries");
@@ -103,6 +111,7 @@ describe("debugFooterHtml", () => {
         { durationMs: 15, sql: "SELECT 2" },
       ],
       renderTimeMs: 50,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("2 queries 25ms");
   });
@@ -112,6 +121,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [{ durationMs: 5, sql: "SELECT 1" }],
       renderTimeMs: 20,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("1 query 5ms");
   });
@@ -124,6 +134,7 @@ describe("debugFooterHtml", () => {
         { durationMs: 20, sql: "SELECT 2" },
       ],
       renderTimeMs: 100,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("sql 50.0ms");
     expect(html).toContain("other 50.0ms");
@@ -137,6 +148,7 @@ describe("debugFooterHtml", () => {
       ],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("Caches (2)");
     expect(html).toContain("sessions: 3");
@@ -151,6 +163,7 @@ describe("debugFooterHtml", () => {
       ],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).toContain("15 cached");
   });
@@ -160,6 +173,7 @@ describe("debugFooterHtml", () => {
       cacheStats: [],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).not.toContain("Caches");
   });
@@ -169,9 +183,20 @@ describe("debugFooterHtml", () => {
       cacheStats: [{ entries: 1, name: "<script>" }],
       queries: [],
       renderTimeMs: 10,
+      uptimeSeconds: 0,
     });
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
+  });
+
+  test("shows app uptime in whole seconds in the summary", () => {
+    const html = debugFooterHtml({
+      cacheStats: [],
+      queries: [],
+      renderTimeMs: 10,
+      uptimeSeconds: 1234.7,
+    });
+    expect(html).toContain("up 1235s");
   });
 });
 
@@ -189,6 +214,14 @@ describe("renderDebugFooter", () => {
       expect(html).toContain('<footer class="debug-footer">');
       expect(html).toContain("Chobble Tickets");
       expect(html).toContain("ms");
+    });
+  });
+
+  test("includes the app uptime gathered from the runtime", () => {
+    runWithQueryLogContext(() => {
+      enableQueryLog();
+      const html = renderDebugFooter();
+      expect(html).toMatch(/up \d+s/);
     });
   });
 });

--- a/test/lib/uptime.test.ts
+++ b/test/lib/uptime.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+import { getUptimeSeconds } from "#shared/uptime.ts";
+
+describe("getUptimeSeconds", () => {
+  test("grows by the wall-clock seconds elapsed since the instance started", () => {
+    const time = new FakeTime();
+    try {
+      const before = getUptimeSeconds();
+      time.tick(3000);
+      expect(getUptimeSeconds() - before).toBeCloseTo(3);
+    } finally {
+      time.restore();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds an "uptime" figure to the admin debug footer so you can see how long the current runtime instance has been alive, in seconds.

The footer summary now reads e.g.:

```
43ms · 2 queries 25ms · 15 cached · up 1234s
```

## Why

We've been assuming edge isolates are short-lived, but the module-level caches in this codebase only pay off when an isolate survives long enough to serve repeat requests:

| Cache | TTL | Scope |
| --- | --- | --- |
| settings (`shared/db/settings.ts`) | 60s | module |
| sessions (`shared/db/sessions.ts`) | 10s | module |
| hybrid decrypt (`shared/crypto/keys.ts`) | 60s | module |
| private keys (`shared/crypto/keys.ts`) | 10s | module |
| AES / HMAC keys (`shared/crypto/encryption.ts`) | ∞ (per instance) | module |
| Stripe / Square clients | ∞ (per instance) | module |

If isolates only lived for a single request these would never hit. Surfacing uptime lets us empirically confirm how long isolates actually persist — load an admin page now, come back later, and watch the number climb on the same isolate.

## How

- New `src/shared/uptime.ts`: a module-level `const startMs = Date.now()` captured when the module is first evaluated (isolate boot on Bunny Edge, process start in local dev) and `getUptimeSeconds()`.
- `renderDebugFooter()` passes `getUptimeSeconds()` through to the (pure) `debugFooterHtml()` renderer — same pattern already used for `renderTimeMs`.

## Notes

- Uptime is only visible where the debug footer already renders: authenticated admin GET pages. No new gating, env vars, or endpoints.
- Uses a module-level `const` (no `let`) so it satisfies the repo's `code-quality` convention checks, and `getUptimeSeconds` is consumed in production so it isn't a test-only export.

## Tests

- `test/lib/uptime.test.ts`: verifies uptime grows by exactly the elapsed wall-clock time using `FakeTime`.
- `test/lib/footer.test.ts`: asserts the summary renders `up Ns` (whole seconds) and that `renderDebugFooter` wires the value through.
- Full `deno task precommit` passes: lint, typecheck, cpd, `build:edge`, and `test:coverage` (100% coverage gate).

https://claude.ai/code/session_01GrFNDYLbYgEAR2YKv9Z2uH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrFNDYLbYgEAR2YKv9Z2uH)_