### PR TITLE
Rename .attendees-filter to .filter-row and reset form styling

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -2038,21 +2038,36 @@ a.cal-day-selected:hover {
 
 /* Guide page */
 
-/* Attendees browser filter/sort form */
-.attendees-filter {
+/* Filter/sort form row */
+.filter-row {
   display: flex;
   flex-wrap: wrap;
+  flex-direction: row;
   align-items: flex-end;
   gap: 1rem;
   margin: 1rem 0;
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+  background: none;
+  max-width: 100%;
 }
 
-.attendees-filter label {
+/* Override dark-mode form box-shadow which would otherwise apply */
+[data-theme="dark"] .filter-row {
+  box-shadow: none;
+}
+
+.filter-row label {
   margin: 0;
 }
 
-.attendees-filter button {
+.filter-row button {
   margin: 0;
+}
+
+.filter-row select {
+  max-width: 15rem;
 }
 
 /* Previous/next pagination */

--- a/src/ui/templates/admin/attendees-list.tsx
+++ b/src/ui/templates/admin/attendees-list.tsx
@@ -82,7 +82,7 @@ const FilterForm = ({
   listingId: number | null;
   sortOrder: AttendeeSort;
 }): JSX.Element => (
-  <form action="/admin/attendees" class="attendees-filter" method="get">
+  <form action="/admin/attendees" class="filter-row" method="get">
     <label>
       Listing
       <select name="listing">


### PR DESCRIPTION
## Summary

Generalises the attendees filter/sort form styling into a reusable `.filter-row` class and makes it render as a plain, full-width row regardless of theme.

## Changes

- **Add styling resets** to the rule (`flex-direction: row`, `padding: 0`, `border: 0`, `box-shadow: none`, `background: none`, `max-width: 100%`) so the filter `<form>` looks like a plain row rather than an MVP form card.
- **Rename `.attendees-filter` → `.filter-row`** (including the `label`, `button` and new `select` descendant rules) so the styling can be reused beyond the attendees page.
- **Add a `[data-theme="dark"] .filter-row` override** for `box-shadow`. The global `[data-theme="dark"] form` rule applies a glow `box-shadow` with higher specificity than a bare `.filter-row` class, so without this override the base `box-shadow: none` is ignored in dark mode.
- **Constrain `select` elements** inside the row to `max-width: 15rem`.
- **Update the attendees list template** (`attendees-list.tsx`) to use the new class name.

## Verification

- `deno task lint` — clean, no reformatting needed
- `deno task typecheck` — passes

https://claude.ai/code/session_01YCbNqxWGRknk7hdTgRHpKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCbNqxWGRknk7hdTgRHpKw)_