### PR TITLE
Highlight Attendees nav on attendee sub-pages

### DIFF
--- a/src/ui/templates/admin/attendee-balance.tsx
+++ b/src/ui/templates/admin/attendee-balance.tsx
@@ -30,7 +30,7 @@ export const attendeeBalancePage = (view: AttendeeBalanceView): string => {
   const outstanding = remainingBalance > 0;
   return String(
     <Layout title={t("attendee_balance.page_title")}>
-      <AdminNav active="/admin/" session={view.session} />
+      <AdminNav active="/admin/attendees" session={view.session} />
       <p>
         <BackButton href={`/admin/attendees/${view.attendeeId}`}>
           {t("attendee_balance.back_to_attendee")}

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -765,7 +765,7 @@ export const attendeeFormPage = (
 
   return String(
     <Layout title={pageTitle(data)}>
-      <AdminNav active="/admin/" session={session} />
+      <AdminNav active="/admin/attendees" session={session} />
 
       <div class="prose">
         <h1>{pageTitle(data)}</h1>

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -478,7 +478,7 @@ export const adminMergeAttendeePage = (
 ): string =>
   String(
     <Layout title={`Merge Attendee: ${target.name}`}>
-      <AdminNav active="/admin/" session={session} />
+      <AdminNav active="/admin/attendees" session={session} />
       <Flash error={error} />
 
       <h2>{t("admin.attendees.merge_attendee")}</h2>


### PR DESCRIPTION
## Problem

On attendee pages under `/admin/attendees/...`, the **Listings** item was highlighted in the admin nav instead of **Attendees**.

The `/admin/attendees` list page was already correct (it uses `active="/admin/attendees"`), but several sub-pages that also live under `/admin/attendees/...` passed `active="/admin/"`, lighting up Listings:

- attendee edit / new form (`attendee-form.tsx`)
- attendee balance page (`attendee-balance.tsx`)
- attendee merge page (`attendees.tsx`)

## Fix

Point those sub-pages at `active="/admin/attendees"` so the correct nav item is marked active.

The delete / refund / resend-notification confirmation pages were left as-is since they live under `/admin/listing/...` (listing context).

## Testing

- `deno task test:files test/lib/server-attendees-list.test.ts test/lib/server-attendee-form.test.ts` — passing
- `deno task lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZWJUY2PgbSVEoc65ioSro)_