### PR TITLE
Add secrets insight and backfill for existing built sites

### DIFF
--- a/src/features/admin/built-sites.ts
+++ b/src/features/admin/built-sites.ts
@@ -30,6 +30,10 @@ import {
   rotateRenewalToken,
   syncReadOnlyFrom,
 } from "#shared/site-assignment.ts";
+import {
+  addMissingSiteSecrets,
+  loadSiteSecretsStatus,
+} from "#shared/site-secrets.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import {
   adminBuiltSiteDeletePage,
@@ -147,11 +151,16 @@ const ownerPost =
 
 /** GET /admin/built-sites/:id/edit */
 const handleEditGet = (request: Request, params: RouteParams) =>
-  withOwnerAndSite(request, params, ({ site }, session) => {
+  withOwnerAndSite(request, params, async ({ site }, session) => {
     const flash = applyFlash(request);
-    return Promise.resolve(
-      htmlResponse(
-        adminBuiltSiteEditPage(site, session, flash.error, flash.success),
+    const secrets = await loadSiteSecretsStatus(site);
+    return htmlResponse(
+      adminBuiltSiteEditPage(
+        site,
+        session,
+        flash.error,
+        flash.success,
+        secrets,
       ),
     );
   });
@@ -174,6 +183,25 @@ const handleRotateToken = ownerPost(async (site, _form, id) => {
     "Renewal token rotated",
     "Renewal token could not be pushed to the site",
   );
+});
+
+/** POST /admin/built-sites/:id/add-secrets
+ *
+ * Backfills the secrets we copy to freshly built sites onto an existing site.
+ * Re-verifies the live secrets first, then sets only the ones still missing —
+ * an existing secret is never overwritten (it may have been changed for a
+ * reason). */
+const handleAddSecrets = ownerPost(async (site, _form, id) => {
+  const result = await addMissingSiteSecrets(site);
+  if (!result.ok) {
+    return editError(id, `Secrets could not be set: ${result.error}`);
+  }
+  if (result.added.length === 0) {
+    return editSuccess(id, "No missing secrets — nothing to set");
+  }
+  const summary = `${result.added.length} missing secret(s): ${result.added.join(", ")}`;
+  await logActivity(`Set ${summary} on '${site.name}'`);
+  return editSuccess(id, `Set ${summary}`);
 });
 
 /** POST /admin/built-sites/:id/bump-deadline */
@@ -271,6 +299,7 @@ export const builtSitesRoutes = {
   "GET /admin/built-sites": handleBuiltSitesListGet,
   // Override the CRUD-provided edit GET to pick up flash messages.
   "GET /admin/built-sites/:id/edit": handleEditGet,
+  "POST /admin/built-sites/:id/add-secrets": handleAddSecrets,
   "POST /admin/built-sites/:id/bump-deadline": handleBumpDeadline,
   "POST /admin/built-sites/:id/override-deadline": handleOverrideDeadline,
   "POST /admin/built-sites/:id/provision-renewal": handleProvisionRenewal,

--- a/src/shared/builder.ts
+++ b/src/shared/builder.ts
@@ -87,6 +87,20 @@ export const testDbConnection = async (
   }
 };
 
+/**
+ * Collect the host-environment secrets that are currently set, as [name, value]
+ * pairs. These are copied onto every freshly built site, and backfilled onto
+ * existing sites that are missing them (see #shared/site-secrets.ts).
+ */
+export const collectHostSecrets = (): [string, string][] => {
+  const secrets: [string, string][] = [];
+  for (const key of HOST_SECRET_KEYS) {
+    const value = getEnv(key);
+    if (value) secrets.push([key, value]);
+  }
+  return secrets;
+};
+
 /** Set multiple secrets on a Bunny edge script, collecting errors */
 const setSecrets = async (
   scriptId: number,
@@ -183,19 +197,14 @@ export const buildSite = async (
   // 4. Generate encryption key
   const encryptionKey = builderApi.generateEncryptionKey();
 
-  // 5. Set secrets
+  // 5. Set secrets: base credentials plus any host secrets that are set
   const secrets: [string, string][] = [
     ["DB_URL", dbCredentials.dbUrl],
     ["DB_TOKEN", dbCredentials.dbToken],
     ["DB_ENCRYPTION_KEY", encryptionKey],
     ["BUNNY_SCRIPT_ID", String(scriptId)],
+    ...collectHostSecrets(),
   ];
-
-  // Copy host secrets that are set
-  for (const key of HOST_SECRET_KEYS) {
-    const value = getEnv(key);
-    if (value) secrets.push([key, value]);
-  }
 
   // Renewal-related secrets (READ_ONLY_FROM, RENEWAL_URL) are pushed later by
   // site-assignment.ts after the site row has been created — the builder

--- a/src/shared/bunny-cdn.ts
+++ b/src/shared/bunny-cdn.ts
@@ -502,6 +502,39 @@ const setEdgeScriptSecretImpl = async (
     `Set secret ${name}`,
   );
 
+/** A secret as reported by the Bunny API (name + metadata only — never the value). */
+export interface EdgeScriptSecret {
+  Id: number;
+  LastModified: string;
+  Name: string;
+}
+
+interface ListEdgeScriptSecretsResponse {
+  Secrets: EdgeScriptSecret[] | null;
+}
+
+type ListSecretsResult =
+  | { ok: true; secrets: EdgeScriptSecret[] }
+  | { ok: false; error: string; errorKey?: string };
+
+/**
+ * List the secrets currently set on a Bunny edge script. The API returns each
+ * secret's name and metadata only — values are never exposed.
+ */
+const listEdgeScriptSecretsImpl = async (
+  scriptId: number | string,
+): Promise<ListSecretsResult> => {
+  const response = await fetchText(
+    `${BUNNY_API_BASE}/compute/script/${encodeURIComponent(scriptId)}/secrets`,
+    { headers: { AccessKey: getBunnyApiKey() } },
+  );
+  if (!response.ok) {
+    return parseBunnyError(response, "List secrets");
+  }
+  const data: ListEdgeScriptSecretsResponse = JSON.parse(response.text);
+  return { ok: true, secrets: data.Secrets ?? [] };
+};
+
 /**
  * Publish a Bunny edge script.
  */
@@ -553,6 +586,7 @@ export const bunnyCdnApi = {
   getCdnHostname: getCdnHostnameImpl,
   getDnsZone: getDnsZoneImpl,
   getEdgeScript: getEdgeScriptImpl,
+  listEdgeScriptSecrets: listEdgeScriptSecretsImpl,
   publishEdgeScript: publishEdgeScriptImpl,
   registerBunnySubdomain: registerBunnySubdomainImpl,
   setEdgeScriptSecret: setEdgeScriptSecretImpl,

--- a/src/shared/bunny-cdn.ts
+++ b/src/shared/bunny-cdn.ts
@@ -39,26 +39,34 @@ interface EdgeScriptResponse {
 }
 
 /**
+ * GET a Bunny API endpoint with AccessKey auth and parse the JSON body, or
+ * surface a Bunny API error. Shared by the edge-script, secrets, and DNS reads.
+ */
+const bunnyGetJson = async <T>(
+  path: string,
+  label: string,
+): Promise<
+  { ok: true; data: T } | { ok: false; error: string; errorKey?: string }
+> => {
+  const response = await fetchText(`${BUNNY_API_BASE}${path}`, {
+    headers: { AccessKey: getBunnyApiKey() },
+  });
+  if (!response.ok) return parseBunnyError(response, label);
+  return { data: JSON.parse(response.text) as T, ok: true };
+};
+
+/**
  * Fetch the edge script details from the Bunny API using BUNNY_SCRIPT_ID.
  * Returns the DefaultHostname and LinkedPullZones.
  */
-const getEdgeScriptImpl = async (): Promise<
+const getEdgeScriptImpl = (): Promise<
   | { ok: true; data: EdgeScriptResponse }
   | { ok: false; error: string; errorKey?: string }
-> => {
-  const scriptId = getBunnyScriptId();
-  const response = await fetchText(
-    `${BUNNY_API_BASE}/compute/script/${encodeURIComponent(scriptId)}`,
-    { headers: { AccessKey: getBunnyApiKey() } },
+> =>
+  bunnyGetJson<EdgeScriptResponse>(
+    `/compute/script/${encodeURIComponent(getBunnyScriptId())}`,
+    "Get edge script",
   );
-
-  if (!response.ok) {
-    return parseBunnyError(response, "Get edge script");
-  }
-
-  const data: EdgeScriptResponse = JSON.parse(response.text);
-  return { data, ok: true };
-};
 
 /** Map edge script data to a result, returning early on API error. */
 const withEdgeScript = async <T>(
@@ -237,17 +245,11 @@ const DNS_RECORD_TYPE_CNAME = 2;
 const getDnsZoneImpl = async (): Promise<
   { ok: true; zone: BunnyDnsZone } | { ok: false; error: string }
 > => {
-  const zoneId = getBunnyDnsZoneId();
-  const response = await fetchText(`${BUNNY_API_BASE}/dnszone/${zoneId}`, {
-    headers: { AccessKey: getBunnyApiKey() },
-  });
-
-  if (!response.ok) {
-    return parseBunnyError(response, "Get DNS zone");
-  }
-
-  const zone: BunnyDnsZone = JSON.parse(response.text);
-  return { ok: true, zone };
+  const result = await bunnyGetJson<BunnyDnsZone>(
+    `/dnszone/${getBunnyDnsZoneId()}`,
+    "Get DNS zone",
+  );
+  return result.ok ? { ok: true, zone: result.data } : result;
 };
 
 /**
@@ -524,15 +526,12 @@ type ListSecretsResult =
 const listEdgeScriptSecretsImpl = async (
   scriptId: number | string,
 ): Promise<ListSecretsResult> => {
-  const response = await fetchText(
-    `${BUNNY_API_BASE}/compute/script/${encodeURIComponent(scriptId)}/secrets`,
-    { headers: { AccessKey: getBunnyApiKey() } },
+  const result = await bunnyGetJson<ListEdgeScriptSecretsResponse>(
+    `/compute/script/${encodeURIComponent(scriptId)}/secrets`,
+    "List secrets",
   );
-  if (!response.ok) {
-    return parseBunnyError(response, "List secrets");
-  }
-  const data: ListEdgeScriptSecretsResponse = JSON.parse(response.text);
-  return { ok: true, secrets: data.Secrets ?? [] };
+  if (!result.ok) return result;
+  return { ok: true, secrets: result.data.Secrets ?? [] };
 };
 
 /**

--- a/src/shared/site-secrets.ts
+++ b/src/shared/site-secrets.ts
@@ -85,23 +85,49 @@ const listSecretNames = async (
   }
 };
 
+type ResolvedSiteSecrets = {
+  scriptId: number;
+  names: string[];
+  present: Set<string>;
+};
+
+/**
+ * Resolve a site's precondition and live secret list into a single context,
+ * shared by the read (status) and write (backfill) paths.
+ */
+const resolveSiteSecrets = async (
+  site: BuiltSite,
+): Promise<
+  { ok: true; data: ResolvedSiteSecrets } | { ok: false; error: string }
+> => {
+  const pre = secretsPrecondition(site);
+  if (!pre.ok) return pre;
+  const listed = await listSecretNames(pre.scriptId);
+  if (!listed.ok) return listed;
+  return {
+    data: {
+      names: listed.names,
+      present: new Set(listed.names),
+      scriptId: pre.scriptId,
+    },
+    ok: true,
+  };
+};
+
 /** Inspect a site's live secrets and diff them against the expected set. */
 export const loadSiteSecretsStatus = async (
   site: BuiltSite,
 ): Promise<SiteSecretsView> => {
-  const pre = secretsPrecondition(site);
-  if (!pre.ok) return pre;
+  const resolved = await resolveSiteSecrets(site);
+  if (!resolved.ok) return resolved;
 
-  const listed = await listSecretNames(pre.scriptId);
-  if (!listed.ok) return listed;
-
-  const present = new Set(listed.names);
+  const { names, present } = resolved.data;
   const expected = expectedSiteSecrets(site).map(([name]) => name);
   return {
     expected,
     missing: expected.filter((name) => !present.has(name)),
     ok: true,
-    present: listed.names,
+    present: names,
   };
 };
 
@@ -117,25 +143,18 @@ export type AddMissingSecretsResult =
 export const addMissingSiteSecrets = async (
   site: BuiltSite,
 ): Promise<AddMissingSecretsResult> => {
-  const pre = secretsPrecondition(site);
-  if (!pre.ok) return pre;
-
   // Re-verify against the live list in case more secrets exist by now.
-  const listed = await listSecretNames(pre.scriptId);
-  if (!listed.ok) return listed;
-  const present = new Set(listed.names);
+  const resolved = await resolveSiteSecrets(site);
+  if (!resolved.ok) return resolved;
 
+  const { present, scriptId } = resolved.data;
   const toAdd = expectedSiteSecrets(site).filter(
     ([name]) => !present.has(name),
   );
   const added: string[] = [];
   const errors: string[] = [];
   for (const [name, value] of toAdd) {
-    const result = await bunnyCdnApi.setEdgeScriptSecret(
-      pre.scriptId,
-      name,
-      value,
-    );
+    const result = await bunnyCdnApi.setEdgeScriptSecret(scriptId, name, value);
     if (result.ok) added.push(name);
     else errors.push(result.error);
   }

--- a/src/shared/site-secrets.ts
+++ b/src/shared/site-secrets.ts
@@ -1,0 +1,145 @@
+/**
+ * Secrets insight + backfill for existing built sites.
+ *
+ * A freshly built site has the full set of secrets copied onto it (see
+ * builder.ts). Host secrets, however, accumulate over time — a site built
+ * before, say, the Google Wallet keys were configured will be missing them.
+ * This module diffs a site's live secrets (read from the Bunny API) against the
+ * set we would copy today, and can backfill the ones that are missing.
+ *
+ * It never overwrites a secret that already exists on the site: a value may
+ * have been changed deliberately. DB_ENCRYPTION_KEY in particular is excluded
+ * from the expected set entirely — it is generated per-site at build time and
+ * never stored, so it cannot be reproduced, and re-setting it with a fresh key
+ * would orphan the site's existing encrypted data.
+ */
+
+import { collectHostSecrets } from "#shared/builder.ts";
+import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
+import type { BuiltSite } from "#shared/db/built-sites.ts";
+import { getEnv } from "#shared/env.ts";
+
+/**
+ * The secrets we would copy to a freshly built site, recomputed for an existing
+ * site from its stored record plus the current host environment. Excludes
+ * DB_ENCRYPTION_KEY (see module docs) and the renewal secrets
+ * (READ_ONLY_FROM / RENEWAL_URL), which the renewal panel manages separately.
+ */
+export const expectedSiteSecrets = (site: BuiltSite): [string, string][] => {
+  const base: [string, string][] = [];
+  if (site.dbUrl) base.push(["DB_URL", site.dbUrl]);
+  if (site.dbToken) base.push(["DB_TOKEN", site.dbToken]);
+  if (site.bunnyScriptId) base.push(["BUNNY_SCRIPT_ID", site.bunnyScriptId]);
+  return [...base, ...collectHostSecrets()];
+};
+
+/** Outcome of inspecting a site's live secrets against the expected set. */
+export type SiteSecretsView =
+  | {
+      ok: true;
+      /** Every secret name currently set on the edge script. */
+      present: string[];
+      /** Expected secret names that are not present on the edge script. */
+      missing: string[];
+      /** All names we would copy to a fresh build of this site. */
+      expected: string[];
+    }
+  | { ok: false; error: string };
+
+type SecretsPrecondition =
+  | { ok: true; scriptId: number }
+  | { ok: false; error: string };
+
+/** A site can only be inspected when it has a script id and the host has an API key. */
+const secretsPrecondition = (site: BuiltSite): SecretsPrecondition => {
+  const scriptId = Number(site.bunnyScriptId);
+  if (!scriptId) {
+    return {
+      error: "This site has no Bunny script ID, so its secrets can't be read.",
+      ok: false,
+    };
+  }
+  if (!getEnv("BUNNY_API_KEY")) {
+    return {
+      error:
+        "BUNNY_API_KEY is not configured on this host, so site secrets can't be read.",
+      ok: false,
+    };
+  }
+  return { ok: true, scriptId };
+};
+
+/** Fetch the live secret names for a script, resilient to network/parse errors. */
+const listSecretNames = async (
+  scriptId: number,
+): Promise<{ ok: true; names: string[] } | { ok: false; error: string }> => {
+  try {
+    const result = await bunnyCdnApi.listEdgeScriptSecrets(scriptId);
+    if (!result.ok) return { error: result.error, ok: false };
+    return { names: result.secrets.map((s) => s.Name), ok: true };
+  } catch (e) {
+    return {
+      error: `Failed to list secrets: ${(e as Error).message}`,
+      ok: false,
+    };
+  }
+};
+
+/** Inspect a site's live secrets and diff them against the expected set. */
+export const loadSiteSecretsStatus = async (
+  site: BuiltSite,
+): Promise<SiteSecretsView> => {
+  const pre = secretsPrecondition(site);
+  if (!pre.ok) return pre;
+
+  const listed = await listSecretNames(pre.scriptId);
+  if (!listed.ok) return listed;
+
+  const present = new Set(listed.names);
+  const expected = expectedSiteSecrets(site).map(([name]) => name);
+  return {
+    expected,
+    missing: expected.filter((name) => !present.has(name)),
+    ok: true,
+    present: listed.names,
+  };
+};
+
+/** Outcome of backfilling a site's missing secrets. */
+export type AddMissingSecretsResult =
+  | { ok: true; added: string[] }
+  | { ok: false; error: string };
+
+/**
+ * Re-verify the site's live secrets, then set only the ones still missing from
+ * the expected set. Never overwrites a secret that already exists.
+ */
+export const addMissingSiteSecrets = async (
+  site: BuiltSite,
+): Promise<AddMissingSecretsResult> => {
+  const pre = secretsPrecondition(site);
+  if (!pre.ok) return pre;
+
+  // Re-verify against the live list in case more secrets exist by now.
+  const listed = await listSecretNames(pre.scriptId);
+  if (!listed.ok) return listed;
+  const present = new Set(listed.names);
+
+  const toAdd = expectedSiteSecrets(site).filter(
+    ([name]) => !present.has(name),
+  );
+  const added: string[] = [];
+  const errors: string[] = [];
+  for (const [name, value] of toAdd) {
+    const result = await bunnyCdnApi.setEdgeScriptSecret(
+      pre.scriptId,
+      name,
+      value,
+    );
+    if (result.ok) added.push(name);
+    else errors.push(result.error);
+  }
+  return errors.length > 0
+    ? { error: errors[0]!, ok: false }
+    : { added, ok: true };
+};

--- a/src/ui/templates/admin/built-sites.tsx
+++ b/src/ui/templates/admin/built-sites.tsx
@@ -14,6 +14,7 @@ import {
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { formatDeadlineLabel, isProvisioned } from "#shared/renewal-helpers.ts";
 import { renewalUrlFor } from "#shared/site-assignment.ts";
+import type { SiteSecretsView } from "#shared/site-secrets.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import {
@@ -111,13 +112,16 @@ export const adminBuiltSitesPage = (
                   <th>Bunny URL</th>
                   <th>Status</th>
                   <th>Read-only from</th>
-                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {sites.map((site) => (
                   <tr>
-                    <td>{site.name}</td>
+                    <td>
+                      <a href={`/admin/built-sites/${site.id}/edit`}>
+                        {site.name}
+                      </a>
+                    </td>
                     <td>
                       <a href={site.bunnyUrl} rel="noopener" target="_blank">
                         {site.bunnyUrl}
@@ -131,12 +135,6 @@ export const adminBuiltSitesPage = (
                           : "Not assignable"}
                     </td>
                     <td>{formatDeadlineLabel(site.readOnlyFrom)}</td>
-                    <td>
-                      <a href={`/admin/built-sites/${site.id}/edit`}>Edit</a>{" "}
-                      <a href={`/admin/built-sites/${site.id}/delete`}>
-                        Delete
-                      </a>
-                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -183,18 +181,18 @@ export const adminBuiltSiteNewPage = (
     </Layout>,
   );
 
-type RenewalActionProps = {
+type SiteActionProps = {
   siteId: number;
   action: string;
   children: JSX.Element | JSX.Element[];
 };
 
-/** Standard renewal action form wrapper — CSRF + path scoping in one place. */
-const RenewalActionForm = ({
+/** Standard built-site action form wrapper — CSRF + path scoping in one place. */
+const SiteActionForm = ({
   siteId,
   action,
   children,
-}: RenewalActionProps): JSX.Element => (
+}: SiteActionProps): JSX.Element => (
   <CsrfForm action={`/admin/built-sites/${siteId}/${action}`}>
     {children}
   </CsrfForm>
@@ -234,7 +232,7 @@ const ProvisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => {
         <strong>Renewal URL:</strong> <code>{renewalUrl}</code>
       </p>
 
-      <RenewalActionForm action="rotate-renewal-token" siteId={site.id}>
+      <SiteActionForm action="rotate-renewal-token" siteId={site.id}>
         <button
           onclick="return confirm('The old URL will stop working. Continue?')"
           type="submit"
@@ -242,23 +240,23 @@ const ProvisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => {
           <Icon name="rotate-ccw" />
           <span>Rotate token</span>
         </button>
-      </RenewalActionForm>
+      </SiteActionForm>
 
-      <RenewalActionForm action="bump-deadline" siteId={site.id}>
+      <SiteActionForm action="bump-deadline" siteId={site.id}>
         <label for="bump_months">Bump deadline by months</label>
         <MonthsInput id="bump_months" />
         <SubmitButton icon="save">Bump</SubmitButton>
-      </RenewalActionForm>
+      </SiteActionForm>
 
-      <RenewalActionForm action="override-deadline" siteId={site.id}>
+      <SiteActionForm action="override-deadline" siteId={site.id}>
         <label for="override_date">Override deadline</label>
         <input id="override_date" name="date" type="date" />
         <SubmitButton icon="save">Override</SubmitButton>
-      </RenewalActionForm>
+      </SiteActionForm>
 
-      <RenewalActionForm action="re-sync-deadline" siteId={site.id}>
+      <SiteActionForm action="re-sync-deadline" siteId={site.id}>
         <SubmitButton icon="rotate-ccw">Re-sync deadline</SubmitButton>
-      </RenewalActionForm>
+      </SiteActionForm>
     </div>
   );
 };
@@ -271,25 +269,94 @@ const UnprovisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => (
     </p>
 
     <h3>Provision renewal</h3>
-    <RenewalActionForm action="provision-renewal" siteId={site.id}>
+    <SiteActionForm action="provision-renewal" siteId={site.id}>
       <label for="provision_months">Initial months</label>
       <MonthsInput id="provision_months" />
       <SubmitButton icon="hammer">Provision</SubmitButton>
-    </RenewalActionForm>
+    </SiteActionForm>
 
     <h3>Bump deadline</h3>
-    <RenewalActionForm action="bump-deadline" siteId={site.id}>
+    <SiteActionForm action="bump-deadline" siteId={site.id}>
       <MonthsInput />
       <SubmitButton icon="save">Bump</SubmitButton>
-    </RenewalActionForm>
+    </SiteActionForm>
 
     <h3>Override deadline</h3>
-    <RenewalActionForm action="override-deadline" siteId={site.id}>
+    <SiteActionForm action="override-deadline" siteId={site.id}>
       <input name="date" type="date" />
       <SubmitButton icon="save">Override</SubmitButton>
-    </RenewalActionForm>
+    </SiteActionForm>
   </div>
 );
+
+/**
+ * Secrets panel: diffs the secrets we copy to freshly built sites against the
+ * ones live on this site's edge script, and offers to backfill the missing
+ * ones. Existing secrets are never shown as actionable — they are left
+ * untouched.
+ */
+const SecretsPanel = ({
+  site,
+  view,
+}: {
+  site: BuiltSite;
+  view?: SiteSecretsView;
+}): JSX.Element => {
+  if (!view) {
+    return <p class="prose">Secrets status is unavailable.</p>;
+  }
+  if (!view.ok) {
+    return (
+      <div class="prose">
+        <div class="error" role="alert">
+          {view.error}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div class="prose">
+      <p>
+        This site has <strong>{String(view.present.length)}</strong> secret(s)
+        set. We copy <strong>{String(view.expected.length)}</strong> secret(s)
+        to freshly built sites.
+      </p>
+      {view.missing.length === 0 ? (
+        <div class="success" role="status">
+          All expected secrets are present on this site.
+        </div>
+      ) : (
+        <SiteActionForm action="add-secrets" siteId={site.id}>
+          <p>
+            Missing from this site (existing secrets are never overwritten):
+          </p>
+          <ul>
+            {view.missing.map((name) => (
+              <li>
+                <code>{name}</code>
+              </li>
+            ))}
+          </ul>
+          <SubmitButton icon="plus">
+            Set {String(view.missing.length)} missing secret(s)
+          </SubmitButton>
+        </SiteActionForm>
+      )}
+      {view.present.length > 0 && (
+        <details>
+          <summary>Secrets currently on this site</summary>
+          <ul>
+            {view.present.map((name) => (
+              <li>
+                <code>{name}</code>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+};
 
 /**
  * Admin built site edit page
@@ -299,6 +366,7 @@ export const adminBuiltSiteEditPage = (
   session: AdminSession,
   error?: string,
   success?: string,
+  secretsView?: SiteSecretsView,
 ): string => {
   const provisioned = isProvisioned(site);
 
@@ -320,6 +388,20 @@ export const adminBuiltSiteEditPage = (
       ) : (
         <UnprovisionedPanel site={site} />
       )}
+
+      <h2>Secrets</h2>
+      <SecretsPanel site={site} view={secretsView} />
+
+      <h2>Delete</h2>
+      <p class="prose">
+        <ActionButton
+          href={`/admin/built-sites/${site.id}/delete`}
+          icon="trash-2"
+          variant="secondary"
+        >
+          Delete this site
+        </ActionButton>
+      </p>
     </Layout>,
   );
 };

--- a/test/admin-built-sites-actions.test.ts
+++ b/test/admin-built-sites-actions.test.ts
@@ -11,6 +11,7 @@ import {
   getAllBuiltSites,
   updateBuiltSiteRenewalState,
 } from "#shared/db/built-sites.ts";
+import { expectedSiteSecrets } from "#shared/site-secrets.ts";
 import {
   adminFormPost,
   createTestBuiltSite,
@@ -592,3 +593,157 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
     });
   });
 });
+
+describeWithEnv(
+  "admin built-sites add-secrets",
+  {
+    db: true,
+    env: { BUNNY_API_KEY: "k", NTFY_URL: "https://ntfy.example.com/t" },
+  },
+  () => {
+    /** Stub the live secret list + a recording setEdgeScriptSecret. */
+    const stubSecrets = (present: string[]) => {
+      const setCalls: { name: string; value: string }[] = [];
+      const listStub = stub(bunnyCdnApi, "listEdgeScriptSecrets", () =>
+        Promise.resolve({
+          ok: true as const,
+          secrets: present.map((Name) => ({
+            Id: 1,
+            LastModified: "2026-01-01T00:00:00Z",
+            Name,
+          })),
+        }),
+      );
+      const setStub = stub(
+        bunnyCdnApi,
+        "setEdgeScriptSecret",
+        (_id: number, name: string, value: string) => {
+          setCalls.push({ name, value });
+          return Promise.resolve({ ok: true as const });
+        },
+      );
+      return {
+        restore: () => {
+          listStub.restore();
+          setStub.restore();
+        },
+        setCalls,
+      };
+    };
+
+    test("backfills secrets missing from the live list and logs the change", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "7100",
+        dbToken: "tok",
+        dbUrl: "libsql://u",
+        name: "Backfill Site",
+      });
+      const secrets = stubSecrets([]); // nothing live yet — everything is missing
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/add-secrets`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          expect.stringContaining("missing secret(s)"),
+        )(response);
+
+        const setNames = secrets.setCalls.map((c) => c.name);
+        expect(setNames).toContain("NTFY_URL");
+        expect(setNames).toContain("DB_URL");
+        // The unreproducible encryption key is never set.
+        expect(setNames).not.toContain("DB_ENCRYPTION_KEY");
+
+        const logs = await getAllActivityLog();
+        expect(logs.some((l) => l.message.includes("missing secret"))).toBe(
+          true,
+        );
+      } finally {
+        secrets.restore();
+      }
+    });
+
+    test("never overwrites a secret that already exists on the site", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "7101",
+        dbToken: "tok",
+        dbUrl: "libsql://u",
+        name: "No Overwrite Site",
+      });
+      // Live list already has everything expected except NTFY_URL.
+      const present = expectedSiteSecrets(site)
+        .map(([name]) => name)
+        .filter((name) => name !== "NTFY_URL");
+      const secrets = stubSecrets(present);
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/add-secrets`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          "Set 1 missing secret(s): NTFY_URL",
+        )(response);
+        // Only the genuinely-missing secret is written.
+        expect(secrets.setCalls.map((c) => c.name)).toEqual(["NTFY_URL"]);
+      } finally {
+        secrets.restore();
+      }
+    });
+
+    test("reports nothing to do when every expected secret is present", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "7102",
+        dbToken: "tok",
+        dbUrl: "libsql://u",
+        name: "All Present Site",
+      });
+      const present = expectedSiteSecrets(site).map(([name]) => name);
+      const secrets = stubSecrets(present);
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/add-secrets`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          "No missing secrets — nothing to set",
+        )(response);
+        expect(secrets.setCalls.length).toBe(0);
+      } finally {
+        secrets.restore();
+      }
+    });
+
+    test("surfaces an error when a secret cannot be set", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "7103",
+        name: "Push Fail Site",
+      });
+      const listStub = stub(bunnyCdnApi, "listEdgeScriptSecrets", () =>
+        Promise.resolve({ ok: true as const, secrets: [] }),
+      );
+      const setStub = stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+        Promise.resolve({ error: "edge push failed", ok: false as const }),
+      );
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/add-secrets`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          expect.stringContaining("Secrets could not be set"),
+          false,
+        )(response);
+      } finally {
+        listStub.restore();
+        setStub.restore();
+      }
+    });
+
+    test("returns 404 for a non-existent built site", async () => {
+      const { response } = await adminFormPost(
+        "/admin/built-sites/999999/add-secrets",
+      );
+      expect(response.status).toBe(404);
+    });
+  },
+);

--- a/test/lib/bunny-cdn/edge-script.test.ts
+++ b/test/lib/bunny-cdn/edge-script.test.ts
@@ -385,6 +385,75 @@ describeWithEnv(
 );
 
 describeWithEnv(
+  "listEdgeScriptSecrets",
+  { env: { BUNNY_API_KEY: "test-bunny-key" } },
+  () => {
+    test("returns the secrets reported by the API", async () => {
+      const secrets = [
+        { Id: 1, LastModified: "2026-01-01T00:00:00Z", Name: "DB_URL" },
+        { Id: 2, LastModified: "2026-01-02T00:00:00Z", Name: "NTFY_URL" },
+      ];
+      await withMocks(
+        () => stubFetchJson({ Secrets: secrets }),
+        async () => {
+          const result = await bunnyCdnApi.listEdgeScriptSecrets(42);
+          expect(result).toEqual({ ok: true, secrets });
+        },
+      );
+    });
+
+    test("GETs the script secrets endpoint", async () => {
+      const calls: { url: string; init?: RequestInit }[] = [];
+      await withMocks(
+        () =>
+          stub(
+            globalThis,
+            "fetch",
+            (input: string | URL | Request, init?: RequestInit) => {
+              calls.push({ init, url: String(input) });
+              return Promise.resolve(
+                new Response(JSON.stringify({ Secrets: [] })),
+              );
+            },
+          ),
+        async () => {
+          await bunnyCdnApi.listEdgeScriptSecrets(7);
+          expect(calls[0]!.url).toContain("/compute/script/7/secrets");
+          // GET is the default method (no explicit method on the request init).
+          expect(calls[0]!.init?.method).toBeUndefined();
+        },
+      );
+    });
+
+    test("treats a null Secrets array as empty", async () => {
+      await withMocks(
+        () => stubFetchJson({ Secrets: null }),
+        async () => {
+          const result = await bunnyCdnApi.listEdgeScriptSecrets(42);
+          expect(result).toEqual({ ok: true, secrets: [] });
+        },
+      );
+    });
+
+    test("returns error on API failure", async () => {
+      await withMocks(
+        () =>
+          stub(globalThis, "fetch", () =>
+            Promise.resolve(new Response("Forbidden", { status: 403 })),
+          ),
+        async () => {
+          const result = await bunnyCdnApi.listEdgeScriptSecrets(42);
+          expect(result.ok).toBe(false);
+          if (!result.ok) {
+            expect(result.error).toContain("List secrets failed (403)");
+          }
+        },
+      );
+    });
+  },
+);
+
+describeWithEnv(
   "updatePullZone",
   { env: { BUNNY_API_KEY: "test-bunny-key" } },
   () => {

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -39,14 +39,18 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
         name: "My Site",
       });
       const { response } = await adminGet("/admin/built-sites");
-      await expectHtmlResponse(
+      const html = await expectHtmlResponse(
         response,
         200,
         "My Site",
         "https://mysite.b-cdn.net",
         `/admin/built-sites/${site.id}/edit`,
-        `/admin/built-sites/${site.id}/delete`,
       );
+      // The site name links to the edit page; delete moved to that page.
+      expect(html).toContain(
+        `href="/admin/built-sites/${site.id}/edit">My Site</a>`,
+      );
+      expect(html).not.toContain(`/admin/built-sites/${site.id}/delete`);
     });
 
     test("shows Not assignable status for default sites", async () => {
@@ -233,6 +237,18 @@ describeWithEnv("server (admin built sites)", { db: true }, () => {
         "https://editme.b-cdn.net",
         "54321",
       );
+    });
+
+    test("renders the Secrets and Delete sections", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8000",
+        name: "Sections",
+      });
+      const { response } = await adminGet(`/admin/built-sites/${site.id}/edit`);
+      const html = await expectHtmlResponse(response, 200, "Edit Built Site");
+      expect(html).toContain("Secrets");
+      expect(html).toContain(`/admin/built-sites/${site.id}/delete`);
+      expect(html).toContain("Delete this site");
     });
 
     test("returns 404 for non-existent built site", async () => {

--- a/test/lib/site-secrets.test.ts
+++ b/test/lib/site-secrets.test.ts
@@ -1,0 +1,278 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { collectHostSecrets } from "#shared/builder.ts";
+import { bunnyCdnApi, type EdgeScriptSecret } from "#shared/bunny-cdn.ts";
+import type { BuiltSite } from "#shared/db/built-sites.ts";
+import {
+  addMissingSiteSecrets,
+  expectedSiteSecrets,
+  loadSiteSecretsStatus,
+} from "#shared/site-secrets.ts";
+import { describeWithEnv, testBuiltSite, withMocks } from "#test-utils";
+
+/** Build a Bunny secret-list entry (name + metadata; the API never returns values). */
+const secret = (name: string): EdgeScriptSecret => ({
+  Id: 1,
+  LastModified: "2026-01-01T00:00:00Z",
+  Name: name,
+});
+
+/** Stub bunnyCdnApi.listEdgeScriptSecrets to return the given names. */
+const stubList = (names: string[]) =>
+  stub(bunnyCdnApi, "listEdgeScriptSecrets", () =>
+    Promise.resolve({ ok: true as const, secrets: names.map(secret) }),
+  );
+
+const buildSite = (overrides: Partial<BuiltSite> = {}): BuiltSite =>
+  testBuiltSite({
+    bunnyScriptId: "555",
+    dbToken: "tok-123",
+    dbUrl: "libsql://site.turso.io",
+    ...overrides,
+  });
+
+/** Names we'd copy to a fresh build of the standard test site. */
+const expectedNamesFor = (site: BuiltSite): string[] =>
+  expectedSiteSecrets(site).map(([name]) => name);
+
+describeWithEnv(
+  "collectHostSecrets",
+  { env: { NTFY_URL: "https://ntfy.example.com/t" } },
+  () => {
+    test("includes host env vars that are set and skips those that are not", () => {
+      const pairs = collectHostSecrets();
+      expect(pairs).toContainEqual(["NTFY_URL", "https://ntfy.example.com/t"]);
+      // STORAGE_ZONE_KEY is not set in this env, so it must be absent.
+      expect(pairs.map(([name]) => name)).not.toContain("STORAGE_ZONE_KEY");
+    });
+  },
+);
+
+describeWithEnv(
+  "expectedSiteSecrets",
+  { env: { NTFY_URL: "https://ntfy.example.com/t" } },
+  () => {
+    test("includes base credentials plus host secrets", () => {
+      const pairs = expectedSiteSecrets(buildSite());
+      expect(pairs).toContainEqual(["DB_URL", "libsql://site.turso.io"]);
+      expect(pairs).toContainEqual(["DB_TOKEN", "tok-123"]);
+      expect(pairs).toContainEqual(["BUNNY_SCRIPT_ID", "555"]);
+      expect(pairs).toContainEqual(["NTFY_URL", "https://ntfy.example.com/t"]);
+    });
+
+    test("never includes DB_ENCRYPTION_KEY (it cannot be reproduced)", () => {
+      expect(expectedNamesFor(buildSite())).not.toContain("DB_ENCRYPTION_KEY");
+    });
+
+    test("omits base credentials the site has no value for", () => {
+      const names = expectedNamesFor(
+        buildSite({ bunnyScriptId: "555", dbToken: "", dbUrl: "" }),
+      );
+      expect(names).not.toContain("DB_URL");
+      expect(names).not.toContain("DB_TOKEN");
+      expect(names).toContain("BUNNY_SCRIPT_ID");
+    });
+
+    test("includes only host secrets when the site has no base values", () => {
+      const names = expectedNamesFor(
+        buildSite({ bunnyScriptId: "", dbToken: "", dbUrl: "" }),
+      );
+      expect(names).not.toContain("BUNNY_SCRIPT_ID");
+      expect(names).not.toContain("DB_URL");
+      expect(names).not.toContain("DB_TOKEN");
+      expect(names).toContain("NTFY_URL");
+    });
+  },
+);
+
+describeWithEnv(
+  "loadSiteSecretsStatus",
+  { env: { BUNNY_API_KEY: "k", NTFY_URL: "https://ntfy.example.com/t" } },
+  () => {
+    test("diffs expected secrets against the live list", async () => {
+      const site = buildSite();
+      // Live list has every expected secret except NTFY_URL, plus an extra
+      // (DB_ENCRYPTION_KEY) that is present but not part of the expected set.
+      const present = expectedNamesFor(site)
+        .filter((n) => n !== "NTFY_URL")
+        .concat("DB_ENCRYPTION_KEY");
+      await withMocks(
+        () => stubList(present),
+        async () => {
+          const view = await loadSiteSecretsStatus(site);
+          expect(view.ok).toBe(true);
+          if (!view.ok) return;
+          expect(view.missing).toEqual(["NTFY_URL"]);
+          // A live secret outside the expected set is never flagged as missing.
+          expect(view.missing).not.toContain("DB_ENCRYPTION_KEY");
+          expect(view.present).toContain("DB_ENCRYPTION_KEY");
+          expect(view.expected).toContain("NTFY_URL");
+        },
+      );
+    });
+
+    test("reports nothing missing when every expected secret is live", async () => {
+      const site = buildSite();
+      await withMocks(
+        () => stubList(expectedNamesFor(site)),
+        async () => {
+          const view = await loadSiteSecretsStatus(site);
+          expect(view.ok).toBe(true);
+          if (view.ok) expect(view.missing).toEqual([]);
+        },
+      );
+    });
+
+    test("surfaces an API error instead of throwing", async () => {
+      await withMocks(
+        () =>
+          stub(bunnyCdnApi, "listEdgeScriptSecrets", () =>
+            Promise.resolve({
+              error: "List secrets failed (500)",
+              ok: false as const,
+            }),
+          ),
+        async () => {
+          const view = await loadSiteSecretsStatus(buildSite());
+          expect(view).toEqual({
+            error: "List secrets failed (500)",
+            ok: false,
+          });
+        },
+      );
+    });
+
+    test("catches a thrown fetch error", async () => {
+      await withMocks(
+        () =>
+          stub(bunnyCdnApi, "listEdgeScriptSecrets", () =>
+            Promise.reject(new Error("network down")),
+          ),
+        async () => {
+          const view = await loadSiteSecretsStatus(buildSite());
+          expect(view.ok).toBe(false);
+          if (!view.ok) expect(view.error).toContain("network down");
+        },
+      );
+    });
+
+    test("refuses a site with no script id", async () => {
+      const view = await loadSiteSecretsStatus(
+        buildSite({ bunnyScriptId: "" }),
+      );
+      expect(view.ok).toBe(false);
+      if (!view.ok) expect(view.error).toContain("no Bunny script ID");
+    });
+  },
+);
+
+describeWithEnv("loadSiteSecretsStatus without an API key", { env: {} }, () => {
+  test("refuses when BUNNY_API_KEY is not configured", async () => {
+    const view = await loadSiteSecretsStatus(buildSite());
+    expect(view.ok).toBe(false);
+    if (!view.ok) expect(view.error).toContain("BUNNY_API_KEY");
+  });
+});
+
+describeWithEnv(
+  "addMissingSiteSecrets",
+  { env: { BUNNY_API_KEY: "k", NTFY_URL: "https://ntfy.example.com/t" } },
+  () => {
+    test("sets only the missing secrets and never overwrites existing ones", async () => {
+      const site = buildSite();
+      // Everything expected is already live except NTFY_URL.
+      const present = expectedNamesFor(site).filter((n) => n !== "NTFY_URL");
+      const setCalls: [string, string][] = [];
+      await withMocks(
+        () => ({
+          listStub: stubList(present),
+          setStub: stub(
+            bunnyCdnApi,
+            "setEdgeScriptSecret",
+            (_id: number, name: string, value: string) => {
+              setCalls.push([name, value]);
+              return Promise.resolve({ ok: true as const });
+            },
+          ),
+        }),
+        async () => {
+          const result = await addMissingSiteSecrets(site);
+          expect(result).toEqual({ added: ["NTFY_URL"], ok: true });
+          // Only the missing secret is written; existing ones are left alone.
+          expect(setCalls).toEqual([
+            ["NTFY_URL", "https://ntfy.example.com/t"],
+          ]);
+        },
+      );
+    });
+
+    test("re-verifies live secrets first, so it skips ones that now exist", async () => {
+      const site = buildSite();
+      const setCalls: string[] = [];
+      await withMocks(
+        () => ({
+          // The live list already has every expected secret (added meanwhile).
+          listStub: stubList(expectedNamesFor(site)),
+          setStub: stub(bunnyCdnApi, "setEdgeScriptSecret", (_i, n: string) => {
+            setCalls.push(n);
+            return Promise.resolve({ ok: true as const });
+          }),
+        }),
+        async () => {
+          const result = await addMissingSiteSecrets(site);
+          expect(result).toEqual({ added: [], ok: true });
+          expect(setCalls).toEqual([]);
+        },
+      );
+    });
+
+    test("returns the error when a secret fails to set", async () => {
+      await withMocks(
+        () => ({
+          listStub: stubList([]),
+          setStub: stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
+            Promise.resolve({
+              error: "Set secret DB_URL failed (403)",
+              ok: false as const,
+            }),
+          ),
+        }),
+        async () => {
+          const result = await addMissingSiteSecrets(buildSite());
+          expect(result).toEqual({
+            error: "Set secret DB_URL failed (403)",
+            ok: false,
+          });
+        },
+      );
+    });
+
+    test("returns the error when the live list cannot be read", async () => {
+      await withMocks(
+        () =>
+          stub(bunnyCdnApi, "listEdgeScriptSecrets", () =>
+            Promise.resolve({
+              error: "List secrets failed (401)",
+              ok: false as const,
+            }),
+          ),
+        async () => {
+          const result = await addMissingSiteSecrets(buildSite());
+          expect(result).toEqual({
+            error: "List secrets failed (401)",
+            ok: false,
+          });
+        },
+      );
+    });
+
+    test("refuses a site with no script id", async () => {
+      const result = await addMissingSiteSecrets(
+        buildSite({ bunnyScriptId: "" }),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("no Bunny script ID");
+    });
+  },
+);

--- a/test/templates/admin/built-sites.test.ts
+++ b/test/templates/admin/built-sites.test.ts
@@ -33,6 +33,14 @@ describe("adminBuiltSitesPage", () => {
     expect(html).toContain("never");
   });
 
+  test("links each site name to its edit page and has no list delete link", () => {
+    const site = testBuiltSite({ id: 7, name: "Linky", readOnlyFrom: "" });
+    const html = adminBuiltSitesPage([site], TEST_SESSION);
+    expect(html).toContain('href="/admin/built-sites/7/edit">Linky</a>');
+    // Delete now lives on the edit page, not the list.
+    expect(html).not.toContain("/admin/built-sites/7/delete");
+  });
+
   test("warns when no qualifying renewal tier is configured", () => {
     const site = testBuiltSite({ readOnlyFrom: "" });
     const html = adminBuiltSitesPage([site], TEST_SESSION, undefined, []);
@@ -123,5 +131,96 @@ describe("adminBuiltSiteEditPage — unprovisioned site", () => {
     expect(html).not.toContain("rotate-renewal-token");
     expect(html).not.toContain("re-sync-deadline");
     expect(html).not.toContain("tier_listing_id");
+  });
+
+  test("links to the delete page from the edit page", () => {
+    const html = adminBuiltSiteEditPage(
+      testBuiltSite({ id: 9, name: "Del" }),
+      TEST_SESSION,
+    );
+    expect(html).toContain("/admin/built-sites/9/delete");
+    expect(html).toContain("Delete this site");
+  });
+});
+
+describe("adminBuiltSiteEditPage — secrets panel", () => {
+  const site = testBuiltSite({ id: 9, name: "Sec" });
+
+  test("lists the missing secrets with a backfill button", () => {
+    const html = adminBuiltSiteEditPage(
+      site,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      {
+        expected: ["DB_URL", "NTFY_URL", "STORAGE_ZONE_KEY"],
+        missing: ["NTFY_URL", "STORAGE_ZONE_KEY"],
+        ok: true,
+        present: ["DB_URL", "DB_ENCRYPTION_KEY"],
+      },
+    );
+    expect(html).toContain("Secrets");
+    expect(html).toContain("/admin/built-sites/9/add-secrets");
+    expect(html).toContain("<code>NTFY_URL</code>");
+    expect(html).toContain("<code>STORAGE_ZONE_KEY</code>");
+    expect(html).toContain("Set 2 missing secret(s)");
+    // Live secrets are listed for insight, including ones outside the copy set.
+    expect(html).toContain("Secrets currently on this site");
+    expect(html).toContain("<code>DB_ENCRYPTION_KEY</code>");
+  });
+
+  test("omits the live-secrets list when the site has none set", () => {
+    const html = adminBuiltSiteEditPage(
+      site,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      {
+        expected: ["NTFY_URL"],
+        missing: ["NTFY_URL"],
+        ok: true,
+        present: [],
+      },
+    );
+    expect(html).not.toContain("Secrets currently on this site");
+    expect(html).toContain("/admin/built-sites/9/add-secrets");
+  });
+
+  test("confirms when every expected secret is already present", () => {
+    const html = adminBuiltSiteEditPage(
+      site,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      {
+        expected: ["DB_URL", "NTFY_URL"],
+        missing: [],
+        ok: true,
+        present: ["DB_URL", "NTFY_URL"],
+      },
+    );
+    expect(html).toContain("All expected secrets are present");
+    expect(html).not.toContain("add-secrets");
+  });
+
+  test("shows the error when secrets cannot be read", () => {
+    const html = adminBuiltSiteEditPage(
+      site,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      {
+        error:
+          "BUNNY_API_KEY is not configured on this host, so site secrets can't be read.",
+        ok: false,
+      },
+    );
+    expect(html).toContain("BUNNY_API_KEY is not configured");
+    expect(html).not.toContain("add-secrets");
+  });
+
+  test("notes when the secrets view is unavailable", () => {
+    const html = adminBuiltSiteEditPage(site, TEST_SESSION);
+    expect(html).toContain("Secrets status is unavailable");
   });
 });


### PR DESCRIPTION
## What & why

Built sites only get their secrets set at build time. There was no way to inspect or fix secrets on a site that was built before a given host secret existed (e.g. a site built before the Google Wallet keys were configured would simply be missing them). This adds visibility and a safe backfill.

## Changes

**Secrets insight + backfill**
- New `bunnyCdnApi.listEdgeScriptSecrets` (GET `/compute/script/{id}/secrets`) — the Bunny API returns secret names + metadata only, never values.
- New `src/shared/site-secrets.ts`:
  - `expectedSiteSecrets(site)` — the set we copy to a fresh build, recomputed for an existing site from its stored record + the current host env.
  - `loadSiteSecretsStatus(site)` — diffs the live secrets against the expected set (resilient to missing script id / API key / network errors).
  - `addMissingSiteSecrets(site)` — **re-verifies** the live list first (in case more exist by now), then sets **only** the missing ones.
- `collectHostSecrets()` extracted from the builder so the build path and the backfill path share one definition of "secrets we copy to new sites".

**Safety**
- Existing secrets are **never overwritten** — a value may have been changed deliberately.
- `DB_ENCRYPTION_KEY` is deliberately excluded from the expected set: it's generated per-site at build time and never stored, so it can't be reproduced, and re-setting it with a fresh key would orphan the site's encrypted data.

**Admin UI** (`/admin/built-sites`)
- The site **name** in the list now links to its edit page; the **Delete** action moved from the list to the edit page.
- The edit page gains a **"Secrets"** panel: a summary, the list of missing secrets with a backfill button, and a collapsible list of the secrets currently live on the site (for insight). When nothing is missing it confirms so; when secrets can't be read (no script id / no API key) it explains why.

## Tests
- Unit tests for `listEdgeScriptSecrets`, `collectHostSecrets`, `expectedSiteSecrets`, `loadSiteSecretsStatus`, `addMissingSiteSecrets` (including the never-overwrite and re-verify behaviour).
- Route tests for `POST /admin/built-sites/:id/add-secrets` (backfill, no-overwrite, nothing-to-do, error, 404).
- Template + server tests for the name→edit link, the delete link moving to the edit page, and the Secrets panel states.
- Full suite green; 100% line/branch/function coverage on all changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YLVUXNuGZ1rxsQ5Hof9Aga)_