### PR TITLE
Reduce false positives/negatives in the test-quality audit

### DIFF
--- a/scripts/test-quality-audit.ts
+++ b/scripts/test-quality-audit.ts
@@ -10,24 +10,28 @@ type Finding = {
 };
 
 const TEST_FILE_PATTERN = /\.(?:test|spec)\.tsx?$/;
-const EXPECT_PATTERN =
-  /\bexpect\s*\(|\bassert\w*\s*\(|\bassertRejects\s*\(|\bassertThrows\s*\(/;
+// Count bare `expect(`/`assert*(` as well as project assertion helpers that
+// wrap them (e.g. `expectHtmlResponse(...)`, `expectRedirectWithFlash(...)`),
+// otherwise tests that only assert through those helpers look assertionless.
+const EXPECT_PATTERN = /\bexpect\w*\s*\(|\bassert\w*\s*\(/;
 const WEAK_ASSERTION_PATTERNS: { message: string; pattern: RegExp }[] = [
   {
     message:
       "presence-only assertion; prefer checking the value, shape, or invariant",
-    pattern: /expect\s*\([^\n]+\)\s*\.\s*toBe(?:Defined|Undefined)\s*\(/g,
+    // `[^;]+?` (lazy) lets the call span multiple lines while staying within a
+    // single statement, so wrapped `expect(...)` calls are still matched.
+    pattern: /expect\s*\([^;]+?\)\s*\.\s*toBe(?:Defined|Undefined)\s*\(/g,
   },
   {
     message:
       "truthiness assertion; prefer an exact value or contract-specific matcher",
-    pattern: /expect\s*\([^\n]+\)\s*\.\s*toBe(?:Truthy|Falsy)\s*\(/g,
+    pattern: /expect\s*\([^;]+?\)\s*\.\s*toBe(?:Truthy|Falsy)\s*\(/g,
   },
   {
     message:
       "compound boolean assertion; split into contract-specific assertions",
     pattern:
-      /expect\s*\([^\n)]*(?:&&|\|\||===|!==|>=|<=|>|<)[^\n)]*\)\s*\.\s*toBe\s*\(\s*(?:true|false)\s*\)/g,
+      /expect\s*\([^)]*(?:&&|\|\||===|!==|>=|<=|>|<)[^)]*\)\s*\.\s*toBe\s*\(\s*(?:true|false)\s*\)/g,
   },
 ];
 
@@ -39,7 +43,10 @@ const lineColumnAt = (content: string, index: number) => {
 
 const testBlockRanges = (content: string): { end: number; start: number }[] => {
   const ranges: { end: number; start: number }[] = [];
-  const startPattern = /\b(?:test|it)\s*\(/g;
+  // Match `test(`/`it(` declarations and `Deno.test(`, but not predicate method
+  // calls such as `someRegex.test(value)` (the lookbehind rejects a leading
+  // `.`/identifier char) which would otherwise be flagged as assertionless.
+  const startPattern = /\bDeno\.test\s*\(|(?<![.\w$])(?:test|it)\s*\(/g;
   for (const match of content.matchAll(startPattern)) {
     const start = match.index ?? 0;
     let depth = 0;


### PR DESCRIPTION
## What

Follow-up to #1356, addressing the three P2 issues [Codex flagged](https://github.com/chobbledotcom/tickets/pull/1356#pullrequestreview-4538301787) on `scripts/test-quality-audit.ts` (the review landed seconds before #1356 merged via the queue, so they couldn't be folded in there).

All three are accuracy bugs in the audit's regexes that hurt its signal-to-noise. On the current suite the audit reported **936 targets, ~65% of them noise**; after these fixes it reports **329**, surfacing genuine weak tests instead of burying them.

## Fixes

| # | Problem | Fix |
|---|---------|-----|
| 1 | `EXPECT_PATTERN` only matched bare `expect(`/`assert*(`, so tests asserting through project helpers (`expectHtmlResponse(...)`, `expectRedirectWithFlash(...)`, `expectInvalid(...)`) were reported as **"test has no visible assertion"** (hundreds of false positives). | Broaden to `expect\w*(` / `assert\w*(`. |
| 2 | `\b(?:test\|it)\(` also matched predicate method calls like `someRegex.test(value)`, flagging them as assertionless tests. | Lookbehind rejects a leading `.`/identifier char — **while still recognising `Deno.test(`** so the one file using it (`test/scripts/compact-test-reporter.test.ts`, 6 tests) stays audited. |
| 3 | Weak-assertion patterns used `[^\n]+`, so a `toBeTruthy()`/`toBeDefined()`/compound-boolean assertion split across lines (e.g. `auth.test.ts:63-65`) escaped detection. | Allow the `expect(...)` call to span lines, bounded to a single statement (`[^;]+?` / `[^)]*`) so detection stays accurate. |

## Verification (Deno 2.5.6)

- `code-quality.test.ts` (`.test()` predicate calls) → **0** assertionless reports (was noisy).
- `theme.test.ts` (asserts via `expect*` helpers) → **0** assertionless reports.
- `auth.test.ts:63` multiline `expect(await verifyUserPassword(...)).toBeTruthy()` → **now detected**.
- `Deno.test(` file still audited (not silently dropped).
- `deno task test:quality-audit` runs, exit 0 (informational); Biome lint (`--error-on-warnings`) + `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBPsxLryex8urSz9C2Ydxn)_