### PR TITLE
Run the strict read-only lint in precommit everywhere

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,10 @@ jobs:
         run: deno install --allow-scripts
 
       # Runs the same battery as a local `deno task precommit` (lint, typecheck,
-      # cpd, build:edge, test:coverage) so CI and precommit can never drift. The
-      # --ci flag makes the lint step fail on unformatted code instead of
-      # silently fixing it.
+      # cpd, build:edge, test:coverage) so CI and precommit can never drift.
+      # precommit always runs the read-only `lint:ci`, so the lint step is just
+      # as strict here as it is locally. The --ci flag only suppresses the
+      # interactive push prompt and the progress spinner.
       - name: Run precommit checks
         env:
           DB_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Even when a caller genuinely needs many columns, list them explicitly rather tha
 - `deno task test:coverage` - Run the full suite with coverage
 - `deno task test:files <file>...` - Run only the given test files with the same setup as the full runner (builds static assets, starts stripe-mock, cleans up after)
 - `deno task lint` - Format and lint all code with Biome (`check --write`; auto-fixes in place). Biome is the sole formatter and linter.
+- `deno task lint:ci` - Strict, read-only lint (`check --error-on-warnings`, no `--write`). Fails on lint warnings (e.g. cognitive complexity) and on any code that *would* be reformatted, without touching the checkout. This is the lint `deno task precommit` runs in **every** environment, so a clean `precommit` locally means the lint step will pass in CI too. Run `deno task lint` to auto-fix before re-running.
 - `deno task build:edge` - Build for Bunny Edge deployment
 - `deno task backup` - Dump the database out-of-band to a `.zip`. Uploads to the configured storage zone by default (so it appears on the Backups page and lets the next migration skip its own inline backup); pass `--out <path>` to write a local file. Runs in a full Deno process, so unlike the in-edge backup it has no per-request subrequest budget and can dump arbitrarily large databases.
 - `deno task precommit` - Run all checks (typecheck, lint, tests)

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ deno task start          # Run server
 deno task test           # Run tests
 deno task test:coverage  # Tests with coverage report
 deno task lint           # Format + lint with Biome — fixes in place
+deno task lint:ci        # Strict read-only lint (what precommit runs everywhere)
 deno task typecheck      # Type check
 deno task build:edge     # Build for Bunny Edge
 deno task deploy:edge <script-id> # Build, upload, and publish to Bunny Edge using BUNNY_ACCESS_KEY from .env

--- a/scripts/precommit/runner.ts
+++ b/scripts/precommit/runner.ts
@@ -125,7 +125,7 @@ export const main = async (): Promise<void> => {
   console.log(bold(ci ? "precommit (ci)" : "precommit"));
   await warnAboutMergeConflicts();
 
-  const steps = getSteps(ci);
+  const steps = getSteps();
   for (const step of steps) {
     const passed = await runStep(step);
     if (!passed) {

--- a/scripts/precommit/steps.ts
+++ b/scripts/precommit/steps.ts
@@ -7,13 +7,13 @@ export interface Step {
   name: string;
 }
 
-export const getSteps = (ci: boolean): Step[] => {
+export const getSteps = (): Step[] => {
   return [
-    // Dev runs the auto-fixing `lint` (Biome `check --write`). CI runs the
-    // read-only `lint:ci`, which fails when code *would* be reformatted or has
-    // a lint warning - catching unformatted code without modifying the checkout
-    // or requiring a clean working tree.
-    { cmd: ["deno", "task", ci ? "lint:ci" : "lint"], name: "lint" },
+    // Always run the read-only `lint:ci` (Biome `check --error-on-warnings`) so
+    // precommit is exactly as strict locally as in CI: it fails on lint warnings
+    // and on code that *would* be reformatted, without modifying the checkout.
+    // Run `deno task lint` separately to auto-fix formatting before committing.
+    { cmd: ["deno", "task", "lint:ci"], name: "lint" },
     { cmd: ["deno", "task", "typecheck"], name: "typecheck" },
     { cmd: ["deno", "task", "cpd"], name: "cpd" },
     { cmd: ["deno", "task", "build:edge"], name: "build:edge" },


### PR DESCRIPTION
## Why

An agent shipped a change that passed its local `precommit` but failed CI's lint step: a `noExcessiveCognitiveComplexity` **warning** (max 15) only failed the build under `--error-on-warnings`. The root cause is that `precommit` was not equally strict in every environment.

`scripts/precommit/steps.ts` branched its lint step on whether it was running in CI:

- **dev** → `lint` (`biome check --write --error-on-warnings`) — auto-fixes formatting in place, so it *silently reformats* instead of failing on would-be-reformatted code.
- **CI** → `lint:ci` (`biome check --error-on-warnings`) — read-only, fails on warnings **and** on any code that would be reformatted.

Because the two variants differ in strictness, a clean local `precommit` could still fail CI's lint step.

## What changed

- **`scripts/precommit/steps.ts`** — `getSteps` now always runs the read-only `lint:ci`, so the lint step is identically strict in dev and CI. Dropped the now-unused `ci` parameter.
- **`scripts/precommit/runner.ts`** — updated the `getSteps()` call to match.
- **`.github/workflows/test.yml`** — refreshed the stale comment; `--ci` now only governs the push prompt and progress spinner, not lint strictness.
- **`AGENTS.md` / `README.md`** — documented `deno task lint:ci` and that `precommit` runs it everywhere, so a clean local `precommit` means the lint step passes in CI too.

Run `deno task lint` to auto-fix formatting before committing; `precommit` (and CI) then verify with the strict read-only check.

## Verification

Empirically confirmed against Biome 2.4.8 with a `src/` function exceeding cognitive complexity 15 (`noExcessiveCognitiveComplexity` is a `warn` for `src/`):

| Command | Exit |
| --- | --- |
| `check` (read-only, no flag) | 0 |
| `check --error-on-warnings` (`lint:ci`) | **1** |
| `check --write --error-on-warnings` (`lint`) | **1** |
| `check --write` (no flag) | 0 |

- Runtime check: `getSteps()` now returns `deno task lint:ci` as the lint step.
- Strict lint (`check --error-on-warnings`) passes on the changed `scripts/` files.
- `deno check` passes on the changed files.
- `deno test test/scripts/precommit.test.ts` — 3 passed (34 steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZohvozmAAysxseeceNKjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZohvozmAAysxseeceNKjV)_