### PR TITLE
Move support nag into the form (bold), rename "Built Sites" nav link to "Builds"

### DIFF
--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -604,9 +604,15 @@ export const CsrfForm = ({
 /**
  * The message textarea and submit button shared by the public contact form and
  * the admin support form. Each form supplies its own surrounding <form> and
- * heading; the contact form adds its own email input above this.
+ * heading; the contact form adds its own email input above this. Any `children`
+ * render between the textarea and the submit button (e.g. the support form's
+ * repeat-submit notice).
  */
-export const MessageFields = (): JSX.Element => (
+export const MessageFields = ({
+  children,
+}: {
+  children?: Child;
+}): JSX.Element => (
   <>
     <label>
       Message
@@ -616,6 +622,7 @@ export const MessageFields = (): JSX.Element => (
         required
       ></textarea>
     </label>
+    {children}
     <button type="submit">Send message</button>
   </>
 );

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -91,7 +91,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => (
           navLink("/admin/holidays", "Holidays", active)}
         {session.adminLevel === "owner" &&
           isBuilderEnabled() &&
-          navLink("/admin/built-sites", "Built Sites", active)}
+          navLink("/admin/built-sites", "Builds", active)}
         {navLink("/admin/guide", "Guide", active)}
         {session.adminLevel === "owner" &&
           isSupportEnabled() &&

--- a/src/ui/templates/admin/support.tsx
+++ b/src/ui/templates/admin/support.tsx
@@ -15,11 +15,22 @@ import { Layout } from "#templates/layout.tsx";
 
 /** Message form delivering to the platform host (no Botpoison). Just a message
  * box: support always comes from the site's own business email, so there's no
- * address for the operator to enter. */
-const SupportForm = (): JSX.Element => (
+ * address for the operator to enter. When the operator submitted recently, a
+ * notice sits between the box and the button to discourage repeat sends. */
+const SupportForm = ({
+  nagLabel,
+}: {
+  nagLabel: string | null;
+}): JSX.Element => (
   <CsrfForm action="/admin/support">
     <h2>Contact support</h2>
-    <MessageFields />
+    <MessageFields>
+      {nagLabel && (
+        <p>
+          You last submitted this form <strong>{nagLabel}</strong>.
+        </p>
+      )}
+    </MessageFields>
   </CsrfForm>
 );
 
@@ -50,7 +61,6 @@ export const adminSupportPage = (opts: {
           <MissingText />
         )}
       </div>
-      {opts.nagLabel && <p>You last submitted this form {opts.nagLabel}.</p>}
-      {opts.formActive && <SupportForm />}
+      {opts.formActive && <SupportForm nagLabel={opts.nagLabel} />}
     </Layout>,
   );

--- a/test/e2e/duration-days.test.ts
+++ b/test/e2e/duration-days.test.ts
@@ -533,7 +533,11 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
       const attendees = await getAttendeesRaw(listing.id);
       const csv = generateAttendeesCsv(attendees, true);
       expect(csv).toContain("2026-06-12 to 2026-06-13");
-      expect(csv).not.toContain("2026-06-16");
+      // Guard against the *max* span (5 days → ...to 2026-06-16) appearing in
+      // the Date column. Check the full range string, not the bare end date —
+      // the Registered column is the created-at ISO timestamp, which contains
+      // today's date and would otherwise make this assertion fail on 2026-06-16.
+      expect(csv).not.toContain("2026-06-12 to 2026-06-16");
     });
 
     test("date column shows single date for 1-day bookings", async () => {

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -413,13 +413,14 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
   });
 
   describe("nav link", () => {
-    test("built sites link visible when CAN_BUILD_SITES is true", async () => {
+    test("builds link visible when CAN_BUILD_SITES is true", async () => {
       Deno.env.set("CAN_BUILD_SITES", "true");
       try {
         const { response } = await adminGet("/admin/built-sites");
         const body = await response.text();
         expect(body).toContain("/admin/built-sites");
-        expect(body).toContain("Built Sites");
+        // The nav link is labelled "Builds" (the page title stays "Built Sites").
+        expect(body).toContain(">Builds<");
       } finally {
         Deno.env.delete("CAN_BUILD_SITES");
       }

--- a/test/lib/server-support.test.ts
+++ b/test/lib/server-support.test.ts
@@ -164,7 +164,13 @@ describeWithEnv(
           expect(settings.supportFormLastSubmitted).not.toBe("");
           const { response } = await adminGet("/admin/support");
           const html = await response.text();
-          expect(html).toContain("You last submitted this form");
+          // Notice sits inside the form with the time value in bold.
+          expect(html).toContain("You last submitted this form <strong>");
+          // ...and it's between the message box and the submit button.
+          const body = html.slice(html.indexOf('name="message"'));
+          expect(body.indexOf("You last submitted this form")).toBeLessThan(
+            body.indexOf("Send message"),
+          );
         } finally {
           mock.restore();
         }


### PR DESCRIPTION
## What

Two small admin-UI tweaks:

1. **Support nag moved into the form, time in bold.** The "You last submitted this form …" notice now sits **between the message box and the submit button**, with the relative time value (e.g. **now**, **yesterday**, **2 days ago**) in `<strong>`. It previously floated above the form. `MessageFields` gained an optional `children` slot rendered between the textarea and the button to support this; the public contact form passes nothing.

2. **"Built Sites" nav link → "Builds".** Only the main-nav link label changes; the page `<title>`/`<h2>` headings stay "Built Sites".

## On the sticky-nav request

The third request — hide the main nav on scroll-down, show it on scroll-up, normal at the top — is **already implemented on `main`** (`initScrollHideNav` in `src/ui/client/admin/scroll-hide-nav.ts` + the `.nav-hidden` CSS, from PR #1166 "Hide scroll nav only after scrolling past it"). The logic matches the description exactly: `nav-hidden` toggles on only when scrolled past the nav's natural position **and** scrolling down. So no code change is included here for it — flagged for confirmation in the chat thread.

## Testing

- Updated `server-support.test.ts` (nag is now bold and inside the form, between the message box and button) and `server-built-sites.test.ts` (nav link asserts the "Builds" label).
- Full `deno task precommit` passes: lint, typecheck, 0 duplication, edge build, all tests, 100% coverage.

https://claude.ai/code/session_01KxfFDx8RcBAy4Kdera6FQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxfFDx8RcBAy4Kdera6FQP)_