### PR TITLE
Make debug-footer SQL timing parallelism-aware

### DIFF
--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -227,7 +227,9 @@ const trackedBatch = async (
   const results = await getDb().batch(statements, mode);
   if (isQueryLogEnabled()) {
     const elapsed = performance.now() - start;
-    for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed);
+    // Every statement shares the one round-trip window [start, start+elapsed],
+    // so the footer's wall-clock union counts that time once (not N times).
+    for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed, start);
   }
   for (const stmt of statements) invalidateForSql(stmt.sql);
   return results;

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -15,10 +15,21 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
-import { lazyRef } from "#fp";
+import { lazyRef, map, pipe, reduce, sort } from "#fp";
 
 /** A single logged query */
-export type QueryLogEntry = { sql: string; durationMs: number };
+export type QueryLogEntry = {
+  sql: string;
+  durationMs: number;
+  /**
+   * `performance.now()` captured when the query started. Stored so the footer
+   * can report the *wall-clock* time the request spent in SQL — the union of
+   * overlapping query intervals — instead of naively summing durations. Summing
+   * double-counts queries that ran concurrently (`Promise.all`) and statements
+   * folded into a single batch round-trip, which both overlap in real time.
+   */
+  startedAtMs: number;
+};
 
 type QueryLogState = {
   enabled: boolean;
@@ -75,13 +86,65 @@ export const isFooterDebugEnabled = (): boolean => getState().footerVisible;
 export const getQueryLogStartTime = (): number => getState().startTime;
 
 /** Record a query (no-op when logging is disabled) */
-export const addQueryLogEntry = (sql: string, durationMs: number): void => {
+export const addQueryLogEntry = (
+  sql: string,
+  durationMs: number,
+  startedAtMs: number,
+): void => {
   const state = getState();
-  if (state.enabled) state.entries.push({ durationMs, sql });
+  if (state.enabled) state.entries.push({ durationMs, sql, startedAtMs });
 };
 
 /** Return a snapshot of all logged queries */
 export const getQueryLog = (): QueryLogEntry[] => [...getState().entries];
+
+/** A query's [start, end) window on the `performance.now()` clock. */
+type Interval = readonly [start: number, end: number];
+
+/** Reduce accumulator: the open interval being extended, plus settled total. */
+type MergedSpan = { total: number; start: number; end: number };
+
+/**
+ * Wall-clock milliseconds during which at least one query was in flight: the
+ * combined length of the query intervals with overlaps merged.
+ *
+ * Summing `durationMs` answers "how much query work ran" but double-counts
+ * concurrency, so it is wrong as a measure of how long the request *waited* on
+ * the database. Reads fanned out with `Promise.all` overlap in wall-clock time,
+ * and every statement in a `queryBatch` shares one round-trip window; merging
+ * overlaps counts that shared time once. Because every query runs within the
+ * request, the result is always ≤ the render time, so `render − sqlWallClock`
+ * is a non-negative "everything that wasn't SQL" figure.
+ */
+export const sqlWallClockMs = (entries: readonly QueryLogEntry[]): number => {
+  if (entries.length === 0) return 0;
+  const intervals: Interval[] = pipe(
+    map(
+      (e: QueryLogEntry): Interval => [
+        e.startedAtMs,
+        e.startedAtMs + e.durationMs,
+      ],
+    ),
+    sort((a: Interval, b: Interval) => a[0] - b[0]),
+  )(entries as QueryLogEntry[]);
+  const [firstStart, firstEnd] = intervals[0]!;
+  const merged = reduce(
+    (span: MergedSpan, [start, end]: Interval): MergedSpan => {
+      if (start > span.end) {
+        // Disjoint from the open interval: settle it and open a new one.
+        span.total += span.end - span.start;
+        span.start = start;
+        span.end = end;
+      } else if (end > span.end) {
+        // Overlapping or adjacent: extend the open interval.
+        span.end = end;
+      }
+      return span;
+    },
+    { end: firstEnd, start: firstStart, total: 0 },
+  )(intervals);
+  return merged.total + (merged.end - merged.start);
+};
 
 /**
  * Max times one parameterized read may run as a separate round-trip within a
@@ -147,6 +210,10 @@ export const trackQuery = async <T>(
   if (!state.enabled) return fn();
   const start = performance.now();
   const result = await fn();
-  state.entries.push({ durationMs: performance.now() - start, sql });
+  state.entries.push({
+    durationMs: performance.now() - start,
+    sql,
+    startedAtMs: start,
+  });
   return result;
 };

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -21,6 +21,7 @@ import {
   getQueryLogStartTime,
   isFooterDebugEnabled,
   type QueryLogEntry,
+  sqlWallClockMs,
 } from "#shared/db/query-log.ts";
 import { getUptimeSeconds } from "#shared/uptime.ts";
 
@@ -40,6 +41,9 @@ export const markAdminFooter = (): void => {
   _adminFooterStore.show = true;
 };
 
+/** Total query work: the sum of every query's duration, counting concurrent
+ * and batched queries in full. Pairs with the wall-clock figure to expose how
+ * much of that work overlapped (the parallel factor). */
 const sumDurations = reduce(
   (total: number, q: QueryLogEntry) => total + q.durationMs,
   0,
@@ -57,8 +61,14 @@ const renderCacheStat = (stat: CacheStat): string =>
  * and cache stats. Shown in the footer only when query logging is active. */
 export const debugDetailsHtml = (data: DebugFooterData): string => {
   const { renderTimeMs, queries, cacheStats, uptimeSeconds } = data;
-  const totalSqlMs = sumDurations(queries);
-  const otherMs = renderTimeMs - totalSqlMs;
+  // Wall-clock time blocked on SQL (overlaps merged) vs. total query work
+  // (durations summed). They diverge exactly when queries ran concurrently or
+  // were batched, so `render = sqlWall + other` is a true, non-negative split
+  // and `work / sqlWall` is the parallel factor.
+  const sqlWallMs = sqlWallClockMs(queries);
+  const sqlWorkMs = sumDurations(queries);
+  const otherMs = renderTimeMs - sqlWallMs;
+  const parallelFactor = sqlWallMs > 0 ? sqlWorkMs / sqlWallMs : 1;
   const totalCacheEntries = reduce(
     (total: number, s: CacheStat) => total + s.entries,
     0,
@@ -67,13 +77,18 @@ export const debugDetailsHtml = (data: DebugFooterData): string => {
   return (
     `<details class="debug-menu">` +
     `<summary>${renderTimeMs.toFixed(0)}ms` +
-    ` &middot; ${queries.length} quer${queries.length === 1 ? "y" : "ies"} ${totalSqlMs.toFixed(
+    ` &middot; ${queries.length} quer${queries.length === 1 ? "y" : "ies"} ${sqlWallMs.toFixed(
       0,
     )}ms` +
     ` &middot; ${totalCacheEntries} cached` +
     ` &middot; up ${uptimeSeconds.toFixed(0)}s</summary>` +
     `<p>Render: ${renderTimeMs.toFixed(1)}ms` +
-    ` (sql ${totalSqlMs.toFixed(1)}ms + other ${otherMs.toFixed(1)}ms)</p>` +
+    ` (sql ${sqlWallMs.toFixed(1)}ms + other ${otherMs.toFixed(1)}ms)</p>` +
+    (queries.length > 0
+      ? `<p>SQL: ${sqlWorkMs.toFixed(1)}ms work across ${queries.length} quer${
+          queries.length === 1 ? "y" : "ies"
+        }, ${parallelFactor.toFixed(1)}&times; parallel</p>`
+      : "") +
     (queries.length > 0
       ? `<details><summary>${t("admin.footer.sql_queries")}</summary><ul>` +
         queries

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -48,8 +48,12 @@ describe("debugDetailsHtml", () => {
     const html = debugDetailsHtml({
       cacheStats: [],
       queries: [
-        { durationMs: 5.2, sql: "SELECT * FROM listings" },
-        { durationMs: 3.1, sql: "SELECT * FROM users WHERE id = ?" },
+        { durationMs: 5.2, sql: "SELECT * FROM listings", startedAtMs: 0 },
+        {
+          durationMs: 3.1,
+          sql: "SELECT * FROM users WHERE id = ?",
+          startedAtMs: 10,
+        },
       ],
       renderTimeMs: 20,
       uptimeSeconds: 0,
@@ -63,7 +67,9 @@ describe("debugDetailsHtml", () => {
   test("escapes HTML in SQL strings", () => {
     const html = debugDetailsHtml({
       cacheStats: [],
-      queries: [{ durationMs: 1.0, sql: "SELECT '<script>' FROM t" }],
+      queries: [
+        { durationMs: 1.0, sql: "SELECT '<script>' FROM t", startedAtMs: 0 },
+      ],
       renderTimeMs: 10,
       uptimeSeconds: 0,
     });
@@ -82,12 +88,13 @@ describe("debugDetailsHtml", () => {
     expect(html).not.toContain("SQL queries");
   });
 
-  test("shows query count and total SQL time in summary", () => {
+  test("summary SQL time is the wall-clock union, not the sum of durations", () => {
+    // Two sequential (disjoint) queries: union 10+15 = 25ms.
     const html = debugDetailsHtml({
       cacheStats: [],
       queries: [
-        { durationMs: 10, sql: "SELECT 1" },
-        { durationMs: 15, sql: "SELECT 2" },
+        { durationMs: 10, sql: "SELECT 1", startedAtMs: 0 },
+        { durationMs: 15, sql: "SELECT 2", startedAtMs: 20 },
       ],
       renderTimeMs: 50,
       uptimeSeconds: 0,
@@ -95,28 +102,99 @@ describe("debugDetailsHtml", () => {
     expect(html).toContain("2 queries 25ms");
   });
 
+  test("summary counts concurrent queries' overlap only once", () => {
+    // Two queries overlapping in wall-clock time: union [0,15] = 15ms, even
+    // though the durations sum to 25ms. The summary reports the honest 15ms.
+    const html = debugDetailsHtml({
+      cacheStats: [],
+      queries: [
+        { durationMs: 10, sql: "SELECT 1", startedAtMs: 0 },
+        { durationMs: 10, sql: "SELECT 2", startedAtMs: 5 },
+      ],
+      renderTimeMs: 50,
+      uptimeSeconds: 0,
+    });
+    expect(html).toContain("2 queries 15ms");
+  });
+
   test("shows singular query for single query", () => {
     const html = debugDetailsHtml({
       cacheStats: [],
-      queries: [{ durationMs: 5, sql: "SELECT 1" }],
+      queries: [{ durationMs: 5, sql: "SELECT 1", startedAtMs: 0 }],
       renderTimeMs: 20,
       uptimeSeconds: 0,
     });
     expect(html).toContain("1 query 5ms");
   });
 
-  test("shows render time breakdown with sql vs other", () => {
+  test("breakdown splits render into wall-clock sql and other", () => {
+    // Disjoint queries → wall-clock sql 50ms, leaving other 50ms of 100ms.
     const html = debugDetailsHtml({
       cacheStats: [],
       queries: [
-        { durationMs: 30, sql: "SELECT 1" },
-        { durationMs: 20, sql: "SELECT 2" },
+        { durationMs: 30, sql: "SELECT 1", startedAtMs: 0 },
+        { durationMs: 20, sql: "SELECT 2", startedAtMs: 30 },
       ],
       renderTimeMs: 100,
       uptimeSeconds: 0,
     });
     expect(html).toContain("sql 50.0ms");
     expect(html).toContain("other 50.0ms");
+  });
+
+  test("breakdown keeps other non-negative when queries overlap", () => {
+    // Durations sum to 60ms but only 35ms of wall-clock ([0,35]); without the
+    // union, other would be render − 60 = −10ms. With it, other is 5ms.
+    const html = debugDetailsHtml({
+      cacheStats: [],
+      queries: [
+        { durationMs: 30, sql: "SELECT 1", startedAtMs: 0 },
+        { durationMs: 30, sql: "SELECT 2", startedAtMs: 5 },
+      ],
+      renderTimeMs: 40,
+      uptimeSeconds: 0,
+    });
+    expect(html).toContain("sql 35.0ms");
+    expect(html).toContain("other 5.0ms");
+  });
+
+  test("reports total query work and the parallel factor", () => {
+    // 60ms of work folded into 35ms wall-clock → 60/35 ≈ 1.7×.
+    const html = debugDetailsHtml({
+      cacheStats: [],
+      queries: [
+        { durationMs: 30, sql: "SELECT 1", startedAtMs: 0 },
+        { durationMs: 30, sql: "SELECT 2", startedAtMs: 5 },
+      ],
+      renderTimeMs: 40,
+      uptimeSeconds: 0,
+    });
+    expect(html).toContain("60.0ms work across 2 queries");
+    expect(html).toContain("1.7&times; parallel");
+  });
+
+  test("reports a 1.0x parallel factor for sequential queries", () => {
+    const html = debugDetailsHtml({
+      cacheStats: [],
+      queries: [
+        { durationMs: 10, sql: "SELECT 1", startedAtMs: 0 },
+        { durationMs: 15, sql: "SELECT 2", startedAtMs: 20 },
+      ],
+      renderTimeMs: 50,
+      uptimeSeconds: 0,
+    });
+    expect(html).toContain("25.0ms work across 2 queries");
+    expect(html).toContain("1.0&times; parallel");
+  });
+
+  test("omits the SQL work line when there are no queries", () => {
+    const html = debugDetailsHtml({
+      cacheStats: [],
+      queries: [],
+      renderTimeMs: 10,
+      uptimeSeconds: 0,
+    });
+    expect(html).not.toContain("parallel");
   });
 
   test("shows cache stats section", () => {

--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -10,6 +10,7 @@ import {
   N_PLUS_ONE_THRESHOLD,
   runWithQueryLogContext,
   setN1GuardNotifyOnly,
+  sqlWallClockMs,
   trackQuery,
 } from "#shared/db/query-log.ts";
 // Preloaded so the guard's dynamic `import("#shared/logger.ts")` is a cache hit,
@@ -36,8 +37,8 @@ describe("query-log", () => {
     test("records entries when enabled", () => {
       runWithQueryLogContext(() => {
         enableQueryLog();
-        addQueryLogEntry("SELECT 1", 1.5);
-        addQueryLogEntry("SELECT 2", 2.3);
+        addQueryLogEntry("SELECT 1", 1.5, 100);
+        addQueryLogEntry("SELECT 2", 2.3, 200);
         const log = getQueryLog();
         expect(log).toHaveLength(2);
         expect(log[0]!.sql).toBe("SELECT 1");
@@ -47,9 +48,17 @@ describe("query-log", () => {
       });
     });
 
+    test("records the query start time for wall-clock math", () => {
+      runWithQueryLogContext(() => {
+        enableQueryLog();
+        addQueryLogEntry("SELECT 1", 1.5, 100);
+        expect(getQueryLog()[0]!.startedAtMs).toBe(100);
+      });
+    });
+
     test("ignores entries when disabled", () => {
       runWithQueryLogContext(() => {
-        addQueryLogEntry("SELECT 1", 1.0);
+        addQueryLogEntry("SELECT 1", 1.0, 0);
         expect(getQueryLog()).toHaveLength(0);
       });
     });
@@ -59,7 +68,7 @@ describe("query-log", () => {
     test("clears log on enable", () => {
       runWithQueryLogContext(() => {
         enableQueryLog();
-        addQueryLogEntry("SELECT old", 1.0);
+        addQueryLogEntry("SELECT old", 1.0, 0);
         expect(getQueryLog()).toHaveLength(1);
 
         enableQueryLog();
@@ -72,12 +81,58 @@ describe("query-log", () => {
     test("returned array is independent of internal state", () => {
       runWithQueryLogContext(() => {
         enableQueryLog();
-        addQueryLogEntry("SELECT 1", 1.0);
+        addQueryLogEntry("SELECT 1", 1.0, 0);
         const snapshot = getQueryLog();
-        addQueryLogEntry("SELECT 2", 2.0);
+        addQueryLogEntry("SELECT 2", 2.0, 1);
         expect(snapshot).toHaveLength(1);
         expect(getQueryLog()).toHaveLength(2);
       });
+    });
+  });
+
+  describe("sqlWallClockMs", () => {
+    const entry = (
+      startedAtMs: number,
+      durationMs: number,
+    ): {
+      sql: string;
+      durationMs: number;
+      startedAtMs: number;
+    } => ({ durationMs, sql: "SELECT 1", startedAtMs });
+
+    test("is zero with no queries", () => {
+      expect(sqlWallClockMs([])).toBe(0);
+    });
+
+    test("equals the duration of a single query", () => {
+      expect(sqlWallClockMs([entry(100, 5)])).toBe(5);
+    });
+
+    test("sums durations of disjoint (sequential) queries", () => {
+      // [100,105] then [200,210] never overlap → 5 + 10.
+      expect(sqlWallClockMs([entry(100, 5), entry(200, 10)])).toBe(15);
+    });
+
+    test("counts overlapping (concurrent) time only once", () => {
+      // [100,110] and [105,115] overlap → union is [100,115] = 15ms,
+      // not the 20ms a naive sum of durations would report.
+      expect(sqlWallClockMs([entry(100, 10), entry(105, 10)])).toBe(15);
+    });
+
+    test("counts one query fully contained in another only once", () => {
+      // [100,120] contains [105,110] → union stays 20ms.
+      expect(sqlWallClockMs([entry(100, 20), entry(105, 5)])).toBe(20);
+    });
+
+    test("counts a shared batch round-trip window once", () => {
+      // Batch statements share one [start, start+elapsed] window.
+      const batch = [entry(100, 10), entry(100, 10), entry(100, 10)];
+      expect(sqlWallClockMs(batch)).toBe(10);
+    });
+
+    test("merges intervals regardless of insertion order", () => {
+      // Entries are appended in completion order, so the helper must sort.
+      expect(sqlWallClockMs([entry(200, 10), entry(100, 5)])).toBe(15);
     });
   });
 
@@ -106,6 +161,22 @@ describe("query-log", () => {
         enableQueryLog();
         const second = getQueryLogStartTime();
         expect(second).toBeGreaterThanOrEqual(first);
+      });
+    });
+  });
+
+  describe("trackQuery recording", () => {
+    test("records duration and start time when logging is enabled", async () => {
+      await runWithQueryLogContext(async () => {
+        enableQueryLog();
+        const before = performance.now();
+        await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+        const after = performance.now();
+        const [logged] = getQueryLog();
+        expect(logged!.sql).toBe("SELECT 1");
+        expect(logged!.startedAtMs).toBeGreaterThanOrEqual(before);
+        expect(logged!.startedAtMs).toBeLessThanOrEqual(after);
+        expect(logged!.durationMs).toBeGreaterThanOrEqual(0);
       });
     });
   });


### PR DESCRIPTION
## The problem

You were right to be suspicious. The footer's `sql` and `other` times **always** added up to the total — but that was a tautology, not a property of the timings:

```ts
const totalSqlMs = sumDurations(queries);   // sum of each query's duration
const otherMs = renderTimeMs - totalSqlMs;  // defined as the remainder
// "Render: {render}ms (sql {totalSqlMs}ms + other {otherMs}ms)"
```

Because `other` was *defined* as `render − sqlSum`, `sql + other === render` could never be anything else. It told you nothing and couldn't reveal parallelism.

Worse, `totalSqlMs` was a **sum of durations**, which is not wall-clock SQL time whenever queries overlap — and they overlap constantly here:

- `src/features/admin/dashboard.ts` runs **4 reads in one `Promise.all`** — overlapping windows, but the sum counts all four in full.
- `trackedBatch` logged **every statement in a batch with the full batch elapsed**, so a 5-statement `queryBatch` taking 10ms was recorded as 5×10 = 50ms.

So `sql` overstated time-on-DB, `other` understated non-SQL time, and under enough overlap `other` could go **negative**.

## The fix

- Record each query's start time (`startedAtMs`) alongside its duration.
- Compute true wall-clock SQL time as the **union of the overlap-merged query intervals** (`sqlWallClockMs`). Concurrent reads and the shared round-trip of a batch are counted once.
- `other = render − sqlWall` is now an honest, always-non-negative split.
- The footer also shows the **summed work** and a **`work / wall` parallel factor**, so concurrency is now visible instead of hidden — e.g. the dashboard's four parallel reads show up as a >1× factor, and a 3-statement batch reads as `3.0× parallel`.

Example footer line, before vs after, for a render dominated by one 3-statement batch (elapsed 10ms, render 12ms):

```
before:  Render: 12.0ms (sql 30.0ms + other -18.0ms)
after:   Render: 12.0ms (sql 10.0ms + other 2.0ms)
         SQL: 30.0ms work across 3 queries, 3.0× parallel
```

## Tests

- New unit tests for `sqlWallClockMs` covering sequential, concurrent, fully-contained, batch (shared-window), and out-of-order intervals.
- `trackQuery` / `addQueryLogEntry` now assert the start time is recorded.
- Footer tests assert the summary/breakdown use wall-clock time, that `other` stays non-negative under overlap, and that the parallel factor renders (and is omitted when there are no queries).
- Full `deno task typecheck`, `deno task lint`, and the touched test files (incl. the real-request `owner-footer` integration tests and `db/client` batch path) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168xr2XL3wjb8847CKxmx35

---
_Generated by [Claude Code](https://claude.ai/code/session_0168xr2XL3wjb8847CKxmx35)_