### PR TITLE
Add min-width: 0 to .admin-footer-top > .inline

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1579,6 +1579,7 @@ button.secondary:hover,
 
 .admin-footer-top > .inline {
   flex: 0 0 auto;
+  min-width: 0;
 }
 
 .admin-footer-info {


### PR DESCRIPTION
## Summary
Adds `min-width: 0` to `.admin-footer-top > .inline` to prevent flexbox items from overflowing their containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvKfHasYpZxhy4EvMqrFAF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvKfHasYpZxhy4EvMqrFAF)_