### PR TITLE
Reuse markdown editor box for contact record private notes

### DIFF
--- a/src/locales/en/attendees.json
+++ b/src/locales/en/attendees.json
@@ -36,7 +36,7 @@
   "contact_history.admin_bookings_label": "Admin bookings",
   "contact_history.messages_label": "Messages sent",
   "contact_history.last_subject_label": "Last message subject",
-  "contact_history.notes_label": "Private notes (markdown)",
+  "contact_history.notes_label": "Private notes",
   "contact_history.last_contacted_label": "Last contacted",
   "contact_history.never": "Never",
   "contact_history.note_preview_label": "Note preview",

--- a/src/ui/templates/admin/contact-history.tsx
+++ b/src/ui/templates/admin/contact-history.tsx
@@ -8,11 +8,13 @@
 import { t } from "#i18n";
 import { formatDatetimeShort } from "#shared/dates.ts";
 import type { ContactRecord } from "#shared/db/contact-preferences.ts";
-import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { CsrfForm, Flash, renderField } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
+import { FORMATTING_HINT } from "#templates/fields.ts";
 import { Layout } from "#templates/layout.tsx";
 
 export type ContactHistoryPageData = {
@@ -96,12 +98,19 @@ export const contactHistoryPage = ({
           <input name="last_subject" type="text" value={record.lastSubject} />
         </label>
 
-        <label>
-          {t("contact_history.notes_label")}
-          <textarea name="admin_notes" rows={6}>
-            {record.adminNotes}
-          </textarea>
-        </label>
+        <Raw
+          html={renderField(
+            {
+              hintHtml: FORMATTING_HINT,
+              label: t("contact_history.notes_label"),
+              markdown: true,
+              maxlength: MAX_TEXTAREA_LENGTH,
+              name: "admin_notes",
+              type: "textarea",
+            },
+            record.adminNotes,
+          )}
+        />
 
         <p class="muted small">
           {t("contact_history.last_contacted_label")}:{" "}

--- a/test/lib/server-contact-history.test.ts
+++ b/test/lib/server-contact-history.test.ts
@@ -67,6 +67,27 @@ describeWithEnv("server (/admin/history/:hmac)", { db: true }, () => {
       expect(html).toContain(param);
     });
 
+    test("renders the private note in the shared markdown editor box, label without '(markdown)'", async () => {
+      const param = toContactHashParam(await hashEmail("mdbox@example.com"));
+      const response = await awaitTestRequest(`/admin/history/${param}`, {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      // The note textarea opts into the shared markdown editor: data-markdown-preview
+      // drives the Preview link, maxlength drives the character counter.
+      expect(html).toMatch(
+        /<textarea[^>]*\bdata-markdown-preview\b[^>]*\bname="admin_notes"/,
+      );
+      expect(html).toMatch(
+        new RegExp(
+          `<textarea[^>]*\\bmaxlength="${MAX_TEXTAREA_LENGTH}"[^>]*\\bname="admin_notes"`,
+        ),
+      );
+      // The "(markdown)" qualifier is dropped from the visible label.
+      expect(html).toContain("Private notes");
+      expect(html).not.toContain("Private notes (markdown)");
+    });
+
     test("renders an empty record with a 'Never' placeholder and no note preview", async () => {
       // An unseen hash has no row at all, so every field is zero/empty.
       const param = toContactHashParam(await hashEmail("unseen@example.com"));


### PR DESCRIPTION
## What

On the **Contact record** editor (`/admin/history/:hmac`), the **Private notes** field rendered a plain `<textarea>`, so it lacked the Preview link and character counter that every other markdown editor in the app has.

This change:
- Renders the notes field through the shared `renderField` markdown path (`markdown: true` → the `data-markdown-preview` Preview link, `maxlength` → the character counter), matching the listing/group description and Terms editors. The same `/admin.js` bundle (`initMarkdownPreview` + `initCharCounters`) already drives those editors, so no client changes were needed.
- Adds the standard "Formatting help" hint, consistent with the other markdown editors.
- Drops the now-redundant `(markdown)` qualifier from the label — it's just **Private notes** now.

Reusing `renderField` (rather than hand-rolling another `data-markdown-preview` textarea) keeps the duplication checker at 0%. Dropping the old `rows={6}` matches the other admin markdown editors, which size via the admin `field-sizing: content` rule (min 3 lines, grows with content).

## Testing

- `deno task typecheck` — passes
- `deno task lint:ci` — passes (no warnings/reformatting)
- `deno task cpd` — 0% duplication
- `deno task test:files test/lib/server-contact-history.test.ts test/markdown-preview.test.ts` — 22/22 pass

Added a test asserting the notes textarea carries `data-markdown-preview` + `maxlength`, and that the label no longer contains `(markdown)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqwZdHAi9wJTuzQ3u4Vr2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqwZdHAi9wJTuzQ3u4Vr2G)_