### PR TITLE
Make jscpd failures tell the agent how to fix duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ The `.tool-versions` file is kept in sync for asdf-compatible tooling.
 ## Preferences
 
 - **Use FP methods**: Prefer curried functional utilities from `#fp` over imperative loops
+- **Zero code duplication**: jscpd runs at a non-negotiable 0% threshold. Fix duplication with a helper or currying — see [Code Duplication](#code-duplication). `jscpd:ignore` is reserved for import blocks, essentially nothing else.
 - **100% test coverage**: All code must have complete test coverage - run `deno coverage` to find uncovered lines/branches
 - **Trust application invariants**: Do not design normal code paths around database states the application says are impossible. If an impossible state is observed, raise it as an error and repair the data explicitly rather than silently accepting or normalising it.
 - **Select only needed columns**: Avoid `SELECT *` and broad "load every row" helpers — query the specific columns a caller actually uses. See [Database Queries](#database-queries).
@@ -92,6 +93,25 @@ the `pipe`-based code. Note `@std/collections` has **no** `groupBy` export
 | `chunk(size)`      | Split array into chunks (std chunk) |
 | `sumOf(selector)`  | Sum by selector (std sumOf)        |
 | `sum(arr)`         | Sum an array of numbers         |
+
+## Code Duplication
+
+`deno task cpd` (run as part of `deno task precommit`) runs jscpd with a **0%
+threshold — this is non-negotiable**. When it fails it prints this same
+guidance. Fix the duplication; do not silence it:
+
+1. **Write a helper.** This is the answer in ~99.999% of cases. If an obvious
+   shared function jumps out, extract it and call it from both sites.
+2. **No obvious helper? Curry.** Lift the parts that differ into arguments of a
+   function that returns the specialised version, then call it at each site.
+   **Then review your work before committing — zoom out one step further.** The
+   first small curry you reach for is often not the best one; a larger, more
+   holistic curry across the call sites is very frequently far better.
+3. **`jscpd:ignore` is the last resort.** It is excusable for basically *one*
+   thing: **import blocks** (plus the rare unavoidable scrap of
+   boilerplate/infrastructure we have no control over). If the duplicated code
+   is not an import block, you almost certainly want option 1 or 2 — an
+   `jscpd:ignore` tag anywhere else is a code smell, not a fix.
 
 ## Database Queries
 

--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,7 @@
     "lint": "deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts",
     "lint:ci": "deno run -A scripts/biome.ts check --error-on-warnings src test scripts",
     "typecheck": "deno check --unstable-tsgo src/**/*.ts src/**/*.tsx test/**/*.ts",
-    "cpd": "deno run -A npm:jscpd src --config .jscpd.json",
+    "cpd": "deno run -A scripts/cpd.ts src --config .jscpd.json",
     "precommit": "deno run -A scripts/precommit.ts",
     "find-unused-src": "deno run --allow-read scripts/find-unused-src.ts",
     "upgrade": "deno run --allow-read --allow-write --allow-net scripts/safe-upgrade.ts"

--- a/scripts/cpd.ts
+++ b/scripts/cpd.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S deno run --allow-all
+/**
+ * jscpd runner that prints actionable guidance when duplication is found.
+ *
+ * jscpd's own console report tells you *where* the duplication is, but not what
+ * to do about it. This wrapper runs jscpd unchanged and forwards every arg, then
+ * — only on a non-zero exit — appends a loud reminder of the project's
+ * non-negotiable 0% policy: extract a helper, or curry, and reserve
+ * `jscpd:ignore` for the one thing it is actually for (import blocks).
+ *
+ * Usage: deno run -A scripts/cpd.ts <jscpd args...>
+ */
+
+import { bold, red, yellow } from "./precommit/colors.ts";
+
+const { code } = await new Deno.Command("deno", {
+  args: ["run", "-A", "npm:jscpd", ...Deno.args],
+}).spawn().status;
+
+if (code !== 0) {
+  console.error(`
+${bold(red("━━━ jscpd: duplicated code found — the 0% threshold is non-negotiable ━━━"))}
+
+Do NOT reach for ${bold("/* jscpd:ignore */")} to silence this. Fix the duplication:
+
+  ${bold("1. Write a helper.")} This is the answer in ~99.999% of cases. If an
+     obvious shared function jumps out, extract it and call it from both sites.
+
+  ${bold("2. No obvious helper? Curry.")} Lift the parts that differ into
+     arguments of a function that returns the specialised version, then call it
+     at each site. ${yellow("Then review your work before committing")} — zoom out
+     one step further. The first small curry you reach for is often not the
+     best one; a larger, more holistic curry across the call sites is very
+     frequently far better.
+
+  ${bold("3. jscpd:ignore is the LAST resort.")} It is excusable for basically
+     ${bold("one")} thing: ${bold("import blocks")} (plus the rare unavoidable scrap of
+     boilerplate/infrastructure we have no control over). If the duplicated
+     code is not an import block, you almost certainly want option 1 or 2 — an
+     ignore tag anywhere else is a code smell, not a fix.
+`);
+}
+
+Deno.exit(code);


### PR DESCRIPTION
## What

A failed `deno task cpd` (jscpd) run previously printed only *where* the duplication was. Now it also prints a loud, prescriptive reminder of *how* to fix it, and the same guidance is documented in `AGENTS.md`.

## Why

The 0% duplication threshold is non-negotiable, but the bare jscpd report invites the wrong fix — reaching for `jscpd:ignore` to silence it. This makes the intended order of preference unmistakable to an agent reading the output.

## How

- **`scripts/cpd.ts`** — a thin wrapper (modelled on `scripts/biome.ts`) that forwards every arg to `npm:jscpd` unchanged and, **only on a non-zero exit**, appends guidance. Clean runs are completely untouched.
- **`deno.json`** — the `cpd` task now routes through the wrapper.
- **`AGENTS.md`** — new **Code Duplication** section plus a Preferences bullet, mirroring the runtime message.

The guidance, in order of preference:

1. **Write a helper** — the answer in ~99.999% of cases.
2. **No obvious helper? Curry** — then review and *zoom out one step further*, because the first small curry is often not the best; a larger, more holistic curry across the call sites is frequently far better.
3. **`jscpd:ignore` is the last resort** — excusable for essentially one thing: import blocks (and the rare unavoidable scrap of infrastructure we don't control). Anywhere else it's a code smell, not a fix.

## Verification

- `deno task cpd` on the clean tree → exit 0, **no** guidance printed (table shows 0 clones).
- Dropped a temporary duplicated file into `src/` → jscpd's own report prints first, then the new guidance, with exit code 1 propagated; temp file removed afterwards.
- `biome check --error-on-warnings scripts/cpd.ts` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152TqydCW7twdTSaRaaq6aC

---
_Generated by [Claude Code](https://claude.ai/code/session_0152TqydCW7twdTSaRaaq6aC)_