### PR TITLE
Fix admin footer layout: logout sized to content, debug menu below

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1553,16 +1553,32 @@ button.secondary:hover,
   box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
 }
 
-/* Admin footer: Chobble link (+ optional debug menu) on the left, logout on
-   the right. */
+/* Admin footer: a top row with the Chobble link (growing to fill) and the
+   logout button (sized to its content), then an optional debug menu below. */
 .admin-footer {
   margin-top: auto;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: var(--space-s);
+  font-size: smaller;
+}
+
+.admin-footer-top {
+  display: flex;
+  flex-wrap: nowrap;
   justify-content: space-between;
   align-items: center;
   gap: var(--space-s);
-  font-size: smaller;
+}
+
+/* The Chobble link grows to fill, the logout form stays its natural width. */
+.admin-footer-top > a {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.admin-footer-top > .inline {
+  flex: 0 0 auto;
 }
 
 .admin-footer-info {

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -113,7 +113,9 @@ export const adminFooterHtml = (debug: DebugFooterData | null): string =>
   `<a href="https://github.com/chobbledotcom/tickets">${t("admin.footer.chobble_tickets")}</a>` +
   logoutFormHtml() +
   "</div>" +
-  (debug ? `<div class="admin-footer-info">${debugDetailsHtml(debug)}</div>` : "") +
+  (debug
+    ? `<div class="admin-footer-info">${debugDetailsHtml(debug)}</div>`
+    : "") +
   "</footer>";
 
 /**

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -1,9 +1,11 @@
 /**
  * Admin footer.
  *
- * Rendered at the bottom of every admin page: the Chobble Tickets link and,
- * when query logging is active, a debug menu (render time, SQL queries, cache
- * stats) on the left; the logout button on the right (flex, space-between).
+ * Rendered at the bottom of every admin page: a top row with the Chobble
+ * Tickets link (growing to fill the space) on the left and the logout button
+ * (sized to its content) on the right, both always on one line; and, when query
+ * logging is active, a debug menu (render time, SQL queries, cache stats) on a
+ * row below them.
  *
  * The footer only renders on admin pages — `markAdminFooter()` is called while
  * the page's nav/header renders, and `renderAdminFooter()` (called once from
@@ -107,11 +109,11 @@ const logoutFormHtml = (): string =>
  * the left, the logout button on the right. */
 export const adminFooterHtml = (debug: DebugFooterData | null): string =>
   `<footer class="admin-footer">` +
-  `<div class="admin-footer-info">` +
+  `<div class="admin-footer-top">` +
   `<a href="https://github.com/chobbledotcom/tickets">${t("admin.footer.chobble_tickets")}</a>` +
-  (debug ? debugDetailsHtml(debug) : "") +
-  "</div>" +
   logoutFormHtml() +
+  "</div>" +
+  (debug ? `<div class="admin-footer-info">${debugDetailsHtml(debug)}</div>` : "") +
   "</footer>";
 
 /**


### PR DESCRIPTION
## What

Reworks the admin footer layout:

- The footer is now a vertical stack. The **top row** holds the Chobble Tickets link (left) and the logout form (right) on a single line that never wraps, even on the smallest devices.
- The Chobble link now **grows to fill** the available space (`flex: 1 1 auto`), while the logout form is sized to **exactly its content** (`flex: 0 0 auto`) instead of taking 50% of the width.
- The **debug menu** (render time / SQL / cache stats) now renders on its own row **below** both, rather than inline next to the Chobble link.

The logout form keeps its `inline` style (no background, no border, no padding).

## Notes

`.admin-footer-info` now wraps only the debug menu. Existing footer tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENCJXMuL1shUNvgounP2Xn)_