### PR TITLE
Improve recalculate UI and redirect to edit after recalculation

### DIFF
--- a/src/features/admin/listings.ts
+++ b/src/features/admin/listings.ts
@@ -780,7 +780,7 @@ const handleListingRecalculatePost: TypedRouteHandler<
         listing,
       );
       return redirect(
-        `/admin/listings/recalculate/${listing.id}`,
+        `/admin/listing/${listing.id}/edit`,
         t("listings_table.recalculate_success"),
         true,
       );

--- a/src/features/admin/listings.ts
+++ b/src/features/admin/listings.ts
@@ -609,17 +609,19 @@ const handleAdminListingEditGet: TypedRouteHandler<
   "GET /admin/listing/:id/edit"
 > = (request, params) =>
   requireSessionOr(request, (session) =>
-    withEntityFromParam(params.id, getListingAndGroups, (ctx) =>
-      htmlResponse(
+    withEntityFromParam(params.id, getListingAndGroups, (ctx) => {
+      const flash = applyFlash(request);
+      return htmlResponse(
         adminListingEditPage(
           ctx.listing,
           ctx.groups,
           session,
-          undefined,
+          flash.error,
           ctx.aggregateRecalculation,
+          flash.success,
         ),
-      ),
-    ),
+      );
+    }),
   );
 
 /**

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -256,7 +256,7 @@ const handleModifierRecalculatePost: TypedRouteHandler<
       await resetModifierAggregateFields(modifier.id, selected);
       await logActivity(`Modifier '${modifier.name}' totals recalculated`);
       return redirect(
-        `/admin/modifiers/recalculate/${modifier.id}`,
+        `/admin/modifiers/${modifier.id}/edit`,
         t("modifiers.recalculate.success"),
         true,
       );

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -182,10 +182,16 @@ const handleEditGet: TypedRouteHandler<"GET /admin/modifiers/:id/edit"> = (
 ) =>
   requireSessionOr(request, (session) =>
     withModifier(id)(async (modifier) => {
-      applyFlash(request);
+      const flash = applyFlash(request);
       const links = await scopeLinksFor(modifier);
       return htmlResponse(
-        adminModifierEditPage(modifier, session, getFlash().error, links),
+        adminModifierEditPage(
+          modifier,
+          session,
+          flash.error,
+          links,
+          flash.success,
+        ),
       );
     }),
   );

--- a/src/locales/en/listings-table.json
+++ b/src/locales/en/listings-table.json
@@ -105,5 +105,6 @@
   "listings_table.recalculate_save": "Save recalculated totals",
   "listings_table.recalculate_success": "Listing totals recalculated",
   "listings_table.duration_warning_message": "Changing booking duration will update existing bookings for this listing.",
-  "listings_table.i_understand": "I understand"
+  "listings_table.i_understand": "I understand",
+  "listings_table.recalculate_description": "Compare the stored listing totals with totals counted from attendee records. Select only the stored values you want to replace."
 }

--- a/src/locales/en/modifiers.json
+++ b/src/locales/en/modifiers.json
@@ -30,5 +30,6 @@
   "modifiers.scope.listings_heading": "Linked listings",
   "modifiers.scope.groups_heading": "Linked groups",
   "modifiers.scope.none": "Nothing available to link yet.",
-  "modifiers.scope.save": "Save scope"
+  "modifiers.scope.save": "Save scope",
+  "modifiers.recalculate.description": "Compare the stored modifier totals with totals counted from attendee records. Select only the stored values you want to replace."
 }

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -1314,6 +1314,7 @@ export const adminListingRecalculatePage = (
     action: `/admin/listings/recalculate/${listing.id}`,
     active: "/admin/",
     currentLabel: t("listings_table.recalculate_current"),
+    description: t("listings_table.recalculate_description"),
     error,
     recalculatedLabel: t("listings_table.recalculate_from_attendees"),
     rows: listingRecalculateRows(snapshot),

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -1635,6 +1635,7 @@ export const adminListingEditPage = (
   session: AdminSession,
   error?: string,
   aggregateRecalculation?: ListingAggregateRecalculation,
+  success?: string,
 ): string => {
   const storageEnabled = isStorageEnabled();
   const builderEnabled = isBuilderEnabled();
@@ -1663,7 +1664,7 @@ export const adminListingEditPage = (
       title={t("listings_table.edit_listing_title", { name: listing.name })}
     >
       <AdminNav active="/admin/" session={session} />
-      <Flash error={error} />
+      <Flash error={error} success={success} />
       <CsrfForm
         action={`/admin/listing/${listing.id}/edit`}
         enctype="multipart/form-data"

--- a/src/ui/templates/admin/modifiers.tsx
+++ b/src/ui/templates/admin/modifiers.tsx
@@ -174,6 +174,7 @@ export const adminModifierRecalculatePage = (
     action: `/admin/modifiers/recalculate/${modifier.id}`,
     active: "/admin/modifiers",
     currentLabel: t("modifiers.recalculate.current"),
+    description: t("modifiers.recalculate.description"),
     error,
     recalculatedLabel: t("modifiers.recalculate.from_attendees"),
     rows: modifierRecalculateRows(snapshot),

--- a/src/ui/templates/admin/modifiers.tsx
+++ b/src/ui/templates/admin/modifiers.tsx
@@ -258,13 +258,14 @@ export const adminModifierEditPage = (
   session: AdminSession,
   error?: string,
   links?: ScopeLinks | null,
+  success?: string,
 ): string =>
   String(
     <Layout title={t("modifiers.edit.heading")}>
       <AdminNav active="/admin/modifiers" session={session} />
       <CsrfForm action={`/admin/modifiers/${modifier.id}/edit`}>
         <h1>{t("modifiers.edit.heading")}</h1>
-        <Flash error={error} />
+        <Flash error={error} success={success} />
         <Raw
           html={renderFields(modifierFields, modifierToFieldValues(modifier))}
         />

--- a/src/ui/templates/admin/recalculate.tsx
+++ b/src/ui/templates/admin/recalculate.tsx
@@ -16,6 +16,7 @@ export const adminRecalculatePage = ({
   action,
   active,
   currentLabel,
+  description,
   error,
   recalculatedLabel,
   rows,
@@ -27,6 +28,7 @@ export const adminRecalculatePage = ({
   action: string;
   active: string;
   currentLabel: string;
+  description: string;
   error?: string;
   recalculatedLabel: string;
   rows: RecalculateRow[];
@@ -41,35 +43,40 @@ export const adminRecalculatePage = ({
       <CsrfForm action={action}>
         <h1>{title}</h1>
         <Flash error={error} success={success} />
-        <div class="table-scroll">
-          <table>
-            <thead>
-              <tr>
-                <th></th>
-                <th>{currentLabel}</th>
-                <th>{recalculatedLabel}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr>
-                  <th>
-                    <label>
-                      <input
-                        name={RECALCULATE_FIELD_NAME}
-                        type="checkbox"
-                        value={row.name}
-                      />{" "}
-                      {row.label}
-                    </label>
-                  </th>
-                  <td>{row.current}</td>
-                  <td>{row.recalculated}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div class="prose">
+          <p>{description}</p>
         </div>
+        <fieldset class="checkboxes">
+          <div class="table-scroll">
+            <table>
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>{currentLabel}</th>
+                  <th>{recalculatedLabel}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr>
+                    <th>
+                      <label>
+                        <input
+                          name={RECALCULATE_FIELD_NAME}
+                          type="checkbox"
+                          value={row.name}
+                        />{" "}
+                        {row.label}
+                      </label>
+                    </th>
+                    <td>{row.current}</td>
+                    <td>{row.recalculated}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </fieldset>
         <SubmitButton icon="save">{submitLabel}</SubmitButton>
       </CsrfForm>
     </Layout>,

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -880,6 +880,34 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       expect(updated?.tickets_count).toBe(5);
     });
 
+    test("shows recalculation success on the redirected edit page", async () => {
+      const { listing } = await setupListingAndLogin({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+
+      const { cookie, response } = await adminFormPost(
+        `/admin/listings/recalculate/${listing.id}`,
+        { recalculate_fields: "booked_quantity" },
+      );
+      expectRedirectWithFlash(
+        `/admin/listing/${listing.id}/edit`,
+        "Listing totals recalculated",
+        true,
+      )(response);
+
+      const editResponse = await followRedirectWithFlash(
+        response,
+        (request) => handleRequest(request),
+        cookie,
+      );
+      await expectHtmlResponse(
+        editResponse,
+        200,
+        "Listing totals recalculated",
+      );
+    });
+
     test("rejects listing recalculation with no selected totals", async () => {
       const { listing } = await setupListingAndLogin({
         maxAttendees: 100,

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -869,7 +869,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         { recalculate_fields: "booked_quantity" },
       );
       expectRedirectWithFlash(
-        `/admin/listings/recalculate/${listing.id}`,
+        `/admin/listing/${listing.id}/edit`,
         "Listing totals recalculated",
         true,
       )(response);

--- a/test/lib/server-modifiers.test.ts
+++ b/test/lib/server-modifiers.test.ts
@@ -424,7 +424,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         { recalculate_fields: "total_uses" },
       );
       expectRedirectWithFlash(
-        `/admin/modifiers/recalculate/${id}`,
+        `/admin/modifiers/${id}/edit`,
         "Modifier totals recalculated",
         true,
       )(response);

--- a/test/lib/server-modifiers.test.ts
+++ b/test/lib/server-modifiers.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import { handleRequest } from "#routes";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import { toMinorUnits } from "#shared/currency.ts";
 import { getDb } from "#shared/db/client.ts";
@@ -24,6 +25,7 @@ import {
   expectHtmlResponse,
   expectRedirectWithFlash,
   expectStatus,
+  followRedirectWithFlash,
   testRequiresAuth,
 } from "#test-utils";
 
@@ -433,6 +435,32 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
       expect(updated.total_uses).toBe(2);
       expect(updated.total_revenue).toBe(9000);
       expect(updated.usage_count).toBe(5);
+    });
+
+    test("shows recalculation success on the redirected edit page", async () => {
+      await adminFormPost("/admin/modifiers", createData({ name: "Reset" }));
+      const { id } = await lastModifier();
+
+      const { cookie, response } = await adminFormPost(
+        `/admin/modifiers/recalculate/${id}`,
+        { recalculate_fields: "total_uses" },
+      );
+      expectRedirectWithFlash(
+        `/admin/modifiers/${id}/edit`,
+        "Modifier totals recalculated",
+        true,
+      )(response);
+
+      const editResponse = await followRedirectWithFlash(
+        response,
+        (request) => handleRequest(request),
+        cookie,
+      );
+      await expectHtmlResponse(
+        editResponse,
+        200,
+        "Modifier totals recalculated",
+      );
     });
 
     test("rejects modifier recalculation with no selected totals", async () => {

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -181,6 +181,8 @@ describe("adminListingRecalculatePage", () => {
     expect(html).toContain("Recalculate: Workshop");
     expect(html).toContain("Current");
     expect(html).toContain("From attendee data");
+    expect(html).toContain("Compare the stored listing totals");
+    expect(html).toContain('class="checkboxes"');
     expect(html).toContain('name="recalculate_fields"');
     expect(html).toContain('value="booked_quantity"');
     expect(html).toContain(">9<");


### PR DESCRIPTION
### Motivation
- Make the admin "recalculate" workflow clearer by explaining what the action does and by returning the user to the edited resource after a successful recalculation.

### Description
- Change post-recalculate redirects from the re-run page to the resource edit pages by returning `redirect` to `/admin/listing/:id/edit` and `/admin/modifiers/:id/edit` instead of the recalculate routes.
- Add descriptive copy keys `listings_table.recalculate_description` and `modifiers.recalculate.description` to the English locale files and wire them into the recalculate templates via a new `description` prop.
- Update the recalculate template to display the description and wrap the checkbox table in a `<fieldset class="checkboxes">` and prose block for the description, while keeping the table of current vs recalculated values.
- Update server and template tests to expect the new redirect targets and the presence of the description and checkbox container.

### Testing
- Ran the server-side admin tests including `test/lib/server-listings.test.ts` and `test/lib/server-modifiers.test.ts` which were updated to expect the new redirects, and they passed.
- Ran the template tests including `test/templates/admin/listings.test.ts` which was updated to assert the presence of the description and checkbox fieldset, and they passed.
- Ran the full test suite (`npm test`) and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b1613320832db84afdb0231a0830)