### PR TITLE
Gate answer-tier sold-out block on eligibility; consume tier stock on free bookings

### DIFF
--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -626,8 +626,15 @@ const processSubmission = async (
     // Record modifier usage (and consume stock) on every completion, including
     // disabled-payments free bookings, so a stock-limited answer tier is capped
     // across all bookings — not just the paid ones the webhook would have
-    // consumed.
-    modifierUsages: finalPricedOrder.modifierApplications,
+    // consumed. With payments disabled the booking collects nothing, so the
+    // applied amounts are zeroed: stock is still consumed (it's keyed on
+    // quantity) while the modifier revenue aggregates correctly stay at zero.
+    modifierUsages: paymentsEnabled
+      ? finalPricedOrder.modifierApplications
+      : finalPricedOrder.modifierApplications.map((m) => ({
+          ...m,
+          amountApplied: 0,
+        })),
     paymentBreakdown: paymentsEnabled
       ? ticketPaymentBreakdown(intent)
       : undefined,

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -20,6 +20,7 @@ import {
   answerModifierQuantities,
   buyerVisits,
   oversubscribedAnswerTiers,
+  type ResolveOptions,
   resolveModifiers,
 } from "#shared/db/modifier-resolve.ts";
 import { consumeModifierStockOrRollback } from "#shared/db/modifier-usage.ts";
@@ -301,10 +302,10 @@ const MODIFIER_SOLD_OUT_MESSAGE =
  * Used for every cart whose final priced total is zero — a free listing, a
  * paid listing discounted to zero, or a zero-price listing whose modifiers net
  * to zero after pricing — and for every cart when payments are disabled (the
- * existing disabled-is-free behaviour). When payments are enabled, the same
- * pricing engine that decided "no provider needed" also produced the modifiers
- * that this path must persist, so a zero-total order still records modifier
- * usage and respects stock limits.
+ * existing disabled-is-free behaviour). Either way the modifiers the pricing
+ * engine resolved are persisted here, so a zero-total or disabled-payments
+ * order still records modifier usage and consumes stock — keeping a
+ * stock-limited answer tier capped across free bookings, not just paid ones.
  */
 const handleFreePath = async (
   params: PathParams & {
@@ -415,19 +416,26 @@ const priceSubmission = (
   return { intent, pricedOrder: priceCheckout(intent) };
 };
 
+/** The resolve options for this submission at a given visit count, shared by
+ * the pricing resolve and the sold-out check so both judge modifier eligibility
+ * (scope, minimum subtotal, visit gate) identically. */
+const submissionModifierOpts = (
+  params: SubmissionPricingParams,
+  visits: number,
+): ResolveOptions => ({
+  addOns: params.addOns,
+  answerQuantities: params.answerQuantities,
+  code: params.promoCode,
+  ctx: { visits },
+});
+
 const resolveSubmissionModifiers = (
   params: SubmissionPricingParams,
   visits = 0,
 ): Promise<CheckoutIntent["modifiers"]> =>
   // Answer-triggered modifiers join the same single resolve pass as automatic,
-  // code, and opt-in add-on modifiers — one engine, one eligibility check. The
-  // answer quantities were computed (scope-aware) and sold-out-checked upstream.
-  resolveModifiers(params.items, {
-    addOns: params.addOns,
-    answerQuantities: params.answerQuantities,
-    code: params.promoCode,
-    ctx: { visits },
-  });
+  // code, and opt-in add-on modifiers — one engine, one eligibility check.
+  resolveModifiers(params.items, submissionModifierOpts(params, visits));
 
 const priceSubmissionBeforeContact = async (
   params: SubmissionPricingParams,
@@ -438,18 +446,22 @@ const priceSubmissionBeforeContact = async (
     await resolveSubmissionModifiers(params),
   );
 
+/** Price with the buyer's real visit count, returning that count so the caller
+ * can run the sold-out check against the same eligibility this pricing used. */
 const priceSubmissionWithContact = async (
   contact: ReturnType<typeof extractContact>,
   params: SubmissionPricingParams,
-): Promise<ReturnType<typeof priceSubmission>> =>
-  priceSubmission(
-    contact,
-    params,
-    await resolveSubmissionModifiers(
+): Promise<ReturnType<typeof priceSubmission> & { visits: number }> => {
+  const visits = await buyerVisits(contact.email, contact.phone);
+  return {
+    ...priceSubmission(
+      contact,
       params,
-      await buyerVisits(contact.email, contact.phone),
+      await resolveSubmissionModifiers(params, visits),
     ),
-  );
+    visits,
+  };
+};
 
 const validatePaymentUpgrade = (
   form: FormParams,
@@ -530,20 +542,12 @@ const processSubmission = async (
   const paymentsEnabled = isPaymentsEnabled();
   const reservationAmount = await publicReservationAmount();
 
-  // Resolve the answer-triggered modifier quantities once (scope-aware). An
-  // answer is recorded on every ticket that picked it, so a stock-limited answer
-  // tier the buyer over-subscribed must block the whole submission rather than
-  // silently charging fewer than chose it.
+  // Resolve the answer-triggered modifier quantities once (scope-aware); these
+  // feed both the pricing resolve and the sold-out check further down.
   const answerQuantities = await answerModifierQuantities(
     computeListingAnswerMap(ctx, info),
     quantities,
   );
-  const soldOutTiers = await oversubscribedAnswerTiers(answerQuantities);
-  if (soldOutTiers.length > 0) {
-    return errorResponse(
-      `Sorry, ${soldOutTiers.join(", ")} is no longer available. Please choose a different option.`,
-    );
-  }
 
   const pricingParams = {
     addOns,
@@ -564,8 +568,11 @@ const processSubmission = async (
   const validated = validateTicketFields(form, ctx, requiresPaidFields);
   if (validated instanceof Response) return validated;
   let contact = extractContact(validated);
-  let { intent, pricedOrder: finalPricedOrder } =
-    await priceSubmissionWithContact(contact, pricingParams);
+  let {
+    intent,
+    pricedOrder: finalPricedOrder,
+    visits,
+  } = await priceSubmissionWithContact(contact, pricingParams);
   const paidUpgradeValidation = validatePaymentUpgrade(
     form,
     ctx,
@@ -575,8 +582,26 @@ const processSubmission = async (
   if (paidUpgradeValidation instanceof Response) return paidUpgradeValidation;
   if (paidUpgradeValidation) {
     contact = extractContact(paidUpgradeValidation);
-    ({ intent, pricedOrder: finalPricedOrder } =
-      await priceSubmissionWithContact(contact, pricingParams));
+    ({
+      intent,
+      pricedOrder: finalPricedOrder,
+      visits,
+    } = await priceSubmissionWithContact(contact, pricingParams));
+  }
+
+  // An answer is recorded on every ticket that picked it, so a stock-limited
+  // answer tier the buyer over-subscribed can't be partially fulfilled — block
+  // the submission. Run against the same eligibility the pricing resolve used
+  // (now that the buyer's visit count is known), so a tier that wouldn't apply
+  // — cart below its minimum, or too few visits — isn't reported sold out.
+  const soldOutTiers = await oversubscribedAnswerTiers(
+    items,
+    submissionModifierOpts(pricingParams, visits),
+  );
+  if (soldOutTiers.length > 0) {
+    return errorResponse(
+      `Sorry, ${soldOutTiers.join(", ")} is no longer available. Please choose a different option.`,
+    );
   }
 
   const finalRequiresPaidFields = finalPricedOrder.total > 0;
@@ -598,9 +623,11 @@ const processSubmission = async (
     dayCount,
     hasCustomisable,
     info,
-    modifierUsages: paymentsEnabled
-      ? finalPricedOrder.modifierApplications
-      : [],
+    // Record modifier usage (and consume stock) on every completion, including
+    // disabled-payments free bookings, so a stock-limited answer tier is capped
+    // across all bookings — not just the paid ones the webhook would have
+    // consumed.
+    modifierUsages: finalPricedOrder.modifierApplications,
     paymentBreakdown: paymentsEnabled
       ? ticketPaymentBreakdown(intent)
       : undefined,

--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -190,36 +190,6 @@ export const answerModifierQuantities = async (
   return quantities;
 };
 
-/**
- * Names of answer-triggered modifiers the buyer over-subscribed: active,
- * stock-limited "answer" modifiers whose requested quantity exceeds the stock
- * remaining. Because an answer is recorded on every ticket that picked it (it
- * can't be partially fulfilled like an opt-in add-on), the submission must be
- * blocked rather than silently clamped to the units still available.
- */
-export const oversubscribedAnswerTiers = async (
-  answerQuantities: Map<number, number>,
-): Promise<string[]> => {
-  if (answerQuantities.size === 0) return [];
-  const byId = await activeModifiersById();
-  const limited = [...answerQuantities]
-    .map(([id, requested]) => ({ modifier: byId.get(id), requested }))
-    .filter(
-      (c): c is { modifier: Modifier; requested: number } =>
-        c.modifier !== undefined &&
-        c.modifier.trigger === "answer" &&
-        c.modifier.stock !== null,
-    );
-  const used = await modifierUsedQuantities(limited.map((c) => c.modifier.id));
-  return limited
-    .filter(
-      // stock is non-null here (the guard above filtered the unlimited ones).
-      ({ modifier, requested }) =>
-        requested > Math.max(0, modifier.stock! - (used.get(modifier.id) ?? 0)),
-    )
-    .map(({ modifier }) => modifier.name);
-};
-
 export type PricingContext = { visits: number };
 
 const NO_VISITS: PricingContext = { visits: 0 };
@@ -241,7 +211,7 @@ export const buyerVisits = async (
   return Math.max(0, ...counts);
 };
 
-type ResolveOptions = {
+export type ResolveOptions = {
   code?: string;
   addOns?: Map<number, number>;
   answerQuantities?: Map<number, number>;
@@ -249,26 +219,28 @@ type ResolveOptions = {
 };
 
 /**
- * The modifiers that apply to a cart: active, triggered, in scope, past their
- * minimum subtotal, past their minimum visit count, and with stock remaining.
- * Automatic modifiers always trigger; a "code" modifier triggers only when the
- * buyer entered its matching code; an "optional" add-on triggers only when the
- * buyer selected it (`opts.addOns` maps modifier id → chosen quantity); an
- * "answer" modifier triggers when the buyer selected a linked answer
- * (`opts.answerQuantities` maps modifier id → selection count). Each is applied
- * its requested number of times.
+ * Active modifiers eligible for a cart, each with the quantity the buyer asked
+ * for, *before* any stock clamp: past the visit gate, actually triggered
+ * (quantity >= 1), in scope, and past the minimum subtotal. Automatic modifiers
+ * always trigger; a "code" modifier triggers only on a matching code; an
+ * "optional" add-on triggers per chosen unit (`opts.addOns`); an "answer"
+ * modifier triggers per linked answer selected (`opts.answerQuantities`).
+ *
+ * `resolveModifiers` clamps these to the stock remaining; the sold-out check
+ * reads the requested quantity straight off them, so both share one eligibility
+ * pass and agree on which modifiers apply.
  */
-export const resolveModifiers = async (
+const eligibleCandidates = async (
   items: CheckoutItem[],
-  opts: ResolveOptions = {},
-): Promise<ModifierSpec[]> => {
+  opts: ResolveOptions,
+): Promise<Candidate[]> => {
   const addOns = opts.addOns ?? new Map<number, number>();
   const answerQuantities = opts.answerQuantities ?? new Map<number, number>();
   const ctx = opts.ctx ?? NO_VISITS;
   const codeIndex = opts.code?.trim()
     ? await hmacHash(normalizeCode(opts.code))
     : null;
-  const candidates = (
+  return (
     await Promise.all(
       (
         await getActiveModifiers()
@@ -291,7 +263,19 @@ export const resolveModifiers = async (
       }),
     )
   ).filter((c): c is Candidate => c !== null);
+};
 
+/**
+ * The modifiers that apply to a cart: {@link eligibleCandidates} with their
+ * quantities clamped to the stock remaining (a candidate clamped to zero drops
+ * out). Each surviving modifier is applied its (possibly clamped) number of
+ * times.
+ */
+export const resolveModifiers = async (
+  items: CheckoutItem[],
+  opts: ResolveOptions = {},
+): Promise<ModifierSpec[]> => {
+  const candidates = await eligibleCandidates(items, opts);
   // One batched usage lookup for every stock-limited candidate.
   const used = await modifierUsedQuantities(
     candidates
@@ -307,6 +291,37 @@ export const resolveModifiers = async (
     .map(({ candidate, quantity }) =>
       toSpec(candidate.modifier, quantity, candidate.listingIds),
     );
+};
+
+/**
+ * Names of answer-triggered modifiers the buyer over-subscribed: tiers that
+ * would actually apply to this cart — the same eligibility `resolveModifiers`
+ * uses (scope, minimum subtotal, visit gate) — and are stock-limited, but whose
+ * requested quantity exceeds the stock remaining. Because an answer is recorded
+ * on every ticket that picked it (it can't be partially fulfilled like an
+ * opt-in add-on), the submission is blocked rather than silently clamped.
+ *
+ * Gating on eligibility, not stock alone, means a tier the cart is too small
+ * for — or that the buyer lacks the visits for — isn't reported sold out when
+ * no surcharge would apply.
+ */
+export const oversubscribedAnswerTiers = async (
+  items: CheckoutItem[],
+  opts: ResolveOptions = {},
+): Promise<string[]> => {
+  const limited = (await eligibleCandidates(items, opts)).filter(
+    (c) => c.modifier.trigger === "answer" && c.modifier.stock !== null,
+  );
+  if (limited.length === 0) return [];
+  const used = await modifierUsedQuantities(limited.map((c) => c.modifier.id));
+  return limited
+    .filter(
+      // stock is non-null here (filtered just above).
+      (c) =>
+        c.quantity >
+        Math.max(0, c.modifier.stock! - (used.get(c.modifier.id) ?? 0)),
+    )
+    .map((c) => c.modifier.name);
 };
 
 /** Whether any active modifier is unlocked by a promo code, so the public

--- a/test/lib/db/modifier-resolve.test.ts
+++ b/test/lib/db/modifier-resolve.test.ts
@@ -320,11 +320,18 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
     test("oversubscribedAnswerTiers flags an answer tier requested beyond its stock", async () => {
       const m = await insertModifier({ name: "VIP tier", stock: 2 });
       await patchModifier(m.id, { trigger: "answer" });
+      const items = [checkoutItem()];
       // Requested 3 > stock 2 → over-subscribed; 2 <= 2 → fine.
-      expect(await oversubscribedAnswerTiers(new Map([[m.id, 3]]))).toEqual([
-        "VIP tier",
-      ]);
-      expect(await oversubscribedAnswerTiers(new Map([[m.id, 2]]))).toEqual([]);
+      expect(
+        await oversubscribedAnswerTiers(items, {
+          answerQuantities: new Map([[m.id, 3]]),
+        }),
+      ).toEqual(["VIP tier"]);
+      expect(
+        await oversubscribedAnswerTiers(items, {
+          answerQuantities: new Map([[m.id, 2]]),
+        }),
+      ).toEqual([]);
     });
 
     test("oversubscribedAnswerTiers accounts for stock already consumed", async () => {
@@ -333,28 +340,80 @@ describeWithEnv("db > modifier-resolve", { db: true }, () => {
       await consumeModifierStock(1, [
         { amountApplied: 0, modifierId: m.id, quantity: 4 },
       ]);
+      const items = [checkoutItem()];
       // 1 remaining: requesting 2 over-subscribes, 1 is fine.
-      expect(await oversubscribedAnswerTiers(new Map([[m.id, 2]]))).toEqual([
-        "Limited",
-      ]);
-      expect(await oversubscribedAnswerTiers(new Map([[m.id, 1]]))).toEqual([]);
+      expect(
+        await oversubscribedAnswerTiers(items, {
+          answerQuantities: new Map([[m.id, 2]]),
+        }),
+      ).toEqual(["Limited"]);
+      expect(
+        await oversubscribedAnswerTiers(items, {
+          answerQuantities: new Map([[m.id, 1]]),
+        }),
+      ).toEqual([]);
     });
 
     test("oversubscribedAnswerTiers ignores empty, unlimited, non-answer, and inactive", async () => {
-      expect(await oversubscribedAnswerTiers(new Map())).toEqual([]);
+      const items = [checkoutItem()];
+      expect(await oversubscribedAnswerTiers(items, {})).toEqual([]);
       const unlimited = await insertModifier({ name: "Unlimited" });
       await patchModifier(unlimited.id, { trigger: "answer" });
       const automatic = await insertModifier({ name: "Auto", stock: 1 });
       const inactive = await insertModifier({ name: "Inactive", stock: 1 });
       await patchModifier(inactive.id, { active: 0, trigger: "answer" });
       expect(
-        await oversubscribedAnswerTiers(
-          new Map([
+        await oversubscribedAnswerTiers(items, {
+          answerQuantities: new Map([
             [unlimited.id, 9],
             [automatic.id, 9],
             [inactive.id, 9],
           ]),
-        ),
+        }),
+      ).toEqual([]);
+    });
+
+    test("oversubscribedAnswerTiers ignores a tier the cart is too small for", async () => {
+      // Stock 1, requested 3 — over-subscribed on stock alone — but the tier's
+      // minimum subtotal isn't met, so resolveModifiers wouldn't apply it and
+      // the booking must not be blocked.
+      const m = await insertModifier({ name: "Big spenders", stock: 1 });
+      await patchModifier(m.id, { min_subtotal: 999999, trigger: "answer" });
+      expect(
+        await oversubscribedAnswerTiers([checkoutItem({ unitPrice: 1000 })], {
+          answerQuantities: new Map([[m.id, 3]]),
+        }),
+      ).toEqual([]);
+    });
+
+    test("oversubscribedAnswerTiers respects the returning-buyer visit gate", async () => {
+      const m = await insertModifier({ name: "Loyalty tier", stock: 1 });
+      await patchModifier(m.id, { min_visits: 1, trigger: "answer" });
+      const items = [checkoutItem()];
+      const answerQuantities = new Map([[m.id, 3]]);
+      // No visits → the gate blocks the tier, so it can't be over-subscribed.
+      expect(
+        await oversubscribedAnswerTiers(items, { answerQuantities }),
+      ).toEqual([]);
+      // Enough visits → the tier applies, and 3 > stock 1 over-subscribes it.
+      expect(
+        await oversubscribedAnswerTiers(items, {
+          answerQuantities,
+          ctx: { visits: 1 },
+        }),
+      ).toEqual(["Loyalty tier"]);
+    });
+
+    test("oversubscribedAnswerTiers ignores a tier scoped to listings not in the cart", async () => {
+      const m = await insertModifier({ name: "L9 tier", stock: 1 });
+      await patchModifier(m.id, { scope: "listings", trigger: "answer" });
+      await linkModifierListing(m.id, 9);
+      // The cart is listing 1; the tier is scoped to listing 9, so it can't
+      // apply and isn't reported sold out despite the over-subscription.
+      expect(
+        await oversubscribedAnswerTiers([checkoutItem({ listingId: 1 })], {
+          answerQuantities: new Map([[m.id, 3]]),
+        }),
       ).toEqual([]);
     });
 

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -4578,6 +4578,46 @@ describeWithEnv("server (public routes)", { db: true, triggers: true }, () => {
       );
     });
 
+    test("a free booking consumes answer-tier stock, blocking the next over it", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        thankYouUrl: "",
+      });
+      const { question, answer1 } = await setupQuestionForListing(listing.id);
+      // Payments are disabled here, so bookings complete for free — but a
+      // stock-limited answer tier must still be consumed so it can't be
+      // over-sold across free bookings.
+      const tier = await modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 5,
+        direction: "charge",
+        name: "VIP upgrade",
+        stock: 1,
+        trigger: "answer",
+      });
+      await setModifierAnswers(tier.id, [answer1.id]);
+
+      const first = await submitTicketForm(listing.slug, {
+        email: "first@example.com",
+        name: "First",
+        [`question_${question.id}`]: String(answer1.id),
+      });
+      expectReservedRedirectWithTokens(first);
+
+      // The single unit is now spent, so the next booking of the tier is blocked.
+      const second = await submitTicketForm(listing.slug, {
+        email: "second@example.com",
+        name: "Second",
+        [`question_${question.id}`]: String(answer1.id),
+      });
+      expect(second.status).toBe(302);
+      expectFlash(
+        second,
+        expect.stringContaining("no longer available"),
+        false,
+      );
+    });
+
     test("returns error when required question is unanswered", async () => {
       const listing = await createTestListing({ maxAttendees: 50 });
       await setupQuestionForListing(listing.id);

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -7,7 +7,11 @@ import { builderApi } from "#shared/builder.ts";
 import { addDays } from "#shared/dates.ts";
 import { insertBuiltSite } from "#shared/db/built-sites.ts";
 import { hashPhone, recordVisit } from "#shared/db/contact-preferences.ts";
-import { modifiersTable, setModifierAnswers } from "#shared/db/modifiers.ts";
+import {
+  getAllModifiers,
+  modifiersTable,
+  setModifierAnswers,
+} from "#shared/db/modifiers.ts";
 import {
   answersTable,
   getAttendeeAnswersBatch,
@@ -4603,6 +4607,14 @@ describeWithEnv("server (public routes)", { db: true, triggers: true }, () => {
         [`question_${question.id}`]: String(answer1.id),
       });
       expectReservedRedirectWithTokens(first);
+
+      // The unit was consumed, but with payments off nothing was collected: the
+      // usage is recorded without inflating the tier's reported revenue.
+      const afterFirst = (await getAllModifiers()).find(
+        (m) => m.id === tier.id,
+      );
+      expect(afterFirst?.total_uses).toBe(1);
+      expect(afterFirst?.total_revenue).toBe(0);
 
       // The single unit is now spent, so the next booking of the tier is blocked.
       const second = await submitTicketForm(listing.slug, {


### PR DESCRIPTION
## What & why

Two follow-up fixes to the answer-trigger pricing feature ([#1301](https://github.com/chobbledotcom/tickets/pull/1301)), addressing Codex P2 review comments that landed just after that PR merged.

### 1. The sold-out block now respects modifier eligibility

A stock-limited answer tier that *also* had a minimum-subtotal or minimum-visits gate was reported "sold out" based on stock **alone**. `resolveModifiers` would then skip that modifier for a cart below the minimum (or a buyer without enough visits), so the surcharge would never apply — yet the booking was still rejected.

- The eligibility pass `resolveModifiers` runs (visit gate → trigger → scope → minimum subtotal, *before* the stock clamp) is extracted into a shared `eligibleCandidates`, so pricing and the sold-out check agree on which tiers actually apply.
- `oversubscribedAnswerTiers` now takes `(items, opts)` and runs **after** the buyer's visit count is known, so the visit gate is evaluated against the real visits the booking prices on. A tier the cart is too small for, scoped to other listings, or gated to returning buyers is no longer reported sold out when no surcharge would apply.
- The completely-sold-out case still blocks: eligibility is checked pre-clamp, so an eligible tier with zero stock left is still caught (it can't be silently dropped).

### 2. Free bookings consume answer-tier stock

The non-payment completion path passed `modifierUsages: []` when payments were disabled, so a finite answer tier was never written to `modifier_usages` — meaning `oversubscribedAnswerTiers` kept seeing full stock and the tier could be over-sold across any number of free bookings.

- `handleFreePath` now persists the resolved modifier usages on **every** completion (zero-total *and* disabled-payments), so stock is capped whether or not a payment provider is in the loop — matching how zero-total paid carts already behaved.

## Edge cases / tests

- `oversubscribedAnswerTiers` tests rewritten to the `(items, opts)` signature, plus new cases for the minimum-subtotal gate, the returning-buyer visit gate (blocked with 0 visits, flagged with enough), and a listings-scoped tier outside the cart.
- New public-route test: a free booking of a `stock: 1` answer tier completes **and** consumes the unit, so the next booking of the same tier is blocked.

## Verification

`deno task precommit` passes end to end: lint, typecheck, copy-paste detection, edge build, and the full suite at 100% line/branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013QKXPhzSwo2qvTB9nr1K8o)_