### PR TITLE
Calendar availability checker + attendee form overhaul

### DIFF
--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -22,6 +22,7 @@ import type { FormParams } from "#shared/form-data.ts";
 import { START_DATE_FIELD } from "#shared/order-select.ts";
 import { type ListingWithCount, normalizeDurationDays } from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
+import { parsePositiveIntId } from "#shared/validation/number.ts";
 import {
   validateAddress,
   validateEmail,
@@ -215,8 +216,8 @@ const parseLines = (
   const seen = new Set<number>();
   for (const [field, raw] of form.entries()) {
     if (!field.startsWith(QTY_PREFIX)) continue;
-    const id = Number.parseInt(field.slice(QTY_PREFIX.length), 10);
-    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) continue;
+    const id = parsePositiveIntId(field.slice(QTY_PREFIX.length));
+    if (id === null || seen.has(id)) continue;
     seen.add(id);
     const key = form.getString(`${LINE_KEY_PREFIX}${id}`);
     lines.push({

--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -1,39 +1,26 @@
 /**
  * Shared form model for the unified add/edit attendee page.
  *
- * Both `/admin/attendees/new` (create) and `/admin/attendees/:id` (edit)
- * render the same field shape, parse the same line-item editor, and run the
- * same validation rules. The only difference is that edit mode hydrates the
- * form from existing attendee + listing_attendees rows.
- *
- * The form is a plain HTTP form. Repeatable line items are indexed by
- * position (line_event_id_N, line_quantity_N, line_date_N, line_key_N) and
- * the server re-renders on add-line / remove-line actions so the operator
- * never needs JavaScript to use the page.
+ * Both `/admin/attendees/new` (create) and `/admin/attendees/:id` (edit) render
+ * the same fields and run the same validation. An attendee has ONE shared date
+ * range — a `start_date` plus a day count — that applies to every daily listing
+ * they book; standard (fixed-date) listings ignore it. The listing editor is a
+ * fixed table with one row per bookable listing (plus any inactive listing the
+ * attendee already booked), each carrying a quantity box: quantity ≥ 1 books the
+ * listing, 0 leaves it out. There are no add/remove-line buttons, so the form
+ * needs no server round-trips to edit the line set.
  */
 
-import { filter, map, pipe } from "#fp";
 import { formatCurrency, toMinorUnits } from "#shared/currency.ts";
-import {
-  addDays,
-  getAvailableDates,
-  isBookingRangeValid,
-} from "#shared/dates.ts";
 import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import type {
   DesiredListingLine,
   ListingAttendeeRow,
   ListingBooking,
 } from "#shared/db/attendee-types.ts";
-import { bookingSlotKey } from "#shared/db/attendees/booking-slot.ts";
 import type { FormParams } from "#shared/form-data.ts";
-import { MAX_FORM_LINES } from "#shared/limits.ts";
-import {
-  dayPriceFor,
-  type Holiday,
-  type ListingWithCount,
-  normalizeDurationDays,
-} from "#shared/types.ts";
+import { START_DATE_FIELD } from "#shared/order-select.ts";
+import { type ListingWithCount, normalizeDurationDays } from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import {
   validateAddress,
@@ -46,51 +33,42 @@ import {
 // Field-name constants — single source of truth for template + parser
 // ---------------------------------------------------------------------------
 
-export const LINE_EVENT_ID_PREFIX = "line_event_id_";
-export const LINE_QUANTITY_PREFIX = "line_quantity_";
-export const LINE_DATE_PREFIX = "line_date_";
-export const LINE_DAY_COUNT_PREFIX = "line_day_count_";
+/** Shared day count (range length) for every daily listing. */
+export const DAY_COUNT_FIELD = "day_count";
+/** Per-listing quantity field: `qty_<listingId>`. */
+export const QTY_PREFIX = "qty_";
+/** Per-listing hidden field carrying the existing booking's line key, so an
+ * edit can move/keep the right `listing_attendees` row: `line_key_<listingId>`. */
 export const LINE_KEY_PREFIX = "line_key_";
-export const LINE_COUNT_FIELD = "line_count";
+/** Checkbox that reveals the not-booked listing rows (pure-CSS, never parsed). */
+export const SHOW_ALL_FIELD = "show_all";
 export const STATUS_FIELD = "status_id";
 export const REMAINING_BALANCE_FIELD = "remaining_balance";
 
-export const ACTION_FIELD = "action";
-export const SAVE_ACTION = "save";
-export const ADD_LINE_ACTION = "add_line";
-export const REMOVE_LINE_ACTION_PREFIX = "remove_line_";
-
-/** DOM id of the add/edit form, also used as the post-save scroll anchor
- * (`#attendee-form`) so the operator lands on the form after a save. */
+/** DOM id of the add/edit form, also the post-save scroll anchor. */
 export const ATTENDEE_FORM_ID = "attendee-form";
 
 // ---------------------------------------------------------------------------
 // Domain types
 // ---------------------------------------------------------------------------
 
-/** A single line in the editor — one listing registration. */
+/** One row of the listing editor — a bookable listing and its quantity. */
 export type AttendeeFormLine = {
-  /** Stable key from the existing listing_attendees row (`${listingId}|${startAt}`).
-   * Empty string for newly-added lines. */
-  key: string;
-  /** Parsed listing id; 0 means the line is blank (no listing chosen). */
+  /** Listing id this row books. */
   listingId: number;
-  /** Parsed quantity; null when the field was blank/non-numeric. */
+  /** Booked quantity; null/0 means the listing is not booked. */
   quantity: number | null;
-  /** Raw date string (YYYY-MM-DD) — only meaningful for daily listings. */
-  date: string;
-  /** Chosen day count for customisable daily listings; null when not submitted
-   * (then the existing booking's span, or 1, is used). */
-  dayCount: number | null;
-  /** Resolved listing reference (null when listingId is unknown or blank). */
+  /** Resolved listing reference (null when the id is unknown). */
   listing: ListingWithCount | null;
-  /** Existing booking row, when editing an existing line. */
+  /** Existing booking row, when the attendee already books this listing. */
   existingBooking: ListingAttendeeRow | null;
+  /** Stable key of the existing row (`${listingId}|${startAt}`); empty when new. */
+  key: string;
   /** Line-level validation error (set by validateParsedForm). */
   error: string | null;
 };
 
-/** The full parsed form — attendee contact fields plus all line items. */
+/** The full parsed form — attendee fields, the shared range, and line items. */
 export type ParsedAttendeeForm = {
   name: string;
   email: string;
@@ -101,16 +79,13 @@ export type ParsedAttendeeForm = {
   statusId: number | null;
   /** Outstanding balance in minor units (order-level, plaintext). */
   remainingBalance: number;
+  /** Shared start date (YYYY-MM-DD) for every daily listing; "" when unset. */
+  startDate: string;
+  /** Shared range length in days (≥ 1) for every daily listing. */
+  dayCount: number;
   lines: AttendeeFormLine[];
-  action: FormAction;
   returnUrl: string;
 };
-
-/** What the operator asked the server to do with the submission. */
-export type FormAction =
-  | { kind: "save" }
-  | { kind: "add_line" }
-  | { kind: "remove_line"; index: number };
 
 /** Attendee-level validation error. */
 export type AttendeeFieldError = {
@@ -124,145 +99,44 @@ export type ValidationResult =
   | {
       valid: false;
       attendeeError: AttendeeFieldError | null;
+      dateError: string | null;
       lineErrors: Map<number, string>;
       values: ParsedAttendeeForm;
     };
 
-/** Resolved daily-line timings used to drive defaults + mixed alert. */
-export type DailyDefaults = {
-  /** True when existing daily lines disagree on start date or duration. */
+/** The shared date range implied by an attendee's existing daily bookings. */
+type SharedDates = {
+  /** Shared start date (YYYY-MM-DD), or "" when there are no daily bookings. */
+  startDate: string;
+  /** Shared day count (≥ 1). */
+  dayCount: number;
+  /** True when the existing daily bookings disagree on start date or duration —
+   * saving will normalise them all onto the one chosen range. */
   hasMixedTimings: boolean;
-  /** Shared start date to pre-fill new daily lines with (when uniform). */
-  inheritedDate: string | null;
-  /** Shared duration (days) observed across existing daily lines. */
-  inheritedDurationDays: number | null;
 };
 
 // ---------------------------------------------------------------------------
-// Keys + helpers
+// Helpers
 // ---------------------------------------------------------------------------
 
-/** True when the line has no listing selected and no existing identity. */
-export const isBlankLine = (line: AttendeeFormLine): boolean =>
-  line.listingId <= 0 && !line.key;
+/** True when the line should become a booking. */
+export const isBookedLine = (line: AttendeeFormLine): boolean =>
+  line.quantity !== null && line.quantity >= 1 && line.listing !== null;
 
-/** True when the line should become a booking: non-blank and resolved to a
- * real listing. The shared predicate for both mutation adapters. */
-const isFillableLine = (line: AttendeeFormLine): boolean =>
-  !isBlankLine(line) && line.listing !== null;
-
-/**
- * Drop the trailing blank line the template always renders so save
- * validation doesn't fail on an operator who left the placeholder row empty.
- * Keep intentionally-blank middle rows so the line indices line up with what
- * the operator saw — only the trailing blank is trimmed.
- */
-export const trimTrailingBlankLines = (
-  lines: AttendeeFormLine[],
-): AttendeeFormLine[] => {
-  const result = [...lines];
-  while (result.length > 1 && isBlankLine(result[result.length - 1]!)) {
-    result.pop();
-  }
-  return result;
+/** Whole-day span of a stored booking row, or null when it has no range. */
+export const bookingDurationDays = (
+  booking: ListingAttendeeRow,
+): number | null => {
+  if (!booking.start_at || !booking.end_at) return null;
+  const ms =
+    new Date(booking.end_at).getTime() - new Date(booking.start_at).getTime();
+  const days = Math.round(ms / 86_400_000);
+  return days >= 1 ? days : null;
 };
 
-// ---------------------------------------------------------------------------
-// Action parsing
-// ---------------------------------------------------------------------------
-
-const parseAction = (form: FormParams): FormAction => {
-  const raw = form.getString(ACTION_FIELD);
-  if (raw === ADD_LINE_ACTION) return { kind: "add_line" };
-  if (raw.startsWith(REMOVE_LINE_ACTION_PREFIX)) {
-    const idx = Number.parseInt(
-      raw.slice(REMOVE_LINE_ACTION_PREFIX.length),
-      10,
-    );
-    if (Number.isInteger(idx) && idx >= 0)
-      return { index: idx, kind: "remove_line" };
-  }
-  // Default and any unrecognized value (including "save") → save.
-  return { kind: "save" };
-};
-
-// ---------------------------------------------------------------------------
-// Form parsing
-// ---------------------------------------------------------------------------
-
-/**
- * Read the attendee contact fields and every line item from the form.
- *
- * Lines are read positionally: for each N in [0, line_count), read the
- * matching `line_*_N` fields. `listingsById` resolves listing references; an
- * unknown listing id is recorded as an unresolved line (validation will flag
- * it). `existingByKey` (edit mode) attaches the original booking row to
- * lines that already existed.
- */
-/** Parse a listing-id field into the numeric id and resolved listing (if any). */
-const resolveListing = (
-  raw: string,
-  listingsById: Map<number, ListingWithCount>,
-): { id: number; listing: ListingWithCount | null } => {
-  const id = Number.parseInt(raw, 10);
-  if (!Number.isInteger(id) || id <= 0) return { id: 0, listing: null };
-  return { id, listing: listingsById.get(id) ?? null };
-};
-
-/** Parse a single line of the editor from the indexed form fields. */
-const parseAttendeeLine = (
-  form: FormParams,
-  i: number,
-  listingsById: Map<number, ListingWithCount>,
-  existingByKey: Map<string, ListingAttendeeRow>,
-): AttendeeFormLine => {
-  const { id, listing } = resolveListing(
-    form.getString(`${LINE_EVENT_ID_PREFIX}${i}`),
-    listingsById,
-  );
-  const key = form.getString(`${LINE_KEY_PREFIX}${i}`);
-  return {
-    date: form.getString(`${LINE_DATE_PREFIX}${i}`),
-    dayCount: form.getOptionalInt(`${LINE_DAY_COUNT_PREFIX}${i}`),
-    error: null,
-    existingBooking: key ? (existingByKey.get(key) ?? null) : null,
-    key,
-    listing,
-    listingId: id,
-    quantity: form.getOptionalInt(`${LINE_QUANTITY_PREFIX}${i}`),
-  };
-};
-
-export const parseAttendeeForm = (
-  form: FormParams,
-  listingsById: Map<number, ListingWithCount>,
-  existingByKey: Map<string, ListingAttendeeRow> = new Map(),
-): ParsedAttendeeForm => {
-  const lineCountRaw = form.getOptionalInt(LINE_COUNT_FIELD);
-  const lineCount =
-    lineCountRaw !== null && lineCountRaw > 0
-      ? Math.min(lineCountRaw, MAX_FORM_LINES)
-      : 1;
-
-  const indices = Array.from({ length: lineCount }, (_, i) => i);
-  const lines = map((i: number) =>
-    parseAttendeeLine(form, i, listingsById, existingByKey),
-  )(indices);
-
-  const statusIdRaw = form.getOptionalInt(STATUS_FIELD);
-  return {
-    action: parseAction(form),
-    address: form.getString("address"),
-    email: form.getString("email"),
-    lines,
-    name: form.getString("name"),
-    phone: form.getString("phone"),
-    remainingBalance: parseMoneyMinor(form.getString(REMAINING_BALANCE_FIELD)),
-    returnUrl: form.getString("return_url"),
-    special_instructions: form.getString("special_instructions"),
-    statusId: statusIdRaw !== null && statusIdRaw > 0 ? statusIdRaw : null,
-  };
-};
+/** Clamp a submitted day count to the valid range; blank defaults to 1. */
+const clampDayCount = (raw: number | null): number =>
+  normalizeDurationDays(raw ?? 1);
 
 /** Parse a money field (major units) to clamped minor units; blank/invalid → 0. */
 const parseMoneyMinor = (raw: string): number => {
@@ -271,53 +145,118 @@ const parseMoneyMinor = (raw: string): number => {
 };
 
 /**
- * Resolve the status an attendee resolves to: their submitted choice, or the
- * public default (the status new bookings start in) when none was given. The
- * form offers no "no status" choice, so a missing/blank value — only reachable
- * from a hand-crafted POST — is coerced back to the default rather than
- * clearing it. Shared by the template (to pre-select) and the save path (to
- * persist) so both agree. A public default always exists once any status does.
+ * The status an attendee resolves to: their submitted choice, or the public
+ * default (the status new bookings start in) when none was given. The form
+ * offers no "no status" choice, so a missing value — only reachable from a
+ * hand-crafted POST — is coerced back to the default rather than clearing it.
  */
 export const resolveStatusId = (
   statusId: number | null,
   statuses: AttendeeStatus[],
 ): number => statusId ?? statuses.find((s) => s.is_public_default)!.id;
 
+/**
+ * Derive the shared date range from an attendee's existing bookings. Only dated
+ * (daily) rows count. When they agree, that range is returned; when they
+ * disagree it seeds from the earliest start and longest duration and flags mixed
+ * timings so the operator is warned before saving normalises them.
+ */
+export const resolveSharedDates = (
+  bookings: ListingAttendeeRow[],
+): SharedDates => {
+  const dated = bookings
+    .filter((b) => b.start_at && b.end_at)
+    .map((b) => ({
+      duration: bookingDurationDays(b) ?? 1,
+      startDate: b.start_at!.slice(0, 10),
+    }));
+  if (dated.length === 0) {
+    return { dayCount: 1, hasMixedTimings: false, startDate: "" };
+  }
+  const first = dated[0]!;
+  const allSame = dated.every(
+    (d) => d.startDate === first.startDate && d.duration === first.duration,
+  );
+  if (allSame) {
+    return {
+      dayCount: first.duration,
+      hasMixedTimings: false,
+      startDate: first.startDate,
+    };
+  }
+  return {
+    dayCount: Math.max(...dated.map((d) => d.duration)),
+    hasMixedTimings: true,
+    startDate: [...dated.map((d) => d.startDate)].sort()[0]!,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Form parsing
+// ---------------------------------------------------------------------------
+
+/** Parse one quantity field value: blank/invalid → null, else the integer. */
+const parseQuantity = (raw: string): number | null => {
+  if (raw.trim() === "") return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) ? n : null;
+};
+
+/** One editor line per `qty_<id>` field in the form, in document order and
+ * de-duplicated, with the listing + existing booking resolved. */
+const parseLines = (
+  form: FormParams,
+  resolve: (
+    id: number,
+    key: string,
+  ) => Pick<AttendeeFormLine, "listing" | "existingBooking">,
+): AttendeeFormLine[] => {
+  const lines: AttendeeFormLine[] = [];
+  const seen = new Set<number>();
+  for (const [field, raw] of form.entries()) {
+    if (!field.startsWith(QTY_PREFIX)) continue;
+    const id = Number.parseInt(field.slice(QTY_PREFIX.length), 10);
+    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) continue;
+    seen.add(id);
+    const key = form.getString(`${LINE_KEY_PREFIX}${id}`);
+    lines.push({
+      error: null,
+      key,
+      listingId: id,
+      quantity: parseQuantity(raw),
+      ...resolve(id, key),
+    });
+  }
+  return lines;
+};
+
+export const parseAttendeeForm = (
+  form: FormParams,
+  listingsById: Map<number, ListingWithCount>,
+  existingByKey: Map<string, ListingAttendeeRow> = new Map(),
+): ParsedAttendeeForm => {
+  const statusIdRaw = form.getOptionalInt(STATUS_FIELD);
+  return {
+    address: form.getString("address"),
+    dayCount: clampDayCount(form.getOptionalInt(DAY_COUNT_FIELD)),
+    email: form.getString("email"),
+    lines: parseLines(form, (id, key) => ({
+      existingBooking: key ? (existingByKey.get(key) ?? null) : null,
+      listing: listingsById.get(id) ?? null,
+    })),
+    name: form.getString("name"),
+    phone: form.getString("phone"),
+    remainingBalance: parseMoneyMinor(form.getString(REMAINING_BALANCE_FIELD)),
+    returnUrl: form.getString("return_url"),
+    special_instructions: form.getString("special_instructions"),
+    startDate: form.getString(START_DATE_FIELD),
+    statusId: statusIdRaw !== null && statusIdRaw > 0 ? statusIdRaw : null,
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
-
-/**
- * Validate the attendee block + each line independently.
- *
- * Per-line errors are attached both to the returned `lineErrors` map and
- * onto the line objects in `values.lines` so the template can read them
- * directly. A single failing line still preserves the rest of the form.
- */
-export const validateParsedForm = (
-  parsed: ParsedAttendeeForm,
-  holidays: Holiday[],
-): ValidationResult => {
-  const attendeeError = validateAttendeeBlock(parsed);
-  const seenLineKeys = new Set<string>();
-  const lineErrors = new Map<number, string>();
-
-  for (let i = 0; i < parsed.lines.length; i++) {
-    const line = parsed.lines[i]!;
-    const error = validateLine(line, holidays, seenLineKeys);
-    if (error) {
-      line.error = error;
-      lineErrors.set(i, error);
-    } else {
-      line.error = null;
-    }
-  }
-
-  if (attendeeError || lineErrors.size > 0) {
-    return { attendeeError, lineErrors, valid: false, values: parsed };
-  }
-  return { valid: true, values: parsed };
-};
 
 const validateAttendeeBlock = (
   parsed: ParsedAttendeeForm,
@@ -325,11 +264,6 @@ const validateAttendeeBlock = (
   if (!parsed.name.trim()) {
     return { field: "name", message: "Name is required" };
   }
-  // Email and phone are optional on this form, but a provided value must be
-  // well-formed. The browser enforces this via type=email / pattern, so only a
-  // no-JS or hand-crafted POST reaches the server with a malformed value —
-  // validating here keeps bad contact data out of the encrypted PII blob.
-  // Reuse the same validators the public ticket form uses so both paths agree.
   if (parsed.email) {
     const emailError = validateEmail(parsed.email);
     if (emailError) return { field: "email", message: emailError };
@@ -338,8 +272,6 @@ const validateAttendeeBlock = (
     const phoneError = validatePhone(parsed.phone);
     if (phoneError) return { field: "phone", message: phoneError };
   }
-  // Length caps backstop the HTML maxlength and keep these fields within the
-  // size the payment-metadata path elsewhere relies on.
   const addressError = validateAddress(parsed.address);
   if (addressError) return { field: "address", message: addressError };
   const instructionsError = validateSpecialInstructions(
@@ -351,187 +283,66 @@ const validateAttendeeBlock = (
   return null;
 };
 
-/**
- * Validate a single line.
- *
- * Returns the first error encountered (in priority order) or null if the
- * line passes. Blank lines (no listing selected, no existing key) are allowed
- * — `trimTrailingBlankLines` cleans them up before validation, and any that
- * survive are treated as no-ops so the operator can submit a partially
- * filled form without losing data.
- */
-/** Validate the date/day-count of a daily line. For customisable listings the
- * date list is computed for a single day (every individually-bookable start)
- * and the chosen span is checked separately; otherwise the listing's fixed
- * duration is used. */
-const validateDailyLine = (
-  line: AttendeeFormLine,
-  listing: ListingWithCount,
-  holidays: Holiday[],
-): string | null => {
-  if (listing.customisable_days) {
-    const days = lineDayCount(line);
-    if (dayPriceFor(listing, days) === null) {
-      return `This listing doesn't offer a ${days}-day booking`;
-    }
-    if (!isBookingRangeValid(listing, line.date, days, holidays)) {
-      return "Those dates aren't all available — choose fewer days or another start date";
-    }
-    return null;
-  }
-  const allowed = new Set(getAvailableDates(listing, holidays));
-  return allowed.has(line.date)
-    ? null
-    : "Date is not bookable for this listing";
-};
+/** True when a booked line targets a daily listing (needs the shared date). */
+const isBookedDaily = (line: AttendeeFormLine): boolean =>
+  isBookedLine(line) && line.listing!.listing_type === "daily";
 
-const validateLine = (
-  line: AttendeeFormLine,
-  holidays: Holiday[],
-  seenLineKeys: Set<string>,
-): string | null => {
-  if (isBlankLine(line)) return null;
-
-  if (!line.listing) {
-    return "Listing no longer exists or is inactive";
+/** Validate one booked line's quantity. Date/duration/overbooking concerns are
+ * surfaced as non-blocking warnings elsewhere, not as errors. */
+const validateLine = (line: AttendeeFormLine): string | null => {
+  // isBookedLine already guarantees an integer quantity ≥ 1; the only quantity
+  // error left is exceeding the listing's per-booking maximum.
+  if (!isBookedLine(line)) return null;
+  if (line.quantity! > line.listing!.max_quantity) {
+    return `Quantity must be at most ${line.listing!.max_quantity}`;
   }
-  if (!line.listing.active) {
-    return `Listing '${line.listing.name}' is inactive`;
-  }
-
-  const qty = line.quantity;
-  if (qty === null || !Number.isInteger(qty) || qty < 1) {
-    return "Quantity must be at least 1";
-  }
-  if (qty > line.listing.max_quantity) {
-    return `Quantity must be at most ${line.listing.max_quantity}`;
-  }
-
-  const isDaily = line.listing.listing_type === "daily";
-  if (isDaily) {
-    if (!line.date) return "Date is required for daily listings";
-    if (!isIsoDate(line.date)) {
-      return "Date must be a valid YYYY-MM-DD value";
-    }
-    const lineError = validateDailyLine(line, line.listing, holidays);
-    if (lineError) return lineError;
-  }
-
-  // Duplicate-line check: same listing + same date would collide on the
-  // (listing_id, attendee_id, start_at) unique index. Reuse the same slot
-  // identity the DB layer dedupes on (bookingSlotKey) so both agree.
-  const dedupeKey = bookingSlotKey(line.listingId, isDaily ? line.date : null);
-  if (seenLineKeys.has(dedupeKey)) {
-    return "Duplicate listing line — same listing and date already added";
-  }
-  seenLineKeys.add(dedupeKey);
   return null;
 };
 
-// ---------------------------------------------------------------------------
-// Daily defaults + mixed-timing detection
-// ---------------------------------------------------------------------------
-
-/** Compute the duration (in days) implied by a listing_attendees row range. */
-export const bookingDurationDays = (
-  booking: ListingAttendeeRow,
-): number | null => {
-  if (!booking.start_at || !booking.end_at) return null;
-  const startMs = new Date(booking.start_at).getTime();
-  const endMs = new Date(booking.end_at).getTime();
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
-  const days = Math.round((endMs - startMs) / 86_400_000);
-  return days >= 1 ? days : null;
-};
-
 /**
- * Inspect the attendee's existing daily lines to drive defaults for newly
- * added lines and the mixed-timing alert.
- *
- * - When all existing daily lines share the same start date AND duration,
- *   new daily lines inherit that start date. `inheritedDurationDays` is
- *   surfaced for display ("matches existing N-day booking").
- * - When existing daily lines disagree, `hasMixedTimings` becomes true so
- *   the template can render the non-blocking alert.
- * - When there are no existing daily lines, `inheritedDate` is null and the
- *   template falls back to tomorrow + the listing's duration.
+ * Validate the attendee block, the shared date, and each booked line. A daily
+ * booking requires a valid shared start date; everything date- or
+ * capacity-related beyond that is a warning, not an error.
  */
-export const resolveDailyDefaults = (
-  lines: AttendeeFormLine[],
-): DailyDefaults => {
-  const dailyBookings = pipe(
-    filter(
-      (line: AttendeeFormLine) =>
-        Boolean(line.existingBooking) &&
-        line.listing?.listing_type === "daily" &&
-        line.existingBooking!.start_at !== null,
-    ),
-    map((line: AttendeeFormLine) => ({
-      duration: bookingDurationDays(line.existingBooking!) ?? 1,
-      startDate: line.existingBooking!.start_at!.slice(0, 10),
-    })),
-  )(lines);
+export const validateParsedForm = (
+  parsed: ParsedAttendeeForm,
+): ValidationResult => {
+  const attendeeError = validateAttendeeBlock(parsed);
+  const hasDailyBooking = parsed.lines.some(isBookedDaily);
+  const dateError =
+    hasDailyBooking && !isIsoDate(parsed.startDate)
+      ? "A start date is required for the booked daily listings"
+      : null;
 
-  if (dailyBookings.length === 0) {
-    return {
-      hasMixedTimings: false,
-      inheritedDate: null,
-      inheritedDurationDays: null,
-    };
+  const lineErrors = new Map<number, string>();
+  for (let i = 0; i < parsed.lines.length; i++) {
+    const error = validateLine(parsed.lines[i]!);
+    parsed.lines[i]!.error = error;
+    if (error) lineErrors.set(i, error);
   }
 
-  const first = dailyBookings[0]!;
-  const allSame = dailyBookings.every(
-    (b) => b.startDate === first.startDate && b.duration === first.duration,
-  );
-  if (allSame) {
+  if (attendeeError || dateError || lineErrors.size > 0) {
     return {
-      hasMixedTimings: false,
-      inheritedDate: first.startDate,
-      inheritedDurationDays: first.duration,
+      attendeeError,
+      dateError,
+      lineErrors,
+      valid: false,
+      values: parsed,
     };
   }
-  return {
-    hasMixedTimings: true,
-    inheritedDate: null,
-    inheritedDurationDays: null,
-  };
+  return { valid: true, values: parsed };
 };
-
-/** Tomorrow's date in YYYY-MM-DD form (UTC day). Used for the create-mode
- * daily-line default when nothing is inherited. */
-export const defaultNewDailyDate = (todayIso: string): string =>
-  addDays(todayIso.slice(0, 10), 1);
 
 // ---------------------------------------------------------------------------
 // Mutation adapters — convert parsed form into the DB-layer input shapes
 // ---------------------------------------------------------------------------
 
-/**
- * Convert a parsed, validated form into the multi-listing AttendeeInput used
- * by `createAttendeeAtomic`. Non-daily lines pass `date: null`.
- */
-/** Whole-day span of an existing booking from its stored [start_at, end_at). */
-const existingSpanDays = (row: ListingAttendeeRow | null): number | null => {
-  if (!row?.start_at || !row?.end_at) return null;
-  const ms = new Date(row.end_at).getTime() - new Date(row.start_at).getTime();
-  const days = Math.round(ms / 86_400_000);
-  return days > 0 ? days : null;
-};
-
-/** Effective day count for a customisable line: the chosen value, else the
- * existing booking's span (so an unrelated edit preserves it), else 1. */
-export const lineDayCount = (line: AttendeeFormLine): number =>
-  normalizeDurationDays(
-    line.dayCount ?? existingSpanDays(line.existingBooking) ?? 1,
-  );
-
-/** Booking duration (days) for a daily line — the chosen span for customisable
- * listings, the listing's fixed duration otherwise. */
-const lineDurationDays = (line: AttendeeFormLine): number =>
-  line.listing!.customisable_days
-    ? lineDayCount(line)
-    : line.listing!.duration_days;
+/** Booking date/duration for a line: the shared range for daily listings, none
+ * for standard listings. */
+const lineDate = (line: AttendeeFormLine, parsed: ParsedAttendeeForm) =>
+  line.listing!.listing_type === "daily"
+    ? { date: parsed.startDate, durationDays: parsed.dayCount }
+    : { date: null, durationDays: 1 };
 
 export const toCreateInput = (
   parsed: ParsedAttendeeForm,
@@ -544,73 +355,54 @@ export const toCreateInput = (
   remainingBalance: number;
   special_instructions: string;
   statusId: number | null;
-} => {
-  const bookings: ListingBooking[] = pipe(
-    filter(isFillableLine),
-    map(
-      (line: AttendeeFormLine): ListingBooking => ({
-        date: line.listing!.listing_type === "daily" ? line.date : null,
-        durationDays:
-          line.listing!.listing_type === "daily"
-            ? lineDurationDays(line)
-            : undefined,
-        listingId: line.listingId,
-        quantity: line.quantity!,
-      }),
-    ),
-  )(parsed.lines);
-
-  return {
-    address: parsed.address,
-    bookings,
-    email: parsed.email,
-    name: parsed.name,
-    phone: parsed.phone,
-    remainingBalance: parsed.remainingBalance,
-    special_instructions: parsed.special_instructions,
-    statusId: parsed.statusId,
-  };
-};
+} => ({
+  address: parsed.address,
+  bookings: parsed.lines.filter(isBookedLine).map((line): ListingBooking => {
+    const { date, durationDays } = lineDate(line, parsed);
+    return {
+      date,
+      durationDays: date ? durationDays : undefined,
+      listingId: line.listingId,
+      quantity: line.quantity!,
+    };
+  }),
+  email: parsed.email,
+  name: parsed.name,
+  phone: parsed.phone,
+  remainingBalance: parsed.remainingBalance,
+  special_instructions: parsed.special_instructions,
+  statusId: parsed.statusId,
+});
 
 /**
- * Compute the desired final-state line set for the atomic update path.
- * Daily listings resolve `date`/`durationDays`; non-daily listings null them.
- * Duplicate (listingId, date) lines are not de-duplicated here — validation
- * already rejects them with a visible error, and the DB layer rejects any
- * that slip past a direct caller; silently dropping a line would hide intent.
+ * Desired final-state lines for the atomic edit. A line that already has a
+ * booking keeps its original key (with the old start_at) and `exists: true`, so
+ * a moved shared date becomes an in-place UPDATE rather than a drop-and-recreate;
+ * not-booked listings are simply absent, so the diff deletes any old row.
  */
 export const toDesiredLines = (
   parsed: ParsedAttendeeForm,
 ): DesiredListingLine[] =>
-  pipe(
-    filter(isFillableLine),
-    map((line: AttendeeFormLine): DesiredListingLine => {
-      const isDaily = line.listing!.listing_type === "daily";
-      return {
-        date: isDaily ? line.date : null,
-        durationDays: isDaily ? lineDurationDays(line) : 1,
-        exists: Boolean(line.key) && Boolean(line.existingBooking),
-        key: line.key,
-        listingId: line.listingId,
-        quantity: line.quantity!,
-      };
-    }),
-  )(parsed.lines);
+  parsed.lines.filter(isBookedLine).map((line): DesiredListingLine => {
+    const { date, durationDays } = lineDate(line, parsed);
+    return {
+      date,
+      durationDays,
+      exists: Boolean(line.existingBooking),
+      key: line.key,
+      listingId: line.listingId,
+      quantity: line.quantity!,
+    };
+  });
 
 /** A status/balance mismatch surfaced on the attendee form. */
 export type BalanceNotice = { tone: "warning" | "info"; message: string };
 
 /**
  * Flag a mismatch between an attendee's status and their balance, or null when
- * the two agree. Three situations warrant a notice:
- *   - a paid status that still owes money (a contradiction → warning);
- *   - a reservation with no recorded balance while part of the order is still
- *     unpaid (the balance looks lost → warning);
- *   - a reservation that's fully paid yet still sitting in a reservation status
- *     (a softer nudge to move it on → info).
- *
- * A reservation that still owes a balance is the normal mid-reservation state,
- * and a balance on any other status is treated as deliberate — both stay quiet.
+ * the two agree: a paid status that still owes (warning), a reservation with no
+ * recorded balance while part of the order is unpaid (warning), or a fully-paid
+ * reservation still in a reservation status (info nudge).
  */
 export const attendeeBalanceNotice = (
   status: { is_paid_default: boolean; is_reservation: boolean } | null,

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -19,6 +19,7 @@ import {
   ATTENDEE_FORM_ID,
   type AttendeeFormLine,
   attendeeBalanceNotice,
+  isBookedLine,
   type ParsedAttendeeForm,
   parseAttendeeForm,
   resolveSharedDates,
@@ -194,6 +195,31 @@ const buildEditFormFromAttendee = (
 /** How many of an attendee's activity-log entries to show on the edit page. */
 const ATTENDEE_LOG_LIMIT = 1000;
 
+/**
+ * Over-duration warnings for the booked lines: a daily listing is designed for
+ * a fixed number of days, but every daily listing shares one range, so a longer
+ * range than a listing allows is permitted — with a warning, not an error.
+ */
+const computeWarnings = (
+  parsed: ParsedAttendeeForm,
+): { byListing: Map<number, string[]>; top: string[] } => {
+  const byListing = new Map<number, string[]>();
+  const top: string[] = [];
+  for (const line of parsed.lines.filter(isBookedLine)) {
+    const listing = line.listing!;
+    if (
+      listing.listing_type === "daily" &&
+      parsed.dayCount > listing.duration_days
+    ) {
+      const max = listing.duration_days;
+      const msg = `${listing.name} is designed for up to ${max} day${max === 1 ? "" : "s"}, but the booking spans ${parsed.dayCount}.`;
+      byListing.set(listing.id, [msg]);
+      top.push(msg);
+    }
+  }
+  return { byListing, top };
+};
+
 /** Build the template data for re-rendering the form. */
 const buildTemplateData = async (
   mode: "create" | "edit",
@@ -223,6 +249,7 @@ const buildTemplateData = async (
   const activityLog = attendee
     ? await getAttendeeActivityLog(attendee.id, ATTENDEE_LOG_LIMIT)
     : [];
+  const warnings = computeWarnings(parsed);
   return {
     activityLog,
     allowedDomain: getEffectiveDomain(),
@@ -234,6 +261,7 @@ const buildTemplateData = async (
     flashError: opts.flashError,
     flashSuccess: opts.flashSuccess,
     hasMixedTimings: opts.hasMixedTimings ?? false,
+    lineWarnings: warnings.byListing,
     mode,
     parsed,
     phonePrefix: settings.phonePrefix,
@@ -242,6 +270,7 @@ const buildTemplateData = async (
     selectedAnswerIds: opts.selectedAnswerIds ?? [],
     statuses,
     todayIso: todayInTz(settings.timezone),
+    topWarnings: warnings.top,
   };
 };
 

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -16,7 +16,7 @@
  *   6. Redirect with a success/failure flash.
  */
 
-import { filter, map, pipe, unique } from "#fp";
+import { compact, filter, map, pipe, unique } from "#fp";
 import { requirePrivateKey } from "#routes/admin/actions.ts";
 import {
   ATTENDEE_FORM_ID,
@@ -79,6 +79,10 @@ import {
 import { settings } from "#shared/db/settings.ts";
 import { ATTENDEE_DEMO_FIELDS, applyDemoOverrides } from "#shared/demo.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import {
+  parseSelectedListingIds,
+  START_DATE_FIELD,
+} from "#shared/order-select.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import {
   type Attendee,
@@ -86,6 +90,7 @@ import {
   type Holiday,
   type ListingWithCount,
 } from "#shared/types.ts";
+import { isIsoDate } from "#shared/validation/date.ts";
 import {
   type AttendeeFormTemplateData,
   attendeeFormPage,
@@ -166,13 +171,14 @@ const emptyLine = (
   quantity: 1,
 });
 
-/** Build the empty create-mode form shell: one blank line with the
- * default daily date pre-filled (so the operator sees a concrete date). */
-const buildEmptyCreateForm = (): ParsedAttendeeForm => ({
+/** A blank create-mode form shell carrying the given listing lines and empty
+ * contact fields — the shared shape behind both the empty form and the
+ * calendar deep-link form. */
+const createFormShell = (lines: AttendeeFormLine[]): ParsedAttendeeForm => ({
   action: { kind: "save" },
   address: "",
   email: "",
-  lines: [emptyLine(todayInTz(settings.timezone), null)],
+  lines,
   name: "",
   phone: "",
   remainingBalance: 0,
@@ -180,6 +186,56 @@ const buildEmptyCreateForm = (): ParsedAttendeeForm => ({
   special_instructions: "",
   statusId: null,
 });
+
+/** Build the empty create-mode form shell: one blank line with the
+ * default daily date pre-filled (so the operator sees a concrete date). */
+const buildEmptyCreateForm = (): ParsedAttendeeForm =>
+  createFormShell([emptyLine(todayInTz(settings.timezone), null)]);
+
+/** Build a create-mode line for a listing chosen on the calendar availability
+ * checker: daily listings inherit the calendar's selected date, standard
+ * listings take none. */
+const prefilledLine = (
+  listing: ListingWithCount,
+  startDate: string,
+  todayIso: string,
+): AttendeeFormLine => ({
+  date:
+    listing.listing_type === "daily"
+      ? isIsoDate(startDate)
+        ? startDate
+        : defaultNewDailyDate(todayIso)
+      : "",
+  dayCount: null,
+  error: null,
+  existingBooking: null,
+  key: "",
+  listing,
+  listingId: listing.id,
+  quantity: 1,
+});
+
+/**
+ * Build the create form from a `?select_<id>=1&start_date=…` deep link (the
+ * calendar availability checker's "Create Attendee" button). Unknown or
+ * inactive listing ids are ignored; with no resolvable selection it falls back
+ * to the empty one-line form so a bare `/admin/attendees/new` still works.
+ */
+const buildCreateFormFromQuery = (
+  request: Request,
+  listingsById: Map<number, ListingWithCount>,
+): ParsedAttendeeForm => {
+  const params = new URL(request.url).searchParams;
+  const startDate = params.get(START_DATE_FIELD) ?? "";
+  const todayIso = todayInTz(settings.timezone);
+  const resolved = compact(
+    parseSelectedListingIds(params).map((id) => listingsById.get(id)),
+  );
+  const lines = resolved.map((listing) =>
+    prefilledLine(listing, startDate, todayIso),
+  );
+  return lines.length === 0 ? buildEmptyCreateForm() : createFormShell(lines);
+};
 
 /** Build the edit-mode form shell from a loaded attendee + its bookings. */
 const buildEditFormFromAttendee = (
@@ -338,7 +394,11 @@ export const handleAttendeeNewGet: TypedRouteHandler<
   "GET /admin/attendees/new"
 > = (request) =>
   requireSessionOr(request, async (session) => {
-    const parsed = buildEmptyCreateForm();
+    const allListings = await getListingsForSelector(null);
+    const parsed = buildCreateFormFromQuery(
+      request,
+      listingsByIdMap(allListings),
+    );
     const data = await buildTemplateData("create", parsed, null, {
       returnUrl: getSearchParam(request, "return_url"),
     });

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -1,36 +1,30 @@
 /**
  * Routes for the unified add/edit attendee page.
  *
- *   GET  /admin/attendees/new      — render empty form (create mode)
+ *   GET  /admin/attendees/new      — render the create form
  *   POST /admin/attendees/new      — handle create submission
- *   GET  /admin/attendees/:id      — render form preloaded with attendee (edit mode)
+ *   GET  /admin/attendees/:id      — render the edit form, preloaded
  *   POST /admin/attendees/:id      — handle edit submission
  *
- * Create and edit share every step:
- *   1. Load available listings + (edit only) current attendee/lines.
- *   2. Parse the form into attendee + line items.
- *   3. If the operator clicked add-line / remove-line, re-render without
- *      saving (preserve all entered data).
- *   4. Otherwise validate. On failure, re-render with line-level errors.
- *   5. Run the atomic create or update.
- *   6. Redirect with a success/failure flash.
+ * The editor is a fixed table — one quantity box per bookable listing (plus any
+ * inactive listing the attendee already booked) — and one shared date range, so
+ * a submission is a single self-contained save with no add/remove-line round
+ * trips. Create can be deep-linked from the calendar availability checker with
+ * `?select_<id>=1&start_date=…` to pre-fill the chosen listings and date.
  */
 
-import { compact, filter, map, pipe, unique } from "#fp";
+import { filter, unique } from "#fp";
 import { requirePrivateKey } from "#routes/admin/actions.ts";
 import {
   ATTENDEE_FORM_ID,
   type AttendeeFormLine,
   attendeeBalanceNotice,
-  type DailyDefaults,
-  defaultNewDailyDate,
   type ParsedAttendeeForm,
   parseAttendeeForm,
-  resolveDailyDefaults,
+  resolveSharedDates,
   resolveStatusId,
   toCreateInput,
   toDesiredLines,
-  trimTrailingBlankLines,
   validateParsedForm,
 } from "#routes/admin/attendee-form-model.ts";
 import {
@@ -45,7 +39,6 @@ import { htmlResponse, notFoundResponse, redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { getSearchParam } from "#routes/url.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
-import { getBookableStartDates } from "#shared/dates.ts";
 import { getAttendeeActivityLog, logActivity } from "#shared/db/activityLog.ts";
 /* jscpd:ignore-end */
 import { getAllAttendeeStatuses } from "#shared/db/attendee-statuses.ts";
@@ -68,7 +61,6 @@ import {
   getEmailStats,
   hashEmail,
 } from "#shared/db/email-preferences.ts";
-import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import {
   loadAttendeeQuestionData,
@@ -84,12 +76,7 @@ import {
   START_DATE_FIELD,
 } from "#shared/order-select.ts";
 import { todayInTz } from "#shared/timezone.ts";
-import {
-  type Attendee,
-  availableDayCounts,
-  type Holiday,
-  type ListingWithCount,
-} from "#shared/types.ts";
+import type { Attendee, ListingWithCount } from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import {
   type AttendeeFormTemplateData,
@@ -100,187 +87,111 @@ import {
 // Shared loaders / helpers
 // ---------------------------------------------------------------------------
 
-/** Listings selectable in the dropdown: active listings plus any currently
- * selected listings (so an inactive selected listing still renders its name). */
-const getListingsForSelector = async (
-  parsed: ParsedAttendeeForm | null,
-): Promise<ListingWithCount[]> => {
-  const allListings = await getAllListings();
-  const active = filter((l: ListingWithCount) => l.active)(allListings);
-  if (!parsed) return active;
-  const selectedIds = new Set(
-    pipe(
-      map((line: AttendeeFormLine) => line.listingId),
-      filter((id: number) => id > 0),
-    )(parsed.lines),
-  );
-  // Active and selected-inactive are disjoint (one is active, the other not),
-  // so concatenating them needs no de-duplication.
-  const selectedInactive = filter(
-    (l: ListingWithCount) => selectedIds.has(l.id) && !l.active,
-  )(allListings);
-  return [...selectedInactive, ...active];
-};
-
-/** Index listings by id for line resolution. */
+/** Index listings by id. */
 const listingsByIdMap = (
   listings: ListingWithCount[],
 ): Map<number, ListingWithCount> => new Map(listings.map((l) => [l.id, l]));
 
-/** Build the available-dates map for every daily listing in the selector. */
-const buildAvailableDates = (
-  listings: ListingWithCount[],
-  holidays: Holiday[],
-): Record<number, string[]> => {
-  const result: Record<number, string[]> = {};
-  for (const listing of listings) {
-    if (listing.listing_type === "daily") {
-      result[listing.id] = getBookableStartDates(listing, holidays);
-    }
-  }
-  return result;
+/** Listings to render rows for: every active listing, plus any inactive listing
+ * the attendee already books (so an existing inactive registration still shows
+ * its quantity and can be edited). Active first, then inactive-booked. */
+const getRenderListings = async (
+  existing: ExistingLine[],
+): Promise<ListingWithCount[]> => {
+  const all = await getAllListings();
+  const active = filter((l: ListingWithCount) => l.active)(all);
+  const bookedIds = new Set(existing.map((e) => e.booking.listing_id));
+  const inactiveBooked = filter(
+    (l: ListingWithCount) => !l.active && bookedIds.has(l.id),
+  )(all);
+  return [...active, ...inactiveBooked];
 };
 
-/** Offered day counts per customisable daily listing, for the day-count picker. */
-const buildCustomisableDayCounts = (
-  listings: ListingWithCount[],
-): Record<number, number[]> => {
-  const result: Record<number, number[]> = {};
-  for (const listing of listings) {
-    if (listing.customisable_days && listing.listing_type === "daily") {
-      result[listing.id] = availableDayCounts(listing);
-    }
+/** First (earliest) existing booking per listing. A legacy attendee with two
+ * bookings of the same listing binds the row to the earliest; the rest fall out
+ * of the desired set on save, normalising onto the one shared range. */
+const firstExistingByListingId = (
+  existing: ExistingLine[],
+): Map<number, ExistingLine> => {
+  const map = new Map<number, ExistingLine>();
+  for (const e of existing) {
+    if (!map.has(e.booking.listing_id)) map.set(e.booking.listing_id, e);
   }
-  return result;
+  return map;
 };
 
-/** A fresh, empty listing line. The daily date defaults to the attendee's
- * shared start date when the existing daily lines are uniform, otherwise to
- * tomorrow — so a daily row never starts with an empty date. */
-const emptyLine = (
-  todayIso: string,
-  inheritedDate: string | null,
-): AttendeeFormLine => ({
-  date: inheritedDate ?? defaultNewDailyDate(todayIso),
-  dayCount: null,
-  error: null,
-  existingBooking: null,
-  key: "",
-  listing: null,
-  listingId: 0,
-  quantity: 1,
-});
+/** Build one editor line per rendered listing: the existing booking's quantity
+ * and key when present, otherwise the pre-selected quantity (0 = not booked). */
+const buildFormLines = (
+  renderListings: ListingWithCount[],
+  existingByListingId: Map<number, ExistingLine>,
+  preselectedQty: Map<number, number>,
+): AttendeeFormLine[] =>
+  renderListings.map((listing) => {
+    const existing = existingByListingId.get(listing.id);
+    return {
+      error: null,
+      existingBooking: existing?.booking ?? null,
+      key: existing?.key ?? "",
+      listing,
+      listingId: listing.id,
+      quantity: existing
+        ? existing.booking.quantity
+        : (preselectedQty.get(listing.id) ?? 0),
+    };
+  });
 
-/** A blank create-mode form shell carrying the given listing lines and empty
- * contact fields — the shared shape behind both the empty form and the
- * calendar deep-link form. */
-const createFormShell = (lines: AttendeeFormLine[]): ParsedAttendeeForm => ({
-  action: { kind: "save" },
+/** Build a create-mode form: a line per active listing (quantity from any
+ * pre-selection) and the shared start date from the deep link. */
+const buildCreateForm = (
+  renderListings: ListingWithCount[],
+  preselectedQty: Map<number, number>,
+  startDate: string,
+): ParsedAttendeeForm => ({
   address: "",
+  dayCount: 1,
   email: "",
-  lines,
+  lines: buildFormLines(renderListings, new Map(), preselectedQty),
   name: "",
   phone: "",
   remainingBalance: 0,
   returnUrl: "",
   special_instructions: "",
+  startDate,
   statusId: null,
 });
 
-/** Build the empty create-mode form shell: one blank line with the
- * default daily date pre-filled (so the operator sees a concrete date). */
-const buildEmptyCreateForm = (): ParsedAttendeeForm =>
-  createFormShell([emptyLine(todayInTz(settings.timezone), null)]);
-
-/** Build a create-mode line for a listing chosen on the calendar availability
- * checker: daily listings inherit the calendar's selected date, standard
- * listings take none. */
-const prefilledLine = (
-  listing: ListingWithCount,
-  startDate: string,
-  todayIso: string,
-): AttendeeFormLine => ({
-  date:
-    listing.listing_type === "daily"
-      ? isIsoDate(startDate)
-        ? startDate
-        : defaultNewDailyDate(todayIso)
-      : "",
-  dayCount: null,
-  error: null,
-  existingBooking: null,
-  key: "",
-  listing,
-  listingId: listing.id,
-  quantity: 1,
-});
-
-/**
- * Build the create form from a `?select_<id>=1&start_date=…` deep link (the
- * calendar availability checker's "Create Attendee" button). Unknown or
- * inactive listing ids are ignored; with no resolvable selection it falls back
- * to the empty one-line form so a bare `/admin/attendees/new` still works.
- */
-const buildCreateFormFromQuery = (
-  request: Request,
-  listingsById: Map<number, ListingWithCount>,
-): ParsedAttendeeForm => {
-  const params = new URL(request.url).searchParams;
-  const startDate = params.get(START_DATE_FIELD) ?? "";
-  const todayIso = todayInTz(settings.timezone);
-  const resolved = compact(
-    parseSelectedListingIds(params).map((id) => listingsById.get(id)),
-  );
-  const lines = resolved.map((listing) =>
-    prefilledLine(listing, startDate, todayIso),
-  );
-  return lines.length === 0 ? buildEmptyCreateForm() : createFormShell(lines);
-};
-
-/** Build the edit-mode form shell from a loaded attendee + its bookings. */
+/** Build the edit-mode form from a loaded attendee + its bookings, seeding the
+ * shared range from the existing daily bookings. */
 const buildEditFormFromAttendee = (
   attendee: Attendee,
   existing: ExistingLine[],
-  listingsById: Map<number, ListingWithCount>,
-): ParsedAttendeeForm => {
-  const lines: AttendeeFormLine[] = existing.map(({ key, booking }) => {
-    const listing = listingsById.get(booking.listing_id) ?? null;
-    return {
-      date: booking.start_at?.slice(0, 10) ?? "",
-      dayCount: null,
-      error: null,
-      existingBooking: booking,
-      key,
-      listing,
-      listingId: booking.listing_id,
-      quantity: booking.quantity,
-    };
-  });
-  // Always append one blank line so the operator has somewhere to type a new
-  // registration without clicking "Add Listing Line" first. It inherits the
-  // attendee's shared daily date when the existing daily lines are uniform.
-  lines.push(
-    emptyLine(
-      todayInTz(settings.timezone),
-      resolveDailyDefaults(lines).inheritedDate,
-    ),
-  );
+  renderListings: ListingWithCount[],
+): { parsed: ParsedAttendeeForm; hasMixedTimings: boolean } => {
+  const shared = resolveSharedDates(existing.map((e) => e.booking));
   return {
-    action: { kind: "save" },
-    address: attendee.address || "",
-    email: attendee.email || "",
-    lines,
-    name: attendee.name,
-    phone: attendee.phone || "",
-    remainingBalance: attendee.remaining_balance,
-    returnUrl: "",
-    special_instructions: attendee.special_instructions || "",
-    statusId: attendee.status_id,
+    hasMixedTimings: shared.hasMixedTimings,
+    parsed: {
+      address: attendee.address || "",
+      dayCount: shared.dayCount,
+      email: attendee.email || "",
+      lines: buildFormLines(
+        renderListings,
+        firstExistingByListingId(existing),
+        new Map(),
+      ),
+      name: attendee.name,
+      phone: attendee.phone || "",
+      remainingBalance: attendee.remaining_balance,
+      returnUrl: "",
+      special_instructions: attendee.special_instructions || "",
+      startDate: shared.startDate,
+      statusId: attendee.status_id,
+    },
   };
 };
 
-/** How many of an attendee's activity-log entries to show on the edit page.
- * High enough to be "all of them" for any real attendee. */
+/** How many of an attendee's activity-log entries to show on the edit page. */
 const ATTENDEE_LOG_LIMIT = 1000;
 
 /** Build the template data for re-rendering the form. */
@@ -290,22 +201,18 @@ const buildTemplateData = async (
   attendee: Attendee | null,
   opts: {
     attendeeError?: string | null;
+    dateError?: string | null;
     flashError?: string;
     flashSuccess?: string;
+    hasMixedTimings?: boolean;
     returnUrl?: string;
     questions?: QuestionWithAnswers[];
     selectedAnswerIds?: number[];
     emailStats?: EmailStats | null;
   } = {},
 ): Promise<AttendeeFormTemplateData> => {
-  const allListings = await getListingsForSelector(parsed);
-  const holidays = await getActiveHolidays();
-  const availableDatesByListing = buildAvailableDates(allListings, holidays);
-  const customisableByListing = buildCustomisableDayCounts(allListings);
-  const dailyDefaults: DailyDefaults = resolveDailyDefaults(parsed.lines);
   const statuses = await getAllAttendeeStatuses();
-  // Surface a status/balance mismatch. The order totals come from the saved
-  // booking (edit only); in create mode there is nothing paid yet.
+  // The order totals come from the saved booking (edit only); create has none.
   const summary = attendee ? await getAttendeeOrderSummary(attendee.id) : null;
   const balanceNotice = attendeeBalanceNotice(
     statuses.find((s) => s.id === parsed.statusId) ?? null,
@@ -313,24 +220,20 @@ const buildTemplateData = async (
     summary?.fullPrice ?? 0,
     summary?.depositPaid ?? 0,
   );
-  // The read-only summary (detail table + activity log) is edit-only; create
-  // mode has no attendee to summarise yet.
   const activityLog = attendee
     ? await getAttendeeActivityLog(attendee.id, ATTENDEE_LOG_LIMIT)
     : [];
   return {
     activityLog,
-    allListings,
     allowedDomain: getEffectiveDomain(),
     attendee,
     attendeeError: opts.attendeeError ?? null,
-    availableDatesByListing,
     balanceNotice,
-    customisableByListing,
-    dailyDefaults,
+    dateError: opts.dateError ?? null,
     emailStats: opts.emailStats ?? null,
     flashError: opts.flashError,
     flashSuccess: opts.flashSuccess,
+    hasMixedTimings: opts.hasMixedTimings ?? false,
     mode,
     parsed,
     phonePrefix: settings.phonePrefix,
@@ -343,11 +246,7 @@ const buildTemplateData = async (
 };
 
 /** Load custom questions + currently-selected answers across ALL of the
- * attendee's booked listings (edit mode only). Rendering and saving every
- * listing's questions — not just the first — is what keeps the save from wiping
- * answers tied to the attendee's other listings: answers are stored per
- * attendee, so the submitted set must cover every question it can have
- * answered. */
+ * attendee's booked listings (edit mode only). */
 const loadQuestionsForExisting = async (
   attendeeId: number,
   existing: ExistingLine[],
@@ -370,8 +269,7 @@ const renderForm = (
   data: AttendeeFormTemplateData,
 ): Response => htmlResponse(attendeeFormPage(data, session));
 
-/** Render a GET of the form, surfacing any post-save flash (cookie) inside the
- * form so the operator lands on it after the redirect. */
+/** Render a GET of the form, surfacing any post-save flash (cookie). */
 const renderAttendeeFormPage = (
   request: Request,
   data: AttendeeFormTemplateData,
@@ -386,18 +284,25 @@ const renderAttendeeFormPage = (
 };
 
 // ---------------------------------------------------------------------------
-// GET /admin/attendees/new  (and GET /admin/attendees/:id)
+// GET handlers
 // ---------------------------------------------------------------------------
 
-/** Handle GET /admin/attendees/new — render the empty create form. */
+/** Handle GET /admin/attendees/new — render the create form, pre-filled from a
+ * calendar deep link when present. */
 export const handleAttendeeNewGet: TypedRouteHandler<
   "GET /admin/attendees/new"
 > = (request) =>
   requireSessionOr(request, async (session) => {
-    const allListings = await getListingsForSelector(null);
-    const parsed = buildCreateFormFromQuery(
-      request,
-      listingsByIdMap(allListings),
+    const renderListings = await getRenderListings([]);
+    const params = new URL(request.url).searchParams;
+    const preselectedQty = new Map(
+      parseSelectedListingIds(params).map((id) => [id, 1]),
+    );
+    const startParam = params.get(START_DATE_FIELD) ?? "";
+    const parsed = buildCreateForm(
+      renderListings,
+      preselectedQty,
+      isIsoDate(startParam) ? startParam : "",
     );
     const data = await buildTemplateData("create", parsed, null, {
       returnUrl: getSearchParam(request, "return_url"),
@@ -412,12 +317,11 @@ export const handleAttendeeEditGet: TypedRouteHandler<
   requireSessionOr(request, async (session) => {
     const loaded = await loadAttendeeForEdit(session, attendeeId);
     if (!loaded) return notFoundResponse();
-    const allListings = await getListingsForSelector(null);
-    const listingsById = listingsByIdMap(allListings);
-    const parsed = buildEditFormFromAttendee(
+    const renderListings = await getRenderListings(loaded.existing);
+    const { parsed, hasMixedTimings } = buildEditFormFromAttendee(
       loaded.attendee,
       loaded.existing,
-      listingsById,
+      renderListings,
     );
     const { questions, selectedAnswerIds } = await loadQuestionsForExisting(
       attendeeId,
@@ -426,6 +330,7 @@ export const handleAttendeeEditGet: TypedRouteHandler<
     const emailStats = await loadEmailStats(session, loaded.attendee);
     const data = await buildTemplateData("edit", parsed, loaded.attendee, {
       emailStats,
+      hasMixedTimings,
       questions,
       returnUrl: getSearchParam(request, "return_url"),
       selectedAnswerIds,
@@ -433,8 +338,7 @@ export const handleAttendeeEditGet: TypedRouteHandler<
     return renderAttendeeFormPage(request, data, session);
   });
 
-/** Read the attendee's bulk-email contact history (null when no email on
- * file). Reused by the edit page to show the "Email History" section. */
+/** Read the attendee's bulk-email contact history (null when no email). */
 const loadEmailStats = async (
   session: AuthSession,
   attendee: Attendee,
@@ -450,7 +354,6 @@ const loadAttendeeForEdit = async (
   attendeeId: number,
 ): Promise<{ attendee: Attendee; existing: ExistingLine[] } | null> => {
   const pk = await requirePrivateKey(session);
-  // PII-only load; the per-listing lines come from loadExistingLines, so no join.
   const attendee = await getAttendee(attendeeId, pk);
   if (!attendee) return null;
   const existing = await loadExistingLines(attendeeId);
@@ -499,54 +402,7 @@ const loadEditContext = async (
 // POST handlers — shared submit logic
 // ---------------------------------------------------------------------------
 
-/** Apply add-line / remove-line transformations to a parsed form.
- *
- * Both actions are pure form-state edits — nothing is written to the
- * database. Removing an existing line just drops it from the form; the actual
- * `listing_attendees` delete happens when the operator saves (the atomic update
- * diffs it out). That keeps removal part of the one logical "save the whole
- * attendee" submission, so other typed-in changes are never lost to a
- * mid-edit redirect. A newly added line inherits the attendee's shared daily
- * start date when the existing daily lines are uniform.
- *
- * Returns `{ kind: "save" }` when the action was a plain save. */
-const applyLineAction = (
-  parsed: ParsedAttendeeForm,
-  todayIso: string,
-): { kind: "rerender"; parsed: ParsedAttendeeForm } | { kind: "save" } => {
-  const action = parsed.action;
-  if (action.kind === "add_line") {
-    const inherited = resolveDailyDefaults(parsed.lines).inheritedDate;
-    return {
-      kind: "rerender",
-      parsed: {
-        ...parsed,
-        lines: [...parsed.lines, emptyLine(todayIso, inherited)],
-      },
-    };
-  }
-  if (action.kind === "remove_line") {
-    const lines = parsed.lines.filter((_, i) => i !== action.index);
-    return {
-      kind: "rerender",
-      parsed: {
-        ...parsed,
-        lines: lines.length > 0 ? lines : [emptyLine(todayIso, null)],
-      },
-    };
-  }
-  return { kind: "save" };
-};
-
-/** Common submit handler for create + edit. `attendeeId` is null in create
- * mode.
- *
- * This uses `withAuth` directly rather than the `createAuthedFormRoute` factory
- * the simpler admin forms use: a single POST here can mean add-line, remove-line,
- * or save, and the non-save actions must re-render the in-progress form without
- * validating or persisting. That preserve-and-rerender, multi-action flow does
- * not fit the factory's validate→onValid/onInvalid shape, so the control flow
- * lives here explicitly. */
+/** Common submit handler for create + edit. `attendeeId` is null in create. */
 const handleSubmit =
   (mode: "create" | "edit", attendeeId: number | null) =>
   (request: Request): Promise<Response> =>
@@ -554,8 +410,7 @@ const handleSubmit =
       handleSubmitInner(mode, attendeeId, session, form),
     );
 
-/** Inner submit logic — extracted so the create/edit wrappers can pass
- * their own identity without conditionals in the hot path. */
+/** Inner submit logic — parse, validate, then run the atomic create or edit. */
 const handleSubmitInner = async (
   mode: "create" | "edit",
   attendeeId: number | null,
@@ -564,7 +419,6 @@ const handleSubmitInner = async (
 ): Promise<Response> => {
   applyDemoOverrides(form, ATTENDEE_DEMO_FIELDS);
 
-  // Load attendee + existing lines + question context (edit mode only).
   const edit =
     mode === "edit" && attendeeId !== null
       ? await loadEditContext(session, attendeeId)
@@ -572,11 +426,9 @@ const handleSubmitInner = async (
   if (edit === null) return notFoundResponse();
   const { attendee, existingByKey, questions, selectedAnswerIds } = edit;
 
-  const allListings = await getAllListings();
-  const listingsById = listingsByIdMap(allListings);
-  // Coerce a missing/blank status (only reachable from a hand-crafted POST,
-  // since the form offers no "no status" choice) back to the public default
-  // rather than clearing it — the same resolver the template pre-selects with.
+  const listingsById = listingsByIdMap(await getAllListings());
+  // Coerce a missing/blank status back to the public default (the form offers
+  // no "no status" choice) — the same resolver the template pre-selects with.
   const statuses = await getAllAttendeeStatuses();
   const rawParsed = parseAttendeeForm(form, listingsById, existingByKey);
   const parsed: ParsedAttendeeForm = {
@@ -589,26 +441,7 @@ const handleSubmitInner = async (
     selectedAnswerIds,
   };
 
-  // Step 1: line-action re-render (no save).
-  const todayIso = todayInTz(settings.timezone);
-  const lineAction = applyLineAction(parsed, todayIso);
-  if (lineAction.kind === "rerender") {
-    return renderForm(
-      session,
-      await buildTemplateData(mode, lineAction.parsed, attendee, renderOpts),
-    );
-  }
-
-  // Step 2: trim trailing blank lines so save validation doesn't fail on
-  // the placeholder row.
-  const trimmed: ParsedAttendeeForm = {
-    ...parsed,
-    lines: trimTrailingBlankLines(parsed.lines),
-  };
-
-  // Step 3: validate attendee + every line.
-  const holidays = await getActiveHolidays();
-  const result = validateParsedForm(trimmed, holidays);
+  const result = validateParsedForm(parsed);
   const dataForRerender = await buildTemplateData(
     mode,
     result.values,
@@ -616,13 +449,15 @@ const handleSubmitInner = async (
     renderOpts,
   );
   if (!result.valid) {
-    const attendeeError = result.attendeeError?.message ?? null;
-    return renderForm(session, { ...dataForRerender, attendeeError });
+    return renderForm(session, {
+      ...dataForRerender,
+      attendeeError: result.attendeeError?.message ?? null,
+      dateError: result.dateError,
+    });
   }
 
-  // Step 4: apply atomic create or edit. On a recoverable failure (capacity,
-  // encryption, no lines) re-render the submitted form in place so the
-  // operator never loses entered data, marking the failing line where known.
+  // Apply atomic create or edit. On a recoverable failure (capacity, no lines)
+  // re-render the submitted form in place so entered data is never lost.
   const outcome =
     mode === "create"
       ? await applyCreate(parsed)
@@ -631,43 +466,34 @@ const handleSubmitInner = async (
           parsed,
           attendee!,
           questions,
-          // Admin edit treats answers as optional — keep only the valid ones.
           parseQuestionAnswers({ optional: true })(form, questions).answerIds,
         );
   if (outcome.ok) return outcome.response;
-  // In-place re-render (no redirect): show the failure inside the form, the
-  // same place a saved success lands, while preserving the entered data.
   return renderForm(session, {
     ...dataForRerender,
     flashError: outcome.flashError,
   });
 };
 
-/** Outcome of an atomic create/edit attempt. A recoverable failure carries
- * the flash to show; the submit handler re-renders the submitted form in
- * place so no entered data is lost. */
+/** Outcome of an atomic create/edit attempt. */
 type SaveOutcome =
   | { ok: true; response: Response }
   | { ok: false; flashError: string };
 
-/** Shown when a submission has no usable listing lines. */
-const NO_LINES_ERROR = "Add at least one listing line before saving";
+/** Shown when a submission has no booked listing. */
+const NO_LINES_ERROR = "Book at least one listing before saving";
 
-/** Shown when capacity can't fit the submitted lines. One wording for both the
- * create and edit paths so the operator never sees two phrasings of the same
- * failure. */
+/** Shown when capacity can't fit the submitted lines. */
 const CAPACITY_SAVE_ERROR =
-  "Not enough spots available for one or more selected listings — nothing was saved. Please review your listing lines and try again.";
+  "Not enough spots available for one or more selected listings — nothing was saved. Please review the quantities and try again.";
 
-/** The edit page for an attendee, carrying the return_url through so the
- * "Back without saving" link still works after a save. */
+/** The edit page for an attendee, carrying the return_url through. */
 const attendeePath = (id: number, returnUrl: string): string =>
   returnUrl
     ? `/admin/attendees/${id}?return_url=${encodeURIComponent(returnUrl)}`
     : `/admin/attendees/${id}`;
 
-/** Redirect back to the saved attendee's own form, scrolling to it via the
- * `#attendee-form` anchor; the flash cookie then shows the success inside it. */
+/** Redirect back to the saved attendee's own form, scrolling to it. */
 const savedRedirect = (
   id: number,
   returnUrl: string,
@@ -675,9 +501,7 @@ const savedRedirect = (
 ): Response =>
   redirect(`${attendeePath(id, returnUrl)}#${ATTENDEE_FORM_ID}`, message, true);
 
-/** Run the atomic create flow. All-or-nothing: `ensureAllBookings` rolls the
- * attendee back unless every submitted line fits, so a partial booking never
- * shows a misleading success. */
+/** Run the atomic create flow. All-or-nothing via `ensureAllBookings`. */
 const applyCreate = async (
   parsed: ParsedAttendeeForm,
 ): Promise<SaveOutcome> => {
@@ -690,14 +514,10 @@ const applyCreate = async (
   if (!check.ok) {
     return { flashError: CAPACITY_SAVE_ERROR, ok: false };
   }
-  // ensureAllBookings guarantees full success past the ok check.
   const { attendees } = createResult as Extract<
     CreateAttendeeResult,
     { success: true }
   >;
-
-  // input.bookings is non-empty (guarded above) and every booking comes from a
-  // fillable line, so its listing id is always present — no re-scan needed.
   const firstListingId = input.bookings[0]!.listingId;
   const newId = attendees[0]!.id;
   await logActivity(
@@ -705,7 +525,6 @@ const applyCreate = async (
     firstListingId,
     newId,
   );
-
   return {
     ok: true,
     response: savedRedirect(newId, parsed.returnUrl, `Added ${parsed.name}`),
@@ -720,9 +539,6 @@ const applyEdit = async (
   questions: QuestionWithAnswers[],
   answerIds: number[],
 ): Promise<SaveOutcome> => {
-  // Re-encrypt the PII blob with the (possibly) updated fields and pass it as
-  // one statement of the atomic batch. Encryption can't realistically fail
-  // (it would mean the whole app is broken), so we don't branch on it.
   const encryptedPiiBlob = (await encryptPiiBlob(
     buildPiiBlob({
       address: parsed.address,
@@ -749,15 +565,12 @@ const applyEdit = async (
     return { flashError: CAPACITY_SAVE_ERROR, ok: false };
   }
 
-  // Status + outstanding balance are plaintext, operator-editable columns;
-  // persist them once the line/PII edit has committed.
   await updateAttendeeOrder(
     attendeeId,
     parsed.statusId,
     parsed.remainingBalance,
   );
 
-  // Save question answers (atomic delete + insert) when the listing has any.
   if (questions.length > 0) {
     await saveAttendeeAnswers(new Map([[attendeeId, answerIds]]));
   }

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -13,7 +13,7 @@
  * `?select_<id>=1&start_date=…` to pre-fill the chosen listings and date.
  */
 
-import { filter, unique } from "#fp";
+import { compact, filter, unique } from "#fp";
 import { requirePrivateKey } from "#routes/admin/actions.ts";
 import {
   ATTENDEE_FORM_ID,
@@ -48,6 +48,7 @@ import {
   applyAttendeeAtomicEdit,
   buildPiiBlob,
   type CreateAttendeeResult,
+  checkLineCapacity,
   createAttendeeAtomic,
   type ExistingLine,
   encryptPiiBlob,
@@ -195,26 +196,65 @@ const buildEditFormFromAttendee = (
 /** How many of an attendee's activity-log entries to show on the edit page. */
 const ATTENDEE_LOG_LIMIT = 1000;
 
-/**
- * Over-duration warnings for the booked lines: a daily listing is designed for
- * a fixed number of days, but every daily listing shares one range, so a longer
- * range than a listing allows is permitted — with a warning, not an error.
- */
-const computeWarnings = (
+/** A booked daily listing booked for longer than its own duration allows —
+ * permitted (every daily listing shares one range), so a warning not an error. */
+const overDurationWarning = (
+  line: AttendeeFormLine,
+  dayCount: number,
+): string | null => {
+  const listing = line.listing!;
+  if (listing.listing_type !== "daily" || dayCount <= listing.duration_days) {
+    return null;
+  }
+  const max = listing.duration_days;
+  return `${listing.name} is designed for up to ${max} day${max === 1 ? "" : "s"}, but the booking spans ${dayCount}.`;
+};
+
+/** A booked line whose quantity exceeds capacity, judged with the same
+ * self-excluding check the save uses. A daily line with no valid shared date is
+ * already blocked by the date error, so it is skipped here. */
+const overbookWarning = async (
+  line: AttendeeFormLine,
   parsed: ParsedAttendeeForm,
-): { byListing: Map<number, string[]>; top: string[] } => {
+  excludeAttendeeId: number | undefined,
+): Promise<string | null> => {
+  const listing = line.listing!;
+  const isDaily = listing.listing_type === "daily";
+  const date = isDaily && isIsoDate(parsed.startDate) ? parsed.startDate : null;
+  if (isDaily && !date) return null;
+  const fits = await checkLineCapacity(
+    {
+      date,
+      durationDays: isDaily ? parsed.dayCount : 1,
+      listingId: listing.id,
+      quantity: line.quantity!,
+    },
+    excludeAttendeeId,
+  );
+  return fits
+    ? null
+    : `${listing.name} is overbooked — there isn't capacity for ${line.quantity} on these dates.`;
+};
+
+/**
+ * Over-duration + overbooking warnings for every booked line, keyed by listing
+ * id plus a flat list for the top-of-page summary. Both are allowed for admin
+ * saves, so they surface as warnings, not errors.
+ */
+const computeWarnings = async (
+  parsed: ParsedAttendeeForm,
+  excludeAttendeeId: number | undefined,
+): Promise<{ byListing: Map<number, string[]>; top: string[] }> => {
   const byListing = new Map<number, string[]>();
   const top: string[] = [];
   for (const line of parsed.lines.filter(isBookedLine)) {
-    const listing = line.listing!;
-    if (
-      listing.listing_type === "daily" &&
-      parsed.dayCount > listing.duration_days
-    ) {
-      const max = listing.duration_days;
-      const msg = `${listing.name} is designed for up to ${max} day${max === 1 ? "" : "s"}, but the booking spans ${parsed.dayCount}.`;
-      byListing.set(listing.id, [msg]);
-      top.push(msg);
+    const warns = compact([
+      overDurationWarning(line, parsed.dayCount),
+      await overbookWarning(line, parsed, excludeAttendeeId),
+    ]);
+    if (warns.length > 0) {
+      byListing.set(line.listingId, warns);
+      top.push(...warns);
     }
   }
   return { byListing, top };
@@ -249,7 +289,7 @@ const buildTemplateData = async (
   const activityLog = attendee
     ? await getAttendeeActivityLog(attendee.id, ATTENDEE_LOG_LIMIT)
     : [];
-  const warnings = computeWarnings(parsed);
+  const warnings = await computeWarnings(parsed, attendee?.id);
   return {
     activityLog,
     allowedDomain: getEffectiveDomain(),
@@ -538,7 +578,11 @@ const applyCreate = async (
   if (input.bookings.length === 0) {
     return { flashError: NO_LINES_ERROR, ok: false };
   }
-  const createResult = await createAttendeeAtomic(input);
+  // Admin manual add may deliberately overbook (a warning is shown, not blocked).
+  const createResult = await createAttendeeAtomic({
+    ...input,
+    allowOverbook: true,
+  });
   const check = await ensureAllBookings(createResult, input.bookings.length);
   if (!check.ok) {
     return { flashError: CAPACITY_SAVE_ERROR, ok: false };
@@ -582,10 +626,12 @@ const applyEdit = async (
   ))!;
 
   const desired = toDesiredLines(parsed);
+  // Admin manual edit may deliberately overbook (warned, not blocked).
   const editResult = await applyAttendeeAtomicEdit(
     attendeeId,
     encryptedPiiBlob,
     desired,
+    true,
   );
   if (!editResult.success) {
     if (editResult.reason === "no_lines") {

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -48,7 +48,7 @@ import {
   applyAttendeeAtomicEdit,
   buildPiiBlob,
   type CreateAttendeeResult,
-  checkLineCapacity,
+  checkLinesCapacity,
   createAttendeeAtomic,
   type ExistingLine,
   encryptPiiBlob,
@@ -210,47 +210,67 @@ const overDurationWarning = (
   return `${listing.name} is designed for up to ${max} day${max === 1 ? "" : "s"}, but the booking spans ${dayCount}.`;
 };
 
-/** A booked line whose quantity exceeds capacity, judged with the same
- * self-excluding check the save uses. A daily line with no valid shared date is
- * already blocked by the date error, so it is skipped here. */
-const overbookWarning = async (
-  line: AttendeeFormLine,
+/** The capacity-check booking shape for a booked line on the shared range
+ * (daily) or no date (standard). */
+const lineBookingFor = (line: AttendeeFormLine, parsed: ParsedAttendeeForm) => {
+  const isDaily = line.listing!.listing_type === "daily";
+  return {
+    date: isDaily ? parsed.startDate : null,
+    durationDays: isDaily ? parsed.dayCount : 1,
+    listingId: line.listingId,
+    quantity: line.quantity!,
+  };
+};
+
+/** The set of booked listing ids that overbook capacity, judged with one
+ * batched self-excluding check (the same one the save uses). A daily line with
+ * no valid shared date is skipped — the date error already blocks saving. */
+const overbookedListingIds = async (
+  booked: AttendeeFormLine[],
   parsed: ParsedAttendeeForm,
   excludeAttendeeId: number | undefined,
-): Promise<string | null> => {
-  const listing = line.listing!;
-  const isDaily = listing.listing_type === "daily";
-  const date = isDaily && isIsoDate(parsed.startDate) ? parsed.startDate : null;
-  if (isDaily && !date) return null;
-  const fits = await checkLineCapacity(
-    {
-      date,
-      durationDays: isDaily ? parsed.dayCount : 1,
-      listingId: listing.id,
-      quantity: line.quantity!,
-    },
+): Promise<Set<number>> => {
+  const checkable = booked.filter(
+    (line) =>
+      line.listing!.listing_type !== "daily" || isIsoDate(parsed.startDate),
+  );
+  const fits = await checkLinesCapacity(
+    checkable.map((line) => lineBookingFor(line, parsed)),
     excludeAttendeeId,
   );
-  return fits
-    ? null
-    : `${listing.name} is overbooked — there isn't capacity for ${line.quantity} on these dates.`;
+  const overbooked = new Set<number>();
+  checkable.forEach((line, i) => {
+    if (!fits[i]) overbooked.add(line.listingId);
+  });
+  return overbooked;
 };
+
+/** Overbooking message for a booked line. */
+const overbookMessage = (line: AttendeeFormLine): string =>
+  `${line.listing!.name} is overbooked — there isn't capacity for ${line.quantity} on these dates.`;
 
 /**
  * Over-duration + overbooking warnings for every booked line, keyed by listing
  * id plus a flat list for the top-of-page summary. Both are allowed for admin
- * saves, so they surface as warnings, not errors.
+ * saves, so they surface as warnings, not errors. The capacity side is one
+ * batched query for the whole form, not one per line.
  */
 const computeWarnings = async (
   parsed: ParsedAttendeeForm,
   excludeAttendeeId: number | undefined,
 ): Promise<{ byListing: Map<number, string[]>; top: string[] }> => {
+  const booked = parsed.lines.filter(isBookedLine);
+  const overbooked = await overbookedListingIds(
+    booked,
+    parsed,
+    excludeAttendeeId,
+  );
   const byListing = new Map<number, string[]>();
   const top: string[] = [];
-  for (const line of parsed.lines.filter(isBookedLine)) {
+  for (const line of booked) {
     const warns = compact([
       overDurationWarning(line, parsed.dayCount),
-      await overbookWarning(line, parsed, excludeAttendeeId),
+      overbooked.has(line.listingId) ? overbookMessage(line) : null,
     ]);
     if (warns.length > 0) {
       byListing.set(line.listingId, warns);

--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -19,7 +19,10 @@ import {
   listingDateToCalendarDate,
 } from "#shared/dates.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
-import { decryptAttendees } from "#shared/db/attendees.ts";
+import {
+  decryptAttendees,
+  getListingRemainingForRange,
+} from "#shared/db/attendees.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import {
   getAllDailyListings,
@@ -36,6 +39,7 @@ import {
   isPaidListing,
   type ListingWithCount,
 } from "#shared/types.ts";
+import type { AvailabilityRow } from "#templates/admin/availability-checker.tsx";
 import {
   adminCalendarPage,
   type CalendarAttendeeRow,
@@ -177,6 +181,27 @@ const loadStandardListingAttendees = async (
   return decryptAttendees(rawStandardAttendees, privateKey);
 };
 
+/** Build availability-checker rows: every active listing with its remaining
+ * capacity for the selected date (or overall, when no date is selected). */
+const buildAvailabilityRows = async (
+  listings: ListingWithCount[],
+  dateFilter: string | null,
+): Promise<AvailabilityRow[]> => {
+  const bookable = filter((l: ListingWithCount) => l.active)(listings);
+  const remaining = await getListingRemainingForRange(bookable, dateFilter, 1);
+  return map(
+    (l: ListingWithCount): AvailabilityRow => ({
+      canPayMore: l.can_pay_more,
+      id: l.id,
+      name: l.name,
+      // getListingRemainingForRange returns an entry for every listing passed.
+      remaining: remaining.get(l.id)!,
+      total: l.max_attendees,
+      unitPrice: l.unit_price,
+    }),
+  )(bookable);
+};
+
 /**
  * Handle GET /admin/calendar
  */
@@ -229,6 +254,10 @@ const handleAdminCalendarGet = (request: Request) =>
     );
 
     const hasPaidListing = allListings.some(isPaidListing);
+    const availabilityRows = await buildAvailabilityRows(
+      allListings,
+      dateFilter,
+    );
 
     return htmlResponse(
       adminCalendarPage(
@@ -242,6 +271,7 @@ const handleAdminCalendarGet = (request: Request) =>
         settings.phonePrefix,
         questionData,
         hasPaidListing,
+        availabilityRows,
       ),
     );
   });

--- a/src/features/public/order.ts
+++ b/src/features/public/order.ts
@@ -22,6 +22,7 @@ import {
 } from "#routes/response.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import { settings } from "#shared/db/settings.ts";
+import { SELECT_PREFIX } from "#shared/order-select.ts";
 import { loadSortedListings } from "#shared/sort-listings.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { orderGalleryPage } from "#templates/public.tsx";
@@ -72,7 +73,9 @@ const handleOrder = async (request: Request): Promise<Response> => {
 
   const listings = await loadOrderListings();
   const params = new URL(request.url).searchParams;
-  const selected = listings.filter((e) => params.get(`select_${e.id}`) === "1");
+  const selected = listings.filter(
+    (e) => params.get(`${SELECT_PREFIX}${e.id}`) === "1",
+  );
   if (selected.length > 0) {
     return redirectResponse(await bookingUrlFor(selected));
   }

--- a/src/features/public/ticket-payment.ts
+++ b/src/features/public/ticket-payment.ts
@@ -13,7 +13,10 @@ import { isPaymentsEnabled } from "#shared/config.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import { getBookableStartDates, isBookingRangeValid } from "#shared/dates.ts";
 import { getPublicStatusId } from "#shared/db/attendee-statuses.ts";
-import type { CreateAttendeeResult } from "#shared/db/attendee-types.ts";
+import type {
+  CreateAttendeeResult,
+  LineBooking,
+} from "#shared/db/attendee-types.ts";
 import {
   checkBatchAvailability,
   createAttendeeAtomic,
@@ -220,12 +223,7 @@ const buildBookings = (
   selected: ListingQty[],
   date: string | null,
   dayCount = 1,
-): {
-  listingId: number;
-  quantity: number;
-  date: string | null;
-  durationDays: number;
-}[] =>
+): LineBooking[] =>
   selected.map(({ listing, qty }) => ({
     listingId: listing.id,
     quantity: qty,

--- a/src/shared/db/attendee-types.ts
+++ b/src/shared/db/attendee-types.ts
@@ -56,6 +56,15 @@ export type ListingBooking = {
   durationDays?: number;
 };
 
+/** A concrete booking line — every field resolved (unlike the optional-field
+ * `ListingBooking` cart input). Used by capacity checks and the booking builder. */
+export type LineBooking = {
+  listingId: number;
+  quantity: number;
+  date: string | null;
+  durationDays: number;
+};
+
 /** Input for creating an attendee atomically (one or more listings) */
 export type AttendeeInput = ContactFields & {
   paymentId?: string;

--- a/src/shared/db/attendee-types.ts
+++ b/src/shared/db/attendee-types.ts
@@ -64,6 +64,10 @@ export type AttendeeInput = ContactFields & {
   remainingBalance?: number;
   /** Owner-defined status id assigned to the new attendee. */
   statusId?: number | null;
+  /** When true the per-booking capacity guard is dropped so the bookings are
+   * inserted unconditionally. Admin manual add only — public/webhook callers
+   * leave it false so capacity is always enforced. */
+  allowOverbook?: boolean;
 };
 
 /** Row from listing_attendees — per-listing booking data */

--- a/src/shared/db/attendees.ts
+++ b/src/shared/db/attendees.ts
@@ -40,7 +40,7 @@ export {
   type UpdateAttendeeAtomicResult,
 } from "#shared/db/attendees/atomic-update.ts";
 export {
-  checkLineCapacity,
+  checkLinesCapacity,
   getGroupRemainingByGroupId,
   getGroupRemainingByListingId,
   getGroupRemainingForListing,

--- a/src/shared/db/attendees.ts
+++ b/src/shared/db/attendees.ts
@@ -40,6 +40,7 @@ export {
   type UpdateAttendeeAtomicResult,
 } from "#shared/db/attendees/atomic-update.ts";
 export {
+  checkLineCapacity,
   getGroupRemainingByGroupId,
   getGroupRemainingByListingId,
   getGroupRemainingForListing,

--- a/src/shared/db/attendees.ts
+++ b/src/shared/db/attendees.ts
@@ -43,6 +43,8 @@ export {
   getGroupRemainingByGroupId,
   getGroupRemainingByListingId,
   getGroupRemainingForListing,
+  getListingRemainingForRange,
+  type ListingCapacityRow,
 } from "#shared/db/attendees/capacity.ts";
 export {
   buildAttendeeInsert,

--- a/src/shared/db/attendees/atomic-update.ts
+++ b/src/shared/db/attendees/atomic-update.ts
@@ -35,14 +35,11 @@ import type {
 import { hasDuplicateBookingSlot } from "#shared/db/attendees/booking-slot.ts";
 import {
   buildCapacityCheckedInsert,
+  checkLineCapacity,
   dateToStartEnd,
 } from "#shared/db/attendees/capacity.ts";
 import { buildCapacityCondition } from "#shared/db/capacity.ts";
-import {
-  executeBatchWithResults,
-  queryAll,
-  queryOne,
-} from "#shared/db/client.ts";
+import { executeBatchWithResults, queryAll } from "#shared/db/client.ts";
 import { invalidateListingsCache } from "#shared/db/listings.ts";
 
 /**
@@ -74,6 +71,15 @@ const lineCapacityCondition = (line: AtomicDesiredLine, attendeeId: number) =>
     attendeeId,
     line.durationDays,
   );
+
+/** The booking shape `checkLineCapacity` and `buildCapacityCheckedInsert`
+ * expect, projected from a desired line. */
+const lineBooking = (line: AtomicDesiredLine) => ({
+  date: line.date,
+  durationDays: line.durationDays,
+  listingId: line.listingId,
+  quantity: line.quantity,
+});
 
 /** Result of an atomic attendee update. */
 export type UpdateAttendeeAtomicResult =
@@ -121,13 +127,7 @@ const allLinesFit = async (
   desired: AtomicDesiredLine[],
 ): Promise<boolean> => {
   for (const line of desired) {
-    const condition = lineCapacityCondition(line, attendeeId);
-    // A bare `SELECT <expr>` always yields exactly one row.
-    const row = (await queryOne<{ ok: number }>(
-      `SELECT (${condition.sql}) AS ok`,
-      condition.args,
-    ))!;
-    if (row.ok === 0) return false;
+    if (!(await checkLineCapacity(lineBooking(line), attendeeId))) return false;
   }
   return true;
 };
@@ -144,6 +144,7 @@ export const applyAttendeeAtomicEdit = async (
   attendeeId: number,
   encryptedPiiBlob: string,
   desired: AtomicDesiredLine[],
+  allowOverbook = false,
 ): Promise<UpdateAttendeeAtomicResult> => {
   if (desired.length === 0) {
     return { reason: "no_lines", success: false };
@@ -158,8 +159,9 @@ export const applyAttendeeAtomicEdit = async (
   // Preflight: reject (without writing anything) when any line can't fit. The
   // common over-capacity case never touches the DB; the per-line CAPACITY_GUARD
   // in the batch below still rolls the whole edit back if a concurrent booking
-  // wins the race between this check and the commit.
-  if (!(await allLinesFit(attendeeId, desired))) {
+  // wins the race between this check and the commit. Skipped entirely when the
+  // caller has opted into overbooking (admin manual edit).
+  if (!allowOverbook && !(await allLinesFit(attendeeId, desired))) {
     return { reason: "capacity_exceeded", success: false };
   }
 
@@ -194,45 +196,42 @@ export const applyAttendeeAtomicEdit = async (
     });
   }
 
-  // Step 3: Update existing lines (capacity-checked, self-excluding). The
-  // WHERE pins the row by its *old* start_at so an attendee holding two
-  // rows for the same daily listing on different dates updates only the one.
+  // Step 3: Update existing lines. The WHERE pins the row by its *old* start_at
+  // so an attendee holding two rows for the same daily listing on different
+  // dates updates only the one. Capacity-checked + guarded unless the caller
+  // opted into overbooking, in which case the update is unconditional.
   for (const line of updates) {
     const oldStartAt = existingByKey.get(line.key)?.start_at ?? null;
     const { startAt, endAt } = dateToStartEnd(line.date, line.durationDays);
+    const pin = [attendeeId, line.listingId, oldStartAt];
+    const setClause = `UPDATE listing_attendees SET quantity = ?, start_at = ?, end_at = ?
+            WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?`;
+    if (allowOverbook) {
+      statements.push({
+        args: [line.quantity, startAt, endAt, ...pin],
+        sql: setClause,
+      });
+      continue;
+    }
     const condition = lineCapacityCondition(line, attendeeId);
     statements.push({
-      args: [
-        line.quantity,
-        startAt,
-        endAt,
-        attendeeId,
-        line.listingId,
-        oldStartAt,
-        ...condition.args,
-      ],
-      sql: `UPDATE listing_attendees SET quantity = ?, start_at = ?, end_at = ?
-            WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?
-              AND ${condition.sql}`,
+      args: [line.quantity, startAt, endAt, ...pin, ...condition.args],
+      sql: `${setClause}\n              AND ${condition.sql}`,
     });
     statements.push(CAPACITY_GUARD);
   }
 
-  // Step 4: Insert new lines (capacity-checked, self-excluding).
+  // Step 4: Insert new lines (capacity-checked + guarded unless overbooking).
   for (const line of inserts) {
     statements.push(
       buildCapacityCheckedInsert(
-        {
-          date: line.date,
-          durationDays: line.durationDays,
-          listingId: line.listingId,
-          quantity: line.quantity,
-        },
+        lineBooking(line),
         "?",
         attendeeId,
+        allowOverbook,
       ),
     );
-    statements.push(CAPACITY_GUARD);
+    if (!allowOverbook) statements.push(CAPACITY_GUARD);
   }
 
   // The batch runs as one ACID transaction. After the preflight above this

--- a/src/shared/db/attendees/atomic-update.ts
+++ b/src/shared/db/attendees/atomic-update.ts
@@ -35,7 +35,7 @@ import type {
 import { hasDuplicateBookingSlot } from "#shared/db/attendees/booking-slot.ts";
 import {
   buildCapacityCheckedInsert,
-  checkLineCapacity,
+  checkLinesCapacity,
   dateToStartEnd,
 } from "#shared/db/attendees/capacity.ts";
 import { buildCapacityCondition } from "#shared/db/capacity.ts";
@@ -126,10 +126,8 @@ const allLinesFit = async (
   attendeeId: number,
   desired: AtomicDesiredLine[],
 ): Promise<boolean> => {
-  for (const line of desired) {
-    if (!(await checkLineCapacity(lineBooking(line), attendeeId))) return false;
-  }
-  return true;
+  const fits = await checkLinesCapacity(desired.map(lineBooking), attendeeId);
+  return fits.every((ok) => ok);
 };
 
 /**

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -157,8 +157,7 @@ export const buildCapacityCheckedInsert = (
 };
 
 // ---------------------------------------------------------------------------
-// Per-day preflight helpers used by hasAvailableSpots. They mirror the per-day
-// SQL safety net but in JS so we can self-exclude an attendee row cleanly.
+// Per-day load helpers for the remaining-capacity lookup and batch preflight.
 //
 // Per-day loads are computed by fetching every row overlapping the whole
 // booking span ONCE and summing per-day in JS — one round trip instead of
@@ -213,94 +212,15 @@ const perDayLoads = (
     ])(days),
   );
 
-/** Fetch all of an listing's rows overlapping the span of `days` — one query
- * regardless of how many days the booking covers. */
-const getOverlappingRows = (
-  listingId: number,
-  days: string[],
-): Promise<IntervalRow[]> => {
-  const { startAt, endAt } = daySpan(days);
-  return queryAll<IntervalRow>(
-    `SELECT start_at, end_at, quantity FROM listing_attendees
-     WHERE listing_id = ? AND start_at < ? AND end_at > ?`,
-    [listingId, endAt, startAt],
-  );
-};
-
-/** A group's cap plus its load split into rows that count on every day
- * (non-daily listings) and per-day interval rows (daily bookings). */
-type GroupSpanLoad = { cap: number; base: number; rows: IntervalRow[] };
-
-/**
- * Group cap + occupancy rows for the span of `days` — two queries
- * regardless of duration. Returns null when the group has no cap, matching
- * `getGroupRemainingByGroupId` omitting uncapped groups from its map.
- */
-const getGroupSpanLoad = async (
-  groupId: number,
-  days: string[],
-): Promise<GroupSpanLoad | null> => {
-  const cap = (await queryOne<{ cap: number }>(
-    "SELECT COALESCE((SELECT max_attendees FROM groups WHERE id = ?), 0) as cap",
-    [groupId],
-  ))!.cap;
-  if (cap <= 0) return null;
-  const { startAt, endAt } = daySpan(days);
-  const groupRows = await queryAll<IntervalRow & { listing_type: ListingType }>(
-    `SELECT ea.start_at, ea.end_at, ea.quantity, e.listing_type
-     FROM listing_attendees ea
-     JOIN listings e ON e.id = ea.listing_id
-     WHERE e.group_id = ? AND (e.listing_type != 'daily' OR (ea.start_at < ? AND ea.end_at > ?))`,
-    [groupId, endAt, startAt],
-  );
-  const isDailyRow = (
-    row: IntervalRow & { listing_type: ListingType },
-  ): boolean => row.listing_type === "daily";
-  return {
-    base: pipe(
-      filter(
-        (row: IntervalRow & { listing_type: ListingType }) => !isDailyRow(row),
-      ),
-      sumQuantity,
-    )(groupRows),
-    cap,
-    rows: filter(isDailyRow)(groupRows),
-  };
-};
-
-/** Per-day group remaining for `days`, or null when no cap applies.
- * remaining(day) = max(0, cap - (base + dailyLoad(day))) — identical to
- * `getGroupRemainingByGroupId` evaluated for each day, in two queries. */
-const getGroupRemainingPerDay = async (
-  groupId: number,
-  days: string[],
-): Promise<Map<string, number> | null> => {
-  const group = await getGroupSpanLoad(groupId, days);
-  if (!group) return null;
-  const loads = perDayLoads(group.rows, days);
-  return new Map(
-    map((day: string): [string, number] => [
-      day,
-      Math.max(0, group.cap - group.base - loads.get(day)!),
-    ])(days),
-  );
-};
-
-/** Date-less remaining capacity for a listing's group, or `undefined` when no
- * cap applies (ungrouped or uncapped group). Shared by the boolean preflight
- * and the count lookup so both read the group cap the same way. */
-const groupRemainingTotal = async (
-  groupId: number,
-): Promise<number | undefined> =>
-  (await getGroupRemainingByGroupId([groupId], null)).get(groupId);
-
 /**
  * Per-day availability check for a single-listing booking. Used by
- * `hasAvailableSpots` (public availability API) and as the preflight in
- * `checkBatchAvailability` (public booking flow).
+ * `hasAvailableSpots` (public availability API).
  *
- * Does NOT self-exclude — admin edit paths skip this preflight and rely on
- * the atomic SQL guard (which does self-exclude via `buildCapacityCondition`).
+ * The capacity rules — per-day for daily listings, cumulative total for
+ * standard/date-less, plus group caps — live entirely in
+ * `buildCapacityCondition`, the same SQL the atomic write uses, so the whole
+ * check is one query (the listing lookup is a cache hit on the booking paths).
+ * Does NOT self-exclude — admin edit paths rely on the atomic SQL guard instead.
  */
 export const checkListingAvailability = async (
   listingId: number,
@@ -310,22 +230,14 @@ export const checkListingAvailability = async (
 ): Promise<boolean> => {
   const listing = await getListingWithCount(listingId);
   if (!listing) return false;
-
-  if (listing.listing_type !== "daily" || !date) {
-    if (listing.attendee_count + quantity > listing.max_attendees) return false;
-    if (listing.group_id <= 0) return true;
-    const remaining = await groupRemainingTotal(listing.group_id);
-    return remaining === undefined || quantity <= remaining;
-  }
-
-  const days = expandDailyRange(date, durationDays);
-  const loads = perDayLoads(await getOverlappingRows(listingId, days), days);
-  if (!days.every((day) => loads.get(day)! + quantity <= listing.max_attendees))
-    return false;
-  if (listing.group_id <= 0) return true;
-  const remaining = await getGroupRemainingPerDay(listing.group_id, days);
-  if (!remaining) return true;
-  return days.every((day) => quantity <= remaining.get(day)!);
+  // A standard listing's rows carry no booking range, so they'd never match a
+  // date overlap — pass null to count them all as a cumulative total instead.
+  const checkDate = listing.listing_type === "daily" ? (date ?? null) : null;
+  return (
+    await checkLinesCapacity([
+      { date: checkDate, durationDays, listingId, quantity },
+    ])
+  )[0]!;
 };
 
 type ListingRow = {

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -9,10 +9,11 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { filter, map, mapParallel, pipe, reduce, unique } from "#fp";
+import { filter, map, pipe, reduce, unique } from "#fp";
 import { addDays } from "#shared/dates.ts";
 import type {
   BatchAvailabilityItem,
+  LineBooking,
   ListingBooking,
 } from "#shared/db/attendee-types.ts";
 import {
@@ -36,6 +37,10 @@ export const dateToStartEnd = (
 
 type RemainingMap = Map<number, number>;
 
+/** Distinct group ids worth a cap lookup — positive only (0 = ungrouped). */
+const uniquePositiveGroupIds = (groupIds: number[]): number[] =>
+  unique(groupIds.filter((id) => id > 0));
+
 /**
  * Per-group remaining capacity. Groups with `max_attendees <= 0` (no cap)
  * are omitted from the map. With `date = null`, daily-listing attendees count
@@ -49,7 +54,7 @@ export const getGroupRemainingByGroupId = async (
   groupIds: number[],
   date: string | null = null,
 ): Promise<RemainingMap> => {
-  const ids = unique(groupIds.filter((id) => id > 0));
+  const ids = uniquePositiveGroupIds(groupIds);
   if (ids.length === 0) return new Map();
   const predicate = buildGroupAttendeePredicate("e", "ea", date);
   const rows = await queryAll<{
@@ -521,86 +526,178 @@ export type ListingCapacityRow = ListingRow;
  * "negatively available" even when it has been overbooked. */
 const atLeastZero = (n: number): number => Math.max(0, n);
 
-/** Remaining bookable units for one listing over `[date, date + durationDays)`.
- * Daily listings report the tightest day; standard listings (and any listing
- * with a null date) use their cumulative total. A group cap can only shrink the
- * figure, never enlarge it. */
-const remainingForListing = async (
-  listing: ListingCapacityRow,
-  date: string | null,
-  durationDays: number,
-): Promise<number> => {
-  if (listing.listing_type !== "daily" || !date) {
-    const base = listing.max_attendees - listing.attendee_count;
-    if (listing.group_id <= 0) return atLeastZero(base);
-    const groupRemaining = await groupRemainingTotal(listing.group_id);
-    return atLeastZero(
-      groupRemaining === undefined ? base : Math.min(base, groupRemaining),
+/** All overlapping interval rows for several listings in one query, grouped by
+ * listing id — so per-day loads come from one round trip, not one per listing. */
+const overlappingRowsByListing = async (
+  listingIds: number[],
+  days: string[],
+): Promise<Map<number, IntervalRow[]>> => {
+  const byListing = new Map<number, IntervalRow[]>();
+  if (listingIds.length === 0) return byListing;
+  const { startAt, endAt } = daySpan(days);
+  const rows = await queryAll<IntervalRow & { listing_id: number }>(
+    `SELECT listing_id, start_at, end_at, quantity FROM listing_attendees
+     WHERE listing_id IN (${inPlaceholders(listingIds)}) AND start_at < ? AND end_at > ?`,
+    [...listingIds, endAt, startAt],
+  );
+  for (const row of rows) {
+    const list = byListing.get(row.listing_id);
+    if (list) list.push(row);
+    else byListing.set(row.listing_id, [row]);
+  }
+  return byListing;
+};
+
+/** Per-day group remaining for several groups in two queries (caps + occupancy
+ * rows), keyed by group id. Uncapped/absent groups are omitted, matching
+ * `getGroupRemainingByGroupId`. */
+const groupPerDayRemainingByGroup = async (
+  groupIds: number[],
+  days: string[],
+): Promise<Map<number, Map<string, number>>> => {
+  const result = new Map<number, Map<string, number>>();
+  const ids = uniquePositiveGroupIds(groupIds);
+  if (ids.length === 0) return result;
+  const caps = await queryAll<{ id: number; max_attendees: number }>(
+    `SELECT id, max_attendees FROM groups
+     WHERE id IN (${inPlaceholders(ids)}) AND max_attendees > 0`,
+    ids,
+  );
+  if (caps.length === 0) return result;
+  const cappedIds = caps.map((c) => c.id);
+  const { startAt, endAt } = daySpan(days);
+  type GroupRow = IntervalRow & { group_id: number; listing_type: ListingType };
+  const rows = await queryAll<GroupRow>(
+    `SELECT e.group_id, ea.start_at, ea.end_at, ea.quantity, e.listing_type
+     FROM listing_attendees ea
+     JOIN listings e ON e.id = ea.listing_id
+     WHERE e.group_id IN (${inPlaceholders(cappedIds)})
+       AND (e.listing_type != 'daily' OR (ea.start_at < ? AND ea.end_at > ?))`,
+    [...cappedIds, endAt, startAt],
+  );
+  const rowsByGroup = new Map<number, GroupRow[]>();
+  for (const row of rows) {
+    const list = rowsByGroup.get(row.group_id);
+    if (list) list.push(row);
+    else rowsByGroup.set(row.group_id, [row]);
+  }
+  for (const { id, max_attendees } of caps) {
+    const groupRows = rowsByGroup.get(id) ?? [];
+    // Non-daily rows count on every day; daily rows count per overlapping day.
+    const base = sumQuantity(
+      filter((r: GroupRow) => r.listing_type !== "daily")(groupRows),
+    );
+    const loads = perDayLoads(
+      filter((r: GroupRow) => r.listing_type === "daily")(groupRows),
+      days,
+    );
+    result.set(
+      id,
+      new Map(
+        days.map((day) => [
+          day,
+          atLeastZero(max_attendees - base - loads.get(day)!),
+        ]),
+      ),
     );
   }
-
-  const days = expandDailyRange(date, durationDays);
-  const loads = perDayLoads(await getOverlappingRows(listing.id, days), days);
-  const listingRemaining = Math.min(
-    ...days.map((day) => listing.max_attendees - loads.get(day)!),
-  );
-  if (listing.group_id <= 0) return atLeastZero(listingRemaining);
-  const groupPerDay = await getGroupRemainingPerDay(listing.group_id, days);
-  if (!groupPerDay) return atLeastZero(listingRemaining);
-  const groupRemaining = Math.min(...days.map((day) => groupPerDay.get(day)!));
-  return atLeastZero(Math.min(listingRemaining, groupRemaining));
+  return result;
 };
 
 /**
  * Remaining bookable units per listing for an anchor date + duration, as a
  * `Map<listingId, number>` (clamped at 0).
  *
- * This is the read-side mirror of the booking-time caps in
- * `checkListingAvailability`: same per-day expansion and group-cap rules, but it
- * returns the actual count for display ("X/Y remaining") and overbooking
- * warnings instead of a yes/no. Daily listings are evaluated per day across the
- * whole range and report the tightest day; standard listings — and every
+ * The read-side mirror of the booking-time caps in `checkListingAvailability`:
+ * same per-day expansion and group-cap rules, returning the count for display
+ * ("X/Y remaining") and overbooking warnings. Daily listings (with a date) are
+ * evaluated per day and report the tightest day; standard listings — and every
  * listing when `date` is null — use their cumulative totals.
+ *
+ * Batched into a constant ≤4 queries regardless of how many listings are passed,
+ * so a large catalogue can't blow the per-request query budget.
  */
 export const getListingRemainingForRange = async (
   listings: ListingCapacityRow[],
   date: string | null,
   durationDays = 1,
 ): Promise<Map<number, number>> => {
-  const entries = await mapParallel(
-    async (listing: ListingCapacityRow): Promise<[number, number]> => [
-      listing.id,
-      await remainingForListing(listing, date, durationDays),
-    ],
-  )(listings);
-  return new Map(entries);
+  const usesRange = (l: ListingCapacityRow): boolean =>
+    l.listing_type === "daily" && date !== null;
+  const daily = filter(usesRange)(listings);
+  const totals = filter((l: ListingCapacityRow) => !usesRange(l))(listings);
+  const days = date ? expandDailyRange(date, durationDays) : [];
+
+  const [totalGroupRemaining, overlapByListing, dailyGroupPerDay] =
+    await Promise.all([
+      getGroupRemainingByGroupId(
+        totals.map((l) => l.group_id),
+        null,
+      ),
+      overlappingRowsByListing(
+        daily.map((l) => l.id),
+        days,
+      ),
+      groupPerDayRemainingByGroup(
+        daily.map((l) => l.group_id),
+        days,
+      ),
+    ]);
+
+  const result = new Map<number, number>();
+  for (const l of totals) {
+    const base = l.max_attendees - l.attendee_count;
+    const group =
+      l.group_id > 0 ? totalGroupRemaining.get(l.group_id) : undefined;
+    result.set(
+      l.id,
+      atLeastZero(group === undefined ? base : Math.min(base, group)),
+    );
+  }
+  for (const l of daily) {
+    const loads = perDayLoads(overlapByListing.get(l.id) ?? [], days);
+    const listingRemaining = Math.min(
+      ...days.map((day) => l.max_attendees - loads.get(day)!),
+    );
+    const groupPerDay = dailyGroupPerDay.get(l.group_id);
+    const remaining = groupPerDay
+      ? Math.min(
+          listingRemaining,
+          Math.min(...days.map((day) => groupPerDay.get(day)!)),
+        )
+      : listingRemaining;
+    result.set(l.id, atLeastZero(remaining));
+  }
+  return result;
 };
 
 /**
- * Whether one booking fits within capacity, using the same self-excluding
- * condition the atomic write uses. Pass `excludeAttendeeId` to ignore that
- * attendee's own rows so an unchanged edit doesn't count against itself. Drives
- * the admin form's overbooking warning; the save itself is allowed to overbook.
+ * Batched capacity check: whether each booking fits, in a single query. The
+ * per-booking self-excluding conditions (the same ones the atomic write uses)
+ * become separate columns of one SELECT, so N lines cost one round trip instead
+ * of N. Pass `excludeAttendeeId` to ignore that attendee's own rows, so an
+ * unchanged edit doesn't count against itself. Drives the admin overbooking
+ * warning and the edit preflight; the save itself is allowed to overbook.
  */
-export const checkLineCapacity = async (
-  booking: {
-    listingId: number;
-    quantity: number;
-    date: string | null;
-    durationDays: number;
-  },
+export const checkLinesCapacity = async (
+  bookings: LineBooking[],
   excludeAttendeeId?: number,
-): Promise<boolean> => {
-  const condition = buildCapacityCondition(
-    booking.listingId,
-    booking.quantity,
-    booking.date,
-    excludeAttendeeId,
-    booking.durationDays,
+): Promise<boolean[]> => {
+  if (bookings.length === 0) return [];
+  const conditions = bookings.map((b) =>
+    buildCapacityCondition(
+      b.listingId,
+      b.quantity,
+      b.date,
+      excludeAttendeeId,
+      b.durationDays,
+    ),
   );
-  const row = (await queryOne<{ ok: number }>(
-    `SELECT (${condition.sql}) AS ok`,
-    condition.args,
+  const columns = conditions.map((c, i) => `(${c.sql}) AS ok${i}`).join(", ");
+  const args = conditions.flatMap((c) => c.args);
+  const row = (await queryOne<Record<string, number>>(
+    `SELECT ${columns}`,
+    args,
   ))!;
-  return row.ok === 1;
+  return conditions.map((_, i) => row[`ok${i}`] === 1);
 };

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -387,86 +387,57 @@ type BatchAvailabilityContext = {
   date: string | null | undefined;
 };
 
-/**
- * Walk each (key, bucket) pair in `demand`, awaiting `passes` and returning
- * false on the first failure. Centralizes the short-circuiting iteration that
- * listing-cap and group-cap checks both need.
- */
-const everyBucketPasses = async <K>(
-  demand: Map<K, DemandBucket>,
-  passes: (key: K, bucket: DemandBucket) => Promise<boolean>,
-): Promise<boolean> => {
-  for (const [key, bucket] of demand) {
-    if (!(await passes(key, bucket))) return false;
-  }
-  return true;
-};
+/** The keys of a demand map whose bucket has per-day (daily) demand. */
+const withDailyDemand = (demand: Map<number, DemandBucket>): number[] =>
+  [...demand].filter(([, b]) => b.perDay.size > 0).map(([key]) => key);
 
-/**
- * Curried: given the listings lookup, build an async predicate that checks a
- * single listing's demand against its `max_attendees` — per-day for daily
- * listings, and as a total against existing bookings.
- */
-const listingBucketPasses =
-  (listingsById: Map<number, ListingRow>) =>
-  async (listingId: number, bucket: DemandBucket): Promise<boolean> => {
-    const ev = listingsById.get(listingId)!;
-    const days = demandedDays(bucket);
-    if (days) {
-      const loads = perDayLoads(
-        await getOverlappingRows(listingId, days),
-        days,
-      );
-      const overCap = [...bucket.perDay].some(
-        ([day, qty]) => loads.get(day)! + qty > ev.max_attendees,
-      );
-      if (overCap) return false;
-    }
-    if (bucket.total > 0 && ev.attendee_count + bucket.total > ev.max_attendees)
-      return false;
-    return true;
-  };
-
-/**
- * Async predicate: does a single group's demand fit within its remaining
- * capacity, both per-day across the requested days and as a total against the
- * group's baseline occupancy?
- */
-const groupBucketPasses = async (
-  groupId: number,
+/** A single listing's demand fits its `max_attendees` — per-day against
+ * pre-fetched occupancy, and total against the existing count. */
+const listingFits = (
+  ev: ListingRow,
   bucket: DemandBucket,
-): Promise<boolean> => {
+  overlapByListing: Map<number, IntervalRow[]>,
+): boolean => {
   const days = demandedDays(bucket);
   if (days) {
-    const remaining = await getGroupRemainingPerDay(groupId, days);
-    const overCap =
-      remaining &&
+    const loads = perDayLoads(overlapByListing.get(ev.id) ?? [], days);
+    if (
       [...bucket.perDay].some(
-        ([day, qty]) => qty + bucket.total > remaining.get(day)!,
-      );
-    if (overCap) return false;
-  } else if (bucket.total > 0) {
-    // Pure non-daily demand against baseline group occupancy.
-    const remaining = (await getGroupRemainingByGroupId([groupId], null)).get(
-      groupId,
-    );
-    if (remaining !== undefined && bucket.total > remaining) return false;
+        ([day, qty]) => loads.get(day)! + qty > ev.max_attendees,
+      )
+    ) {
+      return false;
+    }
   }
-  return true;
+  return !(
+    bucket.total > 0 && ev.attendee_count + bucket.total > ev.max_attendees
+  );
 };
 
-/**
- * Aggregate demand for `ctx` by `keyOf`, then verify every resulting bucket
- * passes `bucketPasses`. The shared shape of the listing-cap and group-cap
- * checks (both follow this aggregate-then-verify pattern) lives here.
- */
-const checkCaps = (
-  ctx: BatchAvailabilityContext,
-  keyOf: (ev: ListingRow) => number | null,
-  bucketPasses: (key: number, bucket: DemandBucket) => Promise<boolean>,
-): Promise<boolean> => {
-  const demand = aggregateDemand(ctx, keyOf);
-  return everyBucketPasses(demand, bucketPasses);
+/** A single group's demand fits its remaining capacity — per-day against
+ * pre-fetched per-day remaining, total against the date-less baseline. */
+const groupFits = (
+  groupId: number,
+  bucket: DemandBucket,
+  groupPerDay: Map<number, Map<string, number>>,
+  totalGroupRemaining: Map<number, number>,
+): boolean => {
+  const remaining = groupPerDay.get(groupId);
+  if (
+    remaining &&
+    [...bucket.perDay].some(
+      ([day, qty]) => qty + bucket.total > remaining.get(day)!,
+    )
+  ) {
+    return false;
+  }
+  if (bucket.perDay.size === 0 && bucket.total > 0) {
+    const groupRemaining = totalGroupRemaining.get(groupId);
+    if (groupRemaining !== undefined && bucket.total > groupRemaining) {
+      return false;
+    }
+  }
+  return true;
 };
 
 /**
@@ -474,6 +445,10 @@ const checkCaps = (
  * For multi-day daily listings, expands each booking into per-day demand so
  * that every day in the range is checked independently. Group caps are
  * similarly evaluated per-day across all listings in each group.
+ *
+ * Batched: per-listing occupancy and per-group caps are each fetched in one
+ * query for the whole cart, so a large multi-listing cart can't fan out a read
+ * per listing or per group.
  */
 export const checkBatchAvailabilityImpl = async (
   items: BatchAvailabilityItem[],
@@ -500,18 +475,37 @@ export const checkBatchAvailabilityImpl = async (
   if (items.some((i) => !listingsById.has(i.listingId))) return false;
 
   const ctx: BatchAvailabilityContext = { date, items, listingsById };
-  // Per-listing caps: each listing's per-day and total demand within max_attendees.
-  if (
-    !(await checkCaps(ctx, (ev) => ev.id, listingBucketPasses(listingsById)))
-  ) {
-    return false;
-  }
-  // Group caps: each group's per-day and total demand within its remaining capacity.
-  return checkCaps(
-    ctx,
-    (ev) => (ev.group_id > 0 ? ev.group_id : null),
-    groupBucketPasses,
+  const listingDemand = aggregateDemand(ctx, (ev) => ev.id);
+  const groupDemand = aggregateDemand(ctx, (ev) =>
+    ev.group_id > 0 ? ev.group_id : null,
   );
+
+  // Prefetch everything the per-bucket checks need, batched: per-listing
+  // occupancy rows, per-group per-day remaining, and date-less group caps.
+  const allDays = unique(
+    [...listingDemand.values()].flatMap((b) => [...b.perDay.keys()]),
+  );
+  const [overlapByListing, groupPerDay, totalGroupRemaining] =
+    await Promise.all([
+      overlappingRowsByListing(withDailyDemand(listingDemand), allDays),
+      groupPerDayRemainingByGroup(withDailyDemand(groupDemand), allDays),
+      getGroupRemainingByGroupId(
+        [...groupDemand]
+          .filter(([, b]) => b.perDay.size === 0 && b.total > 0)
+          .map(([gid]) => gid),
+        null,
+      ),
+    ]);
+
+  for (const [id, bucket] of listingDemand) {
+    if (!listingFits(listingsById.get(id)!, bucket, overlapByListing)) {
+      return false;
+    }
+  }
+  for (const [gid, bucket] of groupDemand) {
+    if (!groupFits(gid, bucket, groupPerDay, totalGroupRemaining)) return false;
+  }
+  return true;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -9,7 +9,7 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { filter, map, pipe, reduce, unique } from "#fp";
+import { filter, map, mapParallel, pipe, reduce, unique } from "#fp";
 import { addDays } from "#shared/dates.ts";
 import type {
   BatchAvailabilityItem,
@@ -279,6 +279,14 @@ const getGroupRemainingPerDay = async (
   );
 };
 
+/** Date-less remaining capacity for a listing's group, or `undefined` when no
+ * cap applies (ungrouped or uncapped group). Shared by the boolean preflight
+ * and the count lookup so both read the group cap the same way. */
+const groupRemainingTotal = async (
+  groupId: number,
+): Promise<number | undefined> =>
+  (await getGroupRemainingByGroupId([groupId], null)).get(groupId);
+
 /**
  * Per-day availability check for a single-listing booking. Used by
  * `hasAvailableSpots` (public availability API) and as the preflight in
@@ -299,9 +307,7 @@ export const checkListingAvailability = async (
   if (listing.listing_type !== "daily" || !date) {
     if (listing.attendee_count + quantity > listing.max_attendees) return false;
     if (listing.group_id <= 0) return true;
-    const remaining = (
-      await getGroupRemainingByGroupId([listing.group_id], null)
-    ).get(listing.group_id);
+    const remaining = await groupRemainingTotal(listing.group_id);
     return remaining === undefined || quantity <= remaining;
   }
 
@@ -499,4 +505,71 @@ export const checkBatchAvailabilityImpl = async (
     (ev) => (ev.group_id > 0 ? ev.group_id : null),
     groupBucketPasses,
   );
+};
+
+// ---------------------------------------------------------------------------
+// Remaining-capacity lookup (display + overbooking warnings)
+// ---------------------------------------------------------------------------
+
+/** A listing's identity + the capacity inputs a remaining-units lookup needs —
+ * the same shape the batch check uses. `ListingWithCount` satisfies it. */
+export type ListingCapacityRow = ListingRow;
+
+/** Clamp a possibly-negative remaining figure to zero — a listing is never
+ * "negatively available" even when it has been overbooked. */
+const atLeastZero = (n: number): number => Math.max(0, n);
+
+/** Remaining bookable units for one listing over `[date, date + durationDays)`.
+ * Daily listings report the tightest day; standard listings (and any listing
+ * with a null date) use their cumulative total. A group cap can only shrink the
+ * figure, never enlarge it. */
+const remainingForListing = async (
+  listing: ListingCapacityRow,
+  date: string | null,
+  durationDays: number,
+): Promise<number> => {
+  if (listing.listing_type !== "daily" || !date) {
+    const base = listing.max_attendees - listing.attendee_count;
+    if (listing.group_id <= 0) return atLeastZero(base);
+    const groupRemaining = await groupRemainingTotal(listing.group_id);
+    return atLeastZero(
+      groupRemaining === undefined ? base : Math.min(base, groupRemaining),
+    );
+  }
+
+  const days = expandDailyRange(date, durationDays);
+  const loads = perDayLoads(await getOverlappingRows(listing.id, days), days);
+  const listingRemaining = Math.min(
+    ...days.map((day) => listing.max_attendees - loads.get(day)!),
+  );
+  if (listing.group_id <= 0) return atLeastZero(listingRemaining);
+  const groupPerDay = await getGroupRemainingPerDay(listing.group_id, days);
+  if (!groupPerDay) return atLeastZero(listingRemaining);
+  const groupRemaining = Math.min(...days.map((day) => groupPerDay.get(day)!));
+  return atLeastZero(Math.min(listingRemaining, groupRemaining));
+};
+
+/**
+ * Remaining bookable units per listing for an anchor date + duration, as a
+ * `Map<listingId, number>` (clamped at 0).
+ *
+ * This is the read-side mirror of the booking-time caps in
+ * `checkListingAvailability`: same per-day expansion and group-cap rules, but it
+ * returns the actual count for display ("X/Y remaining") and overbooking
+ * warnings instead of a yes/no. Daily listings are evaluated per day across the
+ * whole range and report the tightest day; standard listings — and every
+ * listing when `date` is null — use their cumulative totals.
+ */
+export const getListingRemainingForRange = async (
+  listings: ListingCapacityRow[],
+  date: string | null,
+  durationDays = 1,
+): Promise<Map<number, number>> => {
+  const entries = await mapParallel(
+    async (listing: ListingCapacityRow): Promise<[number, number]> => [
+      listing.id,
+      await remainingForListing(listing, date, durationDays),
+    ],
+  )(listings);
+  return new Map(entries);
 };

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -113,14 +113,17 @@ export const getGroupRemainingForListing = async (
 };
 
 /**
- * Build a capacity-checked INSERT into listing_attendees.
+ * Build an INSERT into listing_attendees, capacity-checked by default.
  * @param attendeeIdExpr - SQL expression for attendee_id (e.g. "last_insert_rowid()" or "?")
  * @param attendeeIdArg - Argument for "?" expr, omit for last_insert_rowid()
+ * @param allowOverbook - when true the capacity WHERE is dropped so the row is
+ *   inserted unconditionally (admin manual add/edit may deliberately overbook).
  */
 export const buildCapacityCheckedInsert = (
   booking: ListingBooking,
   attendeeIdExpr = "last_insert_rowid()",
   attendeeIdArg?: number,
+  allowOverbook = false,
 ): { sql: string; args: InValue[] } => {
   const {
     listingId,
@@ -129,6 +132,14 @@ export const buildCapacityCheckedInsert = (
     date = null,
     durationDays = 1,
   } = booking;
+  const { startAt, endAt } = dateToStartEnd(date, durationDays);
+  const args: InValue[] = [listingId];
+  if (attendeeIdArg !== undefined) args.push(attendeeIdArg);
+  args.push(startAt, endAt, qty, pricePaid);
+  const insertSelect = `INSERT INTO listing_attendees (listing_id, attendee_id, start_at, end_at, quantity, price_paid)
+          SELECT ?, ${attendeeIdExpr}, ?, ?, ?, ?`;
+  if (allowOverbook) return { args, sql: insertSelect };
+
   const condition = buildCapacityCondition(
     listingId,
     qty,
@@ -136,17 +147,8 @@ export const buildCapacityCheckedInsert = (
     undefined,
     durationDays,
   );
-  const { startAt, endAt } = dateToStartEnd(date, durationDays);
-  const args: InValue[] = [listingId];
-  if (attendeeIdArg !== undefined) args.push(attendeeIdArg);
-  args.push(startAt, endAt, qty, pricePaid, ...condition.args);
-
-  return {
-    args,
-    sql: `INSERT INTO listing_attendees (listing_id, attendee_id, start_at, end_at, quantity, price_paid)
-          SELECT ?, ${attendeeIdExpr}, ?, ?, ?, ?
-          WHERE ${condition.sql}`,
-  };
+  args.push(...condition.args);
+  return { args, sql: `${insertSelect}\n          WHERE ${condition.sql}` };
 };
 
 // ---------------------------------------------------------------------------
@@ -572,4 +574,33 @@ export const getListingRemainingForRange = async (
     ],
   )(listings);
   return new Map(entries);
+};
+
+/**
+ * Whether one booking fits within capacity, using the same self-excluding
+ * condition the atomic write uses. Pass `excludeAttendeeId` to ignore that
+ * attendee's own rows so an unchanged edit doesn't count against itself. Drives
+ * the admin form's overbooking warning; the save itself is allowed to overbook.
+ */
+export const checkLineCapacity = async (
+  booking: {
+    listingId: number;
+    quantity: number;
+    date: string | null;
+    durationDays: number;
+  },
+  excludeAttendeeId?: number,
+): Promise<boolean> => {
+  const condition = buildCapacityCondition(
+    booking.listingId,
+    booking.quantity,
+    booking.date,
+    excludeAttendeeId,
+    booking.durationDays,
+  );
+  const row = (await queryOne<{ ok: number }>(
+    `SELECT (${condition.sql}) AS ok`,
+    condition.args,
+  ))!;
+  return row.ok === 1;
 };

--- a/src/shared/db/attendees/create.ts
+++ b/src/shared/db/attendees/create.ts
@@ -119,6 +119,7 @@ export const createAttendeeAtomicImpl = async (
     bookings,
     statusId = null,
     remainingBalance = 0,
+    allowOverbook = false,
   } = input;
   const order = { remainingBalance, statusId };
   if (bookings.length === 0) {
@@ -154,7 +155,12 @@ export const createAttendeeAtomicImpl = async (
   const attendeeIdExpr =
     "(SELECT MAX(id) FROM attendees WHERE ticket_token_index = ?)";
   const bookingStatements = bookings.map((booking) => {
-    const insert = buildCapacityCheckedInsert(booking, attendeeIdExpr);
+    const insert = buildCapacityCheckedInsert(
+      booking,
+      attendeeIdExpr,
+      undefined,
+      allowOverbook,
+    );
     // Splice ticketTokenIndex after the first arg (listingId) to bind
     // the ? in the attendeeIdExpr subquery
     const combined: InValue[] = [

--- a/src/shared/order-select.ts
+++ b/src/shared/order-select.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared field-name scheme for selecting listings with hidden checkboxes.
+ *
+ * Used by the public `/order` gallery and the admin calendar availability
+ * checker so both speak the same wire format: a checked box submits
+ * `select_<listingId>=1`, and an optional `start_date` carries the anchor date
+ * the selection was made for. `parseSelectedListingIds` reads the listing ids
+ * back out — the create-attendee form uses it to pre-fill the chosen listings.
+ */
+
+export const SELECT_PREFIX = "select_";
+export const START_DATE_FIELD = "start_date";
+
+/**
+ * Extract selected listing ids from `select_<id>=1` params, de-duplicated and
+ * in ascending id order. Values other than "1" and unparseable ids are ignored,
+ * so a hand-crafted query can't smuggle in junk.
+ */
+export const parseSelectedListingIds = (params: URLSearchParams): number[] => {
+  const ids = new Set<number>();
+  for (const [key, value] of params) {
+    if (!key.startsWith(SELECT_PREFIX) || value !== "1") continue;
+    const id = Number.parseInt(key.slice(SELECT_PREFIX.length), 10);
+    if (Number.isInteger(id) && id > 0) ids.add(id);
+  }
+  return [...ids].sort((a, b) => a - b);
+};

--- a/src/shared/order-select.ts
+++ b/src/shared/order-select.ts
@@ -8,20 +8,22 @@
  * back out — the create-attendee form uses it to pre-fill the chosen listings.
  */
 
+import { parsePositiveIntId } from "#shared/validation/number.ts";
+
 export const SELECT_PREFIX = "select_";
 export const START_DATE_FIELD = "start_date";
 
 /**
  * Extract selected listing ids from `select_<id>=1` params, de-duplicated and
- * in ascending id order. Values other than "1" and unparseable ids are ignored,
- * so a hand-crafted query can't smuggle in junk.
+ * in ascending id order. Values other than "1" and ids that aren't strict
+ * positive integers are ignored, so a hand-crafted query can't smuggle in junk.
  */
 export const parseSelectedListingIds = (params: URLSearchParams): number[] => {
   const ids = new Set<number>();
   for (const [key, value] of params) {
     if (!key.startsWith(SELECT_PREFIX) || value !== "1") continue;
-    const id = Number.parseInt(key.slice(SELECT_PREFIX.length), 10);
-    if (Number.isInteger(id) && id > 0) ids.add(id);
+    const id = parsePositiveIntId(key.slice(SELECT_PREFIX.length));
+    if (id !== null) ids.add(id);
   }
   return [...ids].sort((a, b) => a - b);
 };

--- a/src/shared/validation/number.ts
+++ b/src/shared/validation/number.ts
@@ -1,0 +1,25 @@
+import * as v from "valibot";
+
+/**
+ * A positive integer in plain decimal form — digits only, so no sign, no
+ * leading `+`, no surrounding whitespace, and not zero.
+ *
+ * The app reads listing ids out of dynamic form keys like `select_<id>` and
+ * `qty_<id>`, where a lenient `Number.parseInt` would otherwise accept junk
+ * such as `"5abc"` as `5`. Validating the digits before coercing closes that.
+ *
+ * Mirrors the schema + parse-helper shape of validation/email.ts and
+ * validation/date.ts as the rest of the app's validation migrates to valibot.
+ */
+const PositiveIntIdSchema = v.pipe(
+  v.string(),
+  v.digits(),
+  v.transform(Number),
+  v.minValue(1),
+);
+
+/** Parse a strict positive-integer id from a string, or null when it isn't one. */
+export const parsePositiveIntId = (value: string): number | null => {
+  const result = v.safeParse(PositiveIntIdSchema, value);
+  return result.success ? result.output : null;
+};

--- a/src/ui/client/admin.ts
+++ b/src/ui/client/admin.ts
@@ -6,6 +6,7 @@
  * themselves against missing DOM elements so they are safe to run on
  * every admin page. */
 
+import { initAvailabilityChecker } from "./admin/availability-checker.ts";
 import { initCharCounters } from "./admin/char-counter.ts";
 import { initCheckoutPopup } from "./admin/checkout-popup.ts";
 import { initClosesAtAutofill } from "./admin/closes-at-autofill.ts";
@@ -29,6 +30,7 @@ import { initTicketQuantityRequired } from "./admin/ticket-quantity-required.ts"
 
 initSelectOnClick();
 initNavSelect();
+initAvailabilityChecker();
 initMultiBookingBuilder();
 initFillDefaultTemplate();
 initClosesAtAutofill();

--- a/src/ui/client/admin.ts
+++ b/src/ui/client/admin.ts
@@ -6,6 +6,7 @@
  * themselves against missing DOM elements so they are safe to run on
  * every admin page. */
 
+import { initAttendeeDates } from "./admin/attendee-dates.ts";
 import { initAvailabilityChecker } from "./admin/availability-checker.ts";
 import { initCharCounters } from "./admin/char-counter.ts";
 import { initCheckoutPopup } from "./admin/checkout-popup.ts";
@@ -31,6 +32,7 @@ import { initTicketQuantityRequired } from "./admin/ticket-quantity-required.ts"
 initSelectOnClick();
 initNavSelect();
 initAvailabilityChecker();
+initAttendeeDates();
 initMultiBookingBuilder();
 initFillDefaultTemplate();
 initClosesAtAutofill();

--- a/src/ui/client/admin/attendee-dates.ts
+++ b/src/ui/client/admin/attendee-dates.ts
@@ -1,0 +1,76 @@
+/// <reference lib="dom" />
+/**
+ * Progressive enhancement for the attendee form's shared date controls.
+ *
+ * The form works without JavaScript — the start date and day-count select are
+ * plain fields. This script makes the date-first flow nicer:
+ *   - the day-count (end date) select is hidden until a start date is chosen;
+ *   - its option labels show the resulting end date, recomputed as the start
+ *     date changes (matching the server's `formatDateLabel`);
+ *   - the "availability is inaccurate until dates have been saved" notice is
+ *     re-shown whenever the start date or length is changed, prompting a re-save.
+ */
+
+// Mirrors the server's `formatDateLabel` ("Sunday 15 March 2026") without
+// duplicating its month/day name tables — the English parts come from Intl and
+// are reassembled in the same order.
+const PARTS_FORMAT = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  weekday: "long",
+  year: "numeric",
+});
+
+/** End-date label for an `n`-day booking starting on `iso` (UTC), matching the
+ * server's `formatDateLabel(addDays(start, n - 1))`. */
+const endDateLabel = (iso: string, n: number): string => {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + (n - 1));
+  const parts = new Map(
+    PARTS_FORMAT.formatToParts(d).map((p) => [p.type, p.value]),
+  );
+  return `${parts.get("weekday")} ${parts.get("day")} ${parts.get("month")} ${parts.get("year")}`;
+};
+
+export const initAttendeeDates = (): void => {
+  const start = document.querySelector<HTMLInputElement>(
+    'input[name="start_date"]',
+  );
+  if (!start) return;
+  const dayCount = document.querySelector<HTMLSelectElement>(
+    'select[name="day_count"]',
+  );
+  const dayCountLabel = document.querySelector<HTMLElement>(
+    "[data-day-count-label]",
+  );
+  const notice = document.querySelector<HTMLElement>(
+    "[data-availability-notice]",
+  );
+
+  const updateLabels = (): void => {
+    if (!dayCount || !start.value) return;
+    for (const opt of Array.from(dayCount.options)) {
+      const n = Number(opt.value);
+      opt.textContent = `${n} day${n === 1 ? "" : "s"}: ${endDateLabel(start.value, n)}`;
+    }
+  };
+
+  // Reveal the end-date select only once a start date is present.
+  const syncGate = (): void => {
+    if (dayCountLabel) dayCountLabel.hidden = !start.value;
+  };
+
+  const reshowNotice = (): void => {
+    if (notice) notice.hidden = false;
+  };
+
+  syncGate();
+  updateLabels();
+  start.addEventListener("input", () => {
+    syncGate();
+    updateLabels();
+    reshowNotice();
+  });
+  dayCount?.addEventListener("change", reshowNotice);
+};

--- a/src/ui/client/admin/availability-checker.ts
+++ b/src/ui/client/admin/availability-checker.ts
@@ -1,0 +1,37 @@
+/// <reference lib="dom" />
+/**
+ * Persist the calendar availability checker's open state across a single
+ * navigation.
+ *
+ * When the operator expands the checker and then clicks a calendar day (or the
+ * "Create Attendee" button), the checker should still be open when the next
+ * page loads — but closing it forgets that preference. The flag is written only
+ * as the page is being left (`pagehide`), so it is very short-lived, and it is
+ * consumed on the next load so it never lingers once the checker is closed.
+ */
+
+const STORAGE_KEY = "calendar-availability-open";
+
+export const initAvailabilityChecker = (): void => {
+  const details = document.querySelector<HTMLDetailsElement>(
+    "[data-availability-checker]",
+  );
+  if (!details) return;
+
+  // Restore + consume: a flag set on the previous navigation re-opens the
+  // checker, then is cleared so closing it later genuinely forgets it.
+  if (localStorage.getItem(STORAGE_KEY) === "1") {
+    details.open = true;
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  // Closing forgets the preference immediately.
+  details.addEventListener("toggle", () => {
+    if (!details.open) localStorage.removeItem(STORAGE_KEY);
+  });
+
+  // Re-arm only as we navigate away, and only while still open.
+  globalThis.addEventListener("pagehide", () => {
+    if (details.open) localStorage.setItem(STORAGE_KEY, "1");
+  });
+};

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -2249,3 +2249,76 @@ a.cal-day-selected:hover {
 .order-gallery:not(:has(.order-select:checked)) .order-cart {
   display: none;
 }
+
+/* Calendar availability checker — reuses the order page's hidden-checkbox
+   selection and floating cart button, but lays the listings out as a table. */
+.availability-checker {
+  margin-bottom: var(--space-m);
+}
+
+.availability-checker > summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.availability-checker-body {
+  padding-top: var(--space-s);
+}
+
+/* The selection form resets the shared cart counter and hides the floating
+   create button until at least one listing is ticked (mirrors .order-gallery). */
+.selectable-form {
+  counter-reset: cart;
+}
+
+.selectable-form:not(:has(.order-select:checked)) .order-cart {
+  display: none;
+}
+
+.availability-table th:first-child,
+.availability-table td:first-child {
+  width: 1%;
+  white-space: nowrap;
+}
+
+/* A row's tick box: the .order-select checkbox itself is visually hidden
+   (1px, opacity 0) and absolutely positioned, so anchor it here. */
+.row-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  cursor: pointer;
+}
+
+.row-select-tick {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border: 2px solid var(--color-bg-secondary);
+  border-radius: var(--border-radius);
+}
+
+.order-select:checked + .row-select-tick {
+  border-color: var(--color-secondary);
+  background: var(--color-secondary);
+  color: #fff;
+}
+
+.order-select:checked + .row-select-tick::after {
+  content: "\2713";
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.order-select:focus-visible + .row-select-tick {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 2px;
+}
+
+.availability-table tr:has(.order-select:checked) {
+  background: var(--color-secondary-accent);
+}

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -2322,3 +2322,18 @@ a.cal-day-selected:hover {
 .availability-table tr:has(.order-select:checked) {
   background: var(--color-secondary-accent);
 }
+
+/* Attendee form: fixed listing editor with quantity boxes + a "Show all
+   listings" toggle that reveals the not-booked rows (pure CSS). */
+.listing-editor .show-all {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-s);
+  margin-bottom: var(--space-s);
+  font-weight: normal;
+  cursor: pointer;
+}
+
+.listing-editor:not(:has(.show-all-toggle:checked)) .attendee-line-empty {
+  display: none;
+}

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -1,50 +1,50 @@
 /**
  * Unified add/edit attendee page template.
  *
- * Renders the same form shape for both `/admin/attendees/new` (create) and
- * `/admin/attendees/:id` (edit). The line-item editor is a plain HTML
- * table — add/remove line controls are submit buttons that re-render the
- * form server-side, so the page works without JavaScript. A small inline
- * script progressively enhances date-field visibility (hide on non-daily
- * listings) but is not required for the form to function.
+ * Renders the same form for `/admin/attendees/new` (create) and
+ * `/admin/attendees/:id` (edit). An attendee has ONE shared date range — a
+ * start date plus a length — applied to every daily listing they book. The
+ * listing editor is a fixed table with one quantity box per bookable listing
+ * (plus any inactive listing the attendee already booked); quantity ≥ 1 books
+ * it, 0 leaves it out, so there are no add/remove-line buttons. Not-booked rows
+ * are hidden behind a "Show all listings" toggle (pure CSS). The form works
+ * without JavaScript.
  */
 
 import { compact } from "#fp";
 import {
-  ACTION_FIELD,
-  ADD_LINE_ACTION,
   ATTENDEE_FORM_ID,
   type AttendeeFormLine,
   type BalanceNotice,
-  type DailyDefaults,
-  LINE_COUNT_FIELD,
-  LINE_DATE_PREFIX,
-  LINE_DAY_COUNT_PREFIX,
-  LINE_EVENT_ID_PREFIX,
+  DAY_COUNT_FIELD,
+  isBookedLine,
   LINE_KEY_PREFIX,
-  LINE_QUANTITY_PREFIX,
-  lineDayCount,
   type ParsedAttendeeForm,
+  QTY_PREFIX,
   REMAINING_BALANCE_FIELD,
-  REMOVE_LINE_ACTION_PREFIX,
   resolveStatusId,
-  SAVE_ACTION,
+  SHOW_ALL_FIELD,
   STATUS_FIELD,
 } from "#routes/admin/attendee-form-model.ts";
 import { targetQuery } from "#shared/bulk-email.ts";
 import { toMajorUnits } from "#shared/currency.ts";
-import { formatDateRangeLabel, formatDatetimeShort } from "#shared/dates.ts";
+import {
+  addDays,
+  formatDateLabel,
+  formatDateRangeLabel,
+  formatDatetimeShort,
+} from "#shared/dates.ts";
 import type { ActivityLogEntry } from "#shared/db/activityLog.ts";
 import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import type { EmailStats } from "#shared/db/email-preferences.ts";
 import type { QuestionWithAnswers } from "#shared/db/questions.ts";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import { START_DATE_FIELD } from "#shared/order-select.ts";
 import {
   type AdminSession,
   type Attendee,
-  availableDayCounts,
-  type ListingWithCount,
+  MAX_DURATION_DAYS,
 } from "#shared/types.ts";
 import {
   AttendeeAnswersTable,
@@ -58,58 +58,49 @@ import {
   MaybeButtonLink,
   SubmitButton,
 } from "#templates/components/actions.tsx";
-import { escapeHtml, Layout } from "#templates/layout.tsx";
+import { Layout } from "#templates/layout.tsx";
 
-/** Per-listing available dates (daily listings only) for client-side filtering. */
+/** Template data for the unified attendee form. */
 export type AttendeeFormTemplateData = {
   /** "create" or "edit". */
   mode: "create" | "edit";
-  /** Parsed form values (lines + attendee fields). */
+  /** Parsed form values (shared range + one line per rendered listing). */
   parsed: ParsedAttendeeForm;
-  /** Attendee being edited (edit mode only; create mode passes a shell). */
+  /** Attendee being edited (edit mode only; create mode passes null). */
   attendee: Attendee | null;
-  /** All selectable listings (active + any currently-selected inactive listings). */
-  allListings: ListingWithCount[];
   /** All attendee statuses, for the status dropdown. */
   statuses: AttendeeStatus[];
   /** Status/balance mismatch notice, or null when they agree. */
   balanceNotice: BalanceNotice | null;
-  /** Available dates per daily listing id (for the date picker). */
-  availableDatesByListing: Record<number, string[]>;
-  /** Offered day counts per customisable daily listing id (for the day-count
-   * selector). */
-  customisableByListing: Record<number, number[]>;
-  /** Daily-line defaults computed from existing bookings. */
-  dailyDefaults: DailyDefaults;
+  /** True when the attendee's existing daily bookings disagree on date/length —
+   * saving normalises them onto the one shared range. */
+  hasMixedTimings: boolean;
   /** Attendee-level error (e.g. "Name is required"). */
   attendeeError: string | null;
-  /** Save outcome shown inside the form (success after a save, or a recoverable
-   * failure like capacity lost to a race). */
+  /** Shared-date error (e.g. missing start date for a booked daily listing). */
+  dateError: string | null;
+  /** Save outcome shown inside the form. */
   flashError?: string;
   flashSuccess?: string;
-  /** Custom questions across the attendee's booked listings; empty in create
-   * mode and when no listing has any. */
+  /** Custom questions across the attendee's booked listings. */
   questions: QuestionWithAnswers[];
   /** Currently-selected answer ids for the rendered questions. */
   selectedAnswerIds: number[];
-  /** Today's ISO date — used for the new-daily-line default. */
+  /** Today's ISO date. */
   todayIso: string;
   /** Optional return URL the caller came from. */
   returnUrl?: string;
-  /** Bulk-email contact history for the attendee's email (edit mode only;
-   * null when there is no email on file or it has never been contacted). */
+  /** Bulk-email contact history (edit mode only). */
   emailStats?: EmailStats | null;
   /** Public site domain, for the read-only ticket link (edit mode). */
   allowedDomain: string;
-  /** Country dialling code, for the read-only phone tel/WhatsApp links. */
+  /** Country dialling code, for the read-only phone links. */
   phonePrefix: string;
   /** This attendee's activity log entries, newest first (edit mode only). */
   activityLog: ActivityLogEntry[];
 };
 
-/** Status badges for an existing booking — "Checked in" and/or "Refunded",
- * space-separated. Renders nothing when the booking is absent or has neither
- * status, so a plain booking never leaves a stray node behind. */
+/** Status badges for an existing booking — "Checked in" and/or "Refunded". */
 const bookingStatusBadges = (
   booking: AttendeeFormLine["existingBooking"],
 ): JSX.Element | null => {
@@ -124,79 +115,39 @@ const bookingStatusBadges = (
   ) : null;
 };
 
-/** One row of the line-item editor — one listing registration. */
-const LineRow = ({
-  line,
-  index,
-  allListings,
-}: {
-  line: AttendeeFormLine;
-  index: number;
-  allListings: ListingWithCount[];
-}): JSX.Element => {
-  // The date field is hidden when a listing is picked and is non-daily; the
-  // server validates it conditionally so it is never required at the HTML
-  // level. Blank lines default to daily so a newly-added row shows the picker.
-  const isDaily = !line.listing || line.listing.listing_type === "daily";
-  const isCustomisable = Boolean(
-    line.listing?.customisable_days && line.listing.listing_type === "daily",
-  );
-  const dayCounts = line.listing?.customisable_days
-    ? availableDayCounts(line.listing)
-    : [];
-  const selectedDayCount = isCustomisable ? lineDayCount(line) : 0;
-  const removeLabel = line.existingBooking ? "Remove" : "Drop";
+/** One row of the listing editor — a listing and its quantity box. */
+const ListingRow = ({ line }: { line: AttendeeFormLine }): JSX.Element => {
+  const listing = line.listing!;
+  const booked = isBookedLine(line) || Boolean(line.existingBooking);
+  const isDaily = listing.listing_type === "daily";
   return (
-    <tr data-line-row>
+    <tr class={booked ? "attendee-line" : "attendee-line attendee-line-empty"}>
       <td>
-        <select
-          aria-label={`Listing for line ${index + 1}`}
-          data-line-event
-          name={`${LINE_EVENT_ID_PREFIX}${index}`}
-        >
-          <option selected={line.listingId === 0} value="">
-            Select listing…
-          </option>
-          {allListings.map((listing) => (
-            <option selected={listing.id === line.listingId} value={listing.id}>
-              {listing.name}
-              {listing.active ? "" : " (inactive)"}
-            </option>
-          ))}
-        </select>
+        <a href={`/admin/listing/${listing.id}`}>{listing.name}</a>
+        {listing.active ? "" : <span class="muted small"> (inactive)</span>}
         {bookingStatusBadges(line.existingBooking)}
       </td>
       <td>
-        <input
-          aria-label={`Date for line ${index + 1}`}
-          data-line-date
-          hidden={!isDaily}
-          name={`${LINE_DATE_PREFIX}${index}`}
-          type="date"
-          value={line.date}
-        />
-        <select
-          aria-label={`Number of days for line ${index + 1}`}
-          data-line-day-count
-          hidden={!isCustomisable}
-          name={`${LINE_DAY_COUNT_PREFIX}${index}`}
-        >
-          {dayCounts.map((n) => (
-            <option selected={n === selectedDayCount} value={n}>
-              {n} day{n === 1 ? "" : "s"}
-            </option>
-          ))}
-        </select>
+        {isDaily ? (
+          <span class="muted small">Shared dates</span>
+        ) : (
+          <span class="muted small">Fixed date</span>
+        )}
       </td>
       <td>
         <input
-          aria-label={`Quantity for line ${index + 1}`}
-          max={line.listing ? line.listing.max_quantity : undefined}
-          min="1"
-          name={`${LINE_QUANTITY_PREFIX}${index}`}
+          aria-label={`Quantity for ${listing.name}`}
+          max={listing.max_quantity}
+          min="0"
+          name={`${QTY_PREFIX}${listing.id}`}
           style="width:5em"
           type="number"
-          value={line.quantity === null ? "" : String(line.quantity)}
+          value={line.quantity === null ? "0" : String(line.quantity)}
+        />
+        <input
+          name={`${LINE_KEY_PREFIX}${listing.id}`}
+          type="hidden"
+          value={line.key}
         />
       </td>
       <td>
@@ -214,64 +165,96 @@ const LineRow = ({
           </div>
         ) : null}
       </td>
-      <td style="white-space:nowrap">
-        <input
-          name={`${LINE_KEY_PREFIX}${index}`}
-          type="hidden"
-          value={line.key}
-        />
-        <button
-          class="link-button danger"
-          formnovalidate
-          name={ACTION_FIELD}
-          type="submit"
-          value={`${REMOVE_LINE_ACTION_PREFIX}${index}`}
-        >
-          {removeLabel}
-        </button>
-      </td>
     </tr>
   );
 };
 
-/** The repeatable line-item editor plus the hidden line-count field the parser
- * loops over. */
-const LineEditor = ({
+/** The fixed listing editor: one quantity box per listing, with a "Show all
+ * listings" toggle that reveals the not-booked rows (pure CSS). */
+const ListingEditor = ({
   data,
 }: {
   data: AttendeeFormTemplateData;
 }): JSX.Element => (
-  <>
+  <div class="listing-editor">
+    <label class="show-all">
+      <input class="show-all-toggle" name={SHOW_ALL_FIELD} type="checkbox" />
+      Show all listings
+    </label>
     <div class="table-scroll">
       <table class="line-editor">
         <thead>
           <tr>
             <th>Listing</th>
-            <th>Date</th>
+            <th>Dates</th>
             <th>Qty</th>
             <th></th>
-            <th style="width:1%"></th>
           </tr>
         </thead>
         <tbody>
-          {data.parsed.lines.map((line, index) => (
-            <LineRow allListings={data.allListings} index={index} line={line} />
+          {data.parsed.lines.map((line) => (
+            <ListingRow line={line} />
           ))}
         </tbody>
       </table>
     </div>
-    <input
-      name={LINE_COUNT_FIELD}
-      type="hidden"
-      value={data.parsed.lines.length}
-    />
+  </div>
+);
+
+/** Option list for the day-count select: 1…horizon, each labelled with the
+ * resulting end date when a start date is known. */
+const dayCountOptions = (
+  startDate: string,
+  selected: number,
+): JSX.Element[] => {
+  const options: JSX.Element[] = [];
+  for (let n = 1; n <= MAX_DURATION_DAYS; n++) {
+    const label = startDate
+      ? `${n} day${n === 1 ? "" : "s"}: ${formatDateLabel(addDays(startDate, n - 1))}`
+      : `${n} day${n === 1 ? "" : "s"}`;
+    options.push(
+      <option selected={n === selected} value={n}>
+        {label}
+      </option>,
+    );
+  }
+  return options;
+};
+
+/** Shared start date + length for every daily listing. The length is a select
+ * of day counts (the end date is derived, never edited directly). */
+const SharedDateFields = ({
+  data,
+}: {
+  data: AttendeeFormTemplateData;
+}): JSX.Element => (
+  <>
+    <h3>Dates</h3>
+    {data.dateError && (
+      <output class="error" role="alert">
+        {data.dateError}
+      </output>
+    )}
+    <label for={START_DATE_FIELD}>
+      Start date
+      <input
+        id={START_DATE_FIELD}
+        name={START_DATE_FIELD}
+        required={data.mode === "create"}
+        type="date"
+        value={data.parsed.startDate}
+      />
+    </label>
+    <label for={DAY_COUNT_FIELD}>
+      Length
+      <select id={DAY_COUNT_FIELD} name={DAY_COUNT_FIELD}>
+        {dayCountOptions(data.parsed.startDate, data.parsed.dayCount)}
+      </select>
+    </label>
   </>
 );
 
-/** Render the bulk-email contact history (edit mode only). Shows the contact
- * stats when the attendee has an email and has been contacted, otherwise a
- * placeholder. Owners also get a button to email just this attendee, prefilled
- * by token — disabled when there's no email address to send to. */
+/** Render the bulk-email contact history (edit mode only). */
 const EmailHistory = ({
   attendee,
   emailStats,
@@ -358,12 +341,11 @@ const MergeSection = ({ attendee }: { attendee: Attendee }): JSX.Element => (
 
 /** Page title for the layout. */
 const pageTitle = (data: AttendeeFormTemplateData): string =>
-  data.mode === "create" ? "Add Attendee" : `Attendee: ${data.attendee!.name}`;
+  data.mode === "create"
+    ? "Add new attendee"
+    : `Attendee: ${data.attendee!.name}`;
 
-/**
- * The attendee's current status as an `<h2>`, shown only when the site has more
- * than one status configured (with a single status it carries no information).
- */
+/** The attendee's current status as an `<h2>`, shown only with >1 status. */
 const StatusHeading = ({
   data,
 }: {
@@ -376,64 +358,9 @@ const StatusHeading = ({
   return <h2>Status: {status ? status.name : "None"}</h2>;
 };
 
-/** Tiny progressive-enhancement script: hide the date field on non-daily
- * listings and populate defaults when a daily listing is first chosen. The
- * form is fully usable without it — the server validates conditionally. */
-const renderEnhancementScript = (data: AttendeeFormTemplateData): string => {
-  const availableDatesJson = JSON.stringify(data.availableDatesByListing);
-  const listingsByType: Record<number, "daily" | "standard"> = {};
-  for (const listing of data.allListings) {
-    listingsByType[listing.id] = listing.listing_type;
-  }
-  const listingTypesJson = JSON.stringify(listingsByType);
-  const customisableJson = JSON.stringify(data.customisableByListing);
-  return `<script type="application/json" id="attendee-form-data" data-available-dates='${escapeHtml(availableDatesJson)}' data-listing-types='${escapeHtml(listingTypesJson)}' data-customisable='${escapeHtml(customisableJson)}'></script>
-  <script>
-    (function () {
-      var dataEl = document.getElementById('attendee-form-data');
-      if (!dataEl) return;
-      var availableDates = JSON.parse(dataEl.getAttribute('data-available-dates') || '{}');
-      var listingTypes = JSON.parse(dataEl.getAttribute('data-listing-types') || '{}');
-      var customisable = JSON.parse(dataEl.getAttribute('data-customisable') || '{}');
-      function updateRow(row) {
-        var select = row.querySelector('[data-line-event]');
-        var dateInput = row.querySelector('[data-line-date]');
-        if (!select || !dateInput) return;
-        var listingId = Number(select.value);
-        var isDaily = listingTypes[listingId] === 'daily';
-        dateInput.hidden = !isDaily;
-        if (isDaily && !dateInput.value) {
-          var dates = availableDates[listingId] || [];
-          if (dates.length) dateInput.value = dates[0];
-        }
-        var daySelect = row.querySelector('[data-line-day-count]');
-        if (daySelect) {
-          var counts = customisable[listingId];
-          var isCustomisable = isDaily && counts && counts.length;
-          daySelect.hidden = !isCustomisable;
-          if (isCustomisable) {
-            var prev = daySelect.value;
-            daySelect.innerHTML = counts.map(function (n) {
-              return '<option value="' + n + '"' + (String(n) === prev ? ' selected' : '') + '>' + n + (n === 1 ? ' day' : ' days') + '</option>';
-            }).join('');
-          }
-        }
-      }
-      document.querySelectorAll('[data-line-row]').forEach(function (row) {
-        var select = row.querySelector('[data-line-event]');
-        if (select) select.addEventListener('change', function () { updateRow(row); });
-        updateRow(row);
-      });
-    })();
-  </script>`;
-};
-
 /**
  * Status dropdown, outstanding-balance editor, and a status/balance mismatch
- * notice (precomputed by the route): a warning for a paid status that still
- * owes or a reservation that's lost its balance, and a softer info nudge for a
- * fully-paid reservation. A reservation that still owes is the normal state and
- * shows nothing.
+ * notice (precomputed by the route).
  */
 const StatusAndBalanceFields = ({
   data,
@@ -441,11 +368,6 @@ const StatusAndBalanceFields = ({
   data: AttendeeFormTemplateData;
 }): JSX.Element => {
   const { statusId, remainingBalance } = data.parsed;
-  // An attendee always resolves to a concrete status: their own when set,
-  // otherwise the public default (the status new bookings start in). There is
-  // no "no status" choice — with multiple statuses we fall back to the default,
-  // and with a single status the field isn't shown at all. The save path uses
-  // the same resolver so a blank submission can't clear the status either.
   const selectedId = resolveStatusId(statusId, data.statuses);
   return (
     <>
@@ -456,8 +378,6 @@ const StatusAndBalanceFields = ({
         </output>
       )}
       {data.statuses.length <= 1 ? (
-        // A lone status carries no information (mirrors the status heading), so
-        // keep it off the form but still submit it so a save never clears it.
         <input name={STATUS_FIELD} type="hidden" value={selectedId} />
       ) : (
         <label for={STATUS_FIELD}>
@@ -492,11 +412,8 @@ const StatusAndBalanceFields = ({
 };
 
 /**
- * The editable attendee form: contact details, optional custom questions, and
- * the listing-line editor, all inside one CsrfForm. Status & Balance sit right
- * after the name and before the contact fields, per the agreed field order.
- * The add-line / remove-line / save buttons are all submitters of this one
- * form; the server distinguishes them by the `action` value.
+ * The editable attendee form: contact details, the shared date range, optional
+ * custom questions, and the listing editor — all inside one CsrfForm.
  */
 const AttendeeEditForm = ({
   data,
@@ -582,29 +499,21 @@ const AttendeeEditForm = ({
         </>
       )}
 
+      <SharedDateFields data={data} />
+
       <h3>Listing Registrations</h3>
-      <LineEditor data={data} />
-      <p>
-        <button
-          formnovalidate
-          name={ACTION_FIELD}
-          type="submit"
-          value={ADD_LINE_ACTION}
-        >
-          <Icon name="plus" />
-          <span>Add Listing Line</span>
-        </button>
-      </p>
+      {data.hasMixedTimings && (
+        <output class="warning">
+          This attendee's existing daily listings have different start dates or
+          lengths. Saving will put them all on the one date range above.
+        </output>
+      )}
+      <ListingEditor data={data} />
 
       <hr />
 
       <p class="form-actions">
-        <button
-          class="primary"
-          name={ACTION_FIELD}
-          type="submit"
-          value={SAVE_ACTION}
-        >
+        <button class="primary" type="submit">
           <Icon name="save" />
           <span>{isEdit ? "Save Attendee" : "Create Attendee"}</span>
         </button>
@@ -619,11 +528,9 @@ const AttendeeEditForm = ({
 };
 
 /**
- * Render the unified attendee form page (create or edit).
- *
- * The single CsrfForm wraps every input including the line editor, so the
- * add-line / remove-line / save buttons are all submitters of the same
- * form. The server distinguishes them by the `action` value.
+ * Render the unified attendee form page (create or edit). In edit mode the
+ * read-only summary is the primary view and the form sits in a collapsed
+ * disclosure; in create mode the form is the page.
  */
 export const attendeeFormPage = (
   data: AttendeeFormTemplateData,
@@ -631,9 +538,6 @@ export const attendeeFormPage = (
 ): string => {
   const isEdit = data.mode === "edit";
   const a = data.attendee;
-
-  // In edit mode the read-only summary above is the primary view, so the form
-  // is tucked into a collapsed disclosure (below); in create mode it is the page.
   const editForm = <AttendeeEditForm data={data} />;
 
   return String(
@@ -670,14 +574,6 @@ export const attendeeFormPage = (
         </div>
       )}
 
-      {data.dailyDefaults.hasMixedTimings && (
-        <output class="warning">
-          This attendee's existing daily listings have different start dates or
-          durations. You can still add daily lines, but they won't inherit a
-          shared default — pick the date explicitly for each new line.
-        </output>
-      )}
-
       {isEdit ? (
         <details>
           <summary>Edit Attendee Details</summary>
@@ -696,8 +592,6 @@ export const attendeeFormPage = (
       )}
 
       {isEdit && a && <MergeSection attendee={a} />}
-
-      <Raw html={renderEnhancementScript(data)} />
     </Layout>,
   );
 };

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -98,6 +98,10 @@ export type AttendeeFormTemplateData = {
   phonePrefix: string;
   /** This attendee's activity log entries, newest first (edit mode only). */
   activityLog: ActivityLogEntry[];
+  /** Overbooking / over-duration warnings per listing id (booked lines only). */
+  lineWarnings: Map<number, string[]>;
+  /** All warnings flattened, for the top-of-page summary. */
+  topWarnings: string[];
 };
 
 /** Status badges for an existing booking — "Checked in" and/or "Refunded". */
@@ -116,7 +120,13 @@ const bookingStatusBadges = (
 };
 
 /** One row of the listing editor — a listing and its quantity box. */
-const ListingRow = ({ line }: { line: AttendeeFormLine }): JSX.Element => {
+const ListingRow = ({
+  line,
+  warnings,
+}: {
+  line: AttendeeFormLine;
+  warnings: string[];
+}): JSX.Element => {
   const listing = line.listing!;
   const booked = isBookedLine(line) || Boolean(line.existingBooking);
   const isDaily = listing.listing_type === "daily";
@@ -164,6 +174,11 @@ const ListingRow = ({ line }: { line: AttendeeFormLine }): JSX.Element => {
             {line.error}
           </div>
         ) : null}
+        {warnings.map((w) => (
+          <div class="warning small" role="alert">
+            {w}
+          </div>
+        ))}
       </td>
     </tr>
   );
@@ -193,7 +208,10 @@ const ListingEditor = ({
         </thead>
         <tbody>
           {data.parsed.lines.map((line) => (
-            <ListingRow line={line} />
+            <ListingRow
+              line={line}
+              warnings={data.lineWarnings.get(line.listingId) ?? []}
+            />
           ))}
         </tbody>
       </table>
@@ -560,6 +578,17 @@ export const attendeeFormPage = (
         <h1>{pageTitle(data)}</h1>
         <StatusHeading data={data} />
       </div>
+
+      {data.topWarnings.length > 0 && (
+        <output class="warning" role="alert">
+          <strong>Please double-check:</strong>
+          <ul>
+            {data.topWarnings.map((w) => (
+              <li>{w}</li>
+            ))}
+          </ul>
+        </output>
+      )}
 
       {isEdit && a && (
         <AttendeeDetail

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -222,37 +222,49 @@ const dayCountOptions = (
 };
 
 /** Shared start date + length for every daily listing. The length is a select
- * of day counts (the end date is derived, never edited directly). */
+ * of day counts (the end date is derived, never edited directly). The
+ * "availability inaccurate" notice shows until a date is saved, and a small
+ * progressive-enhancement script (client/admin/attendee-dates.ts) re-shows it
+ * when the dates are changed and reveals the length select once a start date is
+ * set. */
 const SharedDateFields = ({
   data,
 }: {
   data: AttendeeFormTemplateData;
-}): JSX.Element => (
-  <>
-    <h3>Dates</h3>
-    {data.dateError && (
-      <output class="error" role="alert">
-        {data.dateError}
+}): JSX.Element => {
+  // Shown when there's no saved/known date yet (a bare create form); the PE
+  // re-shows it whenever the dates are dirtied so the operator re-saves.
+  const noticeHidden = !(data.mode === "create" && !data.parsed.startDate);
+  return (
+    <>
+      <h3>Dates</h3>
+      {data.dateError && (
+        <output class="error" role="alert">
+          {data.dateError}
+        </output>
+      )}
+      <label for={START_DATE_FIELD}>
+        Start date
+        <input
+          id={START_DATE_FIELD}
+          name={START_DATE_FIELD}
+          required={data.mode === "create"}
+          type="date"
+          value={data.parsed.startDate}
+        />
+      </label>
+      <output class="warning" data-availability-notice hidden={noticeHidden}>
+        Availability is inaccurate until dates have been saved.
       </output>
-    )}
-    <label for={START_DATE_FIELD}>
-      Start date
-      <input
-        id={START_DATE_FIELD}
-        name={START_DATE_FIELD}
-        required={data.mode === "create"}
-        type="date"
-        value={data.parsed.startDate}
-      />
-    </label>
-    <label for={DAY_COUNT_FIELD}>
-      Length
-      <select id={DAY_COUNT_FIELD} name={DAY_COUNT_FIELD}>
-        {dayCountOptions(data.parsed.startDate, data.parsed.dayCount)}
-      </select>
-    </label>
-  </>
-);
+      <label data-day-count-label for={DAY_COUNT_FIELD}>
+        Length
+        <select id={DAY_COUNT_FIELD} name={DAY_COUNT_FIELD}>
+          {dayCountOptions(data.parsed.startDate, data.parsed.dayCount)}
+        </select>
+      </label>
+    </>
+  );
+};
 
 /** Render the bulk-email contact history (edit mode only). */
 const EmailHistory = ({

--- a/src/ui/templates/admin/availability-checker.tsx
+++ b/src/ui/templates/admin/availability-checker.tsx
@@ -1,0 +1,124 @@
+/**
+ * Calendar availability checker.
+ *
+ * A closed-by-default disclosure on the admin calendar listing every bookable
+ * listing with its remaining capacity and price. Listings are selected with the
+ * same hidden-checkbox mechanic the public `/order` page uses (a CSS counter
+ * drives the floating button), and the form GETs to `/admin/attendees/new` so
+ * the chosen listings — and the calendar's selected date — arrive pre-filled on
+ * the create-attendee form. Selection and the live count are pure CSS; a small
+ * progressive-enhancement script (see `client/admin/availability-checker.ts`)
+ * only persists the open/closed state across a single navigation.
+ */
+
+import { sort } from "#fp";
+import { formatCurrency } from "#shared/currency.ts";
+import { SELECT_PREFIX, START_DATE_FIELD } from "#shared/order-select.ts";
+import { Icon } from "#templates/components/actions.tsx";
+
+/** One row of the availability table: a bookable listing and its remaining
+ * capacity for the selected date (or overall when no date is selected). */
+export type AvailabilityRow = {
+  id: number;
+  name: string;
+  remaining: number;
+  total: number;
+  unitPrice: number;
+  canPayMore: boolean;
+};
+
+/** Price label mirroring the public order card: "Free" for £0 listings, a
+ * "From" prefix when the buyer may pay more. */
+const priceLabel = (row: AvailabilityRow): string =>
+  row.unitPrice <= 0
+    ? "Free"
+    : `${row.canPayMore ? "From " : ""}${formatCurrency(row.unitPrice)}`;
+
+/** One selectable listing row. The name links to the listing; the first cell
+ * is the hidden checkbox + tick box that drives selection. */
+const Row = ({ row }: { row: AvailabilityRow }): JSX.Element => {
+  const field = `${SELECT_PREFIX}${row.id}`;
+  return (
+    <tr>
+      <td>
+        <label class="row-select">
+          <input
+            aria-label={`Select ${row.name}`}
+            class="order-select"
+            id={field}
+            name={field}
+            type="checkbox"
+            value="1"
+          />
+          <span aria-hidden="true" class="row-select-tick"></span>
+        </label>
+      </td>
+      <td>
+        <a href={`/admin/listing/${row.id}`}>{row.name}</a>
+      </td>
+      <td class={row.remaining <= 0 ? "danger" : undefined}>
+        {row.remaining}/{row.total}
+      </td>
+      <td>{priceLabel(row)}</td>
+    </tr>
+  );
+};
+
+/**
+ * The availability checker disclosure. Rendered closed; the create-attendee
+ * button is hidden by CSS until at least one listing is selected. `date` (the
+ * calendar's selected day) rides along as a hidden field so the create form can
+ * pre-fill it and show accurate availability.
+ */
+export const AvailabilityChecker = ({
+  rows,
+  date,
+}: {
+  rows: AvailabilityRow[];
+  date: string | null;
+}): JSX.Element => (
+  <details class="availability-checker" data-availability-checker>
+    <summary>Check availability</summary>
+    <div class="availability-checker-body">
+      {rows.length === 0 ? (
+        <p>
+          <em>No bookable listings.</em>
+        </p>
+      ) : (
+        <form
+          action="/admin/attendees/new"
+          class="selectable-form"
+          method="get"
+        >
+          {date && <input name={START_DATE_FIELD} type="hidden" value={date} />}
+          <div class="table-scroll">
+            <table class="availability-table">
+              <thead>
+                <tr>
+                  <th>
+                    <span class="visually-hidden">Select</span>
+                  </th>
+                  <th>Listing</th>
+                  <th>Remaining</th>
+                  <th>Price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sort((a: AvailabilityRow, b: AvailabilityRow) =>
+                  a.name.localeCompare(b.name),
+                )(rows).map((row) => (
+                  <Row row={row} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <button class="order-cart" type="submit">
+            <Icon name="user-plus" />
+            <span aria-hidden="true" class="order-cart-count"></span>
+            <span class="order-cart-label">Create Attendee</span>
+          </button>
+        </form>
+      )}
+    </div>
+  </details>
+);

--- a/src/ui/templates/admin/calendar.tsx
+++ b/src/ui/templates/admin/calendar.tsx
@@ -7,6 +7,10 @@ import { formatDateLabel } from "#shared/dates.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, Attendee } from "#shared/types.ts";
 import {
+  AvailabilityChecker,
+  type AvailabilityRow,
+} from "#templates/admin/availability-checker.tsx";
+import {
   buildSharedDetailRows,
   renderDetailRows,
 } from "#templates/admin/detail-rows.tsx";
@@ -42,6 +46,7 @@ export const adminCalendarPage = (
   phonePrefix?: string,
   questionData?: TableQuestionData,
   hasPaidListing = false,
+  availabilityRows: AvailabilityRow[] = [],
 ): string => {
   const tableRows: AttendeeTableRow[] = pipe(
     map(
@@ -101,6 +106,7 @@ export const adminCalendarPage = (
             <strong>{formatDateLabel(dateFilter)}</strong>
           </p>
         )}
+        <AvailabilityChecker date={dateFilter} rows={availabilityRows} />
         {dateFilter && attendees.length > 0 && (
           <p>
             <a href={`/admin/calendar/export?date=${dateFilter}`}>Export CSV</a>

--- a/src/ui/templates/public.tsx
+++ b/src/ui/templates/public.tsx
@@ -32,6 +32,7 @@ import {
   renderTypeFilter,
 } from "#shared/listing-filter.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
+import { SELECT_PREFIX } from "#shared/order-select.ts";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import {
   availableDayCounts,
@@ -1126,7 +1127,7 @@ const renderOrderCard = (info: TicketListing): string => {
       </div>`;
   }
 
-  const fieldName = `select_${listing.id}`;
+  const fieldName = `${SELECT_PREFIX}${listing.id}`;
   return `<label class="order-card" for="${fieldName}">
       <input class="order-select" id="${fieldName}" name="${fieldName}" type="checkbox" value="1" />
       ${imageHtml}

--- a/test/e2e/ticket-editing.test.ts
+++ b/test/e2e/ticket-editing.test.ts
@@ -39,18 +39,17 @@ const invalidateAllCaches = (): void => {
 };
 
 /**
- * Extract the listing ID for a named listing from a select option in the current page HTML.
- * Used to find the listing id value needed to fill a line's <select> in the unified edit form.
+ * Extract the listing ID for a named listing from its editor-row link in the
+ * current page HTML. The unified form renders `<a href="/admin/listing/N">Name</a>`
+ * for each listing, alongside its quantity box.
  */
-const extractListingIdFromSelect = (
+const extractListingIdFromLink = (
   html: string,
   listingName: string,
 ): string | null => {
   const escaped = listingName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = html.match(
-    new RegExp(
-      `<option[^>]*\\bvalue="(\\d+)"[^>]*>\\s*${escaped}\\s*<\\/option>`,
-    ),
+    new RegExp(`/admin/listing/(\\d+)"[^>]*>${escaped}<`),
   );
   return match?.[1] ?? null;
 };
@@ -291,32 +290,29 @@ describe("e2e: ticket editing flow", () => {
     await visitFirstAttendeeEditPage(browser);
     expect(browser.containsText("Alice Smith")).toBe(true);
 
-    // The Listing Registrations line editor shows Alice's existing booking as a
-    // <select> with Morning Workshop pre-selected (the new form edits the listing
-    // via a dropdown rather than linking out to the listing page).
-    expect(browser.currentHtml).toMatch(
-      /<option selected\b[^>]*>Morning Workshop<\/option>/,
-    );
+    // The Listing Registrations editor shows one quantity box per listing —
+    // Alice's existing Morning Workshop booking plus an empty Evening Seminar row.
     expect(browser.containsText("Morning Workshop")).toBe(true);
+    expect(browser.containsText("Evening Seminar")).toBe(true);
 
-    // 8. Extract the Evening Seminar listing ID from the line select options.
-    //    The unified edit form renders an <option> per active listing inside
-    //    each line's <select>; the option value is the numeric listing id.
-    const eveningSeminarId = extractListingIdFromSelect(
+    // 8. Extract both listing ids from their editor-row links.
+    const morningWorkshopId = extractListingIdFromLink(
+      browser.currentHtml,
+      "Morning Workshop",
+    );
+    const eveningSeminarId = extractListingIdFromLink(
       browser.currentHtml,
       "Evening Seminar",
     );
+    expect(morningWorkshopId).toBeTruthy();
     expect(eveningSeminarId).toBeTruthy();
 
-    // 9. Add Alice to Evening Seminar via the unified form. The form
-    //    already has one existing line (Morning Workshop) plus a trailing
-    //    blank line at index 1. Fill in the blank slot's listing id and
-    //    quantity, then submit "Save Attendee".
+    // 9. Add Alice to Evening Seminar by setting its quantity. submitForm also
+    //    re-submits the visible Morning Workshop quantity, so that booking stays.
     await browser.submitForm(
       {
-        line_event_id_1: eveningSeminarId!,
-        line_quantity_1: "1",
         name: "Alice Smith",
+        [`qty_${eveningSeminarId}`]: "1",
       },
       "Save Attendee",
     );
@@ -327,13 +323,15 @@ describe("e2e: ticket editing flow", () => {
     expect(browser.containsText("Morning Workshop")).toBe(true);
     expect(browser.containsText("Evening Seminar")).toBe(true);
 
-    // 10. Remove Alice from Morning Workshop. The first "Remove" button
-    //     targets the first existing line (Morning Workshop, lower listing id).
-    //     Removal is now a pure form-state edit — it drops the line and
-    //     re-renders; the deletion is committed when the whole attendee is
-    //     saved, so no other in-progress edits are lost to a mid-edit write.
-    await browser.submitForm({}, "Remove");
-    await browser.submitForm({ name: "Alice Smith" }, "Save Attendee");
+    // 10. Remove Alice from Morning Workshop by zeroing its quantity; the save
+    //     deletes that booking while keeping the Evening Seminar one.
+    await browser.submitForm(
+      {
+        name: "Alice Smith",
+        [`qty_${morningWorkshopId}`]: "0",
+      },
+      "Save Attendee",
+    );
     expect(browser.containsText("Updated Alice Smith")).toBe(true);
 
     // 11. Navigate back to Morning Workshop and confirm Alice is no longer there.
@@ -360,9 +358,8 @@ describe("e2e: ticket editing flow", () => {
     // 13. Add Bob to Evening Seminar using the same listing ID extracted earlier
     await browser.submitForm(
       {
-        line_event_id_1: eveningSeminarId!,
-        line_quantity_1: "1",
         name: "Bob Jones",
+        [`qty_${eveningSeminarId}`]: "1",
       },
       "Save Attendee",
     );
@@ -372,10 +369,14 @@ describe("e2e: ticket editing flow", () => {
     expect(browser.containsText("Morning Workshop")).toBe(true);
     expect(browser.containsText("Evening Seminar")).toBe(true);
 
-    // 14. Remove Bob from Morning Workshop (first "Remove" button = Morning
-    //     Workshop), then save to commit the removal.
-    await browser.submitForm({}, "Remove");
-    await browser.submitForm({ name: "Bob Jones" }, "Save Attendee");
+    // 14. Remove Bob from Morning Workshop by zeroing its quantity, then save.
+    await browser.submitForm(
+      {
+        name: "Bob Jones",
+        [`qty_${morningWorkshopId}`]: "0",
+      },
+      "Save Attendee",
+    );
     expect(browser.containsText("Updated Bob Jones")).toBe(true);
 
     // 15. Verify Morning Workshop is now empty — neither Alice nor Bob appear

--- a/test/lib/attendee-form-model.test.ts
+++ b/test/lib/attendee-form-model.test.ts
@@ -1,41 +1,32 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
-  ADD_LINE_ACTION,
   type AttendeeFormLine,
   attendeeBalanceNotice,
   bookingDurationDays,
-  lineDayCount,
+  isBookedLine,
+  type ParsedAttendeeForm,
   parseAttendeeForm,
-  resolveDailyDefaults,
+  resolveSharedDates,
   resolveStatusId,
   toCreateInput,
   toDesiredLines,
-  trimTrailingBlankLines,
   validateParsedForm,
 } from "#routes/admin/attendee-form-model.ts";
-import { addDays } from "#shared/dates.ts";
 import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import type { ListingAttendeeRow } from "#shared/db/attendee-types.ts";
 import { FormParams } from "#shared/form-data.ts";
-import { MAX_FORM_LINES } from "#shared/limits.ts";
-import { todayInTz } from "#shared/timezone.ts";
-import type { Holiday } from "#shared/types.ts";
 import { testListingWithCount } from "#test-utils";
 
 const makeForm = (data: Record<string, string>): FormParams =>
   new FormParams(new URLSearchParams(data));
 
-const blankLine = (
-  overrides: Partial<AttendeeFormLine> = {},
-): AttendeeFormLine => ({
-  date: "",
-  dayCount: null,
+const line = (overrides: Partial<AttendeeFormLine> = {}): AttendeeFormLine => ({
   error: null,
   existingBooking: null,
   key: "",
-  listing: null,
-  listingId: 0,
+  listing: testListingWithCount({ id: 1, max_quantity: 5 }),
+  listingId: 1,
   quantity: 1,
   ...overrides,
 });
@@ -54,94 +45,153 @@ const bookingRow = (
   ...overrides,
 });
 
-describe("trimTrailingBlankLines", () => {
-  test("removes a single trailing blank line", () => {
-    const lines = [
-      blankLine({ listing: testListingWithCount({ id: 1 }), listingId: 1 }),
-      blankLine(),
-    ];
-    expect(trimTrailingBlankLines(lines)).toHaveLength(1);
-  });
-
-  test("removes consecutive trailing blank lines", () => {
-    const lines = [
-      blankLine({ listing: testListingWithCount({ id: 1 }), listingId: 1 }),
-      blankLine(),
-      blankLine(),
-      blankLine(),
-    ];
-    expect(trimTrailingBlankLines(lines)).toHaveLength(1);
-  });
-
-  test("preserves at least one line (the operator's blank placeholder)", () => {
-    expect(trimTrailingBlankLines([blankLine()])).toHaveLength(1);
-  });
-
-  test("does not remove blank lines in the middle", () => {
-    const filled = blankLine({
-      listing: testListingWithCount({ id: 1 }),
-      listingId: 1,
-    });
-    const lines = [filled, blankLine(), filled];
-    expect(trimTrailingBlankLines(lines)).toHaveLength(3);
-  });
+const parsedBase = (
+  overrides: Partial<ParsedAttendeeForm> = {},
+): ParsedAttendeeForm => ({
+  address: "",
+  dayCount: 1,
+  email: "",
+  lines: [],
+  name: "Test",
+  phone: "",
+  remainingBalance: 0,
+  returnUrl: "",
+  special_instructions: "",
+  startDate: "",
+  statusId: null,
+  ...overrides,
 });
 
 describe("parseAttendeeForm", () => {
-  test("reads attendee fields and a single line", () => {
-    const form = makeForm({
-      address: "1 St",
-      email: "a@b.com",
-      line_count: "1",
-      line_event_id_0: "5",
-      line_key_0: "5|",
-      line_quantity_0: "2",
-      name: "Jane",
-      phone: "555",
-      special_instructions: "VIP",
-    });
-    const parsed = parseAttendeeForm(form, new Map());
+  test("reads attendee fields, the shared range, and one qty line", () => {
+    const parsed = parseAttendeeForm(
+      makeForm({
+        address: "1 St",
+        day_count: "3",
+        email: "a@b.com",
+        line_key_5: "5|",
+        name: "Jane",
+        phone: "555",
+        qty_5: "2",
+        special_instructions: "VIP",
+        start_date: "2026-03-02",
+      }),
+      new Map(),
+    );
     expect(parsed.name).toBe("Jane");
     expect(parsed.email).toBe("a@b.com");
-    expect(parsed.phone).toBe("555");
     expect(parsed.address).toBe("1 St");
     expect(parsed.special_instructions).toBe("VIP");
+    expect(parsed.startDate).toBe("2026-03-02");
+    expect(parsed.dayCount).toBe(3);
     expect(parsed.lines).toHaveLength(1);
     expect(parsed.lines[0]!.listingId).toBe(5);
     expect(parsed.lines[0]!.quantity).toBe(2);
     expect(parsed.lines[0]!.key).toBe("5|");
-    expect(parsed.lines[0]!.listing).toBeNull();
-    expect(parsed.action.kind).toBe("save");
   });
 
-  test("reads a selected status id", () => {
+  test("reads one line per qty_<id> field, de-duplicated", () => {
     const parsed = parseAttendeeForm(
-      makeForm({ line_count: "1", name: "X", status_id: "4" }),
+      makeForm({ name: "X", qty_3: "1", qty_7: "0" }),
       new Map(),
     );
-    expect(parsed.statusId).toBe(4);
+    expect(parsed.lines.map((l) => l.listingId)).toEqual([3, 7]);
   });
 
-  test("treats a blank status id as no status", () => {
+  test("resolves listing references against the provided map", () => {
+    const listing = testListingWithCount({ id: 7, name: "Resolved" });
     const parsed = parseAttendeeForm(
-      makeForm({ line_count: "1", name: "X", status_id: "" }),
+      makeForm({ name: "X", qty_7: "1" }),
+      new Map([[7, listing]]),
+    );
+    expect(parsed.lines[0]!.listing?.name).toBe("Resolved");
+  });
+
+  test("ignores non-positive and non-numeric listing ids", () => {
+    const parsed = parseAttendeeForm(
+      makeForm({ name: "X", qty_0: "1", qty_4: "1", qty_abc: "1" }),
       new Map(),
     );
-    expect(parsed.statusId).toBeNull();
+    expect(parsed.lines.map((l) => l.listingId)).toEqual([4]);
   });
 
-  test("treats a non-positive status id as no status", () => {
+  test("treats empty and non-numeric quantity as null", () => {
     const parsed = parseAttendeeForm(
-      makeForm({ line_count: "1", name: "X", status_id: "0" }),
+      makeForm({ name: "X", qty_1: "", qty_2: "abc" }),
       new Map(),
     );
-    expect(parsed.statusId).toBeNull();
+    expect(parsed.lines[0]!.quantity).toBeNull();
+    expect(parsed.lines[1]!.quantity).toBeNull();
   });
 
-  const makeStatus = (
-    id: number,
-    isPublicDefault: boolean,
-  ): AttendeeStatus => ({
+  test("clamps the day count to the valid range", () => {
+    expect(
+      parseAttendeeForm(makeForm({ day_count: "0", name: "X" }), new Map())
+        .dayCount,
+    ).toBe(1);
+    expect(
+      parseAttendeeForm(makeForm({ day_count: "9999", name: "X" }), new Map())
+        .dayCount,
+    ).toBe(90);
+    expect(parseAttendeeForm(makeForm({ name: "X" }), new Map()).dayCount).toBe(
+      1,
+    );
+    // A non-numeric value parses to no count and clamps to 1.
+    expect(
+      parseAttendeeForm(
+        makeForm({ day_count: "garbage", name: "X" }),
+        new Map(),
+      ).dayCount,
+    ).toBe(1);
+  });
+
+  test("reads a selected status id, blank and non-positive as none", () => {
+    expect(
+      parseAttendeeForm(makeForm({ name: "X", status_id: "4" }), new Map())
+        .statusId,
+    ).toBe(4);
+    expect(
+      parseAttendeeForm(makeForm({ name: "X", status_id: "" }), new Map())
+        .statusId,
+    ).toBeNull();
+    expect(
+      parseAttendeeForm(makeForm({ name: "X", status_id: "0" }), new Map())
+        .statusId,
+    ).toBeNull();
+  });
+
+  test("treats blank, zero and negative balances as nothing owed", () => {
+    for (const value of ["", "0", "-5"]) {
+      const parsed = parseAttendeeForm(
+        makeForm({ name: "X", remaining_balance: value }),
+        new Map(),
+      );
+      expect(parsed.remainingBalance).toBe(0);
+    }
+  });
+
+  test("attaches an existing booking row by key", () => {
+    const booking = bookingRow({ listing_id: 5, quantity: 3 });
+    const parsed = parseAttendeeForm(
+      makeForm({ line_key_5: "5|", name: "X", qty_5: "3" }),
+      new Map(),
+      new Map([["5|", booking]]),
+    );
+    expect(parsed.lines[0]!.existingBooking).toEqual(booking);
+  });
+});
+
+describe("isBookedLine", () => {
+  test("true only when quantity ≥ 1 and the listing resolves", () => {
+    expect(isBookedLine(line({ quantity: 2 }))).toBe(true);
+    expect(isBookedLine(line({ quantity: 0 }))).toBe(false);
+    expect(isBookedLine(line({ quantity: null }))).toBe(false);
+    expect(isBookedLine(line({ listing: null }))).toBe(false);
+  });
+});
+
+describe("resolveStatusId", () => {
+  const status = (id: number, isPublicDefault: boolean): AttendeeStatus => ({
     id,
     is_paid_default: false,
     is_public_default: isPublicDefault,
@@ -151,785 +201,318 @@ describe("parseAttendeeForm", () => {
     sort_order: id,
   });
 
-  test("resolveStatusId keeps an explicitly chosen status", () => {
-    const statuses = [makeStatus(1, true), makeStatus(2, false)];
-    expect(resolveStatusId(2, statuses)).toBe(2);
+  test("keeps an explicitly chosen status", () => {
+    expect(resolveStatusId(2, [status(1, true), status(2, false)])).toBe(2);
   });
 
-  test("resolveStatusId falls back to the public default when none is given", () => {
-    const statuses = [makeStatus(1, false), makeStatus(2, true)];
-    expect(resolveStatusId(null, statuses)).toBe(2);
-  });
-
-  test("treats blank, zero and negative balances as nothing owed", () => {
-    for (const value of ["", "0", "-5"]) {
-      const parsed = parseAttendeeForm(
-        makeForm({ line_count: "1", name: "X", remaining_balance: value }),
-        new Map(),
-      );
-      expect(parsed.remainingBalance).toBe(0);
-    }
-  });
-
-  test("toCreateInput carries the status id and balance through", () => {
-    const input = toCreateInput({
-      action: { kind: "save" },
-      address: "",
-      email: "",
-      lines: [blankLine()],
-      name: "X",
-      phone: "",
-      remainingBalance: 1500,
-      returnUrl: "",
-      special_instructions: "",
-      statusId: 7,
-    });
-    expect(input.statusId).toBe(7);
-    expect(input.remainingBalance).toBe(1500);
-    expect(input.bookings).toHaveLength(0);
-  });
-
-  test("resolves listing references against the provided map", () => {
-    const listing = testListingWithCount({ id: 7, name: "Resolved" });
-    const form = makeForm({
-      line_count: "1",
-      line_event_id_0: "7",
-      line_quantity_0: "1",
-      name: "X",
-    });
-    const parsed = parseAttendeeForm(form, new Map([[7, listing]]));
-    expect(parsed.lines[0]!.listing?.name).toBe("Resolved");
-  });
-
-  test("treats non-numeric or missing event_id as blank line (listingId 0)", () => {
-    const form = makeForm({
-      line_count: "1",
-      line_event_id_0: "not-a-number",
-      line_quantity_0: "1",
-      name: "X",
-    });
-    expect(parseAttendeeForm(form, new Map()).lines[0]!.listingId).toBe(0);
-  });
-
-  test("treats empty quantity as null", () => {
-    const form = makeForm({
-      line_count: "1",
-      line_event_id_0: "1",
-      line_quantity_0: "",
-      name: "X",
-    });
-    expect(parseAttendeeForm(form, new Map()).lines[0]!.quantity).toBeNull();
-  });
-
-  test("parses add_line and remove_line actions", () => {
-    const addForm = makeForm({
-      action: ADD_LINE_ACTION,
-      line_count: "1",
-      name: "X",
-    });
-    expect(parseAttendeeForm(addForm, new Map()).action).toEqual({
-      kind: "add_line",
-    });
-
-    const removeForm = makeForm({
-      action: "remove_line_2",
-      line_count: "3",
-      name: "X",
-    });
-    expect(parseAttendeeForm(removeForm, new Map()).action).toEqual({
-      index: 2,
-      kind: "remove_line",
-    });
-  });
-
-  test("falls back to line_count=1 on malformed input", () => {
-    const form = makeForm({ line_count: "garbage", name: "X" });
-    expect(parseAttendeeForm(form, new Map()).lines).toHaveLength(1);
-  });
-
-  test("clamps an abusive line_count to MAX_FORM_LINES", () => {
-    const form = makeForm({
-      line_count: String(MAX_FORM_LINES + 50),
-      name: "X",
-    });
-    expect(parseAttendeeForm(form, new Map()).lines).toHaveLength(
-      MAX_FORM_LINES,
-    );
-  });
-
-  test("attaches existing booking rows by key", () => {
-    const booking = bookingRow({ listing_id: 5, quantity: 3 });
-    const form = makeForm({
-      line_count: "1",
-      line_event_id_0: "5",
-      line_key_0: "5|",
-      line_quantity_0: "3",
-      name: "X",
-    });
-    const parsed = parseAttendeeForm(
-      form,
-      new Map(),
-      new Map([["5|", booking]]),
-    );
-    expect(parsed.lines[0]!.existingBooking).toEqual(booking);
+  test("falls back to the public default when none is given", () => {
+    expect(resolveStatusId(null, [status(1, false), status(2, true)])).toBe(2);
   });
 });
 
 describe("validateParsedForm", () => {
   test("fails when name is blank", () => {
-    const parsed = parseAttendeeForm(
-      makeForm({ line_count: "1", name: "" }),
-      new Map(),
-    );
-    const result = validateParsedForm(parsed, []);
+    const result = validateParsedForm(parsedBase({ name: "" }));
     expect(result.valid).toBe(false);
-    if (!result.valid) {
-      expect(result.attendeeError?.field).toBe("name");
-    }
+    if (!result.valid) expect(result.attendeeError?.field).toBe("name");
   });
 
-  test("passes for a valid line pointing at an active listing", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "2",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
-    );
-    const result = validateParsedForm(parsed, []);
+  test("passes for a booked standard listing with no date", () => {
+    const result = validateParsedForm(parsedBase({ lines: [line()] }));
     expect(result.valid).toBe(true);
   });
 
-  test("fails when selected listing is unknown", () => {
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "999",
-        line_quantity_0: "1",
-        name: "Jane",
+  test("fails when a booked quantity exceeds the listing max", () => {
+    const result = validateParsedForm(
+      parsedBase({
+        lines: [
+          line({
+            listing: testListingWithCount({ id: 1, max_quantity: 5 }),
+            quantity: 10,
+          }),
+        ],
       }),
-      new Map(),
     );
-    const result = validateParsedForm(parsed, []);
     expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.lineErrors.get(0)).toContain("at most 5");
   });
 
-  test("fails when quantity is below 1", () => {
-    const listing = testListingWithCount({ active: true, id: 1 });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "0",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
+  test("treats a 0-quantity line as not booked, not an error", () => {
+    const result = validateParsedForm(
+      parsedBase({ lines: [line({ quantity: 0 })] }),
     );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-  });
-
-  test("fails when quantity exceeds listing max_quantity", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "10",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
-    );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-  });
-
-  test("fails when daily listing is selected but date is missing", () => {
-    const listing = testListingWithCount({
-      bookable_days: ["Monday"],
-      duration_days: 1,
-      id: 1,
-      listing_type: "daily",
-      maximum_days_after: 30,
-      minimum_days_before: 0,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
-    );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-  });
-
-  test("fails on duplicate (listing_id, date) pairs", () => {
-    const listing = testListingWithCount({ active: true, id: 1 });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "2",
-        line_event_id_0: "1",
-        line_event_id_1: "1",
-        line_quantity_0: "1",
-        line_quantity_1: "1",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
-    );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-  });
-
-  test("allows trailing blank lines (the placeholder row)", () => {
-    const listing = testListingWithCount({ active: true, id: 1 });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "2",
-        line_event_id_0: "1",
-        line_event_id_1: "",
-        line_quantity_0: "1",
-        line_quantity_1: "",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
-    );
-    const trimmed = { ...parsed, lines: trimTrailingBlankLines(parsed.lines) };
-    const result = validateParsedForm(trimmed, []);
     expect(result.valid).toBe(true);
   });
 
-  test("rejects a malformed email even though it is optional", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        email: "not-an-email",
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
+  test("ignores an unbooked line whose listing is unknown", () => {
+    const result = validateParsedForm(
+      parsedBase({ lines: [line({ listing: null, quantity: 1 })] }),
     );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.attendeeError?.field).toBe("email");
+    expect(result.valid).toBe(true);
   });
 
-  test("rejects a malformed phone even though it is optional", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-        phone: "not a phone",
+  test("allows keeping a booked inactive listing", () => {
+    const result = validateParsedForm(
+      parsedBase({
+        lines: [
+          line({ listing: testListingWithCount({ active: false, id: 1 }) }),
+        ],
       }),
-      new Map([[1, listing]]),
     );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.attendeeError?.field).toBe("phone");
+    expect(result.valid).toBe(true);
   });
 
-  test("rejects an address that exceeds the length cap", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        address: "x".repeat(251),
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
+  test("fails when a daily listing is booked but the start date is missing", () => {
+    const result = validateParsedForm(
+      parsedBase({
+        lines: [
+          line({
+            listing: testListingWithCount({ id: 1, listing_type: "daily" }),
+          }),
+        ],
+        startDate: "",
       }),
-      new Map([[1, listing]]),
     );
-    const result = validateParsedForm(parsed, []);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.attendeeError?.field).toBe("address");
+    if (!result.valid) expect(result.dateError).toContain("start date");
   });
 
-  test("rejects special instructions that exceed the length cap", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-        special_instructions: "x".repeat(251),
+  test("passes a booked daily listing with a valid start date", () => {
+    const result = validateParsedForm(
+      parsedBase({
+        lines: [
+          line({
+            listing: testListingWithCount({ id: 1, listing_type: "daily" }),
+          }),
+        ],
+        startDate: "2026-03-02",
       }),
-      new Map([[1, listing]]),
     );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-    if (!result.valid) {
-      expect(result.attendeeError?.field).toBe("special_instructions");
-    }
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a malformed email, phone, address and instructions", () => {
+    expect(
+      validateParsedForm(parsedBase({ email: "nope", lines: [line()] })).valid,
+    ).toBe(false);
+    expect(
+      validateParsedForm(parsedBase({ lines: [line()], phone: "not a phone" }))
+        .valid,
+    ).toBe(false);
+    expect(
+      validateParsedForm(
+        parsedBase({ address: "x".repeat(251), lines: [line()] }),
+      ).valid,
+    ).toBe(false);
+    expect(
+      validateParsedForm(
+        parsedBase({ lines: [line()], special_instructions: "x".repeat(251) }),
+      ).valid,
+    ).toBe(false);
   });
 
   test("accepts well-formed optional email and phone", () => {
-    const listing = testListingWithCount({
-      active: true,
-      id: 1,
-      max_quantity: 5,
-    });
-    const parsed = parseAttendeeForm(
-      makeForm({
+    const result = validateParsedForm(
+      parsedBase({
         email: "jane@example.com",
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
+        lines: [line()],
         phone: "+1 (555) 123-4567",
       }),
-      new Map([[1, listing]]),
     );
-    const result = validateParsedForm(parsed, []);
     expect(result.valid).toBe(true);
   });
+});
 
-  test("ignores inactive listing when validation runs", () => {
-    const listing = testListingWithCount({ active: false, id: 1 });
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, listing]]),
+describe("toCreateInput", () => {
+  test("carries the status id and balance through", () => {
+    const input = toCreateInput(
+      parsedBase({ remainingBalance: 1500, statusId: 7 }),
     );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-  });
-});
-
-describe("resolveDailyDefaults", () => {
-  test("returns empty defaults when no existing daily bookings", () => {
-    const result = resolveDailyDefaults([blankLine()]);
-    expect(result.hasMixedTimings).toBe(false);
-    expect(result.inheritedDate).toBeNull();
-    expect(result.inheritedDurationDays).toBeNull();
+    expect(input.statusId).toBe(7);
+    expect(input.remainingBalance).toBe(1500);
+    expect(input.bookings).toHaveLength(0);
   });
 
-  test("inherits uniform daily bookings (same start date + duration)", () => {
-    const listing = testListingWithCount({
-      id: 1,
-      listing_type: "daily",
-    });
-    const booking = bookingRow({
-      end_at: "2026-06-15T00:00:00.000Z",
-      listing_id: 1,
-      start_at: "2026-06-14T00:00:00Z",
-    });
-    const line = blankLine({
-      existingBooking: booking,
-      key: "1|2026-06-14T00:00:00Z",
-      listing,
-      listingId: 1,
-    });
-    const result = resolveDailyDefaults([line]);
-    expect(result.hasMixedTimings).toBe(false);
-    expect(result.inheritedDate).toBe("2026-06-14");
-    expect(result.inheritedDurationDays).toBe(1);
-  });
-
-  test("flags mixed daily timings (different start dates)", () => {
-    const listing = testListingWithCount({
-      id: 1,
-      listing_type: "daily",
-    });
-    const lineA = blankLine({
-      existingBooking: bookingRow({
-        end_at: "2026-06-15T00:00:00.000Z",
-        listing_id: 1,
-        start_at: "2026-06-14T00:00:00Z",
+  test("books daily listings on the shared range and standard with no date", () => {
+    const input = toCreateInput(
+      parsedBase({
+        dayCount: 3,
+        lines: [
+          line({
+            listing: testListingWithCount({ id: 1, listing_type: "daily" }),
+            listingId: 1,
+            quantity: 2,
+          }),
+          line({
+            listing: testListingWithCount({ id: 2, listing_type: "standard" }),
+            listingId: 2,
+            quantity: 1,
+          }),
+          line({ listingId: 3, quantity: 0 }),
+        ],
+        startDate: "2026-03-02",
       }),
-      key: "1|2026-06-14T00:00:00Z",
-      listing,
-      listingId: 1,
-    });
-    const lineB = blankLine({
-      existingBooking: bookingRow({
-        end_at: "2026-07-02T00:00:00.000Z",
-        listing_id: 1,
-        start_at: "2026-07-01T00:00:00Z",
-      }),
-      key: "1|2026-07-01T00:00:00Z",
-      listing,
-      listingId: 1,
-    });
-    const result = resolveDailyDefaults([lineA, lineB]);
-    expect(result.hasMixedTimings).toBe(true);
-    expect(result.inheritedDate).toBeNull();
-  });
-
-  test("flags mixed daily timings (different durations)", () => {
-    const listing = testListingWithCount({
-      id: 1,
-      listing_type: "daily",
-    });
-    const lineA = blankLine({
-      existingBooking: bookingRow({
-        end_at: "2026-06-15T00:00:00.000Z",
-        listing_id: 1,
-        start_at: "2026-06-14T00:00:00Z",
-      }),
-      key: "1|2026-06-14T00:00:00Z",
-      listing,
-      listingId: 1,
-    });
-    const lineB = blankLine({
-      existingBooking: bookingRow({
-        end_at: "2026-06-17T00:00:00.000Z",
-        listing_id: 1,
-        start_at: "2026-06-14T00:00:00Z",
-      }),
-      key: "1|2026-06-14T00:00:00Z",
-      listing,
-      listingId: 1,
-    });
-    const result = resolveDailyDefaults([lineA, lineB]);
-    expect(result.hasMixedTimings).toBe(true);
-  });
-
-  test("ignores standard-listing bookings when computing daily defaults", () => {
-    const standardListing = testListingWithCount({
-      id: 1,
-      listing_type: "standard",
-    });
-    const line = blankLine({
-      existingBooking: bookingRow({ listing_id: 1 }),
-      listing: standardListing,
-      listingId: 1,
-    });
-    const result = resolveDailyDefaults([line]);
-    expect(result.hasMixedTimings).toBe(false);
-    expect(result.inheritedDate).toBeNull();
-  });
-});
-
-describe("parseAttendeeForm quantity edge cases", () => {
-  test("converts non-numeric quantity string to null", () => {
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_event_id_0: "1",
-        line_quantity_0: "abc",
-        name: "Test",
-      }),
-      new Map(),
     );
-    expect(parsed.lines[0]!.quantity).toBeNull();
-  });
-});
-
-describe("validateLine daily date checks", () => {
-  test("rejects an invalid date string for a daily listing", () => {
-    const dailyListing = {
-      ...testListingWithCount({ listing_type: "daily" }),
-      bookableDays: ["2026-06-15"],
-      duration_days: 1,
-    };
-    const holidays: Holiday[] = [];
-    const line = blankLine({
-      date: "not-a-date",
-      listing: dailyListing,
-      listingId: dailyListing.id,
+    expect(input.bookings).toHaveLength(2);
+    expect(input.bookings[0]).toEqual({
+      date: "2026-03-02",
+      durationDays: 3,
+      listingId: 1,
+      quantity: 2,
+    });
+    expect(input.bookings[1]).toEqual({
+      date: null,
+      durationDays: undefined,
+      listingId: 2,
       quantity: 1,
     });
-    const result = validateParsedForm(
-      { ...parsedBase(), lines: [line] },
-      holidays,
-    );
-    expect(result.valid).toBe(false);
-    if (!result.valid) {
-      expect(result.lineErrors.get(0)).toBe(
-        "Date must be a valid YYYY-MM-DD value",
-      );
-    }
   });
+});
 
-  test("rejects a daily date that is not in allowed bookable days", () => {
-    const dailyListing = {
-      ...testListingWithCount({
-        bookable_days: [],
-        listing_type: "daily",
+describe("toDesiredLines", () => {
+  test("marks existing lines as updates and new lines as inserts", () => {
+    const desired = toDesiredLines(
+      parsedBase({
+        dayCount: 2,
+        lines: [
+          line({
+            existingBooking: bookingRow({ listing_id: 1 }),
+            key: "1|2026-03-01T00:00:00Z",
+            listing: testListingWithCount({ id: 1, listing_type: "daily" }),
+            listingId: 1,
+            quantity: 1,
+          }),
+          line({
+            listing: testListingWithCount({ id: 2, listing_type: "daily" }),
+            listingId: 2,
+            quantity: 1,
+          }),
+        ],
+        startDate: "2026-03-05",
       }),
-      duration_days: 1,
-    };
-    const holidays: Holiday[] = [];
-    const line = blankLine({
-      date: "2026-06-20",
-      listing: dailyListing,
-      listingId: dailyListing.id,
+    );
+    // The existing line keeps its old key (so the date move is an UPDATE)…
+    expect(desired[0]).toEqual({
+      date: "2026-03-05",
+      durationDays: 2,
+      exists: true,
+      key: "1|2026-03-01T00:00:00Z",
+      listingId: 1,
       quantity: 1,
     });
-    const result = validateParsedForm(
-      { ...parsedBase(), lines: [line] },
-      holidays,
+    // …the new line is an INSERT.
+    expect(desired[1]!.exists).toBe(false);
+    expect(desired[1]!.key).toBe("");
+  });
+
+  test("excludes unbooked lines", () => {
+    const desired = toDesiredLines(
+      parsedBase({ lines: [line({ quantity: 0 })] }),
     );
-    expect(result.valid).toBe(false);
-    if (!result.valid) {
-      expect(result.lineErrors.get(0)).toBe(
-        "Date is not bookable for this listing",
-      );
-    }
+    expect(desired).toHaveLength(0);
+  });
+});
+
+describe("resolveSharedDates", () => {
+  const addDaysIso = (date: string, n: number): string => {
+    const d = new Date(`${date}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + n);
+    return d.toISOString().slice(0, 10);
+  };
+
+  const daily = (start: string, durationDays: number): ListingAttendeeRow =>
+    bookingRow({
+      end_at: `${addDaysIso(start, durationDays)}T00:00:00.000Z`,
+      start_at: `${start}T00:00:00Z`,
+    });
+
+  test("returns empty defaults when there are no dated bookings", () => {
+    const result = resolveSharedDates([bookingRow({ start_at: null })]);
+    expect(result).toEqual({
+      dayCount: 1,
+      hasMixedTimings: false,
+      startDate: "",
+    });
+  });
+
+  test("returns the shared range when bookings agree", () => {
+    const result = resolveSharedDates([
+      daily("2026-06-14", 1),
+      daily("2026-06-14", 1),
+    ]);
+    expect(result.hasMixedTimings).toBe(false);
+    expect(result.startDate).toBe("2026-06-14");
+    expect(result.dayCount).toBe(1);
+  });
+
+  test("flags mixed start dates, seeding earliest start + longest length", () => {
+    const result = resolveSharedDates([
+      daily("2026-07-01", 1),
+      daily("2026-06-14", 3),
+    ]);
+    expect(result.hasMixedTimings).toBe(true);
+    expect(result.startDate).toBe("2026-06-14");
+    expect(result.dayCount).toBe(3);
+  });
+
+  test("flags mixed durations", () => {
+    const result = resolveSharedDates([
+      daily("2026-06-14", 1),
+      daily("2026-06-14", 3),
+    ]);
+    expect(result.hasMixedTimings).toBe(true);
+  });
+
+  test("ignores a booking with no end date", () => {
+    const result = resolveSharedDates([
+      bookingRow({ end_at: null, start_at: "2026-06-14T00:00:00Z" }),
+    ]);
+    expect(result.startDate).toBe("");
+  });
+
+  test("falls back to length 1 for a dated but zero-length booking", () => {
+    // Both endpoints present (so it passes the filter) but the range is empty,
+    // so the per-booking duration is null and defaults to 1.
+    const result = resolveSharedDates([daily("2026-06-14", 0)]);
+    expect(result.startDate).toBe("2026-06-14");
+    expect(result.dayCount).toBe(1);
+    expect(result.hasMixedTimings).toBe(false);
   });
 });
 
 describe("bookingDurationDays", () => {
-  test("returns null when start_at is missing", () => {
-    const row = bookingRow({ end_at: "2026-06-14", start_at: null });
-    expect(bookingDurationDays(row)).toBeNull();
+  test("returns null when a range endpoint is missing or invalid", () => {
+    expect(
+      bookingDurationDays(bookingRow({ end_at: "x", start_at: null })),
+    ).toBeNull();
+    expect(
+      bookingDurationDays(bookingRow({ end_at: null, start_at: "x" })),
+    ).toBeNull();
+    expect(
+      bookingDurationDays(bookingRow({ end_at: "bad", start_at: "bad" })),
+    ).toBeNull();
   });
 
-  test("returns null when end_at is missing", () => {
-    const row = bookingRow({ end_at: null, start_at: "2026-06-14" });
-    expect(bookingDurationDays(row)).toBeNull();
+  test("returns null for a zero-length range", () => {
+    expect(
+      bookingDurationDays(
+        bookingRow({
+          end_at: "2026-06-14T00:00:00Z",
+          start_at: "2026-06-14T00:00:00Z",
+        }),
+      ),
+    ).toBeNull();
   });
 
-  test("returns null for invalid date strings", () => {
-    const row = bookingRow({ end_at: "also-invalid", start_at: "invalid" });
-    expect(bookingDurationDays(row)).toBeNull();
-  });
-
-  test("returns null when computed duration is less than 1 day", () => {
-    const row = bookingRow({
-      end_at: "2026-06-14T00:00:00Z",
-      start_at: "2026-06-14T00:00:00Z",
-    });
-    expect(bookingDurationDays(row)).toBeNull();
-  });
-});
-
-describe("resolveDailyDefaults fallback", () => {
-  test("falls back to duration 1 when existing daily booking has invalid duration", () => {
-    const dailyListing = testListingWithCount({ listing_type: "daily" });
-    const line = blankLine({
-      existingBooking: bookingRow({
-        end_at: null,
-        listing_id: dailyListing.id,
-        start_at: "2026-06-14",
-      }),
-      listing: dailyListing,
-      listingId: dailyListing.id,
-    });
-    const result = resolveDailyDefaults([line]);
-    expect(result.hasMixedTimings).toBe(false);
-    expect(result.inheritedDate).toBe("2026-06-14");
-    expect(result.inheritedDurationDays).toBe(1);
-  });
-});
-
-function parsedBase() {
-  return {
-    action: { kind: "save" } as const,
-    address: "",
-    email: "",
-    name: "Test",
-    phone: "",
-    remainingBalance: 0,
-    returnUrl: "",
-    special_instructions: "",
-    statusId: null,
-  };
-}
-
-describe("customisable day count (edit)", () => {
-  const custDaily = (overrides = {}) =>
-    testListingWithCount({
-      active: true,
-      customisable_days: true,
-      day_prices: { 1: 0, 2: 0 },
-      duration_days: 2,
-      id: 1,
-      listing_type: "daily",
-      max_quantity: 5,
-      ...overrides,
-    });
-
-  const futureDate = () => addDays(todayInTz("UTC"), 30);
-
-  test("accepts a line whose chosen day count is offered", () => {
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_date_0: futureDate(),
-        line_day_count_0: "2",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, custDaily()]]),
-    );
-    expect(validateParsedForm(parsed, []).valid).toBe(true);
-  });
-
-  test("rejects a day count the listing does not offer", () => {
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_date_0: futureDate(),
-        line_day_count_0: "5",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([
-        [1, custDaily({ day_prices: { 1: 0, 2: 0 }, duration_days: 5 })],
-      ]),
-    );
-    const result = validateParsedForm(parsed, []);
-    expect(result.valid).toBe(false);
-  });
-
-  test("rejects a chosen span that overlaps a holiday", () => {
-    const date = futureDate();
-    const holiday: Holiday = {
-      end_date: addDays(date, 1),
-      id: 1,
-      name: "H",
-      start_date: addDays(date, 1),
-    };
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_date_0: date,
-        line_day_count_0: "2",
-        line_event_id_0: "1",
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, custDaily()]]),
-    );
-    expect(validateParsedForm(parsed, [holiday]).valid).toBe(false);
-  });
-
-  test("preserves an existing booking's span when no count is submitted", () => {
-    const key = "1|2026-09-10T00:00:00Z";
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_date_0: "2026-09-10",
-        line_event_id_0: "1",
-        line_key_0: key,
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, custDaily({ duration_days: 5 })]]),
-      new Map([
-        [
-          key,
-          bookingRow({
-            // A stored 2-day span (10th → exclusive 12th).
-            end_at: "2026-09-12T00:00:00.000Z",
-            listing_id: 1,
-            start_at: "2026-09-10T00:00:00Z",
-          }),
-        ],
-      ]),
-    );
-    expect(toDesiredLines(parsed)[0]!.durationDays).toBe(2);
-  });
-
-  test("uses the submitted count over the existing span", () => {
-    const key = "1|2026-09-10T00:00:00Z";
-    const parsed = parseAttendeeForm(
-      makeForm({
-        line_count: "1",
-        line_date_0: "2026-09-10",
-        line_day_count_0: "1",
-        line_event_id_0: "1",
-        line_key_0: key,
-        line_quantity_0: "1",
-        name: "Jane",
-      }),
-      new Map([[1, custDaily({ duration_days: 5 })]]),
-      new Map([
-        [
-          key,
-          bookingRow({
-            end_at: "2026-09-12T00:00:00.000Z",
-            listing_id: 1,
-            start_at: "2026-09-10T00:00:00Z",
-          }),
-        ],
-      ]),
-    );
-    expect(toDesiredLines(parsed)[0]!.durationDays).toBe(1);
-  });
-});
-
-describe("lineDayCount", () => {
-  const cust = testListingWithCount({
-    customisable_days: true,
-    day_prices: { 1: 0, 2: 0, 3: 0 },
-    duration_days: 3,
-    id: 1,
-  });
-
-  test("uses the chosen count when submitted", () => {
-    expect(lineDayCount(blankLine({ dayCount: 2, listing: cust }))).toBe(2);
-  });
-
-  test("falls back to the existing booking's span", () => {
-    const line = blankLine({
-      dayCount: null,
-      existingBooking: bookingRow({
-        end_at: "2026-09-13T00:00:00.000Z",
-        start_at: "2026-09-10T00:00:00Z",
-      }),
-      listing: cust,
-    });
-    expect(lineDayCount(line)).toBe(3);
-  });
-
-  test("defaults to 1 with no chosen count and no existing booking", () => {
-    expect(lineDayCount(blankLine({ dayCount: null, listing: cust }))).toBe(1);
-  });
-
-  test("defaults to 1 when the existing range is degenerate", () => {
-    const line = blankLine({
-      dayCount: null,
-      existingBooking: bookingRow({
-        end_at: "2026-09-10T00:00:00Z",
-        start_at: "2026-09-10T00:00:00Z",
-      }),
-      listing: cust,
-    });
-    expect(lineDayCount(line)).toBe(1);
+  test("counts whole days for a real range", () => {
+    expect(
+      bookingDurationDays(
+        bookingRow({
+          end_at: "2026-06-17T00:00:00Z",
+          start_at: "2026-06-14T00:00:00Z",
+        }),
+      ),
+    ).toBe(3);
   });
 });
 
@@ -957,7 +540,6 @@ describe("attendeeBalanceNotice", () => {
   });
 
   test("warns when a reservation has no balance but is still unpaid", () => {
-    // £10 order, only the £1 deposit paid, balance wrongly cleared to £0.
     const notice = attendeeBalanceNotice(reservation, 0, 1000, 100);
     expect(notice?.tone).toBe("warning");
     expect(notice?.message).toContain("still unpaid");

--- a/test/lib/attendee-form-model.test.ts
+++ b/test/lib/attendee-form-model.test.ts
@@ -107,9 +107,15 @@ describe("parseAttendeeForm", () => {
     expect(parsed.lines[0]!.listing?.name).toBe("Resolved");
   });
 
-  test("ignores non-positive and non-numeric listing ids", () => {
+  test("ignores non-positive, partly-numeric and non-numeric listing ids", () => {
     const parsed = parseAttendeeForm(
-      makeForm({ name: "X", qty_0: "1", qty_4: "1", qty_abc: "1" }),
+      makeForm({
+        name: "X",
+        qty_0: "1",
+        qty_4: "1",
+        qty_5abc: "1",
+        qty_abc: "1",
+      }),
       new Map(),
     );
     expect(parsed.lines.map((l) => l.listingId)).toEqual([4]);

--- a/test/lib/db/attendees/check-batch-availability.test.ts
+++ b/test/lib/db/attendees/check-batch-availability.test.ts
@@ -2,6 +2,11 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { checkBatchAvailability } from "#shared/db/attendees.ts";
 import {
+  enableQueryLog,
+  getQueryLog,
+  runWithQueryLogContext,
+} from "#shared/db/query-log.ts";
+import {
   bookAttendee,
   createDailyTestListing,
   createTestGroup,
@@ -142,5 +147,21 @@ describeWithEnv("db > attendees > checkBatchAvailability", { db: true }, () => {
     expect(
       await checkBatchAvailability([{ listingId: listing.id, quantity: 1 }]),
     ).toBe(false);
+  });
+
+  test("stays within a constant query budget for a large cart", async () => {
+    // More daily listings than the N+1 read guard threshold (25): a per-listing
+    // fan-out would run the occupancy read once each and trip the guard.
+    const items: { listingId: number; quantity: number }[] = [];
+    for (let i = 0; i < 28; i++) {
+      const listing = await createDailyTestListing({ maxAttendees: 5 });
+      items.push({ listingId: listing.id, quantity: 1 });
+    }
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      expect(await checkBatchAvailability(items, "2026-05-01")).toBe(true);
+      // Listing rows + batched occupancy + group caps — a small constant.
+      expect(getQueryLog().length).toBeLessThanOrEqual(5);
+    });
   });
 });

--- a/test/lib/db/attendees/create-attendee-atomic.test.ts
+++ b/test/lib/db/attendees/create-attendee-atomic.test.ts
@@ -460,4 +460,32 @@ describeWithEnv("db > attendees > createAttendeeAtomic", { db: true }, () => {
       startAt: "2026-04-15T00:00:00Z",
     });
   });
+
+  test("blocks overbooking by default but allows it when opted in", async () => {
+    const listing = await createTestListing({ maxAttendees: 1 });
+    const fill = await createAttendeeAtomic({
+      bookings: [{ listingId: listing.id, quantity: 1 }],
+      email: "",
+      name: "Fill",
+    });
+    expect(fill.success).toBe(true);
+
+    // Default (public/webhook): the capacity guard blocks the second booking.
+    const blocked = await createAttendeeAtomic({
+      bookings: [{ listingId: listing.id, quantity: 1 }],
+      email: "",
+      name: "Blocked",
+    });
+    expect(blocked.success).toBe(false);
+
+    // allowOverbook (admin manual add): the row is inserted anyway.
+    const over = await createAttendeeAtomic({
+      allowOverbook: true,
+      bookings: [{ listingId: listing.id, quantity: 1 }],
+      email: "",
+      name: "Over",
+    });
+    expect(over.success).toBe(true);
+    expect((await getAttendeesRaw(listing.id)).length).toBe(2);
+  });
 });

--- a/test/lib/db/attendees/get-listing-remaining-for-range.test.ts
+++ b/test/lib/db/attendees/get-listing-remaining-for-range.test.ts
@@ -3,6 +3,11 @@ import { it as test } from "@std/testing/bdd";
 import { getListingRemainingForRange } from "#shared/db/attendees.ts";
 import { getDb } from "#shared/db/client.ts";
 import { getListingWithCount } from "#shared/db/listings.ts";
+import {
+  enableQueryLog,
+  getQueryLog,
+  runWithQueryLogContext,
+} from "#shared/db/query-log.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import {
   bookAttendee,
@@ -141,6 +146,19 @@ describeWithEnv(
       expect(await remaining(listing.id, "2026-05-02")).toBe(4);
     });
 
+    test("aggregates multiple bookings on the same listing and group", async () => {
+      const group = await createTestGroup({ maxAttendees: 10 });
+      const listing = await createDailyTestListing({
+        groupId: group.id,
+        maxAttendees: 5,
+      });
+      // Two separate attendees book the same listing + day → two interval rows.
+      await bookAttendee(listing, { date: "2026-05-02", quantity: 1 });
+      await bookAttendee(listing, { date: "2026-05-02", quantity: 2 });
+      // Listing load 3 → 5 - 3 = 2; group load 3 → 10 - 3 = 7; the tighter wins.
+      expect(await remaining(listing.id, "2026-05-02")).toBe(2);
+    });
+
     test("resolves several listings in one call", async () => {
       const standard = await createTestListing({ maxAttendees: 5 });
       const daily = await createDailyTestListing({ maxAttendees: 3 });
@@ -151,6 +169,23 @@ describeWithEnv(
       );
       expect(map.get(standard.id)).toBe(5);
       expect(map.get(daily.id)).toBe(2);
+    });
+
+    test("stays within a constant query budget for a large catalogue", async () => {
+      // More daily listings than the N+1 read guard threshold (25): a per-listing
+      // fan-out would run the same overlap read once each and trip the guard.
+      const listings: ListingWithCount[] = [];
+      for (let i = 0; i < 28; i++) {
+        const listing = await createDailyTestListing({ maxAttendees: 5 });
+        listings.push(await row(listing.id));
+      }
+      await runWithQueryLogContext(async () => {
+        enableQueryLog();
+        const map = await getListingRemainingForRange(listings, "2026-05-01");
+        expect(map.size).toBe(28);
+        // Batched: a small constant number of round trips, not one per listing.
+        expect(getQueryLog().length).toBeLessThanOrEqual(4);
+      });
     });
   },
 );

--- a/test/lib/db/attendees/get-listing-remaining-for-range.test.ts
+++ b/test/lib/db/attendees/get-listing-remaining-for-range.test.ts
@@ -1,0 +1,156 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { getListingRemainingForRange } from "#shared/db/attendees.ts";
+import { getDb } from "#shared/db/client.ts";
+import { getListingWithCount } from "#shared/db/listings.ts";
+import type { ListingWithCount } from "#shared/types.ts";
+import {
+  bookAttendee,
+  createDailyTestListing,
+  createTestAttendee,
+  createTestGroup,
+  createTestListing,
+  describeWithEnv,
+} from "#test-utils";
+
+/** Fetch the listing-with-count row the helper accepts as input. */
+const row = async (id: number): Promise<ListingWithCount> =>
+  (await getListingWithCount(id))!;
+
+/** Remaining units for a single listing over a date + duration. */
+const remaining = async (
+  id: number,
+  date: string | null,
+  durationDays = 1,
+): Promise<number> => {
+  const map = await getListingRemainingForRange(
+    [await row(id)],
+    date,
+    durationDays,
+  );
+  return map.get(id)!;
+};
+
+/** Overbook a listing by lowering its cap below what is already booked,
+ * bypassing the capacity guard that would block it during booking. */
+const lowerMaxAttendees = (id: number, max: number): Promise<unknown> =>
+  getDb().execute({
+    args: [max, id],
+    sql: "UPDATE listings SET max_attendees = ? WHERE id = ?",
+  });
+
+describeWithEnv(
+  "db > attendees > getListingRemainingForRange",
+  { db: true },
+  () => {
+    test("empty list yields an empty map", async () => {
+      const map = await getListingRemainingForRange([], null);
+      expect(map.size).toBe(0);
+    });
+
+    test("standard listing: remaining is cap minus booked", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      await createTestAttendee(listing.id, listing.slug, "A", "a@example.com");
+      expect(await remaining(listing.id, null)).toBe(4);
+    });
+
+    test("standard listing: overbooked remaining clamps to zero", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      await createTestAttendee(listing.id, listing.slug, "A", "a@example.com");
+      await createTestAttendee(listing.id, listing.slug, "B", "b@example.com");
+      await createTestAttendee(listing.id, listing.slug, "C", "c@example.com");
+      await lowerMaxAttendees(listing.id, 2);
+      expect(await remaining(listing.id, null)).toBe(0);
+    });
+
+    test("standard listing: a capped group can shrink remaining", async () => {
+      const group = await createTestGroup({ maxAttendees: 2 });
+      const listing = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 100,
+      });
+      const sibling = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 100,
+      });
+      await createTestAttendee(sibling.id, sibling.slug, "A", "a@example.com");
+      // Listing cap leaves 100, but the group only has 2 - 1 = 1 left.
+      expect(await remaining(listing.id, null)).toBe(1);
+    });
+
+    test("standard listing: an uncapped group never limits remaining", async () => {
+      const group = await createTestGroup({ maxAttendees: 0 });
+      const listing = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 3,
+      });
+      expect(await remaining(listing.id, null)).toBe(3);
+    });
+
+    test("daily listing with no date uses the cumulative total", async () => {
+      const listing = await createDailyTestListing({ maxAttendees: 5 });
+      await bookAttendee(listing, { date: "2026-02-10", quantity: 2 });
+      // With no anchor date a daily listing falls back to its overall total,
+      // the same path the calendar uses before a date is picked.
+      expect(await remaining(listing.id, null)).toBe(3);
+    });
+
+    test("daily listing: remaining is per-date", async () => {
+      const listing = await createDailyTestListing({ maxAttendees: 3 });
+      await bookAttendee(listing, { date: "2026-02-10", quantity: 2 });
+      expect(await remaining(listing.id, "2026-02-10")).toBe(1);
+      expect(await remaining(listing.id, "2026-02-11")).toBe(3);
+    });
+
+    test("daily listing: a multi-day range reports the tightest day", async () => {
+      const listing = await createDailyTestListing({ maxAttendees: 3 });
+      await bookAttendee(listing, { date: "2026-05-02", quantity: 2 });
+      // Range 05-01..05-03: only 05-02 is loaded, so 3 - 2 = 1 spot.
+      expect(await remaining(listing.id, "2026-05-01", 3)).toBe(1);
+    });
+
+    test("daily listing: overbooked day clamps to zero", async () => {
+      const listing = await createDailyTestListing({ maxAttendees: 3 });
+      await bookAttendee(listing, { date: "2026-02-10", quantity: 2 });
+      await lowerMaxAttendees(listing.id, 1);
+      expect(await remaining(listing.id, "2026-02-10")).toBe(0);
+    });
+
+    test("daily listing: a capped group shrinks the day it is full", async () => {
+      const group = await createTestGroup({ maxAttendees: 2 });
+      const listing = await createDailyTestListing({
+        groupId: group.id,
+        maxAttendees: 100,
+      });
+      const sibling = await createDailyTestListing({
+        groupId: group.id,
+        maxAttendees: 100,
+      });
+      await bookAttendee(sibling, { date: "2026-05-02", quantity: 2 });
+      expect(await remaining(listing.id, "2026-05-02")).toBe(0);
+      expect(await remaining(listing.id, "2026-05-03")).toBe(2);
+    });
+
+    test("daily listing: an uncapped group falls back to the listing cap", async () => {
+      const group = await createTestGroup({ maxAttendees: 0 });
+      const listing = await createDailyTestListing({
+        groupId: group.id,
+        maxAttendees: 5,
+      });
+      await bookAttendee(listing, { date: "2026-05-02", quantity: 1 });
+      expect(await remaining(listing.id, "2026-05-02")).toBe(4);
+    });
+
+    test("resolves several listings in one call", async () => {
+      const standard = await createTestListing({ maxAttendees: 5 });
+      const daily = await createDailyTestListing({ maxAttendees: 3 });
+      await bookAttendee(daily, { date: "2026-02-10", quantity: 1 });
+      const map = await getListingRemainingForRange(
+        [await row(standard.id), await row(daily.id)],
+        "2026-02-10",
+      );
+      expect(map.get(standard.id)).toBe(5);
+      expect(map.get(daily.id)).toBe(2);
+    });
+  },
+);

--- a/test/lib/db/attendees/has-available-spots.test.ts
+++ b/test/lib/db/attendees/has-available-spots.test.ts
@@ -2,6 +2,11 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { hasAvailableSpots } from "#shared/db/attendees.ts";
 import {
+  enableQueryLog,
+  getQueryLog,
+  runWithQueryLogContext,
+} from "#shared/db/query-log.ts";
+import {
   bookAttendee,
   createDailyTestListing,
   createTestAttendee,
@@ -124,5 +129,21 @@ describeWithEnv("db > attendees > hasAvailableSpots", { db: true }, () => {
     // 2026-09-01 still only has 5 - 3 = 2 group spots per day.
     expect(await hasAvailableSpots(listing.id, 3, "2026-11-01", 2)).toBe(false);
     expect(await hasAvailableSpots(listing.id, 2, "2026-11-01", 2)).toBe(true);
+  });
+
+  test("checks a grouped daily listing without a query per day or group", async () => {
+    const group = await createTestGroup({ maxAttendees: 5 });
+    const listing = await createDailyTestListing({
+      groupId: group.id,
+      maxAttendees: 5,
+    });
+    await bookAttendee(listing, { date: "2026-05-01", quantity: 1 });
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      expect(await hasAvailableSpots(listing.id, 1, "2026-05-01")).toBe(true);
+      // One capacity query (listing + group caps, all days) plus the listing
+      // lookup — not the overlap + two group reads the old code ran.
+      expect(getQueryLog().length).toBeLessThanOrEqual(2);
+    });
   });
 });

--- a/test/lib/order-select.test.ts
+++ b/test/lib/order-select.test.ts
@@ -18,10 +18,11 @@ describe("parseSelectedListingIds", () => {
     expect(parseSelectedListingIds(params)).toEqual([5]);
   });
 
-  test("ignores non-numeric and non-positive ids", () => {
+  test("ignores non-numeric, partly-numeric and non-positive ids", () => {
     const params = new URLSearchParams(
-      `${SELECT_PREFIX}abc=1&${SELECT_PREFIX}0=1&${SELECT_PREFIX}-2=1&${SELECT_PREFIX}6=1`,
+      `${SELECT_PREFIX}abc=1&${SELECT_PREFIX}0=1&${SELECT_PREFIX}-2=1&${SELECT_PREFIX}5abc=1&${SELECT_PREFIX}6=1`,
     );
+    // "5abc" is rejected outright — strict id parsing, not lenient parseInt.
     expect(parseSelectedListingIds(params)).toEqual([6]);
   });
 

--- a/test/lib/order-select.test.ts
+++ b/test/lib/order-select.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  parseSelectedListingIds,
+  SELECT_PREFIX,
+} from "#shared/order-select.ts";
+
+describe("parseSelectedListingIds", () => {
+  test("extracts selected listing ids in ascending order", () => {
+    const params = new URLSearchParams(
+      "select_8=1&select_3=1&start_date=2026-01-01",
+    );
+    expect(parseSelectedListingIds(params)).toEqual([3, 8]);
+  });
+
+  test("ignores values other than 1", () => {
+    const params = new URLSearchParams("select_3=0&select_4=yes&select_5=1");
+    expect(parseSelectedListingIds(params)).toEqual([5]);
+  });
+
+  test("ignores non-numeric and non-positive ids", () => {
+    const params = new URLSearchParams(
+      `${SELECT_PREFIX}abc=1&${SELECT_PREFIX}0=1&${SELECT_PREFIX}-2=1&${SELECT_PREFIX}6=1`,
+    );
+    expect(parseSelectedListingIds(params)).toEqual([6]);
+  });
+
+  test("de-duplicates repeated ids", () => {
+    const params = new URLSearchParams("select_7=1&select_7=1");
+    expect(parseSelectedListingIds(params)).toEqual([7]);
+  });
+
+  test("returns an empty array when nothing is selected", () => {
+    expect(parseSelectedListingIds(new URLSearchParams("foo=bar"))).toEqual([]);
+  });
+});

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -39,23 +39,26 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
   describe("GET /admin/attendees/new", () => {
     testRequiresAuth("/admin/attendees/new");
 
-    test("renders the empty create form with one blank line", async () => {
-      await createTestListing({ maxAttendees: 100, name: "Pick Me" });
+    test("renders the create form with a quantity box per listing", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 100,
+        name: "Pick Me",
+      });
       const response = await awaitTestRequest("/admin/attendees/new", {
         cookie: await testCookie(),
       });
       const html = await expectHtmlResponse(
         response,
         200,
-        "Add Attendee",
+        "Add new attendee",
         "Listing Registrations",
         "Create Attendee",
-        "Add Listing Line",
         "Pick Me",
       );
-      // One blank line is rendered
-      expect(html).toContain('name="line_event_id_0"');
-      expect(html).toContain('name="line_count" type="hidden" value="1"');
+      // A quantity box per listing and a shared start date — no add-line button.
+      expect(html).toContain(`name="qty_${listing.id}"`);
+      expect(html).toContain('name="start_date"');
+      expect(html).not.toContain("Add Listing Line");
     });
 
     test("pre-fills listings selected from the calendar checker", async () => {
@@ -66,43 +69,50 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         { cookie: await testCookie() },
       );
       const html = await expectHtmlResponse(response, 200);
-      expect(html).toContain('name="line_count" type="hidden" value="2"');
-      expect(hasSelectedOption(html, String(a.id))).toBe(true);
-      expect(hasSelectedOption(html, String(b.id))).toBe(true);
+      // Both chosen listings start at quantity 1.
+      expect(html).toMatch(new RegExp(`name="qty_${a.id}"[^>]*value="1"`));
+      expect(html).toMatch(new RegExp(`name="qty_${b.id}"[^>]*value="1"`));
     });
 
-    test("pre-fills a daily listing's date from start_date", async () => {
+    test("pre-fills the shared start date from the deep link", async () => {
       const listing = await createDailyTestListing({ name: "Daily Pick" });
       const response = await awaitTestRequest(
         `/admin/attendees/new?select_${listing.id}=1&start_date=2026-07-01`,
         { cookie: await testCookie() },
       );
       const html = await expectHtmlResponse(response, 200);
-      expect(hasSelectedOption(html, String(listing.id))).toBe(true);
+      expect(html).toMatch(
+        new RegExp(`name="qty_${listing.id}"[^>]*value="1"`),
+      );
       expect(html).toContain('value="2026-07-01"');
     });
 
-    test("defaults a daily listing's date when start_date is absent", async () => {
+    test("leaves the start date blank when the deep link omits it", async () => {
       const listing = await createDailyTestListing({ name: "No Date Daily" });
       const response = await awaitTestRequest(
         `/admin/attendees/new?select_${listing.id}=1`,
         { cookie: await testCookie() },
       );
       const html = await expectHtmlResponse(response, 200);
-      expect(hasSelectedOption(html, String(listing.id))).toBe(true);
-      expect(html).toContain('name="line_date_0"');
+      expect(html).toMatch(
+        new RegExp(`name="qty_${listing.id}"[^>]*value="1"`),
+      );
+      expect(html).toMatch(/name="start_date"[^>]*value=""/);
     });
 
-    test("falls back to a blank form when no selection resolves", async () => {
+    test("falls back to all-zero quantities when no selection resolves", async () => {
+      const listing = await createTestListing({ maxAttendees: 100, name: "Z" });
       const response = await awaitTestRequest(
         "/admin/attendees/new?select_999999=1",
         { cookie: await testCookie() },
       );
       const html = await expectHtmlResponse(response, 200);
-      expect(html).toContain('name="line_count" type="hidden" value="1"');
+      expect(html).toMatch(
+        new RegExp(`name="qty_${listing.id}"[^>]*value="0"`),
+      );
     });
 
-    test("offers a day-count selector for a customisable daily booking", async () => {
+    test("seeds the shared length from an existing multi-day booking", async () => {
       const listing = await createTestListing({
         customisableDays: true,
         dayPrices: { 1: 0, 2: 0, 3: 0 },
@@ -121,9 +131,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         { cookie: await testCookie() },
       );
       const html = await response.text();
-      expect(html).toContain('name="line_day_count_0"');
-      expect(html).toContain("Number of days");
-      // The booking's current 2-day span is preselected.
+      // The shared day-count select preselects the booking's current 2-day span.
+      expect(html).toContain('id="day_count"');
       expect(hasSelectedOption(html, "2")).toBe(true);
     });
 
@@ -173,10 +182,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
           {
             csrf_token: csrfToken,
             email: "jane@example.com",
-            line_count: "1",
-            line_event_id_0: String(event.id),
-            line_quantity_0: "2",
             name: "Jane Doe",
+            [`qty_${event.id}`]: "2",
           },
           cookie,
         ),
@@ -207,12 +214,9 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
           {
             csrf_token: csrfToken,
             email: "multi@example.com",
-            line_count: "2",
-            line_event_id_0: String(event1.id),
-            line_event_id_1: String(event2.id),
-            line_quantity_0: "1",
-            line_quantity_1: "3",
             name: "Multi",
+            [`qty_${event1.id}`]: "1",
+            [`qty_${event2.id}`]: "3",
           },
           cookie,
         ),
@@ -222,70 +226,6 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       const att2 = await getAttendeesRaw(event2.id);
       expect(att2.length).toBe(1);
       expect(att2[0]!.quantity).toBe(3);
-    });
-
-    test("re-renders the form without saving when 'Add Listing Line' is clicked", async () => {
-      const event = await createTestListing({
-        maxAttendees: 100,
-        maxQuantity: 5,
-      });
-      const { cookie, csrfToken } = await (
-        await import("#test-utils")
-      ).getTestSession();
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/attendees/new",
-          {
-            action: "add_line",
-            csrf_token: csrfToken,
-            email: "preserve@example.com",
-            line_count: "1",
-            line_event_id_0: String(event.id),
-            line_quantity_0: "1",
-            name: "Preserved",
-          },
-          cookie,
-        ),
-      );
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      // Two lines now, the new one is blank
-      expect(html).toContain('name="line_event_id_1"');
-      // Originally entered data is preserved
-      expect(html).toContain("Preserved");
-      expect(html).toContain("preserve@example.com");
-      // No attendee was created
-      expect((await getAttendeesRaw(event.id)).length).toBe(0);
-    });
-
-    test("re-renders with one fewer line when 'Remove' is clicked", async () => {
-      const event = await createTestListing({
-        maxAttendees: 100,
-        maxQuantity: 5,
-      });
-      const { cookie, csrfToken } = await (
-        await import("#test-utils")
-      ).getTestSession();
-      const response = await handleRequest(
-        mockFormRequest(
-          "/admin/attendees/new",
-          {
-            action: "remove_line_0",
-            csrf_token: csrfToken,
-            line_count: "2",
-            line_event_id_0: String(event.id),
-            line_event_id_1: "",
-            line_quantity_0: "1",
-            line_quantity_1: "1",
-            name: "Trim",
-          },
-          cookie,
-        ),
-      );
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      // Only one line should remain
-      expect(html).not.toContain('name="line_event_id_1"');
     });
 
     test("fails validation when name is blank and re-renders with the rest preserved", async () => {
@@ -302,10 +242,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
           {
             csrf_token: csrfToken,
             email: "preserve@example.com",
-            line_count: "1",
-            line_event_id_0: String(event.id),
-            line_quantity_0: "1",
             name: "",
+            [`qty_${event.id}`]: "1",
           },
           cookie,
         ),
@@ -328,10 +266,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       );
       const { response } = await adminFormPost("/admin/attendees/new", {
         email: "second@example.com",
-        line_count: "1",
-        line_event_id_0: String(event.id),
-        line_quantity_0: "1",
         name: "Second",
+        [`qty_${event.id}`]: "1",
       });
       // In-place re-render (not a redirect) so the operator keeps their input.
       expect(response.status).toBe(200);
@@ -353,12 +289,9 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         "filler@example.com",
       );
       const { response } = await adminFormPost("/admin/attendees/new", {
-        line_count: "2",
-        line_event_id_0: String(open.id),
-        line_event_id_1: String(full.id),
-        line_quantity_0: "1",
-        line_quantity_1: "1",
         name: "Multi",
+        [`qty_${open.id}`]: "1",
+        [`qty_${full.id}`]: "1",
       });
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -385,18 +318,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       const existing = await loadExistingLines(attendee.id);
       const form = await buildAttendeeEditForm(attendee.id, {
         lines: [
-          {
-            date: "",
-            eventId: event1.id,
-            key: existing[0]!.key,
-            quantity: 1,
-          },
-          {
-            date: "",
-            eventId: event2.id,
-            key: "",
-            quantity: 1,
-          },
+          { eventId: event1.id, key: existing[0]!.key, quantity: 1 },
+          { eventId: event2.id, key: "", quantity: 1 },
         ],
         name: "Link",
       });
@@ -433,14 +356,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       )!.key;
       // Submit only event1 — event2 should be removed
       const form = await buildAttendeeEditForm(attendeeId, {
-        lines: [
-          {
-            date: "",
-            eventId: event1.id,
-            key: event1Key,
-            quantity: 1,
-          },
-        ],
+        lines: [{ eventId: event1.id, key: event1Key, quantity: 1 }],
         name: "Multi",
       });
       const { response } = await adminFormPost(
@@ -467,14 +383,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       const { loadExistingLines } = await import("#shared/db/attendees.ts");
       const existing = await loadExistingLines(attendee.id);
       const form = await buildAttendeeEditForm(attendee.id, {
-        lines: [
-          {
-            date: "",
-            eventId: event.id,
-            key: existing[0]!.key,
-            quantity: 4,
-          },
-        ],
+        lines: [{ eventId: event.id, key: existing[0]!.key, quantity: 4 }],
         name: "Qty",
       });
       const { response } = await adminFormPost(
@@ -521,7 +430,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         { cookie: await testCookie() },
       );
       const html = await response.text();
-      expect(html).toContain("different start dates or durations");
+      expect(html).toContain("different start dates or lengths");
     });
 
     test("does not show the mixed-timing alert when daily bookings are uniform", async () => {
@@ -554,7 +463,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         { cookie: await testCookie() },
       );
       const html = await response.text();
-      expect(html).not.toContain("different start dates or durations");
+      expect(html).not.toContain("different start dates or lengths");
     });
   });
 
@@ -594,15 +503,12 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
           "/admin/attendees/new",
           {
             csrf_token: csrfToken,
+            day_count: "1",
             email: "mix@example.com",
-            line_count: "2",
-            line_date_0: "",
-            line_date_1: tomorrow,
-            line_event_id_0: String(standard.id),
-            line_event_id_1: String(daily.id),
-            line_quantity_0: "1",
-            line_quantity_1: "2",
             name: "Mix",
+            start_date: tomorrow,
+            [`qty_${standard.id}`]: "1",
+            [`qty_${daily.id}`]: "2",
           },
           cookie,
         ),
@@ -656,20 +562,11 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
 
       const form = await buildAttendeeEditForm(attendee.id, {
         lines: [
-          {
-            date: "",
-            eventId: standard.id,
-            key: existing[0]!.key,
-            quantity: 1,
-          },
-          {
-            date: tomorrow,
-            eventId: daily.id,
-            key: "",
-            quantity: 2,
-          },
+          { eventId: standard.id, key: existing[0]!.key, quantity: 1 },
+          { eventId: daily.id, key: "", quantity: 2 },
         ],
         name: "Edit Mix",
+        startDate: tomorrow,
       });
       const { response } = await adminFormPost(
         `/admin/attendees/${attendee.id}`,
@@ -691,13 +588,11 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
     test("create re-renders with an error when no listing line is filled in", async () => {
       await createTestListing({ maxAttendees: 100 });
       const { response } = await adminFormPost("/admin/attendees/new", {
-        line_count: "1",
-        line_event_id_0: "0",
         name: "No Lines",
       });
       expect(response.status).toBe(200);
       const html = await response.text();
-      expect(html).toContain("Add at least one listing line");
+      expect(html).toContain("Book at least one listing");
       expect(html).toContain("No Lines");
     });
 
@@ -713,10 +608,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
           ),
         async () => {
           const { response } = await adminFormPost("/admin/attendees/new", {
-            line_count: "1",
-            line_event_id_0: String(event.id),
-            line_quantity_0: "1",
             name: "Cap",
+            [`qty_${event.id}`]: "1",
           });
           expect(response.status).toBe(200);
           expect(await response.text()).toContain("spots");
@@ -724,21 +617,19 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       );
     });
 
-    test("create re-renders with null quantity showing empty value", async () => {
+    test("treats a non-numeric quantity as not booked", async () => {
       const event = await createTestListing({
         maxAttendees: 100,
         maxQuantity: 2,
       });
       const { response } = await adminFormPost("/admin/attendees/new", {
-        line_count: "1",
-        line_event_id_0: String(event.id),
-        line_quantity_0: "abc",
         name: "Valid",
+        [`qty_${event.id}`]: "abc",
       });
+      // "abc" parses to no quantity, so nothing is booked.
       expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain('value=""');
-      expect(html).toContain("Quantity must be at least 1");
+      expect(await response.text()).toContain("Book at least one listing");
+      expect((await getAttendeesRaw(event.id)).length).toBe(0);
     });
 
     test("create re-renders with line-level error only (no attendee error)", async () => {
@@ -747,10 +638,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         maxQuantity: 2,
       });
       const { response } = await adminFormPost("/admin/attendees/new", {
-        line_count: "1",
-        line_event_id_0: String(event.id),
-        line_quantity_0: "5",
         name: "Valid Name",
+        [`qty_${event.id}`]: "5",
       });
       expect(response.status).toBe(200);
       const html = await response.text();
@@ -765,10 +654,8 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       });
       const { response } = await adminFormPost("/admin/attendees/new", {
         email: "not-an-email",
-        line_count: "1",
-        line_event_id_0: String(event.id),
-        line_quantity_0: "1",
         name: "Valid Name",
+        [`qty_${event.id}`]: "1",
       });
       // Re-renders in place (200) with the field error; the browser's
       // type=email guard is bypassed by a no-JS / crafted POST, so the server
@@ -780,44 +667,19 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       expect((await getAttendeesRaw(event.id)).length).toBe(0);
     });
 
-    test("edit remove_line drops the line from the form without deleting until save", async () => {
-      const event = await createTestListing({ maxAttendees: 100 });
-      const attendee = await createTestAttendee(
-        event.id,
-        event.slug,
-        "Solo",
-        "solo@example.com",
-      );
-      const form = await buildAttendeeEditForm(attendee.id, {
-        name: "Solo",
-      });
-      const { response } = await adminFormPost(
-        `/admin/attendees/${attendee.id}`,
-        {
-          ...form,
-          action: "remove_line_0",
-        },
-      );
-      // Removal is now a pure form-state edit — re-render, no DB write. The
-      // booking is only deleted when the operator saves.
-      expect(response.status).toBe(200);
-      expect((await getAttendeesRaw(event.id)).length).toBe(1);
-    });
-
-    test("create removing the only new blank line re-renders with a blank line", async () => {
-      await createTestListing({ maxAttendees: 100 });
+    test("create requires a start date for a booked daily listing", async () => {
+      const daily = await createDailyTestListing({ name: "Daily Needs Date" });
       const { response } = await adminFormPost("/admin/attendees/new", {
-        action: "remove_line_0",
-        line_count: "1",
-        line_event_id_0: "0",
-        name: "",
+        name: "Dateless",
+        [`qty_${daily.id}`]: "1",
       });
+      // The shared start date is missing, so the daily booking can't be saved.
       expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain('name="line_event_id_0"');
+      expect(await response.text()).toContain("A start date is required");
+      expect((await getAttendeesRaw(daily.id)).length).toBe(0);
     });
 
-    test("edit with only blank lines re-renders with no_lines error", async () => {
+    test("edit that un-books every listing re-renders with the no-lines error", async () => {
       const event = await createTestListing({ maxAttendees: 100 });
       const attendee = await createTestAttendee(
         event.id,
@@ -825,17 +687,16 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         "Blank",
         "blank@example.com",
       );
+      // Set the only booked listing to quantity 0 — nothing remains booked.
       const { response } = await adminFormPost(
         `/admin/attendees/${attendee.id}`,
         {
-          action: "save",
-          line_count: "1",
-          line_event_id_0: "0",
           name: attendee.name,
+          [`qty_${event.id}`]: "0",
         },
       );
       expect(response.status).toBe(200);
-      expect(await response.text()).toContain("Add at least one listing line");
+      expect(await response.text()).toContain("Book at least one listing");
       // The existing booking is untouched (no_lines short-circuits the diff).
       expect((await getAttendeesRaw(event.id)).length).toBe(1);
     });
@@ -911,15 +772,10 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       ]);
       const { response } = await adminFormPost(
         `/admin/attendees/${attendee.id}`,
-        {
-          action: "save",
-          line_count: "1",
-          line_event_id_0: "0",
-          name: "Orphan",
-        },
+        { name: "Orphan" },
       );
       expect(response.status).toBe(200);
-      expect(await response.text()).toContain("Add at least one listing line");
+      expect(await response.text()).toContain("Book at least one listing");
     });
   });
 

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -491,6 +491,59 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
     });
   });
 
+  describe("over-duration warnings", () => {
+    test("warns when the range is longer than a daily listing allows", async () => {
+      const oneDay = await createDailyTestListing({
+        durationDays: 1,
+        name: "One Day",
+      });
+      const twoDay = await createDailyTestListing({
+        durationDays: 2,
+        name: "Two Day",
+      });
+      const result = await createAttendeeAtomic({
+        bookings: [
+          { date: "2026-05-01", durationDays: 3, listingId: oneDay.id },
+          { date: "2026-05-01", durationDays: 3, listingId: twoDay.id },
+        ],
+        email: "",
+        name: "Over",
+      });
+      const attendeeId = result.success ? result.attendees[0]!.id : 0;
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendeeId}`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      // Per-listing warnings (singular + plural) and a top-of-page summary.
+      expect(html).toContain(
+        "One Day is designed for up to 1 day, but the booking spans 3.",
+      );
+      expect(html).toContain(
+        "Two Day is designed for up to 2 days, but the booking spans 3.",
+      );
+      expect(html).toContain("Please double-check");
+    });
+
+    test("no warning when the range fits the listing's duration", async () => {
+      const daily = await createDailyTestListing({
+        durationDays: 3,
+        name: "Three Day",
+      });
+      const result = await bookAttendee(daily, {
+        date: "2026-05-01",
+        durationDays: 3,
+      });
+      const attendeeId = result.success ? result.attendees[0]!.id : 0;
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendeeId}`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).not.toContain("Please double-check");
+    });
+  });
+
   describe("integration: mixed single-day and multi-day on one attendee", () => {
     test("creates an attendee with both a standard and a daily line", async () => {
       const standard = await createTestListing({

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -280,30 +280,7 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       expect((await getAttendeesRaw(event.id)).length).toBe(0);
     });
 
-    test("re-renders preserving entered data when capacity is exceeded", async () => {
-      const event = await createTestListing({ maxAttendees: 1 });
-      await createTestAttendee(
-        event.id,
-        event.slug,
-        "First",
-        "first@example.com",
-      );
-      const { response } = await adminFormPost("/admin/attendees/new", {
-        email: "second@example.com",
-        name: "Second",
-        [`qty_${event.id}`]: "1",
-      });
-      // In-place re-render (not a redirect) so the operator keeps their input.
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Not enough spots");
-      expect(html).toContain("second@example.com");
-      expect(html).toContain("Second");
-      // All-or-nothing: no second attendee was created (only "First" remains).
-      expect((await getAttendeesRaw(event.id)).length).toBe(1);
-    });
-
-    test("create rolls back entirely when one of several lines is full", async () => {
+    test("create books the open listing and overbooks the full one", async () => {
       const open = await createTestListing({ maxAttendees: 100, name: "Open" });
       const full = await createTestListing({ maxAttendees: 1, name: "Full" });
       await createTestAttendee(
@@ -317,13 +294,10 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         [`qty_${open.id}`]: "1",
         [`qty_${full.id}`]: "1",
       });
-      expect(response.status).toBe(200);
-      const html = await response.text();
-      expect(html).toContain("Not enough spots");
-      // Nothing committed: the open event gained no row, the full event still
-      // has only its original filler.
-      expect((await getAttendeesRaw(open.id)).length).toBe(0);
-      expect((await getAttendeesRaw(full.id)).length).toBe(1);
+      // Admin manual add is allowed to overbook, so both bookings are created.
+      expect(response.status).toBe(302);
+      expect((await getAttendeesRaw(open.id)).length).toBe(1);
+      expect((await getAttendeesRaw(full.id)).length).toBe(2);
     });
   });
 
@@ -541,6 +515,112 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       );
       const html = await expectHtmlResponse(response, 200);
       expect(html).not.toContain("Please double-check");
+    });
+  });
+
+  describe("admin overbooking", () => {
+    test("create may overbook a full listing", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 1,
+        name: "Tiny",
+      });
+      await createTestAttendee(listing.id, listing.slug, "First", "f@e.com");
+      // Capacity is 1 and already full; the admin adds a second anyway.
+      const { response } = await adminFormPost("/admin/attendees/new", {
+        name: "Second",
+        [`qty_${listing.id}`]: "1",
+      });
+      expect(response.status).toBe(302);
+      expect((await getAttendeesRaw(listing.id)).length).toBe(2);
+    });
+
+    test("edit may overbook by raising the quantity past capacity", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 2,
+        maxQuantity: 10,
+        name: "Cap2",
+      });
+      const attendee = await createTestAttendee(
+        listing.id,
+        listing.slug,
+        "A",
+        "a@e.com",
+      );
+      const { loadExistingLines } = await import("#shared/db/attendees.ts");
+      const key = (await loadExistingLines(attendee.id))[0]!.key;
+      const form = await buildAttendeeEditForm(attendee.id, {
+        lines: [{ eventId: listing.id, key, quantity: 10 }],
+        name: "A",
+      });
+      const { response } = await adminFormPost(
+        `/admin/attendees/${attendee.id}`,
+        form,
+      );
+      expect(response.status).toBe(302);
+      expect((await getAttendeesRaw(listing.id))[0]!.quantity).toBe(10);
+    });
+
+    test("edit may overbook by adding a full listing", async () => {
+      const home = await createTestListing({ maxAttendees: 100, name: "Home" });
+      const full = await createTestListing({ maxAttendees: 1, name: "Full" });
+      await createTestAttendee(full.id, full.slug, "Filler", "fill@e.com");
+      const attendee = await createTestAttendee(
+        home.id,
+        home.slug,
+        "B",
+        "b@e.com",
+      );
+      const { loadExistingLines } = await import("#shared/db/attendees.ts");
+      const homeKey = (await loadExistingLines(attendee.id))[0]!.key;
+      const form = await buildAttendeeEditForm(attendee.id, {
+        lines: [
+          { eventId: home.id, key: homeKey, quantity: 1 },
+          { eventId: full.id, quantity: 1 },
+        ],
+        name: "B",
+      });
+      const { response } = await adminFormPost(
+        `/admin/attendees/${attendee.id}`,
+        form,
+      );
+      expect(response.status).toBe(302);
+      expect((await getAttendeesRaw(full.id)).length).toBe(2);
+    });
+
+    test("warns on the form when a booking overbooks a listing", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 1,
+        name: "Solo",
+      });
+      await createTestAttendee(listing.id, listing.slug, "First", "f1@e.com");
+      // Blank name forces an in-place re-render that surfaces the warning.
+      const { response } = await adminFormPost("/admin/attendees/new", {
+        name: "",
+        [`qty_${listing.id}`]: "1",
+      });
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).toContain("Solo is overbooked");
+    });
+
+    test("does not warn when an at-capacity booking is edited unchanged", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 1,
+        name: "Exact",
+      });
+      const attendee = await createTestAttendee(
+        listing.id,
+        listing.slug,
+        "Only",
+        "only@e.com",
+      );
+      // The booking fills the listing, but it is the attendee's own row — the
+      // self-excluding check means no overbooking warning.
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).not.toContain("is overbooked");
     });
   });
 

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -20,6 +20,7 @@ import {
   awaitTestRequest,
   bookAttendee,
   buildAttendeeEditForm,
+  createDailyTestListing,
   createTestAttendee,
   createTestListing,
   describeWithEnv,
@@ -54,6 +55,50 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       );
       // One blank line is rendered
       expect(html).toContain('name="line_event_id_0"');
+      expect(html).toContain('name="line_count" type="hidden" value="1"');
+    });
+
+    test("pre-fills listings selected from the calendar checker", async () => {
+      const a = await createTestListing({ maxAttendees: 100, name: "Kayak" });
+      const b = await createTestListing({ maxAttendees: 100, name: "Canoe" });
+      const response = await awaitTestRequest(
+        `/admin/attendees/new?select_${a.id}=1&select_${b.id}=1`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).toContain('name="line_count" type="hidden" value="2"');
+      expect(hasSelectedOption(html, String(a.id))).toBe(true);
+      expect(hasSelectedOption(html, String(b.id))).toBe(true);
+    });
+
+    test("pre-fills a daily listing's date from start_date", async () => {
+      const listing = await createDailyTestListing({ name: "Daily Pick" });
+      const response = await awaitTestRequest(
+        `/admin/attendees/new?select_${listing.id}=1&start_date=2026-07-01`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(hasSelectedOption(html, String(listing.id))).toBe(true);
+      expect(html).toContain('value="2026-07-01"');
+    });
+
+    test("defaults a daily listing's date when start_date is absent", async () => {
+      const listing = await createDailyTestListing({ name: "No Date Daily" });
+      const response = await awaitTestRequest(
+        `/admin/attendees/new?select_${listing.id}=1`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(hasSelectedOption(html, String(listing.id))).toBe(true);
+      expect(html).toContain('name="line_date_0"');
+    });
+
+    test("falls back to a blank form when no selection resolves", async () => {
+      const response = await awaitTestRequest(
+        "/admin/attendees/new?select_999999=1",
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
       expect(html).toContain('name="line_count" type="hidden" value="1"');
     });
 

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -61,6 +61,30 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       expect(html).not.toContain("Add Listing Line");
     });
 
+    test("shows the availability notice on a dateless create form", async () => {
+      await createTestListing({ maxAttendees: 100, name: "L" });
+      const response = await awaitTestRequest("/admin/attendees/new", {
+        cookie: await testCookie(),
+      });
+      const html = await expectHtmlResponse(
+        response,
+        200,
+        "Availability is inaccurate until dates have been saved",
+      );
+      // Visible (not hidden) when no date is known.
+      expect(html).toContain("data-availability-notice>");
+    });
+
+    test("hides the availability notice when a date is pre-filled", async () => {
+      const listing = await createDailyTestListing({ name: "D" });
+      const response = await awaitTestRequest(
+        `/admin/attendees/new?select_${listing.id}=1&start_date=2026-07-01`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).toContain("data-availability-notice hidden>");
+    });
+
     test("pre-fills listings selected from the calendar checker", async () => {
       const a = await createTestListing({ maxAttendees: 100, name: "Kayak" });
       const b = await createTestListing({ maxAttendees: 100, name: "Canoe" });

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1087,13 +1087,12 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         response,
         200,
         "Listing Registrations",
-        "Add Listing Line",
         "Save Attendee",
       );
       // Listing link table shows the listing
       expect(html).toContain("Edit Page Listing");
-      // Line editor has listing selector
-      expect(html).toContain("line_event_id_");
+      // The editor renders a quantity box per listing
+      expect(html).toContain("qty_");
     });
 
     test("edit page shows checked-in badge for checked-in attendee", async () => {
@@ -1120,7 +1119,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       await expectHtmlResponse(response, 200, "Checked in");
     });
 
-    test("edit page loads available dates for daily listings", async () => {
+    test("edit page seeds the shared start date from a daily booking", async () => {
       const listing = await createTestListing({
         listingType: "daily",
         maxAttendees: 100,
@@ -1141,9 +1140,9 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         response,
         200,
         "Daily Dates Listing",
-        "attendee-form-data",
       );
-      expect(html).toContain("2026-");
+      // The shared start date is seeded from the daily booking.
+      expect(html).toContain('value="2026-04-07"');
     });
 
     test("includes active listings in add-to-listing selector", async () => {
@@ -1475,13 +1474,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         `/admin/attendees/${attendee.id}`,
         { cookie: await testCookie() },
       );
-      await expectHtmlResponse(
-        response,
-        200,
-        "Listing 1",
-        "Listing 2",
-        "Add Listing Line",
-      );
+      await expectHtmlResponse(response, 200, "Listing 1", "Listing 2");
     });
 
     test("shows edit form with empty email field", async () => {
@@ -1602,7 +1595,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         `/admin/attendees/${attendee.id}`,
         { cookie: await testCookie() },
       );
-      await expectHtmlResponse(response, 200, 'name="line_quantity_');
+      await expectHtmlResponse(response, 200, 'name="qty_');
     });
   });
 

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -207,10 +207,13 @@ describeWithEnv(
         );
       });
 
-      test("excludes standard listings without a date", async () => {
+      test("excludes standard listings without a date from the date picker", async () => {
         await createTestListing({ name: "Standard Listing" });
         const html = await fetchCalendarHtml();
-        expect(html).not.toContain("Standard Listing");
+        // A dateless standard listing contributes no selectable date…
+        expect(html).not.toContain("?date=");
+        // …but it is still bookable, so the availability checker lists it.
+        expect(html).toContain("Standard Listing");
       });
 
       test("shows standard listing date in dropdown", async () => {
@@ -471,6 +474,46 @@ describeWithEnv(
         expect(csv).toContain("Standard CSV");
         expect(csv).toContain(dailyListing.name);
         expect(csv).toContain("Workshop");
+      });
+    });
+
+    describe("availability checker", () => {
+      test("lists bookable listings with remaining and a create form", async () => {
+        const listing = await createTestListing({
+          maxAttendees: 5,
+          name: "Avail Listing",
+        });
+        const html = await fetchCalendarHtml();
+        expect(html).toContain("Check availability");
+        expect(html).toContain("data-availability-checker");
+        expect(html).toContain("Avail Listing");
+        expect(html).toContain("5/5");
+        expect(html).toContain('action="/admin/attendees/new"');
+        expect(html).toContain(`name="select_${listing.id}"`);
+      });
+
+      test("reflects bookings in the remaining count", async () => {
+        await createTestListing({ maxAttendees: 5, name: "Half Full" });
+        const listing = await createTestListing({
+          maxAttendees: 5,
+          name: "Booked Up",
+        });
+        await bookAttendee(listing, { quantity: 2 });
+        const html = await fetchCalendarHtml();
+        expect(html).toContain("3/5");
+      });
+
+      test("passes the selected calendar date to the create form", async () => {
+        const date = tomorrow();
+        const listing = await createDailyTestListing({ name: "Daily Avail" });
+        await bookDailyTicket(listing.slug, {
+          date,
+          email: "a@test.com",
+          name: "A",
+        });
+        const html = await fetchCalendarHtml(`/admin/calendar?date=${date}`);
+        expect(html).toContain('name="start_date"');
+        expect(html).toContain(`value="${date}"`);
       });
     });
   },

--- a/test/lib/validation/number.test.ts
+++ b/test/lib/validation/number.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { parsePositiveIntId } from "#shared/validation/number.ts";
+
+describe("parsePositiveIntId", () => {
+  test("parses plain positive integers, dropping leading zeros", () => {
+    expect(parsePositiveIntId("5")).toBe(5);
+    expect(parsePositiveIntId("12")).toBe(12);
+    expect(parsePositiveIntId("007")).toBe(7);
+  });
+
+  test("rejects zero, blanks and non-digit junk", () => {
+    expect(parsePositiveIntId("0")).toBeNull();
+    expect(parsePositiveIntId("")).toBeNull();
+    // Lenient parseInt would have returned 5 for "5abc" — strict parsing won't.
+    expect(parsePositiveIntId("5abc")).toBeNull();
+    expect(parsePositiveIntId("abc")).toBeNull();
+  });
+
+  test("rejects signs and surrounding whitespace", () => {
+    expect(parsePositiveIntId("-2")).toBeNull();
+    expect(parsePositiveIntId("+5")).toBeNull();
+    expect(parsePositiveIntId(" 5")).toBeNull();
+    expect(parsePositiveIntId("5 ")).toBeNull();
+  });
+});

--- a/test/templates/admin/calendar.test.ts
+++ b/test/templates/admin/calendar.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "@std/expect";
 import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
+import { formatCurrency } from "#shared/currency.ts";
+import type { AvailabilityRow } from "#templates/admin/availability-checker.tsx";
 import {
   adminCalendarPage,
   type CalendarAttendeeRow,
@@ -544,5 +546,86 @@ describe("admin nav Calendar link", () => {
     const html = adminDashboardPage([], TEST_SESSION);
     expect(html).toContain('href="/admin/calendar"');
     expect(html).toContain("Calendar");
+  });
+});
+
+describe("adminCalendarPage availability checker", () => {
+  const availabilityRow = (
+    overrides: Partial<AvailabilityRow> = {},
+  ): AvailabilityRow => ({
+    canPayMore: false,
+    id: 1,
+    name: "Listing",
+    remaining: 3,
+    total: 5,
+    unitPrice: 1000,
+    ...overrides,
+  });
+
+  const checkerHtml = (
+    rows: AvailabilityRow[],
+    dateFilter: string | null = null,
+  ): string =>
+    adminCalendarPage(
+      [],
+      "localhost",
+      TEST_SESSION,
+      dateFilter,
+      [],
+      "2026-03-10",
+      null,
+      undefined,
+      undefined,
+      false,
+      rows,
+    );
+
+  test("renders a closed disclosure with a selectable row per listing", () => {
+    const html = checkerHtml([
+      availabilityRow({ id: 7, name: "Kayak Hire", remaining: 3, total: 5 }),
+    ]);
+    expect(html).toContain("Check availability");
+    expect(html).toContain("data-availability-checker");
+    expect(html).toContain('href="/admin/listing/7"');
+    expect(html).toContain("Kayak Hire");
+    expect(html).toContain("3/5");
+    expect(html).toContain('name="select_7"');
+    expect(html).toContain('action="/admin/attendees/new"');
+  });
+
+  test("marks a sold-out row as danger", () => {
+    const html = checkerHtml([
+      availabilityRow({ id: 8, remaining: 0, total: 2 }),
+    ]);
+    expect(html).toContain("0/2");
+    expect(html).toContain('class="danger"');
+  });
+
+  test("shows Free, From and plain prices", () => {
+    const html = checkerHtml([
+      availabilityRow({ id: 1, unitPrice: 0 }),
+      availabilityRow({ canPayMore: true, id: 2, unitPrice: 500 }),
+      availabilityRow({ canPayMore: false, id: 3, unitPrice: 1000 }),
+    ]);
+    expect(html).toContain("Free");
+    expect(html).toContain(`From ${formatCurrency(500)}`);
+    expect(html).toContain(formatCurrency(1000));
+  });
+
+  test("includes the selected date as a hidden start_date field", () => {
+    const html = checkerHtml([availabilityRow()], "2026-03-15");
+    expect(html).toContain('name="start_date"');
+    expect(html).toContain('value="2026-03-15"');
+  });
+
+  test("omits start_date when no date is selected", () => {
+    const html = checkerHtml([availabilityRow()]);
+    expect(html).not.toContain('name="start_date"');
+  });
+
+  test("shows a fallback when there are no bookable listings", () => {
+    const html = checkerHtml([]);
+    expect(html).toContain("Check availability");
+    expect(html).toContain("No bookable listings");
   });
 });

--- a/test/test-utils/db-helpers.ts
+++ b/test/test-utils/db-helpers.ts
@@ -384,13 +384,14 @@ export const createTestAttendeeDirect = async (
 };
 
 /**
- * Build form data for the unified attendee edit form (`POST /admin/attendees/:id`)
- * that preserves the attendee's existing event-registration lines.
+ * Build form data for the unified attendee edit form (`POST /admin/attendees/:id`).
  *
- * Reads the attendee's current `event_attendees` rows and emits one
- * `line_*_N` block per existing booking with the correct `line_key_N`. Use
- * `overrides.lines` to swap / add / drop lines, and the top-level overrides
- * for PII fields.
+ * Emits the shared `start_date` + `day_count` (seeded from the attendee's
+ * existing bookings) and one `qty_<listingId>` / `line_key_<listingId>` pair per
+ * existing booking, so a bare call preserves the attendee unchanged. Pass
+ * `overrides.lines` to set the full booked set (each `{ eventId, quantity, key }`
+ * — quantity 0 or an omitted listing un-books it), or `startDate` / `dayCount`
+ * to move the shared range.
  */
 export const buildAttendeeEditForm = async (
   attendeeId: number,
@@ -401,11 +402,12 @@ export const buildAttendeeEditForm = async (
     address?: string;
     special_instructions?: string;
     returnUrl?: string;
+    startDate?: string;
+    dayCount?: number;
     lines?: Array<{
       eventId: number;
       quantity?: number;
-      date?: string;
-      /** Omit to add as a new line; pass the existing key to update. */
+      /** Omit to book as a new line; pass the existing key to keep/move it. */
       key?: string;
     }>;
     /** Extra fields to merge in (e.g. `question_<id>`). */
@@ -413,31 +415,32 @@ export const buildAttendeeEditForm = async (
   } = {},
 ): Promise<Record<string, string>> => {
   const { loadExistingLines } = await import("#shared/db/attendees.ts");
+  const { resolveSharedDates } = await import(
+    "#routes/admin/attendee-form-model.ts"
+  );
   const existing = await loadExistingLines(attendeeId);
+  const shared = resolveSharedDates(existing.map((e) => e.booking));
   const lines =
     overrides.lines ??
     existing.map(({ key, booking }) => ({
-      date: booking.start_at?.slice(0, 10) ?? "",
       eventId: booking.listing_id,
       key,
       quantity: booking.quantity,
     }));
   const form: Record<string, string> = {
-    action: "save",
     address: overrides.address ?? "",
+    day_count: String(overrides.dayCount ?? shared.dayCount),
     email: overrides.email ?? "",
-    line_count: String(lines.length),
     name: overrides.name ?? "",
     phone: overrides.phone ?? "",
     special_instructions: overrides.special_instructions ?? "",
+    start_date: overrides.startDate ?? shared.startDate,
   };
   if (overrides.returnUrl) form.return_url = overrides.returnUrl;
-  lines.forEach((line, i) => {
-    form[`line_event_id_${i}`] = String(line.eventId);
-    form[`line_quantity_${i}`] = String(line.quantity ?? 1);
-    form[`line_date_${i}`] = line.date ?? "";
-    form[`line_key_${i}`] = line.key ?? "";
-  });
+  for (const line of lines) {
+    form[`qty_${line.eventId}`] = String(line.quantity ?? 1);
+    form[`line_key_${line.eventId}`] = line.key ?? "";
+  }
   if (overrides.extra) Object.assign(form, overrides.extra);
   return form;
 };


### PR DESCRIPTION
## Summary

Reworks attendee management around a calendar **availability checker** and a single shared **date range** with per-listing **quantity boxes**, cutting the clicks needed to register an attendee. Delivered as five green commits on this branch.

## Decisions (confirmed up front)

- **Daily listings drive the shared date range.** Standard (fixed-date) listings keep their own date and show date-independent capacity.
- **Overbooking is admin-only.** Public website + webhook bookings stay hard-capacity-guarded; admin add/edit may overbook with warnings.
- **The end-date select offers a fixed horizon** (up to `MAX_DURATION_DAYS`), warning per-listing when a listing's own duration is exceeded.
- Single-date-range enforcement lives in the shared model layer (no new API).

## What's in it

**1. Calendar availability checker** — a closed-by-default "Check availability" disclosure on `/admin/calendar` listing every bookable listing with remaining capacity (X/Y) and price for the selected date. Same hidden-checkbox selection as `/order` (shared `select_<id>` scheme + `getListingRemainingForRange`); a floating "Create Attendee" button deep-links to `/admin/attendees/new` with the chosen listings + date pre-filled. A short-lived `localStorage` key keeps it open across a single navigation.

**2. Attendee form overhaul** — one shared `start_date` + length (a day count; the end date is derived) applied to every daily listing; standard listings keep their fixed date. The editor is a fixed table with one quantity box per active listing (plus any inactive listing already booked) — no add/remove-line buttons — and a pure-CSS "Show all listings" toggle hides the not-booked rows. Changing the shared date moves bookings in place (keys preserved) rather than dropping them; legacy mixed-date attendees are seeded from the earliest/longest booking with a warning. Create page titled "Add new attendee".

**3. Date-first progressive enhancement** — an "Availability is inaccurate until dates have been saved" notice under the start date, a length select revealed once a start date is set (with end-date labels recomputed client-side), and the notice re-shown whenever the dates are dirtied.

**4. Over-duration warnings** — a daily listing booked for longer than its own duration is allowed (shared range) but warned, per-listing and in a top-of-page summary.

**5. Admin overbooking** — admin add/edit may deliberately exceed capacity (warned, not blocked) via an `allowOverbook` flag threaded through `createAttendeeAtomic` / `applyAttendeeAtomicEdit`; **public and webhook bookings stay guarded** (flag defaults off). The overbooking warning uses the same self-excluding capacity check the save uses, so an unchanged edit never warns against itself.

## Tests

The model, the unified form routes, the capacity helpers, the calendar route, the deep-link pre-fill, and the editing e2e are all covered (incl. an explicit guard that public/default bookings still block overbooking). `deno task precommit` is green throughout — lint, typecheck, copy-paste detection, and the full suite at **100% coverage**.

https://claude.ai/code/session_01DAVuZLSg45DfQPTmduxURQ