### PR TITLE
Multiply modifiers by quantity, defer calendar agent load, and user auth query optimization

### DIFF
--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -26,8 +26,7 @@ import {
 } from "#shared/db/attendees.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import {
-  getAllDailyListings,
-  getAllStandardListings,
+  getAllListings,
   getAttendeesByListingIds,
   getDailyListingAttendeeDates,
   getDailyListingAttendeesByDate,
@@ -234,11 +233,20 @@ const withCalendarSession = (
     handler(session, getDateFilter(request)),
   );
 
-/** Load standard listings and build their date map */
-const loadStandardListingContext = async () => {
-  const standardListings = await getAllStandardListings();
+/** Split the cached listing list once for the calendar view/export. */
+const loadListingContext = async () => {
+  const allListings = await getAllListings();
+  const dailyListings = allListings.filter((e) => e.listing_type === "daily");
+  const standardListings = allListings.filter(
+    (e) => e.listing_type === "standard",
+  );
   const standardListingDateMap = buildStandardListingDateMap(standardListings);
-  return { standardListingDateMap, standardListings };
+  return {
+    allListings,
+    dailyListings,
+    standardListingDateMap,
+    standardListings,
+  };
 };
 
 /** Load and decrypt attendees for standard listings matching a calendar date */
@@ -288,17 +296,21 @@ const buildAvailabilityRows = async (
  */
 const handleAdminCalendarGet = (request: Request) =>
   withCalendarSession(request, async (session, dateFilter) => {
-    const [dailyListings, attendeeDates, holidays, standardCtx] =
-      await Promise.all([
-        getAllDailyListings(),
-        getDailyListingAttendeeDates(),
-        getActiveHolidays(),
-        loadStandardListingContext(),
-      ]);
+    const [listingCtx, attendeeDates, holidays] = await Promise.all([
+      loadListingContext(),
+      getDailyListingAttendeeDates(),
+      getActiveHolidays(),
+    ]);
 
-    const { agents, agentFilter } = await resolveAgentFilter(request);
-
-    const allListings = [...dailyListings, ...standardCtx.standardListings];
+    const {
+      allListings,
+      dailyListings,
+      standardListings,
+      standardListingDateMap,
+    } = listingCtx;
+    const { agents, agentFilter } = dateFilter
+      ? await resolveAgentFilter(request)
+      : { agentFilter: "all" as AgentFilter, agents: [] };
     let attendees: CalendarAttendeeRow[] = [];
     if (dateFilter) {
       const privateKey = (await getPrivateKey(session))!;
@@ -306,9 +318,9 @@ const handleAdminCalendarGet = (request: Request) =>
         getDailyListingAttendeesByDate(dateFilter),
         loadStandardListingAttendees(
           dateFilter,
-          standardCtx.standardListingDateMap,
+          standardListingDateMap,
           privateKey,
-          standardCtx.standardListings,
+          standardListings,
         ),
       ]);
       const hasPaidDailyListing = dailyListings.some(isPaidListing);
@@ -330,8 +342,8 @@ const handleAdminCalendarGet = (request: Request) =>
     const availableDates = compileDateOptions(
       dailyListings,
       attendeeDates,
-      standardCtx.standardListingDateMap,
-      standardCtx.standardListings,
+      standardListingDateMap,
+      standardListings,
       holidays,
     );
     const questionData = await loadAttendeeQuestionData(
@@ -374,22 +386,21 @@ const handleAdminCalendarExport = (request: Request) =>
     }
 
     const privateKey = (await getPrivateKey(session))!;
-    const [dailyListings, rawDailyAttendees, standardCtx] = await Promise.all([
-      getAllDailyListings(),
+    const [listingCtx, rawDailyAttendees] = await Promise.all([
+      loadListingContext(),
       getDailyListingAttendeesByDate(dateFilter),
-      loadStandardListingContext(),
     ]);
+    const { allListings, standardListingDateMap } = listingCtx;
 
     const [dailyDecrypted, standardAttendees] = await Promise.all([
       decryptAttendees(rawDailyAttendees, privateKey),
       loadStandardListingAttendees(
         dateFilter,
-        standardCtx.standardListingDateMap,
+        standardListingDateMap,
         privateKey,
       ),
     ]);
 
-    const allListings = [...dailyListings, ...standardCtx.standardListings];
     const allAttendees = sortAttendeesByCreatedDesc([
       ...dailyDecrypted,
       ...standardAttendees,

--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -692,7 +692,8 @@ const createAttendeeForSession = async (
     const consumed = await consumeModifierStock(
       attendeeId,
       modifierSpecs.map((s) => ({
-        amountApplied: Math.abs(modifierDelta(fullTotal, s.kind, s.value)),
+        amountApplied:
+          Math.abs(modifierDelta(fullTotal, s.kind, s.value)) * s.quantity,
         modifierId: s.id,
         quantity: s.quantity,
       })),

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -24,7 +24,7 @@ import {
 import { getApiKeyByToken, touchApiKeyLastUsed } from "#shared/db/api-keys.ts";
 import { deleteSession, getSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
-import { decryptAdminLevel, getUserById } from "#shared/db/users.ts";
+import { decryptAdminLevel, getUserAuthFieldsById } from "#shared/db/users.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { setSavedFormData } from "#shared/forms.tsx";
 import { SCANNER_CSRF_MAX_AGE_S } from "#shared/limits.ts";
@@ -93,7 +93,7 @@ export const getAuthenticatedSession = async (
   }
 
   // Load user and decrypt admin level
-  const user = await getUserById(session.user_id);
+  const user = await getUserAuthFieldsById(session.user_id);
   if (!user) {
     logError({
       code: ErrorCode.AUTH_INVALID_SESSION,
@@ -170,7 +170,7 @@ export const getAuthenticatedApiKey = async (
     return null;
   }
 
-  const user = await getUserById(apiKeyRow.user_id);
+  const user = await getUserAuthFieldsById(apiKeyRow.user_id);
   if (!user) {
     logError({
       code: ErrorCode.AUTH_INVALID_SESSION,

--- a/src/shared/checkout-pricing.ts
+++ b/src/shared/checkout-pricing.ts
@@ -150,8 +150,9 @@ type ModifierPass = {
 };
 
 /** Apply one modifier: an additive delta becomes an extra line; a negative
- * delta is allocated across the in-scope units as a discount (clamped to what
- * those units can absorb). A zero delta is a no-op. */
+ * delta is multiplied by the selected quantity, then allocated across the
+ * in-scope units as a discount (clamped to what those units can absorb). A
+ * zero delta is a no-op. */
 const applyOne = (pass: ModifierPass, spec: ModifierSpec): ModifierPass => {
   const scoped = pass.units.filter((u) => inScope(spec, u));
   const delta = modifierDelta(
@@ -177,7 +178,7 @@ const applyOne = (pass: ModifierPass, spec: ModifierSpec): ModifierPass => {
 
   const reduced = allocateDiscount(
     scoped.map((u) => u.price),
-    -delta,
+    -delta * spec.quantity,
   );
   let next = 0;
   const units = pass.units.map((u) =>

--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -39,8 +39,9 @@ const signedValue = (modifier: Modifier): number => {
 
 /** The listing ids a modifier is charged on, or null for the whole order. */
 const listingIdsFor = (modifier: Modifier): Promise<number[]> | null => {
-  if (modifier.scope === "groups")
+  if (modifier.scope === "groups") {
     return getModifierGroupListingIds(modifier.id);
+  }
   if (modifier.scope === "listings") return getModifierListingIds(modifier.id);
   return null;
 };
@@ -102,8 +103,9 @@ const triggerQuantity = (
   codeIndex: string | null,
   addOns: Map<number, number>,
 ): number => {
-  if (modifier.trigger === "code")
+  if (modifier.trigger === "code") {
     return codeIndex !== null && modifier.code_index === codeIndex ? 1 : 0;
+  }
   if (modifier.trigger === "optional") return addOns.get(modifier.id) ?? 0;
   return 1;
 };
@@ -186,7 +188,7 @@ const addOnPriceLabel = (modifier: Modifier): string => {
     modifier.calc_kind === "fixed"
       ? formatCurrency(toMinorUnits(modifier.calc_value))
       : `${modifier.calc_value}%`;
-  return `${sign}${amount}`;
+  return `${sign}${amount} each`;
 };
 
 /**

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -33,6 +33,11 @@ const USER_DISPLAY_SELECT =
 
 const USER_ID_SELECT = "SELECT id FROM users ORDER BY id ASC";
 
+const USER_AUTH_SELECT =
+  "SELECT id, admin_level FROM users WHERE id = ? LIMIT 1";
+
+export type UserAuthFields = Pick<User, "admin_level" | "id">;
+
 /**
  * Users change rarely and there are few of them, so the cache loads the whole
  * set and answers by-id / by-username reads from it. The TTL is shorter than
@@ -145,6 +150,12 @@ export const getUserByUsername = async (
  */
 export const getUserById = (id: number): Promise<User | null> =>
   usersCache.getById(id);
+
+/** Get the minimal encrypted user fields needed to authenticate a session. */
+export const getUserAuthFieldsById = async (
+  id: number,
+): Promise<UserAuthFields | null> =>
+  (await queryAll<UserAuthFields>(USER_AUTH_SELECT, [id]))[0] ?? null;
 
 /**
  * Check if a username is already taken

--- a/src/ui/templates/admin/calendar.tsx
+++ b/src/ui/templates/admin/calendar.tsx
@@ -79,8 +79,7 @@ export const adminCalendarPage = (
     if (dateFilter) params.set("date", dateFilter);
     const param = agentFilterParam(f);
     if (param) params.set("agent", param);
-    const query = params.toString();
-    return `/admin/calendar${query ? `?${query}` : ""}#attendees`;
+    return `/admin/calendar?${params.toString()}#attendees`;
   };
 
   // The export carries the active agent filter so it matches the on-screen

--- a/test/lib/checkout-pricing.test.ts
+++ b/test/lib/checkout-pricing.test.ts
@@ -247,6 +247,55 @@ describe("applyModifiers", () => {
     expect(result.modifierTotal).toBe(1500);
   });
 
+  test("multiplies a fixed discount by its quantity", () => {
+    const result = applyModifiers(lines, [
+      modifier({ kind: "fixed", quantity: 3, value: -500 }),
+    ]);
+
+    expect(result.lines).toEqual([
+      { chargedUnitAmount: 667, item: item({ listingId: 1 }), quantity: 2 },
+      {
+        chargedUnitAmount: 1666,
+        item: item({ listingId: 2, slug: "vip" }),
+        quantity: 1,
+      },
+    ]);
+    expect(result.modifierTotal).toBe(-1500);
+  });
+
+  test("multiplies a percent discount by its quantity", () => {
+    const result = applyModifiers(lines, [
+      modifier({ kind: "percent", quantity: 3, value: -10 }),
+    ]);
+
+    // Quantity 3 of a 10% discount applies 30% of the original subtotal.
+    expect(result.modifierTotal).toBe(-1350);
+    expect(result.lines).toEqual([
+      { chargedUnitAmount: 700, item: item({ listingId: 1 }), quantity: 2 },
+      {
+        chargedUnitAmount: 1750,
+        item: item({ listingId: 2, slug: "vip" }),
+        quantity: 1,
+      },
+    ]);
+  });
+
+  test("clamps multiplied discounts so no charged unit goes negative", () => {
+    const result = applyModifiers(lines, [
+      modifier({ kind: "percent", quantity: 3, value: -50 }),
+    ]);
+
+    expect(result.lines).toEqual([
+      { chargedUnitAmount: 0, item: item({ listingId: 1 }), quantity: 2 },
+      {
+        chargedUnitAmount: 0,
+        item: item({ listingId: 2, slug: "vip" }),
+        quantity: 1,
+      },
+    ]);
+    expect(result.modifierTotal).toBe(-4500);
+  });
+
   test("treats a zero-delta modifier as a no-op", () => {
     const result = applyModifiers(lines, [
       modifier({ kind: "percent", value: 0 }),

--- a/test/lib/db/modifier-resolve.test.ts
+++ b/test/lib/db/modifier-resolve.test.ts
@@ -237,7 +237,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
           id: m.id,
           maxQuantity: ADDON_MAX_QUANTITY,
           name: "Parking",
-          priceLabel: "+£5",
+          priceLabel: "+£5 each",
         },
       ]);
     });
@@ -251,7 +251,7 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       });
       await patchModifier(m.id, { trigger: "optional" });
       const addOns = await getOptionalAddOns([1]);
-      expect(addOns[0]?.priceLabel).toBe("−10%");
+      expect(addOns[0]?.priceLabel).toBe("−10% each");
     });
 
     test("labels a multiplier add-on with its bare factor", async () => {

--- a/test/lib/server-calendar-logistics.test.ts
+++ b/test/lib/server-calendar-logistics.test.ts
@@ -91,13 +91,12 @@ describeWithEnv(
       expect(html).toContain("Agent User");
     });
 
-    test("renders the agent filter bar even with no date selected", async () => {
+    test("does not load the agent filter bar until a date is selected", async () => {
       await setup();
-      // With a non-default agent active and no date, the "All" link carries
-      // neither a date nor an agent param.
       const html = await calendarHtml("/admin/calendar?agent=none");
-      expect(html).toContain("Agent:");
-      expect(html).toContain('href="/admin/calendar#attendees"');
+      expect(html).not.toContain("Agent:");
+      expect(html).not.toContain("SELECT * FROM logistics_agents");
+      expect(html).toContain('href="/admin/deliveries"');
     });
 
     test("filtering to the assigned agent keeps the attendee", async () => {

--- a/test/lib/server-payments.test.ts
+++ b/test/lib/server-payments.test.ts
@@ -876,13 +876,21 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         unitPrice: 1000,
       });
 
-      // An opt-in add-on and a promo-code discount, both whole-order. A second
-      // add-on is offered but left unselected (its quantity field stays 0).
+      // An opt-in charge, an opt-in discount, and a promo-code discount, all
+      // whole-order. A second add-on is offered but left unselected (its
+      // quantity field stays 0).
       const addOn = await modifiersTable.insert({
         calcKind: "fixed",
         calcValue: 5,
         direction: "charge",
         name: "T-shirt",
+      });
+      const discountAddOn = await modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 2,
+        direction: "discount",
+        name: "Member discount",
+        stock: 5,
       });
       const skippedAddOn = await modifiersTable.insert({
         calcKind: "fixed",
@@ -898,6 +906,10 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
       });
       await getDb().execute({
         args: ["optional", addOn.id],
+        sql: "UPDATE modifiers SET trigger = ? WHERE id = ?",
+      });
+      await getDb().execute({
+        args: ["optional", discountAddOn.id],
         sql: "UPDATE modifiers SET trigger = ? WHERE id = ?",
       });
       await getDb().execute({
@@ -932,6 +944,7 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         const response = await submitTicketForm(listing.slug, {
           // The second add-on's field is omitted entirely (left unselected).
           [`addon_${addOn.id}`]: "2",
+          [`addon_${discountAddOn.id}`]: "3",
           email: "john@example.com",
           name: "John Doe",
           promo_code: "save10",
@@ -941,9 +954,11 @@ describeWithEnv("server (payment flow)", { db: true }, () => {
         const byId = new Map(
           (capturedIntent?.modifiers ?? []).map((m) => [m.id, m]),
         );
-        // The add-on is applied at the chosen quantity, the promo at quantity 1,
-        // and the unselected add-on is absent.
+        // Add-ons (including discounts) are applied at the chosen quantity, the
+        // promo at quantity 1, and the unselected add-on is absent.
         expect(byId.get(addOn.id)?.quantity).toBe(2);
+        expect(byId.get(discountAddOn.id)?.quantity).toBe(3);
+        expect(byId.get(discountAddOn.id)?.value).toBe(-200);
         expect(byId.get(promo.id)?.quantity).toBe(1);
         expect(byId.has(skippedAddOn.id)).toBe(false);
       } finally {

--- a/test/templates/public.test.ts
+++ b/test/templates/public.test.ts
@@ -553,7 +553,14 @@ describe("ticketPage", () => {
       ),
     ];
     const html = ticketPage({
-      addOns: [{ id: 7, maxQuantity: 5, name: "T-shirt", priceLabel: "+£5" }],
+      addOns: [
+        {
+          id: 7,
+          maxQuantity: 5,
+          name: "T-shirt",
+          priceLabel: "+£5 each",
+        },
+      ],
       listings,
       slugs: ["ab12c"],
     });


### PR DESCRIPTION
### Motivation
- Ensure modifier effects (both charges and discounts) account for the selected quantity when applied to checkouts and webhook-created attendees.  
- Avoid loading logistics/agent data for the admin calendar until a date is selected to reduce unnecessary queries and simplify the UI state.  
- Reduce the data fetched for authentication flows by introducing a minimal user lookup for session/API key validation.

### Description
- Multiplied modifier deltas by `spec.quantity` when allocating discounts and when computing `amountApplied` in the webhook `consumeModifierStock` call, and adjusted the pricing engine accordingly (`src/shared/checkout-pricing.ts` and `src/features/api/webhooks.ts`).
- Updated modifier UI labels to append `each` for opt-in add-ons and percentage discounts in `addOnPriceLabel` (`src/shared/db/modifier-resolve.ts`) and propagated that to relevant templates and tests.  
- Refactored calendar listing loading into `loadListingContext` which returns `allListings`, `dailyListings`, `standardListings`, and `standardListingDateMap`, and deferred resolving the agent filter until a `date` is selected (`src/features/admin/calendar.ts` and `src/ui/templates/admin/calendar.tsx`).
- Added a minimal `getUserAuthFieldsById` query and `UserAuthFields` type and updated authentication callers to use the lighter-weight lookup to avoid pulling unnecessary user fields (`src/shared/db/users.ts` and `src/features/auth.ts`).
- Minor fixes and syntactic cleanups: brace fixes in `listingIdsFor`, small comment updates, and test adjustments to reflect the new behavior.

### Testing
- Ran unit tests touching modifiers and pricing, including `test/lib/checkout-pricing.test.ts` and `test/lib/db/modifier-resolve.test.ts`, and they passed after adding coverage for quantity-multiplied modifiers.  
- Ran server tests related to calendar/logistics and payments (including `test/lib/server-calendar-logistics.test.ts` and `test/lib/server-payments.test.ts`) which were updated to match the deferred agent-load behavior and modifier quantity handling and passed.  
- Updated template tests (`test/templates/public.test.ts`) to reflect label changes and confirmed they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e122dba0832d8baf6102118bc627)