### PR TITLE
Add margin-right to inputs inside .radios and .checkboxes labels

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1305,6 +1305,11 @@ fieldset {
   max-width: none;
 }
 
+.checkboxes label input,
+.radios label input {
+  margin-right: 0.5rem;
+}
+
 label.terms-agree {
   display: block;
 }


### PR DESCRIPTION
Adds `margin-right: 0.5rem` to `input` elements inside `.checkboxes label` and `.radios label` so there is spacing between the checkbox/radio input and its label text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xj294ZfL6feQSvA7cQ1yFm)_