### PR TITLE
Clarify SumUp private vs public API key and disable field autocomplete

### DIFF
--- a/src/ui/templates/admin/guide.tsx
+++ b/src/ui/templates/admin/guide.tsx
@@ -892,8 +892,11 @@ export const adminGuidePage = (
               <a href="https://me.sumup.com/en-gb/settings/api-keys">
                 me.sumup.com/en-gb/settings/api-keys
               </a>
-              . Click <strong>Create API key</strong>, give it a name, and copy
-              the key &mdash; it is shown only once.
+              . That page shows a <strong>Public API key</strong> near the top
+              &mdash; <strong>that is not the one you need</strong>. Instead, in
+              the <strong>API Keys</strong> section below it, click{" "}
+              <strong>Create API key</strong>, give it a name, and copy the new
+              (private) key &mdash; it is shown only once.
             </li>
             <li>
               <strong>Merchant Code</strong> &mdash; your SumUp merchant code (a

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -1121,6 +1121,7 @@ export const squareWebhookFields: Field[] = [
  */
 export const sumupFields: Field[] = [
   {
+    autocomplete: "off",
     hint: "Your SumUp secret API key, from me.sumup.com → For Developers → API Keys",
     label: "SumUp API Key",
     name: "sumup_api_key",
@@ -1129,6 +1130,7 @@ export const sumupFields: Field[] = [
     type: "password",
   },
   {
+    autocomplete: "off",
     hint: "Your SumUp merchant code, shown in your SumUp account profile (must match the API key's account)",
     label: "Merchant Code",
     name: "sumup_merchant_code",

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -110,6 +110,15 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       );
     });
 
+    test("warns the SumUp public API key is not the one to use", async () => {
+      await assertAdminHtml(
+        "/admin/guide",
+        "Public API key",
+        "that is not the one you need",
+        "Create API key",
+      );
+    });
+
     test("contains public site section", async () => {
       await assertAdminHtml(
         "/admin/guide",

--- a/test/lib/server-settings/sumup.test.ts
+++ b/test/lib/server-settings/sumup.test.ts
@@ -106,6 +106,18 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       expect(html).not.toContain("sumup-test-btn");
     });
 
+    test("disables browser autocomplete on the SumUp credential fields", async () => {
+      await settings.update.paymentProvider("sumup");
+      const response = await awaitTestRequest("/admin/settings", {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      const inputTag = (name: string): string =>
+        html.match(new RegExp(`<input[^>]*name="${name}"[^>]*>`))?.[0] ?? "";
+      expect(inputTag("sumup_api_key")).toContain('autocomplete="off"');
+      expect(inputTag("sumup_merchant_code")).toContain('autocomplete="off"');
+    });
+
     test("shows the configured message and the test button", async () => {
       await adminFormPost("/admin/settings/sumup", {
         sumup_api_key: "sk_test_configured",


### PR DESCRIPTION
Follow-up to #1212.

## Changes

1. **Guide: public vs private SumUp API key.** The SumUp API Keys page shows a **Public API key** near the top, which is *not* the credential the integration needs. The guide now explicitly warns about it and directs owners to create a new **private** key in the **API Keys** section of that same page.

2. **Disable autocomplete on the SumUp settings fields.** `autocomplete="off"` is now set on both the SumUp API key and merchant code inputs, so browsers don't autofill or cache them.

## Tests
- Guide test asserting the "Public API key … that is not the one you need … Create API key" wording.
- Settings test asserting both `sumup_api_key` and `sumup_merchant_code` inputs render `autocomplete="off"`.
- `deno task lint` + `deno task typecheck` clean; affected test files green.

https://claude.ai/code/session_011eVFhbnmhrT6pmoN46rRko

---
_Generated by [Claude Code](https://claude.ai/code/session_011eVFhbnmhrT6pmoN46rRko)_