### PR TITLE
Polish calendar row-select and attendee date fields

### DIFF
--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -320,6 +320,12 @@ const buildTemplateData = async (
     emailStats: opts.emailStats ?? null,
     flashError: opts.flashError,
     flashSuccess: opts.flashSuccess,
+    // The shared date range only affects daily listings; the form's rendered
+    // lines cover every active listing plus any inactive one this attendee
+    // already books, so a daily line here is exactly when the dates matter.
+    hasDailyListings: parsed.lines.some(
+      (l) => l.listing?.listing_type === "daily",
+    ),
     hasMixedTimings: opts.hasMixedTimings ?? false,
     lineWarnings: warnings.byListing,
     mode,

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -874,6 +874,15 @@ label > select[name^="quantity_"] {
   flex: 0 0 auto;
 }
 
+/* Attendee form length select: widen to 20rem. The default `label > select`
+   rule is `flex: 1`, which would stretch it to fill the row and ignore the
+   width, so opt out of growing/shrinking here for the width to take effect. */
+#attendee-form label > select[name="day_count"] {
+  width: 20rem;
+  max-width: 100%;
+  flex: 0 0 auto;
+}
+
 label > input[type="text"],
 label > input[type="password"],
 label > input[type="email"] {
@@ -2290,6 +2299,10 @@ a.cal-day-selected:hover {
   justify-content: center;
   margin: 0;
   cursor: pointer;
+  /* Align by the box's middle, not its baseline: an empty tick box has no text
+     baseline but a ticked one does, and letting that shift the line box made the
+     row jiggle in height as it was selected/deselected. */
+  vertical-align: middle;
 }
 
 .row-select-tick {
@@ -2300,6 +2313,14 @@ a.cal-day-selected:hover {
   height: 1.4rem;
   border: 2px solid var(--color-bg-secondary);
   border-radius: var(--border-radius);
+}
+
+/* In dark mode the unchecked tick border (--color-bg-secondary) is the same
+   colour as the striped alternate rows, hiding the box until it's ticked. Use
+   the accent colour (which also fills the checked box) so the outline reads on
+   every row. */
+[data-theme="dark"] .row-select-tick {
+  border-color: var(--color-secondary);
 }
 
 .order-select:checked + .row-select-tick {

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -75,6 +75,10 @@ export type AttendeeFormTemplateData = {
   /** True when the attendee's existing daily bookings disagree on date/length —
    * saving normalises them onto the one shared range. */
   hasMixedTimings: boolean;
+  /** True when at least one daily listing is in play (active, or already booked
+   * by this attendee). The shared date range only affects daily listings, so the
+   * whole Dates section is hidden when this is false. */
+  hasDailyListings: boolean;
   /** Attendee-level error (e.g. "Name is required"). */
   attendeeError: string | null;
   /** Shared-date error (e.g. missing start date for a booked daily listing). */
@@ -244,18 +248,27 @@ const dayCountOptions = (
  * "availability inaccurate" notice shows until a date is saved, and a small
  * progressive-enhancement script (client/admin/attendee-dates.ts) re-shows it
  * when the dates are changed and reveals the length select once a start date is
- * set. */
+ * set.
+ *
+ * The dates only apply to daily listings, so the whole section is hidden when
+ * there are none in play, and the start date is never HTML-`required` — it's
+ * optional unless a daily listing is actually booked, which the server enforces. */
 const SharedDateFields = ({
   data,
 }: {
   data: AttendeeFormTemplateData;
-}): JSX.Element => {
+}): JSX.Element | null => {
+  if (!data.hasDailyListings) return null;
   // Shown when there's no saved/known date yet (a bare create form); the PE
   // re-shows it whenever the dates are dirtied so the operator re-saves.
   const noticeHidden = !(data.mode === "create" && !data.parsed.startDate);
   return (
     <>
       <h3>Dates</h3>
+      <p class="small">
+        Optional — the date only affects daily listings. A start date is
+        required once you book a daily listing below.
+      </p>
       {data.dateError && (
         <output class="error" role="alert">
           {data.dateError}
@@ -266,7 +279,6 @@ const SharedDateFields = ({
         <input
           id={START_DATE_FIELD}
           name={START_DATE_FIELD}
-          required={data.mode === "create"}
           type="date"
           value={data.parsed.startDate}
         />
@@ -547,11 +559,6 @@ const AttendeeEditForm = ({
           <Icon name="save" />
           <span>{isEdit ? "Save Attendee" : "Create Attendee"}</span>
         </button>
-        {!isEdit && (
-          <a class="button" href={data.returnUrl || "/admin/"}>
-            Back without saving
-          </a>
-        )}
       </p>
     </CsrfForm>
   );

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -55,14 +55,48 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
         "Create Attendee",
         "Pick Me",
       );
-      // A quantity box per listing and a shared start date — no add-line button.
+      // A quantity box per listing, and no add-line button (fixed table).
       expect(html).toContain(`name="qty_${listing.id}"`);
-      expect(html).toContain('name="start_date"');
       expect(html).not.toContain("Add Listing Line");
     });
 
+    test("hides the date fields when there are no daily listings", async () => {
+      // The shared date range only affects daily listings, so a site with only
+      // standard (fixed-date) listings never sees the Dates section.
+      await createTestListing({ maxAttendees: 100, name: "Standard Only" });
+      const response = await awaitTestRequest("/admin/attendees/new", {
+        cookie: await testCookie(),
+      });
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).not.toContain('name="start_date"');
+      expect(html).not.toContain('id="day_count"');
+      expect(html).not.toContain("only affects daily listings");
+    });
+
+    test("shows the optional date fields when a daily listing exists", async () => {
+      await createDailyTestListing({ name: "Daily One" });
+      const response = await awaitTestRequest("/admin/attendees/new", {
+        cookie: await testCookie(),
+      });
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).toContain('name="start_date"');
+      expect(html).toContain('id="day_count"');
+      // The note makes clear the date is optional and daily-only.
+      expect(html).toContain("only affects daily listings");
+    });
+
+    test("omits the 'Back without saving' link", async () => {
+      // The browser back button is enough; the explicit link was removed.
+      await createTestListing({ maxAttendees: 100, name: "Pick Me" });
+      const response = await awaitTestRequest("/admin/attendees/new", {
+        cookie: await testCookie(),
+      });
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).not.toContain("Back without saving");
+    });
+
     test("shows the availability notice on a dateless create form", async () => {
-      await createTestListing({ maxAttendees: 100, name: "L" });
+      await createDailyTestListing({ name: "L" });
       const response = await awaitTestRequest("/admin/attendees/new", {
         cookie: await testCookie(),
       });


### PR DESCRIPTION
## Summary

Small UI fixes to the `/admin/calendar` row-select and the add/edit attendee form.

### Calendar row-select (CSS)
- **Dark mode visibility** — the unchecked tick box used `--color-bg-secondary` for its border, which is the *same* colour as the striped alternate rows in dark mode, so the checkbox was invisible on every other row until ticked. It now uses the accent colour (the same colour that fills the box once checked), so the outline reads on both row colours.
- **Row height jiggle** — the tick box is `inline-flex`; an empty box has no text baseline but a ticked one does (the `✓`), and that shifting baseline nudged the row's height as you selected/deselected. The box is now aligned by its middle (`vertical-align: middle`), so the height is stable.

### Attendee form
- **`day_count` (Length) width** — set to `20rem`. The default `label > select` rule is `flex: 1`, which stretched the select to fill the row and ignored any width, so it's now `flex: 0 0 auto` (scoped to `#attendee-form` so the public booking page is untouched). `max-width: 100%` keeps it responsive on narrow screens.
- **"Back without saving" link removed** from the create form — the browser back button is enough.
- **Dates section is now optional and daily-only:**
  - The whole section (start date **and** length/end date) is hidden when there are no daily listings in play — i.e. a site that only sells fixed-date events never sees it. "In play" means an active daily listing, or an inactive one this attendee already books, so an existing daily booking can always still be edited.
  - The HTML `required` flag was dropped from the start date so it's genuinely optional; the server still enforces a start date when a daily listing is actually booked.
  - Added a short note: *"Optional — the date only affects daily listings. A start date is required once you book a daily listing below."*

## Testing
- Updated/added tests in `test/lib/server-attendee-form.test.ts` covering: date fields hidden with standard-only listings, shown with a daily listing (incl. the new note), and the removed "Back without saving" link.
- Full `deno task precommit` passes (lint, typecheck, cpd, build:edge, test:coverage — 100% on `src/`).

> Note: the row-select height/visibility fixes are CSS-only; this repo's test harness is an HTTP-level simulator with no rendering engine, so those two are verified by reasoning + matching selectors to markup rather than a rendered screenshot.

https://claude.ai/code/session_01K3j6s8afQspeig6X3BZY6W

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3j6s8afQspeig6X3BZY6W)_