### PR TITLE
Add refunded_amount implementation plan

### DIFF
--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -68,18 +68,25 @@ The flattened `Attendee` type (a join of one `attendees` row + one
 Replaces today's "are you sure?" confirm page (`adminRefundAttendeePage` in
 `src/ui/templates/admin/attendees.tsx`). It shows:
 
-- A **"Refund the whole order"** checkbox, **checked by default**. Checked = today's
-  behaviour (refund everything still owed across the order).
+- A **"Refund all ticket lines"** checkbox, **checked by default**. Checked =
+  refund each ticket line to its `price_paid` (everything still owed on the
+  ticket lines). **Note (review):** call it "all ticket lines", not "the whole
+  order" — booking fees are not refundable through this form (§16), so on a
+  fee-bearing order this does *not* return 100% of what the customer paid. The
+  copy must not promise a full-order refund.
 - When **unchecked** (pure-CSS reveal, like the existing `show_all` pattern in the
   attendee form), a row per booking line in the order:
-  - listing name (label),
+  - listing name **and the booking date/range** for daily/customisable bookings
+    (review): the same listing can appear on several `start_at` dates with the
+    same name and price, so the date is what makes the rows distinguishable. The
+    row submits the booking's **row key (`start_at`)** so the write hits the
+    right line (§5).
   - "Paid: £X.XX" (the line's `price_paid`),
-  - an amount input in **major currency units** (£/$, like every other admin money
-    field — see `parseMoneyMinor` in `attendee-form-model.ts`), `min=0`,
-    `max=` the line's **remaining refundable** shown in major units
-    (`(price_paid − refunded_amount) / 100`), prefilled with that max. The server
-    converts back to minor units on submit and re-clamps (never trust the
-    client). **Do not** render the raw minor-unit integer (review).
+  - an amount input in **major currency units**, `min=0`, `max=` the line's
+    **remaining refundable** — both produced with `toMajorUnits` and parsed back
+    with `toMinorUnits`/`parseMoneyMinor` (`src/shared/currency.ts`), **never a
+    hard-coded `/100`** (review: JPY and 3-decimal currencies would be wrong).
+    Server converts and re-clamps on submit (never trust the client).
 - Confirm field (the existing name/identifier confirmation) + submit.
 
 Optionally, a status selector defaulting to a "Refunded" order status when one
@@ -116,9 +123,16 @@ refund = the operator's per-line numbers.
 
 ### 2c. Bulk — `POST /admin/listing/:id/refund-all`
 
-Keep it; it refunds every **not-fully-refunded** line of every order on the
-listing to its `price_paid` (full refund per attendee), batched as today
-(`REFUND_BATCH_LIMIT`). "Refundable" is redefined in §6.
+Keep it; it refunds every **not-fully-refunded** line to its `price_paid`,
+batched as today (`REFUND_BATCH_LIMIT`). "Refundable" is redefined in §6.
+
+**Group by order before calling the provider (review).** The bulk loader returns
+one row per `listing_attendees` line, so an attendee booked on two dates for the
+listing appears twice with the **same `payment_id`**. A line-oriented loop would
+call the provider twice for one payment (duplicate/again-failing refund) while
+recording only some lines. Group the lines by attendee/`payment_id`, refund each
+payment **once** with the summed remaining amount, then write all that order's
+lines atomically (§2b step 4).
 
 ---
 
@@ -138,19 +152,31 @@ return-shape churn, no reading amounts back, no caller sweep. Two additions:
   the caller's `idempotencyKey` **instead of the fresh `crypto.randomUUID()` it
   generates per call** (`square.ts:624`) so retries dedupe.
 - **SumUp**: confirm partial-refund support. If it is full-only, the per-item UI
-  must be hidden **and the POST handler must reject any non-full SumUp refund**
-  server-side (review) — a stale/crafted POST otherwise refunds the whole
-  transaction (`sumup.ts` refunds in full) while storing only a partial
-  `refunded_amount`. Don't rely on hiding controls alone.
+  must be hidden **and the POST handler must reject any refund whose total is less
+  than the provider transaction total** server-side (review) — a stale/crafted
+  POST otherwise refunds the whole transaction (`sumup.ts` refunds in full) while
+  storing only a partial `refunded_amount`. Note this is stricter than "reject
+  non-full ticket refund": because the form caps at `price_paid` and excludes
+  booking fees (§16), even the **default "all ticket lines"** total is *less than*
+  the provider transaction whenever a fee was charged — so for SumUp, fee-bearing
+  orders can't be fully refunded through this form at all and must be refused (or
+  refunded out-of-band). Don't rely on hiding controls alone.
 
 **Idempotency / double-submit (review).** Partial amounts make a duplicate
 submission materially worse than today's full-refund retry: two concurrent £5
 POSTs could both succeed before either records `refunded_amount`, turning a £5
-refund into £10. Mitigate with a **stable per-refund idempotency key** (so the
-provider dedupes) plus a **local guard** — either a single-use form token, or
-reserve the `refunded_amount` rows (conditional UPDATE on the expected current
-value) *before* calling the provider so a racing second POST sees no remaining
-refundable. This must land **with** partial amounts, not after.
+refund into £10. A **single-use form token is not sufficient** — two tabs/two
+admins render *different* tokens for the same remaining balance, get *different*
+provider idempotency keys, and both succeed. The guard must be tied to the
+**current refunded amounts**, not the form: derive the provider idempotency key
+deterministically from `(payment_id, per-line target amounts)` so identical
+requests dedupe at the provider, **and** gate locally on the live remaining
+refundable. Do **not** "reserve" by writing the *final* `refunded_amount` before
+the provider call (review) — a provider failure would then leave the line
+recorded as refunded with no money moved, contradicting "provider failure records
+nothing". Use a **separate pending-refund reservation** (or an amount-conditional
+write applied only *after* provider success) so failure leaves no trace. This
+must land **with** partial amounts, not after.
 
 `isPaymentRefunded` is unchanged (still boolean) — see the refresh path (§8).
 
@@ -170,28 +196,34 @@ No trigger change: the `LISTING_AGGREGATE_TRIGGERS` UPDATE trigger fires
 `listings.income`/capacity (income keeps counting refunded rows, exactly as
 today).
 
-### 4b. Migration — recreate the table
+### 4b. Migration — add the column first, *then* recreate the table
 
-Removing a column needs a table rebuild, not `ADD COLUMN`. Model it on
-`2026-06-18_answer_modifiers.ts` / `2026-06-20_free_text_questions.ts`:
+Removing a column needs a table rebuild, not `ADD COLUMN`. **Order matters
+(review, P1):** `recreateTable` rebuilds from the *current* SCHEMA and copies via
+`INSERT INTO …_new (…, refunded_amount, …) SELECT …, refunded_amount, … FROM
+listing_attendees` — so `refunded_amount` must already exist on the old table
+before the recreate, or the copy SELECT fails. The fix is to use the
+`schemaMigration` wrapper, which runs `applySchemaChanges()` (the ADD COLUMN)
+**before** the `after` hook — exactly how `2026-06-18_answer_modifiers.ts` adds
+columns via `recreateTable`:
 
 ```ts
 // src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts
-export default (context) =>
-  context.additive({
-    id: "2026-06-21_attendee_refunded_amount",
-    description:
-      "Add per-line refunded_amount to listing_attendees and drop the refunded boolean (refund state moves to order statuses)",
-    requires: { columns: { listing_attendees: ["refunded_amount"] } },
-    up: async () => {
-      // recreateTable rebuilds listing_attendees from the *current* SCHEMA:
-      // it copies surviving columns (so `refunded` is dropped, its data
-      // discarded — there are no refunds), adds refunded_amount (DEFAULT 0),
-      // and re-creates the table's indexes + aggregate triggers.
-      await context.recreateTable("listing_attendees");
-      await context.syncTriggers();
-    },
-  });
+import { schemaMigration } from "./define.ts";
+
+export default schemaMigration(
+  "2026-06-21_attendee_refunded_amount",
+  "Add per-line refunded_amount to listing_attendees and drop the refunded boolean (refund state moves to order statuses)",
+  // applySchemaChanges runs first: ADD COLUMN refunded_amount onto the old table.
+  { columns: { listing_attendees: ["refunded_amount"] } },
+  // after(): now the column exists, recreateTable rebuilds from SCHEMA —
+  // copying surviving columns (so `refunded` is dropped, data discarded — there
+  // are no refunds) and re-creating indexes + aggregate triggers.
+  async ({ recreateTable, syncTriggers }) => {
+    await recreateTable("listing_attendees");
+    await syncTriggers();
+  },
+);
 ```
 
 Register it in `src/shared/db/migrations.ts` (import + append to `MIGRATIONS`).
@@ -248,7 +280,9 @@ check. Concretely:
 - **Selects** — every per-line column list adds `refunded_amount` and drops
   `refunded`:
   - `src/shared/db/attendees/queries.ts` — `EA_COLS`, `ATTENDEE_LEFT_JOIN_SELECT`
-    (`COALESCE(ea.refunded_amount,0)`), `getAttendeesByTokens`.
+    (must be `COALESCE(ea.refunded_amount, 0) AS refunded_amount` — keep the
+    `AS <field>` alias, or libsql exposes the column under the expression text and
+    `decryptAttendeeFields` silently reads `0`), `getAttendeesByTokens`.
   - `src/features/admin/attendees-edit.ts` — `loadRefreshContext`.
   - `src/features/admin/attendees-merge.ts` — `loadAttendeeBookings`.
   - `src/shared/db/attendees/atomic-update.ts` — `loadExistingLines`.
@@ -294,6 +328,13 @@ check. Concretely:
   a boolean — **unchanged** (no row exists to record against). `webhook-types.ts`
   /`webhook.ts` outbound payload: drop `refunded` if present; optionally add
   `refunded_amount` (§14).
+- **Operator guide (review).** The admin refunds guide
+  (`src/locales/en/guide.json` ~`:147-152`, `:276-277`, rendered by the refunds
+  guide section under `src/ui/templates/admin/guide/`) currently states that
+  individual refunds are always full, partial refunds are unsupported, and booking
+  fees are refunded. All three are now false — update the guide copy (and any
+  per-locale copies) so the documentation matches the new partial-refund form and
+  the fee exclusion. This is required work, not optional.
 
 ---
 
@@ -427,7 +468,7 @@ Out of scope unless wanted.
 | File | Change | Req? |
 | --- | --- | --- |
 | `migrations/schema.ts` | drop `refunded`, add `refunded_amount` on `listing_attendees`; bump `LATEST_UPDATE` | ✅ |
-| `migrations/2026-06-21_attendee_refunded_amount.ts` | new migration: `recreateTable` + `syncTriggers` | ✅ |
+| `migrations/2026-06-21_attendee_refunded_amount.ts` | new migration: **`schemaMigration(…, after)`** — ADD COLUMN then `recreateTable` + `syncTriggers` (order matters, §4b) | ✅ |
 | `migrations.ts` | import + append to `MIGRATIONS` | ✅ |
 | `migrations/schema-sync.ts` | legacy `backfillListingAttendees`: stop writing `refunded`/`refunded_v2`, map to `refunded_amount` | ✅ |
 | `types.ts`, `attendee-types.ts` | `Attendee`/`ListingAttendeeRow`: −`refunded`, +`refunded_amount` | ✅ |
@@ -435,7 +476,8 @@ Out of scope unless wanted.
 | `attendees/update.ts` | `markRefunded`→`recordLineRefund` (single-row, capped); `updateCheckedIn` gains `start_at` row identity | ✅ |
 | `attendees/pii.ts` | map `refunded_amount`; drop `refunded` | ✅ |
 | `attendees-edit.ts`, `attendees-merge.ts`, `atomic-update.ts` | loaders select `refunded_amount` | ✅ |
-| `attendee-refunds.ts` | per-item form handler; all-order loader; major→minor conversion; idempotency guard; atomic batch writes; redefine `getRefundable` | ✅ |
+| `attendee-refunds.ts` | per-item form handler; all-order loader; major→minor conversion; idempotency guard; atomic batch writes; **bulk: group by order/payment, one provider call each**; redefine `getRefundable` | ✅ |
+| `src/locales/en/guide.json` + refunds guide template | rewrite refunds guide: partial refunds supported, fees not refundable (§6) | ✅ |
 | `payments.ts` + `stripe.ts`/`square.ts`/`sumup-provider.ts` (+providers) | `refundPayment(ref, amount?, idempotencyKey?)`; SumUp reject partial server-side | ✅ |
 | `attendees.tsx` (refund form, major-unit inputs + `PaymentDetails` sum) | UI | ✅ |
 | `checkin.ts` (+ scanner, token path) | move off boolean (§12); carry `start_at` to pin check-in writes | ✅ |
@@ -499,18 +541,29 @@ Out of scope unless wanted.
 
 ## 18. Definition of done
 
-- [ ] Migration recreates `listing_attendees` (no `refunded`, has
-      `refunded_amount`); `verify()` passes; `SCHEMA_HASH`/`LATEST_UPDATE` updated.
+- [ ] Migration **adds `refunded_amount` (ADD COLUMN) before** `recreateTable`
+      (via the `schemaMigration(…, after)` wrapper, §4b); ends with no `refunded`,
+      has `refunded_amount`; `verify()` passes; `SCHEMA_HASH`/`LATEST_UPDATE`
+      updated. Legacy `schema-sync.ts` backfill no longer writes `refunded`.
 - [ ] `recordLineRefund` writes one row (by `start_at`), caps at `price_paid`,
       accumulates on repeat — tested incl. the two-dates identity case.
-- [ ] `refundPayment(ref, amount?)` issues partial refunds on Stripe/Square;
-      omitted `amount` = full; SumUp partial verified or per-item disabled for it.
-- [ ] Refund form loads the **whole order** (all lines); "whole order" (default)
-      and per-item (0…remaining, **major-unit** inputs) both work; total refunded
-      at the provider matches; provider failure records nothing; per-line writes
-      are **atomic** (one batch after provider success).
-- [ ] **Idempotency:** a double-submit / concurrent partial refund cannot stack
-      (stable provider idempotency key + local reservation/single-use token).
+- [ ] `refundPayment(ref, amount?, idempotencyKey?)` issues partial refunds on
+      Stripe/Square; omitted `amount` = full; SumUp rejects any refund below the
+      provider transaction total (incl. fee-bearing "all ticket lines").
+- [ ] Refund form loads **all order lines**; default "all ticket lines" and
+      per-item (0…remaining) both work, inputs in **major units via
+      `toMajorUnits`/`toMinorUnits`** (not `/100`); each row shows its booking
+      **date** and submits its `start_at` row key; total refunded at the provider
+      matches; provider failure records nothing; per-line writes **atomic** (one
+      batch after provider success).
+- [ ] **Idempotency:** a double-submit / concurrent partial refund (incl. two
+      tabs/admins) cannot stack — provider key derived from `(payment_id, target
+      amounts)` + a local guard on **live remaining refundable** (not a form
+      token, and not by pre-writing the final `refunded_amount`).
+- [ ] **Bulk refund** groups lines by order/`payment_id` and calls the provider
+      **once per payment** with the summed amount.
+- [ ] Operator **refunds guide** (`guide.json` + template) rewritten: partial
+      refunds supported, booking fees not refundable.
 - [ ] **Per-line payment scoping decided** (§16): balance-paid reservations and
       merged multi-payment attendees either refund the correct payment(s) or are
       blocked — never silently mis-record. SumUp non-full refunds rejected

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -27,8 +27,9 @@ decisions simplified it a lot — see "What changed & why it's simpler" at the e
    `amount`; we pass the operator's total in. It keeps returning a boolean
    (success/failure) — we are *commanding* the refund, not reading it back.
 
-One thing still needs a yes/no from you — **check-in behaviour** (§12). Everything
-else is specified.
+Check-in behaviour is also decided (§12): a ticket is blocked from check-in once
+it is **fully** refunded (`refunded_amount >= price_paid`). The plan is now fully
+specified.
 
 ---
 
@@ -227,7 +228,10 @@ check. Concretely:
 - **Check-in** — `src/features/checkin.ts:101` filters `!attendee.refunded`, and
   the scanner (`src/features/admin/scanner.ts`, `scanner.tsx`, client
   `scanner.js`, `manual-checkin.ts`) shows a refunded badge / blocks refunded
-  tickets. These must move off the boolean — **see §12 for the behaviour decision.**
+  tickets. Move these to the **fully-refunded** test (decided, §12): a line is
+  blocked when `refunded_amount >= price_paid` (and `price_paid > 0`). A helper
+  like `isFullyRefunded(line)` keeps the rule in one place; partial refunds do
+  **not** block.
 - **Merge** — `src/shared/merge/attendee-merge.ts`: `bookingInsertStatement` copies
   `refunded_amount` (and no longer `refunded`); the duplicate-detection compare in
   `buildBookingDiffItems` swaps `refunded` for `refunded_amount`.
@@ -311,24 +315,22 @@ place of `refunded`.
 
 ---
 
-## 12. OPEN QUESTION — check-in behaviour
+## 12. Check-in behaviour (decided: block when fully refunded)
 
-Removing the boolean removes today's automatic "Cannot check in refunded tickets"
-guard (`checkin.ts:101`). Pick one:
+Removing the boolean removed today's automatic "Cannot check in refunded tickets"
+guard (`checkin.ts:101`). **Decision (owner, 2026-06-21): block when fully
+refunded.** A line counts as refunded for check-in when `refunded_amount >=
+price_paid` (and `price_paid > 0`); partial refunds do not block (the holder
+still paid part of it).
 
-- **(A — recommended) Block on fully-refunded lines via the amount.** A line is
-  "refunded" for check-in when `refunded_amount >= price_paid` (and `price_paid >
-  0`). Preserves today's safety with no new schema; partial refunds don't block
-  (the holder still paid part of it).
-- **(B) Block on an order status.** Add an `is_refunded`/`blocks_checkin` flag to
-  `attendee_statuses` and gate check-in on the attendee's status. Matches "use
-  order statuses" most literally, but adds a status-schema change and an operator
-  step (they must set the status for check-in to block).
-- **(C) Don't auto-block.** Check-in never blocks on refunds; operators rely on
-  the status/amount being visible. Simplest, least safe.
-
-My recommendation is **A** (keeps the existing protection, no extra moving parts).
-Tell me A/B/C and I'll lock it into §6.
+- Replace the `!attendee.refunded` filter in `checkin.ts` with
+  `!isFullyRefunded(line)`, and update the scanner badge/guards
+  (`scanner.ts`, `scanner.tsx`, `scanner.js`, `manual-checkin.ts`) to the same
+  rule. Keep `isFullyRefunded` in one shared place so check-in, the scanner, and
+  the badge agree.
+- This preserves today's protection with no new schema and no extra operator
+  step. (Rejected alternatives: a `blocks_checkin` flag on `attendee_statuses` —
+  more schema + an operator action; or no auto-block at all — least safe.)
 
 ---
 
@@ -344,8 +346,9 @@ Tell me A/B/C and I'll lock it into §6.
   `stripePaymentProvider.refundPayment` — assert the `amount` arg now.)
 - **Provider:** Stripe/Square `refundPayment(ref, amount)` issues a partial refund
   with the right amount; omitted `amount` = full (existing tests).
-- **Removal regression:** check-in (per §12 choice), merge (moved line keeps
-  amount), scanner badge, CSV column, payment panel sum.
+- **Removal regression:** check-in blocks a **fully**-refunded line but allows a
+  **partially**-refunded one (§12); merge (moved line keeps amount); scanner
+  badge; CSV column; payment panel sum.
 - **`refund-all`:** every not-fully-refunded line goes to `price_paid`.
 - Run `deno task test:quality-audit` for the new tests.
 
@@ -433,7 +436,8 @@ Out of scope unless wanted.
 - [ ] Tests added (§13); `deno task test:coverage` 100% & deterministic;
       `test:quality-audit` clean.
 - [ ] `deno task precommit` (typecheck, `lint:ci`, tests, `cpd` 0%) passes.
-- [ ] §12 (check-in) answered and implemented.
+- [ ] Check-in blocks fully-refunded lines (`refunded_amount >= price_paid > 0`)
+      and allows partially-refunded ones (§12), via a shared `isFullyRefunded`.
 
 ---
 
@@ -452,5 +456,5 @@ Your decisions removed three whole problem areas the earlier draft wrestled with
 
 What it *added*: removing the `refunded` boolean (a broad but mechanical refactor)
 and partial refunds at the provider (a small, additive change). Net: a clearer
-model — **state = order status, money = `refunded_amount` per item** — and one
-open question (check-in, §12).
+model — **state = order status, money = `refunded_amount` per item**, check-in
+blocks only fully-refunded lines — and no open questions remaining.

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -112,9 +112,10 @@ it as "the chosen path"; "option A / fallback" means the two narrow cases above.
 1. **Column**: `refunded_amount INTEGER NOT NULL DEFAULT 0` on
    `listing_attendees`. Minor units, never null, defaults to 0 (so existing
    rows and non-refunded rows read as 0 — "nothing refunded").
-2. **Value written**: `markRefunded(attendeeId, listingId, amount?)` sets
-   `refunded = 1` and `refunded_amount = amount`, in a single atomic UPDATE so
-   the flag and amount can never drift. The `amount` is:
+2. **Value written**: `markRefunded(attendeeId, listingId, startAt, amount?)`
+   sets `refunded = 1` and `refunded_amount = amount` on the **one** line
+   identified by (listing_id, attendee_id, start_at — §6), in a single atomic
+   UPDATE so the flag and amount can never drift. The `amount` is:
    - the **provider's actual refunded amount** (option B) where available — the
      refund routes already hold the provider result and can pass it in; or
    - the line's **`price_paid`** as the fallback (`amount` omitted → the SQL
@@ -308,37 +309,53 @@ column, so `markRefunded` needs its own statement (the helper stays for
 const setCheckedIn = updateListingAttendeeField("checked_in");
 
 /**
- * Mark a booking line refunded and record the refunded amount. The amount
- * defaults to what was paid for the line (the only case we support today —
- * full refunds via provider.refundPayment); a caller may pass a smaller
- * amount once partial refunds are supported.
+ * Mark ONE booking line refunded and record the refunded amount.
+ *
+ * The row identity is (listing_id, attendee_id, start_at) — the table's unique
+ * index. Filtering by (attendee_id, listing_id) alone is NOT enough: an attendee
+ * can book the same listing on several dates, so that predicate matches multiple
+ * rows. With a single provider amount that would stamp the full amount onto every
+ * dated row and double-count the SUM (review). Pass start_at (or the row id) to
+ * target exactly one line.
  */
 export const markRefunded = async (
   attendeeId: number,
   listingId: number,
+  startAt: string | null,
   amount?: number,
 ): Promise<void> => {
+  // `start_at IS ?` handles the NULL (standard-listing) case as well as a date.
   await execute(
     amount === undefined
-      ? "UPDATE listing_attendees SET refunded = 1, refunded_amount = price_paid WHERE attendee_id = ? AND listing_id = ?"
-      : "UPDATE listing_attendees SET refunded = 1, refunded_amount = ? WHERE attendee_id = ? AND listing_id = ?",
+      ? "UPDATE listing_attendees SET refunded = 1, refunded_amount = price_paid WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?"
+      : "UPDATE listing_attendees SET refunded = 1, refunded_amount = ? WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?",
     amount === undefined
-      ? [attendeeId, listingId]
-      : [amount, attendeeId, listingId],
+      ? [attendeeId, listingId, startAt]
+      : [amount, attendeeId, listingId, startAt],
   );
 };
 ```
 
 Notes:
+- **Row identity (review):** the added `start_at` filter is required so the write
+  hits exactly one line. The existing boolean `markRefunded` already over-matches
+  here (it marks every same-listing row), which is a latent bug today; option B's
+  per-line amount makes it actively wrong (double-counted totals), so the
+  signature gains `startAt`. **All callers change** to pass it —
+  `attendee-refunds.ts` and `attendees-edit.ts` already hold the booking's
+  `start_at` (the flattened `Attendee` carries the date), and the bulk path
+  iterates rows it can key. (If a stable `listing_attendees.id` is threaded
+  through instead, key on that — even simpler.)
 - `refunded_amount = price_paid` copies the column in-SQL, so it always equals
   exactly what was paid for that line — no read-then-write race.
 - No JSCPD concern: this is one helper, not duplicated logic. If the two
   branches trip the duplication check, fold them into one parameterised
   statement builder.
-- The **signature is backward-compatible** (the `amount` param is optional), but
-  with **option B chosen the refund routes do change** to pass the provider
-  amount: `attendee-refunds.ts` (single + bulk) and the refresh path (§10) call
-  `markRefunded(id, listingId, providerAmount)`. The no-amount form
+- The signature gains a **required `startAt`** (row identity, above) and an
+  optional `amount`, so **all callers change** regardless of option. With
+  **option B** the refund routes also pass the provider amount:
+  `attendee-refunds.ts` (single + bulk) and the refresh path (§10) call
+  `markRefunded(id, listingId, startAt, providerAmount)`. The no-amount form
   (`refunded_amount = price_paid`) is reserved for the **fallback** cases only —
   SumUp (no provider amount) and the historical backfill (§18). Do not assume
   callers are unchanged (the §20 DoD reflects this).
@@ -539,7 +556,7 @@ This is **two layers**, not just the provider wrapper:
      `price_paid` (acceptable; documented).
 3. **All `refundPayment` callers must read the new shape** (see also §9):
    - `attendee-refunds.ts` single (`:101-112`) + bulk (`:160-163`) — branch on
-     `.ok`, pass `.amount` into `markRefunded(id, listingId, amount)`.
+     `.ok`, pass `.amount` into `markRefunded(id, listingId, startAt, amount)`.
    - `webhooks.ts:239` auto-refund — branch on `.ok` (no amount stored).
 4. **Refresh path needs the amount too (review #3) — and `isPaymentRefunded` has
    more than one caller (review #4).** `handleRefreshPayment` does **not** call
@@ -589,7 +606,11 @@ fan-out correctly does not exist yet. Options, in rough order of correctness:
   internal order/checkout id** (or an encrypted value with a blind index)
   instead, captured at creation, so a refund can mark exactly the lines sharing
   that order. This is a second schema change — arguably the *right* foundation
-  for refunds, but larger scope; call it out as its own decision.
+  for refunds, but larger scope; call it out as its own decision. **If chosen,
+  the marker is subject to the same read/write sweep as `refunded_amount`
+  (review):** every per-line SELECT (§5) and the merge loader+insert (§5c/§14)
+  must carry it, or a merged booking loses its order key and falls back to the
+  exact attendee-level ambiguity this option fixes.
 - **Restrict refunds to order-level for un-merged attendees, and block/flag
   refunds on merged attendees** until a per-line marker exists.
 - **Narrow predicate without new columns:** only fan out across lines that were
@@ -728,14 +749,18 @@ In a DB-backed test (see `test/lib/db/auto-cache-invalidation.test.ts` which
 already calls `markRefunded`):
 
 - Create a paid attendee/line with a known `price_paid` (e.g. 500).
-- Call `markRefunded(id, listingId)`.
+- Call `markRefunded(id, listingId, startAt)` (fallback form).
 - Assert the `listing_attendees` row has `refunded = 1` **and**
   `refunded_amount = 500` (read it back via a query).
 - Idempotency: call `markRefunded` again, assert `refunded_amount` is still 500
   (not doubled) — this is the mutation-resistant assertion that proves
   `= price_paid` (copy) vs `+= price_paid` (accumulate).
-- With the optional `amount` arg: `markRefunded(id, listingId, 200)` sets
+- With the `amount` arg: `markRefunded(id, listingId, startAt, 200)` sets
   `refunded_amount = 200`.
+- **Row identity:** create the *same* attendee on the *same* listing for **two
+  different dates**, call `markRefunded` for one date, and assert only that row
+  is refunded (the other stays `refunded = 0, refunded_amount = 0`). This is the
+  mutation-resistant test for the `start_at` filter (§6).
 
 ### 15b. Route integration — extend `test/lib/server-refunds.test.ts`
 
@@ -805,7 +830,7 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | `src/shared/db/attendee-types.ts` | `ListingAttendeeRow.refunded_amount` | ✅ |
 | `src/shared/types.ts` | `Attendee.refunded_amount` | ✅ |
 | `src/shared/db/attendees/queries.ts` | `EA_COLS`, `ATTENDEE_LEFT_JOIN_SELECT`, `getAttendeesByTokens` | ✅ |
-| `src/shared/db/attendees/update.ts` | `markRefunded` sets `refunded_amount = price_paid` | ✅ |
+| `src/shared/db/attendees/update.ts` | `markRefunded` gains `startAt` (single-row target, §6) + `amount`; stores the **provider amount** (option B), `price_paid` only for SumUp/backfill | ✅ |
 | `src/shared/db/attendees/pii.ts` | Map `refunded_amount` in `decryptAttendeeFields` | ✅ |
 | `src/shared/db/attendees/atomic-update.ts` | `loadExistingLines` SELECT must add `refunded_amount` (§5d) | ✅ |
 | `src/features/admin/attendees-edit.ts` | Add column to refresh-context select | ✅ |
@@ -815,7 +840,7 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | Tests (§15) | New/extended coverage | ✅ |
 | `src/features/admin/attendees-merge.ts` | `loadAttendeeBookings` must SELECT `refunded_amount` (§5c) | ✅ (merge runs regardless) |
 | `src/shared/merge/attendee-merge.ts` | Insert copies `refunded_amount`; add to dedup compare under option B (§14) | ✅ (else merges zero it) |
-| `src/features/admin/attendees-csv.ts` + csv locale | Export column (label "ticket-only/approx" if option A — §8.5) | ⭕ recommended |
+| `src/features/admin/attendees-csv.ts` + csv locale | Export column (§13; label per provenance, §18) | ✅ (DoD requires it) |
 | Provider layer (§10a): `*-provider.ts` + `square.ts` lower layer + Stripe `retrievePaymentIntent` narrowing + `isPaymentRefunded` + all `refundPayment`/`isPaymentRefunded` callers (incl. `webhooks.ts`) | Record provider's **actual** refunded amount (option B) | ✅ (owner-chosen) |
 | Refund routes + maybe per-line payment marker (§10b) | Fan out an order-level refund across covered lines — **open sub-decision** | 🔶 decision required (§10b) |
 | `src/features/admin/attendee-form-model.ts` + `attendee-form.tsx` | Per-line amount in bookings table | ⭕ optional |

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -263,12 +263,23 @@ select `refunded_amount`. This pairs with §14: the merge *insert* copies
 `undefined` into the `NOT NULL` column. Read site (5c) and write site (§14) go
 together — do not land one without the other.
 
-### 5d. Anywhere else selecting `listing_attendees` per-line columns
+### 5d. `src/shared/db/attendees/atomic-update.ts` — `loadExistingLines`
+
+**Required.** `loadExistingLines` (used by the atomic add/edit attendee path)
+selects `listing_id, start_at, end_at, quantity, checked_in, refunded,
+price_paid, attachment_downloads` into `ListingAttendeeRow[]`. Once §4 adds
+`refunded_amount` to `ListingAttendeeRow`, this SELECT must include it too —
+otherwise the completed rows carry `refunded_amount === undefined`, breaking any
+edit-form summary/copy/compare logic that reads the full row shape.
+
+### 5e. Anywhere else selecting `listing_attendees` per-line columns
 
 Grep check: `rg "checked_in, refunded, price_paid"` and
 `rg "ea\\.refunded"` — update every explicit column list that already pulls
-`refunded`/`price_paid` to also pull `refunded_amount`. Known sites are 5a–5c;
-confirm none were missed.
+`refunded`/`price_paid` to also pull `refunded_amount`. Known sites are 5a–5d
+(`queries.ts` ×2, `attendees-edit.ts`, `attendees-merge.ts`,
+`atomic-update.ts`); re-run the grep at implementation time to confirm none
+were added since.
 
 ---
 
@@ -310,9 +321,14 @@ Notes:
 - No JSCPD concern: this is one helper, not duplicated logic. If the two
   branches trip the duplication check, fold them into one parameterised
   statement builder.
-- All existing callers (`attendee-refunds.ts` single + bulk,
-  `attendees-edit.ts` refresh) keep calling `markRefunded(id, listingId)`
-  unchanged and get `refunded_amount = price_paid` for free.
+- The **signature is backward-compatible** (the `amount` param is optional), but
+  whether callers *change* depends on the §2 option:
+  - **Option A (fallback):** callers keep `markRefunded(id, listingId)` and get
+    `refunded_amount = price_paid` for free.
+  - **Option B (provider amount, recommended):** the refund routes
+    (`attendee-refunds.ts` single + bulk, and the refresh path — see §10) **must
+    pass the amount**: `markRefunded(id, listingId, providerAmount)`. Do not
+    assume callers are unchanged under option B (the §20 DoD reflects this).
 
 ---
 
@@ -426,12 +442,12 @@ Optional but nice for the multi-line case (where the flattened
   the recommended source of truth.** The provider's refund response is the one
   number that is correct in all three cases — it is exactly the money returned.
 - Case 3 needs a **write-fan-out** fix independent of which amount we store: when
-  an order-level refund succeeds, mark **every** `listing_attendees` line that
-  shares that `payment_id`, not just the operator's line. See §10 (promoted from
-  "future" to a tracked decision). If option B is used, allocate the provider's
-  total across those lines (e.g. by `price_paid` weight, largest-remainder — the
-  codebase already has `allocateByLargestRemainder` in `checkout-pricing.ts`);
-  if option A, each line records its own `price_paid`.
+  an order-level refund succeeds, mark every line that payment covered, not just
+  the operator's line. **Scoping that fan-out correctly is the open question** —
+  attendee-level `payment_id` is insufficient because a merge can leave one
+  attendee holding lines from several payments (see §10b). It likely needs a new
+  per-line payment/order marker, or the smaller-scope "accept + document"
+  choice. See §10b for the options and recommendation.
 - If we ship option A first anyway (e.g. to avoid provider churn), the plan must
   **document `refunded_amount` as "ticket revenue refunded, fee-exclusive, and
   approximate for balance-paid reservations"** in the column comment, the admin
@@ -444,12 +460,20 @@ the explicit "ticket-only / approximate" labelling and a follow-up issue for B.
 
 ---
 
-## 9. Webhook auto-refund path (explicitly out of scope)
+## 9. Webhook auto-refund path
 
 `src/features/api/webhooks.ts:239` refunds *untrusted/invalid* checkout
 sessions that never become an attendee. There is no `listing_attendees` row, so
-there is nothing to set `refunded_amount` on. No change. Call this out in the
-PR description so it isn't mistaken for a gap.
+there is nothing to set `refunded_amount` on — **no amount-storage change here.**
+
+**But it is not fully out of scope under option B.** This caller uses the result
+as a boolean: `if (await provider.refundPayment(paymentReference)) { … }`. If
+§10a changes `refundPayment` to return an object, `{ ok: false }` is **truthy**,
+so a *failed* defensive refund would be logged/treated as a success. Therefore
+§10a must update **every** `refundPayment` caller — including this one — to
+inspect `.ok`. Listed here so it isn't missed; covered by the existing webhook
+refund tests (`server-webhooks.test.ts` has many `refundPayment` stubs whose
+return shape would need updating).
 
 (If we ever want to ledger those defensive refunds, that's a separate
 "refunds log" table, not this column.)
@@ -464,38 +488,84 @@ decision**, not a nice-to-have.
 
 ### 10a. Surface the provider amount (option B)
 
-Widen the provider interface so the real refunded amount reaches `markRefunded`:
+Widen the provider interface so the real refunded amount reaches `markRefunded`.
+This is **two layers**, not just the provider wrapper:
 
-- `PaymentProvider.refundPayment(ref): Promise<boolean>` →
-  `Promise<{ ok: boolean; amount?: number }>` (or `number | null`).
-- Stripe already has it: `s.refunds.create(...)` returns `Stripe.Refund.amount`
-  (`src/shared/stripe.ts`). Square's refund response carries `amount_money`.
-  SumUp returns boolean only → `amount` undefined → fall back to `price_paid`.
-- Refund routes pass the returned amount into
-  `markRefunded(id, listingId, amount)` (the optional param added in §6).
+1. **Interface + wrappers** — `PaymentProvider.refundPayment(ref):
+   Promise<boolean>` → `Promise<{ ok: boolean; amount?: number }>` (or
+   `number | null`). Update `stripe-provider.ts`, `square-provider.ts`,
+   `sumup-provider.ts`.
+2. **Lower API layers** (the easy-to-miss part):
+   - **Stripe** — `src/shared/stripe.ts:322` already returns `Stripe.Refund`
+     (carrying `.amount`), so only the provider wrapper needs to stop discarding
+     it. ✅ no lower-layer change.
+   - **Square** — `src/shared/square.ts:608` *computes* the refund amount
+     (`payment.amountMoney.amount`) but its `withClient` callback returns only
+     `true`, and the REST adapter (`refunds.refundPayment`, ~`:343`) returns
+     `{}`. **`square.ts` (and its tests) must be changed to return the amount**;
+     changing `square-provider.ts` alone leaves Square falling back to
+     `price_paid`.
+   - **SumUp** — returns boolean only → `amount` undefined → fall back to
+     `price_paid` (acceptable; documented).
+3. **All callers must read the new shape** (see also §9):
+   - `attendee-refunds.ts` single (`:101-112`) + bulk (`:160-163`) — branch on
+     `.ok`, pass `.amount` into `markRefunded(id, listingId, amount)`.
+   - `webhooks.ts:239` auto-refund — branch on `.ok` (no amount stored).
+4. **Refresh path needs the amount too (review #3).** `handleRefreshPayment`
+   does **not** call `refundPayment`; it calls `isPaymentRefunded(ref)` →
+   boolean, then `markRefunded`. For refunds made directly in Stripe/Square and
+   then refreshed in-app, widening only `refundPayment` still leaves this path on
+   the `price_paid` fallback. To record the provider's actual amount here,
+   `isPaymentRefunded` must also return the refunded amount (e.g.
+   `Promise<{ refunded: boolean; amount?: number }>` or a companion
+   `getRefundedAmount(ref)`), and `handleRefreshPayment` must pass it through.
+   This widens a second interface method across all three providers.
 
-Cost: touches all three providers (`stripe-provider.ts`, `square-provider.ts`,
-`sumup-provider.ts`) and many provider tests/stubs (~100 `refundPayment` stub
-sites in `test/`). The mechanical fix is to update each stub's return shape;
-budget for it.
+Cost: touches all three providers + two lower API layers + every
+`refundPayment`/`isPaymentRefunded` caller, and many provider tests/stubs (~100
+`refundPayment` stub sites in `test/`, plus `isPaymentRefunded` stubs). The
+mechanical fix is to update each stub's return shape; budget for it.
 
 ### 10b. Mark every line covered by the payment (case 3 from §8.5)
 
 `provider.refundPayment(payment_id)` refunds the **whole order**, so on success
-the routes must mark **all** of the attendee's `listing_attendees` lines that
-belong to that payment — not just the operator's line. Today there is no
-per-line payment reference (the `payment_id` is attendee-level in the pii_blob),
-so "lines covered by that payment" = all of that attendee's lines created by the
-original checkout. Concretely:
+the routes must mark all the lines that payment covered — not just the operator's
+line.
 
-- Single refund (`attendee-refunds.ts`) and refresh (`attendees-edit.ts`):
-  after a successful provider refund, mark every line for the attendee.
-- With option B, allocate the provider's returned total across those lines
-  (by `price_paid` weight, largest-remainder — reuse
-  `allocateByLargestRemainder`, `checkout-pricing.ts`); with option A, set each
-  line's `refunded_amount = price_paid`.
-- Alternatively (smaller, but a UX change) **disallow per-line refunds for
-  multi-line orders** and only offer an order-level "refund this order" action.
+**The naive predicate "mark all of the attendee's lines" is wrong (review #1).**
+The attendee↔payment relationship is not 1:1 after a merge: `applyAttendeeMerge`
+copies a *source* attendee's booking lines onto the *target* while keeping only
+the target's `payment_id` (`attendees-merge.ts:190-194`,
+`merge/attendee-merge.ts:405-420`). So a single attendee can hold lines paid by
+**different** (now-discarded) payments. Fanning out to "all attendee lines" would
+mark — and, under option B, allocate refund money to — lines whose payment was
+never refunded.
+
+There is currently **no per-line payment reference** (the `payment_id` lives
+attendee-level in the encrypted pii_blob), so the data needed to scope the
+fan-out correctly does not exist yet. Options, in rough order of correctness:
+
+- **(Best) Add a per-line payment/order marker.** Store the
+  payment reference (or an order/checkout id) on `listing_attendees` at creation,
+  so a refund can mark exactly the lines that share the refunded reference. This
+  is a second schema change — arguably the *right* foundation for refunds, but
+  larger scope; call it out as its own decision.
+- **Restrict refunds to order-level for un-merged attendees, and block/he-flag
+  refunds on merged attendees** until a per-line marker exists.
+- **Narrow predicate without new columns:** only fan out across lines that were
+  not brought in by a merge — but there's no reliable flag for that today, so
+  this is fragile and not recommended.
+- **Keep single-line marking** (status quo of the boolean `refunded`) and accept
+  the under-report, documented per §8.5 — the smallest scope, and honest if
+  paired with the "approximate" labelling.
+
+Allocation (when a marker exists and option B is used): split the provider's
+returned total across the covered lines by `price_paid` weight using
+`allocateByLargestRemainder` (`checkout-pricing.ts`); under option A each covered
+line records its own `price_paid`.
+
+**This is the one genuinely open design question in the feature** — it needs a
+decision (per-line marker vs. accept-and-document) before the fan-out is built.
 
 ### 10c. Partial refunds (future)
 
@@ -691,8 +761,8 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | `src/features/admin/attendees-merge.ts` | **`loadAttendeeBookings` must SELECT `refunded_amount`** (§5c) | ✅ if merge carries it |
 | `src/shared/merge/attendee-merge.ts` | Carry `refunded_amount` on moved lines (insert) | ⭕ recommended (pairs with row above) |
 | `src/features/admin/attendees-csv.ts` + csv locale | Export column (label "ticket-only/approx" if option A — §8.5) | ⭕ recommended |
-| Provider interface (§10a) | Record provider's **actual** refunded amount | 🔶 recommended for correctness (§8.5) |
-| Refund routes (§10b) | Mark **all** lines of an order-level refund (multi-line fix) | 🔶 recommended for correctness (§8.5) |
+| Provider layer (§10a): `*-provider.ts` + `square.ts` lower layer + `isPaymentRefunded` + all `refundPayment` callers (incl. `webhooks.ts`) | Record provider's **actual** refunded amount | 🔶 recommended for correctness (§8.5) |
+| Refund routes + maybe per-line payment marker (§10b) | Fan out an order-level refund across covered lines — **open design question** | 🔶 decision required (§8.5/§10b) |
 | `src/features/admin/attendee-form-model.ts` + `attendee-form.tsx` | Per-line amount in bookings table | ⭕ optional |
 | `src/shared/columns/attendee-columns.ts` | Amount in list status badge | ⭕ optional |
 | `src/shared/webhook.ts` (+docs, factory) (§16) | Webhook payload | ⭕ future |
@@ -761,14 +831,23 @@ explicitly. ⭕ = scope choices.
 ## 20. Definition of done
 
 - [ ] Migration applies on a populated DB; `verify()` passes; `SCHEMA_HASH`
-      bumped; `LATEST_UPDATE` updated.
-- [ ] `markRefunded` sets `refunded_amount = price_paid` atomically and
-      idempotently; all existing callers unchanged.
-- [ ] `Attendee.refunded_amount` populated through every read path; type checks.
+      bumped; `LATEST_UPDATE` updated; legacy refunded rows backfilled (§18).
+- [ ] `markRefunded` sets `refunded` + `refunded_amount` atomically and
+      idempotently (copy semantics). **Under option B the refund routes pass the
+      provider amount** — callers change, the signature stays compatible (the
+      "unchanged callers" claim only holds for option A; see §6).
+- [ ] `Attendee.refunded_amount` populated through **every** read path (§5a–5e,
+      including `attendees-merge.ts` and `atomic-update.ts` loaders); type checks.
 - [ ] Amount shown in the admin payment details panel.
-- [ ] (Recommended) merge + CSV carry it.
+- [ ] (Recommended) merge loader+insert (§5c/§14) and CSV carry it.
+- [ ] **Amount source decided (§2/§8.5/§10):** option A (`price_paid`, with
+      "ticket-only/approximate" labelling) or option B (provider amount — widen
+      `refundPayment` *and* `isPaymentRefunded`, update Square's `square.ts`
+      lower layer, and all callers incl. `webhooks.ts` to read `.ok`).
+- [ ] **Multi-line fan-out decided (§10b):** per-line payment marker vs.
+      accept-and-document. (Open question — don't ship the fan-out without it.)
 - [ ] Tests added per §15; `deno task test:coverage` is 100% and deterministic;
       `deno task test:quality-audit` clean for new tests.
 - [ ] `deno task precommit` (typecheck, `lint:ci`, tests, `cpd` at 0%) passes.
-- [ ] PR notes the out-of-scope webhook auto-refund path (§9) and the deferred
-      provider-amount enhancement (§10).
+- [ ] PR notes the webhook auto-refund caller (§9, must read `.ok` under option
+      B) and records the §8.5/§10b decisions.

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -1,965 +1,456 @@
-# Plan: track a `refunded_amount` for attendees
+# Plan: per-item `refunded_amount` + a partial-refund flow
 
-Goal: record **how much money was refunded** for a booking, not just the
-boolean "was it refunded?" we store today. The amount is in **minor units**
-(pence/cents), matching every other money column in the system.
+Track **how much money was refunded for each item in an order**, and let the
+operator refund either the whole order or specific amounts per item.
 
----
-
-## 0. TL;DR / the one decision to make first
-
-The request says "add a `refunded_amount` column to **attendees**". The
-codebase reality is that the existing refund state does **not** live on the
-`attendees` table — it lives on **`listing_attendees`** (the per-booking-line
-join table):
-
-- `listing_attendees.refunded` — `INTEGER NOT NULL DEFAULT 0` (the 0/1 flag)
-- `listing_attendees.price_paid` — `INTEGER NOT NULL DEFAULT 0` (minor units paid for that line)
-- `markRefunded(attendeeId, listingId)` sets `refunded = 1` for **one line**
-
-The `Attendee` TypeScript type is a *flattened join* of one `attendees` row +
-one `listing_attendees` row, which is why `attendee.refunded` and
-`attendee.price_paid` *read* like attendee fields in the code even though they
-are physically per-line.
-
-**Recommendation: put `refunded_amount` on `listing_attendees`, mirroring
-`refunded` and `price_paid`.** Reasons:
-
-1. It sits next to the data it describes (`price_paid`, `refunded`) and is
-   written by the same code path (`markRefunded`).
-2. A refund is fundamentally per-line today (`markRefunded` takes
-   `listingId`). An attendee booked onto two listings can have one line
-   refunded and the other not.
-3. Per-line is strictly more granular — an attendee-level total is always
-   recoverable as `SUM(refunded_amount)` over the attendee's lines, but the
-   reverse is not true.
-4. It matches the project's "mirror the existing structure" preference
-   (AGENTS.md).
-
-The flattened `Attendee` type still gains a `refunded_amount` field, so from
-the route/template layer it still *looks* like "an attendee's refunded amount"
-— satisfying the spirit of the request.
-
-This plan is written for the **recommended (listing_attendees) approach**.
-§11 documents exactly what changes if we instead put it on `attendees`.
-
-> If you want the attendee-level design instead, say so and I'll re-issue the
-> plan around §11; everything else here still applies.
+This is v2 of the plan, rewritten after owner decisions (2026-06-21). Those
+decisions simplified it a lot — see "What changed & why it's simpler" at the end.
 
 ---
 
-## 1. How money & refunds work today (context for reviewers)
+## 0. Decisions (locked)
 
-| Concept | Where it lives | Type | Notes |
-| --- | --- | --- | --- |
-| Amount paid for a booking line | `listing_attendees.price_paid` | `INTEGER` minor units | **Ticket revenue only** — excludes the booking fee (a separate `extras` line at checkout, not folded into any line's `price_paid`; see §8.5). Reservation balance payments *are* folded in by `settleAttendeeBalance`. Trigger-summed into `listings.income`. |
-| Refunded? (per line) | `listing_attendees.refunded` | `INTEGER` 0/1 | Set by `markRefunded`. |
-| Payment reference | encrypted `attendees.pii_blob` (`pi`) | string | Surfaced as `attendee.payment_id` after decryption. |
-| Outstanding balance (order-level) | `attendees.remaining_balance` | `INTEGER` minor units | Reservations/part-payments. |
+1. **Column:** add `refunded_amount` (minor units) **per booking line**, on
+   `listing_attendees` — next to `price_paid`. One amount per item in the order.
+2. **Remove the `refunded` boolean** from `listing_attendees`. Refund *state*
+   (e.g. "Refunded", "Partially refunded") is expressed with the existing
+   **order statuses** (`attendee_statuses` / `attendees.status_id`); money is
+   expressed with `refunded_amount`. The yes/no flag goes away entirely.
+3. **No backfill, no provenance marker.** There are no existing refunds, so every
+   recorded amount is exact by definition. Nothing to migrate or label.
+4. **Refund flow is operator-driven and per-item.** A refund form with a "refund
+   everything" checkbox (checked by default); unchecking reveals one row per
+   listing in the order (label + price paid) with an amount input, `0` →
+   `price paid`. We refund the chosen total at the provider and store each
+   item's amount.
+5. **Provider gains partial refunds.** `refundPayment` takes an optional
+   `amount`; we pass the operator's total in. It keeps returning a boolean
+   (success/failure) — we are *commanding* the refund, not reading it back.
 
-Refund flow:
+One thing still needs a yes/no from you — **check-in behaviour** (§12). Everything
+else is specified.
 
-- **Admin single refund** — `src/features/admin/attendee-refunds.ts`
-  (`handleAttendeeRefund`): calls `provider.refundPayment(payment_id)` then
-  `markRefunded(attendee.id, listingId)`.
-- **Admin bulk refund** — same file (`processRefundAll` → `refundOneAttendee`):
-  same two calls per refundable line.
-- **Refresh from provider** — `src/features/admin/attendees-edit.ts`
-  (`handleRefreshPayment`): polls `provider.isPaymentRefunded(...)` and, if the
-  provider says refunded, calls `markRefunded`.
-- **Webhook auto-refund** — `src/features/api/webhooks.ts:239`: refunds an
-  *untrusted/invalid* checkout **before any attendee/line exists**. There is no
-  row to attach an amount to, so this path is out of scope (see §9).
+---
 
-`markRefunded` is the single DB write for all in-scope paths
-(`src/shared/db/attendees/update.ts`):
+## 1. Data model
+
+`listing_attendees` is the per-(attendee, listing) booking line. One attendee/order
+can have several lines. Money already lives here:
+
+| Column | Type | Meaning |
+| --- | --- | --- |
+| `price_paid` | `INTEGER` minor units | what was paid for this line (ticket only — excludes booking fees, which are a separate checkout `extras` line) |
+| ~~`refunded`~~ | ~~`INTEGER` 0/1~~ | **removed** — refund state now lives in the order status |
+| `refunded_amount` | `INTEGER` minor units, `NOT NULL DEFAULT 0` | **new** — how much of this line has been refunded (`0` ≤ amount ≤ `price_paid`) |
+
+The provider payment reference stays where it is — in the **encrypted**
+`attendees.pii_blob` (`payment_id`), one per order — so refunds are issued
+against the order's payment.
+
+The flattened `Attendee` type (a join of one `attendees` row + one
+`listing_attendees` row) loses `refunded` and gains `refunded_amount: number`.
+
+---
+
+## 2. The refund flow (the centrepiece)
+
+### 2a. The form — `GET /admin/listing/:listingId/attendee/:attendeeId/refund`
+
+Replaces today's "are you sure?" confirm page (`adminRefundAttendeePage` in
+`src/ui/templates/admin/attendees.tsx`). It shows:
+
+- A **"Refund the whole order"** checkbox, **checked by default**. Checked = today's
+  behaviour (refund everything still owed across the order).
+- When **unchecked** (pure-CSS reveal, like the existing `show_all` pattern in the
+  attendee form), a row per booking line in the order:
+  - listing name (label),
+  - "Paid: £X.XX" (the line's `price_paid`),
+  - an amount input, `min=0`, `max=` the line's **remaining refundable**
+    (`price_paid − refunded_amount`; `= price_paid` on a first refund), prefilled
+    with that max.
+- Confirm field (the existing name/identifier confirmation) + submit.
+
+Optionally, a status selector defaulting to a "Refunded" order status when one
+exists, so the operator marks state and money in one step. Nice-to-have; the
+operator can also change status on the normal edit form.
+
+### 2b. Submit — `POST .../refund`
+
+`src/features/admin/attendee-refunds.ts`:
+
+1. Parse the form. If "whole order" is checked, the per-item amounts are each
+   line's remaining refundable; otherwise use the entered amounts (clamp each to
+   `0 … remaining refundable`, integers, minor units).
+2. `total = sum(per-item amounts)`. If `total === 0`, reject ("nothing to refund").
+3. Require a `payment_id` (the order's payment). `provider.refundPayment(payment_id,
+   total)` — **partial refund of `total`** (§3).
+4. On success, for each line with a non-zero amount, add it to that line's
+   `refunded_amount` (capped at `price_paid`), keyed to the exact row (§5). Log
+   the activity (per line or once for the order).
+5. On failure, redirect with an error; record nothing.
+
+"Refund everything" therefore = each line refunded to its `price_paid`; a partial
+refund = the operator's per-line numbers.
+
+### 2c. Bulk — `POST /admin/listing/:id/refund-all`
+
+Keep it; it refunds every **not-fully-refunded** line of every order on the
+listing to its `price_paid` (full refund per attendee), batched as today
+(`REFUND_BATCH_LIMIT`). "Refundable" is redefined in §6.
+
+---
+
+## 3. Provider layer — add partial refunds (small change)
+
+We are *telling* the provider what to refund, so the only change is an **optional
+amount**; the return stays a boolean. No return-shape churn, no reading amounts
+back, no caller sweep.
+
+- `PaymentProvider.refundPayment(ref: string, amount?: number): Promise<boolean>`
+  — `amount` omitted = full refund (today's behaviour, so existing callers like
+  the webhook auto-refund are untouched).
+- **Stripe** (`src/shared/stripe.ts`): `s.refunds.create({ payment_intent: ref,
+  amount })` — `amount` is the partial-refund field; omit for full.
+- **Square** (`src/shared/square.ts`): pass the chosen `amount` as
+  `amountMoney.amount` instead of the full payment amount it currently reads.
+- **SumUp** (`src/shared/sumup-provider.ts`): confirm partial-refund support;
+  if it is full-only, disable the per-item option for SumUp sites (offer only
+  "refund everything") rather than silently over-refunding.
+
+`isPaymentRefunded` is unchanged (still boolean) — see the refresh path (§8c).
+
+---
+
+## 4. Schema & migration
+
+### 4a. Declarative schema — `src/shared/db/migrations/schema.ts`
+
+In the `listing_attendees` table: **delete** the `["refunded", …]` column and
+**add** `["refunded_amount", "INTEGER NOT NULL DEFAULT 0"]` next to `price_paid`.
+Update `LATEST_UPDATE` to describe both. (`SCHEMA_HASH` recomputes automatically.)
+
+No trigger change: the `LISTING_AGGREGATE_TRIGGERS` UPDATE trigger fires
+`AFTER UPDATE OF quantity, price_paid, listing_id` — it never referenced
+`refunded` and won't reference `refunded_amount`, so refunds still don't disturb
+`listings.income`/capacity (income keeps counting refunded rows, exactly as
+today).
+
+### 4b. Migration — recreate the table
+
+Removing a column needs a table rebuild, not `ADD COLUMN`. Model it on
+`2026-06-18_answer_modifiers.ts` / `2026-06-20_free_text_questions.ts`:
 
 ```ts
-const setRefunded = updateListingAttendeeField("refunded");
-export const markRefunded = (attendeeId, listingId) =>
-  setRefunded(attendeeId, listingId, 1);
+// src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts
+export default (context) =>
+  context.additive({
+    id: "2026-06-21_attendee_refunded_amount",
+    description:
+      "Add per-line refunded_amount to listing_attendees and drop the refunded boolean (refund state moves to order statuses)",
+    requires: { columns: { listing_attendees: ["refunded_amount"] } },
+    up: async () => {
+      // recreateTable rebuilds listing_attendees from the *current* SCHEMA:
+      // it copies surviving columns (so `refunded` is dropped, its data
+      // discarded — there are no refunds), adds refunded_amount (DEFAULT 0),
+      // and re-creates the table's indexes + aggregate triggers.
+      await context.recreateTable("listing_attendees");
+      await context.syncTriggers();
+    },
+  });
 ```
 
-Key fact about the value to store: `provider.refundPayment()` returns a
-**boolean** (full refund only). The underlying Stripe call
-(`src/shared/stripe.ts:322`, `s.refunds.create(...)`) actually returns a
-`Stripe.Refund` carrying the real refunded `amount`, but the
-`PaymentProvider` interface throws it away. So the actual provider-refunded
-amount is *available at Stripe/Square* but *not* at the interface today.
+Register it in `src/shared/db/migrations.ts` (import + append to `MIGRATIONS`).
+The generated `verify()` asserts `refunded_amount` is present; the recreate
+guarantees `refunded` is gone (the helper has no "assert column absent", which is
+fine — the rebuild is authoritative).
 
-**DECIDED — `refunded_amount` stores the provider's actual refunded amount
-(option B).** (Owner decision, 2026-06-21.) The alternative — recording the
-line's `price_paid` — was rejected because it is only the *ticket* portion and
-diverges from the money actually returned in three real configurations (booking
-fees, balance-paid reservations, multi-line orders; see **§8.5**). Option B is
-the one number correct in all of them: exactly the money the provider returned.
-
-`price_paid` survives only as a **fallback**, used in two narrow places:
-
-- **SumUp**, whose API returns no refund amount (boolean only); and
-- the **historical backfill** (§18), where the provider amount is no longer
-  retrievable for already-refunded rows.
-
-The cost of option B is the interface work in **§10** (widen `refundPayment` and
-`isPaymentRefunded`, stop the lower Stripe/Square layers discarding the amount,
-and update every caller). Where the plan below still says "under option B", read
-it as "the chosen path"; "option A / fallback" means the two narrow cases above.
+Backups round-trip the new shape automatically (schema-driven dump).
 
 ---
 
-## 2. Design decisions
+## 5. Write path — `src/shared/db/attendees/update.ts`
 
-1. **Column**: `refunded_amount INTEGER NOT NULL DEFAULT 0` on
-   `listing_attendees`. Minor units, never null, defaults to 0 (so existing
-   rows and non-refunded rows read as 0 — "nothing refunded").
-2. **Value written**: `markRefunded(attendeeId, listingId, startAt, amount?)`
-   sets `refunded = 1` and `refunded_amount = amount` on the **one** line
-   identified by (listing_id, attendee_id, start_at — §6), in a single atomic
-   UPDATE so the flag and amount can never drift. The `amount` is:
-   - the **provider's actual refunded amount** (option B) where available — the
-     refund routes already hold the provider result and can pass it in; or
-   - the line's **`price_paid`** as the fallback (`amount` omitted → the SQL
-     copies `price_paid`), used for SumUp and the historical backfill.
-
-   See §8.5 for why `price_paid` alone is not a reliable amount, and §10 for the
-   small interface change that surfaces the provider amount.
-3. **Idempotency**: re-running `markRefunded` is harmless — it re-sets
-   `refunded = 1, refunded_amount = <amount>` (a copy, never an accumulate), so
-   a repeat call lands the same value. (The routes also guard against
-   double-refunding at the provider via the `refunded` check.)
-4. **No trigger changes**. The `listings` aggregate triggers
-   (`LISTING_AGGREGATE_TRIGGERS`) are scoped to `OF quantity, price_paid,
-   listing_id`; writing `refunded_amount` won't fire them. This deliberately
-   preserves existing behaviour ("refunded rows still count" toward
-   capacity/income — refunds set a flag/amount, not `quantity`/`price_paid`).
-5. **Type**: integer minor units, formatted for display with
-   `formatCurrency()` (`src/shared/currency.ts`) exactly like `price_paid`.
-6. **Future partial refunds**: give `markRefunded` an optional `amount`
-   parameter defaulting to the line's `price_paid`. Today every caller uses the
-   default; partial-refund support later only needs to pass a value (and widen
-   the provider interface, §10). Documented, not built.
-
----
-
-## 3. Schema & migration
-
-### 3a. Declarative schema — `src/shared/db/migrations/schema.ts`
-
-Add the column to the `listing_attendees` table definition, next to
-`price_paid`:
+Replace `markRefunded` (which set the boolean) with a per-item amount writer that
+targets **one** row by its real identity `(listing_id, attendee_id, start_at)` —
+the table's unique key. Filtering by `(attendee_id, listing_id)` alone is wrong:
+an attendee can book the same listing on several dates, so it would hit every
+dated row and double-count.
 
 ```ts
-["price_paid", "INTEGER NOT NULL DEFAULT 0"],
-["refunded_amount", "INTEGER NOT NULL DEFAULT 0"], // minor units refunded for this line
-["attachment_downloads", "INTEGER NOT NULL DEFAULT 0"],
-```
-
-Update `LATEST_UPDATE` (append a clause describing the change), e.g.:
-
-> "…; add a refunded_amount column to listing_attendees recording the amount
-> (minor units) refunded for each booking line, set to the line's price_paid
-> when it is refunded."
-
-(`SCHEMA_HASH` recomputes automatically from the schema, so the version marker
-changes even if `LATEST_UPDATE` were forgotten — but update it anyway.)
-
-### 3b. Named migration file
-
-Create `src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts`
-(follow `2026-06-20_answer_active.ts`):
-
-```ts
-import { schemaMigration } from "./define.ts";
-
-export default schemaMigration(
-  "2026-06-21_attendee_refunded_amount",
-  "Add a refunded_amount column to listing_attendees recording how much " +
-    "(minor units) was refunded for each booking line",
-  {
-    columns: { listing_attendees: ["refunded_amount"] },
-  },
-  // 4th arg: after() — runs post-ADD COLUMN. Backfill legacy refunded rows so
-  // they don't report 0 (see §18; they cannot self-heal via the refresh path).
-  async ({ getDb }) => {
-    await getDb().execute(
-      "UPDATE listing_attendees SET refunded_amount = price_paid WHERE refunded = 1 AND refunded_amount = 0",
-    );
-  },
-);
-```
-
-> The `after` callback is **part of the required migration** (§18), not optional
-> — without it every historical `refunded = 1` row reports `refunded_amount = 0`.
-> `schemaMigration`'s 4th argument receives the `MigrationContext` (so `getDb`
-> is available). Confirm `after` runs *after* `applySchemaChanges` (it does — see
-> `define.ts`'s `up`).
-
-`schemaMigration` runs `applySchemaChanges()` (ADD COLUMN for any missing
-schema column) and the generated `verify()` asserts the live table has
-`refunded_amount` (`verifyRequirement` → `assertLiveTableColumns`). A
-`NOT NULL DEFAULT 0` column is safe to `ADD COLUMN` onto a populated table.
-
-### 3c. Register the migration — `src/shared/db/migrations.ts`
-
-- Add the import alongside the others.
-- Append `attendeeRefundedAmountMigration` to the `MIGRATIONS` array (order
-  matters — append at the end).
-
-### 3d. Backup/restore
-
-No work needed. Per AGENTS.md, `backup.ts` dumps every column (schema-driven
-`SELECT *` via the `Table` helpers), so the new column round-trips
-automatically. Worth a one-line confirmation while testing (export → import →
-diff) but no code change.
-
----
-
-## 4. Types
-
-### 4a. `src/shared/db/attendee-types.ts`
-
-Add to `ListingAttendeeRow` (used by token resolution, merge, refresh):
-
-```ts
-export type ListingAttendeeRow = {
-  ...
-  refunded: number;
-  price_paid: number;
-  refunded_amount: number; // minor units refunded for this line
-  attachment_downloads: number;
-};
-```
-
-### 4b. `src/shared/types.ts`
-
-Add to the flattened `Attendee` interface (keep it next to `refunded` /
-`price_paid`):
-
-```ts
-price_paid: string;       // existing (note: string on Attendee)
-refunded: boolean;        // existing
-refunded_amount: number;  // minor units refunded (0 when not refunded)
-```
-
-Note the asymmetry that already exists: `Attendee.price_paid` is a **string**
-(stringified in `decryptAttendeeFields`), while on the DB row it's a number.
-Keep `refunded_amount` a **number** (no decryption/stringify needed — it's a
-plaintext integer like `remaining_balance`). This is the simplest, least
-surprising choice.
-
----
-
-## 5. Read paths (SELECTs)
-
-`refunded_amount` must be selected wherever `refunded`/`price_paid` are, so the
-flattened `Attendee`/`ListingAttendeeRow` carry it.
-
-### 5a. `src/shared/db/attendees/queries.ts`
-
-- `EA_COLS` (the per-line column list for joins): add `ea.refunded_amount`.
-- `ATTENDEE_LEFT_JOIN_SELECT`: add
-  `COALESCE(ea.refunded_amount, 0) as refunded_amount` (mirrors the other
-  COALESCE'd join columns so left-join misses read as 0).
-- `getAttendeesByTokens` — the explicit `listing_attendees` column list in
-  Query 2 and the `bookingsByAttendee` row mapping: add `refunded_amount`.
-
-### 5b. `src/features/admin/attendees-edit.ts`
-
-`loadRefreshContext` selects an explicit `listing_attendees` column list — add
-`refunded_amount` there too (keeps the `ListingAttendeeRow` shape complete).
-
-### 5c. `src/features/admin/attendees-merge.ts` — `loadAttendeeBookings`
-
-**Required, and easy to miss.** `loadAttendeeBookings` (the merge route's
-loader) selects `listing_id, start_at, end_at, quantity, checked_in, refunded,
-price_paid, attachment_downloads` into `ListingAttendeeRow[]`. It must also
-select `refunded_amount`. This pairs with §14: the merge *insert* copies
-`refunded_amount`, so if the loader doesn't select it the moved booking passes
-`undefined` into the `NOT NULL` column. Read site (5c) and write site (§14) go
-together — do not land one without the other.
-
-### 5d. `src/shared/db/attendees/atomic-update.ts` — `loadExistingLines`
-
-**Required.** `loadExistingLines` (used by the atomic add/edit attendee path)
-selects `listing_id, start_at, end_at, quantity, checked_in, refunded,
-price_paid, attachment_downloads` into `ListingAttendeeRow[]`. Once §4 adds
-`refunded_amount` to `ListingAttendeeRow`, this SELECT must include it too —
-otherwise the completed rows carry `refunded_amount === undefined`, breaking any
-edit-form summary/copy/compare logic that reads the full row shape.
-
-### 5e. Anywhere else selecting `listing_attendees` per-line columns
-
-Grep check: `rg "checked_in, refunded, price_paid"` and
-`rg "ea\\.refunded"` — update every explicit column list that already pulls
-`refunded`/`price_paid` to also pull `refunded_amount`. Known sites are 5a–5d
-(`queries.ts` ×2, `attendees-edit.ts`, `attendees-merge.ts`,
-`atomic-update.ts`); re-run the grep at implementation time to confirm none
-were added since.
-
----
-
-## 6. Write path — `src/shared/db/attendees/update.ts`
-
-Change `markRefunded` so the same atomic UPDATE records the amount. The current
-generic `updateListingAttendeeField("refunded")` helper sets one constant
-column, so `markRefunded` needs its own statement (the helper stays for
-`setCheckedIn`):
-
-```ts
-const setCheckedIn = updateListingAttendeeField("checked_in");
-
-/**
- * Mark ONE booking line refunded and record the refunded amount.
- *
- * The row identity is (listing_id, attendee_id, start_at) — the table's unique
- * index. Filtering by (attendee_id, listing_id) alone is NOT enough: an attendee
- * can book the same listing on several dates, so that predicate matches multiple
- * rows. With a single provider amount that would stamp the full amount onto every
- * dated row and double-count the SUM (review). Pass start_at (or the row id) to
- * target exactly one line.
- */
-export const markRefunded = async (
+/** Record a refund of `amount` (minor units) against one booking line. Adds to
+ *  any existing refunded_amount, capped at the line's price_paid. */
+export const recordLineRefund = async (
   attendeeId: number,
   listingId: number,
   startAt: string | null,
-  amount?: number,
+  amount: number,
 ): Promise<void> => {
-  // `start_at IS ?` handles the NULL (standard-listing) case as well as a date.
   await execute(
-    amount === undefined
-      ? "UPDATE listing_attendees SET refunded = 1, refunded_amount = price_paid WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?"
-      : "UPDATE listing_attendees SET refunded = 1, refunded_amount = ? WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?",
-    amount === undefined
-      ? [attendeeId, listingId, startAt]
-      : [amount, attendeeId, listingId, startAt],
+    `UPDATE listing_attendees
+        SET refunded_amount = MIN(price_paid, refunded_amount + ?)
+      WHERE attendee_id = ? AND listing_id = ? AND start_at IS ?`,
+    [amount, attendeeId, listingId, startAt],
   );
 };
 ```
 
-Notes:
-- **Row identity (review):** the added `start_at` filter is required so the write
-  hits exactly one line. The existing boolean `markRefunded` already over-matches
-  here (it marks every same-listing row), which is a latent bug today; option B's
-  per-line amount makes it actively wrong (double-counted totals), so the
-  signature gains `startAt`. **All callers change** to pass it —
-  `attendee-refunds.ts` and `attendees-edit.ts` already hold the booking's
-  `start_at` (the flattened `Attendee` carries the date), and the bulk path
-  iterates rows it can key. (If a stable `listing_attendees.id` is threaded
-  through instead, key on that — even simpler.)
-- `refunded_amount = price_paid` copies the column in-SQL, so it always equals
-  exactly what was paid for that line — no read-then-write race.
-- No JSCPD concern: this is one helper, not duplicated logic. If the two
-  branches trip the duplication check, fold them into one parameterised
-  statement builder.
-- The signature gains a **required `startAt`** (row identity, above) and an
-  optional `amount`, so **all callers change** regardless of option. With
-  **option B** the refund routes also pass the provider amount:
-  `attendee-refunds.ts` (single + bulk) and the refresh path (§10) call
-  `markRefunded(id, listingId, startAt, providerAmount)`. The no-amount form
-  (`refunded_amount = price_paid`) is reserved for the **fallback** cases only —
-  SumUp (no provider amount) and the historical backfill (§18). Do not assume
-  callers are unchanged (the §20 DoD reflects this).
+- `MIN(price_paid, …)` enforces the per-line cap in SQL.
+- `start_at IS ?` matches the NULL (standard-listing) case as well as a date.
+- For "refund everything", the route passes `price_paid − refunded_amount` per
+  line (or call a small `refundLineInFull` that sets `refunded_amount =
+  price_paid`).
 
 ---
 
-## 7. Decryption / row→Attendee mapping
+## 6. Removing the boolean — the refactor surface
 
-`src/shared/db/attendees/pii.ts` → `decryptAttendeeFields` builds the
-`Attendee` from a raw row. It already coerces `checked_in`, `price_paid`,
-`refunded`. Add `refunded_amount` so the field is always present and numeric:
+`refunded` is referenced in ~60 files; this is the bulk of the work. Each read of
+the boolean becomes either a `refunded_amount`-derived check or an order-status
+check. Concretely:
 
-```ts
-return {
-  ...row,
-  ...pii,
-  checked_in: Boolean(row.checked_in),
-  price_paid: String(row.price_paid),
-  refunded: paidListing ? Boolean(row.refunded) : false,
-  refunded_amount: paidListing ? Number(row.refunded_amount ?? 0) : 0,
-  split_logistics_agents: Boolean(row.split_logistics_agents),
-};
-```
-
-Mirror the `paidListing` gating used for `refunded`: on an unpaid listing,
-payment/refund fields are suppressed, so `refunded_amount` reads 0 there too.
-
----
-
-## 8. UI / display
-
-### 8a. Payment details panel (primary surface) — `src/ui/templates/admin/attendees.tsx`
-
-In `PaymentDetails` (the read-only payment block on the attendee edit page),
-show the refunded amount next to the existing refund-status badge.
-
-> **Multi-line caveat (review):** `attendee.refunded_amount` on this flattened
-> `Attendee` is **one booking line's** value — `getAttendeeRaw` is a `queryOne`
-> over a single `listing_attendees` row, not the order total. For an attendee
-> with several booking lines (and especially after the §10b fan-out), this panel
-> would **under-report** the total refund. Fix one of two ways: (a) sum
-> `refunded_amount` across the attendee's loaded booking rows for the headline
-> figure, or (b) move the amount into the per-line bookings table (§8d) so each
-> line shows its own. The headline "Amount Refunded" must be the **sum**, not a
-> single line.
-
-```tsx
-<p>
-  <strong>{t("admin.attendees.refund_status")}</strong>{" "}
-  {isRefunded ? (
-    <span class="badge-alert">{t("admin.attendees.refunded")}</span>
-  ) : (
-    t("admin.attendees.not_refunded")
-  )}
-</p>
-{isRefunded && attendee.refunded_amount > 0 && (
-  <p>
-    <strong>{t("admin.attendees.amount_refunded")}</strong>{" "}
-    {formatCurrency(attendee.refunded_amount)}
-  </p>
-)}
-```
-
-### 8b. Refund confirmation page — same file
-
-`adminRefundAttendeePage` warns "This will issue a full refund". Optionally show
-the amount before confirming — but **do not present `attendee.price_paid` as "the
-exact amount"**: per §8.5 it excludes booking fees and over-states balance-paid
-reservations, so the operator would see the wrong figure. Either show the
-provider/order total when available, or label it explicitly as a *ticket-only
-estimate* (e.g. "≈ £10.00 ticket value; final refund set by the provider").
-
-### 8c. Attendee table status column — `src/shared/columns/attendee-columns.ts`
-
-The `status` column renders the refunded badge via `opts.renderStatus(row)`.
-Optional: when refunded, include the amount in the badge/title (e.g.
-`title="Refunded £5.00"`). Find `renderStatus` (it builds the check-in /
-refunded badge) and thread `refunded_amount` through if we want it on the list.
-Low priority.
-
-### 8d. Form-model booking summary — `src/features/admin/attendee-form-model.ts`
-
-`AttendeeBooking` + `attendeeBookingsFromLines` project a line into the
-read-only bookings table. If we want the per-line refunded amount in that table:
-
-- add `refundedAmount: number` to `AttendeeBooking`,
-- set `refundedAmount: booking.refunded_amount` in `attendeeBookingsFromLines`,
-- render it in the bookings table template (`attendee-form.tsx`).
-
-Optional but nice for the multi-line case (where the flattened
-`PaymentDetails` only reflects one line).
+- **Types** — `src/shared/types.ts` (`Attendee`), `src/shared/db/attendee-types.ts`
+  (`ListingAttendeeRow`): drop `refunded`, add `refunded_amount: number`.
+- **Selects** — every per-line column list adds `refunded_amount` and drops
+  `refunded`:
+  - `src/shared/db/attendees/queries.ts` — `EA_COLS`, `ATTENDEE_LEFT_JOIN_SELECT`
+    (`COALESCE(ea.refunded_amount,0)`), `getAttendeesByTokens`.
+  - `src/features/admin/attendees-edit.ts` — `loadRefreshContext`.
+  - `src/features/admin/attendees-merge.ts` — `loadAttendeeBookings`.
+  - `src/shared/db/attendees/atomic-update.ts` — `loadExistingLines`.
+  - Re-run `rg "ea\.refunded|checked_in, refunded, price_paid"` to confirm.
+- **Decryption** — `src/shared/db/attendees/pii.ts` `decryptAttendeeFields`: map
+  `refunded_amount: paidListing ? Number(row.refunded_amount ?? 0) : 0`; remove
+  the `refunded` mapping.
+- **"Refundable" predicate** — `attendee-refunds.ts` `getRefundable`: was
+  `payment_id !== "" && !refunded`; becomes `payment_id !== "" && hasUnrefunded`,
+  where a line/order is "unrefunded" if any line has `refunded_amount < price_paid`.
+- **Check-in** — `src/features/checkin.ts:101` filters `!attendee.refunded`, and
+  the scanner (`src/features/admin/scanner.ts`, `scanner.tsx`, client
+  `scanner.js`, `manual-checkin.ts`) shows a refunded badge / blocks refunded
+  tickets. These must move off the boolean — **see §12 for the behaviour decision.**
+- **Merge** — `src/shared/merge/attendee-merge.ts`: `bookingInsertStatement` copies
+  `refunded_amount` (and no longer `refunded`); the duplicate-detection compare in
+  `buildBookingDiffItems` swaps `refunded` for `refunded_amount`.
+- **Form model** — `src/features/admin/attendee-form-model.ts`: `AttendeeBooking`
+  drops `refunded`, adds `refundedAmount`; `attendeeBookingsFromLines` sets it.
+- **Templates** — `attendees.tsx` (`PaymentDetails`, the refund pages),
+  `attendee-detail.tsx`, `attendee-form.tsx`, `attendee-table.tsx`,
+  `scanner.tsx`: the "Refunded" badge derives from `refunded_amount` now (e.g.
+  "Refunded £X" when `> 0`, "Partially refunded" when `0 < amount < price_paid`).
+- **Webhooks** — `src/features/api/webhooks.ts`: the auto-refund of invalid
+  checkouts still calls `provider.refundPayment(ref)` (no amount = full) and reads
+  a boolean — **unchanged** (no row exists to record against). `webhook-types.ts`
+  /`webhook.ts` outbound payload: drop `refunded` if present; optionally add
+  `refunded_amount` (§14).
 
 ---
 
-## 8.5 Accuracy of the recorded amount — when `price_paid` ≠ money refunded
+## 7. UI / display
 
-> Added in response to PR review. `refunded_amount = price_paid` is correct for
-> a full refund of a single-line, fee-free, non-reservation booking — but **not**
-> in the three configurations below. Each is verified against current code.
+### 7a. The refund form (§2a) — `attendees.tsx`
 
-1. **Booking fees are excluded from `price_paid`.** At checkout the booking fee
-   is a separate `extras` line (`feeExtras`, `src/shared/checkout-pricing.ts:86-92`),
-   and `paidByListing` (`src/features/api/webhooks.ts:587-597`) sums only the
-   ticket lines into each line's `price_paid`. So a £10 ticket + £1 fee stores
-   `price_paid = 1000`, but a full provider refund returns **1100**. Recording
-   `price_paid` under-reports by the fee.
-2. **Balance-paid reservations fold extra money into `price_paid`.**
-   `settleAttendeeBalance` (`src/shared/db/attendees/balance.ts`) does
-   `UPDATE listing_attendees SET price_paid = price_paid + <balance>` on the
-   first line, while the attendee's stored `payment_id` stays the **original
-   deposit** reference. Refunding that stored payment returns only the deposit,
-   but `price_paid` now holds deposit + balance — so `price_paid`
-   **over-reports** the actual refund. (And the balance was a *second* payment
-   the stored `payment_id` can't even refund.)
-3. **Multi-line orders share one payment.** `provider.refundPayment(payment_id)`
-   refunds the *entire* order, but the single-refund and refresh paths call
-   `markRefunded(attendee.id, listingId)` for **one** line only
-   (`attendee-refunds.ts:101-111`, `attendees-edit.ts:86-88`). The other lines
-   keep `refunded = false`, `refunded_amount = 0` even though their money was
-   returned. (This is a **pre-existing** quirk of the boolean `refunded` flag,
-   not introduced here — but `refunded_amount` makes the under-report visible in
-   money terms.)
+The new checkbox + per-item table. Build the per-item rows from the order's
+booking lines (listing name + `price_paid` + remaining refundable). The reveal is
+pure-CSS off the checkbox (no JS required), mirroring the existing `show_all`
+pattern in the attendee editor.
 
-**Implications for the design (with option B decided):**
+### 7b. Payment details panel — `PaymentDetails` in `attendees.tsx`
 
-- Cases 1 and 2 are **resolved by the chosen option B**: the provider's refund
-  response is exactly the money returned, so fees are included and a deposit-only
-  refund records the deposit (not the inflated `price_paid`). This is why B was
-  chosen over `price_paid`.
-- Case 3 still needs a **write-fan-out**, independent of the amount source: when
-  an order-level refund succeeds, mark every line that payment covered, not just
-  the operator's line. **Scoping that fan-out correctly is the one remaining open
-  sub-decision** — attendee-level `payment_id` is insufficient because a merge
-  can leave one attendee holding lines from several payments (see §10b). It needs
-  either a new per-line payment/order marker or the smaller "accept + document"
-  choice (§10b).
-- The historical **backfill** (§18) still uses the `price_paid` fallback (the
-  provider amount isn't retrievable for old rows), so backfilled rows inherit the
-  fee/reservation inaccuracy. Label those as approximate (§18) — going forward,
-  newly-refunded rows carry the exact provider amount.
+Show the **order total refunded** = **sum** of `refunded_amount` across the
+attendee's lines (not a single flattened join row — `getAttendeeRaw` returns one
+row). Render per-line amounts in the bookings table (§7c) for the breakdown.
+
+### 7c. Bookings table — `attendee-form.tsx` (+ `attendee-form-model.ts`)
+
+Each booking row shows its `refundedAmount` alongside quantity/dates, so a
+partially-refunded order is legible line by line.
+
+### 7d. List + scanner badges
+
+`attendee-columns.ts` status column and the scanner badge derive the
+refunded label from `refunded_amount` (none / partial / full) instead of the
+boolean.
 
 ---
 
-## 9. Webhook auto-refund path
+## 8. Refresh-from-provider path (external refunds)
 
-`src/features/api/webhooks.ts:239` refunds *untrusted/invalid* checkout
-sessions that never become an attendee. There is no `listing_attendees` row, so
-there is nothing to set `refunded_amount` on — **no amount-storage change here.**
-
-**But it is not fully out of scope under option B.** This caller uses the result
-as a boolean: `if (await provider.refundPayment(paymentReference)) { … }`. If
-§10a changes `refundPayment` to return an object, `{ ok: false }` is **truthy**,
-so a *failed* defensive refund would be logged/treated as a success. Therefore
-§10a must update **every** `refundPayment` caller — including this one — to
-inspect `.ok`. Listed here so it isn't missed; covered by the existing webhook
-refund tests (`server-webhooks.test.ts` has many `refundPayment` stubs whose
-return shape would need updating).
-
-(If we ever want to ledger those defensive refunds, that's a separate
-"refunds log" table, not this column.)
+`src/features/admin/attendees-edit.ts` `handleRefreshPayment` polls
+`isPaymentRefunded(payment_id)` (boolean) and, today, flips `refunded`. New
+behaviour: if the provider reports the order refunded, set every line's
+`refunded_amount = price_paid` (treat an externally-issued refund as full — we
+can't attribute partial external refunds per line) and/or move the order to a
+refunded status. This stays boolean-only; no provider return-shape change.
 
 ---
 
-## 10. Recording the *provider's actual* refunded amount + the multi-line fan-out
+## 9. i18n
 
-This was "optional/deferred" in the first draft; PR review (§8.5) showed
-`price_paid` is wrong in common configurations, and the owner has now **chosen
-option B** — so §10a is **core required work**, not a nice-to-have. §10b (the
-multi-line fan-out scoping) remains the one open sub-decision.
-
-### 10a. Surface the provider amount (option B — REQUIRED)
-
-Widen the provider interface so the real refunded amount reaches `markRefunded`.
-This is **two layers**, not just the provider wrapper:
-
-1. **Interface + wrappers** — `PaymentProvider.refundPayment(ref):
-   Promise<boolean>` → `Promise<{ ok: boolean; amount?: number }>` (or
-   `number | null`). Update `stripe-provider.ts`, `square-provider.ts`,
-   `sumup-provider.ts`.
-2. **Lower API layers** (the easy-to-miss part):
-   - **Stripe — `refundPayment` only:** `src/shared/stripe.ts:322` already
-     returns `Stripe.Refund` (carrying `.amount`), so for the *refund* path only
-     the provider wrapper needs to stop discarding it. **But the refresh path is
-     different** (review #1): it reads `retrievePaymentIntent`, whose narrowing
-     `StripePaymentIntentFields` reduces `latest_charge` to `{ refunded }`
-     (`stripe.ts:72-87`), throwing away `amount_refunded`. To surface the
-     provider amount on refresh, that narrowing (and its tests) must add the
-     refunded amount too. So "no lower-layer change" holds for `refundPayment`,
-     **not** for the refresh path.
-   - **Square** — `src/shared/square.ts:608` *computes* the refund amount
-     (`payment.amountMoney.amount`) but its `withClient` callback returns only
-     `true`, and the REST adapter (`refunds.refundPayment`, ~`:343`) returns
-     `{}`. **`square.ts` (and its tests) must be changed to return the amount**;
-     changing `square-provider.ts` alone leaves Square falling back to
-     `price_paid`. (For the refresh path, Square reads refund state via its own
-     retrieve path — check it surfaces the amount too.)
-   - **SumUp** — returns boolean only → `amount` undefined → fall back to
-     `price_paid` (acceptable; documented).
-3. **All `refundPayment` callers must read the new shape** (see also §9):
-   - `attendee-refunds.ts` single (`:101-112`) + bulk (`:160-163`) — branch on
-     `.ok`, pass `.amount` into `markRefunded(id, listingId, startAt, amount)`.
-   - `webhooks.ts:239` auto-refund — branch on `.ok` (no amount stored).
-4. **Refresh path needs the amount too (review #3) — and `isPaymentRefunded` has
-   more than one caller (review #4).** `handleRefreshPayment` does **not** call
-   `refundPayment`; it calls `isPaymentRefunded(ref)` → boolean, then
-   `markRefunded`. To record the provider's actual amount here, `isPaymentRefunded`
-   must also return the amount (e.g. `Promise<{ refunded: boolean; amount?:
-   number }>` or a companion `getRefundedAmount(ref)`), the Stripe/Square lower
-   retrieve layers must stop discarding it (Stripe: the `latest_charge` narrowing
-   above), and **every** `isPaymentRefunded` caller must read `.refunded` rather
-   than truthiness:
-   - `attendees-edit.ts:86` `handleRefreshPayment` — pass the amount into
-     `markRefunded`.
-   - `webhooks.ts:251` `tryRefund` fallback — `if (await
-     provider.isPaymentRefunded(ref))` after a failed refund; an object
-     `{ refunded: false }` is truthy, so a failed defensive refund would be
-     mis-classified as already-refunded unless this reads `.refunded`.
-   This widens a second interface method across all three providers.
-
-Cost: touches all three providers + two lower API layers + every
-`refundPayment`/`isPaymentRefunded` caller, and many provider tests/stubs (~100
-`refundPayment` stub sites in `test/`, plus `isPaymentRefunded` stubs). The
-mechanical fix is to update each stub's return shape; budget for it.
-
-### 10b. Mark every line covered by the payment (case 3 from §8.5)
-
-`provider.refundPayment(payment_id)` refunds the **whole order**, so on success
-the routes must mark all the lines that payment covered — not just the operator's
-line.
-
-**The naive predicate "mark all of the attendee's lines" is wrong (review #1).**
-The attendee↔payment relationship is not 1:1 after a merge: `applyAttendeeMerge`
-copies a *source* attendee's booking lines onto the *target* while keeping only
-the target's `payment_id` (`attendees-merge.ts:190-194`,
-`merge/attendee-merge.ts:405-420`). So a single attendee can hold lines paid by
-**different** (now-discarded) payments. Fanning out to "all attendee lines" would
-mark — and, under option B, allocate refund money to — lines whose payment was
-never refunded.
-
-There is currently **no per-line payment reference** (the `payment_id` lives
-attendee-level in the encrypted pii_blob), so the data needed to scope the
-fan-out correctly does not exist yet. Options, in rough order of correctness:
-
-- **(Best) Add a per-line order marker — but NOT the raw payment reference
-  (review #3).** `listing_attendees` is a plaintext table that backups dump,
-  whereas the provider `payment_id` is deliberately kept in the *encrypted* PII
-  blob. Putting the raw reference here would leak it. Store a **non-sensitive
-  internal order/checkout id** (or an encrypted value with a blind index)
-  instead, captured at creation, so a refund can mark exactly the lines sharing
-  that order. This is a second schema change — arguably the *right* foundation
-  for refunds, but larger scope; call it out as its own decision. **If chosen,
-  the marker is subject to the same read/write sweep as `refunded_amount`
-  (review):** every per-line SELECT (§5) and the merge loader+insert (§5c/§14)
-  must carry it, or a merged booking loses its order key and falls back to the
-  exact attendee-level ambiguity this option fixes.
-- **Restrict refunds to order-level for un-merged attendees, and block/flag
-  refunds on merged attendees** until a per-line marker exists.
-- **Narrow predicate without new columns:** only fan out across lines that were
-  not brought in by a merge — but there's no reliable flag for that today, so
-  this is fragile and not recommended.
-- **Keep single-line marking** (status quo of the boolean `refunded`) and accept
-  the under-report, documented per §8.5 — the smallest scope, and honest if
-  paired with the "approximate" labelling.
-
-Allocation (when a marker exists): split the provider's returned total across the
-covered lines with `allocateByLargestRemainder` (`checkout-pricing.ts`) — **but
-not weighted by the current `price_paid` (review #2)**. For balance-paid
-reservations, `settleAttendeeBalance` folds the later balance payment into the
-earliest line's `price_paid`, so weighting by today's `price_paid` would shovel
-too much of the refund onto that line. The weight must be the **per-line amount
-that the refunded payment actually charged**, captured at checkout (the same
-per-line snapshot the order marker would carry) — not the mutated `price_paid`.
-This is another reason the per-line marker should record the charged amount, not
-just an id.
-
-**This is the one genuinely open design question in the feature** — it needs a
-decision (per-line marker vs. accept-and-document) before the fan-out is built.
-
-### 10c. Partial refunds (future)
-
-The `amount` parameter on `markRefunded` already accommodates a partial value;
-no schema change needed when partial-refund support arrives.
-
-**Plan:** 10a is required (option B chosen) and ships with the core feature —
-it's the difference between `refunded_amount` meaning "money returned" vs. "ticket
-revenue on one line". 10b (the fan-out scoping) is the remaining open
-sub-decision; resolve it (per-line marker vs. accept-and-document) before
-building the fan-out, but 10a does not depend on it.
+- `src/locales/en/admin.json`: add `admin.attendees.amount_refunded` ("Amount
+  Refunded:") and form strings ("Refund the whole order", per-item labels). The
+  existing `refunded` / `not_refunded` badge strings can stay (re-used for the
+  derived badge) or be replaced with amount-based copy.
+- Mirror into other `src/locales/*/admin.json` if locales are kept in sync.
 
 ---
 
-## 11. Alternative: column on `attendees` (the literal request)
+## 10. CSV / export — `src/features/admin/attendees-csv.ts`
 
-If we instead put `refunded_amount` on the **`attendees`** table (order-level
-total refunded):
-
-- **Schema**: add `["refunded_amount", "INTEGER NOT NULL DEFAULT 0"]` to the
-  `attendees` table block; migration `requires.columns.attendees`.
-- **Semantics**: it becomes an order-level accumulator. `markRefunded` (which
-  is per-line) must `UPDATE attendees SET refunded_amount = refunded_amount +
-  (that line's price_paid) WHERE id = ?` — now a two-table write, and
-  **no longer idempotent** (re-running double-counts). You'd need a guard so a
-  line is only added once (e.g. only add when the line flips 0→1, which means
-  reading the line first or doing it in one conditional statement).
-- **Reads**: `ATTENDEE_COLS` in `queries.ts` (not `EA_COLS`) gains the column;
-  `getAttendeeBalanceState`-style selects can read it directly without a join.
-- **Type**: `Attendee.refunded_amount` (number), plus it would belong on
-  `AttendeeWithBookings` rather than `ListingAttendeeRow`.
-- **Merge**: when merging attendees you'd sum `refunded_amount` across the two
-  attendees rather than carrying it on the moved booking rows.
-- **Downside**: it fights the per-line `refunded` flag (you can have one line
-  refunded but a single attendee-level number), loses per-line granularity, and
-  makes the write non-idempotent. This is why §0 recommends `listing_attendees`.
-
-Everything else (UI, i18n, tests, currency formatting) is the same.
+Add an "Amount Refunded" column to `standardAttendeeColumns`
+(`formatPrice(String(a.refunded_amount))`), and the `csv.col.amount_refunded`
+key. Shared with the calendar export, so it appears there too (intended).
 
 ---
 
-## 12. i18n
+## 11. Merge — `src/shared/merge/attendee-merge.ts`
 
-Add one key (both the badge label and "Not refunded" already exist):
-
-- `src/locales/en/admin.json`: add
-  `"admin.attendees.amount_refunded": "Amount Refunded:"` (next to the existing
-  `admin.attendees.amount_paid` / `refund_status` keys).
-- Add the same key to any other locale files under `src/locales/*/admin.json`
-  if the project keeps locales in sync (check what exists; only `en` may be
-  present).
-
-No new keys are needed if §8 is limited to reusing existing labels, but a
-dedicated "Amount Refunded" label reads best.
+Required (the merge runs regardless once the column exists): the loader (§6)
+selects `refunded_amount`, and `bookingInsertStatement` copies it, so a moved
+booking keeps its refunded amount; the dedup compare uses `refunded_amount` in
+place of `refunded`.
 
 ---
 
-## 13. CSV / export
+## 12. OPEN QUESTION — check-in behaviour
 
-`src/features/admin/attendees-csv.ts` → `standardAttendeeColumns` currently has
-`price_paid` and `transaction_id` but **no refund column**. Add a refunded
-column so exports carry it:
+Removing the boolean removes today's automatic "Cannot check in refunded tickets"
+guard (`checkin.ts:101`). Pick one:
 
-```ts
-{ header: t("csv.col.amount_refunded"), value: (a) => formatPrice(String(a.refunded_amount)) },
-```
+- **(A — recommended) Block on fully-refunded lines via the amount.** A line is
+  "refunded" for check-in when `refunded_amount >= price_paid` (and `price_paid >
+  0`). Preserves today's safety with no new schema; partial refunds don't block
+  (the holder still paid part of it).
+- **(B) Block on an order status.** Add an `is_refunded`/`blocks_checkin` flag to
+  `attendee_statuses` and gate check-in on the attendee's status. Matches "use
+  order statuses" most literally, but adds a status-schema change and an operator
+  step (they must set the status for check-in to block).
+- **(C) Don't auto-block.** Check-in never blocks on refunds; operators rely on
+  the status/amount being visible. Simplest, least safe.
 
-(Reuse the local `formatPrice` helper, which is `toMajorUnits(parseInt(...))`.)
-Add `csv.col.amount_refunded` to `src/locales/en/csv.json` (or wherever the
-`csv.col.*` keys live). This column is shared with the calendar export, so it
-appears there too — confirm that's desired; if not, add it only to the
-attendee-specific column block instead of `standardAttendeeColumns`.
-
----
-
-## 14. Merge — `src/shared/merge/attendee-merge.ts` (REQUIRED, not optional)
-
-The merge runs against live data regardless of whether we "opt in" to merge
-support, so once the column exists these two changes are **required** to avoid
-silent data loss (review #6) — not the "recommended" niceties the first draft
-called them:
-
-1. **Insert** — `bookingInsertStatement` copies a source booking line to the
-   target; add `refunded_amount: booking.refunded_amount` to the
-   `insert("listing_attendees", {...})` payload. Without it, every moved/replaced
-   refunded line is re-inserted at the column **default 0**, silently zeroing the
-   recorded refund on each merge.
-2. **Loader (§5c)** — the insert reads `booking.refunded_amount`, which is only
-   populated if `loadAttendeeBookings` selects the column. Land the loader and
-   insert together; cover with a merge test (§15g) that moves a refunded line and
-   asserts the amount survives.
-
-**Duplicate detection (review #2) — required under option B.**
-`buildBookingDiffItems` classifies a source booking as a `duplicate` (and skips
-it) when it matches the target on `quantity`, `price_paid`, `checked_in`,
-`refunded`. Under **option A** `refunded_amount` is derived from
-`price_paid`+`refunded`, so adding it changes nothing. Under **option B** it is
-*not* derived (fees, balance refunds, and the backfill make it diverge), so two
-lines equal on the four fields can differ on `refunded_amount` — and skipping the
-source would silently drop that amount. Therefore: add `refunded_amount` to the
-comparison whenever option B is in play (harmless under A, so just include it).
+My recommendation is **A** (keeps the existing protection, no extra moving parts).
+Tell me A/B/C and I'll lock it into §6.
 
 ---
 
-## 15. Tests
+## 13. Tests (100%, deterministic — AGENTS.md)
 
-Follow the existing patterns (BDD + `@std/expect`, helpers from `#test-utils`).
-100% coverage is required and must be **deterministic** (in-process unit tests,
-not just subprocess/e2e coverage — AGENTS.md).
-
-### 15a. DB write — new/extended unit test for `markRefunded`
-
-In a DB-backed test (see `test/lib/db/auto-cache-invalidation.test.ts` which
-already calls `markRefunded`):
-
-- Create a paid attendee/line with a known `price_paid` (e.g. 500).
-- Call `markRefunded(id, listingId, startAt)` (fallback form).
-- Assert the `listing_attendees` row has `refunded = 1` **and**
-  `refunded_amount = 500` (read it back via a query).
-- Idempotency: call `markRefunded` again, assert `refunded_amount` is still 500
-  (not doubled) — this is the mutation-resistant assertion that proves
-  `= price_paid` (copy) vs `+= price_paid` (accumulate).
-- With the `amount` arg: `markRefunded(id, listingId, startAt, 200)` sets
-  `refunded_amount = 200`.
-- **Row identity:** create the *same* attendee on the *same* listing for **two
-  different dates**, call `markRefunded` for one date, and assert only that row
-  is refunded (the other stays `refunded = 0, refunded_amount = 0`). This is the
-  mutation-resistant test for the `start_at` filter (§6).
-
-### 15b. Route integration — extend `test/lib/server-refunds.test.ts`
-
-After a successful single refund (and after `refund-all`), assert the
-attendee's persisted `refunded_amount` equals the recorded amount — the line's
-`price_paid` under option A, or the stubbed provider amount under option B (§10a).
-The file already has `createPaidTestAttendee`, `submitRefund`, `submitRefundAll`,
-and a `stripePaymentProvider.refundPayment` stub — extend the success assertions
-to read the row back (or re-fetch via `getAttendeeRaw`/`getAttendeesByTokens`)
-and check `refunded_amount`. If §10b ships, add a **multi-line** case: an
-attendee with two listings on one payment, refund once, assert **both** lines
-end up `refunded` with the amount allocated across them.
-
-### 15c. Refresh-payment path — `test/lib/server-attendees.test.ts`
-
-The refresh-payment tests (around the `isPaymentRefunded` stubs) should assert
-`refunded_amount` is set when the provider reports a refund.
-
-### 15d. Decryption / type mapping
-
-A `decryptAttendeeFields` test (or wherever `pii.ts` is covered) asserting
-`refunded_amount` is numeric and 0 when unpaid (`paidListing = false`).
-
-### 15e. Display
-
-- `PaymentDetails` template test: refunded attendee with `refunded_amount > 0`
-  renders the formatted amount; non-refunded attendee does not.
-- If §8c/§8d are done, extend `test/lib/attendee-table.test.ts` /
-  `attendee-form-model.test.ts` accordingly.
-
-### 15f. CSV
-
-Extend the attendees-csv test to assert the new column header + a refunded
-attendee's formatted value.
-
-### 15g. Merge
-
-Extend `test/lib/attendee-merge.test.ts` to assert a moved booking line keeps
-its `refunded_amount`.
-
-### 15h. Factories — `test/test-utils/factories.ts`
-
-Add `refunded_amount: 0` to `testAttendee()` (the `Attendee` factory). Check
-`createPaidTestAttendee` / any `listing_attendees` insert helpers in
-`#test-utils` set the column (the DEFAULT 0 covers inserts that omit it).
-`WebhookAttendee` factory (`makeTestAttendee`) only needs it if §16 is done.
+- **`recordLineRefund` unit (DB):** sets `refunded_amount`; caps at `price_paid`;
+  adds on repeat (partial then more); **row identity** — same attendee+listing on
+  two dates, refund one, assert only that row changes.
+- **Refund route:** "whole order" refunds every line to `price_paid` and calls
+  `refundPayment(ref, total)` with the right total; "per-item" stores the entered
+  amounts and refunds their sum; `total === 0` rejected; provider failure records
+  nothing. (Extend `test/lib/server-refunds.test.ts`; it already stubs
+  `stripePaymentProvider.refundPayment` — assert the `amount` arg now.)
+- **Provider:** Stripe/Square `refundPayment(ref, amount)` issues a partial refund
+  with the right amount; omitted `amount` = full (existing tests).
+- **Removal regression:** check-in (per §12 choice), merge (moved line keeps
+  amount), scanner badge, CSV column, payment panel sum.
+- **`refund-all`:** every not-fully-refunded line goes to `price_paid`.
+- Run `deno task test:quality-audit` for the new tests.
 
 ---
 
-## 16. Webhook payload (optional)
+## 14. Webhook payload (optional) — `src/shared/webhook.ts`
 
-`src/shared/webhook.ts` builds the outbound `WebhookAttendee` (it already
-includes `price_paid` and `payment_id`, but **not** `refunded`). If consumers
-should see refunds, add `refunded_amount` (and probably `refunded`) to the
-webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
-(`src/docs/webhooks.ts`). Out of scope unless explicitly wanted — flag it.
+Drop `refunded` from the outbound attendee if present; optionally add
+`refunded_amount` (+ `makeTestAttendee` factory + `src/docs/webhooks.ts`).
+Out of scope unless wanted.
 
 ---
 
-## 17. File-by-file checklist
+## 15. File-by-file checklist
 
-| File | Change | Required? |
+| File | Change | Req? |
 | --- | --- | --- |
-| `src/shared/db/migrations/schema.ts` | Add column to `listing_attendees`; update `LATEST_UPDATE` | ✅ |
-| `src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts` | New migration **+ `after()` backfill** of legacy refunded rows (§18) | ✅ |
-| `src/shared/db/migrations.ts` | Import + append to `MIGRATIONS` | ✅ |
-| `src/shared/db/attendee-types.ts` | `ListingAttendeeRow.refunded_amount` | ✅ |
-| `src/shared/types.ts` | `Attendee.refunded_amount` | ✅ |
-| `src/shared/db/attendees/queries.ts` | `EA_COLS`, `ATTENDEE_LEFT_JOIN_SELECT`, `getAttendeesByTokens` | ✅ |
-| `src/shared/db/attendees/update.ts` | `markRefunded` gains `startAt` (single-row target, §6) + `amount`; stores the **provider amount** (option B), `price_paid` only for SumUp/backfill | ✅ |
-| `src/shared/db/attendees/pii.ts` | Map `refunded_amount` in `decryptAttendeeFields` | ✅ |
-| `src/shared/db/attendees/atomic-update.ts` | `loadExistingLines` SELECT must add `refunded_amount` (§5d) | ✅ |
-| `src/features/admin/attendees-edit.ts` | Add column to refresh-context select | ✅ |
-| `src/ui/templates/admin/attendees.tsx` | Show amount in `PaymentDetails` (+ refund confirm) | ✅ |
-| `src/locales/en/admin.json` | `admin.attendees.amount_refunded` | ✅ |
-| `test/test-utils/factories.ts` | `refunded_amount: 0` in `testAttendee` | ✅ |
-| Tests (§15) | New/extended coverage | ✅ |
-| `src/features/admin/attendees-merge.ts` | `loadAttendeeBookings` must SELECT `refunded_amount` (§5c) | ✅ (merge runs regardless) |
-| `src/shared/merge/attendee-merge.ts` | Insert copies `refunded_amount`; add to dedup compare under option B (§14) | ✅ (else merges zero it) |
-| `src/features/admin/attendees-csv.ts` + csv locale | Export column (§13; label per provenance, §18) | ✅ (DoD requires it) |
-| Provider layer (§10a): `*-provider.ts` + `square.ts` lower layer + Stripe `retrievePaymentIntent` narrowing + `isPaymentRefunded` + all `refundPayment`/`isPaymentRefunded` callers (incl. `webhooks.ts`) | Record provider's **actual** refunded amount (option B) | ✅ (owner-chosen) |
-| Refund routes + maybe per-line payment marker (§10b) | Fan out an order-level refund across covered lines — **open sub-decision** | 🔶 decision required (§10b) |
-| `src/features/admin/attendee-form-model.ts` + `attendee-form.tsx` | Per-line amount in bookings table | ⭕ optional |
-| `src/shared/columns/attendee-columns.ts` | Amount in list status badge | ⭕ optional |
-| `src/shared/webhook.ts` (+docs, factory) (§16) | Webhook payload | ⭕ future |
-
-✅ = required for a correct, tested feature. 🔶 = recommended for *accuracy* —
-without these, `refunded_amount` is ticket-only/approximate (see §8.5); decide
-explicitly. ⭕ = scope choices.
+| `migrations/schema.ts` | drop `refunded`, add `refunded_amount` on `listing_attendees`; bump `LATEST_UPDATE` | ✅ |
+| `migrations/2026-06-21_attendee_refunded_amount.ts` | new migration: `recreateTable` + `syncTriggers` | ✅ |
+| `migrations.ts` | import + append to `MIGRATIONS` | ✅ |
+| `types.ts`, `attendee-types.ts` | `Attendee`/`ListingAttendeeRow`: −`refunded`, +`refunded_amount` | ✅ |
+| `attendees/queries.ts` | selects: −`refunded`, +`refunded_amount` (`EA_COLS`, left-join, by-tokens) | ✅ |
+| `attendees/update.ts` | replace `markRefunded` with `recordLineRefund` (single-row, capped) | ✅ |
+| `attendees/pii.ts` | map `refunded_amount`; drop `refunded` | ✅ |
+| `attendees-edit.ts`, `attendees-merge.ts`, `atomic-update.ts` | loaders select `refunded_amount` | ✅ |
+| `attendee-refunds.ts` | new per-item form handler; redefine `getRefundable` | ✅ |
+| `payments.ts` + `stripe.ts`/`square.ts`/`sumup-provider.ts` (+providers) | `refundPayment(ref, amount?)` partial refund | ✅ |
+| `attendees.tsx` (refund form + `PaymentDetails` sum) | UI | ✅ |
+| `checkin.ts` (+ scanner) | move off boolean (per §12) | ✅ |
+| `merge/attendee-merge.ts` | carry `refunded_amount`; dedup compare | ✅ |
+| `attendee-form-model.ts` + `attendee-form.tsx` | `AttendeeBooking.refundedAmount`; per-line display | ✅ |
+| `attendee-columns.ts` / `scanner.tsx` | badge from `refunded_amount` | ✅ |
+| `attendees-csv.ts` + csv locale | export column | ✅ |
+| `locales/.../admin.json` | form + amount strings | ✅ |
+| Tests (§13) | coverage | ✅ |
+| `webhook.ts` (+docs/factory) | payload | ⭕ optional |
 
 ---
 
-## 18. Edge cases & invariants
+## 16. Edge cases & limitations
 
-- **Legacy already-refunded rows — backfill is recommended (PR review).** New
-  rows default to `refunded_amount = 0`, so every historically refunded line
-  (`refunded = 1`) would report **0** in the admin UI and CSV — under-reporting
-  past refunds. Crucially this **cannot self-heal**: `handleRefreshPayment` only
-  calls `markRefunded` when `!attendee.refunded`
-  (`attendees-edit.ts:87`), so an already-refunded row is never revisited.
-  Therefore the migration should backfill in its `after()` hook:
-
-  ```sql
-  UPDATE listing_attendees SET refunded_amount = price_paid
-  WHERE refunded = 1 AND refunded_amount = 0
-  ```
-
-  Caveat: the backfill inherits the §8.5 inaccuracies (it uses `price_paid`, so
-  fees are excluded and balance-paid reservations are over-stated) — but for
-  *historical* rows the provider amount is not retrievable cheaply, so
-  `price_paid` is the best available estimate. Either way, **do not silently
-  leave legacy rows at 0** — that is the one option review explicitly flagged as
-  wrong.
-- **Provenance — we can't tell exact from approximate rows (review).** Once the
-  column is just a number, three kinds of value are indistinguishable: provider-
-  exact (Stripe/Square new refunds), SumUp fallback (`price_paid`), and the
-  historical backfill (`price_paid`). If the UI/CSV shows a plain "Amount
-  Refunded", a fee/reservation backfill row looks as authoritative as an exact
-  one. Two ways to resolve, **decide explicitly**:
-  - **(a) Store provenance** — a small `refunded_amount_source` marker (e.g.
-    `'provider' | 'estimate'`) set when the row is written, so the UI can label
-    estimates and exact values differently. Cleanest; one extra small column.
-  - **(b) Label everything as approximate** — simplest, but loses the accuracy
-    win of option B for the rows that *are* exact.
-  Recommendation: (a) — it's cheap and preserves option B's value. (Note this is
-  a *different* flag from the abandoned `NOT NULL`/`NULL` "unknown" idea: the
-  amount stays a non-null integer; the marker only records how it was derived.)
-- **Unpaid listings**: `refunded_amount` suppressed to 0 alongside `refunded`
-  (the `paidListing` gate in `pii.ts`).
-- **Balance-paid reservations — the `refunded` *flag* is the real problem
-  (review).** Option B records the right *amount* (the provider's true deposit
-  refund), but `markRefunded` still sets `refunded = 1` on the line — and the
-  rest of the app reads that boolean as **fully refunded**: `checkin.ts:101`
-  filters out `!attendee.refunded` and shows "Cannot check in refunded tickets".
-  So refunding only the original deposit of a reservation whose balance was later
-  paid would record the correct (partial) amount **but wrongly mark the booking
-  fully refunded**, blocking check-in for someone who still paid most of the
-  order. Recording the amount accurately is *not* enough here. This path must
-  either be **excluded** (don't allow a deposit-only refund to flip `refunded`)
-  or modeled as a **partial refund** (a `refunded` state that means "partially
-  refunded, still valid" — i.e. the boolean is insufficient and may need to
-  become a status). **This is a real gap to resolve**, related to but separate
-  from the §10b fan-out; flag it as a decision, don't call it "correct".
-- **Free bookings** (`price_paid = 0`): refunding sets `refunded = 1`,
-  `refunded_amount = 0` — correct (£0 refunded).
-- **Idempotency**: the write **copies** the recorded amount (the provider amount,
-  or the `price_paid` fallback) rather than accumulating, so repeated
-  `markRefunded` calls are stable. Tested in §15a.
-- **Aggregates untouched**: confirm `listings.income` / capacity are unchanged
-  by a refund (they already are; `refunded_amount` writes don't fire the
-  aggregate trigger). A regression test asserting `income` is unaffected by a
-  refund is cheap insurance.
+- **Booking fees aren't refundable via this form.** `price_paid` is ticket-only,
+  so the per-item cap excludes the fee. Refunding a fee is a manual provider
+  action. Documented limitation, not a bug.
+- **Merged attendees with >1 original payment.** After a merge an attendee can
+  hold lines from different payments, but only one `payment_id` is stored.
+  Refunding more than that payment covered will be rejected by the provider. Rare;
+  flag in the activity log when a refund fails.
+- **Repeated/incremental refunds** are supported: the input max is the *remaining*
+  refundable and `recordLineRefund` adds-and-caps, so refunding £2 then £3 of a
+  £10 line leaves `refunded_amount = 5`.
+- **Free lines** (`price_paid = 0`): max refundable is 0; nothing to do.
+- **Aggregates/capacity** unchanged by refunds (no trigger fires; income still
+  counts the rows).
 
 ---
 
-## 19. Rollout / safety
+## 17. Rollout / safety
 
-1. Additive `NOT NULL DEFAULT 0` `ADD COLUMN` — safe online, no rewrite, no
-   downtime, no FK churn.
-2. Fresh DBs get it via `applySchemaChanges()` on first boot; existing DBs get
-   it via the named migration. The migration's generated `verify()` fails the
-   boot loudly if the column didn't apply.
-3. Reversible: dropping the column (if ever needed) only loses the recorded
-   amounts; the `refunded` flag is independent.
-4. Backups already round-trip new columns (§3d) — verify once in testing.
+1. The migration recreates `listing_attendees` once (drops `refunded`, adds
+   `refunded_amount`, re-creates its indexes + aggregate triggers). Model exists
+   (`2026-06-18_answer_modifiers.ts`).
+2. Fresh DBs get the final shape from the declarative schema on first boot.
+3. No data loss of consequence — there are no refunds to lose; `refunded` was
+   all-zero.
+4. The provider change is backward-compatible (`amount` optional), so any
+   un-migrated caller still does a full refund.
 
 ---
 
-## 20. Definition of done
+## 18. Definition of done
 
-- [ ] Migration applies on a populated DB; `verify()` passes; `SCHEMA_HASH`
-      bumped; `LATEST_UPDATE` updated; legacy refunded rows backfilled (§18).
-- [ ] `markRefunded` sets `refunded` + `refunded_amount` atomically and
-      idempotently (copy semantics). The refund routes pass the **provider
-      amount** (option B); the optional `amount` param keeps the signature
-      compatible, but callers do change (see §6).
-- [ ] `Attendee.refunded_amount` populated through **every** read path (§5a–5e,
-      including `attendees-merge.ts` and `atomic-update.ts` loaders); type checks.
-- [ ] Amount shown in the admin payment details panel — as the **sum** across
-      the attendee's booking lines, not a single flattened row (§8a).
-- [ ] Merge loader+insert (§5c/§14) and CSV carry it.
-- [ ] **Provenance decided (§18):** add a `refunded_amount_source`
-      (provider/estimate) marker, or label all amounts approximate — so exact and
-      fallback rows aren't shown identically.
-- [ ] **Deposit-only / partial refunds decided (§18):** a deposit-only refund of
-      a balance-paid reservation must NOT flip the `refunded` boolean to "fully
-      refunded" (it blocks check-in — `checkin.ts:101`). Either exclude that path
-      or model partial refunds (the boolean may need to become a status).
-- [ ] **Amount source = option B (decided):** widen `refundPayment` **and**
-      `isPaymentRefunded` across all 3 providers, stop the lower Stripe
-      (`retrievePaymentIntent` narrowing) and Square (`square.ts`) layers
-      discarding the amount, and update **every** caller — incl. `webhooks.ts`
-      auto-refund (`.ok`) and `tryRefund` (`.refunded`). `price_paid` remains the
-      fallback only for SumUp and the historical backfill.
-- [ ] **Multi-line fan-out decided (§10b):** per-line payment marker vs.
-      accept-and-document. (The one remaining open question — don't ship the
-      fan-out without it.)
-- [ ] Tests added per §15; `deno task test:coverage` is 100% and deterministic;
-      `deno task test:quality-audit` clean for new tests.
-- [ ] `deno task precommit` (typecheck, `lint:ci`, tests, `cpd` at 0%) passes.
-- [ ] PR notes the webhook auto-refund callers (§9 — `.ok`/`.refunded` under
-      option B) and records the §10b decision.
+- [ ] Migration recreates `listing_attendees` (no `refunded`, has
+      `refunded_amount`); `verify()` passes; `SCHEMA_HASH`/`LATEST_UPDATE` updated.
+- [ ] `recordLineRefund` writes one row (by `start_at`), caps at `price_paid`,
+      accumulates on repeat — tested incl. the two-dates identity case.
+- [ ] `refundPayment(ref, amount?)` issues partial refunds on Stripe/Square;
+      omitted `amount` = full; SumUp partial verified or per-item disabled for it.
+- [ ] Refund form: "whole order" (default) and per-item (0…remaining) both work;
+      total refunded at the provider matches; provider failure records nothing.
+- [ ] `refunded` boolean fully removed; every former reader migrated
+      (check-in per §12, scanner, merge, form-model, templates, CSV, types,
+      selects).
+- [ ] Payment panel shows the **summed** order refund; per-line amounts visible.
+- [ ] Tests added (§13); `deno task test:coverage` 100% & deterministic;
+      `test:quality-audit` clean.
+- [ ] `deno task precommit` (typecheck, `lint:ci`, tests, `cpd` 0%) passes.
+- [ ] §12 (check-in) answered and implemented.
+
+---
+
+## What changed from v1 & why it's simpler
+
+Your decisions removed three whole problem areas the earlier draft wrestled with:
+
+- **No "read the amount back" from the provider.** We now *tell* the provider the
+  amount, so `refundPayment` stays boolean — deleting the return-shape change, the
+  `isPaymentRefunded` widening, the Stripe `retrievePaymentIntent` / Square
+  lower-layer fixes, and the all-callers sweep.
+- **No multi-line fan-out guessing.** The operator picks per-item amounts in the
+  form, so there's nothing to allocate and no need for a per-line payment marker.
+- **No provenance/backfill.** No existing refunds ⇒ no historical estimates to
+  label.
+
+What it *added*: removing the `refunded` boolean (a broad but mechanical refactor)
+and partial refunds at the provider (a small, additive change). Net: a clearer
+model — **state = order status, money = `refunded_amount` per item** — and one
+open question (check-in, §12).

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -176,8 +176,21 @@ export default schemaMigration(
   {
     columns: { listing_attendees: ["refunded_amount"] },
   },
+  // 4th arg: after() — runs post-ADD COLUMN. Backfill legacy refunded rows so
+  // they don't report 0 (see §18; they cannot self-heal via the refresh path).
+  async ({ getDb }) => {
+    await getDb().execute(
+      "UPDATE listing_attendees SET refunded_amount = price_paid WHERE refunded = 1 AND refunded_amount = 0",
+    );
+  },
 );
 ```
+
+> The `after` callback is **part of the required migration** (§18), not optional
+> — without it every historical `refunded = 1` row reports `refunded_amount = 0`.
+> `schemaMigration`'s 4th argument receives the `MigrationContext` (so `getDb`
+> is available). Confirm `after` runs *after* `applySchemaChanges` (it does — see
+> `define.ts`'s `up`).
 
 `schemaMigration` runs `applySchemaChanges()` (ADD COLUMN for any missing
 schema column) and the generated `verify()` asserts the live table has
@@ -381,9 +394,12 @@ show the refunded amount next to the existing refund-status badge:
 
 ### 8b. Refund confirmation page — same file
 
-`adminRefundAttendeePage` warns "This will issue a full refund". Optionally
-show the exact amount that will be refunded (`attendee.price_paid`) so the
-operator sees it before confirming. Pure copy/markup change.
+`adminRefundAttendeePage` warns "This will issue a full refund". Optionally show
+the amount before confirming — but **do not present `attendee.price_paid` as "the
+exact amount"**: per §8.5 it excludes booking fees and over-states balance-paid
+reservations, so the operator would see the wrong figure. Either show the
+provider/order total when available, or label it explicitly as a *ticket-only
+estimate* (e.g. "≈ £10.00 ticket value; final refund set by the provider").
 
 ### 8c. Attendee table status column — `src/shared/columns/attendee-columns.ts`
 
@@ -496,29 +512,43 @@ This is **two layers**, not just the provider wrapper:
    `number | null`). Update `stripe-provider.ts`, `square-provider.ts`,
    `sumup-provider.ts`.
 2. **Lower API layers** (the easy-to-miss part):
-   - **Stripe** — `src/shared/stripe.ts:322` already returns `Stripe.Refund`
-     (carrying `.amount`), so only the provider wrapper needs to stop discarding
-     it. ✅ no lower-layer change.
+   - **Stripe — `refundPayment` only:** `src/shared/stripe.ts:322` already
+     returns `Stripe.Refund` (carrying `.amount`), so for the *refund* path only
+     the provider wrapper needs to stop discarding it. **But the refresh path is
+     different** (review #1): it reads `retrievePaymentIntent`, whose narrowing
+     `StripePaymentIntentFields` reduces `latest_charge` to `{ refunded }`
+     (`stripe.ts:72-87`), throwing away `amount_refunded`. To surface the
+     provider amount on refresh, that narrowing (and its tests) must add the
+     refunded amount too. So "no lower-layer change" holds for `refundPayment`,
+     **not** for the refresh path.
    - **Square** — `src/shared/square.ts:608` *computes* the refund amount
      (`payment.amountMoney.amount`) but its `withClient` callback returns only
      `true`, and the REST adapter (`refunds.refundPayment`, ~`:343`) returns
      `{}`. **`square.ts` (and its tests) must be changed to return the amount**;
      changing `square-provider.ts` alone leaves Square falling back to
-     `price_paid`.
+     `price_paid`. (For the refresh path, Square reads refund state via its own
+     retrieve path — check it surfaces the amount too.)
    - **SumUp** — returns boolean only → `amount` undefined → fall back to
      `price_paid` (acceptable; documented).
-3. **All callers must read the new shape** (see also §9):
+3. **All `refundPayment` callers must read the new shape** (see also §9):
    - `attendee-refunds.ts` single (`:101-112`) + bulk (`:160-163`) — branch on
      `.ok`, pass `.amount` into `markRefunded(id, listingId, amount)`.
    - `webhooks.ts:239` auto-refund — branch on `.ok` (no amount stored).
-4. **Refresh path needs the amount too (review #3).** `handleRefreshPayment`
-   does **not** call `refundPayment`; it calls `isPaymentRefunded(ref)` →
-   boolean, then `markRefunded`. For refunds made directly in Stripe/Square and
-   then refreshed in-app, widening only `refundPayment` still leaves this path on
-   the `price_paid` fallback. To record the provider's actual amount here,
-   `isPaymentRefunded` must also return the refunded amount (e.g.
-   `Promise<{ refunded: boolean; amount?: number }>` or a companion
-   `getRefundedAmount(ref)`), and `handleRefreshPayment` must pass it through.
+4. **Refresh path needs the amount too (review #3) — and `isPaymentRefunded` has
+   more than one caller (review #4).** `handleRefreshPayment` does **not** call
+   `refundPayment`; it calls `isPaymentRefunded(ref)` → boolean, then
+   `markRefunded`. To record the provider's actual amount here, `isPaymentRefunded`
+   must also return the amount (e.g. `Promise<{ refunded: boolean; amount?:
+   number }>` or a companion `getRefundedAmount(ref)`), the Stripe/Square lower
+   retrieve layers must stop discarding it (Stripe: the `latest_charge` narrowing
+   above), and **every** `isPaymentRefunded` caller must read `.refunded` rather
+   than truthiness:
+   - `attendees-edit.ts:86` `handleRefreshPayment` — pass the amount into
+     `markRefunded`.
+   - `webhooks.ts:251` `tryRefund` fallback — `if (await
+     provider.isPaymentRefunded(ref))` after a failed refund; an object
+     `{ refunded: false }` is truthy, so a failed defensive refund would be
+     mis-classified as already-refunded unless this reads `.refunded`.
    This widens a second interface method across all three providers.
 
 Cost: touches all three providers + two lower API layers + every
@@ -640,25 +670,32 @@ attendee-specific column block instead of `standardAttendeeColumns`.
 
 ---
 
-## 14. Merge — `src/shared/merge/attendee-merge.ts`
+## 14. Merge — `src/shared/merge/attendee-merge.ts` (REQUIRED, not optional)
 
-`bookingInsertStatement` copies a source booking line to the target; add
-`refunded_amount: booking.refunded_amount` to the `insert("listing_attendees",
-{...})` payload so a moved/replaced line keeps its refunded amount.
+The merge runs against live data regardless of whether we "opt in" to merge
+support, so once the column exists these two changes are **required** to avoid
+silent data loss (review #6) — not the "recommended" niceties the first draft
+called them:
 
-> **Pairs with §5c.** This insert reads `booking.refunded_amount`, which is only
-> populated if `loadAttendeeBookings` in `attendees-merge.ts` selects the
-> column. Without that SELECT, `booking.refunded_amount` is `undefined` and the
-> insert violates the `NOT NULL` constraint (or silently drops the amount). Land
-> the loader change (§5c) and this insert change together, and cover it with a
-> merge test (§15g) that moves a refunded line and asserts the amount survives.
+1. **Insert** — `bookingInsertStatement` copies a source booking line to the
+   target; add `refunded_amount: booking.refunded_amount` to the
+   `insert("listing_attendees", {...})` payload. Without it, every moved/replaced
+   refunded line is re-inserted at the column **default 0**, silently zeroing the
+   recorded refund on each merge.
+2. **Loader (§5c)** — the insert reads `booking.refunded_amount`, which is only
+   populated if `loadAttendeeBookings` selects the column. Land the loader and
+   insert together; cover with a merge test (§15g) that moves a refunded line and
+   asserts the amount survives.
 
-Optionally include `refunded_amount` in the duplicate-detection comparison in
-`buildBookingDiffItems` (currently compares `quantity`, `price_paid`,
-`checked_in`, `refunded`). Since `refunded_amount` is derived from
-`price_paid`+`refunded`, two lines equal on those three will almost always be
-equal on `refunded_amount` too — adding it is harmless and precise but not
-strictly required. Include for completeness.
+**Duplicate detection (review #2) — required under option B.**
+`buildBookingDiffItems` classifies a source booking as a `duplicate` (and skips
+it) when it matches the target on `quantity`, `price_paid`, `checked_in`,
+`refunded`. Under **option A** `refunded_amount` is derived from
+`price_paid`+`refunded`, so adding it changes nothing. Under **option B** it is
+*not* derived (fees, balance refunds, and the backfill make it diverge), so two
+lines equal on the four fields can differ on `refunded_amount` — and skipping the
+source would silently drop that amount. Therefore: add `refunded_amount` to the
+comparison whenever option B is in play (harmless under A, so just include it).
 
 ---
 
@@ -753,13 +790,14 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | `src/shared/db/attendees/queries.ts` | `EA_COLS`, `ATTENDEE_LEFT_JOIN_SELECT`, `getAttendeesByTokens` | ✅ |
 | `src/shared/db/attendees/update.ts` | `markRefunded` sets `refunded_amount = price_paid` | ✅ |
 | `src/shared/db/attendees/pii.ts` | Map `refunded_amount` in `decryptAttendeeFields` | ✅ |
+| `src/shared/db/attendees/atomic-update.ts` | `loadExistingLines` SELECT must add `refunded_amount` (§5d) | ✅ |
 | `src/features/admin/attendees-edit.ts` | Add column to refresh-context select | ✅ |
 | `src/ui/templates/admin/attendees.tsx` | Show amount in `PaymentDetails` (+ refund confirm) | ✅ |
 | `src/locales/en/admin.json` | `admin.attendees.amount_refunded` | ✅ |
 | `test/test-utils/factories.ts` | `refunded_amount: 0` in `testAttendee` | ✅ |
 | Tests (§15) | New/extended coverage | ✅ |
-| `src/features/admin/attendees-merge.ts` | **`loadAttendeeBookings` must SELECT `refunded_amount`** (§5c) | ✅ if merge carries it |
-| `src/shared/merge/attendee-merge.ts` | Carry `refunded_amount` on moved lines (insert) | ⭕ recommended (pairs with row above) |
+| `src/features/admin/attendees-merge.ts` | `loadAttendeeBookings` must SELECT `refunded_amount` (§5c) | ✅ (merge runs regardless) |
+| `src/shared/merge/attendee-merge.ts` | Insert copies `refunded_amount`; add to dedup compare under option B (§14) | ✅ (else merges zero it) |
 | `src/features/admin/attendees-csv.ts` + csv locale | Export column (label "ticket-only/approx" if option A — §8.5) | ⭕ recommended |
 | Provider layer (§10a): `*-provider.ts` + `square.ts` lower layer + `isPaymentRefunded` + all `refundPayment` callers (incl. `webhooks.ts`) | Record provider's **actual** refunded amount | 🔶 recommended for correctness (§8.5) |
 | Refund routes + maybe per-line payment marker (§10b) | Fan out an order-level refund across covered lines — **open design question** | 🔶 decision required (§8.5/§10b) |

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -52,7 +52,7 @@ This plan is written for the **recommended (listing_attendees) approach**.
 
 | Concept | Where it lives | Type | Notes |
 | --- | --- | --- | --- |
-| Amount paid for a booking line | `listing_attendees.price_paid` | `INTEGER` minor units | Trigger-summed into `listings.income`. |
+| Amount paid for a booking line | `listing_attendees.price_paid` | `INTEGER` minor units | **Ticket revenue only** — excludes the booking fee (a separate `extras` line at checkout, not folded into any line's `price_paid`; see §8.5). Reservation balance payments *are* folded in by `settleAttendeeBalance`. Trigger-summed into `listings.income`. |
 | Refunded? (per line) | `listing_attendees.refunded` | `INTEGER` 0/1 | Set by `markRefunded`. |
 | Payment reference | encrypted `attendees.pii_blob` (`pi`) | string | Surfaced as `attendee.payment_id` after decryption. |
 | Outstanding balance (order-level) | `attendees.remaining_balance` | `INTEGER` minor units | Reservations/part-payments. |
@@ -85,9 +85,24 @@ Key fact about the value to store: `provider.refundPayment()` returns a
 (`src/shared/stripe.ts:322`, `s.refunds.create(...)`) actually returns a
 `Stripe.Refund` carrying the real refunded `amount`, but the
 `PaymentProvider` interface throws it away. So the actual provider-refunded
-amount is *available at Stripe/Square* but *not* at the interface today (see
-the optional enhancement in §10). For v1 we record the line's `price_paid` as
-the refunded amount, which is correct for the full refunds we support.
+amount is *available at Stripe/Square* but *not* at the interface today.
+
+There are **two candidate values** for `refunded_amount`:
+
+- **(A) the line's `price_paid`** — zero interface churn, but it is only the
+  *ticket* portion and diverges from the money actually returned in three real
+  configurations (booking fees, balance-paid reservations, multi-line orders —
+  see **§8.5**, the accuracy section, which exists because of PR review
+  feedback).
+- **(B) the provider's actual refunded amount** — the true money moved, but it
+  requires widening the provider interface (§10).
+
+Because the divergences in §8.5 are real and not rare, **the recommended source
+of truth is (B), the provider's actual amount, with (A) `price_paid` as the
+fallback** when a provider can't report an amount (SumUp) or for the historical
+backfill. Read §8.5 and §10 before locking this in — it is the single most
+important correctness decision in the feature, and it shifted from the original
+draft after review.
 
 ---
 
@@ -96,13 +111,20 @@ the refunded amount, which is correct for the full refunds we support.
 1. **Column**: `refunded_amount INTEGER NOT NULL DEFAULT 0` on
    `listing_attendees`. Minor units, never null, defaults to 0 (so existing
    rows and non-refunded rows read as 0 — "nothing refunded").
-2. **Value written**: when a line is marked refunded, set
-   `refunded_amount = price_paid` (what was paid for that line). Implemented as
-   a single atomic UPDATE inside `markRefunded` so it can never drift from the
-   `refunded` flag.
+2. **Value written**: `markRefunded(attendeeId, listingId, amount?)` sets
+   `refunded = 1` and `refunded_amount = amount`, in a single atomic UPDATE so
+   the flag and amount can never drift. The `amount` is:
+   - the **provider's actual refunded amount** (option B) where available — the
+     refund routes already hold the provider result and can pass it in; or
+   - the line's **`price_paid`** as the fallback (`amount` omitted → the SQL
+     copies `price_paid`), used for SumUp and the historical backfill.
+
+   See §8.5 for why `price_paid` alone is not a reliable amount, and §10 for the
+   small interface change that surfaces the provider amount.
 3. **Idempotency**: re-running `markRefunded` is harmless — it re-sets
-   `refunded = 1, refunded_amount = price_paid`. (The routes already guard
-   against double-refunding at the provider via the `refunded` check.)
+   `refunded = 1, refunded_amount = <amount>` (a copy, never an accumulate), so
+   a repeat call lands the same value. (The routes also guard against
+   double-refunding at the provider via the `refunded` check.)
 4. **No trigger changes**. The `listings` aggregate triggers
    (`LISTING_AGGREGATE_TRIGGERS`) are scoped to `OF quantity, price_paid,
    listing_id`; writing `refunded_amount` won't fire them. This deliberately
@@ -231,11 +253,21 @@ flattened `Attendee`/`ListingAttendeeRow` carry it.
 `loadRefreshContext` selects an explicit `listing_attendees` column list — add
 `refunded_amount` there too (keeps the `ListingAttendeeRow` shape complete).
 
-### 5c. Anywhere else selecting `listing_attendees` per-line columns
+### 5c. `src/features/admin/attendees-merge.ts` — `loadAttendeeBookings`
+
+**Required, and easy to miss.** `loadAttendeeBookings` (the merge route's
+loader) selects `listing_id, start_at, end_at, quantity, checked_in, refunded,
+price_paid, attachment_downloads` into `ListingAttendeeRow[]`. It must also
+select `refunded_amount`. This pairs with §14: the merge *insert* copies
+`refunded_amount`, so if the loader doesn't select it the moved booking passes
+`undefined` into the `NOT NULL` column. Read site (5c) and write site (§14) go
+together — do not land one without the other.
+
+### 5d. Anywhere else selecting `listing_attendees` per-line columns
 
 Grep check: `rg "checked_in, refunded, price_paid"` and
 `rg "ea\\.refunded"` — update every explicit column list that already pulls
-`refunded`/`price_paid` to also pull `refunded_amount`. Known sites are 5a/5b;
+`refunded`/`price_paid` to also pull `refunded_amount`. Known sites are 5a–5c;
 confirm none were missed.
 
 ---
@@ -359,6 +391,59 @@ Optional but nice for the multi-line case (where the flattened
 
 ---
 
+## 8.5 Accuracy of the recorded amount — when `price_paid` ≠ money refunded
+
+> Added in response to PR review. `refunded_amount = price_paid` is correct for
+> a full refund of a single-line, fee-free, non-reservation booking — but **not**
+> in the three configurations below. Each is verified against current code.
+
+1. **Booking fees are excluded from `price_paid`.** At checkout the booking fee
+   is a separate `extras` line (`feeExtras`, `src/shared/checkout-pricing.ts:86-92`),
+   and `paidByListing` (`src/features/api/webhooks.ts:587-597`) sums only the
+   ticket lines into each line's `price_paid`. So a £10 ticket + £1 fee stores
+   `price_paid = 1000`, but a full provider refund returns **1100**. Recording
+   `price_paid` under-reports by the fee.
+2. **Balance-paid reservations fold extra money into `price_paid`.**
+   `settleAttendeeBalance` (`src/shared/db/attendees/balance.ts`) does
+   `UPDATE listing_attendees SET price_paid = price_paid + <balance>` on the
+   first line, while the attendee's stored `payment_id` stays the **original
+   deposit** reference. Refunding that stored payment returns only the deposit,
+   but `price_paid` now holds deposit + balance — so `price_paid`
+   **over-reports** the actual refund. (And the balance was a *second* payment
+   the stored `payment_id` can't even refund.)
+3. **Multi-line orders share one payment.** `provider.refundPayment(payment_id)`
+   refunds the *entire* order, but the single-refund and refresh paths call
+   `markRefunded(attendee.id, listingId)` for **one** line only
+   (`attendee-refunds.ts:101-111`, `attendees-edit.ts:86-88`). The other lines
+   keep `refunded = false`, `refunded_amount = 0` even though their money was
+   returned. (This is a **pre-existing** quirk of the boolean `refunded` flag,
+   not introduced here — but `refunded_amount` makes the under-report visible in
+   money terms.)
+
+**Implications for the design:**
+
+- Cases 1 and 2 are why **option B (record the provider's actual amount, §10) is
+  the recommended source of truth.** The provider's refund response is the one
+  number that is correct in all three cases — it is exactly the money returned.
+- Case 3 needs a **write-fan-out** fix independent of which amount we store: when
+  an order-level refund succeeds, mark **every** `listing_attendees` line that
+  shares that `payment_id`, not just the operator's line. See §10 (promoted from
+  "future" to a tracked decision). If option B is used, allocate the provider's
+  total across those lines (e.g. by `price_paid` weight, largest-remainder — the
+  codebase already has `allocateByLargestRemainder` in `checkout-pricing.ts`);
+  if option A, each line records its own `price_paid`.
+- If we ship option A first anyway (e.g. to avoid provider churn), the plan must
+  **document `refunded_amount` as "ticket revenue refunded, fee-exclusive, and
+  approximate for balance-paid reservations"** in the column comment, the admin
+  UI, and the CSV header — so no one reads it as "total returned to the
+  customer".
+
+**Recommendation:** treat §8.5 as a gating decision. My recommendation is
+option B + the case-3 fan-out; if that is too much scope now, ship option A with
+the explicit "ticket-only / approximate" labelling and a follow-up issue for B.
+
+---
+
 ## 9. Webhook auto-refund path (explicitly out of scope)
 
 `src/features/api/webhooks.ts:239` refunds *untrusted/invalid* checkout
@@ -371,36 +456,56 @@ PR description so it isn't mistaken for a gap.
 
 ---
 
-## 10. Optional enhancement: record the *provider's actual* refunded amount
+## 10. Recording the *provider's actual* refunded amount + the multi-line fan-out
 
-Today the recorded amount = the line's `price_paid`. That is exactly right for
-full refunds of single-line orders. Two cases where it can diverge from the
-true money moved:
+This was "optional/deferred" in the first draft; PR review (§8.5) showed
+`price_paid` is wrong in common configurations, so it is now a **tracked
+decision**, not a nice-to-have.
 
-1. **Multi-line orders on one payment.** `provider.refundPayment(payment_id)`
-   refunds the *entire* Stripe/Square payment (all lines), but the single-refund
-   route marks only the one line the operator was on. So `refunded_amount` for
-   that line under-reports the actual refund. (This is a pre-existing modelling
-   quirk of `refunded` too, not introduced here.)
-2. **Partial refunds**, if ever supported.
+### 10a. Surface the provider amount (option B)
 
-To record the real number we'd widen the provider interface:
+Widen the provider interface so the real refunded amount reaches `markRefunded`:
 
 - `PaymentProvider.refundPayment(ref): Promise<boolean>` →
   `Promise<{ ok: boolean; amount?: number }>` (or `number | null`).
 - Stripe already has it: `s.refunds.create(...)` returns `Stripe.Refund.amount`
   (`src/shared/stripe.ts`). Square's refund response carries `amount_money`.
-  SumUp returns boolean only — fall back to `price_paid`.
-- Pass the returned amount into `markRefunded(id, listingId, amount)`.
+  SumUp returns boolean only → `amount` undefined → fall back to `price_paid`.
+- Refund routes pass the returned amount into
+  `markRefunded(id, listingId, amount)` (the optional param added in §6).
 
-**Recommendation: defer.** It touches all three providers
-(`stripe-provider.ts`, `square-provider.ts`, `sumup-provider.ts`) and a large
-number of provider tests/stubs (see the ~100 `refundPayment` stub call sites in
-`test/`). v1 = `price_paid`, which is correct for the full-refund flows we
-actually ship. Add a TODO referencing this section. For the multi-line
-single-refund quirk, a cheaper interim fix is to mark **all** of the payment's
-lines refunded (loop the attendee's `listing_attendees` rows sharing that
-payment) — note as a follow-up, don't bundle it here.
+Cost: touches all three providers (`stripe-provider.ts`, `square-provider.ts`,
+`sumup-provider.ts`) and many provider tests/stubs (~100 `refundPayment` stub
+sites in `test/`). The mechanical fix is to update each stub's return shape;
+budget for it.
+
+### 10b. Mark every line covered by the payment (case 3 from §8.5)
+
+`provider.refundPayment(payment_id)` refunds the **whole order**, so on success
+the routes must mark **all** of the attendee's `listing_attendees` lines that
+belong to that payment — not just the operator's line. Today there is no
+per-line payment reference (the `payment_id` is attendee-level in the pii_blob),
+so "lines covered by that payment" = all of that attendee's lines created by the
+original checkout. Concretely:
+
+- Single refund (`attendee-refunds.ts`) and refresh (`attendees-edit.ts`):
+  after a successful provider refund, mark every line for the attendee.
+- With option B, allocate the provider's returned total across those lines
+  (by `price_paid` weight, largest-remainder — reuse
+  `allocateByLargestRemainder`, `checkout-pricing.ts`); with option A, set each
+  line's `refunded_amount = price_paid`.
+- Alternatively (smaller, but a UX change) **disallow per-line refunds for
+  multi-line orders** and only offer an order-level "refund this order" action.
+
+### 10c. Partial refunds (future)
+
+The `amount` parameter on `markRefunded` already accommodates a partial value;
+no schema change needed when partial-refund support arrives.
+
+**Recommendation:** do 10a + 10b together with the core feature — they are the
+difference between `refunded_amount` meaning "money returned" vs. "ticket
+revenue on one line". If scope must shrink, ship option A (§2) with the explicit
+"ticket-only/approximate" labelling from §8.5 and open a follow-up for 10a/10b.
 
 ---
 
@@ -471,6 +576,13 @@ attendee-specific column block instead of `standardAttendeeColumns`.
 `refunded_amount: booking.refunded_amount` to the `insert("listing_attendees",
 {...})` payload so a moved/replaced line keeps its refunded amount.
 
+> **Pairs with §5c.** This insert reads `booking.refunded_amount`, which is only
+> populated if `loadAttendeeBookings` in `attendees-merge.ts` selects the
+> column. Without that SELECT, `booking.refunded_amount` is `undefined` and the
+> insert violates the `NOT NULL` constraint (or silently drops the amount). Land
+> the loader change (§5c) and this insert change together, and cover it with a
+> merge test (§15g) that moves a refunded line and asserts the amount survives.
+
 Optionally include `refunded_amount` in the duplicate-detection comparison in
 `buildBookingDiffItems` (currently compares `quantity`, `price_paid`,
 `checked_in`, `refunded`). Since `refunded_amount` is derived from
@@ -504,11 +616,14 @@ already calls `markRefunded`):
 ### 15b. Route integration — extend `test/lib/server-refunds.test.ts`
 
 After a successful single refund (and after `refund-all`), assert the
-attendee's persisted `refunded_amount` equals the line's `price_paid`. The file
-already has `createPaidTestAttendee`, `submitRefund`, `submitRefundAll`, and a
-`stripePaymentProvider.refundPayment` stub — extend the success assertions to
-read the row back (or re-fetch via `getAttendeeRaw`/`getAttendeesByTokens`) and
-check `refunded_amount`.
+attendee's persisted `refunded_amount` equals the recorded amount — the line's
+`price_paid` under option A, or the stubbed provider amount under option B (§10a).
+The file already has `createPaidTestAttendee`, `submitRefund`, `submitRefundAll`,
+and a `stripePaymentProvider.refundPayment` stub — extend the success assertions
+to read the row back (or re-fetch via `getAttendeeRaw`/`getAttendeesByTokens`)
+and check `refunded_amount`. If §10b ships, add a **multi-line** case: an
+attendee with two listings on one payment, refund once, assert **both** lines
+end up `refunded` with the amount allocated across them.
 
 ### 15c. Refresh-payment path — `test/lib/server-attendees.test.ts`
 
@@ -561,7 +676,7 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | File | Change | Required? |
 | --- | --- | --- |
 | `src/shared/db/migrations/schema.ts` | Add column to `listing_attendees`; update `LATEST_UPDATE` | ✅ |
-| `src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts` | New migration | ✅ |
+| `src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts` | New migration **+ `after()` backfill** of legacy refunded rows (§18) | ✅ |
 | `src/shared/db/migrations.ts` | Import + append to `MIGRATIONS` | ✅ |
 | `src/shared/db/attendee-types.ts` | `ListingAttendeeRow.refunded_amount` | ✅ |
 | `src/shared/types.ts` | `Attendee.refunded_amount` | ✅ |
@@ -573,28 +688,52 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | `src/locales/en/admin.json` | `admin.attendees.amount_refunded` | ✅ |
 | `test/test-utils/factories.ts` | `refunded_amount: 0` in `testAttendee` | ✅ |
 | Tests (§15) | New/extended coverage | ✅ |
-| `src/shared/merge/attendee-merge.ts` | Carry `refunded_amount` on moved lines | ⭕ recommended |
-| `src/features/admin/attendees-csv.ts` + csv locale | Export column | ⭕ recommended |
+| `src/features/admin/attendees-merge.ts` | **`loadAttendeeBookings` must SELECT `refunded_amount`** (§5c) | ✅ if merge carries it |
+| `src/shared/merge/attendee-merge.ts` | Carry `refunded_amount` on moved lines (insert) | ⭕ recommended (pairs with row above) |
+| `src/features/admin/attendees-csv.ts` + csv locale | Export column (label "ticket-only/approx" if option A — §8.5) | ⭕ recommended |
+| Provider interface (§10a) | Record provider's **actual** refunded amount | 🔶 recommended for correctness (§8.5) |
+| Refund routes (§10b) | Mark **all** lines of an order-level refund (multi-line fix) | 🔶 recommended for correctness (§8.5) |
 | `src/features/admin/attendee-form-model.ts` + `attendee-form.tsx` | Per-line amount in bookings table | ⭕ optional |
 | `src/shared/columns/attendee-columns.ts` | Amount in list status badge | ⭕ optional |
-| Provider interface (§10) | Real provider refund amount | ⭕ future |
 | `src/shared/webhook.ts` (+docs, factory) (§16) | Webhook payload | ⭕ future |
 
-✅ = required for a correct, tested feature. ⭕ = scope choices.
+✅ = required for a correct, tested feature. 🔶 = recommended for *accuracy* —
+without these, `refunded_amount` is ticket-only/approximate (see §8.5); decide
+explicitly. ⭕ = scope choices.
 
 ---
 
 ## 18. Edge cases & invariants
 
-- **Non-refunded / legacy rows** read `refunded_amount = 0` (DEFAULT + COALESCE
-  on left joins). No backfill needed — historically refunded rows simply show 0
-  until re-refreshed, which is acceptable (we never recorded the amount before).
-  If a backfill is wanted, a one-off `UPDATE listing_attendees SET
-  refunded_amount = price_paid WHERE refunded = 1 AND refunded_amount = 0`
-  could run in the migration's `after()` hook — **decide explicitly**; default
-  is no backfill.
+- **Legacy already-refunded rows — backfill is recommended (PR review).** New
+  rows default to `refunded_amount = 0`, so every historically refunded line
+  (`refunded = 1`) would report **0** in the admin UI and CSV — under-reporting
+  past refunds. Crucially this **cannot self-heal**: `handleRefreshPayment` only
+  calls `markRefunded` when `!attendee.refunded`
+  (`attendees-edit.ts:87`), so an already-refunded row is never revisited.
+  Therefore the migration should backfill in its `after()` hook:
+
+  ```sql
+  UPDATE listing_attendees SET refunded_amount = price_paid
+  WHERE refunded = 1 AND refunded_amount = 0
+  ```
+
+  Caveat: the backfill inherits the §8.5 inaccuracies (it uses `price_paid`, so
+  fees are excluded and balance-paid reservations are over-stated) — but for
+  *historical* rows the provider amount is not retrievable cheaply, so
+  `price_paid` is the best available estimate. The alternative is an explicit
+  "unknown" sentinel (e.g. leave a separate `refunded_amount_known` flag / use
+  `NULL`), but that complicates the `NOT NULL` column and every reader; the
+  pragmatic choice is the `price_paid` backfill **plus** the "approximate"
+  labelling from §8.5. Either way, **do not silently leave legacy rows at 0** —
+  that is the one option review explicitly flagged as wrong.
 - **Unpaid listings**: `refunded_amount` suppressed to 0 alongside `refunded`
   (the `paidListing` gate in `pii.ts`).
+- **Balance-paid reservations (§8.5 case 2)**: refunding the stored deposit
+  `payment_id` returns only the deposit, but `price_paid` was inflated by
+  `settleAttendeeBalance`. With option A, `refunded_amount` over-reports here;
+  option B (provider amount) records the true deposit refund. Call this out
+  wherever `refunded_amount` is shown if option A ships first.
 - **Free bookings** (`price_paid = 0`): refunding sets `refunded = 1`,
   `refunded_amount = 0` — correct (£0 refunded).
 - **Idempotency**: `= price_paid` (copy, not accumulate) keeps repeated

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -28,7 +28,15 @@ decisions simplified it a lot — see "What changed & why it's simpler" at the e
    (success/failure) — we are *commanding* the refund, not reading it back.
 
 Check-in behaviour is also decided (§12): a ticket is blocked from check-in once
-it is **fully** refunded (`refunded_amount >= price_paid`). The plan is now fully
+it is **fully** refunded (`refunded_amount >= price_paid`).
+
+One design decision remains, surfaced by review (§16): **how to scope a refund to
+the right payment** when an order has more than one (balance-paid reservations,
+or merged attendees). The amount/UI/migration are all specified; this is about
+*which provider payment* a refund hits. My recommendation is to **record the
+balance payment reference at settle-time** (so reservations refund correctly) and
+**block refunds on merged multi-payment attendees** until a per-line key exists —
+but it adds scope, so it's flagged rather than assumed. Everything else is fully
 specified.
 
 ---
@@ -66,9 +74,12 @@ Replaces today's "are you sure?" confirm page (`adminRefundAttendeePage` in
   attendee form), a row per booking line in the order:
   - listing name (label),
   - "Paid: £X.XX" (the line's `price_paid`),
-  - an amount input, `min=0`, `max=` the line's **remaining refundable**
-    (`price_paid − refunded_amount`; `= price_paid` on a first refund), prefilled
-    with that max.
+  - an amount input in **major currency units** (£/$, like every other admin money
+    field — see `parseMoneyMinor` in `attendee-form-model.ts`), `min=0`,
+    `max=` the line's **remaining refundable** shown in major units
+    (`(price_paid − refunded_amount) / 100`), prefilled with that max. The server
+    converts back to minor units on submit and re-clamps (never trust the
+    client). **Do not** render the raw minor-unit integer (review).
 - Confirm field (the existing name/identifier confirmation) + submit.
 
 Optionally, a status selector defaulting to a "Refunded" order status when one
@@ -79,15 +90,25 @@ operator can also change status on the normal edit form.
 
 `src/features/admin/attendee-refunds.ts`:
 
-1. Parse the form. If "whole order" is checked, the per-item amounts are each
-   line's remaining refundable; otherwise use the entered amounts (clamp each to
-   `0 … remaining refundable`, integers, minor units).
+0. **Load the whole order, not one row (review).** Today's refund handlers load a
+   single flattened attendee/listing row (`loadAttendeeForListing` /
+   `getListingWithAttendeeRaw`, `attendees-route-helpers.ts`). The form and the
+   POST both need **every** booking line of the order, so add an all-bookings
+   loader (the attendee's `listing_attendees` rows + listing names) used for
+   rendering *and* validation. Without it "refund the whole order" only sees the
+   URL listing's line.
+1. Parse the form. Convert each entered major-unit value to minor units
+   server-side and clamp to `0 … remaining refundable` per line (integers). If
+   "whole order" is checked, use each line's remaining refundable.
 2. `total = sum(per-item amounts)`. If `total === 0`, reject ("nothing to refund").
 3. Require a `payment_id` (the order's payment). `provider.refundPayment(payment_id,
-   total)` — **partial refund of `total`** (§3).
-4. On success, for each line with a non-zero amount, add it to that line's
-   `refunded_amount` (capped at `price_paid`), keyed to the exact row (§5). Log
-   the activity (per line or once for the order).
+   total, idempotencyKey)` — **partial refund of `total`** (§3), with a stable
+   idempotency key (§3, review) so a double-submit can't stack refunds.
+4. On success, write **all** per-line `refunded_amount` updates in **one batch /
+   transaction** (review): the provider has already moved the money, so the local
+   record must be all-or-nothing — never "provider refunded, only some rows
+   updated". Use `executeBatch` with one `recordLineRefund`-style statement per
+   non-zero line (§5). Log the activity.
 5. On failure, redirect with an error; record nothing.
 
 "Refund everything" therefore = each line refunded to its `price_paid`; a partial
@@ -101,24 +122,37 @@ listing to its `price_paid` (full refund per attendee), batched as today
 
 ---
 
-## 3. Provider layer — add partial refunds (small change)
+## 3. Provider layer — add partial refunds (+ idempotency)
 
-We are *telling* the provider what to refund, so the only change is an **optional
-amount**; the return stays a boolean. No return-shape churn, no reading amounts
-back, no caller sweep.
+We are *telling* the provider what to refund, so the return stays a boolean. No
+return-shape churn, no reading amounts back, no caller sweep. Two additions:
 
-- `PaymentProvider.refundPayment(ref: string, amount?: number): Promise<boolean>`
-  — `amount` omitted = full refund (today's behaviour, so existing callers like
-  the webhook auto-refund are untouched).
+- `PaymentProvider.refundPayment(ref: string, amount?: number, idempotencyKey?:
+  string): Promise<boolean>` — `amount` omitted = full refund (today's behaviour,
+  so existing callers like the webhook auto-refund are untouched).
 - **Stripe** (`src/shared/stripe.ts`): `s.refunds.create({ payment_intent: ref,
-  amount })` — `amount` is the partial-refund field; omit for full.
+  amount }, { idempotencyKey })` — `amount` is the partial-refund field; omit for
+  full.
 - **Square** (`src/shared/square.ts`): pass the chosen `amount` as
-  `amountMoney.amount` instead of the full payment amount it currently reads.
-- **SumUp** (`src/shared/sumup-provider.ts`): confirm partial-refund support;
-  if it is full-only, disable the per-item option for SumUp sites (offer only
-  "refund everything") rather than silently over-refunding.
+  `amountMoney.amount` (it currently reads the *full* payment amount), and pass
+  the caller's `idempotencyKey` **instead of the fresh `crypto.randomUUID()` it
+  generates per call** (`square.ts:624`) so retries dedupe.
+- **SumUp**: confirm partial-refund support. If it is full-only, the per-item UI
+  must be hidden **and the POST handler must reject any non-full SumUp refund**
+  server-side (review) — a stale/crafted POST otherwise refunds the whole
+  transaction (`sumup.ts` refunds in full) while storing only a partial
+  `refunded_amount`. Don't rely on hiding controls alone.
 
-`isPaymentRefunded` is unchanged (still boolean) — see the refresh path (§8c).
+**Idempotency / double-submit (review).** Partial amounts make a duplicate
+submission materially worse than today's full-refund retry: two concurrent £5
+POSTs could both succeed before either records `refunded_amount`, turning a £5
+refund into £10. Mitigate with a **stable per-refund idempotency key** (so the
+provider dedupes) plus a **local guard** — either a single-use form token, or
+reserve the `refunded_amount` rows (conditional UPDATE on the expected current
+value) *before* calling the provider so a racing second POST sees no remaining
+refundable. This must land **with** partial amounts, not after.
+
+`isPaymentRefunded` is unchanged (still boolean) — see the refresh path (§8).
 
 ---
 
@@ -232,6 +266,20 @@ check. Concretely:
   blocked when `refunded_amount >= price_paid` (and `price_paid > 0`). A helper
   like `isFullyRefunded(line)` keeps the rule in one place; partial refunds do
   **not** block.
+- **Check-in write path (review).** `updateCheckedIn`
+  (`attendees/update.ts:21`) writes by `(attendee_id, listing_id)` only, so for an
+  attendee booked on the same listing on two dates, checking in one date would
+  also flip the fully-refunded date. Carry `start_at` (or the row id) through the
+  token/scanner path and pin the UPDATE to the exact row — the same row-identity
+  fix as `recordLineRefund` (§5).
+- **Legacy baseline backfill (review).** `backfillListingAttendees` in
+  `src/shared/db/migrations/schema-sync.ts` (~`:236-259`) requires and inserts the
+  old `refunded_v2` shape when reconstructing `listing_attendees` from a very old
+  `attendees`-only database. Once `refunded` leaves the schema, that backfill must
+  stop writing it and map the old value to `refunded_amount` (or simply drop it —
+  a legacy refunded row can backfill `refunded_amount = price_paid`). Add
+  `schema-sync.ts` to the checklist so this legacy path isn't left writing a
+  dropped column.
 - **Merge** — `src/shared/merge/attendee-merge.ts`: `bookingInsertStatement` copies
   `refunded_amount` (and no longer `refunded`); the duplicate-detection compare in
   `buildBookingDiffItems` swaps `refunded` for `refunded_amount`.
@@ -339,15 +387,27 @@ still paid part of it).
 - **`recordLineRefund` unit (DB):** sets `refunded_amount`; caps at `price_paid`;
   adds on repeat (partial then more); **row identity** — same attendee+listing on
   two dates, refund one, assert only that row changes.
-- **Refund route:** "whole order" refunds every line to `price_paid` and calls
-  `refundPayment(ref, total)` with the right total; "per-item" stores the entered
-  amounts and refunds their sum; `total === 0` rejected; provider failure records
-  nothing. (Extend `test/lib/server-refunds.test.ts`; it already stubs
+- **Refund route — multi-line:** an order spanning two listings shows/records
+  **all** lines (not just the URL listing); "whole order" refunds every line to
+  `price_paid` and calls `refundPayment(ref, total)` with the right total;
+  "per-item" stores the entered amounts and refunds their sum; `total === 0`
+  rejected; provider failure records nothing. (Extend
+  `test/lib/server-refunds.test.ts`; it already stubs
   `stripePaymentProvider.refundPayment` — assert the `amount` arg now.)
+- **Units:** an operator entering `5.00` records `500` minor units (not `5`);
+  `max` reflects remaining refundable in major units.
+- **Idempotency / double-submit:** two identical partial-refund POSTs result in a
+  **single** refund (provider called once / deduped, `refunded_amount` not
+  stacked).
+- **Atomicity:** if a per-line write fails after provider success, the batch
+  rolls back (no partial local record). (Assert via a forced failure on one
+  statement.)
 - **Provider:** Stripe/Square `refundPayment(ref, amount)` issues a partial refund
-  with the right amount; omitted `amount` = full (existing tests).
+  with the right amount + idempotency key; omitted `amount` = full (existing
+  tests); a **non-full SumUp** refund POST is rejected server-side.
 - **Removal regression:** check-in blocks a **fully**-refunded line but allows a
-  **partially**-refunded one (§12); merge (moved line keeps amount); scanner
+  **partially**-refunded one (§12); check-in writes hit the right dated row
+  (same attendee+listing, two dates); merge (moved line keeps amount); scanner
   badge; CSV column; payment panel sum.
 - **`refund-all`:** every not-fully-refunded line goes to `price_paid`.
 - Run `deno task test:quality-audit` for the new tests.
@@ -369,15 +429,16 @@ Out of scope unless wanted.
 | `migrations/schema.ts` | drop `refunded`, add `refunded_amount` on `listing_attendees`; bump `LATEST_UPDATE` | ✅ |
 | `migrations/2026-06-21_attendee_refunded_amount.ts` | new migration: `recreateTable` + `syncTriggers` | ✅ |
 | `migrations.ts` | import + append to `MIGRATIONS` | ✅ |
+| `migrations/schema-sync.ts` | legacy `backfillListingAttendees`: stop writing `refunded`/`refunded_v2`, map to `refunded_amount` | ✅ |
 | `types.ts`, `attendee-types.ts` | `Attendee`/`ListingAttendeeRow`: −`refunded`, +`refunded_amount` | ✅ |
 | `attendees/queries.ts` | selects: −`refunded`, +`refunded_amount` (`EA_COLS`, left-join, by-tokens) | ✅ |
-| `attendees/update.ts` | replace `markRefunded` with `recordLineRefund` (single-row, capped) | ✅ |
+| `attendees/update.ts` | `markRefunded`→`recordLineRefund` (single-row, capped); `updateCheckedIn` gains `start_at` row identity | ✅ |
 | `attendees/pii.ts` | map `refunded_amount`; drop `refunded` | ✅ |
 | `attendees-edit.ts`, `attendees-merge.ts`, `atomic-update.ts` | loaders select `refunded_amount` | ✅ |
-| `attendee-refunds.ts` | new per-item form handler; redefine `getRefundable` | ✅ |
-| `payments.ts` + `stripe.ts`/`square.ts`/`sumup-provider.ts` (+providers) | `refundPayment(ref, amount?)` partial refund | ✅ |
-| `attendees.tsx` (refund form + `PaymentDetails` sum) | UI | ✅ |
-| `checkin.ts` (+ scanner) | move off boolean (per §12) | ✅ |
+| `attendee-refunds.ts` | per-item form handler; all-order loader; major→minor conversion; idempotency guard; atomic batch writes; redefine `getRefundable` | ✅ |
+| `payments.ts` + `stripe.ts`/`square.ts`/`sumup-provider.ts` (+providers) | `refundPayment(ref, amount?, idempotencyKey?)`; SumUp reject partial server-side | ✅ |
+| `attendees.tsx` (refund form, major-unit inputs + `PaymentDetails` sum) | UI | ✅ |
+| `checkin.ts` (+ scanner, token path) | move off boolean (§12); carry `start_at` to pin check-in writes | ✅ |
 | `merge/attendee-merge.ts` | carry `refunded_amount`; dedup compare | ✅ |
 | `attendee-form-model.ts` + `attendee-form.tsx` | `AttendeeBooking.refundedAmount`; per-line display | ✅ |
 | `attendee-columns.ts` / `scanner.tsx` | badge from `refunded_amount` | ✅ |
@@ -393,10 +454,27 @@ Out of scope unless wanted.
 - **Booking fees aren't refundable via this form.** `price_paid` is ticket-only,
   so the per-item cap excludes the fee. Refunding a fee is a manual provider
   action. Documented limitation, not a bug.
-- **Merged attendees with >1 original payment.** After a merge an attendee can
-  hold lines from different payments, but only one `payment_id` is stored.
-  Refunding more than that payment covered will be rejected by the provider. Rare;
-  flag in the activity log when a refund fails.
+- **Balance-paid reservations need the balance payment ref (review).**
+  `settleAttendeeBalance` folds the later balance payment into a line's
+  `price_paid` **without** updating `attendees.payment_id`
+  (`attendees/balance.ts:170-183`). So "refund the whole order" would try to
+  refund deposit+balance against the **deposit** payment id — the provider refunds
+  at most the deposit and the balance stays unrefundable from the app. **Must
+  handle, not just note:** either record the balance payment reference at
+  settle-time (so the refund can target both payments), or cap the refundable
+  total per payment, or disable the refund flow for settled reservations. Pick one
+  before building (recommend: store the balance payment ref alongside the deposit
+  so both can be refunded).
+- **Merged attendees with >1 original payment (review).** A merge can leave one
+  attendee holding lines paid by a *different*, discarded payment while only the
+  target's single `payment_id` is kept (`attendees-merge.ts:189-194`). The
+  per-item form could then refund a moved (source-paid) line against the target's
+  payment: if the amount fits the target payment's remaining balance the provider
+  *succeeds*, but `recordLineRefund` marks a line whose money came from another
+  payment — so the records no longer match the money returned. **Must handle:**
+  track a per-line/order payment key, or **block refunds on merged
+  multi-payment attendees** until one exists. (This is the same per-line-payment
+  gap as reservations; one marker solves both.)
 - **Repeated/incremental refunds** are supported: the input max is the *remaining*
   refundable and `recordLineRefund` adds-and-caps, so refunding £2 then £3 of a
   £10 line leaves `refunded_amount = 5`.
@@ -427,11 +505,20 @@ Out of scope unless wanted.
       accumulates on repeat — tested incl. the two-dates identity case.
 - [ ] `refundPayment(ref, amount?)` issues partial refunds on Stripe/Square;
       omitted `amount` = full; SumUp partial verified or per-item disabled for it.
-- [ ] Refund form: "whole order" (default) and per-item (0…remaining) both work;
-      total refunded at the provider matches; provider failure records nothing.
+- [ ] Refund form loads the **whole order** (all lines); "whole order" (default)
+      and per-item (0…remaining, **major-unit** inputs) both work; total refunded
+      at the provider matches; provider failure records nothing; per-line writes
+      are **atomic** (one batch after provider success).
+- [ ] **Idempotency:** a double-submit / concurrent partial refund cannot stack
+      (stable provider idempotency key + local reservation/single-use token).
+- [ ] **Per-line payment scoping decided** (§16): balance-paid reservations and
+      merged multi-payment attendees either refund the correct payment(s) or are
+      blocked — never silently mis-record. SumUp non-full refunds rejected
+      server-side.
 - [ ] `refunded` boolean fully removed; every former reader migrated
-      (check-in per §12, scanner, merge, form-model, templates, CSV, types,
-      selects).
+      (check-in per §12, scanner + `updateCheckedIn` row identity, merge,
+      form-model, templates, CSV, types, selects, legacy `schema-sync.ts`
+      backfill).
 - [ ] Payment panel shows the **summed** order refund; per-line amounts visible.
 - [ ] Tests added (§13); `deno task test:coverage` 100% & deterministic;
       `test:quality-audit` clean.
@@ -455,6 +542,8 @@ Your decisions removed three whole problem areas the earlier draft wrestled with
   label.
 
 What it *added*: removing the `refunded` boolean (a broad but mechanical refactor)
-and partial refunds at the provider (a small, additive change). Net: a clearer
+and partial refunds at the provider (a small, additive change — plus idempotency
+and atomic per-line writes, which partial amounts make necessary). Net: a clearer
 model — **state = order status, money = `refunded_amount` per item**, check-in
-blocks only fully-refunded lines — and no open questions remaining.
+blocks only fully-refunded lines. One residual decision remains: per-payment
+scoping for reservations / merged orders (§16) — recommendation given.

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -87,22 +87,23 @@ Key fact about the value to store: `provider.refundPayment()` returns a
 `PaymentProvider` interface throws it away. So the actual provider-refunded
 amount is *available at Stripe/Square* but *not* at the interface today.
 
-There are **two candidate values** for `refunded_amount`:
+**DECIDED — `refunded_amount` stores the provider's actual refunded amount
+(option B).** (Owner decision, 2026-06-21.) The alternative — recording the
+line's `price_paid` — was rejected because it is only the *ticket* portion and
+diverges from the money actually returned in three real configurations (booking
+fees, balance-paid reservations, multi-line orders; see **§8.5**). Option B is
+the one number correct in all of them: exactly the money the provider returned.
 
-- **(A) the line's `price_paid`** — zero interface churn, but it is only the
-  *ticket* portion and diverges from the money actually returned in three real
-  configurations (booking fees, balance-paid reservations, multi-line orders —
-  see **§8.5**, the accuracy section, which exists because of PR review
-  feedback).
-- **(B) the provider's actual refunded amount** — the true money moved, but it
-  requires widening the provider interface (§10).
+`price_paid` survives only as a **fallback**, used in two narrow places:
 
-Because the divergences in §8.5 are real and not rare, **the recommended source
-of truth is (B), the provider's actual amount, with (A) `price_paid` as the
-fallback** when a provider can't report an amount (SumUp) or for the historical
-backfill. Read §8.5 and §10 before locking this in — it is the single most
-important correctness decision in the feature, and it shifted from the original
-draft after review.
+- **SumUp**, whose API returns no refund amount (boolean only); and
+- the **historical backfill** (§18), where the provider amount is no longer
+  retrievable for already-refunded rows.
+
+The cost of option B is the interface work in **§10** (widen `refundPayment` and
+`isPaymentRefunded`, stop the lower Stripe/Square layers discarding the amount,
+and update every caller). Where the plan below still says "under option B", read
+it as "the chosen path"; "option A / fallback" means the two narrow cases above.
 
 ---
 
@@ -335,13 +336,12 @@ Notes:
   branches trip the duplication check, fold them into one parameterised
   statement builder.
 - The **signature is backward-compatible** (the `amount` param is optional), but
-  whether callers *change* depends on the §2 option:
-  - **Option A (fallback):** callers keep `markRefunded(id, listingId)` and get
-    `refunded_amount = price_paid` for free.
-  - **Option B (provider amount, recommended):** the refund routes
-    (`attendee-refunds.ts` single + bulk, and the refresh path — see §10) **must
-    pass the amount**: `markRefunded(id, listingId, providerAmount)`. Do not
-    assume callers are unchanged under option B (the §20 DoD reflects this).
+  with **option B chosen the refund routes do change** to pass the provider
+  amount: `attendee-refunds.ts` (single + bulk) and the refresh path (§10) call
+  `markRefunded(id, listingId, providerAmount)`. The no-amount form
+  (`refunded_amount = price_paid`) is reserved for the **fallback** cases only —
+  SumUp (no provider amount) and the historical backfill (§18). Do not assume
+  callers are unchanged (the §20 DoD reflects this).
 
 ---
 
@@ -452,27 +452,23 @@ Optional but nice for the multi-line case (where the flattened
    not introduced here — but `refunded_amount` makes the under-report visible in
    money terms.)
 
-**Implications for the design:**
+**Implications for the design (with option B decided):**
 
-- Cases 1 and 2 are why **option B (record the provider's actual amount, §10) is
-  the recommended source of truth.** The provider's refund response is the one
-  number that is correct in all three cases — it is exactly the money returned.
-- Case 3 needs a **write-fan-out** fix independent of which amount we store: when
+- Cases 1 and 2 are **resolved by the chosen option B**: the provider's refund
+  response is exactly the money returned, so fees are included and a deposit-only
+  refund records the deposit (not the inflated `price_paid`). This is why B was
+  chosen over `price_paid`.
+- Case 3 still needs a **write-fan-out**, independent of the amount source: when
   an order-level refund succeeds, mark every line that payment covered, not just
-  the operator's line. **Scoping that fan-out correctly is the open question** —
-  attendee-level `payment_id` is insufficient because a merge can leave one
-  attendee holding lines from several payments (see §10b). It likely needs a new
-  per-line payment/order marker, or the smaller-scope "accept + document"
-  choice. See §10b for the options and recommendation.
-- If we ship option A first anyway (e.g. to avoid provider churn), the plan must
-  **document `refunded_amount` as "ticket revenue refunded, fee-exclusive, and
-  approximate for balance-paid reservations"** in the column comment, the admin
-  UI, and the CSV header — so no one reads it as "total returned to the
-  customer".
-
-**Recommendation:** treat §8.5 as a gating decision. My recommendation is
-option B + the case-3 fan-out; if that is too much scope now, ship option A with
-the explicit "ticket-only / approximate" labelling and a follow-up issue for B.
+  the operator's line. **Scoping that fan-out correctly is the one remaining open
+  sub-decision** — attendee-level `payment_id` is insufficient because a merge
+  can leave one attendee holding lines from several payments (see §10b). It needs
+  either a new per-line payment/order marker or the smaller "accept + document"
+  choice (§10b).
+- The historical **backfill** (§18) still uses the `price_paid` fallback (the
+  provider amount isn't retrievable for old rows), so backfilled rows inherit the
+  fee/reservation inaccuracy. Label those as approximate (§18) — going forward,
+  newly-refunded rows carry the exact provider amount.
 
 ---
 
@@ -499,10 +495,11 @@ return shape would need updating).
 ## 10. Recording the *provider's actual* refunded amount + the multi-line fan-out
 
 This was "optional/deferred" in the first draft; PR review (§8.5) showed
-`price_paid` is wrong in common configurations, so it is now a **tracked
-decision**, not a nice-to-have.
+`price_paid` is wrong in common configurations, and the owner has now **chosen
+option B** — so §10a is **core required work**, not a nice-to-have. §10b (the
+multi-line fan-out scoping) remains the one open sub-decision.
 
-### 10a. Surface the provider amount (option B)
+### 10a. Surface the provider amount (option B — REQUIRED)
 
 Widen the provider interface so the real refunded amount reaches `markRefunded`.
 This is **two layers**, not just the provider wrapper:
@@ -602,10 +599,11 @@ decision (per-line marker vs. accept-and-document) before the fan-out is built.
 The `amount` parameter on `markRefunded` already accommodates a partial value;
 no schema change needed when partial-refund support arrives.
 
-**Recommendation:** do 10a + 10b together with the core feature — they are the
-difference between `refunded_amount` meaning "money returned" vs. "ticket
-revenue on one line". If scope must shrink, ship option A (§2) with the explicit
-"ticket-only/approximate" labelling from §8.5 and open a follow-up for 10a/10b.
+**Plan:** 10a is required (option B chosen) and ships with the core feature —
+it's the difference between `refunded_amount` meaning "money returned" vs. "ticket
+revenue on one line". 10b (the fan-out scoping) is the remaining open
+sub-decision; resolve it (per-line marker vs. accept-and-document) before
+building the fan-out, but 10a does not depend on it.
 
 ---
 
@@ -799,8 +797,8 @@ webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
 | `src/features/admin/attendees-merge.ts` | `loadAttendeeBookings` must SELECT `refunded_amount` (§5c) | ✅ (merge runs regardless) |
 | `src/shared/merge/attendee-merge.ts` | Insert copies `refunded_amount`; add to dedup compare under option B (§14) | ✅ (else merges zero it) |
 | `src/features/admin/attendees-csv.ts` + csv locale | Export column (label "ticket-only/approx" if option A — §8.5) | ⭕ recommended |
-| Provider layer (§10a): `*-provider.ts` + `square.ts` lower layer + `isPaymentRefunded` + all `refundPayment` callers (incl. `webhooks.ts`) | Record provider's **actual** refunded amount | 🔶 recommended for correctness (§8.5) |
-| Refund routes + maybe per-line payment marker (§10b) | Fan out an order-level refund across covered lines — **open design question** | 🔶 decision required (§8.5/§10b) |
+| Provider layer (§10a): `*-provider.ts` + `square.ts` lower layer + Stripe `retrievePaymentIntent` narrowing + `isPaymentRefunded` + all `refundPayment`/`isPaymentRefunded` callers (incl. `webhooks.ts`) | Record provider's **actual** refunded amount (option B) | ✅ (owner-chosen) |
+| Refund routes + maybe per-line payment marker (§10b) | Fan out an order-level refund across covered lines — **open sub-decision** | 🔶 decision required (§10b) |
 | `src/features/admin/attendee-form-model.ts` + `attendee-form.tsx` | Per-line amount in bookings table | ⭕ optional |
 | `src/shared/columns/attendee-columns.ts` | Amount in list status badge | ⭕ optional |
 | `src/shared/webhook.ts` (+docs, factory) (§16) | Webhook payload | ⭕ future |
@@ -839,13 +837,15 @@ explicitly. ⭕ = scope choices.
   (the `paidListing` gate in `pii.ts`).
 - **Balance-paid reservations (§8.5 case 2)**: refunding the stored deposit
   `payment_id` returns only the deposit, but `price_paid` was inflated by
-  `settleAttendeeBalance`. With option A, `refunded_amount` over-reports here;
-  option B (provider amount) records the true deposit refund. Call this out
-  wherever `refunded_amount` is shown if option A ships first.
+  `settleAttendeeBalance`. Option B (chosen) records the provider's true deposit
+  refund, so this is correct going forward; only the historical *backfill* (which
+  must use the `price_paid` fallback) over-states it — hence the "approximate"
+  labelling above.
 - **Free bookings** (`price_paid = 0`): refunding sets `refunded = 1`,
   `refunded_amount = 0` — correct (£0 refunded).
-- **Idempotency**: `= price_paid` (copy, not accumulate) keeps repeated
-  `markRefunded` calls stable. Tested in §15a.
+- **Idempotency**: the write **copies** the recorded amount (the provider amount,
+  or the `price_paid` fallback) rather than accumulating, so repeated
+  `markRefunded` calls are stable. Tested in §15a.
 - **Aggregates untouched**: confirm `listings.income` / capacity are unchanged
   by a refund (they already are; `refunded_amount` writes don't fire the
   aggregate trigger). A regression test asserting `income` is unaffected by a
@@ -871,21 +871,24 @@ explicitly. ⭕ = scope choices.
 - [ ] Migration applies on a populated DB; `verify()` passes; `SCHEMA_HASH`
       bumped; `LATEST_UPDATE` updated; legacy refunded rows backfilled (§18).
 - [ ] `markRefunded` sets `refunded` + `refunded_amount` atomically and
-      idempotently (copy semantics). **Under option B the refund routes pass the
-      provider amount** — callers change, the signature stays compatible (the
-      "unchanged callers" claim only holds for option A; see §6).
+      idempotently (copy semantics). The refund routes pass the **provider
+      amount** (option B); the optional `amount` param keeps the signature
+      compatible, but callers do change (see §6).
 - [ ] `Attendee.refunded_amount` populated through **every** read path (§5a–5e,
       including `attendees-merge.ts` and `atomic-update.ts` loaders); type checks.
 - [ ] Amount shown in the admin payment details panel.
-- [ ] (Recommended) merge loader+insert (§5c/§14) and CSV carry it.
-- [ ] **Amount source decided (§2/§8.5/§10):** option A (`price_paid`, with
-      "ticket-only/approximate" labelling) or option B (provider amount — widen
-      `refundPayment` *and* `isPaymentRefunded`, update Square's `square.ts`
-      lower layer, and all callers incl. `webhooks.ts` to read `.ok`).
+- [ ] Merge loader+insert (§5c/§14) and CSV carry it.
+- [ ] **Amount source = option B (decided):** widen `refundPayment` **and**
+      `isPaymentRefunded` across all 3 providers, stop the lower Stripe
+      (`retrievePaymentIntent` narrowing) and Square (`square.ts`) layers
+      discarding the amount, and update **every** caller — incl. `webhooks.ts`
+      auto-refund (`.ok`) and `tryRefund` (`.refunded`). `price_paid` remains the
+      fallback only for SumUp and the historical backfill.
 - [ ] **Multi-line fan-out decided (§10b):** per-line payment marker vs.
-      accept-and-document. (Open question — don't ship the fan-out without it.)
+      accept-and-document. (The one remaining open question — don't ship the
+      fan-out without it.)
 - [ ] Tests added per §15; `deno task test:coverage` is 100% and deterministic;
       `deno task test:quality-audit` clean for new tests.
 - [ ] `deno task precommit` (typecheck, `lint:ci`, tests, `cpd` at 0%) passes.
-- [ ] PR notes the webhook auto-refund caller (§9, must read `.ok` under option
-      B) and records the §8.5/§10b decisions.
+- [ ] PR notes the webhook auto-refund callers (§9 — `.ok`/`.refunded` under
+      option B) and records the §10b decision.

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -373,7 +373,17 @@ payment/refund fields are suppressed, so `refunded_amount` reads 0 there too.
 ### 8a. Payment details panel (primary surface) — `src/ui/templates/admin/attendees.tsx`
 
 In `PaymentDetails` (the read-only payment block on the attendee edit page),
-show the refunded amount next to the existing refund-status badge:
+show the refunded amount next to the existing refund-status badge.
+
+> **Multi-line caveat (review):** `attendee.refunded_amount` on this flattened
+> `Attendee` is **one booking line's** value — `getAttendeeRaw` is a `queryOne`
+> over a single `listing_attendees` row, not the order total. For an attendee
+> with several booking lines (and especially after the §10b fan-out), this panel
+> would **under-report** the total refund. Fix one of two ways: (a) sum
+> `refunded_amount` across the attendee's loaded booking rows for the headline
+> figure, or (b) move the amount into the per-line bookings table (§8d) so each
+> line shows its own. The headline "Amount Refunded" must be the **sum**, not a
+> single line.
 
 ```tsx
 <p>
@@ -572,12 +582,15 @@ There is currently **no per-line payment reference** (the `payment_id` lives
 attendee-level in the encrypted pii_blob), so the data needed to scope the
 fan-out correctly does not exist yet. Options, in rough order of correctness:
 
-- **(Best) Add a per-line payment/order marker.** Store the
-  payment reference (or an order/checkout id) on `listing_attendees` at creation,
-  so a refund can mark exactly the lines that share the refunded reference. This
-  is a second schema change — arguably the *right* foundation for refunds, but
-  larger scope; call it out as its own decision.
-- **Restrict refunds to order-level for un-merged attendees, and block/he-flag
+- **(Best) Add a per-line order marker — but NOT the raw payment reference
+  (review #3).** `listing_attendees` is a plaintext table that backups dump,
+  whereas the provider `payment_id` is deliberately kept in the *encrypted* PII
+  blob. Putting the raw reference here would leak it. Store a **non-sensitive
+  internal order/checkout id** (or an encrypted value with a blind index)
+  instead, captured at creation, so a refund can mark exactly the lines sharing
+  that order. This is a second schema change — arguably the *right* foundation
+  for refunds, but larger scope; call it out as its own decision.
+- **Restrict refunds to order-level for un-merged attendees, and block/flag
   refunds on merged attendees** until a per-line marker exists.
 - **Narrow predicate without new columns:** only fan out across lines that were
   not brought in by a merge — but there's no reliable flag for that today, so
@@ -586,10 +599,16 @@ fan-out correctly does not exist yet. Options, in rough order of correctness:
   the under-report, documented per §8.5 — the smallest scope, and honest if
   paired with the "approximate" labelling.
 
-Allocation (when a marker exists and option B is used): split the provider's
-returned total across the covered lines by `price_paid` weight using
-`allocateByLargestRemainder` (`checkout-pricing.ts`); under option A each covered
-line records its own `price_paid`.
+Allocation (when a marker exists): split the provider's returned total across the
+covered lines with `allocateByLargestRemainder` (`checkout-pricing.ts`) — **but
+not weighted by the current `price_paid` (review #2)**. For balance-paid
+reservations, `settleAttendeeBalance` folds the later balance payment into the
+earliest line's `price_paid`, so weighting by today's `price_paid` would shovel
+too much of the refund onto that line. The weight must be the **per-line amount
+that the refunded payment actually charged**, captured at checkout (the same
+per-line snapshot the order marker would carry) — not the mutated `price_paid`.
+This is another reason the per-line marker should record the charged amount, not
+just an id.
 
 **This is the one genuinely open design question in the feature** — it needs a
 decision (per-line marker vs. accept-and-document) before the fan-out is built.
@@ -827,20 +846,39 @@ explicitly. ⭕ = scope choices.
   Caveat: the backfill inherits the §8.5 inaccuracies (it uses `price_paid`, so
   fees are excluded and balance-paid reservations are over-stated) — but for
   *historical* rows the provider amount is not retrievable cheaply, so
-  `price_paid` is the best available estimate. The alternative is an explicit
-  "unknown" sentinel (e.g. leave a separate `refunded_amount_known` flag / use
-  `NULL`), but that complicates the `NOT NULL` column and every reader; the
-  pragmatic choice is the `price_paid` backfill **plus** the "approximate"
-  labelling from §8.5. Either way, **do not silently leave legacy rows at 0** —
-  that is the one option review explicitly flagged as wrong.
+  `price_paid` is the best available estimate. Either way, **do not silently
+  leave legacy rows at 0** — that is the one option review explicitly flagged as
+  wrong.
+- **Provenance — we can't tell exact from approximate rows (review).** Once the
+  column is just a number, three kinds of value are indistinguishable: provider-
+  exact (Stripe/Square new refunds), SumUp fallback (`price_paid`), and the
+  historical backfill (`price_paid`). If the UI/CSV shows a plain "Amount
+  Refunded", a fee/reservation backfill row looks as authoritative as an exact
+  one. Two ways to resolve, **decide explicitly**:
+  - **(a) Store provenance** — a small `refunded_amount_source` marker (e.g.
+    `'provider' | 'estimate'`) set when the row is written, so the UI can label
+    estimates and exact values differently. Cleanest; one extra small column.
+  - **(b) Label everything as approximate** — simplest, but loses the accuracy
+    win of option B for the rows that *are* exact.
+  Recommendation: (a) — it's cheap and preserves option B's value. (Note this is
+  a *different* flag from the abandoned `NOT NULL`/`NULL` "unknown" idea: the
+  amount stays a non-null integer; the marker only records how it was derived.)
 - **Unpaid listings**: `refunded_amount` suppressed to 0 alongside `refunded`
   (the `paidListing` gate in `pii.ts`).
-- **Balance-paid reservations (§8.5 case 2)**: refunding the stored deposit
-  `payment_id` returns only the deposit, but `price_paid` was inflated by
-  `settleAttendeeBalance`. Option B (chosen) records the provider's true deposit
-  refund, so this is correct going forward; only the historical *backfill* (which
-  must use the `price_paid` fallback) over-states it — hence the "approximate"
-  labelling above.
+- **Balance-paid reservations — the `refunded` *flag* is the real problem
+  (review).** Option B records the right *amount* (the provider's true deposit
+  refund), but `markRefunded` still sets `refunded = 1` on the line — and the
+  rest of the app reads that boolean as **fully refunded**: `checkin.ts:101`
+  filters out `!attendee.refunded` and shows "Cannot check in refunded tickets".
+  So refunding only the original deposit of a reservation whose balance was later
+  paid would record the correct (partial) amount **but wrongly mark the booking
+  fully refunded**, blocking check-in for someone who still paid most of the
+  order. Recording the amount accurately is *not* enough here. This path must
+  either be **excluded** (don't allow a deposit-only refund to flip `refunded`)
+  or modeled as a **partial refund** (a `refunded` state that means "partially
+  refunded, still valid" — i.e. the boolean is insufficient and may need to
+  become a status). **This is a real gap to resolve**, related to but separate
+  from the §10b fan-out; flag it as a decision, don't call it "correct".
 - **Free bookings** (`price_paid = 0`): refunding sets `refunded = 1`,
   `refunded_amount = 0` — correct (£0 refunded).
 - **Idempotency**: the write **copies** the recorded amount (the provider amount,
@@ -876,8 +914,16 @@ explicitly. ⭕ = scope choices.
       compatible, but callers do change (see §6).
 - [ ] `Attendee.refunded_amount` populated through **every** read path (§5a–5e,
       including `attendees-merge.ts` and `atomic-update.ts` loaders); type checks.
-- [ ] Amount shown in the admin payment details panel.
+- [ ] Amount shown in the admin payment details panel — as the **sum** across
+      the attendee's booking lines, not a single flattened row (§8a).
 - [ ] Merge loader+insert (§5c/§14) and CSV carry it.
+- [ ] **Provenance decided (§18):** add a `refunded_amount_source`
+      (provider/estimate) marker, or label all amounts approximate — so exact and
+      fallback rows aren't shown identically.
+- [ ] **Deposit-only / partial refunds decided (§18):** a deposit-only refund of
+      a balance-paid reservation must NOT flip the `refunded` boolean to "fully
+      refunded" (it blocks check-in — `checkin.ts:101`). Either exclude that path
+      or model partial refunds (the boolean may need to become a status).
 - [ ] **Amount source = option B (decided):** widen `refundPayment` **and**
       `isPaymentRefunded` across all 3 providers, stop the lower Stripe
       (`retrievePaymentIntent` narrowing) and Square (`square.ts`) layers

--- a/refunded_amount.md
+++ b/refunded_amount.md
@@ -1,0 +1,635 @@
+# Plan: track a `refunded_amount` for attendees
+
+Goal: record **how much money was refunded** for a booking, not just the
+boolean "was it refunded?" we store today. The amount is in **minor units**
+(pence/cents), matching every other money column in the system.
+
+---
+
+## 0. TL;DR / the one decision to make first
+
+The request says "add a `refunded_amount` column to **attendees**". The
+codebase reality is that the existing refund state does **not** live on the
+`attendees` table — it lives on **`listing_attendees`** (the per-booking-line
+join table):
+
+- `listing_attendees.refunded` — `INTEGER NOT NULL DEFAULT 0` (the 0/1 flag)
+- `listing_attendees.price_paid` — `INTEGER NOT NULL DEFAULT 0` (minor units paid for that line)
+- `markRefunded(attendeeId, listingId)` sets `refunded = 1` for **one line**
+
+The `Attendee` TypeScript type is a *flattened join* of one `attendees` row +
+one `listing_attendees` row, which is why `attendee.refunded` and
+`attendee.price_paid` *read* like attendee fields in the code even though they
+are physically per-line.
+
+**Recommendation: put `refunded_amount` on `listing_attendees`, mirroring
+`refunded` and `price_paid`.** Reasons:
+
+1. It sits next to the data it describes (`price_paid`, `refunded`) and is
+   written by the same code path (`markRefunded`).
+2. A refund is fundamentally per-line today (`markRefunded` takes
+   `listingId`). An attendee booked onto two listings can have one line
+   refunded and the other not.
+3. Per-line is strictly more granular — an attendee-level total is always
+   recoverable as `SUM(refunded_amount)` over the attendee's lines, but the
+   reverse is not true.
+4. It matches the project's "mirror the existing structure" preference
+   (AGENTS.md).
+
+The flattened `Attendee` type still gains a `refunded_amount` field, so from
+the route/template layer it still *looks* like "an attendee's refunded amount"
+— satisfying the spirit of the request.
+
+This plan is written for the **recommended (listing_attendees) approach**.
+§11 documents exactly what changes if we instead put it on `attendees`.
+
+> If you want the attendee-level design instead, say so and I'll re-issue the
+> plan around §11; everything else here still applies.
+
+---
+
+## 1. How money & refunds work today (context for reviewers)
+
+| Concept | Where it lives | Type | Notes |
+| --- | --- | --- | --- |
+| Amount paid for a booking line | `listing_attendees.price_paid` | `INTEGER` minor units | Trigger-summed into `listings.income`. |
+| Refunded? (per line) | `listing_attendees.refunded` | `INTEGER` 0/1 | Set by `markRefunded`. |
+| Payment reference | encrypted `attendees.pii_blob` (`pi`) | string | Surfaced as `attendee.payment_id` after decryption. |
+| Outstanding balance (order-level) | `attendees.remaining_balance` | `INTEGER` minor units | Reservations/part-payments. |
+
+Refund flow:
+
+- **Admin single refund** — `src/features/admin/attendee-refunds.ts`
+  (`handleAttendeeRefund`): calls `provider.refundPayment(payment_id)` then
+  `markRefunded(attendee.id, listingId)`.
+- **Admin bulk refund** — same file (`processRefundAll` → `refundOneAttendee`):
+  same two calls per refundable line.
+- **Refresh from provider** — `src/features/admin/attendees-edit.ts`
+  (`handleRefreshPayment`): polls `provider.isPaymentRefunded(...)` and, if the
+  provider says refunded, calls `markRefunded`.
+- **Webhook auto-refund** — `src/features/api/webhooks.ts:239`: refunds an
+  *untrusted/invalid* checkout **before any attendee/line exists**. There is no
+  row to attach an amount to, so this path is out of scope (see §9).
+
+`markRefunded` is the single DB write for all in-scope paths
+(`src/shared/db/attendees/update.ts`):
+
+```ts
+const setRefunded = updateListingAttendeeField("refunded");
+export const markRefunded = (attendeeId, listingId) =>
+  setRefunded(attendeeId, listingId, 1);
+```
+
+Key fact about the value to store: `provider.refundPayment()` returns a
+**boolean** (full refund only). The underlying Stripe call
+(`src/shared/stripe.ts:322`, `s.refunds.create(...)`) actually returns a
+`Stripe.Refund` carrying the real refunded `amount`, but the
+`PaymentProvider` interface throws it away. So the actual provider-refunded
+amount is *available at Stripe/Square* but *not* at the interface today (see
+the optional enhancement in §10). For v1 we record the line's `price_paid` as
+the refunded amount, which is correct for the full refunds we support.
+
+---
+
+## 2. Design decisions
+
+1. **Column**: `refunded_amount INTEGER NOT NULL DEFAULT 0` on
+   `listing_attendees`. Minor units, never null, defaults to 0 (so existing
+   rows and non-refunded rows read as 0 — "nothing refunded").
+2. **Value written**: when a line is marked refunded, set
+   `refunded_amount = price_paid` (what was paid for that line). Implemented as
+   a single atomic UPDATE inside `markRefunded` so it can never drift from the
+   `refunded` flag.
+3. **Idempotency**: re-running `markRefunded` is harmless — it re-sets
+   `refunded = 1, refunded_amount = price_paid`. (The routes already guard
+   against double-refunding at the provider via the `refunded` check.)
+4. **No trigger changes**. The `listings` aggregate triggers
+   (`LISTING_AGGREGATE_TRIGGERS`) are scoped to `OF quantity, price_paid,
+   listing_id`; writing `refunded_amount` won't fire them. This deliberately
+   preserves existing behaviour ("refunded rows still count" toward
+   capacity/income — refunds set a flag/amount, not `quantity`/`price_paid`).
+5. **Type**: integer minor units, formatted for display with
+   `formatCurrency()` (`src/shared/currency.ts`) exactly like `price_paid`.
+6. **Future partial refunds**: give `markRefunded` an optional `amount`
+   parameter defaulting to the line's `price_paid`. Today every caller uses the
+   default; partial-refund support later only needs to pass a value (and widen
+   the provider interface, §10). Documented, not built.
+
+---
+
+## 3. Schema & migration
+
+### 3a. Declarative schema — `src/shared/db/migrations/schema.ts`
+
+Add the column to the `listing_attendees` table definition, next to
+`price_paid`:
+
+```ts
+["price_paid", "INTEGER NOT NULL DEFAULT 0"],
+["refunded_amount", "INTEGER NOT NULL DEFAULT 0"], // minor units refunded for this line
+["attachment_downloads", "INTEGER NOT NULL DEFAULT 0"],
+```
+
+Update `LATEST_UPDATE` (append a clause describing the change), e.g.:
+
+> "…; add a refunded_amount column to listing_attendees recording the amount
+> (minor units) refunded for each booking line, set to the line's price_paid
+> when it is refunded."
+
+(`SCHEMA_HASH` recomputes automatically from the schema, so the version marker
+changes even if `LATEST_UPDATE` were forgotten — but update it anyway.)
+
+### 3b. Named migration file
+
+Create `src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts`
+(follow `2026-06-20_answer_active.ts`):
+
+```ts
+import { schemaMigration } from "./define.ts";
+
+export default schemaMigration(
+  "2026-06-21_attendee_refunded_amount",
+  "Add a refunded_amount column to listing_attendees recording how much " +
+    "(minor units) was refunded for each booking line",
+  {
+    columns: { listing_attendees: ["refunded_amount"] },
+  },
+);
+```
+
+`schemaMigration` runs `applySchemaChanges()` (ADD COLUMN for any missing
+schema column) and the generated `verify()` asserts the live table has
+`refunded_amount` (`verifyRequirement` → `assertLiveTableColumns`). A
+`NOT NULL DEFAULT 0` column is safe to `ADD COLUMN` onto a populated table.
+
+### 3c. Register the migration — `src/shared/db/migrations.ts`
+
+- Add the import alongside the others.
+- Append `attendeeRefundedAmountMigration` to the `MIGRATIONS` array (order
+  matters — append at the end).
+
+### 3d. Backup/restore
+
+No work needed. Per AGENTS.md, `backup.ts` dumps every column (schema-driven
+`SELECT *` via the `Table` helpers), so the new column round-trips
+automatically. Worth a one-line confirmation while testing (export → import →
+diff) but no code change.
+
+---
+
+## 4. Types
+
+### 4a. `src/shared/db/attendee-types.ts`
+
+Add to `ListingAttendeeRow` (used by token resolution, merge, refresh):
+
+```ts
+export type ListingAttendeeRow = {
+  ...
+  refunded: number;
+  price_paid: number;
+  refunded_amount: number; // minor units refunded for this line
+  attachment_downloads: number;
+};
+```
+
+### 4b. `src/shared/types.ts`
+
+Add to the flattened `Attendee` interface (keep it next to `refunded` /
+`price_paid`):
+
+```ts
+price_paid: string;       // existing (note: string on Attendee)
+refunded: boolean;        // existing
+refunded_amount: number;  // minor units refunded (0 when not refunded)
+```
+
+Note the asymmetry that already exists: `Attendee.price_paid` is a **string**
+(stringified in `decryptAttendeeFields`), while on the DB row it's a number.
+Keep `refunded_amount` a **number** (no decryption/stringify needed — it's a
+plaintext integer like `remaining_balance`). This is the simplest, least
+surprising choice.
+
+---
+
+## 5. Read paths (SELECTs)
+
+`refunded_amount` must be selected wherever `refunded`/`price_paid` are, so the
+flattened `Attendee`/`ListingAttendeeRow` carry it.
+
+### 5a. `src/shared/db/attendees/queries.ts`
+
+- `EA_COLS` (the per-line column list for joins): add `ea.refunded_amount`.
+- `ATTENDEE_LEFT_JOIN_SELECT`: add
+  `COALESCE(ea.refunded_amount, 0) as refunded_amount` (mirrors the other
+  COALESCE'd join columns so left-join misses read as 0).
+- `getAttendeesByTokens` — the explicit `listing_attendees` column list in
+  Query 2 and the `bookingsByAttendee` row mapping: add `refunded_amount`.
+
+### 5b. `src/features/admin/attendees-edit.ts`
+
+`loadRefreshContext` selects an explicit `listing_attendees` column list — add
+`refunded_amount` there too (keeps the `ListingAttendeeRow` shape complete).
+
+### 5c. Anywhere else selecting `listing_attendees` per-line columns
+
+Grep check: `rg "checked_in, refunded, price_paid"` and
+`rg "ea\\.refunded"` — update every explicit column list that already pulls
+`refunded`/`price_paid` to also pull `refunded_amount`. Known sites are 5a/5b;
+confirm none were missed.
+
+---
+
+## 6. Write path — `src/shared/db/attendees/update.ts`
+
+Change `markRefunded` so the same atomic UPDATE records the amount. The current
+generic `updateListingAttendeeField("refunded")` helper sets one constant
+column, so `markRefunded` needs its own statement (the helper stays for
+`setCheckedIn`):
+
+```ts
+const setCheckedIn = updateListingAttendeeField("checked_in");
+
+/**
+ * Mark a booking line refunded and record the refunded amount. The amount
+ * defaults to what was paid for the line (the only case we support today —
+ * full refunds via provider.refundPayment); a caller may pass a smaller
+ * amount once partial refunds are supported.
+ */
+export const markRefunded = async (
+  attendeeId: number,
+  listingId: number,
+  amount?: number,
+): Promise<void> => {
+  await execute(
+    amount === undefined
+      ? "UPDATE listing_attendees SET refunded = 1, refunded_amount = price_paid WHERE attendee_id = ? AND listing_id = ?"
+      : "UPDATE listing_attendees SET refunded = 1, refunded_amount = ? WHERE attendee_id = ? AND listing_id = ?",
+    amount === undefined
+      ? [attendeeId, listingId]
+      : [amount, attendeeId, listingId],
+  );
+};
+```
+
+Notes:
+- `refunded_amount = price_paid` copies the column in-SQL, so it always equals
+  exactly what was paid for that line — no read-then-write race.
+- No JSCPD concern: this is one helper, not duplicated logic. If the two
+  branches trip the duplication check, fold them into one parameterised
+  statement builder.
+- All existing callers (`attendee-refunds.ts` single + bulk,
+  `attendees-edit.ts` refresh) keep calling `markRefunded(id, listingId)`
+  unchanged and get `refunded_amount = price_paid` for free.
+
+---
+
+## 7. Decryption / row→Attendee mapping
+
+`src/shared/db/attendees/pii.ts` → `decryptAttendeeFields` builds the
+`Attendee` from a raw row. It already coerces `checked_in`, `price_paid`,
+`refunded`. Add `refunded_amount` so the field is always present and numeric:
+
+```ts
+return {
+  ...row,
+  ...pii,
+  checked_in: Boolean(row.checked_in),
+  price_paid: String(row.price_paid),
+  refunded: paidListing ? Boolean(row.refunded) : false,
+  refunded_amount: paidListing ? Number(row.refunded_amount ?? 0) : 0,
+  split_logistics_agents: Boolean(row.split_logistics_agents),
+};
+```
+
+Mirror the `paidListing` gating used for `refunded`: on an unpaid listing,
+payment/refund fields are suppressed, so `refunded_amount` reads 0 there too.
+
+---
+
+## 8. UI / display
+
+### 8a. Payment details panel (primary surface) — `src/ui/templates/admin/attendees.tsx`
+
+In `PaymentDetails` (the read-only payment block on the attendee edit page),
+show the refunded amount next to the existing refund-status badge:
+
+```tsx
+<p>
+  <strong>{t("admin.attendees.refund_status")}</strong>{" "}
+  {isRefunded ? (
+    <span class="badge-alert">{t("admin.attendees.refunded")}</span>
+  ) : (
+    t("admin.attendees.not_refunded")
+  )}
+</p>
+{isRefunded && attendee.refunded_amount > 0 && (
+  <p>
+    <strong>{t("admin.attendees.amount_refunded")}</strong>{" "}
+    {formatCurrency(attendee.refunded_amount)}
+  </p>
+)}
+```
+
+### 8b. Refund confirmation page — same file
+
+`adminRefundAttendeePage` warns "This will issue a full refund". Optionally
+show the exact amount that will be refunded (`attendee.price_paid`) so the
+operator sees it before confirming. Pure copy/markup change.
+
+### 8c. Attendee table status column — `src/shared/columns/attendee-columns.ts`
+
+The `status` column renders the refunded badge via `opts.renderStatus(row)`.
+Optional: when refunded, include the amount in the badge/title (e.g.
+`title="Refunded £5.00"`). Find `renderStatus` (it builds the check-in /
+refunded badge) and thread `refunded_amount` through if we want it on the list.
+Low priority.
+
+### 8d. Form-model booking summary — `src/features/admin/attendee-form-model.ts`
+
+`AttendeeBooking` + `attendeeBookingsFromLines` project a line into the
+read-only bookings table. If we want the per-line refunded amount in that table:
+
+- add `refundedAmount: number` to `AttendeeBooking`,
+- set `refundedAmount: booking.refunded_amount` in `attendeeBookingsFromLines`,
+- render it in the bookings table template (`attendee-form.tsx`).
+
+Optional but nice for the multi-line case (where the flattened
+`PaymentDetails` only reflects one line).
+
+---
+
+## 9. Webhook auto-refund path (explicitly out of scope)
+
+`src/features/api/webhooks.ts:239` refunds *untrusted/invalid* checkout
+sessions that never become an attendee. There is no `listing_attendees` row, so
+there is nothing to set `refunded_amount` on. No change. Call this out in the
+PR description so it isn't mistaken for a gap.
+
+(If we ever want to ledger those defensive refunds, that's a separate
+"refunds log" table, not this column.)
+
+---
+
+## 10. Optional enhancement: record the *provider's actual* refunded amount
+
+Today the recorded amount = the line's `price_paid`. That is exactly right for
+full refunds of single-line orders. Two cases where it can diverge from the
+true money moved:
+
+1. **Multi-line orders on one payment.** `provider.refundPayment(payment_id)`
+   refunds the *entire* Stripe/Square payment (all lines), but the single-refund
+   route marks only the one line the operator was on. So `refunded_amount` for
+   that line under-reports the actual refund. (This is a pre-existing modelling
+   quirk of `refunded` too, not introduced here.)
+2. **Partial refunds**, if ever supported.
+
+To record the real number we'd widen the provider interface:
+
+- `PaymentProvider.refundPayment(ref): Promise<boolean>` →
+  `Promise<{ ok: boolean; amount?: number }>` (or `number | null`).
+- Stripe already has it: `s.refunds.create(...)` returns `Stripe.Refund.amount`
+  (`src/shared/stripe.ts`). Square's refund response carries `amount_money`.
+  SumUp returns boolean only — fall back to `price_paid`.
+- Pass the returned amount into `markRefunded(id, listingId, amount)`.
+
+**Recommendation: defer.** It touches all three providers
+(`stripe-provider.ts`, `square-provider.ts`, `sumup-provider.ts`) and a large
+number of provider tests/stubs (see the ~100 `refundPayment` stub call sites in
+`test/`). v1 = `price_paid`, which is correct for the full-refund flows we
+actually ship. Add a TODO referencing this section. For the multi-line
+single-refund quirk, a cheaper interim fix is to mark **all** of the payment's
+lines refunded (loop the attendee's `listing_attendees` rows sharing that
+payment) — note as a follow-up, don't bundle it here.
+
+---
+
+## 11. Alternative: column on `attendees` (the literal request)
+
+If we instead put `refunded_amount` on the **`attendees`** table (order-level
+total refunded):
+
+- **Schema**: add `["refunded_amount", "INTEGER NOT NULL DEFAULT 0"]` to the
+  `attendees` table block; migration `requires.columns.attendees`.
+- **Semantics**: it becomes an order-level accumulator. `markRefunded` (which
+  is per-line) must `UPDATE attendees SET refunded_amount = refunded_amount +
+  (that line's price_paid) WHERE id = ?` — now a two-table write, and
+  **no longer idempotent** (re-running double-counts). You'd need a guard so a
+  line is only added once (e.g. only add when the line flips 0→1, which means
+  reading the line first or doing it in one conditional statement).
+- **Reads**: `ATTENDEE_COLS` in `queries.ts` (not `EA_COLS`) gains the column;
+  `getAttendeeBalanceState`-style selects can read it directly without a join.
+- **Type**: `Attendee.refunded_amount` (number), plus it would belong on
+  `AttendeeWithBookings` rather than `ListingAttendeeRow`.
+- **Merge**: when merging attendees you'd sum `refunded_amount` across the two
+  attendees rather than carrying it on the moved booking rows.
+- **Downside**: it fights the per-line `refunded` flag (you can have one line
+  refunded but a single attendee-level number), loses per-line granularity, and
+  makes the write non-idempotent. This is why §0 recommends `listing_attendees`.
+
+Everything else (UI, i18n, tests, currency formatting) is the same.
+
+---
+
+## 12. i18n
+
+Add one key (both the badge label and "Not refunded" already exist):
+
+- `src/locales/en/admin.json`: add
+  `"admin.attendees.amount_refunded": "Amount Refunded:"` (next to the existing
+  `admin.attendees.amount_paid` / `refund_status` keys).
+- Add the same key to any other locale files under `src/locales/*/admin.json`
+  if the project keeps locales in sync (check what exists; only `en` may be
+  present).
+
+No new keys are needed if §8 is limited to reusing existing labels, but a
+dedicated "Amount Refunded" label reads best.
+
+---
+
+## 13. CSV / export
+
+`src/features/admin/attendees-csv.ts` → `standardAttendeeColumns` currently has
+`price_paid` and `transaction_id` but **no refund column**. Add a refunded
+column so exports carry it:
+
+```ts
+{ header: t("csv.col.amount_refunded"), value: (a) => formatPrice(String(a.refunded_amount)) },
+```
+
+(Reuse the local `formatPrice` helper, which is `toMajorUnits(parseInt(...))`.)
+Add `csv.col.amount_refunded` to `src/locales/en/csv.json` (or wherever the
+`csv.col.*` keys live). This column is shared with the calendar export, so it
+appears there too — confirm that's desired; if not, add it only to the
+attendee-specific column block instead of `standardAttendeeColumns`.
+
+---
+
+## 14. Merge — `src/shared/merge/attendee-merge.ts`
+
+`bookingInsertStatement` copies a source booking line to the target; add
+`refunded_amount: booking.refunded_amount` to the `insert("listing_attendees",
+{...})` payload so a moved/replaced line keeps its refunded amount.
+
+Optionally include `refunded_amount` in the duplicate-detection comparison in
+`buildBookingDiffItems` (currently compares `quantity`, `price_paid`,
+`checked_in`, `refunded`). Since `refunded_amount` is derived from
+`price_paid`+`refunded`, two lines equal on those three will almost always be
+equal on `refunded_amount` too — adding it is harmless and precise but not
+strictly required. Include for completeness.
+
+---
+
+## 15. Tests
+
+Follow the existing patterns (BDD + `@std/expect`, helpers from `#test-utils`).
+100% coverage is required and must be **deterministic** (in-process unit tests,
+not just subprocess/e2e coverage — AGENTS.md).
+
+### 15a. DB write — new/extended unit test for `markRefunded`
+
+In a DB-backed test (see `test/lib/db/auto-cache-invalidation.test.ts` which
+already calls `markRefunded`):
+
+- Create a paid attendee/line with a known `price_paid` (e.g. 500).
+- Call `markRefunded(id, listingId)`.
+- Assert the `listing_attendees` row has `refunded = 1` **and**
+  `refunded_amount = 500` (read it back via a query).
+- Idempotency: call `markRefunded` again, assert `refunded_amount` is still 500
+  (not doubled) — this is the mutation-resistant assertion that proves
+  `= price_paid` (copy) vs `+= price_paid` (accumulate).
+- With the optional `amount` arg: `markRefunded(id, listingId, 200)` sets
+  `refunded_amount = 200`.
+
+### 15b. Route integration — extend `test/lib/server-refunds.test.ts`
+
+After a successful single refund (and after `refund-all`), assert the
+attendee's persisted `refunded_amount` equals the line's `price_paid`. The file
+already has `createPaidTestAttendee`, `submitRefund`, `submitRefundAll`, and a
+`stripePaymentProvider.refundPayment` stub — extend the success assertions to
+read the row back (or re-fetch via `getAttendeeRaw`/`getAttendeesByTokens`) and
+check `refunded_amount`.
+
+### 15c. Refresh-payment path — `test/lib/server-attendees.test.ts`
+
+The refresh-payment tests (around the `isPaymentRefunded` stubs) should assert
+`refunded_amount` is set when the provider reports a refund.
+
+### 15d. Decryption / type mapping
+
+A `decryptAttendeeFields` test (or wherever `pii.ts` is covered) asserting
+`refunded_amount` is numeric and 0 when unpaid (`paidListing = false`).
+
+### 15e. Display
+
+- `PaymentDetails` template test: refunded attendee with `refunded_amount > 0`
+  renders the formatted amount; non-refunded attendee does not.
+- If §8c/§8d are done, extend `test/lib/attendee-table.test.ts` /
+  `attendee-form-model.test.ts` accordingly.
+
+### 15f. CSV
+
+Extend the attendees-csv test to assert the new column header + a refunded
+attendee's formatted value.
+
+### 15g. Merge
+
+Extend `test/lib/attendee-merge.test.ts` to assert a moved booking line keeps
+its `refunded_amount`.
+
+### 15h. Factories — `test/test-utils/factories.ts`
+
+Add `refunded_amount: 0` to `testAttendee()` (the `Attendee` factory). Check
+`createPaidTestAttendee` / any `listing_attendees` insert helpers in
+`#test-utils` set the column (the DEFAULT 0 covers inserts that omit it).
+`WebhookAttendee` factory (`makeTestAttendee`) only needs it if §16 is done.
+
+---
+
+## 16. Webhook payload (optional)
+
+`src/shared/webhook.ts` builds the outbound `WebhookAttendee` (it already
+includes `price_paid` and `payment_id`, but **not** `refunded`). If consumers
+should see refunds, add `refunded_amount` (and probably `refunded`) to the
+webhook attendee type + builder + `makeTestAttendee` factory + webhook docs
+(`src/docs/webhooks.ts`). Out of scope unless explicitly wanted — flag it.
+
+---
+
+## 17. File-by-file checklist
+
+| File | Change | Required? |
+| --- | --- | --- |
+| `src/shared/db/migrations/schema.ts` | Add column to `listing_attendees`; update `LATEST_UPDATE` | ✅ |
+| `src/shared/db/migrations/2026-06-21_attendee_refunded_amount.ts` | New migration | ✅ |
+| `src/shared/db/migrations.ts` | Import + append to `MIGRATIONS` | ✅ |
+| `src/shared/db/attendee-types.ts` | `ListingAttendeeRow.refunded_amount` | ✅ |
+| `src/shared/types.ts` | `Attendee.refunded_amount` | ✅ |
+| `src/shared/db/attendees/queries.ts` | `EA_COLS`, `ATTENDEE_LEFT_JOIN_SELECT`, `getAttendeesByTokens` | ✅ |
+| `src/shared/db/attendees/update.ts` | `markRefunded` sets `refunded_amount = price_paid` | ✅ |
+| `src/shared/db/attendees/pii.ts` | Map `refunded_amount` in `decryptAttendeeFields` | ✅ |
+| `src/features/admin/attendees-edit.ts` | Add column to refresh-context select | ✅ |
+| `src/ui/templates/admin/attendees.tsx` | Show amount in `PaymentDetails` (+ refund confirm) | ✅ |
+| `src/locales/en/admin.json` | `admin.attendees.amount_refunded` | ✅ |
+| `test/test-utils/factories.ts` | `refunded_amount: 0` in `testAttendee` | ✅ |
+| Tests (§15) | New/extended coverage | ✅ |
+| `src/shared/merge/attendee-merge.ts` | Carry `refunded_amount` on moved lines | ⭕ recommended |
+| `src/features/admin/attendees-csv.ts` + csv locale | Export column | ⭕ recommended |
+| `src/features/admin/attendee-form-model.ts` + `attendee-form.tsx` | Per-line amount in bookings table | ⭕ optional |
+| `src/shared/columns/attendee-columns.ts` | Amount in list status badge | ⭕ optional |
+| Provider interface (§10) | Real provider refund amount | ⭕ future |
+| `src/shared/webhook.ts` (+docs, factory) (§16) | Webhook payload | ⭕ future |
+
+✅ = required for a correct, tested feature. ⭕ = scope choices.
+
+---
+
+## 18. Edge cases & invariants
+
+- **Non-refunded / legacy rows** read `refunded_amount = 0` (DEFAULT + COALESCE
+  on left joins). No backfill needed — historically refunded rows simply show 0
+  until re-refreshed, which is acceptable (we never recorded the amount before).
+  If a backfill is wanted, a one-off `UPDATE listing_attendees SET
+  refunded_amount = price_paid WHERE refunded = 1 AND refunded_amount = 0`
+  could run in the migration's `after()` hook — **decide explicitly**; default
+  is no backfill.
+- **Unpaid listings**: `refunded_amount` suppressed to 0 alongside `refunded`
+  (the `paidListing` gate in `pii.ts`).
+- **Free bookings** (`price_paid = 0`): refunding sets `refunded = 1`,
+  `refunded_amount = 0` — correct (£0 refunded).
+- **Idempotency**: `= price_paid` (copy, not accumulate) keeps repeated
+  `markRefunded` calls stable. Tested in §15a.
+- **Aggregates untouched**: confirm `listings.income` / capacity are unchanged
+  by a refund (they already are; `refunded_amount` writes don't fire the
+  aggregate trigger). A regression test asserting `income` is unaffected by a
+  refund is cheap insurance.
+
+---
+
+## 19. Rollout / safety
+
+1. Additive `NOT NULL DEFAULT 0` `ADD COLUMN` — safe online, no rewrite, no
+   downtime, no FK churn.
+2. Fresh DBs get it via `applySchemaChanges()` on first boot; existing DBs get
+   it via the named migration. The migration's generated `verify()` fails the
+   boot loudly if the column didn't apply.
+3. Reversible: dropping the column (if ever needed) only loses the recorded
+   amounts; the `refunded` flag is independent.
+4. Backups already round-trip new columns (§3d) — verify once in testing.
+
+---
+
+## 20. Definition of done
+
+- [ ] Migration applies on a populated DB; `verify()` passes; `SCHEMA_HASH`
+      bumped; `LATEST_UPDATE` updated.
+- [ ] `markRefunded` sets `refunded_amount = price_paid` atomically and
+      idempotently; all existing callers unchanged.
+- [ ] `Attendee.refunded_amount` populated through every read path; type checks.
+- [ ] Amount shown in the admin payment details panel.
+- [ ] (Recommended) merge + CSV carry it.
+- [ ] Tests added per §15; `deno task test:coverage` is 100% and deterministic;
+      `deno task test:quality-audit` clean for new tests.
+- [ ] `deno task precommit` (typecheck, `lint:ci`, tests, `cpd` at 0%) passes.
+- [ ] PR notes the out-of-scope webhook auto-refund path (§9) and the deferred
+      provider-amount enhancement (§10).


### PR DESCRIPTION
## Summary

Adds `refunded_amount.md`, a comprehensive implementation plan for tracking **how much money was refunded** for a booking (not just the existing boolean "was it refunded?").

This PR contains **only the plan document** — no code changes yet.

## Key findings the plan is built on

- The existing refund state (`refunded` flag + `price_paid` in minor units) lives on **`listing_attendees`** (the per-booking-line join table), **not** on `attendees`. The `Attendee` type is a flattened join, which is why `attendee.refunded` reads like an attendee field in code.
- `markRefunded(attendeeId, listingId)` is the single DB write for all in-scope refund paths (admin single + bulk refund, refresh-from-provider).
- `provider.refundPayment()` returns a **boolean** today (full refund only); the real refunded amount exists at Stripe/Square but is discarded at the interface.

## What the plan recommends

- **Put `refunded_amount` on `listing_attendees`** (mirroring `refunded`/`price_paid`) rather than `attendees`, with a full breakdown of the alternative if `attendees` is preferred (§11).
- `INTEGER NOT NULL DEFAULT 0` minor units; `markRefunded` sets `refunded_amount = price_paid` atomically and idempotently.
- Covers: declarative schema + named migration, type changes, every read path (SELECTs), the write path, decryption mapping, UI/templates, i18n, CSV export, attendee merge, a file-by-file checklist, a full testing plan (100% deterministic coverage), edge cases, rollout safety, and clearly-scoped optional/future work (provider-amount enhancement, webhook payload).

## Out of scope (noted in the plan)

- The webhook auto-refund path (refunds invalid checkouts before any booking row exists — nothing to attach an amount to).
- Widening the provider interface to record the provider's *actual* refunded amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8MBdhXkuLLcdqNhXPFDwC

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8MBdhXkuLLcdqNhXPFDwC)_