### PR TITLE
Show all listings by default on a bare create-attendee form

### DIFF
--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -41,7 +41,9 @@ export const QTY_PREFIX = "qty_";
 /** Per-listing hidden field carrying the existing booking's line key, so an
  * edit can move/keep the right `listing_attendees` row: `line_key_<listingId>`. */
 export const LINE_KEY_PREFIX = "line_key_";
-/** Checkbox that reveals the not-booked listing rows (pure-CSS, never parsed). */
+/** Checkbox that reveals the not-booked listing rows when at least one line is
+ * already booked (pure-CSS, never parsed; omitted on a bare create form, which
+ * shows every listing). */
 export const SHOW_ALL_FIELD = "show_all";
 export const STATUS_FIELD = "status_id";
 export const REMAINING_BALANCE_FIELD = "remaining_balance";

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -2355,6 +2355,7 @@ a.cal-day-selected:hover {
   cursor: pointer;
 }
 
-.listing-editor:not(:has(.show-all-toggle:checked)) .attendee-line-empty {
+.listing-editor:not(.show-all-listings):not(:has(.show-all-toggle:checked))
+  .attendee-line-empty {
   display: none;
 }

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -6,9 +6,11 @@
  * start date plus a length — applied to every daily listing they book. The
  * listing editor is a fixed table with one quantity box per bookable listing
  * (plus any inactive listing the attendee already booked); quantity ≥ 1 books
- * it, 0 leaves it out, so there are no add/remove-line buttons. Not-booked rows
- * are hidden behind a "Show all listings" toggle (pure CSS). The form works
- * without JavaScript.
+ * it, 0 leaves it out, so there are no add/remove-line buttons. When something
+ * is already booked (an edit, or a create pre-filled from the calendar) the
+ * not-booked rows hide behind a "Show all listings" toggle (pure CSS); a bare
+ * create form has nothing booked, so it drops the toggle and shows every
+ * listing. The form works without JavaScript.
  */
 
 import { compact } from "#fp";
@@ -188,40 +190,59 @@ const ListingRow = ({
   );
 };
 
-/** The fixed listing editor: one quantity box per listing, with a "Show all
- * listings" toggle that reveals the not-booked rows (pure CSS). */
+/** The fixed listing editor: one quantity box per listing. When at least one
+ * line is already booked — an edit, or a create deep-linked from the calendar
+ * with pre-selected listings — the not-booked rows tuck behind an un-ticked
+ * "Show all listings" toggle (pure CSS). A bare create form has nothing booked,
+ * so every row would hide behind that toggle; there we drop it and show every
+ * listing instead. */
 const ListingEditor = ({
   data,
 }: {
   data: AttendeeFormTemplateData;
-}): JSX.Element => (
-  <div class="listing-editor">
-    <label class="show-all">
-      <input class="show-all-toggle" name={SHOW_ALL_FIELD} type="checkbox" />
-      Show all listings
-    </label>
-    <div class="table-scroll">
-      <table class="line-editor">
-        <thead>
-          <tr>
-            <th>Listing</th>
-            <th>Dates</th>
-            <th>Qty</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.parsed.lines.map((line) => (
-            <ListingRow
-              line={line}
-              warnings={data.lineWarnings.get(line.listingId) ?? []}
-            />
-          ))}
-        </tbody>
-      </table>
+}): JSX.Element => {
+  const hasBookedLines = data.parsed.lines.some(
+    (line) => isBookedLine(line) || Boolean(line.existingBooking),
+  );
+  return (
+    <div
+      class={
+        hasBookedLines ? "listing-editor" : "listing-editor show-all-listings"
+      }
+    >
+      {hasBookedLines && (
+        <label class="show-all">
+          <input
+            class="show-all-toggle"
+            name={SHOW_ALL_FIELD}
+            type="checkbox"
+          />
+          Show all listings
+        </label>
+      )}
+      <div class="table-scroll">
+        <table class="line-editor">
+          <thead>
+            <tr>
+              <th>Listing</th>
+              <th>Dates</th>
+              <th>Qty</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.parsed.lines.map((line) => (
+              <ListingRow
+                line={line}
+                warnings={data.lineWarnings.get(line.listingId) ?? []}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 /** Option list for the day-count select: 1…horizon, each labelled with the
  * resulting end date when a start date is known. */

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -132,6 +132,40 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       expect(html).toMatch(new RegExp(`name="qty_${b.id}"[^>]*value="1"`));
     });
 
+    test("omits the 'Show all listings' toggle on a bare create form", async () => {
+      // Nothing is booked yet, so an un-ticked toggle would hide every row.
+      // Instead the form drops the toggle and shows every listing.
+      await createTestListing({ maxAttendees: 100, name: "Pick Me" });
+      const response = await awaitTestRequest("/admin/attendees/new", {
+        cookie: await testCookie(),
+      });
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).not.toContain("Show all listings");
+      expect(html).not.toContain('name="show_all"');
+      // The editor carries the show-all modifier so the not-booked rows stay
+      // visible despite the CSS that hides them under the toggle.
+      expect(html).toContain("listing-editor show-all-listings");
+    });
+
+    test("keeps the un-ticked 'Show all listings' toggle when listings are pre-filled", async () => {
+      // A calendar deep link pre-selects a listing; the other rows stay tucked
+      // behind the toggle, which starts un-ticked.
+      const picked = await createTestListing({
+        maxAttendees: 100,
+        name: "Kayak",
+      });
+      await createTestListing({ maxAttendees: 100, name: "Canoe" });
+      const response = await awaitTestRequest(
+        `/admin/attendees/new?select_${picked.id}=1`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200, "Show all listings");
+      expect(html).toContain('name="show_all"');
+      // Un-ticked: the checkbox carries no `checked` attribute.
+      expect(html).not.toMatch(/name="show_all"[^>]*checked/);
+      expect(html).not.toContain("listing-editor show-all-listings");
+    });
+
     test("pre-fills the shared start date from the deep link", async () => {
       const listing = await createDailyTestListing({ name: "Daily Pick" });
       const response = await awaitTestRequest(
@@ -192,6 +226,24 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
       // The shared day-count select preselects the booking's current 2-day span.
       expect(html).toContain('id="day_count"');
       expect(hasSelectedOption(html, "2")).toBe(true);
+    });
+
+    test("keeps the 'Show all listings' toggle on the edit form", async () => {
+      // An existing attendee always has a booked line, so the toggle stays to
+      // tuck the not-booked rows away — the show-all modifier is not applied.
+      const listing = await createTestListing({
+        maxAttendees: 100,
+        name: "Booked",
+      });
+      const result = await bookAttendee(listing);
+      const attendeeId = result.success ? result.attendees[0]!.id : 0;
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendeeId}`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200, "Show all listings");
+      expect(html).toContain('name="show_all"');
+      expect(html).not.toContain("listing-editor show-all-listings");
     });
 
     test("preserves return_url as a hidden field when provided", async () => {


### PR DESCRIPTION
## Problem

On `/admin/attendees/new`, the listing editor always rendered a **"Show all listings"** toggle, un-ticked by default. The toggle is pure-CSS: when un-ticked it hides every not-booked row. On a bare create form *nothing* is booked yet, so the un-ticked toggle hid **every** row — an operator opening the create form saw an empty listing table and had to tick the box before they could book anything.

## Fix

Render the toggle only when at least one line is already booked:

- **Bare create form** (no calendar pre-selection): drop the toggle and show every listing. A new `show-all-listings` modifier class on the editor opts the container out of the CSS hide rule.
- **Create deep-linked from the calendar** (pre-selected listings) or **edit mode** (existing bookings): keep the toggle, un-ticked, exactly as before — the not-booked rows stay tucked away.

The decision is derived from the rendered lines (`isBookedLine(line) || line.existingBooking`), so it falls out naturally for create, calendar deep-link, edit, and post-submit re-render paths without a new template flag.

## Tests

Added three cases to `test/lib/server-attendee-form.test.ts`:

- bare create form omits the toggle and carries the `show-all-listings` modifier;
- a calendar deep link keeps the un-ticked toggle and no modifier;
- the edit form keeps the toggle.

All checks pass locally — typecheck, Biome lint, and the full suite at 100% line/branch coverage (the three changed source files included).

https://claude.ai/code/session_01UVding22T9bRWLBtrCjBKu

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVding22T9bRWLBtrCjBKu)_