### PR TITLE
Invalidate settings cache on settings table writes

### DIFF
--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -134,6 +134,14 @@ export const setDb = (client: Client | null): void => dbSetter(client);
 export const resultRows = <T>(result: ResultSet): T[] =>
   result.rows as unknown as T[];
 
+const executeTrackedStatement = (
+  sql: string,
+  args?: InValue[],
+): Promise<ResultSet> =>
+  trackQuery(sql, () =>
+    args ? getDb().execute({ args, sql }) : getDb().execute(sql),
+  );
+
 /**
  * Run a single statement: track it for the query log / N+1 guard, then fire any
  * table-scoped cache invalidation. Every single-statement read and write goes
@@ -144,12 +152,22 @@ export const execute = async (
   sql: string,
   args?: InValue[],
 ): Promise<ResultSet> => {
-  const result = await trackQuery(sql, () =>
-    args ? getDb().execute({ args, sql }) : getDb().execute(sql),
-  );
+  const result = await executeTrackedStatement(sql, args);
   invalidateForSql(sql);
   return result;
 };
+
+/**
+ * Run a single statement without table-scoped cache invalidation.
+ *
+ * This is intentionally narrow: callers that maintain their own cache state
+ * during a write can avoid a broad invalidation/reset while still preserving
+ * query tracking. Other writes should use `execute`.
+ */
+export const executeWithoutCacheInvalidation = async (
+  sql: string,
+  args?: InValue[],
+): Promise<ResultSet> => executeTrackedStatement(sql, args);
 
 /** Query single row, returning null if not found */
 export const queryOne = async <T>(

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -15,7 +15,10 @@
  */
 
 import { lazyRef, unique } from "#fp";
-import { registerCache } from "#shared/cache-registry.ts";
+import {
+  registerCache,
+  registerTableInvalidation,
+} from "#shared/cache-registry.ts";
 import { DEFAULT_COUNTRY, getCountry } from "#shared/countries.ts";
 import { decrypt, encrypt, encryptWithKey } from "#shared/crypto/encryption.ts";
 import { hashPassword } from "#shared/crypto/hashing.ts";
@@ -26,7 +29,11 @@ import {
   unwrapKey,
   wrapKey,
 } from "#shared/crypto/keys.ts";
-import { execute, queryAll } from "#shared/db/client.ts";
+import {
+  execute,
+  executeWithoutCacheInvalidation,
+  queryAll,
+} from "#shared/db/client.ts";
 import { deleteAllSessions } from "#shared/db/sessions.ts";
 import {
   recordSettingRead,
@@ -411,10 +418,10 @@ const syncCache = (mutate: (state: CacheState) => void): void => {
 
 /** Write a setting to the DB and update the raw cache in-place. */
 const writeRaw = async (key: string, value: string): Promise<void> => {
-  await execute("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", [
-    key,
-    value,
-  ]);
+  await executeWithoutCacheInvalidation(
+    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    [key, value],
+  );
   // A write makes the key's value known this request, so reading it back is
   // safe in production too — record it as available for the read audit.
   recordSettingsLoaded([key]);
@@ -426,7 +433,9 @@ const writeRaw = async (key: string, value: string): Promise<void> => {
 
 /** Delete a setting from the DB and remove it from the raw cache. */
 const deleteRaw = async (key: string): Promise<void> => {
-  await execute("DELETE FROM settings WHERE key = ?", [key]);
+  await executeWithoutCacheInvalidation("DELETE FROM settings WHERE key = ?", [
+    key,
+  ]);
   recordSettingsLoaded([key]);
   syncCache((s) => {
     s.values.delete(key);
@@ -759,6 +768,8 @@ const invalidateCache = (): void => {
   }
 };
 
+registerTableInvalidation(["settings"], invalidateCache);
+
 // ---------------------------------------------------------------------------
 // Setup-complete permanent cache
 // ---------------------------------------------------------------------------
@@ -868,11 +879,12 @@ const withCurrentTask = async <T>(
   fn: () => Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false; error: string }> => {
   // Ensure the row exists (no-op if already present)
-  await execute("INSERT OR IGNORE INTO settings (key, value) VALUES (?, '')", [
-    CONFIG_KEYS.CURRENT_TASK,
-  ]);
+  await executeWithoutCacheInvalidation(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES (?, '')",
+    [CONFIG_KEYS.CURRENT_TASK],
+  );
   // Atomic claim: only succeeds when no task is running
-  const claim = await execute(
+  const claim = await executeWithoutCacheInvalidation(
     "UPDATE settings SET value = ? WHERE key = ? AND value = ''",
     [taskName, CONFIG_KEYS.CURRENT_TASK],
   );

--- a/test/lib/db/settings.test.ts
+++ b/test/lib/db/settings.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
-import { getDb } from "#shared/db/client.ts";
+import { execute, getDb } from "#shared/db/client.ts";
 import {
   ALL_SETTINGS_KEYS,
   CONFIG_KEYS,
@@ -34,6 +34,21 @@ describeWithEnv("db > settings", { db: true }, () => {
       await settings.loadKeys(["key"]);
       const value = settings.getCachedRaw("key");
       expect(value).toBe("value2");
+    });
+
+    test("settings table writes invalidate the loaded settings cache", async () => {
+      await settings.update.paymentProvider("stripe");
+      settings.invalidateCache();
+      await settings.loadKeys([CONFIG_KEYS.PAYMENT_PROVIDER]);
+      expect(settings.paymentProvider).toBe("stripe");
+
+      await execute("UPDATE settings SET value = ? WHERE key = ?", [
+        "square",
+        CONFIG_KEYS.PAYMENT_PROVIDER,
+      ]);
+      await settings.loadKeys([CONFIG_KEYS.PAYMENT_PROVIDER]);
+
+      expect(settings.paymentProvider).toBe("square");
     });
   });
 


### PR DESCRIPTION
### Motivation
- Fix the observed lag after changing settings (e.g. business email) by purging the settings snapshot immediately when the `settings` table is written so new requests see updates without waiting for the TTL.
- Reuse the existing table→cache invalidation machinery so cache purging is consistent with other DB-backed caches.

### Description
- Register the settings raw cache with the table invalidation registry via `registerTableInvalidation(["settings"], invalidateCache)` so writes to the `settings` table clear the snapshot immediately (`src/shared/db/settings.ts`).
- Add a tracked helper `executeTrackedStatement` and a narrow `executeWithoutCacheInvalidation` wrapper to the DB client so callers can run SQL that should not trigger the general per-statement invalidation while still being tracked (`src/shared/db/client.ts`).
- Switch internal settings write paths (`writeRaw`, `deleteRaw`, and the `current_task` claim) to use `executeWithoutCacheInvalidation` because they already update the in-memory cache state directly and should not cause duplicate invalidation (`src/shared/db/settings.ts`).
- Add a regression test that updates the `settings` table directly and asserts the loaded snapshot is refreshed on next `loadKeys` (`test/lib/db/settings.test.ts`).

### Testing
- Ran the focused test file with `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/lib/db/settings.test.ts`, and the test suite for that file passed (44 passed). 
- Ran the full precommit checks with `DENO_TLS_CA_STORE=system mise exec -- deno task precommit`, and the precommit pipeline (lint, typecheck, cpd, build:edge, test:coverage) completed successfully after the changes.
- The new regression test verifying that a direct `UPDATE settings` is reflected by `settings.loadKeys` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a359d1e3bc4832db6794083185e3d60)