### PR TITLE
Make email template delete a typed-confirmation page

### DIFF
--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -14,6 +14,7 @@
  */
 
 import { requirePrivateKey } from "#routes/admin/actions.ts";
+import { createConfirmedHandlers } from "#routes/admin/confirmation.ts";
 import {
   type AuthSession,
   OWNER_FORM,
@@ -21,7 +22,6 @@ import {
   withAuth,
 } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
-import { ownerFormById } from "#routes/entity.ts";
 import {
   errorRedirect,
   htmlResponse,
@@ -82,6 +82,7 @@ import { ok } from "#shared/response.ts";
 import {
   bulkEmailComposePage,
   bulkEmailPreviewPage,
+  bulkEmailTemplateDeletePage,
 } from "#templates/admin/bulk-email.tsx";
 
 const COMPOSE_PATH = "/admin/emails";
@@ -422,19 +423,42 @@ const handleTemplateSavePost = (request: Request): Promise<Response> =>
   });
 /* jscpd:ignore-end */
 
-/** POST /admin/emails/templates/:id/delete — delete a template. */
-const handleTemplateDeletePost = ownerFormById(async (id) => {
-  const existing = await getRawEmailTemplate(id);
-  if (!existing) return notFoundResponse();
-  await deleteEmailTemplate(id);
-  return ok(`${COMPOSE_PATH}?audience=active`, "Template deleted.");
-});
+/**
+ * GET/POST /admin/emails/templates/:id/delete — typed-confirmation delete,
+ * matching the round-trip flow used for other named resources. The subject is
+ * encrypted, so it's decrypted with the owner's private key both to display the
+ * confirmation page and to be the identifier the owner must re-type.
+ */
+const templateDelete = createConfirmedHandlers<{ id: number; subject: string }>(
+  {
+    auth: "owner",
+    identifier: (template) => template.subject,
+    identifierLabel: "Template subject",
+    load: async (id, session) => {
+      const raw = await getRawEmailTemplate(id);
+      if (!raw) return null;
+      const privateKey = await requirePrivateKey(session);
+      return {
+        id,
+        subject: await decryptWithOwnerKey(raw.subject, privateKey),
+      };
+    },
+    onConfirm: async (_template, id) => {
+      await deleteEmailTemplate(id);
+    },
+    path: "/admin/emails/templates/:id/delete",
+    render: (template, session, error) =>
+      bulkEmailTemplateDeletePage(session, template, error),
+    successMessage: "Template deleted.",
+    successRedirect: `${COMPOSE_PATH}?audience=active`,
+  },
+);
 
 export const bulkEmailRoutes = defineRoutes({
+  ...templateDelete.routes,
   "GET /admin/emails": handleComposeGet,
   "GET /admin/emails/preview": handlePreviewGet,
   "POST /admin/emails/preview": handlePreviewPost,
   "POST /admin/emails/send": handleSendPost,
   "POST /admin/emails/templates": handleTemplateSavePost,
-  "POST /admin/emails/templates/:id/delete": handleTemplateDeletePost,
 });

--- a/src/locales/en/bulk-email.json
+++ b/src/locales/en/bulk-email.json
@@ -39,5 +39,9 @@
   "bulk_email.update_existing_checkbox": "Update existing template",
   "bulk_email.template_to_update_label": "Template to update",
   "bulk_email.save_as_new_template": "Save as new template",
-  "bulk_email.update_template_button": "Update template"
+  "bulk_email.update_template_button": "Update template",
+  "bulk_email.delete_template_heading": "Delete template",
+  "bulk_email.delete_template_intro": "Are you sure you want to delete the saved template with subject:",
+  "bulk_email.delete_template_prompt": "Type the template subject to confirm:",
+  "bulk_email.delete_template_submit": "Delete template"
 }

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -10,7 +10,7 @@ import {
   MAX_BULK_EMAIL_SUBJECT_LENGTH,
   targetQuery,
 } from "#shared/bulk-email.ts";
-import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
@@ -140,14 +140,12 @@ export const bulkEmailComposePage = (
                   </a>
                   {state.selectedTemplateId === tpl.id &&
                     ` ${t("bulk_email.template_loaded_marker")}`}{" "}
-                  <CsrfForm
-                    action={`/admin/emails/templates/${tpl.id}/delete`}
-                    class="inline"
+                  <a
+                    class="danger small"
+                    href={`/admin/emails/templates/${tpl.id}/delete`}
                   >
-                    <button class="link-button danger small" type="submit">
-                      {t("common.delete")}
-                    </button>
-                  </CsrfForm>
+                    {t("common.delete")}
+                  </a>
                 </li>
               ))}
             </ul>
@@ -250,6 +248,36 @@ export const bulkEmailComposePage = (
     </Layout>,
   );
 };
+
+/**
+ * Confirmation page for deleting a saved bulk-email template. The owner must
+ * re-type the template's subject, matching the typed-identifier delete flow used
+ * for other named resources.
+ */
+export const bulkEmailTemplateDeletePage = (
+  session: AdminSession,
+  template: { id: number; subject: string },
+  error?: string,
+): string =>
+  String(
+    <Layout title={t("bulk_email.delete_template_heading")}>
+      <AdminNav active={NAV_ACTIVE} session={session} />
+      <ConfirmForm
+        action={`/admin/emails/templates/${template.id}/delete`}
+        buttonText={t("bulk_email.delete_template_submit")}
+        label={t("bulk_email.subject_label")}
+        name={template.subject}
+      >
+        <h1>{t("bulk_email.delete_template_heading")}</h1>
+        <Flash error={error} />
+        <p>
+          {t("bulk_email.delete_template_intro")}{" "}
+          <strong>{template.subject}</strong>
+        </p>
+        <p>{t("bulk_email.delete_template_prompt")}</p>
+      </ConfirmForm>
+    </Layout>,
+  );
 
 export type BulkEmailPreviewState = {
   draft: BulkEmailDraft;

--- a/test/lib/server-bulk-email.test.ts
+++ b/test/lib/server-bulk-email.test.ts
@@ -933,11 +933,32 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
       expectFlash(response, "That template no longer exists.", false);
     });
 
-    test("POST /admin/emails/templates/:id/delete removes the template", async () => {
+    test("GET /admin/emails/templates/:id/delete shows the confirmation page with the decrypted subject", async () => {
+      const id = await seedTemplate("To delete", "Body");
+      const response = await awaitTestRequest(
+        `/admin/emails/templates/${id}/delete`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).toContain("Delete template");
+      // The subject (encrypted at rest) is decrypted to confirm against.
+      expect(html).toContain("To delete");
+      expect(html).toContain('name="confirm_identifier"');
+    });
+
+    test("GET /admin/emails/templates/:id/delete 404s for unknown template", async () => {
+      const response = await awaitTestRequest(
+        "/admin/emails/templates/9999/delete",
+        { cookie: await testCookie() },
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("POST /admin/emails/templates/:id/delete removes the template when the subject matches", async () => {
       const id = await seedTemplate("To delete", "Body");
       const { response } = await adminFormPost(
         `/admin/emails/templates/${id}/delete`,
-        {},
+        { confirm_identifier: "To delete" },
       );
       expectRedirectWithFlash(
         "/admin/emails?audience=active",
@@ -945,10 +966,23 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
       )(response);
     });
 
+    test("POST /admin/emails/templates/:id/delete rejects a mismatched subject", async () => {
+      const id = await seedTemplate("To delete", "Body");
+      const { response } = await adminFormPost(
+        `/admin/emails/templates/${id}/delete`,
+        { confirm_identifier: "Wrong subject" },
+      );
+      expectFlash(
+        response,
+        "Template subject does not match. Please type the exact template subject to confirm deletion.",
+        false,
+      );
+    });
+
     test("POST /admin/emails/templates/:id/delete 404s for unknown template", async () => {
       const { response } = await adminFormPost(
         "/admin/emails/templates/9999/delete",
-        {},
+        { confirm_identifier: "anything" },
       );
       expect(response.status).toBe(404);
     });


### PR DESCRIPTION
## Summary

The delete control on saved bulk-email templates was an inline POST button that deleted immediately. This replaces it with a link to a confirmation page that requires re-typing the template's subject, matching the round-trip typed-identifier delete flow used for other named resources (groups, listings, users, etc.).

## Changes

- **`src/ui/templates/admin/bulk-email.tsx`**: The compose page's template list now renders a `Delete` **link** to `/admin/emails/templates/:id/delete` instead of an inline `CsrfForm` + button. Added a new `bulkEmailTemplateDeletePage` that uses the shared `ConfirmForm` component.
- **`src/features/admin/bulk-email.ts`**: Replaced the immediate `POST .../delete` handler with a `createConfirmedHandlers` GET/POST pair. Because template subjects are encrypted at rest, the subject is decrypted with the owner's private key both to render the confirmation page and to serve as the identifier the owner must re-type.
- **`src/locales/en/bulk-email.json`**: Added the delete-page strings.
- **`test/lib/server-bulk-email.test.ts`**: Updated the delete tests to cover the new flow — GET confirmation page (with decrypted subject), 404 for unknown templates on both GET and POST, successful delete on subject match, and rejection on mismatch.

## Verification

- `deno task typecheck`, `deno task lint`, and `deno task build:edge` all pass.
- `deno task test:files test/lib/server-bulk-email.test.ts` passes with 100% line/branch coverage on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvNyRb7ZcXwUGYXh7BCVjW)_