### PR TITLE
Slim number input widths

### DIFF
--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -878,6 +878,16 @@ label > input[type="time"] {
   width: auto;
 }
 
+input[type="number"] {
+  box-sizing: border-box;
+  max-width: 100%;
+  width: 8ch;
+}
+
+label > input[type="number"] {
+  flex: 0 0 auto;
+}
+
 label > select[name="quantity"],
 label > select[name^="quantity_"] {
   width: 8ch;


### PR DESCRIPTION
### Motivation
- Numeric inputs (quantities, amounts, and other `type="number"` fields) were stretching too wide in form rows; tighten them so they only take the space they need while preserving responsive wrapping and flex behaviour.

### Description
- Add compact sizing rules to `src/ui/static/mvp.css`: `input[type="number"]` is set to `box-sizing: border-box; max-width: 100%; width: 8ch;` and `label > input[type="number"]` is set to `flex: 0 0 auto;` to prevent number inputs from growing to fill flex rows.

### Testing
- Ran the project linter with `mise exec -- deno task lint` (ran successfully; in CI-like environments the command was executed with `DENO_TLS_CA_STORE=system` to allow dependency downloads). 
- Ran a quick repository check with `git diff --check` to ensure no whitespace/errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b21f8994832daa5c91b38509718d)