### PR TITLE
Remove aspect-ratio sizing from textareas

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -716,36 +716,18 @@ input[type="file"] {
 }
 
 textarea {
-  aspect-ratio: 4 / 3;
   resize: vertical;
 }
 
-textarea[name="address"],
-textarea[name="special_instructions"] {
-  aspect-ratio: 4 / 1;
-}
-
-@media (min-width: 769px) {
-  textarea {
-    aspect-ratio: 16 / 9;
-  }
-
-  textarea[name="address"],
-  textarea[name="special_instructions"] {
-    aspect-ratio: 16 / 3;
-  }
-}
-
-/* On admin pages, textareas grow to fit their content via field-sizing rather
-   than the fixed aspect-ratios above (width stays 100% so they only grow
-   vertically). Tidy bounds keep an empty field a few lines tall and stop very
-   long content from running off the page — past the cap it scrolls. Public
-   ticket forms keep the aspect-ratio sizing. Guarded by @supports so browsers
-   without field-sizing fall back to that sizing. */
+/* On admin pages, textareas grow to fit their content via field-sizing (width
+   stays 100% so they only grow vertically). Tidy bounds keep an empty field a
+   few lines tall and stop very long content from running off the page — past
+   the cap it scrolls. Public ticket forms fall back to the browser's default
+   textarea size. Guarded by @supports so browsers without field-sizing get
+   that default too. */
 @supports (field-sizing: content) {
   body:has(#main-nav) textarea {
     field-sizing: content;
-    aspect-ratio: auto;
     min-block-size: 3lh;
     max-block-size: 30lh;
   }


### PR DESCRIPTION
## Summary

Removes all `aspect-ratio` sizing from textareas, letting the browser default size be enough. `field-sizing` is widely supported now, so the aspect-ratio fallbacks are no longer needed.

## Changes

- Drop `aspect-ratio: 4 / 3` from the base `textarea` rule (keeps `resize: vertical`).
- Remove the `textarea[name="address"], textarea[name="special_instructions"]` override (it only set `aspect-ratio: 4 / 1`).
- Remove the `@media (min-width: 769px)` block (it only set the `16 / 9` and `16 / 3` desktop aspect-ratios).
- Drop the now-redundant `aspect-ratio: auto` reset inside the `@supports (field-sizing: content)` block, and refresh its comment.

After this:
- **Public ticket forms** use the browser's default textarea size.
- **Admin pages** (`body:has(#main-nav)`) keep the `field-sizing: content` auto-grow with `min-block-size: 3lh` / `max-block-size: 30lh` bounds.

The two remaining `aspect-ratio` rules in the stylesheet are for images (`.ticket-card-qr img`, `.order-card-image`) and are intentionally left untouched.

## Testing

- `deno task build:static` compiles the SCSS cleanly; the generated CSS contains no textarea `aspect-ratio` and retains the `@supports` field-sizing block.
- The repo's `deno task typecheck` reports 21 pre-existing `--unstable-tsgo` DOM-iteration errors in client `.ts` files; these are present on the base branch (verified by stashing this change) and are unrelated to this CSS-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Xro3NJcCRtBjyJdGLyfq5

---
_Generated by [Claude Code](https://claude.ai/code/session_015Xro3NJcCRtBjyJdGLyfq5)_