### PR TITLE
Align the CLI to the admin API resources that actually exist

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -36,7 +36,16 @@ mise exec -- deno task cli:api get listings 1
 mise exec -- deno task cli:api create listings '{"name":"Demo","max_attendees":10}'
 mise exec -- deno task cli:api update listings 1 '{"active":false}'
 mise exec -- deno task cli:api delete listings 1 '{"confirm_identifier":"Demo"}'
+
+mise exec -- deno task cli:api list groups
+mise exec -- deno task cli:api create holidays '{"name":"Christmas","start_date":"2025-12-25","end_date":"2025-12-26"}'
 ```
 
-`attendees` and `modifiers` are included as first-class resource names so these
-scripts are ready as soon as matching `/api/admin/:resource` endpoints exist.
+## Resources
+
+The resource names — `listings`, `groups`, and `holidays` — mirror the admin
+JSON API exactly. `cli/resources.ts` is the single source of truth: both the
+TUI and the agent script read from it, and `test/lib/cli.test.ts` derives the
+expected set from the server's `adminApiRoutes` and fails if the two ever
+diverge. Exposing a new `/api/admin/:resource` family is therefore a one-line
+addition here.

--- a/cli/api.ts
+++ b/cli/api.ts
@@ -2,11 +2,10 @@
 import { loadConfig } from "./config.ts";
 import { type CurlOptions, curlJson } from "./curl.ts";
 import { writeErr, writeOut } from "./io.ts";
-import { parseResource, resourcePath } from "./resources.ts";
+import { parseResource, resourcePath, resources } from "./resources.ts";
 
 const [command, resourceRaw, idOrBody, maybeBody] = Deno.args;
-const usage =
-  "Usage: deno task cli:api <list|get|create|update|delete> <listings|attendees|modifiers> [id] [json]\n";
+const usage = `Usage: deno task cli:api <list|get|create|update|delete> <${resources.join("|")}> [id] [json]\n`;
 
 const parseBody = (raw?: string): unknown =>
   raw ? JSON.parse(raw) : undefined;

--- a/cli/resources.ts
+++ b/cli/resources.ts
@@ -1,6 +1,6 @@
-export type ResourceName = "listings" | "attendees" | "modifiers";
+export const resources = ["listings", "groups", "holidays"] as const;
 
-export const resources = ["listings", "attendees", "modifiers"] as const;
+export type ResourceName = (typeof resources)[number];
 
 export const resourcePath = (resource: ResourceName, id?: string): string =>
   id ? `/api/admin/${resource}/${id}` : `/api/admin/${resource}`;

--- a/test/lib/cli.test.ts
+++ b/test/lib/cli.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import { adminApiRoutes } from "#routes/admin/api.ts";
 import { setTestEnv } from "#test-utils";
 import { loadConfig } from "../../cli/config.ts";
 import { buildCurlArgs, curlFailureMessage, curlJson } from "../../cli/curl.ts";
-import { parseResource, resourcePath } from "../../cli/resources.ts";
+import { parseResource, resourcePath, resources } from "../../cli/resources.ts";
 
 const withTempCwd = async <T>(fn: () => Promise<T>): Promise<T> => {
   const original = Deno.cwd();
@@ -210,9 +211,23 @@ describe("CLI resources", () => {
   });
 
   test("parses known resources and rejects unknown resources", () => {
-    expect(parseResource("attendees")).toBe("attendees");
+    expect(parseResource("holidays")).toBe("holidays");
     expect(() => parseResource("orders")).toThrow(
-      "Unknown resource: orders. Expected listings, attendees, modifiers",
+      "Unknown resource: orders. Expected listings, groups, holidays",
     );
+  });
+
+  test("exposes exactly the resources the admin API serves", () => {
+    // Derive the resource segment from every registered admin API route key
+    // (e.g. "POST /api/admin/groups/:groupId" → "groups"). The CLI's resource
+    // list must match this set exactly, so neither side can silently drift.
+    const served = [
+      ...new Set(
+        Object.keys(adminApiRoutes).map(
+          (route) => route.match(/\/api\/admin\/([a-z]+)/)?.[1] ?? "",
+        ),
+      ),
+    ].sort();
+    expect([...resources].sort()).toEqual(served);
   });
 });


### PR DESCRIPTION
## What & why

While reading through `cli/`, I found the resource list had drifted from the server. The curl-backed CLI declared its resources as `listings, attendees, modifiers`, but the admin JSON API (`defineCrudApi` → `adminApiRoutes`) actually serves **`listings, groups, holidays`**. So today:

- `attendees` / `modifiers` are advertised by the CLI but **404 at runtime** (no endpoints exist)
- `groups` / `holidays` are **fully working CRUD endpoints** the CLI literally can't reach — `parseResource` throws `Unknown resource`

## The change

Point `cli/resources.ts` — the single source of truth that feeds both the agent script (`cli:api`) and the human TUI (`cli:tui`) — at the resources the server actually serves. Both entrypoints immediately gain full CRUD over **groups** and **holidays**, with no other code changes needed (they already loop over `resources`).

Small cleanups in the same spirit:
- **Derive `ResourceName` from the `resources` array** (`(typeof resources)[number]`) so the type and the runtime list can't disagree.
- **Build `api.ts`'s usage string from `resources`** instead of a hardcoded duplicate of the names.

## Drift guard

To stop this from silently happening again, I added a test that derives the resource set straight from the server's `adminApiRoutes` keys and asserts the CLI list matches exactly:

```ts
test("exposes exactly the resources the admin API serves", () => {
  const served = [...new Set(
    Object.keys(adminApiRoutes).map(
      (route) => route.match(/\/api\/admin\/([a-z]+)/)?.[1] ?? "",
    ),
  )].sort();
  expect([...resources].sort()).toEqual(served);
});
```

This mirrors the existing docs↔routes guard in `admin-api-example.test.ts`. When `attendees`/`modifiers` endpoints do land, this test fails until they're added here — turning the old hand-maintained "ready when endpoints exist" placeholder into an enforced contract. The CLI itself stays pure and dependency-free; the coupling lives only in the test.

## Verification

- ✅ `deno task lint` (Biome, `--error-on-warnings`) — clean
- ✅ `deno task cpd` — 0 clones / 0%
- ✅ Affected tests pass: `test/lib/cli.test.ts` + `test/e2e/cli-api.test.ts` (26/26), including the new drift guard and the e2e usage-string assertion
- ✅ All `cli/*` files typecheck cleanly under `--unstable-tsgo`

> **Note (pre-existing, not from this PR):** `deno task typecheck` currently reports 21 errors in `src/ui/client/admin/*` browser code (DOM-iteration types under the `--unstable-tsgo` preview compiler). The count is identical with this PR's changes stashed, and none of the errors are in touched files — so it's independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwjwJc2aqxJo6y5QxZ4J3S

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwjwJc2aqxJo6y5QxZ4J3S)_