### PR TITLE
Match footer padding-inline to main

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -174,14 +174,18 @@ main {
   padding: var(--space-lg) var(--space-m);
 }
 
+body > footer,
 main {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xl);
   /* Fluid horizontal padding: stays at the small --space-m floor on mobile,
      eases through ~lg across tablet widths, and caps at the --space-xl
      ceiling on desktop. Vertical padding stays as set by the base rule. */
   padding-inline: clamp(var(--space-m), 4.5vw, var(--space-xl));
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
 }
 
 /* Stack reset: gap controls spacing, not browser default margins */


### PR DESCRIPTION
The page `<footer>` was inheriting the fixed `var(--space-m)` horizontal padding from the base rule, while `main` uses a fluid `clamp(var(--space-m), 4.5vw, var(--space-xl))` padding-inline. This made the footer content sit out of alignment with the main content on wider screens.

Now `body > footer` shares the same `padding-inline` rule as `main`, so their content edges line up at all widths. The footer's vertical padding and `main`'s flex layout are left unchanged.

https://claude.ai/code/session_01QkyoFpQoqR57q1hCJSESEd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkyoFpQoqR57q1hCJSESEd)_