### PR TITLE
Make SumUp "Test Connection" 401 message clear and useful

### DIFF
--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -113,17 +113,19 @@ const getMerchantCode = (): string | null => {
 /**
  * Turn a failed merchant lookup into an actionable connection-test message.
  *
- * SumUp answers the merchant lookup with a 401 whenever it rejects the
- * credentials — most often because the API key was truncated on paste, or
- * because the API key and merchant code belong to different accounts (e.g. a
- * sandbox key with a live merchant code). The raw SumUp body is just an opaque
- * trace id, so for a 401 we replace it with guidance and pass other errors
- * (network failures, 5xx, etc.) through unchanged.
+ * SumUp answers the merchant lookup with a 401 whenever it rejects the API key.
+ * The most common cause is pasting the wrong key: the dashboard prominently
+ * shows a "Public API key", but checkouts need a *secret* API key created under
+ * For Developers → API Keys (shown only once). Less commonly the key was
+ * truncated on paste, or the key and merchant code belong to different accounts
+ * (e.g. a sandbox key with a live merchant code). The raw SumUp body is just an
+ * opaque trace id, so for a 401 we replace it with guidance and pass other
+ * errors (network failures, 5xx, etc.) through unchanged.
  */
 const sumupKeyError = (err: unknown): string => {
   const message = errorMessage(err);
   return message.startsWith("401")
-    ? "401 Unauthorized — SumUp rejected these credentials. Check the API key was copied in full, and that the API key and Merchant Code belong to the same SumUp account (a sandbox key will not work with a live merchant code, or vice-versa)."
+    ? '401 Unauthorized — SumUp rejected this API key. The most common cause is using the wrong key: the "Public API key" shown on the SumUp dashboard will not work here. You need a secret API key — create one under For Developers → API Keys (https://me.sumup.com/en-gb/settings/api-keys), then copy the key it shows you, which is only displayed once. If you are already using a secret key, check it was copied in full and that the API key and Merchant Code belong to the same SumUp account (a sandbox key will not work with a live merchant code, or vice-versa).'
     : message;
 };
 

--- a/src/ui/client/admin/payment-test-buttons.ts
+++ b/src/ui/client/admin/payment-test-buttons.ts
@@ -110,14 +110,21 @@ export const initPaymentTestButtons = (): void => {
     "sumup-test-result",
     "/admin/settings/sumup/test",
     "sumup-test-result",
-    (data) => [
-      formatCredentialLine("API Key", data.apiKey),
-      data.merchant.configured
-        ? `Merchant: ${data.merchant.merchantCode}`
-        : `Merchant: Not configured${data.merchant.error ? ` - ${data.merchant.error}` : ""}`,
-      data.currency.supported
-        ? `Currency: ${data.currency.code} (supported)`
-        : `Currency: ${data.currency.code} is not supported by SumUp`,
-    ],
+    (data) => {
+      const apiKeyLine = formatCredentialLine("API Key", data.apiKey);
+      // A rejected key means the merchant lookup never ran, so "Merchant: Not
+      // configured" would be misleading and the currency note is just noise.
+      // The API Key line already carries the full, actionable fix.
+      if (!data.apiKey.valid) return [apiKeyLine];
+      return [
+        apiKeyLine,
+        data.merchant.configured
+          ? `Merchant: ${data.merchant.merchantCode}`
+          : `Merchant: Not configured${data.merchant.error ? ` - ${data.merchant.error}` : ""}`,
+        data.currency.supported
+          ? `Currency: ${data.currency.code} (supported)`
+          : `Currency: ${data.currency.code} is not supported by SumUp`,
+      ];
+    },
   );
 };

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1797,9 +1797,10 @@ button.secondary:hover,
   text-decoration: underline;
 }
 
-/* Stripe/Square test result */
+/* Stripe/Square/SumUp test result */
 .stripe-test-result,
-.square-test-result {
+.square-test-result,
+.sumup-test-result {
   white-space: pre-wrap;
 }
 

--- a/test/lib/sumup.test.ts
+++ b/test/lib/sumup.test.ts
@@ -346,7 +346,10 @@ describe("sumup", () => {
         expect(result.ok).toBe(false);
         expect(result.apiKey.valid).toBe(false);
         expect(result.apiKey.error).toContain("401");
-        // The opaque SumUp body is replaced with a hint about the likely cause.
+        // The opaque SumUp body is replaced with a hint about the likely causes:
+        // the public-vs-secret key mix-up first, then the cross-account mismatch.
+        expect(result.apiKey.error).toContain("Public API key");
+        expect(result.apiKey.error).toContain("secret API key");
         expect(result.apiKey.error).toContain("same SumUp account");
         expect(result.apiKey.error).not.toContain("detail");
       });


### PR DESCRIPTION
## Problem

Testing valid-looking SumUp credentials produced a confusing run-on message:

```
API Key: Invalid - 401 Unauthorized — SumUp rejected these credentials. Check the API key was copied in full, and that the API key and Merchant Code belong to the same SumUp account (a sandbox key will not work with a live merchant code, or vice-versa). Merchant: Not configured Currency: GBP (supported)
```

Three separate problems:

1. **The real cause wasn't mentioned.** SumUp's dashboard prominently shows a **"Public API key"**, but checkouts need a **secret API key** created under For Developers → API Keys (shown only once). Pasting the public key gives a 401, and the old message never said so.
2. **"Merchant: Not configured" was misleading.** A merchant code *was* entered — the lookup just never ran because the key was rejected. "Currency: GBP (supported)" was pure noise next to a failure.
3. **It rendered as one run-on line.** `.sumup-test-result` was missing from the `white-space: pre-wrap` CSS rule (only `.stripe-test-result` / `.square-test-result` were listed), so the three lines collapsed together.

## Changes

- **`src/shared/sumup.ts`** — Rewrite the 401 guidance to lead with the public-vs-secret key mix-up, link the API keys page (`https://me.sumup.com/en-gb/settings/api-keys`), and note the key is shown only once. Keep "copied in full" / same-account as secondary checks.
- **`src/ui/client/admin/payment-test-buttons.ts`** — When the API key is invalid, show only the (now self-contained) API Key line, dropping the misleading "Merchant: Not configured" and the noise currency line. The valid path is unchanged, so the unsupported-currency warning still shows.
- **`src/ui/static/mvp.css`** — Add `.sumup-test-result` to the `pre-wrap` rule so the lines render separately.
- **`test/lib/sumup.test.ts`** — Extend the 401 test to assert the new guidance mentions the public/secret key distinction.

## New message on a rejected key

> API Key: Invalid - 401 Unauthorized — SumUp rejected this API key. The most common cause is using the wrong key: the "Public API key" shown on the SumUp dashboard will not work here. You need a secret API key — create one under For Developers → API Keys (https://me.sumup.com/en-gb/settings/api-keys), then copy the key it shows you, which is only displayed once. If you are already using a secret key, check it was copied in full and that the API key and Merchant Code belong to the same SumUp account (a sandbox key will not work with a live merchant code, or vice-versa).

## Testing

- `deno task test:files test/lib/sumup.test.ts` — pass (incl. updated 401 test)
- `deno task test:files test/templates/admin/settings.test.ts test/lib/server-settings/sumup.test.ts` — pass
- `deno task typecheck` — clean
- `deno task lint` — clean (no fixes)

https://claude.ai/code/session_015MAAR3KK5gouNm6b9K2YBz

---
_Generated by [Claude Code](https://claude.ai/code/session_015MAAR3KK5gouNm6b9K2YBz)_