### PR TITLE
Address mailto bulk email to a single recipient directly; BCC from business email

### DIFF
--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -205,7 +205,12 @@ const handlePreviewGet = ownerEmailPage(async (_request, session) => {
       contactSummary: contactFrequencySummary(counts),
       disabledReason,
       draft,
-      mailtoLink: buildMailtoLink(sendable, draft.subject, draft.body),
+      mailtoLink: buildMailtoLink(
+        sendable,
+        draft.subject,
+        draft.body,
+        settings.businessEmail,
+      ),
       providerLabel:
         canBulkSend && config ? EMAIL_PROVIDER_LABELS[config.provider] : "",
       recipientCount: recipients.length,

--- a/src/shared/bulk-email.ts
+++ b/src/shared/bulk-email.ts
@@ -272,8 +272,12 @@ export const summarizeProviderResponse = (
 // ── mailto fallback ─────────────────────────────────────────────────
 
 /**
- * Build a `mailto:` link that BCCs every recipient with the subject and body
- * prefilled. Addresses go in BCC so recipients can't see each other. Used as a
+ * Build a `mailto:` link with the subject and body prefilled.
+ *
+ * A lone recipient is addressed directly in the `To:` field — there's no one
+ * to hide them from, so no BCC. Multiple recipients go in BCC so they can't
+ * see each other, and the draft is addressed to the owner's own
+ * `businessEmail` (when set) so the `To:` field isn't left empty. Used as a
  * fallback for admins without a configured (bulk-capable) email provider, and
  * offered alongside provider sending in all cases.
  */
@@ -281,9 +285,14 @@ export const buildMailtoLink = (
   emails: string[],
   subject: string,
   body: string,
+  businessEmail = "",
 ): string => {
   const parts: string[] = [];
-  if (emails.length > 0) {
+  let to = "";
+  if (emails.length === 1) {
+    to = emails[0]!;
+  } else if (emails.length > 1) {
+    to = businessEmail;
     parts.push(`bcc=${emails.map((e) => encodeURIComponent(e)).join(",")}`);
   }
   if (subject) parts.push(`subject=${encodeURIComponent(subject)}`);
@@ -293,5 +302,5 @@ export const buildMailtoLink = (
     const normalizedBody = body.replace(/\r\n?/g, "\n");
     parts.push(`body=${encodeURIComponent(normalizedBody)}`);
   }
-  return `mailto:?${parts.join("&")}`;
+  return `mailto:${encodeURIComponent(to)}?${parts.join("&")}`;
 };

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -226,9 +226,8 @@ export const bulkEmailPreviewPage = (
   state: BulkEmailPreviewState,
 ): string => {
   const { draft } = state;
-  const recipients = `${state.sendableCount} recipient${
-    state.sendableCount === 1 ? "" : "s"
-  }`;
+  const single = state.sendableCount === 1;
+  const recipients = `${state.sendableCount} recipient${single ? "" : "s"}`;
   return String(
     <Layout title="Preview bulk email">
       <AdminNav active={NAV_ACTIVE} session={session} />
@@ -312,13 +311,18 @@ export const bulkEmailPreviewPage = (
       <div class="prose">
         <h2>Or send from your own email app</h2>
         <p>
-          This opens your email app with everyone in BCC. It needs no provider
-          setup, but sending lots of mail this way, especially marketing, is a
-          quick way to get your account rate-limited or blocked. It's best for
-          small, genuinely transactional messages.
+          {single
+            ? "This opens your email app with the message addressed straight to your one recipient."
+            : "This opens your email app with everyone in BCC."}{" "}
+          It needs no provider setup, but sending lots of mail this way,
+          especially marketing, is a quick way to get your account rate-limited
+          or blocked. It's best for small, genuinely transactional messages.
         </p>
         <p>
-          <a href={state.mailtoLink}>Open a BCC draft to {recipients}</a>
+          <a href={state.mailtoLink}>
+            {single ? "Open a draft to " : "Open a BCC draft to "}
+            {recipients}
+          </a>
         </p>
       </div>
 

--- a/src/ui/templates/admin/guide.tsx
+++ b/src/ui/templates/admin/guide.tsx
@@ -1886,12 +1886,15 @@ export const adminGuidePage = (
         <Q q="What is the BCC email-app option?">
           <p>
             On the preview page there's always an option to open the email in
-            your own mail app with every recipient in <strong>BCC</strong> and
-            the subject and body pre-filled. It needs no provider setup, so it
-            works even when system sending is disabled. Use it sparingly though
-            &mdash; sending lots of mail this way, especially marketing, is a
-            quick way to get your personal email account rate-limited or
-            blocked. It's best for small, genuinely transactional messages.
+            your own mail app with the subject and body pre-filled. When it's
+            going to several people they all go in <strong>BCC</strong> (with
+            the draft addressed from your business email) so they can't see each
+            other; a single recipient is simply addressed directly. It needs no
+            provider setup, so it works even when system sending is disabled.
+            Use it sparingly though &mdash; sending lots of mail this way,
+            especially marketing, is a quick way to get your personal email
+            account rate-limited or blocked. It's best for small, genuinely
+            transactional messages.
           </p>
         </Q>
 

--- a/test/lib/bulk-email.test.ts
+++ b/test/lib/bulk-email.test.ts
@@ -297,7 +297,33 @@ describe("summarizeProviderResponse", () => {
 });
 
 describe("mailto and unsubscribe footers", () => {
-  test("buildMailtoLink BCCs everyone with subject and body", () => {
+  test("buildMailtoLink addresses a lone recipient directly without BCC", () => {
+    // One recipient: there's no one to hide them from, so put them in To.
+    expect(buildMailtoLink(["a@b.com"], "Hi there", "Body & more")).toBe(
+      "mailto:a%40b.com?subject=Hi%20there&body=Body%20%26%20more",
+    );
+  });
+
+  test("buildMailtoLink addresses a lone recipient directly even with a business email", () => {
+    expect(buildMailtoLink(["a@b.com"], "Hi", "Body", "owner@biz.com")).toBe(
+      "mailto:a%40b.com?subject=Hi&body=Body",
+    );
+  });
+
+  test("buildMailtoLink BCCs several recipients from the business email", () => {
+    expect(
+      buildMailtoLink(
+        ["a@b.com", "c@d.com"],
+        "Hi there",
+        "Body & more",
+        "owner@biz.com",
+      ),
+    ).toBe(
+      "mailto:owner%40biz.com?bcc=a%40b.com,c%40d.com&subject=Hi%20there&body=Body%20%26%20more",
+    );
+  });
+
+  test("buildMailtoLink leaves To empty for several recipients with no business email", () => {
     expect(
       buildMailtoLink(["a@b.com", "c@d.com"], "Hi there", "Body & more"),
     ).toBe(

--- a/test/lib/server-bulk-email.test.ts
+++ b/test/lib/server-bulk-email.test.ts
@@ -230,6 +230,42 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
       expect(html).toContain("alice@example.com, bob@example.com");
     });
 
+    test("BCCs several recipients from the owner's business email", async () => {
+      useResend();
+      settings.setForTest({ business_email: "owner@example.com" });
+      const listing = await seedListingWithAttendees();
+      await adminFormPost("/admin/emails/preview", {
+        body: "Hello",
+        listing_id: String(listing.id),
+        subject: "Big news",
+      });
+      const html = await awaitTestRequest("/admin/emails/preview", {
+        cookie: await testCookie(),
+      }).then((r) => r.text());
+      expect(html).toContain("everyone in BCC");
+      expect(html).toContain("Open a BCC draft to 2 recipients");
+      expect(html).toContain("mailto:owner%40example.com?bcc=");
+    });
+
+    test("addresses a lone recipient directly instead of using BCC", async () => {
+      useResend();
+      // A business email is set but must be ignored for a single recipient.
+      settings.setForTest({ business_email: "owner@example.com" });
+      const listing = await seedSingleAttendeeListing();
+      await adminFormPost("/admin/emails/preview", {
+        body: "Hello",
+        listing_id: String(listing.id),
+        subject: "Big news",
+      });
+      const html = await awaitTestRequest("/admin/emails/preview", {
+        cookie: await testCookie(),
+      }).then((r) => r.text());
+      expect(html).toContain("Open a draft to 1 recipient");
+      expect(html).toContain("addressed straight to your one recipient");
+      expect(html).toContain("mailto:alice%40example.com?");
+      expect(html).not.toContain("BCC");
+    });
+
     test("omits the address list when there are no recipients", async () => {
       useResend();
       settings.setForTest({


### PR DESCRIPTION
## What & why

The "Or send from your own email app" mailto fallback on the bulk-email preview page always put **every** recipient in BCC and left the `To:` field empty. That's wrong in two cases:

- **One recipient** — there's no one to hide them from, so BCC is pointless. We now address them directly in `To:` and the wording no longer claims "everyone in BCC".
- **Several recipients** — an empty `To:` field looks broken to mail clients and recipients. We now address the draft from the owner's **business email** (when one is set) and keep everyone in BCC so they still can't see each other.

## Changes

- `buildMailtoLink` gains an optional `businessEmail` argument and branches on recipient count:
  - 1 recipient → `mailto:<recipient>?subject=…&body=…` (no BCC)
  - 2+ recipients → `mailto:<businessEmail>?bcc=…&subject=…&body=…`
  - 0 recipients / no business email → unchanged (`mailto:?…`)
- The preview page (`bulkEmailPreviewPage`) reworks the explanatory paragraph and link text for the single-recipient case ("Open a draft to…" instead of "Open a BCC draft to…").
- The call site passes `settings.businessEmail` through.
- The admin guide FAQ ("What is the BCC email-app option?") is updated to describe both cases accurately.

## Tests

- New unit tests for `buildMailtoLink`: lone recipient (direct, and that a set business email is ignored for one recipient), several recipients addressed from the business email, and several with no business email (empty `To:`).
- New preview integration tests asserting the single-recipient wording/`mailto:` and the multi-recipient BCC + business-email `To:`.
- Full suite green (434 passed / 7563 steps), 100% branch/function/line coverage on the changed files, typecheck and Biome lint clean.

https://claude.ai/code/session_01SdYDitVVvmiAMcFKMn3hr7

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdYDitVVvmiAMcFKMn3hr7)_