### PR TITLE
Promo-code field visibility + SCSS stylesheet with a :has() visibility mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 bunny-script.ts
 .build-tag
 src/ui/static/*.js
+src/ui/static/style.css
 
 .bin/
 .direnv/

--- a/deno.json
+++ b/deno.json
@@ -47,6 +47,7 @@
     "stripe": "npm:stripe@^22.0.1",
     "@sumup/sdk": "npm:@sumup/sdk@^0.1.6",
     "esbuild": "npm:esbuild@^0.28.0",
+    "sass": "npm:sass@^1.101.0",
     "@bunny.net/edgescript-sdk": "npm:@bunny.net/edgescript-sdk@^0.12.1",
     "@internationalized/date": "npm:@internationalized/date@^3.12.0",
     "@bunny.net/storage-sdk": "npm:@bunny.net/storage-sdk@^0.3.1",

--- a/deno.lock
+++ b/deno.lock
@@ -52,6 +52,7 @@
     "npm:node-forge@^1.4.0": "1.4.0",
     "npm:postmark@*": "4.0.7",
     "npm:resend@*": "6.12.4",
+    "npm:sass@^1.101.0": "1.101.0",
     "npm:stripe@^22.0.1": "22.1.0",
     "npm:uqr@~0.1.3": "0.1.3",
     "npm:valibot@*": "1.4.1",
@@ -606,6 +607,96 @@
         "fastq"
       ]
     },
+    "@parcel/watcher-android-arm64@2.5.6": {
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@parcel/watcher-darwin-arm64@2.5.6": {
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@parcel/watcher-darwin-x64@2.5.6": {
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@parcel/watcher-freebsd-x64@2.5.6": {
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@parcel/watcher-linux-arm-glibc@2.5.6": {
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@parcel/watcher-linux-arm-musl@2.5.6": {
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@parcel/watcher-linux-arm64-glibc@2.5.6": {
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@parcel/watcher-linux-arm64-musl@2.5.6": {
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@parcel/watcher-linux-x64-glibc@2.5.6": {
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@parcel/watcher-linux-x64-musl@2.5.6": {
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@parcel/watcher-win32-arm64@2.5.6": {
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@parcel/watcher-win32-ia32@2.5.6": {
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@parcel/watcher-win32-x64@2.5.6": {
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@parcel/watcher@2.5.6": {
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dependencies": [
+        "detect-libc@2.1.2",
+        "is-glob",
+        "node-addon-api",
+        "picomatch@4.0.4"
+      ],
+      "optionalDependencies": [
+        "@parcel/watcher-android-arm64",
+        "@parcel/watcher-darwin-arm64",
+        "@parcel/watcher-darwin-x64",
+        "@parcel/watcher-freebsd-x64",
+        "@parcel/watcher-linux-arm-glibc",
+        "@parcel/watcher-linux-arm-musl",
+        "@parcel/watcher-linux-arm64-glibc",
+        "@parcel/watcher-linux-arm64-musl",
+        "@parcel/watcher-linux-x64-glibc",
+        "@parcel/watcher-linux-x64-musl",
+        "@parcel/watcher-win32-arm64",
+        "@parcel/watcher-win32-ia32",
+        "@parcel/watcher-win32-x64"
+      ],
+      "scripts": true
+    },
     "@sendgrid/client@8.1.6": {
       "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
       "dependencies": [
@@ -735,6 +826,12 @@
         "is-regex"
       ]
     },
+    "chokidar@5.0.0": {
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dependencies": [
+        "readdirp"
+      ]
+    },
     "cli-table3@0.6.5": {
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dependencies": [
@@ -800,6 +897,9 @@
     },
     "detect-libc@2.0.2": {
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
+    },
+    "detect-libc@2.1.2": {
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "doctypes@1.1.0": {
       "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="
@@ -1031,6 +1131,9 @@
     "human-signals@1.1.1": {
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
+    "immutable@5.1.6": {
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ=="
+    },
     "intl-messageformat@10.7.18": {
       "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
       "dependencies": [
@@ -1142,7 +1245,7 @@
       "integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
       "dependencies": [
         "@neon-rs/load",
-        "detect-libc"
+        "detect-libc@2.0.2"
       ],
       "optionalDependencies": [
         "@libsql/darwin-arm64",
@@ -1196,7 +1299,7 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": [
         "braces",
-        "picomatch"
+        "picomatch@2.3.1"
       ]
     },
     "mime-db@1.52.0": {
@@ -1213,6 +1316,9 @@
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-addon-api@7.1.1": {
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
     },
     "node-domexception@1.0.0": {
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
@@ -1271,6 +1377,9 @@
     },
     "picomatch@2.3.1": {
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "picomatch@4.0.4": {
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
     },
     "postal-mime@2.7.4": {
       "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="
@@ -1391,6 +1500,9 @@
     "queue-microtask@1.2.3": {
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "readdirp@5.0.0": {
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="
+    },
     "repeat-string@1.6.1": {
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
     },
@@ -1422,6 +1534,18 @@
         "queue-microtask"
       ]
     },
+    "sass@1.101.0": {
+      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
+      "dependencies": [
+        "chokidar",
+        "immutable",
+        "source-map-js"
+      ],
+      "optionalDependencies": [
+        "@parcel/watcher"
+      ],
+      "bin": true
+    },
     "shebang-command@2.0.0": {
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dependencies": [
@@ -1433,6 +1557,9 @@
     },
     "signal-exit@3.0.7": {
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "source-map-js@1.2.1": {
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "spark-md5@3.0.2": {
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
@@ -1598,6 +1725,7 @@
       "npm:liquidjs@^10.25.5",
       "npm:marked@18",
       "npm:node-forge@^1.4.0",
+      "npm:sass@^1.101.0",
       "npm:stripe@^22.0.1",
       "npm:uqr@~0.1.3",
       "npm:valibot@^1.4.1"

--- a/scripts/build-edge.ts
+++ b/scripts/build-edge.ts
@@ -21,7 +21,7 @@ await buildStaticAssets();
 const BUILD_TS = Math.floor(Date.now() / 1000);
 
 // Read static assets at build time for inlining (client bundles freshly built above)
-const rawCss = await Deno.readTextFile("./src/ui/static/mvp.css");
+const rawCss = await Deno.readTextFile("./src/ui/static/style.css");
 const minifiedCss = await minifyCss(rawCss);
 
 const JS = "application/javascript; charset=utf-8";
@@ -34,7 +34,7 @@ const ASSET_DEFS: [string, string, string, string][] = [
   ["robots.txt", "handleRobotsTxt", TEXT, ""],
   ["favicon.svg", "handleFavicon", SVG, ""],
   ["icons.svg", "handleIcons", SVG, "ICONS_PATH"],
-  ["mvp.css", "handleMvpCss", CSS, "CSS_PATH"],
+  ["style.css", "handleStyleCss", CSS, "CSS_PATH"],
   ["admin.js", "handleAdminJs", JS, "JS_PATH"],
   ["scanner.js", "handleScannerJs", JS, "SCANNER_JS_PATH"],
   [
@@ -55,11 +55,11 @@ const ASSET_DEFS: [string, string, string, string][] = [
 
 const STATIC_ASSETS: Record<string, string> = {
   "favicon.svg": await Deno.readTextFile("./src/ui/static/favicon.svg"),
-  "mvp.css": minifiedCss,
+  "style.css": minifiedCss,
 };
 
 for (const [filename] of ASSET_DEFS) {
-  if (filename === "favicon.svg" || filename === "mvp.css") continue;
+  if (filename === "favicon.svg" || filename === "style.css") continue;
   STATIC_ASSETS[filename] = await Deno.readTextFile(
     `./src/ui/static/${filename}`,
   );

--- a/scripts/build-static-assets.ts
+++ b/scripts/build-static-assets.ts
@@ -5,6 +5,7 @@
 import { fromFileUrl } from "@std/path";
 import type { Plugin } from "esbuild";
 import * as esbuild from "esbuild";
+import * as sass from "sass";
 
 const denoConfig = JSON.parse(await Deno.readTextFile("./deno.json"));
 const denoImports: Record<string, string> = denoConfig.imports;
@@ -21,11 +22,26 @@ const STATIC_DIR = "./src/ui/static";
 export const STATIC_ASSET_OUTFILES = {
   admin: `${STATIC_DIR}/admin.js`,
   contact: `${STATIC_DIR}/contact.js`,
+  css: `${STATIC_DIR}/style.css`,
   embed: `${STATIC_DIR}/embed.js`,
   iframeResizerChild: `${STATIC_DIR}/iframe-resizer-child.js`,
   iframeResizerParent: `${STATIC_DIR}/iframe-resizer-parent.js`,
   scanner: `${STATIC_DIR}/scanner.js`,
 } as const;
+
+/** Source SCSS stylesheet compiled to {@link STATIC_ASSET_OUTFILES.css}. */
+const CSS_ENTRY = `${STATIC_DIR}/style.scss`;
+
+/**
+ * Compile the SCSS stylesheet to the served CSS file. Kept expanded (not
+ * minified) for dev/serving parity with the previous hand-written CSS; the edge
+ * build minifies it separately when inlining.
+ */
+const buildCss = async (quiet = false): Promise<void> => {
+  const { css } = sass.compile(CSS_ENTRY, { style: "expanded" });
+  await Deno.writeTextFile(STATIC_ASSET_OUTFILES.css, css);
+  if (!quiet) console.log(`CSS build complete: ${STATIC_ASSET_OUTFILES.css}`);
+};
 
 const buildBundle = async (
   label: string,
@@ -120,6 +136,8 @@ export const buildStaticAssets = async (
 ): Promise<void> => {
   const quiet = options.quiet ?? false;
   await Promise.all([
+    buildCss(quiet),
+
     buildBundle(
       "Scanner",
       {

--- a/src/features/assets.ts
+++ b/src/features/assets.ts
@@ -33,7 +33,7 @@ const TEXT = "text/plain; charset=utf-8";
 export const handleRobotsTxt = staticHandler("robots.txt", TEXT);
 export const handleFavicon = staticHandler("favicon.svg", SVG);
 export const handleIcons = staticHandler("icons.svg", SVG);
-export const handleMvpCss = staticHandler("mvp.css", CSS);
+export const handleStyleCss = staticHandler("style.css", CSS);
 export const handleAdminJs = staticHandler("admin.js", JS);
 export const handleScannerJs = staticHandler("scanner.js", JS);
 export const handleEmbedJs = staticHandler("embed.js", JS);

--- a/src/features/static.ts
+++ b/src/features/static.ts
@@ -11,9 +11,9 @@ import {
   handleIcons,
   handleIframeResizerChildJs,
   handleIframeResizerParentJs,
-  handleMvpCss,
   handleRobotsTxt,
   handleScannerJs,
+  handleStyleCss,
 } from "#routes/assets.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 
@@ -27,9 +27,9 @@ const staticRoutes = defineRoutes({
   "GET /icons.svg": () => handleIcons(),
   "GET /iframe-resizer-child.js": () => handleIframeResizerChildJs(),
   "GET /iframe-resizer-parent.js": () => handleIframeResizerParentJs(),
-  "GET /mvp.css": () => handleMvpCss(),
   "GET /robots.txt": () => handleRobotsTxt(),
   "GET /scanner.js": () => handleScannerJs(),
+  "GET /style.css": () => handleStyleCss(),
 });
 
 /** Route static asset requests */

--- a/src/shared/asset-paths.ts
+++ b/src/shared/asset-paths.ts
@@ -5,7 +5,7 @@
  */
 
 /** CSS stylesheet path, cache-busted at build time */
-export const CSS_PATH = "/mvp.css";
+export const CSS_PATH = "/style.css";
 
 /** Admin JS path, cache-busted at build time */
 export const JS_PATH = "/admin.js";

--- a/src/ui/static/mvp.css
+++ b/src/ui/static/mvp.css
@@ -1455,6 +1455,15 @@ form:not(:has(input[name="is_reservation"]:checked))
   display: none;
 }
 
+/* The promo-code field only applies to a promo-code-triggered modifier, so it
+   is shown only when the Trigger select has "Promo code" chosen — mirroring the
+   listing_type rule above. CSS-only show/hide keeps the single labelled field in
+   the DOM, so its "Promo code" label stays associated for screen readers. */
+form:not(:has(select[name="trigger"] option[value="code"]:checked))
+  label:has([name="code"]) {
+  display: none;
+}
+
 /* Utility classes for strict CSP (no inline styles) */
 .hidden {
   display: none;

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1414,55 +1414,87 @@ label.terms-agree {
   border-bottom: 1px solid var(--color-bg-secondary);
 }
 
-/* Daily-only scheduling fields are grouped in one section, hidden entirely for
-   standard listings (which book a single fixed date instead). */
-form:has(select[name="listing_type"] option[value="standard"]:checked)
-  .listing-section--daily {
-  display: none;
+// ---------------------------------------------------------------------------
+// Conditional field visibility
+//
+// Several admin forms reveal a control only while another input is in a given
+// state. It is done purely in CSS via :has() so no JavaScript runs and every
+// field keeps its real <label>, so the label association survives for screen
+// readers when the field is shown. These mixins capture the shared shape: hide
+// a target inside a form whenever the form matches (or fails to match) a
+// controlling state.
+// ---------------------------------------------------------------------------
+
+// Core: hide $target inside any form whose state matches $when — a chain of
+// :has()/:not() pseudo-classes appended directly to `form`.
+@mixin hidden-in-form($when, $target) {
+  form#{$when} #{$target} {
+    display: none;
+  }
 }
 
-/* Booking duration applies to daily listings, or to any listing using
-   customisable day pricing (where it caps how many days a visitor may pick). */
-form:has(select[name="listing_type"] option[value="standard"]:checked):not(
-  :has(input[name="customisable_days"]:checked)
-)
-  label:has([name="duration_days"]) {
-  display: none;
+// Reveal $target only while the checkbox named $name is ticked.
+@mixin reveal-when-checked($name, $target) {
+  @include hidden-in-form(':not(:has(input[name="#{$name}"]:checked))', $target);
 }
 
-/* Hide listing date field when listing type is "daily" (dates are chosen per
-   booking instead). */
-form:has(select[name="listing_type"] option[value="daily"]:checked)
-  label:has([name="date_date"]) {
-  display: none;
+// Reveal $target only while the <select> named $name has $value chosen.
+@mixin reveal-when-selected($name, $value, $target) {
+  @include hidden-in-form(
+    ':not(:has(select[name="#{$name}"] option[value="#{$value}"]:checked))',
+    $target
+  );
 }
 
-/* Day prices only apply when "Customisable Days" is enabled; revealed in place
-   right beneath the checkbox that controls them. */
-form:not(:has(input[name="customisable_days"]:checked)) #day-prices {
-  display: none;
+// Hide $target while the <select> named $name has $value chosen.
+@mixin hidden-when-selected($name, $value, $target) {
+  @include hidden-in-form(
+    ':has(select[name="#{$name}"] option[value="#{$value}"]:checked)',
+    $target
+  );
 }
 
-/* Hide max price field when "Allow Pay More" is not checked */
-form:not(:has(input[name="can_pay_more"]:checked))
-  label:has([name="max_price"]) {
-  display: none;
-}
+// Daily-only scheduling fields are grouped in one section, hidden entirely for
+// standard listings (which book a single fixed date instead).
+@include hidden-when-selected(
+  "listing_type",
+  "standard",
+  ".listing-section--daily"
+);
 
-/* Hide reservation amount field when "This is a reservation" is not checked */
-form:not(:has(input[name="is_reservation"]:checked))
-  > label:has([name="reservation_amount"]) {
-  display: none;
-}
+// Booking duration applies to daily listings, or any listing using customisable
+// day pricing (where it caps how many days a visitor may pick), so it is hidden
+// only for a standard listing without customisable days.
+@include hidden-in-form(
+  ':has(select[name="listing_type"] option[value="standard"]:checked):not(:has(input[name="customisable_days"]:checked))',
+  'label:has([name="duration_days"])'
+);
 
-/* The promo-code field only applies to a promo-code-triggered modifier, so it
-   is shown only when the Trigger select has "Promo code" chosen — mirroring the
-   listing_type rule above. CSS-only show/hide keeps the single labelled field in
-   the DOM, so its "Promo code" label stays associated for screen readers. */
-form:not(:has(select[name="trigger"] option[value="code"]:checked))
-  label:has([name="code"]) {
-  display: none;
-}
+// Hide the listing date field for daily listings (dates are chosen per booking).
+@include hidden-when-selected(
+  "listing_type",
+  "daily",
+  'label:has([name="date_date"])'
+);
+
+// Day prices only apply when "Customisable Days" is enabled; revealed in place
+// right beneath the checkbox that controls them.
+@include reveal-when-checked("customisable_days", "#day-prices");
+
+// Hide the max price field unless "Allow Pay More" is checked.
+@include reveal-when-checked("can_pay_more", 'label:has([name="max_price"])');
+
+// Hide the reservation amount field unless "This is a reservation" is checked.
+@include reveal-when-checked(
+  "is_reservation",
+  '> label:has([name="reservation_amount"])'
+);
+
+// The promo-code field only applies to a promo-code-triggered modifier, so it is
+// shown only when the Trigger select has "Promo code" chosen. CSS-only show/hide
+// keeps the single labelled field in the DOM, so its "Promo code" label stays
+// associated for screen readers.
+@include reveal-when-selected("trigger", "code", 'label:has([name="code"])');
 
 /* Utility classes for strict CSP (no inline styles) */
 .hidden {

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -1387,7 +1387,7 @@ const getListingFieldsWithAutofocus = (): Field[] =>
 // and the edit-only duration-change warning.
 //
 // Conditional visibility (daily-only fields, day prices, max price) is handled
-// entirely in CSS via :has() — see the form rules in mvp.css. The day-prices
+// entirely in CSS via :has() — see the form rules in style.scss. The day-prices
 // block sits right under the "Customisable Days" checkbox so enabling it
 // reveals the prices in place.
 // ---------------------------------------------------------------------------

--- a/test/lib/server-public.test.ts
+++ b/test/lib/server-public.test.ts
@@ -629,9 +629,9 @@ describeWithEnv("server (public routes)", { db: true, triggers: true }, () => {
     });
   });
 
-  describe("GET /mvp.css", () => {
+  describe("GET /style.css", () => {
     test("returns CSS stylesheet", async () => {
-      const response = await handleRequest(mockRequest("/mvp.css"));
+      const response = await handleRequest(mockRequest("/style.css"));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe(
         "text/css; charset=utf-8",
@@ -641,8 +641,8 @@ describeWithEnv("server (public routes)", { db: true, triggers: true }, () => {
       expect(css).toContain("--color-link");
     });
 
-    test("returns 404 for non-GET requests to /mvp.css", async () => {
-      const response = await awaitTestRequest("/mvp.css", {
+    test("returns 404 for non-GET requests to /style.css", async () => {
+      const response = await awaitTestRequest("/style.css", {
         data: {},
         method: "POST",
       });
@@ -650,7 +650,7 @@ describeWithEnv("server (public routes)", { db: true, triggers: true }, () => {
     });
 
     test("has long cache headers", async () => {
-      const response = await handleRequest(mockRequest("/mvp.css"));
+      const response = await handleRequest(mockRequest("/style.css"));
       expect(response.headers.get("cache-control")).toBe(
         "public, max-age=31536000, immutable",
       );

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -159,7 +159,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
       test("static assets work without a settings table", async () => {
         await resetToBrandNewDatabase();
 
-        const response = await handleRequest(mockRequest("/mvp.css"));
+        const response = await handleRequest(mockRequest("/style.css"));
 
         expect(response.status).toBe(200);
         expect(response.headers.get("content-type")).toContain("text/css");
@@ -181,7 +181,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
             },
           );
 
-          const response = await handleRequest(mockRequest("/mvp.css"));
+          const response = await handleRequest(mockRequest("/style.css"));
           expect(response.status).toBe(200);
           expect(response.headers.get("content-type")).toContain("text/css");
         } finally {

--- a/test/templates/admin/modifiers.test.ts
+++ b/test/templates/admin/modifiers.test.ts
@@ -171,7 +171,7 @@ describe("adminModifierDeletePage", () => {
 
 describe("adminModifierEditPage promo-code visibility", () => {
   // The promo-code field is shown only when the Trigger select has "Promo code"
-  // chosen, handled entirely in CSS (see mvp.css). This locks in the markup that
+  // chosen, handled entirely in CSS (see style.scss). This locks in the markup that
   // rule depends on: a trigger select carrying the "code" option, and the
   // promo-code input wrapped by its "Promo code" label so the association stays
   // intact for screen readers when the field is revealed.

--- a/test/templates/admin/modifiers.test.ts
+++ b/test/templates/admin/modifiers.test.ts
@@ -169,6 +169,19 @@ describe("adminModifierDeletePage", () => {
   });
 });
 
+describe("adminModifierEditPage promo-code visibility", () => {
+  // The promo-code field is shown only when the Trigger select has "Promo code"
+  // chosen, handled entirely in CSS (see mvp.css). This locks in the markup that
+  // rule depends on: a trigger select carrying the "code" option, and the
+  // promo-code input wrapped by its "Promo code" label so the association stays
+  // intact for screen readers when the field is revealed.
+  test("renders the trigger 'code' option and labelled promo-code field the CSS toggle hooks into", () => {
+    const html = adminModifierEditPage(mod(), SESSION);
+    expect(html).toContain('<option value="code">Promo code</option>');
+    expect(html).toContain('<label>Promo code<input name="code"');
+  });
+});
+
 describe("adminModifierEditPage scope editor", () => {
   test("renders listing checkboxes (with current links checked)", () => {
     const html = adminModifierEditPage(


### PR DESCRIPTION
## What

1. **Feature:** the **Promo code** field on the modifier create/edit form (`/admin/modifiers/:id/edit`) now only shows when the **Trigger** select is set to **Promo code**, done entirely in CSS (mirroring the daily-vs-standard listing-type toggle).
2. **Refactor/infra:** the stylesheet is now authored in **SCSS**, and the duplicated CSS conditional-visibility rules (there were several near-identical `:has()` copies) are generated from a small mixin.

## Conditional-visibility mixin

These rules — "hide a field unless/while a controlling input is in a given state", pure CSS via `:has()` so no JS runs and each field keeps its real `<label>` (association preserved for screen readers) — collapsed into:

```scss
@mixin hidden-in-form($when, $target) {
  form#{$when} #{$target} { display: none; }
}
@mixin reveal-when-checked($name, $target) { … }   // checkbox
@mixin reveal-when-selected($name, $value, $target) { … }  // <select> option
@mixin hidden-when-selected($name, $value, $target) { … }
```

So each toggle (daily section, booking duration, listing date, day prices, max price, reservation amount, and the new promo code) is a one-line `@include`. Adding the promo-code rule:

```scss
@include reveal-when-selected("trigger", "code", 'label:has([name="code"])');
```

The compiled CSS is **byte-identical** to the previous hand-written rules (verified by normalising both through sass and diffing).

## SCSS toolchain (gitignored, build-generated — matches the JS bundles)

- Source: `src/ui/static/style.scss` (renamed from `mvp.css`).
- Compiled to `src/ui/static/style.css` by `build:static` via `npm:sass` (a build-only dep, never shipped to the edge bundle), and **gitignored** like `src/ui/static/*.js`. The test harness builds and cleans it up the same way; the edge build minifies it when inlining.
- Served path renamed `/mvp.css` → `/style.css` (`CSS_PATH`, the asset handler/route, and the edge `ASSET_DEFS` updated together).

## Accessibility

CSS-only show/hide keeps the single labelled field in the DOM, so its `Promo code` label stays associated with the input when shown, and is removed from the a11y tree (via `display: none`) when hidden — consistent with the listing-type fields.

## Tests

Regression test locks in the markup the CSS toggle depends on (the trigger `code` option + the labelled promo-code input). Static-asset tests now target `/style.css`. Full `deno task precommit` passes: lint, typecheck, cpd (0% duplication), build:edge, and the suite at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bQUUXf7TjzWB26aC9oG2