### PR TITLE
Replace admin table Actions columns with name links and edit-page actions

### DIFF
--- a/src/features/admin/api-keys.ts
+++ b/src/features/admin/api-keys.ts
@@ -7,7 +7,7 @@ import { createActionHandler } from "#routes/admin/actions.ts";
 import { createConfirmedHandlers } from "#routes/admin/confirmation.ts";
 import { requireOwnerOr } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
-import { htmlResponse } from "#routes/response.ts";
+import { htmlResponse, notFoundResponse } from "#routes/response.ts";
 import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import {
   ADMIN_API_ENDPOINTS,
@@ -24,6 +24,7 @@ import {
 import { defineForm } from "#shared/forms.tsx";
 import {
   adminApiDocsPage,
+  adminApiKeyManagePage,
   adminApiKeysPage,
   adminDeleteApiKeyPage,
 } from "#templates/admin/api-keys.tsx";
@@ -123,6 +124,25 @@ const apiKeyDelete = createConfirmedHandlers<{ id: number; name: string }>({
 });
 
 /**
+ * Handle GET /admin/api-keys/:apiKeyId — per-key management page
+ */
+const handleApiKeyManageGet: TypedRouteHandler<
+  "GET /admin/api-keys/:apiKeyId"
+> = (request, { apiKeyId }) =>
+  requireOwnerOr(request, async (session) => {
+    const keys = await getApiKeysForUser(session.userId);
+    const apiKey = keys.find((k) => k.id === apiKeyId);
+    if (!apiKey) return notFoundResponse();
+    const flash = applyFlash(request);
+    return htmlResponse(
+      adminApiKeyManagePage(apiKey, session, {
+        error: flash.error,
+        success: flash.success,
+      }),
+    );
+  });
+
+/**
  * Handle GET /admin/api-keys/docs — API documentation page
  */
 const handleApiDocsGet: TypedRouteHandler<"GET /admin/api-keys/docs"> = (
@@ -138,6 +158,7 @@ export const apiKeysRoutes = {
   ...apiKeyDelete.routes,
   ...defineRoutes({
     "GET /admin/api-keys": handleApiKeysGet,
+    "GET /admin/api-keys/:apiKeyId": handleApiKeyManageGet,
     "GET /admin/api-keys/docs": handleApiDocsGet,
     "POST /admin/api-keys": handleApiKeysPost,
   }),

--- a/src/features/admin/api-keys.ts
+++ b/src/features/admin/api-keys.ts
@@ -22,6 +22,7 @@ import {
   getApiKeysForUser,
 } from "#shared/db/api-keys.ts";
 import { defineForm } from "#shared/forms.tsx";
+import type { AdminSession } from "#shared/types.ts";
 import {
   adminApiDocsPage,
   adminApiKeyManagePage,
@@ -43,12 +44,23 @@ export const apiKeyForm = defineForm({
   id: "apiKey",
 });
 
+/** Owner-guarded handler that loads the caller's API keys up front. */
+const withOwnerApiKeys = (
+  request: Request,
+  handle: (
+    session: AdminSession,
+    keys: Awaited<ReturnType<typeof getApiKeysForUser>>,
+  ) => Response | Promise<Response>,
+): Promise<Response> =>
+  requireOwnerOr(request, async (session) =>
+    handle(session, await getApiKeysForUser(session.userId)),
+  );
+
 /**
  * Handle GET /admin/api-keys
  */
 const handleApiKeysGet: TypedRouteHandler<"GET /admin/api-keys"> = (request) =>
-  requireOwnerOr(request, async (session) => {
-    const keys = await getApiKeysForUser(session.userId);
+  withOwnerApiKeys(request, (session, keys) => {
     const flash = applyFlash(request);
     // The API key is embedded in the flash success message after a newline
     const newLineIdx = flash.success?.indexOf("\n") ?? -1;
@@ -129,8 +141,7 @@ const apiKeyDelete = createConfirmedHandlers<{ id: number; name: string }>({
 const handleApiKeyManageGet: TypedRouteHandler<
   "GET /admin/api-keys/:apiKeyId"
 > = (request, { apiKeyId }) =>
-  requireOwnerOr(request, async (session) => {
-    const keys = await getApiKeysForUser(session.userId);
+  withOwnerApiKeys(request, (session, keys) => {
     const apiKey = keys.find((k) => k.id === apiKeyId);
     if (!apiKey) return notFoundResponse();
     const flash = applyFlash(request);

--- a/src/features/admin/settings-statuses.ts
+++ b/src/features/admin/settings-statuses.ts
@@ -7,6 +7,7 @@
  */
 
 /* jscpd:ignore-start */
+import { verifyOrRedirect } from "#routes/admin/confirmation.ts";
 import { OWNER_FORM, ownerPage, requireOwnerOr } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
 import {
@@ -38,6 +39,7 @@ import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { validateReservationAmount } from "#shared/reservation-amount.ts";
 import {
+  adminAttendeeStatusDeletePage,
   adminAttendeeStatusesPage,
   adminAttendeeStatusFormPage,
 } from "#templates/admin/settings-statuses.tsx";
@@ -175,22 +177,41 @@ const editPost = ownerFormById(async (id, _session, form) => {
   return redirect(LIST_PATH, "Status updated", true);
 });
 
-const deletePost = ownerFormById(async (id) => {
+const deleteGet: IdRouteHandler = (request, { id }) =>
+  requireOwnerOr(request, (session) => {
+    applyFlash(request);
+    return withEntity<AttendeeStatus>((status) =>
+      htmlResponse(
+        adminAttendeeStatusDeletePage(status, session, getFlash().error),
+      ),
+    )(() => getAttendeeStatus(id));
+  });
+
+const deletePost = ownerFormById(async (id, _session, form) => {
   const status = await getAttendeeStatus(id);
   if (!status) return notFoundResponse();
+  const confirmPath = `${LIST_PATH}/${id}/delete`;
+  const mismatch = verifyOrRedirect(
+    form,
+    status.name,
+    confirmPath,
+    "Name",
+    "deletion",
+  );
+  if (mismatch) return mismatch;
   const all = await getAllAttendeeStatuses();
   if (all.length <= 1) {
-    return errorRedirect(LIST_PATH, "You must keep at least one status");
+    return errorRedirect(confirmPath, "You must keep at least one status");
   }
   if (status.is_public_default) {
     return errorRedirect(
-      LIST_PATH,
+      confirmPath,
       "Choose another public default before deleting this status",
     );
   }
   if (status.is_paid_default) {
     return errorRedirect(
-      LIST_PATH,
+      confirmPath,
       "Choose another paid default before deleting this status",
     );
   }
@@ -199,7 +220,7 @@ const deletePost = ownerFormById(async (id) => {
     sql: "SELECT 1 FROM attendees WHERE status_id = ? LIMIT 1",
   });
   if (inUse.rows.length > 0) {
-    return errorRedirect(LIST_PATH, "This status is in use by attendees");
+    return errorRedirect(confirmPath, "This status is in use by attendees");
   }
   await attendeeStatusesTable.deleteById(id);
   await logActivity(`Attendee status '${status.name}' deleted`);
@@ -219,6 +240,7 @@ const moveHandler = (direction: -1 | 1) =>
 
 export const attendeeStatusesRoutes = defineRoutes({
   "GET /admin/settings/statuses": listGet,
+  "GET /admin/settings/statuses/:id/delete": deleteGet,
   "GET /admin/settings/statuses/:id/edit": editGet,
   "GET /admin/settings/statuses/new": newGet,
   "POST /admin/settings/statuses": createPost,

--- a/src/features/admin/settings-statuses.ts
+++ b/src/features/admin/settings-statuses.ts
@@ -38,6 +38,7 @@ import { getDb } from "#shared/db/client.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { validateReservationAmount } from "#shared/reservation-amount.ts";
+import type { AdminSession } from "#shared/types.ts";
 import {
   adminAttendeeStatusDeletePage,
   adminAttendeeStatusesPage,
@@ -126,18 +127,22 @@ const newGet = ownerPage((session) =>
   adminAttendeeStatusFormPage(session, { error: getFlash().error }),
 );
 
-const editGet: IdRouteHandler = (request, { id }) =>
-  requireOwnerOr(request, (session) => {
-    applyFlash(request);
-    return withEntity<AttendeeStatus>((status) =>
-      htmlResponse(
-        adminAttendeeStatusFormPage(session, {
-          error: getFlash().error,
-          status,
-        }),
-      ),
-    )(() => getAttendeeStatus(id));
-  });
+/** Owner-guarded GET that loads a status by id (or 404s) and renders a page. */
+const ownerStatusPage =
+  (
+    render: (status: AttendeeStatus, session: AdminSession) => string,
+  ): IdRouteHandler =>
+  (request, { id }) =>
+    requireOwnerOr(request, (session) => {
+      applyFlash(request);
+      return withEntity<AttendeeStatus>((status) =>
+        htmlResponse(render(status, session)),
+      )(() => getAttendeeStatus(id));
+    });
+
+const editGet = ownerStatusPage((status, session) =>
+  adminAttendeeStatusFormPage(session, { error: getFlash().error, status }),
+);
 
 const createPost = createAuthedHandler({
   auth: OWNER_FORM,
@@ -177,15 +182,9 @@ const editPost = ownerFormById(async (id, _session, form) => {
   return redirect(LIST_PATH, "Status updated", true);
 });
 
-const deleteGet: IdRouteHandler = (request, { id }) =>
-  requireOwnerOr(request, (session) => {
-    applyFlash(request);
-    return withEntity<AttendeeStatus>((status) =>
-      htmlResponse(
-        adminAttendeeStatusDeletePage(status, session, getFlash().error),
-      ),
-    )(() => getAttendeeStatus(id));
-  });
+const deleteGet = ownerStatusPage((status, session) =>
+  adminAttendeeStatusDeletePage(status, session, getFlash().error),
+);
 
 const deletePost = ownerFormById(async (id, _session, form) => {
   const status = await getAttendeeStatus(id);

--- a/src/features/admin/users.ts
+++ b/src/features/admin/users.ts
@@ -68,6 +68,13 @@ const VALID_ADMIN_LEVELS = ["owner", "manager", "agent"] as const;
 const loadAssignableAgents = (): Promise<LogisticsAgent[]> =>
   settings.hasLogistics ? getAllLogisticsAgents() : Promise.resolve([]);
 
+/** Map of assignable logistics-agent id → name, for resolving agent users'
+ * assignments to display names. */
+const loadAgentNameById = async (): Promise<Map<number, string>> => {
+  const agents = await loadAssignableAgents();
+  return new Map(agents.map((a) => [a.id, a.name]));
+};
+
 /** Resolve the chosen `agent_ids` from a form down to the ids that are real
  * logistics agents, dropping anything unknown. */
 const parseAssignedAgentIds = (
@@ -122,11 +129,10 @@ const renderUsersPage = async (
   session: AuthSession,
   opts: UsersPageOpts,
 ): Promise<string> => {
-  const [users, agents] = await Promise.all([
+  const [users, agentNameById] = await Promise.all([
     getAllUsers(),
-    loadAssignableAgents(),
+    loadAgentNameById(),
   ]);
-  const agentNameById = new Map(agents.map((a) => [a.id, a.name]));
   const displayUsers = await Promise.all(
     users.map((user) => toDisplayUser(user, agentNameById)),
   );
@@ -166,30 +172,37 @@ const handleUsersGet: TypedRouteHandler<"GET /admin/users"> = (request) =>
   });
 
 /** Build a DisplayUser with its assigned logistics-agent names resolved. */
-const toDisplayUserWithAgents = async (user: User): Promise<DisplayUser> => {
-  const agents = await loadAssignableAgents();
-  const agentNameById = new Map(agents.map((a) => [a.id, a.name]));
-  return toDisplayUser(user, agentNameById);
-};
+const toDisplayUserWithAgents = async (user: User): Promise<DisplayUser> =>
+  toDisplayUser(user, await loadAgentNameById());
+
+/** Owner-guarded GET handler that loads the target user (or 404s), then renders. */
+const ownerUserPage =
+  (
+    handler: (
+      user: User,
+      session: AuthSession,
+      errorPage: UserErrorPageFn,
+    ) => Response | Promise<Response>,
+  ) =>
+  (request: Request, { id }: { id: number }): Promise<Response> =>
+    requireOwnerOr(request, (session) =>
+      withLoadedUser(session, id, (user, errorPage) =>
+        handler(user, session, errorPage),
+      ),
+    );
 
 /** Handle GET /admin/users/:id - per-user management page */
-const handleUserManageGet: TypedRouteHandler<"GET /admin/users/:id"> = (
-  request,
-  { id },
-) =>
-  requireOwnerOr(request, (session) =>
-    withLoadedUser(session, id, async (user) => {
-      const displayUser = await toDisplayUserWithAgents(user);
-      const flash = getFlash();
-      return htmlResponse(
-        adminUserManagePage(displayUser, session, {
-          currentUserId: session.userId,
-          error: flash.error,
-          success: flash.success,
-        }),
-      );
+const handleUserManageGet = ownerUserPage(async (user, session) => {
+  const displayUser = await toDisplayUserWithAgents(user);
+  const flash = getFlash();
+  return htmlResponse(
+    adminUserManagePage(displayUser, session, {
+      currentUserId: session.userId,
+      error: flash.error,
+      success: flash.success,
     }),
   );
+});
 
 /**
  * Handle GET /admin/user/new - show invite user form
@@ -299,15 +312,9 @@ const renderUserAgentsPage = async (
 };
 
 /** Handle GET /admin/users/:id/agents - edit an agent user's logistics agents */
-const handleUserAgentsGet: TypedRouteHandler<"GET /admin/users/:id/agents"> = (
-  request,
-  { id },
-) =>
-  requireOwnerOr(request, (session) =>
-    withLoadedUser(session, id, (user, errorPage) =>
-      renderUserAgentsPage(session, user, errorPage),
-    ),
-  );
+const handleUserAgentsGet = ownerUserPage((user, session, errorPage) =>
+  renderUserAgentsPage(session, user, errorPage),
+);
 
 /** Handle POST /admin/users/:id/agents - save an agent user's logistics agents */
 const handleUserAgentsPost: TypedRouteHandler<

--- a/src/features/admin/users.ts
+++ b/src/features/admin/users.ts
@@ -45,6 +45,7 @@ import type { LogisticsAgent, User } from "#shared/types.ts";
 import {
   adminUserAgentsPage,
   adminUserDeletePage,
+  adminUserManagePage,
   adminUserNewPage,
   adminUsersPage,
   type DisplayUser,
@@ -163,6 +164,32 @@ const handleUsersGet: TypedRouteHandler<"GET /admin/users"> = (request) =>
       }),
     );
   });
+
+/** Build a DisplayUser with its assigned logistics-agent names resolved. */
+const toDisplayUserWithAgents = async (user: User): Promise<DisplayUser> => {
+  const agents = await loadAssignableAgents();
+  const agentNameById = new Map(agents.map((a) => [a.id, a.name]));
+  return toDisplayUser(user, agentNameById);
+};
+
+/** Handle GET /admin/users/:id - per-user management page */
+const handleUserManageGet: TypedRouteHandler<"GET /admin/users/:id"> = (
+  request,
+  { id },
+) =>
+  requireOwnerOr(request, (session) =>
+    withLoadedUser(session, id, async (user) => {
+      const displayUser = await toDisplayUserWithAgents(user);
+      const flash = getFlash();
+      return htmlResponse(
+        adminUserManagePage(displayUser, session, {
+          currentUserId: session.userId,
+          error: flash.error,
+          success: flash.success,
+        }),
+      );
+    }),
+  );
 
 /**
  * Handle GET /admin/user/new - show invite user form
@@ -398,6 +425,7 @@ export const usersRoutes = {
   ...defineRoutes({
     "GET /admin/user/new": handleUserNewGet,
     "GET /admin/users": handleUsersGet,
+    "GET /admin/users/:id": handleUserManageGet,
     "GET /admin/users/:id/agents": handleUserAgentsGet,
     "POST /admin/users": handleUsersPost,
     "POST /admin/users/:id/activate": handleUserActivatePost,

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -102,8 +102,6 @@
   "admin.attendee_table.check_out": "Check out",
   "admin.attendee_table.check_in": "Check in",
   "admin.attendee_table.refunded_badge": "Refunded",
-  "admin.attendee_table.refund": "Refund",
-  "admin.attendee_table.resend_notification": "Re-send Notification",
   "admin.checkin.title": "Check-in",
   "admin.checkin.heading": "Check-in",
   "admin.checkin.check_out_all": "Check Out All",

--- a/src/locales/en/statuses.json
+++ b/src/locales/en/statuses.json
@@ -17,5 +17,8 @@
   "statuses.form_reservation_amount_label": "Reservation amount",
   "statuses.form_reservation_amount_hint": ". Only used for reservations.",
   "statuses.form_save_button": "Save status",
-  "statuses.form_create_button": "Create status"
+  "statuses.form_create_button": "Create status",
+  "statuses.delete_button": "Delete status",
+  "statuses.delete_title": "Delete Attendee Status",
+  "statuses.delete_confirm": "Type the status name \"{name}\" to confirm deletion:"
 }

--- a/src/shared/columns/attendee-columns.ts
+++ b/src/shared/columns/attendee-columns.ts
@@ -149,12 +149,6 @@ const registered: AttendeeCol = {
   rawValue: (row) => row.attendee.created,
 };
 
-const actions = componentRenderedCol(
-  "Actions",
-  "Refund, edit, delete, and re-send notification links",
-  (row, opts) => opts.renderActions(row),
-);
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -187,7 +181,6 @@ export const ATTENDEE_TABLE_COLUMNS: ColumnGenerators<
   AttendeeTableRow,
   AttendeeColumnOpts
 > = {
-  actions,
   address,
   answers,
   date,
@@ -216,5 +209,4 @@ export const ATTENDEE_DEFAULT_ORDER = [
   "qty",
   "ticket",
   "registered",
-  "actions",
 ] as const;

--- a/src/ui/templates/admin/api-keys.tsx
+++ b/src/ui/templates/admin/api-keys.tsx
@@ -10,7 +10,7 @@ import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { DeleteSection, SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 type ApiKeyDisplay = {
@@ -23,17 +23,14 @@ type ApiKeyDisplay = {
 const ApiKeyRow = ({ apiKey }: { apiKey: ApiKeyDisplay }): string =>
   String(
     <tr>
-      <td>{apiKey.name}</td>
+      <td>
+        <a href={`/admin/api-keys/${apiKey.id}`}>{apiKey.name}</a>
+      </td>
       <td>{new Date(apiKey.created).toLocaleDateString()}</td>
       <td>
         {apiKey.lastUsed
           ? new Date(apiKey.lastUsed).toLocaleDateString()
           : t("api_keys.never")}
-      </td>
-      <td>
-        <a class="danger small" href={`/admin/api-keys/${apiKey.id}/delete`}>
-          {t("common.delete")}
-        </a>
       </td>
     </tr>,
   );
@@ -52,7 +49,7 @@ export const adminApiKeysPage = (
           map((k: ApiKeyDisplay) => ApiKeyRow({ apiKey: k })),
           joinStrings,
         )(keys)
-      : `<tr><td colspan="4">${t("api_keys.no_keys")}</td></tr>`;
+      : `<tr><td colspan="3">${t("api_keys.no_keys")}</td></tr>`;
 
   return String(
     <Layout title={t("api_keys.title")}>
@@ -85,7 +82,6 @@ export const adminApiKeysPage = (
               <th>{t("common.name")}</th>
               <th>{t("common.created")}</th>
               <th>{t("api_keys.col.last_used")}</th>
-              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -104,6 +100,50 @@ export const adminApiKeysPage = (
     </Layout>,
   );
 };
+
+/**
+ * Per-key management page — the destination for the name link in the API keys
+ * table. API keys aren't editable, so this read-only summary exists mainly to
+ * host the delete action (moved off the table and behind a typed-name
+ * confirmation).
+ */
+export const adminApiKeyManagePage = (
+  apiKey: ApiKeyDisplay,
+  session: AdminSession,
+  opts: { error?: string; success?: string } = {},
+): string =>
+  String(
+    <Layout title={`${t("api_keys.title")}: ${apiKey.name}`}>
+      <AdminNav active="/admin/users" session={session} />
+      <UsersSubNav />
+      <h1>{apiKey.name}</h1>
+      <Flash error={opts.error} success={opts.success} />
+      <div class="table-scroll">
+        <table class="listing-details-table">
+          <tbody>
+            <tr>
+              <th>{t("common.created")}</th>
+              <td>{new Date(apiKey.created).toLocaleDateString()}</td>
+            </tr>
+            <tr>
+              <th>{t("api_keys.col.last_used")}</th>
+              <td>
+                {apiKey.lastUsed
+                  ? new Date(apiKey.lastUsed).toLocaleDateString()
+                  : t("api_keys.never")}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <DeleteSection
+        heading={t("common.delete")}
+        href={`/admin/api-keys/${apiKey.id}/delete`}
+      >
+        {t("api_keys.delete_submit")}
+      </DeleteSection>
+    </Layout>,
+  );
 
 /**
  * Admin API key delete confirmation page

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -64,6 +64,7 @@ import {
 import { EditQuestions, PaymentDetails } from "#templates/admin/attendees.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import {
+  ActionButton,
   Icon,
   MaybeButtonLink,
   SubmitButton,
@@ -519,6 +520,52 @@ const EmailHistory = ({
   );
 };
 
+/** An attendee is refundable when they have a captured payment that has not
+ * already been refunded. */
+const isRefundable = (attendee: Attendee): boolean =>
+  !!attendee.payment_id && !attendee.refunded;
+
+/**
+ * Per-attendee actions (edit mode only) — refund, re-send notification, and
+ * delete. These used to live in the attendee table's "Actions" column; they now
+ * sit on the edit page, each routed through its own typed-name confirmation
+ * page. The booking-scoped routes are keyed on the attendee's home listing.
+ */
+const AttendeeActions = ({ attendee }: { attendee: Attendee }): JSX.Element => {
+  const base = `/admin/listing/${attendee.listing_id}/attendee/${attendee.id}`;
+  const ret = `?return_url=${encodeURIComponent(`/admin/attendees/${attendee.id}`)}`;
+  return (
+    <article>
+      <h3>Actions</h3>
+      <p class="actions">
+        {isRefundable(attendee) && (
+          <ActionButton
+            href={`${base}/refund${ret}`}
+            icon="credit-card"
+            variant="secondary"
+          >
+            Refund
+          </ActionButton>
+        )}
+        <ActionButton
+          href={`${base}/resend-notification${ret}`}
+          icon="rotate-ccw"
+          variant="secondary"
+        >
+          Re-send notification
+        </ActionButton>
+        <ActionButton
+          href={`${base}/delete`}
+          icon="trash-2"
+          variant="secondary"
+        >
+          Delete attendee
+        </ActionButton>
+      </p>
+    </article>
+  );
+};
+
 /** Render the "Merge Attendee" section (edit mode only). */
 const MergeSection = ({ attendee }: { attendee: Attendee }): JSX.Element => (
   <article>
@@ -783,6 +830,8 @@ export const attendeeFormPage = (
       )}
 
       {isEdit && a && <Raw html={PaymentDetails({ attendee: a })} />}
+
+      {isEdit && a && <AttendeeActions attendee={a} />}
 
       {isEdit && <AttendeeLogSection entries={data.activityLog} />}
 

--- a/src/ui/templates/admin/attendees-list.tsx
+++ b/src/ui/templates/admin/attendees-list.tsx
@@ -196,7 +196,7 @@ export const adminAttendeesListPage = (props: AttendeesListPageProps): string =>
             phonePrefix: props.phonePrefix,
             presorted: true,
             rows: props.rows,
-            showActions: false,
+            showCheckin: false,
             showDate: false,
             showListing: true,
           })}

--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -169,7 +169,7 @@ const newestAttendeesSection = (
             allowedDomain: getEffectiveDomain(),
             presorted: true,
             rows: tableRows,
-            showActions: false,
+            showCheckin: false,
             showDate: false,
             showListing: true,
           })}

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -71,7 +71,6 @@ export const adminGroupsPage = (
               <tr>
                 <th>{t("common.name")}</th>
                 <th>{t("common.slug")}</th>
-                <th>{t("common.actions")}</th>
               </tr>
             </thead>
             <tbody>
@@ -81,18 +80,6 @@ export const adminGroupsPage = (
                     <a href={`/admin/groups/${g.id}`}>{g.name}</a>
                   </td>
                   <td>{g.slug}</td>
-                  <td>
-                    {!isReadOnly() && (
-                      <>
-                        <a href={`/admin/groups/${g.id}/edit`}>
-                          {t("common.edit")}
-                        </a>{" "}
-                      </>
-                    )}
-                    <a href={`/admin/groups/${g.id}/delete`}>
-                      {t("common.delete")}
-                    </a>
-                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/ui/templates/admin/holidays.tsx
+++ b/src/ui/templates/admin/holidays.tsx
@@ -15,6 +15,7 @@ import type { AdminSession, Holiday } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import {
   ActionButton,
+  DeleteSection,
   GuideLink,
   SubmitButton,
 } from "#templates/components/actions.tsx";
@@ -51,23 +52,18 @@ export const adminHolidaysPage = (
                 <th>{t("common.name")}</th>
                 <th>{t("holidays.col.start_date")}</th>
                 <th>{t("holidays.col.end_date")}</th>
-                <th>{t("common.actions")}</th>
               </tr>
             </thead>
             <tbody>
               {holidays.map((holiday) => (
                 <tr>
-                  <td>{holiday.name}</td>
-                  <td>{holiday.start_date}</td>
-                  <td>{holiday.end_date}</td>
                   <td>
                     <a href={`/admin/holidays/${holiday.id}/edit`}>
-                      {t("common.edit")}
-                    </a>{" "}
-                    <a href={`/admin/holidays/${holiday.id}/delete`}>
-                      {t("common.delete")}
+                      {holiday.name}
                     </a>
                   </td>
+                  <td>{holiday.start_date}</td>
+                  <td>{holiday.end_date}</td>
                 </tr>
               ))}
             </tbody>
@@ -123,6 +119,12 @@ export const adminHolidayEditPage = (
         />
         <SubmitButton icon="save">{t("common.save_changes")}</SubmitButton>
       </CsrfForm>
+      <DeleteSection
+        heading={t("common.delete")}
+        href={`/admin/holidays/${holiday.id}/delete`}
+      >
+        {t("holidays.delete.submit")}
+      </DeleteSection>
     </Layout>,
   );
 

--- a/src/ui/templates/admin/logistics.tsx
+++ b/src/ui/templates/admin/logistics.tsx
@@ -18,7 +18,11 @@ import {
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, LogisticsAgent } from "#shared/types.ts";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
-import { GuideLink, SubmitButton } from "#templates/components/actions.tsx";
+import {
+  DeleteSection,
+  GuideLink,
+  SubmitButton,
+} from "#templates/components/actions.tsx";
 import { logisticsAgentFields } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
@@ -72,16 +76,13 @@ const AgentsSection = (agents: LogisticsAgent[]): JSX.Element => (
           <thead>
             <tr>
               <th>Name</th>
-              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             {agents.map((agent) => (
               <tr>
-                <td>{agent.name}</td>
                 <td>
-                  <a href={`/admin/logistics/${agent.id}/edit`}>Edit</a>{" "}
-                  <a href={`/admin/logistics/${agent.id}/delete`}>Delete</a>
+                  <a href={`/admin/logistics/${agent.id}/edit`}>{agent.name}</a>
                 </td>
               </tr>
             ))}
@@ -162,6 +163,12 @@ export const adminLogisticsAgentEditPage = (
         />
         <SubmitButton icon="save">Save Changes</SubmitButton>
       </CsrfForm>
+      <DeleteSection
+        heading="Delete"
+        href={`/admin/logistics/${agent.id}/delete`}
+      >
+        Delete Agent
+      </DeleteSection>
     </Layout>,
   );
 

--- a/src/ui/templates/admin/settings-statuses.tsx
+++ b/src/ui/templates/admin/settings-statuses.tsx
@@ -4,12 +4,16 @@
 
 import { t } from "#i18n";
 import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
-import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { ConfirmForm, CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { RESERVATION_AMOUNT_HINT } from "#shared/reservation-amount.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
-import { ActionButton, SubmitButton } from "#templates/components/actions.tsx";
+import {
+  ActionButton,
+  DeleteSection,
+  SubmitButton,
+} from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const LIST_PATH = "/admin/settings/statuses";
@@ -93,7 +97,6 @@ export const adminAttendeeStatusesPage = (
             <th>{t("statuses.order_header")}</th>
             <th>{t("common.name")}</th>
             <th>{t("statuses.flags_header")}</th>
-            <th>{t("common.actions")}</th>
           </tr>
         </thead>
         <tbody>
@@ -104,14 +107,6 @@ export const adminAttendeeStatusesPage = (
                 <a href={`${LIST_PATH}/${s.id}/edit`}>{s.name}</a>
               </td>
               <td>{statusBadges(s)}</td>
-              <td>
-                <a href={`${LIST_PATH}/${s.id}/edit`}>{t("common.edit")}</a>{" "}
-                <CsrfForm action={`${LIST_PATH}/${s.id}/delete`} class="inline">
-                  <button class="link-button danger small" type="submit">
-                    {t("common.delete")}
-                  </button>
-                </CsrfForm>
-              </td>
             </tr>
           ))}
         </tbody>
@@ -189,6 +184,38 @@ export const adminAttendeeStatusFormPage = (
             : t("statuses.form_create_button")}
         </SubmitButton>
       </CsrfForm>
+      {editing && (
+        <DeleteSection
+          heading={t("common.delete")}
+          href={`${LIST_PATH}/${status.id}/delete`}
+        >
+          {t("statuses.delete_button")}
+        </DeleteSection>
+      )}
     </Layout>,
   );
 };
+
+/** Confirmation page for deleting an attendee status. */
+export const adminAttendeeStatusDeletePage = (
+  status: AttendeeStatus,
+  session: AdminSession,
+  error?: string,
+): string =>
+  String(
+    <Layout title={t("statuses.delete_title")}>
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
+      <ConfirmForm
+        action={`${LIST_PATH}/${status.id}/delete`}
+        buttonText={t("statuses.delete_button")}
+        danger={false}
+        label={t("common.name")}
+        name={status.name}
+      >
+        <h1>{t("statuses.delete_title")}</h1>
+        <Flash error={error} />
+        <p>{t("statuses.delete_confirm", { name: status.name })}</p>
+      </ConfirmForm>
+    </Layout>,
+  );

--- a/src/ui/templates/admin/users.tsx
+++ b/src/ui/templates/admin/users.tsx
@@ -13,6 +13,7 @@ import type {
 import { AdminNav, UsersSubNav } from "#templates/admin/nav.tsx";
 import {
   ActionButton,
+  DeleteSection,
   GuideLink,
   SubmitButton,
 } from "#templates/components/actions.tsx";
@@ -116,14 +117,14 @@ export const adminUsersPage = (
               <th>{t("common.username")}</th>
               <th>{t("users.col.role")}</th>
               <th>{t("common.status")}</th>
-              <th>{t("common.actions")}</th>
-              <th></th>
             </tr>
           </thead>
           <tbody>
             {users.map((user) => (
               <tr>
-                <td>{user.username}</td>
+                <td>
+                  <a href={`/admin/users/${user.id}`}>{user.username}</a>
+                </td>
                 <td>
                   {user.adminLevel}
                   {user.adminLevel === "agent" && (
@@ -138,35 +139,80 @@ export const adminUsersPage = (
                   )}
                 </td>
                 <td>{userStatus(user)}</td>
-                <td>
-                  {user.hasPassword && !user.hasDataKey && (
-                    <CsrfForm
-                      action={`/admin/users/${user.id}/activate`}
-                      class="inline"
-                    >
-                      <SubmitButton icon="check">
-                        {t("users.activate")}
-                      </SubmitButton>
-                    </CsrfForm>
-                  )}
-                  {user.adminLevel === "agent" && (
-                    <a href={`/admin/users/${user.id}/agents`}>
-                      {t("users.agents.edit_link")}
-                    </a>
-                  )}
-                </td>
-                <td>
-                  {user.id !== opts.currentUserId && (
-                    <a href={`/admin/users/${user.id}/delete`}>
-                      {t("common.delete")}
-                    </a>
-                  )}
-                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+    </Layout>,
+  );
+
+/**
+ * Per-user management page — the destination for the username link in the
+ * users table. Consolidates the activate, edit-agents, and delete actions that
+ * used to sit inline in the table's "Actions" columns.
+ */
+export const adminUserManagePage = (
+  user: DisplayUser,
+  session: AdminSession,
+  opts: { currentUserId: number; error?: string; success?: string },
+): string =>
+  String(
+    <Layout title={`${t("terms.users")}: ${user.username}`}>
+      <AdminNav active="/admin/users" session={session} />
+      <UsersSubNav />
+      <h1>{user.username}</h1>
+      <Flash error={opts.error} success={opts.success} />
+
+      <div class="table-scroll">
+        <table class="listing-details-table">
+          <tbody>
+            <tr>
+              <th>{t("users.col.role")}</th>
+              <td>{user.adminLevel}</td>
+            </tr>
+            <tr>
+              <th>{t("common.status")}</th>
+              <td>{userStatus(user)}</td>
+            </tr>
+            {user.adminLevel === "agent" && (
+              <tr>
+                <th>{t("users.agents.legend")}</th>
+                <td>
+                  {user.agentNames && user.agentNames.length > 0
+                    ? user.agentNames.join(", ")
+                    : t("users.agents.none_assigned")}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <p class="actions">
+        {user.hasPassword && !user.hasDataKey && (
+          <CsrfForm action={`/admin/users/${user.id}/activate`} class="inline">
+            <SubmitButton icon="check">{t("users.activate")}</SubmitButton>
+          </CsrfForm>
+        )}
+        {user.adminLevel === "agent" && (
+          <ActionButton
+            href={`/admin/users/${user.id}/agents`}
+            variant="secondary"
+          >
+            {t("users.agents.edit_link")}
+          </ActionButton>
+        )}
+      </p>
+
+      {user.id !== opts.currentUserId && (
+        <DeleteSection
+          heading={t("common.delete")}
+          href={`/admin/users/${user.id}/delete`}
+        >
+          {t("users.delete_user.submit")}
+        </DeleteSection>
+      )}
     </Layout>,
   );
 

--- a/src/ui/templates/attendee-table.tsx
+++ b/src/ui/templates/attendee-table.tsx
@@ -47,8 +47,6 @@ export type AttendeeColumnOpts = {
   phonePrefix: string;
   /** Render the status cell (check-in button or refunded badge) */
   renderStatus: (row: AttendeeTableRow) => string;
-  /** Render the actions cell (refund, edit, delete, resend links) */
-  renderActions: (row: AttendeeTableRow) => string;
   /** Answer maps for question-based columns */
   answerTextMap: Map<number, string>;
   answerQuestionMap: Map<number, string>;
@@ -66,8 +64,9 @@ export type AttendeeTableOptions = {
   returnUrl?: string;
   emptyMessage?: string;
   phonePrefix?: string;
-  /** Show check-in/check-out status and actions columns (default: true) */
-  showActions?: boolean;
+  /** Show the check-in/check-out status column (default: true). Per-attendee
+   * edit/refund/delete actions live on the attendee edit page, not the table. */
+  showCheckin?: boolean;
   /** Skip default sort and use rows as-is (default: false) */
   presorted?: boolean;
   /** Question data for the Answers column */
@@ -85,9 +84,8 @@ const computeVisibilityMap = (
   rows: AttendeeTableRow[],
   opts: AttendeeTableOptions,
 ): Record<string, boolean> => {
-  const showActions = opts.showActions !== false;
+  const showCheckin = opts.showCheckin !== false;
   return {
-    actions: showActions,
     address: rows.some((r) => !!r.attendee.address),
     answers: !!opts.questionData && opts.questionData.questions.length > 0,
     date: opts.showDate,
@@ -98,7 +96,7 @@ const computeVisibilityMap = (
     qty: true,
     registered: true,
     special_instructions: rows.some((r) => !!r.attendee.special_instructions),
-    status: showActions,
+    status: showCheckin,
     ticket: true,
   };
 };
@@ -185,10 +183,6 @@ const buildAnswerQuestionMap = (
 // Status & Actions — complex JSX renderers passed as callbacks
 // ---------------------------------------------------------------------------
 
-/** Build a return_url query suffix for action links */
-const returnSuffix = (returnUrl: string | undefined): string =>
-  returnUrl ? `?return_url=${encodeURIComponent(returnUrl)}` : "";
-
 /** Render the check-in/check-out button form */
 const CheckinButton = ({
   a,
@@ -222,10 +216,6 @@ const CheckinButton = ({
   );
 };
 
-/** Check if attendee is eligible for refund (has payment, not yet refunded) */
-const isRefundable = (row: AttendeeTableRow): boolean =>
-  !!row.attendee.payment_id && !row.attendee.refunded;
-
 /** Create the renderStatus callback for column opts */
 const createStatusRenderer =
   (opts: AttendeeTableOptions) =>
@@ -243,39 +233,6 @@ const createStatusRenderer =
       listingId: row.listingId,
       returnUrl: opts.returnUrl,
     });
-  };
-
-/** Create the renderActions callback for column opts */
-const createActionsRenderer =
-  (returnUrl: string | undefined) =>
-  (row: AttendeeTableRow): string => {
-    const a = row.attendee;
-    const suffix = returnSuffix(returnUrl);
-    return String(
-      <>
-        {isRefundable(row) && (
-          <a
-            class="danger"
-            href={`/admin/listing/${row.listingId}/attendee/${a.id}/refund${suffix}`}
-          >
-            {t("admin.attendee_table.refund")}
-          </a>
-        )}
-        {isRefundable(row) && " "}
-        <a href={`/admin/attendees/${a.id}${suffix}`}>{t("common.edit")}</a>{" "}
-        <a
-          class="danger"
-          href={`/admin/listing/${row.listingId}/attendee/${a.id}/delete${suffix}`}
-        >
-          {t("common.delete")}
-        </a>{" "}
-        <a
-          href={`/admin/listing/${row.listingId}/attendee/${a.id}/resend-notification${suffix}`}
-        >
-          {t("admin.attendee_table.resend_notification")}
-        </a>
-      </>,
-    );
   };
 
 // ---------------------------------------------------------------------------
@@ -326,7 +283,6 @@ export const AttendeeTable = (opts: AttendeeTableOptions): string => {
     answerTextMap,
     phonePrefix: opts.phonePrefix || "44",
     questionData: opts.questionData,
-    renderActions: createActionsRenderer(opts.returnUrl),
     renderStatus: createStatusRenderer(opts),
   };
 

--- a/src/ui/templates/components/actions.tsx
+++ b/src/ui/templates/components/actions.tsx
@@ -87,6 +87,33 @@ export const SubmitButton = ({
 );
 
 /**
+ * The "Delete" affordance shown at the bottom of an entity's edit page. Renders
+ * a heading plus a secondary, button-styled link to the delete-confirmation
+ * page, so every edit page exposes deletion the same way (and the destructive
+ * action always goes through the typed-name confirmation round trip rather than
+ * sitting inline in a list table). Pass the confirmation-page `href`, the
+ * section `heading`, and the link label as children.
+ */
+export const DeleteSection = ({
+  href,
+  heading,
+  children,
+}: {
+  href: string;
+  heading: string;
+  children?: Child;
+}): SafeHtml => (
+  <>
+    <h2>{heading}</h2>
+    <p class="prose">
+      <ActionButton href={href} icon="trash-2" variant="secondary">
+        {children}
+      </ActionButton>
+    </p>
+  </>
+);
+
+/**
  * A link that can be disabled. When enabled, renders an `<a>` pointing at
  * `href`. When `disabled`, renders a non-interactive `<span>` carrying
  * `.btn--disabled` (greyed out, not clickable) so the affordance stays visible

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -323,6 +323,40 @@ describeWithEnv("API Keys", { db: true }, () => {
       const html = await response.text();
       expect(html).toContain("Visible Key");
       expect(html).not.toContain("Never");
+      // The name links to the per-key manage page, not an inline delete link.
+      expect(html).toContain(`href="/admin/api-keys/${id}"`);
+    });
+
+    test("GET /admin/api-keys/:id shows the manage page with a delete link", async () => {
+      const { id } = await createTestApiKeyFull("Managed Key");
+      const cookie = await testCookie();
+
+      // A never-used key shows the "Never" placeholder for last used.
+      const first = await handleRequest(
+        mockRequest(`/admin/api-keys/${id}`, { headers: { cookie } }),
+      );
+      expect(first.status).toBe(200);
+      const firstHtml = await first.text();
+      expect(firstHtml).toContain("Managed Key");
+      expect(firstHtml).toContain(`/admin/api-keys/${id}/delete`);
+      expect(firstHtml).toContain("Never");
+
+      // Once used, the manage page renders the formatted last-used date.
+      await touchApiKeyLastUsed(id);
+      const second = await handleRequest(
+        mockRequest(`/admin/api-keys/${id}`, { headers: { cookie } }),
+      );
+      const secondHtml = await second.text();
+      expect(secondHtml).not.toContain("Never");
+    });
+
+    test("GET /admin/api-keys/:id returns 404 for a nonexistent key", async () => {
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        mockRequest("/admin/api-keys/99999", { headers: { cookie } }),
+      );
+
+      expect(response.status).toBe(404);
     });
 
     test("GET /admin/api-keys shows success message from flash cookie", async () => {

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -100,12 +100,13 @@ describe("AttendeeTable", () => {
       expect(html).toContain("<th>Registered</th>");
     });
 
-    test("renders Actions column with Edit and Delete", () => {
+    test("no longer renders an Actions column (moved to the edit page)", () => {
       const html = AttendeeTable(makeOpts());
-      expect(html).toContain("/admin/attendees/1");
-      expect(html).toContain("Edit");
-      expect(html).toContain("Delete");
-      expect(html).toContain("Re-send Notification");
+      expect(html).not.toContain("<th>Actions</th>");
+      expect(html).not.toContain(">Edit<");
+      expect(html).not.toContain(">Delete<");
+      expect(html).not.toContain("Re-send Notification");
+      expect(html).not.toContain("/refund");
     });
   });
 
@@ -128,7 +129,7 @@ describe("AttendeeTable", () => {
       const headers = [...html.matchAll(/<th(?:\s[^>]*)?>([^<]*)<\/th>/g)].map(
         (m) => m[1],
       );
-      // Empty headers are for Checked In (first) and Actions (last)
+      // The single empty header is for the Checked In / status column (first)
       expect(headers).toEqual([
         "",
         "Listing",
@@ -141,7 +142,6 @@ describe("AttendeeTable", () => {
         "Qty",
         "Ticket",
         "Registered",
-        "",
       ]);
     });
   });
@@ -328,36 +328,16 @@ describe("AttendeeTable", () => {
     });
   });
 
-  describe("actions", () => {
-    test("shows Refund link when attendee has payment_id", () => {
+  describe("per-attendee actions moved to the edit page", () => {
+    test("never renders refund links, even for a payable attendee", () => {
       const rows = [
         makeRow({
           attendee: testAttendee({ payment_id: "pay_123" }),
         }),
       ];
       const html = AttendeeTable(makeOpts({ rows }));
-      expect(html).toContain("Refund");
-      expect(html).toContain("/refund");
-    });
-
-    test("hides Refund link when attendee has no payment_id", () => {
-      const rows = [
-        makeRow({
-          attendee: testAttendee({ payment_id: "" }),
-        }),
-      ];
-      const html = AttendeeTable(makeOpts({ rows }));
-      expect(html).not.toContain("Refund");
-    });
-
-    test("hides Refund link when attendee is already refunded", () => {
-      const rows = [
-        makeRow({
-          attendee: testAttendee({ payment_id: "pay_123", refunded: true }),
-        }),
-      ];
-      const html = AttendeeTable(makeOpts({ rows }));
       expect(html).not.toContain("/refund");
+      expect(html).not.toContain("/delete");
     });
   });
 
@@ -384,11 +364,6 @@ describe("AttendeeTable", () => {
   });
 
   describe("return_url", () => {
-    test("appends return_url to action links when provided", () => {
-      const html = AttendeeTable(makeOpts({ returnUrl: "/checkin/abc" }));
-      expect(html).toContain("return_url=%2Fcheckin%2Fabc");
-    });
-
     test("includes return_url as hidden form field in check-in form", () => {
       const html = AttendeeTable(makeOpts({ returnUrl: "/checkin/abc" }));
       expect(hasInputWithValue(html, "return_url", "/checkin/abc")).toBe(true);
@@ -417,27 +392,25 @@ describe("AttendeeTable", () => {
       const html = AttendeeTable(
         makeOpts({ rows: [], showDate: false, showListing: false }),
       );
-      expect(html).toContain('colspan="6"');
+      expect(html).toContain('colspan="5"');
     });
 
     test("empty row colspan includes optional visible columns", () => {
       const html = AttendeeTable(
         makeOpts({ rows: [], showDate: true, showListing: true }),
       );
-      expect(html).toContain('colspan="8"');
+      expect(html).toContain('colspan="7"');
     });
   });
 
-  describe("showActions option", () => {
-    test("hides check-in and action cells when showActions is false", () => {
-      const html = AttendeeTable(makeOpts({ showActions: false }));
+  describe("showCheckin option", () => {
+    test("hides the check-in column when showCheckin is false", () => {
+      const html = AttendeeTable(makeOpts({ showCheckin: false }));
       expect(html).not.toContain("Check in");
-      expect(html).not.toContain("Edit");
-      expect(html).not.toContain("Delete");
     });
 
-    test("retains data columns when showActions is false", () => {
-      const html = AttendeeTable(makeOpts({ showActions: false }));
+    test("retains data columns when showCheckin is false", () => {
+      const html = AttendeeTable(makeOpts({ showCheckin: false }));
       expect(html).toContain("John Doe");
       expect(html).toContain("test-token-1");
     });
@@ -447,8 +420,8 @@ describe("AttendeeTable", () => {
       expect(html).toContain("Check in");
     });
 
-    test("empty row colspan is reduced when showActions is false", () => {
-      const html = AttendeeTable(makeOpts({ rows: [], showActions: false }));
+    test("empty row colspan drops the status column when showCheckin is false", () => {
+      const html = AttendeeTable(makeOpts({ rows: [], showCheckin: false }));
       expect(html).toContain('colspan="4"');
     });
   });
@@ -718,7 +691,7 @@ describe("AttendeeTable columnTemplate", () => {
     const html = AttendeeTable(
       makeOpts({
         columnTemplate: "{{name}}, {{qty}}, {{registered}}",
-        showActions: false,
+        showCheckin: false,
       }),
     );
     const headers = [...html.matchAll(/<th(?:\s[^>]*)?>([^<]*)<\/th>/g)].map(
@@ -744,7 +717,7 @@ describe("AttendeeTable columnTemplate", () => {
       makeOpts({
         columnTemplate: "{{name}}, {{email}}, {{qty}}",
         rows,
-        showActions: false,
+        showCheckin: false,
       }),
     );
     expect(html).not.toContain("<th>Email</th>");
@@ -760,7 +733,7 @@ describe("AttendeeTable columnTemplate", () => {
       makeOpts({
         columnTemplate: "{{qty}}, {{name}}, {{email}}",
         rows,
-        showActions: false,
+        showCheckin: false,
       }),
     );
     const headers = [...html.matchAll(/<th(?:\s[^>]*)?>([^<]*)<\/th>/g)].map(
@@ -779,7 +752,7 @@ describe("AttendeeTable columnTemplate", () => {
       makeOpts({
         columnTemplate: '{{name}}, {{registered | date: "%B %d, %Y"}}',
         rows,
-        showActions: false,
+        showCheckin: false,
       }),
     );
     expect(html).toContain("April 10, 2026");
@@ -795,7 +768,7 @@ describe("AttendeeTable columnTemplate", () => {
       makeOpts({
         columnTemplate: "{{name}}, {{registered}}",
         rows,
-        showActions: false,
+        showCheckin: false,
       }),
     );
     // Default uses formatDatetimeShort (e.g. "10/04/2026 14:00"), not Liquid strftime

--- a/test/lib/column-order/columns.test.ts
+++ b/test/lib/column-order/columns.test.ts
@@ -121,7 +121,6 @@ describe("ATTENDEE_TABLE_COLUMNS cell renderers", () => {
     answerQuestionMap: new Map(),
     answerTextMap: new Map(),
     phonePrefix: "44",
-    renderActions: () => "",
     renderStatus: () => "",
   };
   const makeRow = (

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -58,14 +58,14 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
       });
 
       const { response } = await adminGet("/admin/groups");
+      // The name links to the group detail page; edit/delete live there now,
+      // not inline in the list table.
       await expectHtmlResponse(
         response,
         200,
         "Group One",
         "group-one",
         `/admin/groups/${group.id}">`,
-        `/admin/groups/${group.id}/edit`,
-        `/admin/groups/${group.id}/delete`,
       );
     });
   });

--- a/test/lib/server-holidays.test.ts
+++ b/test/lib/server-holidays.test.ts
@@ -116,6 +116,8 @@ describeWithEnv("server (admin holidays)", { db: true }, () => {
         startDate: "2026-12-25",
       });
       const { response } = await adminGet("/admin/holidays");
+      // The name links to the edit page; delete now lives on that edit page,
+      // not inline in the list table.
       await expectHtmlResponse(
         response,
         200,
@@ -123,7 +125,6 @@ describeWithEnv("server (admin holidays)", { db: true }, () => {
         "2026-12-25",
         "2026-12-26",
         `/admin/holidays/${holiday.id}/edit`,
-        `/admin/holidays/${holiday.id}/delete`,
       );
     });
   });
@@ -264,6 +265,8 @@ describeWithEnv("server (admin holidays)", { db: true }, () => {
         "Christmas",
         "2026-12-25",
         "2026-12-26",
+        // Delete moved off the list table onto the edit page.
+        `/admin/holidays/${holiday.id}/delete`,
       );
     });
 

--- a/test/lib/server-logistics.test.ts
+++ b/test/lib/server-logistics.test.ts
@@ -99,7 +99,8 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
         "Logistics agent created",
       )(response);
       const list = await adminGet("/admin/logistics");
-      await expectHtmlResponse(list.response, 200, "Van 1", "/edit", "/delete");
+      // The agent name links to its edit page; delete lives on that page now.
+      await expectHtmlResponse(list.response, 200, "Van 1", "/edit");
     });
 
     test("rejects an empty agent name", async () => {
@@ -128,6 +129,8 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
       expect(editHtml).toContain(`action="/admin/logistics/${id}/edit"`);
       expect(editHtml).toContain("Edit Logistics Agent");
       expect(editHtml).toContain("Van A");
+      // Delete moved off the agents list onto the edit page.
+      expect(editHtml).toContain(`/admin/logistics/${id}/delete`);
       const { response } = await adminFormPost(`/admin/logistics/${id}/edit`, {
         name: "Van B",
       });

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -725,7 +725,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       return response.text();
     };
 
-    test("shows Refund link for paid attendees on paid listings", async () => {
+    test("shows the listing-level Refund All on a paid listing", async () => {
       const listing = await createPaidListing();
       await createPaidTestAttendee(
         listing.id,
@@ -737,7 +737,9 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       const response = await awaitTestRequest(`/admin/listing/${listing.id}`, {
         cookie: await testCookie(),
       });
-      await expectHtmlResponse(response, 200, "/refund", "Refund All");
+      // The per-attendee refund link moved to the attendee edit page; the
+      // listing page keeps the listing-wide Refund All action.
+      await expectHtmlResponse(response, 200, "Refund All");
     });
 
     const createAttendeeAndGetHtml = async (
@@ -749,7 +751,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       return getListingPageHtml(listing.id);
     };
 
-    test("does not show Refund link for free listings", async () => {
+    test("does not show Refund All for free listings", async () => {
       const listing = await createTestListing({ maxAttendees: 100 });
       const html = await createAttendeeAndGetHtml(
         listing,
@@ -759,19 +761,46 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       expect(html).not.toContain("Refund All");
     });
 
-    test("does not show Refund link for attendees without payment_id on paid listings", async () => {
+    test("shows the per-attendee Refund action on a paid attendee's edit page", async () => {
       const listing = await createPaidListing();
-      // Create a free attendee on a paid listing (no payment_id)
-      const html = await createAttendeeAndGetHtml(
-        listing,
+      const attendee = await createPaidTestAttendee(
+        listing.id,
+        "Paid User",
+        "paid@example.com",
+        "pi_edit_1",
+      );
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).toContain(
+        `/admin/listing/${listing.id}/attendee/${attendee.id}/refund`,
+      );
+    });
+
+    test("hides the Refund action but keeps delete/resend when the attendee has no payment", async () => {
+      const listing = await createPaidListing();
+      const attendee = await createTestAttendee(
+        listing.id,
+        listing.slug,
         "No Payment User",
         "nopay@example.com",
       );
-      // The listing nav should still show Refund All (because it's a paid listing)
-      expect(html).toContain("Refund All");
-      // But the attendee row should NOT show an individual refund link
-      // since the attendee has no payment_id
-      expect(html).not.toContain('/refund"');
+      const response = await awaitTestRequest(
+        `/admin/attendees/${attendee.id}`,
+        { cookie: await testCookie() },
+      );
+      const html = await expectHtmlResponse(response, 200);
+      expect(html).not.toContain(
+        `/admin/listing/${listing.id}/attendee/${attendee.id}/refund`,
+      );
+      expect(html).toContain(
+        `/admin/listing/${listing.id}/attendee/${attendee.id}/delete`,
+      );
+      expect(html).toContain(
+        `/admin/listing/${listing.id}/attendee/${attendee.id}/resend-notification`,
+      );
     });
   });
 });

--- a/test/lib/server-settings/statuses.test.ts
+++ b/test/lib/server-settings/statuses.test.ts
@@ -170,7 +170,13 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
     test("renders the edit form for an existing status", async () => {
       const seed = await seedStatus();
       const { response } = await adminGet(`${PATH}/${seed.id}/edit`);
-      await expectHtmlResponse(response, 200, "Edit Attendee Status");
+      // The edit page hosts the delete control (the list table no longer does).
+      await expectHtmlResponse(
+        response,
+        200,
+        "Edit Attendee Status",
+        `${PATH}/${seed.id}/delete`,
+      );
     });
 
     test("pre-fills a reservation status's fields when editing", async () => {
@@ -219,12 +225,48 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
     });
   });
 
+  describe("GET /admin/settings/statuses/:id/delete", () => {
+    testRequiresAuth(`${PATH}/1/delete`);
+
+    test("renders the typed-name confirmation page", async () => {
+      const seed = await seedStatus();
+      const { response } = await adminGet(`${PATH}/${seed.id}/delete`);
+      await expectHtmlResponse(
+        response,
+        200,
+        "Delete Attendee Status",
+        "confirm_identifier",
+        seed.name,
+      );
+    });
+
+    test("returns 404 for a missing status", async () => {
+      const { response } = await adminGet(`${PATH}/9999/delete`);
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe("POST /admin/settings/statuses/:id/delete", () => {
+    test("rejects a mismatched confirmation name", async () => {
+      const spare = await attendeeStatusesTable.insert({ name: "Disposable" });
+      const { response } = await adminFormPost(`${PATH}/${spare.id}/delete`, {
+        confirm_identifier: "wrong",
+      });
+      expectRedirectWithFlash(
+        `${PATH}/${spare.id}/delete`,
+        "Name does not match. Please type the exact name to confirm deletion.",
+        false,
+      )(response);
+      expect(await getAttendeeStatus(spare.id)).not.toBeNull();
+    });
+
     test("refuses to delete the last status", async () => {
       const seed = await seedStatus();
-      const { response } = await adminFormPost(`${PATH}/${seed.id}/delete`);
+      const { response } = await adminFormPost(`${PATH}/${seed.id}/delete`, {
+        confirm_identifier: seed.name,
+      });
       expectRedirectWithFlash(
-        PATH,
+        `${PATH}/${seed.id}/delete`,
         "You must keep at least one status",
         false,
       )(response);
@@ -233,9 +275,11 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
     test("refuses to delete the public default", async () => {
       const seed = await seedStatus();
       await attendeeStatusesTable.insert({ name: "Spare" });
-      const { response } = await adminFormPost(`${PATH}/${seed.id}/delete`);
+      const { response } = await adminFormPost(`${PATH}/${seed.id}/delete`, {
+        confirm_identifier: seed.name,
+      });
       expectRedirectWithFlash(
-        PATH,
+        `${PATH}/${seed.id}/delete`,
         "Choose another public default before deleting this status",
         false,
       )(response);
@@ -247,9 +291,11 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         args: [inUse.id],
         sql: "INSERT INTO attendees (created, pii_blob, status_id) VALUES ('2024-01-01T00:00:00Z', '', ?)",
       });
-      const { response } = await adminFormPost(`${PATH}/${inUse.id}/delete`);
+      const { response } = await adminFormPost(`${PATH}/${inUse.id}/delete`, {
+        confirm_identifier: "Active",
+      });
       expectRedirectWithFlash(
-        PATH,
+        `${PATH}/${inUse.id}/delete`,
         "This status is in use by attendees",
         false,
       )(response);
@@ -257,13 +303,17 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
 
     test("deletes a spare, unused status", async () => {
       const spare = await attendeeStatusesTable.insert({ name: "Disposable" });
-      const { response } = await adminFormPost(`${PATH}/${spare.id}/delete`);
+      const { response } = await adminFormPost(`${PATH}/${spare.id}/delete`, {
+        confirm_identifier: "Disposable",
+      });
       expectRedirectWithFlash(PATH, "Status deleted")(response);
       expect(await getAttendeeStatus(spare.id)).toBeNull();
     });
 
     test("returns 404 deleting a missing status", async () => {
-      const { response } = await adminFormPost(`${PATH}/9999/delete`);
+      const { response } = await adminFormPost(`${PATH}/9999/delete`, {
+        confirm_identifier: "anything",
+      });
       expect(response.status).toBe(404);
     });
 
@@ -273,9 +323,11 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const settled = (await getAllAttendeeStatuses()).find(
         (s) => s.name === "Settled",
       )!;
-      const { response } = await adminFormPost(`${PATH}/${settled.id}/delete`);
+      const { response } = await adminFormPost(`${PATH}/${settled.id}/delete`, {
+        confirm_identifier: "Settled",
+      });
       expectRedirectWithFlash(
-        PATH,
+        `${PATH}/${settled.id}/delete`,
         "Choose another paid default before deleting this status",
         false,
       )(response);

--- a/test/lib/server-users-agents.test.ts
+++ b/test/lib/server-users-agents.test.ts
@@ -49,6 +49,25 @@ describeWithEnv("server (agent user management)", { db: true }, () => {
     expect(await getUserAgentIds(user!.id)).toEqual([]);
   });
 
+  test("the manage page lists an agent user's assigned logistics agents", async () => {
+    await settings.update.hasLogistics(true);
+    const van = await logisticsAgentsTable.insert({ name: "Van 1" });
+    const { userId } = await createTestAgentSession({
+      agentIds: [van.id],
+      token: "umanage",
+      username: "drivermanage",
+    });
+
+    const response = await awaitTestRequest(`/admin/users/${userId}`, {
+      cookie: await testCookie(),
+    });
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("drivermanage");
+    expect(html).toContain("Van 1");
+    expect(html).toContain(`/admin/users/${userId}/agents`);
+  });
+
   test("the edit-agents page renders the agent's checkboxes", async () => {
     await settings.update.hasLogistics(true);
     const van = await logisticsAgentsTable.insert({ name: "Van 1" });

--- a/test/lib/server-users-ui.test.ts
+++ b/test/lib/server-users-ui.test.ts
@@ -111,7 +111,15 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       const usersResponse = await awaitTestRequest("/admin/users", { cookie });
       const html = await usersResponse.text();
       expect(html).toContain("Pending Activation");
-      expect(html).toContain("Activate");
+      // The Activate action moved off the list onto the per-user manage page.
+      expect(html).toContain('href="/admin/users/2"');
+      expect(html).not.toContain("Activate");
+
+      const manageResponse = await awaitTestRequest("/admin/users/2", {
+        cookie,
+      });
+      const manageHtml = await manageResponse.text();
+      expect(manageHtml).toContain("Activate");
     });
   });
 

--- a/test/templates/admin/users-agents.test.ts
+++ b/test/templates/admin/users-agents.test.ts
@@ -68,7 +68,7 @@ describe("adminUserAgentsPage", () => {
 });
 
 describe("adminUsersPage agent rows", () => {
-  test("shows assigned agent names and an edit link for agent users", () => {
+  test("shows assigned agent names and links to the manage page for agent users", () => {
     const users: DisplayUser[] = [
       {
         adminLevel: "agent",
@@ -85,7 +85,9 @@ describe("adminUsersPage agent rows", () => {
       inviteLink: "",
     });
     expect(html).toContain("Van 1, Van 2");
-    expect(html).toContain('href="/admin/users/4/agents"');
+    // The edit-agents link moved to the per-user manage page.
+    expect(html).toContain('<a href="/admin/users/4">driver</a>');
+    expect(html).not.toContain('href="/admin/users/4/agents"');
   });
 
   test("shows a placeholder when an agent user has no agents", () => {

--- a/test/templates/admin/users.test.ts
+++ b/test/templates/admin/users.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
 import {
   adminUserDeletePage,
+  adminUserManagePage,
   adminUsersPage,
   type DisplayUser,
 } from "#templates/admin/users.tsx";
@@ -16,7 +17,7 @@ beforeAll(async () => {
 });
 
 describe("adminUsersPage", () => {
-  test("renders statuses and actions for different user states", () => {
+  test("renders statuses and links each username to its manage page", () => {
     const users: DisplayUser[] = [
       {
         adminLevel: "owner",
@@ -52,10 +53,12 @@ describe("adminUsersPage", () => {
     expect(html).toContain("Active");
     expect(html).toContain("Pending Activation");
     expect(html).toContain("Invited");
-    expect(html).toContain('action="/admin/users/2/activate"');
-    expect(html).toContain('href="/admin/users/2/delete"');
-    expect(html).toContain('href="/admin/users/3/delete"');
-    expect(html).not.toContain('href="/admin/users/1/delete"');
+    // The username links to the per-user manage page; the activate/delete
+    // actions live there now, not inline in the table.
+    expect(html).toContain('<a href="/admin/users/2">pending</a>');
+    expect(html).toContain('<a href="/admin/users/3">invited</a>');
+    expect(html).not.toContain("/activate");
+    expect(html).not.toContain("/delete");
   });
 
   test("renders Invite Expired status for expired invite", () => {
@@ -107,6 +110,67 @@ describe("adminUsersPage", () => {
     expect(html).toContain("https://example.com/join/abc123");
     expect(html).toContain("Invite created");
     expect(html).toContain("Something went wrong");
+  });
+});
+
+describe("adminUserManagePage", () => {
+  const manager: DisplayUser = {
+    adminLevel: "manager",
+    hasDataKey: false,
+    hasPassword: true,
+    id: 2,
+    inviteExpired: false,
+    username: "pending",
+  };
+
+  test("shows the activate form for a pending user", () => {
+    const html = adminUserManagePage(manager, TEST_SESSION, {
+      currentUserId: 1,
+    });
+    expect(html).toContain('action="/admin/users/2/activate"');
+  });
+
+  test("shows the delete section for another user", () => {
+    const html = adminUserManagePage(manager, TEST_SESSION, {
+      currentUserId: 1,
+    });
+    expect(html).toContain('href="/admin/users/2/delete"');
+  });
+
+  test("hides the delete section for the current user", () => {
+    const html = adminUserManagePage(manager, TEST_SESSION, {
+      currentUserId: 2,
+    });
+    expect(html).not.toContain('href="/admin/users/2/delete"');
+  });
+
+  test("shows edit-agents link and assigned agent names for an agent user", () => {
+    const agent: DisplayUser = {
+      adminLevel: "agent",
+      agentNames: ["Van 1"],
+      hasDataKey: true,
+      hasPassword: true,
+      id: 4,
+      inviteExpired: false,
+      username: "driver",
+    };
+    const html = adminUserManagePage(agent, TEST_SESSION, { currentUserId: 1 });
+    expect(html).toContain('href="/admin/users/4/agents"');
+    expect(html).toContain("Van 1");
+  });
+
+  test("shows a placeholder when an agent user has no assigned agents", () => {
+    const agent: DisplayUser = {
+      adminLevel: "agent",
+      agentNames: [],
+      hasDataKey: true,
+      hasPassword: true,
+      id: 4,
+      inviteExpired: false,
+      username: "driver",
+    };
+    const html = adminUserManagePage(agent, TEST_SESSION, { currentUserId: 1 });
+    expect(html).toContain("No agents assigned");
   });
 });
 


### PR DESCRIPTION
## What & why

You wanted to get rid of "Actions" columns across the admin system. Every admin table now follows one pattern:

- The **Name** is a link to the entity's edit / manage page.
- **Delete links are removed from tables** — delete still goes through the existing typed-name confirmation round trip, just reached from the edit page now.
- **Other per-row actions** (refund, resend, activate, edit-agents) move onto the edit page.
- **Check-in / check-out is left untouched.**

## Per table

| Table | Change |
| --- | --- |
| **Holidays** | Name → edit page; Actions column removed; delete link added to the edit page. |
| **Logistics agents** | Same as holidays. |
| **Groups** | Actions column removed (Name already linked to the detail page, which already hosts edit + delete). |
| **Attendee statuses** | Actions column removed; delete moved to the edit page **and converted to a typed-name confirmation round trip** (it was previously a one-click POST). |
| **Attendees** (listing detail) | Actions column (refund/edit/delete/resend) removed; Name still links to the attendee edit page; refund/resend/delete now sit on that edit page. The check-in status column stays. |
| **Users** | No edit page existed, so added a per-user manage page (`GET /admin/users/:id`) hosting activate / edit-agents / delete; the username links there. |
| **API keys** | No edit page existed, so added a per-key manage page (`GET /admin/api-keys/:apiKeyId`) hosting delete; the key name links there. |

A small shared `DeleteSection` component standardises the "Delete" affordance on edit pages.

## Notes / out of scope

- The **Failed Payments** table on a listing keeps its inline delete button. It's a specialised cleanup tool for abandoned checkouts whose `delete-incomplete` action is deliberately frictionless (no name confirmation), so it didn't fit the "name → edit page, confirm to delete" pattern. Happy to fold it in if you'd prefer.

## Verification

- `deno task typecheck` and `deno task lint` clean.
- Full suite: **492 passed, 0 failed**, **100% line and branch coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN5UmhpSyvz843xGd5mVCU)_