### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/biome-fix.yml
+++ b/.github/workflows/biome-fix.yml
@@ -55,7 +55,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/biome-fix.yml
+++ b/.github/workflows/biome-fix.yml
@@ -54,6 +54,11 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/bunny-deploy.yml
+++ b/.github/workflows/bunny-deploy.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/deploy-clients.yml
+++ b/.github/workflows/deploy-clients.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/deploy-clients.yml
+++ b/.github/workflows/deploy-clients.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:


### PR DESCRIPTION
### Motivation
- Ensure a consistent Node.js 24 runtime is available in CI runs that also prepare the Deno environment. 
- Some tooling used during builds and precommit checks relies on Node being present and at a supported version. 
- Make workflows explicit about Node compatibility so runner environments match local expectations (Node 24 / Deno 2.x).

### Description
- Add a `Setup Node.js` step using `actions/setup-node@v4` with `node-version: 24` immediately before `Setup Deno` in all workflows that prepare the Deno environment. 
- Updated the following workflow files: `.github/workflows/biome-fix.yml`, `.github/workflows/bunny-deploy.yml`, `.github/workflows/deploy-clients.yml`, `.github/workflows/docs.yml`, `.github/workflows/release.yml`, and `.github/workflows/test.yml`. 
- The new step is placed prior to the existing `denoland/setup-deno@v2` step so Node is available for any npm-based tools invoked during the job.

### Testing
- Ran `git diff --check` to validate there are no whitespace or patch errors and it passed. 
- Attempted to run `mise exec -- deno task precommit` to exercise the full precommit pipeline, but it was blocked by an external npm registry TLS certificate error while caching dependencies (`invalid peer certificate: UnknownIssuer`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3404fb7524832db167ce6a3987fc8a)