### PR TITLE
Add per-site "update" button on /admin/built-sites/:id

### DIFF
--- a/src/features/admin/built-sites.ts
+++ b/src/features/admin/built-sites.ts
@@ -18,6 +18,8 @@ import {
   builtSitesCrudTable,
   getAllBuiltSites,
 } from "#shared/db/built-sites.ts";
+import { settings } from "#shared/db/settings.ts";
+import { getEnv } from "#shared/env.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import { isProvisioned } from "#shared/renewal-helpers.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
@@ -34,6 +36,8 @@ import {
   addMissingSiteSecrets,
   loadSiteSecretsStatus,
 } from "#shared/site-secrets.ts";
+import { loadBuiltSiteUpdateState } from "#shared/site-update.ts";
+import { deployLatestReleaseToScript } from "#shared/update.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import {
   adminBuiltSiteDeletePage,
@@ -153,7 +157,10 @@ const ownerPost =
 const handleEditGet = (request: Request, params: RouteParams) =>
   withOwnerAndSite(request, params, async ({ site }, session) => {
     const flash = applyFlash(request);
-    const secrets = await loadSiteSecretsStatus(site);
+    const [secrets, updateState] = await Promise.all([
+      loadSiteSecretsStatus(site),
+      loadBuiltSiteUpdateState(site),
+    ]);
     return htmlResponse(
       adminBuiltSiteEditPage(
         site,
@@ -161,9 +168,44 @@ const handleEditGet = (request: Request, params: RouteParams) =>
         flash.error,
         flash.success,
         secrets,
+        updateState,
       ),
     );
   });
+
+/** POST /admin/built-sites/:id/update — deploy the latest release to the site.
+ *
+ * Runs the exact self-update path (fetch latest GitHub release, upload + publish
+ * its asset) but targets the site's own Bunny script instead of this host's. */
+const handleUpdateSite = ownerPost(async (site, _form, id) => {
+  if (!getEnv("BUNNY_API_KEY")) {
+    return editError(
+      id,
+      "BUNNY_API_KEY is not configured on this host, so sites can't be updated.",
+    );
+  }
+  if (!site.bunnyScriptId) {
+    return editError(
+      id,
+      "This site has no Bunny script ID, so it can't be updated.",
+    );
+  }
+  try {
+    const result = await settings.withCurrentTask("update", () =>
+      deployLatestReleaseToScript(site.bunnyScriptId),
+    );
+    if (!result.ok) return editError(id, result.error);
+    await logActivity(
+      `Updated built site '${site.name}' to ${result.value.name} (${result.value.tagName})`,
+    );
+    return editSuccess(
+      id,
+      `Updated '${site.name}' to ${result.value.name} — the new version will be active shortly`,
+    );
+  } catch (e) {
+    return editError(id, `Update failed: ${(e as Error).message}`);
+  }
+});
 
 /** POST /admin/built-sites/:id/rotate-renewal-token */
 const handleRotateToken = ownerPost(async (site, _form, id) => {
@@ -305,4 +347,5 @@ export const builtSitesRoutes = {
   "POST /admin/built-sites/:id/provision-renewal": handleProvisionRenewal,
   "POST /admin/built-sites/:id/re-sync-deadline": handleReSyncDeadline,
   "POST /admin/built-sites/:id/rotate-renewal-token": handleRotateToken,
+  "POST /admin/built-sites/:id/update": handleUpdateSite,
 };

--- a/src/features/admin/update.ts
+++ b/src/features/admin/update.ts
@@ -12,7 +12,7 @@ import { logActivity } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import {
-  deployRelease,
+  deployLatestReleaseToScript,
   fetchLatestRelease,
   formatBuildDate,
   isNewerVersion,
@@ -78,14 +78,9 @@ const deployUpdate = async (): Promise<Response> => {
   }
 
   try {
-    const result = await settings.withCurrentTask("update", async () => {
-      const release = await fetchLatestRelease();
-      if (!release.assetUrl) {
-        throw new Error("Release has no downloadable asset");
-      }
-      await deployRelease(release.assetUrl);
-      return release;
-    });
+    const result = await settings.withCurrentTask("update", () =>
+      deployLatestReleaseToScript(),
+    );
 
     if (!result.ok) {
       return errorRedirect(UPDATE_PATH, result.error);

--- a/src/locales/en/built-sites.json
+++ b/src/locales/en/built-sites.json
@@ -48,5 +48,16 @@
   "built_sites.delete_confirmation_prompt": "Type the site name \"{name}\" to confirm:",
   "built_sites.delete_built_site_button": "Delete Built Site",
   "built_sites.resync_deadline_button": "Re-sync deadline",
+  "built_sites.update_title": "Software update",
+  "built_sites.update_site_version_label": "Site version:",
+  "built_sites.update_unknown_version": "Unknown — no read-only database credentials are stored for this site (or it predates version reporting).",
+  "built_sites.update_version_error": "Couldn't read the site's version: {error}",
+  "built_sites.update_latest_label": "Latest known release:",
+  "built_sites.update_latest_none": "None checked yet — use the Update page to check for the latest release.",
+  "built_sites.update_available": "An update is available for this site.",
+  "built_sites.update_up_to_date": "This site is on the latest known release.",
+  "built_sites.update_button": "Update this site",
+  "built_sites.update_confirm": "Deploy the latest release to this site now?",
+  "built_sites.update_unavailable": "Automatic update needs BUNNY_API_KEY on this host and a Bunny script ID on this site.",
   "built_sites.delete_label": "Site name"
 }

--- a/src/shared/builder.ts
+++ b/src/shared/builder.ts
@@ -16,6 +16,7 @@ import { bunnyDbApi, type CreateDatabaseResult } from "#shared/bunny-db.ts";
 import { toBase64 } from "#shared/crypto/utils.ts";
 import { getEnv } from "#shared/env.ts";
 import { fetchText } from "#shared/fetch.ts";
+import { withSiteDb } from "#shared/site-db.ts";
 import { fetchLatestRelease } from "#shared/update.ts";
 
 /**
@@ -99,14 +100,10 @@ export const testDbConnection = async (
   dbUrl: string,
   dbToken: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> => {
-  try {
-    const { createClient } = await import("@libsql/client");
-    const client = createClient({ authToken: dbToken, url: dbUrl });
-    await client.execute("SELECT 1");
-    return { ok: true };
-  } catch (e) {
-    return { error: (e as Error).message, ok: false };
-  }
+  const result = await withSiteDb({ dbToken, dbUrl }, (client) =>
+    client.execute("SELECT 1"),
+  );
+  return result.ok ? { ok: true } : { error: result.error, ok: false };
 };
 
 /**

--- a/src/shared/bunny-cdn.ts
+++ b/src/shared/bunny-cdn.ts
@@ -555,12 +555,14 @@ const updatePullZoneImpl = (
 // ---------------------------------------------------------------------------
 
 /**
- * Upload new code to a Bunny edge script and publish it.
- * Used by the admin self-update feature.
+ * Upload new code to a Bunny edge script and publish it. Defaults to this
+ * host's own script (self-update); pass `scriptId` to deploy the same release
+ * to another edge script, e.g. updating a built site.
  */
-const deployScriptCodeImpl = async (code: string): Promise<BunnyApiResult> => {
-  const scriptId = getBunnyScriptId();
-
+const deployScriptCodeImpl = async (
+  code: string,
+  scriptId: number | string = getBunnyScriptId(),
+): Promise<BunnyApiResult> => {
   const upload = await scriptAction(
     scriptId,
     "code",
@@ -610,6 +612,9 @@ export const registerBunnySubdomain = (subdomain: string) =>
 export const getCdnHostname = (): Promise<CdnHostnameResult> =>
   bunnyCdnApi.getCdnHostname();
 
-/** Upload and publish new script code to Bunny CDN. */
-export const deployScriptCode = (code: string): Promise<BunnyApiResult> =>
-  bunnyCdnApi.deployScriptCode(code);
+/** Upload and publish new script code to a Bunny edge script (defaults to this
+ * host's own script when `scriptId` is omitted). */
+export const deployScriptCode = (
+  code: string,
+  scriptId?: number | string,
+): Promise<BunnyApiResult> => bunnyCdnApi.deployScriptCode(code, scriptId);

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -20,6 +20,7 @@ import { getEnv } from "#shared/env.ts";
 import { logDebug } from "#shared/logger.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
 import { isStorageEnabled } from "#shared/storage.ts";
+import { recordScriptVersion } from "#shared/update.ts";
 import currentSchemaMigration from "./migrations/2026-06-11_current_schema.ts";
 import sumupCheckoutsMigration from "./migrations/2026-06-12_sumup_checkouts.ts";
 import eventAttendeesOverlapIndexMigration from "./migrations/2026-06-13_event_attendees_overlap_index.ts";
@@ -381,6 +382,9 @@ export const initDb = async (opts: InitDbOptions = {}): Promise<void> => {
   const client = getDb();
   if (client === getReadyClient()) return;
   await initDbUncached(opts.allowMissingSettings ?? false);
+  // Self-record the running build's version so a parent host can read it back.
+  // Best-effort and once per isolate (initDb caches the ready client below).
+  await recordScriptVersion();
   setReadyClient(client);
 };
 

--- a/src/shared/site-db.ts
+++ b/src/shared/site-db.ts
@@ -1,0 +1,80 @@
+/**
+ * Generic read access to a built site's own database.
+ *
+ * For every site we build we keep its libsql URL and a **read-only** auth token
+ * (never its DB_ENCRYPTION_KEY). That is enough to read the site's unencrypted
+ * rows — e.g. plaintext `settings` markers — without ever being able to decrypt
+ * its private data. This module is the single, reusable place that opens such a
+ * connection; callers pass a small read function and get a tagged result back.
+ *
+ * Only plaintext columns are meaningful here: anything stored encrypted on the
+ * site (see ENCRYPTED_KEYS in settings.ts) is unreadable without the per-site
+ * key we deliberately never hold.
+ */
+
+import { type Client, createClient } from "@libsql/client";
+import type { BuiltSite } from "#shared/db/built-sites.ts";
+
+/** Credentials needed to open a read-only connection to a site's database. */
+export type SiteDbCredentials = Pick<BuiltSite, "dbUrl" | "dbToken">;
+
+/** Result of a read against a site database. */
+export type SiteDbResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+/** Stubbable client factory so tests can inject an in-memory database. */
+export const siteDbApi = {
+  createClient: (url: string, authToken: string): Client =>
+    createClient(authToken ? { authToken, url } : { url }),
+};
+
+/** Do we hold both a URL and a read-only token for this site's database? */
+export const hasSiteDbCredentials = (creds: SiteDbCredentials): boolean =>
+  Boolean(creds.dbUrl && creds.dbToken);
+
+/**
+ * Open a connection to a site's database with its read-only keys, run `fn`, and
+ * always close the connection. Connection/query errors are caught and returned
+ * as `{ ok: false }` rather than thrown, so a parent host stays up even when a
+ * child site's database is unreachable.
+ */
+export const withSiteDb = async <T>(
+  creds: SiteDbCredentials,
+  fn: (client: Client) => Promise<T>,
+): Promise<SiteDbResult<T>> => {
+  if (!creds.dbUrl)
+    return { error: "No database URL for this site", ok: false };
+  // Close on both the success and failure paths rather than in a `finally`:
+  // the catch always returns (never rethrows), so a `finally` would carry an
+  // exception-in-flight branch that can never be taken. `client` is undefined
+  // only when opening the connection itself threw, hence the optional close.
+  let client: Client | undefined;
+  try {
+    client = siteDbApi.createClient(creds.dbUrl, creds.dbToken);
+    const value = await fn(client);
+    client.close();
+    return { ok: true, value };
+  } catch (e) {
+    client?.close();
+    return { error: (e as Error).message, ok: false };
+  }
+};
+
+/**
+ * Read a single plaintext value from a site's `settings` table. Resolves to
+ * `null` when the key is absent, or `{ ok: false }` when the database can't be
+ * reached. Encrypted settings come back as ciphertext and are not useful here.
+ */
+export const readSiteSetting = (
+  creds: SiteDbCredentials,
+  key: string,
+): Promise<SiteDbResult<string | null>> =>
+  withSiteDb(creds, async (client) => {
+    const result = await client.execute({
+      args: [key],
+      sql: "SELECT value FROM settings WHERE key = ?",
+    });
+    const row = result.rows[0];
+    return row ? (row.value as string) : null;
+  });

--- a/src/shared/site-update.ts
+++ b/src/shared/site-update.ts
@@ -1,0 +1,85 @@
+/**
+ * Built-site update support: read a site's recorded version through its
+ * read-only database keys and decide whether it is behind the latest release.
+ *
+ * The deploy itself reuses the exact self-update path (`deployLatestReleaseToScript`
+ * in #shared/update.ts) against the site's own Bunny script; this module only
+ * gathers the comparison state shown next to the Update button.
+ */
+
+import type { BuiltSite } from "#shared/db/built-sites.ts";
+import { settings } from "#shared/db/settings.ts";
+import { getEnv } from "#shared/env.ts";
+import {
+  hasSiteDbCredentials,
+  readSiteSetting,
+  type SiteDbResult,
+} from "#shared/site-db.ts";
+import {
+  CURRENT_SCRIPT_VERSION_KEY,
+  formatBuildDate,
+  isNewerVersion,
+} from "#shared/update.ts";
+
+/** State for the built-site update panel. */
+export type BuiltSiteUpdateState = {
+  /** Host has BUNNY_API_KEY set (required to deploy at all). */
+  bunnyConfigured: boolean;
+  /** Site has a Bunny script id to deploy to. */
+  hasScriptId: boolean;
+  /** Human-readable version the site reported, or null when unknown. */
+  siteVersionLabel: string | null;
+  /** Error reading the site's database, if we tried and failed. */
+  siteVersionError: string | null;
+  /** Latest release tag the host knows about ("" when never checked). */
+  latestVersion: string;
+  /** Latest release display name. */
+  latestVersionName: string;
+  /** The latest known release is newer than what the site is running. */
+  updateAvailable: boolean;
+  /** The site is on the latest known release. */
+  upToDate: boolean;
+};
+
+/** Read the version a built site recorded for itself, via its read-only keys. */
+export const readSiteScriptVersion = (
+  site: BuiltSite,
+): Promise<SiteDbResult<string | null>> =>
+  readSiteSetting(site, CURRENT_SCRIPT_VERSION_KEY);
+
+/**
+ * Gather the update panel state for a site: its recorded version (when we hold
+ * its database keys) compared against the latest release the host knows about.
+ */
+export const loadBuiltSiteUpdateState = async (
+  site: BuiltSite,
+): Promise<BuiltSiteUpdateState> => {
+  const latestVersion = settings.latestScriptVersion;
+  const latestVersionName = settings.latestScriptVersionName;
+
+  let siteVersion: string | null = null;
+  let siteVersionError: string | null = null;
+  if (hasSiteDbCredentials(site)) {
+    const result = await readSiteScriptVersion(site);
+    if (result.ok) siteVersion = result.value;
+    else siteVersionError = result.error;
+  }
+
+  const haveLatest = latestVersion !== "";
+  const updateAvailable =
+    Boolean(siteVersion) &&
+    haveLatest &&
+    isNewerVersion(latestVersion, siteVersion!);
+  const upToDate = Boolean(siteVersion) && haveLatest && !updateAvailable;
+
+  return {
+    bunnyConfigured: Boolean(getEnv("BUNNY_API_KEY")),
+    hasScriptId: Boolean(site.bunnyScriptId),
+    latestVersion,
+    latestVersionName,
+    siteVersionError,
+    siteVersionLabel: siteVersion ? formatBuildDate(siteVersion) : null,
+    updateAvailable,
+    upToDate,
+  };
+};

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -9,9 +9,20 @@
 import { lazyRef } from "#fp";
 import { BUILD_TIMESTAMP } from "#shared/build-info.ts";
 import { deployScriptCode } from "#shared/bunny-cdn.ts";
+import { execute, queryOne } from "#shared/db/client.ts";
+import { logDebug } from "#shared/logger.ts";
 
 /** GitHub repo URL — update here if the repo moves */
 export const GITHUB_REPO = "chobbledotcom/tickets";
+
+/**
+ * Plaintext settings key under which the running build records its own version
+ * (the build timestamp). Stored unencrypted on purpose: a parent host reads it
+ * from a built site's database using only the site's read-only keys, so it can
+ * tell which release the site is on. Mirrors the raw schema markers written by
+ * the migrator (db_schema_hash / latest_db_update), not a snapshot setting.
+ */
+export const CURRENT_SCRIPT_VERSION_KEY = "current_script_version";
 
 /** GitHub releases page URL */
 export const GITHUB_RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`;
@@ -56,14 +67,47 @@ const getEffectiveBuildTimestamp = (): string =>
   getBuildTimestampOverride() ?? BUILD_TIMESTAMP;
 
 /**
- * Check if a release tag represents a version newer than the current build.
- * Returns false in development (no build timestamp) or for unparseable tags.
+ * Check if a release tag is newer than a build timestamp. Defaults to this
+ * host's own build (self-update check); pass `buildTimestamp` to compare a
+ * built site's recorded version against the latest release. Returns false when
+ * the timestamp is empty (development) or the tag is unparseable.
  */
-export const isNewerVersion = (tagName: string): boolean => {
+export const isNewerVersion = (
+  tagName: string,
+  buildTimestamp: string = getEffectiveBuildTimestamp(),
+): boolean => {
   const releaseDate = parseReleaseTag(tagName);
-  const ts = getEffectiveBuildTimestamp();
-  if (!releaseDate || !ts) return false;
-  return releaseDate.getTime() > new Date(ts).getTime();
+  if (!releaseDate || !buildTimestamp) return false;
+  return releaseDate.getTime() > new Date(buildTimestamp).getTime();
+};
+
+/**
+ * Record the running build's version into this database's `settings` table so a
+ * parent host can read it back (read-only) and tell which release we are on.
+ * Writes only when the stored value differs from the running build, so the
+ * common unchanged path costs a single indexed read and no write. Best-effort:
+ * any failure is logged and swallowed so it can never block boot, and it is a
+ * no-op for development/test builds where the timestamp is empty.
+ */
+export const recordScriptVersion = async (): Promise<void> => {
+  const version = getEffectiveBuildTimestamp();
+  if (!version) return;
+  try {
+    const row = await queryOne<{ value: string }>(
+      "SELECT value FROM settings WHERE key = ?",
+      [CURRENT_SCRIPT_VERSION_KEY],
+    );
+    if (row?.value === version) return;
+    await execute(
+      "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+      [CURRENT_SCRIPT_VERSION_KEY, version],
+    );
+  } catch (e) {
+    logDebug(
+      "Migration",
+      `Failed to record script version: ${(e as Error).message}`,
+    );
+  }
 };
 
 /**
@@ -99,10 +143,14 @@ export const fetchLatestRelease = async (): Promise<ReleaseInfo> => {
 };
 
 /**
- * Download a release asset from GitHub and deploy it to Bunny CDN.
- * Uses the shared bunny-cdn module for the upload + publish step.
+ * Download a release asset from GitHub and deploy it to a Bunny edge script.
+ * Defaults to this host's own script; pass `scriptId` to deploy the same
+ * release to another site. Uses the shared bunny-cdn module for upload+publish.
  */
-export const deployRelease = async (assetUrl: string): Promise<void> => {
+export const deployRelease = async (
+  assetUrl: string,
+  scriptId?: number | string,
+): Promise<void> => {
   const assetResponse = await fetch(assetUrl);
   if (!assetResponse.ok) {
     throw new Error(
@@ -111,8 +159,25 @@ export const deployRelease = async (assetUrl: string): Promise<void> => {
   }
   const code = await assetResponse.text();
 
-  const result = await deployScriptCode(code);
+  const result = await deployScriptCode(code, scriptId);
   if (!result.ok) {
     throw new Error(result.error);
   }
+};
+
+/**
+ * Fetch the latest GitHub release and deploy its asset to a Bunny edge script,
+ * returning the release on success. This is the exact deploy our self-update
+ * runs; pass `scriptId` to run it against a built site's script instead.
+ * Throws on any failure (no release asset, download, or deploy error).
+ */
+export const deployLatestReleaseToScript = async (
+  scriptId?: number | string,
+): Promise<ReleaseInfo> => {
+  const release = await fetchLatestRelease();
+  if (!release.assetUrl) {
+    throw new Error("Release has no downloadable asset");
+  }
+  await deployRelease(release.assetUrl, scriptId);
+  return release;
 };

--- a/src/ui/templates/admin/built-sites.tsx
+++ b/src/ui/templates/admin/built-sites.tsx
@@ -19,6 +19,7 @@ import {
   hostInfraSecretNames,
   type SiteSecretsView,
 } from "#shared/site-secrets.ts";
+import type { BuiltSiteUpdateState } from "#shared/site-update.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav, SettingsSubNav } from "#templates/admin/nav.tsx";
 import {
@@ -411,6 +412,60 @@ const SecretsPanel = ({
 };
 
 /**
+ * Update panel: shows the version the site reported (read through its read-only
+ * database keys) against the latest release the host knows about, and a button
+ * that deploys the latest release to the site — the same process as our own
+ * self-update, just targeting the site's edge script.
+ */
+const UpdatePanel = ({
+  site,
+  state,
+}: {
+  site: BuiltSite;
+  state: BuiltSiteUpdateState;
+}): JSX.Element => (
+  <div class="prose">
+    <p>
+      <strong>{t("built_sites.update_site_version_label")}</strong>{" "}
+      {state.siteVersionLabel ??
+        (state.siteVersionError
+          ? t("built_sites.update_version_error", {
+              error: state.siteVersionError,
+            })
+          : t("built_sites.update_unknown_version"))}
+    </p>
+    <p>
+      <strong>{t("built_sites.update_latest_label")}</strong>{" "}
+      {state.latestVersion
+        ? `${state.latestVersionName} (${state.latestVersion})`
+        : t("built_sites.update_latest_none")}
+    </p>
+    {state.updateAvailable ? (
+      <p>
+        <strong>{t("built_sites.update_available")}</strong>
+      </p>
+    ) : state.upToDate ? (
+      <output class="success">{t("built_sites.update_up_to_date")}</output>
+    ) : null}
+    {state.bunnyConfigured && state.hasScriptId ? (
+      <SiteActionForm action="update" siteId={site.id}>
+        <button
+          onclick={`return confirm('${t("built_sites.update_confirm")}')`}
+          type="submit"
+        >
+          <Icon name="rotate-ccw" />
+          <span>{t("built_sites.update_button")}</span>
+        </button>
+      </SiteActionForm>
+    ) : (
+      <p>
+        <em>{t("built_sites.update_unavailable")}</em>
+      </p>
+    )}
+  </div>
+);
+
+/**
  * Admin built site edit page
  */
 export const adminBuiltSiteEditPage = (
@@ -419,6 +474,7 @@ export const adminBuiltSiteEditPage = (
   error?: string,
   success?: string,
   secretsView?: SiteSecretsView,
+  updateState?: BuiltSiteUpdateState,
 ): string => {
   const provisioned = isProvisioned(site);
 
@@ -447,6 +503,13 @@ export const adminBuiltSiteEditPage = (
 
       <h2>{t("built_sites.secrets_title")}</h2>
       <SecretsPanel site={site} view={secretsView} />
+
+      {updateState && (
+        <>
+          <h2>{t("built_sites.update_title")}</h2>
+          <UpdatePanel site={site} state={updateState} />
+        </>
+      )}
 
       <h2>{t("common.delete")}</h2>
       <p class="prose">

--- a/test/lib/bunny-cdn/edge-script.test.ts
+++ b/test/lib/bunny-cdn/edge-script.test.ts
@@ -260,6 +260,22 @@ describeWithEnv(
       );
     });
 
+    test("deploys to an explicit script id instead of the host's", async () => {
+      await withMocks(
+        () => stubFetchRecorder(),
+        async (recorder) => {
+          const result = await bunnyCdnApi.deployScriptCode("code", 12345);
+          expect(result).toEqual({ ok: true });
+          expect(recorder.calls[0]!.url).toContain(
+            "/compute/script/12345/code",
+          );
+          expect(recorder.calls[1]!.url).toContain(
+            "/compute/script/12345/publish",
+          );
+        },
+      );
+    });
+
     test("returns error when code upload fails", async () => {
       await withMocks(
         () =>

--- a/test/lib/server-built-sites-update.test.ts
+++ b/test/lib/server-built-sites-update.test.ts
@@ -1,0 +1,193 @@
+import { expect } from "@std/expect";
+import { afterEach, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { handleRequest } from "#routes";
+import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
+import { getAllActivityLog } from "#shared/db/activityLog.ts";
+import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
+import {
+  adminFormPost,
+  createTestBuiltSite,
+  describeWithEnv,
+  expectRedirectWithFlash,
+  testCookie,
+} from "#test-utils";
+
+const MOCK_RELEASE = {
+  assets: [
+    {
+      browser_download_url:
+        "https://github.com/chobbledotcom/tickets/releases/download/v2099-01-01-120000/bunny-script.ts",
+      name: "bunny-script.ts",
+    },
+  ],
+  name: "2099-01-01 - Big Update",
+  published_at: "2099-01-01T12:00:00Z",
+  tag_name: "v2099-01-01-120000",
+};
+
+/** Stub the GitHub release fetch + asset download. */
+const stubReleaseFetch = () =>
+  stub(globalThis, "fetch", (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes("releases/latest")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(MOCK_RELEASE), { status: 200 }),
+      );
+    }
+    return Promise.resolve(
+      new Response("console.log('updated')", { status: 200 }),
+    );
+  });
+
+describeWithEnv(
+  "POST /admin/built-sites/:id/update",
+  { db: true, env: { BUNNY_API_KEY: "host-key" } },
+  () => {
+    afterEach(() => {
+      settings.clearTestOverrides();
+    });
+
+    test("deploys the latest release to the site's own script", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8500",
+        name: "Update Me",
+      });
+      const fetchStub = stubReleaseFetch();
+      const deployStub = stub(bunnyCdnApi, "deployScriptCode", () =>
+        Promise.resolve({ ok: true as const }),
+      );
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/update`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          expect.stringContaining(
+            "Updated 'Update Me' to 2099-01-01 - Big Update",
+          ),
+        )(response);
+
+        // Deployed to the site's script id, not this host's.
+        expect(deployStub.calls[0]!.args[1]).toBe("8500");
+
+        const logs = await getAllActivityLog();
+        expect(
+          logs.some((l) =>
+            l.message.includes("Updated built site 'Update Me'"),
+          ),
+        ).toBe(true);
+      } finally {
+        deployStub.restore();
+        fetchStub.restore();
+      }
+    });
+
+    test("errors when the site has no Bunny script ID", async () => {
+      const site = await createTestBuiltSite({ name: "No Script" });
+      const { response } = await adminFormPost(
+        `/admin/built-sites/${site.id}/update`,
+      );
+      expectRedirectWithFlash(
+        `/admin/built-sites/${site.id}/edit`,
+        expect.stringContaining("no Bunny script ID"),
+        false,
+      )(response);
+    });
+
+    test("surfaces a deploy failure", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8501",
+        name: "Deploy Fails",
+      });
+      const fetchStub = stubReleaseFetch();
+      const deployStub = stub(bunnyCdnApi, "deployScriptCode", () =>
+        Promise.resolve({ error: "upload failed (500)", ok: false as const }),
+      );
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/update`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          expect.stringContaining("Update failed"),
+          false,
+        )(response);
+      } finally {
+        deployStub.restore();
+        fetchStub.restore();
+      }
+    });
+
+    test("refuses to start when another task is in progress", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8502",
+        name: "Busy Host",
+      });
+      await settings.update.currentTask("other-task");
+      settings.invalidateCache();
+      await settings.loadKeys(ALL_SETTINGS_KEYS);
+      const fetchStub = stubReleaseFetch();
+      try {
+        const { response } = await adminFormPost(
+          `/admin/built-sites/${site.id}/update`,
+        );
+        expectRedirectWithFlash(
+          `/admin/built-sites/${site.id}/edit`,
+          expect.stringContaining("already in progress"),
+          false,
+        )(response);
+      } finally {
+        fetchStub.restore();
+        await settings.update.currentTask("");
+      }
+    });
+
+    test("returns 404 for a non-existent built site", async () => {
+      const { response } = await adminFormPost(
+        "/admin/built-sites/999999/update",
+      );
+      expect(response.status).toBe(404);
+    });
+
+    test("requires a CSRF token", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8503",
+        name: "CSRF Update",
+      });
+      const cookie = await testCookie();
+      const response = await handleRequest(
+        new Request(`http://localhost/admin/built-sites/${site.id}/update`, {
+          body: "",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie,
+          },
+          method: "POST",
+        }),
+      );
+      expect(response.status).toBe(403);
+    });
+  },
+);
+
+describeWithEnv(
+  "POST /admin/built-sites/:id/update without BUNNY_API_KEY",
+  { db: true },
+  () => {
+    test("errors when the host has no Bunny API key", async () => {
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8600",
+        name: "No Host Key",
+      });
+      const { response } = await adminFormPost(
+        `/admin/built-sites/${site.id}/update`,
+      );
+      expectRedirectWithFlash(
+        `/admin/built-sites/${site.id}/edit`,
+        expect.stringContaining("BUNNY_API_KEY is not configured"),
+        false,
+      )(response);
+    });
+  },
+);

--- a/test/lib/site-db.test.ts
+++ b/test/lib/site-db.test.ts
@@ -1,0 +1,114 @@
+import { type Client, createClient } from "@libsql/client";
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { type Stub, stub } from "@std/testing/mock";
+import {
+  hasSiteDbCredentials,
+  readSiteSetting,
+  siteDbApi,
+  withSiteDb,
+} from "#shared/site-db.ts";
+
+/** Build an in-memory libsql client seeded with a settings table. */
+const seededClient = async (rows: [string, string][]): Promise<Client> => {
+  const client = createClient({ url: ":memory:" });
+  await client.execute(
+    "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)",
+  );
+  for (const [key, value] of rows) {
+    await client.execute({
+      args: [key, value],
+      sql: "INSERT INTO settings (key, value) VALUES (?, ?)",
+    });
+  }
+  return client;
+};
+
+describe("hasSiteDbCredentials", () => {
+  test("true only when both URL and token are present", () => {
+    expect(hasSiteDbCredentials({ dbToken: "t", dbUrl: "libsql://u" })).toBe(
+      true,
+    );
+    expect(hasSiteDbCredentials({ dbToken: "", dbUrl: "libsql://u" })).toBe(
+      false,
+    );
+    expect(hasSiteDbCredentials({ dbToken: "t", dbUrl: "" })).toBe(false);
+  });
+});
+
+describe("withSiteDb", () => {
+  test("returns an error without ever connecting when URL is empty", async () => {
+    const createStub = stub(siteDbApi, "createClient");
+    try {
+      const result = await withSiteDb({ dbToken: "t", dbUrl: "" }, () =>
+        Promise.resolve("unused"),
+      );
+      expect(result).toEqual({
+        error: "No database URL for this site",
+        ok: false,
+      });
+      expect(createStub.calls.length).toBe(0);
+    } finally {
+      createStub.restore();
+    }
+  });
+
+  test("returns an error when opening the connection throws", async () => {
+    const createStub = stub(siteDbApi, "createClient", () => {
+      throw new Error("connect boom");
+    });
+    try {
+      const result = await withSiteDb(
+        { dbToken: "t", dbUrl: "libsql://x" },
+        () => Promise.resolve("unused"),
+      );
+      expect(result).toEqual({ error: "connect boom", ok: false });
+    } finally {
+      createStub.restore();
+    }
+  });
+});
+
+describe("readSiteSetting", () => {
+  let client: Client;
+  let createStub: Stub;
+
+  beforeEach(async () => {
+    client = await seededClient([
+      ["current_script_version", "2026-06-19T12:00:00Z"],
+    ]);
+    createStub = stub(siteDbApi, "createClient", () => client);
+  });
+
+  afterEach(() => {
+    createStub.restore();
+    client.close();
+  });
+
+  test("returns the stored value for a present key", async () => {
+    const result = await readSiteSetting(
+      { dbToken: "t", dbUrl: "libsql://u" },
+      "current_script_version",
+    );
+    expect(result).toEqual({ ok: true, value: "2026-06-19T12:00:00Z" });
+  });
+
+  test("connects with the site's read-only URL and token", async () => {
+    await readSiteSetting(
+      { dbToken: "ro-token", dbUrl: "libsql://site.example" },
+      "current_script_version",
+    );
+    expect(createStub.calls[0]!.args).toEqual([
+      "libsql://site.example",
+      "ro-token",
+    ]);
+  });
+
+  test("returns null for a missing key", async () => {
+    const result = await readSiteSetting(
+      { dbToken: "t", dbUrl: "libsql://u" },
+      "does_not_exist",
+    );
+    expect(result).toEqual({ ok: true, value: null });
+  });
+});

--- a/test/lib/site-update.test.ts
+++ b/test/lib/site-update.test.ts
@@ -1,0 +1,179 @@
+import { type Client, createClient } from "@libsql/client";
+import { expect } from "@std/expect";
+import { afterEach, it as test } from "@std/testing/bdd";
+import { type Stub, stub } from "@std/testing/mock";
+import { queryOne } from "#shared/db/client.ts";
+import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
+import { siteDbApi } from "#shared/site-db.ts";
+import { loadBuiltSiteUpdateState } from "#shared/site-update.ts";
+import {
+  CURRENT_SCRIPT_VERSION_KEY,
+  recordScriptVersion,
+  setBuildTimestampForTest,
+} from "#shared/update.ts";
+import { createTestBuiltSite, describeWithEnv } from "#test-utils";
+
+const LATEST_TAG = "v2099-01-01-120000";
+
+/** Seed an in-memory libsql client standing in for the remote site's DB. */
+const seedSiteDb = async (version: string | null): Promise<Client> => {
+  const client = createClient({ url: ":memory:" });
+  await client.execute(
+    "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)",
+  );
+  if (version !== null) {
+    await client.execute({
+      args: [CURRENT_SCRIPT_VERSION_KEY, version],
+      sql: "INSERT INTO settings (key, value) VALUES (?, ?)",
+    });
+  }
+  return client;
+};
+
+/** Store a host-known latest release and refresh the settings snapshot. */
+const setLatestRelease = async (tag: string): Promise<void> => {
+  await settings.update.latestScriptVersion(tag);
+  await settings.update.latestScriptVersionName("2099-01-01 - Big Update");
+  settings.invalidateCache();
+  await settings.loadKeys(ALL_SETTINGS_KEYS);
+};
+
+describeWithEnv(
+  "loadBuiltSiteUpdateState",
+  { db: true, env: { BUNNY_API_KEY: "host-key" } },
+  () => {
+    let createStub: Stub | null;
+
+    afterEach(() => {
+      createStub?.restore();
+      createStub = null;
+      settings.clearTestOverrides();
+    });
+
+    /** Point the site-db factory at a seeded in-memory client. */
+    const stubSiteDb = (client: Client): void => {
+      createStub = stub(siteDbApi, "createClient", () => client);
+    };
+
+    test("reports an update when the latest release is newer than the site", async () => {
+      await setLatestRelease(LATEST_TAG);
+      stubSiteDb(await seedSiteDb("2026-01-01T00:00:00Z"));
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8001",
+        dbToken: "ro",
+        dbUrl: "libsql://site",
+        name: "Behind Site",
+      });
+
+      const state = await loadBuiltSiteUpdateState(site);
+
+      expect(state.siteVersionLabel).toContain("2026");
+      expect(state.updateAvailable).toBe(true);
+      expect(state.upToDate).toBe(false);
+      expect(state.bunnyConfigured).toBe(true);
+      expect(state.hasScriptId).toBe(true);
+      expect(state.siteVersionError).toBeNull();
+    });
+
+    test("reports up to date when the site is on the latest release", async () => {
+      await setLatestRelease(LATEST_TAG);
+      stubSiteDb(await seedSiteDb("2100-01-01T00:00:00Z"));
+      const site = await createTestBuiltSite({
+        bunnyScriptId: "8002",
+        dbToken: "ro",
+        dbUrl: "libsql://site",
+        name: "Current Site",
+      });
+
+      const state = await loadBuiltSiteUpdateState(site);
+
+      expect(state.updateAvailable).toBe(false);
+      expect(state.upToDate).toBe(true);
+    });
+
+    test("leaves the version unknown when no database keys are stored", async () => {
+      await setLatestRelease(LATEST_TAG);
+      const site = await createTestBuiltSite({ name: "No DB Site" });
+
+      const state = await loadBuiltSiteUpdateState(site);
+
+      expect(state.siteVersionLabel).toBeNull();
+      expect(state.siteVersionError).toBeNull();
+      expect(state.updateAvailable).toBe(false);
+      expect(state.upToDate).toBe(false);
+      expect(state.hasScriptId).toBe(false);
+    });
+
+    test("surfaces a read error when the site's database is unreachable", async () => {
+      await setLatestRelease(LATEST_TAG);
+      createStub = stub(siteDbApi, "createClient", () => {
+        throw new Error("connection refused");
+      });
+      const site = await createTestBuiltSite({
+        dbToken: "ro",
+        dbUrl: "libsql://unreachable",
+        name: "Broken DB Site",
+      });
+
+      const state = await loadBuiltSiteUpdateState(site);
+
+      expect(state.siteVersionLabel).toBeNull();
+      expect(state.siteVersionError).toBe("connection refused");
+    });
+
+    test("cannot compare when the host has never checked for a release", async () => {
+      stubSiteDb(await seedSiteDb("2026-01-01T00:00:00Z"));
+      const site = await createTestBuiltSite({
+        dbToken: "ro",
+        dbUrl: "libsql://site",
+        name: "No Latest Site",
+      });
+
+      const state = await loadBuiltSiteUpdateState(site);
+
+      expect(state.latestVersion).toBe("");
+      expect(state.siteVersionLabel).toContain("2026");
+      expect(state.updateAvailable).toBe(false);
+      expect(state.upToDate).toBe(false);
+    });
+  },
+);
+
+describeWithEnv("recordScriptVersion", { db: true }, () => {
+  afterEach(() => {
+    setBuildTimestampForTest(null);
+  });
+
+  const readVersion = (): Promise<{ value: string } | null> =>
+    queryOne<{ value: string }>("SELECT value FROM settings WHERE key = ?", [
+      CURRENT_SCRIPT_VERSION_KEY,
+    ]);
+
+  test("records the running build's version", async () => {
+    setBuildTimestampForTest("2026-06-19T12:00:00Z");
+    await recordScriptVersion();
+    expect((await readVersion())?.value).toBe("2026-06-19T12:00:00Z");
+  });
+
+  test("leaves the stored version untouched when it is unchanged", async () => {
+    setBuildTimestampForTest("2026-06-19T12:00:00Z");
+    await recordScriptVersion();
+    // Second call takes the unchanged fast-path and must not corrupt the value.
+    await recordScriptVersion();
+    expect((await readVersion())?.value).toBe("2026-06-19T12:00:00Z");
+  });
+
+  test("is a no-op for development builds with no version", async () => {
+    setBuildTimestampForTest(null);
+    await recordScriptVersion();
+    expect(await readVersion()).toBeNull();
+  });
+
+  test("swallows database errors so it can never block boot", async () => {
+    setBuildTimestampForTest("2026-06-19T12:00:00Z");
+    const { getDb } = await import("#shared/db/client.ts");
+    await getDb().execute("DROP TABLE settings");
+    // Reading/writing the missing table throws inside; the call must still resolve.
+    await recordScriptVersion();
+  });
+});

--- a/test/templates/admin/built-sites.test.ts
+++ b/test/templates/admin/built-sites.test.ts
@@ -245,3 +245,70 @@ describe("adminBuiltSiteEditPage — secrets panel", () => {
     expect(html).toContain("Secrets status is unavailable");
   });
 });
+
+describe("adminBuiltSiteEditPage — update panel", () => {
+  const site = testBuiltSite({ id: 42, name: "Panel Site" });
+  const baseState = {
+    bunnyConfigured: true,
+    hasScriptId: true,
+    latestVersion: "v2099-01-01-120000",
+    latestVersionName: "2099-01-01 - Big Update",
+    siteVersionError: null as string | null,
+    siteVersionLabel: "Thu, 01 Jan 2026 00:00:00 UTC" as string | null,
+    updateAvailable: true,
+    upToDate: false,
+  };
+  const render = (overrides: Partial<typeof baseState> = {}): string =>
+    adminBuiltSiteEditPage(
+      site,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      undefined,
+      { ...baseState, ...overrides },
+    );
+
+  test("shows the version, latest release, and an update button when behind", () => {
+    const html = render();
+    expect(html).toContain("Software update");
+    expect(html).toContain("Thu, 01 Jan 2026 00:00:00 UTC");
+    expect(html).toContain("2099-01-01 - Big Update (v2099-01-01-120000)");
+    expect(html).toContain("An update is available");
+    expect(html).toContain("/admin/built-sites/42/update");
+    expect(html).toContain("Update this site");
+  });
+
+  test("shows up to date when the site is on the latest release", () => {
+    const html = render({ updateAvailable: false, upToDate: true });
+    expect(html).toContain("on the latest known release");
+  });
+
+  test("shows unknown when no database keys are stored", () => {
+    const html = render({ siteVersionLabel: null, updateAvailable: false });
+    expect(html).toContain("no read-only database credentials");
+  });
+
+  test("shows the read error when the site database is unreachable", () => {
+    const html = render({
+      siteVersionError: "connection refused",
+      siteVersionLabel: null,
+      updateAvailable: false,
+    });
+    expect(html).toContain("connection refused");
+  });
+
+  test("notes when the host has not checked for a release yet", () => {
+    const html = render({ latestVersion: "", updateAvailable: false });
+    expect(html).toContain("None checked yet");
+  });
+
+  test("explains when automatic update is unavailable", () => {
+    const html = render({
+      bunnyConfigured: false,
+      updateAvailable: false,
+      upToDate: false,
+    });
+    expect(html).toContain("Automatic update needs BUNNY_API_KEY");
+    expect(html).not.toContain("Update this site");
+  });
+});


### PR DESCRIPTION
## What & why

Adds an **Update** button to a built site's edit page (`/admin/built-sites/:id`). It runs the **exact same process as our own self-update** — fetch the latest GitHub release, upload its `bunny-script.ts` asset to a Bunny edge script, and publish — but targets the **site's own** script instead of this host's.

Where we hold a site's database info, we also read its **current version** from its settings and compare it against the latest release, so the panel can show whether the site is behind.

## How it works

**Sites self-record their version.** A running build's version isn't stored in the DB today (it's a compile-time constant), so each site now writes its `BUILD_TIMESTAMP` to a plaintext `current_script_version` setting on boot — **only when it changed**, via a single indexed read (`recordScriptVersion`, wired into `initDb`, once per isolate, best-effort, no-op in dev). Stored plaintext on purpose: the parent host reads it back with the site's **read-only** keys (we never hold the per-site `DB_ENCRYPTION_KEY`).

**Generic read-only DB access** (`src/shared/site-db.ts`) — the reusable layer for "read a built site's database" that we'll want for more things later:
- `withSiteDb(creds, fn)` — open with the read-only keys, run a read, always close
- `readSiteSetting(creds, key)` — read one plaintext setting
- `builder.ts`'s `testDbConnection` now delegates here (removing the duplicated connect-and-query block)

**Shared deploy path.** `bunny-cdn.ts`'s `deployScriptCode` and `update.ts`'s `deployRelease` take an optional target `scriptId`; both self-update and the new site update call the shared `deployLatestReleaseToScript(scriptId?)` — no duplication. `isNewerVersion` accepts an explicit build timestamp so a site's recorded version can be compared to the latest release.

**UI.** `POST /admin/built-sites/:id/update` (owner + CSRF, runs under the same `withCurrentTask("update")` lock, logs activity) plus an update panel showing the site's version vs the latest known release ("update available" / "up to date" / "unknown").

## Comparison target

"Up to date" compares the site's version against the **latest GitHub release** — exactly what the button deploys.

## Tests

New/extended coverage for the generic DB layer, version recording, the parameterized deploy, the comparison state, the route handler (success / no key / no script id / task-in-progress / deploy failure / 404 / CSRF), and the template panel. `deno task precommit` passes — lint, typecheck, 0% duplication, build, and **100% test coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDqbtX3nc7M6X3meC2D8pN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDqbtX3nc7M6X3meC2D8pN)_