### PR TITLE
Avoid balance summary listing N+1 queries

### DIFF
--- a/src/shared/db/attendees/balance.ts
+++ b/src/shared/db/attendees/balance.ts
@@ -8,6 +8,7 @@
 
 import type { InValue } from "@libsql/client";
 import { compact, mapParallel, sumOf } from "#fp";
+import { decrypt } from "#shared/crypto/encryption.ts";
 import { formatCurrency } from "#shared/currency.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import { getPaidDefaultStatus } from "#shared/db/attendee-statuses.ts";
@@ -16,7 +17,6 @@ import {
   queryAll,
   queryOne,
 } from "#shared/db/client.ts";
-import { getListingWithCount } from "#shared/db/listings.ts";
 
 /** Plaintext reservation state for an attendee. */
 export type AttendeeBalanceState = {
@@ -65,35 +65,50 @@ export type OrderSummary = {
  * full order price (current listing prices), the quantity and what's been paid
  * so far. Used by the admin balance panel and the public balance page.
  */
-type OrderRow = { listing_id: number; quantity: number; price_paid: number };
+type OrderRow = {
+  listing_id: number;
+  quantity: number;
+  price_paid: number;
+  listing_name: string | null;
+  listing_unit_price: number | null;
+};
+
+const getAttendeeOrderRows = (attendeeId: number): Promise<OrderRow[]> =>
+  queryAll<OrderRow>(
+    `SELECT listingAttendee.listing_id,
+            listingAttendee.quantity,
+            listingAttendee.price_paid,
+            listing.name AS listing_name,
+            listing.unit_price AS listing_unit_price
+       FROM listing_attendees AS listingAttendee
+       LEFT JOIN listings AS listing ON listing.id = listingAttendee.listing_id
+      WHERE listingAttendee.attendee_id = ?
+      ORDER BY listingAttendee.id`,
+    [attendeeId],
+  );
+
+const orderLineFromRow = async (row: OrderRow): Promise<OrderLine | null> =>
+  row.listing_name === null || row.listing_unit_price === null
+    ? null
+    : {
+        listingId: row.listing_id,
+        name: await decrypt(row.listing_name),
+        pricePaid: row.price_paid,
+        quantity: row.quantity,
+        unitPrice: row.listing_unit_price,
+      };
 
 export const getAttendeeOrderSummary = async (
   attendeeId: number,
 ): Promise<OrderSummary> => {
   const [rows, state] = await Promise.all([
-    queryAll<OrderRow>(
-      "SELECT listing_id, quantity, price_paid FROM listing_attendees WHERE attendee_id = ? ORDER BY id",
-      [attendeeId],
-    ),
+    getAttendeeOrderRows(attendeeId),
     getAttendeeBalanceState(attendeeId),
   ]);
 
-  // Resolve each line's current listing (concurrently); drop lines whose
-  // listing has since been deleted.
-  const lines = compact(
-    await mapParallel(async (row: OrderRow): Promise<OrderLine | null> => {
-      const listing = await getListingWithCount(row.listing_id);
-      return listing
-        ? {
-            listingId: row.listing_id,
-            name: listing.name,
-            pricePaid: row.price_paid,
-            quantity: row.quantity,
-            unitPrice: listing.unit_price,
-          }
-        : null;
-    })(rows),
-  );
+  // The LEFT JOIN keeps dangling booking rows visible so we can preserve the
+  // previous behavior of dropping lines whose listing has since been deleted.
+  const lines = compact(await mapParallel(orderLineFromRow)(rows));
 
   const depositPaid = sumOf((l: OrderLine) => l.pricePaid)(lines);
   const listedFullPrice = sumOf((l: OrderLine) => l.unitPrice * l.quantity)(

--- a/test/lib/db/settle-balance.test.ts
+++ b/test/lib/db/settle-balance.test.ts
@@ -13,6 +13,11 @@ import {
 } from "#shared/db/attendees/balance.ts";
 import { createAttendeeAtomic } from "#shared/db/attendees.ts";
 import { getDb } from "#shared/db/client.ts";
+import {
+  enableQueryLog,
+  getQueryLog,
+  runWithQueryLogContext,
+} from "#shared/db/query-log.ts";
 import { createTestListing, describeWithEnv } from "#test-utils";
 
 /** Create a reserved attendee with an outstanding balance. */
@@ -180,5 +185,41 @@ describeWithEnv("db > settle attendee balance", { db: true }, () => {
     const summary = await getAttendeeOrderSummary(attendeeId);
     // Only the real listing is included; the dangling row is dropped.
     expect(summary.lines).toHaveLength(1);
+  });
+
+  test("order summary loads booking listings with one joined read", async () => {
+    const { attendeeId, listingId } = await createReservedAttendee(1500);
+    const otherListing = await createTestListing({
+      maxAttendees: 10,
+      thankYouUrl: "https://example.com/other",
+      unitPrice: 1200,
+    });
+    await getDb().execute({
+      args: [otherListing.id, attendeeId],
+      sql: "INSERT INTO listing_attendees (listing_id, attendee_id, quantity, price_paid) VALUES (?, ?, 2, 240)",
+    });
+
+    const { entries, summary } = await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      const summary = await getAttendeeOrderSummary(attendeeId);
+      return { entries: getQueryLog(), summary };
+    });
+
+    expect(summary.lines.map((line) => line.listingId)).toEqual([
+      listingId,
+      otherListing.id,
+    ]);
+    expect(
+      entries.filter((entry) =>
+        entry.sql.includes("FROM listing_attendees AS listingAttendee"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      entries.filter(
+        (entry) =>
+          entry.sql.includes("FROM listings AS listing") &&
+          !entry.sql.includes("JOIN listings"),
+      ),
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
### Motivation

- The attendee balance/order summary did a per-booking `getListingWithCount()` lookup, causing an N+1 when an attendee has multiple booked lines.
- The change aims to perform a single read for all booking listings while preserving the previous behavior for deleted listings (dangling booking rows should be dropped).

### Description

- Replace the per-row `getListingWithCount()` calls with a single `LEFT JOIN` query that selects `listing.name` and `listing.unit_price` alongside each `listing_attendees` row and expose those fields via `getAttendeeOrderRows`.
- Add `orderLineFromRow` to convert joined rows into `OrderLine` instances, using `LEFT JOIN` null checks to drop bookings whose listing was deleted and `decrypt()` to decrypt the listing name.
- Remove the concurrent per-row cache lookups and map the joined results with `mapParallel`, returning the same `OrderSummary` shape.
- Add a regression test that enables the query log and asserts the summary loads booking listings with a single joined read and that no standalone listing lookup SQL is emitted.

### Testing

- Ran the focused unit tests with `DENO_TLS_CA_STORE=system deno task test:files test/lib/db/settle-balance.test.ts` and the file passed (all tests in that file are OK).
- Ran the full precommit checks with `DENO_TLS_CA_STORE=system mise exec -- deno task precommit`; lint passed but the `typecheck` step failed due to existing unrelated TypeScript errors under `src/ui/client/admin/*` (these are pre-existing and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ea1bb66c832da7b62d9b2b84895a)