### PR TITLE
Add SumUp API Keys link to guide and clarify the connection-test 401

### DIFF
--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -111,6 +111,23 @@ const getMerchantCode = (): string | null => {
 };
 
 /**
+ * Turn a failed merchant lookup into an actionable connection-test message.
+ *
+ * SumUp answers the merchant lookup with a 401 whenever it rejects the
+ * credentials — most often because the API key was truncated on paste, or
+ * because the API key and merchant code belong to different accounts (e.g. a
+ * sandbox key with a live merchant code). The raw SumUp body is just an opaque
+ * trace id, so for a 401 we replace it with guidance and pass other errors
+ * (network failures, 5xx, etc.) through unchanged.
+ */
+const sumupKeyError = (err: unknown): string => {
+  const message = errorMessage(err);
+  return message.startsWith("401")
+    ? "401 Unauthorized — SumUp rejected these credentials. Check the API key was copied in full, and that the API key and Merchant Code belong to the same SumUp account (a sandbox key will not work with a live merchant code, or vice-versa)."
+    : message;
+};
+
+/**
  * Normalize a SumUp checkout resource into our internal shape.
  * amount and checkout_reference are always present on checkouts we created
  * (webhook ids are pre-filtered against our staging rows before fetching),
@@ -253,7 +270,7 @@ export const sumupApi: {
       result.merchant = { configured: true, merchantCode };
       result.ok = result.currency.supported;
     } catch (err) {
-      result.apiKey = { error: errorMessage(err), valid: false };
+      result.apiKey = { error: sumupKeyError(err), valid: false };
     }
     return result;
   },

--- a/src/ui/templates/admin/guide.tsx
+++ b/src/ui/templates/admin/guide.tsx
@@ -879,27 +879,38 @@ export const adminGuidePage = (
           <p>
             SumUp uses its Hosted Checkout, and the webhook is handled
             automatically &mdash; there's nothing to configure in the SumUp
-            dashboard. You need two values:
+            dashboard. You need two values, and{" "}
+            <strong>both must come from the same SumUp account</strong>:
           </p>
           <ol>
             <li>
               <strong>API Key</strong> &mdash; a secret API key from your SumUp
-              account, starting with <code>sk_live_</code> (real payments) or{" "}
-              <code>sk_test_</code> (testing). Create one under{" "}
-              <strong>Developers</strong> &rarr; <strong>API keys</strong> in
-              the SumUp dashboard.
+              dashboard. The developer settings are easy to miss: go to{" "}
+              <strong>Profile</strong> &rarr; <strong>Settings</strong> &rarr;{" "}
+              <strong>For Developers</strong> &rarr; <strong>Toolkit</strong>{" "}
+              &rarr; <strong>API Keys</strong>, or use this direct link:{" "}
+              <a href="https://me.sumup.com/en-gb/settings/api-keys">
+                me.sumup.com/en-gb/settings/api-keys
+              </a>
+              . Click <strong>Create API key</strong>, give it a name, and copy
+              the key &mdash; it is shown only once.
             </li>
             <li>
-              <strong>Merchant Code</strong> &mdash; your SumUp merchant code
-              (e.g. <code>MC...</code>), shown in your SumUp dashboard.
+              <strong>Merchant Code</strong> &mdash; your SumUp merchant code (a
+              short identifier, usually starting with <code>M</code>), shown in
+              your SumUp dashboard under your profile/account settings.
             </li>
           </ol>
           <p>
             Paste both into the SumUp section on the{" "}
-            <a href="/admin/settings">Settings</a> page and save. As with
-            Stripe, the Settings page shows a <strong>Test mode</strong> or{" "}
-            <strong>Live mode</strong> badge based on your key prefix, and a{" "}
-            <strong>Test Connection</strong> button to verify it works.
+            <a href="/admin/settings">Settings</a> page and save, then click{" "}
+            <strong>Test Connection</strong> to verify they work. The test looks
+            up your merchant account using the API key, so if the two don't
+            belong to the same account &mdash; for example a <em>sandbox</em>{" "}
+            API key paired with your live merchant code &mdash; it reports a{" "}
+            <code>401 Unauthorized</code> error. If you see that, re-copy the
+            key in full and double-check the merchant code is the one shown in
+            the same SumUp account that created the key.
           </p>
           <p>
             SumUp only supports certain currencies. If your site currency isn't
@@ -965,10 +976,16 @@ export const adminGuidePage = (
               . Untick Sandbox mode when switching to production.
             </li>
             <li>
-              <strong>SumUp:</strong> Use an API key starting with{" "}
-              <code>sk_test_</code>. As with Stripe, the Settings page shows a{" "}
-              <strong>Test mode</strong> badge so you know which environment is
-              active. Swap to your <code>sk_live_</code> key to go live.
+              <strong>SumUp:</strong> SumUp has no separate test-key prefix.
+              Instead, create a <strong>sandbox merchant account</strong> in
+              your SumUp developer settings, then use that sandbox account's own
+              API key and merchant code (with{" "}
+              <a href="https://developer.sumup.com/online-payments/testing">
+                SumUp's test cards
+              </a>
+              ) to make test bookings. Switch to your live account's API key and
+              merchant code when you're ready for real payments &mdash; the key
+              and merchant code must always come from the same account.
             </li>
           </ul>
           <p>

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -1121,18 +1121,18 @@ export const squareWebhookFields: Field[] = [
  */
 export const sumupFields: Field[] = [
   {
-    hint: "Your SumUp secret API key (sk_live_... or sk_test_...)",
+    hint: "Your SumUp secret API key, from me.sumup.com → For Developers → API Keys",
     label: "SumUp API Key",
     name: "sumup_api_key",
-    placeholder: "sk_live_... or sk_test_...",
+    placeholder: "Paste your SumUp API key",
     required: true,
     type: "password",
   },
   {
-    hint: "Your SumUp merchant code (found in the SumUp dashboard, e.g. MC...)",
+    hint: "Your SumUp merchant code, shown in your SumUp account profile (must match the API key's account)",
     label: "Merchant Code",
     name: "sumup_merchant_code",
-    placeholder: "MC...",
+    placeholder: "M...",
     required: true,
     type: "text",
   },

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -100,6 +100,16 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       await assertAdminHtml("/admin/guide", "test or live credentials");
     });
 
+    test("contains SumUp setup with the API keys link and 401 guidance", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "How do I set up SumUp?",
+        "me.sumup.com/en-gb/settings/api-keys",
+        "same SumUp account",
+        "401 Unauthorized",
+      );
+    });
+
     test("contains public site section", async () => {
       await assertAdminHtml(
         "/admin/guide",

--- a/test/lib/sumup.test.ts
+++ b/test/lib/sumup.test.ts
@@ -336,15 +336,31 @@ describe("sumup", () => {
       });
     });
 
-    test("reports an invalid key when the merchant lookup throws", async () => {
+    test("turns a 401 from the merchant lookup into actionable guidance", async () => {
       const client = makeClient({
-        merchantGet: () => Promise.reject(new Error("401 Unauthorized")),
+        merchantGet: () =>
+          Promise.reject(new Error('401: {"detail":"Unauthorized."}')),
       });
       await withClient(client, async () => {
         const result = await testSumupConnection();
         expect(result.ok).toBe(false);
         expect(result.apiKey.valid).toBe(false);
         expect(result.apiKey.error).toContain("401");
+        // The opaque SumUp body is replaced with a hint about the likely cause.
+        expect(result.apiKey.error).toContain("same SumUp account");
+        expect(result.apiKey.error).not.toContain("detail");
+      });
+    });
+
+    test("passes non-401 merchant lookup errors through unchanged", async () => {
+      const client = makeClient({
+        merchantGet: () => Promise.reject(new Error("503 Service Unavailable")),
+      });
+      await withClient(client, async () => {
+        const result = await testSumupConnection();
+        expect(result.ok).toBe(false);
+        expect(result.apiKey.valid).toBe(false);
+        expect(result.apiKey.error).toBe("503 Service Unavailable");
       });
     });
   });


### PR DESCRIPTION
## What & why

Two things from the report:

1. **SumUp developer settings are hard to find.** The admin guide now links straight to the API Keys page (`me.sumup.com/en-gb/settings/api-keys`) with the in‑dashboard navigation path (`Profile → Settings → For Developers → Toolkit → API Keys`), and explains where to find the merchant code.

2. **The "API Key: Invalid – 401 …" test failure.** The connection test validates the key with `GET /v1/merchants/{merchant_code}`. SumUp answers that with a **401** when it rejects the credentials — most commonly because the API key and merchant code belong to **different accounts** (e.g. a *sandbox* key paired with a live merchant code, or vice‑versa) or the key was truncated on paste. SumUp's body is just an opaque `trace_id`, which is what the user saw. The test now replaces a 401 with actionable guidance and passes other errors (network/5xx) through unchanged.

> Note: the "Merchant: Not configured" line in the original error is a red herring — that block only flips to *configured* **after** a successful lookup, so the merchant code was present; the key lookup itself was rejected.

### Also corrected: SumUp ≠ Stripe key prefixes

SumUp keys have **no** `sk_test_`/`sk_live_` prefix — test mode uses a separate **sandbox merchant account**, not a key prefix. The guide's "test or live credentials" section and the SumUp API‑key **form field hint/placeholder** no longer claim a Stripe‑style prefix. (Stripe's own sections are unchanged.)

## Changes
- `src/ui/templates/admin/guide.tsx` — API Keys link + nav path, merchant‑code location, "both must be the same account", 401 explanation; fixed test/live wording.
- `src/ui/templates/fields.ts` — accurate SumUp API‑key + merchant‑code field hints/placeholder.
- `src/shared/sumup.ts` — `sumupKeyError()` turns a 401 into an actionable message.
- Tests: new guide assertion for the link + 401 guidance; updated SumUp test to check the actionable message; added a non‑401 passthrough test.

## Verification
- `deno task test:files` on the SumUp/guide/settings template files — all green.
- `sumup.ts` branch/line coverage **100%**.
- `deno task lint` and `deno task typecheck` clean.

## Not changed (noted for follow‑up)
The shared connection‑test display still shows `Valid (unknown mode)` for a successful SumUp key, since SumUp has no test/live prefix for `keyMode` to read. It's cosmetic and only appears on success; removing the mode concept for SumUp touches the shared Stripe/Square formatter, so I left it out of this PR. Happy to do it separately.

https://claude.ai/code/session_011eVFhbnmhrT6pmoN46rRko

---
_Generated by [Claude Code](https://claude.ai/code/session_011eVFhbnmhrT6pmoN46rRko)_