### PR TITLE
Fix cookie-authenticated calendar feed GETs failing CSRF

### DIFF
--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -447,12 +447,23 @@ export const authFailure = (
   reason: AuthFailureReason,
 ): Response => AUTH_FAILURES[reason][channel]();
 
+/**
+ * Safe HTTP methods (RFC 7231 §4.2.1): read-only, so a request using one cannot
+ * mutate state and carries no body. Such requests need no CSRF token — CSRF
+ * defends state-changing submissions, and cross-origin reads of the response are
+ * already blocked by the Same-Origin Policy. This lets cookie-authenticated
+ * calendar clients fetch GET /caldav/events.ics without an x-csrf-token header
+ * they have no way to attach.
+ */
+const isSafeMethod = (request: Request): boolean =>
+  request.method === "GET" || request.method === "HEAD";
+
 /** Parse JSON body, returning empty object for non-JSON GET/HEAD requests */
 const parseJsonBody = async (
   request: Request,
 ): Promise<Record<string, unknown> | Response> => {
   const contentType = (request.headers.get("content-type") ?? "").toLowerCase();
-  const bodyRequired = request.method !== "GET" && request.method !== "HEAD";
+  const bodyRequired = !isSafeMethod(request);
 
   if (!contentType.includes("application/json")) {
     if (bodyRequired) {
@@ -493,6 +504,9 @@ const verifyCsrf = async (
  *
  * `skipCsrf` only applies to JSON bodies (used for API key auth). Form and
  * multipart bodies are always CSRF-checked because API key clients use JSON.
+ * Safe-method (GET/HEAD) JSON requests also skip CSRF: they cannot mutate state,
+ * so the token is moot — this keeps read-only JSON routes (e.g. the calendar
+ * feed) reachable by cookie sessions that can't send an x-csrf-token header.
  * `maxAge` overrides the CSRF token expiry window (seconds). */
 const parseCsrfBody = async (
   request: Request,
@@ -502,7 +516,7 @@ const parseCsrfBody = async (
 ): Promise<FormParams | FormData | Record<string, unknown> | Response> => {
   const channel = channelFor(mode);
   if (mode === "json") {
-    if (!skipCsrf) {
+    if (!skipCsrf && !isSafeMethod(request)) {
       const err = await verifyCsrf(
         request.headers.get("x-csrf-token") ?? "",
         channel,

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -698,17 +698,24 @@ describeWithEnv("API Keys", { db: true }, () => {
       expect(response.status).toBe(401);
     });
 
-    test("GET /api/admin/listings returns 401 for cookie without CSRF header", async () => {
+    test("GET /api/admin/listings serves a cookie without a CSRF header", async () => {
       await createTestListing({ name: "CSRF Listing" });
       const cookie = await testCookie();
 
-      const response = await handleRequest(
-        mockRequest("/api/admin/listings", {
-          headers: { cookie },
-        }),
+      // A safe GET carries no body and can't mutate state, so a cookie session
+      // need not (and a feed/browser client often cannot) send an x-csrf-token
+      // header to read a JSON endpoint.
+      await assertJson(
+        handleRequest(
+          mockRequest("/api/admin/listings", {
+            headers: { cookie },
+          }),
+        ),
+        200,
+        (body) => {
+          expect(body.listings).toBeDefined();
+        },
       );
-
-      expect(response.status).toBe(403);
     });
 
     test("request succeeds when touchApiKeyLastUsed fails (fire-and-forget)", async () => {

--- a/test/lib/server-feeds.test.ts
+++ b/test/lib/server-feeds.test.ts
@@ -429,10 +429,43 @@ describeWithEnv("calendar attendee feeds", { db: true }, () => {
     expect(response.status).toBe(404);
   });
 
-  test("requires an API key when enabled", async () => {
+  test("rejects unauthenticated requests when enabled", async () => {
     await settings.update.calendarFeedsEnabled(true);
     const response = await handleRequest(mockRequest("/caldav/events.ics"));
     expect(response.status).toBe(401);
+  });
+
+  test("serves a cookie session without a CSRF header", async () => {
+    const { getTestSession } = await import("#test-utils/session.ts");
+    const { createTestAttendee } = await import("#test-utils/db-helpers.ts");
+    await settings.update.calendarFeedsEnabled(true);
+    await settings.update.calendarFeedsGroupBy("attendees");
+    const listing = await createTestListing({
+      date: "2026-08-01T09:30",
+      maxAttendees: 10,
+      name: "Cookie Show",
+    });
+    await createTestAttendee(
+      listing.id,
+      listing.slug,
+      "Cookie Person",
+      "cookie@test.com",
+    );
+
+    // A calendar client subscribing to the feed sends its session cookie but
+    // cannot attach an x-csrf-token header, so this safe GET must not demand
+    // one — otherwise the feed is unusable from a browser/calendar session.
+    const { cookie } = await getTestSession();
+    const response = await handleRequest(
+      mockRequest("/caldav/events.ics", { headers: { cookie } }),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/calendar; charset=utf-8",
+    );
+    expect(body).toContain("SUMMARY:Cookie Person");
   });
 
   test("returns attendee-grouped events for API keys", async () => {


### PR DESCRIPTION
## Problem

`GET /caldav/events.ics` (wired to `buildCalendarFeed`) authenticates with `withAuth` using `{ allowApiKey: true, body: "json", roles: [...] }`.

`withAuth` only skips the `x-csrf-token` check when the request authenticates via **API key**. For a normal logged-in **cookie** session, `parseCsrfBody` still enforced an `x-csrf-token` header on every JSON-mode request before parsing the body — even though `parseJsonBody` already treats GET/HEAD as bodyless (returns `{}`).

The result: cookie-authenticated `GET /caldav/events.ics` requests with no CSRF header were rejected with `403` before reaching the feed builder. That made the feed unusable for the most likely browser/session path and for calendar subscribers that can send cookies but cannot attach a CSRF header — the route was effectively API-key-only despite the settings UI advertising it.

This affected **every** read-only JSON route under cookie auth, not just the calendar feed.

## Fix

CSRF defends *state-changing* submissions. A safe method (`GET`/`HEAD`) cannot mutate state, and the Same-Origin Policy already blocks cross-origin reads of the response, so a CSRF token is moot. `parseCsrfBody` now skips the CSRF check for safe-method JSON requests, via a shared `isSafeMethod` helper that also drives `parseJsonBody`'s bodyless handling (no duplicated GET/HEAD check).

State-changing requests (`POST`/`PUT`/`DELETE`) still require CSRF exactly as before — the scanner's "403 when `x-csrf-token` header is absent" test (a POST) and the cookie-auth malformed-JSON POST tests remain green.

## Tests

- Added: cookie GET of `/caldav/events.ics` with no CSRF header returns `200` with the expected events (verified to fail with `403` before the fix).
- Added: cookie GET of `/api/admin/listings` with no CSRF header returns `200`.
- Updated: the `api-keys` test that codified the old `403` behaviour now asserts the corrected success path.
- Renamed the feed's unauthenticated-access test for accuracy (the route is no longer API-key-only).

`deno task precommit` passes (lint, typecheck, cpd at 0%, build:edge, full test suite with 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhTw8V4iXCuuofYQrJHz6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhTw8V4iXCuuofYQrJHz6J)_