### PR TITLE
Extract shared bump/override deadline forms in built-site panels

### DIFF
--- a/src/ui/templates/admin/built-sites.tsx
+++ b/src/ui/templates/admin/built-sites.tsx
@@ -11,7 +11,7 @@ import {
   Flash,
   renderFields,
 } from "#shared/forms.tsx";
-import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import { type Child, Raw } from "#shared/jsx/jsx-runtime.ts";
 import { formatDeadlineLabel, isProvisioned } from "#shared/renewal-helpers.ts";
 import { renewalUrlFor } from "#shared/site-assignment.ts";
 import type { SiteSecretsView } from "#shared/site-secrets.ts";
@@ -184,7 +184,7 @@ export const adminBuiltSiteNewPage = (
 type SiteActionProps = {
   siteId: number;
   action: string;
-  children: JSX.Element | JSX.Element[];
+  children: Child;
 };
 
 /** Standard built-site action form wrapper — CSRF + path scoping in one place. */
@@ -215,6 +215,39 @@ const MonthsInput = ({
   />
 );
 
+type DeadlineFormProps = { site: BuiltSite; inputId?: string };
+
+/**
+ * Bump-deadline form, shared by the provisioned and unprovisioned panels.
+ * Pass `inputId` to render an inline label (provisioned); omit it when a
+ * surrounding heading already labels the field (unprovisioned).
+ */
+const BumpDeadlineForm = ({
+  site,
+  inputId,
+}: DeadlineFormProps): JSX.Element => (
+  <SiteActionForm action="bump-deadline" siteId={site.id}>
+    {inputId ? <label for={inputId}>Bump deadline by months</label> : null}
+    <MonthsInput id={inputId} />
+    <SubmitButton icon="save">Bump</SubmitButton>
+  </SiteActionForm>
+);
+
+/**
+ * Override-deadline form, shared by both panels. See {@link BumpDeadlineForm}
+ * for the `inputId` labelling convention.
+ */
+const OverrideDeadlineForm = ({
+  site,
+  inputId,
+}: DeadlineFormProps): JSX.Element => (
+  <SiteActionForm action="override-deadline" siteId={site.id}>
+    {inputId ? <label for={inputId}>Override deadline</label> : null}
+    <input id={inputId} name="date" type="date" />
+    <SubmitButton icon="save">Override</SubmitButton>
+  </SiteActionForm>
+);
+
 const ProvisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => {
   const renewalUrl = renewalUrlFor(site.renewalToken!);
   return (
@@ -242,17 +275,9 @@ const ProvisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => {
         </button>
       </SiteActionForm>
 
-      <SiteActionForm action="bump-deadline" siteId={site.id}>
-        <label for="bump_months">Bump deadline by months</label>
-        <MonthsInput id="bump_months" />
-        <SubmitButton icon="save">Bump</SubmitButton>
-      </SiteActionForm>
+      <BumpDeadlineForm inputId="bump_months" site={site} />
 
-      <SiteActionForm action="override-deadline" siteId={site.id}>
-        <label for="override_date">Override deadline</label>
-        <input id="override_date" name="date" type="date" />
-        <SubmitButton icon="save">Override</SubmitButton>
-      </SiteActionForm>
+      <OverrideDeadlineForm inputId="override_date" site={site} />
 
       <SiteActionForm action="re-sync-deadline" siteId={site.id}>
         <SubmitButton icon="rotate-ccw">Re-sync deadline</SubmitButton>
@@ -276,16 +301,10 @@ const UnprovisionedPanel = ({ site }: { site: BuiltSite }): JSX.Element => (
     </SiteActionForm>
 
     <h3>Bump deadline</h3>
-    <SiteActionForm action="bump-deadline" siteId={site.id}>
-      <MonthsInput />
-      <SubmitButton icon="save">Bump</SubmitButton>
-    </SiteActionForm>
+    <BumpDeadlineForm site={site} />
 
     <h3>Override deadline</h3>
-    <SiteActionForm action="override-deadline" siteId={site.id}>
-      <input name="date" type="date" />
-      <SubmitButton icon="save">Override</SubmitButton>
-    </SiteActionForm>
+    <OverrideDeadlineForm site={site} />
   </div>
 );
 

--- a/test/templates/admin/built-sites.test.ts
+++ b/test/templates/admin/built-sites.test.ts
@@ -114,6 +114,13 @@ describe("adminBuiltSiteEditPage — provisioned site", () => {
     expect(html).toContain("/renew/?t=real-customer-renewal-token");
     expect(html).not.toContain("?t=<token>");
   });
+
+  test("labels the shared bump/override forms inline (no headings)", () => {
+    const html = adminBuiltSiteEditPage(provisionedSite, TEST_SESSION);
+    expect(html).toContain('<label for="bump_months">Bump deadline by months');
+    expect(html).toContain('<label for="override_date">Override deadline');
+    expect(html).not.toContain("<h3>Bump deadline</h3>");
+  });
 });
 
 describe("adminBuiltSiteEditPage — unprovisioned site", () => {
@@ -131,6 +138,14 @@ describe("adminBuiltSiteEditPage — unprovisioned site", () => {
     expect(html).not.toContain("rotate-renewal-token");
     expect(html).not.toContain("re-sync-deadline");
     expect(html).not.toContain("tier_listing_id");
+  });
+
+  test("labels the shared bump/override forms with headings (no inline labels)", () => {
+    const html = adminBuiltSiteEditPage(unprovisionedSite, TEST_SESSION);
+    expect(html).toContain("<h3>Bump deadline</h3>");
+    expect(html).toContain("<h3>Override deadline</h3>");
+    expect(html).not.toContain('for="bump_months"');
+    expect(html).not.toContain('for="override_date"');
   });
 
   test("links to the delete page from the edit page", () => {


### PR DESCRIPTION
## What & why

`ProvisionedPanel` and `UnprovisionedPanel` (`src/ui/templates/admin/built-sites.tsx`) each rendered their own copy of the **bump-deadline** and **override-deadline** forms. This removes that duplication.

## Changes

- Extracted **`BumpDeadlineForm`** and **`OverrideDeadlineForm`**, now used by both panels.
- An optional `inputId` prop controls labelling:
  - **present** → renders an inline `<label>` (the provisioned panel's style),
  - **absent** → relies on the surrounding `<h3>` heading (the unprovisioned panel's style).
- Relaxed `SiteActionForm`'s `children` type to the JSX `Child` type (matching the `CsrfForm` it wraps) so the conditional label child typechecks.

## Verification

- **Rendered output is byte-for-byte identical** for both panels (verified by diffing the edit page HTML against `main`) — pure deduplication, no behaviour change.
- Added two tests pinning the labelling convention (provisioned = inline labels, unprovisioned = headings).
- Full `precommit --ci` passes: lint, typecheck, **cpd (0 clones)**, build:edge, and `test:coverage` (100% line+branch coverage).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YLVUXNuGZ1rxsQ5Hof9Aga)_