### PR TITLE
Hoist PublicListingSchema to shared test-utils and reuse it

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,3 +1,4 @@
+export * from "./test-utils/api-schemas.ts";
 export * from "./test-utils/assertions.ts";
 export { getTestDataKey, getTestPrivateKey } from "./test-utils/crypto.ts";
 export * from "./test-utils/csrf.ts";

--- a/src/test-utils/api-schemas.ts
+++ b/src/test-utils/api-schemas.ts
@@ -1,0 +1,39 @@
+/**
+ * valibot schemas mirroring the JSON API response shapes, for validating
+ * responses in tests. Keeping them here lets every API test assert against one
+ * canonical shape instead of re-deriving it (hand-rolled key checks or casts).
+ */
+
+import * as v from "valibot";
+
+/**
+ * Shape of a public listing as returned by the JSON API (mirrors the production
+ * `PublicListing` type from `#routes/api/index.ts`). `strictObject` rejects any
+ * unexpected key, so a leaked internal field (id, max_attendees, hidden, …)
+ * fails the parse. JSON object keys are strings, so `dayPrices` is keyed by
+ * string here. `entriesFromList` groups same-typed fields to keep it compact.
+ */
+export const PublicListingSchema = v.strictObject({
+  ...v.entriesFromList(
+    ["description", "fields", "listingType", "name", "slug"],
+    v.string(),
+  ),
+  ...v.entriesFromList(["maxPrice", "maxPurchasable", "unitPrice"], v.number()),
+  ...v.entriesFromList(
+    [
+      "canPayMore",
+      "customisableDays",
+      "isClosed",
+      "isSoldOut",
+      "nonTransferable",
+      "purchaseOnly",
+    ],
+    v.boolean(),
+  ),
+  ...v.entriesFromList(
+    ["date", "imageUrl", "location"],
+    v.nullable(v.string()),
+  ),
+  availableDates: v.optional(v.array(v.string())),
+  dayPrices: v.optional(v.record(v.string(), v.number())),
+});

--- a/test/lib/admin-api-example.test.ts
+++ b/test/lib/admin-api-example.test.ts
@@ -6,8 +6,9 @@
 
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import * as v from "valibot";
 import { adminApiRoutes, toAdminListing } from "#routes/admin/api.ts";
-import { apiRoutes, toPublicListing } from "#routes/api/index.ts";
+import { apiRoutes } from "#routes/api/index.ts";
 import {
   ADMIN_API_ENDPOINTS,
   ADMIN_API_EXAMPLE_ADMIN_LISTING,
@@ -15,6 +16,7 @@ import {
   type EndpointDoc,
   PUBLIC_API_ENDPOINTS,
 } from "#shared/admin-api-example.ts";
+import { PublicListingSchema } from "#test-utils";
 
 describe("admin API example", () => {
   test("toAdminListing output matches the documented example", () => {
@@ -52,15 +54,11 @@ describe("endpoint docs", () => {
       (e: EndpointDoc) => e.method === "GET" && e.path === "/api/listings",
     )!;
     const parsed = JSON.parse(listEndpoint.response);
-    const realPublicListing = toPublicListing(
-      ADMIN_API_EXAMPLE_LISTING,
-      false,
-      undefined,
-      undefined,
-    );
-    const realKeys = Object.keys(realPublicListing).sort();
-    const exampleKeys = Object.keys(parsed.listings[0]).sort();
-    expect(exampleKeys).toEqual(realKeys);
+    // strictObject validates both the keys and the field types of the
+    // documented example — a stronger check than the previous key-set compare.
+    expect(() =>
+      v.parse(PublicListingSchema, parsed.listings[0]),
+    ).not.toThrow();
   });
 
   test("admin listing list response uses AdminListing shape", () => {

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -34,6 +34,7 @@ const FORBIDDEN_PATTERNS = [
  * Test utility files - excluded from all code quality checks
  */
 const TEST_UTILITY_FILES = [
+  "test-utils/api-schemas.ts",
   "test-utils/internal.ts",
   "test-utils/db.ts",
   "test-utils/email.ts",

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -12,6 +12,7 @@ import {
   createTestListing,
   deactivateTestListing,
   describeWithEnv,
+  PublicListingSchema,
   setupStripe,
 } from "#test-utils";
 
@@ -43,38 +44,6 @@ const jsonBody = (response: Response): Promise<Record<string, unknown>> =>
 const expectCorsHeaders = (response: Response): void => {
   expect(response.headers.get("access-control-allow-origin")).toBe("*");
 };
-
-/**
- * Shape of a public listing as returned by the JSON API (mirrors the
- * production `PublicListing` type). `strictObject` rejects any unexpected key,
- * so a leaked internal field (id, max_attendees, hidden, …) fails the parse —
- * which is what the "does not expose internal fields" test relies on. JSON
- * object keys are strings, so `dayPrices` is keyed by string here.
- */
-const PublicListingSchema = v.strictObject({
-  ...v.entriesFromList(
-    ["description", "fields", "listingType", "name", "slug"],
-    v.string(),
-  ),
-  ...v.entriesFromList(["maxPrice", "maxPurchasable", "unitPrice"], v.number()),
-  ...v.entriesFromList(
-    [
-      "canPayMore",
-      "customisableDays",
-      "isClosed",
-      "isSoldOut",
-      "nonTransferable",
-      "purchaseOnly",
-    ],
-    v.boolean(),
-  ),
-  ...v.entriesFromList(
-    ["date", "imageUrl", "location"],
-    v.nullable(v.string()),
-  ),
-  availableDates: v.optional(v.array(v.string())),
-  dayPrices: v.optional(v.record(v.string(), v.number())),
-});
 
 describeWithEnv("Public API", { db: true }, () => {
   beforeEach(async () => {


### PR DESCRIPTION
## What

Follow-up to #1178. That PR introduced `PublicListingSchema` inline in `test/routes/api.test.ts`. As you noted, the shape is generic — it describes *every* public-listing JSON response — so this hoists it to a shared module and reuses it.

- **`src/test-utils/api-schemas.ts`** (new) — the canonical `PublicListingSchema`, re-exported from the `#test-utils` barrel. (Also added to `code-quality.test.ts`'s `TEST_UTILITY_FILES` allowlist, since test-only modules are exempt from the "exports must be used in production code" rule.)
- **`test/routes/api.test.ts`** — imports the schema instead of defining it inline.
- **`test/lib/admin-api-example.test.ts`** — validates the documented public-listing example with the schema (keys **and** types) instead of comparing key sets against `toPublicListing` output:

```diff
-    const realPublicListing = toPublicListing(ADMIN_API_EXAMPLE_LISTING, false, undefined, undefined);
-    const realKeys = Object.keys(realPublicListing).sort();
-    const exampleKeys = Object.keys(parsed.listings[0]).sort();
-    expect(exampleKeys).toEqual(realKeys);
+    expect(() => v.parse(PublicListingSchema, parsed.listings[0])).not.toThrow();
```

The schema now backs assertions in two test files instead of one, so it earns its keep — and the `admin-api-example` check got stronger (it validates field types, not just key names).

## Note on placement

I kept the schema **test-scoped** (in `#test-utils`) rather than making it the production source of truth for the `PublicListing` type. Deriving the production type from the schema (`type PublicListing = v.InferOutput<…>`) is possible and would delete the ~25-line hand-written type for a net reduction, but it's an architectural change and shifts `dayPrices` from `Record<number, number>` to `Record<string, number>` — happy to do that as a separate PR if you want it.

## Checks

`deno task precommit` passes on top of current `main`: lint ✓, typecheck ✓, cpd ✓, build:edge ✓, test:coverage ✓ (100% coverage maintained).

https://claude.ai/code/session_01Yb2kAWx4pHWakmnjotpfTH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yb2kAWx4pHWakmnjotpfTH)_