### PR TITLE
Soften running total mismatch notice

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -39,9 +39,8 @@
   "common.quantity": "Quantity",
   "common.close": "Close",
   "common.continue": "Continue",
-  "expected_actual.badge_error": "Error",
-  "expected_actual.click_for_info": "Click for info.",
-  "expected_actual.default_title": "Stored total error",
+  "expected_actual.badge_error": "Mismatch",
+  "expected_actual.default_title": "Stored total mismatch",
   "expected_actual.expected": "expected",
   "expected_actual.got": "got",
   "expected_actual.more": "(+{count} more)"

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1161,9 +1161,7 @@ input[type="submit"].danger:hover,
 }
 
 .expected-actual-notice {
-  border-left: 4px solid #cc0000;
   margin: var(--space-s) 0;
-  padding-left: var(--space-s);
 }
 
 .expected-actual-notice summary {
@@ -1174,10 +1172,6 @@ input[type="submit"].danger:hover,
 .expected-actual-notice ul {
   margin-bottom: var(--space-s);
   margin-top: var(--space-s);
-}
-
-.expected-actual-click {
-  color: var(--color-text-secondary);
 }
 
 .success-text {
@@ -1202,9 +1196,6 @@ input[type="submit"].danger:hover,
 }
 [data-theme="dark"] .danger-text {
   color: #ff5555;
-}
-[data-theme="dark"] .expected-actual-notice {
-  border-left-color: #ff5555;
 }
 [data-theme="dark"] .success-text {
   color: #50fa7b;

--- a/src/ui/templates/admin/expected-actual.tsx
+++ b/src/ui/templates/admin/expected-actual.tsx
@@ -39,10 +39,7 @@ export const ExpectedActualNotice = ({
         <span class="badge-alert">{badge}</span> <strong>{first.label}</strong>:{" "}
         {t("expected_actual.expected")} <strong>{first.expected}</strong>,{" "}
         {t("expected_actual.got")} <strong>{first.actual}</strong>
-        {extra}.{" "}
-        <span class="expected-actual-click">
-          {t("expected_actual.click_for_info")}
-        </span>
+        {extra}.
       </summary>
       <div>
         <p>{noticeTitle}</p>

--- a/test/templates/admin/expected-actual.test.tsx
+++ b/test/templates/admin/expected-actual.test.tsx
@@ -8,7 +8,8 @@ test("ExpectedActualNotice uses the default title when none is provided", () => 
     items: [{ actual: "4", expected: "3", label: "Total" }],
   })!.toString();
 
-  expect(html).toContain("Stored total error");
+  expect(html).toContain("Stored total mismatch");
   expect(html).toContain("expected <strong>3</strong>, got");
-  expect(html).toContain("Click for info.");
+  expect(html).toContain("Mismatch");
+  expect(html).not.toContain("Click for info.");
 });

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -159,7 +159,7 @@ describe("adminListingEditPage form sections", () => {
       income: { current: 2500, recalculated: 1500 },
       tickets_count: { current: 3, recalculated: 3 },
     });
-    expect(html).toContain("Error");
+    expect(html).toContain("Mismatch");
     expect(html).toContain("expected <strong>4</strong>, got");
     expect(html).toContain("expected <strong>£15</strong>, got");
     expect(html).toContain(`/admin/listings/recalculate/${listing.id}`);
@@ -446,7 +446,8 @@ describe("adminListingPage", () => {
     });
     expect(html).toContain("Running total check");
     expect(html).toContain("expected <strong>1</strong>, got");
-    expect(html).toContain("Click for info");
+    expect(html).toContain("Mismatch");
+    expect(html).not.toContain("Click for info");
   });
 
   test("renders no Group Attendees row when groupContext is omitted", () => {


### PR DESCRIPTION
### Motivation
- The running-total check UI is too alarmist when stored totals and recalculated totals disagree; it should indicate a non-fatal mismatch rather than an "error" with heavy visual emphasis.
- Keep the expandable details with full explanation and action link, but reduce the visual prominence and remove the redundant "click for info" hint.

### Description
- Change copy: rename the badge/title from "Error"/"Stored total error" to "Mismatch"/"Stored total mismatch" in `src/locales/en/common.json`.
- Remove the small helper text in the summary so the details disclosure no longer shows the "Click for info" hint by editing `src/ui/templates/admin/expected-actual.tsx`.
- Soften styling by removing the red left border and padding on the notice while preserving the red badge color in `src/ui/static/mvp.css`.
- Update template tests to assert the new copy/behavior in `test/templates/admin/expected-actual.test.tsx` and `test/templates/admin/listings.test.ts`.

### Testing
- Ran the linter with `DENO_TLS_CA_STORE=system mise exec -- deno task lint` and it completed with no issues.
- Ran the affected template tests with `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/templates/admin/expected-actual.test.tsx test/templates/admin/listings.test.ts test/templates/admin/groups.test.ts` and the targeted suite passed (all tests in that run passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a3e771a0832d9784f79d94dbf00f)