### PR TITLE
Use targeted user queries for logistics admin

### DIFF
--- a/src/features/admin/settings-logistics.ts
+++ b/src/features/admin/settings-logistics.ts
@@ -43,11 +43,11 @@ import {
 import type { FormParams } from "#shared/form-data.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
 import {
+  type AgentUserOption,
   adminLogisticsAgentDeletePage,
   adminLogisticsAgentEditPage,
   adminLogisticsAgentNewPage,
   adminLogisticsPage,
-  type AgentUserOption,
 } from "#templates/admin/logistics.tsx";
 import { logisticsAgentFields } from "#templates/fields.ts";
 

--- a/src/features/admin/settings-logistics.ts
+++ b/src/features/admin/settings-logistics.ts
@@ -37,16 +37,17 @@ import {
 import {
   decryptAdminLevel,
   decryptUsername,
-  getAllUsers,
+  getAllUserIds,
+  getUserDisplayFields,
 } from "#shared/db/users.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
 import {
-  type AgentUserOption,
   adminLogisticsAgentDeletePage,
   adminLogisticsAgentEditPage,
   adminLogisticsAgentNewPage,
   adminLogisticsPage,
+  type AgentUserOption,
 } from "#templates/admin/logistics.tsx";
 import { logisticsAgentFields } from "#templates/fields.ts";
 
@@ -99,7 +100,7 @@ const crud = createOwnerCrudHandlers({
  * user class can drive an agent — agents only ever see the deliveries page,
  * while owners and managers reach it from the Calendar menu. */
 const loadAgentUserOptions = async (): Promise<AgentUserOption[]> => {
-  const users = await getAllUsers();
+  const users = await getUserDisplayFields();
   return Promise.all(
     users.map(async (user) => ({
       adminLevel: await decryptAdminLevel(user),
@@ -111,7 +112,7 @@ const loadAgentUserOptions = async (): Promise<AgentUserOption[]> => {
 
 /** The chosen `user_ids` reduced to ids that are real users. */
 const parseAssignedUserIds = async (form: FormParams): Promise<number[]> => {
-  const valid = new Set((await getAllUsers()).map((u) => u.id));
+  const valid = new Set(await getAllUserIds());
   return form.getNumberArray("user_ids").filter((id) => valid.has(id));
 };
 

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -214,8 +214,7 @@ export const setUserPassword = async (
 
   await getDb().execute({
     args: [encryptedHash, encryptedNull, encryptedNull, userId],
-    sql:
-      "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
+    sql: "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
   });
   invalidateUsersCache();
 
@@ -323,9 +322,9 @@ export const usersApi = {
   getAllUserIds,
   getAllUsers,
   getUserById,
-  getUserDisplayFields,
   getUserByInviteCode,
   getUserByUsername,
+  getUserDisplayFields,
   hashInviteCode,
   hasPassword,
   invalidateUsersCache,

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -23,6 +23,16 @@ import { type AdminLevel, isAdminLevel, type User } from "#shared/types.ts";
 const USER_SELECT =
   "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users ORDER BY id ASC";
 
+export type UserDisplayFields = Pick<
+  User,
+  "admin_level" | "id" | "username_hash"
+>;
+
+const USER_DISPLAY_SELECT =
+  "SELECT id, username_hash, admin_level FROM users ORDER BY id ASC";
+
+const USER_ID_SELECT = "SELECT id FROM users ORDER BY id ASC";
+
 /**
  * Users change rarely and there are few of them, so the cache loads the whole
  * set and answers by-id / by-username reads from it. The TTL is shorter than
@@ -149,6 +159,14 @@ export const isUsernameTaken = async (username: string): Promise<boolean> => {
  */
 export const getAllUsers = (): Promise<User[]> => loadAllUsers();
 
+/** Get the minimal encrypted user fields needed to show assignable users. */
+export const getUserDisplayFields = (): Promise<UserDisplayFields[]> =>
+  queryAll<UserDisplayFields>(USER_DISPLAY_SELECT);
+
+/** Get all user ids, ordered by id, for validating submitted user links. */
+export const getAllUserIds = async (): Promise<number[]> =>
+  (await queryAll<{ id: number }>(USER_ID_SELECT)).map((row) => row.id);
+
 /**
  * Verify a user's password (decrypt stored hash, then verify)
  * Returns the decrypted password hash if valid (needed for KEK derivation)
@@ -166,7 +184,9 @@ export const verifyUserPassword = async (
 /**
  * Decrypt a user's admin level
  */
-export const decryptAdminLevel = async (user: User): Promise<AdminLevel> => {
+export const decryptAdminLevel = async (
+  user: Pick<User, "admin_level">,
+): Promise<AdminLevel> => {
   const level = await decrypt(user.admin_level);
   if (!isAdminLevel(level)) {
     throw new Error(`Invalid admin level: ${level}`);
@@ -177,8 +197,9 @@ export const decryptAdminLevel = async (user: User): Promise<AdminLevel> => {
 /**
  * Decrypt a user's username
  */
-export const decryptUsername = (user: User): Promise<string> =>
-  decrypt(user.username_hash);
+export const decryptUsername = (
+  user: Pick<User, "username_hash">,
+): Promise<string> => decrypt(user.username_hash);
 
 /**
  * Set a user's password (for invite flow)
@@ -193,7 +214,8 @@ export const setUserPassword = async (
 
   await getDb().execute({
     args: [encryptedHash, encryptedNull, encryptedNull, userId],
-    sql: "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
+    sql:
+      "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
   });
   invalidateUsersCache();
 
@@ -298,8 +320,10 @@ export const usersApi = {
   decryptAdminLevel,
   decryptUsername,
   deleteUser,
+  getAllUserIds,
   getAllUsers,
   getUserById,
+  getUserDisplayFields,
   getUserByInviteCode,
   getUserByUsername,
   hashInviteCode,


### PR DESCRIPTION
### Motivation
- The logistics admin edit flow previously loaded full `users` rows (including password/invite fields) when only a few display/validation fields were needed, causing unnecessary work and broader access to sensitive columns.
- The change reduces query surface and decryption work for the logistics UI by fetching only the minimal fields required to render assignable user options and validate submitted ids.

### Description
- Add `UserDisplayFields`, `USER_DISPLAY_SELECT`, and `USER_ID_SELECT` to `src/shared/db/users.ts` and expose `getUserDisplayFields()` and `getAllUserIds()` helpers that run small targeted queries. 
- Relax `decryptAdminLevel` and `decryptUsername` to accept `Pick<User, ...>` shapes so the targeted query results can be decrypted without full `User` rows. 
- Update `src/features/admin/settings-logistics.ts` to use `getUserDisplayFields()` in `loadAgentUserOptions()` and `getAllUserIds()` in `parseAssignedUserIds()` instead of loading all user records. 
- Export the new helpers from the users API surface so other callers can use the lightweight reads.

### Testing
- Ran formatting and type checks with `deno fmt --check` and `deno check --unstable-tsgo` (via the project's `mise` wrapper), which completed successfully. 
- Ran the logistics server tests with `deno task test:files test/lib/server-logistics.test.ts`, and the test file passed (all steps OK). 
- The changed files were formatted by `deno fmt` as part of the verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c9847a24832daa2655c027ec5148)