### PR TITLE
fix(superuser): guard account-state cache against invalidation races

### DIFF
--- a/src/shared/superuser.ts
+++ b/src/shared/superuser.ts
@@ -1,4 +1,4 @@
-import { ttlCache } from "#fp";
+import { lazyRef, ttlCache } from "#fp";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { hashPassword } from "#shared/crypto/hashing.ts";
 import { deriveKEK, wrapKey } from "#shared/crypto/keys.ts";
@@ -78,7 +78,14 @@ const superuserAccountCache = ttlCache<string, SuperuserAccount>(
   SUPERUSER_ACCOUNT_TTL_MS,
   nowMs,
 );
-onUsersInvalidated(() => superuserAccountCache.clear());
+// Bumped on every users-cache invalidation. A lookup that began before an
+// invalidation captured the pre-write generation, so it must not write that
+// now-stale result back — mirroring the keyed cache's own generation guard.
+const [getCacheGeneration, setCacheGeneration] = lazyRef<number>(() => 0);
+onUsersInvalidated(() => {
+  superuserAccountCache.clear();
+  setCacheGeneration(getCacheGeneration() + 1);
+});
 
 /** Resolve the superuser account state, serving from cache when warm. */
 const getSuperuserAccount = async (
@@ -86,12 +93,18 @@ const getSuperuserAccount = async (
 ): Promise<SuperuserAccount> => {
   const cached = superuserAccountCache.get(username);
   if (cached) return cached;
+  // Snapshot the generation before the await; if a user write invalidates the
+  // cache while getUserByUsername is in flight, this result predates the write,
+  // so it is handed back to this caller but never cached.
+  const generation = getCacheGeneration();
   const user = await getUserByUsername(username);
   const account: SuperuserAccount = {
     activated: user !== null && user.wrapped_data_key !== null,
     userExists: user !== null,
   };
-  superuserAccountCache.set(username, account);
+  if (generation === getCacheGeneration()) {
+    superuserAccountCache.set(username, account);
+  }
   return account;
 };
 

--- a/test/shared/superuser.test.ts
+++ b/test/shared/superuser.test.ts
@@ -340,6 +340,27 @@ describeWithEnv("getSuperuserState account lookup", { db: true }, () => {
       expect(getQueryLog().length).toBeGreaterThan(0);
     });
   });
+
+  test("discards a lookup that a concurrent user write raced, never caching stale state", async () => {
+    restoreEnv = setTestEnv({ ADMIN_EMAIL_ADDRESS: "admin@example.com" });
+    // Start a lookup: it runs synchronously until getUserByUsername suspends on
+    // its hashing await, having already captured the cache generation.
+    const inflight = getSuperuserState();
+    // A concurrent user write lands while that lookup is in flight, clearing the
+    // derived cache and bumping the generation.
+    invalidateUsersCache();
+    await inflight;
+    // The raced result predates the write, so it must not have been written
+    // back. A follow-up read therefore misses the cache and re-queries rather
+    // than serving the poisoned entry for the rest of the TTL.
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      await getSuperuserState();
+      expect(
+        getQueryLog().some((q) => q.sql.includes("username_index IN")),
+      ).toBe(true);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #1305, addressing the P2 raised in [Codex's review](https://github.com/chobbledotcom/tickets/pull/1305#discussion_r3441107353).

## The race

The superuser account-state cache added in #1305 has a TOCTOU window. If a user write fires `invalidateUsersCache()` (which clears the derived cache) **while `getUserByUsername` is in flight**, the older lookup then runs `superuserAccountCache.set(...)` *after* the clear — writing its pre-write `userExists`/`activated` result back and leaving stale state cached for up to the 15s TTL.

That's long enough for the owner settings-nag or a superuser settings POST to act on stale account state immediately after a concurrent `createUser` / `activateUser` / `deleteUser`. The underlying keyed cache guards this exact race with a generation counter; the derived cache didn't.

## The fix

Add a generation counter, bumped on every users-cache invalidation, and snapshot it before the `await`:

```ts
const generation = getCacheGeneration();
const user = await getUserByUsername(username);
const account = { activated: ..., userExists: ... };
if (generation === getCacheGeneration()) {
  superuserAccountCache.set(username, account);
}
return account;
```

A lookup whose generation no longer matches on completion is still returned to its caller (this request may legitimately predate the write) but is **never written to the cache**, so the next read re-resolves against fresh data. This mirrors `keyed-cache.ts`'s `remember`/generation guard. The counter uses `lazyRef` rather than a module-level `let` to satisfy the in-memory-state code-quality guard.

## Tests

Added a deterministic race test in `test/shared/superuser.test.ts`: it starts a lookup (which suspends on the hashing await with the generation captured), fires `invalidateUsersCache()` synchronously mid-flight, then asserts the raced result was discarded — a follow-up read misses the cache and re-queries rather than serving a poisoned entry. Without the guard, the follow-up would be a cache hit.

Lint, typecheck, the code-quality guards, and the superuser suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz3FMRBXA9TjUzVdfou1Du

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz3FMRBXA9TjUzVdfou1Du)_