### PR TITLE
Modifiers: promo codes and opt-in add-ons in the public order form

### DIFF
--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -9,6 +9,7 @@ import { applyFlash } from "#routes/csrf.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
 import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import { createAuthedHandler } from "#shared/app-forms.ts";
+import { hmacHash } from "#shared/crypto/hashing.ts";
 import { toMinorUnits } from "#shared/currency.ts";
 import { getAllGroups } from "#shared/db/groups.ts";
 import { getAllListings } from "#shared/db/listings.ts";
@@ -28,8 +29,11 @@ import {
   isCalcKind,
   isModifierDirection,
   isModifierScope,
+  isModifierTrigger,
   type ModifierDirection,
   type ModifierScope,
+  type ModifierTrigger,
+  normalizeCode,
   validateCalcValue,
 } from "#shared/price-modifier.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
@@ -49,26 +53,41 @@ import { withEntityLoader } from "./entity-handlers.ts";
 
 /** Build modifier input from validated form values. The value is stored as the
  * positive magnitude the owner typed; converting it to the signed engine value
- * happens where modifiers are applied to a checkout. */
-const extractModifierInput = (values: ModifierFormValues): ModifierInput => ({
-  active: values.active === "1",
-  calcKind: values.calc_kind as CalcKind,
-  calcValue: values.calc_value,
-  direction: values.direction as ModifierDirection,
-  minSubtotal: toMinorUnits(values.min_subtotal),
-  name: values.name,
-  scope: values.scope as ModifierScope,
-  stock: values.stock,
-});
+ * happens where modifiers are applied to a checkout. A promo code is kept only
+ * for "code" modifiers, with its blind index computed for public lookup. */
+const extractModifierInput = async (
+  values: ModifierFormValues,
+): Promise<ModifierInput> => {
+  const code = values.trigger === "code" ? values.code.trim() : "";
+  return {
+    active: values.active === "1",
+    calcKind: values.calc_kind as CalcKind,
+    calcValue: values.calc_value,
+    code,
+    codeIndex: code ? await hmacHash(normalizeCode(code)) : null,
+    direction: values.direction as ModifierDirection,
+    minSubtotal: toMinorUnits(values.min_subtotal),
+    name: values.name,
+    scope: values.scope as ModifierScope,
+    stock: values.stock,
+    trigger: values.trigger as ModifierTrigger,
+  };
+};
 
-/** Validate a modifier's kind, direction, scope, and value (the select options
- * can be bypassed by a crafted POST, so re-check membership here). */
+/** Validate a modifier's kind, direction, trigger, scope, and value (the select
+ * options can be bypassed by a crafted POST, so re-check membership here). */
 const validateModifier = (input: ModifierInput): Promise<string | null> => {
   if (!isCalcKind(input.calcKind)) {
     return Promise.resolve("Invalid modifier type");
   }
   if (!isModifierDirection(input.direction)) {
     return Promise.resolve("Invalid direction");
+  }
+  if (input.trigger !== undefined && !isModifierTrigger(input.trigger)) {
+    return Promise.resolve("Invalid trigger");
+  }
+  if (input.trigger === "code" && !input.code) {
+    return Promise.resolve("A promo-code modifier needs a code");
   }
   if (input.scope !== undefined && !isModifierScope(input.scope)) {
     return Promise.resolve("Invalid scope");

--- a/src/features/public/ticket-form.ts
+++ b/src/features/public/ticket-form.ts
@@ -6,6 +6,7 @@ import { filter, map } from "#fp";
 import { capacityErrorFormatter } from "#routes/format.ts";
 import { errorRedirect, htmlResponse } from "#routes/response.ts";
 import { validatePrice } from "#shared/currency.ts";
+import type { AddOnOption } from "#shared/db/modifier-resolve.ts";
 import type {
   QuestionListingMap,
   QuestionWithAnswers,
@@ -123,6 +124,25 @@ export const listingsWithQuantity = (
     qty: quantities.get(listing.id) ?? 0,
   }))(listings);
   return filter(({ qty }: ListingQty) => qty > 0)(withQty);
+};
+
+/** Parse opt-in add-on selections from the form into a modifier-id → quantity
+ * map. Only add-ons offered on the page are read, each clamped to its quantity
+ * ceiling; zero or invalid entries are dropped so they don't apply. */
+export const parseAddOnSelections = (
+  form: FormParams,
+  addOns: AddOnOption[],
+): Map<number, number> => {
+  const selections = new Map<number, number>();
+  for (const addOn of addOns) {
+    const quantity = parseQuantityValue(
+      form.get(`addon_${addOn.id}`) || "0",
+      addOn.maxQuantity,
+      0,
+    );
+    if (quantity > 0) selections.set(addOn.id, quantity);
+  }
+  return selections;
 };
 
 /** Determine merged fields setting for selected listings */

--- a/src/features/public/ticket-payment.ts
+++ b/src/features/public/ticket-payment.ts
@@ -24,6 +24,10 @@ import {
 } from "#shared/db/attendees.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getListingsBySlugsBatch } from "#shared/db/listings.ts";
+import {
+  getOptionalAddOns,
+  hasPromoCodeModifiers,
+} from "#shared/db/modifier-resolve.ts";
 import { getQuestionsWithListingIds } from "#shared/db/questions.ts";
 import { settings } from "#shared/db/settings.ts";
 import type { EmailEntry } from "#shared/email.ts";
@@ -358,16 +362,21 @@ export const getTicketContext = async (
   group?: Group,
 ): Promise<TicketSharedContext> => {
   const listingIds = activeListings.map((e) => e.listing.id);
-  const [dates, globalTerms, questionsResult] = await Promise.all([
-    computeSharedDates(activeListings),
-    Promise.resolve(settings.terms),
-    getQuestionsWithListingIds(listingIds),
-  ]);
+  const [dates, globalTerms, questionsResult, promoCodesEnabled, addOns] =
+    await Promise.all([
+      computeSharedDates(activeListings),
+      Promise.resolve(settings.terms),
+      getQuestionsWithListingIds(listingIds),
+      hasPromoCodeModifiers(),
+      getOptionalAddOns(listingIds),
+    ]);
   const terms = group
     ? group.terms_and_conditions || globalTerms || ""
     : globalTerms;
   return {
+    addOns,
     dates,
+    promoCodesEnabled,
     terms,
     ...questionsResult,
     ...(group && {

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -37,6 +37,7 @@ import {
   extractContact,
   getTicketFieldsSetting,
   listingsWithQuantity,
+  parseAddOnSelections,
   parseCustomPrice,
   parseQuantities,
   ticketFormErrorResponse,
@@ -188,6 +189,8 @@ const handlePaidPath = async (
   params: PathParams & {
     items: ReturnType<typeof buildRegistrationItems>;
     reservationAmount?: string;
+    promoCode?: string;
+    addOns?: Map<number, number>;
   },
 ): Promise<Response> => {
   const {
@@ -200,6 +203,8 @@ const handlePaidPath = async (
     items,
     info,
     reservationAmount,
+    promoCode,
+    addOns,
   } = params;
   const available = await checkAvailability(
     ctx.listings,
@@ -215,7 +220,9 @@ const handlePaidPath = async (
   const listingAnswerIds = computeListingAnswerMap(ctx, info);
   // Modifiers apply only to full-payment orders for now; reservations (deposits)
   // compose with modifiers in a later step.
-  const modifiers = reservationAmount ? [] : await resolveModifiers(items);
+  const modifiers = reservationAmount
+    ? []
+    : await resolveModifiers(items, { addOns, code: promoCode });
   const intent = {
     ...contact,
     date,
@@ -352,6 +359,7 @@ const processSubmission = async (
 
   if (await anyRequiresPayment(items)) {
     return handlePaidPath(request, {
+      addOns: parseAddOnSelections(form, ctx.addOns),
       contact,
       ctx,
       date,
@@ -359,6 +367,7 @@ const processSubmission = async (
       hasCustomisable,
       info,
       items,
+      promoCode: form.getString("promo_code"),
       quantities,
       reservationAmount: await publicReservationAmount(),
     });

--- a/src/features/public/types.ts
+++ b/src/features/public/types.ts
@@ -2,6 +2,7 @@
  * Shared types, constants, and tiny utilities for public ticket routes
  */
 
+import type { AddOnOption } from "#shared/db/modifier-resolve.ts";
 import type {
   QuestionListingMap,
   QuestionWithAnswers,
@@ -27,6 +28,10 @@ export type TicketCtx = {
   /** When set, threaded into paid/free registration completion so renewals can
    * bump a built site's READ_ONLY_FROM after successful reservation. */
   siteToken?: string;
+  /** Whether a promo-code field should be offered (any active code modifier). */
+  promoCodesEnabled?: boolean;
+  /** Opt-in add-ons offered for the page's listings (empty when none apply). */
+  addOns: AddOnOption[];
 };
 
 /** Possibly-async response handler */
@@ -44,6 +49,9 @@ export type TicketSharedContext = {
   groupDescription?: string;
   actionUrl?: string;
   siteToken?: string;
+  promoCodesEnabled?: boolean;
+  /** Opt-in add-ons offered for the page's listings (empty when none apply). */
+  addOns: AddOnOption[];
 };
 
 /** Shared context provider for ticket pages */

--- a/src/locales/en/public.json
+++ b/src/locales/en/public.json
@@ -72,5 +72,10 @@
   "unsubscribe.subscribed_message": "You're currently subscribed to our marketing emails.",
   "unsubscribe.unsubscribe_button": "Unsubscribe",
   "public.send_us_a_message": "Send us a message",
-  "public.select_items_to_order": "Select items to order"
+  "public.select_items_to_order": "Select items to order",
+  "public.addons.heading": "Add-ons",
+  "public.addons.quantity": "Quantity",
+  "public.promo.heading": "Promo code",
+  "public.promo.hint": "Have a promo code? Enter it to apply it at checkout.",
+  "public.promo.placeholder": "Promo code"
 }

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -53,7 +53,7 @@ type Trigger = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "rename the event domain to listing (tables, columns and indexes); add a global sort_order column to questions for unified ordering; add email_preferences table for marketing opt-outs and contact history; add customisable_days and day_prices columns to listings for visitor-chosen multi-day bookings with per-day-count pricing; add attendee_statuses table with status_id and remaining_balance on attendees, plus attendee_id on activity_log, for the reservation and balance-payment flow; add idx_activity_log_listing_id so per-listing activity log reads are index scans instead of full-table scans; add a logistics_agents table plus a uses_logistics flag on listings, a split_logistics_agents flag on attendees, and start_agent_id/end_agent_id/start_time/end_time on listing_attendees for the logistics flow; add email_templates table for owner-keypair-encrypted reusable email subjects and bodies; add a user_logistics_agents table linking agent users to the logistics agents they drive, plus start_done/end_done flags on listing_attendees so delivery agents can mark drop-offs and collections complete; add failure_data to processed_payments so handled payment failures are recorded as a terminal outcome for idempotent redirect/webhook replay; add booked_quantity, tickets_count and income aggregate columns to listings, maintained by triggers on listing_attendees so listing reads and active-listing stats avoid scanning the attendee rows; add modifiers table for owner-defined price modifiers (surcharges, discounts, add-ons), with active/trigger/code_index/scope/stock/max_per_order/min_subtotal columns plus modifier_listings, modifier_groups and modifier_usages tables for scoping and stock";
+  "rename the event domain to listing (tables, columns and indexes); add a global sort_order column to questions for unified ordering; add email_preferences table for marketing opt-outs and contact history; add customisable_days and day_prices columns to listings for visitor-chosen multi-day bookings with per-day-count pricing; add attendee_statuses table with status_id and remaining_balance on attendees, plus attendee_id on activity_log, for the reservation and balance-payment flow; add idx_activity_log_listing_id so per-listing activity log reads are index scans instead of full-table scans; add a logistics_agents table plus a uses_logistics flag on listings, a split_logistics_agents flag on attendees, and start_agent_id/end_agent_id/start_time/end_time on listing_attendees for the logistics flow; add email_templates table for owner-keypair-encrypted reusable email subjects and bodies; add a user_logistics_agents table linking agent users to the logistics agents they drive, plus start_done/end_done flags on listing_attendees so delivery agents can mark drop-offs and collections complete; add failure_data to processed_payments so handled payment failures are recorded as a terminal outcome for idempotent redirect/webhook replay; add booked_quantity, tickets_count and income aggregate columns to listings, maintained by triggers on listing_attendees so listing reads and active-listing stats avoid scanning the attendee rows; add modifiers table for owner-defined price modifiers (surcharges, discounts, add-ons), with active/trigger/code_index/scope/stock/max_per_order/min_subtotal columns plus modifier_listings, modifier_groups and modifier_usages tables for scoping and stock; add an encrypted code column to modifiers for promo-code modifiers";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 
@@ -457,6 +457,7 @@ const SCHEMA: [name: string, table: Table][] = [
         ["direction", "TEXT NOT NULL"],
         ["active", "INTEGER NOT NULL DEFAULT 1"],
         ["trigger", "TEXT NOT NULL DEFAULT 'automatic'"],
+        ["code", "TEXT NOT NULL DEFAULT ''"],
         ["code_index", "TEXT"],
         ["scope", "TEXT NOT NULL DEFAULT 'all'"],
         ["stock", "INTEGER"],
@@ -1497,6 +1498,9 @@ const REQ_MODIFIERS: SchemaRequirement = {
     "modifier_usages",
   ],
 };
+const REQ_MODIFIER_CODE: SchemaRequirement = {
+  columns: { modifiers: ["code"] },
+};
 const REQ_LISTING_AGGREGATES: SchemaRequirement = {
   columns: { listings: ["booked_quantity", "tickets_count", "income"] },
   triggers: [
@@ -1652,6 +1656,15 @@ export const MIGRATIONS: Migration[] = [
     up: async () => {
       await applySchemaChanges();
       await syncIndexes();
+    },
+  }),
+  additive({
+    description:
+      "Add an encrypted code column to modifiers for promo-code (trigger=code) modifiers; the public code box matches against code_index",
+    id: "2026-06-17_modifier_code",
+    requires: REQ_MODIFIER_CODE,
+    up: async () => {
+      await applySchemaChanges();
     },
   }),
 ];

--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -9,7 +9,8 @@
  */
 
 import { itemsSubtotal } from "#shared/booking-fee.ts";
-import { toMinorUnits } from "#shared/currency.ts";
+import { hmacHash } from "#shared/crypto/hashing.ts";
+import { formatCurrency, toMinorUnits } from "#shared/currency.ts";
 import { modifierUsedQuantities } from "#shared/db/modifier-usage.ts";
 import {
   getActiveModifiers,
@@ -21,6 +22,7 @@ import type {
   ModifierRef,
   ModifierSpec,
 } from "#shared/payments.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
 import type { Modifier } from "#shared/types.ts";
 
 /** The signed pricing value the engine applies, from a modifier's stored
@@ -69,31 +71,72 @@ const inScopeSubtotal = (
       : items.filter((i) => listingIds.includes(i.listingId)),
   );
 
-/** A modifier eligible by scope and minimum subtotal (stock checked after). */
-type Candidate = { modifier: Modifier; listingIds: number[] | null };
+/** A modifier eligible by scope and minimum subtotal, with the quantity the
+ * buyer asked for (1 for automatic/code modifiers; the chosen count for an
+ * opt-in add-on). Stock is clamped after candidates are gathered. */
+type Candidate = {
+  modifier: Modifier;
+  listingIds: number[] | null;
+  quantity: number;
+};
 
-/** Whether a stock-limited modifier still has a unit left. */
-const hasStock = (modifier: Modifier, used: Map<number, number>): boolean =>
-  modifier.stock === null || modifier.stock - (used.get(modifier.id) ?? 0) >= 1;
+/** How many units of a modifier can actually be applied, capping the requested
+ * quantity at the remaining stock. Unlimited stock grants the full request. */
+const stockedQuantity = (
+  modifier: Modifier,
+  requested: number,
+  used: Map<number, number>,
+): number => {
+  if (modifier.stock === null) return requested;
+  const remaining = modifier.stock - (used.get(modifier.id) ?? 0);
+  return Math.max(0, Math.min(requested, remaining));
+};
+
+/** How many times a modifier is requested for a cart: automatic modifiers
+ * apply once, a "code" modifier applies once when the entered code matches, and
+ * an opt-in add-on applies as many times as the buyer chose (0 = not selected).
+ * A result below 1 means the modifier doesn't trigger at all. */
+const triggerQuantity = (
+  modifier: Modifier,
+  codeIndex: string | null,
+  addOns: Map<number, number>,
+): number => {
+  if (modifier.trigger === "code")
+    return codeIndex !== null && modifier.code_index === codeIndex ? 1 : 0;
+  if (modifier.trigger === "optional") return addOns.get(modifier.id) ?? 0;
+  return 1;
+};
 
 /**
- * The modifiers that automatically apply to a cart: active, automatic, in
- * scope, past their minimum subtotal, and with stock remaining.
+ * The modifiers that apply to a cart: active, triggered, in scope, past their
+ * minimum subtotal, and with stock remaining. Automatic modifiers always
+ * trigger; a "code" modifier triggers only when the buyer entered its matching
+ * code; an "optional" add-on triggers only when the buyer selected it
+ * (`opts.addOns` maps modifier id → chosen quantity), and is applied that many
+ * times.
  */
 export const resolveModifiers = async (
   items: CheckoutItem[],
+  opts: { code?: string; addOns?: Map<number, number> } = {},
 ): Promise<ModifierSpec[]> => {
-  const automatic = (await getActiveModifiers()).filter(
-    (m) => m.trigger === "automatic",
-  );
+  const addOns = opts.addOns ?? new Map<number, number>();
+  const codeIndex = opts.code?.trim()
+    ? await hmacHash(normalizeCode(opts.code))
+    : null;
   const candidates = (
     await Promise.all(
-      automatic.map(async (modifier): Promise<Candidate | null> => {
+      (
+        await getActiveModifiers()
+      ).map(async (modifier): Promise<Candidate | null> => {
+        const quantity = triggerQuantity(modifier, codeIndex, addOns);
+        if (quantity < 1) return null;
         const listingIds = await listingIdsFor(modifier);
         const base = inScopeSubtotal(items, listingIds);
         // A scoped modifier only applies alongside its listings/groups.
         if (listingIds !== null && base === 0) return null;
-        return base >= modifier.min_subtotal ? { listingIds, modifier } : null;
+        return base >= modifier.min_subtotal
+          ? { listingIds, modifier, quantity }
+          : null;
       }),
     )
   ).filter((c): c is Candidate => c !== null);
@@ -105,8 +148,83 @@ export const resolveModifiers = async (
       .map((c) => c.modifier.id),
   );
   return candidates
-    .filter((c) => hasStock(c.modifier, used))
-    .map((c) => toSpec(c.modifier, 1, c.listingIds));
+    .map((c) => ({
+      candidate: c,
+      quantity: stockedQuantity(c.modifier, c.quantity, used),
+    }))
+    .filter(({ quantity }) => quantity >= 1)
+    .map(({ candidate, quantity }) =>
+      toSpec(candidate.modifier, quantity, candidate.listingIds),
+    );
+};
+
+/** Whether any active modifier is unlocked by a promo code, so the public
+ * order form knows to offer a code field. */
+export const hasPromoCodeModifiers = async (): Promise<boolean> =>
+  (await getActiveModifiers()).some((m) => m.trigger === "code");
+
+/** Display details for an opt-in add-on offered on the public order form. */
+export type AddOnOption = {
+  id: number;
+  name: string;
+  /** Buyer-facing price effect, e.g. "+£5", "−10%", "×1.5". */
+  priceLabel: string;
+  /** The most units a buyer may select, capped by remaining stock. */
+  maxQuantity: number;
+};
+
+/** Default ceiling on the add-on quantity selector when stock is unlimited. */
+export const ADDON_MAX_QUANTITY = 20;
+
+/** The buyer-facing price label for an add-on: a signed amount or percentage,
+ * or a bare multiplier (whose factor already encodes its direction). */
+const addOnPriceLabel = (modifier: Modifier): string => {
+  if (modifier.calc_kind === "multiply") return `×${modifier.calc_value}`;
+  const sign = modifier.direction === "discount" ? "−" : "+";
+  const amount =
+    modifier.calc_kind === "fixed"
+      ? formatCurrency(toMinorUnits(modifier.calc_value))
+      : `${modifier.calc_value}%`;
+  return `${sign}${amount}`;
+};
+
+/**
+ * The opt-in add-ons offered for a page's listings: active "optional"
+ * modifiers whose scope covers the whole order or overlaps the page, with
+ * stock left. Each carries the quantity ceiling the selector should allow.
+ */
+export const getOptionalAddOns = async (
+  pageListingIds: number[],
+): Promise<AddOnOption[]> => {
+  const optional = (await getActiveModifiers()).filter(
+    (m) => m.trigger === "optional",
+  );
+  const pageIds = new Set(pageListingIds);
+  const scoped = (
+    await Promise.all(
+      optional.map(async (modifier) => {
+        const listingIds = await listingIdsFor(modifier);
+        const inScope =
+          listingIds === null || listingIds.some((id) => pageIds.has(id));
+        return inScope ? modifier : null;
+      }),
+    )
+  ).filter((m): m is Modifier => m !== null);
+  const used = await modifierUsedQuantities(
+    scoped.filter((m) => m.stock !== null).map((m) => m.id),
+  );
+  return scoped
+    .map((modifier) => ({
+      maxQuantity: stockedQuantity(modifier, ADDON_MAX_QUANTITY, used),
+      modifier,
+    }))
+    .filter(({ maxQuantity }) => maxQuantity >= 1)
+    .map(({ maxQuantity, modifier }) => ({
+      id: modifier.id,
+      maxQuantity,
+      name: modifier.name,
+      priceLabel: addOnPriceLabel(modifier),
+    }));
 };
 
 /**

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -30,6 +30,9 @@ export type ModifierInput = {
   calcValue: number;
   direction: ModifierDirection;
   active?: boolean;
+  trigger?: ModifierTrigger;
+  code?: string;
+  codeIndex?: string | null;
   scope?: ModifierScope;
   minSubtotal?: number;
   stock?: number | null;
@@ -47,6 +50,8 @@ export const modifiersTable = defineIdTable<Modifier, ModifierInput>(
     active: col.boolean(true),
     calc_kind: col.simple<CalcKind>(),
     calc_value: col.simple<number>(),
+    code: col.encryptedText(encrypt, decrypt),
+    code_index: col.withDefault<string | null>(() => null),
     direction: col.simple<ModifierDirection>(),
     min_subtotal: col.withDefault(() => 0),
     scope: col.withDefault<ModifierScope>(() => "all"),

--- a/src/shared/price-modifier.ts
+++ b/src/shared/price-modifier.ts
@@ -26,7 +26,16 @@ export type ModifierDirection = v.InferOutput<typeof ModifierDirectionSchema>;
 
 /** How a modifier becomes part of a checkout: applied automatically, unlocked
  * by a promo code, or an opt-in add-on the buyer chooses. */
-export type ModifierTrigger = "automatic" | "code" | "optional";
+export const ModifierTriggerSchema = v.picklist([
+  "automatic",
+  "code",
+  "optional",
+]);
+export type ModifierTrigger = v.InferOutput<typeof ModifierTriggerSchema>;
+
+/** Type guard: is the string a valid modifier trigger? */
+export const isModifierTrigger = (value: string): value is ModifierTrigger =>
+  v.is(ModifierTriggerSchema, value);
 
 /** Which cart items a modifier is charged on: the whole order, specific
  * listings, or every listing in specific groups. */
@@ -36,6 +45,11 @@ export type ModifierScope = v.InferOutput<typeof ModifierScopeSchema>;
 /** Type guard: is the string a valid modifier scope? */
 export const isModifierScope = (value: string): value is ModifierScope =>
   v.is(ModifierScopeSchema, value);
+
+/** Normalise a promo code for storage and matching: trimmed and lower-cased so
+ * codes are case-insensitive. The blind index is the HMAC of this. */
+export const normalizeCode = (code: string): string =>
+  code.trim().toLowerCase();
 
 /** Type guard: is the string a valid calc kind? */
 export const isCalcKind = (value: string): value is CalcKind =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -412,6 +412,11 @@ export interface Modifier {
   direction: ModifierDirection;
   active: boolean;
   trigger: ModifierTrigger;
+  /** Promo code (trigger = "code"), shown to the owner; "" for other triggers. */
+  code: string;
+  /** Blind index (HMAC) of the normalised code, for public code lookup; null
+   * when the modifier has no code. */
+  code_index: string | null;
   scope: ModifierScope;
   /** Minimum in-scope subtotal (minor units) for the modifier to apply. */
   min_subtotal: number;

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -876,6 +876,8 @@ export type ModifierFormValues = {
   calc_kind: string;
   direction: string;
   calc_value: number;
+  trigger: string;
+  code: string;
   scope: string;
   min_subtotal: number;
   stock: number | null;
@@ -924,6 +926,25 @@ export const modifierFields: Field[] = [
     type: "text",
     validate: (value: string) =>
       Number.isFinite(Number.parseFloat(value)) ? null : "Enter a valid number",
+  },
+  {
+    defaultValue: "automatic",
+    hint: "When this applies. Promo codes are entered by the buyer at checkout; optional add-ons are chosen by the buyer.",
+    label: "Trigger",
+    name: "trigger",
+    options: [
+      { label: "Automatic (always)", value: "automatic" },
+      { label: "Promo code", value: "code" },
+      { label: "Optional add-on", value: "optional" },
+    ],
+    type: "select",
+  },
+  {
+    hint: "The code buyers enter at checkout. Required for promo-code modifiers; ignored otherwise.",
+    label: "Promo code",
+    name: "code",
+    placeholder: "SUMMER20",
+    type: "text",
   },
   {
     defaultValue: "all",

--- a/src/ui/templates/public.tsx
+++ b/src/ui/templates/public.tsx
@@ -12,6 +12,7 @@ import {
   formatDateLabel,
   formatDatetimeLabel,
 } from "#shared/dates.ts";
+import type { AddOnOption } from "#shared/db/modifier-resolve.ts";
 import type {
   QuestionListingMap,
   QuestionWithAnswers,
@@ -824,6 +825,10 @@ export type TicketPageOptions = {
   prefill?: BookingPrefill;
   /** Override the <form action="…"> URL. Defaults to `/ticket/<slugs>`. */
   actionUrl?: string;
+  /** Opt-in add-ons to offer below the questions. */
+  addOns?: AddOnOption[];
+  /** Whether to offer a promo-code field. */
+  promoCodesEnabled?: boolean;
 };
 
 /** Unavailability message shown when all listings are sold out or closed */
@@ -878,6 +883,50 @@ const TicketPageHeader = ({
   </>
 );
 
+/** Opt-in add-on selectors: one quantity input per add-on, defaulting to 0
+ * (not selected) and restored on validation error. */
+const AddOnsFieldset = ({ addOns }: { addOns: AddOnOption[] }): JSX.Element => (
+  <fieldset class="ticket-addons">
+    <legend>{t("public.addons.heading")}</legend>
+    {addOns.map((addOn) => {
+      const field = `addon_${addOn.id}`;
+      return (
+        <label class="addon-row">
+          <span class="addon-name">
+            {addOn.name} <span class="addon-price">({addOn.priceLabel})</span>
+          </span>
+          <input
+            aria-label={`${addOn.name} — ${t("public.addons.quantity")}`}
+            max={String(addOn.maxQuantity)}
+            min="0"
+            name={field}
+            placeholder="0"
+            type="number"
+            value={savedFormValue(field)}
+          />
+        </label>
+      );
+    })}
+  </fieldset>
+);
+
+/** Promo-code text input, shown when any active modifier is unlocked by a code.
+ * The entered value is restored on a validation-error re-render. */
+const PromoCodeField = (): JSX.Element => (
+  <div class="promo-code">
+    <label>
+      {t("public.promo.heading")}
+      <input
+        name="promo_code"
+        placeholder={t("public.promo.placeholder")}
+        type="text"
+        value={savedFormValue("promo_code")}
+      />
+    </label>
+    <p class="hint">{t("public.promo.hint")}</p>
+  </div>
+);
+
 /** Form body with fields, date selector, listing rows, questions, terms, and submit */
 const TicketPageForm = ({
   slugs,
@@ -896,6 +945,8 @@ const TicketPageForm = ({
   questionListingMap,
   terms,
   prefill,
+  addOns,
+  promoCodesEnabled,
 }: {
   slugs: string[];
   actionUrl?: string;
@@ -913,6 +964,8 @@ const TicketPageForm = ({
   questionListingMap: QuestionListingMap | undefined;
   terms: string | null | undefined;
   prefill?: BookingPrefill;
+  addOns: AddOnOption[] | undefined;
+  promoCodesEnabled: boolean | undefined;
 }): JSX.Element => {
   const fieldValues: Record<string, string> = {};
   if (prefill?.name) fieldValues.name = prefill.name;
@@ -947,6 +1000,8 @@ const TicketPageForm = ({
       {questions && questions.length > 0 && (
         <Raw html={renderQuestions(questions, questionListingMap)} />
       )}
+      {addOns && addOns.length > 0 && <AddOnsFieldset addOns={addOns} />}
+      {promoCodesEnabled && <PromoCodeField />}
       {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
       <button type="submit">{t("common.continue")}</button>
     </CsrfForm>
@@ -997,6 +1052,8 @@ export const ticketPage = ({
   groupDescription,
   prefill,
   actionUrl,
+  addOns,
+  promoCodesEnabled,
 }: TicketPageOptions): string => {
   const inIframe = getIframeMode();
   const allUnavailable = listings.every((e) => e.isSoldOut || e.isClosed);
@@ -1070,6 +1127,7 @@ export const ticketPage = ({
       ) : (
         <TicketPageForm
           actionUrl={actionUrl}
+          addOns={addOns}
           dates={dates}
           dayCountPriceFor={dayCountPriceFor}
           dayCounts={dayCounts}
@@ -1081,6 +1139,7 @@ export const ticketPage = ({
           isSingleListing={isSingleListing}
           listingRows={listingRows}
           prefill={prefill}
+          promoCodesEnabled={promoCodesEnabled}
           questionListingMap={questionListingMap}
           questions={questions}
           slugs={slugs}

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -912,8 +912,9 @@ describe("db > migrations > schema change guard", () => {
         "2026-06-16_processed_payments_failure_data",
         "2026-06-16_listing_aggregates",
         "2026-06-16_modifiers",
+        "2026-06-17_modifier_code",
       ],
-      schemaHash: "16t49nl",
+      schemaHash: "8fe2m0",
     });
   });
 });

--- a/test/lib/db/modifier-resolve.test.ts
+++ b/test/lib/db/modifier-resolve.test.ts
@@ -1,14 +1,19 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { hmacHash } from "#shared/crypto/hashing.ts";
 import { toMinorUnits } from "#shared/currency.ts";
 import { getDb } from "#shared/db/client.ts";
 import {
+  ADDON_MAX_QUANTITY,
+  getOptionalAddOns,
+  hasPromoCodeModifiers,
   resolveModifiers,
   specsFromRefs,
 } from "#shared/db/modifier-resolve.ts";
 import { consumeModifierStock } from "#shared/db/modifier-usage.ts";
 import { type ModifierInput, modifiersTable } from "#shared/db/modifiers.ts";
 import type { CheckoutItem } from "#shared/payments.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
 import { createTestListing, describeWithEnv } from "#test-utils";
 
 const linkListing = (modifierId: number, listingId: number) =>
@@ -138,6 +143,47 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       expect(skipped.map((s) => s.name)).not.toContain("VIP");
     });
 
+    test("applies a code modifier only when the matching code is entered", async () => {
+      const m = await insertModifier({ name: "SUMMER" });
+      await patchModifier(m.id, {
+        code_index: await hmacHash(normalizeCode("Summer25")),
+        trigger: "code",
+      });
+
+      const withoutCode = await resolveModifiers([item()]);
+      expect(withoutCode.map((s) => s.name)).not.toContain("SUMMER");
+
+      const wrongCode = await resolveModifiers([item()], { code: "winter" });
+      expect(wrongCode.map((s) => s.name)).not.toContain("SUMMER");
+
+      // Matching is case-insensitive (normalised before hashing).
+      const rightCode = await resolveModifiers([item()], { code: "SUMMER25" });
+      expect(rightCode.map((s) => s.name)).toContain("SUMMER");
+    });
+
+    test("applies an opt-in add-on at the chosen quantity only when selected", async () => {
+      const m = await insertModifier({ name: "T-shirt" });
+      await patchModifier(m.id, { trigger: "optional" });
+
+      const unselected = await resolveModifiers([item()]);
+      expect(unselected.map((s) => s.name)).not.toContain("T-shirt");
+
+      const selected = await resolveModifiers([item()], {
+        addOns: new Map([[m.id, 3]]),
+      });
+      expect(selected.find((s) => s.name === "T-shirt")?.quantity).toBe(3);
+    });
+
+    test("caps an opt-in add-on quantity at the remaining stock", async () => {
+      const m = await insertModifier({ name: "Limited tee", stock: 2 });
+      await patchModifier(m.id, { trigger: "optional" });
+
+      const specs = await resolveModifiers([item()], {
+        addOns: new Map([[m.id, 5]]),
+      });
+      expect(specs.find((s) => s.name === "Limited tee")?.quantity).toBe(2);
+    });
+
     test("applies a group-scoped modifier to the linked group's listings", async () => {
       const listing = await createTestListing({
         maxAttendees: 10,
@@ -160,6 +206,95 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       expect(applied.find((s) => s.name === "GroupWide")?.listingIds).toEqual([
         listing.id,
       ]);
+    });
+  });
+
+  describe("hasPromoCodeModifiers", () => {
+    test("is false with no code modifiers and true once one exists", async () => {
+      await insertModifier({ name: "Automatic" });
+      expect(await hasPromoCodeModifiers()).toBe(false);
+
+      const coded = await insertModifier({ name: "Coded" });
+      await patchModifier(coded.id, { trigger: "code" });
+      expect(await hasPromoCodeModifiers()).toBe(true);
+    });
+  });
+
+  describe("getOptionalAddOns", () => {
+    test("offers a whole-order add-on with its price label and quantity cap", async () => {
+      const m = await insertModifier({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "Parking",
+      });
+      await patchModifier(m.id, { trigger: "optional" });
+
+      const addOns = await getOptionalAddOns([1]);
+      expect(addOns).toEqual([
+        {
+          id: m.id,
+          maxQuantity: ADDON_MAX_QUANTITY,
+          name: "Parking",
+          priceLabel: "+£5",
+        },
+      ]);
+    });
+
+    test("labels a percentage discount add-on with a minus sign", async () => {
+      const m = await insertModifier({
+        calcKind: "percent",
+        calcValue: 10,
+        direction: "discount",
+        name: "Member rebate",
+      });
+      await patchModifier(m.id, { trigger: "optional" });
+      const addOns = await getOptionalAddOns([1]);
+      expect(addOns[0]?.priceLabel).toBe("−10%");
+    });
+
+    test("labels a multiplier add-on with its bare factor", async () => {
+      const m = await insertModifier({
+        calcKind: "multiply",
+        calcValue: 1.5,
+        direction: "charge",
+        name: "Peak surcharge",
+      });
+      await patchModifier(m.id, { trigger: "optional" });
+      const addOns = await getOptionalAddOns([1]);
+      expect(addOns[0]?.priceLabel).toBe("×1.5");
+    });
+
+    test("caps maxQuantity at the remaining stock", async () => {
+      const m = await insertModifier({ name: "Tee", stock: 3 });
+      await patchModifier(m.id, { trigger: "optional" });
+      const addOns = await getOptionalAddOns([1]);
+      expect(addOns[0]?.maxQuantity).toBe(3);
+    });
+
+    test("omits a sold-out add-on", async () => {
+      const m = await insertModifier({ name: "Sold out", stock: 1 });
+      await patchModifier(m.id, { trigger: "optional" });
+      await consumeModifierStock(1, [
+        { amountApplied: 500, modifierId: m.id, quantity: 1 },
+      ]);
+      expect(await getOptionalAddOns([1])).toEqual([]);
+    });
+
+    test("offers a listing-scoped add-on only on a page with its listing", async () => {
+      const m = await insertModifier({ name: "Scoped tee" });
+      await patchModifier(m.id, { scope: "listings", trigger: "optional" });
+      await linkListing(m.id, 7);
+
+      expect(await getOptionalAddOns([7])).toHaveLength(1);
+      expect(await getOptionalAddOns([8])).toEqual([]);
+    });
+
+    test("excludes automatic and code modifiers", async () => {
+      await insertModifier({ name: "Automatic" });
+      const coded = await insertModifier({ name: "Coded" });
+      await patchModifier(coded.id, { trigger: "code" });
+      expect(await getOptionalAddOns([1])).toEqual([]);
     });
   });
 

--- a/test/lib/server-modifiers.test.ts
+++ b/test/lib/server-modifiers.test.ts
@@ -1,11 +1,13 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { hmacHash } from "#shared/crypto/hashing.ts";
 import { toMinorUnits } from "#shared/currency.ts";
 import {
   getAllModifiers,
   getModifierGroupIds,
   getModifierListingIds,
 } from "#shared/db/modifiers.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
 import type { Modifier } from "#shared/types.ts";
 import {
   adminFormPost,
@@ -440,6 +442,62 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         {},
       );
       expectStatus(404)(response);
+    });
+  });
+
+  describe("trigger and promo code", () => {
+    test("stores the chosen trigger", async () => {
+      await adminFormPost(
+        "/admin/modifiers",
+        createData({ trigger: "optional" }),
+      );
+      expect((await lastModifier()).trigger).toBe("optional");
+    });
+
+    test("rejects an unknown trigger", async () => {
+      const { response } = await adminFormPost(
+        "/admin/modifiers",
+        createData({ trigger: "magic" }),
+      );
+      expectRedirectWithFlash(
+        "/admin/modifiers/new",
+        "Invalid trigger",
+        false,
+      )(response);
+    });
+
+    test("requires a code when the trigger is a promo code", async () => {
+      const { response } = await adminFormPost(
+        "/admin/modifiers",
+        createData({ code: "", trigger: "code" }),
+      );
+      expectRedirectWithFlash(
+        "/admin/modifiers/new",
+        "A promo-code modifier needs a code",
+        false,
+      )(response);
+    });
+
+    test("stores a promo code and its blind index", async () => {
+      await adminFormPost(
+        "/admin/modifiers",
+        createData({ code: "Summer25", trigger: "code" }),
+      );
+      const modifier = await lastModifier();
+      expect(modifier.code).toBe("Summer25");
+      expect(modifier.code_index).toBe(
+        await hmacHash(normalizeCode("Summer25")),
+      );
+    });
+
+    test("ignores a code entered for a non-code trigger", async () => {
+      await adminFormPost(
+        "/admin/modifiers",
+        createData({ code: "LEFTOVER", trigger: "automatic" }),
+      );
+      const modifier = await lastModifier();
+      expect(modifier.code).toBe("");
+      expect(modifier.code_index).toBeNull();
     });
   });
 });

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -1,6 +1,10 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
+import { hmacHash } from "#shared/crypto/hashing.ts";
+import { getDb } from "#shared/db/client.ts";
+import { modifiersTable } from "#shared/db/modifiers.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
 import {
   assertPublicHtml,
@@ -858,6 +862,90 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         // The chosen span and its price are carried into the checkout intent.
         expect(capturedIntent?.dayCount).toBe(2);
         expect(capturedIntent?.items[0]?.unitPrice).toBe(1800);
+      } finally {
+        mockCreate.restore();
+      }
+    });
+
+    test("carries a selected add-on and entered promo code into the checkout intent", async () => {
+      await setupStripe();
+
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice: 1000,
+      });
+
+      // An opt-in add-on and a promo-code discount, both whole-order. A second
+      // add-on is offered but left unselected (its quantity field stays 0).
+      const addOn = await modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "T-shirt",
+      });
+      const skippedAddOn = await modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 3,
+        direction: "charge",
+        name: "Tote bag",
+      });
+      const promo = await modifiersTable.insert({
+        calcKind: "percent",
+        calcValue: 10,
+        direction: "discount",
+        name: "SAVE10",
+      });
+      await getDb().execute({
+        args: ["optional", addOn.id],
+        sql: "UPDATE modifiers SET trigger = ? WHERE id = ?",
+      });
+      await getDb().execute({
+        args: ["optional", skippedAddOn.id],
+        sql: "UPDATE modifiers SET trigger = ? WHERE id = ?",
+      });
+      await getDb().execute({
+        args: ["code", await hmacHash(normalizeCode("SAVE10")), promo.id],
+        sql: "UPDATE modifiers SET trigger = ?, code_index = ? WHERE id = ?",
+      });
+
+      const { stub } = await import("@std/testing/mock");
+      const { stripePaymentProvider } = await import(
+        "#shared/stripe-provider.ts"
+      );
+      let capturedIntent:
+        | import("#shared/payments.ts").CheckoutIntent
+        | undefined;
+      const mockCreate = stub(
+        stripePaymentProvider,
+        "createCheckoutSession",
+        (intent: import("#shared/payments.ts").CheckoutIntent) => {
+          capturedIntent = intent;
+          return Promise.resolve({
+            checkoutUrl: "https://stripe.test/checkout",
+            sessionId: "cs_modifiers_web",
+          });
+        },
+      );
+
+      try {
+        const response = await submitTicketForm(listing.slug, {
+          // The second add-on's field is omitted entirely (left unselected).
+          [`addon_${addOn.id}`]: "2",
+          email: "john@example.com",
+          name: "John Doe",
+          promo_code: "save10",
+        });
+
+        expect(response.status).toBe(302);
+        const byId = new Map(
+          (capturedIntent?.modifiers ?? []).map((m) => [m.id, m]),
+        );
+        // The add-on is applied at the chosen quantity, the promo at quantity 1,
+        // and the unselected add-on is absent.
+        expect(byId.get(addOn.id)?.quantity).toBe(2);
+        expect(byId.get(promo.id)?.quantity).toBe(1);
+        expect(byId.has(skippedAddOn.id)).toBe(false);
       } finally {
         mockCreate.restore();
       }

--- a/test/templates/admin/modifiers.test.ts
+++ b/test/templates/admin/modifiers.test.ts
@@ -16,6 +16,8 @@ const mod = (overrides: Partial<Modifier> = {}): Modifier => ({
   active: true,
   calc_kind: "percent",
   calc_value: 10,
+  code: "",
+  code_index: null,
   direction: "discount",
   id: 1,
   min_subtotal: 0,

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -500,6 +500,69 @@ describe("ticketPage", () => {
     expect(html).toContain('data-listing-ids="1"');
   });
 
+  test("renders a promo-code field when promo codes are enabled", () => {
+    const listings = [
+      buildTicketListing(
+        testListingWithCount({
+          attendee_count: 0,
+          id: 1,
+          name: "Listing A",
+          slug: "ab12c",
+        }),
+        false,
+        undefined,
+      ),
+    ];
+    const html = ticketPage({
+      listings,
+      promoCodesEnabled: true,
+      slugs: ["ab12c"],
+    });
+    expect(html).toContain('name="promo_code"');
+    expect(html).toContain("Promo code");
+  });
+
+  test("omits the promo-code field when promo codes are disabled", () => {
+    const listings = [
+      buildTicketListing(
+        testListingWithCount({
+          attendee_count: 0,
+          id: 1,
+          name: "Listing A",
+          slug: "ab12c",
+        }),
+        false,
+        undefined,
+      ),
+    ];
+    const html = ticketPage({ listings, slugs: ["ab12c"] });
+    expect(html).not.toContain('name="promo_code"');
+  });
+
+  test("renders an opt-in add-on selector with its price label", () => {
+    const listings = [
+      buildTicketListing(
+        testListingWithCount({
+          attendee_count: 0,
+          id: 1,
+          name: "Listing A",
+          slug: "ab12c",
+        }),
+        false,
+        undefined,
+      ),
+    ];
+    const html = ticketPage({
+      addOns: [{ id: 7, maxQuantity: 5, name: "T-shirt", priceLabel: "+£5" }],
+      listings,
+      slugs: ["ab12c"],
+    });
+    expect(html).toContain('name="addon_7"');
+    expect(html).toContain("T-shirt");
+    expect(html).toContain("+£5");
+    expect(html).toContain('max="5"');
+  });
+
   test("appends ?iframe=true to form action in iframe mode", () => {
     detectIframeMode("https://example.com/?iframe=true");
     const listings = [


### PR DESCRIPTION
Completes the remaining follow-ups from the price-modifiers work (#1213, #1232): the two buyer-facing modifier triggers in the public order form.

## Promo codes (`trigger="code"`)
- New encrypted `code` column on `modifiers` plus an HMAC blind index (`code_index`), added via migration `2026-06-17_modifier_code`.
- Owners set a case-insensitive code on a code-triggered modifier; `normalizeCode` (trim + lowercase) is hashed for the blind index, so the plaintext code is never compared directly.
- The order form shows a **promo code** field whenever any active code modifier exists (`hasPromoCodeModifiers`). The entered code is matched by blind index at resolve time — metadata amounts are still never trusted.
- Admin form gains a **trigger** select and a **code** field; `validateModifier` rejects an unknown trigger and requires a code when the trigger is "code". A code entered for a non-code trigger is discarded.

## Opt-in add-ons (`trigger="optional"`)
- `getOptionalAddOns` returns the active optional modifiers whose scope covers the whole order or overlaps the page's listings, each with a buyer-facing price label (e.g. `+£5`, `−10%`, `×1.5`) and a quantity ceiling capped by remaining stock.
- The order form renders a **quantity selector per add-on**; the chosen quantities are parsed (`parseAddOnSelections`, clamped to each add-on's max) and flow through the existing modifier pipeline (`ModifierSpec.quantity` → metadata id-refs → webhook re-derivation).

## Resolution
`resolveModifiers` now resolves all three triggers in one pass: automatic modifiers always apply, code modifiers apply on a matching code, and add-ons apply at the selected quantity (clamped to stock). Pricing, the metadata id-ref scheme, and the refund-on-mismatch webhook path are unchanged.

## Testing
- `modifier-resolve`: code matching (case-insensitive, wrong/absent code), add-on quantity + stock clamping, `getOptionalAddOns` (price labels for fixed/percent/multiply, stock cap, sold-out omission, scope filtering, automatic/code exclusion), `hasPromoCodeModifiers`.
- `server-modifiers`: trigger create/validate, promo-code-required, blind-index storage, code discarded for non-code trigger.
- `server-payments`: an end-to-end paid submission carrying a selected add-on (qty 2) and a promo code into the checkout intent, with a second add-on left unselected.
- `templates/public`: promo field shown/hidden, add-on selector rendering.

lint, typecheck, cpd (0 clones), build:edge and the full 100% line & branch coverage suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTBpdKEefGw6ivXRE5H4ya

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTBpdKEefGw6ivXRE5H4ya)_