### PR TITLE
Pin migration schema reads to the primary

### DIFF
--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -113,6 +113,17 @@ const batchFor =
 export const queryBatch = batchFor("read");
 
 /**
+ * Run read queries pinned to the primary in a single round-trip.
+ *
+ * libsql routes "read"-mode batches to a replica that can lag behind a
+ * just-committed write, so a caller that must read its own writes (the
+ * migrator verifying DDL it just applied) uses "write" mode, which Turso
+ * always serves from the primary. A write-mode transaction may contain only
+ * SELECTs — it just guarantees the primary, read-your-writes connection.
+ */
+export const queryBatchPrimary = batchFor("write");
+
+/**
  * Execute multiple write statements and return their ResultSets.
  * Statements run in order within a single transaction (Turso batch API).
  * Ideal for cascading deletes and multi-step writes.

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -15,7 +15,7 @@ import type { Client, InValue } from "@libsql/client";
 import { lazyRef } from "#fp";
 import { ensureDefaultAttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import { createAndUploadBackup, hasRecentBackup } from "#shared/db/backup.ts";
-import { executeBatch, getDb, queryBatch } from "#shared/db/client.ts";
+import { executeBatch, getDb, queryBatchPrimary } from "#shared/db/client.ts";
 import { getEnv } from "#shared/env.ts";
 import { logDebug } from "#shared/logger.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
@@ -620,9 +620,14 @@ type LiveSchema = {
  * are collapsed into two SELECTs sent as one read batch. The first joins
  * `sqlite_master` against the `pragma_table_info` table-valued function to read
  * every column of every table at once; the second lists every index name.
+ *
+ * Pinned to the primary (not a replica): every caller runs inside a migration,
+ * where the snapshot must reflect DDL applied moments earlier in the same run.
+ * A replica that lags behind that write would report a just-created table as
+ * missing, failing verify() spuriously (see queryBatchPrimary).
  */
 const snapshotLiveSchema = async (): Promise<LiveSchema> => {
-  const [columns, indexRows] = await queryBatch([
+  const [columns, indexRows] = await queryBatchPrimary([
     {
       args: [],
       sql:

--- a/test/lib/db/migration-restore.test.ts
+++ b/test/lib/db/migration-restore.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { spy } from "@std/testing/mock";
 import { getDb, insert } from "#shared/db/client.ts";
 import {
   MIGRATIONS,
@@ -117,6 +118,30 @@ describeWithEnv("db > migration restore", { db: true }, () => {
       }
     });
   }
+
+  test("verify reads the live schema from the primary, not a replica", async () => {
+    // A replica can lag behind the DDL a migration just committed, so verify()
+    // must read its own writes from the primary or it reports a freshly-created
+    // table as missing. libsql routes "write"-mode batches to the primary and
+    // "read"-mode batches to a (possibly stale) replica.
+    const client = getDb();
+    const batchSpy = spy(client, "batch");
+    try {
+      await migrationById("2026-06-16_email_templates").verify();
+    } finally {
+      batchSpy.restore();
+    }
+
+    const schemaReads = batchSpy.calls.filter(({ args }) =>
+      (args[0] as Array<{ sql: string }>).some((stmt) =>
+        stmt.sql.includes("pragma_table_info"),
+      ),
+    );
+    expect(schemaReads.length).toBeGreaterThan(0);
+    for (const call of schemaReads) {
+      expect(call.args[1]).toBe("write");
+    }
+  });
 
   test("a fully-migrated database satisfies every migration's verify()", async () => {
     for (const migration of MIGRATIONS) {


### PR DESCRIPTION
## What

Migration `verify()` read the live schema through a `"read"`-mode libsql batch (`snapshotLiveSchema` → `queryBatch`). Turso routes `"read"`-mode batches to a replica, which can lag behind DDL the migration **just** committed to the primary. So a freshly-created table looked missing and `verify()` threw:

```
Migration verification failed: missing table email_templates
```

Because `verify()` runs *before* `markMigrationApplied()`, the migration was left unrecorded and the next request retried and succeeded — the user saw a one-off transient CDN 500, not data corruption.

## Fix

`snapshotLiveSchema` is only ever called inside a migration, where it must read its own just-applied writes. Pin it to the primary via a new `queryBatchPrimary` helper (`"write"`-mode batch, which Turso always serves from the primary, read-your-writes). Every other migration-path read is a single `execute` that isn't tagged for the replica, so this one chokepoint is the complete fix.

## Test

`test/lib/db/migration-restore.test.ts` now asserts the schema-snapshot batch runs in `"write"` mode. Confirmed it fails against the old `"read"`-mode behaviour and passes with the fix.

- `deno task test:files test/lib/db/migration-restore.test.ts` ✅
- `deno task test:files test/lib/db/migrations.test.ts` ✅
- `deno task lint` ✅
- `deno check` on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126uamTuDpknxmbWbJDtkhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0126uamTuDpknxmbWbJDtkhZ)_