### PR TITLE
Make “Log out” an inline link and add /admin/logout confirmation page

### DIFF
--- a/src/features/admin/auth.ts
+++ b/src/features/admin/auth.ts
@@ -7,6 +7,7 @@ import { loginResponse } from "#routes/admin/dashboard.ts";
 import {
   ANY_USER_FORM,
   adminLandingPath,
+  anyUserPage,
   generateSecureToken,
   getAuthenticatedSession,
   withAuth,
@@ -39,6 +40,7 @@ import { nowMs } from "#shared/now.ts";
 import { fail, ok } from "#shared/response.ts";
 import { getSkipLoginDelay } from "#shared/test-overrides.ts";
 import type { AdminLevel } from "#shared/types.ts";
+import { adminLogoutPage } from "#templates/admin/logout.tsx";
 import { getLoginFields, type LoginFormValues } from "#templates/fields.ts";
 
 /** Random delay between 100-200ms to prevent timing attacks */
@@ -160,9 +162,12 @@ const handleLoginGet = async (request: Request): Promise<Response> => {
   return loginResponse(request);
 };
 
+const handleLogoutGet = anyUserPage((session) => adminLogoutPage(session));
+
 /** Authentication routes */
 export const authRoutes = defineRoutes({
   "GET /admin/login": handleLoginGet,
+  "GET /admin/logout": handleLogoutGet,
   "POST /admin/login": handleAdminLogin,
   "POST /admin/logout": handleAdminLogout,
 });

--- a/src/locales/en/login.json
+++ b/src/locales/en/login.json
@@ -19,5 +19,8 @@
   "password.current": "Current Password",
   "password.new": "New Password",
   "password.new_hint": "Minimum 8 characters",
-  "password.confirm": "Confirm New Password"
+  "password.confirm": "Confirm New Password",
+  "logout.title": "Log out",
+  "logout.confirm_heading": "Are you sure you want to log out?",
+  "logout.confirm_body": "You will need to log in again to manage tickets."
 }

--- a/src/locales/en/nav.json
+++ b/src/locales/en/nav.json
@@ -7,7 +7,7 @@
   "nav.built_sites": "Builds",
   "nav.guide": "Guide",
   "nav.support": "Support",
-  "nav.logout": "Logout",
+  "nav.logout": "Log out",
   "nav.readonly.banner": "This site is in read-only mode",
   "nav.readonly.renew": "Renew now",
   "nav.readonly.expires": "Your site expires on {date}",

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -16,8 +16,15 @@
   --color-text-secondary: #999;
   --color-scrollbar: #cacae8;
   --font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu,
-    Cantarell, "Helvetica Neue", sans-serif;
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen-Sans,
+    Ubuntu,
+    Cantarell,
+    "Helvetica Neue",
+    sans-serif;
   --hover-brightness: 1.2;
   --justify-important: left;
   --justify-normal: left;
@@ -1574,8 +1581,8 @@ button.secondary:hover,
   box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
 }
 
-/* Admin footer: a top row with the Chobble link (growing to fill) and the
-   logout button (sized to its content), then an optional debug menu below. */
+/* Admin footer: a top row with the Chobble link (growing to fill) and
+   inline utility links, then an optional debug menu below. */
 .admin-footer {
   margin-top: auto;
   display: flex;
@@ -1592,15 +1599,16 @@ button.secondary:hover,
   gap: var(--space-s);
 }
 
-/* The Chobble link grows to fill, the logout form stays its natural width. */
+/* The Chobble link grows to fill, the utility links stay their natural width. */
 .admin-footer-top > a {
   flex: 1 1 auto;
   min-width: 0;
 }
 
-.admin-footer-top > .inline {
+.admin-footer-links {
   flex: 0 0 auto;
   min-width: 0;
+  white-space: nowrap;
 }
 
 .admin-footer-info {

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -2,8 +2,8 @@
  * Admin footer.
  *
  * Rendered at the bottom of every admin page: a top row with the Chobble
- * Tickets link (growing to fill the space) on the left and the logout button
- * (sized to its content) on the right, both always on one line; and, when query
+ * Tickets link (growing to fill the space) on the left and inline utility links
+ * on the right, all always on one line; and, when query
  * logging is active, a debug menu (render time, SQL queries, cache stats) on a
  * row below them.
  *
@@ -22,9 +22,7 @@ import {
   isFooterDebugEnabled,
   type QueryLogEntry,
 } from "#shared/db/query-log.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import { getUptimeSeconds } from "#shared/uptime.ts";
-import { SubmitButton } from "#templates/components/actions.tsx";
 
 /** Data passed to the debug-details renderer */
 export type DebugFooterData = {
@@ -89,7 +87,9 @@ export const debugDetailsHtml = (data: DebugFooterData): string => {
         "</ul></details>"
       : "") +
     (cacheStats.length > 0
-      ? `<details><summary>${t("admin.footer.caches")} (${cacheStats.length})</summary><ul>` +
+      ? `<details><summary>${t(
+          "admin.footer.caches",
+        )} (${cacheStats.length})</summary><ul>` +
         cacheStats.map(renderCacheStat).join("") +
         "</ul></details>"
       : "") +
@@ -97,26 +97,21 @@ export const debugDetailsHtml = (data: DebugFooterData): string => {
   );
 };
 
-/** The footer's logout form, rendered to a string. */
-const logoutFormHtml = (): string =>
-  String(
-    <CsrfForm action="/admin/logout" class="inline">
-      <SubmitButton icon="log-out">{t("nav.logout")}</SubmitButton>
-    </CsrfForm>,
-  );
-
 /** Build the admin footer: Chobble link (plus the debug menu when present) on
- * the left, the logout button on the right. */
+ * the left, utility links on the right. */
 export const adminFooterHtml = (debug: DebugFooterData | null): string =>
   `<footer class="admin-footer">` +
   `<div class="admin-footer-top">` +
-  `<a href="https://github.com/chobbledotcom/tickets">${t("admin.footer.chobble_tickets")}</a>` +
+  `<a href="https://github.com/chobbledotcom/tickets">${t(
+    "admin.footer.chobble_tickets",
+  )}</a>` +
   `<div class="admin-footer-links">` +
   `<a href="/admin/log">${t("nav.log")}</a>` +
   " &middot; " +
   `<a href="/admin/guide">${t("nav.guide")}</a>` +
+  " &middot; " +
+  `<a href="/admin/logout">${t("nav.logout")}</a>` +
   "</div>" +
-  logoutFormHtml() +
   "</div>" +
   (debug
     ? `<div class="admin-footer-info">${debugDetailsHtml(debug)}</div>`

--- a/src/ui/templates/admin/logout.tsx
+++ b/src/ui/templates/admin/logout.tsx
@@ -1,0 +1,43 @@
+/**
+ * Admin logout confirmation page template.
+ */
+
+import { t } from "#i18n";
+import { CsrfForm } from "#shared/forms.tsx";
+import type { AdminSession } from "#shared/types.ts";
+import { markAdminFooter } from "#templates/admin/footer.tsx";
+import { AdminNav } from "#templates/admin/nav.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
+import { Layout } from "#templates/layout.tsx";
+
+const LogoutAgentHeader = (): JSX.Element => {
+  markAdminFooter();
+  return (
+    <header class="agent-header">
+      <h1>{t("logout.title")}</h1>
+    </header>
+  );
+};
+
+export const adminLogoutPage = (session: AdminSession): string =>
+  String(
+    <Layout title={t("logout.title")}>
+      {session.adminLevel === "agent" ? (
+        <LogoutAgentHeader />
+      ) : (
+        <>
+          <AdminNav active="" session={session} />
+          <h1>{t("logout.title")}</h1>
+        </>
+      )}
+      <section aria-labelledby="logout-confirm-heading">
+        <h2 id="logout-confirm-heading">{t("logout.confirm_heading")}</h2>
+        <p>{t("logout.confirm_body")}</p>
+        <CsrfForm action="/admin/logout" class="one-button">
+          <SubmitButton class="secondary" icon="log-out">
+            {t("nav.logout")}
+          </SubmitButton>
+        </CsrfForm>
+      </section>
+    </Layout>,
+  );

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -192,9 +192,14 @@ describe("adminFooterHtml", () => {
     expect(html).toContain("Chobble Tickets</a>");
   });
 
-  test("includes a logout form", () => {
+  test("includes inline utility links separated by dots", () => {
     const html = adminFooterHtml(null);
-    expect(html).toContain('action="/admin/logout"');
+    expect(html).toContain('<div class="admin-footer-links">');
+    expect(html).toContain(
+      '<a href="/admin/log">Log</a> &middot; <a href="/admin/guide">Guide</a> &middot; <a href="/admin/logout">Log out</a>',
+    );
+    expect(html).not.toContain('action="/admin/logout"');
+    expect(html).not.toContain("#log-out");
   });
 
   test("omits the debug menu when no debug data is supplied", () => {
@@ -226,7 +231,7 @@ describe("renderAdminFooter", () => {
       markAdminFooter();
       const html = renderAdminFooter();
       expect(html).toContain('<footer class="admin-footer">');
-      expect(html).toContain('action="/admin/logout"');
+      expect(html).toContain('<a href="/admin/logout">Log out</a>');
       expect(html).not.toContain("debug-menu");
     });
   });

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -9,6 +9,7 @@ import {
   assertAdminHtml,
   assertPublicHtml,
   awaitTestRequest,
+  createTestAgentSession,
   describeWithEnv,
   expectFlash,
   expectHtmlResponse,
@@ -234,9 +235,38 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
   });
 
   describe("GET /admin/logout", () => {
-    test("returns 404 not found", async () => {
-      const response = await handleRequest(mockRequest("/admin/logout"));
-      await expectHtmlResponse(response, 404, "Not Found");
+    testRequiresAuth("/admin/logout");
+
+    test("shows confirmation page with the actual POST form", async () => {
+      const { cookie } = await loginAsAdmin();
+
+      const response = await handleRequest(
+        mockRequest("/admin/logout", { headers: { cookie } }),
+      );
+
+      await expectHtmlResponse(
+        response,
+        200,
+        "Are you sure you want to log out?",
+        'action="/admin/logout"',
+        'method="POST"',
+      );
+    });
+
+    test("shows confirmation page to delivery agents", async () => {
+      const { cookie } = await createTestAgentSession();
+
+      const response = await handleRequest(
+        mockRequest("/admin/logout", { headers: { cookie } }),
+      );
+
+      await expectHtmlResponse(
+        response,
+        200,
+        "Are you sure you want to log out?",
+        'action="/admin/logout"',
+        'method="POST"',
+      );
     });
   });
 

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -258,7 +258,7 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
         "/admin/guide",
         "/admin/guide",
         "Listings",
-        "Logout",
+        "Log out",
       );
     });
 


### PR DESCRIPTION
### Motivation
- Replace the footer's inline logout POST button (with an icon) with a semantic inline link so the footer becomes purely navigational and avoids embedding a form control in the chrome. 
- Keep the same visual separator (middle dot) between `Log`, `Guide` and `Log out` so the footer layout remains consistent. 
- Provide an explicit confirmation step and a proper CSRF-protected POST endpoint for the destructive logout action at `/admin/logout` to improve accessibility and semantics. 

### Description
- Changed the admin footer to render `Log`, `Guide` and a plain `<a href="/admin/logout">Log out</a>` joined by `&middot;` and removed the inline logout form and icon from the footer (`src/ui/templates/admin/footer.tsx`).
- Added a new confirmation page template `adminLogoutPage` that shows the heading "Are you sure you want to log out?" and contains the actual `CsrfForm` POST to `/admin/logout` (`src/ui/templates/admin/logout.tsx`).
- Registered a `GET /admin/logout` route that serves the confirmation page to any authenticated user while keeping the existing `POST /admin/logout` handler that performs the session deletion with CSRF validation (`src/features/admin/auth.ts`).
- Updated styles so the right-side footer utilities behave as inline links without wrapping (`src/ui/static/mvp.css`), adjusted localization copy to "Log out" and added confirmation strings (`src/locales/en/nav.json`, `src/locales/en/login.json`), and removed the unused inline form/icon imports from the footer template.
- Updated unit tests that asserted the footer and logout behavior to reflect the new link and confirmation page and added a delivery-agent confirmation test (`test/lib/footer.test.ts`, `test/lib/server-auth.test.ts`, `test/lib/server-guide.test.ts`).

### Testing
- Ran the focused tests with `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/lib/footer.test.ts test/lib/server-auth.test.ts` and the two tests passed. 
- Ran the full precommit pipeline with `DENO_TLS_CA_STORE=system mise exec -- deno task precommit` (lint, typecheck, cpd, build:edge, test:coverage) and it passed after adding coverage for the new confirmation-page branch. 
- Verified the updated footer HTML and logout confirmation page render and that `POST /admin/logout` still performs the CSRF-protected session deletion in the test suite (all tests referenced above passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f6351290832d88b83beab7932d4b)