### PR TITLE
Fix edge bundle JSX transform (React-is-not-defined regression)

### DIFF
--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -208,6 +208,8 @@ await esbuild.build({
   entryPoints: ["./src/edge.ts"],
   external: nodeExternals,
   format: "esm",
+  jsx: "automatic",
+  jsxImportSource: "#jsx",
   minify: true,
   outdir: "./dist",
   platform: "browser",
@@ -222,6 +224,17 @@ await esbuild.build({
 
 // esbuild.build() throws on failure, so if we reach here the output file exists
 const content = await Deno.readTextFile("./dist/edge.js");
+
+// Guard: the app renders with a custom JSX runtime (#jsx), never React. If
+// esbuild ever falls back to the classic JSX transform, the bundle references
+// an undefined `React` and every page 500s at runtime ("React is not defined").
+// Tests don't catch this (they run TSX under Deno), so assert on the bundle.
+if (content.includes("React.createElement")) {
+  console.error(
+    "Edge bundle contains React.createElement — JSX automatic runtime is misconfigured (expected jsx: 'automatic', jsxImportSource: '#jsx')",
+  );
+  Deno.exit(1);
+}
 
 // Bunny Edge Scripting has a 10MB script size limit
 const BUNNY_MAX_SCRIPT_SIZE = 10_000_000;


### PR DESCRIPTION
**Hotfix for a production regression introduced by #1175.**

#1175 replaced the edge bundler's hand-rolled resolver with `esbuild-deno-loader`. The loader loads `.tsx` through its own esbuild namespace, which bypasses esbuild's `tsconfig.json` auto-detection of the JSX setting — so esbuild fell back to the **classic** JSX transform (`React.createElement`) instead of the automatic runtime. The app has no React, so every page threw `ReferenceError: React is not defined` at runtime (`GET / → 500`).

Tests didn't catch it: they run TSX directly under Deno (which reads `deno.json`'s `jsx: react-jsx`); only the esbuild bundle was affected. `build:edge` succeeded because building is not the same as a correct transform.

## Fix
Set the JSX runtime explicitly on the esbuild build:
```ts
jsx: "automatic",
jsxImportSource: "#jsx",
```
JSX now compiles to imports from `#jsx/jsx-runtime` (the project's server-side runtime), exactly as Deno and the tests already compile it.

## Regression guard
Added a post-build assertion that fails `build:edge` if the bundle ever contains `React.createElement` again. `build:edge` runs in CI, so this can't ship silently a second time.

## Verified
- Bundle now has **0** `React` references (was 29 `React.createElement`)
- The icon component that broke now renders to `<svg class="icon">` via the JSX runtime
- libsql web build (`hrana`, no `node:` deps) and node-forge remain intact

https://claude.ai/code/session_016yhnoqH4BkFoP5tDhJLYub

---
_Generated by [Claude Code](https://claude.ai/code/session_016yhnoqH4BkFoP5tDhJLYub)_