### PR TITLE
Test-quality methodology, mutation-resistance criteria, and example tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,16 @@ All tests must meet these mandatory criteria:
 - Each test has a single reason to fail
 - If you need "and" in the description, split the test
 
+### 7. Assertion Strength and Mutation Resistance
+
+- Treat 100% coverage as a hygiene floor, not proof that tests would catch meaningful regressions.
+- Prefer assertions that would fail under realistic mutants: wrong arithmetic/operator, skipped validation, inverted permission checks, missing persistence, or omitted escaping.
+- Avoid compound boolean assertions such as `expect(a && b).toBe(true)`; assert the observable contract directly with exact values, object shape, persisted rows, HTTP status/body, or rendered content.
+- Avoid ending a test at `toBeTruthy()` / `toBeDefined()` unless mere existence is the actual user-visible contract. If existence matters, pair it with format, value, range, ordering, persistence, or security invariants.
+- For pure functions, add table-driven or property-style examples that cover families of inputs and state the invariant being protected. Keep any generated cases deterministic.
+- For critical flows, include negative-path, idempotency, concurrency, and metamorphic tests: e.g. payment/webhook replay does not double-credit, capacity cannot go below zero across edits/deletes, role downgrades remove access, and PII/secrets remain encrypted or absent from responses/logs.
+- When generated or bulk-added tests are involved, run `deno task test:quality-audit` and review assertionless, truthiness, presence-only, and compound-boolean findings before trusting the coverage number.
+
 ### Coverage Requirements
 
 100% test coverage is required to merge into main. To find which specific lines are uncovered, run:

--- a/TEST_QUALITY_IMPROVEMENTS.md
+++ b/TEST_QUALITY_IMPROVEMENTS.md
@@ -1,0 +1,181 @@
+# Test suite quality improvement plan
+
+This repository already treats coverage as a hard hygiene floor:
+`deno task precommit` runs linting, type checking, duplicate-code detection, the
+edge build, and full line/branch coverage. That is valuable, but the quoted
+critique is right: it does not prove that the assertions would catch meaningful
+regressions. The next step is to measure assertion strength and production-like
+failure modes directly.
+
+## Current suite shape
+
+A quick static audit of `test/**/*.ts(x)` found:
+
+- 378 test files.
+- 7,404 `test()` / `it()` declarations.
+- 1,347 boolean-shape assertions such as `expect(...).toBe(true|false)`.
+- 53 truthiness/falsiness assertions.
+- 266 defined/undefined assertions.
+- No snapshot assertions.
+
+Those numbers are not failures by themselves. Boolean and presence checks are
+often appropriate for guards, permissions, and optional state. They are also
+where weak assertions tend to hide, because a broken implementation can still
+produce “some truthy value” or make a compound expression true for the wrong
+reason.
+
+## Substantive improvements
+
+### 1. Add mutation testing as an explicit quality gate
+
+Coverage should remain mandatory, but mutation testing should be the
+suite-quality metric. Start with high-risk pure or near-pure modules where
+mutants run quickly:
+
+- pricing and payment calculations;
+- booking capacity/range logic;
+- date and timezone helpers;
+- permission/role guards;
+- URL and embed safety helpers;
+- CSV/export formatting;
+- cryptographic token validation boundaries.
+
+Recommended rollout:
+
+1. Create a mutation task that runs against a small allowlist of fast modules.
+2. Record the first mutation score as a baseline instead of failing the build.
+3. Require no score regression on touched modules.
+4. Ratchet the baseline upward as surviving mutants are converted into stronger
+   behavioral tests.
+5. Only then expand to route and database-heavy modules, where runtime and flaky
+   mutants need more tuning.
+
+A useful first target is not “100% mutation score”; it is “every safety-critical
+change must either kill relevant mutants or document why the surviving mutant is
+semantically equivalent.”
+
+### 2. Replace compound boolean assertions with state-specific assertions
+
+Assertions like:
+
+```ts
+expect(state.available && state.username === "admin").toBe(true);
+```
+
+should become explicit checks on the observable contract:
+
+```ts
+expect(state).toMatchObject({ available: true, username: "admin" });
+```
+
+This gives failures better diagnostics and prevents one broad boolean from
+hiding which part of the behavior regressed. The audit found enough boolean
+assertions to justify a gradual cleanup rule: new or touched tests should avoid
+compound boolean expressions unless the tested API truly returns a boolean.
+
+### 3. Strengthen presence checks into value or invariant checks
+
+`toBeDefined()` and `toBeTruthy()` should usually be the beginning of an
+assertion, not the end. For example, a generated key test can assert format,
+length, round-trip use, encryption-at-rest, and that the plaintext is not
+stored. A response-body test can assert the exact subset of fields that matters
+to callers, not just that a field exists.
+
+Proposed rule for code review: if a test only proves a value exists, require a
+short explanation of why existence is the user-visible contract. Otherwise,
+assert the specific value, shape, range, ordering, persistence effect, or denial
+mode.
+
+### 4. Add negative-path and metamorphic tests around critical invariants
+
+For ticket reservations, the disaster cases are mostly boundary and invariant
+violations. Add table-driven tests that probe these properties:
+
+- capacity never goes below zero under edits, deletes, mixed orders, or
+  overlapping booking ranges;
+- payment callbacks are idempotent and cannot over-credit an order;
+- role downgrades immediately remove access to owner-only and manager-only
+  paths;
+- encrypted settings and PII never appear in plaintext database columns,
+  backups, logs, or rendered pages;
+- CSV/export filters only include selected rows and columns;
+- date-range rules behave identically across DST boundaries and configured
+  timezones.
+
+These tests should assert durable outcomes after production code runs: database
+rows, HTTP statuses, emitted emails/messages, cache invalidation, or rendered
+content. Avoid asserting private helper call order unless that order is itself
+the contract.
+
+### 5. Add property-based tests for compact, high-risk pure functions
+
+Property tests are a good complement to examples for modules with clear
+invariants:
+
+- slug generation is idempotent, bounded, and safe for URLs;
+- CSV generation round-trips commas, quotes, CRLF, and empty cells;
+- date formatting/parsing preserves local dates across timezones;
+- token parsers reject malformed, truncated, or mixed-case values;
+- URL safety rejects private networks, scheme smuggling, and encoded bypasses.
+
+Keep property tests deterministic by seeding the generator and storing any
+failing seed in the test name or fixture. They should not replace example tests;
+they should explore the weird inputs humans forget.
+
+### 6. Run a weak-assertion audit before large test additions
+
+Before accepting generated or bulk-added tests, run a lightweight audit that
+reports:
+
+- tests with no visible assertion;
+- assertions that only check truthiness or definedness;
+- compound boolean assertions;
+- tests that assert on values set directly in the test without intervening
+  production behavior;
+- excessive mocking of the module under test.
+
+This should initially be informational, then become a CI warning, and finally a
+review gate for touched files. The goal is not to ban every weak-looking
+assertion; it is to force deliberate review where false confidence is most
+likely.
+
+### 7. Add production-shape tests outside unit coverage
+
+Some disasters are not line-coverage problems. Add scheduled or release-blocking
+checks for:
+
+- edge bundle smoke tests in the closest available Bunny/Deno runtime;
+- backup/restore drills with encrypted settings and attendee PII;
+- concurrent reservation attempts against libsql to prove atomic capacity
+  updates;
+- webhook replay/idempotency tests for Stripe and SumUp;
+- basic load tests for listing, checkout, and admin attendee pages;
+- security scans for redirects, iframe/embed host rules, and secret leakage.
+
+These checks do not need to run on every save. They should run before release or
+on a nightly schedule, with clear ownership for failures.
+
+## Suggested priority order
+
+1. Introduce mutation testing on a small critical allowlist.
+2. Clean up compound boolean assertions in touched files.
+3. Convert presence-only checks in security/payment/booking tests into contract
+   assertions.
+4. Add concurrency/idempotency tests for reservations and webhooks.
+5. Add property-based tests for pure parsers/formatters/safety helpers.
+6. Add release-level smoke, backup/restore, and load checks.
+
+## Success metrics
+
+Track these alongside coverage:
+
+- mutation score on the allowlisted critical modules;
+- number of surviving non-equivalent mutants;
+- count of assertionless or presence-only tests in touched files;
+- number of production-shape checks run before each release;
+- escaped defects classified by the missing test layer: unit assertion weakness,
+  integration gap, deployment/config, data migration, load, security, or wrong
+  spec.
+
+Coverage stays the floor. Mutation score, invariant tests, and production-shape
+checks become the evidence that the suite would actually notice important bugs.

--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,8 @@
     "upgrade": "deno run --allow-read --allow-write --allow-net scripts/safe-upgrade.ts",
     "backup": "deno run --env-file --allow-env --allow-read --allow-write --allow-net --allow-sys --allow-ffi scripts/backup.ts",
     "cli:tui": "deno run --allow-env --allow-read --allow-run cli/tui.ts",
-    "cli:api": "deno run --allow-env --allow-read --allow-run cli/api.ts"
+    "cli:api": "deno run --allow-env --allow-read --allow-run cli/api.ts",
+    "test:quality-audit": "deno run --allow-read scripts/test-quality-audit.ts"
   },
   "imports": {
     "#fp": "./src/fp.ts",

--- a/scripts/test-quality-audit.ts
+++ b/scripts/test-quality-audit.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env -S deno run --allow-read
+
+import { relative } from "node:path";
+
+type Finding = {
+  column: number;
+  line: number;
+  message: string;
+  path: string;
+};
+
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.tsx?$/;
+const EXPECT_PATTERN =
+  /\bexpect\s*\(|\bassert\w*\s*\(|\bassertRejects\s*\(|\bassertThrows\s*\(/;
+const WEAK_ASSERTION_PATTERNS: { message: string; pattern: RegExp }[] = [
+  {
+    message:
+      "presence-only assertion; prefer checking the value, shape, or invariant",
+    pattern: /expect\s*\([^\n]+\)\s*\.\s*toBe(?:Defined|Undefined)\s*\(/g,
+  },
+  {
+    message:
+      "truthiness assertion; prefer an exact value or contract-specific matcher",
+    pattern: /expect\s*\([^\n]+\)\s*\.\s*toBe(?:Truthy|Falsy)\s*\(/g,
+  },
+  {
+    message:
+      "compound boolean assertion; split into contract-specific assertions",
+    pattern:
+      /expect\s*\([^\n)]*(?:&&|\|\||===|!==|>=|<=|>|<)[^\n)]*\)\s*\.\s*toBe\s*\(\s*(?:true|false)\s*\)/g,
+  },
+];
+
+const lineColumnAt = (content: string, index: number) => {
+  const before = content.slice(0, index);
+  const lines = before.split("\n");
+  return { column: lines.at(-1)!.length + 1, line: lines.length };
+};
+
+const testBlockRanges = (content: string): { end: number; start: number }[] => {
+  const ranges: { end: number; start: number }[] = [];
+  const startPattern = /\b(?:test|it)\s*\(/g;
+  for (const match of content.matchAll(startPattern)) {
+    const start = match.index ?? 0;
+    let depth = 0;
+    let seenOpen = false;
+    for (let index = start; index < content.length; index += 1) {
+      const char = content[index];
+      if (char === "(") {
+        depth += 1;
+        seenOpen = true;
+      }
+      if (char === ")") depth -= 1;
+      if (seenOpen && depth === 0) {
+        ranges.push({ end: index + 1, start });
+        break;
+      }
+    }
+  }
+  return ranges;
+};
+
+const findAssertionlessTests = (path: string, content: string): Finding[] =>
+  testBlockRanges(content)
+    .filter(({ end, start }) => !EXPECT_PATTERN.test(content.slice(start, end)))
+    .map(({ start }) => ({
+      ...lineColumnAt(content, start),
+      message: "test has no visible assertion",
+      path,
+    }));
+
+const findWeakAssertions = (path: string, content: string): Finding[] => {
+  const findings: Finding[] = [];
+  for (const { message, pattern } of WEAK_ASSERTION_PATTERNS) {
+    for (const match of content.matchAll(pattern)) {
+      findings.push({
+        ...lineColumnAt(content, match.index ?? 0),
+        message,
+        path,
+      });
+    }
+  }
+  return findings;
+};
+
+const auditFile = async (path: string): Promise<Finding[]> => {
+  const content = await Deno.readTextFile(path);
+  return [
+    ...findAssertionlessTests(path, content),
+    ...findWeakAssertions(path, content),
+  ];
+};
+
+const collectTestFiles = async (directory: string): Promise<string[]> => {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(directory)) {
+    const path = `${directory}/${entry.name}`;
+    if (entry.isDirectory) {
+      files.push(...(await collectTestFiles(path)));
+      continue;
+    }
+    if (entry.isFile && TEST_FILE_PATTERN.test(path)) files.push(path);
+  }
+  return files;
+};
+
+const testFiles = async (): Promise<string[]> =>
+  (await collectTestFiles("test")).sort();
+
+const formatFinding = (finding: Finding): string =>
+  `${relative(
+    Deno.cwd(),
+    finding.path,
+  )}:${finding.line}:${finding.column} ${finding.message}`;
+
+if (import.meta.main) {
+  const findings = (
+    await Promise.all((await testFiles()).map(auditFile))
+  ).flat();
+  if (findings.length === 0) {
+    console.log("Test quality audit found no weak assertion patterns.");
+  } else {
+    console.log(`Test quality audit found ${findings.length} review targets:`);
+    for (const finding of findings) console.log(formatFinding(finding));
+  }
+}

--- a/test/lib/slug.test.ts
+++ b/test/lib/slug.test.ts
@@ -71,6 +71,20 @@ describe("slug", () => {
     test("handles combined transformations", () => {
       expect(normalizeSlug("  My Listing Name  ")).toBe("my-listing-name");
     });
+
+    test("is idempotent for representative user-entered names", () => {
+      const examples = [
+        "  Summer Gala  ",
+        "Already-normal",
+        "multiple   spaces",
+        "MIXED_case  Name",
+      ];
+
+      for (const example of examples) {
+        const once = normalizeSlug(example);
+        expect(normalizeSlug(once)).toBe(once);
+      }
+    });
   });
 
   describe("validateSlug", () => {

--- a/test/lib/url-safety.test.ts
+++ b/test/lib/url-safety.test.ts
@@ -22,6 +22,8 @@ describe("url-safety", () => {
       "not a url", // unparseable
       "https://example", // not a proper domain
       "https://localhost/hook",
+      "https://example.com@localhost/hook",
+      "https://example.com%2f@localhost/hook",
       "https://api.localhost/hook",
       "https://example.local/hook",
       "https://service.internal/hook",
@@ -44,6 +46,21 @@ describe("url-safety", () => {
     ];
     for (const url of unsafe) {
       test(url, () => expect(isSafeServerFetchUrl(url)).toBe(false));
+    }
+  });
+
+  test("keeps host safety decisions stable when paths, credentials, and ports change", () => {
+    const variants = [
+      ["https://example.com", true],
+      ["https://user:pass@example.com:8443/path?next=http://localhost", true],
+      ["https://127.0.0.1", false],
+      ["https://user:pass@127.0.0.1:8443/path?next=https://example.com", false],
+      ["https://service.internal", false],
+      ["https://user:pass@service.internal:8443/path", false],
+    ] as const;
+
+    for (const [url, expected] of variants) {
+      expect(isSafeServerFetchUrl(url)).toBe(expected);
     }
   });
 });

--- a/test/shared/csv/generate.test.ts
+++ b/test/shared/csv/generate.test.ts
@@ -48,4 +48,25 @@ describe("CSV.generate", () => {
     );
     expect(csv).toBe("Q,Q\n1,2");
   });
+
+  test("preserves empty cells while escaping every RFC 4180 special character", () => {
+    const csv = CSV.generate(
+      [
+        { note: "", title: "plain" },
+        { note: "line\rbreak", title: 'quoted, "value"' },
+      ],
+      [
+        {
+          header: "Title",
+          value: (row: { note: string; title: string }) => row.title,
+        },
+        {
+          header: "Note",
+          value: (row: { note: string; title: string }) => row.note,
+        },
+      ],
+    );
+
+    expect(csv).toBe('Title,Note\nplain,\n"quoted, ""value""","line\rbreak"');
+  });
 });


### PR DESCRIPTION
## What

Introduces a test-effectiveness methodology that goes beyond the existing 100% line/branch coverage floor, plus the criteria, tooling, and a few worked examples to support it.

This is a focused, scoped-down rebuild of the test-suite-effectiveness work. The branch had previously been damaged by a botched "sync main" that squashed a large, stale snapshot of `main` (backups, scheduled endpoints, CLI, flake, storage, running-total, contact-tracking, etc.) into the same commit as the genuine test work — see "Background" below. It has been rebuilt on top of current `main` so it now contains **only** the test-methodology changes.

## Changes (7 files)

- **`TEST_QUALITY_IMPROVEMENTS.md`** (new) — the plan: adopt mutation testing as the suite-quality metric (coverage stays the floor), replace compound-boolean and presence-only assertions with contract assertions, and add negative-path / idempotency / concurrency / metamorphic and release-level production-shape checks. Includes a suggested rollout and success metrics.
- **`AGENTS.md`** — new test criterion **"§7 Assertion Strength and Mutation Resistance"** codifying the above for contributors.
- **`scripts/test-quality-audit.ts`** (new) + **`deno task test:quality-audit`** — a lightweight, dependency-free static audit that flags assertionless tests, truthiness (`toBeTruthy`/`toBeDefined`) assertions, presence-only checks, and compound-boolean (`expect(a && b).toBe(true)`) assertions. Informational by design.
- **Example contract/property tests** demonstrating the approach on pure, high-risk helpers:
  - `test/lib/slug.test.ts` — slug normalization is idempotent for representative user-entered names.
  - `test/lib/url-safety.test.ts` — host-safety decisions stay stable across path, credential, and port variation (incl. `user@host` smuggling).
  - `test/shared/csv/generate.test.ts` — CSV generation escapes every RFC 4180 special character and preserves empty cells.

## Testing

Run with the pinned Deno 2.5.6 toolchain:

- `deno task test:quality-audit` — runs and reports findings (exit 0, informational).
- `deno task test:files test/lib/slug.test.ts test/lib/url-safety.test.ts test/shared/csv/generate.test.ts` — **69 passed**, including the 3 new tests.
- Biome lint (`--error-on-warnings`) and `deno check` on all changed files — clean.

## Background — what went wrong

The original branch was a single commit, `Sync main and fix precommit`, that touched 86 files. Most of that was a stale, partial copy of `main` accidentally folded into the commit, which is why it failed to merge. The genuine work was just the 7 files above. The fix was to reset to current `main` and re-apply only those 7 changes. The unrelated `--unstable-tsgo` typecheck flag that had also been swept in was intentionally dropped (out of scope, and it breaks `typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBPsxLryex8urSz9C2Ydxn)_