### PR TITLE
Move listing-type filter from public page to admin dashboard

### DIFF
--- a/src/features/admin/dashboard.ts
+++ b/src/features/admin/dashboard.ts
@@ -8,6 +8,7 @@ import { applyFlash } from "#routes/csrf.ts";
 import { htmlResponse } from "#routes/response.ts";
 /* jscpd:ignore-start */
 import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
+import { getSearchParam } from "#routes/url.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
 import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import {
@@ -19,6 +20,7 @@ import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getFlash } from "#shared/flash-context.ts";
+import { isListingFilter, type ListingFilter } from "#shared/listing-filter.ts";
 import { sortListings } from "#shared/sort-listings.ts";
 /* jscpd:ignore-end */
 import { adminGlobalActivityLogPage } from "#templates/admin/activityLog.tsx";
@@ -55,6 +57,10 @@ const handleAdminGet = (request: Request): Promise<Response> =>
       const newestAttendees = await decryptAttendees(newestRaw, privateKey);
       const sortedListings = sortListings(listings, holidays);
       const stats = await getActiveListingStats(sortedListings);
+      const rawType = getSearchParam(request, "type");
+      const activeType: ListingFilter = isListingFilter(rawType)
+        ? rawType
+        : "all";
       return htmlResponse(
         adminDashboardPage(
           sortedListings,
@@ -64,6 +70,7 @@ const handleAdminGet = (request: Request): Promise<Response> =>
           successMessage,
           stats,
           settings.listingColumnOrder,
+          activeType,
         ),
       );
     },

--- a/src/features/public/pages.ts
+++ b/src/features/public/pages.ts
@@ -2,7 +2,6 @@
  * Public pages - home, listings, terms, contact
  */
 
-import { unique } from "#fp";
 import { applyFlash, requireMessageField, withCsrfForm } from "#routes/csrf.ts";
 import {
   errorRedirect,
@@ -11,7 +10,6 @@ import {
   redirect,
   redirectResponse,
 } from "#routes/response.ts";
-import { getSearchParam } from "#routes/url.ts";
 import { BOTPOISON_FIELD, verifyBotpoisonSolution } from "#shared/botpoison.ts";
 import { isBotpoisonEnabled } from "#shared/config.ts";
 import {
@@ -24,11 +22,6 @@ import { getAllGroups } from "#shared/db/groups.ts";
 import { settings } from "#shared/db/settings.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { MESSAGE_SEND_FAILED } from "#shared/inbound-message.ts";
-import {
-  isListingFilter,
-  type ListingFilter,
-  listingCategory,
-} from "#shared/listing-filter.ts";
 import { loadSortedListings } from "#shared/sort-listings.ts";
 import type { Group, ListingWithCount } from "#shared/types.ts";
 import { parseEmail } from "#shared/validation/email.ts";
@@ -69,32 +62,18 @@ const renderPublicPage = (
 export const handleHome = (): Response =>
   renderPublicPage("home", () => settings.homepageText);
 
-/** Handle GET /listings - public listings listing, optionally filtered by type
- * via `?filter=standard|daily|purchase-only`. Groups are shown only on the
- * unfiltered ("all") view since they aren't a listing type. */
-export const handlePublicListings = (
-  request: Request,
-): Response | Promise<Response> =>
+/** Handle GET /listings - public listings listing. Shows every active, visible
+ * listing alongside the non-hidden groups. (Type filtering lives on the admin
+ * listings dashboard, not the public page.) */
+export const handlePublicListings = (): Response | Promise<Response> =>
   requirePublicSite(async () => {
     const [groups, { listings }] = await Promise.all([
       loadPublicGroups(),
       loadSortedListings(isPublicListing),
     ]);
-    const raw = getSearchParam(request, "filter");
-    const active: ListingFilter = isListingFilter(raw) ? raw : "all";
-    const categories = unique(listings.map(listingCategory));
-    const shown =
-      active === "all"
-        ? listings
-        : listings.filter((e) => listingCategory(e) === active);
-    const ticketListings = await buildTicketListingsWithGroupCapacity(shown);
+    const ticketListings = await buildTicketListingsWithGroupCapacity(listings);
     return htmlResponse(
-      homepagePage(
-        ticketListings,
-        settings.websiteTitle,
-        active === "all" ? groups : [],
-        { active, categories },
-      ),
+      homepagePage(ticketListings, settings.websiteTitle, groups),
     );
   });
 

--- a/src/shared/listing-filter.ts
+++ b/src/shared/listing-filter.ts
@@ -1,5 +1,5 @@
 /**
- * Shared "by listing type" filter used on the public listings page and the
+ * Shared "by listing type" filter used on the admin listings dashboard and the
  * admin attendees list: the filter values, the category a listing falls under,
  * and the rendered "Showing: All / Standard / …" bar. Keeping it in one place
  * lets both pages drive the same control with their own link targets.

--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -2,7 +2,7 @@
  * Admin dashboard page template
  */
 
-import { filter, joinStrings, map, pipe, reduce } from "#fp";
+import { filter, joinStrings, map, pipe, reduce, unique } from "#fp";
 import {
   getHeaderText,
   renderCells,
@@ -18,6 +18,11 @@ import type { ActiveListingStats } from "#shared/db/attendees.ts";
 import { isReadOnly } from "#shared/env.ts";
 import { Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import {
+  type ListingFilter,
+  listingCategory,
+  renderTypeFilter,
+} from "#shared/listing-filter.ts";
 import type {
   AdminSession,
   Attendee,
@@ -199,6 +204,7 @@ export const adminDashboardPage = (
   successMessage?: string,
   stats?: ActiveListingStats | null,
   listingColumnTemplate?: string,
+  activeType: ListingFilter = "all",
 ): string => {
   const { columnKeys, filters } = resolveColumnLayout(
     listingColumnTemplate ?? "",
@@ -206,12 +212,30 @@ export const adminDashboardPage = (
     LISTING_DEFAULT_ORDER,
   );
 
+  // Type filter narrows the listing table only; the stats, multi-booking, and
+  // newest-attendee sections below stay based on the full set. Offer the bar
+  // (same control as the public/attendee filters) only when more than one
+  // listing type is present.
+  const categories = unique(listings.map(listingCategory));
+  const shownListings =
+    activeType === "all"
+      ? listings
+      : filter((e: ListingWithCount) => listingCategory(e) === activeType)(
+          listings,
+        );
+  const typeFilterHtml =
+    categories.length > 1
+      ? renderTypeFilter(activeType, categories, (f) =>
+          f === "all" ? "/admin/" : `/admin/?type=${f}`,
+        )
+      : "";
+
   const listingRows =
-    listings.length > 0
+    shownListings.length > 0
       ? pipe(
           map((e: ListingWithCount) => ListingRow({ columnKeys, e, filters })),
           joinStrings,
-        )(listings)
+        )(shownListings)
       : `<tr><td colspan="${columnKeys.length}">No listings yet</td></tr>`;
 
   const activeListings = filter((e: ListingWithCount) => e.active)(listings);
@@ -232,6 +256,8 @@ export const adminDashboardPage = (
           </ActionButton>
         </p>
       )}
+
+      <Raw html={typeFilterHtml} />
 
       <div class="table-scroll">
         <Raw html={renderListingTable(columnKeys, listingRows)} />

--- a/src/ui/templates/public.tsx
+++ b/src/ui/templates/public.tsx
@@ -27,10 +27,6 @@ import {
 } from "#shared/forms.tsx";
 import { getIframeMode } from "#shared/iframe.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
-import {
-  type ListingFilter,
-  renderTypeFilter,
-} from "#shared/listing-filter.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import {
@@ -255,23 +251,14 @@ export const homepagePage = (
   listings: TicketListing[],
   websiteTitle: string | null | undefined,
   groups: Group[],
-  filter: { active: ListingFilter; categories: readonly ListingFilter[] },
 ): string => {
   const title = websiteTitle ? `Listings - ${websiteTitle}` : "Listings";
-  // Offer the type filter only when more than one listing type is on the page.
-  const filterHtml =
-    filter.categories.length > 1
-      ? renderTypeFilter(filter.active, filter.categories, (f) =>
-          f === "all" ? "/listings" : `/listings?filter=${f}`,
-        )
-      : "";
 
   if (listings.length === 0 && groups.length === 0) {
     return String(
       <Layout headExtra={FEED_DISCOVERY_TAGS} title={title}>
         {websiteTitle && <h1>{websiteTitle}</h1>}
         <PublicNav {...navFlags()} />
-        <Raw html={filterHtml} />
         <p>
           <em>No listings listed.</em>
         </p>
@@ -297,7 +284,6 @@ export const homepagePage = (
       {websiteTitle && <h1>{websiteTitle}</h1>}
       <PublicNav {...navFlags()} />
       <h2>All bookable listings</h2>
-      <Raw html={filterHtml} />
       <Raw html={groupListings} />
       <Raw html={listingListings} />
       <footer class="homepage-footer">

--- a/test/lib/server-listings-filter.test.ts
+++ b/test/lib/server-listings-filter.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { settings } from "#shared/db/settings.ts";
 import {
-  createTestGroup,
+  adminGet,
   createTestListing,
   describeWithEnv,
   expectHtmlResponse,
@@ -19,99 +19,91 @@ const DAILY = {
   minimumDaysBefore: 0,
 };
 
-describeWithEnv("server (public listings type filter)", { db: true }, () => {
-  describe("filtering", () => {
-    beforeEach(async () => {
-      await settings.update.showPublicSite(true);
-    });
-
+describeWithEnv("listings type filter", { db: true }, () => {
+  describe("admin listings dashboard", () => {
     test("shows the type filter when more than one type is present", async () => {
       await createTestListing({ name: "Standard One" });
       await createTestListing({ name: "Daily One", ...DAILY });
-      const html = await expectHtmlResponse(
-        await get("/listings"),
-        200,
-        "Showing:",
-        "Standard",
-        "Daily",
-      );
-      expect(html).toContain('href="/listings?filter=standard"');
+      const { response } = await adminGet("/admin");
+      const html = await response.text();
+      expect(html).toContain("Showing:");
+      expect(html).toContain("Standard");
+      expect(html).toContain("Daily");
+      expect(html).toContain('href="/admin/?type=standard"');
     });
 
     test("hides the type filter when only one type is present", async () => {
       await createTestListing({ name: "Standard One" });
       await createTestListing({ name: "Standard Two" });
-      const html = await expectHtmlResponse(await get("/listings"), 200);
+      const { response } = await adminGet("/admin");
+      const html = await response.text();
       expect(html).not.toContain("Showing:");
     });
 
-    test("filters to standard listings and hides other types and groups", async () => {
-      await createTestListing({ name: "Standard One" });
-      await createTestListing({ name: "Daily One", ...DAILY });
-      const group = await createTestGroup({ name: "Group One", slug: "grp" });
-      await createTestListing({ groupId: group.id, name: "Grouped" });
-
-      const html = await expectHtmlResponse(
-        await get("/listings?filter=standard"),
-        200,
-        "Standard One",
-      );
-      expect(html).not.toContain("Daily One");
-      expect(html).not.toContain("Group One");
+    // The table is the only place that links a listing to /admin/listing/:id
+    // (the multi-booking builder below the table uses slugs), so asserting on
+    // that link proves the table itself was filtered.
+    test("filters the listing table to standard listings", async () => {
+      const standard = await createTestListing({ name: "Standard One" });
+      const daily = await createTestListing({ name: "Daily One", ...DAILY });
+      const { response } = await adminGet("/admin?type=standard");
+      const html = await response.text();
+      expect(html).toContain(`href="/admin/listing/${standard.id}"`);
+      expect(html).not.toContain(`href="/admin/listing/${daily.id}"`);
       // Active filter is bold + underlined; others remain links.
       expect(html).toContain("<strong><u>Standard</u></strong>");
-      expect(html).toContain('href="/listings?filter=daily"');
+      expect(html).toContain('href="/admin/?type=daily"');
     });
 
-    test("filters to daily listings", async () => {
-      await createTestListing({ name: "Standard One" });
-      await createTestListing({ name: "Daily One", ...DAILY });
-      const html = await expectHtmlResponse(
-        await get("/listings?filter=daily"),
-        200,
-        "Daily One",
-      );
-      expect(html).not.toContain("Standard One");
+    test("filters the listing table to daily listings", async () => {
+      const standard = await createTestListing({ name: "Standard One" });
+      const daily = await createTestListing({ name: "Daily One", ...DAILY });
+      const { response } = await adminGet("/admin?type=daily");
+      const html = await response.text();
+      expect(html).toContain(`href="/admin/listing/${daily.id}"`);
+      expect(html).not.toContain(`href="/admin/listing/${standard.id}"`);
       expect(html).toContain("<strong><u>Daily</u></strong>");
     });
 
-    test("filters to purchase-only listings", async () => {
-      await createTestListing({ name: "Standard One" });
-      await createTestListing({ name: "Merch", purchaseOnly: true });
-      const html = await expectHtmlResponse(
-        await get("/listings?filter=purchase-only"),
-        200,
-        "Merch",
-      );
-      expect(html).not.toContain("Standard One");
+    test("filters the listing table to purchase-only listings", async () => {
+      const standard = await createTestListing({ name: "Standard One" });
+      const merch = await createTestListing({
+        name: "Merch",
+        purchaseOnly: true,
+      });
+      const { response } = await adminGet("/admin?type=purchase-only");
+      const html = await response.text();
+      expect(html).toContain(`href="/admin/listing/${merch.id}"`);
+      expect(html).not.toContain(`href="/admin/listing/${standard.id}"`);
       expect(html).toContain("Purchase Only");
     });
 
-    test("shows all listings and groups on the unfiltered view", async () => {
-      await createTestListing({ name: "Standard One" });
-      const group = await createTestGroup({ name: "Group One", slug: "grp" });
-      await createTestListing({ groupId: group.id, name: "Grouped" });
+    test("treats an unknown type as 'all'", async () => {
+      const standard = await createTestListing({ name: "Standard One" });
+      const daily = await createTestListing({ name: "Daily One", ...DAILY });
+      const { response } = await adminGet("/admin?type=bogus");
+      const html = await response.text();
+      expect(html).toContain(`href="/admin/listing/${standard.id}"`);
+      expect(html).toContain(`href="/admin/listing/${daily.id}"`);
+      expect(html).toContain("<strong><u>All</u></strong>");
+    });
+  });
 
+  describe("public listings page", () => {
+    beforeEach(async () => {
+      await settings.update.showPublicSite(true);
+    });
+
+    test("lists every type together without a filter bar", async () => {
+      await createTestListing({ name: "Standard One" });
+      await createTestListing({ name: "Daily One", ...DAILY });
       const html = await expectHtmlResponse(
         await get("/listings"),
         200,
         "Standard One",
-        "Group One",
-      );
-      // Only one listing type present → no filter bar.
-      expect(html).not.toContain("Showing:");
-    });
-
-    test("treats an unknown filter value as 'all'", async () => {
-      await createTestListing({ name: "Standard One" });
-      await createTestListing({ name: "Daily One", ...DAILY });
-      const html = await expectHtmlResponse(
-        await get("/listings?filter=bogus"),
-        200,
-        "Standard One",
         "Daily One",
       );
-      expect(html).toContain("<strong><u>All</u></strong>");
+      expect(html).not.toContain("Showing:");
     });
   });
 });

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -365,6 +365,90 @@ describe("adminDashboardPage multi-booking link", () => {
   });
 });
 
+describe("adminDashboardPage type filter", () => {
+  const standard = testListingWithCount({
+    id: 1,
+    listing_type: "standard",
+    name: "Standard Listing",
+    slug: "std01",
+  });
+  const daily = testListingWithCount({
+    id: 2,
+    listing_type: "daily",
+    name: "Daily Listing",
+    slug: "day01",
+  });
+
+  test("shows the filter bar when more than one type is present", () => {
+    const html = adminDashboardPage([standard, daily], TEST_SESSION);
+    expect(html).toContain("Showing:");
+    expect(html).toContain('href="/admin/?type=standard"');
+    expect(html).toContain('href="/admin/?type=daily"');
+  });
+
+  test("hides the filter bar when only one type is present", () => {
+    const onlyStandard = testListingWithCount({
+      id: 3,
+      listing_type: "standard",
+      slug: "std02",
+    });
+    const html = adminDashboardPage([standard, onlyStandard], TEST_SESSION);
+    expect(html).not.toContain("Showing:");
+  });
+
+  test("shows every type and marks 'All' active on the default view", () => {
+    const html = adminDashboardPage([standard, daily], TEST_SESSION);
+    expect(html).toContain("Standard Listing");
+    expect(html).toContain("Daily Listing");
+    expect(html).toContain("<strong><u>All</u></strong>");
+  });
+
+  test("filters the listing table to the active type", () => {
+    // Standard is inactive so the multi-booking builder (active listings only)
+    // doesn't render and the only place its name could appear is the table.
+    const standardInactive = testListingWithCount({
+      active: false,
+      id: 1,
+      listing_type: "standard",
+      name: "Standard Listing",
+      slug: "std01",
+    });
+    const html = adminDashboardPage(
+      [standardInactive, daily],
+      TEST_SESSION,
+      undefined,
+      [],
+      undefined,
+      null,
+      undefined,
+      "daily",
+    );
+    expect(html).toContain("Daily Listing");
+    expect(html).not.toContain("Standard Listing");
+    expect(html).toContain("<strong><u>Daily</u></strong>");
+    // The "All" option links back to the unfiltered dashboard.
+    expect(html).toContain('<a href="/admin/">All</a>');
+  });
+
+  test("keeps the multi-booking builder based on every active listing", () => {
+    // Filtering the table to one type must not drop the others from the
+    // multi-booking builder, which reflects all active listings.
+    const html = adminDashboardPage(
+      [standard, daily],
+      TEST_SESSION,
+      undefined,
+      [],
+      undefined,
+      null,
+      undefined,
+      "daily",
+    );
+    expect(html).toContain("Multi-booking link");
+    expect(html).toContain('data-multi-booking-slug="std01"');
+    expect(html).toContain('data-multi-booking-slug="day01"');
+  });
+});
+
 describeWithEnv(
   "listing images",
   { env: { STORAGE_ZONE_KEY: "testkey", STORAGE_ZONE_NAME: "testzone" } },


### PR DESCRIPTION
## Summary

Moves the **"Showing: All / Standard / Daily"** listing-type filter off the public-facing `/listings` page and onto the **admin listings dashboard** (`GET /admin`), where it sits above the listings table and filters that table.

The control reuses the existing shared `renderTypeFilter` helper, so the **style and markup are unchanged** (`<p class="type-filter">Showing: …</p>`) — only its location and what it filters changed.

## Changes

- **Public page** (`features/public/pages.ts`, `templates/public.tsx`): removed the filter bar and all `?filter=` handling. `/listings` now always lists every active, visible listing plus the non-hidden groups.
- **Admin dashboard** (`features/admin/dashboard.ts`, `templates/admin/dashboard.tsx`): added the filter bar above the listings table. It reads `?type=standard|daily|purchase-only`, filters the table, and links to `/admin/?type=<type>`.
  - The bar only appears when more than one listing type is present (same rule as before).
  - It narrows the **listings table only** — the Active Listing Statistics, Multi-booking link builder, and Newest Attendees sections stay based on the full set (e.g. you can still build a multi-booking link across types while viewing one).
- **Docs** (`shared/listing-filter.ts`): updated the module comment to reflect the new usage.

## Tests

- Repurposed `test/lib/server-listings-filter.test.ts` to exercise the admin dashboard filter end-to-end (bar visibility, table filtering by detail-link, unknown → all) and to assert the public page no longer renders the bar.
- Added template-level tests in `test/templates/admin/dashboard.test.ts` covering bar visibility, default vs. active states, table filtering, and that the multi-booking builder stays based on all active listings.
- Full suite passes with 100% line + branch coverage (`deno task test:coverage`).

https://claude.ai/code/session_015kgAy78Nzs7UQmjjs8jykh

---
_Generated by [Claude Code](https://claude.ai/code/session_015kgAy78Nzs7UQmjjs8jykh)_