### PR TITLE
admin/calendar: overlap availability query with date-picker loads

### DIFF
--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -296,11 +296,22 @@ const buildAvailabilityRows = async (
  */
 const handleAdminCalendarGet = (request: Request) =>
   withCalendarSession(request, async (session, dateFilter) => {
-    const [listingCtx, attendeeDates, holidays] = await Promise.all([
-      loadListingContext(),
-      getDailyListingAttendeeDates(),
-      getActiveHolidays(),
-    ]);
+    // The availability rows need the listings list, so chain that query onto
+    // loadListingContext rather than awaiting it separately — it then fires the
+    // moment the listings resolve and overlaps with the date-picker and holiday
+    // queries still in flight (hiding under the slowest of them) instead of
+    // costing an extra serial round trip after this batch.
+    const listingCtxPromise = loadListingContext();
+    const availabilityRowsPromise = listingCtxPromise.then((ctx) =>
+      buildAvailabilityRows(ctx.allListings, dateFilter),
+    );
+    const [listingCtx, attendeeDates, holidays, availabilityRows] =
+      await Promise.all([
+        listingCtxPromise,
+        getDailyListingAttendeeDates(),
+        getActiveHolidays(),
+        availabilityRowsPromise,
+      ]);
 
     const {
       allListings,
@@ -352,10 +363,6 @@ const handleAdminCalendarGet = (request: Request) =>
     );
 
     const hasPaidListing = allListings.some(isPaidListing);
-    const availabilityRows = await buildAvailabilityRows(
-      allListings,
-      dateFilter,
-    );
 
     return htmlResponse(
       adminCalendarPage(

--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -296,21 +296,21 @@ const buildAvailabilityRows = async (
  */
 const handleAdminCalendarGet = (request: Request) =>
   withCalendarSession(request, async (session, dateFilter) => {
-    // The availability rows need the listings list, so chain that query onto
-    // loadListingContext rather than awaiting it separately — it then fires the
-    // moment the listings resolve and overlaps with the date-picker and holiday
-    // queries still in flight (hiding under the slowest of them) instead of
-    // costing an extra serial round trip after this batch.
+    // The availability rows only need the listings list, so build them in a
+    // small async helper that awaits loadListingContext and runs inside the same
+    // Promise.all. It starts as soon as the listings resolve and overlaps with
+    // the date-picker and holiday queries still in flight (hiding under the
+    // slowest of them) instead of costing an extra serial round trip after this
+    // batch.
     const listingCtxPromise = loadListingContext();
-    const availabilityRowsPromise = listingCtxPromise.then((ctx) =>
-      buildAvailabilityRows(ctx.allListings, dateFilter),
-    );
+    const loadAvailabilityRows = async (): Promise<AvailabilityRow[]> =>
+      buildAvailabilityRows((await listingCtxPromise).allListings, dateFilter);
     const [listingCtx, attendeeDates, holidays, availabilityRows] =
       await Promise.all([
         listingCtxPromise,
         getDailyListingAttendeeDates(),
         getActiveHolidays(),
-        availabilityRowsPromise,
+        loadAvailabilityRows(),
       ]);
 
     const {


### PR DESCRIPTION
## What

On `/admin/calendar`, the availability-checker rows were built in a **serial `await buildAvailabilityRows(...)`** that ran only after the listings / date-picker / holiday `Promise.all` batch had fully resolved. Because those rows depend solely on the listings list (already loaded in that batch), this cost an extra database round trip on every calendar render.

This change chains the availability build onto `loadListingContext()` and folds it into the same `Promise.all`, so it fires the moment the listings resolve and overlaps with the date-picker and holiday queries still in flight.

## Why this ordering

Querying remote libsql (Turso) is a per-query network hop, so removing a serial round trip matters. The chained-promise approach is strictly better than the previous structure in **both** cache states:

- **Warm caches** (listings + holidays cached): the group/availability query (`groups … WHERE g.id IN(…)`) no longer waits for the date-picker query — page goes from 2 serial round trips to 1.
- **Cold caches**: the availability query starts as soon as the listings resolve and finishes *underneath* the slower holidays query, rather than following the whole batch — so it adds no measurable latency instead of a full extra round trip.

## Scope

Investigation of the no-date calendar page surfaced one other item — the owner settings-nag loading every user's full row to check superuser existence — but that's broader than the calendar (it's on the shared auth/nag path) and is being addressed separately.

## Behaviour

No behavioural change — the same data is rendered. Verified with `deno task typecheck`, `deno task lint`, and the calendar suites (`test/templates/admin/calendar.test.ts`, `test/lib/server-calendar.test.ts`, `test/lib/server-calendar-logistics.test.ts` — 95 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114mezXYuo4ootuUABGAUuj)_