### PR TITLE
Remove dark-mode filter-row box-shadow on focus too

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -2053,8 +2053,9 @@ a.cal-day-selected:hover {
   max-width: 100%;
 }
 
-/* Override dark-mode form box-shadow which would otherwise apply */
-[data-theme="dark"] .filter-row {
+/* Override dark-mode form box-shadow (base and focus) which would otherwise apply */
+[data-theme="dark"] .filter-row,
+[data-theme="dark"] .filter-row:focus-within {
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1194. In dark mode the filter row still showed the form glow **on focus**, because the override only covered the base state.

## Root cause

The global dark-mode rule `[data-theme="dark"] form:focus-within` has specificity **(0,2,1)** (attribute selector + pseudo-class + `form` type selector). The existing override `[data-theme="dark"] .filter-row` is only **(0,2,0)**, so on focus the `form:focus-within` glow won by that extra type selector. (The non-focus base case was already correctly overridden, since (0,2,0) beats `[data-theme="dark"] form` at (0,1,1).)

## Fix

Add a `:focus-within` selector to the override, landing at **(0,3,0)**, which outranks the (0,2,1) global focus rule:

```css
[data-theme="dark"] .filter-row,
[data-theme="dark"] .filter-row:focus-within {
  box-shadow: none;
}
```

## Verification

- `deno task lint` — clean, no reformatting needed

https://claude.ai/code/session_01YCbNqxWGRknk7hdTgRHpKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCbNqxWGRknk7hdTgRHpKw)_