### PR TITLE
Fix overlap index migration failing on pre-rename databases

### DIFF
--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -1530,14 +1530,27 @@ export const MIGRATIONS: Migration[] = [
       await syncIndexes();
     },
   }),
-  additive({
+  {
     description:
       "Reorder listing_attendees overlap index to (listing_id, end_at, start_at) so per-day capacity scans skip historical rows",
     // NB: legacy id retained verbatim — this is a stored marker, not display text
     id: "2026-06-13_event_attendees_overlap_index",
     requires: REQ_OVERLAP_INDEX,
-    up: syncIndexes,
-  }),
+    up: async () => {
+      // Pre-rename databases still have the "events" table; "listings" doesn't
+      // exist yet, so syncIndexes() would fail trying to create indexes on it.
+      // The rename_events_to_listings migration that follows calls syncIndexes()
+      // after renaming the tables, which creates the reordered index there.
+      if (await tableExists("events")) return;
+      await syncIndexes();
+    },
+    verify: async () => {
+      // On pre-rename databases the index doesn't exist yet — it lands via the
+      // rename migration's syncIndexes() call. Nothing to verify here.
+      if (await tableExists("events")) return;
+      await verifyRequirement(REQ_OVERLAP_INDEX)();
+    },
+  },
   additive({
     description:
       "Rename the 'event' domain to 'listing' (tables, columns and indexes)",

--- a/test/lib/db/migration-restore.test.ts
+++ b/test/lib/db/migration-restore.test.ts
@@ -207,25 +207,25 @@ describeWithEnv("db > migration restore", { db: true }, () => {
     );
   });
 
+  // Rename the current listing-named tables/columns back to their historical
+  // "event" names, reproducing the pre-rename shape on disk.
+  const downgradeToLegacyNames = () =>
+    getDb().batch(
+      [
+        "ALTER TABLE listings RENAME COLUMN listing_type TO event_type",
+        "ALTER TABLE listings RENAME TO events",
+        "ALTER TABLE listing_attendees RENAME COLUMN listing_id TO event_id",
+        "ALTER TABLE listing_attendees RENAME TO event_attendees",
+        "ALTER TABLE listing_questions RENAME COLUMN listing_id TO event_id",
+        "ALTER TABLE listing_questions RENAME TO event_questions",
+        "ALTER TABLE activity_log RENAME COLUMN listing_id TO event_id",
+        "ALTER TABLE built_sites RENAME COLUMN assigned_listing_id TO assigned_event_id",
+      ],
+      "write",
+    );
+
   describe("rename migration verify", () => {
     const rename = () => migrationById("2026-06-14_rename_events_to_listings");
-
-    // Rename the current listing-named tables/columns back to their historical
-    // "event" names, reproducing the pre-rename shape on disk.
-    const downgradeToLegacyNames = () =>
-      getDb().batch(
-        [
-          "ALTER TABLE listings RENAME COLUMN listing_type TO event_type",
-          "ALTER TABLE listings RENAME TO events",
-          "ALTER TABLE listing_attendees RENAME COLUMN listing_id TO event_id",
-          "ALTER TABLE listing_attendees RENAME TO event_attendees",
-          "ALTER TABLE listing_questions RENAME COLUMN listing_id TO event_id",
-          "ALTER TABLE listing_questions RENAME TO event_questions",
-          "ALTER TABLE activity_log RENAME COLUMN listing_id TO event_id",
-          "ALTER TABLE built_sites RENAME COLUMN assigned_listing_id TO assigned_event_id",
-        ],
-        "write",
-      );
 
     test("rejects while legacy event tables are still present", async () => {
       await downgradeToLegacyNames();
@@ -238,6 +238,23 @@ describeWithEnv("db > migration restore", { db: true }, () => {
       await downgradeToLegacyNames();
       await rename().up();
       await rename().verify();
+    });
+  });
+
+  describe("overlap index migration on pre-rename database", () => {
+    const overlapIdx = () =>
+      migrationById("2026-06-13_event_attendees_overlap_index");
+
+    test("up() is a no-op when legacy 'events' table exists", async () => {
+      await downgradeToLegacyNames();
+      // Must not throw (would fail with "no such table: main.listings" before fix)
+      await overlapIdx().up();
+    });
+
+    test("verify() passes when legacy 'events' table exists", async () => {
+      await downgradeToLegacyNames();
+      // Defers to rename migration — nothing to verify yet
+      await overlapIdx().verify();
     });
   });
 });


### PR DESCRIPTION
## Summary

- `2026-06-13_event_attendees_overlap_index` called `syncIndexes()` which uses the current post-rename SCHEMA. On databases where `current_schema` and `sumup_checkouts` were already applied by the old code, the `events` table still exists and `listings` does not — so `syncIndexes()` failed with `no such table: main.listings`
- Fixed by guarding `up()` and `verify()` with `tableExists("events")`: when the legacy table is present, the migration is a no-op; the rename migration immediately following calls `syncIndexes()` after renaming, which creates the reordered index there instead
- Added two regression tests covering `up()` and `verify()` on a pre-rename database (downgraded via the existing `downgradeToLegacyNames` helper)

## Test plan

- [ ] All existing migration restore tests pass (27 steps)
- [ ] New tests: `overlap index migration on pre-rename database > up() is a no-op when legacy 'events' table exists`
- [ ] New tests: `overlap index migration on pre-rename database > verify() passes when legacy 'events' table exists`
- [ ] Deploy to affected site and confirm migrations complete (events → listings rename runs through successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018x2gdXQJVsdnMZPsDTvfUp

---
_Generated by [Claude Code](https://claude.ai/code/session_018x2gdXQJVsdnMZPsDTvfUp)_