### PR TITLE
Alias listings table as `listing` instead of single-letter `e` in SQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ The `.tool-versions` file is kept in sync for asdf-compatible tooling.
 - **Use FP methods**: Prefer curried functional utilities from `#fp` over imperative loops
 - **100% test coverage**: All code must have complete test coverage - run `deno coverage` to find uncovered lines/branches
 - **Trust application invariants**: Do not design normal code paths around database states the application says are impossible. If an impossible state is observed, raise it as an error and repair the data explicitly rather than silently accepting or normalising it.
+- **SQL table aliases**: Alias tables with the full singular word using `AS`, not a single letter — write `FROM listings AS listing`, never `FROM listings e` (the `e` is a leftover from when listings were called "events"). When one query references the same table more than once (e.g. correlated subqueries that compare a row against its group), give each occurrence a descriptive word alias — `listing` for the row being checked, `groupListing` for sibling rows in its group.
 - **Final check**: Run `deno task precommit` (via `mise exec -- deno task precommit` when using the pinned toolchain) before finishing any job with code or documentation changes.
 
 ## FP Imports

--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -144,7 +144,7 @@ export const getListingWithActivityLog = async (
   const results = await queryBatch([
     {
       args: [listingId],
-      sql: `${LISTING_COUNT_SELECT} WHERE e.id = ? ${LISTING_COUNT_GROUP_BY}`,
+      sql: `${LISTING_COUNT_SELECT} WHERE listing.id = ? ${LISTING_COUNT_GROUP_BY}`,
     },
     {
       args: [listingId, limit],

--- a/src/shared/db/attendees/capacity.ts
+++ b/src/shared/db/attendees/capacity.ts
@@ -52,21 +52,21 @@ export const getGroupRemainingByGroupId = async (
   const range = date ? dateToRange(date) : null;
   const datedCount = date
     ? `COALESCE((
-        SELECT SUM(e.booked_quantity)
-          FROM listings e
-         WHERE e.group_id = g.id AND e.listing_type != 'daily'
+        SELECT SUM(listing.booked_quantity)
+          FROM listings AS listing
+         WHERE listing.group_id = g.id AND listing.listing_type != 'daily'
       ), 0) + COALESCE((
         SELECT SUM(ea.quantity)
           FROM listing_attendees ea
-          JOIN listings e ON e.id = ea.listing_id
-         WHERE e.group_id = g.id
-           AND e.listing_type = 'daily'
+          JOIN listings AS listing ON listing.id = ea.listing_id
+         WHERE listing.group_id = g.id
+           AND listing.listing_type = 'daily'
            AND ea.start_at < ? AND ea.end_at > ?
       ), 0)`
     : `COALESCE((
-        SELECT SUM(e.booked_quantity)
-          FROM listings e
-         WHERE e.group_id = g.id
+        SELECT SUM(listing.booked_quantity)
+          FROM listings AS listing
+         WHERE listing.group_id = g.id
       ), 0)`;
   const countArgs = range ? [range.endAt, range.startAt] : [];
   const rows = await queryAll<{
@@ -379,10 +379,10 @@ export const checkBatchAvailabilityImpl = async (
   const listingIds = map((i: BatchAvailabilityItem) => i.listingId)(items);
 
   const listingRows = await queryAll<ListingRow>(
-    `SELECT e.id, e.max_attendees, e.group_id, e.listing_type,
-            e.booked_quantity as attendee_count
-     FROM listings e
-     WHERE e.id IN (${inPlaceholders(listingIds)})`,
+    `SELECT listing.id, listing.max_attendees, listing.group_id, listing.listing_type,
+            listing.booked_quantity as attendee_count
+     FROM listings AS listing
+     WHERE listing.id IN (${inPlaceholders(listingIds)})`,
     listingIds,
   );
   const listingsById = new Map(listingRows.map((r) => [r.id, r]));
@@ -477,9 +477,9 @@ const groupPerDayRemainingByGroup = async (
   }>(
     `SELECT g.id, g.max_attendees,
             COALESCE((
-              SELECT SUM(e.booked_quantity)
-                FROM listings e
-               WHERE e.group_id = g.id AND e.listing_type != 'daily'
+              SELECT SUM(listing.booked_quantity)
+                FROM listings AS listing
+               WHERE listing.group_id = g.id AND listing.listing_type != 'daily'
             ), 0) AS base
        FROM groups g
      WHERE g.id IN (${inPlaceholders(ids)}) AND g.max_attendees > 0`,
@@ -490,11 +490,11 @@ const groupPerDayRemainingByGroup = async (
   const { startAt, endAt } = daySpan(days);
   type GroupRow = IntervalRow & { group_id: number };
   const rows = await queryAll<GroupRow>(
-    `SELECT e.group_id, ea.start_at, ea.end_at, ea.quantity
+    `SELECT listing.group_id, ea.start_at, ea.end_at, ea.quantity
      FROM listing_attendees ea
-     JOIN listings e ON e.id = ea.listing_id
-     WHERE e.group_id IN (${inPlaceholders(cappedIds)})
-       AND e.listing_type = 'daily'
+     JOIN listings AS listing ON listing.id = ea.listing_id
+     WHERE listing.group_id IN (${inPlaceholders(cappedIds)})
+       AND listing.listing_type = 'daily'
        AND ea.start_at < ? AND ea.end_at > ?`,
     [...cappedIds, endAt, startAt],
   );

--- a/src/shared/db/attendees/update.ts
+++ b/src/shared/db/attendees/update.ts
@@ -135,10 +135,10 @@ export const checkGroupCapAfterDurationChange = async (
     end_at: string | null;
     quantity: number;
   }>(
-    `SELECT ea.listing_id, e.listing_type, ea.start_at, ea.end_at, ea.quantity
+    `SELECT ea.listing_id, listing.listing_type, ea.start_at, ea.end_at, ea.quantity
      FROM listing_attendees ea
-     JOIN listings e ON e.id = ea.listing_id
-     WHERE e.group_id = ?`,
+     JOIN listings AS listing ON listing.id = ea.listing_id
+     WHERE listing.group_id = ?`,
     [groupId],
   );
 

--- a/src/shared/db/capacity.ts
+++ b/src/shared/db/capacity.ts
@@ -57,7 +57,7 @@ const buildDailyListingCountSql = (
     listingId,
   ],
   sql: `(SELECT CASE
-          WHEN e0.listing_type = 'daily' THEN (
+          WHEN listing.listing_type = 'daily' THEN (
             SELECT COALESCE(SUM(ea2.quantity), 0)
               FROM listing_attendees ea2
              WHERE ea2.listing_id = ? ${attendeeExclusionSql(
@@ -66,9 +66,9 @@ const buildDailyListingCountSql = (
              )}
                AND ea2.start_at < ? AND ea2.end_at > ?
           )
-          ELSE e0.booked_quantity
+          ELSE listing.booked_quantity
         END
-        FROM listings e0 WHERE e0.id = ?)`,
+        FROM listings AS listing WHERE listing.id = ?)`,
 });
 
 const buildUndatedListingCountSql = (
@@ -113,9 +113,9 @@ const buildDailyNonListingGroupExclusionSql = (
   return `- COALESCE((
           SELECT SUM(ea4.quantity)
             FROM listing_attendees ea4
-            JOIN listings e4 ON e4.id = ea4.listing_id
-           WHERE e4.group_id = ev.group_id
-             AND e4.listing_type != 'daily'
+            JOIN listings AS groupListing ON groupListing.id = ea4.listing_id
+           WHERE groupListing.group_id = listing.group_id
+             AND groupListing.listing_type != 'daily'
              AND ea4.attendee_id = ?
         ), 0)`;
 };
@@ -126,8 +126,8 @@ const buildUndatedGroupExclusionSql = (excludeAttendeeId?: number): string => {
   return `- COALESCE((
           SELECT SUM(ea3.quantity)
             FROM listing_attendees ea3
-            JOIN listings e3 ON e3.id = ea3.listing_id
-           WHERE e3.group_id = ev.group_id AND ea3.attendee_id = ?
+            JOIN listings AS groupListing ON groupListing.id = ea3.listing_id
+           WHERE groupListing.group_id = listing.group_id AND ea3.attendee_id = ?
         ), 0)`;
 };
 
@@ -142,17 +142,17 @@ const buildDailyGroupCountSql = (
     dayRange.startAt,
   ],
   sql: `(COALESCE((
-          SELECT SUM(e2.booked_quantity)
-            FROM listings e2
-           WHERE e2.group_id = ev.group_id AND e2.listing_type != 'daily'
+          SELECT SUM(groupListing.booked_quantity)
+            FROM listings AS groupListing
+           WHERE groupListing.group_id = listing.group_id AND groupListing.listing_type != 'daily'
         ), 0)
         ${buildDailyNonListingGroupExclusionSql(excludeAttendeeId)}
         + COALESCE((
           SELECT SUM(ea3.quantity)
             FROM listing_attendees ea3
-            JOIN listings e3 ON e3.id = ea3.listing_id
-           WHERE e3.group_id = ev.group_id
-             AND e3.listing_type = 'daily' ${attendeeExclusionSql(
+            JOIN listings AS groupListing ON groupListing.id = ea3.listing_id
+           WHERE groupListing.group_id = listing.group_id
+             AND groupListing.listing_type = 'daily' ${attendeeExclusionSql(
                "ea3",
                excludeAttendeeId,
              )}
@@ -165,9 +165,9 @@ const buildUndatedGroupCountSql = (
 ): SqlFragment => ({
   args: attendeeExclusionArgs(excludeAttendeeId),
   sql: `(COALESCE((
-          SELECT SUM(e2.booked_quantity)
-            FROM listings e2
-           WHERE e2.group_id = ev.group_id
+          SELECT SUM(groupListing.booked_quantity)
+            FROM listings AS groupListing
+           WHERE groupListing.group_id = listing.group_id
         ), 0)
         ${buildUndatedGroupExclusionSql(excludeAttendeeId)})`,
 });
@@ -206,14 +206,14 @@ const buildDayCapacitySql = (
   ) + ? <= (SELECT max_attendees FROM listings WHERE id = ?)
   AND (
     SELECT CASE
-      WHEN ev.group_id = 0 THEN 1
+      WHEN listing.group_id = 0 THEN 1
       WHEN COALESCE(g.max_attendees, 0) = 0 THEN 1
       WHEN ${groupCount.sql} + ? <= g.max_attendees THEN 1
       ELSE 0
     END
-    FROM listings ev
-    LEFT JOIN groups g ON g.id = ev.group_id
-    WHERE ev.id = ?
+    FROM listings AS listing
+    LEFT JOIN groups g ON g.id = listing.group_id
+    WHERE listing.id = ?
   ) = 1`;
 
   return {

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -110,8 +110,8 @@ const queryGroupListings = (
 ): Promise<ListingWithCount[]> =>
   queryListingsWithCounts(
     activeOnly
-      ? "WHERE e.active = 1 AND e.group_id = ?"
-      : "WHERE e.group_id = ?",
+      ? "WHERE listing.active = 1 AND listing.group_id = ?"
+      : "WHERE listing.group_id = ?",
     [groupId],
   );
 
@@ -164,7 +164,7 @@ export const validateGroupListingType = async (
  * Get ungrouped listings (group_id = 0) with attendee counts.
  */
 export const getUngroupedListings = (): Promise<ListingWithCount[]> =>
-  queryListingsWithCounts("WHERE e.group_id = 0");
+  queryListingsWithCounts("WHERE listing.group_id = 0");
 
 /**
  * Assign listings to a group by updating their group_id.

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -201,8 +201,8 @@ const rawListingsTable = defineIdTable<Listing, ListingInput>("listings", {
  * so the count source lives in one place. The count reads the precomputed
  * `booked_quantity` column (maintained by triggers on listing_attendees), so
  * this no longer joins or scans the attendee rows. */
-export const LISTING_COUNT_SELECT = `SELECT e.*, e.booked_quantity AS attendee_count
-     FROM listings e`;
+export const LISTING_COUNT_SELECT = `SELECT listing.*, listing.booked_quantity AS attendee_count
+     FROM listings AS listing`;
 
 /** GROUP BY clause that pairs with {@link LISTING_COUNT_SELECT}. Empty now that
  * the count comes from a column rather than an aggregate over a join. */
@@ -241,7 +241,7 @@ export const queryListingsWithCounts = async (
   args: InValue[] = [],
 ): Promise<ListingWithCount[]> => {
   const rows = await queryAll<ListingWithCount>(
-    `${LISTING_COUNT_SELECT} ${whereClause} ${LISTING_COUNT_GROUP_BY} ORDER BY e.created DESC, e.id DESC`,
+    `${LISTING_COUNT_SELECT} ${whereClause} ${LISTING_COUNT_GROUP_BY} ORDER BY listing.created DESC, listing.id DESC`,
     args,
   );
   return mapParallel(decryptListingWithCount)(rows);
@@ -275,10 +275,10 @@ const listingsEntity = cachedEntityTable<
   rawListingsTable,
   {
     fetchAll: () => queryListingsWithCounts(),
-    fetchById: (id) => queryOneListingWithCount("e.id = ?", [id]),
+    fetchById: (id) => queryOneListingWithCount("listing.id = ?", [id]),
     fetchByKeys: (slugIndexes) =>
       queryListingsWithCounts(
-        `WHERE e.slug_index IN (${inPlaceholders(slugIndexes)})`,
+        `WHERE listing.slug_index IN (${inPlaceholders(slugIndexes)})`,
         slugIndexes,
       ),
     idOf: (e) => e.id,
@@ -513,8 +513,8 @@ export const getDailyListingAttendeeDates = async (): Promise<string[]> => {
   // filtering on both being non-null lets the row type stay honestly non-null.
   const rows = await queryAll<{ start_at: string; end_at: string }>(
     `SELECT DISTINCT ea.start_at, ea.end_at FROM listing_attendees ea
-     INNER JOIN listings e ON ea.listing_id = e.id
-     WHERE e.listing_type = 'daily'
+     INNER JOIN listings AS listing ON ea.listing_id = listing.id
+     WHERE listing.listing_type = 'daily'
        AND ea.start_at IS NOT NULL AND ea.end_at IS NOT NULL`,
   );
   // Expand each booking's [start_at, end_at) span into every calendar date it
@@ -546,8 +546,8 @@ export const getDailyListingAttendeesByDate = (
     `SELECT ${ATTENDEE_JOIN_SELECT}
      FROM attendees a
      JOIN listing_attendees ea ON ea.attendee_id = a.id
-     JOIN listings e ON ea.listing_id = e.id
-     WHERE e.listing_type = 'daily' AND ea.start_at < ? AND ea.end_at > ?
+     JOIN listings AS listing ON ea.listing_id = listing.id
+     WHERE listing.listing_type = 'daily' AND ea.start_at < ? AND ea.end_at > ?
      ORDER BY a.created DESC`,
     [endAt, startAt],
   );

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -178,8 +178,8 @@ export const getModifierGroupListingIds = (
   modifierId: number,
 ): Promise<number[]> =>
   modifierIdColumn(
-    `SELECT e.id FROM listings e
-       JOIN modifier_groups mg ON mg.group_id = e.group_id
+    `SELECT listing.id FROM listings AS listing
+       JOIN modifier_groups mg ON mg.group_id = listing.group_id
      WHERE mg.modifier_id = ?`,
     modifierId,
   );


### PR DESCRIPTION
## What

`listings` used to be called "events", which left a confusing single-letter
`e` alias scattered across the SQL. This replaces it with the full word
`listing` everywhere, so queries read `FROM listings AS listing` / `listing.col`
instead of `FROM listings e` / `e.col`.

## Files changed

- `src/shared/db/listings.ts` — `LISTING_COUNT_SELECT`, `queryListingsWithCounts`
  ordering, cache fetchers, daily-listing date/attendee queries
- `src/shared/db/groups.ts` — group / ungrouped WHERE clauses
- `src/shared/db/modifiers.ts` — modifier → group listing ids
- `src/shared/db/activityLog.ts` — listing-with-activity-log query
- `src/shared/db/attendees/update.ts` — group-cap-after-duration-change query
- `src/shared/db/attendees/capacity.ts` — group remaining / batch availability queries
- `src/shared/db/capacity.ts` — atomic capacity-check builders (see note below)
- `AGENTS.md` — documents the full-word table-alias convention

## Note on `capacity.ts`

That file's queries reference the `listings` table more than once inside
**correlated subqueries** — a row is compared against the other listings in
its group. Collapsing every alias to `listing` would shadow the outer
reference and silently break the correlation. So the row being checked is
`listing` and its in-group siblings are `groupListing`, keeping
`groupListing.group_id = listing.group_id` correct. (These were the numbered
`e0`/`e2`/`e3`/`e4`/`ev` aliases before.)

Purely a rename — no behaviour change, no schema change.

## Verification

Run in isolation: `lint` ✅ · `typecheck` ✅ · `cpd` ✅ (0 clones) ·
`build:edge` ✅ · `test:coverage` ✅ (full suite + 100% line/branch coverage).
The capacity/group-cap correlation cases — "group cart with mismatched
durations rejects", "concurrent at-capacity multi-day bookings — only one
wins", and atomic-edit capacity rejections — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUaxZMVpWwEuzQ167R87mT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUaxZMVpWwEuzQ167R87mT)_