### PR TITLE
Migrate timezone/date utilities to Temporal (bundled polyfill)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -62,6 +62,7 @@
     "fflate": "npm:fflate@^0.8.2",
     "auto-console-group": "npm:auto-console-group@^1.3.0",
     "valibot": "npm:valibot@^1.4.1",
+    "temporal-polyfill": "npm:temporal-polyfill@^0.3.0",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/collections": "jsr:@std/collections@^1.2.0",
     "@std/expect": "jsr:@std/expect@^1.0.18",

--- a/deno.json
+++ b/deno.json
@@ -49,7 +49,6 @@
     "esbuild": "npm:esbuild@^0.28.0",
     "sass": "npm:sass@^1.101.0",
     "@bunny.net/edgescript-sdk": "npm:@bunny.net/edgescript-sdk@^0.12.1",
-    "@internationalized/date": "npm:@internationalized/date@^3.12.0",
     "@bunny.net/storage-sdk": "npm:@bunny.net/storage-sdk@^0.3.1",
     "@botpoison/browser": "npm:@botpoison/browser@^0.1.30",
     "jsqr": "npm:jsqr@^1.4.0",

--- a/deno.lock
+++ b/deno.lock
@@ -34,6 +34,7 @@
     "npm:@iframe-resizer/child@^5.5.9": "5.5.9",
     "npm:@iframe-resizer/core@^5.5.9": "5.5.9",
     "npm:@iframe-resizer/parent@^5.5.9": "5.5.9",
+    "npm:@internationalized/date@^3.12.0": "3.12.2",
     "npm:@libsql/client@0.17.2": "0.17.2",
     "npm:@libsql/client@~0.17.2": "0.17.2",
     "npm:@sendgrid/mail@*": "8.1.6",
@@ -458,6 +459,12 @@
         "auto-console-group"
       ]
     },
+    "@internationalized/date@3.12.2": {
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "dependencies": [
+        "@swc/helpers"
+      ]
+    },
     "@jscpd/badge-reporter@4.0.4": {
       "integrity": "sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==",
       "dependencies": [
@@ -715,6 +722,12 @@
     },
     "@sumup/sdk@0.1.6": {
       "integrity": "sha512-7uCcP2vTz9FOcmGl8mTXe6V83AdwbGNQiVUuK7c2Ezh7JLpuNK2vZcch/9YD7cuM7Ge6Spbb8OBMCo6LzKUtzA=="
+    },
+    "@swc/helpers@0.5.23": {
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dependencies": [
+        "tslib"
+      ]
     },
     "@types/node@25.5.2": {
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",

--- a/deno.lock
+++ b/deno.lock
@@ -34,7 +34,6 @@
     "npm:@iframe-resizer/child@^5.5.9": "5.5.9",
     "npm:@iframe-resizer/core@^5.5.9": "5.5.9",
     "npm:@iframe-resizer/parent@^5.5.9": "5.5.9",
-    "npm:@internationalized/date@^3.12.0": "3.12.0",
     "npm:@libsql/client@0.17.2": "0.17.2",
     "npm:@libsql/client@~0.17.2": "0.17.2",
     "npm:@sendgrid/mail@*": "8.1.6",
@@ -459,12 +458,6 @@
         "auto-console-group"
       ]
     },
-    "@internationalized/date@3.12.0": {
-      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
-      "dependencies": [
-        "@swc/helpers"
-      ]
-    },
     "@jscpd/badge-reporter@4.0.4": {
       "integrity": "sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==",
       "dependencies": [
@@ -722,12 +715,6 @@
     },
     "@sumup/sdk@0.1.6": {
       "integrity": "sha512-7uCcP2vTz9FOcmGl8mTXe6V83AdwbGNQiVUuK7c2Ezh7JLpuNK2vZcch/9YD7cuM7Ge6Spbb8OBMCo6LzKUtzA=="
-    },
-    "@swc/helpers@0.5.21": {
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "dependencies": [
-        "tslib"
-      ]
     },
     "@types/node@25.5.2": {
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
@@ -1714,7 +1701,6 @@
       "npm:@iframe-resizer/child@^5.5.9",
       "npm:@iframe-resizer/core@^5.5.9",
       "npm:@iframe-resizer/parent@^5.5.9",
-      "npm:@internationalized/date@^3.12.0",
       "npm:@libsql/client@~0.17.2",
       "npm:@sumup/sdk@~0.1.6",
       "npm:auto-console-group@^1.3.0",

--- a/deno.lock
+++ b/deno.lock
@@ -34,7 +34,6 @@
     "npm:@iframe-resizer/child@^5.5.9": "5.5.9",
     "npm:@iframe-resizer/core@^5.5.9": "5.5.9",
     "npm:@iframe-resizer/parent@^5.5.9": "5.5.9",
-    "npm:@internationalized/date@^3.12.0": "3.12.2",
     "npm:@libsql/client@0.17.2": "0.17.2",
     "npm:@libsql/client@~0.17.2": "0.17.2",
     "npm:@sendgrid/mail@*": "8.1.6",
@@ -54,6 +53,7 @@
     "npm:resend@*": "6.12.4",
     "npm:sass@^1.101.0": "1.101.0",
     "npm:stripe@^22.0.1": "22.1.0",
+    "npm:temporal-polyfill@0.3": "0.3.2",
     "npm:uqr@~0.1.3": "0.1.3",
     "npm:valibot@*": "1.4.1",
     "npm:valibot@^1.4.1": "1.4.1"
@@ -459,12 +459,6 @@
         "auto-console-group"
       ]
     },
-    "@internationalized/date@3.12.2": {
-      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
-      "dependencies": [
-        "@swc/helpers"
-      ]
-    },
     "@jscpd/badge-reporter@4.0.4": {
       "integrity": "sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==",
       "dependencies": [
@@ -722,12 +716,6 @@
     },
     "@sumup/sdk@0.1.6": {
       "integrity": "sha512-7uCcP2vTz9FOcmGl8mTXe6V83AdwbGNQiVUuK7c2Ezh7JLpuNK2vZcch/9YD7cuM7Ge6Spbb8OBMCo6LzKUtzA=="
-    },
-    "@swc/helpers@0.5.23": {
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "dependencies": [
-        "tslib"
-      ]
     },
     "@types/node@25.5.2": {
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
@@ -1594,6 +1582,15 @@
     "supports-preserve-symlinks-flag@1.0.0": {
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "temporal-polyfill@0.3.2": {
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "dependencies": [
+        "temporal-spec"
+      ]
+    },
+    "temporal-spec@0.3.1": {
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw=="
+    },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": [
@@ -1726,6 +1723,7 @@
       "npm:node-forge@^1.4.0",
       "npm:sass@^1.101.0",
       "npm:stripe@^22.0.1",
+      "npm:temporal-polyfill@0.3",
       "npm:uqr@~0.1.3",
       "npm:valibot@^1.4.1"
     ]

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -2,7 +2,6 @@
  * Date computation for daily listings
  */
 
-import { fromAbsolute } from "@internationalized/date";
 import { filter } from "#fp";
 import { settings } from "#shared/db/settings.ts";
 import {
@@ -10,6 +9,7 @@ import {
   formatDatetimeShortInTz,
   localToUtc,
   todayInTz,
+  utcToZoned,
 } from "#shared/timezone.ts";
 import {
   type Holiday,
@@ -449,14 +449,9 @@ export const formatTimeAgo = (
  * Used by the calendar view to map standard listing dates to calendar days.
  */
 export const listingDateToCalendarDate = (utcIso: string): string | null => {
-  const tz = settings.timezone;
   if (!utcIso) return null;
   try {
-    const ms = new Date(utcIso).getTime();
-    if (Number.isNaN(ms)) return null;
-    const zoned = fromAbsolute(ms, tz);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return `${zoned.year}-${pad(zoned.month)}-${pad(zoned.day)}`;
+    return utcToZoned(utcIso, settings.timezone).toPlainDate().toString();
   } catch {
     return null;
   }

--- a/src/shared/timezone.ts
+++ b/src/shared/timezone.ts
@@ -1,17 +1,10 @@
 /**
- * Timezone conversion utilities using @internationalized/date.
+ * Timezone conversion utilities built on the standard Temporal API.
  *
- * Wraps the library to provide simple string-in/string-out functions
- * for the rest of the codebase, with correct DST handling and
- * explicit disambiguation.
+ * Provides simple string-in/string-out functions for the rest of the
+ * codebase, with correct DST handling and explicit disambiguation.
  */
 
-import {
-  fromAbsolute,
-  today as libToday,
-  parseDateTime,
-  toZoned,
-} from "@internationalized/date";
 import { formatIsoForPreview } from "#shared/bulk-replace.ts";
 
 /** Default timezone when none is configured */
@@ -21,13 +14,19 @@ export const DEFAULT_TIMEZONE = "Europe/London";
 const pad2 = (n: number): string => String(n).padStart(2, "0");
 
 /** Parse a UTC ISO string into a ZonedDateTime in the given timezone */
-const utcToZoned = (utcIso: string, tz: string) =>
-  fromAbsolute(new Date(utcIso).getTime(), tz);
+export const utcToZoned = (
+  utcIso: string,
+  tz: string,
+): Temporal.ZonedDateTime =>
+  Temporal.Instant.fromEpochMilliseconds(
+    new Date(utcIso).getTime(),
+  ).toZonedDateTimeISO(tz);
 
 /**
  * Get today's date as YYYY-MM-DD in the given timezone.
  */
-export const todayInTz = (tz: string): string => libToday(tz).toString();
+export const todayInTz = (tz: string): string =>
+  Temporal.Now.plainDateISO(tz).toString();
 
 /**
  * Convert a naive datetime-local value (YYYY-MM-DDTHH:MM) to a UTC ISO string,
@@ -35,12 +34,15 @@ export const todayInTz = (tz: string): string => libToday(tz).toString();
  *
  * Uses 'compatible' disambiguation: spring-forward gaps resolve to the later
  * (post-transition) time; fall-back overlaps resolve to the earlier occurrence.
+ * `overflow: "reject"` rejects impossible calendar dates (e.g. 2026-02-30)
+ * rather than silently clamping them.
  */
 export const localToUtc = (naive: string, tz: string): string => {
   try {
-    const dt = parseDateTime(naive);
-    const zoned = toZoned(dt, tz, "compatible");
-    return zoned.toAbsoluteString();
+    return Temporal.PlainDateTime.from(naive, { overflow: "reject" })
+      .toZonedDateTime(tz, { disambiguation: "compatible" })
+      .toInstant()
+      .toString({ fractionalSecondDigits: 3 });
   } catch {
     throw new Error(`Invalid datetime: ${naive}`);
   }
@@ -107,7 +109,7 @@ export const isValidTimezone = (tz: string): boolean => {
  */
 export const isValidDatetime = (value: string): boolean => {
   try {
-    parseDateTime(value);
+    Temporal.PlainDateTime.from(value, { overflow: "reject" });
     return true;
   } catch {
     return false;

--- a/src/shared/timezone.ts
+++ b/src/shared/timezone.ts
@@ -29,17 +29,37 @@ export const todayInTz = (tz: string): string =>
   Temporal.Now.plainDateISO(tz).toString();
 
 /**
+ * Strict datetime-local shape: a calendar date optionally followed by a
+ * wall-clock time. Deliberately excludes any UTC designator (`Z`), numeric
+ * offset, or bracketed IANA zone — the rest of the app interprets these values
+ * in the configured timezone, and `Temporal.PlainDateTime.from` would silently
+ * *discard* such a suffix rather than reject it, storing a different instant.
+ */
+const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?)?$/;
+
+/**
+ * Parse a naive datetime-local value into a PlainDateTime, rejecting
+ * offset/zone-bearing input up front, then delegating real calendar-validity
+ * checks to Temporal (`overflow: "reject"` catches impossible dates like
+ * 2026-02-30 rather than silently clamping them).
+ */
+const parseNaiveDateTime = (value: string): Temporal.PlainDateTime => {
+  if (!NAIVE_DATETIME.test(value)) {
+    throw new RangeError(`Non-naive datetime: ${value}`);
+  }
+  return Temporal.PlainDateTime.from(value, { overflow: "reject" });
+};
+
+/**
  * Convert a naive datetime-local value (YYYY-MM-DDTHH:MM) to a UTC ISO string,
  * interpreting the value as local time in the given timezone.
  *
  * Uses 'compatible' disambiguation: spring-forward gaps resolve to the later
  * (post-transition) time; fall-back overlaps resolve to the earlier occurrence.
- * `overflow: "reject"` rejects impossible calendar dates (e.g. 2026-02-30)
- * rather than silently clamping them.
  */
 export const localToUtc = (naive: string, tz: string): string => {
   try {
-    return Temporal.PlainDateTime.from(naive, { overflow: "reject" })
+    return parseNaiveDateTime(naive)
       .toZonedDateTime(tz, { disambiguation: "compatible" })
       .toInstant()
       .toString({ fractionalSecondDigits: 3 });
@@ -109,7 +129,7 @@ export const isValidTimezone = (tz: string): boolean => {
  */
 export const isValidDatetime = (value: string): boolean => {
   try {
-    Temporal.PlainDateTime.from(value, { overflow: "reject" });
+    parseNaiveDateTime(value);
     return true;
   } catch {
     return false;

--- a/src/shared/timezone.ts
+++ b/src/shared/timezone.ts
@@ -43,11 +43,20 @@ export const todayInTz = (tz: string): string =>
 /**
  * Strict datetime-local shape: a calendar date optionally followed by a
  * wall-clock time. Deliberately excludes any UTC designator (`Z`), numeric
- * offset, or bracketed IANA zone — the rest of the app interprets these values
- * in the configured timezone, and `Temporal.PlainDateTime.from` would silently
- * *discard* such a suffix rather than reject it, storing a different instant.
+ * offset, or bracketed IANA zone, since the rest of the app interprets these
+ * values in the configured timezone. `Temporal.PlainDateTime.from` handles
+ * those suffixes inconsistently — it *rejects* a `Z` but silently *discards* a
+ * numeric offset or bracketed zone (storing a different instant than written) —
+ * so the regex rejects all three up front rather than relying on that.
+ *
+ * The time fields are range-constrained (`HH` 00–23, `MM`/`SS` 00–59) rather
+ * than bare `\d{2}`: Temporal rejects an out-of-range hour/minute, but it
+ * *clamps* a `:60` leap second to `:59` even under `overflow: "reject"`, which
+ * would silently shift the stored time. The regex rejects it instead. Calendar
+ * validity (real month/day) is still delegated to Temporal's `overflow`.
  */
-const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?)?$/;
+const NAIVE_DATETIME =
+  /^\d{4}-\d{2}-\d{2}(T([01]\d|2[0-3]):[0-5]\d(:[0-5]\d(\.\d+)?)?)?$/;
 
 /**
  * Parse a naive datetime-local value into a PlainDateTime, rejecting

--- a/src/shared/timezone.ts
+++ b/src/shared/timezone.ts
@@ -1,10 +1,17 @@
 /**
- * Timezone conversion utilities built on the standard Temporal API.
+ * Timezone conversion utilities built on the Temporal API.
+ *
+ * Temporal is imported from `temporal-polyfill` rather than used as a runtime
+ * global: the deployed Bunny Edge bundle must run on whichever Deno the edge
+ * happens to use, and Deno only exposes `Temporal` as a stable global from
+ * 2.7+. Bundling the polyfill keeps behaviour identical across runtimes (and
+ * in tests) instead of depending on an API the baseline runtime lacks.
  *
  * Provides simple string-in/string-out functions for the rest of the
  * codebase, with correct DST handling and explicit disambiguation.
  */
 
+import { Temporal } from "temporal-polyfill";
 import { formatIsoForPreview } from "#shared/bulk-replace.ts";
 
 /** Default timezone when none is configured */

--- a/src/shared/timezone.ts
+++ b/src/shared/timezone.ts
@@ -13,20 +13,25 @@ export const DEFAULT_TIMEZONE = "Europe/London";
 /** Pad a number to two digits */
 const pad2 = (n: number): string => String(n).padStart(2, "0");
 
+/** Convert epoch milliseconds to a ZonedDateTime in the given timezone */
+const msToZoned = (ms: number, tz: string): Temporal.ZonedDateTime =>
+  Temporal.Instant.fromEpochMilliseconds(ms).toZonedDateTimeISO(tz);
+
 /** Parse a UTC ISO string into a ZonedDateTime in the given timezone */
 export const utcToZoned = (
   utcIso: string,
   tz: string,
-): Temporal.ZonedDateTime =>
-  Temporal.Instant.fromEpochMilliseconds(
-    new Date(utcIso).getTime(),
-  ).toZonedDateTimeISO(tz);
+): Temporal.ZonedDateTime => msToZoned(new Date(utcIso).getTime(), tz);
 
 /**
  * Get today's date as YYYY-MM-DD in the given timezone.
+ *
+ * Reads the clock via `Date.now()` rather than `Temporal.Now` so the helper
+ * stays controllable under `@std/testing/time`'s `FakeTime`, which patches
+ * `Date`/timers but not `Temporal.Now`.
  */
 export const todayInTz = (tz: string): string =>
-  Temporal.Now.plainDateISO(tz).toString();
+  msToZoned(Date.now(), tz).toPlainDate().toString();
 
 /**
  * Strict datetime-local shape: a calendar date optionally followed by a

--- a/test/lib/timezone.test.ts
+++ b/test/lib/timezone.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import {
   DEFAULT_TIMEZONE,
   formatDatetimeInTz,
@@ -32,6 +33,18 @@ describe("timezone", () => {
       const a = todayInTz("UTC");
       const b = todayInTz("UTC");
       expect(a).toBe(b);
+    });
+
+    test("is controllable under FakeTime (reads the fakeable clock)", () => {
+      // Temporal.Now bypasses FakeTime; todayInTz must derive "today" from
+      // Date.now() so date-dependent code stays deterministic in frozen-time
+      // tests (booking windows, holiday cutoffs, calendar/delivery pages).
+      const time = new FakeTime(new Date("2030-01-15T12:00:00Z"));
+      try {
+        expect(todayInTz("Europe/London")).toBe("2030-01-15");
+      } finally {
+        time.restore();
+      }
     });
   });
 

--- a/test/lib/timezone.test.ts
+++ b/test/lib/timezone.test.ts
@@ -84,6 +84,27 @@ describe("timezone", () => {
       expect(() => localToUtc("not-a-date", "UTC")).toThrow("Invalid datetime");
     });
 
+    test("rejects a datetime carrying a numeric offset", () => {
+      // Input must be naive: an offset would otherwise be silently discarded
+      // and the wall-clock time reinterpreted in the target timezone, storing
+      // a different instant than the string implies.
+      expect(() =>
+        localToUtc("2026-06-15T14:30+09:00", "Europe/London"),
+      ).toThrow("Invalid datetime");
+    });
+
+    test("rejects a datetime carrying a bracketed IANA zone", () => {
+      expect(() =>
+        localToUtc("2026-06-15T14:30[Asia/Tokyo]", "Europe/London"),
+      ).toThrow("Invalid datetime");
+    });
+
+    test("rejects a datetime carrying a UTC designator", () => {
+      expect(() => localToUtc("2026-06-15T14:30Z", "Europe/London")).toThrow(
+        "Invalid datetime",
+      );
+    });
+
     test("handles DST spring-forward gap with 'compatible' disambiguation", () => {
       // 2026-03-29 01:30 Europe/London doesn't exist (clocks skip from 01:00 GMT to 02:00 BST)
       // 'compatible' maps to the later (post-transition) interpretation: 02:30 BST = 01:30 UTC
@@ -252,6 +273,19 @@ describe("timezone", () => {
 
     test("rejects empty string", () => {
       expect(isValidDatetime("")).toBe(false);
+    });
+
+    test("rejects an impossible calendar date", () => {
+      // overflow: "reject" must not clamp 2026-02-30 to a real day.
+      expect(isValidDatetime("2026-02-30T00:00")).toBe(false);
+    });
+
+    test("rejects a datetime carrying a numeric offset", () => {
+      expect(isValidDatetime("2026-06-15T14:30+09:00")).toBe(false);
+    });
+
+    test("rejects a datetime carrying a bracketed IANA zone", () => {
+      expect(isValidDatetime("2026-06-15T14:30[Asia/Tokyo]")).toBe(false);
     });
   });
 

--- a/test/lib/timezone.test.ts
+++ b/test/lib/timezone.test.ts
@@ -300,6 +300,12 @@ describe("timezone", () => {
     test("rejects a datetime carrying a bracketed IANA zone", () => {
       expect(isValidDatetime("2026-06-15T14:30[Asia/Tokyo]")).toBe(false);
     });
+
+    test("rejects a :60 leap second instead of clamping it to :59", () => {
+      // Temporal clamps :60 to :59 even under overflow:"reject"; the naive
+      // shape guard rejects it so a crafted value never stores a shifted time.
+      expect(isValidDatetime("2026-06-15T14:30:60")).toBe(false);
+    });
   });
 
   describe("round-trip: localToUtc -> utcToLocalInput", () => {


### PR DESCRIPTION
## Summary

Replaces `@internationalized/date` with the **Temporal API**, sourced from the bundled `temporal-polyfill` rather than the runtime global. All timezone/date logic is server-only (the library never reached the browser bundle), so this is confined to `src/shared/timezone.ts` + one call in `dates.ts`.

## Why a polyfill, not the native global

Bunny Edge runs **either Deno 2.7 or 2.5**, and only the built script is deployed — `deno.json` and any `--unstable-temporal` flag do **not** travel with it:

| | Deno 2.7.x | Deno 2.5.x (baseline) |
|---|---|---|
| `Temporal` global | stable | **absent** without `--unstable-temporal` |

Relying on the global would throw `ReferenceError: Temporal is not defined` on the 2.5 baseline, which we can't fix from the artifact. Importing `temporal-polyfill` bundles the implementation into the script, so the **same Temporal runs on both Deno versions and in tests** — deterministic regardless of which runtime Bunny lands on.

Verified:
- Identical test suite passes on **both Deno 2.5.6 and 2.7.12** (no flags).
- The edge bundle **inlines the polyfill** with **zero `globalThis.Temporal` references**, and stays well under Bunny's 10 MB limit (~2.4 MB).

## Changes
- **`timezone.ts`** — `import { Temporal } from "temporal-polyfill"`; `todayInTz`, `localToUtc`, `isValidDatetime`, and shared `utcToZoned`/`msToZoned` helpers built on it.
- **`dates.ts`** — `listingDateToCalendarDate` reuses the shared `utcToZoned`.
- **`deno.json` / `deno.lock`** — drop `@internationalized/date`, add `temporal-polyfill`.

## Parity details handled
1. **Milliseconds** — Temporal omits zero ms; `localToUtc` uses `{ fractionalSecondDigits: 3 }` to keep the `…:00.000Z` format.
2. **Strict validation** — `parseNaiveDateTime` rejects offset/zone-bearing input (`+09:00`, `[Asia/Tokyo]`, `Z`) before parsing, then `{ overflow: "reject" }` rejects impossible dates (`2026-02-30`) — matching the old `parseDateTime`. *(Codex review #1)*
3. **Fakeable clock** — `todayInTz` derives "today" from `Date.now()` (via `msToZoned`), since `Temporal.Now` bypasses `@std/testing/time`'s `FakeTime`. *(Codex review #2)*

## Tested
Full typecheck, jscpd (0%), Biome, 100% coverage on changed code; timezone/dates/validation suites and FakeTime/date-touching server suites (329 tests) via the harness — all green on 2.7.12, and the focused suites confirmed on 2.5.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)