### PR TITLE
Scope listing deletion so it never affects another listing's attendees

### DIFF
--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -296,29 +296,20 @@ export const isSlugTaken = async (
 };
 
 /**
- * Delete an listing and all its attendees in a single database round-trip.
- * Uses write batch to cascade: processed_payments → attendees → listing.
- * Reduces 3 sequential HTTP round-trips to 1.
+ * Delete a listing and its own bookings in a single database round-trip.
+ *
+ * Only the deleted listing's rows are touched: its `listing_attendees` links,
+ * its `activity_log` entries, and the listing itself. Attendees are deliberately
+ * left alone — an attendee booked onto another listing keeps that booking (and
+ * all of its answers/payments) completely untouched, and an attendee left with
+ * no bookings is simply orphaned rather than purged. This scoping guarantees
+ * that deleting one listing can never affect another listing's attendees.
  */
 export const deleteListing = async (listingId: number): Promise<void> => {
   await executeBatch([
-    // Remove listing links first
     {
       args: [listingId],
       sql: "DELETE FROM listing_attendees WHERE listing_id = ?",
-    },
-    // Delete orphaned attendees (no remaining listing links) and their dependent data
-    {
-      args: [],
-      sql: "DELETE FROM processed_payments WHERE attendee_id NOT IN (SELECT attendee_id FROM listing_attendees)",
-    },
-    {
-      args: [],
-      sql: "DELETE FROM attendee_answers WHERE attendee_id NOT IN (SELECT attendee_id FROM listing_attendees)",
-    },
-    {
-      args: [],
-      sql: "DELETE FROM attendees WHERE id NOT IN (SELECT attendee_id FROM listing_attendees)",
     },
     { args: [listingId], sql: "DELETE FROM activity_log WHERE listing_id = ?" },
     { args: [listingId], sql: "DELETE FROM listings WHERE id = ?" },

--- a/test/lib/db/listings.test.ts
+++ b/test/lib/db/listings.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   createAttendeeAtomic,
   decryptAttendees,
+  getAttendeeRaw,
   getAttendeesRaw,
 } from "#shared/db/attendees.ts";
 import { getDb } from "#shared/db/client.ts";
@@ -31,6 +32,12 @@ import {
   isSessionProcessed,
   reserveSession,
 } from "#shared/db/processed-payments.ts";
+import {
+  answersTable,
+  getAttendeeAnswersBatch,
+  questionsTable,
+  saveAttendeeAnswers,
+} from "#shared/db/questions.ts";
 import { MAX_DURATION_DAYS } from "#shared/types.ts";
 import {
   createTestAttendee,
@@ -284,7 +291,7 @@ describeWithEnv("db > listings", { db: true }, () => {
       expect(attendees).toEqual([]);
     });
 
-    test("removes processed payment records for attendees", async () => {
+    test("keeps the processed payment of an orphaned attendee", async () => {
       const listing = await createTestListing({
         maxAttendees: 50,
         thankYouUrl: "https://example.com",
@@ -301,8 +308,9 @@ describeWithEnv("db > listings", { db: true }, () => {
 
       await deleteListing(listing.id);
 
+      // The attendee is orphaned, not purged, so its payment record survives.
       const processed = await isSessionProcessed("sess_listing_delete");
-      expect(processed).toBeNull();
+      expect(processed?.attendee_id).toBe(attendee.id);
     });
 
     test("removes activity log entries for the listing", async () => {
@@ -339,28 +347,70 @@ describeWithEnv("db > listings", { db: true }, () => {
       expect(fetched).toBeNull();
     });
 
-    test("preserves attendees linked to other listings", async () => {
+    // Book one attendee onto two listings, with distinct quantities so an
+    // untouched booking is provable by its own value. Returns both listings and
+    // the (shared) attendee id.
+    const bookAttendeeOnTwoListings = async () => {
       const listing1 = await createTestListing({ maxAttendees: 50 });
       const listing2 = await createTestListing({ maxAttendees: 50 });
       const result = await createAttendeeAtomic({
-        bookings: [{ listingId: listing1.id }, { listingId: listing2.id }],
+        bookings: [
+          { listingId: listing1.id, quantity: 2 },
+          { listingId: listing2.id, quantity: 3 },
+        ],
         email: "multi@example.com",
         name: "Multi",
       });
-      expect(result.success).toBe(true);
-      if (!result.success) return;
-      const attendeeId = result.attendees[0]!.id;
+      if (!result.success) throw new Error("failed to set up test attendee");
+      return { attendeeId: result.attendees[0]!.id, listing1, listing2 };
+    };
+
+    test("preserves attendees linked to other listings", async () => {
+      const { attendeeId, listing1, listing2 } =
+        await bookAttendeeOnTwoListings();
 
       await deleteListing(listing1.id);
 
-      const raw = await getAttendeesRaw(listing2.id);
-      expect(raw.length).toBe(1);
-      expect(raw[0]!.id).toBe(attendeeId);
+      // The deleted listing's booking link is gone …
+      expect(await getAttendeesRaw(listing1.id)).toEqual([]);
+      // … while the other listing keeps the same attendee, with its own
+      // booking quantity (3) untouched.
+      const remaining = await getAttendeesRaw(listing2.id);
+      expect(remaining.length).toBe(1);
+      expect(remaining[0]!.id).toBe(attendeeId);
+      expect(remaining[0]!.quantity).toBe(3);
     });
 
-    test("cleans up orphaned attendees", async () => {
+    test("keeps the shared attendee's answers when one listing is deleted", async () => {
+      const { attendeeId, listing1 } = await bookAttendeeOnTwoListings();
+      const question = await questionsTable.insert({ text: "Meal choice?" });
+      const answer = await answersTable.insert({
+        questionId: question.id,
+        sortOrder: 0,
+        text: "Vegan",
+      });
+      await saveAttendeeAnswers(new Map([[attendeeId, [answer.id]]]));
+
+      await deleteListing(listing1.id);
+
+      const answers = await getAttendeeAnswersBatch([attendeeId]);
+      expect(answers.get(attendeeId)).toEqual([answer.id]);
+    });
+
+    test("keeps the shared attendee's processed payment when one listing is deleted", async () => {
+      const { attendeeId, listing1 } = await bookAttendeeOnTwoListings();
+      await reserveSession("sess_multi_listing");
+      await finalizePaymentSession("sess_multi_listing", attendeeId);
+
+      await deleteListing(listing1.id);
+
+      const processed = await isSessionProcessed("sess_multi_listing");
+      expect(processed?.attendee_id).toBe(attendeeId);
+    });
+
+    test("leaves an attendee orphaned rather than deleting it", async () => {
       const listing = await createTestListing({ maxAttendees: 50 });
-      await createTestAttendee(
+      const attendee = await createTestAttendee(
         listing.id,
         listing.slug,
         "Solo",
@@ -369,11 +419,14 @@ describeWithEnv("db > listings", { db: true }, () => {
 
       await deleteListing(listing.id);
 
-      const { getDb } = await import("#shared/db/client.ts");
-      const rows = await getDb().execute(
-        "SELECT COUNT(*) as count FROM attendees",
-      );
-      expect(rows.rows[0]!.count).toBe(0);
+      // The listing no longer lists the attendee …
+      expect(await getAttendeesRaw(listing.id)).toEqual([]);
+      // … but the attendee row itself survives with no listing link (orphaned),
+      // which getAttendeeRaw surfaces as listing_id 0.
+      const orphan = await getAttendeeRaw(attendee.id);
+      expect(orphan).not.toBeNull();
+      expect(orphan!.id).toBe(attendee.id);
+      expect(orphan!.listing_id).toBe(0);
     });
 
     test("invalidates cache", async () => {

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -1590,7 +1590,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       expectRedirectWithFlash("/admin", "Listing deleted")(response);
     });
 
-    test("deletes listing and all attendees", async () => {
+    test("deletes the listing and unlinks its attendees", async () => {
       const { listing, cookie, csrfToken } = await setupListingAndLogin({
         maxAttendees: 100,
         name: "Test Listing",
@@ -1621,7 +1621,8 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       );
       expect(response.status).toBe(302);
 
-      // Verify listing and attendees were deleted
+      // The listing is gone and no attendees remain linked to it (the attendee
+      // rows themselves are orphaned, not purged).
       const { getListing } = await import("#shared/db/listings.ts");
       const { getAttendeesRaw } = await import("#shared/db/attendees.ts");
       const deleted = await getListing(listing.id);
@@ -2094,10 +2095,10 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
   });
 
   describe("POST /admin/listing/:id/delete with custom onDelete", () => {
-    test("deletes listing and cascades to attendees", async () => {
+    test("deletes the listing when identifier verification is skipped", async () => {
       const { listing, cookie, csrfToken } = await setupListingAndLogin({
         maxAttendees: 50,
-        name: "Cascade Delete",
+        name: "Skip Verify Delete",
       });
       await createTestAttendee(
         listing.id,
@@ -2151,10 +2152,10 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       await expectHtmlResponse(response, 400, "Listing Name is required");
     });
 
-    test("listing delete cascades to attendees using custom onDelete", async () => {
+    test("unlinks the listing's attendees when deleted with verification skipped", async () => {
       const { listing, cookie, csrfToken } = await setupListingAndLogin({
         maxAttendees: 50,
-        name: "Cascade Del Test",
+        name: "Skip Verify Del Test",
       });
       await createTestAttendee(
         listing.id,


### PR DESCRIPTION
## What & why

When an attendee is booked onto two listings and an admin deletes one of them, the other listing's booking must be left completely intact.

`deleteListing` used to remove the listing's bookings and then **purge any now-orphaned attendee** along with their `attendee_answers` and `processed_payments` (global `NOT IN (SELECT attendee_id FROM listing_attendees)` deletes). An attendee booked onto another listing was already preserved, but the operation reached across the whole `attendees` table on every delete.

It now only deletes:

- the deleted listing's `listing_attendees` links,
- its `activity_log` rows, and
- the listing row itself.

Attendees are never purged. One booked onto another listing keeps that booking and all of its answers/payments untouched; one left with no bookings is simply **orphaned** rather than deleted. Orphaned attendees are already a tolerated, handled state elsewhere in the app (scanner, check-in, Apple Wallet, token lookup all return 404 / empty for an attendee with no listing links), so nothing downstream breaks.

## Tests

`test/lib/db/listings.test.ts`:

- **preserves attendees linked to other listings** — strengthened: the deleted listing's link is gone, while the other listing keeps the same attendee with its own booking quantity untouched.
- **keeps the shared attendee's answers when one listing is deleted** — new.
- **keeps the shared attendee's processed payment when one listing is deleted** — new.
- **leaves an attendee orphaned rather than deleting it** — replaces the old "cleans up orphaned attendees"; the attendee row survives with `listing_id` 0.
- **keeps the processed payment of an orphaned attendee** — replaces the old "removes processed payment records for attendees".

Three route tests in `test/lib/server-listings.test.ts` were renamed to drop the now-inaccurate "cascade" wording (their assertions — that the listing's attendees no longer appear — are unchanged and still pass).

## Verification

- `deno task test` — 460 passed (7818 steps), 0 failed
- `deno task typecheck` — clean
- `deno task lint` — clean
- Coverage — 100% line/branch on `listings.ts`, `listings-actions.ts`, and `attendees/delete.ts`

https://claude.ai/code/session_011SuKK7sxnFQsyNS2SCqQs6

---
_Generated by [Claude Code](https://claude.ai/code/session_011SuKK7sxnFQsyNS2SCqQs6)_