### PR TITLE
Simplify delivery run sheet markup and show ticket token

### DIFF
--- a/src/features/admin/deliveries.ts
+++ b/src/features/admin/deliveries.ts
@@ -31,6 +31,7 @@ import {
 } from "#shared/db/logistics-agents.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getUserAgentIds } from "#shared/db/user-agents.ts";
+import { getFlash } from "#shared/flash-context.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { Attendee } from "#shared/types.ts";
 import {
@@ -74,6 +75,7 @@ const bookingsForDate = (
         listingId: leg.listingId,
         listingName: lookups.listingNameById.get(leg.listingId)!,
         phone: attendee.phone,
+        ticketToken: attendee.ticket_token,
       };
       byBooking.set(key, booking);
     }
@@ -136,9 +138,14 @@ const loadLegLookups = async (
 
 /** Handle GET /admin/deliveries — render the agent's run sheet. */
 const handleDeliveriesGet = agentPage(async (session) => {
+  const flash = getFlash();
   const agentIds = await getUserAgentIds(session.userId);
   if (agentIds.length === 0) {
-    return agentDeliveriesPage([], settings.phonePrefix, { noAgents: true });
+    return agentDeliveriesPage([], settings.phonePrefix, {
+      error: flash.error,
+      noAgents: true,
+      success: flash.success,
+    });
   }
 
   const today = todayInTz(settings.timezone);
@@ -148,7 +155,11 @@ const handleDeliveriesGet = agentPage(async (session) => {
   const privateKey = (await getPrivateKey(session))!;
   const lookups = await loadLegLookups(legs, privateKey);
   const groups = buildGroups(legs, today, tomorrow, lookups);
-  return agentDeliveriesPage(groups, settings.phonePrefix, { noAgents: false });
+  return agentDeliveriesPage(groups, settings.phonePrefix, {
+    error: flash.error,
+    noAgents: false,
+    success: flash.success,
+  });
 });
 
 /** Handle POST /admin/deliveries/mark — toggle a leg done, scoped to the

--- a/src/locales/en/deliveries.json
+++ b/src/locales/en/deliveries.json
@@ -9,6 +9,7 @@
   "deliveries.listing_label": "Listing:",
   "deliveries.address_label": "Address:",
   "deliveries.phone_label": "Phone:",
+  "deliveries.token_label": "Token:",
   "deliveries.mark_done": "Mark done",
   "deliveries.mark_not_done": "Mark not done",
   "deliveries.today": "Today",

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -213,6 +213,23 @@ article > * {
   margin-bottom: 0;
 }
 
+/* Agent run sheet: the top-level booking list has no bullets or indent; the
+   nested job/detail lists drop their bullets but keep their padding so they
+   still read as indented sub-lists. */
+.delivery-bookings {
+  list-style-type: none;
+  padding: 0;
+}
+
+.delivery-bookings ul {
+  list-style-type: none;
+}
+
+/* Space the inline "mark done" toggle away from the job it belongs to. */
+.delivery-mark {
+  margin-left: 1rem;
+}
+
 /* Outlines a rendered email body so it reads as a preview, not page content.
    Constrained to a typical email column width so it reads like a real email. */
 .email-preview {

--- a/src/ui/templates/admin/deliveries.tsx
+++ b/src/ui/templates/admin/deliveries.tsx
@@ -34,6 +34,8 @@ export type DeliveryBookingView = {
   attendeeName: string;
   address: string;
   phone: string;
+  /** The booking's ticket token — the id the customer can quote to confirm. */
+  ticketToken: string;
   /** The jobs (drop-off and/or collection) for this booking on this day. */
   legs: DeliveryLegView[];
 };
@@ -66,13 +68,13 @@ const LegItem = ({
   leg: DeliveryLegView;
 }): JSX.Element => (
   <li class={leg.done ? "delivery-leg done" : "delivery-leg"}>
-    <span class="delivery-kind">
+    <span>
       {leg.kind === "start"
         ? t("deliveries.dropoff")
         : t("deliveries.collection")}
       {leg.time ? ` · ${leg.time}` : ""} · {leg.agentName}
     </span>
-    <CsrfForm action="/admin/deliveries/mark" class="inline">
+    <CsrfForm action="/admin/deliveries/mark" class="delivery-mark inline">
       <input
         name="attendee_id"
         type="hidden"
@@ -85,9 +87,9 @@ const LegItem = ({
       />
       <input name="kind" type="hidden" value={leg.kind} />
       <input name="done" type="hidden" value={leg.done ? "0" : "1"} />
-      <SubmitButton icon={leg.done ? "rotate-ccw" : "check"}>
+      <button type="submit">
         {leg.done ? t("deliveries.mark_not_done") : t("deliveries.mark_done")}
-      </SubmitButton>
+      </button>
     </CsrfForm>
   </li>
 );
@@ -102,16 +104,16 @@ const BookingCard = ({
   booking: DeliveryBookingView;
   phonePrefix: string;
 }): JSX.Element => (
-  <li class="delivery-booking">
-    <ul class="delivery-details">
-      <li class="delivery-attendee">
+  <li>
+    <ul>
+      <li>
         <strong>{t("deliveries.name_label")}</strong> {booking.attendeeName}
       </li>
-      <li class="delivery-listing">
+      <li>
         <strong>{t("deliveries.listing_label")}</strong> {booking.listingName}
       </li>
       {booking.address && (
-        <li class="delivery-address">
+        <li>
           <strong>{t("deliveries.address_label")}</strong> {booking.address}
           <MapsLinks query={booking.address} />
         </li>
@@ -122,8 +124,11 @@ const BookingCard = ({
           <PhoneLinks phone={booking.phone} phonePrefix={phonePrefix} />
         </li>
       )}
-      <li class="delivery-jobs">
-        <ul class="delivery-legs">
+      <li>
+        <strong>{t("deliveries.token_label")}</strong> {booking.ticketToken}
+      </li>
+      <li>
+        <ul>
           {booking.legs.map((leg) => (
             <LegItem booking={booking} leg={leg} />
           ))}
@@ -163,18 +168,20 @@ export const agentDeliveriesPage = (
       ) : (
         groups.map((group) => (
           <section class="delivery-day">
-            <h2>{group.heading}</h2>
-            {group.bookings.length === 0 ? (
-              <p>
-                <em>{t("deliveries.nothing_scheduled")}</em>
-              </p>
-            ) : (
-              <ul class="delivery-bookings">
-                {group.bookings.map((booking) => (
-                  <BookingCard booking={booking} phonePrefix={phonePrefix} />
-                ))}
-              </ul>
-            )}
+            <div class="prose">
+              <h2>{group.heading}</h2>
+              {group.bookings.length === 0 ? (
+                <p>
+                  <em>{t("deliveries.nothing_scheduled")}</em>
+                </p>
+              ) : (
+                <ul class="delivery-bookings">
+                  {group.bookings.map((booking) => (
+                    <BookingCard booking={booking} phonePrefix={phonePrefix} />
+                  ))}
+                </ul>
+              )}
+            </div>
           </section>
         ))
       )}

--- a/src/ui/templates/components/phone-links.tsx
+++ b/src/ui/templates/components/phone-links.tsx
@@ -25,10 +25,13 @@ export const PhoneLinks = ({
         <>
           {" "}
           <small>
-            <a href={links.tel}>{t("attendee_detail.tel")}</a>{" "}
+            {"("}
+            <a href={links.tel}>{t("attendee_detail.tel")}</a>
+            {" / "}
             <a href={links.whatsapp} rel="noopener" target="_blank">
               {t("attendee_detail.whatsapp")}
             </a>
+            {")"}
           </small>
         </>
       )}

--- a/test/templates/admin/deliveries.test.ts
+++ b/test/templates/admin/deliveries.test.ts
@@ -32,6 +32,7 @@ const booking = (
   listingId: 9,
   listingName: "Bouncy Castle",
   phone: "07700900000",
+  ticketToken: "TOKEN123",
   ...over,
 });
 
@@ -70,6 +71,8 @@ describe("agentDeliveriesPage", () => {
     expect(html).toContain('action="/admin/deliveries/mark"');
     expect(html).toContain('value="start"');
     expect(html).toContain("Mark done");
+    // The ticket token the customer can quote is shown.
+    expect(html).toContain("<strong>Token:</strong> TOKEN123");
     // The empty Tomorrow group shows its own placeholder.
     expect(html).toContain("Nothing scheduled");
   });
@@ -130,11 +133,19 @@ describe("agentDeliveriesPage", () => {
     expect(html).not.toContain("delivery-phone");
   });
 
-  test("renders flash messages", () => {
+  test("renders an error flash message", () => {
     const html = agentDeliveriesPage([], "44", {
       error: "Something went wrong",
       noAgents: true,
     });
     expect(html).toContain("Something went wrong");
+  });
+
+  test("renders a success flash message", () => {
+    const html = agentDeliveriesPage([], "44", {
+      noAgents: true,
+      success: "Marked done",
+    });
+    expect(html).toContain("Marked done");
   });
 });


### PR DESCRIPTION
## Summary

Tidies up the delivery agent run sheet (`/admin/deliveries`) and addresses several rough edges.

- **Strip CSS cruft** — removed the pile of `delivery-*` classes that weren't doing anything; only classes that carry styling or behaviour remain.
- **`.delivery-bookings` styling** — now `list-style-type: none` with no padding. Nested ULs lose their bullets too but keep their padding, so they still read as indented sub-lists.
- **Mark-done forms** — dropped the SVG icon from the inline toggle and gave the form `1rem` of left margin.
- **Success flash** — the GET handler now reads the flash message and passes it to the page, so marking a leg done / not done actually shows a confirmation banner.
- **Ticket token** — shown as `Token:` underneath the listing details; this is the id a customer can quote to confirm.
- **`.prose` wrapper** — each day's listing is wrapped in `.prose` inside `.delivery-day`.
- **Phone links** — `tel` / WhatsApp links are now bracketed and slash-separated (`(tel / whatsapp)`) to match the maps links format. This is in the shared `PhoneLinks` component, so the attendee detail page picks it up too.

## Testing

- `deno task test:files` for the deliveries template, phone-links, attendee-detail, and server agent-deliveries suites — all green
- `deno task lint` and `deno task typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Svo4beYSp736cwnxrSP2CZ)_