### PR TITLE
Batch modifier scope resolution

### DIFF
--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -58,12 +58,10 @@ const listingIdsByModifierId = async (
     getModifierListingIdsByModifierId(listingScoped.map((m) => m.id)),
     getModifierGroupListingIdsByModifierId(groupScoped.map((m) => m.id)),
   ]);
-  for (const modifier of listingScoped) {
-    scopes.set(modifier.id, listingLinks.get(modifier.id) ?? []);
-  }
-  for (const modifier of groupScoped) {
-    scopes.set(modifier.id, groupLinks.get(modifier.id) ?? []);
-  }
+  // Each lookup seeds an entry for every id it was given, so these maps cover
+  // exactly the scoped modifiers — copy their links straight in.
+  for (const [id, ids] of listingLinks) scopes.set(id, ids);
+  for (const [id, ids] of groupLinks) scopes.set(id, ids);
   return scopes;
 };
 

--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -20,8 +20,8 @@ import {
 import { modifierUsedQuantities } from "#shared/db/modifier-usage.ts";
 import {
   getActiveModifiers,
-  getModifierGroupListingIds,
-  getModifierListingIds,
+  getModifierGroupListingIdsByModifierId,
+  getModifierListingIdsByModifierId,
   modifierIdsByAnswerId,
 } from "#shared/db/modifiers.ts";
 import type {
@@ -44,13 +44,27 @@ const signedValue = (modifier: Modifier): number => {
   return modifier.direction === "discount" ? -magnitude : magnitude;
 };
 
-/** The listing ids a modifier is charged on, or null for the whole order. */
-const listingIdsFor = (modifier: Modifier): Promise<number[]> | null => {
-  if (modifier.scope === "groups") {
-    return getModifierGroupListingIds(modifier.id);
+/** Batched listing scopes for modifiers: null = whole order, array = scoped. */
+const listingIdsByModifierId = async (
+  modifiers: Modifier[],
+): Promise<Map<number, number[] | null>> => {
+  const scopes = new Map<number, number[] | null>();
+  const listingScoped = modifiers.filter((m) => m.scope === "listings");
+  const groupScoped = modifiers.filter((m) => m.scope === "groups");
+  for (const modifier of modifiers) {
+    if (modifier.scope === "all") scopes.set(modifier.id, null);
   }
-  if (modifier.scope === "listings") return getModifierListingIds(modifier.id);
-  return null;
+  const [listingLinks, groupLinks] = await Promise.all([
+    getModifierListingIdsByModifierId(listingScoped.map((m) => m.id)),
+    getModifierGroupListingIdsByModifierId(groupScoped.map((m) => m.id)),
+  ]);
+  for (const modifier of listingScoped) {
+    scopes.set(modifier.id, listingLinks.get(modifier.id) ?? []);
+  }
+  for (const modifier of groupScoped) {
+    scopes.set(modifier.id, groupLinks.get(modifier.id) ?? []);
+  }
+  return scopes;
 };
 
 /** Build the checkout spec for a modifier applied `quantity` times. */
@@ -134,16 +148,13 @@ const answerModifierScopes = async (
   ids: number[],
 ): Promise<Map<number, number[] | null>> => {
   const byId = await activeModifiersById();
-  const scopes = new Map<number, number[] | null>();
-  await Promise.all(
-    ids.map(async (id) => {
-      const modifier = byId.get(id);
-      if (modifier?.trigger !== "answer") return;
-      const listingIds = listingIdsFor(modifier);
-      scopes.set(id, listingIds === null ? null : await listingIds);
-    }),
+  return listingIdsByModifierId(
+    ids
+      .map((id) => byId.get(id))
+      .filter(
+        (modifier): modifier is Modifier => modifier?.trigger === "answer",
+      ),
   );
-  return scopes;
 };
 
 /** Whether a resolved scope covers a listing: null = whole order (always),
@@ -240,11 +251,11 @@ const eligibleCandidates = async (
   const codeIndex = opts.code?.trim()
     ? await hmacHash(normalizeCode(opts.code))
     : null;
+  const activeModifiers = await getActiveModifiers();
+  const scopes = await listingIdsByModifierId(activeModifiers);
   return (
     await Promise.all(
-      (
-        await getActiveModifiers()
-      ).map(async (modifier): Promise<Candidate | null> => {
+      activeModifiers.map(async (modifier): Promise<Candidate | null> => {
         if (modifier.min_visits > ctx.visits) return null;
         const quantity = triggerQuantity(
           modifier,
@@ -253,7 +264,7 @@ const eligibleCandidates = async (
           answerQuantities,
         );
         if (quantity < 1) return null;
-        const listingIds = await listingIdsFor(modifier);
+        const listingIds = scopes.get(modifier.id)!;
         const base = inScopeSubtotal(items, listingIds);
         // A scoped modifier only applies alongside its listings/groups.
         if (listingIds !== null && base === 0) return null;
@@ -371,16 +382,11 @@ export const getOptionalAddOns = async (
     (m) => m.trigger === "optional",
   );
   const pageIds = new Set(pageListingIds);
-  const scoped = (
-    await Promise.all(
-      optional.map(async (modifier) => {
-        const listingIds = await listingIdsFor(modifier);
-        const inScope =
-          listingIds === null || listingIds.some((id) => pageIds.has(id));
-        return inScope ? modifier : null;
-      }),
-    )
-  ).filter((m): m is Modifier => m !== null);
+  const scopes = await listingIdsByModifierId(optional);
+  const scoped = optional.filter((modifier) => {
+    const listingIds = scopes.get(modifier.id)!;
+    return listingIds === null || listingIds.some((id) => pageIds.has(id));
+  });
   const used = await modifierUsedQuantities(
     scoped.filter((m) => m.stock !== null).map((m) => m.id),
   );
@@ -411,14 +417,14 @@ export const specsFromRefs = async (
 ): Promise<ModifierSpec[]> => {
   if (refs.length === 0) return [];
   const byId = await activeModifiersById();
-  const specs = await Promise.all(
-    refs.map(async (ref) => {
-      const modifier = byId.get(ref.i);
-      if (modifier && modifier.min_visits > ctx.visits) return null;
-      return modifier
-        ? toSpec(modifier, ref.q, await listingIdsFor(modifier))
-        : null;
-    }),
-  );
+  const refModifiers = refs
+    .map((ref) => byId.get(ref.i))
+    .filter((modifier): modifier is Modifier => modifier !== undefined);
+  const scopes = await listingIdsByModifierId(refModifiers);
+  const specs = refs.map((ref) => {
+    const modifier = byId.get(ref.i);
+    if (modifier && modifier.min_visits > ctx.visits) return null;
+    return modifier ? toSpec(modifier, ref.q, scopes.get(modifier.id)!) : null;
+  });
   return specs.filter((s): s is ModifierSpec => s !== null);
 };

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -173,18 +173,6 @@ export const getModifierListingIds = (modifierId: number): Promise<number[]> =>
     modifierId,
   );
 
-/** Listing ids belonging to the groups a modifier is linked to (scope = "groups"). */
-export const getModifierGroupListingIds = (
-  modifierId: number,
-): Promise<number[]> =>
-  modifierIdColumn(
-    `SELECT listing.id FROM listings AS listing
-       JOIN modifier_groups AS modifierGroup
-         ON modifierGroup.group_id = listing.group_id
-     WHERE modifierGroup.modifier_id = ?`,
-    modifierId,
-  );
-
 type ModifierListingLinkRow = { listing_id: number; modifier_id: number };
 
 const emptyModifierScopeMap = (modifierIds: number[]): Map<number, number[]> =>
@@ -200,33 +188,36 @@ const appendModifierListingLinks = (
   return links;
 };
 
+/** Build a batched modifier->listing scope lookup: the returned function runs
+ * `buildSql` (given the bound `IN (...)` placeholders) and buckets the rows by
+ * modifier id. */
+const modifierScopeListingIdsLookup =
+  (buildSql: (placeholders: string) => string) =>
+  async (modifierIds: number[]): Promise<Map<number, number[]>> => {
+    if (modifierIds.length === 0) return new Map();
+    const rows = await queryAll<ModifierListingLinkRow>(
+      buildSql(inPlaceholders(modifierIds)),
+      modifierIds,
+    );
+    return appendModifierListingLinks(emptyModifierScopeMap(modifierIds), rows);
+  };
+
 /** Listing ids directly linked to each listing-scoped modifier id. */
-export const getModifierListingIdsByModifierId = async (
-  modifierIds: number[],
-): Promise<Map<number, number[]>> => {
-  if (modifierIds.length === 0) return new Map();
-  const rows = await queryAll<ModifierListingLinkRow>(
+export const getModifierListingIdsByModifierId = modifierScopeListingIdsLookup(
+  (placeholders) =>
     `SELECT modifier_id, listing_id FROM modifier_listings
-     WHERE modifier_id IN (${inPlaceholders(modifierIds)})`,
-    modifierIds,
-  );
-  return appendModifierListingLinks(emptyModifierScopeMap(modifierIds), rows);
-};
+     WHERE modifier_id IN (${placeholders})`,
+);
 
 /** Listing ids belonging to linked groups for each group-scoped modifier id. */
-export const getModifierGroupListingIdsByModifierId = async (
-  modifierIds: number[],
-): Promise<Map<number, number[]>> => {
-  if (modifierIds.length === 0) return new Map();
-  const rows = await queryAll<ModifierListingLinkRow>(
-    `SELECT modifierGroup.modifier_id, listing.id AS listing_id
-     FROM modifier_groups AS modifierGroup
-       JOIN listings AS listing ON listing.group_id = modifierGroup.group_id
-     WHERE modifierGroup.modifier_id IN (${inPlaceholders(modifierIds)})`,
-    modifierIds,
+export const getModifierGroupListingIdsByModifierId =
+  modifierScopeListingIdsLookup(
+    (placeholders) =>
+      `SELECT modifierGroup.modifier_id, listing.id AS listing_id
+       FROM modifier_groups AS modifierGroup
+         JOIN listings AS listing ON listing.group_id = modifierGroup.group_id
+       WHERE modifierGroup.modifier_id IN (${placeholders})`,
   );
-  return appendModifierListingLinks(emptyModifierScopeMap(modifierIds), rows);
-};
 
 /** Group ids a modifier is linked to (for the admin scope editor). */
 export const getModifierGroupIds = (modifierId: number): Promise<number[]> =>

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -179,10 +179,54 @@ export const getModifierGroupListingIds = (
 ): Promise<number[]> =>
   modifierIdColumn(
     `SELECT listing.id FROM listings AS listing
-       JOIN modifier_groups mg ON mg.group_id = listing.group_id
-     WHERE mg.modifier_id = ?`,
+       JOIN modifier_groups AS modifierGroup
+         ON modifierGroup.group_id = listing.group_id
+     WHERE modifierGroup.modifier_id = ?`,
     modifierId,
   );
+
+type ModifierListingLinkRow = { listing_id: number; modifier_id: number };
+
+const emptyModifierScopeMap = (modifierIds: number[]): Map<number, number[]> =>
+  new Map(modifierIds.map((id) => [id, []]));
+
+const appendModifierListingLinks = (
+  links: Map<number, number[]>,
+  rows: ModifierListingLinkRow[],
+): Map<number, number[]> => {
+  for (const row of rows) {
+    links.get(row.modifier_id)!.push(row.listing_id);
+  }
+  return links;
+};
+
+/** Listing ids directly linked to each listing-scoped modifier id. */
+export const getModifierListingIdsByModifierId = async (
+  modifierIds: number[],
+): Promise<Map<number, number[]>> => {
+  if (modifierIds.length === 0) return new Map();
+  const rows = await queryAll<ModifierListingLinkRow>(
+    `SELECT modifier_id, listing_id FROM modifier_listings
+     WHERE modifier_id IN (${inPlaceholders(modifierIds)})`,
+    modifierIds,
+  );
+  return appendModifierListingLinks(emptyModifierScopeMap(modifierIds), rows);
+};
+
+/** Listing ids belonging to linked groups for each group-scoped modifier id. */
+export const getModifierGroupListingIdsByModifierId = async (
+  modifierIds: number[],
+): Promise<Map<number, number[]>> => {
+  if (modifierIds.length === 0) return new Map();
+  const rows = await queryAll<ModifierListingLinkRow>(
+    `SELECT modifierGroup.modifier_id, listing.id AS listing_id
+     FROM modifier_groups AS modifierGroup
+       JOIN listings AS listing ON listing.group_id = modifierGroup.group_id
+     WHERE modifierGroup.modifier_id IN (${inPlaceholders(modifierIds)})`,
+    modifierIds,
+  );
+  return appendModifierListingLinks(emptyModifierScopeMap(modifierIds), rows);
+};
 
 /** Group ids a modifier is linked to (for the admin scope editor). */
 export const getModifierGroupIds = (modifierId: number): Promise<number[]> =>

--- a/test/lib/checkout-pricing-consistency.test.ts
+++ b/test/lib/checkout-pricing-consistency.test.ts
@@ -8,6 +8,11 @@ import {
   resolveModifiers,
   specsFromRefs,
 } from "#shared/db/modifier-resolve.ts";
+import {
+  enableQueryLog,
+  getQueryLog,
+  runWithQueryLogContext,
+} from "#shared/db/query-log.ts";
 import { answersTable, questionsTable } from "#shared/db/questions.ts";
 import { toModifierRefs } from "#shared/payment-helpers.ts";
 import type {
@@ -161,6 +166,36 @@ describeWithEnv(
       const specs = await resolveModifiers(items);
       expect(specs[0]!.listingIds).toEqual([1]);
       await expectConsistent(items, specs);
+    });
+
+    test("listing-scoped modifier resolution batches scope links", async () => {
+      const modifiers = await Promise.all(
+        [1, 2, 3].map(async (listingId) => {
+          const m = await insertModifier({
+            calcKind: "fixed",
+            calcValue: 1,
+            direction: "charge",
+            name: `Scope ${listingId}`,
+          });
+          await patchModifier(m.id, { scope: "listings" });
+          await linkModifierListing(m.id, listingId);
+          return m;
+        }),
+      );
+
+      const { scopeQueries, specs } = await runWithQueryLogContext(async () => {
+        enableQueryLog();
+        const specs = await resolveModifiers([checkoutItem({ listingId: 1 })]);
+        return {
+          scopeQueries: getQueryLog().filter((entry) =>
+            entry.sql.includes("FROM modifier_listings"),
+          ),
+          specs,
+        };
+      });
+
+      expect(specs.map((s) => s.id)).toEqual([modifiers[0]!.id]);
+      expect(scopeQueries).toHaveLength(1);
     });
 
     test("a code modifier is re-applied on the webhook without re-entering the code", async () => {


### PR DESCRIPTION
### Motivation
- Public checkout was performing one DB lookup per listing- or group-scoped modifier, causing unbounded subrequests as modifier count grows.  The change batches scope lookups to keep DB round-trips bounded.

### Description
- Add batched scope-link helpers `getModifierListingIdsByModifierId` and `getModifierGroupListingIdsByModifierId` in `src/shared/db/modifiers.ts` and small join-alias fix to the existing single-id helpers.
- Introduce `listingIdsByModifierId` in `src/shared/db/modifier-resolve.ts` and replace per-modifier `modifier_listings` / `modifier_groups` calls with a single batched map lookup.
- Update callers to use the batched scope map: `resolveModifiers`, `answerModifierScopes` / `answerModifierQuantities`, `getOptionalAddOns`, and `specsFromRefs` so scope resolution is performed in at most a few queries rather than one per modifier.
- Add a regression test `listing-scoped modifier resolution batches scope links` in `test/lib/checkout-pricing-consistency.test.ts` that asserts only one `FROM modifier_listings` query is emitted for multiple listing-scoped modifiers.

### Testing
- Ran lint with `DENO_TLS_CA_STORE=system mise exec -- deno task lint` which completed successfully.
- Ran the focused test file with `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/lib/checkout-pricing-consistency.test.ts` and the new regression test passed (full file passed).
- Ran `DENO_TLS_CA_STORE=system mise exec -- deno task precommit`; lint passed but typechecking failed on unrelated UI client `NodeListOf` / implicit-any issues outside the modified DB/code-paths, so precommit did not fully complete due to existing type errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ea078700832d9d00210d36c642cb)