### PR TITLE
Add N+1 read guard to the DB query layer

### DIFF
--- a/src/edge.ts
+++ b/src/edge.ts
@@ -8,6 +8,7 @@ import { once } from "#fp";
 import { handleRequest } from "#routes";
 import { temporaryErrorResponse } from "#routes/response.ts";
 import { validateEncryptionKey } from "#shared/crypto/encryption.ts";
+import { setN1GuardNotifyOnly } from "#shared/db/query-log.ts";
 import {
   ErrorCode,
   formatRequestError,
@@ -17,6 +18,9 @@ import {
 
 const initialize = once((): void => {
   validateEncryptionKey();
+  // In production a request must never be killed by the N+1 guard: report it
+  // to the error log instead of throwing (dev/test keep the default throw).
+  setN1GuardNotifyOnly(true);
   logDebug("Setup", "App started");
 });
 

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -1,11 +1,21 @@
 /**
- * Request-scoped SQL query logging for the admin debug footer.
+ * Request-scoped SQL query logging for the admin debug footer, plus an N+1
+ * read guard.
  *
- * Call `enableQueryLog()` at the start of a request and `getQueryLog()`
+ * Footer: call `enableQueryLog()` at the start of a request and `getQueryLog()`
  * after the response body has been built to retrieve every tracked query.
+ *
+ * N+1 guard: regardless of footer logging, every single-query read is counted
+ * by its SQL within a request. Because queries are parameterized, a per-row
+ * lookup loop runs the *same* SQL string N times — the N+1 signature — whether
+ * the loop is sequential or fanned out with Promise.all. Crossing
+ * `N_PLUS_ONE_THRESHOLD` throws in dev/test (so the request fails loudly) or, in
+ * production, reports via the error log (see `setN1GuardNotifyOnly`). Batched
+ * reads (`queryBatch`) are a single round-trip and never reach this guard.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
+import { lazyRef } from "#fp";
 
 /** A single logged query */
 export type QueryLogEntry = { sql: string; durationMs: number };
@@ -14,12 +24,15 @@ type QueryLogState = {
   enabled: boolean;
   entries: QueryLogEntry[];
   startTime: number;
+  /** Per-request count of each read SQL string, for the N+1 guard */
+  readCounts: Map<string, number>;
 };
 
 const asyncLocalStorage = new AsyncLocalStorage<QueryLogState>();
 const fallbackState: QueryLogState = {
   enabled: false,
   entries: [],
+  readCounts: new Map(),
   startTime: 0,
 };
 
@@ -27,7 +40,10 @@ const getState = (): QueryLogState =>
   asyncLocalStorage.getStore() ?? fallbackState;
 
 export const runWithQueryLogContext = <T>(fn: () => T): T =>
-  asyncLocalStorage.run({ enabled: false, entries: [], startTime: 0 }, fn);
+  asyncLocalStorage.run(
+    { enabled: false, entries: [], readCounts: new Map(), startTime: 0 },
+    fn,
+  );
 
 /** Enable query logging and clear previous entries */
 export const enableQueryLog = (): void => {
@@ -52,12 +68,67 @@ export const addQueryLogEntry = (sql: string, durationMs: number): void => {
 /** Return a snapshot of all logged queries */
 export const getQueryLog = (): QueryLogEntry[] => [...getState().entries];
 
-/** Run an async DB operation and log it when tracking is active */
+/**
+ * Max times one parameterized read may run as a separate round-trip within a
+ * single request before the N+1 guard fires. Set above the worst legitimate
+ * repeat in the suite; lower it to catch smaller N+1s.
+ */
+export const N_PLUS_ONE_THRESHOLD = 25;
+
+/**
+ * When true, an N+1 violation is reported via the error log instead of thrown.
+ * Production (`src/edge.ts`) opts in so a real request is never killed; dev and
+ * tests stay in throw mode so the offending request fails loudly. Pass `null`
+ * to reset to the default (throw).
+ */
+const [getN1NotifyOnly, setN1NotifyOnly] = lazyRef<boolean>(() => false);
+
+/** Switch the N+1 guard between throw (default) and notify-only (production). */
+export const setN1GuardNotifyOnly = (value: boolean | null): void =>
+  setN1NotifyOnly(value);
+
+/** Only single-statement reads are the N+1-prone shape we count. */
+const isReadSql = (sql: string): boolean => /^\s*(?:with|select)\b/i.test(sql);
+
+/**
+ * Report a violation without a static `logger` import — query-log is imported by
+ * the db client, which the logger transitively depends on, so a static import
+ * would form a cycle. The dynamic import mirrors `env.ts`'s `isReadOnly`.
+ */
+const notifyN1Violation = async (detail: string): Promise<void> => {
+  const { ErrorCode, logError } = await import("#shared/logger.ts");
+  logError({ code: ErrorCode.DB_QUERY, detail });
+};
+
+/**
+ * Count a read round-trip within a request and fire once, exactly when the
+ * count crosses the threshold. Writes and queries outside a request scope (the
+ * fallback state, e.g. startup migrations) are never counted.
+ */
+const enforceN1Guard = (state: QueryLogState, sql: string): void => {
+  if (!isReadSql(sql)) return;
+  const count = (state.readCounts.get(sql) ?? 0) + 1;
+  state.readCounts.set(sql, count);
+  if (count !== N_PLUS_ONE_THRESHOLD + 1) return;
+  const detail = `N+1 query detected: same read ran ${count} times (limit ${N_PLUS_ONE_THRESHOLD}) in one request: ${sql}`;
+  if (getN1NotifyOnly()) {
+    void notifyN1Violation(detail);
+  } else {
+    throw new Error(detail);
+  }
+};
+
+/**
+ * Run an async DB operation, enforcing the N+1 read guard and logging it when
+ * footer tracking is active.
+ */
 export const trackQuery = async <T>(
   sql: string,
   fn: () => Promise<T>,
 ): Promise<T> => {
-  const state = getState();
+  const store = asyncLocalStorage.getStore();
+  if (store) enforceN1Guard(store, sql);
+  const state = store ?? fallbackState;
   if (!state.enabled) return fn();
   const start = performance.now();
   const result = await fn();

--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -1,13 +1,20 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import {
   addQueryLogEntry,
   enableQueryLog,
   getQueryLog,
   getQueryLogStartTime,
   isQueryLogEnabled,
+  N_PLUS_ONE_THRESHOLD,
   runWithQueryLogContext,
+  setN1GuardNotifyOnly,
+  trackQuery,
 } from "#shared/db/query-log.ts";
+// Preloaded so the guard's dynamic `import("#shared/logger.ts")` is a cache hit,
+// making the notify-mode test's flush deterministic rather than time-dependent.
+import "#shared/logger.ts";
 
 describe("query-log", () => {
   describe("enableQueryLog", () => {
@@ -100,6 +107,85 @@ describe("query-log", () => {
         const second = getQueryLogStartTime();
         expect(second).toBeGreaterThanOrEqual(first);
       });
+    });
+  });
+
+  describe("N+1 read guard", () => {
+    // Reset to the default (throw) after any test that switches modes.
+    afterEach(() => setN1GuardNotifyOnly(null));
+
+    test("allows a read to repeat up to the threshold", async () => {
+      await runWithQueryLogContext(async () => {
+        let last: unknown;
+        for (let i = 0; i < N_PLUS_ONE_THRESHOLD; i++) {
+          last = await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+        }
+        expect(last).toBe("ok");
+      });
+    });
+
+    test("throws when the same read crosses the threshold", async () => {
+      await runWithQueryLogContext(async () => {
+        for (let i = 0; i < N_PLUS_ONE_THRESHOLD; i++) {
+          await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+        }
+        await expect(
+          trackQuery("SELECT 1", () => Promise.resolve("ok")),
+        ).rejects.toThrow(/N\+1 query detected/);
+      });
+    });
+
+    test("does not count writes toward the guard", async () => {
+      await runWithQueryLogContext(async () => {
+        let last: unknown;
+        for (let i = 0; i < N_PLUS_ONE_THRESHOLD * 2; i++) {
+          last = await trackQuery("INSERT INTO t (id) VALUES (?)", () =>
+            Promise.resolve("ok"),
+          );
+        }
+        expect(last).toBe("ok");
+      });
+    });
+
+    test("counts each distinct read separately", async () => {
+      await runWithQueryLogContext(async () => {
+        let last: unknown;
+        for (let i = 0; i < N_PLUS_ONE_THRESHOLD; i++) {
+          await trackQuery("SELECT a", () => Promise.resolve("a"));
+          last = await trackQuery("SELECT b", () => Promise.resolve("b"));
+        }
+        expect(last).toBe("b");
+      });
+    });
+
+    test("does not enforce outside a request scope", async () => {
+      let last: unknown;
+      for (let i = 0; i <= N_PLUS_ONE_THRESHOLD; i++) {
+        last = await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+      }
+      expect(last).toBe("ok");
+    });
+
+    test("notify mode reports the violation instead of throwing", async () => {
+      const errorSpy = stub(console, "error");
+      setN1GuardNotifyOnly(true);
+      try {
+        await runWithQueryLogContext(async () => {
+          let last: unknown;
+          for (let i = 0; i <= N_PLUS_ONE_THRESHOLD; i++) {
+            last = await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+          }
+          expect(last).toBe("ok");
+        });
+        // Let the fire-and-forget dynamic import + logError settle.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        errorSpy.restore();
+      }
+      const reported = errorSpy.calls.some((call) =>
+        call.args.some((arg) => String(arg).includes("N+1 query detected")),
+      );
+      expect(reported).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What

Adds a guardrail that catches the N+1 query anti-pattern — looping over the
results of one query and firing another read per row.

Every parameterized read is counted by its SQL string within a request, reusing
the existing `runWithQueryLogContext` `AsyncLocalStorage` scope. Because queries
are parameterized, a per-row lookup loop runs the **same** SQL string N times —
the N+1 signature — whether the loop is sequential or fanned out with
`Promise.all`. Crossing `N_PLUS_ONE_THRESHOLD` (25):

- **dev/test:** throws, so the offending request fails loudly (and CI catches it)
- **production:** reports via the error log (ntfy + activity log) instead of
  throwing, so a real user's request is never killed — `src/edge.ts` opts into
  this notify-only mode in its `initialize()`

Exempt by design:
- **writes** (`INSERT`/`UPDATE`/`DELETE`) — only `SELECT`/`WITH` reads are counted
- **batched reads** (`queryBatch`) — a single round-trip, which is the *fix* for
  N+1, not the disease
- **queries outside a request scope** (e.g. startup migrations)

## Why not "one read at a time"

The original idea was a flag that crashes on a second concurrent read. That
rule is inverted: with `await`, the queries in an N+1 loop never overlap (each
finishes before the next starts), so the flag would never trip — while the
~40 legitimate `Promise.all([...])` fan-outs in the codebase *do* run reads
concurrently and would all crash. Counting repeated identical SQL targets the
real signature instead.

## Notes

- The guard hooks the single existing choke point (`trackQuery`), so no call
  sites changed.
- Threshold of 25 was calibrated against the full suite — nothing trips it, so
  no false positives on existing paths. It's a named, documented constant; lower
  it to catch smaller N+1s.
- The production reporter uses a dynamic `import("#shared/logger.ts")` to avoid
  an import cycle (query-log ← db client ← logger), mirroring `env.ts`.

## Testing

- `deno task test:coverage` — full suite green, 100% line and branch coverage
- 6 new tests cover: under-threshold, crossing the threshold (throws), writes
  exempt, distinct reads keyed separately, no enforcement outside a request
  scope, and notify-only mode reporting instead of throwing.

https://claude.ai/code/session_012yEbssdqpom4ybC5TzKzFE

---
_Generated by [Claude Code](https://claude.ai/code/session_012yEbssdqpom4ybC5TzKzFE)_