### PR TITLE
Reach full coverage for safe fetch paths

### DIFF
--- a/src/features/admin/owner-crud.ts
+++ b/src/features/admin/owner-crud.ts
@@ -39,7 +39,7 @@ type CrudConfig<Row, Input> = {
     successMessage?: string,
   ) => string;
   renderNew: (session: AdminSession, error?: string) => string;
-  renderEdit: (row: Row, session: AdminSession, error?: string) => string;
+  renderEdit?: (row: Row, session: AdminSession, error?: string) => string;
   renderDelete: (row: Row, session: AdminSession, error?: string) => string;
   getName: (row: Row) => string;
 };
@@ -121,7 +121,7 @@ const createCrudHandlersWithAuth = <Row, Input>(
 
   const createPost = authForm(createHandler);
 
-  const editGet = authRowHtml(cfg.renderEdit);
+  const editGet = cfg.renderEdit ? authRowHtml(cfg.renderEdit) : undefined;
 
   const editPost: IdRouteHandler = (request, { id }) =>
     auth.withForm(request, async (_session, form) => {
@@ -157,7 +157,7 @@ const createCrudHandlersWithAuth = <Row, Input>(
     [`GET ${cfg.listPath}`]: listGet,
     [`GET ${cfg.listPath}/new`]: newGet,
     [`POST ${cfg.listPath}`]: createPost,
-    [`GET ${cfg.listPath}/:id/edit`]: editGet,
+    ...(editGet ? { [`GET ${cfg.listPath}/:id/edit`]: editGet } : {}),
     [`POST ${cfg.listPath}/:id/edit`]: editPost,
   } as Record<string, RouteHandlerFn>;
 

--- a/src/features/admin/settings-logistics.ts
+++ b/src/features/admin/settings-logistics.ts
@@ -85,10 +85,6 @@ const crud = createOwnerCrudHandlers({
   getName: (a) => a.name,
   listPath: "/admin/logistics",
   renderDelete: adminLogisticsAgentDeletePage,
-  // The edit GET/POST routes are overridden below to load/save user
-  // assignments; this adapter only keeps the CRUD config types satisfied.
-  renderEdit: (agent, session) =>
-    adminLogisticsAgentEditPage(agent, [], new Set(), session),
   renderList: adminLogisticsPage,
   renderNew: adminLogisticsAgentNewPage,
   resource: logisticsAgentsResource,

--- a/src/shared/safe-fetch.ts
+++ b/src/shared/safe-fetch.ts
@@ -38,11 +38,8 @@ export const fetchTextFollowingSafeRedirects = async (
 ): Promise<FetchResult> => {
   let currentUrl = url;
 
-  for (
-    let redirectCount = 0;
-    redirectCount <= MAX_SAFE_REDIRECTS;
-    redirectCount++
-  ) {
+  let redirectCount = 0;
+  while (true) {
     if (!isSafeServerFetchUrl(currentUrl)) {
       throw new Error("Unsafe redirect URL");
     }
@@ -57,7 +54,6 @@ export const fetchTextFollowingSafeRedirects = async (
     }
 
     currentUrl = resolveRedirectUrl(location, currentUrl);
+    redirectCount++;
   }
-
-  throw new Error("Too many redirects");
 };

--- a/src/shared/url-safety.ts
+++ b/src/shared/url-safety.ts
@@ -18,7 +18,8 @@ const isInternalHostname = (h: string): boolean =>
 
 /** True when the host is an IPv4 or IPv6 literal rather than a real domain. */
 const isIpLiteral = (host: string): boolean => {
-  const h = host.replace(/^\[|\]$/g, "");
+  const h =
+    host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
   if (h.includes(":")) return true;
   return /^(\d{1,3}\.){3}\d{1,3}$/.test(h);
 };
@@ -41,9 +42,9 @@ export const isSafeServerFetchUrl = (raw: string): boolean => {
   const host = url.hostname.toLowerCase();
   return (
     url.protocol === "https:" &&
-    isDomainHostname(host) &&
     !isInternalHostname(host) &&
-    !isIpLiteral(host)
+    !isIpLiteral(host) &&
+    isDomainHostname(host)
   );
 };
 

--- a/test/lib/safe-fetch.test.ts
+++ b/test/lib/safe-fetch.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { FetchResult } from "#shared/fetch.ts";
+import { fetchTextFollowingSafeRedirects } from "#shared/safe-fetch.ts";
+
+const response = (status: number, location?: string): FetchResult => ({
+  headers: new Headers(location ? { location } : undefined),
+  ok: status >= 200 && status < 300,
+  status,
+  text: "body",
+});
+
+describe("safe-fetch", () => {
+  test("returns a redirect response unchanged when location is missing", async () => {
+    const result = await fetchTextFollowingSafeRedirects(
+      "https://example.com/start",
+      undefined,
+      () => Promise.resolve(response(302)),
+    );
+
+    expect(result.status).toBe(302);
+  });
+
+  test("rejects syntactically invalid redirect locations", async () => {
+    await expect(
+      fetchTextFollowingSafeRedirects(
+        "https://example.com/start",
+        undefined,
+        () => Promise.resolve(response(302, "http://[::1")),
+      ),
+    ).rejects.toThrow("Unsafe redirect URL");
+  });
+
+  test("rejects unsafe redirect targets before fetching them", async () => {
+    const seen: string[] = [];
+
+    await expect(
+      fetchTextFollowingSafeRedirects(
+        "https://example.com/start",
+        undefined,
+        (url) => {
+          seen.push(url);
+          return Promise.resolve(response(302, "http://internal.local/hook"));
+        },
+      ),
+    ).rejects.toThrow("Unsafe redirect URL");
+
+    expect(seen).toEqual(["https://example.com/start"]);
+  });
+
+  test("stops after the maximum safe redirect hops", async () => {
+    await expect(
+      fetchTextFollowingSafeRedirects(
+        "https://example.com/start",
+        undefined,
+        () => Promise.resolve(response(302, "/next")),
+      ),
+    ).rejects.toThrow("Too many redirects");
+  });
+});

--- a/test/lib/url-safety.test.ts
+++ b/test/lib/url-safety.test.ts
@@ -36,6 +36,7 @@ describe("url-safety", () => {
       "https://100.64.0.1/", // CGNAT
       "https://8.8.8.8/hook",
       "https://[2001:db8::1]/", // IPv6 literal
+      "https://2001:db8::1/", // bare IPv6-like host fails as an IP literal before domain checks
       "https://[::1]/", // IPv6 loopback
       "https://[fe80::1]/", // IPv6 link-local
       "https://[fc00::1]/", // IPv6 unique-local


### PR DESCRIPTION
### Motivation
- Bring line and branch coverage to 100% for the safe-fetch and URL-safety code paths that were reported as uncovered. 
- Remove or simplify code that was impossible to hit in practice instead of writing tautological tests to cover dead paths. 
- Add outcome-focused tests for redirect handling edge cases so the runtime behavior is verified (malformed redirects, missing Location, unsafe hops, and too many hops).

### Description
- Made the generic CRUD `renderEdit` optional so resources that override the edit GET/POST routes do not need a dead adapter to satisfy the type system by changing `renderEdit` to an optional property in `src/features/admin/owner-crud.ts` and conditionally registering the GET edit route. 
- Removed the unreachable logistics adapter in `src/features/admin/settings-logistics.ts` because logistics registers its own edit handlers and the generic adapter was genuinely dead. 
- Refactored redirect-following loop in `src/shared/safe-fetch.ts` from a bounded `for` loop with an unreachable trailing `throw` into a `while (true)` loop that still enforces `MAX_SAFE_REDIRECTS` before following the next hop. 
- Tightened `isIpLiteral` handling and reordered checks in `src/shared/url-safety.ts` so IP literal detection (including bracketed IPv6) and internal-host checks occur before the public-domain shape test, making IPv6-literal cases meaningful and testable. 
- Added tests in `test/lib/safe-fetch.test.ts` for missing `Location`, malformed redirect URLs, unsafe redirect targets, and excessive redirects, and extended `test/lib/url-safety.test.ts` with a bare IPv6-like host case to exercise the IP-literal branch. 

### Testing
- Ran `deno fmt` on modified files and added tests; formatting succeeded. 
- Ran the focused tests with `deno task test:files` for `test/lib/safe-fetch.test.ts`, `test/lib/url-safety.test.ts` and `test/lib/server-balance.test.ts` and they passed. 
- Initially `deno task precommit` failed in the environment because native `biome` was missing; re-ran the precommit pipeline with `BIOME_NPM=1 deno task precommit` and it passed. 
- Coverage run (`deno task test:coverage` as part of precommit) now shows the previously uncovered branches/lines in `src/shared/safe-fetch.ts` and `src/shared/url-safety.ts` are exercised by tests and the precommit coverage check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d14ebf10832d9783e7cda70e0cc8)