### PR TITLE
perf(admin): stop loading all users for the owner settings nag

### DIFF
--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -20,8 +20,21 @@ import { createKeyedCache, registerCache } from "#shared/db/common-schema.ts";
 import { now } from "#shared/now.ts";
 import { type AdminLevel, isAdminLevel, type User } from "#shared/types.ts";
 
-const USER_SELECT =
-  "SELECT id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry FROM users ORDER BY id ASC";
+const USER_COLUMNS =
+  "id, username_hash, username_index, password_hash, wrapped_data_key, admin_level, invite_code_hash, invite_expiry";
+
+const USER_SELECT = `SELECT ${USER_COLUMNS} FROM users ORDER BY id ASC`;
+
+/** Fetch only the users matching the given blind-index keys, in one query, so a
+ * by-username read never loads the whole table. Powers the cache's targeted
+ * `getByKey`/`getByKeys` path. */
+const fetchUsersByIndex = (keys: string[]): Promise<User[]> =>
+  queryAll<User>(
+    `SELECT ${USER_COLUMNS} FROM users WHERE username_index IN (${keys
+      .map(() => "?")
+      .join(", ")})`,
+    keys,
+  );
 
 export type UserDisplayFields = Pick<
   User,
@@ -49,10 +62,22 @@ export type UserAuthFields = Pick<User, "admin_level" | "id">;
 const USERS_CACHE_TTL_MS = 15_000;
 const usersCache = createKeyedCache<User>({
   fetchAll: () => queryAll<User>(USER_SELECT),
+  fetchByKeys: fetchUsersByIndex,
   idOf: (u) => u.id,
   keyOf: (u) => u.username_index,
   ttlMs: USERS_CACHE_TTL_MS,
 });
+
+/**
+ * Callbacks fired on every users-cache invalidation, so derived caches (e.g.
+ * the superuser account-state cache) can clear in lockstep with user writes.
+ */
+const usersInvalidationListeners = new Set<() => void>();
+
+/** Register a callback to run whenever the users cache is invalidated. */
+export const onUsersInvalidated = (listener: () => void): void => {
+  usersInvalidationListeners.add(listener);
+};
 
 const loadAllUsers = (): Promise<User[]> => usersCache.getAll();
 
@@ -61,6 +86,7 @@ registerCache(() => ({ entries: usersCache.size(), name: "users" }));
 /** Invalidate the users cache (for testing or after writes). */
 export const invalidateUsersCache = (): void => {
   usersCache.invalidate();
+  for (const listener of usersInvalidationListeners) listener();
 };
 
 /** Shared user creation logic */

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -71,12 +71,13 @@ const usersCache = createKeyedCache<User>({
 /**
  * Callbacks fired on every users-cache invalidation, so derived caches (e.g.
  * the superuser account-state cache) can clear in lockstep with user writes.
+ * Registered once per module at load time, mirroring the cache-stats registry.
  */
-const usersInvalidationListeners = new Set<() => void>();
+const usersInvalidationListeners: Array<() => void> = [];
 
 /** Register a callback to run whenever the users cache is invalidated. */
 export const onUsersInvalidated = (listener: () => void): void => {
-  usersInvalidationListeners.add(listener);
+  usersInvalidationListeners.push(listener);
 };
 
 const loadAllUsers = (): Promise<User[]> => usersCache.getAll();

--- a/src/shared/superuser.ts
+++ b/src/shared/superuser.ts
@@ -1,12 +1,18 @@
+import { ttlCache } from "#fp";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { hashPassword } from "#shared/crypto/hashing.ts";
 import { deriveKEK, wrapKey } from "#shared/crypto/keys.ts";
 import { settings } from "#shared/db/settings.ts";
-import { createUser, getUserByUsername } from "#shared/db/users.ts";
+import {
+  createUser,
+  getUserByUsername,
+  onUsersInvalidated,
+} from "#shared/db/users.ts";
 import { type EmailConfig, sendEmail } from "#shared/email.ts";
 import { getEnv } from "#shared/env.ts";
 import { escapeHtml } from "#shared/jsx/jsx-runtime.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
+import { nowMs } from "#shared/now.ts";
 import type { SuperuserChoice } from "#shared/types.ts";
 import {
   emailLocalPart,
@@ -56,6 +62,39 @@ export const getSuperuserUsername = (email: ValidEmail): string | null => {
   return username;
 };
 
+/** Whether the derived superuser account exists and has been activated. */
+type SuperuserAccount = { userExists: boolean; activated: boolean };
+
+/**
+ * Cache of the superuser account-state lookup — the only DB-touching part of the
+ * owner settings nag, recomputed on every owner page view. Keyed by the derived
+ * username so a username change (tests only) gets its own entry. Cleared on any
+ * user write: createUser / activateUser / deleteUser all funnel through
+ * invalidateUsersCache, which fires the registered listener below. The TTL
+ * matches the users cache so cross-isolate staleness is bounded identically.
+ */
+const SUPERUSER_ACCOUNT_TTL_MS = 15_000;
+const superuserAccountCache = ttlCache<string, SuperuserAccount>(
+  SUPERUSER_ACCOUNT_TTL_MS,
+  nowMs,
+);
+onUsersInvalidated(() => superuserAccountCache.clear());
+
+/** Resolve the superuser account state, serving from cache when warm. */
+const getSuperuserAccount = async (
+  username: string,
+): Promise<SuperuserAccount> => {
+  const cached = superuserAccountCache.get(username);
+  if (cached) return cached;
+  const user = await getUserByUsername(username);
+  const account: SuperuserAccount = {
+    activated: user !== null && user.wrapped_data_key !== null,
+    userExists: user !== null,
+  };
+  superuserAccountCache.set(username, account);
+  return account;
+};
+
 export const getSuperuserState = async (): Promise<SuperuserState> => {
   const raw = getEnv("ADMIN_EMAIL_ADDRESS");
   const email = getAdminEmailAddress();
@@ -66,9 +105,7 @@ export const getSuperuserState = async (): Promise<SuperuserState> => {
   const username = getSuperuserUsername(email);
   if (!username) return { available: false, reason: "invalid-username" };
 
-  const user = await getUserByUsername(username);
-  const userExists = user !== null;
-  const activated = userExists && user.wrapped_data_key !== null;
+  const { userExists, activated } = await getSuperuserAccount(username);
 
   const choice = settings.superuserChoice;
 

--- a/test/shared/superuser.test.ts
+++ b/test/shared/superuser.test.ts
@@ -3,10 +3,16 @@ import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { setEffectiveDomainForTest } from "#shared/config.ts";
 import { hashPassword } from "#shared/crypto/hashing.ts";
+import {
+  enableQueryLog,
+  getQueryLog,
+  runWithQueryLogContext,
+} from "#shared/db/query-log.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   createUser,
   getUserByUsername,
+  invalidateUsersCache,
   verifyUserPassword,
 } from "#shared/db/users.ts";
 import {
@@ -269,6 +275,70 @@ describeWithEnv("getSuperuserState", { db: true }, () => {
     settings.setForTest({ superuser_choice: "enabled" });
     const state = await getSuperuserState();
     expect(state).toEqual({ available: false, reason: "missing-env" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSuperuserState() — account lookup efficiency
+// ---------------------------------------------------------------------------
+
+describeWithEnv("getSuperuserState account lookup", { db: true }, () => {
+  let restoreEnv: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreEnv?.();
+  });
+
+  test("resolves the superuser by blind index, never scanning the whole users table", async () => {
+    restoreEnv = setTestEnv({ ADMIN_EMAIL_ADDRESS: "admin@example.com" });
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      await getSuperuserState();
+      const sql = getQueryLog().map((q) => q.sql);
+      expect(sql.some((s) => s.includes("username_index IN"))).toBe(true);
+      // The old path loaded every user via "... FROM users ORDER BY id ASC".
+      expect(sql.some((s) => /FROM users\s+ORDER BY id ASC/.test(s))).toBe(
+        false,
+      );
+    });
+  });
+
+  test("caches the account state so a repeat read issues no query", async () => {
+    restoreEnv = setTestEnv({ ADMIN_EMAIL_ADDRESS: "admin@example.com" });
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      await getSuperuserState();
+      expect(getQueryLog().length).toBeGreaterThan(0);
+      // Re-arm the log; the warm cache should satisfy the second read.
+      enableQueryLog();
+      await getSuperuserState();
+      expect(getQueryLog().length).toBe(0);
+    });
+  });
+
+  test("re-queries after a user write invalidates the cache", async () => {
+    restoreEnv = setTestEnv({ ADMIN_EMAIL_ADDRESS: "admin@example.com" });
+    // Warm the cache with the not-yet-created state.
+    expect((await getSuperuserState()).available).toBe(true);
+    expect(await getUserByUsername("admin")).toBeNull();
+
+    // Creating the account invalidates the users cache, which must clear the
+    // derived superuser-account cache so the nag stops showing.
+    await createUser("admin", await hashPassword("pw"), "wrapped", "owner");
+
+    const state = await getSuperuserState();
+    expect(state.available && state.userExists && state.activated).toBe(true);
+  });
+
+  test("a manual users-cache invalidation also clears the cached account state", async () => {
+    restoreEnv = setTestEnv({ ADMIN_EMAIL_ADDRESS: "admin@example.com" });
+    await getSuperuserState(); // warm cache
+    invalidateUsersCache();
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      await getSuperuserState();
+      expect(getQueryLog().length).toBeGreaterThan(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Background

While investigating the queries on `/admin/listings`, the standout inefficiency wasn't any of the page's own data queries — those are indexed, minimal, and cache-backed. It was an incidental one:

```
SELECT id, username_hash, username_index, password_hash, wrapped_data_key,
       admin_level, invite_code_hash, invite_expiry
FROM users ORDER BY id ASC   — 10.5ms
```

This **full users-table scan** is fired by the owner settings-nag check (rendered on every owner page, including this one): `getAuthenticatedSession` → `getSettingsNagItemsForOwner` → `getSuperuserState` → `getUserByUsername(superuserName)`. That call resolved through the users cache's *load-everything* path, pulling every user's encrypted row just to answer one bit — "does the superuser account exist / is it activated?" — and re-running every ~15s as the cache expired.

## Changes

1. **Targeted lookup.** Give the users cache a `fetchByKeys` so by-username reads resolve via an indexed `WHERE username_index IN (...)` point lookup instead of a full-table scan. This benefits every `getUserByUsername` / `isUsernameTaken` caller, and results stay positive-cached and write-invalidated exactly as before.

2. **Cache the nag's account state.** Cache the superuser account-existence/activation result — the only DB-touching part of the nag, including the common *not-yet-created* (negative) case that a point lookup alone wouldn't cache — with a TTL matching the users cache. It's cleared in lockstep with user writes via a new users-cache invalidation listener, so `createUser` / `activateUser` / `deleteUser` propagate instantly.

The `superuser_choice` and env-derived parts of the nag stay read fresh, so resolving a nag (e.g. enabling the superuser) is never delayed by the cache.

## Net effect

On owner page loads, the widest of the six queries is removed from the common path: a cold lookup becomes a ~1ms indexed point query, and a warm one hits no DB at all.

## Tests

Added coverage in `test/shared/superuser.test.ts` asserting (via the request query log) that `getSuperuserState`:
- resolves by blind index and never emits the `FROM users ORDER BY id ASC` scan,
- serves a repeat read entirely from cache (zero queries),
- re-queries after a user write / manual users-cache invalidation.

Typecheck, lint, jscpd, and the affected suites (auth, users-db, settings-nags, superuser, keyed-cache, backup, settings, server-users) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz3FMRBXA9TjUzVdfou1Du

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz3FMRBXA9TjUzVdfou1Du)_