### PR TITLE
Admin: add Listings page, rename Dashboard nav to Home, move Add Attendee and tweak attendees UI

### DIFF
--- a/src/features/admin/dashboard.ts
+++ b/src/features/admin/dashboard.ts
@@ -24,7 +24,10 @@ import { isListingFilter, type ListingFilter } from "#shared/listing-filter.ts";
 import { sortListings } from "#shared/sort-listings.ts";
 /* jscpd:ignore-end */
 import { adminGlobalActivityLogPage } from "#templates/admin/activityLog.tsx";
-import { adminDashboardPage } from "#templates/admin/dashboard.tsx";
+import {
+  adminDashboardPage,
+  adminListingsPage,
+} from "#templates/admin/dashboard.tsx";
 import { adminLoginPage } from "#templates/admin/login.tsx";
 
 /** Login page response helper */
@@ -81,6 +84,20 @@ const handleAdminGet = (request: Request): Promise<Response> =>
     () => loginResponse(request),
   );
 
+/** Handle GET /admin/listings */
+const handleAdminListingsGet: TypedRouteHandler<"GET /admin/listings"> =
+  sessionPage(async (session) => {
+    const [listings, holidays] = await Promise.all([
+      getAllListings(),
+      getActiveHolidays(),
+    ]);
+    return adminListingsPage(
+      sortListings(listings, holidays),
+      session,
+      settings.listingColumnOrder,
+    );
+  });
+
 /** Maximum number of log entries to display */
 const LOG_DISPLAY_LIMIT = 200;
 
@@ -101,5 +118,6 @@ const handleAdminLog: TypedRouteHandler<"GET /admin/log"> = sessionPage(
 /** Dashboard routes */
 export const dashboardRoutes = defineRoutes({
   "GET /admin": handleAdminGet,
+  "GET /admin/listings": handleAdminListingsGet,
   "GET /admin/log": handleAdminLog,
 });

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -11,6 +11,7 @@
   "admin.dashboard.booking_link": "Booking link",
   "admin.dashboard.select_two_or_more": "Select two or more listings",
   "admin.dashboard.newest_attendees": "Newest {count, plural, one {1 Attendee} other {{count} Attendees}}",
+  "admin.dashboard.deactivated": "Deactivated",
   "admin.listings.duplicate": "Duplicate",
   "admin.listings.log": "Log",
   "admin.listings.scanner": "Scanner",

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -2151,7 +2151,7 @@ a.cal-day-selected:hover {
   flex-direction: row;
   align-items: flex-end;
   gap: 1rem;
-  margin: 1rem 0;
+  margin: 0;
   padding: 0;
   border: 0;
   box-shadow: none;
@@ -2175,6 +2175,12 @@ a.cal-day-selected:hover {
 
 .filter-row select {
   max-width: 15rem;
+}
+
+.attendees-table-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 /* Previous/next pagination */

--- a/src/ui/templates/admin/attendees-list.tsx
+++ b/src/ui/templates/admin/attendees-list.tsx
@@ -20,6 +20,7 @@ import type {
 } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { AttendeeTable } from "#templates/attendee-table.tsx";
+import { ActionButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const NAV_ACTIVE = "/admin/attendees";
@@ -165,42 +166,48 @@ export const adminAttendeesListPage = (props: AttendeesListPageProps): string =>
     <Layout title={t("terms.attendees")}>
       <AdminNav active={NAV_ACTIVE} session={props.session} />
 
-      <h1>{t("terms.attendees")}</h1>
+      <p class="actions">
+        <ActionButton href="/admin/attendees/new" icon="plus">
+          {t("admin.listings.add_attendee")}
+        </ActionButton>
+      </p>
 
-      {props.categories.length > 1 && (
-        <Raw
-          html={renderTypeFilter(props.type, props.categories, (f) =>
-            typeFilterHref(f, props.sort),
-          )}
+      <div class="attendees-table-controls">
+        {props.categories.length > 1 && (
+          <Raw
+            html={renderTypeFilter(props.type, props.categories, (f) =>
+              typeFilterHref(f, props.sort),
+            )}
+          />
+        )}
+
+        {props.type !== "all" && (
+          <p>
+            {t("attendees_list.showing_count", { count: props.count })}{" "}
+            <strong>{listingFilterLabel(props.type)}</strong>
+          </p>
+        )}
+
+        <FilterForm
+          listingId={props.listingId}
+          listings={props.listings}
+          sortOrder={props.sort}
         />
-      )}
 
-      {props.type !== "all" && (
-        <p>
-          {t("attendees_list.showing_count", { count: props.count })}{" "}
-          <strong>{listingFilterLabel(props.type)}</strong>
-        </p>
-      )}
-
-      <FilterForm
-        listingId={props.listingId}
-        listings={props.listings}
-        sortOrder={props.sort}
-      />
-
-      <div class="table-scroll">
-        <Raw
-          html={AttendeeTable({
-            allowedDomain: props.allowedDomain,
-            emptyMessage: t("attendees_list.no_attendees_yet"),
-            phonePrefix: props.phonePrefix,
-            presorted: true,
-            rows: props.rows,
-            showCheckin: false,
-            showDate: false,
-            showListing: true,
-          })}
-        />
+        <div class="table-scroll">
+          <Raw
+            html={AttendeeTable({
+              allowedDomain: props.allowedDomain,
+              emptyMessage: t("attendees_list.no_attendees_yet"),
+              phonePrefix: props.phonePrefix,
+              presorted: true,
+              rows: props.rows,
+              showCheckin: false,
+              showDate: false,
+              showListing: true,
+            })}
+          />
+        </div>
       </div>
 
       <Pagination

--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -193,6 +193,26 @@ export const renderListingTable = (
   return `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
 };
 
+const renderListingsTableSection = (
+  listings: ListingWithCount[],
+  columnKeys: string[],
+  filters: Map<string, string>,
+): string => {
+  const listingRows =
+    listings.length > 0
+      ? pipe(
+          map((e: ListingWithCount) => ListingRow({ columnKeys, e, filters })),
+          joinStrings,
+        )(listings)
+      : `<tr><td colspan="${columnKeys.length}">${t("admin.dashboard.no_listings")}</td></tr>`;
+
+  return String(
+    <div class="table-scroll">
+      <Raw html={renderListingTable(columnKeys, listingRows)} />
+    </div>,
+  );
+};
+
 /**
  * Admin dashboard page
  */
@@ -216,12 +236,13 @@ export const adminDashboardPage = (
   // newest-attendee sections below stay based on the full set. Offer the bar
   // (same control as the public/attendee filters) only when more than one
   // listing type is present.
+  const activeListings = filter((e: ListingWithCount) => e.active)(listings);
   const categories = unique(listings.map(listingCategory));
   const shownListings =
     activeType === "all"
-      ? listings
+      ? activeListings
       : filter((e: ListingWithCount) => listingCategory(e) === activeType)(
-          listings,
+          activeListings,
         );
   const typeFilterHtml =
     categories.length > 1
@@ -229,16 +250,6 @@ export const adminDashboardPage = (
           f === "all" ? "/admin/" : `/admin/?type=${f}`,
         )
       : "";
-
-  const listingRows =
-    shownListings.length > 0
-      ? pipe(
-          map((e: ListingWithCount) => ListingRow({ columnKeys, e, filters })),
-          joinStrings,
-        )(shownListings)
-      : `<tr><td colspan="${columnKeys.length}">${t("admin.dashboard.no_listings")}</td></tr>`;
-
-  const activeListings = filter((e: ListingWithCount) => e.active)(listings);
 
   return String(
     <Layout title={t("terms.listings")}>
@@ -251,17 +262,14 @@ export const adminDashboardPage = (
           <ActionButton href="/admin/listing/new" icon="plus">
             {t("admin.dashboard.add_listing")}
           </ActionButton>
-          <ActionButton href="/admin/attendees/new" icon="plus">
-            Add Attendee
-          </ActionButton>
         </p>
       )}
 
       <Raw html={typeFilterHtml} />
 
-      <div class="table-scroll">
-        <Raw html={renderListingTable(columnKeys, listingRows)} />
-      </div>
+      <Raw
+        html={renderListingsTableSection(shownListings, columnKeys, filters)}
+      />
 
       {stats && <Raw html={activeListingStatsSection(stats)} />}
 
@@ -271,6 +279,54 @@ export const adminDashboardPage = (
 
       {newestAttendees.length > 0 && (
         <Raw html={newestAttendeesSection(newestAttendees, listings)} />
+      )}
+    </Layout>,
+  );
+};
+
+/** Admin listings index page with active and deactivated listings split. */
+export const adminListingsPage = (
+  listings: ListingWithCount[],
+  session: AdminSession,
+  listingColumnTemplate?: string,
+): string => {
+  const { columnKeys, filters } = resolveColumnLayout(
+    listingColumnTemplate ?? "",
+    Object.keys(LISTING_TABLE_COLUMNS),
+    LISTING_DEFAULT_ORDER,
+  );
+  const activeListings = filter((e: ListingWithCount) => e.active)(listings);
+  const deactivatedListings = filter((e: ListingWithCount) => !e.active)(
+    listings,
+  );
+
+  return String(
+    <Layout title={t("terms.listings")}>
+      <AdminNav active="/admin/listings" session={session} />
+
+      {!isReadOnly() && (
+        <p class="actions">
+          <ActionButton href="/admin/listing/new" icon="plus">
+            {t("admin.dashboard.add_listing")}
+          </ActionButton>
+        </p>
+      )}
+
+      <Raw
+        html={renderListingsTableSection(activeListings, columnKeys, filters)}
+      />
+
+      {deactivatedListings.length > 0 && (
+        <>
+          <h2>{t("admin.dashboard.deactivated")}</h2>
+          <Raw
+            html={renderListingsTableSection(
+              deactivatedListings,
+              columnKeys,
+              filters,
+            )}
+          />
+        </>
       )}
     </Layout>,
   );

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -81,7 +81,8 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => {
       )}
       <nav id="main-nav">
         <ul>
-          {navLink("/admin/", t("terms.listings"), active)}
+          {navLink("/admin/", t("nav.public.home"), active)}
+          {navLink("/admin/listings", t("terms.listings"), active)}
           {navLink("/admin/calendar", t("nav.calendar"), active)}
           {navLink("/admin/attendees", t("terms.attendees"), active)}
           {session.adminLevel === "owner" &&

--- a/test/lib/server-attendees-list.test.ts
+++ b/test/lib/server-attendees-list.test.ts
@@ -29,10 +29,13 @@ describeWithEnv("server (admin attendees list)", { db: true }, () => {
 
       await assertAdminHtml(
         "/admin/attendees",
-        "<h1>Attendees</h1>",
+        'href="/admin/attendees/new"',
         "Alice",
         "Gala Night",
       );
+      const { response } = await adminGet("/admin/attendees");
+      const html = await response.text();
+      expect(html).not.toContain("<h1>Attendees</h1>");
     });
 
     test("lists the newest registration first by default", async () => {

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -50,6 +50,26 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
     setDemoModeForTest(false);
   });
 
+  describe("GET /admin/listings", () => {
+    testRequiresAuth("/admin/listings");
+
+    test("renders active listings before deactivated listings", async () => {
+      const active = await createTestListing({ name: "Active Show" });
+      const deactivated = await createTestListing({ name: "Old Show" });
+      await deactivateTestListing(deactivated.id);
+
+      const { response } = await adminGet("/admin/listings");
+      const html = await response.text();
+      expect(response.status).toBe(200);
+      expect(html).toContain('class="active" href="/admin/listings"');
+      expect(html).toContain(active.name);
+      expect(html).toContain(deactivated.name);
+      expect(html.indexOf(active.name)).toBeLessThan(
+        html.indexOf(deactivated.name),
+      );
+    });
+  });
+
   describe("GET /admin/listing/new", () => {
     testRequiresAuth("/admin/listing/new");
 

--- a/test/templates/admin/attendees-list.test.ts
+++ b/test/templates/admin/attendees-list.test.ts
@@ -55,7 +55,9 @@ describe("adminAttendeesListPage", () => {
     const html = adminAttendeesListPage(buildProps());
     expect(html).toContain("<title>Attendees</title>");
     expect(html).toContain('href="/admin/attendees"');
-    expect(html).toContain("<h1>Attendees</h1>");
+    expect(html).toContain('href="/admin/attendees/new"');
+    expect(html).toContain("Add Attendee");
+    expect(html).not.toContain("<h1>Attendees</h1>");
   });
 
   test("renders the filter/sort form as a GET form", () => {

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -4,6 +4,7 @@ import { signCsrfToken } from "#shared/csrf.ts";
 import {
   activeListingStatsSection,
   adminDashboardPage,
+  adminListingsPage,
 } from "#templates/admin/dashboard.tsx";
 import {
   describeWithEnv,
@@ -45,14 +46,6 @@ describe("adminDashboardPage", () => {
     const html = adminDashboardPage([], TEST_SESSION);
     expect(html).toContain('href="/admin/listing/new"');
     expect(html).toContain("Add Listing");
-  });
-
-  test("renders add attendee link to the create-attendee route", () => {
-    // The "Add Attendee" button must point at the registered create route
-    // (plural /admin/attendees/new); a singular typo here 404s the page.
-    const html = adminDashboardPage([], TEST_SESSION);
-    expect(html).toContain('href="/admin/attendees/new"');
-    expect(html).toContain("Add Attendee");
   });
 
   test("includes logout link", () => {
@@ -139,13 +132,18 @@ describe("adminDashboardPage", () => {
 });
 
 describe("adminDashboardPage inactive listings", () => {
-  test("renders inactive listing with reduced opacity", () => {
+  test("hides inactive listings from home", () => {
     const listings = [
-      testListingWithCount({ active: false, attendee_count: 5 }),
+      testListingWithCount({
+        active: false,
+        attendee_count: 5,
+        name: "Inactive",
+      }),
     ];
     const html = adminDashboardPage(listings, TEST_SESSION);
-    expect(html).toContain("inactive-row");
-    expect(html).toContain("Inactive");
+    expect(html).not.toContain("inactive-row");
+    expect(html).not.toContain('href="/admin/listing/1"');
+    expect(html).toContain("No listings yet");
   });
 });
 
@@ -477,3 +475,32 @@ describeWithEnv(
     });
   },
 );
+
+describe("adminListingsPage", () => {
+  test("renders active listings first and deactivated listings second", () => {
+    const active = testListingWithCount({
+      active: true,
+      id: 1,
+      name: "Active Show",
+    });
+    const inactive = testListingWithCount({
+      active: false,
+      id: 2,
+      name: "Old Show",
+    });
+    const html = adminListingsPage([active, inactive], TEST_SESSION);
+    expect(html).toContain('class="active" href="/admin/listings"');
+    expect(html).toContain("Active Show");
+    expect(html).toContain("Deactivated");
+    expect(html).toContain("Old Show");
+    expect(html.indexOf("Active Show")).toBeLessThan(html.indexOf("Old Show"));
+  });
+
+  test("omits the deactivated heading when every listing is active", () => {
+    const html = adminListingsPage(
+      [testListingWithCount({ active: true, name: "Active Show" })],
+      TEST_SESSION,
+    );
+    expect(html).not.toContain("Deactivated");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a separate `/admin/listings` index that shows active listings first and deactivated listings second so the dashboard (`/admin/`) can focus on active listings only.
- Make the top nav clearer by renaming the dashboard link to “Home” and exposing a dedicated “Listings” link to reach the new index.
- Move the manual “Add Attendee” action onto the attendees page and simplify the attendees header/UI for a tighter layout.
- Keep templates localised (no hard-coded strings) and preserve existing dashboard features (stats, multi-booking, newest attendees) while adjusting which listings they use.

### Description
- Added a new `adminListingsPage` template and a `GET /admin/listings` handler (`src/ui/templates/admin/dashboard.tsx`, `src/features/admin/dashboard.ts`) that render active listings first and then deactivated listings under a localized “Deactivated” heading.
- Updated `adminDashboardPage` to show only active listings on Home and to reuse a `renderListingsTableSection` helper to avoid duplication (`src/ui/templates/admin/dashboard.tsx`).
- Changed the admin navigation to show `Home` (`/admin/`) and a separate `Listings` link (`/admin/listings`) (`src/ui/templates/admin/nav.tsx`).
- Moved the “Add Attendee” action into the attendees browser page and removed the H1 heading there, wrapping the filters and table in a grouped container with preserved gap (`src/ui/templates/admin/attendees-list.tsx`).
- Adjusted styles: removed vertical margins from `.filter-row` and added `.attendees-table-controls` to group attendees controls with a 1rem gap (`src/ui/static/mvp.css`).
- Added the i18n key for the deactivated heading and updated tests that expected the previous headings/links (`src/locales/en/admin.json`, several `test/*` updates).

### Testing
- Ran focused template unit tests with `deno task test:files test/templates/admin/dashboard.test.ts test/templates/admin/attendees-list.test.ts test/ui/templates/admin/nav.test.tsx` and they passed locally.
- Ran the i18n coverage and server tests that cover the updated pages with `deno task test:files test/lib/i18n-coverage.test.ts test/lib/server-attendees-list.test.ts test/templates/admin/dashboard.test.ts test/templates/admin/attendees-list.test.ts` and they passed after the changes to use localized strings.
- Exercised listing server tests with `deno task test:files test/lib/server-listings.test.ts` which passed, including a new assertion for `GET /admin/listings` ordering.
- Ran the full precommit suite via `deno task precommit` (lint, typecheck, cpd, build:edge and coverage) and the precommit checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3417647020832d84e7de2591b3bd3c)