### PR TITLE
Harden CI: fail lint on Biome warnings, and run Biome read-only in CI

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
     "test:coverage": "deno run -A scripts/run-tests.ts --coverage",
     "test:raw": "deno task build:static && deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/",
     "lint": "deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts",
+    "lint:ci": "deno run -A scripts/biome.ts check --error-on-warnings src test scripts",
     "typecheck": "deno check --unstable-tsgo src/**/*.ts src/**/*.tsx test/**/*.ts",
     "cpd": "deno run -A npm:jscpd src --config .jscpd.json",
     "precommit": "deno run -A scripts/precommit.ts",

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,7 @@
     "test": "deno run -A scripts/run-tests.ts",
     "test:coverage": "deno run -A scripts/run-tests.ts --coverage",
     "test:raw": "deno task build:static && deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/",
-    "lint": "deno run -A scripts/biome.ts check --write src test scripts",
+    "lint": "deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts",
     "typecheck": "deno check --unstable-tsgo src/**/*.ts src/**/*.tsx test/**/*.ts",
     "cpd": "deno run -A npm:jscpd src --config .jscpd.json",
     "precommit": "deno run -A scripts/precommit.ts",

--- a/scripts/precommit.ts
+++ b/scripts/precommit.ts
@@ -17,8 +17,6 @@ interface Step {
   cmd: string[];
   filterOutput?: (stdout: string, stderr: string) => string;
   name: string;
-  /** Runs after a successful command; return an error message to fail the step */
-  verify?: () => Promise<string | null>;
 }
 
 /** True when a line starts an ERRORS or FAILURES section or is a summary line */
@@ -52,29 +50,13 @@ const filterTestOutput = (stdout: string, stderr: string): string => {
 const isCi = (): boolean =>
   Deno.args.includes("--ci") || Boolean(Deno.env.get("CI"));
 
-/**
- * In CI, `lint` (Biome `check --write`) silently fixes files and exits 0, so a
- * passing lint step would hide unformatted code. After it runs, fail if the
- * working tree changed — the same guard the CI workflow used to inline.
- */
-const checkFormatted = async (): Promise<string | null> => {
-  const { success } = await new Deno.Command("git", {
-    args: ["diff", "--exit-code"],
-    stderr: "null",
-    stdout: "null",
-  }).output();
-  return success
-    ? null
-    : "Code is not formatted/linted. Run 'deno task lint' locally and commit the result.";
-};
-
 const getSteps = (ci: boolean): Step[] => {
   return [
-    {
-      cmd: ["deno", "task", "lint"],
-      name: "lint",
-      verify: ci ? checkFormatted : undefined,
-    },
+    // Dev runs the auto-fixing `lint` (Biome `check --write`). CI runs the
+    // read-only `lint:ci`, which fails when code *would* be reformatted or has
+    // a lint warning — catching unformatted code without modifying the checkout
+    // or requiring a clean working tree.
+    { cmd: ["deno", "task", ci ? "lint:ci" : "lint"], name: "lint" },
     { cmd: ["deno", "task", "typecheck"], name: "typecheck" },
     { cmd: ["deno", "task", "cpd"], name: "cpd" },
     { cmd: ["deno", "task", "build:edge"], name: "build:edge" },
@@ -100,14 +82,8 @@ const runStep = async (step: Step): Promise<boolean> => {
   const elapsed = ((performance.now() - start) / 1000).toFixed(1);
 
   if (result.success) {
-    const verifyError = step.verify ? await step.verify() : null;
-    if (!verifyError) {
-      write(`${green("✓")} ${dim(`${elapsed}s`)}\n`);
-      return true;
-    }
-    write(`${red("✗")} ${dim(`${elapsed}s`)}\n`);
-    console.log(verifyError);
-    return false;
+    write(`${green("✓")} ${dim(`${elapsed}s`)}\n`);
+    return true;
   }
 
   write(`${red("✗")} ${dim(`${elapsed}s`)}\n`);


### PR DESCRIPTION
## Why

While investigating why a Biome cognitive-complexity warning didn't block #1176 from merging, we found two gaps in the CI/lint pipeline:

1. **Biome warnings never failed CI.** `deno task lint` runs `biome check --write`, which exits `0` on warnings (only errors fail). So warn-level rules — e.g. `noExcessiveCognitiveComplexity`, which is `"warn"` for `src/**` — were purely advisory. Proven: `biome check --write` exits `0` with warnings present; `biome check --error-on-warnings` exits `1`.
2. **The CI lint guard required a clean working tree.** The `--ci` path ran `git diff --exit-code` across the whole tree after `--write`, so `precommit --ci` failed on *any* uncommitted change — even ones unrelated to formatting — forcing a commit before precommit could pass.

## What changed

**Warnings now block (every linter in the pipeline).**
- Biome: added `--error-on-warnings` to the `lint` task, so any Biome warning fails the step locally and in CI. This makes all warn-level rules blocking at once, rather than bumping rules one by one.
- jscpd already fails on any finding (`threshold: 0`, `exitCode: 1`) and `deno check` has no non-fatal tier — so no change needed there.

**CI lint is now read-only; no clean tree required.**
- Added a `lint:ci` task — `biome check --error-on-warnings` (no `--write`) — which fails when code *would* be reformatted or carries a lint warning, **without modifying the checkout or depending on git state**.
- `precommit` uses `lint:ci` in CI and the auto-fixing `lint` in dev. The `git diff --exit-code` guard and its verify hook are removed.

Net effect:
- **In CI:** unformatted code or any warning fails the build (read-only check).
- **In dev:** `deno task precommit` auto-fixes formatting and never requires a clean/committed tree; it only fails on genuine lint warnings/errors.

## Testing
- `deno task precommit --ci` passes on an intentionally **dirty** working tree (previously it failed at lint with "Run 'deno task lint' ... and commit"), confirming commits are no longer required.
- `deno task lint:ci` exits `0` on the current (warning-free) tree; the contrast case (`--error-on-warnings` on code with a warning) exits `1`, confirming warnings block.
- Full battery green: lint, typecheck, cpd, build:edge, test:coverage (100%).

https://claude.ai/code/session_01Rchh1gjyGWotYJWS4Prar6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rchh1gjyGWotYJWS4Prar6)_