### PR TITLE
Fix listing deletion FK failure and clarify attendee unlinking

### DIFF
--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -56,7 +56,7 @@
   "admin.listings.remove_image": "Remove Image",
   "admin.listings.current_attachment": "Current attachment:",
   "admin.listings.remove_attachment": "Remove Attachment",
-  "admin.listings.delete_listing.warning": "Warning: This will permanently delete the listing, all {count, plural, one {1 attendee} other {{count} attendees}}, any associated payment records, and all activity log entries for this listing.",
+  "admin.listings.delete_listing.warning": "Warning: This permanently deletes the listing and its activity log entries. Its {count, plural, one {1 attendee} other {{count} attendees}} will be unlinked from this listing rather than deleted — their attendee records and any payments are kept, and any bookings on other listings are unaffected.",
   "admin.listings.delete_listing.confirm_prompt": "To delete this listing, type its name \"{name}\" into the box below:",
   "admin.listings.delete_listing.label": "Listing name",
   "admin.listings.delete_listing.submit": "Delete Listing",

--- a/src/locales/en/listings-table.json
+++ b/src/locales/en/listings-table.json
@@ -74,7 +74,7 @@
   "listings_table.delete_listing": "Delete Listing",
   "listings_table.listing_name": "Listing name",
   "listings_table.warning": "Warning",
-  "listings_table.delete_warning_text": "This will permanently delete the listing, all {count} attendee(s), any associated payment records, and all activity log entries for this listing.",
+  "listings_table.delete_warning_text": "This permanently deletes the listing and its activity log entries. Its {count} attendee(s) will be unlinked from this listing rather than deleted — their attendee records and any payments are kept, and any bookings they have on other listings are unaffected.",
   "listings_table.delete_confirmation_text": "To delete this listing, type its name \"{name}\" into the box below:",
   "listings_table.deactivate_listing_title": "Deactivate: {name}",
   "listings_table.deactivate_listing": "Deactivate Listing",

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -326,17 +326,30 @@ export const isSlugTaken = async (
  * Delete a listing and its own bookings in a single database round-trip.
  *
  * Only the deleted listing's rows are touched: its `listing_attendees` links,
- * its `activity_log` entries, and the listing itself. Attendees are deliberately
- * left alone — an attendee booked onto another listing keeps that booking (and
- * all of its answers/payments) completely untouched, and an attendee left with
- * no bookings is simply orphaned rather than purged. This scoping guarantees
- * that deleting one listing can never affect another listing's attendees.
+ * its `listing_questions` assignments, its `activity_log` entries, and the
+ * listing itself. Attendees are deliberately left alone — an attendee booked
+ * onto another listing keeps that booking (and all of its answers/payments)
+ * completely untouched, and an attendee left with no bookings is simply
+ * orphaned rather than purged. This scoping guarantees that deleting one
+ * listing can never affect another listing's attendees.
+ *
+ * The `listing_questions` assignments must be cleared before the listing row.
+ * Databases migrated from the legacy schema still carry that table's original
+ * `FOREIGN KEY (listing_id) REFERENCES listings(id)` constraint — the migration
+ * only rebuilds the attendee-related tables to drop their FKs, never this one —
+ * so deleting a listing that had any questions assigned would otherwise fail
+ * with "FOREIGN KEY constraint failed". Clearing the links first also stops
+ * orphaned rows accumulating on fresh databases that have no such constraint.
  */
 export const deleteListing = async (listingId: number): Promise<void> => {
   await executeBatch([
     {
       args: [listingId],
       sql: "DELETE FROM listing_attendees WHERE listing_id = ?",
+    },
+    {
+      args: [listingId],
+      sql: "DELETE FROM listing_questions WHERE listing_id = ?",
     },
     { args: [listingId], sql: "DELETE FROM activity_log WHERE listing_id = ?" },
     { args: [listingId], sql: "DELETE FROM listings WHERE id = ?" },

--- a/test/lib/db/legacy-migration.test.ts
+++ b/test/lib/db/legacy-migration.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { insert, setDb } from "#shared/db/client.ts";
+import { deleteListing } from "#shared/db/listings.ts";
 import { initDb, invalidateInitDbCache } from "#shared/db/migrations.ts";
 import { resetDb, setupTestEncryptionKey } from "#test-utils";
 
@@ -371,6 +372,43 @@ describe("db > listing_attendees migration from legacy schema", () => {
     expect(answers.rows).toEqual([
       { id: 1, question_id: 1, text: "Encrypted answer" },
     ]);
+  });
+
+  test("deletes a migrated listing that still has a legacy listing_questions FK", async () => {
+    const client = await createLegacyDb();
+    await client.execute("PRAGMA foreign_keys = ON");
+
+    await client.execute(
+      insert("listings", {
+        created: "2024-01-01T00:00:00Z",
+        id: 1,
+        max_attendees: 100,
+        name: "Test Listing",
+      }),
+    );
+    await client.execute(insert("questions", { id: 1, text: "Encrypted" }));
+    await client.execute(
+      insert("listing_questions", { id: 1, listing_id: 1, question_id: 1 }),
+    );
+
+    const pragmaStub = stubPragmaForeignKeysOff(client);
+    try {
+      await initDb();
+    } finally {
+      pragmaStub.restore();
+    }
+
+    // Migration only rebuilds the attendee tables, so listing_questions keeps
+    // its original FOREIGN KEY (listing_id) REFERENCES listings(id). With FK
+    // enforcement on (as on the Turso primary), deleting a listing that has a
+    // question assigned must clear those rows first, or libsql rejects the
+    // whole delete with "FOREIGN KEY constraint failed".
+    await deleteListing(1);
+
+    const listings = await client.execute("SELECT id FROM listings");
+    expect(listings.rows.length).toBe(0);
+    const links = await client.execute("SELECT id FROM listing_questions");
+    expect(links.rows.length).toBe(0);
   });
 
   test("drops PII columns when listing_id was dropped in a prior partial run", async () => {

--- a/test/lib/db/listings.test.ts
+++ b/test/lib/db/listings.test.ts
@@ -12,7 +12,7 @@ import {
   getAttendeeRaw,
   getAttendeesRaw,
 } from "#shared/db/attendees.ts";
-import { getDb } from "#shared/db/client.ts";
+import { getDb, queryAll } from "#shared/db/client.ts";
 import {
   computeSlugIndex,
   deleteListing,
@@ -37,6 +37,7 @@ import {
   getAttendeeAnswersBatch,
   questionsTable,
   saveAttendeeAnswers,
+  setListingQuestions,
 } from "#shared/db/questions.ts";
 import { MAX_DURATION_DAYS } from "#shared/types.ts";
 import {
@@ -398,6 +399,28 @@ describeWithEnv("db > listings", { db: true, triggers: true }, () => {
 
       const answers = await getAttendeeAnswersBatch([attendeeId]);
       expect(answers.get(attendeeId)).toEqual([answer.id]);
+    });
+
+    test("removes the deleted listing's question assignments, keeping other listings'", async () => {
+      const listing1 = await createTestListing({ maxAttendees: 50 });
+      const listing2 = await createTestListing({ maxAttendees: 50 });
+      const question = await questionsTable.insert({
+        displayType: "radio",
+        text: "Meal choice?",
+      });
+      await setListingQuestions(listing1.id, [question.id]);
+      await setListingQuestions(listing2.id, [question.id]);
+
+      await deleteListing(listing1.id);
+
+      // Only the deleted listing's assignment is removed; listing2 keeps its
+      // own. Leaving it behind would orphan the row (and, on databases migrated
+      // from the legacy schema, the listing_questions → listings FK would have
+      // blocked the delete entirely).
+      const rows = await queryAll<{ listing_id: number }>(
+        "SELECT listing_id FROM listing_questions ORDER BY listing_id",
+      );
+      expect(rows.map((r) => r.listing_id)).toEqual([listing2.id]);
     });
 
     test("keeps the shared attendee's processed payment when one listing is deleted", async () => {


### PR DESCRIPTION
## What & why

Two related fixes around deleting a listing.

### 1. Clarify that attendees are *unlinked*, not deleted

The delete confirmation page warned that deletion would *"permanently delete the listing, all N attendee(s), any associated payment records…"*. That's wrong — `deleteListing` only removes the listing's `listing_attendees` **links**. The attendee rows survive (orphaned if they have no other bookings), and their processed-payment records are kept. The wording is corrected on both copies of the message (`listings_table.delete_warning_text` used by the page, and the parallel unused `admin.listings.delete_listing.warning`) to say the attendees are unlinked from the listing rather than deleted, with their records/payments and any other-listing bookings left intact. The unlink behaviour itself was already correct, so no behaviour change there.

### 2. Fix `FOREIGN KEY constraint failed` when deleting a listing

Reported error:

```
POST /admin/listing/[id]/delete: PROXY_ERROR: error executing a request on the primary: FOREIGN KEY constraint failed
```

**Root cause:** databases created from the legacy schema have `FOREIGN KEY (listing_id) REFERENCES listings(id)` on `listing_questions`. The migration only rebuilds the *attendee-related* tables (`listing_attendees`, `processed_payments`, `attendee_answers`, `attendees`) to drop their FKs — it never recreates `listing_questions`, so that table keeps its original constraint. `deleteListing` cleared `listing_attendees` and `activity_log` but **not** `listing_questions`, so deleting a listing that had any questions assigned was rejected by the FK on the primary (FK enforcement is effectively always on there). Fresh databases have no FKs, which is why this only bit migrated production data.

**Fix:** `deleteListing` now deletes the listing's `listing_questions` rows before the listing row, alongside the existing `listing_attendees` / `activity_log` cleanup. This unblocks the delete on legacy databases and also stops orphaned `listing_questions` rows accumulating on fresh ones.

> Note: this resolves the reported FK error. It is *not* fixed by the wording change in (1) — the error was about `listing_questions`, not attendees.

## Tests

- **`test/lib/db/legacy-migration.test.ts`** — new regression test that builds the legacy schema (with the `listing_questions` FK), runs the migration, then deletes a listing with a question assigned **with FK enforcement on**. Verified it **fails without the fix** (`FOREIGN KEY constraint failed`) and passes with it.
- **`test/lib/db/listings.test.ts`** — unit test that deleting one listing removes only its own question assignments and leaves another listing's intact.

All green locally: `typecheck`, `lint`, `cpd` (0%), and the `db/listings`, `legacy-migration`, `server-listings`, `admin-api-listings`, template and `i18n` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZnYPu8Rq6T1RYdKq9SNqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZnYPu8Rq6T1RYdKq9SNqW)_