### PR TITLE
Fix dashboard "Add Attendee" button linking to a 404

### DIFF
--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -251,7 +251,7 @@ export const adminDashboardPage = (
           <ActionButton href="/admin/listing/new" icon="plus">
             Add Listing
           </ActionButton>
-          <ActionButton href="/admin/attendee/new" icon="plus">
+          <ActionButton href="/admin/attendees/new" icon="plus">
             Add Attendee
           </ActionButton>
         </p>

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -47,6 +47,14 @@ describe("adminDashboardPage", () => {
     expect(html).toContain("Add Listing");
   });
 
+  test("renders add attendee link to the create-attendee route", () => {
+    // The "Add Attendee" button must point at the registered create route
+    // (plural /admin/attendees/new); a singular typo here 404s the page.
+    const html = adminDashboardPage([], TEST_SESSION);
+    expect(html).toContain('href="/admin/attendees/new"');
+    expect(html).toContain("Add Attendee");
+  });
+
   test("includes logout link", () => {
     const html = adminDashboardPage([], TEST_SESSION);
     expect(html).toContain("/admin/logout");


### PR DESCRIPTION
## What happened

The create-attendee page itself was never actually lost — it's alive, well-tested, and was just polished in #1207. What broke is the way to *reach* it from the admin dashboard.

The dashboard's **"Add Attendee"** action button points at the **singular** path `/admin/attendee/new`:

```tsx
<ActionButton href="/admin/attendee/new" icon="plus">
  Add Attendee
</ActionButton>
```

…but the page is registered (and linked everywhere else) under the **plural** `/admin/attendees/new`:

- route registration — `src/features/admin/attendees.ts` (`GET`/`POST /admin/attendees/new`)
- the form template's own self-reference — `attendee-form.tsx`
- the calendar availability checker's form action — `availability-checker.tsx`
- every test — `test/lib/server-attendee-form.test.ts`, etc.

Routes match by exact regex (`^…$` in `src/features/router.ts`), so the singular link matched **no route** and returned a 404. Clicking "Add Attendee" on the dashboard therefore looked like the page had been "lost".

The singular path was the lone typo in the codebase — it existed in exactly one place (`dashboard.tsx`), introduced alongside the button in #1155 and never reachable.

## Fix

- Point the dashboard button at the canonical `/admin/attendees/new`.
- Add a dashboard-template regression test asserting the `href` (mirroring the existing "Add Listing" link test) so a future typo can't silently break it again.

## Verification

- `deno task test:files test/templates/admin/dashboard.test.ts` — 47 pass (incl. new test)
- `deno task test:files test/lib/server-attendee-form.test.ts` — 72 steps pass
- `deno task lint` — clean
- `deno task typecheck` — pass

https://claude.ai/code/session_011quq41zuVbXLdEGnyuzzaj

---
_Generated by [Claude Code](https://claude.ai/code/session_011quq41zuVbXLdEGnyuzzaj)_