### PR TITLE
Auto-size admin textareas to their content with field-sizing

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -715,6 +715,21 @@ textarea[name="special_instructions"] {
   }
 }
 
+/* On admin pages, textareas grow to fit their content via field-sizing rather
+   than the fixed aspect-ratios above (width stays 100% so they only grow
+   vertically). Tidy bounds keep an empty field a few lines tall and stop very
+   long content from running off the page — past the cap it scrolls. Public
+   ticket forms keep the aspect-ratio sizing. Guarded by @supports so browsers
+   without field-sizing fall back to that sizing. */
+@supports (field-sizing: content) {
+  body:has(#main-nav) textarea {
+    field-sizing: content;
+    aspect-ratio: auto;
+    min-block-size: 3lh;
+    max-block-size: 30lh;
+  }
+}
+
 input[readonly],
 textarea[readonly] {
   background-color: var(--color-bg-secondary);


### PR DESCRIPTION
## What

Admin-side `<textarea>`s now use the CSS [`field-sizing: content`](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing) property so they grow and shrink to fit their content, instead of being locked to a fixed `aspect-ratio`.

## Why

The previous fixed aspect-ratios (4/3 on mobile, 16/9 on desktop) made admin textareas a tall, fixed box regardless of content — lots of empty space for a short listing description, and a small scroll box for long terms or email bodies. `field-sizing` lets each field size itself to what's actually in it.

## How

```css
@supports (field-sizing: content) {
  body:has(#main-nav) textarea {
    field-sizing: content;
    aspect-ratio: auto;
    min-block-size: 3lh;
    max-block-size: 30lh;
  }
}
```

Minimal, tidy defaults:

- **`field-sizing: content`** — grow/shrink to fit content.
- **`aspect-ratio: auto`** — clears the inherited fixed aspect-ratios so height is content-driven.
- **`min-block-size: 3lh`** — an empty field stays a sensible ~3 lines tall (not collapsed).
- **`max-block-size: 30lh`** — caps growth at ~30 lines, then scrolls, so a huge document doesn't run off the page.
- Width is left at the existing `100%`, so fields only grow **vertically** (no jarring horizontal shifts).

### Scope & fallback

- **Admin only** — scoped via `body:has(#main-nav)`, the existing convention for distinguishing admin from public pages. The public ticket form's `address` / `special_instructions` textareas keep their aspect-ratio sizing. (Those same fields on the admin attendee form *do* auto-size, which is the intended "admin side" behaviour.)
- **Progressive enhancement** — wrapped in `@supports (field-sizing: content)`, so browsers without support fall back to the existing aspect-ratio sizing unchanged.

## Testing

- `deno task lint` — clean (Biome applied no fixes).
- `deno task build:edge` — succeeds; esbuild minifies the new `@supports` / `field-sizing` / `lh` CSS without issue.
- `GET /mvp.css` server tests pass. (The only failing tests in the suite are Stripe-checkout flows, which require the `stripe-mock` binary that isn't installed in this environment — unrelated to this CSS-only change.)

CSS-only change; no TypeScript added, so coverage is unaffected.

https://claude.ai/code/session_01Nxdtv9Xk1fGjAd2aTuSY7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nxdtv9Xk1fGjAd2aTuSY7v)_