### PR TITLE
Column-aware cache invalidation for listing_attendees → listings dependency

### DIFF
--- a/src/features/admin/settings-statuses.ts
+++ b/src/features/admin/settings-statuses.ts
@@ -34,7 +34,7 @@ import {
   invalidateAttendeeStatusesCache,
   swapAttendeeStatusOrder,
 } from "#shared/db/attendee-statuses.ts";
-import { getDb } from "#shared/db/client.ts";
+import { execute } from "#shared/db/client.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { validateReservationAmount } from "#shared/reservation-amount.ts";
@@ -98,16 +98,16 @@ const clearOtherDefaults = async (
   data: StatusFormData,
 ): Promise<void> => {
   if (data.isPublicDefault) {
-    await getDb().execute({
-      args: [id],
-      sql: "UPDATE attendee_statuses SET is_public_default = 0 WHERE id != ?",
-    });
+    await execute(
+      "UPDATE attendee_statuses SET is_public_default = 0 WHERE id != ?",
+      [id],
+    );
   }
   if (data.isPaidDefault) {
-    await getDb().execute({
-      args: [id],
-      sql: "UPDATE attendee_statuses SET is_paid_default = 0 WHERE id != ?",
-    });
+    await execute(
+      "UPDATE attendee_statuses SET is_paid_default = 0 WHERE id != ?",
+      [id],
+    );
   }
   invalidateAttendeeStatusesCache();
 };
@@ -214,10 +214,10 @@ const deletePost = ownerFormById(async (id, _session, form) => {
       "Choose another paid default before deleting this status",
     );
   }
-  const inUse = await getDb().execute({
-    args: [id],
-    sql: "SELECT 1 FROM attendees WHERE status_id = ? LIMIT 1",
-  });
+  const inUse = await execute(
+    "SELECT 1 FROM attendees WHERE status_id = ? LIMIT 1",
+    [id],
+  );
   if (inUse.rows.length > 0) {
     return errorRedirect(confirmPath, "This status is in use by attendees");
   }

--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -34,26 +34,112 @@ export const getAllCacheStats = (): CacheStat[] => providers.map((p) => p());
  * remember to invalidate by hand. Inverting the dependency this way (caches
  * push their invalidator in at load time) keeps the low-level client free of
  * any static import of the cache modules.
+ *
+ * Column-gated registrations narrow the UPDATE case: a dependency with
+ * `whenColumns` only fires when the UPDATE assigns at least one listed column.
+ * INSERT, DELETE, and REPLACE always fire regardless of the gate, because a
+ * row entering or leaving always shifts the aggregates.
  */
-type Invalidator = () => void;
-const invalidatorsByTable = new Map<string, Set<Invalidator>>();
 
-/** Register `invalidate` to run whenever any of `tables` is written. */
+/** Verb of a mutating SQL statement */
+export type WriteVerb = "delete" | "insert" | "replace" | "update";
+
+/** Context extracted from a write statement for column-gated invalidation */
+export type WriteInfo = {
+  verb: WriteVerb;
+  /** Lower-cased columns assigned by an UPDATE SET clause; empty for non-updates */
+  columns: ReadonlySet<string>;
+};
+
+type Invalidator = () => void;
+type Registration = {
+  invalidate: Invalidator;
+  /** If set, an UPDATE only fires when it assigns at least one of these columns.
+   * INSERT / DELETE / REPLACE always fire. */
+  whenColumns?: ReadonlySet<string>;
+};
+
+const invalidatorsByTable = new Map<string, Set<Registration>>();
+
+const setsIntersect = (
+  a: ReadonlySet<string>,
+  b: ReadonlySet<string>,
+): boolean => {
+  for (const v of a) if (b.has(v)) return true;
+  return false;
+};
+
+/**
+ * Register `invalidate` to run whenever any of `tables` is written.
+ *
+ * Pass `opts.whenColumns` to gate a dependency on specific UPDATE columns:
+ * the invalidator is skipped for UPDATEs that don't assign any listed column
+ * (INSERT / DELETE / REPLACE still always fire).
+ */
 export const registerTableInvalidation = (
   tables: readonly string[],
   invalidate: Invalidator,
+  opts?: { whenColumns?: readonly string[] },
 ): void => {
+  const whenColumns = opts?.whenColumns ? new Set(opts.whenColumns) : undefined;
+  const registration: Registration = { invalidate, whenColumns };
   for (const table of tables) {
-    const set = invalidatorsByTable.get(table) ?? new Set<Invalidator>();
-    set.add(invalidate);
+    const set = invalidatorsByTable.get(table) ?? new Set<Registration>();
+    set.add(registration);
     invalidatorsByTable.set(table, set);
   }
 };
 
-/** Fire every cache invalidator registered against `table` (no-op if none). */
-export const invalidateCachesForTable = (table: string): void => {
+/** Fire registered cache invalidators for `table`, respecting column gates. */
+export const invalidateCachesForWrite = (
+  table: string,
+  info: WriteInfo,
+): void => {
   const set = invalidatorsByTable.get(table);
-  if (set) for (const invalidate of set) invalidate();
+  if (!set) return;
+  for (const reg of set) {
+    if (
+      info.verb === "update" &&
+      reg.whenColumns !== undefined &&
+      !setsIntersect(info.columns, reg.whenColumns)
+    ) {
+      continue;
+    }
+    reg.invalidate();
+  }
+};
+
+/** Fire every cache invalidator registered against `table` (no-op if none).
+ * Treats the write as unconditional (INSERT semantics): always fires column-gated entries too. */
+export const invalidateCachesForTable = (table: string): void =>
+  invalidateCachesForWrite(table, { columns: new Set(), verb: "insert" });
+
+/** A `dependsOn` entry accepted by `cachedTable` / `cachedEntityTable`. */
+export type DependsOnEntry =
+  | string
+  | { table: string; whenColumns?: readonly string[] };
+
+/**
+ * Register `invalidate` to fire whenever `ownTable` or any `deps` entry is
+ * written. Plain string entries are unconditional; object entries may carry
+ * `whenColumns` to gate on specific UPDATE columns (INSERT/DELETE always fire).
+ * Centralises the registration loop shared by `cachedTable` and `cachedEntityTable`.
+ */
+export const registerDependencies = (
+  ownTable: string,
+  deps: ReadonlyArray<DependsOnEntry>,
+  invalidate: () => void,
+): void => {
+  registerTableInvalidation([ownTable], invalidate);
+  for (const dep of deps) {
+    if (typeof dep === "string") {
+      registerTableInvalidation([dep], invalidate);
+    } else {
+      registerTableInvalidation([dep.table], invalidate, {
+        whenColumns: dep.whenColumns,
+      });
+    }
+  }
 };
 
 /** Reset the registry (for testing) */

--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -23,7 +23,41 @@ export const registerCache = (provider: CacheStatProvider): void => {
 /** Collect stats from all registered caches */
 export const getAllCacheStats = (): CacheStat[] => providers.map((p) => p());
 
+/**
+ * Table → cache invalidation registry.
+ *
+ * A cache declares the physical tables whose mutation should clear it (its own
+ * table, plus any table a DB trigger writes through to — e.g. the listings
+ * cache depends on `listing_attendees` because triggers there maintain the
+ * listings aggregate columns). The db client inspects every write statement's
+ * target table and fires the registered invalidators, so no write path has to
+ * remember to invalidate by hand. Inverting the dependency this way (caches
+ * push their invalidator in at load time) keeps the low-level client free of
+ * any static import of the cache modules.
+ */
+type Invalidator = () => void;
+const invalidatorsByTable = new Map<string, Set<Invalidator>>();
+
+/** Register `invalidate` to run whenever any of `tables` is written. */
+export const registerTableInvalidation = (
+  tables: readonly string[],
+  invalidate: Invalidator,
+): void => {
+  for (const table of tables) {
+    const set = invalidatorsByTable.get(table) ?? new Set<Invalidator>();
+    set.add(invalidate);
+    invalidatorsByTable.set(table, set);
+  }
+};
+
+/** Fire every cache invalidator registered against `table` (no-op if none). */
+export const invalidateCachesForTable = (table: string): void => {
+  const set = invalidatorsByTable.get(table);
+  if (set) for (const invalidate of set) invalidate();
+};
+
 /** Reset the registry (for testing) */
 export const resetCacheRegistry = (): void => {
   providers.length = 0;
+  invalidatorsByTable.clear();
 };

--- a/src/shared/db/api-keys.ts
+++ b/src/shared/db/api-keys.ts
@@ -14,7 +14,7 @@ import { hmacHash } from "#shared/crypto/hashing.ts";
 import { wrapKeyWithToken } from "#shared/crypto/keys.ts";
 import {
   deleteByField,
-  getDb,
+  execute,
   insert,
   queryAll,
   queryOne,
@@ -39,16 +39,15 @@ export const createApiKey = async (
   const wrappedDataKey = await wrapKeyWithToken(dataKey, apiKey);
   const encryptedName = await encrypt(name);
 
-  const result = await getDb().execute(
-    insert("api_keys", {
-      created: nowIso(),
-      key_index: keyIndex,
-      last_used: "",
-      name: encryptedName,
-      user_id: userId,
-      wrapped_data_key: wrappedDataKey,
-    }),
-  );
+  const { sql, args } = insert("api_keys", {
+    created: nowIso(),
+    key_index: keyIndex,
+    last_used: "",
+    name: encryptedName,
+    user_id: userId,
+    wrapped_data_key: wrappedDataKey,
+  });
+  const result = await execute(sql, args);
 
   return { apiKey, id: Number(result.lastInsertRowid) };
 };
@@ -123,10 +122,10 @@ export const deleteApiKey = async (
   id: number,
   userId: number,
 ): Promise<boolean> => {
-  const result = await getDb().execute({
-    args: [id, userId],
-    sql: "DELETE FROM api_keys WHERE id = ? AND user_id = ?",
-  });
+  const result = await execute(
+    "DELETE FROM api_keys WHERE id = ? AND user_id = ?",
+    [id, userId],
+  );
   return result.rowsAffected > 0;
 };
 
@@ -143,10 +142,10 @@ export const deleteAllApiKeysForUser = (userId: number): Promise<void> =>
 export const touchApiKeyLastUsed = async (id: number): Promise<void> => {
   const override = getTouchOverride();
   if (override) throw override;
-  await getDb().execute({
-    args: [nowIso(), id],
-    sql: "UPDATE api_keys SET last_used = ? WHERE id = ?",
-  });
+  await execute("UPDATE api_keys SET last_used = ? WHERE id = ?", [
+    nowIso(),
+    id,
+  ]);
 };
 
 export const apiKeysApi = {

--- a/src/shared/db/attendee-phone-index.ts
+++ b/src/shared/db/attendee-phone-index.ts
@@ -2,7 +2,7 @@
  * Attendee phone blind-index reads/writes (see #shared/sms/phone-index.ts).
  */
 
-import { getDb, queryOne } from "#shared/db/client.ts";
+import { execute, queryOne } from "#shared/db/client.ts";
 
 /**
  * Store the phone blind-index on an attendee, but only if one isn't set yet.
@@ -13,10 +13,10 @@ export const setAttendeePhoneIndexIfEmpty = async (
   phoneIndex: string,
 ): Promise<void> => {
   if (!phoneIndex) return;
-  await getDb().execute({
-    args: [phoneIndex, attendeeId],
-    sql: "UPDATE attendees SET phone_index = ? WHERE id = ? AND phone_index = ''",
-  });
+  await execute(
+    "UPDATE attendees SET phone_index = ? WHERE id = ? AND phone_index = ''",
+    [phoneIndex, attendeeId],
+  );
 };
 
 /** Find the attendee id whose phone blind-index matches, if any. */

--- a/src/shared/db/attendee-statuses.ts
+++ b/src/shared/db/attendee-statuses.ts
@@ -9,7 +9,7 @@
  */
 
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { executeBatch, getDb, queryAll } from "#shared/db/client.ts";
+import { execute, executeBatch, queryAll } from "#shared/db/client.ts";
 import { queryAndMap, swapSortOrder } from "#shared/db/query.ts";
 import { cachedTable, col, defineTable } from "#shared/db/table.ts";
 
@@ -153,9 +153,8 @@ export const ensureDefaultAttendeeStatus = async (): Promise<void> => {
     reservationAmount: "0",
     sortOrder: 0,
   });
-  await getDb().execute({
-    args: [status.id],
-    sql: "UPDATE attendees SET status_id = ? WHERE status_id IS NULL",
-  });
+  await execute("UPDATE attendees SET status_id = ? WHERE status_id IS NULL", [
+    status.id,
+  ]);
   invalidateAttendeeStatusesCache();
 };

--- a/src/shared/db/attendees/atomic-update.ts
+++ b/src/shared/db/attendees/atomic-update.ts
@@ -40,7 +40,6 @@ import {
 } from "#shared/db/attendees/capacity.ts";
 import { buildCapacityCondition } from "#shared/db/capacity.ts";
 import { executeBatchWithResults, queryAll } from "#shared/db/client.ts";
-import { invalidateListingsCache } from "#shared/db/listings.ts";
 
 /**
  * A guard statement that aborts the whole write batch when the immediately
@@ -238,7 +237,6 @@ export const applyAttendeeAtomicEdit = async (
   // thrown error (the caller retries), never a partial write.
   await executeBatchWithResults(statements);
 
-  invalidateListingsCache();
   return { success: true };
 };
 

--- a/src/shared/db/attendees/balance.ts
+++ b/src/shared/db/attendees/balance.ts
@@ -16,10 +16,7 @@ import {
   queryAll,
   queryOne,
 } from "#shared/db/client.ts";
-import {
-  getListingWithCount,
-  invalidateListingsCache,
-} from "#shared/db/listings.ts";
+import { getListingWithCount } from "#shared/db/listings.ts";
 
 /** Plaintext reservation state for an attendee. */
 export type AttendeeBalanceState = {
@@ -183,8 +180,6 @@ export const settleAttendeeBalance = async (
   // changed the balance between our read and this write.
   if (results[results.length - 1]!.rowsAffected === 0)
     return { reason: "amount_mismatch", settled: false };
-
-  invalidateListingsCache();
 
   const firstListing = await queryOne<{ listing_id: number }>(
     "SELECT listing_id FROM listing_attendees WHERE attendee_id = ? ORDER BY id LIMIT 1",

--- a/src/shared/db/attendees/create.ts
+++ b/src/shared/db/attendees/create.ts
@@ -23,7 +23,6 @@ import {
   hashPhone,
   recordVisit,
 } from "#shared/db/contact-preferences.ts";
-import { invalidateListingsCache } from "#shared/db/listings.ts";
 import { type Attendee, normalizeDurationDays } from "#shared/types.ts";
 
 /**
@@ -240,6 +239,5 @@ export const createAttendeeAtomicImpl = async (
   // the customer on future checkouts.
   await recordOrderVisit(email, phone);
 
-  invalidateListingsCache();
   return { attendees: successfulBookings, success: true };
 };

--- a/src/shared/db/attendees/delete.ts
+++ b/src/shared/db/attendees/delete.ts
@@ -4,7 +4,6 @@
 
 import type { InValue } from "@libsql/client";
 import { executeBatch, queryAll } from "#shared/db/client.ts";
-import { invalidateListingsCache } from "#shared/db/listings.ts";
 
 type DeleteAttendeeOptions = { releaseBookings?: boolean };
 type ListingContribution = {
@@ -73,5 +72,4 @@ export const deleteAttendee = async (
     ? []
     : await attendeeListingContributions(attendeeId);
   await purgeAttendee(attendeeId, contributions);
-  invalidateListingsCache();
 };

--- a/src/shared/db/attendees/update.ts
+++ b/src/shared/db/attendees/update.ts
@@ -5,8 +5,7 @@
 import { filter, map, pipe, reduce, sumOf, unique } from "#fp";
 import type { UpdateAttendeePIIInput } from "#shared/db/attendee-types.ts";
 import { buildPiiBlob, encryptPiiBlob } from "#shared/db/attendees/pii.ts";
-import { getDb, queryAll } from "#shared/db/client.ts";
-import { invalidateListingsCache } from "#shared/db/listings.ts";
+import { execute, queryAll } from "#shared/db/client.ts";
 import { settings } from "#shared/db/settings.ts";
 import { normalizeDurationDays } from "#shared/types.ts";
 
@@ -18,10 +17,10 @@ const updateListingAttendeeField =
     listingId: number,
     value: number,
   ): Promise<void> => {
-    await getDb().execute({
-      args: [value, attendeeId, listingId],
-      sql: `UPDATE listing_attendees SET ${field} = ? WHERE attendee_id = ? AND listing_id = ?`,
-    });
+    await execute(
+      `UPDATE listing_attendees SET ${field} = ? WHERE attendee_id = ? AND listing_id = ?`,
+      [value, attendeeId, listingId],
+    );
   };
 
 const setRefunded = updateListingAttendeeField("refunded");
@@ -48,20 +47,20 @@ export const updateAttendeeOrder = async (
   statusId: number | null,
   remainingBalance: number,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [statusId, remainingBalance, attendeeId],
-    sql: "UPDATE attendees SET status_id = ?, remaining_balance = ? WHERE id = ?",
-  });
+  await execute(
+    "UPDATE attendees SET status_id = ?, remaining_balance = ? WHERE id = ?",
+    [statusId, remainingBalance, attendeeId],
+  );
 };
 
 export const incrementAttachmentDownloads = async (
   attendeeId: number,
   listingId: number,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [attendeeId, listingId],
-    sql: "UPDATE listing_attendees SET attachment_downloads = attachment_downloads + 1 WHERE attendee_id = ? AND listing_id = ?",
-  });
+  await execute(
+    "UPDATE listing_attendees SET attachment_downloads = attachment_downloads + 1 WHERE attendee_id = ? AND listing_id = ?",
+    [attendeeId, listingId],
+  );
 };
 
 export const updateAttendeePII = async (
@@ -76,10 +75,10 @@ export const updateAttendeePII = async (
     }),
     settings.publicKey,
   );
-  await getDb().execute({
-    args: [encryptedPiiBlob, attendeeId],
-    sql: "UPDATE attendees SET pii_blob = ? WHERE id = ?",
-  });
+  await execute("UPDATE attendees SET pii_blob = ? WHERE id = ?", [
+    encryptedPiiBlob,
+    attendeeId,
+  ]);
 };
 
 /**
@@ -93,13 +92,12 @@ export const recomputeListingBookingRanges = async (
   durationDays: number,
 ): Promise<void> => {
   const duration = normalizeDurationDays(durationDays);
-  await getDb().execute({
-    args: [duration, listingId],
-    sql: `UPDATE listing_attendees
+  await execute(
+    `UPDATE listing_attendees
            SET end_at = REPLACE(datetime(start_at, '+' || ? || ' days'), ' ', 'T') || '.000Z'
            WHERE listing_id = ? AND start_at IS NOT NULL`,
-  });
-  invalidateListingsCache();
+    [duration, listingId],
+  );
 };
 
 /** A booking's day range as [start, end) YYYY-MM-DD strings (day-aligned —

--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -12,7 +12,7 @@
 
 import { unzipSync, zipSync } from "fflate";
 import { chunk, compact } from "#fp";
-import { executeBatch, getDb, queryAll } from "#shared/db/client.ts";
+import { execute, executeBatch, queryAll } from "#shared/db/client.ts";
 import { invalidateGroupsCache } from "#shared/db/groups.ts";
 import { invalidateListingsCache } from "#shared/db/listings.ts";
 import {
@@ -318,9 +318,9 @@ export const restoreFromSql = async (sql: string): Promise<void> => {
   // default attendee_statuses row; clear them so the backup's own rows don't
   // collide on primary keys. (An older backup with no attendee_statuses rows
   // re-seeds on the next initDb, which runs because the markers are cleared.)
-  await getDb().execute("DELETE FROM settings");
-  await getDb().execute("DELETE FROM schema_migrations");
-  await getDb().execute("DELETE FROM attendee_statuses");
+  await execute("DELETE FROM settings");
+  await execute("DELETE FROM schema_migrations");
+  await execute("DELETE FROM attendee_statuses");
 
   const statements = splitStatements(sql);
   if (statements.length > 0) {

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -14,7 +14,10 @@ import {
   type TransactionMode,
 } from "@libsql/client";
 import { lazyRef } from "#fp";
-import { invalidateCachesForTable } from "#shared/cache-registry.ts";
+import {
+  invalidateCachesForWrite,
+  type WriteVerb,
+} from "#shared/cache-registry.ts";
 import {
   addQueryLogEntry,
   isQueryLogEnabled,
@@ -32,15 +35,76 @@ const WRITE_TABLE_RE =
   /^\s*(?:insert(?:\s+or\s+\w+)?\s+into|replace\s+into|update(?:\s+or\s+\w+)?|delete\s+from)\s+["'`]?(\w+)/i;
 
 /**
+ * Parse the column names assigned by an UPDATE SET clause.
+ * Returns a lower-cased Set, or null if the SET clause cannot be found.
+ * Each `col = expr` left-hand side is extracted; commas inside parentheses
+ * are skipped so subexpressions don't split assignments. If extraction yields
+ * no columns the caller falls back to unconditional invalidation.
+ * Exported for unit testing; not part of the public db-client API.
+ */
+export const extractUpdateColumns = (
+  sql: string,
+): ReadonlySet<string> | null => {
+  const setMatch = /\bSET\s+([\s\S]*?)(?:\s+WHERE\b|$)/i.exec(sql);
+  if (!setMatch) return null;
+  const setClause = setMatch[1]!.trim();
+  const columns = new Set<string>();
+  const addAssignment = (frag: string): void => {
+    const eqIdx = frag.indexOf("=");
+    if (eqIdx < 0) return;
+    const col = frag
+      .slice(0, eqIdx)
+      .trim()
+      .split(".")
+      .pop()!
+      .replace(/["`[\]]/g, "")
+      .toLowerCase();
+    if (col) columns.add(col);
+  };
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < setClause.length; i++) {
+    const ch = setClause[i]!;
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (ch === "," && depth === 0) {
+      addAssignment(setClause.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  addAssignment(setClause.slice(start).trim());
+  return columns.size > 0 ? columns : null;
+};
+
+/**
  * After a successful write, invalidate every cache that declared a dependency
  * on the mutated table. A no-op for reads (the regex doesn't match) and for
- * tables no cache depends on. Over-invalidation is only a cache miss; the
- * failure we are designing out — a forgotten manual invalidate leaving stale
- * data — cannot happen because the write itself drives this.
+ * tables no cache depends on. For UPDATEs, the SET-clause columns are
+ * extracted so column-gated dependencies (e.g. listings ← listing_attendees
+ * only when quantity / price_paid / listing_id are written) can skip the
+ * invalidation when only unrelated columns are touched. If column extraction
+ * fails the write is treated as unconditional — safe over stale.
  */
 const invalidateForSql = (sql: string): void => {
   const match = WRITE_TABLE_RE.exec(sql);
-  if (match) invalidateCachesForTable(match[1]!.toLowerCase());
+  if (!match) return;
+  const table = match[1]!.toLowerCase();
+  const firstWord = sql.trimStart().split(/\s/)[0]!.toLowerCase();
+  const verb: WriteVerb =
+    firstWord === "delete" || firstWord === "update" || firstWord === "replace"
+      ? (firstWord as WriteVerb)
+      : "insert";
+  if (verb === "update") {
+    const columns = extractUpdateColumns(sql);
+    if (columns === null) {
+      // Parse failure: fall back to unconditional (treat as INSERT-like)
+      invalidateCachesForWrite(table, { columns: new Set(), verb: "insert" });
+    } else {
+      invalidateCachesForWrite(table, { columns, verb: "update" });
+    }
+  } else {
+    invalidateCachesForWrite(table, { columns: new Set(), verb });
+  }
 };
 
 const createDbClient = (): Client => {

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -14,12 +14,34 @@ import {
   type TransactionMode,
 } from "@libsql/client";
 import { lazyRef } from "#fp";
+import { invalidateCachesForTable } from "#shared/cache-registry.ts";
 import {
   addQueryLogEntry,
   isQueryLogEnabled,
   trackQuery,
 } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
+
+/**
+ * Match the target table of a mutating statement (INSERT/UPDATE/DELETE/REPLACE),
+ * the mirror of query-log's read detector. Anchored at the start so it fails
+ * fast on the SELECTs that dominate the call volume. The optional
+ * `OR <action>` / `OR <action> INTO` clauses cover libsql's conflict variants.
+ */
+const WRITE_TABLE_RE =
+  /^\s*(?:insert(?:\s+or\s+\w+)?\s+into|replace\s+into|update(?:\s+or\s+\w+)?|delete\s+from)\s+["'`]?(\w+)/i;
+
+/**
+ * After a successful write, invalidate every cache that declared a dependency
+ * on the mutated table. A no-op for reads (the regex doesn't match) and for
+ * tables no cache depends on. Over-invalidation is only a cache miss; the
+ * failure we are designing out — a forgotten manual invalidate leaving stale
+ * data — cannot happen because the write itself drives this.
+ */
+const invalidateForSql = (sql: string): void => {
+  const match = WRITE_TABLE_RE.exec(sql);
+  if (match) invalidateCachesForTable(match[1]!.toLowerCase());
+};
 
 const createDbClient = (): Client => {
   const url = getEnv("DB_URL");
@@ -48,13 +70,29 @@ export const setDb = (client: Client | null): void => dbSetter(client);
 export const resultRows = <T>(result: ResultSet): T[] =>
   result.rows as unknown as T[];
 
+/**
+ * Run a single statement: track it for the query log / N+1 guard, then fire any
+ * table-scoped cache invalidation. Every single-statement read and write goes
+ * through here (queryOne/queryAll wrap it), so cache invalidation is driven by
+ * the write itself rather than by each call site remembering to invalidate.
+ */
+export const execute = async (
+  sql: string,
+  args?: InValue[],
+): Promise<ResultSet> => {
+  const result = await trackQuery(sql, () =>
+    args ? getDb().execute({ args, sql }) : getDb().execute(sql),
+  );
+  invalidateForSql(sql);
+  return result;
+};
+
 /** Query single row, returning null if not found */
 export const queryOne = async <T>(
   sql: string,
   args: InValue[],
 ): Promise<T | null> => {
-  const result = await trackQuery(sql, () => getDb().execute({ args, sql }));
-  const rows = resultRows<T>(result);
+  const rows = resultRows<T>(await execute(sql, args));
   return rows.length === 0 ? null : rows[0]!;
 };
 
@@ -62,12 +100,7 @@ export const queryOne = async <T>(
 export const queryAll = async <T>(
   sql: string,
   args?: InValue[],
-): Promise<T[]> => {
-  const result = await trackQuery(sql, () =>
-    args ? getDb().execute({ args, sql }) : getDb().execute(sql),
-  );
-  return resultRows<T>(result);
-};
+): Promise<T[]> => resultRows<T>(await execute(sql, args));
 
 /** Count all rows in a table. `table` must be a trusted constant, not input. */
 export const countRows = async (table: string): Promise<number> => {
@@ -85,8 +118,7 @@ export const deleteByField = async (
   field: string,
   value: InValue,
 ): Promise<void> => {
-  const sql = `DELETE FROM ${table} WHERE ${field} = ?`;
-  await trackQuery(sql, () => getDb().execute({ args: [value], sql }));
+  await execute(`DELETE FROM ${table} WHERE ${field} = ?`, [value]);
 };
 
 /** Delete rows from multiple tables in a single batch transaction */
@@ -114,24 +146,26 @@ export const resetAggregates = async <T extends string>(
   const sql = `UPDATE ${table} SET ${fields
     .map((field) => resetSql[field])
     .join(", ")} WHERE id = ?`;
-  await trackQuery(sql, () =>
-    getDb().execute({
-      args: fields.map(() => entityId).concat(entityId),
-      sql,
-    }),
-  );
+  await execute(sql, fields.map(() => entityId).concat(entityId));
 };
 
-/** Execute a batch with optional query logging and timing */
+/**
+ * Execute a batch with optional query logging, then invalidate caches for every
+ * table the batch mutated. Invalidation runs once the transaction has
+ * committed; if the batch throws (rollback) it is skipped, so a cache is never
+ * cleared for a write that did not land.
+ */
 const trackedBatch = async (
   statements: Array<{ sql: string; args: InValue[] }>,
   mode: TransactionMode,
 ): Promise<ResultSet[]> => {
-  if (!isQueryLogEnabled()) return getDb().batch(statements, mode);
   const start = performance.now();
   const results = await getDb().batch(statements, mode);
-  const elapsed = performance.now() - start;
-  for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed);
+  if (isQueryLogEnabled()) {
+    const elapsed = performance.now() - start;
+    for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed);
+  }
+  for (const stmt of statements) invalidateForSql(stmt.sql);
   return results;
 };
 

--- a/src/shared/db/common-schema.ts
+++ b/src/shared/db/common-schema.ts
@@ -1,5 +1,7 @@
 import {
+  type DependsOnEntry,
   registerCache,
+  registerDependencies,
   registerTableInvalidation,
 } from "#shared/cache-registry.ts";
 import {
@@ -23,18 +25,21 @@ export { createKeyedCache, registerCache, registerTableInvalidation };
  * trio that listings and groups would otherwise each repeat. `Cached` lets the
  * cache hold a richer row than the table writes (e.g. listings cached with
  * attendee counts).
+ *
+ * `dependsOn` entries may carry `whenColumns` to narrow the `listing_attendees`
+ * → `listings` dependency: the cache is only cleared on UPDATEs that touch one
+ * of those columns. INSERT / DELETE always clear.
  */
 export const cachedEntityTable = <Row, Input, Cached = Row>(
   name: string,
   table: Table<Row, Input>,
   config: KeyedCacheConfig<Cached>,
-  dependsOn: readonly string[] = [],
+  dependsOn: ReadonlyArray<DependsOnEntry> = [],
 ): { cache: KeyedCache<Cached>; table: Table<Row, Input> } => {
   const cache = createKeyedCache(config);
   registerCache(() => ({ entries: cache.size(), name }));
-  registerTableInvalidation([table.name, ...dependsOn], () =>
-    cache.invalidate(),
-  );
+  const invalidate = (): void => cache.invalidate();
+  registerDependencies(table.name, dependsOn, invalidate);
   return { cache, table };
 };
 

--- a/src/shared/db/common-schema.ts
+++ b/src/shared/db/common-schema.ts
@@ -1,34 +1,41 @@
-import { registerCache } from "#shared/cache-registry.ts";
+import {
+  registerCache,
+  registerTableInvalidation,
+} from "#shared/cache-registry.ts";
 import {
   createKeyedCache,
   type KeyedCache,
   type KeyedCacheConfig,
 } from "#shared/db/keyed-cache.ts";
-import { col, type Table, withCacheInvalidation } from "#shared/db/table.ts";
+import { col, type Table } from "#shared/db/table.ts";
 
 export { defineIdTable } from "#shared/db/define-id-table.ts";
 // Re-exported for users.ts, which caches a table-less query and so wires the
 // cache by hand rather than through cachedEntityTable.
-export { createKeyedCache, registerCache };
+export { createKeyedCache, registerCache, registerTableInvalidation };
 
 /**
  * Wire a keyed cache to an id-table in one step: build the cache, register it
- * for the debug-footer stats, and wrap the table so every write invalidates the
- * cache. Centralises the create-cache + register + invalidate-on-write trio that
- * listings and groups would otherwise each repeat. `Cached` lets the cache hold
- * a richer row than the table writes (e.g. listings cached with attendee counts).
+ * for the debug-footer stats, and register it with the table→cache invalidation
+ * registry so any write to the table (or to a `dependsOn` table whose triggers
+ * feed it — e.g. listings depend on listing_attendees) clears the cache
+ * automatically at the db-client layer. Centralises the create-cache + register
+ * trio that listings and groups would otherwise each repeat. `Cached` lets the
+ * cache hold a richer row than the table writes (e.g. listings cached with
+ * attendee counts).
  */
 export const cachedEntityTable = <Row, Input, Cached = Row>(
   name: string,
   table: Table<Row, Input>,
   config: KeyedCacheConfig<Cached>,
+  dependsOn: readonly string[] = [],
 ): { cache: KeyedCache<Cached>; table: Table<Row, Input> } => {
   const cache = createKeyedCache(config);
   registerCache(() => ({ entries: cache.size(), name }));
-  return {
-    cache,
-    table: withCacheInvalidation(table, () => cache.invalidate()),
-  };
+  registerTableInvalidation([table.name, ...dependsOn], () =>
+    cache.invalidate(),
+  );
+  return { cache, table };
 };
 
 type EncryptFn = (v: string) => Promise<string>;

--- a/src/shared/db/contact-preferences.ts
+++ b/src/shared/db/contact-preferences.ts
@@ -13,8 +13,8 @@ import {
   encryptWithOwnerKey,
 } from "#shared/crypto/keys.ts";
 import {
+  execute,
   executeBatch,
-  getDb,
   inPlaceholders,
   queryAll,
   queryOne,
@@ -45,7 +45,7 @@ export const hashPhone = (phone: string): Promise<string> =>
   contactHash("sms", phone);
 
 const run = async (sql: string, args: (string | number)[]): Promise<void> => {
-  await getDb().execute({ args, sql });
+  await execute(sql, args);
 };
 
 export const isHashUnsubscribed = async (hash: string): Promise<boolean> => {

--- a/src/shared/db/email-templates.ts
+++ b/src/shared/db/email-templates.ts
@@ -7,7 +7,7 @@
  * TEXT values.
  */
 
-import { countRows, getDb, queryAll, queryOne } from "#shared/db/client.ts";
+import { countRows, execute, queryAll, queryOne } from "#shared/db/client.ts";
 
 export type RawEmailTemplate = { id: number; subject: string; body: string };
 
@@ -27,10 +27,10 @@ export const insertEmailTemplate = async (
   subject: string,
   body: string,
 ): Promise<number> => {
-  const result = await getDb().execute({
-    args: [subject, body],
-    sql: "INSERT INTO email_templates (subject, body) VALUES (?, ?)",
-  });
+  const result = await execute(
+    "INSERT INTO email_templates (subject, body) VALUES (?, ?)",
+    [subject, body],
+  );
   return Number(result.lastInsertRowid);
 };
 
@@ -39,16 +39,13 @@ export const updateEmailTemplate = async (
   subject: string,
   body: string,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [subject, body, id],
-    sql: "UPDATE email_templates SET subject = ?, body = ? WHERE id = ?",
-  });
+  await execute(
+    "UPDATE email_templates SET subject = ?, body = ? WHERE id = ?",
+    [subject, body, id],
+  );
 };
 
 export const deleteEmailTemplate = async (id: number): Promise<void> => {
-  await getDb().execute({
-    args: [id],
-    sql: "DELETE FROM email_templates WHERE id = ?",
-  });
+  await execute("DELETE FROM email_templates WHERE id = ?", [id]);
 };
 /* jscpd:ignore-end */

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -4,17 +4,14 @@
 
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { getDb } from "#shared/db/client.ts";
+import { execute, queryAll } from "#shared/db/client.ts";
 import {
   cachedEntityTable,
   defineIdTable,
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
 } from "#shared/db/common-schema.ts";
-import {
-  invalidateListingsCache,
-  queryListingsWithCounts,
-} from "#shared/db/listings.ts";
+import { queryListingsWithCounts } from "#shared/db/listings.ts";
 import { queryAndMap } from "#shared/db/query.ts";
 import { col } from "#shared/db/table.ts";
 import type { Group, ListingType, ListingWithCount } from "#shared/types.ts";
@@ -92,18 +89,18 @@ export const isGroupSlugTaken = async (
 ): Promise<boolean> => {
   const slugIndex = await computeGroupSlugIndex(slug);
 
-  const listingHit = await getDb().execute({
-    args: [slugIndex],
-    sql: "SELECT 1 FROM listings WHERE slug_index = ? LIMIT 1",
-  });
-  if (listingHit.rows.length > 0) return true;
+  const listingHit = await queryAll(
+    "SELECT 1 FROM listings WHERE slug_index = ? LIMIT 1",
+    [slugIndex],
+  );
+  if (listingHit.length > 0) return true;
 
   const sql = excludeGroupId
     ? "SELECT 1 FROM groups WHERE slug_index = ? AND id != ? LIMIT 1"
     : "SELECT 1 FROM groups WHERE slug_index = ? LIMIT 1";
   const args = excludeGroupId ? [slugIndex, excludeGroupId] : [slugIndex];
-  const groupHit = await getDb().execute({ args, sql });
-  return groupHit.rows.length > 0;
+  const groupHit = await queryAll(sql, args);
+  return groupHit.length > 0;
 };
 
 /** Query listings in a group with attendee counts, optionally filtering to active only */
@@ -177,23 +174,20 @@ export const assignListingsToGroup = async (
   groupId: number,
 ): Promise<void> => {
   for (const listingId of listingIds) {
-    await getDb().execute({
-      args: [groupId, listingId],
-      sql: "UPDATE listings SET group_id = ? WHERE id = ?",
-    });
+    await execute("UPDATE listings SET group_id = ? WHERE id = ?", [
+      groupId,
+      listingId,
+    ]);
   }
-  if (listingIds.length > 0) invalidateListingsCache();
 };
 
 /**
  * Reset group assignment on all listings in a group.
  */
 export const resetGroupListings = async (groupId: number): Promise<void> => {
-  await getDb().execute({
-    args: [groupId],
-    sql: "UPDATE listings SET group_id = 0 WHERE group_id = ?",
-  });
-  invalidateListingsCache();
+  await execute("UPDATE listings SET group_id = 0 WHERE group_id = ?", [
+    groupId,
+  ]);
 };
 
 /**
@@ -204,10 +198,9 @@ export const setGroupListingsActive = async (
   groupId: number,
   active: boolean,
 ): Promise<number> => {
-  const result = await getDb().execute({
-    args: [active ? 1 : 0, groupId],
-    sql: "UPDATE listings SET active = ? WHERE group_id = ?",
-  });
-  invalidateListingsCache();
+  const result = await execute(
+    "UPDATE listings SET active = ? WHERE group_id = ?",
+    [active ? 1 : 0, groupId],
+  );
   return result.rowsAffected;
 };

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -13,8 +13,8 @@ import {
 } from "#shared/db/attendees.ts";
 import { dateToRange } from "#shared/db/capacity.ts";
 import {
+  execute,
   executeBatch,
-  getDb,
   inPlaceholders,
   queryAll,
   queryBatch,
@@ -255,27 +255,37 @@ const queryOneListingWithCount = async (
 
 /**
  * Listings cache: single-record reads (by id / slug) load and decrypt only the
- * one listing they need; getAll/getByType load the whole set. Writes through
- * {@link listingsTable} (and the explicit invalidate calls in the attendee
- * write paths) clear it.
+ * one listing they need; getAll/getByType load the whole set.
+ *
+ * The cache holds the trigger-maintained aggregate columns (booked_quantity,
+ * tickets_count, income), which are mutated by writes to `listing_attendees`,
+ * not to `listings` itself — so the cache declares a dependency on that table
+ * and the db client clears it on any listing_attendees write, the same as for a
+ * direct listings write. This replaces the explicit invalidate calls that every
+ * attendee write path used to have to remember.
  */
 const LISTINGS_CACHE_TTL_MS = 30_000;
 const listingsEntity = cachedEntityTable<
   Listing,
   ListingInput,
   ListingWithCount
->("listings", rawListingsTable, {
-  fetchAll: () => queryListingsWithCounts(),
-  fetchById: (id) => queryOneListingWithCount("e.id = ?", [id]),
-  fetchByKeys: (slugIndexes) =>
-    queryListingsWithCounts(
-      `WHERE e.slug_index IN (${inPlaceholders(slugIndexes)})`,
-      slugIndexes,
-    ),
-  idOf: (e) => e.id,
-  keyOf: (e) => e.slug_index,
-  ttlMs: LISTINGS_CACHE_TTL_MS,
-});
+>(
+  "listings",
+  rawListingsTable,
+  {
+    fetchAll: () => queryListingsWithCounts(),
+    fetchById: (id) => queryOneListingWithCount("e.id = ?", [id]),
+    fetchByKeys: (slugIndexes) =>
+      queryListingsWithCounts(
+        `WHERE e.slug_index IN (${inPlaceholders(slugIndexes)})`,
+        slugIndexes,
+      ),
+    idOf: (e) => e.id,
+    keyOf: (e) => e.slug_index,
+    ttlMs: LISTINGS_CACHE_TTL_MS,
+  },
+  ["listing_attendees"],
+);
 const listingsCache = listingsEntity.cache;
 
 /** Listings table with CRUD operations — writes auto-invalidate the cache */
@@ -302,7 +312,7 @@ export const isSlugTaken = async (
   const args = excludeListingId
     ? [slugIndex, excludeListingId, slugIndex]
     : [slugIndex, slugIndex];
-  const result = await getDb().execute({ args, sql });
+  const result = await execute(sql, args);
   return result.rows.length > 0;
 };
 
@@ -325,7 +335,6 @@ export const deleteListing = async (listingId: number): Promise<void> => {
     { args: [listingId], sql: "DELETE FROM activity_log WHERE listing_id = ?" },
     { args: [listingId], sql: "DELETE FROM listings WHERE id = ?" },
   ]);
-  invalidateListingsCache();
 };
 
 /** The precomputed aggregate columns every `SELECT * FROM listings` row carries. */
@@ -432,16 +441,10 @@ export const updateListingAggregateValues = async (
   listingId: number,
   values: ListingAggregateValues,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [
-      values.booked_quantity,
-      values.tickets_count,
-      values.income,
-      listingId,
-    ],
-    sql: "UPDATE listings SET booked_quantity = ?, tickets_count = ?, income = ? WHERE id = ?",
-  });
-  invalidateListingsCache();
+  await execute(
+    "UPDATE listings SET booked_quantity = ?, tickets_count = ?, income = ? WHERE id = ?",
+    [values.booked_quantity, values.tickets_count, values.income, listingId],
+  );
 };
 
 const aggregateResetSql: Record<ListingAggregateField, string> = {
@@ -459,7 +462,6 @@ export const resetListingAggregateFields = async (
   fields: ListingAggregateField[],
 ): Promise<void> => {
   await resetAggregates("listings", listingId, fields, aggregateResetSql);
-  invalidateListingsCache();
 };
 
 /** Result type for combined listing + attendees query */

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -28,6 +28,7 @@ import {
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
 } from "#shared/db/common-schema.ts";
+import { LISTING_AGGREGATE_WRITE_COLUMNS } from "#shared/db/migrations/schema.ts";
 import { col } from "#shared/db/table.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
 import { nowIso } from "#shared/now.ts";
@@ -284,7 +285,12 @@ const listingsEntity = cachedEntityTable<
     keyOf: (e) => e.slug_index,
     ttlMs: LISTINGS_CACHE_TTL_MS,
   },
-  ["listing_attendees"],
+  [
+    {
+      table: "listing_attendees",
+      whenColumns: [...LISTING_AGGREGATE_WRITE_COLUMNS],
+    },
+  ],
 );
 const listingsCache = listingsEntity.cache;
 

--- a/src/shared/db/login-attempts.ts
+++ b/src/shared/db/login-attempts.ts
@@ -10,7 +10,7 @@
  */
 
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { deleteByField, getDb, queryOne } from "#shared/db/client.ts";
+import { deleteByField, execute, queryOne } from "#shared/db/client.ts";
 import { LOGIN_LOCKOUT_MS, MAX_LOGIN_ATTEMPTS } from "#shared/limits.ts";
 import { nowMs } from "#shared/now.ts";
 
@@ -60,17 +60,17 @@ const makeRecordAttempt =
 
     if (newAttempts >= maxAttempts) {
       const lockedUntil = nowMs() + lockoutMs;
-      await getDb().execute({
-        args: [hashedIp, newAttempts, lockedUntil],
-        sql: "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)",
-      });
+      await execute(
+        "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)",
+        [hashedIp, newAttempts, lockedUntil],
+      );
       return true;
     }
 
-    await getDb().execute({
-      args: [hashedIp, newAttempts],
-      sql: "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, NULL)",
-    });
+    await execute(
+      "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, NULL)",
+      [hashedIp, newAttempts],
+    );
     return false;
   };
 

--- a/src/shared/db/logistics.ts
+++ b/src/shared/db/logistics.ts
@@ -10,8 +10,8 @@
 
 import { compact, flatMap } from "#fp";
 import {
+  execute,
   executeBatch,
-  getDb,
   inPlaceholders,
   queryAll,
 } from "#shared/db/client.ts";
@@ -223,12 +223,12 @@ export const setLegDone = async (
   if (agentIds.length === 0) return false;
   const doneColumn = kind === "start" ? "start_done" : "end_done";
   const agentColumn = kind === "start" ? "start_agent_id" : "end_agent_id";
-  const result = await getDb().execute({
-    args: [done ? 1 : 0, attendeeId, listingId, ...agentIds],
-    sql: `UPDATE listing_attendees SET ${doneColumn} = ?
+  const result = await execute(
+    `UPDATE listing_attendees SET ${doneColumn} = ?
           WHERE attendee_id = ? AND listing_id = ?
             AND ${agentColumn} IN (${inPlaceholders(agentIds)})`,
-  });
+    [done ? 1 : 0, attendeeId, listingId, ...agentIds],
+  );
   return result.rowsAffected > 0;
 };
 

--- a/src/shared/db/migrations/schema.ts
+++ b/src/shared/db/migrations/schema.ts
@@ -736,6 +736,18 @@ export const SCHEMA: [name: string, table: Table][] = [
 ];
 
 /**
+ * The listing_attendees columns that shift listing aggregates (booked_quantity,
+ * tickets_count, income). The UPDATE trigger fires on exactly these columns;
+ * the cache-invalidation gate in listings.ts reads the same constant so the
+ * two cannot drift.
+ */
+export const LISTING_AGGREGATE_WRITE_COLUMNS = [
+  "quantity",
+  "price_paid",
+  "listing_id",
+] as const;
+
+/**
  * Triggers that keep the listings aggregate columns (booked_quantity,
  * tickets_count, income) in lockstep with listing_attendees, so the hot
  * listing reads and the active-listing stats cost one row read instead of
@@ -783,7 +795,7 @@ END`,
   {
     name: "trg_listing_attendees_aggregates_update",
     sql: `CREATE TRIGGER IF NOT EXISTS trg_listing_attendees_aggregates_update
-AFTER UPDATE OF quantity, price_paid, listing_id ON listing_attendees
+AFTER UPDATE OF ${LISTING_AGGREGATE_WRITE_COLUMNS.join(", ")} ON listing_attendees
 FOR EACH ROW
 BEGIN
   UPDATE listings SET

--- a/src/shared/db/modifier-usage.ts
+++ b/src/shared/db/modifier-usage.ts
@@ -11,8 +11,8 @@
 import type { InValue } from "@libsql/client";
 import { deleteAttendee } from "#shared/db/attendees/delete.ts";
 import {
+  execute,
   executeBatchWithResults,
-  getDb,
   inPlaceholders,
   queryAll,
 } from "#shared/db/client.ts";
@@ -83,10 +83,9 @@ export const consumeModifierStock = async (
     usages.map((u) => guardedUsageInsert(attendeeId, u)),
   );
   if (results.every((r) => r.rowsAffected > 0)) return true;
-  await getDb().execute({
-    args: [attendeeId],
-    sql: "DELETE FROM modifier_usages WHERE attendee_id = ?",
-  });
+  await execute("DELETE FROM modifier_usages WHERE attendee_id = ?", [
+    attendeeId,
+  ]);
   return false;
 };
 

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -9,8 +9,8 @@
 
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import {
+  execute,
   executeBatch,
-  getDb,
   inPlaceholders,
   queryAll,
   queryOne,
@@ -134,15 +134,10 @@ export const updateModifierAggregateValues = async (
   modifierId: number,
   values: ModifierAggregateValues,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [
-      values.total_uses,
-      values.usage_count,
-      values.total_revenue,
-      modifierId,
-    ],
-    sql: "UPDATE modifiers SET total_uses = ?, usage_count = ?, total_revenue = ? WHERE id = ?",
-  });
+  await execute(
+    "UPDATE modifiers SET total_uses = ?, usage_count = ?, total_revenue = ? WHERE id = ?",
+    [values.total_uses, values.usage_count, values.total_revenue, modifierId],
+  );
 };
 
 const aggregateResetSql: Record<ModifierAggregateField, string> = {

--- a/src/shared/db/processed-payments.ts
+++ b/src/shared/db/processed-payments.ts
@@ -15,7 +15,7 @@
 
 import type { InValue } from "@libsql/client";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { getDb, insert, queryOne } from "#shared/db/client.ts";
+import { execute, insert, queryOne } from "#shared/db/client.ts";
 import { STALE_RESERVATION_MS } from "#shared/limits.ts";
 import { nowIso, nowMs } from "#shared/now.ts";
 
@@ -99,7 +99,7 @@ export const isUnresolvedReservation = (row: ProcessedPayment): boolean =>
 
 /** Execute a SQL statement parameterized by a single payment session ID */
 const execWithSessionId = (sessionId: string, sql: string): Promise<unknown> =>
-  getDb().execute({ args: [sessionId], sql });
+  execute(sql, [sessionId]);
 
 /**
  * Delete a stale reservation to allow retry. Only abandoned, outcome-less rows
@@ -123,10 +123,10 @@ export const deleteStaleReservation = async (
  */
 export const deleteAllStaleReservations = async (): Promise<number> => {
   const cutoff = new Date(nowMs() - STALE_RESERVATION_MS).toISOString();
-  const result = await getDb().execute({
-    args: [cutoff],
-    sql: `DELETE FROM processed_payments WHERE ${UNRESOLVED_RESERVATION} AND processed_at < ?`,
-  });
+  const result = await execute(
+    `DELETE FROM processed_payments WHERE ${UNRESOLVED_RESERVATION} AND processed_at < ?`,
+    [cutoff],
+  );
   return result.rowsAffected;
 };
 
@@ -143,13 +143,12 @@ export const reserveSession = async (
   sessionId: string,
 ): Promise<ReserveSessionResult> => {
   try {
-    await getDb().execute(
-      insert("processed_payments", {
-        attendee_id: null,
-        payment_session_id: sessionId,
-        processed_at: nowIso(),
-      }),
-    );
+    const { sql, args } = insert("processed_payments", {
+      attendee_id: null,
+      payment_session_id: sessionId,
+      processed_at: nowIso(),
+    });
+    await execute(sql, args);
     return { reserved: true };
   } catch (e) {
     const errorMsg = String(e);
@@ -192,10 +191,10 @@ export const finalizeSession = async (
 ): Promise<void> => {
   const joined = ticketTokens.join("+");
   const encryptedTokens = joined ? await encrypt(joined) : "";
-  await getDb().execute({
-    args: [attendeeId, encryptedTokens, sessionId],
-    sql: "UPDATE processed_payments SET attendee_id = ?, ticket_tokens = ? WHERE payment_session_id = ?",
-  });
+  await execute(
+    "UPDATE processed_payments SET attendee_id = ?, ticket_tokens = ? WHERE payment_session_id = ?",
+    [attendeeId, encryptedTokens, sessionId],
+  );
 };
 
 /**
@@ -210,10 +209,10 @@ export const markSessionFailed = async (
   sessionId: string,
   failure: StoredPaymentFailure,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [await encrypt(JSON.stringify(failure)), sessionId],
-    sql: `UPDATE processed_payments SET failure_data = ? WHERE payment_session_id = ? AND ${UNRESOLVED_RESERVATION}`,
-  });
+  await execute(
+    `UPDATE processed_payments SET failure_data = ? WHERE payment_session_id = ? AND ${UNRESOLVED_RESERVATION}`,
+    [await encrypt(JSON.stringify(failure)), sessionId],
+  );
 };
 
 /** Generic terminal failure used when stored failure_data can't be parsed. */

--- a/src/shared/db/processed-sms-inbound.ts
+++ b/src/shared/db/processed-sms-inbound.ts
@@ -6,7 +6,7 @@
  * `sms:received` events cannot create duplicate activity-log entries.
  */
 
-import { executeBatch, getDb, insert } from "#shared/db/client.ts";
+import { execute, executeBatch, insert } from "#shared/db/client.ts";
 import { nowIso } from "#shared/now.ts";
 
 /** Claim an inbound webhook id. Returns false when it was already processed. */
@@ -18,10 +18,10 @@ export const claimProcessedSmsInbound = async (
     created: nowIso(),
     webhook_id: webhookId,
   });
-  const result = await getDb().execute({
-    args: stmt.args,
-    sql: stmt.sql.replace("INSERT INTO", "INSERT OR IGNORE INTO"),
-  });
+  const result = await execute(
+    stmt.sql.replace("INSERT INTO", "INSERT OR IGNORE INTO"),
+    stmt.args,
+  );
   return result.rowsAffected > 0;
 };
 

--- a/src/shared/db/prune.ts
+++ b/src/shared/db/prune.ts
@@ -22,7 +22,7 @@
  * pruned only when PRUNE_INTERVAL_MS has elapsed since its last run.
  */
 
-import { getDb } from "#shared/db/client.ts";
+import { execute } from "#shared/db/client.ts";
 import { RESOLVED_OUTCOME } from "#shared/db/processed-payments.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
@@ -45,7 +45,7 @@ import { nowMs } from "#shared/now.ts";
 const isoAgePruner =
   (sql: string, retentionMs: number) => async (): Promise<number> => {
     const cutoffIso = new Date(nowMs() - retentionMs).toISOString();
-    const result = await getDb().execute({ args: [cutoffIso], sql });
+    const result = await execute(sql, [cutoffIso]);
     return result.rowsAffected;
   };
 
@@ -79,10 +79,9 @@ export const pruneSumupCheckouts = isoAgePruner(
  */
 export const pruneSessions = async (): Promise<number> => {
   const cutoffMs = nowMs() - PRUNE_SESSIONS_RETENTION_MS;
-  const result = await getDb().execute({
-    args: [cutoffMs],
-    sql: "DELETE FROM sessions WHERE expires < ?",
-  });
+  const result = await execute("DELETE FROM sessions WHERE expires < ?", [
+    cutoffMs,
+  ]);
   return result.rowsAffected;
 };
 
@@ -93,10 +92,10 @@ export const pruneSessions = async (): Promise<number> => {
  */
 export const pruneLoginAttempts = async (): Promise<number> => {
   const cutoffMs = nowMs() - PRUNE_LOGINS_RETENTION_MS;
-  const result = await getDb().execute({
-    args: [cutoffMs],
-    sql: "DELETE FROM login_attempts WHERE locked_until IS NOT NULL AND locked_until < ?",
-  });
+  const result = await execute(
+    "DELETE FROM login_attempts WHERE locked_until IS NOT NULL AND locked_until < ?",
+    [cutoffMs],
+  );
   return result.rowsAffected;
 };
 
@@ -107,20 +106,20 @@ export const pruneLoginAttempts = async (): Promise<number> => {
  */
 export const pruneTokenAttempts = async (): Promise<number> => {
   const cutoffMs = nowMs() - PRUNE_TOKENS_RETENTION_MS;
-  const result = await getDb().execute({
-    args: [cutoffMs],
-    sql: "DELETE FROM token_attempts WHERE last_attempt < ?",
-  });
+  const result = await execute(
+    "DELETE FROM token_attempts WHERE last_attempt < ?",
+    [cutoffMs],
+  );
   return result.rowsAffected;
 };
 
 /** Delete subscribed contact-preference rows untouched beyond retention. */
 export const pruneContacts = async (): Promise<number> => {
   const cutoffMs = nowMs() - PRUNE_CONTACTS_RETENTION_MS;
-  const result = await getDb().execute({
-    args: [cutoffMs],
-    sql: "DELETE FROM contact_preferences WHERE unsubscribed = 0 AND last_activity < ?",
-  });
+  const result = await execute(
+    "DELETE FROM contact_preferences WHERE unsubscribed = 0 AND last_activity < ?",
+    [cutoffMs],
+  );
   return result.rowsAffected;
 };
 

--- a/src/shared/db/query.ts
+++ b/src/shared/db/query.ts
@@ -1,11 +1,5 @@
 import { mapParallel } from "#fp";
-import {
-  executeBatch,
-  getDb,
-  queryAll,
-  resultRows,
-} from "#shared/db/client.ts";
-import { trackQuery } from "#shared/db/query-log.ts";
+import { execute, executeBatch, queryAll, resultRows } from "#shared/db/client.ts";
 
 /**
  * Execute a SQL query and map result rows through an async transformer.
@@ -14,10 +8,8 @@ import { trackQuery } from "#shared/db/query-log.ts";
  */
 export const queryAndMap =
   <Row, Out>(toOut: (row: Row) => Promise<Out>) =>
-  async (sql: string): Promise<Out[]> => {
-    const result = await trackQuery(sql, () => getDb().execute(sql));
-    return mapParallel(toOut)(resultRows<Row>(result));
-  };
+  async (sql: string): Promise<Out[]> =>
+    mapParallel(toOut)(resultRows<Row>(await execute(sql)));
 
 /**
  * Swap the `sort_order` of two rows (by id) in a table that has `id` and

--- a/src/shared/db/query.ts
+++ b/src/shared/db/query.ts
@@ -1,5 +1,10 @@
 import { mapParallel } from "#fp";
-import { execute, executeBatch, queryAll, resultRows } from "#shared/db/client.ts";
+import {
+  execute,
+  executeBatch,
+  queryAll,
+  resultRows,
+} from "#shared/db/client.ts";
 
 /**
  * Execute a SQL query and map result rows through an async transformer.

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -9,8 +9,8 @@ import type { InValue } from "@libsql/client";
 import { filter, map, reduce } from "#fp";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import {
+  execute,
   executeBatch,
-  getDb,
   inPlaceholders,
   insert,
   queryAll,
@@ -666,10 +666,10 @@ export const setAnswerModifier = async (
   answerId: number,
   modifierId: number | null,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [modifierId, answerId],
-    sql: "UPDATE answers SET modifier_id = ? WHERE id = ?",
-  });
+  await execute("UPDATE answers SET modifier_id = ? WHERE id = ?", [
+    modifierId,
+    answerId,
+  ]);
 };
 
 /** Swap the sort_order of two answers by their IDs */

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -6,7 +6,7 @@ import { registerCache } from "#shared/cache-registry.ts";
 import { hashSessionToken } from "#shared/crypto/hashing.ts";
 import {
   deleteByField,
-  getDb,
+  execute,
   insert,
   queryAll,
   queryOne,
@@ -86,23 +86,17 @@ export const createSession = async (
   userId: number,
 ): Promise<void> => {
   const tokenHash = await hashSessionToken(token);
-  await getDb().execute(
-    insert("sessions", {
-      csrf_token: csrfToken,
-      expires,
-      token: tokenHash,
-      user_id: userId,
-      wrapped_data_key: wrappedDataKey,
-    }),
-  );
-  // Pre-cache the new session using token hash as key
-  cacheSession(tokenHash, {
+  const session = {
     csrf_token: csrfToken,
     expires,
     token: tokenHash,
     user_id: userId,
     wrapped_data_key: wrappedDataKey,
-  });
+  };
+  const { sql, args } = insert("sessions", session);
+  await execute(sql, args);
+  // Pre-cache the new session using token hash as key
+  cacheSession(tokenHash, session);
 };
 
 /**
@@ -140,7 +134,7 @@ export const deleteSession = async (token: string): Promise<void> => {
  */
 export const deleteAllSessions = async (): Promise<void> => {
   clearSessionCache();
-  await getDb().execute("DELETE FROM sessions");
+  await execute("DELETE FROM sessions");
 };
 
 /**
@@ -167,8 +161,5 @@ export const deleteOtherSessions = async (
     sessionCache.set(tokenHash, currentEntry);
   }
 
-  await getDb().execute({
-    args: [tokenHash],
-    sql: "DELETE FROM sessions WHERE token != ?",
-  });
+  await execute("DELETE FROM sessions WHERE token != ?", [tokenHash]);
 };

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -26,7 +26,7 @@ import {
   unwrapKey,
   wrapKey,
 } from "#shared/crypto/keys.ts";
-import { getDb, queryAll } from "#shared/db/client.ts";
+import { execute, queryAll } from "#shared/db/client.ts";
 import { deleteAllSessions } from "#shared/db/sessions.ts";
 import {
   recordSettingRead,
@@ -399,10 +399,10 @@ const syncCache = (mutate: (state: CacheState) => void): void => {
 
 /** Write a setting to the DB and update the raw cache in-place. */
 const writeRaw = async (key: string, value: string): Promise<void> => {
-  await getDb().execute({
-    args: [key, value],
-    sql: "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
-  });
+  await execute("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", [
+    key,
+    value,
+  ]);
   // A write makes the key's value known this request, so reading it back is
   // safe in production too — record it as available for the read audit.
   recordSettingsLoaded([key]);
@@ -414,10 +414,7 @@ const writeRaw = async (key: string, value: string): Promise<void> => {
 
 /** Delete a setting from the DB and remove it from the raw cache. */
 const deleteRaw = async (key: string): Promise<void> => {
-  await getDb().execute({
-    args: [key],
-    sql: "DELETE FROM settings WHERE key = ?",
-  });
+  await execute("DELETE FROM settings WHERE key = ?", [key]);
   recordSettingsLoaded([key]);
   syncCache((s) => {
     s.values.delete(key);
@@ -821,10 +818,10 @@ const updateUserPassword = async (
   const encryptedNewHash = await encrypt(newHash);
   const newKek = await deriveKEK(newHash);
   const newWrappedDataKey = await wrapKey(dk, newKek);
-  await getDb().execute({
-    args: [encryptedNewHash, newWrappedDataKey, userId],
-    sql: "UPDATE users SET password_hash = ?, wrapped_data_key = ? WHERE id = ?",
-  });
+  await execute(
+    "UPDATE users SET password_hash = ?, wrapped_data_key = ? WHERE id = ?",
+    [encryptedNewHash, newWrappedDataKey, userId],
+  );
   invalidateUsersCache();
   await deleteAllSessions();
   return true;
@@ -848,15 +845,14 @@ const withCurrentTask = async <T>(
   fn: () => Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false; error: string }> => {
   // Ensure the row exists (no-op if already present)
-  await getDb().execute({
-    args: [CONFIG_KEYS.CURRENT_TASK],
-    sql: "INSERT OR IGNORE INTO settings (key, value) VALUES (?, '')",
-  });
+  await execute("INSERT OR IGNORE INTO settings (key, value) VALUES (?, '')", [
+    CONFIG_KEYS.CURRENT_TASK,
+  ]);
   // Atomic claim: only succeeds when no task is running
-  const claim = await getDb().execute({
-    args: [taskName, CONFIG_KEYS.CURRENT_TASK],
-    sql: "UPDATE settings SET value = ? WHERE key = ? AND value = ''",
-  });
+  const claim = await execute(
+    "UPDATE settings SET value = ? WHERE key = ? AND value = ''",
+    [taskName, CONFIG_KEYS.CURRENT_TASK],
+  );
   if (claim.rowsAffected === 0) {
     return {
       error: "Another task is already in progress",

--- a/src/shared/db/sms-messages.ts
+++ b/src/shared/db/sms-messages.ts
@@ -11,7 +11,7 @@
 import {
   countRows,
   deleteByField,
-  getDb,
+  execute,
   insert,
   queryOne,
 } from "#shared/db/client.ts";
@@ -33,14 +33,13 @@ export const recordSmsMessage = async (input: {
   listingId: number;
   providerId: string;
 }): Promise<void> => {
-  await getDb().execute(
-    insert("sms_messages", {
-      attendee_id: input.attendeeId,
-      created: nowIso(),
-      listing_id: input.listingId,
-      provider_id: input.providerId,
-    }),
-  );
+  const { sql, args } = insert("sms_messages", {
+    attendee_id: input.attendeeId,
+    created: nowIso(),
+    listing_id: input.listingId,
+    provider_id: input.providerId,
+  });
+  await execute(sql, args);
 };
 
 /** Find the message a status event refers to, by the gateway's message id. */
@@ -66,8 +65,5 @@ export const deleteSmsMessage = (id: number): Promise<void> =>
 export const pruneSmsMessagesBefore = async (
   cutoffIso: string,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [cutoffIso],
-    sql: "DELETE FROM sms_messages WHERE created < ?",
-  });
+  await execute("DELETE FROM sms_messages WHERE created < ?", [cutoffIso]);
 };

--- a/src/shared/db/sumup-checkouts.ts
+++ b/src/shared/db/sumup-checkouts.ts
@@ -36,7 +36,7 @@ import {
   unwrapKeyWithToken,
   wrapKeyWithToken,
 } from "#shared/crypto/keys.ts";
-import { getDb, insert, queryOne } from "#shared/db/client.ts";
+import { execute, insert, queryOne } from "#shared/db/client.ts";
 import { nowIso } from "#shared/now.ts";
 
 type SumupCheckoutRow = {
@@ -62,15 +62,14 @@ export const storeSumupCheckout = async (
     wrapKeyWithToken(dataKey, reference),
     encryptWithKey(JSON.stringify(metadata), dataKey),
   ]);
-  await getDb().execute(
-    insert("sumup_checkouts", {
-      created_at: nowIso(),
-      metadata: ciphertext,
-      reference_index: referenceIndex,
-      sumup_id: "",
-      wrapped_key: wrappedKey,
-    }),
-  );
+  const { sql, args } = insert("sumup_checkouts", {
+    created_at: nowIso(),
+    metadata: ciphertext,
+    reference_index: referenceIndex,
+    sumup_id: "",
+    wrapped_key: wrappedKey,
+  });
+  await execute(sql, args);
 };
 
 /** Record the SumUp-side checkout id once creation succeeds. */
@@ -78,10 +77,10 @@ export const setSumupCheckoutId = async (
   reference: string,
   sumupId: string,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [sumupId, await hmacHash(reference)],
-    sql: "UPDATE sumup_checkouts SET sumup_id = ? WHERE reference_index = ?",
-  });
+  await execute(
+    "UPDATE sumup_checkouts SET sumup_id = ? WHERE reference_index = ?",
+    [sumupId, await hmacHash(reference)],
+  );
 };
 
 /** Whether a webhook's checkout id belongs to a checkout we created.

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -11,8 +11,11 @@
 import type { InValue } from "@libsql/client";
 import * as v from "valibot";
 import { compact, filter, mapParallel, reduce } from "#fp";
-import { registerCache } from "#shared/cache-registry.ts";
-import { getDb, queryAll, queryOne } from "#shared/db/client.ts";
+import {
+  registerCache,
+  registerTableInvalidation,
+} from "#shared/cache-registry.ts";
+import { execute, queryAll, queryOne } from "#shared/db/client.ts";
 import { requestCache } from "#shared/request-cache.ts";
 
 /**
@@ -283,10 +286,7 @@ export const defineTable = <Row, Input = Row>(config: {
     // Safe: columns are Object.keys(dbValues), so all values exist
     const args: InValue[] = columns.map((col) => dbValues[col] as InValue);
 
-    const result = await getDb().execute({
-      args,
-      sql: buildInsertSql(name, columns),
-    });
+    const result = await execute(buildInsertSql(name, columns), args);
 
     const initialRow = schema[primaryKey].generated
       ? { [primaryKey]: Number(result.lastInsertRowid) }
@@ -341,10 +341,7 @@ export const defineTable = <Row, Input = Row>(config: {
 
   // Delete by ID implementation
   const deleteById = async (id: InValue): Promise<void> => {
-    await getDb().execute({
-      args: [id],
-      sql: `DELETE FROM ${name} WHERE ${primaryKey} = ?`,
-    });
+    await execute(`DELETE FROM ${name} WHERE ${primaryKey} = ?`, [id]);
   };
 
   // Find all implementation
@@ -389,38 +386,14 @@ export const defineTable = <Row, Input = Row>(config: {
 };
 
 /**
- * Wrap a table so that insert, update, and deleteById automatically
- * call an invalidation callback (e.g. cache invalidation).
- * Eliminates the repeated spread-and-override pattern in groups/holidays/listings.
- */
-export const withCacheInvalidation = <Row, Input>(
-  table: Table<Row, Input>,
-  invalidate: () => void,
-): Table<Row, Input> => ({
-  ...table,
-  deleteById: async (id) => {
-    await table.deleteById(id);
-    invalidate();
-  },
-  insert: async (input) => {
-    const result = await table.insert(input);
-    invalidate();
-    return result;
-  },
-  update: async (id, input) => {
-    const result = await table.update(id, input);
-    invalidate();
-    return result;
-  },
-});
-
-/**
  * Bundle a request-scoped cache around a table.
  *
- * Wires together the three pieces every cached table used to repeat by hand:
+ * Wires together the pieces every cached table used to repeat by hand:
  *  - a {@link requestCache} over `fetchAll` (the decrypted/mapped rows),
  *  - registration with the cache-stats registry under `name`, and
- *  - a `table` wrapped via {@link withCacheInvalidation} so writes clear it.
+ *  - registration with the table→cache invalidation registry, so any write to
+ *    the table (or to a `dependsOn` table whose triggers feed it) clears the
+ *    cache automatically at the db-client layer — no per-write-path call.
  *
  * `fetchAll` may resolve a richer row type than the table's own `Row`
  * (e.g. listings cached with attendee counts), captured by `Cached`.
@@ -429,6 +402,8 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
   fetchAll: () => Promise<Cached[]>;
   name: string;
   table: Table<Row, Input>;
+  /** Extra tables (beyond the table itself) whose writes should clear it. */
+  dependsOn?: readonly string[];
 }): {
   getAll: () => Promise<Cached[]>;
   invalidate: () => void;
@@ -439,11 +414,11 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
   const invalidate = (): void => {
     cache.invalidate();
   };
-  return {
-    getAll: () => cache.getAll(),
+  registerTableInvalidation(
+    [config.table.name, ...(config.dependsOn ?? [])],
     invalidate,
-    table: withCacheInvalidation(config.table, invalidate),
-  };
+  );
+  return { getAll: () => cache.getAll(), invalidate, table: config.table };
 };
 
 /** Transform function type for column read/write */

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -12,8 +12,9 @@ import type { InValue } from "@libsql/client";
 import * as v from "valibot";
 import { compact, filter, mapParallel, reduce } from "#fp";
 import {
+  type DependsOnEntry,
   registerCache,
-  registerTableInvalidation,
+  registerDependencies,
 } from "#shared/cache-registry.ts";
 import { execute, queryAll, queryOne } from "#shared/db/client.ts";
 import { requestCache } from "#shared/request-cache.ts";
@@ -402,8 +403,9 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
   fetchAll: () => Promise<Cached[]>;
   name: string;
   table: Table<Row, Input>;
-  /** Extra tables (beyond the table itself) whose writes should clear it. */
-  dependsOn?: readonly string[];
+  /** Extra tables (beyond the table itself) whose writes should clear it.
+   * Entries may carry `whenColumns` to gate on specific UPDATE columns. */
+  dependsOn?: ReadonlyArray<DependsOnEntry>;
 }): {
   getAll: () => Promise<Cached[]>;
   invalidate: () => void;
@@ -414,10 +416,7 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
   const invalidate = (): void => {
     cache.invalidate();
   };
-  registerTableInvalidation(
-    [config.table.name, ...(config.dependsOn ?? [])],
-    invalidate,
-  );
+  registerDependencies(config.table.name, config.dependsOn ?? [], invalidate);
   return { getAll: () => cache.getAll(), invalidate, table: config.table };
 };
 

--- a/src/shared/db/token-attempts.ts
+++ b/src/shared/db/token-attempts.ts
@@ -21,7 +21,7 @@
  */
 
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { deleteByField, getDb, queryOne } from "#shared/db/client.ts";
+import { deleteByField, execute, queryOne } from "#shared/db/client.ts";
 import {
   MAX_TOKEN_404S,
   TOKEN_LOCKOUT_MS,
@@ -82,17 +82,17 @@ export const recordTokenFailure = async (
 
   if (merged.size >= MAX_TOKEN_404S) {
     const lockedUntil = currentMs + TOKEN_LOCKOUT_MS;
-    await getDb().execute({
-      args: [hashedIp, "[]", lockedUntil, currentMs, currentMs],
-      sql: "INSERT OR REPLACE INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt) VALUES (?, ?, ?, ?, ?)",
-    });
+    await execute(
+      "INSERT OR REPLACE INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt) VALUES (?, ?, ?, ?, ?)",
+      [hashedIp, "[]", lockedUntil, currentMs, currentMs],
+    );
     return true;
   }
 
-  await getDb().execute({
-    args: [hashedIp, JSON.stringify([...merged]), windowStart, currentMs],
-    sql: "INSERT OR REPLACE INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt) VALUES (?, ?, NULL, ?, ?)",
-  });
+  await execute(
+    "INSERT OR REPLACE INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt) VALUES (?, ?, NULL, ?, ?)",
+    [hashedIp, JSON.stringify([...merged]), windowStart, currentMs],
+  );
   return false;
 };
 

--- a/src/shared/db/user-agents.ts
+++ b/src/shared/db/user-agents.ts
@@ -8,7 +8,7 @@
  */
 
 import { unique } from "#fp";
-import { executeBatch, getDb, queryAll } from "#shared/db/client.ts";
+import { execute, executeBatch, queryAll } from "#shared/db/client.ts";
 
 /** The logistics agent ids assigned to a user, ascending. */
 export const getUserAgentIds = async (userId: number): Promise<number[]> => {
@@ -71,8 +71,7 @@ export const setAgentUserIds = (
 export const clearUserAgentLinksForAgent = async (
   agentId: number,
 ): Promise<void> => {
-  await getDb().execute({
-    args: [agentId],
-    sql: "DELETE FROM user_logistics_agents WHERE agent_id = ?",
-  });
+  await execute("DELETE FROM user_logistics_agents WHERE agent_id = ?", [
+    agentId,
+  ]);
 };

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -87,14 +87,17 @@ export const onUsersInvalidated = (listener: () => void): void => {
 const loadAllUsers = (): Promise<User[]> => usersCache.getAll();
 
 registerCache(() => ({ entries: usersCache.size(), name: "users" }));
-// Any write to the users table clears the cache automatically (db-client layer).
-registerTableInvalidation(["users"], () => usersCache.invalidate());
 
 /** Invalidate the users cache (for testing or after writes). */
 export const invalidateUsersCache = (): void => {
   usersCache.invalidate();
   for (const listener of usersInvalidationListeners) listener();
 };
+
+// Any write to the users table clears the cache automatically (db-client layer).
+// Must call invalidateUsersCache() (not just usersCache.invalidate()) so that
+// onUsersInvalidated listeners such as the superuser account-state cache also fire.
+registerTableInvalidation(["users"], invalidateUsersCache);
 
 /** Shared user creation logic */
 const insertUser = async (opts: {

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -12,11 +12,15 @@ import {
 import { deriveKEK, wrapKey } from "#shared/crypto/keys.ts";
 import {
   deleteByFieldBatch,
-  getDb,
+  execute,
   insert,
   queryAll,
 } from "#shared/db/client.ts";
-import { createKeyedCache, registerCache } from "#shared/db/common-schema.ts";
+import {
+  createKeyedCache,
+  registerCache,
+  registerTableInvalidation,
+} from "#shared/db/common-schema.ts";
 import { now } from "#shared/now.ts";
 import { type AdminLevel, isAdminLevel, type User } from "#shared/types.ts";
 
@@ -83,6 +87,8 @@ export const onUsersInvalidated = (listener: () => void): void => {
 const loadAllUsers = (): Promise<User[]> => usersCache.getAll();
 
 registerCache(() => ({ entries: usersCache.size(), name: "users" }));
+// Any write to the users table clears the cache automatically (db-client layer).
+registerTableInvalidation(["users"], () => usersCache.invalidate());
 
 /** Invalidate the users cache (for testing or after writes). */
 export const invalidateUsersCache = (): void => {
@@ -121,9 +127,8 @@ const insertUser = async (opts: {
     username_index: usernameIndex,
     wrapped_data_key: opts.wrappedDataKey,
   };
-  const result = await getDb().execute(insert("users", values));
-
-  invalidateUsersCache();
+  const { sql, args } = insert("users", values);
+  const result = await execute(sql, args);
   const id = Number(result.lastInsertRowid);
   return { id, ...values };
 };
@@ -250,11 +255,10 @@ export const setUserPassword = async (
   const encryptedHash = await encrypt(passwordHash);
   const encryptedNull = await encrypt("");
 
-  await getDb().execute({
-    args: [encryptedHash, encryptedNull, encryptedNull, userId],
-    sql: "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
-  });
-  invalidateUsersCache();
+  await execute(
+    "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
+    [encryptedHash, encryptedNull, encryptedNull, userId],
+  );
 
   return passwordHash;
 };
@@ -270,11 +274,10 @@ export const activateUser = async (
   const kek = await deriveKEK(decryptedPasswordHash);
   const wrappedDataKey = await wrapKey(dataKey, kek);
 
-  await getDb().execute({
-    args: [wrappedDataKey, userId],
-    sql: "UPDATE users SET wrapped_data_key = ? WHERE id = ?",
-  });
-  invalidateUsersCache();
+  await execute("UPDATE users SET wrapped_data_key = ? WHERE id = ?", [
+    wrappedDataKey,
+    userId,
+  ]);
 };
 
 /**
@@ -287,7 +290,6 @@ export const deleteUser = async (userId: number): Promise<void> => {
     { field: "user_id", table: "user_logistics_agents", value: userId },
     { field: "id", table: "users", value: userId },
   ]);
-  invalidateUsersCache();
 };
 
 /**

--- a/src/shared/merge/attendee-merge.ts
+++ b/src/shared/merge/attendee-merge.ts
@@ -9,7 +9,6 @@
 import { filter, map, reduce } from "#fp";
 import type { ListingAttendeeRow } from "#shared/db/attendee-types.ts";
 import { executeBatch, insert } from "#shared/db/client.ts";
-import { invalidateListingsCache } from "#shared/db/listings.ts";
 import type { QuestionWithAnswers } from "#shared/db/questions.ts";
 import {
   getAttendeeAnswersByQuestion,
@@ -524,8 +523,6 @@ export const applyAttendeeMerge = async (
 
   // Save merged answers for target (one answer per question → flat id list).
   await saveAttendeeAnswers(new Map([[targetId, [...finalAnswers.values()]]]));
-
-  invalidateListingsCache();
 
   const summary: AttendeeMergeApplySummary = {
     answersCleared,

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -11,7 +11,6 @@ import {
   encryptAttendeeFields,
 } from "#shared/db/attendees.ts";
 import { executeBatch, insert, queryAll, rawSql } from "#shared/db/client.ts";
-import { invalidateListingsCache } from "#shared/db/listings.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   DEMO_ADDRESSES,
@@ -211,7 +210,6 @@ export const createSeeds = async (
     )(listingData),
   );
   await executeBatch(listingStatements);
-  invalidateListingsCache();
 
   // Query the newly created listing IDs (ordered by id DESC, limit to listingCount)
   const rows = await queryAll<{ id: number }>(
@@ -241,8 +239,6 @@ export const createSeeds = async (
       totalAttendees += batchSize;
     }
   }
-
-  invalidateListingsCache();
 
   return {
     attendeesCreated: totalAttendees,

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -616,6 +616,11 @@ describe("code quality", () => {
       "shared/test-overrides.ts:setTouchOverrideForTest",
       // Reset the in-memory form re-fill stash between tests
       "shared/form-stash.ts:clearFormStash",
+      // Backward-compat wrapper: fires all invalidators unconditionally (no production caller now
+      // that client.ts uses invalidateCachesForWrite, but kept for external callers and tests)
+      "shared/cache-registry.ts:invalidateCachesForTable",
+      // SET-clause column extractor: internal parser exposed for unit testing only
+      "shared/db/client.ts:extractUpdateColumns",
     ];
 
     /**

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -36,6 +36,9 @@ const FORBIDDEN_PATTERNS = [
  * rule is src-only; test code may use Maps/Sets freely).
  */
 const ALLOWED_FILES_STATE = [
+  // Process-local registry of cache-invalidation callbacks, wired at module
+  // load (like the providers array beside it); not persistent app state.
+  "shared/cache-registry.ts",
   // Session cache with 10s TTL - legitimate performance optimization
   "shared/db/sessions.ts",
   // Settings test overrides Map for injecting test values into the snapshot
@@ -350,6 +353,44 @@ describe("code quality", () => {
           if (pattern.test(content)) {
             violations.push(`${relativePath}: ${description}`);
           }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("db writes go through the client", () => {
+    // Direct getDb().execute / .batch calls bypass the single client choke
+    // point that drives automatic, table-scoped cache invalidation, so a write
+    // through them can silently leave a cache stale. All callers must use
+    // execute()/queryOne()/queryAll()/executeBatch() instead. Only the client
+    // itself and the migrator (which runs DDL/backfill before caches matter)
+    // may touch the raw connection.
+    const ALLOWED_RAW_DB = [
+      "shared/db/client.ts",
+      // The migrator runs DDL / schema setup / backfill before the app serves
+      // requests, so cache invalidation does not apply to it.
+      "shared/db/migrations.ts",
+      "shared/db/migrations/",
+    ];
+    const RAW_DB_PATTERN = /getDb\(\)\.(?:execute|batch)\s*\(/;
+
+    test("no source file calls getDb().execute/.batch directly", async () => {
+      await ensureLoaded();
+      const violations: string[] = [];
+
+      for (const file of srcFiles) {
+        const relativePath = getRelativePath(file);
+        if (
+          ALLOWED_RAW_DB.some((allowed) => relativePath.startsWith(allowed))
+        ) {
+          continue;
+        }
+        if (RAW_DB_PATTERN.test(srcContents.get(file)!)) {
+          violations.push(
+            `${relativePath}: use execute()/queryOne()/queryAll()/executeBatch() from #shared/db/client.ts instead of getDb().execute/.batch`,
+          );
         }
       }
 

--- a/test/lib/db/auto-cache-invalidation.test.ts
+++ b/test/lib/db/auto-cache-invalidation.test.ts
@@ -1,6 +1,11 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
+import {
+  incrementAttachmentDownloads,
+  markRefunded,
+  updateCheckedIn,
+} from "#shared/db/attendees/update.ts";
 import { execute } from "#shared/db/client.ts";
 import { getAllListings, getListingWithCount } from "#shared/db/listings.ts";
 import {
@@ -54,6 +59,71 @@ describeWithEnv(
       )!;
       expect(afterSecond.tickets_count).toBe(2);
       expect(afterSecond.income).toBe(3000);
+    });
+
+    test("markRefunded does not invalidate the listings cache", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 10,
+        unitPrice: 0,
+      });
+      const attendee = await createPaidTestAttendee(
+        listing.id,
+        "Dave",
+        "dave@example.com",
+        "",
+        0,
+      );
+      // Warm the cache.
+      const before = (await getAllListings()).find((e) => e.id === listing.id)!;
+      expect(before.tickets_count).toBe(1);
+
+      await markRefunded(attendee.id, listing.id);
+
+      // Cache must not be cleared: same tickets_count, no re-fetch.
+      const after = (await getAllListings()).find((e) => e.id === listing.id)!;
+      expect(after.tickets_count).toBe(1);
+      expect(after).toBe(before); // same cached reference
+    });
+
+    test("updateCheckedIn does not invalidate the listings cache", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 10,
+        unitPrice: 0,
+      });
+      const attendee = await createPaidTestAttendee(
+        listing.id,
+        "Eve",
+        "eve@example.com",
+        "",
+        0,
+      );
+      const before = (await getAllListings()).find((e) => e.id === listing.id)!;
+      expect(before.tickets_count).toBe(1);
+
+      await updateCheckedIn(attendee.id, listing.id, true);
+
+      const after = (await getAllListings()).find((e) => e.id === listing.id)!;
+      expect(after).toBe(before); // same cached reference
+    });
+
+    test("incrementAttachmentDownloads does not invalidate the listings cache", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 10,
+        unitPrice: 0,
+      });
+      const attendee = await createPaidTestAttendee(
+        listing.id,
+        "Frank",
+        "frank@example.com",
+        "",
+        0,
+      );
+      const before = (await getAllListings()).find((e) => e.id === listing.id)!;
+
+      await incrementAttachmentDownloads(attendee.id, listing.id);
+
+      const after = (await getAllListings()).find((e) => e.id === listing.id)!;
+      expect(after).toBe(before); // same cached reference
     });
 
     test("settling a balance refreshes the cached listing income", async () => {

--- a/test/lib/db/auto-cache-invalidation.test.ts
+++ b/test/lib/db/auto-cache-invalidation.test.ts
@@ -1,0 +1,88 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
+import { execute } from "#shared/db/client.ts";
+import { getAllListings, getListingWithCount } from "#shared/db/listings.ts";
+import {
+  createPaidTestAttendee,
+  createTestListing,
+  describeWithEnv,
+} from "#test-utils";
+
+/**
+ * These tests pin the behaviour that used to require a manual
+ * invalidateListingsCache() in every attendee write path (and whose omission in
+ * settleAttendeeBalance was a real staleness bug): a write to listing_attendees
+ * must make the listings cache serve fresh aggregate columns, driven entirely by
+ * the db-client layer with no explicit invalidate call.
+ */
+describeWithEnv(
+  "db > auto cache invalidation",
+  { db: true, triggers: true },
+  () => {
+    test("a new booking refreshes the cached listing aggregates", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+
+      await createPaidTestAttendee(
+        listing.id,
+        "Alice",
+        "alice@example.com",
+        "pay_1",
+        1000,
+      );
+      // Warm the isolate-level listings cache with the post-first-booking state.
+      const afterFirst = (await getAllListings()).find(
+        (e) => e.id === listing.id,
+      )!;
+      expect(afterFirst.tickets_count).toBe(1);
+      expect(afterFirst.income).toBe(1000);
+
+      // A second booking writes listing_attendees through the create path, which
+      // no longer calls invalidateListingsCache — the client must invalidate it.
+      await createPaidTestAttendee(
+        listing.id,
+        "Bob",
+        "bob@example.com",
+        "pay_2",
+        2000,
+      );
+      const afterSecond = (await getAllListings()).find(
+        (e) => e.id === listing.id,
+      )!;
+      expect(afterSecond.tickets_count).toBe(2);
+      expect(afterSecond.income).toBe(3000);
+    });
+
+    test("settling a balance refreshes the cached listing income", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        unitPrice: 500,
+      });
+      const attendee = await createPaidTestAttendee(
+        listing.id,
+        "Carol",
+        "carol@example.com",
+        "pay_3",
+        1000,
+      );
+      // Give the attendee an outstanding balance to settle.
+      await execute("UPDATE attendees SET remaining_balance = ? WHERE id = ?", [
+        500,
+        attendee.id,
+      ]);
+
+      // Warm the by-id cache entry before the settlement write.
+      const before = (await getListingWithCount(listing.id))!;
+      expect(before.income).toBe(1000);
+
+      const result = await settleAttendeeBalance(attendee.id, 500);
+      expect(result.settled).toBe(true);
+
+      const after = (await getListingWithCount(listing.id))!;
+      expect(after.income).toBe(1500);
+    });
+  },
+);

--- a/test/lib/db/client.test.ts
+++ b/test/lib/db/client.test.ts
@@ -1,7 +1,13 @@
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import {
+  registerTableInvalidation,
+  resetCacheRegistry,
+} from "#shared/cache-registry.ts";
+import {
+  execute,
+  extractUpdateColumns,
   getDb,
   insert,
   rawSql,
@@ -9,6 +15,113 @@ import {
   setDb,
 } from "#shared/db/client.ts";
 import { describeWithEnv, setTestEnv } from "#test-utils";
+
+describe("extractUpdateColumns", () => {
+  test("single column assignment", () => {
+    const cols = extractUpdateColumns(
+      "UPDATE listing_attendees SET refunded = ? WHERE attendee_id = ? AND listing_id = ?",
+    );
+    expect(cols).toBeDefined();
+    expect([...cols!]).toEqual(["refunded"]);
+  });
+
+  test("multiple column assignments", () => {
+    const cols = extractUpdateColumns("UPDATE t SET a = a + 1, b = ?");
+    expect(cols).toBeDefined();
+    expect([...cols!].sort()).toEqual(["a", "b"]);
+  });
+
+  test("WHERE clause = signs are not mistaken for assignments", () => {
+    const cols = extractUpdateColumns(
+      "UPDATE users SET password_hash = ?, invite_code_hash = ?, invite_expiry = ? WHERE id = ?",
+    );
+    expect(cols).toBeDefined();
+    expect([...cols!].sort()).toEqual([
+      "invite_code_hash",
+      "invite_expiry",
+      "password_hash",
+    ]);
+  });
+
+  test("table-qualified column name strips the qualifier", () => {
+    const cols = extractUpdateColumns("UPDATE t SET t.col = ?");
+    expect(cols).toBeDefined();
+    expect([...cols!]).toEqual(["col"]);
+  });
+
+  test("quoted column name strips the quotes", () => {
+    const cols = extractUpdateColumns('UPDATE t SET "my_col" = ?');
+    expect(cols).toBeDefined();
+    expect([...cols!]).toEqual(["my_col"]);
+  });
+
+  test("commas inside parentheses in an expression do not split the assignment", () => {
+    const cols = extractUpdateColumns("UPDATE t SET a = coalesce(x, 0), b = ?");
+    expect(cols).toBeDefined();
+    expect([...cols!].sort()).toEqual(["a", "b"]);
+  });
+
+  test("returns null for non-UPDATE SQL (no SET clause)", () => {
+    expect(extractUpdateColumns("INSERT INTO t (a) VALUES (?)")).toBeNull();
+  });
+
+  test("returns null when SET clause has no parseable assignments", () => {
+    // Empty content between SET and WHERE: covers the eqIdx < 0 guard and the
+    // columns.size === 0 → null return path.
+    expect(extractUpdateColumns("UPDATE t SET WHERE true")).toBeNull();
+  });
+
+  test("column names are lower-cased", () => {
+    const cols = extractUpdateColumns("UPDATE t SET MyCol = ?");
+    expect(cols).toBeDefined();
+    expect([...cols!]).toEqual(["mycol"]);
+  });
+});
+
+describeWithEnv("invalidateForSql fallback path", { db: true }, () => {
+  beforeEach(() => resetCacheRegistry());
+  afterEach(() => resetCacheRegistry());
+
+  test("UPDATE with unparseable SET fires column-gated invalidators unconditionally", async () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["t"],
+      () => {
+        fired++;
+      },
+      { whenColumns: ["col1"] },
+    );
+    const executeStub = stub(getDb(), "execute", () =>
+      Promise.resolve({
+        columns: [],
+        columnTypes: [],
+        lastInsertRowid: undefined,
+        rows: [],
+        rowsAffected: 0,
+        toJSON: () => ({}),
+      }),
+    );
+    try {
+      // Empty SET clause → extractUpdateColumns returns null → fallback fires
+      await execute("UPDATE t SET WHERE true", []);
+      expect(fired).toBe(1);
+    } finally {
+      executeStub.restore();
+    }
+  });
+
+  test("REPLACE INTO invalidates the target table", async () => {
+    let fired = 0;
+    registerTableInvalidation(["settings"], () => {
+      fired++;
+    });
+    await execute("REPLACE INTO settings (key, value) VALUES (?, ?)", [
+      "replace_test",
+      "val",
+    ]);
+    expect(fired).toBe(1);
+  });
+});
 
 describeWithEnv("db > client", { db: true }, () => {
   test("getDb throws error when DB_URL is not set", () => {

--- a/test/lib/db/listing-aggregates.test.ts
+++ b/test/lib/db/listing-aggregates.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { getDb } from "#shared/db/client.ts";
 import {
   getListingAggregateRecalculation,
@@ -8,8 +8,25 @@ import {
   resetListingAggregateFields,
   updateListingAggregateValues,
 } from "#shared/db/listings.ts";
+import {
+  LISTING_AGGREGATE_WRITE_COLUMNS,
+  TRIGGERS,
+} from "#shared/db/migrations/schema.ts";
 import { MIGRATIONS } from "#shared/db/migrations.ts";
 import { createTestListing, describeWithEnv } from "#test-utils";
+
+describe("LISTING_AGGREGATE_WRITE_COLUMNS matches the trigger SQL", () => {
+  test("the UPDATE trigger fires on exactly the columns in LISTING_AGGREGATE_WRITE_COLUMNS", () => {
+    const updateTrigger = TRIGGERS.find(
+      (t) => t.name === "trg_listing_attendees_aggregates_update",
+    );
+    expect(updateTrigger).toBeDefined();
+    const expectedCols = [...LISTING_AGGREGATE_WRITE_COLUMNS].join(", ");
+    expect(updateTrigger!.sql).toContain(
+      `AFTER UPDATE OF ${expectedCols} ON listing_attendees`,
+    );
+  });
+});
 
 /**
  * The listings aggregate columns (booked_quantity, tickets_count, income) are

--- a/test/lib/request-cache.test.ts
+++ b/test/lib/request-cache.test.ts
@@ -2,7 +2,9 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import {
   getAllCacheStats,
+  invalidateCachesForTable,
   registerCache,
+  registerTableInvalidation,
   resetCacheRegistry,
 } from "#shared/cache-registry.ts";
 import { getAllHolidays, holidaysTable } from "#shared/db/holidays.ts";
@@ -56,6 +58,67 @@ describe("cache-registry", () => {
     expect(getAllCacheStats()).toHaveLength(1);
     resetCacheRegistry();
     expect(getAllCacheStats()).toHaveLength(0);
+  });
+});
+
+describe("table invalidation registry", () => {
+  beforeEach(() => {
+    resetCacheRegistry();
+  });
+
+  afterEach(() => {
+    resetCacheRegistry();
+  });
+
+  test("fires the invalidator registered for a written table", () => {
+    let fired = 0;
+    registerTableInvalidation(["listings"], () => {
+      fired++;
+    });
+    invalidateCachesForTable("listings");
+    expect(fired).toBe(1);
+  });
+
+  test("ignores tables with no registered invalidator", () => {
+    let fired = 0;
+    registerTableInvalidation(["listings"], () => {
+      fired++;
+    });
+    invalidateCachesForTable("sessions");
+    expect(fired).toBe(0);
+  });
+
+  test("one invalidator can depend on several tables", () => {
+    let fired = 0;
+    registerTableInvalidation(["listings", "listing_attendees"], () => {
+      fired++;
+    });
+    invalidateCachesForTable("listing_attendees");
+    expect(fired).toBe(1);
+  });
+
+  test("fires every invalidator registered against the same table", () => {
+    let a = 0;
+    let b = 0;
+    registerTableInvalidation(["users"], () => {
+      a++;
+    });
+    registerTableInvalidation(["users"], () => {
+      b++;
+    });
+    invalidateCachesForTable("users");
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+  });
+
+  test("resetCacheRegistry clears table invalidators", () => {
+    let fired = 0;
+    registerTableInvalidation(["listings"], () => {
+      fired++;
+    });
+    resetCacheRegistry();
+    invalidateCachesForTable("listings");
+    expect(fired).toBe(0);
   });
 });
 

--- a/test/lib/request-cache.test.ts
+++ b/test/lib/request-cache.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import {
   getAllCacheStats,
   invalidateCachesForTable,
+  invalidateCachesForWrite,
   registerCache,
+  registerDependencies,
   registerTableInvalidation,
   resetCacheRegistry,
 } from "#shared/cache-registry.ts";
@@ -119,6 +121,160 @@ describe("table invalidation registry", () => {
     resetCacheRegistry();
     invalidateCachesForTable("listings");
     expect(fired).toBe(0);
+  });
+});
+
+describe("column-gated invalidation", () => {
+  beforeEach(() => {
+    resetCacheRegistry();
+  });
+
+  afterEach(() => {
+    resetCacheRegistry();
+  });
+
+  test("column-gated UPDATE fires when it touches a listed column", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity", "price_paid"],
+      },
+    );
+    invalidateCachesForWrite("listing_attendees", {
+      columns: new Set(["quantity"]),
+      verb: "update",
+    });
+    expect(fired).toBe(1);
+  });
+
+  test("column-gated UPDATE does not fire when only other columns are touched", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity", "price_paid"],
+      },
+    );
+    invalidateCachesForWrite("listing_attendees", {
+      columns: new Set(["checked_in"]),
+      verb: "update",
+    });
+    expect(fired).toBe(0);
+  });
+
+  test("column-gated dependency always fires for INSERT", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity"],
+      },
+    );
+    invalidateCachesForWrite("listing_attendees", {
+      columns: new Set(),
+      verb: "insert",
+    });
+    expect(fired).toBe(1);
+  });
+
+  test("column-gated dependency always fires for DELETE", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity"],
+      },
+    );
+    invalidateCachesForWrite("listing_attendees", {
+      columns: new Set(),
+      verb: "delete",
+    });
+    expect(fired).toBe(1);
+  });
+
+  test("column-gated dependency always fires for REPLACE", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity"],
+      },
+    );
+    invalidateCachesForWrite("listing_attendees", {
+      columns: new Set(),
+      verb: "replace",
+    });
+    expect(fired).toBe(1);
+  });
+
+  test("ungated dependency fires for any UPDATE regardless of columns", () => {
+    let fired = 0;
+    registerTableInvalidation(["users"], () => {
+      fired++;
+    });
+    invalidateCachesForWrite("users", {
+      columns: new Set(["some_col"]),
+      verb: "update",
+    });
+    expect(fired).toBe(1);
+  });
+
+  test("fallback (INSERT verb) fires column-gated entries unconditionally", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity"],
+      },
+    );
+    invalidateCachesForWrite("listing_attendees", {
+      columns: new Set(),
+      verb: "insert",
+    });
+    expect(fired).toBe(1);
+  });
+
+  test("invalidateCachesForTable fires column-gated entries unconditionally", () => {
+    let fired = 0;
+    registerTableInvalidation(
+      ["listing_attendees"],
+      () => {
+        fired++;
+      },
+      {
+        whenColumns: ["quantity"],
+      },
+    );
+    invalidateCachesForTable("listing_attendees");
+    expect(fired).toBe(1);
+  });
+
+  test("registerDependencies wires a plain-string dep unconditionally", () => {
+    let fired = 0;
+    registerDependencies("own_table", ["other_table"], () => {
+      fired++;
+    });
+    invalidateCachesForTable("other_table");
+    expect(fired).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Why

Cache invalidation was a manual, easy-to-forget step (fixed in the previous commit series). This PR adds the refinement described in the spec: only invalidate the `listings` cache when an UPDATE to `listing_attendees` actually touches the aggregate columns — not on every attendee write.

Before this PR, a check-in (`checked_in = true`), refund (`refunded = true`), or attachment-download (`attachment_downloads = attachment_downloads + 1`) write would needlessly flush the listings cache, even though none of those columns feed the aggregate trigger.

## What

### Column-gated registry entries (`cache-registry.ts`)

- New `WriteVerb` / `WriteInfo` types carry verb + extracted SET columns through the invalidation path.
- `registerTableInvalidation` accepts an optional `whenColumns` array; UPDATE-verb writes only fire that invalidator when at least one listed column is assigned. INSERT / DELETE / REPLACE always fire (a row entering/leaving always shifts aggregates).
- New `invalidateCachesForWrite(table, info)` replaces `invalidateCachesForTable` in the db client; `invalidateCachesForTable` is kept as a backward-compatible alias (INSERT semantics).
- New `registerDependencies(ownTable, deps, invalidate)` helper centralises the registration loop shared by `cachedTable` and `cachedEntityTable`, eliminating a CPD violation.
- New `DependsOnEntry` type: `string | { table: string; whenColumns?: readonly string[] }`.

### UPDATE column parser (`client.ts`)

`extractUpdateColumns(sql)` parses the SET clause:
- Splits on top-level commas (skips commas inside parentheses, e.g. `coalesce(x, 0)`).
- Strips table qualifiers (`t.col → col`), quotes, and brackets.
- Lower-cases all column names.
- Stops at `WHERE` so `WHERE id = ?` equality signs aren't mistaken for assignments.
- Returns `null` for non-UPDATE SQL or an empty / unparseable SET — triggering a safe fallback that fires all registered invalidators unconditionally.

### Single source of truth for aggregate columns (`schema.ts`)

`LISTING_AGGREGATE_WRITE_COLUMNS = ["quantity", "price_paid", "listing_id"]` is exported and interpolated into both the `UPDATE OF …` trigger clause and the cache dependency — one place to update if the schema changes.

### listings cache dependency (`listings.ts`)

```ts
[{ table: "listing_attendees", whenColumns: [...LISTING_AGGREGATE_WRITE_COLUMNS] }]
```

Check-in, refund, and attachment-download UPDATEs no longer clear the cache.

## Tests

- `extractUpdateColumns` parser: 9 unit tests (single col, multiple cols, WHERE guards, table-qualified names, quoted names, parens, null for non-UPDATE, null for empty SET, lowercase).
- Column-gated registry: 9 unit tests (UPDATE fires/skips based on columns, INSERT/DELETE/REPLACE always fire, `invalidateCachesForTable` fires unconditionally, `registerDependencies` plain-string dep).
- `invalidateForSql` fallback: 2 integration tests (unparseable SET fires unconditionally; REPLACE INTO fires).
- Behavioral: 3 tests confirming `markRefunded`, `updateCheckedIn`, `incrementAttachmentDownloads` return the same cached reference (no invalidation on non-aggregate writes).
- Schema: trigger SQL contains `UPDATE OF quantity, price_paid, listing_id`.
- Full `deno task precommit` passes (lint, typecheck, cpd, build, all tests + coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kc1bTNTMWqxfNrrs3WLXSW