### PR TITLE
SMS webhook freshness and replay protection

### DIFF
--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -15,6 +15,10 @@ import { createRouter, defineRoutes } from "#routes/router.ts";
 import { constantTimeEqual } from "#shared/crypto/utils.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import { findAttendeeIdByPhoneIndex } from "#shared/db/attendee-phone-index.ts";
+import {
+  claimProcessedSmsInbound,
+  pruneProcessedSmsInboundBefore,
+} from "#shared/db/processed-sms-inbound.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   deleteSmsMessage,
@@ -28,6 +32,9 @@ import { computePhoneIndex } from "#shared/sms/phone-index.ts";
 
 /** How long to keep id→attendee rows as a backstop for missed webhooks. */
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Maximum signed webhook age/skew accepted, matching Stripe-style Unix seconds. */
+const SMS_WEBHOOK_TOLERANCE_SECONDS = 300;
 
 const EnvelopeSchema = v.object({
   event: v.string(),
@@ -48,6 +55,15 @@ const hmacHex = async (secret: string, message: string): Promise<string> => {
   return new Uint8Array(sig).toHex();
 };
 
+/** Parse the signed Unix-seconds timestamp and enforce freshness. */
+const isFreshTimestamp = (timestamp: string): boolean => {
+  if (!/^\d+$/.test(timestamp)) return false;
+  const seconds = Number(timestamp);
+  if (!Number.isSafeInteger(seconds)) return false;
+  const nowSeconds = Math.floor(nowMs() / 1000);
+  return Math.abs(nowSeconds - seconds) <= SMS_WEBHOOK_TOLERANCE_SECONDS;
+};
+
 /** Verify the X-Signature / X-Timestamp headers against the raw body. */
 const isValidSignature = async (
   request: Request,
@@ -56,7 +72,7 @@ const isValidSignature = async (
 ): Promise<boolean> => {
   const signature = request.headers.get("x-signature");
   const timestamp = request.headers.get("x-timestamp");
-  if (!signature || !timestamp) return false;
+  if (!signature || !timestamp || !isFreshTimestamp(timestamp)) return false;
   const expected = await hmacHex(secret, rawBody + timestamp);
   return constantTimeEqual(expected, signature);
 };
@@ -101,10 +117,14 @@ const handleStatus = (
     await deleteSmsMessage(row.id);
   });
 
+const inboundWebhookId = (payload: Record<string, unknown>): string =>
+  str(payload.messageId) || str(payload.id);
+
 const handleReceived = async (
   payload: Record<string, unknown>,
   passphrase: string,
 ): Promise<void> => {
+  if (!(await claimProcessedSmsInbound(inboundWebhookId(payload)))) return;
   const message = await tryDecrypt(str(payload.message), passphrase);
   const sender = await tryDecrypt(str(payload.sender), passphrase);
   const attendeeId = await findAttendeeIdByPhoneIndex(
@@ -140,7 +160,9 @@ export const handleSmsWebhook = async (request: Request): Promise<Response> => {
   }
 
   // Backstop cleanup for rows whose delivery webhook never arrived.
-  await pruneSmsMessagesBefore(new Date(nowMs() - RETENTION_MS).toISOString());
+  const retentionCutoff = new Date(nowMs() - RETENTION_MS).toISOString();
+  await pruneSmsMessagesBefore(retentionCutoff);
+  await pruneProcessedSmsInboundBefore(retentionCutoff);
 
   return jsonResponse({ ok: true });
 };

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -53,7 +53,7 @@ type Trigger = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "rename the event domain to listing (tables, columns and indexes); add a global sort_order column to questions for unified ordering; add email_preferences table for marketing opt-outs and contact history; add customisable_days and day_prices columns to listings for visitor-chosen multi-day bookings with per-day-count pricing; add attendee_statuses table with status_id and remaining_balance on attendees, plus attendee_id on activity_log, for the reservation and balance-payment flow; add idx_activity_log_listing_id so per-listing activity log reads are index scans instead of full-table scans; add a logistics_agents table plus a uses_logistics flag on listings, a split_logistics_agents flag on attendees, and start_agent_id/end_agent_id/start_time/end_time on listing_attendees for the logistics flow; add email_templates table for owner-keypair-encrypted reusable email subjects and bodies; add a user_logistics_agents table linking agent users to the logistics agents they drive, plus start_done/end_done flags on listing_attendees so delivery agents can mark drop-offs and collections complete; add failure_data to processed_payments so handled payment failures are recorded as a terminal outcome for idempotent redirect/webhook replay; add booked_quantity, tickets_count and income aggregate columns to listings, maintained by triggers on listing_attendees so listing reads and active-listing stats avoid scanning the attendee rows; add modifiers table for owner-defined price modifiers (surcharges, discounts, add-ons), with active/trigger/code_index/scope/stock/max_per_order/min_subtotal columns plus modifier_listings, modifier_groups and modifier_usages tables for scoping and stock; add an encrypted code column to modifiers for promo-code modifiers; add sms_messages table mapping gateway message ids to attendees for SMS status webhooks (content lives in the encrypted activity log); add phone_index to attendees so inbound SMS replies can be matched to an attendee";
+  "rename the event domain to listing (tables, columns and indexes); add a global sort_order column to questions for unified ordering; add email_preferences table for marketing opt-outs and contact history; add customisable_days and day_prices columns to listings for visitor-chosen multi-day bookings with per-day-count pricing; add attendee_statuses table with status_id and remaining_balance on attendees, plus attendee_id on activity_log, for the reservation and balance-payment flow; add idx_activity_log_listing_id so per-listing activity log reads are index scans instead of full-table scans; add a logistics_agents table plus a uses_logistics flag on listings, a split_logistics_agents flag on attendees, and start_agent_id/end_agent_id/start_time/end_time on listing_attendees for the logistics flow; add email_templates table for owner-keypair-encrypted reusable email subjects and bodies; add a user_logistics_agents table linking agent users to the logistics agents they drive, plus start_done/end_done flags on listing_attendees so delivery agents can mark drop-offs and collections complete; add failure_data to processed_payments so handled payment failures are recorded as a terminal outcome for idempotent redirect/webhook replay; add booked_quantity, tickets_count and income aggregate columns to listings, maintained by triggers on listing_attendees so listing reads and active-listing stats avoid scanning the attendee rows; add modifiers table for owner-defined price modifiers (surcharges, discounts, add-ons), with active/trigger/code_index/scope/stock/max_per_order/min_subtotal columns plus modifier_listings, modifier_groups and modifier_usages tables for scoping and stock; add an encrypted code column to modifiers for promo-code modifiers; add sms_messages table mapping gateway message ids to attendees for SMS status webhooks (content lives in the encrypted activity log); add processed_sms_inbound table for inbound SMS webhook replay protection; add phone_index to attendees so inbound SMS replies can be matched to an attendee";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 
@@ -713,6 +713,21 @@ const SCHEMA: [name: string, table: Table][] = [
       indexes: [
         { columns: ["provider_id"], name: "idx_sms_messages_provider_id" },
         { columns: ["created"], name: "idx_sms_messages_created" },
+      ],
+    },
+  ],
+
+  [
+    // Short-lived inbound idempotency ledger keyed by the gateway's stable
+    // inbound id. Contains no SMS content or sender number.
+    "processed_sms_inbound",
+    {
+      columns: [
+        ["webhook_id", "TEXT PRIMARY KEY"],
+        ["created", "TEXT NOT NULL"],
+      ],
+      indexes: [
+        { columns: ["created"], name: "idx_processed_sms_inbound_created" },
       ],
     },
   ],
@@ -1628,6 +1643,10 @@ const REQ_SMS_MESSAGES: SchemaRequirement = {
   indexes: ["idx_sms_messages_provider_id", "idx_sms_messages_created"],
   newTables: ["sms_messages"],
 };
+const REQ_PROCESSED_SMS_INBOUND: SchemaRequirement = {
+  indexes: ["idx_processed_sms_inbound_created"],
+  newTables: ["processed_sms_inbound"],
+};
 const REQ_ATTENDEE_PHONE_INDEX: SchemaRequirement = {
   columns: { attendees: ["phone_index"] },
   indexes: ["idx_attendees_phone_index"],
@@ -1824,6 +1843,16 @@ export const MIGRATIONS: Migration[] = [
       "Add sms_messages table mapping gateway message ids to attendees for status webhooks (PII-free; content lives in the activity log)",
     id: "2026-06-16_sms_messages",
     requires: REQ_SMS_MESSAGES,
+    up: async () => {
+      await applySchemaChanges();
+      await syncIndexes();
+    },
+  }),
+  additive({
+    description:
+      "Add processed_sms_inbound table for inbound SMS webhook replay protection",
+    id: "2026-06-17_processed_sms_inbound",
+    requires: REQ_PROCESSED_SMS_INBOUND,
     up: async () => {
       await applySchemaChanges();
       await syncIndexes();

--- a/src/shared/db/processed-sms-inbound.ts
+++ b/src/shared/db/processed-sms-inbound.ts
@@ -1,0 +1,37 @@
+/**
+ * processed_sms_inbound table operations.
+ *
+ * Short-lived idempotency ledger for inbound SMS webhook ids. The stable
+ * gateway id is stored without message content or sender details so replayed
+ * `sms:received` events cannot create duplicate activity-log entries.
+ */
+
+import { executeBatch, getDb, insert } from "#shared/db/client.ts";
+import { nowIso } from "#shared/now.ts";
+
+/** Claim an inbound webhook id. Returns false when it was already processed. */
+export const claimProcessedSmsInbound = async (
+  webhookId: string,
+): Promise<boolean> => {
+  if (webhookId === "") return true;
+  const stmt = insert("processed_sms_inbound", {
+    created: nowIso(),
+    webhook_id: webhookId,
+  });
+  const result = await getDb().execute({
+    args: stmt.args,
+    sql: stmt.sql.replace("INSERT INTO", "INSERT OR IGNORE INTO"),
+  });
+  return result.rowsAffected > 0;
+};
+
+/** Prune rows older than the given ISO cutoff. */
+export const pruneProcessedSmsInboundBefore = (
+  cutoffIso: string,
+): Promise<void> =>
+  executeBatch([
+    {
+      args: [cutoffIso],
+      sql: "DELETE FROM processed_sms_inbound WHERE created < ?",
+    },
+  ]);

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -914,10 +914,11 @@ describe("db > migrations > schema change guard", () => {
         "2026-06-16_modifiers",
         "2026-06-17_modifier_code",
         "2026-06-16_sms_messages",
+        "2026-06-17_processed_sms_inbound",
         "2026-06-16_attendee_phone_index",
         "2026-06-17_modifier_aggregates",
       ],
-      schemaHash: "1lq777j",
+      schemaHash: "1ldxgs3",
     });
   });
 });

--- a/test/lib/sms/webhook.test.ts
+++ b/test/lib/sms/webhook.test.ts
@@ -41,18 +41,21 @@ const hmacHex = async (secret: string, message: string): Promise<string> => {
   return new Uint8Array(sig).toHex();
 };
 
+const currentTimestamp = (offsetSeconds = 0): string =>
+  String(Math.floor(Date.now() / 1000) + offsetSeconds);
+
 const postWebhook = async (
   body: unknown,
-  opts: { sign?: boolean; rawBody?: string } = {},
+  opts: { sign?: boolean; rawBody?: string; timestamp?: string } = {},
 ): Promise<Response> => {
   const raw = opts.rawBody ?? JSON.stringify(body);
-  const ts = "1700000000";
+  const ts = opts.timestamp ?? currentTimestamp();
   // Force the next request to re-read settings written directly in the test.
   settings.invalidateCache();
   const headers = new Headers({ "content-type": "application/json" });
   if (opts.sign !== false) {
     headers.set("x-signature", await hmacHex(SECRET, raw + ts));
-    headers.set("x-timestamp", ts);
+    if (opts.timestamp !== "") headers.set("x-timestamp", ts);
   }
   return handleRequest(
     new Request("http://localhost/sms/webhook", {
@@ -120,6 +123,57 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
       {
         sign: false,
       },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("valid signature with a current timestamp succeeds", async () => {
+    await configure();
+    const res = await postWebhook({ event: "sms:received", payload: {} });
+    expect(res.status).toBe(200);
+  });
+
+  test("missing timestamp fails", async () => {
+    await configure();
+    const res = await postWebhook(
+      { event: "sms:received", payload: {} },
+      { timestamp: "" },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("malformed timestamp fails", async () => {
+    await configure();
+    const res = await postWebhook(
+      { event: "sms:received", payload: {} },
+      { timestamp: "not-a-unix-second" },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("unsafe integer timestamp fails", async () => {
+    await configure();
+    const res = await postWebhook(
+      { event: "sms:received", payload: {} },
+      { timestamp: "999999999999999999999" },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("timestamp older than tolerance fails", async () => {
+    await configure();
+    const res = await postWebhook(
+      { event: "sms:received", payload: {} },
+      { timestamp: currentTimestamp(-301) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("timestamp too far in the future fails", async () => {
+    await configure();
+    const res = await postWebhook(
+      { event: "sms:received", payload: {} },
+      { timestamp: currentTimestamp(301) },
     );
     expect(res.status).toBe(401);
   });
@@ -247,6 +301,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
     await postWebhook({
       event: "sms:received",
       payload: {
+        id: "inbound-1",
         message: await encryptField("see you there", PASS),
         sender: await encryptField("07700900123", PASS),
       },
@@ -255,6 +310,49 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
     const log = await getAttendeeActivityLog(attendee.id);
     expect(log.some((e) => e.message.includes("received: see you there"))).toBe(
       true,
+    );
+  });
+
+  test("replaying the same inbound id does not duplicate activity", async () => {
+    await configure();
+    await settings.update.smsGatewayPassphrase(PASS);
+
+    const body = {
+      event: "sms:received",
+      payload: {
+        id: "inbound-replay",
+        message: "hi once",
+        sender: "+440000000000",
+      },
+    };
+    expect((await postWebhook(body)).status).toBe(200);
+    expect((await postWebhook(body)).status).toBe(200);
+
+    const all = await getAllActivityLog();
+    expect(
+      all.filter((e) => e.message.includes("received: hi once")).length,
+    ).toBe(1);
+  });
+
+  test("replayed delivered event remains idempotent", async () => {
+    await configure();
+    const attendee = await makeAttendee();
+    await recordSmsMessage({
+      attendeeId: attendee.id,
+      listingId: 1,
+      providerId: "msg-replay",
+    });
+    const body = {
+      event: "sms:delivered",
+      payload: { messageId: "msg-replay" },
+    };
+
+    expect((await postWebhook(body)).status).toBe(200);
+    expect((await postWebhook(body)).status).toBe(200);
+
+    const log = await getAttendeeActivityLog(attendee.id);
+    expect(log.filter((e) => e.message.includes("SMS delivered")).length).toBe(
+      1,
     );
   });
 


### PR DESCRIPTION
### Motivation

- SMS webhooks included an `x-timestamp` in the signature but the server never validated its freshness, allowing indefinite replay of captured inbound events.
- Inbound `sms:received` events had no idempotency key or replay guard, which could create duplicate activity-log entries on replay.
- The change hardens webhook handling by enforcing timestamp freshness and adding a short-lived replay ledger for inbound events.

### Description

- Enforce signed Unix-seconds timestamp freshness with a 5-minute tolerance via `SMS_WEBHOOK_TOLERANCE_SECONDS` and `isFreshTimestamp()`, and reject missing/malformed/unsafe/stale/future timestamps prior to HMAC validation. (`src/features/api/sms-webhook.ts`)
- Preserve constant-time HMAC comparison for valid timestamp shapes by still computing and comparing the expected signature when the timestamp format is acceptable. (`src/features/api/sms-webhook.ts`)
- Add a short-lived idempotency ledger (`processed_sms_inbound`) and helper module exposing `claimProcessedSmsInbound` and `pruneProcessedSmsInboundBefore` to claim inbound webhook ids and prune old entries; ledger stores only the inbound id and created timestamp (no PII). (`src/shared/db/processed-sms-inbound.ts`)
- Wire replay protection into the webhook flow by claiming the inbound id at the start of handling `sms:received` and skipping duplicate processing, and by pruning the ledger alongside existing SMS message pruning. (`src/features/api/sms-webhook.ts`)
- Add migration/schema entries and a named migration to create the `processed_sms_inbound` table and its index, and update the schema snapshot used by tests. (`src/shared/db/migrations.ts`, `test/lib/db/migrations.test.ts`)
- Extend unit tests to cover timestamp validation (current/missing/malformed/unsafe/stale/future), inbound replay deduplication, and idempotent status-event replays. (`test/lib/sms/webhook.test.ts`)

### Testing

- Ran targeted unit tests: `test/lib/sms/webhook.test.ts` and `test/lib/admin/sms.test.ts`, both passed. (`mise exec -- deno task test:files test/lib/sms/webhook.test.ts test/lib/admin/sms.test.ts`)
- Ran migration and webhook test subset: `test/lib/db/migrations.test.ts`, `test/lib/sms/webhook.test.ts`, and `test/lib/admin/sms.test.ts`, and they passed. (`mise exec -- deno task test:files test/lib/db/migrations.test.ts test/lib/sms/webhook.test.ts test/lib/admin/sms.test.ts`)
- Ran the full precommit pipeline (lint/typecheck/cpd/build/tests/coverage); it initially failed due to the native `biome` binary not being on PATH, then succeeded when rerun using the npm Biome shim (`BIOME_NPM=1`), and `precommit` passed. (`BIOME_NPM=1 mise exec -- deno task precommit`)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e1d019d4832da511f8006261586b)