### PR TITLE
Scope backups to a per-site storage folder

### DIFF
--- a/src/features/admin/backup.ts
+++ b/src/features/admin/backup.ts
@@ -15,9 +15,11 @@ import { defineRoutes, type TypedRouteHandler } from "#routes/router.ts";
 import { getEncryptionKeyString } from "#shared/crypto/encryption.ts";
 import { formatDatetimeLabel } from "#shared/dates.ts";
 import {
-  backupPrefix,
+  backupDir,
   countZipStatements,
   createAndUploadBackup,
+  isBackupLeaf,
+  isBackupPath,
   isRemoteDatabase,
   parseBackupTime,
   readManifest,
@@ -28,6 +30,7 @@ import { formatBytes, MAX_BACKUPS } from "#shared/limits.ts";
 import {
   deleteFile,
   downloadRaw,
+  getBasename,
   isStorageEnabled,
   listFilesWithMeta,
   type StorageFileMeta,
@@ -53,21 +56,22 @@ const isSafeBackupFilename = (filename: string): boolean =>
   !filename.includes("\\") &&
   !filename.includes("..");
 
-/** Parse a backup file into display info (friendly date + human size).
- *  Filenames are server-generated, so parseBackupTime always succeeds. */
+/** Parse a backup file into display info (friendly date + human size). The
+ *  download link uses the bare leaf; filenames are server-generated, so
+ *  parseBackupTime always succeeds. */
 const parseBackupEntry = (file: StorageFileMeta): BackupEntry => ({
-  filename: file.name,
+  filename: getBasename(file.name),
   label: formatDatetimeLabel(
     new Date(parseBackupTime(file.name)!).toISOString(),
   ),
   sizeLabel: formatBytes(file.size),
 });
 
-/** Pick out this DB's backups from a zone listing, newest first.
- *  Filenames embed ISO timestamps, so name order is chronological. */
+/** Pick out the backups from a folder listing, newest first. Filenames embed
+ *  ISO timestamps, so name order is chronological. */
 const toBackupEntries = (files: StorageFileMeta[]): BackupEntry[] =>
   files
-    .filter((f) => f.name.startsWith(backupPrefix()) && f.name.endsWith(".zip"))
+    .filter((f) => isBackupPath(f.name))
     .reverse()
     .map(parseBackupEntry);
 
@@ -80,8 +84,8 @@ const cleanupStalePendingFiles = (files: StorageFileMeta[]): Promise<unknown> =>
       .map((f) => deleteFile(f.name)),
   );
 
-/** Build page state. The Bunny listing has no server-side prefix filter, so we
- *  fetch the zone once and reuse it for both the backup list and temp cleanup. */
+/** Build page state: this DB's backups (from its own folder) plus a best-effort
+ *  sweep of stale restore-pending temp files at the storage root. */
 const getBackupPageState = async (): Promise<BackupPageState> => {
   const base = {
     encryptionKey: getEncryptionKeyString(),
@@ -92,9 +96,14 @@ const getBackupPageState = async (): Promise<BackupPageState> => {
   if (!isStorageEnabled()) return { ...base, backups: [] };
 
   try {
-    const files = await listFilesWithMeta("");
-    await cleanupStalePendingFiles(files);
-    return { ...base, backups: toBackupEntries(files) };
+    // Backups live in this DB's folder; restore-pending temp files sit at the
+    // storage root. One listing each, in parallel.
+    const [backupFiles, rootFiles] = await Promise.all([
+      listFilesWithMeta(backupDir()),
+      listFilesWithMeta(""),
+    ]);
+    await cleanupStalePendingFiles(rootFiles);
+    return { ...base, backups: toBackupEntries(backupFiles) };
   } catch {
     // Storage listing unavailable — still render the page (encryption key,
     // forms) rather than failing the whole request on a transient CDN error.
@@ -128,15 +137,14 @@ const handleBackupDownload: TypedRouteHandler<
   "GET /admin/backup/download/:filename"
 > = (request, { filename }) =>
   requireOwnerOr(request, async () => {
-    if (
-      !filename.startsWith(backupPrefix()) ||
-      !filename.endsWith(".zip") ||
-      !isSafeBackupFilename(filename)
-    ) {
+    // The route param is a bare leaf. The anchored leaf check rejects anything
+    // that isn't "backup-{timestamp}.zip" (path separators included), and we
+    // resolve it inside this DB's own folder — so it can only reach our backups.
+    if (!isBackupLeaf(filename)) {
       return htmlResponse("Invalid backup filename", 400);
     }
 
-    const data = await downloadRaw(filename);
+    const data = await downloadRaw(`${backupDir()}${filename}`);
     if (!data) return htmlResponse("Backup file not found", 404);
 
     const body = data.buffer.slice(

--- a/src/features/admin/built-sites.ts
+++ b/src/features/admin/built-sites.ts
@@ -13,7 +13,7 @@ import {
 } from "#routes/response.ts";
 import type { RouteParams } from "#routes/router.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
-import { backupPrefix, dbName, hasRecentBackup } from "#shared/db/backup.ts";
+import { dbName, hasRecentBackup } from "#shared/db/backup.ts";
 import type { BuiltSite, BuiltSiteFormInput } from "#shared/db/built-sites.ts";
 import {
   builtSitesCrudTable,
@@ -194,7 +194,7 @@ const handleUpdateSite = ownerPost(async (site, _form, id) => {
   // The site migrates on its next request after deploy, so require a recent
   // backup of *this site's* database (taken to our storage by the upgrade
   // workflow) before pushing a new version.
-  if (!(await hasRecentBackup(undefined, backupPrefix(dbName(site.dbUrl))))) {
+  if (!(await hasRecentBackup(undefined, dbName(site.dbUrl)))) {
     return editError(
       id,
       "No backup of this site in the last hour — back it up before updating.",

--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -317,6 +317,10 @@ export const hasRecentBackup = async (
   const now = Date.now();
   const files = await listFiles(backupDir(name));
   for (const file of files) {
+    // Only real backups count — ignore anything else left in the folder, so a
+    // stray "{name}/manual-…Z.zip" can't spoof the freshness gate (mirrors
+    // pruneOldBackups).
+    if (!isBackupPath(file)) continue;
     const ms = parseBackupTime(file);
     if (ms !== null && now - ms < maxAgeMs) return true;
   }

--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -26,7 +26,12 @@ import {
 import { invalidateUsersCache } from "#shared/db/users.ts";
 import { requireEnv } from "#shared/env.ts";
 import { MAX_BACKUPS, readLimit } from "#shared/limits.ts";
-import { deleteFile, listFiles, uploadRaw } from "#shared/storage.ts";
+import {
+  deleteFile,
+  getBasename,
+  listFiles,
+  uploadRaw,
+} from "#shared/storage.ts";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -197,9 +202,24 @@ export const createBackup = async (): Promise<TableBackup[]> => {
   return backups;
 };
 
-/** Generate a timestamped backup filename scoped to the current DB */
-export const backupFilename = (timestamp: string): string =>
-  `backup-${dbName()}-${timestamp}.zip`;
+/**
+ * Per-site folder that scopes a database's backups within shared storage
+ * (defaults to the current DB; pass a name from `dbName(url)` to target another
+ * instance). Because it is a real path segment — not a name prefix — listing one
+ * site's folder can never pick up another's, even when one db name is a string
+ * prefix of another ("tickets" vs "tickets-spencer").
+ */
+export const backupDir = (name: string = dbName()): string => `${name}/`;
+
+/** Leaf filename for a backup taken at `timestamp`, e.g.
+ *  "backup-2024-01-15T12-30-00-000Z.zip". Lives inside `backupDir()`. */
+export const backupLeaf = (timestamp: string): string =>
+  `backup-${timestamp}.zip`;
+
+/** Full storage key for a backup: "{name}/backup-{timestamp}.zip". Defaults to
+ *  the current DB; pass a name to target another instance. */
+export const backupKey = (timestamp: string, name: string = dbName()): string =>
+  `${backupDir(name)}${backupLeaf(timestamp)}`;
 
 /** Generate a timestamp string for backup filenames */
 export const backupTimestamp = (date = new Date()): string =>
@@ -239,16 +259,11 @@ export const createBackupZip = async (): Promise<Uint8Array> => {
 export const createAndUploadBackup = async (): Promise<string> => {
   const timestamp = backupTimestamp();
   const zipData = await createBackupZip();
-  const filename = backupFilename(timestamp);
+  const filename = backupKey(timestamp);
   await uploadRaw(zipData, filename);
   await pruneOldBackups();
   return filename;
 };
-
-/** Prefix for listing backups, scoped to a DB (defaults to the current DB).
- *  Pass a name from `dbName(url)` to scope it to another instance's database. */
-export const backupPrefix = (name: string = dbName()): string =>
-  `backup-${name}-`;
 
 /**
  * How fresh a backup must be to satisfy the pre-upgrade gate on /admin/update
@@ -257,30 +272,50 @@ export const backupPrefix = (name: string = dbName()): string =>
  */
 export const BACKUP_REQUIRED_WITHIN_MS = 60 * 60 * 1000;
 
+/** ISO-8601-ish timestamp as it appears in a backup filename (":"/"." → "-"),
+ *  with the date/time pieces captured so parseBackupTime can rebuild the real
+ *  ISO string. Defined once and reused by every backup-filename matcher. */
+const BACKUP_TIMESTAMP = String.raw`(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z`;
+
+/** Matches the "{timestamp}.zip" tail at the end of a backup key. */
+const BACKUP_TIME_TAIL = new RegExp(`${BACKUP_TIMESTAMP}\\.zip$`);
+
+/** Matches a leaf that is *exactly* "backup-{timestamp}.zip" — no directory and
+ *  no extra characters, so it also rejects any path separators. */
+const BACKUP_LEAF = new RegExp(`^backup-${BACKUP_TIMESTAMP}\\.zip$`);
+
 /**
  * Parse the epoch-ms encoded in a backup filename, or null if it doesn't match.
- * Inverse of backupTimestamp: "...-2024-01-15T12-30-00-000Z.zip" → epoch ms.
+ * Inverse of backupTimestamp: "…/backup-2024-01-15T12-30-00-000Z.zip" → epoch ms.
  */
 export const parseBackupTime = (filename: string): number | null => {
-  const m = filename.match(
-    /(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z\.zip$/,
-  );
+  const m = filename.match(BACKUP_TIME_TAIL);
   if (!m) return null;
   const ms = Date.parse(`${m[1]}T${m[2]}:${m[3]}:${m[4]}.${m[5]}Z`);
   return Number.isNaN(ms) ? null : ms;
 };
 
+/** True when a bare leaf name is exactly "backup-{timestamp}.zip". Anchored, so
+ *  it also doubles as traversal-proofing for the download route's filename. */
+export const isBackupLeaf = (leaf: string): boolean => BACKUP_LEAF.test(leaf);
+
+/** True when a storage key ("{name}/backup-…zip") is one of our backups — i.e.
+ *  its leaf is a valid backup filename. Picks backups out of a folder listing
+ *  while ignoring anything else stored alongside them. */
+export const isBackupPath = (key: string): boolean =>
+  isBackupLeaf(getBasename(key));
+
 /**
- * True if a backup younger than `maxAgeMs` exists for the given prefix. Defaults
- * to the current DB within the upgrade-gate window; callers gating another
- * instance pass `backupPrefix(dbName(site.dbUrl))`.
+ * True if a backup younger than `maxAgeMs` exists for the given database
+ * (defaults to the current DB) within the upgrade-gate window. Callers gating
+ * another instance pass `dbName(site.dbUrl)`.
  */
 export const hasRecentBackup = async (
   maxAgeMs: number = BACKUP_REQUIRED_WITHIN_MS,
-  prefix: string = backupPrefix(),
+  name: string = dbName(),
 ): Promise<boolean> => {
   const now = Date.now();
-  const files = await listFiles(prefix);
+  const files = await listFiles(backupDir(name));
   for (const file of files) {
     const ms = parseBackupTime(file);
     if (ms !== null && now - ms < maxAgeMs) return true;
@@ -297,11 +332,8 @@ export const hasRecentBackup = async (
 export const pruneOldBackups = async (
   keep = MAX_BACKUPS,
 ): Promise<string[]> => {
-  const files = await listFiles(backupPrefix());
-  const stale = files
-    .filter((f) => f.endsWith(".zip"))
-    .reverse()
-    .slice(keep);
+  const files = await listFiles(backupDir());
+  const stale = files.filter(isBackupPath).reverse().slice(keep);
   const removed = await Promise.all(
     stale.map(async (file) => {
       try {

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -491,12 +491,17 @@ export const listFilesWithMeta = async (
     headers: { AccessKey: config.zoneKey },
   });
   // A folder with no objects yet (e.g. a site that has never been backed up)
-  // 404s rather than returning an empty list; treat that as "no files", the
-  // same way the local backend's readDirSafe does for a missing directory.
-  if (!response.ok) return [];
+  // 404s; treat only that as "no files", the same way the local backend's
+  // readDirSafe handles a missing directory. Other failures (401/403 bad
+  // credentials, 5xx outages) must surface, not masquerade as an empty zone.
+  if (response.status === 404) return [];
   const items = (await response.json()) as Array<Record<string, unknown>>;
   return byName(
     items
+      // Bunny lists directories alongside files; keep only files so per-site
+      // backup folders don't surface as entries (the local backend filters to
+      // isFile for the same reason).
+      .filter((item) => !item.IsDirectory)
       .map((item) => ({
         name: String(item.ObjectName ?? ""),
         size: Number(item.Length) || 0,

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -208,14 +208,15 @@ export const generateImageFilename = (detectedType: string): string => {
 // Local filesystem backend
 // ---------------------------------------------------------------------------
 
-/** Write encrypted bytes to the local storage directory */
+/** Write encrypted bytes to the local storage directory. Filenames may include
+ *  a subfolder (e.g. "acme/backup-…zip"), so create the file's parent first. */
 const localWrite = async (
   data: Uint8Array,
   filename: string,
 ): Promise<void> => {
-  const dir = getLocalStoragePath() as string;
-  await Deno.mkdir(dir, { recursive: true });
-  await Deno.writeFile(`${dir}/${filename}`, data);
+  const path = `${getLocalStoragePath() as string}/${filename}`;
+  await Deno.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  await Deno.writeFile(path, data);
 };
 
 /** Read encrypted bytes from the local storage directory. Returns null if missing. */
@@ -444,30 +445,55 @@ export type StorageFileMeta = { name: string; size: number };
 const byName = sort<StorageFileMeta>((a, b) => (a.name < b.name ? -1 : 1));
 
 /**
- * List files (with size metadata) matching a prefix, sorted by name.
- * For Bunny CDN the size comes from the `Length` field of the listing API.
+ * Split a listing prefix into the directory to read and the leaf-name filter
+ * applied within it. The directory is matched as a real path component, not a
+ * string prefix, so listing one folder can never leak into a sibling whose name
+ * extends it ("acme/" vs "acme-test/"):
+ *   "backup-"      → read the root,   keep names starting "backup-"
+ *   "acme/"        → read "acme",     keep everything
+ *   "acme/backup-" → read "acme",     keep names starting "backup-"
+ */
+const splitListingPrefix = (
+  prefix: string,
+): { dir: string; namePrefix: string } => {
+  const slash = prefix.lastIndexOf("/");
+  return slash === -1
+    ? { dir: "", namePrefix: prefix }
+    : { dir: prefix.slice(0, slash + 1), namePrefix: prefix.slice(slash + 1) };
+};
+
+/**
+ * List files (with size metadata) matching a path prefix, sorted by name. The
+ * prefix may name a subfolder (see `splitListingPrefix`); returned names always
+ * include that folder so callers can download/delete them directly. For Bunny
+ * CDN the size comes from the `Length` field of the listing API.
  */
 export const listFilesWithMeta = async (
   prefix: string,
 ): Promise<StorageFileMeta[]> => {
+  const { dir, namePrefix } = splitListingPrefix(prefix);
   if (getLocalStoragePath() !== null) {
-    const dir = getLocalStoragePath() as string;
-    const entries = await readDirSafe(dir);
+    const base = `${getLocalStoragePath() as string}/${dir}`;
+    const entries = await readDirSafe(base);
     const files = await Promise.all(
       entries
-        .filter((e) => e.isFile && e.name.startsWith(prefix))
+        .filter((e) => e.isFile && e.name.startsWith(namePrefix))
         .map(async (e) => ({
-          name: e.name,
-          size: (await Deno.stat(`${dir}/${e.name}`)).size,
+          name: `${dir}${e.name}`,
+          size: (await Deno.stat(`${base}${e.name}`)).size,
         })),
     );
     return byName(files);
   }
   const config = getStorageConfig();
-  const url = `https://storage.bunnycdn.com/${config.zoneName}/`;
+  const url = `https://storage.bunnycdn.com/${config.zoneName}/${dir}`;
   const response = await fetch(url, {
     headers: { AccessKey: config.zoneKey },
   });
+  // A folder with no objects yet (e.g. a site that has never been backed up)
+  // 404s rather than returning an empty list; treat that as "no files", the
+  // same way the local backend's readDirSafe does for a missing directory.
+  if (!response.ok) return [];
   const items = (await response.json()) as Array<Record<string, unknown>>;
   return byName(
     items
@@ -475,7 +501,8 @@ export const listFilesWithMeta = async (
         name: String(item.ObjectName ?? ""),
         size: Number(item.Length) || 0,
       }))
-      .filter((f) => f.name.startsWith(prefix)),
+      .filter((f) => f.name !== "" && f.name.startsWith(namePrefix))
+      .map((f) => ({ name: `${dir}${f.name}`, size: f.size })),
   );
 };
 

--- a/test/lib/backup.test.ts
+++ b/test/lib/backup.test.ts
@@ -417,7 +417,13 @@ describeWithEnv("backup", { db: true }, () => {
       const tmpDir = Deno.makeTempDirSync();
       const restore = setTestEnv({ LOCAL_STORAGE_PATH: tmpDir });
       try {
-        await uploadRaw(new Uint8Array([1]), `${backupDir()}garbage.zip`);
+        // A fresh file with a valid timestamp tail but not a "backup-…" name
+        // must NOT satisfy the gate — parseBackupTime alone would accept it, so
+        // the recency check filters to real backups first.
+        await uploadRaw(
+          new Uint8Array([1]),
+          `${backupDir()}manual-${backupTimestamp()}.zip`,
+        );
         expect(await hasRecentBackup()).toBe(false);
       } finally {
         restore();

--- a/test/lib/backup.test.ts
+++ b/test/lib/backup.test.ts
@@ -4,8 +4,9 @@ import { unzipSync, zipSync } from "fflate";
 import {
   BACKUP_REQUIRED_WITHIN_MS,
   type BackupManifest,
-  backupFilename,
-  backupPrefix,
+  backupDir,
+  backupKey,
+  backupLeaf,
   backupTimestamp,
   countZipStatements,
   createBackup,
@@ -13,6 +14,8 @@ import {
   dbName,
   exportTable,
   hasRecentBackup,
+  isBackupLeaf,
+  isBackupPath,
   isRemoteDatabase,
   parseBackupTime,
   pruneOldBackups,
@@ -230,24 +233,47 @@ describeWithEnv("backup", { db: true }, () => {
     });
   });
 
-  describe("backupPrefix", () => {
-    test("defaults to the current DB's prefix", () => {
+  describe("backupDir", () => {
+    test("defaults to the current DB's folder", () => {
       // Test env DB_URL is :memory:, so dbName() falls back to "local".
-      expect(backupPrefix()).toBe("backup-local-");
+      expect(backupDir()).toBe("local/");
     });
 
     test("scopes to a named database when given one", () => {
-      expect(backupPrefix(dbName("libsql://01-client-acme.turso.io"))).toBe(
-        "backup-client-acme-",
+      expect(backupDir(dbName("libsql://01-client-acme.turso.io"))).toBe(
+        "client-acme/",
       );
+    });
+
+    test("a name that extends another is a distinct folder, not a prefix", () => {
+      // The exact bug this scheme prevents: "tickets" must not be a string
+      // prefix that swallows "tickets-spencer". As folders, the "/" boundary
+      // keeps them separate.
+      expect(backupDir("tickets")).toBe("tickets/");
+      expect(backupDir("tickets-spencer")).toBe("tickets-spencer/");
+      expect(
+        backupDir("tickets-spencer").startsWith(backupDir("tickets")),
+      ).toBe(false);
     });
   });
 
-  describe("backupFilename / backupTimestamp", () => {
-    test("creates filename with db name and .zip extension", () => {
-      // In test env, DB_URL is :memory: so dbName() returns "local"
-      expect(backupFilename("2024-01-15T12-30-00-000Z")).toBe(
-        "backup-local-2024-01-15T12-30-00-000Z.zip",
+  describe("backupLeaf / backupKey / backupTimestamp", () => {
+    test("backupLeaf names the file with .zip extension, no folder", () => {
+      expect(backupLeaf("2024-01-15T12-30-00-000Z")).toBe(
+        "backup-2024-01-15T12-30-00-000Z.zip",
+      );
+    });
+
+    test("backupKey nests the leaf inside the current DB's folder", () => {
+      // In test env, DB_URL is :memory: so dbName() returns "local".
+      expect(backupKey("2024-01-15T12-30-00-000Z")).toBe(
+        "local/backup-2024-01-15T12-30-00-000Z.zip",
+      );
+    });
+
+    test("backupKey scopes to a named database when given one", () => {
+      expect(backupKey("2024-01-15T12-30-00-000Z", "client-acme")).toBe(
+        "client-acme/backup-2024-01-15T12-30-00-000Z.zip",
       );
     });
 
@@ -258,28 +284,56 @@ describeWithEnv("backup", { db: true }, () => {
     });
   });
 
+  describe("isBackupLeaf / isBackupPath", () => {
+    const leaf = backupLeaf(backupTimestamp(new Date("2024-01-15T12:30:00Z")));
+
+    test("isBackupLeaf accepts an exact backup leaf", () => {
+      expect(isBackupLeaf(leaf)).toBe(true);
+    });
+
+    test("isBackupLeaf rejects non-backup or malformed leaves", () => {
+      expect(isBackupLeaf("restore-pending-abc.zip")).toBe(false);
+      expect(isBackupLeaf("backup-not-a-date.zip")).toBe(false);
+      expect(isBackupLeaf("notes.txt")).toBe(false);
+    });
+
+    test("isBackupLeaf rejects anything carrying a path separator", () => {
+      // The download route relies on this to refuse traversal payloads.
+      expect(isBackupLeaf(`local/${leaf}`)).toBe(false);
+      expect(isBackupLeaf(`../${leaf}`)).toBe(false);
+    });
+
+    test("isBackupPath matches a backup by its leaf, ignoring the folder", () => {
+      expect(
+        isBackupPath(backupKey(backupTimestamp(), "tickets-spencer")),
+      ).toBe(true);
+      expect(isBackupPath("local/restore-pending-abc.zip")).toBe(false);
+      expect(isBackupPath("local/notes.txt")).toBe(false);
+    });
+  });
+
   describe("parseBackupTime", () => {
-    test("round-trips a filename produced by backupFilename/backupTimestamp", () => {
+    test("round-trips a key produced by backupKey/backupTimestamp", () => {
       const when = new Date("2024-01-15T12:30:00.000Z");
-      const filename = backupFilename(backupTimestamp(when));
+      const filename = backupKey(backupTimestamp(when));
       expect(parseBackupTime(filename)).toBe(when.getTime());
     });
 
     test("returns null for filenames that are not backups", () => {
       expect(parseBackupTime("image.png")).toBeNull();
-      expect(parseBackupTime("backup-local-not-a-date.zip")).toBeNull();
+      expect(parseBackupTime("local/backup-not-a-date.zip")).toBeNull();
     });
 
     test("returns null when the digits form an impossible date", () => {
       expect(
-        parseBackupTime("backup-local-2024-13-45T99-99-99-999Z.zip"),
+        parseBackupTime("local/backup-2024-13-45T99-99-99-999Z.zip"),
       ).toBeNull();
     });
   });
 
   describe("hasRecentBackup", () => {
     const seedBackup = (when: Date) =>
-      uploadRaw(new Uint8Array([1]), backupFilename(backupTimestamp(when)));
+      uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp(when)));
 
     test("true when a backup is within the freshness window", async () => {
       const tmpDir = Deno.makeTempDirSync();
@@ -307,20 +361,41 @@ describeWithEnv("backup", { db: true }, () => {
       }
     });
 
-    test("checks a passed maxAge and prefix (another instance's backup)", async () => {
+    test("checks a passed maxAge and name (another instance's backup)", async () => {
       const tmpDir = Deno.makeTempDirSync();
       const restore = setTestEnv({ LOCAL_STORAGE_PATH: tmpDir });
       try {
-        const sitePrefix = backupPrefix(
-          dbName("libsql://01-client-acme.lite.bunnydb.net"),
-        );
+        const site = dbName("libsql://01-client-acme.lite.bunnydb.net");
         await uploadRaw(
           new Uint8Array([1]),
-          `${sitePrefix}${backupTimestamp(new Date(Date.now() - 60_000))}.zip`,
+          backupKey(backupTimestamp(new Date(Date.now() - 60_000)), site),
         );
-        // Found under the site's prefix, but not under the current DB's prefix.
-        expect(await hasRecentBackup(60 * 60 * 1000, sitePrefix)).toBe(true);
+        // Found under the site's folder, but not under the current DB's.
+        expect(await hasRecentBackup(60 * 60 * 1000, site)).toBe(true);
         expect(await hasRecentBackup(60 * 60 * 1000)).toBe(false);
+      } finally {
+        restore();
+        Deno.removeSync(tmpDir, { recursive: true });
+      }
+    });
+
+    test("a site's backup never satisfies a site whose name it extends", async () => {
+      // The reported bug: "tickets" must not pick up "tickets-spencer"'s
+      // backups just because one name is a string prefix of the other.
+      const tmpDir = Deno.makeTempDirSync();
+      const restore = setTestEnv({ LOCAL_STORAGE_PATH: tmpDir });
+      try {
+        await uploadRaw(
+          new Uint8Array([1]),
+          backupKey(
+            backupTimestamp(new Date(Date.now() - 60_000)),
+            "tickets-spencer",
+          ),
+        );
+        expect(await hasRecentBackup(60 * 60 * 1000, "tickets-spencer")).toBe(
+          true,
+        );
+        expect(await hasRecentBackup(60 * 60 * 1000, "tickets")).toBe(false);
       } finally {
         restore();
         Deno.removeSync(tmpDir, { recursive: true });
@@ -338,11 +413,11 @@ describeWithEnv("backup", { db: true }, () => {
       }
     });
 
-    test("ignores prefix-matching files whose name is not a valid backup", async () => {
+    test("ignores files in the folder that are not valid backups", async () => {
       const tmpDir = Deno.makeTempDirSync();
       const restore = setTestEnv({ LOCAL_STORAGE_PATH: tmpDir });
       try {
-        await uploadRaw(new Uint8Array([1]), `${backupPrefix()}garbage.zip`);
+        await uploadRaw(new Uint8Array([1]), `${backupDir()}garbage.zip`);
         expect(await hasRecentBackup()).toBe(false);
       } finally {
         restore();
@@ -353,9 +428,9 @@ describeWithEnv("backup", { db: true }, () => {
 
   describe("pruneOldBackups", () => {
     const seed = (when: Date) =>
-      uploadRaw(new Uint8Array([1]), backupFilename(backupTimestamp(when)));
+      uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp(when)));
 
-    test("removes the oldest backups beyond the keep count, ignoring non-zip files", async () => {
+    test("removes the oldest backups beyond the keep count, ignoring non-backup files", async () => {
       const tmpDir = Deno.makeTempDirSync();
       const restore = setTestEnv({ LOCAL_STORAGE_PATH: tmpDir });
       try {
@@ -365,18 +440,18 @@ describeWithEnv("backup", { db: true }, () => {
         await seed(d1);
         await seed(d2);
         await seed(d3);
-        // A non-zip file is ignored entirely.
-        await uploadRaw(new Uint8Array([1]), `${backupPrefix()}notes.txt`);
+        // A non-backup file in the same folder is ignored entirely.
+        await uploadRaw(new Uint8Array([1]), `${backupDir()}notes.txt`);
 
         const removed = await pruneOldBackups(2);
 
-        expect(removed).toEqual([backupFilename(backupTimestamp(d1))]);
+        expect(removed).toEqual([backupKey(backupTimestamp(d1))]);
 
-        const remaining = await listFiles(backupPrefix());
+        const remaining = await listFiles(backupDir());
         expect(remaining).toEqual([
-          backupFilename(backupTimestamp(d2)),
-          backupFilename(backupTimestamp(d3)),
-          `${backupPrefix()}notes.txt`,
+          backupKey(backupTimestamp(d2)),
+          backupKey(backupTimestamp(d3)),
+          `${backupDir()}notes.txt`,
         ]);
       } finally {
         restore();
@@ -411,7 +486,7 @@ describeWithEnv("backup", { db: true }, () => {
           setDeleteOverride(null);
         }
         // Both backups survive the failed purge attempt.
-        const remaining = await listFiles(backupPrefix());
+        const remaining = await listFiles(backupDir());
         expect(remaining).toHaveLength(2);
       } finally {
         restore();

--- a/test/lib/server-backup.test.ts
+++ b/test/lib/server-backup.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { zipSync } from "fflate";
 import { handleRequest } from "#routes";
-import { createBackupZip } from "#shared/db/backup.ts";
+import { backupDir, createBackupZip } from "#shared/db/backup.ts";
 import { downloadRaw, uploadRaw } from "#shared/storage.ts";
 import { RESTORE_CONFIRM_PHRASE } from "#templates/admin/backup.tsx";
 import {
@@ -82,9 +82,10 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
       });
     });
 
-    test("lists only .zip files on backup page", async () => {
+    test("lists only valid backup files on backup page", async () => {
       await withLocalStorageEnabled(async () => {
-        await uploadRaw(new Uint8Array(0), "backup-stale.tmp");
+        // A non-backup file sharing the folder must not appear in the list.
+        await uploadRaw(new Uint8Array(0), `${backupDir()}backup-stale.tmp`);
         await adminFormPost("/admin/backup/create");
         const { response } = await adminGet("/admin/backup");
         const html = await response.text();
@@ -116,8 +117,9 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
 
     test("returns 404 for missing file", async () => {
       await withLocalStorageEnabled(async () => {
+        // Validly formatted leaf, but no such backup exists in this DB's folder.
         const { response } = await adminGet(
-          "/admin/backup/download/backup-local-2024-test.zip",
+          "/admin/backup/download/backup-2024-01-15T12-30-00-000Z.zip",
         );
         expect(response.status).toBe(404);
       });

--- a/test/lib/server-built-sites-update.test.ts
+++ b/test/lib/server-built-sites-update.test.ts
@@ -4,7 +4,7 @@ import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { getAllActivityLog } from "#shared/db/activityLog.ts";
-import { backupPrefix, backupTimestamp, dbName } from "#shared/db/backup.ts";
+import { backupKey, backupTimestamp, dbName } from "#shared/db/backup.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
 import { uploadRaw } from "#shared/storage.ts";
 import {
@@ -16,15 +16,12 @@ import {
   testCookie,
 } from "#test-utils";
 
-/** A built site database URL whose backups land under a site-specific prefix. */
+/** A built site database URL whose backups land in a site-specific folder. */
 const SITE_DB_URL = "libsql://01ABC-client-site.lite.bunnydb.net";
 
 /** Seed a fresh backup for the given site so the pre-update gate passes. */
 const seedSiteBackup = (dbUrl: string): Promise<string> =>
-  uploadRaw(
-    new Uint8Array([1]),
-    `${backupPrefix(dbName(dbUrl))}${backupTimestamp()}.zip`,
-  );
+  uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp(), dbName(dbUrl)));
 
 const MOCK_RELEASE = {
   assets: [

--- a/test/lib/server-update.test.ts
+++ b/test/lib/server-update.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
-import { backupFilename, backupTimestamp } from "#shared/db/backup.ts";
+import { backupKey, backupTimestamp } from "#shared/db/backup.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
 import { uploadRaw } from "#shared/storage.ts";
 import { setBuildTimestampForTest } from "#shared/update.ts";
@@ -50,7 +50,7 @@ const simulateProductionBuild = () => {
 
 /** Seed a fresh backup so the pre-update gate passes. */
 const seedRecentBackup = (): Promise<string> =>
-  uploadRaw(new Uint8Array([1]), backupFilename(backupTimestamp()));
+  uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp()));
 
 /** Set up state for a deploy test: production build + newer version stored,
  *  plus a recent backup so the pre-update gate is satisfied. */

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -799,7 +799,7 @@ describeWithEnv(
           );
         });
 
-        test("treats a missing folder (non-OK response) as empty", async () => {
+        test("treats a missing folder (404) as empty", async () => {
           await runWithStorageConfig(
             { zoneKey: "testkey", zoneName: "testzone" },
             () =>
@@ -814,6 +814,49 @@ describeWithEnv(
                 // A brand-new site's backup folder doesn't exist yet, so the
                 // listing must resolve to [] rather than throwing.
                 expect(await listFiles("newsite/")).toEqual([]);
+              }),
+          );
+        });
+
+        test("surfaces a non-404 listing failure instead of reporting empty", async () => {
+          await runWithStorageConfig(
+            { zoneKey: "testkey", zoneName: "testzone" },
+            () =>
+              withFetchMock(async (originalFetch) => {
+                installUrlHandler(originalFetch, (url) =>
+                  url.includes("storage.bunnycdn.com")
+                    ? Promise.resolve(
+                        new Response("Server Error", { status: 500 }),
+                      )
+                    : null,
+                );
+                // A 5xx/auth error must not masquerade as "no files" — it would
+                // make the gate report "no backup" when backups exist.
+                await expect(listFiles("acme/")).rejects.toThrow();
+              }),
+          );
+        });
+
+        test("excludes directory entries from the listing", async () => {
+          await runWithStorageConfig(
+            { zoneKey: "testkey", zoneName: "testzone" },
+            () =>
+              withFetchMock(async (originalFetch) => {
+                installUrlHandler(originalFetch, (url) =>
+                  url.includes("storage.bunnycdn.com")
+                    ? Promise.resolve(
+                        Response.json([
+                          { IsDirectory: true, ObjectName: "tickets" },
+                          {
+                            IsDirectory: false,
+                            ObjectName: "restore-pending-x.zip",
+                          },
+                        ]),
+                      )
+                    : null,
+                );
+                // The per-site folder entry must not come back as a file.
+                expect(await listFiles("")).toEqual(["restore-pending-x.zip"]);
               }),
           );
         });

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -240,6 +240,47 @@ describeWithEnv(
           ]);
         });
       });
+
+      test("lists a subfolder, returning names that include the folder", async () => {
+        await withLocalStorageEnabled(async () => {
+          // uploadRaw creates the nested folder on demand.
+          await uploadRaw(new Uint8Array(0), "acme/backup-a.zip");
+          await uploadRaw(new Uint8Array(0), "acme/backup-b.zip");
+          const files = await listFiles("acme/");
+          expect(files).toEqual(["acme/backup-a.zip", "acme/backup-b.zip"]);
+        });
+      });
+
+      test("a folder listing filters by the leaf name after the slash", async () => {
+        await withLocalStorageEnabled(async () => {
+          await uploadRaw(new Uint8Array(0), "acme/backup-a.zip");
+          await uploadRaw(new Uint8Array(0), "acme/notes.txt");
+          const files = await listFiles("acme/backup-");
+          expect(files).toEqual(["acme/backup-a.zip"]);
+        });
+      });
+
+      test("a folder named like a prefix of another stays separate", async () => {
+        await withLocalStorageEnabled(async () => {
+          await uploadRaw(new Uint8Array(0), "tickets/backup-a.zip");
+          await uploadRaw(new Uint8Array(0), "tickets-spencer/backup-b.zip");
+          // Listing "tickets/" must not leak "tickets-spencer/"'s file even
+          // though "tickets" is a string prefix of "tickets-spencer".
+          expect(await listFiles("tickets/")).toEqual(["tickets/backup-a.zip"]);
+          expect(await listFiles("tickets-spencer/")).toEqual([
+            "tickets-spencer/backup-b.zip",
+          ]);
+        });
+      });
+
+      test("a root listing does not descend into subfolders", async () => {
+        await withLocalStorageEnabled(async () => {
+          await uploadRaw(new Uint8Array(0), "root-file.zip");
+          await uploadRaw(new Uint8Array(0), "acme/backup-a.zip");
+          // Only the root-level file; the subfolder's contents are not listed.
+          expect(await listFiles("")).toEqual(["root-file.zip"]);
+        });
+      });
     });
 
     describe("getImageProxyUrl", () => {
@@ -727,6 +768,52 @@ describeWithEnv(
 
                 const files = await listFiles("backup-");
                 expect(files).toEqual(["backup-2024.zip", "backup-2025.zip"]);
+              }),
+          );
+        });
+
+        test("listFiles requests a subfolder URL and prefixes returned names", async () => {
+          await runWithStorageConfig(
+            { zoneKey: "testkey", zoneName: "testzone" },
+            () =>
+              withFetchMock(async (originalFetch) => {
+                let listedUrl = "";
+                installUrlHandler(originalFetch, (url) => {
+                  if (url.includes("storage.bunnycdn.com")) {
+                    listedUrl = url;
+                    // Bunny returns leaf names within the requested folder.
+                    return Promise.resolve(
+                      Response.json([{ ObjectName: "backup-2024.zip" }]),
+                    );
+                  }
+                  return null;
+                });
+
+                const files = await listFiles("acme/");
+
+                // The folder is part of the request path, not a name filter…
+                expect(listedUrl).toContain("/testzone/acme/");
+                // …and returned names carry the folder so callers can act on them.
+                expect(files).toEqual(["acme/backup-2024.zip"]);
+              }),
+          );
+        });
+
+        test("treats a missing folder (non-OK response) as empty", async () => {
+          await runWithStorageConfig(
+            { zoneKey: "testkey", zoneName: "testzone" },
+            () =>
+              withFetchMock(async (originalFetch) => {
+                installUrlHandler(originalFetch, (url) =>
+                  url.includes("storage.bunnycdn.com")
+                    ? Promise.resolve(
+                        new Response("Not Found", { status: 404 }),
+                      )
+                    : null,
+                );
+                // A brand-new site's backup folder doesn't exist yet, so the
+                // listing must resolve to [] rather than throwing.
+                expect(await listFiles("newsite/")).toEqual([]);
               }),
           );
         });


### PR DESCRIPTION
## Problem

The **Existing Backups** page listed backups belonging to *other* sites.

Backups were stored flat at the storage-zone root as `backup-{dbName}-{ts}.zip` and selected by the **string prefix** `backup-{dbName}-`. When one database name is a string prefix of another — e.g. `tickets` vs `tickets-spencer` — the shorter-named site's listing matched the longer-named site's files:

```
site "tickets" filters startsWith("backup-tickets-")
  ✓ backup-tickets-2024-…zip          (its own — correct)
  ✓ backup-tickets-spencer-2024-…zip  (tickets-spencer's — WRONG)
```

This shows up on the builder instance, whose storage zone holds every built site's backups (pushed by the upgrade workflow). The same flaw also let `pruneOldBackups` **delete** another site's backups, let the pre-update freshness gate be satisfied by another site's backup, and let the download route **fetch** another site's backup.

## Fix

Store each database's backups in **its own folder**: `{dbName}/backup-{ts}.zip`. Listing, pruning, the recency gate, and downloads are all scoped to that folder, so a real path boundary (`/`) — not a string prefix — separates sites. Collisions become structurally impossible (`tickets/` can never match `tickets-spencer/`).

### Changes
- **storage** — `listFilesWithMeta` is now directory-aware: a path prefix splits into the folder to read plus a leaf-name filter, and returned names are folder-qualified so callers can download/delete them directly. The local backend creates parent folders on write; the Bunny backend treats a missing folder (a site never backed up) as empty rather than throwing.
- **backup** — `backupDir` / `backupLeaf` / `backupKey` replace the flat `backupFilename` / `backupPrefix`. `isBackupLeaf` / `isBackupPath` identify backups precisely (exact `backup-{timestamp}.zip`). `hasRecentBackup` now takes a db **name** and lists that site's folder.
- **download route** — validates the bare leaf against an anchored `backup-{timestamp}.zip` pattern and resolves it inside the current DB's folder, so it is traversal-proof and can only ever reach this site's backups.

Existing backups in the old flat layout are **intentionally not migrated** (as requested — the operator will sort those).

## Tests
- New unit tests for the folder/key helpers and the `tickets` vs `tickets-spencer` non-collision (`backupDir`, `isBackupLeaf`/`isBackupPath`, a cross-site `hasRecentBackup` case).
- New storage tests for subfolder listing, prefix-named sibling folders staying separate, root listings not descending, and missing-folder → `[]`.
- Updated the backup/route/update tests to the new scheme.
- All changed source files at **100% line + branch** coverage; lint clean; jscpd 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4448KYnMaJeLJzW6YCxDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4448KYnMaJeLJzW6YCxDx)_