### PR TITLE
Harden i18n + public↔webhook pricing seams (fixes answer-modifier ref collision)

### DIFF
--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -193,13 +193,23 @@ export const buildItemsMetadata = async (
       : undefined,
   });
 
-/** Compact the resolved modifier specs to id/quantity references for metadata. */
+/**
+ * Compact the resolved modifier specs to id/quantity references for metadata.
+ *
+ * Answer price modifiers are excluded: the webhook re-derives them from the
+ * stored `answer_ids`, not from these refs, and an answer id can collide with
+ * an unrelated modifier id (the two tables autoincrement independently). Were
+ * they included, `specsFromRefs` would re-fetch that id from the modifiers
+ * table and wrongly revive a same-id modifier on payment completion.
+ */
 export const toModifierRefs = (
   specs: CheckoutIntent["modifiers"],
-): ModifierRef[] | undefined =>
-  specs && specs.length > 0
-    ? specs.map((s) => ({ i: s.id, q: s.quantity }))
+): ModifierRef[] | undefined => {
+  const real = (specs ?? []).filter((s) => s.source !== "answer");
+  return real.length > 0
+    ? real.map((s) => ({ i: s.id, q: s.quantity }))
     : undefined;
+};
 
 /** Input for buildMetadata — like BookingIntent but with optional contact fields */
 type MetadataInput = Pick<BookingIntent, "name" | "email" | "items" | "date"> &

--- a/test/lib/checkout-pricing-consistency.test.ts
+++ b/test/lib/checkout-pricing-consistency.test.ts
@@ -1,0 +1,312 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { priceCheckout } from "#shared/checkout-pricing.ts";
+import { hmacHash } from "#shared/crypto/hashing.ts";
+import { toMinorUnits } from "#shared/currency.ts";
+import {
+  resolveModifiers,
+  specsFromRefs,
+} from "#shared/db/modifier-resolve.ts";
+import { toModifierRefs } from "#shared/payment-helpers.ts";
+import type {
+  CheckoutIntent,
+  CheckoutItem,
+  ModifierRef,
+  ModifierSpec,
+} from "#shared/payments.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
+import {
+  checkoutItem,
+  describeWithEnv,
+  insertModifier,
+  linkModifierListing,
+  patchModifier,
+  useSetting,
+} from "#test-utils";
+
+/**
+ * The public checkout and the webhook must price the same cart identically: the
+ * buyer is charged the total the public pricing computed, and on payment the
+ * webhook re-derives that total from session metadata and refunds on a
+ * mismatch. The two paths share priceCheckout but resolve modifiers
+ * differently — resolveModifiers (live, by scope/code/stock) up front vs
+ * specsFromRefs (re-fetched by id) on completion — so a divergence between them
+ * silently refunds good orders. These tests pin the round-trip:
+ *
+ *   resolveModifiers → toModifierRefs → (metadata JSON) → specsFromRefs
+ *
+ * must land on the same priced total and modifier applications.
+ */
+
+const buyer = {
+  address: "",
+  email: "buyer@example.com",
+  name: "Buyer",
+  phone: "",
+  special_instructions: "",
+};
+
+const pricingIntent = (
+  items: CheckoutItem[],
+  modifiers: ModifierSpec[],
+  overrides: Partial<CheckoutIntent> = {},
+): CheckoutIntent => ({
+  ...buyer,
+  date: null,
+  items,
+  modifiers,
+  ...overrides,
+});
+
+/** Reproduce the webhook's modifier rebuild: compact the resolved specs to the
+ * id/quantity refs stored in provider metadata, pass them through the JSON
+ * boundary the webhook parses, then re-fetch by id — exactly as production. */
+const rebuildFromMetadata = async (
+  publicSpecs: ModifierSpec[],
+  ctx: { visits: number } = { visits: 0 },
+): Promise<ModifierSpec[]> => {
+  const refs = toModifierRefs(publicSpecs) ?? [];
+  const fromMetadata = JSON.parse(JSON.stringify(refs)) as ModifierRef[];
+  return specsFromRefs(fromMetadata, ctx);
+};
+
+/** Assert the public specs and their webhook-rebuilt counterparts price a cart
+ * to the same total and the same applications. */
+const expectConsistent = async (
+  items: CheckoutItem[],
+  publicSpecs: ModifierSpec[],
+  opts: { ctx?: { visits: number }; overrides?: Partial<CheckoutIntent> } = {},
+): Promise<void> => {
+  const ctx = opts.ctx ?? { visits: 0 };
+  const webhookSpecs = await rebuildFromMetadata(publicSpecs, ctx);
+  const pub = priceCheckout(pricingIntent(items, publicSpecs, opts.overrides));
+  const web = priceCheckout(pricingIntent(items, webhookSpecs, opts.overrides));
+  expect(web.total).toBe(pub.total);
+  expect(web.modifierApplications).toEqual(pub.modifierApplications);
+};
+
+describeWithEnv(
+  "checkout pricing consistency (public ↔ webhook)",
+  { db: true },
+  () => {
+    // Zero the booking fee so totals are pure modifier math; the fee is equal on
+    // both paths regardless, but this keeps the cases easy to reason about.
+    useSetting({ booking_fee: "0" });
+
+    test("a whole-order fixed surcharge re-prices identically", async () => {
+      await insertModifier({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "Parking",
+      });
+      const items = [checkoutItem({ quantity: 2 })];
+      const specs = await resolveModifiers(items);
+      expect(specs).toHaveLength(1);
+      await expectConsistent(items, specs);
+    });
+
+    test("a percentage discount keeps its negative value through the round-trip", async () => {
+      await insertModifier({
+        calcKind: "percent",
+        calcValue: 10,
+        direction: "discount",
+        name: "Loyalty",
+      });
+      const items = [checkoutItem({ quantity: 3 })];
+      const specs = await resolveModifiers(items);
+      expect(specs[0]!.value).toBe(-10);
+      await expectConsistent(items, specs);
+    });
+
+    test("a multiplier re-prices identically", async () => {
+      await insertModifier({
+        calcKind: "multiply",
+        calcValue: 1.5,
+        direction: "charge",
+        name: "Peak",
+      });
+      const items = [checkoutItem()];
+      const specs = await resolveModifiers(items);
+      expect(specs[0]!.value).toBe(1.5);
+      await expectConsistent(items, specs);
+    });
+
+    test("a listing-scoped modifier rebuilds its listing ids (which refs don't store)", async () => {
+      const m = await insertModifier({
+        calcKind: "percent",
+        calcValue: 20,
+        direction: "charge",
+        name: "VIP",
+      });
+      await patchModifier(m.id, { scope: "listings" });
+      await linkModifierListing(m.id, 1);
+      const items = [checkoutItem({ listingId: 1 })];
+      const specs = await resolveModifiers(items);
+      expect(specs[0]!.listingIds).toEqual([1]);
+      await expectConsistent(items, specs);
+    });
+
+    test("a code modifier is re-applied on the webhook without re-entering the code", async () => {
+      const m = await insertModifier({
+        calcKind: "fixed",
+        calcValue: 8,
+        direction: "charge",
+        name: "SUMMER",
+      });
+      await patchModifier(m.id, {
+        code_index: await hmacHash(normalizeCode("Summer25")),
+        trigger: "code",
+      });
+      const items = [checkoutItem()];
+      const specs = await resolveModifiers(items, { code: "SUMMER25" });
+      expect(specs.map((s) => s.name)).toEqual(["SUMMER"]);
+      await expectConsistent(items, specs);
+    });
+
+    test("an opt-in add-on keeps its chosen quantity", async () => {
+      const m = await insertModifier({
+        calcKind: "fixed",
+        calcValue: 4,
+        direction: "charge",
+        name: "T-shirt",
+      });
+      await patchModifier(m.id, { trigger: "optional" });
+      const items = [checkoutItem()];
+      const specs = await resolveModifiers(items, {
+        addOns: new Map([[m.id, 3]]),
+      });
+      expect(specs[0]!.quantity).toBe(3);
+      await expectConsistent(items, specs);
+    });
+
+    test("a stock-clamped add-on charges the clamped quantity, not the requested one", async () => {
+      const m = await insertModifier({
+        calcKind: "fixed",
+        calcValue: 4,
+        direction: "charge",
+        name: "Limited tee",
+        stock: 2,
+      });
+      await patchModifier(m.id, { trigger: "optional" });
+      const items = [checkoutItem()];
+      const specs = await resolveModifiers(items, {
+        addOns: new Map([[m.id, 5]]),
+      });
+      // Resolution clamped 5 → 2; the webhook must re-price the clamped 2.
+      expect(specs[0]!.quantity).toBe(2);
+      await expectConsistent(items, specs);
+    });
+
+    test("a visit-gated modifier re-prices identically for the same visit count", async () => {
+      await insertModifier({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "discount",
+        minVisits: 1,
+        name: "Welcome back",
+      });
+      const items = [checkoutItem()];
+      const specs = await resolveModifiers(items, { ctx: { visits: 2 } });
+      expect(specs).toHaveLength(1);
+      await expectConsistent(items, specs, { ctx: { visits: 2 } });
+    });
+
+    test("several modifiers on a multi-item cart re-price identically", async () => {
+      await insertModifier({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "Parking",
+      });
+      await insertModifier({
+        calcKind: "percent",
+        calcValue: 10,
+        direction: "discount",
+        name: "Loyalty",
+      });
+      const scoped = await insertModifier({
+        calcKind: "percent",
+        calcValue: 25,
+        direction: "charge",
+        name: "VIP",
+      });
+      await patchModifier(scoped.id, { scope: "listings" });
+      await linkModifierListing(scoped.id, 2);
+      const items = [
+        checkoutItem({ listingId: 1, quantity: 2, unitPrice: 1000 }),
+        checkoutItem({
+          listingId: 2,
+          quantity: 1,
+          slug: "vip",
+          unitPrice: 5000,
+        }),
+      ];
+      const specs = await resolveModifiers(items);
+      expect(specs).toHaveLength(3);
+      await expectConsistent(items, specs);
+    });
+
+    test("a reservation deposit combined with a modifier re-prices identically", async () => {
+      await insertModifier({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "Parking",
+      });
+      const items = [checkoutItem({ quantity: 2 })];
+      const specs = await resolveModifiers(items);
+      expect(specs).toHaveLength(1);
+      await expectConsistent(items, specs, {
+        overrides: { reservationAmount: "10%" },
+      });
+    });
+
+    test("an answer modifier whose id collides with an active modifier is not re-applied as that modifier", async () => {
+      // An active opt-in add-on the buyer did NOT select, so resolveModifiers
+      // skips it for this cart. specsFromRefs does not re-check the opt-in
+      // trigger, so a metadata ref carrying this id would wrongly revive it.
+      const addOn = await insertModifier({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "Unselected add-on",
+      });
+      await patchModifier(addOn.id, { trigger: "optional" });
+
+      // An answer price modifier the buyer DID pick, sharing the add-on's id
+      // (answer ids and modifier ids autoincrement in separate tables, so low
+      // ids collide). The webhook re-derives answer specs from answer_ids, not
+      // from modifier refs, so the add-on's id must never leak into the refs.
+      const answerSpec: ModifierSpec = {
+        id: addOn.id,
+        kind: "fixed",
+        listingIds: null,
+        name: "Premium answer",
+        quantity: 1,
+        source: "answer",
+        trigger: "automatic",
+        value: toMinorUnits(3),
+      };
+      const items = [checkoutItem()];
+
+      // Public total: just the +£3 answer. Add-on was not selected.
+      const publicSpecs = [answerSpec];
+      const publicTotal = priceCheckout(
+        pricingIntent(items, publicSpecs),
+      ).total;
+
+      // Webhook: real modifiers come from the refs, answers are re-added from
+      // answer_ids. The unselected add-on must not reappear via the refs.
+      const refs = toModifierRefs(publicSpecs) ?? [];
+      const fromMetadata = JSON.parse(JSON.stringify(refs)) as ModifierRef[];
+      const webhookModifiers = await specsFromRefs(fromMetadata);
+      const webhookSpecs = [...webhookModifiers, answerSpec];
+      const webhookTotal = priceCheckout(
+        pricingIntent(items, webhookSpecs),
+      ).total;
+
+      expect(webhookTotal).toBe(publicTotal);
+    });
+  },
+);

--- a/test/lib/db/modifier-resolve.test.ts
+++ b/test/lib/db/modifier-resolve.test.ts
@@ -17,50 +17,16 @@ import {
   specsFromRefs,
 } from "#shared/db/modifier-resolve.ts";
 import { consumeModifierStock } from "#shared/db/modifier-usage.ts";
-import { type ModifierInput, modifiersTable } from "#shared/db/modifiers.ts";
-import type { CheckoutItem } from "#shared/payments.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
-import { createTestListing, describeWithEnv } from "#test-utils";
-
-const linkListing = (modifierId: number, listingId: number) =>
-  getDb().execute({
-    args: [modifierId, listingId],
-    sql: "INSERT INTO modifier_listings (modifier_id, listing_id) VALUES (?, ?)",
-  });
-
-const linkGroup = (modifierId: number, groupId: number) =>
-  getDb().execute({
-    args: [modifierId, groupId],
-    sql: "INSERT INTO modifier_groups (modifier_id, group_id) VALUES (?, ?)",
-  });
-
-const item = (overrides: Partial<CheckoutItem> = {}): CheckoutItem => ({
-  listingId: 1,
-  name: "General",
-  quantity: 1,
-  slug: "general",
-  unitPrice: 1000,
-  ...overrides,
-});
-
-const insertModifier = (overrides: Partial<ModifierInput> = {}) =>
-  modifiersTable.insert({
-    calcKind: "fixed",
-    calcValue: 5,
-    direction: "charge",
-    name: "Add-on",
-    ...overrides,
-  });
-
-/** Override behavioural columns the base create form doesn't expose yet. */
-const patchModifier = (id: number, set: Record<string, string | number>) => {
-  const cols = Object.keys(set);
-  const assignments = cols.map((c) => `${c} = ?`).join(", ");
-  return getDb().execute({
-    args: [...cols.map((c) => set[c]!), id],
-    sql: `UPDATE modifiers SET ${assignments} WHERE id = ?`,
-  });
-};
+import {
+  checkoutItem,
+  createTestListing,
+  describeWithEnv,
+  insertModifier,
+  linkModifierGroup,
+  linkModifierListing,
+  patchModifier,
+} from "#test-utils";
 
 describeWithEnv("db > modifier-resolve", { db: true }, () => {
   describe("resolveModifiers", () => {
@@ -71,7 +37,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
         direction: "charge",
         name: "Parking",
       });
-      const specs = await resolveModifiers([item()]);
+      const specs = await resolveModifiers([checkoutItem()]);
       expect(specs).toEqual([
         {
           id: specs[0]!.id,
@@ -98,7 +64,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
         direction: "charge",
         name: "Peak",
       });
-      const specs = await resolveModifiers([item()]);
+      const specs = await resolveModifiers([checkoutItem()]);
       const byName = new Map(specs.map((s) => [s.name, s]));
       expect(byName.get("Loyalty")!.value).toBe(-10);
       expect(byName.get("Peak")!.value).toBe(1.5);
@@ -114,13 +80,13 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       const gated = await insertModifier({ name: "BigSpendOnly" });
       await patchModifier(gated.id, { min_subtotal: 999999 });
 
-      const specs = await resolveModifiers([item({ unitPrice: 1000 })]);
+      const specs = await resolveModifiers([checkoutItem({ unitPrice: 1000 })]);
       expect(specs.map((s) => s.name)).toEqual([]);
     });
 
     test("includes a stock-limited modifier while stock remains", async () => {
       await insertModifier({ name: "Plenty", stock: 5 });
-      const specs = await resolveModifiers([item()]);
+      const specs = await resolveModifiers([checkoutItem()]);
       expect(specs.map((s) => s.name)).toContain("Plenty");
     });
 
@@ -129,7 +95,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       await consumeModifierStock(1, [
         { amountApplied: 500, modifierId: m.id, quantity: 1 },
       ]);
-      const specs = await resolveModifiers([item()]);
+      const specs = await resolveModifiers([checkoutItem()]);
       expect(specs.map((s) => s.name)).not.toContain("Limited");
     });
 
@@ -141,12 +107,12 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
         name: "VIP",
       });
       await patchModifier(m.id, { scope: "listings" });
-      await linkListing(m.id, 1);
+      await linkModifierListing(m.id, 1);
 
-      const applied = await resolveModifiers([item({ listingId: 1 })]);
+      const applied = await resolveModifiers([checkoutItem({ listingId: 1 })]);
       expect(applied.find((s) => s.name === "VIP")?.listingIds).toEqual([1]);
 
-      const skipped = await resolveModifiers([item({ listingId: 2 })]);
+      const skipped = await resolveModifiers([checkoutItem({ listingId: 2 })]);
       expect(skipped.map((s) => s.name)).not.toContain("VIP");
     });
 
@@ -157,14 +123,18 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
         trigger: "code",
       });
 
-      const withoutCode = await resolveModifiers([item()]);
+      const withoutCode = await resolveModifiers([checkoutItem()]);
       expect(withoutCode.map((s) => s.name)).not.toContain("SUMMER");
 
-      const wrongCode = await resolveModifiers([item()], { code: "winter" });
+      const wrongCode = await resolveModifiers([checkoutItem()], {
+        code: "winter",
+      });
       expect(wrongCode.map((s) => s.name)).not.toContain("SUMMER");
 
       // Matching is case-insensitive (normalised before hashing).
-      const rightCode = await resolveModifiers([item()], { code: "SUMMER25" });
+      const rightCode = await resolveModifiers([checkoutItem()], {
+        code: "SUMMER25",
+      });
       expect(rightCode.map((s) => s.name)).toContain("SUMMER");
     });
 
@@ -172,10 +142,10 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       const m = await insertModifier({ name: "T-shirt" });
       await patchModifier(m.id, { trigger: "optional" });
 
-      const unselected = await resolveModifiers([item()]);
+      const unselected = await resolveModifiers([checkoutItem()]);
       expect(unselected.map((s) => s.name)).not.toContain("T-shirt");
 
-      const selected = await resolveModifiers([item()], {
+      const selected = await resolveModifiers([checkoutItem()], {
         addOns: new Map([[m.id, 3]]),
       });
       expect(selected.find((s) => s.name === "T-shirt")?.quantity).toBe(3);
@@ -188,9 +158,11 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
         name: "Welcome back",
       });
 
-      expect((await resolveModifiers([item()])).map((s) => s.name)).toEqual([]);
+      expect(
+        (await resolveModifiers([checkoutItem()])).map((s) => s.name),
+      ).toEqual([]);
 
-      const returning = await resolveModifiers([item()], {
+      const returning = await resolveModifiers([checkoutItem()], {
         ctx: { visits: 1 },
       });
       expect(returning.map((s) => s.name)).toEqual(["Welcome back"]);
@@ -200,7 +172,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       const m = await insertModifier({ name: "Limited tee", stock: 2 });
       await patchModifier(m.id, { trigger: "optional" });
 
-      const specs = await resolveModifiers([item()], {
+      const specs = await resolveModifiers([checkoutItem()], {
         addOns: new Map([[m.id, 5]]),
       });
       expect(specs.find((s) => s.name === "Limited tee")?.quantity).toBe(2);
@@ -222,9 +194,11 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
         name: "GroupWide",
       });
       await patchModifier(m.id, { scope: "groups" });
-      await linkGroup(m.id, 42);
+      await linkModifierGroup(m.id, 42);
 
-      const applied = await resolveModifiers([item({ listingId: listing.id })]);
+      const applied = await resolveModifiers([
+        checkoutItem({ listingId: listing.id }),
+      ]);
       expect(applied.find((s) => s.name === "GroupWide")?.listingIds).toEqual([
         listing.id,
       ]);
@@ -323,7 +297,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
     test("offers a listing-scoped add-on only on a page with its listing", async () => {
       const m = await insertModifier({ name: "Scoped tee" });
       await patchModifier(m.id, { scope: "listings", trigger: "optional" });
-      await linkListing(m.id, 7);
+      await linkModifierListing(m.id, 7);
 
       expect(await getOptionalAddOns([7])).toHaveLength(1);
       expect(await getOptionalAddOns([8])).toEqual([]);
@@ -366,7 +340,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
     test("rebuilds the listing ids for a scoped reference", async () => {
       const m = await insertModifier({ name: "Scoped" });
       await patchModifier(m.id, { scope: "listings" });
-      await linkListing(m.id, 3);
+      await linkModifierListing(m.id, 3);
       const specs = await specsFromRefs([{ i: m.id, q: 1 }]);
       expect(specs[0]?.listingIds).toEqual([3]);
     });

--- a/test/lib/i18n-coverage.test.ts
+++ b/test/lib/i18n-coverage.test.ts
@@ -6,63 +6,96 @@ import en from "#locales/en/index.ts";
  * Codebase-level i18n coverage, verified in both directions:
  *   forward  — every t("key") reference in the source resolves to a real
  *              locale key (no typos / dangling references);
- *   backward — no user-facing string is left hard-coded in a template
- *              (everything goes through t()), except the files still pending
- *              wiring, listed in LEFTOVER_ALLOWLIST below.
+ *   backward — no user-facing string is left hard-coded in a scanned source
+ *              file (everything goes through t()), except a budget of strings
+ *              still pending wiring, recorded per file in LEFTOVER_ALLOWLIST.
  *
- * As pages are wired, delete them from the allowlist — the "allowlist is not
- * stale" test fails until you do, so the list can only shrink.
+ * The backward scan covers JSX templates (.tsx) AND the .ts modules that hold
+ * field/copy definitions (e.g. fields.ts, email/defaults.ts) plus the shared
+ * form framework — places where hard-coded labels used to slip through because
+ * the scan only looked at .tsx text/attributes.
+ *
+ * LEFTOVER_ALLOWLIST is a ratchet, not a free pass: it records the EXACT number
+ * of hard-coded strings each unfinished file still has. The backward test fails
+ * if a file grows past its number (so a migrated file can never gain new
+ * hard-coded copy), and the stale test fails if a file drops below its number
+ * (lower it to lock in the progress) or reaches zero (remove the entry). The
+ * debt can therefore only shrink, and every change to it shows up as a diff
+ * here for review.
  */
 
 const messages = en as Record<string, string>;
 
+const SRC_DIR = "src";
 const TEMPLATES_DIR = "src/ui/templates";
 
-/** Templates that still contain hard-coded user-facing strings (paths relative
- * to src/ui/templates/). The remaining i18n wiring to tackle. */
-const LEFTOVER_ALLOWLIST = new Set<string>([
-  "admin/api-keys.tsx",
-  "admin/attendee-form.tsx",
-  "admin/attendees.tsx",
-  "admin/calendar.tsx",
-  "admin/database-reset.tsx",
-  "admin/debug.tsx",
-  "admin/guide.tsx",
-  "admin/guide/accounts.tsx",
-  "admin/guide/components.tsx",
-  "admin/guide/domains.tsx",
-  "admin/guide/email.tsx",
-  "admin/guide/integrations.tsx",
-  "admin/guide/operations.tsx",
-  "admin/guide/payments.tsx",
-  "admin/guide/tickets.tsx",
-  "admin/listings.tsx",
-  "admin/questions.tsx",
-  "admin/scanner.tsx",
-  "admin/sessions.tsx",
-  "admin/settings/apple-wallet.tsx",
-  "admin/settings/business-email.tsx",
-  "admin/settings/custom-domain.tsx",
-  "admin/settings/email-tpl-confirmation.tsx",
-  "admin/settings/email.tsx",
-  "admin/settings/embed-hosts.tsx",
-  "admin/settings/google-wallet.tsx",
-  "admin/settings/payment.tsx",
-  "admin/settings/public-api.tsx",
-  "admin/site.tsx",
-  "public/reservations.tsx",
-  "public/shared.tsx",
+/** Copy-bearing modules outside src/ui/templates that must also be kept honest:
+ * the shared form framework renders its own labels and submit buttons. */
+const EXTRA_SCAN_FILES = ["src/shared/forms.tsx"];
+
+/** Files (relative to src/) with hard-coded user-facing strings still pending
+ * i18n wiring, mapped to the exact number of leftover literals each still has.
+ * Wire a file's strings with t(), then lower its number — or delete the entry
+ * once it reaches zero. The number may never go up. */
+const LEFTOVER_ALLOWLIST = new Map<string, number>([
+  ["shared/forms.tsx", 5],
+  ["ui/templates/admin/api-keys.tsx", 3],
+  ["ui/templates/admin/attendee-form.tsx", 25],
+  ["ui/templates/admin/attendees.tsx", 10],
+  ["ui/templates/admin/calendar.tsx", 1],
+  ["ui/templates/admin/database-reset.tsx", 1],
+  ["ui/templates/admin/debug.tsx", 6],
+  ["ui/templates/admin/guide.tsx", 1],
+  ["ui/templates/admin/guide/accounts.tsx", 3],
+  ["ui/templates/admin/guide/components.tsx", 3],
+  ["ui/templates/admin/guide/domains.tsx", 4],
+  ["ui/templates/admin/guide/email.tsx", 9],
+  ["ui/templates/admin/guide/integrations.tsx", 9],
+  ["ui/templates/admin/guide/operations.tsx", 7],
+  ["ui/templates/admin/guide/payments.tsx", 3],
+  ["ui/templates/admin/guide/tickets.tsx", 17],
+  ["ui/templates/admin/listings.tsx", 1],
+  ["ui/templates/admin/questions.tsx", 4],
+  ["ui/templates/admin/scanner.tsx", 2],
+  ["ui/templates/admin/sessions.tsx", 1],
+  ["ui/templates/admin/settings/apple-wallet.tsx", 2],
+  ["ui/templates/admin/settings/business-email.tsx", 1],
+  ["ui/templates/admin/settings/custom-domain.tsx", 5],
+  ["ui/templates/admin/settings/email-tpl-confirmation.tsx", 11],
+  ["ui/templates/admin/settings/email.tsx", 1],
+  ["ui/templates/admin/settings/embed-hosts.tsx", 1],
+  ["ui/templates/admin/settings/google-wallet.tsx", 2],
+  ["ui/templates/admin/settings/payment.tsx", 10],
+  ["ui/templates/admin/settings/public-api.tsx", 1],
+  ["ui/templates/admin/site.tsx", 2],
+  ["ui/templates/email/defaults.ts", 10],
+  ["ui/templates/fields.ts", 45],
+  ["ui/templates/public/shared.tsx", 2],
 ]);
 
 /** t("key") / t('key') / t(`key`) not preceded by an identifier char. */
 const T_CALL = /(?<![A-Za-z0-9_$])t\(\s*(["'`])([^"'`]+)\1/g;
 
-/** Hard-coded user-facing attribute values. */
+/** Hard-coded user-facing JSX attribute values. */
 const ATTR =
   /\b(placeholder|title|aria-label|alt|label)\s*=\s*(["'])([^"'{][^"']*)\2/g;
-/** JSX text node: capitalised words containing a lowercase letter ({expr}
- * children start with "{", not a letter, so are excluded). */
-const TEXT = />\s*([A-Z][A-Za-z][A-Za-z ,.'!?&():-]{1,})\s*</g;
+/** Hard-coded user-facing object-property values (field definitions in .ts
+ * modules build labels/placeholders/hints as object properties, not JSX). */
+const PROP =
+  /\b(placeholder|title|label|hint|hintHtml|legend|summary|description)\s*:\s*(["'])([^"'{][^"']*)\2/g;
+/** JSX text node: capitalised words containing a lowercase letter. The (?<!=)
+ * skips `=> Foo<…>` arrow-return generics, which are types, not copy. */
+const TEXT = /(?<!=)>\s*([A-Z][A-Za-z][A-Za-z ,.'!?&():-]{1,})\s*</g;
+
+/** Comment lines never render to users, so strings in them aren't leftovers. */
+const isCommentLine = (line: string): boolean => {
+  const t = line.trimStart();
+  return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*");
+};
+
+/** Prose needing translation has a lowercase letter; bare numbers/symbols
+ * (placeholder="0", "ID", "£") are locale-independent and don't count. */
+const wordy = (s: string): boolean => /[a-z]/.test(s);
 
 const walk = (dir: string, exts: string[]): string[] => {
   const out: string[] = [];
@@ -77,16 +110,36 @@ const walk = (dir: string, exts: string[]): string[] => {
   return out;
 };
 
-/** Hard-coded user-facing strings still present in a template's source. */
-const leftoverLiterals = (src: string): string[] => {
+/** The files the backward scan covers: every .ts/.tsx under templates plus the
+ * explicit extra copy-bearing modules. */
+const scanTargets = (): string[] => [
+  ...walk(TEMPLATES_DIR, [".ts", ".tsx"]),
+  ...EXTRA_SCAN_FILES,
+];
+
+const relFromSrc = (file: string): string => file.slice(SRC_DIR.length + 1);
+
+/** Object-property labels are a .ts-module idiom; .tsx uses JSX instead. */
+const isTsModule = (file: string): boolean => file.endsWith(".ts");
+
+/** Hard-coded user-facing strings still present in a file's source. */
+const leftoverLiterals = (src: string, isTs: boolean): string[] => {
   const hits: string[] = [];
   src.split("\n").forEach((line, i) => {
+    if (isCommentLine(line)) return;
     for (const m of line.matchAll(ATTR)) {
-      hits.push(`L${i + 1} ${m[1]}="${m[3]}"`);
+      const value = m[3] ?? "";
+      if (wordy(value)) hits.push(`L${i + 1} ${m[1]}="${value}"`);
+    }
+    if (isTs) {
+      for (const m of line.matchAll(PROP)) {
+        const value = m[3] ?? "";
+        if (wordy(value)) hits.push(`L${i + 1} ${m[1]}: "${value}"`);
+      }
     }
     for (const m of line.matchAll(TEXT)) {
-      const text = m[1] ?? "";
-      if (/[a-z]/.test(text)) hits.push(`L${i + 1} text "${text.trim()}"`);
+      const text = (m[1] ?? "").trim();
+      if (wordy(text)) hits.push(`L${i + 1} text "${text}"`);
     }
   });
   return hits;
@@ -95,7 +148,7 @@ const leftoverLiterals = (src: string): string[] => {
 describe("i18n coverage", () => {
   test('forward: every t("key") in the source resolves to a locale key', () => {
     const missing: string[] = [];
-    for (const file of walk("src", [".ts", ".tsx"])) {
+    for (const file of walk(SRC_DIR, [".ts", ".tsx"])) {
       const src = Deno.readTextFileSync(file);
       for (const m of src.matchAll(T_CALL)) {
         const key = m[2]!;
@@ -106,21 +159,30 @@ describe("i18n coverage", () => {
     expect(missing).toEqual([]);
   });
 
-  test("backward: templates have no hard-coded user-facing strings (except allowlisted)", () => {
+  test("backward: no hard-coded user-facing strings beyond each file's budget", () => {
     const offenders: string[] = [];
-    for (const file of walk(TEMPLATES_DIR, [".tsx"])) {
-      const rel = file.slice(TEMPLATES_DIR.length + 1);
-      if (LEFTOVER_ALLOWLIST.has(rel)) continue;
-      const hits = leftoverLiterals(Deno.readTextFileSync(file));
-      if (hits.length) offenders.push(`${rel}: ${hits.slice(0, 3).join("; ")}`);
+    for (const file of scanTargets()) {
+      const rel = relFromSrc(file);
+      const allowed = LEFTOVER_ALLOWLIST.get(rel) ?? 0;
+      const hits = leftoverLiterals(
+        Deno.readTextFileSync(file),
+        isTsModule(file),
+      );
+      if (hits.length > allowed) {
+        offenders.push(
+          `${rel}: ${hits.length} hard-coded (budget ${allowed}) — wire with ` +
+            "t(), or bump its allowlist count if still mid-migration: " +
+            hits.slice(0, 3).join("; "),
+        );
+      }
     }
     expect(offenders).toEqual([]);
   });
 
-  test("the leftover allowlist has no stale entries (wired files must be removed)", () => {
+  test("the leftover allowlist ratchets down (no stale or inflated entries)", () => {
     const stale: string[] = [];
-    for (const rel of LEFTOVER_ALLOWLIST) {
-      const path = `${TEMPLATES_DIR}/${rel}`;
+    for (const [rel, allowed] of LEFTOVER_ALLOWLIST) {
+      const path = `${SRC_DIR}/${rel}`;
       const src = (() => {
         try {
           return Deno.readTextFileSync(path);
@@ -128,9 +190,14 @@ describe("i18n coverage", () => {
           return null;
         }
       })();
-      if (src === null) stale.push(`${rel} (missing — remove from allowlist)`);
-      else if (leftoverLiterals(src).length === 0) {
-        stale.push(`${rel} (now clean — remove from allowlist)`);
+      if (src === null) {
+        stale.push(`${rel} (missing — remove from allowlist)`);
+        continue;
+      }
+      const count = leftoverLiterals(src, isTsModule(path)).length;
+      if (count === 0) stale.push(`${rel} (now clean — remove from allowlist)`);
+      else if (count < allowed) {
+        stale.push(`${rel} (down to ${count} — lower its allowlist count)`);
       }
     }
     expect(stale).toEqual([]);

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -9,6 +9,7 @@ export * from "./test-utils/env.ts";
 export * from "./test-utils/factories.ts";
 export * from "./test-utils/internal.ts";
 export * from "./test-utils/mocks.ts";
+export * from "./test-utils/modifiers.ts";
 export * from "./test-utils/session.ts";
 export * from "./test-utils/settings.ts";
 export { TestBrowser } from "./test-utils/test-browser.ts";

--- a/test/test-utils/modifiers.ts
+++ b/test/test-utils/modifiers.ts
@@ -1,0 +1,53 @@
+import { getDb } from "#shared/db/client.ts";
+import { type ModifierInput, modifiersTable } from "#shared/db/modifiers.ts";
+import type { CheckoutItem } from "#shared/payments.ts";
+
+/** A checkout line item with sensible defaults for pricing/modifier tests. */
+export const checkoutItem = (
+  overrides: Partial<CheckoutItem> = {},
+): CheckoutItem => ({
+  listingId: 1,
+  name: "General",
+  quantity: 1,
+  slug: "general",
+  unitPrice: 1000,
+  ...overrides,
+});
+
+/** Insert a modifier through the production table, defaulting to a £5 charge. */
+export const insertModifier = (overrides: Partial<ModifierInput> = {}) =>
+  modifiersTable.insert({
+    calcKind: "fixed",
+    calcValue: 5,
+    direction: "charge",
+    name: "Add-on",
+    ...overrides,
+  });
+
+/** Set behavioural columns the base create form doesn't expose (trigger,
+ * scope, stock, code_index, active, min_visits, …). */
+export const patchModifier = (
+  id: number,
+  set: Record<string, string | number>,
+) => {
+  const cols = Object.keys(set);
+  const assignments = cols.map((c) => `${c} = ?`).join(", ");
+  return getDb().execute({
+    args: [...cols.map((c) => set[c]!), id],
+    sql: `UPDATE modifiers SET ${assignments} WHERE id = ?`,
+  });
+};
+
+/** Link a "listings"-scoped modifier to a listing. */
+export const linkModifierListing = (modifierId: number, listingId: number) =>
+  getDb().execute({
+    args: [modifierId, listingId],
+    sql: "INSERT INTO modifier_listings (modifier_id, listing_id) VALUES (?, ?)",
+  });
+
+/** Link a "groups"-scoped modifier to a group. */
+export const linkModifierGroup = (modifierId: number, groupId: number) =>
+  getDb().execute({
+    args: [modifierId, groupId],
+    sql: "INSERT INTO modifier_groups (modifier_id, group_id) VALUES (?, ?)",
+  });


### PR DESCRIPTION
First concrete improvements from a cohesion/testability review of the last week's changes. Each commit extends an existing guard discipline to a place it currently misses, and one of them caught a real mispricing bug.

## 1. i18n coverage guard reaches the field/form modules, with a count ratchet
The backward i18n scan only walked `.tsx` templates and only matched JSX attributes/text, so user-facing copy defined as **object properties** in `.ts` modules slipped through entirely — `fields.ts` alone carried 45 untranslated labels/placeholders no test could see, and `shared/forms.tsx` was out of scope.

- Widen the scan to `.ts` modules under `templates/` plus `shared/forms.tsx`; add an object-property matcher (`label:`/`placeholder:`/`hint:` …).
- Drop two false-positive classes the old detector accepted (non-prose values like `placeholder="0"`, and `=> Foo<…>` arrow-return generics read as JSX text) and ignore comment lines.
- Replace the allowlist `Set` with a per-file **count map that ratchets**: the backward test fails if a file grows past its number, the stale test fails if it drops below (lower it) or hits zero (remove it). The i18n debt can now only shrink, and every change to it is a reviewable diff — closing the "allowlisted files grow forever" gap.

## 2. Extract modifier test helpers into `#test-utils`
`insertModifier`, `patchModifier`, the link helpers and the checkout-item factory were local to `modifier-resolve.test.ts`. Moved to a shared module so the new suite reuses them instead of duplicating (per the project's `#test-utils` guidance). Pure refactor.

## 3. Pin public↔webhook pricing consistency — and a real bug it caught
The public checkout resolves modifiers live (`resolveModifiers`) and stores compact id/quantity refs in provider metadata; the webhook rebuilds them by id (`specsFromRefs`) and re-prices, refunding on a mismatch. Nothing guarded that this round-trip preserves the priced total.

New suite prices a cart through `resolveModifiers → toModifierRefs → JSON → specsFromRefs` and asserts the same total + applications across surcharges, discounts, multipliers, scoped/code/visit-gated modifiers, stock-clamped add-ons, multi-item carts and reservation deposits.

**The bug:** answer price modifiers were compacted into the modifier refs, but the webhook re-derives answers separately from `answer_ids` and re-fetches every ref id from the **modifiers** table. Answer ids and modifier ids autoincrement in **separate tables**, so a low answer id collides with an unrelated modifier id — the webhook then revived that modifier on payment completion, re-derived a higher total, and **refunded a legitimate order**. Fix: exclude answer-source specs from `toModifierRefs` (they're reconstructed from `answer_ids`, never from refs).

## Verification
- Full suite green; 100% line + branch coverage on production code.
- Tree-wide typecheck and Biome lint clean (845 files).

## Follow-ups (discussed, not in this PR)
To prevent the whole class of public↔webhook divergence without manual checking: a property-based version of the consistency test, and routing "inputs-intact" mismatch refunds to the existing NTFY hook so a genuine divergence pages you on first occurrence. Deeper structural options: price the serialized form through one shared function, a typed/lossless metadata codec with a round-trip test, or an HMAC-signed price computed once at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGhkGXogxko2UEhuMXcRvN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGhkGXogxko2UEhuMXcRvN)_