### PR TITLE
Use gap-s instead of gap-m for label elements

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -834,7 +834,7 @@ textarea[readonly] {
 label {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-m);
+  gap: var(--space-s);
   align-items: baseline;
   font-weight: bold;
   font-size: inherit;


### PR DESCRIPTION
Changes `label` gap from `var(--space-m)` to `var(--space-s)` in `src/ui/static/mvp.css`.

https://claude.ai/code/session_01UuTQgFGYyqQWHSRMJZogjZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuTQgFGYyqQWHSRMJZogjZ)_