### PR TITLE
Slim admin nav to 6 items

### DIFF
--- a/src/ui/templates/admin/built-sites.tsx
+++ b/src/ui/templates/admin/built-sites.tsx
@@ -20,7 +20,7 @@ import {
   type SiteSecretsView,
 } from "#shared/site-secrets.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import {
   ActionButton,
   Icon,
@@ -92,7 +92,8 @@ export const adminBuiltSitesPage = (
 
   return String(
     <Layout title={t("built_sites.list_title")}>
-      <AdminNav active="/admin/built-sites" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <Flash success={successMessage} />
       <p class="actions">
         <ActionButton href="/admin/built-sites/new" icon="plus">
@@ -175,7 +176,8 @@ export const adminBuiltSiteNewPage = (
 ): string =>
   String(
     <Layout title={t("built_sites.add_site_title")}>
-      <AdminNav active="/admin/built-sites" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <CsrfForm action="/admin/built-sites">
         <h1>{t("built_sites.add_site_title")}</h1>
         <Flash error={error} />
@@ -422,7 +424,8 @@ export const adminBuiltSiteEditPage = (
 
   return String(
     <Layout title={t("built_sites.edit_site_title")}>
-      <AdminNav active="/admin/built-sites" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <CsrfForm action={`/admin/built-sites/${site.id}/edit`}>
         <h1>{t("built_sites.edit_site_title")}</h1>
         <Flash error={error} success={success} />
@@ -469,7 +472,8 @@ export const adminBuiltSiteDeletePage = (
 ): string =>
   String(
     <Layout title={t("built_sites.delete_page_title")}>
-      <AdminNav active="/admin/built-sites" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <ConfirmForm
         action={`/admin/built-sites/${site.id}/delete`}
         buttonText={t("built_sites.delete_built_site_button")}

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -15,11 +15,11 @@ import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { AdminSession } from "#shared/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import { ActionButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
-const NAV_ACTIVE = "/admin/emails";
+const NAV_ACTIVE = "/admin/settings";
 
 /** Deep link to the Email Notifications form on the advanced settings page. */
 const EMAIL_SETTINGS_LINK = "/admin/settings-advanced#settings-email";
@@ -107,6 +107,7 @@ export const bulkEmailComposePage = (
   return String(
     <Layout title={copy.heading}>
       <AdminNav active={NAV_ACTIVE} session={session} />
+      <SettingsSubNav />
       <Flash />
 
       <div class="prose">
@@ -262,6 +263,7 @@ export const bulkEmailTemplateDeletePage = (
   String(
     <Layout title={t("bulk_email.delete_template_heading")}>
       <AdminNav active={NAV_ACTIVE} session={session} />
+      <SettingsSubNav />
       <ConfirmForm
         action={`/admin/emails/templates/${template.id}/delete`}
         buttonText={t("bulk_email.delete_template_submit")}
@@ -326,6 +328,7 @@ export const bulkEmailPreviewPage = (
   return String(
     <Layout title={t("bulk_email.preview_page_title")}>
       <AdminNav active={NAV_ACTIVE} session={session} />
+      <SettingsSubNav />
       <Flash />
 
       <div class="prose">

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -113,9 +113,9 @@ export const adminFooterHtml = (debug: DebugFooterData | null): string =>
   `<a href="https://github.com/chobbledotcom/tickets">${t("admin.footer.chobble_tickets")}</a>` +
   `<div class="admin-footer-links">` +
   `<a href="/admin/log">${t("nav.log")}</a>` +
-  ` &middot; ` +
+  " &middot; " +
   `<a href="/admin/guide">${t("nav.guide")}</a>` +
-  `</div>` +
+  "</div>" +
   logoutFormHtml() +
   "</div>" +
   (debug

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -111,6 +111,11 @@ export const adminFooterHtml = (debug: DebugFooterData | null): string =>
   `<footer class="admin-footer">` +
   `<div class="admin-footer-top">` +
   `<a href="https://github.com/chobbledotcom/tickets">${t("admin.footer.chobble_tickets")}</a>` +
+  `<div class="admin-footer-links">` +
+  `<a href="/admin/log">${t("nav.log")}</a>` +
+  ` &middot; ` +
+  `<a href="/admin/guide">${t("nav.guide")}</a>` +
+  `</div>` +
   logoutFormHtml() +
   "</div>" +
   (debug

--- a/src/ui/templates/admin/holidays.tsx
+++ b/src/ui/templates/admin/holidays.tsx
@@ -12,7 +12,7 @@ import {
 } from "#shared/forms.tsx";
 import { escapeHtml, Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, Holiday } from "#shared/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import {
   ActionButton,
   DeleteSection,
@@ -32,7 +32,8 @@ export const adminHolidaysPage = (
 ): string =>
   String(
     <Layout title={t("terms.holidays")}>
-      <AdminNav active="/admin/holidays" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <Flash success={successMessage} />
       <p class="actions">
         <ActionButton href="/admin/holidays/new" icon="plus">
@@ -90,7 +91,8 @@ export const adminHolidayNewPage = (
 ): string =>
   String(
     <Layout title={t("holidays.add.title")}>
-      <AdminNav active="/admin/holidays" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <CsrfForm action="/admin/holidays">
         <h1>{t("holidays.add.heading")}</h1>
         <Flash error={error} />
@@ -110,7 +112,8 @@ export const adminHolidayEditPage = (
 ): string =>
   String(
     <Layout title={t("holidays.edit.title")}>
-      <AdminNav active="/admin/holidays" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <CsrfForm action={`/admin/holidays/${holiday.id}/edit`}>
         <h1>{t("holidays.edit.heading")}</h1>
         <Flash error={error} />
@@ -138,7 +141,8 @@ export const adminHolidayDeletePage = (
 ): string =>
   String(
     <Layout title={t("holidays.delete.heading")}>
-      <AdminNav active="/admin/holidays" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <ConfirmForm
         action={`/admin/holidays/${holiday.id}/delete`}
         buttonText={t("holidays.delete.submit")}

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -86,25 +86,10 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => {
           {navLink("/admin/attendees", t("terms.attendees"), active)}
           {session.adminLevel === "owner" &&
             navLink("/admin/users", t("terms.users"), active)}
-          {session.adminLevel === "owner" &&
-            settings.showPublicSite &&
-            navLink("/admin/site", t("nav.site"), active)}
-          {session.adminLevel === "owner" &&
-            navLink("/admin/emails", t("nav.emails"), active)}
-          {session.adminLevel === "owner" &&
-            navLink("/admin/settings", t("nav.settings"), active)}
-          {navLink("/admin/log", t("nav.log"), active)}
           {navLink("/admin/groups", t("terms.groups"), active)}
           {navLink("/admin/modifiers", t("terms.modifiers"), active)}
           {session.adminLevel === "owner" &&
-            navLink("/admin/holidays", t("terms.holidays"), active)}
-          {session.adminLevel === "owner" &&
-            isBuilderEnabled() &&
-            navLink("/admin/built-sites", t("nav.built_sites"), active)}
-          {navLink("/admin/guide", t("nav.guide"), active)}
-          {session.adminLevel === "owner" &&
-            isSupportEnabled() &&
-            navLink("/admin/support", t("nav.support"), active)}
+            navLink("/admin/settings", t("nav.settings"), active)}
         </ul>
       </nav>
     </>
@@ -159,6 +144,22 @@ export const SettingsSubNav = (): JSX.Element => (
         <a href="/admin/logistics">{t("nav.logistics")}</a>
       </li>
       <li>
+        <a href="/admin/emails">{t("nav.emails")}</a>
+      </li>
+      {settings.showPublicSite && (
+        <li>
+          <a href="/admin/site">{t("nav.site")}</a>
+        </li>
+      )}
+      <li>
+        <a href="/admin/holidays">{t("terms.holidays")}</a>
+      </li>
+      {isBuilderEnabled() && (
+        <li>
+          <a href="/admin/built-sites">{t("nav.built_sites")}</a>
+        </li>
+      )}
+      <li>
         <a href="/admin/settings-advanced">{t("nav.sub.advanced")}</a>
       </li>
       <li>
@@ -170,6 +171,11 @@ export const SettingsSubNav = (): JSX.Element => (
       <li>
         <a href="/admin/debug">{t("nav.sub.debug")}</a>
       </li>
+      {isSupportEnabled() && (
+        <li>
+          <a href="/admin/support">{t("nav.support")}</a>
+        </li>
+      )}
     </ul>
   </nav>
 );

--- a/src/ui/templates/admin/site.tsx
+++ b/src/ui/templates/admin/site.tsx
@@ -11,7 +11,7 @@ import {
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
@@ -44,7 +44,8 @@ export const adminSiteHomePage = (
 ): string =>
   String(
     <Layout title={t("site.home_title")}>
-      <AdminNav active="/admin/site" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <SiteSubNav />
 
       <Flash error={error} success={success} />
@@ -139,7 +140,8 @@ export const adminSiteContactPage = (
 ): string =>
   String(
     <Layout title={t("site.contact_title")}>
-      <AdminNav active="/admin/site" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <SiteSubNav />
 
       <Flash error={error} success={success} />
@@ -205,7 +207,8 @@ export const adminSiteOrderPage = (
 ): string =>
   String(
     <Layout title={t("site.order_title")}>
-      <AdminNav active="/admin/site" session={session} />
+      <AdminNav active="/admin/settings" session={session} />
+      <SettingsSubNav />
       <SiteSubNav />
 
       <Flash error={error} success={success} />

--- a/src/ui/templates/admin/support.tsx
+++ b/src/ui/templates/admin/support.tsx
@@ -11,7 +11,7 @@ import { CsrfForm, Flash, MessageFields } from "#shared/forms.tsx";
 import { escapeHtml, Raw } from "#shared/jsx/jsx-runtime.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { AdminSession } from "#shared/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /** Message form delivering to the platform host (no Botpoison). Just a message
@@ -56,7 +56,8 @@ export const adminSupportPage = (opts: {
 }): string =>
   String(
     <Layout title={t("support.page_title")}>
-      <AdminNav active="/admin/support" session={opts.session} />
+      <AdminNav active="/admin/settings" session={opts.session} />
+      <SettingsSubNav />
       <Flash error={opts.error} success={opts.success} />
       <div class="prose">
         {opts.supportText ? (

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -692,12 +692,10 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       expect(response.headers.get("location")).toBe("/admin");
     });
 
-    test("nav contains guide link", async () => {
+    test("footer contains guide link", async () => {
       const { response } = await adminGet("/admin/guide");
       const body = await response.text();
-      expect(body).toMatch(
-        /<a[^>]*\bclass="active"[^>]*\bhref="\/admin\/guide"[^>]*>\s*Guide\s*<\/a>/,
-      );
+      expect(body).toMatch(/<a[^>]*\bhref="\/admin\/guide"[^>]*>\s*Guide\s*<\/a>/);
     });
   });
 });

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -695,7 +695,9 @@ describeWithEnv("QR Scanner", { db: true }, () => {
     test("footer contains guide link", async () => {
       const { response } = await adminGet("/admin/guide");
       const body = await response.text();
-      expect(body).toMatch(/<a[^>]*\bhref="\/admin\/guide"[^>]*>\s*Guide\s*<\/a>/);
+      expect(body).toMatch(
+        /<a[^>]*\bhref="\/admin\/guide"[^>]*>\s*Guide\s*<\/a>/,
+      );
     });
   });
 });

--- a/test/lib/server-support.test.ts
+++ b/test/lib/server-support.test.ts
@@ -101,8 +101,8 @@ describeWithEnv(
         expect(html).not.toContain('name="email"');
       });
 
-      test("shows the Support link in the admin nav", async () => {
-        const { response } = await adminGet("/admin/");
+      test("shows the Support link in the settings sub-nav", async () => {
+        const { response } = await adminGet("/admin/settings");
         const html = await response.text();
         expect(html).toContain('href="/admin/support"');
       });
@@ -258,8 +258,8 @@ describeWithEnv("server (admin support, disabled)", { db: true }, () => {
     expect(response.status).toBe(404);
   });
 
-  test("hides the Support link in the admin nav", async () => {
-    const { response } = await adminGet("/admin/");
+  test("hides the Support link in the settings sub-nav", async () => {
+    const { response } = await adminGet("/admin/settings");
     const html = await response.text();
     expect(html).not.toContain('href="/admin/support"');
   });


### PR DESCRIPTION
## Summary

- Main nav trimmed to 6 items: Listings, Calendar, Attendees, Groups, Modifiers, Settings (Users remains for owners)
- Owner-only config pages (Site, Emails, Holidays, Built Sites, Support) moved into the existing `SettingsSubNav`
- Log and Guide moved to the admin footer, where they're always reachable without cluttering the nav
- Updated `active` prop and added `SettingsSubNav` to all affected page templates (holidays, built-sites, bulk-email, support, site)
- Updated one test that was asserting Guide appeared as an active nav link (it now lives in the footer)

## Test plan

- [ ] Owner nav shows exactly: Listings, Calendar, Attendees, Users, Groups, Modifiers, Settings
- [ ] Manager nav shows: Listings, Calendar, Attendees, Groups, Modifiers (no Settings, no Users)
- [ ] Settings sub-nav includes Emails, Holidays, Site (when enabled), Built Sites (when enabled), Support (when enabled)
- [ ] Log and Guide links appear in the footer on every admin page
- [ ] Navigating to /admin/holidays, /admin/emails, /admin/built-sites, /admin/support, /admin/site highlights "Settings" in the main nav and shows the settings sub-nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zdmwqGPzqWpFi9mFCV2HF

---
_Generated by [Claude Code](https://claude.ai/code/session_011zdmwqGPzqWpFi9mFCV2HF)_