### PR TITLE
Make schema migration DDL race tolerant

### DIFF
--- a/src/shared/db/migrations/schema-sync.ts
+++ b/src/shared/db/migrations/schema-sync.ts
@@ -333,11 +333,13 @@ export const applySchemaChanges = async (): Promise<void> => {
       }
     }
   }
-  // Single batched write (one subrequest) instead of one execute per
-  // CREATE/ALTER. Pre-filtering against the snapshot means every statement is
-  // genuinely needed, so the batch never hits the "already exists" errors that
-  // runMigration used to swallow; a real failure rolls the batch back as a unit.
-  if (statements.length > 0) await executeBatch(statements);
+  // Run statements through runMigration rather than a single batch so another
+  // edge isolate can safely win the same additive schema race after our
+  // snapshot. runMigration ignores idempotent duplicate/already-exists DDL
+  // errors but still surfaces real failures.
+  for (const statement of statements) {
+    await runMigration(statement.sql);
+  }
 };
 
 /** Create missing indexes and drop legacy ones */


### PR DESCRIPTION
### Motivation

- A production migration could fail when multiple edge isolates applied the same additive DDL from a stale schema snapshot, producing idempotent DDL errors like `duplicate column name: contact_hash` and causing requests to 503. 
- The migrator must tolerate concurrent additive schema races across isolates while still surfacing real (non-idempotent) failures.

### Description

- Change `applySchemaChanges` to run each planned DDL statement through the existing idempotent `runMigration` runner instead of sending a single all-or-nothing `executeBatch` for the whole plan. 
- `runMigration` preserves the previous behaviour of treating `already exists`/`duplicate` errors as expected for idempotent DDL retries while rethrowing real errors. 
- This makes additive schema application race-tolerant for concurrent edge isolates without changing verification or index/trigger sync logic.

### Testing

- Ran the migration unit tests with `deno task test:files test/lib/db/migrations/2026-06-18_contact_preferences.test.ts` and they passed. 
- Ran the full precommit checks with `deno task precommit` (typecheck, lint, tests, coverage) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3486d42aac832d82ed649eea60c203)