### PR TITLE
Disable aggregate database triggers by default in tests

### DIFF
--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -1039,10 +1039,14 @@ const createIndexesForTable = async (
  * idempotent.
  */
 const createTriggersForTable = async (tableName: string): Promise<void> => {
+  if (areAggregateTriggersDisabledForTest()) return;
   for (const trg of TRIGGERS) {
     if (trg.table === tableName) await runMigration(trg.sql);
   }
 };
+
+const areAggregateTriggersDisabledForTest = (): boolean =>
+  getEnv("DISABLE_AGGREGATE_TRIGGERS_FOR_TEST") === "1";
 
 /**
  * Recreate a table from its SCHEMA definition, preserving data for matching columns.
@@ -1264,8 +1268,10 @@ const syncIndexes = async (): Promise<void> => {
 const syncTriggers = async (): Promise<void> => {
   const live = await snapshotLiveSchema();
   const declaredNames = new Set(TRIGGERS.map((t) => t.name));
-  for (const trg of TRIGGERS) {
-    if (!live.triggers.has(trg.name)) await runMigration(trg.sql);
+  if (!areAggregateTriggersDisabledForTest()) {
+    for (const trg of TRIGGERS) {
+      if (!live.triggers.has(trg.name)) await runMigration(trg.sql);
+    }
   }
   for (const name of live.triggers) {
     if (name.startsWith("trg_") && !declaredNames.has(name)) {
@@ -1341,6 +1347,7 @@ const verifyCurrentAppSchema = async (): Promise<void> => {
     }
   }
 
+  if (areAggregateTriggersDisabledForTest()) return;
   for (const trigger of TRIGGERS) {
     if (!live.triggers.has(trigger.name)) {
       throw new Error(
@@ -1449,6 +1456,7 @@ const assertRequiredTriggers = (
   live: LiveSchema,
   req: SchemaRequirement,
 ): void => {
+  if (areAggregateTriggersDisabledForTest()) return;
   for (const trigger of req.triggers ?? []) {
     if (!live.triggers.has(trigger)) {
       throw new Error(

--- a/test/lib/db/attendees/get-active-listing-stats.test.ts
+++ b/test/lib/db/attendees/get-active-listing-stats.test.ts
@@ -8,105 +8,112 @@ import {
   describeWithEnv,
 } from "#test-utils";
 
-describeWithEnv("db > attendees > getActiveListingStats", { db: true }, () => {
-  test("returns zeros for empty listings", async () => {
-    const stats = await getActiveListingStats([]);
-    expect(stats).toEqual({ attendees: 0, income: 0, tickets: 0 });
-  });
+describeWithEnv(
+  "db > attendees > getActiveListingStats",
+  {
+    db: true,
+    triggers: true,
+  },
+  () => {
+    test("returns zeros for empty listings", async () => {
+      const stats = await getActiveListingStats([]);
+      expect(stats).toEqual({ attendees: 0, income: 0, tickets: 0 });
+    });
 
-  test("returns zeros when all listings inactive", async () => {
-    const listing = await createTestListing({
-      maxAttendees: 50,
-      unitPrice: 500,
+    test("returns zeros when all listings inactive", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      await createPaidTestAttendee(
+        listing.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      const listings = await getAllListings();
+      const inactive = listings.map((e) => ({ ...e, active: false }));
+      const stats = await getActiveListingStats(inactive);
+      expect(stats).toEqual({ attendees: 0, income: 0, tickets: 0 });
     });
-    await createPaidTestAttendee(
-      listing.id,
-      "Alice",
-      "alice@example.com",
-      "pay_1",
-      1000,
-    );
-    const listings = await getAllListings();
-    const inactive = listings.map((e) => ({ ...e, active: false }));
-    const stats = await getActiveListingStats(inactive);
-    expect(stats).toEqual({ attendees: 0, income: 0, tickets: 0 });
-  });
 
-  test("counts tickets and sums income for active listings", async () => {
-    const listing = await createTestListing({
-      maxAttendees: 50,
-      unitPrice: 500,
+    test("counts tickets and sums income for active listings", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      await createPaidTestAttendee(
+        listing.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      await createPaidTestAttendee(
+        listing.id,
+        "Bob",
+        "bob@example.com",
+        "pay_2",
+        2000,
+      );
+      const listings = await getAllListings();
+      const stats = await getActiveListingStats(listings);
+      expect(stats.tickets).toBe(2);
+      expect(stats.income).toBe(3000);
+      expect(stats.attendees).toBe(2);
     });
-    await createPaidTestAttendee(
-      listing.id,
-      "Alice",
-      "alice@example.com",
-      "pay_1",
-      1000,
-    );
-    await createPaidTestAttendee(
-      listing.id,
-      "Bob",
-      "bob@example.com",
-      "pay_2",
-      2000,
-    );
-    const listings = await getAllListings();
-    const stats = await getActiveListingStats(listings);
-    expect(stats.tickets).toBe(2);
-    expect(stats.income).toBe(3000);
-    expect(stats.attendees).toBe(2);
-  });
 
-  test("excludes inactive listings", async () => {
-    const listing1 = await createTestListing({
-      maxAttendees: 50,
-      unitPrice: 500,
+    test("excludes inactive listings", async () => {
+      const listing1 = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      const listing2 = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      await createPaidTestAttendee(
+        listing1.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      await createPaidTestAttendee(
+        listing2.id,
+        "Bob",
+        "bob@example.com",
+        "pay_2",
+        2000,
+      );
+      const listings = await getAllListings();
+      const mixed = listings.map((e) =>
+        e.id === listing2.id ? { ...e, active: false } : e,
+      );
+      const stats = await getActiveListingStats(mixed);
+      expect(stats.tickets).toBe(1);
+      expect(stats.income).toBe(1000);
+      expect(stats.attendees).toBe(1);
     });
-    const listing2 = await createTestListing({
-      maxAttendees: 50,
-      unitPrice: 500,
-    });
-    await createPaidTestAttendee(
-      listing1.id,
-      "Alice",
-      "alice@example.com",
-      "pay_1",
-      1000,
-    );
-    await createPaidTestAttendee(
-      listing2.id,
-      "Bob",
-      "bob@example.com",
-      "pay_2",
-      2000,
-    );
-    const listings = await getAllListings();
-    const mixed = listings.map((e) =>
-      e.id === listing2.id ? { ...e, active: false } : e,
-    );
-    const stats = await getActiveListingStats(mixed);
-    expect(stats.tickets).toBe(1);
-    expect(stats.income).toBe(1000);
-    expect(stats.attendees).toBe(1);
-  });
 
-  test("treats non-numeric price_paid as zero", async () => {
-    const listing = await createTestListing({
-      maxAttendees: 50,
-      unitPrice: 0,
+    test("treats non-numeric price_paid as zero", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 0,
+      });
+      await createPaidTestAttendee(
+        listing.id,
+        "Free Alice",
+        "free@example.com",
+        "",
+        0,
+      );
+      const listings = await getAllListings();
+      const stats = await getActiveListingStats(listings);
+      expect(stats.tickets).toBe(1);
+      expect(stats.income).toBe(0);
+      expect(stats.attendees).toBe(1);
     });
-    await createPaidTestAttendee(
-      listing.id,
-      "Free Alice",
-      "free@example.com",
-      "",
-      0,
-    );
-    const listings = await getAllListings();
-    const stats = await getActiveListingStats(listings);
-    expect(stats.tickets).toBe(1);
-    expect(stats.income).toBe(0);
-    expect(stats.attendees).toBe(1);
-  });
-});
+  },
+);

--- a/test/lib/db/attendees/get-listing-remaining-for-range.test.ts
+++ b/test/lib/db/attendees/get-listing-remaining-for-range.test.ts
@@ -46,7 +46,7 @@ const lowerMaxAttendees = (id: number, max: number): Promise<unknown> =>
 
 describeWithEnv(
   "db > attendees > getListingRemainingForRange",
-  { db: true },
+  { db: true, triggers: true },
   () => {
     test("empty list yields an empty map", async () => {
       const map = await getListingRemainingForRange([], null);

--- a/test/lib/db/groups.test.ts
+++ b/test/lib/db/groups.test.ts
@@ -26,7 +26,7 @@ import {
   describeWithEnv,
 } from "#test-utils";
 
-describeWithEnv("db > groups", { db: true }, () => {
+describeWithEnv("db > groups", { db: true, triggers: true }, () => {
   describe("CRUD", () => {
     test("groupsTable create, update, findById, deleteById", async () => {
       const created = await createTestGroup({

--- a/test/lib/db/listing-aggregates.test.ts
+++ b/test/lib/db/listing-aggregates.test.ts
@@ -12,151 +12,158 @@ import { createTestListing, describeWithEnv } from "#test-utils";
  * moving a row between listings, and leaving the columns untouched when an
  * unrelated column changes.
  */
-describeWithEnv("db > listings aggregate triggers", { db: true }, () => {
-  type Aggregates = {
-    booked_quantity: number;
-    tickets_count: number;
-    income: number;
-  };
-
-  const aggregates = async (listingId: number): Promise<Aggregates> => {
-    const result = await getDb().execute({
-      args: [listingId],
-      sql: "SELECT booked_quantity, tickets_count, income FROM listings WHERE id = ?",
-    });
-    const row = result.rows[0]!;
-    return {
-      booked_quantity: Number(row.booked_quantity),
-      income: Number(row.income),
-      tickets_count: Number(row.tickets_count),
+describeWithEnv(
+  "db > listings aggregate triggers",
+  {
+    db: true,
+    triggers: true,
+  },
+  () => {
+    type Aggregates = {
+      booked_quantity: number;
+      tickets_count: number;
+      income: number;
     };
-  };
 
-  const insertAttendee = (
-    listingId: number,
-    attendeeId: number,
-    quantity: number,
-    pricePaid: number,
-  ): Promise<unknown> =>
-    getDb().execute({
-      args: [listingId, attendeeId, quantity, pricePaid],
-      sql: "INSERT INTO listing_attendees (listing_id, attendee_id, quantity, price_paid) VALUES (?, ?, ?, ?)",
+    const aggregates = async (listingId: number): Promise<Aggregates> => {
+      const result = await getDb().execute({
+        args: [listingId],
+        sql: "SELECT booked_quantity, tickets_count, income FROM listings WHERE id = ?",
+      });
+      const row = result.rows[0]!;
+      return {
+        booked_quantity: Number(row.booked_quantity),
+        income: Number(row.income),
+        tickets_count: Number(row.tickets_count),
+      };
+    };
+
+    const insertAttendee = (
+      listingId: number,
+      attendeeId: number,
+      quantity: number,
+      pricePaid: number,
+    ): Promise<unknown> =>
+      getDb().execute({
+        args: [listingId, attendeeId, quantity, pricePaid],
+        sql: "INSERT INTO listing_attendees (listing_id, attendee_id, quantity, price_paid) VALUES (?, ?, ?, ?)",
+      });
+
+    test("a new listing starts with zeroed aggregates", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      expect(await aggregates(listing.id)).toEqual({
+        booked_quantity: 0,
+        income: 0,
+        tickets_count: 0,
+      });
     });
 
-  test("a new listing starts with zeroed aggregates", async () => {
-    const listing = await createTestListing({ maxAttendees: 50 });
-    expect(await aggregates(listing.id)).toEqual({
-      booked_quantity: 0,
-      income: 0,
-      tickets_count: 0,
-    });
-  });
-
-  test("insert increments quantity, ticket count and income", async () => {
-    const listing = await createTestListing({ maxAttendees: 50 });
-    await insertAttendee(listing.id, 1, 3, 1500);
-    await insertAttendee(listing.id, 2, 2, 1000);
-    expect(await aggregates(listing.id)).toEqual({
-      booked_quantity: 5,
-      income: 2500,
-      tickets_count: 2,
-    });
-  });
-
-  test("delete decrements the row's contribution", async () => {
-    const listing = await createTestListing({ maxAttendees: 50 });
-    await insertAttendee(listing.id, 1, 3, 1500);
-    await insertAttendee(listing.id, 2, 2, 1000);
-    await getDb().execute({
-      args: [listing.id, 1],
-      sql: "DELETE FROM listing_attendees WHERE listing_id = ? AND attendee_id = ?",
-    });
-    expect(await aggregates(listing.id)).toEqual({
-      booked_quantity: 2,
-      income: 1000,
-      tickets_count: 1,
-    });
-  });
-
-  test("updating quantity and price_paid applies the delta", async () => {
-    const listing = await createTestListing({ maxAttendees: 50 });
-    await insertAttendee(listing.id, 1, 3, 1500);
-    await getDb().execute({
-      args: [listing.id, 1],
-      sql: "UPDATE listing_attendees SET quantity = 5, price_paid = 4000 WHERE listing_id = ? AND attendee_id = ?",
-    });
-    expect(await aggregates(listing.id)).toEqual({
-      booked_quantity: 5,
-      income: 4000,
-      tickets_count: 1,
-    });
-  });
-
-  test("moving a row to another listing shifts its aggregates", async () => {
-    const from = await createTestListing({ maxAttendees: 50 });
-    const to = await createTestListing({ maxAttendees: 50 });
-    await insertAttendee(from.id, 1, 4, 2000);
-
-    await getDb().execute({
-      args: [to.id, from.id, 1],
-      sql: "UPDATE listing_attendees SET listing_id = ? WHERE listing_id = ? AND attendee_id = ?",
+    test("insert increments quantity, ticket count and income", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      await insertAttendee(listing.id, 1, 3, 1500);
+      await insertAttendee(listing.id, 2, 2, 1000);
+      expect(await aggregates(listing.id)).toEqual({
+        booked_quantity: 5,
+        income: 2500,
+        tickets_count: 2,
+      });
     });
 
-    expect(await aggregates(from.id)).toEqual({
-      booked_quantity: 0,
-      income: 0,
-      tickets_count: 0,
-    });
-    expect(await aggregates(to.id)).toEqual({
-      booked_quantity: 4,
-      income: 2000,
-      tickets_count: 1,
-    });
-  });
-
-  test("updating an unrelated column leaves aggregates unchanged", async () => {
-    const listing = await createTestListing({ maxAttendees: 50 });
-    await insertAttendee(listing.id, 1, 3, 1500);
-    const before = await aggregates(listing.id);
-
-    // checked_in is not in the trigger's UPDATE OF list, so this must not fire.
-    await getDb().execute({
-      args: [listing.id, 1],
-      sql: "UPDATE listing_attendees SET checked_in = 1 WHERE listing_id = ? AND attendee_id = ?",
+    test("delete decrements the row's contribution", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      await insertAttendee(listing.id, 1, 3, 1500);
+      await insertAttendee(listing.id, 2, 2, 1000);
+      await getDb().execute({
+        args: [listing.id, 1],
+        sql: "DELETE FROM listing_attendees WHERE listing_id = ? AND attendee_id = ?",
+      });
+      expect(await aggregates(listing.id)).toEqual({
+        booked_quantity: 2,
+        income: 1000,
+        tickets_count: 1,
+      });
     });
 
-    expect(await aggregates(listing.id)).toEqual(before);
-  });
-
-  test("the migration's backfill recomputes stale aggregates from scratch", async () => {
-    const listing = await createTestListing({ maxAttendees: 50 });
-    await insertAttendee(listing.id, 1, 3, 1500);
-    await insertAttendee(listing.id, 2, 2, 1000);
-
-    // Reproduce a pre-trigger state: drop the triggers, then corrupt the
-    // columns directly (no trigger fires to correct them).
-    const migration = MIGRATIONS.find(
-      (m) => m.id === "2026-06-16_listing_aggregates",
-    )!;
-    await getDb().batch(
-      [
-        "DROP TRIGGER IF EXISTS trg_listing_attendees_aggregates_insert",
-        "DROP TRIGGER IF EXISTS trg_listing_attendees_aggregates_delete",
-        "DROP TRIGGER IF EXISTS trg_listing_attendees_aggregates_update",
-      ],
-      "write",
-    );
-    await getDb().execute(
-      "UPDATE listings SET booked_quantity = 999, tickets_count = 999, income = 999",
-    );
-
-    // Re-running up() recreates the triggers and recomputes the absolute totals.
-    await migration.up();
-
-    expect(await aggregates(listing.id)).toEqual({
-      booked_quantity: 5,
-      income: 2500,
-      tickets_count: 2,
+    test("updating quantity and price_paid applies the delta", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      await insertAttendee(listing.id, 1, 3, 1500);
+      await getDb().execute({
+        args: [listing.id, 1],
+        sql: "UPDATE listing_attendees SET quantity = 5, price_paid = 4000 WHERE listing_id = ? AND attendee_id = ?",
+      });
+      expect(await aggregates(listing.id)).toEqual({
+        booked_quantity: 5,
+        income: 4000,
+        tickets_count: 1,
+      });
     });
-  });
-});
+
+    test("moving a row to another listing shifts its aggregates", async () => {
+      const from = await createTestListing({ maxAttendees: 50 });
+      const to = await createTestListing({ maxAttendees: 50 });
+      await insertAttendee(from.id, 1, 4, 2000);
+
+      await getDb().execute({
+        args: [to.id, from.id, 1],
+        sql: "UPDATE listing_attendees SET listing_id = ? WHERE listing_id = ? AND attendee_id = ?",
+      });
+
+      expect(await aggregates(from.id)).toEqual({
+        booked_quantity: 0,
+        income: 0,
+        tickets_count: 0,
+      });
+      expect(await aggregates(to.id)).toEqual({
+        booked_quantity: 4,
+        income: 2000,
+        tickets_count: 1,
+      });
+    });
+
+    test("updating an unrelated column leaves aggregates unchanged", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      await insertAttendee(listing.id, 1, 3, 1500);
+      const before = await aggregates(listing.id);
+
+      // checked_in is not in the trigger's UPDATE OF list, so this must not fire.
+      await getDb().execute({
+        args: [listing.id, 1],
+        sql: "UPDATE listing_attendees SET checked_in = 1 WHERE listing_id = ? AND attendee_id = ?",
+      });
+
+      expect(await aggregates(listing.id)).toEqual(before);
+    });
+
+    test("the migration's backfill recomputes stale aggregates from scratch", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      await insertAttendee(listing.id, 1, 3, 1500);
+      await insertAttendee(listing.id, 2, 2, 1000);
+
+      // Reproduce a pre-trigger state: drop the triggers, then corrupt the
+      // columns directly (no trigger fires to correct them).
+      const migration = MIGRATIONS.find(
+        (m) => m.id === "2026-06-16_listing_aggregates",
+      )!;
+      await getDb().batch(
+        [
+          "DROP TRIGGER IF EXISTS trg_listing_attendees_aggregates_insert",
+          "DROP TRIGGER IF EXISTS trg_listing_attendees_aggregates_delete",
+          "DROP TRIGGER IF EXISTS trg_listing_attendees_aggregates_update",
+        ],
+        "write",
+      );
+      await getDb().execute(
+        "UPDATE listings SET booked_quantity = 999, tickets_count = 999, income = 999",
+      );
+
+      // Re-running up() recreates the triggers and recomputes the absolute totals.
+      await migration.up();
+
+      expect(await aggregates(listing.id)).toEqual({
+        booked_quantity: 5,
+        income: 2500,
+        tickets_count: 2,
+      });
+    });
+  },
+);

--- a/test/lib/db/listings.test.ts
+++ b/test/lib/db/listings.test.ts
@@ -46,7 +46,7 @@ import {
   getTestPrivateKey,
 } from "#test-utils";
 
-describeWithEnv("db > listings", { db: true }, () => {
+describeWithEnv("db > listings", { db: true, triggers: true }, () => {
   describe("CRUD", () => {
     test("createListing creates listing with correct properties", async () => {
       const listing = await createTestListing({

--- a/test/lib/db/migration-restore.test.ts
+++ b/test/lib/db/migration-restore.test.ts
@@ -17,7 +17,7 @@ import { describeWithEnv } from "#test-utils";
  * and verify() for each migration in isolation, and keeps each migration's
  * declared `requires` honest against what up() actually creates.
  */
-describeWithEnv("db > migration restore", { db: true }, () => {
+describeWithEnv("db > migration restore", { db: true, triggers: true }, () => {
   const migrationById = (id: string): Migration =>
     MIGRATIONS.find((m) => m.id === id)!;
 

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -35,7 +35,7 @@ import {
   withFetchMock,
 } from "#test-utils";
 
-describeWithEnv("db > migrations", { db: true }, () => {
+describeWithEnv("db > migrations", { db: true, triggers: true }, () => {
   const markCurrentSchemaMigrationPending = () => {
     // Clearing recorded history must also clear the per-isolate ready cache,
     // otherwise initDb never re-inspects this client.

--- a/test/lib/db/modifier-aggregates.test.ts
+++ b/test/lib/db/modifier-aggregates.test.ts
@@ -13,170 +13,177 @@ import { describeWithEnv } from "#test-utils";
  * moving a row between modifiers, and leaving the columns untouched when an
  * unrelated column changes.
  */
-describeWithEnv("db > modifiers aggregate triggers", { db: true }, () => {
-  type Aggregates = {
-    total_uses: number;
-    usage_count: number;
-    total_revenue: number;
-  };
-
-  const makeModifier = () =>
-    modifiersTable.insert({
-      calcKind: "fixed",
-      calcValue: 5,
-      direction: "charge",
-      name: "Add-on",
-    });
-
-  const aggregates = async (modifierId: number): Promise<Aggregates> => {
-    const result = await getDb().execute({
-      args: [modifierId],
-      sql: "SELECT total_uses, usage_count, total_revenue FROM modifiers WHERE id = ?",
-    });
-    const row = result.rows[0]!;
-    return {
-      total_revenue: Number(row.total_revenue),
-      total_uses: Number(row.total_uses),
-      usage_count: Number(row.usage_count),
+describeWithEnv(
+  "db > modifiers aggregate triggers",
+  {
+    db: true,
+    triggers: true,
+  },
+  () => {
+    type Aggregates = {
+      total_uses: number;
+      usage_count: number;
+      total_revenue: number;
     };
-  };
 
-  const insertUsage = (
-    modifierId: number,
-    attendeeId: number,
-    quantity: number,
-    amountApplied: number,
-  ): Promise<unknown> =>
-    getDb().execute({
-      args: [modifierId, attendeeId, quantity, amountApplied, "2026-06-17"],
-      sql: "INSERT INTO modifier_usages (modifier_id, attendee_id, quantity, amount_applied, created) VALUES (?, ?, ?, ?, ?)",
+    const makeModifier = () =>
+      modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "Add-on",
+      });
+
+    const aggregates = async (modifierId: number): Promise<Aggregates> => {
+      const result = await getDb().execute({
+        args: [modifierId],
+        sql: "SELECT total_uses, usage_count, total_revenue FROM modifiers WHERE id = ?",
+      });
+      const row = result.rows[0]!;
+      return {
+        total_revenue: Number(row.total_revenue),
+        total_uses: Number(row.total_uses),
+        usage_count: Number(row.usage_count),
+      };
+    };
+
+    const insertUsage = (
+      modifierId: number,
+      attendeeId: number,
+      quantity: number,
+      amountApplied: number,
+    ): Promise<unknown> =>
+      getDb().execute({
+        args: [modifierId, attendeeId, quantity, amountApplied, "2026-06-17"],
+        sql: "INSERT INTO modifier_usages (modifier_id, attendee_id, quantity, amount_applied, created) VALUES (?, ?, ?, ?, ?)",
+      });
+
+    test("a new modifier starts with zeroed aggregates", async () => {
+      const m = await makeModifier();
+      expect(await aggregates(m.id)).toEqual({
+        total_revenue: 0,
+        total_uses: 0,
+        usage_count: 0,
+      });
     });
 
-  test("a new modifier starts with zeroed aggregates", async () => {
-    const m = await makeModifier();
-    expect(await aggregates(m.id)).toEqual({
-      total_revenue: 0,
-      total_uses: 0,
-      usage_count: 0,
-    });
-  });
-
-  test("modifiersTable read exposes the trigger-maintained aggregates", async () => {
-    const m = await makeModifier();
-    await insertUsage(m.id, 1, 3, 1500);
-    const reread = await modifiersTable.findById(m.id);
-    expect(reread).toMatchObject({
-      total_revenue: 1500,
-      total_uses: 3,
-      usage_count: 1,
-    });
-  });
-
-  test("insert increments uses, usage count and revenue", async () => {
-    const m = await makeModifier();
-    await insertUsage(m.id, 1, 3, 1500);
-    await insertUsage(m.id, 2, 2, 1000);
-    expect(await aggregates(m.id)).toEqual({
-      total_revenue: 2500,
-      total_uses: 5,
-      usage_count: 2,
-    });
-  });
-
-  test("delete decrements the row's contribution", async () => {
-    const m = await makeModifier();
-    await insertUsage(m.id, 1, 3, 1500);
-    await insertUsage(m.id, 2, 2, 1000);
-    await getDb().execute({
-      args: [m.id, 1],
-      sql: "DELETE FROM modifier_usages WHERE modifier_id = ? AND attendee_id = ?",
-    });
-    expect(await aggregates(m.id)).toEqual({
-      total_revenue: 1000,
-      total_uses: 2,
-      usage_count: 1,
-    });
-  });
-
-  test("updating quantity and amount_applied applies the delta", async () => {
-    const m = await makeModifier();
-    await insertUsage(m.id, 1, 3, 1500);
-    await getDb().execute({
-      args: [m.id, 1],
-      sql: "UPDATE modifier_usages SET quantity = 5, amount_applied = 4000 WHERE modifier_id = ? AND attendee_id = ?",
-    });
-    expect(await aggregates(m.id)).toEqual({
-      total_revenue: 4000,
-      total_uses: 5,
-      usage_count: 1,
-    });
-  });
-
-  test("moving a row to another modifier shifts its aggregates", async () => {
-    const from = await makeModifier();
-    const to = await makeModifier();
-    await insertUsage(from.id, 1, 4, 2000);
-
-    await getDb().execute({
-      args: [to.id, from.id, 1],
-      sql: "UPDATE modifier_usages SET modifier_id = ? WHERE modifier_id = ? AND attendee_id = ?",
+    test("modifiersTable read exposes the trigger-maintained aggregates", async () => {
+      const m = await makeModifier();
+      await insertUsage(m.id, 1, 3, 1500);
+      const reread = await modifiersTable.findById(m.id);
+      expect(reread).toMatchObject({
+        total_revenue: 1500,
+        total_uses: 3,
+        usage_count: 1,
+      });
     });
 
-    expect(await aggregates(from.id)).toEqual({
-      total_revenue: 0,
-      total_uses: 0,
-      usage_count: 0,
-    });
-    expect(await aggregates(to.id)).toEqual({
-      total_revenue: 2000,
-      total_uses: 4,
-      usage_count: 1,
-    });
-  });
-
-  test("updating an unrelated column leaves aggregates unchanged", async () => {
-    const m = await makeModifier();
-    await insertUsage(m.id, 1, 3, 1500);
-    const before = await aggregates(m.id);
-
-    // created is not in the trigger's UPDATE OF list, so this must not fire.
-    await getDb().execute({
-      args: [m.id, 1],
-      sql: "UPDATE modifier_usages SET created = '2099-01-01' WHERE modifier_id = ? AND attendee_id = ?",
+    test("insert increments uses, usage count and revenue", async () => {
+      const m = await makeModifier();
+      await insertUsage(m.id, 1, 3, 1500);
+      await insertUsage(m.id, 2, 2, 1000);
+      expect(await aggregates(m.id)).toEqual({
+        total_revenue: 2500,
+        total_uses: 5,
+        usage_count: 2,
+      });
     });
 
-    expect(await aggregates(m.id)).toEqual(before);
-  });
-
-  test("the migration's backfill recomputes stale aggregates from scratch", async () => {
-    const m = await makeModifier();
-    await insertUsage(m.id, 1, 3, 1500);
-    await insertUsage(m.id, 2, 2, 1000);
-
-    // Reproduce a pre-trigger state: drop the triggers, then corrupt the
-    // columns directly (no trigger fires to correct them).
-    const migration = MIGRATIONS.find(
-      (mig) => mig.id === "2026-06-17_modifier_aggregates",
-    )!;
-    await getDb().batch(
-      [
-        "DROP TRIGGER IF EXISTS trg_modifier_usages_aggregates_insert",
-        "DROP TRIGGER IF EXISTS trg_modifier_usages_aggregates_delete",
-        "DROP TRIGGER IF EXISTS trg_modifier_usages_aggregates_update",
-      ],
-      "write",
-    );
-    await getDb().execute(
-      "UPDATE modifiers SET total_uses = 999, usage_count = 999, total_revenue = 999",
-    );
-
-    // Re-running up() recreates the triggers and recomputes the absolute totals.
-    await migration.up();
-
-    expect(await aggregates(m.id)).toEqual({
-      total_revenue: 2500,
-      total_uses: 5,
-      usage_count: 2,
+    test("delete decrements the row's contribution", async () => {
+      const m = await makeModifier();
+      await insertUsage(m.id, 1, 3, 1500);
+      await insertUsage(m.id, 2, 2, 1000);
+      await getDb().execute({
+        args: [m.id, 1],
+        sql: "DELETE FROM modifier_usages WHERE modifier_id = ? AND attendee_id = ?",
+      });
+      expect(await aggregates(m.id)).toEqual({
+        total_revenue: 1000,
+        total_uses: 2,
+        usage_count: 1,
+      });
     });
-  });
-});
+
+    test("updating quantity and amount_applied applies the delta", async () => {
+      const m = await makeModifier();
+      await insertUsage(m.id, 1, 3, 1500);
+      await getDb().execute({
+        args: [m.id, 1],
+        sql: "UPDATE modifier_usages SET quantity = 5, amount_applied = 4000 WHERE modifier_id = ? AND attendee_id = ?",
+      });
+      expect(await aggregates(m.id)).toEqual({
+        total_revenue: 4000,
+        total_uses: 5,
+        usage_count: 1,
+      });
+    });
+
+    test("moving a row to another modifier shifts its aggregates", async () => {
+      const from = await makeModifier();
+      const to = await makeModifier();
+      await insertUsage(from.id, 1, 4, 2000);
+
+      await getDb().execute({
+        args: [to.id, from.id, 1],
+        sql: "UPDATE modifier_usages SET modifier_id = ? WHERE modifier_id = ? AND attendee_id = ?",
+      });
+
+      expect(await aggregates(from.id)).toEqual({
+        total_revenue: 0,
+        total_uses: 0,
+        usage_count: 0,
+      });
+      expect(await aggregates(to.id)).toEqual({
+        total_revenue: 2000,
+        total_uses: 4,
+        usage_count: 1,
+      });
+    });
+
+    test("updating an unrelated column leaves aggregates unchanged", async () => {
+      const m = await makeModifier();
+      await insertUsage(m.id, 1, 3, 1500);
+      const before = await aggregates(m.id);
+
+      // created is not in the trigger's UPDATE OF list, so this must not fire.
+      await getDb().execute({
+        args: [m.id, 1],
+        sql: "UPDATE modifier_usages SET created = '2099-01-01' WHERE modifier_id = ? AND attendee_id = ?",
+      });
+
+      expect(await aggregates(m.id)).toEqual(before);
+    });
+
+    test("the migration's backfill recomputes stale aggregates from scratch", async () => {
+      const m = await makeModifier();
+      await insertUsage(m.id, 1, 3, 1500);
+      await insertUsage(m.id, 2, 2, 1000);
+
+      // Reproduce a pre-trigger state: drop the triggers, then corrupt the
+      // columns directly (no trigger fires to correct them).
+      const migration = MIGRATIONS.find(
+        (mig) => mig.id === "2026-06-17_modifier_aggregates",
+      )!;
+      await getDb().batch(
+        [
+          "DROP TRIGGER IF EXISTS trg_modifier_usages_aggregates_insert",
+          "DROP TRIGGER IF EXISTS trg_modifier_usages_aggregates_delete",
+          "DROP TRIGGER IF EXISTS trg_modifier_usages_aggregates_update",
+        ],
+        "write",
+      );
+      await getDb().execute(
+        "UPDATE modifiers SET total_uses = 999, usage_count = 999, total_revenue = 999",
+      );
+
+      // Re-running up() recreates the triggers and recomputes the absolute totals.
+      await migration.up();
+
+      expect(await aggregates(m.id)).toEqual({
+        total_revenue: 2500,
+        total_uses: 5,
+        usage_count: 2,
+      });
+    });
+  },
+);

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -19,7 +19,9 @@ import {
   updateTestBuiltSite,
 } from "#test-utils";
 
-describeWithEnv("server (admin built sites)", { db: true }, () => {
+const builtSitesTestEnv = { db: true, triggers: true };
+
+describeWithEnv("server (admin built sites)", builtSitesTestEnv, () => {
   describe("GET /admin/built-sites", () => {
     testRequiresAuth("/admin/built-sites");
 

--- a/test/lib/server-calendar.test.ts
+++ b/test/lib/server-calendar.test.ts
@@ -84,7 +84,7 @@ async function setupMixedBookings(
 
 describeWithEnv(
   "admin calendar",
-  { db: true, env: { NTFY_URL: undefined } },
+  { db: true, env: { NTFY_URL: undefined }, triggers: true },
   () => {
     describe("GET /admin/calendar", () => {
       testRequiresAuth("/admin/calendar");

--- a/test/lib/server-order.test.ts
+++ b/test/lib/server-order.test.ts
@@ -19,7 +19,7 @@ const selectOrder = (ids: number[]): Promise<Response> => {
   return handleRequest(mockRequest(`/order?${query}`));
 };
 
-describeWithEnv("server (public order)", { db: true }, () => {
+describeWithEnv("server (public order)", { db: true, triggers: true }, () => {
   describe("availability guard", () => {
     test("redirects to admin login when the public site is disabled", async () => {
       await settings.update.orderEnabled(true);

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -24,7 +24,7 @@ import {
   withMocks,
 } from "#test-utils";
 
-describeWithEnv("server (payment flow)", { db: true }, () => {
+describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
   describe("GET /payment/success", () => {
     test("returns error for missing session_id", async () => {
       const response = await handleRequest(mockRequest("/payment/success"));

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -50,7 +50,7 @@ const expectReservedRedirectWithTokens = (response: Response): void => {
   expect(location).toMatch(/^\/ticket\/reserved\?tokens=.+$/);
 };
 
-describeWithEnv("server (public routes)", { db: true }, () => {
+describeWithEnv("server (public routes)", { db: true, triggers: true }, () => {
   describe("GET /", () => {
     test("redirects to admin when public site is disabled", async () => {
       const response = await handleRequest(mockRequest("/"));

--- a/test/routes/api.test.ts
+++ b/test/routes/api.test.ts
@@ -56,7 +56,7 @@ const expectCorsHeaders = (response: Response): void => {
   expect(response.headers.get("access-control-allow-origin")).toBe("*");
 };
 
-describeWithEnv("Public API", { db: true }, () => {
+describeWithEnv("Public API", { db: true, triggers: true }, () => {
   beforeEach(async () => {
     await settings.update.showPublicApi(true);
   });

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -32,7 +32,7 @@ import {
   TEST_ADMIN_USERNAME,
 } from "#test-utils/internal.ts";
 
-const prepareTestClient = async (): Promise<void> => {
+const prepareTestClient = async (triggers = false): Promise<void> => {
   setupTestEncryptionKey();
   settings.setup.clearCache();
   resetSessionCache();
@@ -42,19 +42,25 @@ const prepareTestClient = async (): Promise<void> => {
   invalidateGroupsCache();
   invalidateLogisticsAgentsCache();
 
-  setTestEnv({ DB_URL: ":memory:" });
+  setTestEnv({
+    DB_URL: ":memory:",
+    DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: triggers ? undefined : "1",
+  });
   const client = createClient({ url: ":memory:" });
   setDb(client);
   await initDb({ allowMissingSettings: true });
 };
 
-export const createTestDb = async (): Promise<void> => {
-  await prepareTestClient();
+export const createTestDb = async (triggers = false): Promise<void> => {
+  await prepareTestClient(triggers);
   resetTestSession();
 };
 
-export const createTestDbWithSetup = async (country = "GB"): Promise<void> => {
-  await prepareTestClient();
+export const createTestDbWithSetup = async (
+  country = "GB",
+  triggers = false,
+): Promise<void> => {
+  await prepareTestClient(triggers);
   resetTestSession();
 
   if (getCachedSetupSettings()) {
@@ -210,7 +216,7 @@ export const describeWithEnv = (
         setHostEmailConfigForTest(null);
         settings.appleWallet.setHostConfigForTest(null);
         settings.googleWallet.setHostConfigForTest(null);
-        await createTestDbWithSetup();
+        await createTestDbWithSetup("GB", options.triggers ?? false);
       }
       if (options.env) restoreEnv = setTestEnv(options.env);
     });

--- a/test/test-utils/internal.ts
+++ b/test/test-utils/internal.ts
@@ -55,6 +55,7 @@ export interface DescribeEnvOptions {
   db?: boolean;
   encryptionKey?: boolean;
   env?: Record<string, string | undefined>;
+  triggers?: boolean;
 }
 
 export interface TestRequestOptions {


### PR DESCRIPTION
### Motivation

- Aggregate-maintenance triggers (listings/modifiers) are useful in production but slow down every DB write in tests; tests that don't exercise triggers should run without them to improve performance and determinism.
- Provide a minimal switch to skip trigger creation/verification in test databases while keeping the trigger SQL unchanged for production and for tests that explicitly opt-in.

### Description

- Add a test-only toggle checked via `DISABLE_AGGREGATE_TRIGGERS_FOR_TEST` (helper `areAggregateTriggersDisabledForTest()` in `src/shared/db/migrations.ts`) and early-return in trigger creation, sync, and verification paths when disabled.
- Skip trigger checks in `createTriggersForTable()`, `syncTriggers()`, `verifyCurrentAppSchema()` and `assertRequiredTriggers()` when the toggle is active so DDL/verify still runs but triggers are not created/required.
- Make the test DB setup disable aggregate triggers by default by passing `DISABLE_AGGREGATE_TRIGGERS_FOR_TEST=1` in `test/test-utils/db.ts` unless a new `triggers` option is set.
- Add a `triggers?: boolean` field to `DescribeEnvOptions` and propagate it through `describeWithEnv()` and `createTestDbWithSetup()` so tests that target trigger behaviour can opt in; update all trigger-dependent tests to set `triggers: true`.

### Testing

- Ran the trigger-focused unit tests (`test/lib/db/listing-aggregates.test.ts`, `test/lib/db/modifier-aggregates.test.ts`, `test/lib/db/migration-restore.test.ts`, `test/lib/db/migrations.test.ts`) while enabling triggers for those suites, and they passed locally.
- Ran the full precommit pipeline with `deno task precommit` (lint, typecheck, cpd, build:static and the test coverage run) and it completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d40b6adc832db4d41ccfc9c53925)