### PR TITLE
Fix setup cache invalidation

### DIFF
--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -776,13 +776,15 @@ const completeSetup = async (
   await writeRaw(CONFIG_KEYS.PUBLIC_KEY, publicKey);
   await writeRaw(CONFIG_KEYS.COUNTRY, country);
   await writeRaw(CONFIG_KEYS.SETUP_COMPLETE, "true");
-  // Keep the in-memory snapshot in sync with the freshly-written rows so the
-  // next request doesn't read stale defaults while the raw cache is still
-  // valid (loadKeys short-circuits for up to SETTINGS_CACHE_TTL_MS).
-  setSnapshotField(CONFIG_KEYS.WRAPPED_PRIVATE_KEY, encryptedPrivateKey);
-  setSnapshotField(CONFIG_KEYS.PUBLIC_KEY, publicKey);
-  data.country = country;
-  applyCountryDerived(getCountry(country));
+
+  // Setup flips the global routing gate. Drop any partially-loaded settings
+  // snapshot from pre-setup requests so the next request cannot keep serving
+  // stale defaults (notably a cached missing setup_complete row). Mark the
+  // permanent setup gate as confirmed so the immediate /setup/complete redirect
+  // succeeds without another DB round-trip.
+  invalidateCache();
+  setSetupCompleteCache(true);
+  setSetupConfirmed(true);
 };
 
 // ---------------------------------------------------------------------------

--- a/test/lib/db/settings.test.ts
+++ b/test/lib/db/settings.test.ts
@@ -74,26 +74,22 @@ describeWithEnv("db > settings", { db: true }, () => {
       expect(settings.wrappedPrivateKey).toBeTruthy();
     });
 
-    test("completeSetup updates snapshot so wrappedPrivateKey is readable without invalidation", async () => {
-      // Regression: previously completeSetup only updated the raw entries
-      // cache, leaving the snapshot holding default "" values. Because
-      // loadAll() short-circuits while the 60s TTL is valid, the first
-      // GET /admin after setup would see settings.wrappedPrivateKey === ""
-      // and throw SessionKeyError ("Private key unavailable for session").
+    test("completeSetup clears stale pre-setup settings cache and confirms setup", async () => {
       await getDb().execute("DELETE FROM users");
       await getDb().execute("DELETE FROM settings");
-      // Prime the snapshot with a fresh loadKeys so the cache is valid and
-      // contains default empty values for wrapped_private_key/public_key.
+      settings.setup.clearCache();
       settings.invalidateCache();
       await settings.loadKeys(ALL_SETTINGS_KEYS);
       expect(settings.wrappedPrivateKey).toBe("");
       expect(settings.publicKey).toBe("");
+      expect(await settings.setup.isComplete()).toBe(false);
 
       await settings.setup.complete("setupuser", "mypassword", "US");
 
-      // Do NOT invalidate or reload — the snapshot should already reflect the
-      // values just written, since subsequent requests rely on loadAll() being
-      // a no-op while the cache is still valid.
+      expect(await settings.setup.isComplete()).toBe(true);
+      expect(settings.wrappedPrivateKey).toBe("");
+      expect(settings.publicKey).toBe("");
+      await settings.loadKeys(ALL_SETTINGS_KEYS);
       expect(settings.wrappedPrivateKey).toBeTruthy();
       expect(settings.publicKey).toBeTruthy();
       expect(settings.country).toBe("US");

--- a/test/shared/db/settings.test.ts
+++ b/test/shared/db/settings.test.ts
@@ -165,16 +165,22 @@ describeWithEnv("db > settings", { db: true }, () => {
       expect(settings.wrappedPrivateKey).toBeTruthy();
     });
 
-    test("completeSetup updates snapshot so wrappedPrivateKey is readable without invalidation", async () => {
+    test("completeSetup clears stale pre-setup settings cache and confirms setup", async () => {
       await getDb().execute("DELETE FROM users");
       await getDb().execute("DELETE FROM settings");
+      settings.setup.clearCache();
       settings.invalidateCache();
       await settings.loadKeys(ALL_SETTINGS_KEYS);
       expect(settings.wrappedPrivateKey).toBe("");
       expect(settings.publicKey).toBe("");
+      expect(await settings.setup.isComplete()).toBe(false);
 
       await settings.setup.complete("setupuser", "mypassword", "US");
 
+      expect(await settings.setup.isComplete()).toBe(true);
+      expect(settings.wrappedPrivateKey).toBe("");
+      expect(settings.publicKey).toBe("");
+      await settings.loadKeys(ALL_SETTINGS_KEYS);
       expect(settings.wrappedPrivateKey).toBeTruthy();
       expect(settings.publicKey).toBeTruthy();
       expect(settings.country).toBe("US");

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -404,8 +404,9 @@ describe("migrationInProgressPage", () => {
 describe("siteNotActivatedPage", () => {
   test("renders not-activated message in the error dialog style", () => {
     const html = siteNotActivatedPage();
-    expect(html).toContain("<h1>Not Activated</h1>");
-    expect(html).toContain("This site has not been activated yet.");
+    expect(html).toContain(
+      '<div class="prose"><h1>Not Activated</h1><p>This site has not been activated yet.</p></div>',
+    );
     expect(html).toContain("<style>");
     expect(html).toContain("font-family:system-ui");
   });


### PR DESCRIPTION
### Motivation
- After finishing initial setup the app could continue to serve a partially-warmed pre-setup settings snapshot (showing the site as "Not Activated"); the change ensures the runtime flips the global setup gate and removes stale snapshot state so the immediate redirect to `/setup/complete` does not see inactive defaults.
- The site not-activated message should be rendered inside the existing content wrapper (`<div class="prose">…</div>`), so tests assert the rendered structure rather than loose fragments.

### Description
- After writing key material, country, and `setup_complete` in `completeSetup`, clear the in-memory settings snapshot by calling `invalidateCache()`, then mark the permanent setup gate as confirmed with `setSetupCompleteCache(true)` and `setSetupConfirmed(true)` so subsequent requests do not observe stale pre-setup defaults (`src/shared/db/settings.ts`).
- Strengthened regression tests: replaced the old expectation about immediate snapshot update with a test that verifies `completeSetup` clears stale pre-setup cache, confirms setup, and requires a fresh `loadKeys` before key material becomes readable; mirrored this in both `test/lib/db/settings.test.ts` and `test/shared/db/settings.test.ts`.
- Adjusted `siteNotActivatedPage` test to assert the heading/message is wrapped in the `.prose` container (updated `test/templates/public.test.ts`).

### Testing
- Ran targeted unit tests: `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/lib/db/settings.test.ts test/shared/db/settings.test.ts test/templates/public.test.ts`, and the three-file run passed (`PASS 217 passed`).
- Ran the full precommit pipeline: `DENO_TLS_CA_STORE=system mise exec -- deno task precommit`, which completed successfully (`precommit passed`).
- Verified the modified tests exercise the new cache behaviour and the `siteNotActivatedPage` structure and all automated checks passed after the fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34048df754832d90a0c2f8a9f8b94b)