### PR TITLE
Add focused test runner that builds and cleans up static assets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,9 @@ the `pipe`-based code.
 ## Scripts
 
 - `deno task start` - Run the server
-- `deno task test` - Run tests
-- `deno task test:coverage` - Run tests with coverage
+- `deno task test` - Run the full suite
+- `deno task test:coverage` - Run the full suite with coverage
+- `deno task test:files <file>...` - Run only the given test files with the same setup as the full runner (builds static assets, starts stripe-mock, cleans up after)
 - `deno task lint` - Format and lint all code with Biome (`check --write`; auto-fixes in place). Biome is the sole formatter and linter.
 - `deno task build:edge` - Build for Bunny Edge deployment
 - `deno task precommit` - Run all checks (typecheck, lint, tests)
@@ -86,19 +87,28 @@ the `pipe`-based code.
 
 **Do NOT use `deno task test -- --filter`** to debug a specific test — it still loads the entire test suite and is very slow.
 
-Instead, run `deno test` directly on the specific file:
+Instead, use `deno task test:files`, which runs only the files you pass but reuses the full runner's setup — it builds the static client assets the app reads at import time, starts stripe-mock with `STRIPE_MOCK_HOST/PORT` exported, and removes any assets it generated afterwards. This means a fresh checkout can run a subset of the suite without manual preparation or leftover build artifacts:
+
+```bash
+deno task test:files test/lib/dates.test.ts
+```
+
+Arguments are forwarded verbatim to `deno test`, so multiple files, directories, and flags such as `--filter` all work:
+
+```bash
+deno task test:files test/lib/dates.test.ts --filter "formats date"
+deno task test:files test/lib/server-balance.test.ts test/lib/server-webhooks.test.ts
+```
+
+#### Lower-level alternative
+
+For a pure unit test that imports neither the app nor Stripe, you can skip the harness and run `deno test` directly on the file (fastest, but it fails on a missing `src/ui/static/*.js` asset or an unstarted stripe-mock if the test does import them):
 
 ```bash
 deno test --no-check --allow-all test/lib/dates.test.ts
 ```
 
-To filter to a specific test case within that file, add `--filter`:
-
-```bash
-deno test --no-check --allow-all test/lib/dates.test.ts --filter "formats date"
-```
-
-For tests that depend on stripe-mock (anything importing Stripe), ensure stripe-mock is running first by running `deno task test` once, or start it manually from `.bin/stripe-mock -http-port 12111`. Then set the env vars:
+To do this for a test that depends on stripe-mock (anything importing Stripe), start the mock first (`deno task test:files` or `deno task test` does this for you, or run `.bin/stripe-mock -http-port 12111` manually) and set the env vars:
 
 ```bash
 STRIPE_MOCK_HOST=localhost STRIPE_MOCK_PORT=12111 deno test --no-check --allow-all test/lib/stripe-mock.test.ts

--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,7 @@
     "build:edge": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net scripts/build-edge.ts",
     "test": "deno run -A scripts/run-tests.ts",
     "test:coverage": "deno run -A scripts/run-tests.ts --coverage",
+    "test:files": "deno run -A scripts/run-test-files.ts",
     "test:raw": "deno task build:static && deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/",
     "lint": "deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts",
     "lint:ci": "deno run -A scripts/biome.ts check --error-on-warnings src test scripts",

--- a/scripts/build-static-assets.ts
+++ b/scripts/build-static-assets.ts
@@ -11,6 +11,22 @@ const denoImports: Record<string, string> = denoConfig.imports;
 
 const projectRoot = fromFileUrl(new URL("..", import.meta.url));
 
+const STATIC_DIR = "./src/ui/static";
+
+/**
+ * Output files produced by {@link buildStaticAssets}, keyed by bundle. These
+ * are generated build artifacts (gitignored), so the test harness uses this
+ * list to clean up any it generates after a run.
+ */
+export const STATIC_ASSET_OUTFILES = {
+  admin: `${STATIC_DIR}/admin.js`,
+  contact: `${STATIC_DIR}/contact.js`,
+  embed: `${STATIC_DIR}/embed.js`,
+  iframeResizerChild: `${STATIC_DIR}/iframe-resizer-child.js`,
+  iframeResizerParent: `${STATIC_DIR}/iframe-resizer-parent.js`,
+  scanner: `${STATIC_DIR}/scanner.js`,
+} as const;
+
 const buildBundle = async (
   label: string,
   options: esbuild.BuildOptions,
@@ -105,7 +121,7 @@ export const buildStaticAssets = async (
     entryPoints: ["./src/ui/client/scanner.js"],
     format: "iife",
     minify: true,
-    outfile: "./src/ui/static/scanner.js",
+    outfile: STATIC_ASSET_OUTFILES.scanner,
     platform: "browser",
     plugins: [denoNpmResolvePlugin],
   });
@@ -115,7 +131,7 @@ export const buildStaticAssets = async (
     entryPoints: ["./src/ui/client/admin.ts"],
     format: "iife",
     minify: true,
-    outfile: "./src/ui/static/admin.js",
+    outfile: STATIC_ASSET_OUTFILES.admin,
     platform: "browser",
     plugins: [denoImportMapPlugin],
   });
@@ -125,7 +141,7 @@ export const buildStaticAssets = async (
     entryPoints: ["./src/ui/client/embed.ts"],
     format: "iife",
     minify: true,
-    outfile: "./src/ui/static/embed.js",
+    outfile: STATIC_ASSET_OUTFILES.embed,
     platform: "browser",
   });
 
@@ -134,7 +150,7 @@ export const buildStaticAssets = async (
     entryPoints: ["./src/ui/client/contact.ts"],
     format: "iife",
     minify: true,
-    outfile: "./src/ui/static/contact.js",
+    outfile: STATIC_ASSET_OUTFILES.contact,
     platform: "browser",
     plugins: [botpoisonResolvePlugin],
   });
@@ -144,7 +160,7 @@ export const buildStaticAssets = async (
     entryPoints: ["./src/ui/client/iframe-resizer-parent.ts"],
     format: "iife",
     minify: true,
-    outfile: "./src/ui/static/iframe-resizer-parent.js",
+    outfile: STATIC_ASSET_OUTFILES.iframeResizerParent,
     platform: "browser",
     plugins: [iframeResizerResolvePlugin],
   });
@@ -155,7 +171,7 @@ export const buildStaticAssets = async (
     entryPoints: ["./src/ui/client/iframe-resizer-child.ts"],
     format: "iife",
     minify: true,
-    outfile: "./src/ui/static/iframe-resizer-child.js",
+    outfile: STATIC_ASSET_OUTFILES.iframeResizerChild,
     platform: "browser",
     plugins: [iframeResizerResolvePlugin],
   });

--- a/scripts/run-test-files.ts
+++ b/scripts/run-test-files.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env -S deno run --allow-all
+/**
+ * Focused test runner: reuses the full runner's setup (built static assets +
+ * stripe-mock, via the shared test harness) but runs only the test files
+ * passed as arguments and skips coverage enforcement. This lets a fresh
+ * checkout run a subset of the suite without manual preparation or leftover
+ * build artifacts.
+ *
+ *   deno task test:files test/lib/server-balance.test.ts
+ *   deno task test:files test/lib/dates.test.ts --filter "formats date"
+ *
+ * Arguments are forwarded verbatim to `deno test`, so paths, directories, and
+ * flags such as `--filter` all work. At least one argument is required.
+ */
+
+import { runTests, withTestHarness } from "./test-harness.ts";
+
+const main = async (): Promise<void> => {
+  if (Deno.args.length === 0) {
+    console.error(
+      "Usage: deno task test:files <test-file> [<test-file>...] [--filter <name>]",
+    );
+    Deno.exit(1);
+  }
+
+  const exitCode = await withTestHarness(() => runTests(Deno.args, false));
+  Deno.exit(exitCode);
+};
+
+main();

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -1,141 +1,13 @@
 #!/usr/bin/env -S deno run --allow-all
 /**
- * Test runner script that ensures stripe-mock is running before tests
+ * Full test runner: builds static assets and starts stripe-mock (via the
+ * shared test harness), runs the whole suite, and—with --coverage—enforces
+ * 100% line and branch coverage. Generated static assets are cleaned up by the
+ * harness once the run completes.
  */
 
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { buildStaticAssets } from "./build-static-assets.ts";
-
-const STRIPE_MOCK_VERSION = "0.188.0";
-const STRIPE_MOCK_PORT = 12111;
-const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const BIN_DIR = join(projectRoot, ".bin");
-const STRIPE_MOCK_PATH = join(BIN_DIR, "stripe-mock");
-
-/** Check if stripe-mock is running */
-const isStripeMockRunning = async (): Promise<boolean> => {
-  try {
-    const conn = await Deno.connect({
-      hostname: "127.0.0.1",
-      port: STRIPE_MOCK_PORT,
-    });
-    conn.close();
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/** Download stripe-mock if needed */
-const downloadStripeMock = async (): Promise<void> => {
-  try {
-    await Deno.stat(STRIPE_MOCK_PATH);
-    return;
-  } catch {
-    // Download needed
-  }
-
-  console.log("Downloading stripe-mock...");
-  await Deno.mkdir(BIN_DIR, { recursive: true });
-
-  const platform = Deno.build.os === "darwin" ? "darwin" : "linux";
-  const arch = Deno.build.arch === "aarch64" ? "arm64" : "amd64";
-  const url = `https://github.com/stripe/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_${platform}_${arch}.tar.gz`;
-
-  const curlCmd = new Deno.Command("curl", {
-    args: ["-sL", url, "-o", "-"],
-    stderr: "null",
-    stdout: "piped",
-  });
-  const curlResult = await curlCmd.output();
-  if (!curlResult.success) {
-    throw new Error("Failed to download stripe-mock");
-  }
-
-  const tarPath = join(BIN_DIR, "stripe-mock.tar.gz");
-  await Deno.writeFile(tarPath, curlResult.stdout);
-
-  await new Deno.Command("tar", {
-    args: ["-xzf", tarPath, "-C", BIN_DIR],
-  }).output();
-
-  await new Deno.Command("chmod", {
-    args: ["+x", STRIPE_MOCK_PATH],
-  }).output();
-
-  await Deno.remove(tarPath);
-  console.log("stripe-mock downloaded");
-};
-
-/** Start stripe-mock and return the process */
-const startStripeMock = async (): Promise<Deno.ChildProcess | null> => {
-  if (await isStripeMockRunning()) {
-    console.log("stripe-mock already running on port", STRIPE_MOCK_PORT);
-    return null;
-  }
-
-  await downloadStripeMock();
-
-  console.log("Starting stripe-mock on port", STRIPE_MOCK_PORT);
-  const cmd = new Deno.Command(STRIPE_MOCK_PATH, {
-    args: ["-http-port", String(STRIPE_MOCK_PORT)],
-    stderr: "null",
-    stdout: "null",
-  });
-  const process = cmd.spawn();
-
-  // Wait for it to be ready
-  for (let i = 0; i < 30; i++) {
-    if (await isStripeMockRunning()) {
-      console.log("stripe-mock started");
-      return process;
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-
-  throw new Error("stripe-mock failed to start");
-};
-
-/** Build the deno test CLI args */
-const buildDenoTestArgs = (useCoverage: boolean): string[] => {
-  const args = [
-    "test",
-    "--no-check",
-    "--allow-net",
-    "--allow-env",
-    "--allow-read",
-    "--allow-write",
-    "--allow-run",
-    "--allow-sys",
-    "--allow-ffi",
-    "--parallel",
-  ];
-  if (useCoverage) args.push("--coverage=coverage");
-  args.push("test/");
-  return args;
-};
-
-/** Run deno test and return the exit code */
-const runTests = async (useCoverage: boolean): Promise<number> => {
-  console.log("Running tests...");
-  const testCmd = new Deno.Command(Deno.execPath(), {
-    args: buildDenoTestArgs(useCoverage),
-    cwd: projectRoot,
-    env: {
-      ...Deno.env.toObject(),
-      NO_PROXY: "localhost,127.0.0.1,::1",
-      no_proxy: "localhost,127.0.0.1,::1",
-      STRIPE_MOCK_HOST: "localhost",
-      STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
-    },
-    stderr: "inherit",
-    stdin: "inherit",
-    stdout: "inherit",
-  });
-  const result = await testCmd.output();
-  return result.code;
-};
+import { join } from "node:path";
+import { projectRoot, runTests, withTestHarness } from "./test-harness.ts";
 
 /** Extract uncovered line numbers from DA: entries in an lcov record */
 const extractUncoveredLines = (record: string): number[] => {
@@ -296,21 +168,12 @@ const checkCoverage = async (): Promise<void> => {
   reportCoverageFailures(lineFailures, branchFailures);
 };
 
-/** Main: start stripe-mock, run tests, cleanup */
+/** Main: run the whole suite inside the harness, then enforce coverage */
 const main = async (): Promise<void> => {
-  await buildStaticAssets({ stop: true });
-  const stripeMockProcess = await startStripeMock();
-
-  Deno.env.set("STRIPE_MOCK_HOST", "localhost");
-  Deno.env.set("STRIPE_MOCK_PORT", String(STRIPE_MOCK_PORT));
-
   const useCoverage = Deno.args.includes("--coverage");
-  const exitCode = await runTests(useCoverage);
-
-  if (stripeMockProcess) {
-    console.log("Stopping stripe-mock...");
-    stripeMockProcess.kill();
-  }
+  const exitCode = await withTestHarness(() =>
+    runTests(["test/"], useCoverage),
+  );
 
   if (exitCode !== 0) Deno.exit(exitCode);
   if (useCoverage) await checkCoverage();

--- a/scripts/test-harness.ts
+++ b/scripts/test-harness.ts
@@ -1,0 +1,216 @@
+/**
+ * Shared setup/teardown for the test runners.
+ *
+ * Both the full runner (`run-tests.ts`) and the focused runner
+ * (`run-test-files.ts`) need the same environment before any test can import
+ * the app: the static client assets must be built (the app reads them at
+ * module load, see src/features/assets.ts) and stripe-mock must be running
+ * with STRIPE_MOCK_HOST/PORT exported. This module owns that lifecycle so a
+ * fresh checkout can run either runner without manual preparation, and so any
+ * generated assets are cleaned up afterwards rather than left in the tree.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildStaticAssets,
+  STATIC_ASSET_OUTFILES,
+} from "./build-static-assets.ts";
+
+const STRIPE_MOCK_VERSION = "0.188.0";
+export const STRIPE_MOCK_PORT = 12111;
+export const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BIN_DIR = join(projectRoot, ".bin");
+const STRIPE_MOCK_PATH = join(BIN_DIR, "stripe-mock");
+
+/** Check if stripe-mock is running */
+const isStripeMockRunning = async (): Promise<boolean> => {
+  try {
+    const conn = await Deno.connect({
+      hostname: "127.0.0.1",
+      port: STRIPE_MOCK_PORT,
+    });
+    conn.close();
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Download stripe-mock if needed */
+const downloadStripeMock = async (): Promise<void> => {
+  try {
+    await Deno.stat(STRIPE_MOCK_PATH);
+    return;
+  } catch {
+    // Download needed
+  }
+
+  console.log("Downloading stripe-mock...");
+  await Deno.mkdir(BIN_DIR, { recursive: true });
+
+  const platform = Deno.build.os === "darwin" ? "darwin" : "linux";
+  const arch = Deno.build.arch === "aarch64" ? "arm64" : "amd64";
+  const url = `https://github.com/stripe/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_${platform}_${arch}.tar.gz`;
+
+  const curlCmd = new Deno.Command("curl", {
+    args: ["-sL", url, "-o", "-"],
+    stderr: "null",
+    stdout: "piped",
+  });
+  const curlResult = await curlCmd.output();
+  if (!curlResult.success) {
+    throw new Error("Failed to download stripe-mock");
+  }
+
+  const tarPath = join(BIN_DIR, "stripe-mock.tar.gz");
+  await Deno.writeFile(tarPath, curlResult.stdout);
+
+  await new Deno.Command("tar", {
+    args: ["-xzf", tarPath, "-C", BIN_DIR],
+  }).output();
+
+  await new Deno.Command("chmod", {
+    args: ["+x", STRIPE_MOCK_PATH],
+  }).output();
+
+  await Deno.remove(tarPath);
+  console.log("stripe-mock downloaded");
+};
+
+/** Start stripe-mock and return the process (null if one is already running) */
+const startStripeMock = async (): Promise<Deno.ChildProcess | null> => {
+  if (await isStripeMockRunning()) {
+    console.log("stripe-mock already running on port", STRIPE_MOCK_PORT);
+    return null;
+  }
+
+  await downloadStripeMock();
+
+  console.log("Starting stripe-mock on port", STRIPE_MOCK_PORT);
+  const cmd = new Deno.Command(STRIPE_MOCK_PATH, {
+    args: ["-http-port", String(STRIPE_MOCK_PORT)],
+    stderr: "null",
+    stdout: "null",
+  });
+  const process = cmd.spawn();
+
+  // Wait for it to be ready
+  for (let i = 0; i < 30; i++) {
+    if (await isStripeMockRunning()) {
+      console.log("stripe-mock started");
+      return process;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  throw new Error("stripe-mock failed to start");
+};
+
+/** True if a file exists on disk */
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Build the static client assets, returning a cleanup function that removes
+ * only the outputs this call generated. Outputs that already existed (e.g. a
+ * developer's prior `deno task build:static`) are left untouched, while a fresh
+ * checkout is restored to its asset-free state once tests finish.
+ */
+const setupStaticAssets = async (): Promise<() => Promise<void>> => {
+  const generated: string[] = [];
+  for (const outfile of Object.values(STATIC_ASSET_OUTFILES)) {
+    const path = join(projectRoot, outfile);
+    if (!(await fileExists(path))) generated.push(path);
+  }
+
+  await buildStaticAssets({ stop: true });
+
+  return async () => {
+    for (const path of generated) {
+      await Deno.remove(path).catch(() => {});
+    }
+  };
+};
+
+/** Build the deno test CLI args from the standard flags plus caller extras */
+const buildDenoTestArgs = (
+  extraArgs: string[],
+  useCoverage: boolean,
+): string[] => {
+  const args = [
+    "test",
+    "--no-check",
+    "--allow-net",
+    "--allow-env",
+    "--allow-read",
+    "--allow-write",
+    "--allow-run",
+    "--allow-sys",
+    "--allow-ffi",
+    "--parallel",
+  ];
+  if (useCoverage) args.push("--coverage=coverage");
+  args.push(...extraArgs);
+  return args;
+};
+
+/**
+ * Run `deno test` with the standard permission flags. `extraArgs` are appended
+ * verbatim — the full runner passes `["test/"]`, the focused runner passes the
+ * requested files (and any flags such as `--filter`). Returns the exit code.
+ */
+export const runTests = async (
+  extraArgs: string[],
+  useCoverage: boolean,
+): Promise<number> => {
+  console.log("Running tests...");
+  const testCmd = new Deno.Command(Deno.execPath(), {
+    args: buildDenoTestArgs(extraArgs, useCoverage),
+    cwd: projectRoot,
+    env: {
+      ...Deno.env.toObject(),
+      NO_PROXY: "localhost,127.0.0.1,::1",
+      no_proxy: "localhost,127.0.0.1,::1",
+      STRIPE_MOCK_HOST: "localhost",
+      STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
+    },
+    stderr: "inherit",
+    stdin: "inherit",
+    stdout: "inherit",
+  });
+  const result = await testCmd.output();
+  return result.code;
+};
+
+/**
+ * Run `task` with the full test environment in place: built static assets, a
+ * running stripe-mock, and STRIPE_MOCK_HOST/PORT exported. Afterwards the mock
+ * is stopped and any freshly generated static assets are removed, leaving the
+ * working tree as it was found even if `task` throws.
+ */
+export const withTestHarness = async <T>(
+  task: () => Promise<T>,
+): Promise<T> => {
+  const cleanupStaticAssets = await setupStaticAssets();
+  const stripeMockProcess = await startStripeMock();
+
+  Deno.env.set("STRIPE_MOCK_HOST", "localhost");
+  Deno.env.set("STRIPE_MOCK_PORT", String(STRIPE_MOCK_PORT));
+
+  try {
+    return await task();
+  } finally {
+    if (stripeMockProcess) {
+      console.log("Stopping stripe-mock...");
+      stripeMockProcess.kill();
+    }
+    await cleanupStaticAssets();
+  }
+};


### PR DESCRIPTION
## Problem

Running a subset of test files directly (e.g. `deno test test/lib/server-balance.test.ts ...`) fails before reaching the target logic:

- **Missing static assets** — the app reads the bundled static client assets (`src/ui/static/*.js`) at import time (`src/features/assets.ts` calls `Deno.readTextFileSync` at module load), so any test that imports the app dies with `NotFound: ... readfile 'src/ui/static/admin.js'` on a fresh checkout.
- **No stripe-mock** — without stripe-mock running and `STRIPE_MOCK_HOST/PORT` set, the Stripe-dependent tests hit the real Stripe API with `sk_test_mock` and get an error page instead of a checkout redirect.

Only the full runner (`deno task test`) performed this setup, and it left the generated assets behind in the working tree afterwards.

## Change

Extract the shared setup/teardown out of `run-tests.ts` into **`scripts/test-harness.ts`** (stripe-mock lifecycle, static-asset build with cleanup, and the `deno test` invocation), then build two thin entry points on top of it:

- **`deno task test:files <file>...`** (new, `scripts/run-test-files.ts`) — runs only the requested files with the exact same setup as the full runner, skipping coverage. Arguments are forwarded verbatim to `deno test`, so multiple files, directories, and flags like `--filter` all work.
- **`deno task test`** (`scripts/run-tests.ts`) — slimmed to a thin entry point over the harness; coverage-enforcement logic stays here.

Both runners now build the static assets up front and **remove only the assets they generated** afterwards — a fresh checkout is restored to its pristine, asset-free state, while assets a developer built themselves (e.g. via `deno task build:static` for `deno task start`) are preserved.

`scripts/build-static-assets.ts` now exports `STATIC_ASSET_OUTFILES` as the single source of truth for the generated output paths, used both by the build itself and by the harness for cleanup.

## Verification

- `deno task test:files` on the reported subset → `10 passed (213 steps), 0 failed`, with stripe-mock started and stopped automatically.
- Full `deno task test:coverage` → `461 passed (7863 steps), 0 failed` and `All files have 100% line and branch coverage`.
- `deno task build:edge` still builds (it shares `buildStaticAssets`).
- `deno task lint:ci` passes.
- Confirmed cleanup removes only freshly-generated assets and preserves pre-existing ones; working tree is pristine after both runners.

## Docs

`CLAUDE.md` now points to `deno task test:files` as the way to run individual files, keeping the raw `deno test` approach documented as a lower-level alternative for pure unit tests that import neither the app nor Stripe.

https://claude.ai/code/session_01TLXxkTzUE28PiF2NMMaQpw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLXxkTzUE28PiF2NMMaQpw)_