### PR TITLE
Disable browser autofill on admin customer-info fields

### DIFF
--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -670,6 +670,7 @@ const AttendeeEditForm = ({
       <label for="name">
         Name
         <input
+          autocomplete="off"
           autofocus
           id="name"
           name="name"
@@ -684,6 +685,7 @@ const AttendeeEditForm = ({
       <label for="email">
         Email
         <input
+          autocomplete="off"
           id="email"
           name="email"
           type="email"
@@ -694,6 +696,7 @@ const AttendeeEditForm = ({
       <label for="phone">
         Phone
         <input
+          autocomplete="off"
           id="phone"
           name="phone"
           pattern="[+\d][\d\s\-()]{5,}"
@@ -705,7 +708,13 @@ const AttendeeEditForm = ({
 
       <label for="address">
         Address
-        <textarea id="address" maxlength={250} name="address" rows={3}>
+        <textarea
+          autocomplete="off"
+          id="address"
+          maxlength={250}
+          name="address"
+          rows={3}
+        >
           {data.parsed.address || ""}
         </textarea>
       </label>
@@ -713,6 +722,7 @@ const AttendeeEditForm = ({
       <label for="special_instructions">
         Special Instructions
         <textarea
+          autocomplete="off"
           id="special_instructions"
           maxlength={250}
           name="special_instructions"

--- a/src/ui/templates/admin/settings/business-email.tsx
+++ b/src/ui/templates/admin/settings/business-email.tsx
@@ -16,7 +16,7 @@ export const BusinessEmailForm = (s: SettingsPageState): JSX.Element => (
     <label>
       {t("settings.business_email")}
       <input
-        autocomplete="email"
+        autocomplete="off"
         name="business_email"
         placeholder="contact@example.com"
         type="email"

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -1164,7 +1164,14 @@ export const getAddAttendeeFields = (
   isDaily: boolean,
   dayCounts?: number[],
 ): Field[] => {
-  const result = [...getTicketFields(fields, false), addAttendeeQuantityField];
+  // Admin enters a customer's details here, so disable native autofill: we don't
+  // want the operator's browser to store or suggest other customers' PII. The
+  // shared ticket fields keep their semantic autocomplete for the public form,
+  // so override on copies rather than mutating the originals.
+  const contactFields = getTicketFields(fields, false).map(
+    (f): Field => ({ ...f, autocomplete: "off" }),
+  );
+  const result = [...contactFields, addAttendeeQuantityField];
   if (isDaily) result.push(addAttendeeDateField);
   if (dayCounts && dayCounts.length > 0) {
     result.push(addAttendeeDayCountField(dayCounts));

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -1243,6 +1243,7 @@ export const getChangePasswordFields = (): Field[] => [
  */
 export const getStripeKeyFields = (): Field[] => [
   {
+    autocomplete: "off",
     hint: t("fields.stripe.secret_key_hint"),
     label: t("fields.stripe.secret_key"),
     name: "stripe_secret_key",
@@ -1257,6 +1258,7 @@ export const getStripeKeyFields = (): Field[] => [
  */
 export const getSquareAccessTokenFields = (): Field[] => [
   {
+    autocomplete: "off",
     hint: t("fields.square.access_token_hint"),
     label: t("fields.square.access_token"),
     name: "square_access_token",
@@ -1265,6 +1267,7 @@ export const getSquareAccessTokenFields = (): Field[] => [
     type: "password",
   },
   {
+    autocomplete: "off",
     hint: t("fields.square.location_id_hint"),
     label: t("fields.square.location_id"),
     name: "square_location_id",
@@ -1279,6 +1282,7 @@ export const getSquareAccessTokenFields = (): Field[] => [
  */
 export const getSquareWebhookFields = (): Field[] => [
   {
+    autocomplete: "off",
     hint: t("fields.square.webhook_key_hint"),
     label: t("fields.square.webhook_key"),
     name: "square_webhook_signature_key",

--- a/test/lib/forms/ticket-fields.test.ts
+++ b/test/lib/forms/ticket-fields.test.ts
@@ -4,6 +4,7 @@ import { stub } from "@std/testing/mock";
 import { renderFields } from "#shared/forms.tsx";
 import {
   fieldsApi,
+  getAddAttendeeFields,
   getTicketFields,
   mergeListingFields,
   validateAddress,
@@ -95,6 +96,26 @@ describe("getTicketFields — field validation", () => {
     expect(html).toContain('autocomplete="email"');
     expect(html).toContain('autocomplete="tel"');
     expect(html).toContain('autocomplete="street-address"');
+  });
+});
+
+describe("getAddAttendeeFields — autocomplete", () => {
+  test("disables native autofill on the admin contact fields", () => {
+    // Admin enters another person's PII here; the browser must not store or
+    // suggest it, so every contact field is forced to autocomplete="off"
+    // (unlike the public ticket form, which keeps semantic autocomplete).
+    const fields = getAddAttendeeFields("email,phone,address", false);
+    const contactFields = fields.filter((f) =>
+      ["name", "email", "phone", "address"].includes(f.name),
+    );
+    expect(contactFields).toHaveLength(4);
+    for (const field of contactFields) {
+      expect(field.autocomplete).toBe("off");
+    }
+    const html = renderFields(fields);
+    expect(html).not.toContain('autocomplete="email"');
+    expect(html).not.toContain('autocomplete="tel"');
+    expect(html).not.toContain('autocomplete="street-address"');
   });
 });
 


### PR DESCRIPTION
## Problem

In the admin area, operators enter data the browser shouldn't store or suggest:
- **Attendee forms** — customers' personal details (name, email, phone, address).
- **Settings forms** — the business email and payment-provider secrets.

Browsers were offering to autofill/store these because the relevant fields carried semantic `autocomplete` values (`name`/`email`/`tel`/`street-address`/`email`), which override the `<form autocomplete="off">` wrapper. Some payment-secret fields also lacked any `autocomplete`, so password managers could offer to save them.

## Fix

Force `autocomplete="off"` on the admin fields that hold data we don't want cached:

**Attendee forms**
- `getAddAttendeeFields` (inline "add attendee" form) overrides `autocomplete` on **copies** of the shared ticket fields, so the public ticket form keeps its semantic autocomplete while the admin form doesn't.
- The standalone add/edit attendee form (`attendee-form.tsx`) sets `autocomplete="off"` on its inline name/email/phone/address/special-instructions inputs.

**Settings forms**
- Business email input: `autocomplete="email"` → `"off"`.
- Stripe secret key, Square access token / location id, and Square webhook signing key fields now set `autocomplete="off"`, matching the SumUp fields and keeping payment secrets out of the browser's password manager.

Admin **login** (username/password) is intentionally left as-is — those benefit from password managers and aren't customer/secret data the user wanted suppressed. Other settings inputs are radios / file / checkbox / public-content textareas that already inherit the form-level `autocomplete="off"` and don't trigger personal-data autofill.

## Tests

Added a test asserting the admin add-attendee fields render without semantic autocomplete. Existing form, attendee, and settings template tests pass; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)