### PR TITLE
Format bookable days with spaces

### DIFF
--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -1169,7 +1169,7 @@ const formatDatetimeLocal = (iso: string | null): string | null => {
   return utcToLocalInput(iso, settings.timezone);
 };
 
-const formatBookableDays = (days: string[]): string => days.join(",");
+const formatBookableDays = (days: string[]): string => days.join(", ");
 
 /**
  * Render the per-day-count price inputs for "customisable days" listings: one

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -2956,7 +2956,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         "Listing Type",
         "Daily",
         "Bookable Days",
-        "Monday,Tuesday",
+        "Monday, Tuesday",
         "Booking Window",
         "3 to 60 days",
         "Capacity of",


### PR DESCRIPTION
### Motivation
- Improve readability of admin-facing bookable-days lists by separating day names with a comma and space instead of a bare comma.

### Description
- Change `formatBookableDays` to use `days.join(", ")` and update the corresponding test expectation in `test/lib/server-listings.test.ts` to match the new `"Monday, Tuesday"` formatting.

### Testing
- Ran the repository precommit checks via `DENO_TLS_CA_STORE=system mise exec -- deno task precommit` which completed successfully; and ran the targeted listing test via `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/lib/server-listings.test.ts --filter "admin listing detail page shows Daily type"` which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34336d82a8832d86763f6bd6a016e5)