### PR TITLE
Fix scroll-hide nav never hiding on desktop (sticky offsetTop)

### DIFF
--- a/src/ui/client/admin/scroll-hide-nav.ts
+++ b/src/ui/client/admin/scroll-hide-nav.ts
@@ -1,9 +1,20 @@
 /// <reference lib="dom" />
-/** Scroll-hide nav: hide sticky main nav on scroll down once it has been
- * scrolled past, show on scroll up or while still within its natural area. */
+/** Scroll-hide nav: once the sticky main nav is "stuck" (scrolled past its
+ * natural place), hide it while scrolling down and show it again on scroll up;
+ * while it is still in its natural place near the top of the page, leave it put.
+ *
+ * "Stuck" is detected from the live bounding rect — its top reaching the sticky
+ * offset — rather than from offsetTop. On a `position: sticky` element offsetTop
+ * reports the *stuck* position, which tracks scroll, so the previous
+ * `scrollY > offsetTop` check was never true and the nav never hid on desktop. */
 export const initScrollHideNav = (): void => {
   const nav = document.querySelector<HTMLElement>("#main-nav");
   if (!nav) return;
+
+  // The viewport offset the nav settles at once stuck (its CSS `top`, e.g.
+  // 1rem). Resolves to 0 where the nav isn't sticky (mobile) — harmless there,
+  // since the .nav-hidden styles only apply at the sticky breakpoint.
+  const stuckTop = Number.parseFloat(getComputedStyle(nav).top) || 0;
 
   if (location.hash) {
     nav.classList.add("nav-no-transition", "nav-hidden");
@@ -20,11 +31,8 @@ export const initScrollHideNav = (): void => {
       ticking = true;
       requestAnimationFrame(() => {
         const y = scrollY;
-        // Only hide once scrolled past the nav's natural position, so it
-        // slides away while already off-screen rather than visibly flying
-        // off the top while the user is still near the top of the page.
-        const navBottom = nav.offsetTop + nav.offsetHeight;
-        nav.classList.toggle("nav-hidden", y > navBottom && y > lastY);
+        const stuck = nav.getBoundingClientRect().top <= stuckTop + 1;
+        nav.classList.toggle("nav-hidden", stuck && y > lastY);
         lastY = y;
         ticking = false;
       });


### PR DESCRIPTION
## What

Fixes the main admin nav not hiding on scroll-down (desktop).

## Root cause

`scroll-hide-nav.ts` computed `navBottom = nav.offsetTop + nav.offsetHeight` on every scroll and hid the nav when `scrollY > navBottom`. For a `position: sticky` element, **`offsetTop` reports the *stuck* position**, which tracks scroll — so `navBottom ≈ scrollY + …` and the condition was effectively never true. The nav therefore never got `.nav-hidden` once it became sticky. (This regressed when the nav was made sticky; the `#1166` "scrolled past it" guard relies on `offsetTop`.)

## Fix

Detect "stuck" from the live `getBoundingClientRect().top` reaching the sticky `top` offset, instead of reading `offsetTop`:

```ts
const stuckTop = Number.parseFloat(getComputedStyle(nav).top) || 0; // 1rem on desktop
// per scroll tick:
const stuck = nav.getBoundingClientRect().top <= stuckTop + 1;
nav.classList.toggle("nav-hidden", stuck && y > lastY);
```

Behaviour now matches the request:
- At the top of the page the nav sits in its normal (sticky) place.
- Once it's stuck (scrolled past its natural spot), it hides on scroll-down and reappears on scroll-up.
- On mobile (`< 769px`) the nav isn't sticky and `.nav-hidden` doesn't apply, so the `stuckTop = 0` fallback is harmless.

## Testing

- `deno task precommit` passes (lint, typecheck, 0 duplication, edge build, all tests + 100% coverage).
- `scroll-hide-nav.ts` is browser-only client JS (never imported by tests, so not coverage-enforced and untested upstream); I verified it lints, typechecks, and bundles cleanly into `admin.js`. The scroll/sticky behaviour itself needs a real browser to exercise — worth a quick manual check on desktop after merge.

https://claude.ai/code/session_01KxfFDx8RcBAy4Kdera6FQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxfFDx8RcBAy4Kdera6FQP)_