### PR TITLE
Align the whole toolchain to the pinned Deno 2.5.6 and make the suite green on it

### DIFF
--- a/.github/actions/build-bunny-script/action.yml
+++ b/.github/actions/build-bunny-script/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Setup Deno
       uses: denoland/setup-deno@v2
       with:
-        deno-version: v2.x
+        deno-version: v2.5.6
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.6
 
       - name: Install dependencies
         run: deno install --allow-scripts

--- a/.github/workflows/biome-fix.yml
+++ b/.github/workflows/biome-fix.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.6
 
       - name: Install dependencies
         run: deno install --allow-scripts

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.6
 
       - name: Generate docs
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.6
 
       - name: Install dependencies
         run: deno install --allow-scripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.6
 
       # stripe-mock is downloaded, started, and stopped by scripts/run-tests.ts
       # (invoked via the test:coverage step inside precommit). Caching .bin just

--- a/cli/api-request.ts
+++ b/cli/api-request.ts
@@ -1,0 +1,45 @@
+import type { CurlOptions } from "./curl.ts";
+import { parseResource, resourcePath } from "./resources.ts";
+
+/** Parse an optional JSON body argument; an absent/empty value means no body. */
+export const parseBody = (raw?: string): unknown =>
+  raw ? JSON.parse(raw) : undefined;
+
+/**
+ * Build the curl request for a CLI command, or null when the command is not a
+ * recognised verb. Pure over its arguments (the entrypoint passes the parsed
+ * `Deno.args`) so the request-building logic can be unit-tested in-process
+ * without running the CLI.
+ */
+export const buildRequest = (
+  command: string,
+  resourceRawValue: string,
+  idOrBody?: string,
+  maybeBody?: string,
+): CurlOptions | null => {
+  const resource = parseResource(resourceRawValue);
+  if (command === "list") return { path: resourcePath(resource) };
+  if (command === "get") return { path: resourcePath(resource, idOrBody) };
+  if (command === "create") {
+    return {
+      body: parseBody(idOrBody),
+      method: "POST",
+      path: resourcePath(resource),
+    };
+  }
+  if (command === "update") {
+    return {
+      body: parseBody(maybeBody),
+      method: "PUT",
+      path: resourcePath(resource, idOrBody),
+    };
+  }
+  if (command === "delete") {
+    return {
+      body: parseBody(maybeBody),
+      method: "DELETE",
+      path: resourcePath(resource, idOrBody),
+    };
+  }
+  return null;
+};

--- a/cli/api.ts
+++ b/cli/api.ts
@@ -1,49 +1,19 @@
 #!/usr/bin/env -S deno run --allow-env --allow-read --allow-run
+import { buildRequest } from "./api-request.ts";
 import { loadConfig } from "./config.ts";
-import { type CurlOptions, curlJson } from "./curl.ts";
+import { curlJson } from "./curl.ts";
 import { writeErr, writeOut } from "./io.ts";
-import { parseResource, resourcePath, resources } from "./resources.ts";
+import { resources } from "./resources.ts";
 
 const [command, resourceRaw, idOrBody, maybeBody] = Deno.args;
 const usage = `Usage: deno task cli:api <list|get|create|update|delete> <${resources.join("|")}> [id] [json]\n`;
-
-const parseBody = (raw?: string): unknown =>
-  raw ? JSON.parse(raw) : undefined;
-
-const buildRequest = (resourceRawValue: string): CurlOptions | null => {
-  const resource = parseResource(resourceRawValue);
-  if (command === "list") return { path: resourcePath(resource) };
-  if (command === "get") return { path: resourcePath(resource, idOrBody) };
-  if (command === "create") {
-    return {
-      body: parseBody(idOrBody),
-      method: "POST",
-      path: resourcePath(resource),
-    };
-  }
-  if (command === "update") {
-    return {
-      body: parseBody(maybeBody),
-      method: "PUT",
-      path: resourcePath(resource, idOrBody),
-    };
-  }
-  if (command === "delete") {
-    return {
-      body: parseBody(maybeBody),
-      method: "DELETE",
-      path: resourcePath(resource, idOrBody),
-    };
-  }
-  return null;
-};
 
 if (!command || !resourceRaw) {
   await writeErr(usage);
   Deno.exit(2);
 }
 
-const request = buildRequest(resourceRaw);
+const request = buildRequest(command, resourceRaw, idOrBody, maybeBody);
 if (!request) {
   await writeErr(usage);
   Deno.exit(2);

--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,7 @@
     "test:raw": "deno task build:static && deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/",
     "lint": "deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts cli",
     "lint:ci": "deno run -A scripts/biome.ts check --error-on-warnings src test scripts cli",
-    "typecheck": "deno check --unstable-tsgo src/**/*.ts src/**/*.tsx test/**/*.ts cli/**/*.ts",
+    "typecheck": "deno check src/**/*.ts src/**/*.tsx test/**/*.ts cli/**/*.ts",
     "cpd": "deno run -A scripts/cpd.ts src --config .jscpd.json",
     "precommit": "deno run -A scripts/precommit.ts",
     "find-unused-src": "deno run --allow-read scripts/find-unused-src.ts",

--- a/flake.lock
+++ b/flake.lock
@@ -14,9 +14,26 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-deno": {
+      "locked": {
+        "lastModified": 1763934636,
+        "narHash": "sha256-9glbI7f1uU+yzQCq5LwLgdZqx6svOhZWkd4JRY265fc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-deno": "nixpkgs-deno"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,6 @@
               (pkgs.writeShellScriptBin "pc" ''
                 exec ${deno}/bin/deno task precommit "$@"
               '')
-              pkgs.typescript-go
               pkgs.biome
               pkgs.openssl
               pkgs.buildah

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,15 @@
 {
-  inputs.nixpkgs.url = "nixpkgs";
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    # Pinned solely to provide Deno 2.5.6 — the lowest Bunny Edge Scripting
+    # runtime this project supports and the version the suite is verified
+    # against. Everything else in the dev shell comes from `nixpkgs`, so only
+    # Deno is held back; bump this rev when the supported floor moves.
+    nixpkgs-deno.url = "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261";
+  };
 
   outputs =
-    { nixpkgs, ... }:
+    { nixpkgs, nixpkgs-deno, ... }:
     let
       denoVersion = "2.5.6";
       systems = [
@@ -14,64 +21,72 @@
       eachSystem = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
     in
     {
-      devShells = eachSystem (pkgs: {
-        default = pkgs.mkShell {
-          packages = [
-            pkgs.deno
-            (pkgs.writeShellScriptBin "pc" ''
-              exec ${pkgs.deno}/bin/deno task precommit "$@"
-            '')
-            pkgs.typescript-go
-            pkgs.biome
-            pkgs.openssl
-            pkgs.buildah
-          ];
-          shellHook = ''
-            deno_version="$(${pkgs.deno}/bin/deno --version | sed -n 's/^deno \([^ ]*\).*/\1/p')"
-            if [ "$deno_version" != "${denoVersion}" ]; then
-              echo "tickets requires Deno ${denoVersion}, but nixpkgs provides $deno_version" >&2
-              return 1
-            fi
-
-            echo "tickets dev shell"
-            echo "  deno task start      - run server"
-            echo "  deno task test       - run tests"
-            echo "  deno task build:edge - build for edge"
-            echo "  deno task precommit  - typecheck + lint + cpd + build + test"
-            echo "  pc                   - run precommit"
-            echo "  nix run .#docker     - build container image"
-            echo "  nix run .#docker-start - build and run container"
-            export DB_ENCRYPTION_KEY="$(openssl rand -base64 32)"
-            export DB_URL=":memory:"
-            export PORT=8080
-
-            install_precommit_hook() {
-              if ! ${pkgs.git}/bin/git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-                return
+      devShells = eachSystem (
+        pkgs:
+        let
+          # Take Deno from the pinned nixpkgs so the shell uses exactly
+          # ${denoVersion} regardless of what the main nixpkgs currently ships.
+          deno = nixpkgs-deno.legacyPackages.${pkgs.stdenv.hostPlatform.system}.deno;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              deno
+              (pkgs.writeShellScriptBin "pc" ''
+                exec ${deno}/bin/deno task precommit "$@"
+              '')
+              pkgs.typescript-go
+              pkgs.biome
+              pkgs.openssl
+              pkgs.buildah
+            ];
+            shellHook = ''
+              deno_version="$(${deno}/bin/deno --version | sed -n 's/^deno \([^ ]*\).*/\1/p')"
+              if [ "$deno_version" != "${denoVersion}" ]; then
+                echo "tickets requires Deno ${denoVersion}, but the pinned nixpkgs provides $deno_version" >&2
+                return 1
               fi
 
-              hook_path="$(${pkgs.git}/bin/git rev-parse --git-path hooks/pre-commit)"
-              hook_marker="# Installed by tickets flake.nix"
+              echo "tickets dev shell"
+              echo "  deno task start      - run server"
+              echo "  deno task test       - run tests"
+              echo "  deno task build:edge - build for edge"
+              echo "  deno task precommit  - typecheck + lint + cpd + build + test"
+              echo "  pc                   - run precommit"
+              echo "  nix run .#docker     - build container image"
+              echo "  nix run .#docker-start - build and run container"
+              export DB_ENCRYPTION_KEY="$(openssl rand -base64 32)"
+              export DB_URL=":memory:"
+              export PORT=8080
 
-              if [ -e "$hook_path" ] && ! grep -Fqx "$hook_marker" "$hook_path"; then
-                echo "  pre-commit hook already exists; leaving it unchanged"
-                return
-              fi
+              install_precommit_hook() {
+                if ! ${pkgs.git}/bin/git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+                  return
+                fi
 
-              mkdir -p "$(dirname "$hook_path")"
-              cat > "$hook_path" <<'HOOK'
+                hook_path="$(${pkgs.git}/bin/git rev-parse --git-path hooks/pre-commit)"
+                hook_marker="# Installed by tickets flake.nix"
+
+                if [ -e "$hook_path" ] && ! grep -Fqx "$hook_marker" "$hook_path"; then
+                  echo "  pre-commit hook already exists; leaving it unchanged"
+                  return
+                fi
+
+                mkdir -p "$(dirname "$hook_path")"
+                cat > "$hook_path" <<'HOOK'
 #!/usr/bin/env sh
 # Installed by tickets flake.nix
 exec deno task precommit
 HOOK
-              chmod +x "$hook_path"
-              echo "  installed pre-commit hook - deno task precommit"
-            }
+                chmod +x "$hook_path"
+                echo "  installed pre-commit hook - deno task precommit"
+              }
 
-            install_precommit_hook
-          '';
-        };
-      });
+              install_precommit_hook
+            '';
+          };
+        }
+      );
 
       apps = eachSystem (pkgs: {
         docker = {

--- a/src/ui/client/admin.ts
+++ b/src/ui/client/admin.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Admin page behaviors - bundled by build-static-assets.ts for strict CSP.
  *
  * Thin entry point: each behavior lives in its own module under ./admin/

--- a/src/ui/client/admin/attendee-dates.ts
+++ b/src/ui/client/admin/attendee-dates.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /**
  * Progressive enhancement for the attendee form's shared date controls.
  *

--- a/src/ui/client/admin/availability-checker.ts
+++ b/src/ui/client/admin/availability-checker.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /**
  * Persist the calendar availability checker's open state across a single
  * navigation.

--- a/src/ui/client/admin/char-counter.ts
+++ b/src/ui/client/admin/char-counter.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Remaining chars counter for textareas with maxlength. */
 export const initCharCounters = (): void => {
   for (const ta of document.querySelectorAll<HTMLTextAreaElement>(

--- a/src/ui/client/admin/checkout-popup.ts
+++ b/src/ui/client/admin/checkout-popup.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Stripe checkout popup: opens Stripe in a new window when embedded in an iframe.
  * No-JS fallback: the Pay Now link has target="_blank" and works as a plain link. */
 export const initCheckoutPopup = (): void => {

--- a/src/ui/client/admin/closes-at-autofill.ts
+++ b/src/ui/client/admin/closes-at-autofill.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Auto-populate closes_at from listing date when closes_at is empty. */
 export const initClosesAtAutofill = (): void => {
   const dateInput =

--- a/src/ui/client/admin/csrf.ts
+++ b/src/ui/client/admin/csrf.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** POST a form-encoded body with a CSRF token, return parsed JSON. */
 export const csrfPost = async (
   url: string,

--- a/src/ui/client/admin/custom-question-visibility.ts
+++ b/src/ui/client/admin/custom-question-visibility.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Question visibility: show custom questions only when at least one
  * associated listing has quantity > 0. A question is a radio <fieldset> or a
  * select <label>, both tagged .custom-question. Questions without

--- a/src/ui/client/admin/duplicate-preview.ts
+++ b/src/ui/client/admin/duplicate-preview.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /**
  * Duplicate-group preview: re-renders the preview table live as the admin
  * types into the form. Uses the same buildDuplicatePreview helper that the

--- a/src/ui/client/admin/duration-warning.ts
+++ b/src/ui/client/admin/duration-warning.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Listing edit form: warn + gate save when booking duration changes, since
  * saving rewrites end_at on every existing booking for the listing. */
 export const initDurationWarning = (): void => {

--- a/src/ui/client/admin/fill-default-template.ts
+++ b/src/ui/client/admin/fill-default-template.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Fill default template: clicking "Edit default template" fills the textarea
  * from its data-default-tpl attribute when the textarea is empty. */
 export const initFillDefaultTemplate = (): void => {

--- a/src/ui/client/admin/form-submit-disable.ts
+++ b/src/ui/client/admin/form-submit-disable.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Disable form controls on submit to prevent double-submission, and re-enable
  * them when the page is restored from bfcache (back/forward navigation).
  *

--- a/src/ui/client/admin/iframe-scroll-into-view.ts
+++ b/src/ui/client/admin/iframe-scroll-into-view.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Scroll parent page so the iframe is visible on checkout and success pages.
  * parentIframe is created synchronously by iframe-resizer-child (loaded before
  * this deferred script) and buffers calls until the parent handshake completes.

--- a/src/ui/client/admin/listing-date-picker.ts
+++ b/src/ui/client/admin/listing-date-picker.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Listing link date picker: filter date <select> options based on selected listing. */
 export const initListingDatePicker = (): void => {
   const datesEl = document.getElementById("available-dates-data");

--- a/src/ui/client/admin/manual-checkin.ts
+++ b/src/ui/client/admin/manual-checkin.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Manual check-in: custom combobox + fetch-based form submission.
  * Posts to the scan JSON API without a page reload so the camera keeps running. */
 export const initManualCheckin = (): void => {

--- a/src/ui/client/admin/markdown-preview.ts
+++ b/src/ui/client/admin/markdown-preview.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /**
  * Markdown preview: adds a "Preview" link under each markdown editor (opposite
  * the character counter) that renders the current content via the admin-only

--- a/src/ui/client/admin/multi-booking.ts
+++ b/src/ui/client/admin/multi-booking.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 import { buildEmbedSnippets } from "#shared/embed.ts";
 
 /** Multi-booking link builder: track checkbox selection order and

--- a/src/ui/client/admin/nav-select.ts
+++ b/src/ui/client/admin/nav-select.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Navigate to selected option value on change. */
 export const initNavSelect = (): void => {
   for (const el of document.querySelectorAll<HTMLSelectElement>(

--- a/src/ui/client/admin/payment-result.ts
+++ b/src/ui/client/admin/payment-result.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Payment result pages: notify opener iframe via postMessage when in a popup. */
 export const initPaymentResultNotifier = (): void => {
   const paymentResult = document.querySelector<HTMLElement>(

--- a/src/ui/client/admin/payment-test-buttons.ts
+++ b/src/ui/client/admin/payment-test-buttons.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 import { csrfPost } from "./csrf.ts";
 
 /** Wire up a payment provider "Test Connection" button.

--- a/src/ui/client/admin/qr-refresh.ts
+++ b/src/ui/client/admin/qr-refresh.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Auto-refresh the admin QR result panel every minute so stale links are
  *  obvious to anyone watching the screen. Fades the old QR out (500ms), swaps
  *  in the new SVG + URL, then fades the new one in (500ms). */

--- a/src/ui/client/admin/running-total.ts
+++ b/src/ui/client/admin/running-total.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Booking-form running total.
  *
  * Progressively enhances the "show total" button — which, without JS, POSTs the

--- a/src/ui/client/admin/scroll-hide-nav.ts
+++ b/src/ui/client/admin/scroll-hide-nav.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Scroll-hide nav: once the sticky main nav is "stuck" (scrolled past its
  * natural place), hide it while scrolling down and show it again on scroll up;
  * while it is still in its natural place near the top of the page, leave it put.

--- a/src/ui/client/admin/select-on-click.ts
+++ b/src/ui/client/admin/select-on-click.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Auto-select input contents when clicked. */
 export const initSelectOnClick = (): void => {
   for (const el of document.querySelectorAll<HTMLInputElement>(

--- a/src/ui/client/admin/ticket-quantity-required.ts
+++ b/src/ui/client/admin/ticket-quantity-required.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Block submission of the public ticket form when no tickets are selected.
  *
  * Mirrors the server-side check in processSubmission so users get immediate

--- a/src/ui/client/contact.ts
+++ b/src/ui/client/contact.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /**
  * Public contact form: solve the Botpoison proof-of-work challenge on submit
  * and inject the resulting solution as a hidden field before the form posts.

--- a/src/ui/client/embed.ts
+++ b/src/ui/client/embed.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** Embed loader: creates an iframe and wires iframe-resizer. */
 
 (() => {

--- a/src/ui/client/iframe-resizer-parent.ts
+++ b/src/ui/client/iframe-resizer-parent.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /** iframe-resizer parent - bundled for embedders to load from our domain */
 
 import iframeResize from "@iframe-resizer/parent";

--- a/test/lib/cli.test.ts
+++ b/test/lib/cli.test.ts
@@ -3,8 +3,10 @@ import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { adminApiRoutes } from "#routes/admin/api.ts";
 import { setTestEnv } from "#test-utils";
+import { buildRequest, parseBody } from "../../cli/api-request.ts";
 import { loadConfig } from "../../cli/config.ts";
 import { buildCurlArgs, curlFailureMessage, curlJson } from "../../cli/curl.ts";
+import { clearScreen, writeErr, writeOut } from "../../cli/io.ts";
 import { parseResource, resourcePath, resources } from "../../cli/resources.ts";
 
 const withTempCwd = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -229,5 +231,99 @@ describe("CLI resources", () => {
       ),
     ].sort();
     expect([...resources].sort()).toEqual(served);
+  });
+});
+
+describe("CLI api-request", () => {
+  test("parseBody returns undefined when no JSON argument is given", () => {
+    expect(parseBody(undefined)).toBeUndefined();
+    expect(parseBody("")).toBeUndefined();
+  });
+
+  test("parseBody parses a JSON string into a value", () => {
+    expect(parseBody('{"name":"Demo"}')).toEqual({ name: "Demo" });
+  });
+
+  test("builds a bodyless list request", () => {
+    expect(buildRequest("list", "listings")).toEqual({
+      path: "/api/admin/listings",
+    });
+  });
+
+  test("builds a get request addressing a single entity", () => {
+    expect(buildRequest("get", "listings", "5")).toEqual({
+      path: "/api/admin/listings/5",
+    });
+  });
+
+  test("builds a create request with a parsed JSON body", () => {
+    expect(buildRequest("create", "listings", '{"name":"Demo"}')).toEqual({
+      body: { name: "Demo" },
+      method: "POST",
+      path: "/api/admin/listings",
+    });
+  });
+
+  test("builds an update request from an id and JSON body", () => {
+    expect(buildRequest("update", "groups", "7", '{"name":"G"}')).toEqual({
+      body: { name: "G" },
+      method: "PUT",
+      path: "/api/admin/groups/7",
+    });
+  });
+
+  test("builds a delete request that defaults to no body", () => {
+    expect(buildRequest("delete", "holidays", "9")).toEqual({
+      body: undefined,
+      method: "DELETE",
+      path: "/api/admin/holidays/9",
+    });
+  });
+
+  test("returns null for an unrecognised command", () => {
+    expect(buildRequest("publish", "listings")).toBeNull();
+  });
+});
+
+describe("CLI io", () => {
+  const decode = (bytes: Uint8Array): string => new TextDecoder().decode(bytes);
+
+  // Stub both std streams while running `act`, returning whatever each received.
+  // A single curried recorder keeps the two stubs identical without repetition.
+  const captureStdio = async (
+    act: () => Promise<void>,
+  ): Promise<{ out: string[]; err: string[] }> => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const recorder = (sink: string[]) => (bytes: Uint8Array) => {
+      sink.push(decode(bytes));
+      return Promise.resolve(bytes.length);
+    };
+    const outStub = stub(Deno.stdout, "write", recorder(out));
+    const errStub = stub(Deno.stderr, "write", recorder(err));
+    try {
+      await act();
+    } finally {
+      outStub.restore();
+      errStub.restore();
+    }
+    return { err, out };
+  };
+
+  test("writeOut writes encoded text to stdout", async () => {
+    const { out, err } = await captureStdio(() => writeOut("hello"));
+    expect(out).toEqual(["hello"]);
+    expect(err).toEqual([]);
+  });
+
+  test("writeErr writes encoded text to stderr", async () => {
+    const { out, err } = await captureStdio(() => writeErr("nope\n"));
+    expect(err).toEqual(["nope\n"]);
+    expect(out).toEqual([]);
+  });
+
+  test("clearScreen writes the ANSI clear-and-home sequence to stdout", async () => {
+    const { out } = await captureStdio(() => clearScreen());
+    expect(out).toEqual(["\x1b[2J\x1b[H"]);
   });
 });


### PR DESCRIPTION
## Why

The repo pins **Deno 2.5.6** (the lowest supported Bunny Edge runtime), and that's the version we ship on — but the toolchain had quietly drifted away from it. Tests passed on a local 2.8.x setup yet failed whenever the project actually ran on its pinned 2.5.6, because two problems only bite on 2.5.6:

1. **`typecheck` used `deno check --unstable-tsgo`.** That flag only exists in newer Deno. On 2.5.6 it's silently ignored and the **stable** checker runs instead — and the stable checker (unlike `tsgo`) needs the `dom.iterable` lib to iterate `NodeListOf` in the browser client code. Result: **21 type errors** on 2.5.6 that never appeared on a drifted local 2.8.x + `tsgo`. All 21 cascaded from the single missing `dom.iterable` lib.
2. **CI used `deno-version: v2.x`,** floating to 2.8.x, so CI never exercised the 2.5.6 toolchain the project is meant to run on.

## What

Go all-in on the stable 2.5.6 toolchain, end to end:

- **Drop `--unstable-tsgo`** from the `typecheck` task — type-check with the stable default checker everywhere.
- **Pair `dom.iterable` with the existing `dom`** lib reference in all 28 browser client files, so NodeList iteration type-checks on the stable checker (and on any Deno version).
- **Pin every workflow/action to `deno-version: v2.5.6`** so CI can't drift off the runtime floor again.
- **Pin the local Nix dev shell to Deno 2.5.6.** `flake.nix` took `pkgs.deno` from the floating nixpkgs (2.8.x), which tripped the shellHook's own version guard. A dedicated `nixpkgs-deno` input pinned to the nixpkgs rev that packages 2.5.6 now supplies Deno; everything else in the shell stays on the main nixpkgs.

Pinning CI to 2.5.6 surfaced a **coverage gap that 2.8.x's subprocess-coverage instrumentation had been papering over**: `cli/api.ts`'s `parseBody` / `return null` and `cli/io.ts`'s `writeErr` / `clearScreen` were only ever exercised through the e2e *subprocess*, which 2.5.6 attributes differently. Rather than depend on fragile subprocess coverage:

- Extract the pure request-building logic from the auto-running `cli/api.ts` entrypoint into an importable `cli/api-request.ts`.
- Cover it (and the `cli/io.ts` helpers) with **in-process** unit tests so 100% line/branch coverage holds on 2.5.6.

## Verification

`deno task precommit --ci` on a clean **Deno 2.5.6** install passes end to end:

```
lint … ✓   typecheck … ✓   cpd … ✓ (0%)   build:edge … ✓   test:coverage … ✓ (100%)
```

The flake change was verified with `nix eval`: the dev shell resolves Deno **2.5.6** on both `x86_64-linux` and `aarch64-darwin`, and the derivation evaluates without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)