### PR TITLE
Improve compact TAP reporter progress total handling

### DIFF
--- a/scripts/compact-test-reporter.ts
+++ b/scripts/compact-test-reporter.ts
@@ -44,7 +44,7 @@ type CompactTapReporterOptions = {
 
 const PROGRESS_WIDTH = 24;
 const TEST_RESULT_RE = /^\s*(not\s+)?ok\s+\d+(?:\s+-\s+(.*))?$/;
-const PLAN_RE = /^\s*\d+\.\.\d+(?:\s+#.*)?$/;
+const PLAN_RE = /^\s*(\d+)\.\.(\d+)(?:\s+#.*)?$/;
 const STEP_FAILURE_RE = /^\d+\s+test\s+steps?\s+failed\.$/;
 const REPORTER_FLAGS = new Set(["--reporter"]);
 const FILE_ARG_VALUE_FLAGS = new Set([
@@ -343,8 +343,15 @@ export class CompactTapReporter {
 
     if (!trimmed) return;
 
-    if (trimmed === "TAP version 14" || PLAN_RE.test(trimmed)) {
+    if (trimmed === "TAP version 14") {
       this.#sawTap = true;
+      return;
+    }
+
+    const plan = trimmed.match(PLAN_RE);
+    if (plan) {
+      this.#sawTap = true;
+      this.#growEstimatedTotal(Number(plan[2]));
       return;
     }
 
@@ -430,12 +437,18 @@ export class CompactTapReporter {
     return progress ? `${prefix} ${progress} ${name}` : `${prefix} ${name}`;
   }
 
+  #growEstimatedTotal(total: number): void {
+    if (!Number.isFinite(total) || total <= 0) return;
+    this.#estimatedTotal = Math.max(this.#estimatedTotal ?? 0, total);
+  }
+
   #progress(): string {
     if (this.#hideProgress) return "";
 
     const done = this.#passed + this.#failed;
+    this.#growEstimatedTotal(done);
     const total = this.#estimatedTotal;
-    if (!total || done > total) {
+    if (!total) {
       return `[${String(done).padStart(4, " ")} done]`;
     }
 

--- a/test/scripts/compact-test-reporter.test.ts
+++ b/test/scripts/compact-test-reporter.test.ts
@@ -175,7 +175,7 @@ Deno.test("compact TAP reporter can hide progress for CI output", () => {
   expect(out).toEqual(["ok   passes without progress"]);
 });
 
-Deno.test("compact TAP reporter falls back to done count when estimate is exceeded", () => {
+Deno.test("compact TAP reporter grows the estimated total when it is exceeded", () => {
   const out: string[] = [];
   const reporter = new CompactTapReporter({
     cwd: Deno.cwd(),
@@ -193,7 +193,7 @@ Deno.test("compact TAP reporter falls back to done count when estimate is exceed
   expect(reporter.finish().passed).toBe(2);
   expect(out).toEqual([
     "ok   [########################] 1/1 first",
-    "ok   [   2 done] second",
+    "ok   [########################] 2/2 second",
   ]);
 });
 


### PR DESCRIPTION
### Motivation
- The compact TAP progress counter can under-report the total and fall back to a bare "done" display when the runner discovers more tests than the initial estimate, making the (current/total) display inaccurate.
- Update the reporter so it can learn a larger total as TAP plan lines or observed results arrive, keeping the familiar counter UI rather than reverting to a done-only form.

### Description
- Parse TAP plan lines (`N..M`) and use the plan's upper bound to grow the reporter's estimated total when encountered (`scripts/compact-test-reporter.ts`).
- Grow the internal `estimatedTotal` whenever the observed completed count exceeds the current estimate so progress stays expressed as `current/total` instead of switching to `done` only.
- Add a helper `#growEstimatedTotal` and call it from plan parsing and progress computation to centralise logic.
- Update the regression test to expect the progress counter to grow (test now asserts `1/1` → `2/2`) (`test/scripts/compact-test-reporter.test.ts`).

### Testing
- Ran the updated reporter unit tests with `DENO_TLS_CA_STORE=system mise exec -- deno test --reload --no-check --allow-all test/scripts/compact-test-reporter.test.ts` which passed.
- Ran the focused runner with `DENO_TLS_CA_STORE=system mise exec -- deno task test:files test/scripts/compact-test-reporter.test.ts` which passed (all 6 tests OK).
- Ran the full precommit suite with `DENO_TLS_CA_STORE=system mise exec -- deno task precommit` which did not complete due to unrelated existing TypeScript typecheck errors in client DOM files (examples: `NodeListOf` non-iterable and implicit `any` parameters in `src/ui/client/...`), so the precommit step failed at `typecheck` before exercising the full test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a364f904dc0832d8b110541b8dd0861)