### PR TITLE
Move calendar feeds form to settings page and fix rendering

### DIFF
--- a/src/features/admin/settings-general.ts
+++ b/src/features/admin/settings-general.ts
@@ -150,7 +150,6 @@ export const handleShowPublicApiPost = settingsToggle({
 
 /** Handle POST /admin/settings/calendar-feeds - owner only */
 export const handleCalendarFeedsPost = settingsHandler({
-  advanced: true,
   extract: (form) => ({
     enabled: form.getString("calendar_feeds_enabled") === "true",
     groupBy: form.getString("calendar_feeds_group_by"),

--- a/src/features/admin/settings-page.ts
+++ b/src/features/admin/settings-page.ts
@@ -33,6 +33,8 @@ const getSettingsPageState = async () => {
   return {
     bookingFee: settings.bookingFee,
     businessEmail: settings.businessEmail,
+    calendarFeedsEnabled: settings.calendarFeedsEnabled,
+    calendarFeedsGroupBy: settings.calendarFeedsGroupBy,
     country: settings.country,
     embedHosts: settings.embedHosts,
     headerImageUrl: settings.headerImageUrl,
@@ -82,8 +84,6 @@ const getAdvancedSettingsPageState = async (
       : "",
     bunnySubdomain: settings.bunnySubdomain,
     businessEmail: settings.businessEmail,
-    calendarFeedsEnabled: settings.calendarFeedsEnabled,
-    calendarFeedsGroupBy: settings.calendarFeedsGroupBy,
     cdnHostname: cdnResult?.ok ? cdnResult.hostname : "",
     confirmationTemplates,
     customDomain: (bunnyCdnConfigured ? settings.customDomain : null) ?? "",

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -144,11 +144,11 @@
   "admin.attendees.search_by_token": "Search by Ticket Token",
   "admin.attendees.merge_preview": "Merge Preview",
   "admin.attendees.field": "Field",
-  "settings.advanced.calendar_feeds": "Calendar feeds",
-  "settings.advanced.calendar_feeds_hint": "Enable a read-only authenticated calendar feed for staff API keys. Calendar clients can subscribe with a Bearer API key at",
-  "settings.advanced.calendar_feeds_enabled": "Enable calendar feeds",
-  "settings.advanced.calendar_feeds_group_by": "Group feed entries by",
-  "settings.advanced.calendar_feeds_group_by_attendees": "Attendees",
-  "settings.advanced.calendar_feeds_group_by_listings": "Listings",
-  "settings.advanced.save_calendar_feeds": "Save calendar feed settings"
+  "settings.calendar_feeds": "Calendar feeds",
+  "settings.calendar_feeds_hint": "Enable a read-only authenticated calendar feed for staff API keys. Calendar clients can subscribe with a Bearer API key at",
+  "settings.calendar_feeds_enabled": "Enable calendar feeds",
+  "settings.calendar_feeds_group_by": "Group feed entries by",
+  "settings.calendar_feeds_group_by_attendees": "Attendees",
+  "settings.calendar_feeds_group_by_listings": "Listings",
+  "settings.save_calendar_feeds": "Save calendar feed settings"
 }

--- a/src/ui/templates/admin/settings-advanced.tsx
+++ b/src/ui/templates/admin/settings-advanced.tsx
@@ -7,7 +7,6 @@ import type { AdminSession, Theme } from "#shared/types.ts";
 import { ResetDatabaseForm } from "#templates/admin/database-reset.tsx";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import { AppleWalletForm } from "#templates/admin/settings/apple-wallet.tsx";
-import { CalendarFeedsForm } from "#templates/admin/settings/calendar-feeds.tsx";
 import {
   AttendeeColumnOrderForm,
   ListingColumnOrderForm,
@@ -39,8 +38,6 @@ export type AdvancedSettingsPageState = {
     html: string;
     text: string;
   };
-  calendarFeedsEnabled: boolean;
-  calendarFeedsGroupBy: "attendees" | "listings";
   bunnyCdnEnabled: boolean;
   bunnyDnsEnabled: boolean;
   bunnySubdomain: string;
@@ -92,7 +89,6 @@ export const adminAdvancedSettingsPage = (
       {ListingColumnOrderForm(s)}
       {AttendeeColumnOrderForm(s)}
       {PublicApiForm(s)}
-      {CalendarFeedsForm(s)}
       {GoogleWalletForm(s)}
       {AppleWalletForm(s)}
       {SmsGatewayForm(s)}

--- a/src/ui/templates/admin/settings.tsx
+++ b/src/ui/templates/admin/settings.tsx
@@ -7,6 +7,7 @@ import type { SuperuserState } from "#shared/superuser.ts";
 import type { AdminSession, Theme } from "#shared/types.ts";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import { BusinessEmailForm } from "#templates/admin/settings/business-email.tsx";
+import { CalendarFeedsForm } from "#templates/admin/settings/calendar-feeds.tsx";
 import { ChangePasswordForm } from "#templates/admin/settings/change-password.tsx";
 import { CountryForm } from "#templates/admin/settings/country.tsx";
 import { EmbedHostsForm } from "#templates/admin/settings/embed-hosts.tsx";
@@ -45,6 +46,8 @@ export type SettingsPageState = {
   headerImageUrl: string;
   storageEnabled: boolean;
   superuser: SuperuserState;
+  calendarFeedsEnabled: boolean;
+  calendarFeedsGroupBy: "attendees" | "listings";
 };
 
 /**
@@ -60,6 +63,7 @@ export type SettingsPageState = {
  * 7. Terms and Conditions
  * 8. Embed Hosts - niche
  * 9. Change Password - rare maintenance
+ * 10. Calendar Feeds - niche read-only feed
  */
 export const adminSettingsPage = (
   session: AdminSession,
@@ -87,5 +91,6 @@ export const adminSettingsPage = (
       {EmbedHostsForm(s)}
       <SuperuserForm superuser={s.superuser} />
       <ChangePasswordForm />
+      {CalendarFeedsForm(s)}
     </Layout>,
   );

--- a/src/ui/templates/admin/settings/calendar-feeds.tsx
+++ b/src/ui/templates/admin/settings/calendar-feeds.tsx
@@ -1,48 +1,42 @@
-/** Calendar feed settings form for advanced settings. */
+/** Calendar feed settings form for the settings page. */
 
 import { t } from "#i18n";
-import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
+import type { SettingsPageState } from "#templates/admin/settings.tsx";
 import { SettingsSection } from "#templates/components/settings-section.tsx";
 
-export const CalendarFeedsForm = (s: AdvancedSettingsPageState): string =>
-  String(
-    <SettingsSection
-      action="/admin/settings/calendar-feeds"
-      description={
-        <p>
-          {t("settings.advanced.calendar_feeds_hint")}{" "}
-          <code>/caldav/events.ics</code>
-        </p>
-      }
-      id="settings-calendar-feeds"
-      submitLabel={t("settings.advanced.save_calendar_feeds")}
-      title={t("settings.advanced.calendar_feeds")}
-    >
-      <label>
-        <input
-          checked={s.calendarFeedsEnabled}
-          name="calendar_feeds_enabled"
-          type="checkbox"
-          value="true"
-        />{" "}
-        {t("settings.advanced.calendar_feeds_enabled")}
-      </label>
-      <label for="calendar_feeds_group_by">
-        {t("settings.advanced.calendar_feeds_group_by")}
-      </label>
-      <select id="calendar_feeds_group_by" name="calendar_feeds_group_by">
-        <option
-          selected={s.calendarFeedsGroupBy === "attendees"}
-          value="attendees"
-        >
-          {t("settings.advanced.calendar_feeds_group_by_attendees")}
-        </option>
-        <option
-          selected={s.calendarFeedsGroupBy === "listings"}
-          value="listings"
-        >
-          {t("settings.advanced.calendar_feeds_group_by_listings")}
-        </option>
-      </select>
-    </SettingsSection>,
-  );
+export const CalendarFeedsForm = (s: SettingsPageState): JSX.Element => (
+  <SettingsSection
+    action="/admin/settings/calendar-feeds"
+    description={
+      <p>
+        {t("settings.calendar_feeds_hint")} <code>/caldav/events.ics</code>
+      </p>
+    }
+    submitLabel={t("settings.save_calendar_feeds")}
+    title={t("settings.calendar_feeds")}
+  >
+    <label>
+      <input
+        checked={s.calendarFeedsEnabled}
+        name="calendar_feeds_enabled"
+        type="checkbox"
+        value="true"
+      />{" "}
+      {t("settings.calendar_feeds_enabled")}
+    </label>
+    <label for="calendar_feeds_group_by">
+      {t("settings.calendar_feeds_group_by")}
+    </label>
+    <select id="calendar_feeds_group_by" name="calendar_feeds_group_by">
+      <option
+        selected={s.calendarFeedsGroupBy === "attendees"}
+        value="attendees"
+      >
+        {t("settings.calendar_feeds_group_by_attendees")}
+      </option>
+      <option selected={s.calendarFeedsGroupBy === "listings"} value="listings">
+        {t("settings.calendar_feeds_group_by_listings")}
+      </option>
+    </select>
+  </SettingsSection>
+);

--- a/test/templates/admin/settings.test.ts
+++ b/test/templates/admin/settings.test.ts
@@ -23,6 +23,8 @@ beforeAll(async () => {
 const defaultState = (): SettingsPageState => ({
   bookingFee: "0",
   businessEmail: "",
+  calendarFeedsEnabled: false,
+  calendarFeedsGroupBy: "attendees",
   country: "GB",
   embedHosts: "",
   headerImageUrl: "",
@@ -92,6 +94,23 @@ describe("adminSettingsPage", () => {
     expect(html).toContain('href="/admin/settings-advanced"');
     expect(html).toContain('href="/admin/backup"');
     expect(html).toContain('href="/admin/debug"');
+  });
+
+  test("renders the calendar feeds form as markup, not escaped HTML", () => {
+    const html = adminSettingsPage(TEST_SESSION, defaultState());
+    expect(html).toContain('action="/admin/settings/calendar-feeds"');
+    expect(html).toContain('name="calendar_feeds_enabled"');
+    expect(html).toContain('name="calendar_feeds_group_by"');
+    // The form is real markup, not an escaped string rendered as text.
+    expect(html).not.toContain("&lt;form");
+  });
+
+  test("checks the calendar feeds toggle when enabled", () => {
+    const html = adminSettingsPage(TEST_SESSION, {
+      ...defaultState(),
+      calendarFeedsEnabled: true,
+    });
+    expect(hasCheckedInput(html, "calendar_feeds_enabled", "true")).toBe(true);
   });
 });
 
@@ -444,8 +463,6 @@ describe("adminAdvancedSettingsPage", () => {
     bunnyDnsSubdomainSuffix: "",
     bunnySubdomain: "",
     businessEmail: "",
-    calendarFeedsEnabled: false,
-    calendarFeedsGroupBy: "attendees",
     cdnHostname: "",
     confirmationTemplates: { html: "", subject: "", text: "" },
     customDomain: "",


### PR DESCRIPTION
## Summary

The calendar feeds form rendered as **escaped raw HTML** on the advanced settings page. This PR fixes the rendering, moves the form to the bottom of the regular settings page, and makes it 100% consistent with the other settings forms.

## The rendering bug

`CalendarFeedsForm` returned `String(<SettingsSection>…)` — an HTML *string*. Every other settings form returns a `JSX.Element` directly (e.g. `PublicApiForm`). When the string was embedded as `{CalendarFeedsForm(s)}`, the JSX runtime text-escaped it, so the markup showed up as literal `<form …>` text on the page.

The fix is to return a `JSX.Element` directly, like every other form.

## Changes

- **`calendar-feeds.tsx`** — return `JSX.Element` instead of `String(...)`; type against `SettingsPageState`; drop the redundant explicit `id` (it's derived from the form action, matching the other forms).
- **`settings.tsx`** — render `CalendarFeedsForm` at the bottom of the regular settings page; add `calendarFeedsEnabled` / `calendarFeedsGroupBy` to `SettingsPageState`.
- **`settings-advanced.tsx`** — remove the form, its import, and its state fields.
- **`settings-page.ts`** — move the two state values from the advanced page state to the regular settings page state.
- **`settings-general.ts`** — drop `advanced: true` from `handleCalendarFeedsPost` so it redirects back to `/admin/settings`.
- **`admin.json`** — move the translation keys out of the `settings.advanced.*` namespace into `settings.*`.

## Tests

- Updated the template test fixtures (added the fields to the regular settings default state, removed from the advanced one).
- Added regression tests: the calendar feeds form renders as real markup (not escaped) on the settings page, and the toggle reflects the enabled state.
- Full `settings` + `calendar-feeds` test files pass (58 tests); `typecheck` and `lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cAqPYafymTKUsyjmtMkDF

---
_Generated by [Claude Code](https://claude.ai/code/session_016cAqPYafymTKUsyjmtMkDF)_