### PR TITLE
Render flash on save across admin pages; add follow-and-render redirect assertion

### DIFF
--- a/src/features/admin/attendee-refunds.ts
+++ b/src/features/admin/attendee-refunds.ts
@@ -49,7 +49,7 @@ const refundError = (
 /** Handle GET /admin/listing/:listingId/attendee/:attendeeId/refund */
 const handleAdminAttendeeRefundGet = attendeeGetRoute(
   (data, session, request) => {
-    applyFlash(request);
+    const flash = applyFlash(request);
     const returnUrl = getReturnUrl(request);
     if (!data.attendee.payment_id) {
       return htmlResponse(
@@ -74,7 +74,7 @@ const handleAdminAttendeeRefundGet = attendeeGetRoute(
       );
     }
     return htmlResponse(
-      adminRefundAttendeePage(data, session, undefined, returnUrl),
+      adminRefundAttendeePage(data, session, flash.error, returnUrl),
     );
   },
 );
@@ -128,7 +128,7 @@ const handleAdminRefundAllGet = (
   { id }: ListingRouteParams,
 ): Promise<Response> =>
   withListingAttendeesAuth(request, id, (listing, attendees, session) => {
-    applyFlash(request);
+    const flash = applyFlash(request);
     const count = getRefundable(attendees).length;
     return count === 0
       ? htmlResponse(
@@ -136,11 +136,19 @@ const handleAdminRefundAllGet = (
             listing,
             0,
             session,
-            t("error.no_attendees_to_refund"),
+            flash.error ?? t("error.no_attendees_to_refund"),
           ),
           400,
         )
-      : htmlResponse(adminRefundAllAttendeesPage(listing, count, session));
+      : htmlResponse(
+          adminRefundAllAttendeesPage(
+            listing,
+            count,
+            session,
+            flash.error,
+            flash.success,
+          ),
+        );
   });
 
 type RefundResult = "ok" | "failed" | "errored";

--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -75,6 +75,7 @@ import {
   getEmailConfig,
   sendBulkEmails,
 } from "#shared/email.ts";
+import type { Flash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { MAX_EMAIL_TEMPLATES } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
@@ -147,14 +148,20 @@ const saveDraft = async (
   await settings.update.bulkEmailDraft(encrypted);
 };
 
-/** Wrap an owner-only page builder: gate on owner, apply flash, then build. */
+/** Wrap an owner-only page builder: gate on owner, apply flash, then build.
+ * The flash is handed to the builder so the page can render it as a banner. */
 const ownerEmailPage =
-  (build: (request: Request, session: AuthSession) => Promise<Response>) =>
+  (
+    build: (
+      request: Request,
+      session: AuthSession,
+      flash: Flash,
+    ) => Promise<Response>,
+  ) =>
   (request: Request): Promise<Response> =>
-    requireOwnerOr(request, (session) => {
-      applyFlash(request);
-      return build(request, session);
-    });
+    requireOwnerOr(request, (session) =>
+      build(request, session, applyFlash(request)),
+    );
 
 /** Split recipients into those who'll be sent to and a skipped (unsubscribed) count. */
 const partitionRecipients = async (
@@ -186,7 +193,7 @@ const decryptTemplateSubjects = async (
 };
 
 /** GET /admin/emails — compose form. */
-const handleComposeGet = ownerEmailPage(async (request, session) => {
+const handleComposeGet = ownerEmailPage(async (request, session, flash) => {
   const params = new URL(request.url).searchParams;
   const target = await targetFromQuery(params);
   if (!target) return notFoundResponse();
@@ -227,9 +234,11 @@ const handleComposeGet = ownerEmailPage(async (request, session) => {
       copy: targetComposeCopy(target),
       disabledReason,
       draft,
+      error: flash.error,
       recipientCount: recipients.length,
       selectedTemplateId,
       single: targetIsSingleRecipient(target),
+      success: flash.success,
       targetLabel,
       templateLinkBase: `${COMPOSE_PATH}${targetQuery(target)}`,
       templates,
@@ -286,7 +295,7 @@ const handlePreviewPost = (request: Request): Promise<Response> =>
 /* jscpd:ignore-end */
 
 /** GET /admin/emails/preview — render the saved draft for confirmation. */
-const handlePreviewGet = ownerEmailPage(async (_request, session) => {
+const handlePreviewGet = ownerEmailPage(async (_request, session, flash) => {
   const privateKey = await requirePrivateKey(session);
   const draft = await parseSavedDraft(privateKey);
   if (!draft) return redirectResponse(COMPOSE_PATH);
@@ -308,6 +317,7 @@ const handlePreviewGet = ownerEmailPage(async (_request, session) => {
       contactSummary: contactFrequencySummary(counts),
       disabledReason,
       draft,
+      error: flash.error,
       mailtoLink: buildMailtoLink(
         sendable,
         draft.subject,
@@ -320,6 +330,7 @@ const handlePreviewGet = ownerEmailPage(async (_request, session) => {
       sendableCount: sendable.length,
       sendableEmails: sendable,
       skippedCount: skipped,
+      success: flash.success,
       targetLabel,
     }),
   );

--- a/src/features/admin/dashboard.ts
+++ b/src/features/admin/dashboard.ts
@@ -40,7 +40,7 @@ export const loginResponse = async (
 ): Promise<Response> => {
   const flash = applyFlash(request);
   await signCsrfToken();
-  return htmlResponse(adminLoginPage(flash.error), status);
+  return htmlResponse(adminLoginPage(flash.error, flash.success), status);
 };
 
 /** Maximum number of newest attendees to show on dashboard */

--- a/src/features/admin/groups.ts
+++ b/src/features/admin/groups.ts
@@ -189,7 +189,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
         phonePrefix = prefix;
       }
       const allowedDomain = getEffectiveDomain();
-      const successMessage = getFlash().success;
+      const flash = getFlash();
       const questionData = await loadAttendeeQuestionData(
         listingIds,
         attendees.map((a) => a.id),
@@ -205,8 +205,9 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
           session,
           allowedDomain,
           phonePrefix,
-          successMessage,
+          flash.success,
           questionData,
+          flash.error,
         ),
       );
     }),

--- a/src/features/admin/owner-crud.ts
+++ b/src/features/admin/owner-crud.ts
@@ -82,13 +82,15 @@ const createCrudHandlersWithAuth = <Row, Input>(
   const authHtml = authPage(auth.requireSession);
 
   const authRowHtml =
-    (render: (row: Row, session: AdminSession) => string): IdRouteHandler =>
+    (
+      render: (row: Row, session: AdminSession, error?: string) => string,
+    ): IdRouteHandler =>
     (request, { id }) =>
       auth.requireSession(request, (session) => {
-        applyFlash(request);
-        return withEntity<Row>((row) => htmlResponse(render(row, session)))(
-          () => cfg.resource.table.findById(id),
-        );
+        const flash = applyFlash(request);
+        return withEntity<Row>((row) =>
+          htmlResponse(render(row, session, flash.error)),
+        )(() => cfg.resource.table.findById(id));
       });
 
   const logAndRedirect = async (

--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -148,6 +148,7 @@ const handleQuestionsGet = ownerPage(async (session) => {
     flash.error,
     listingNames,
     allListings.length,
+    flash.success,
   );
 });
 
@@ -189,6 +190,7 @@ const handleQuestionGet = ownerGetById(
         answerCounts,
         allListings,
         new Set(assignedListingIds),
+        flash.success,
       ),
     );
   },
@@ -388,6 +390,7 @@ const handleEditAnswerGet = answerRoute(async (question, answer, session) => {
       aggregateRecalculation,
       modifiers,
       modifierId,
+      flash.success,
     ),
   );
 });

--- a/src/features/admin/users.ts
+++ b/src/features/admin/users.ts
@@ -206,7 +206,7 @@ const handleUserManageGet = ownerUserPage(async (user, session) => {
  * Handle GET /admin/user/new - show invite user form
  */
 const handleUserNewGet = ownerPage(async (session) =>
-  adminUserNewPage(session, await loadAssignableAgents()),
+  adminUserNewPage(session, await loadAssignableAgents(), getFlash().error),
 );
 
 /** Handle POST /admin/users - create invited user */
@@ -363,7 +363,8 @@ const userDelete = createConfirmedHandlers<DisplayUser>({
     id === session.userId
       ? usersErrorResponse(session, t("error.cannot_delete_self"), 400)
       : null,
-  render: (displayUser, session) => adminUserDeletePage(displayUser, session),
+  render: (displayUser, session, error) =>
+    adminUserDeletePage(displayUser, session, error),
   successMessage: t("success.user_deleted"),
   successRedirect: "/admin/users",
 });

--- a/src/features/csrf.ts
+++ b/src/features/csrf.ts
@@ -9,13 +9,9 @@ import {
   signCsrfToken,
   verifySignedCsrfToken,
 } from "#shared/csrf.ts";
-import { type Flash, getFlash } from "#shared/flash-context.ts";
+import { type Flash, getFlash, setFlashFormId } from "#shared/flash-context.ts";
 import { FormParams } from "#shared/form-data.ts";
-import {
-  setFormError,
-  setFormSuccess,
-  setSavedFormData,
-} from "#shared/forms.tsx";
+import { setSavedFormData } from "#shared/forms.tsx";
 import { validateMessageText } from "#shared/inbound-message.ts";
 
 export { FormParams } from "#shared/form-data.ts";
@@ -102,16 +98,12 @@ export const withCsrfForm = async (
 };
 
 /**
- * Apply flash message from cookie to form stores for the current request.
- * Call before rendering any page that displays form messages.
- * Reads the flash cookie (set by a previous redirect) and populates the
- * per-request success/error stores so CsrfForm can display them.
- * Returns the flash object for callers that need additional logic.
+ * Record the form a redirect targeted (`?form=`) so a matching CsrfForm renders
+ * the flash inline, and return the flash for callers that need it. The flash
+ * itself is already in the request context (set by middleware) and is rendered
+ * by the Layout backstop or the targeted form — handlers no longer thread it.
  */
 export const applyFlash = (request: Request): Flash => {
-  const flash = getFlash();
-  const formId = getSearchParam(request, "form");
-  if (flash.success) setFormSuccess(formId, flash.success);
-  if (flash.error) setFormError(formId, flash.error);
-  return flash;
+  setFlashFormId(getSearchParam(request, "form"));
+  return getFlash();
 };

--- a/src/shared/flash-context.ts
+++ b/src/shared/flash-context.ts
@@ -20,11 +20,40 @@ export type Flash = {
   formToken?: string;
 };
 
-const flashStore = new AsyncLocalStorage<Flash>();
+/**
+ * Internal store shape: the flash message plus two render-coordination fields.
+ * `formId` is the form a redirect targeted (`?form=`), so a matching CsrfForm
+ * renders the flash inline; `consumed` is set once any component has rendered
+ * it, so the Layout backstop doesn't render it a second time.
+ */
+type FlashStore = Flash & { formId?: string; consumed?: boolean };
+
+const flashStore = new AsyncLocalStorage<FlashStore>();
 
 /** Run a function within a flash context scope */
 export const runWithFlashContext = <T>(fn: () => T): T =>
   flashStore.run({}, fn);
+
+/** Record which form a redirect targeted, so the matching CsrfForm renders the
+ *  flash inline rather than the Layout rendering it at the top of the page. */
+export const setFlashFormId = (formId: string | null): void => {
+  const store = flashStore.getStore();
+  if (store && formId) store.formId = formId;
+};
+
+/** The form a redirect targeted, or undefined when the flash isn't form-scoped. */
+export const getFlashFormId = (): string | undefined =>
+  flashStore.getStore()?.formId;
+
+/** Mark the flash as rendered, so the Layout backstop won't render it again. */
+export const consumeFlash = (): void => {
+  const store = flashStore.getStore();
+  if (store) store.consumed = true;
+};
+
+/** Whether the flash has already been rendered this request. */
+export const flashConsumed = (): boolean =>
+  flashStore.getStore()?.consumed === true;
 
 /** Set the flash context for the current request (called by middleware) */
 export const setFlashContext = (flash: Flash): void => {

--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -5,6 +5,12 @@
 import { joinStrings, map, pipe } from "#fp";
 import { type Child, Raw } from "#jsx/jsx-runtime.ts";
 import { getCurrentCsrfToken } from "#shared/csrf.ts";
+import {
+  consumeFlash,
+  flashConsumed,
+  getFlash,
+  getFlashFormId,
+} from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { appendIframeParam } from "#shared/iframe.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
@@ -485,6 +491,11 @@ export const defineForm = <
 /**
  * Flash message component for error/success notifications.
  * Renders divs with role="alert" so screen readers announce them.
+ *
+ * Rendering any banner marks the request's flash as consumed, so the Layout
+ * backstop (which renders the context flash on every page) won't render it a
+ * second time. This is what lets a page render its flash inline — or not at all
+ * — without ever double-rendering or dropping it.
  */
 export const Flash = ({
   error,
@@ -494,25 +505,28 @@ export const Flash = ({
   error?: string;
   success?: string;
   info?: string;
-}): JSX.Element => (
-  <>
-    {success ? (
-      <div class="success" role="alert">
-        {success}
-      </div>
-    ) : null}
-    {info ? (
-      <div class="info" role="alert">
-        {info}
-      </div>
-    ) : null}
-    {error ? (
-      <div class="error" role="alert">
-        {error}
-      </div>
-    ) : null}
-  </>
-);
+}): JSX.Element => {
+  if (error || success || info) consumeFlash();
+  return (
+    <>
+      {success ? (
+        <div class="success" role="alert">
+          {success}
+        </div>
+      ) : null}
+      {info ? (
+        <div class="info" role="alert">
+          {info}
+        </div>
+      ) : null}
+      {error ? (
+        <div class="error" role="alert">
+          {error}
+        </div>
+      ) : null}
+    </>
+  );
+};
 
 /**
  * Render error message if present
@@ -586,24 +600,6 @@ const getSavedValue = (field: Field): string => {
   return _savedFormData.form.getString(field.name);
 };
 
-/** Per-request success state, readable synchronously by CsrfForm */
-const _successStore = { formId: "", message: "" };
-
-/** Set the success state for the current request (call before rendering) */
-export const setFormSuccess = (formId: string, message = ""): void => {
-  _successStore.formId = formId;
-  _successStore.message = message;
-};
-
-/** Per-request error state, readable synchronously by CsrfForm */
-const _errorStore = { formId: "", message: "" };
-
-/** Set the error state for the current request (call before rendering) */
-export const setFormError = (formId: string, message: string): void => {
-  _errorStore.formId = formId;
-  _errorStore.message = message;
-};
-
 /**
  * Form component that always includes CSRF token.
  * Renders a POST form with a hidden csrf_token input.
@@ -611,7 +607,11 @@ export const setFormError = (formId: string, message: string): void => {
  * which is always called before rendering begins.
  * Supports extra attributes like class and enctype for multipart forms.
  * When `id` is provided, the form gets an id attribute (also usable as an anchor).
- * Shows a success or error message when the form's id matches the current state.
+ *
+ * When a redirect targeted this form (its `id` matches the flash's `?form=`),
+ * the form renders the flash inline — keeping the message next to the form that
+ * was submitted on multi-form pages — and marks it consumed so the Layout
+ * backstop doesn't also render it at the top.
  */
 export const CsrfForm = ({
   action,
@@ -634,11 +634,8 @@ export const CsrfForm = ({
     {...rest}
   >
     <input name="csrf_token" type="hidden" value={getCurrentCsrfToken()} />
-    {rest.id && rest.id === _successStore.formId && (
-      <Flash success={_successStore.message} />
-    )}
-    {rest.id && rest.id === _errorStore.formId && (
-      <Flash error={_errorStore.message} />
+    {rest.id && rest.id === getFlashFormId() && !flashConsumed() && (
+      <Flash error={getFlash().error} success={getFlash().success} />
     )}
     {children}
   </form>

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -138,11 +138,12 @@ export const adminRefundAllAttendeesPage = (
   refundableCount: number,
   session: AdminSession,
   error?: string,
+  success?: string,
 ): string =>
   String(
     <Layout title={`Refund All: ${listing.name}`}>
       <AdminNav active="/admin/" session={session} />
-      <Flash error={error} />
+      <Flash error={error} success={success} />
 
       <ConfirmForm
         action={`/admin/listing/${listing.id}/refund-all`}

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -25,6 +25,9 @@ const NAV_ACTIVE = "/admin/settings";
 const EMAIL_SETTINGS_LINK = "/admin/settings-advanced#settings-email";
 
 export type BulkEmailComposeState = {
+  /** Flash messages surfaced after a redirect back to the compose form. */
+  error?: string;
+  success?: string;
   /** How to render the recipient control (spec-driven: selector or fixed). */
   control: ComposeControl;
   /** Heading + intro for this kind of target (spec-driven). */
@@ -108,7 +111,7 @@ export const bulkEmailComposePage = (
     <Layout title={copy.heading}>
       <AdminNav active={NAV_ACTIVE} session={session} />
       <SettingsSubNav />
-      <Flash />
+      <Flash error={state.error} success={state.success} />
 
       <div class="prose">
         <h1>{copy.heading}</h1>
@@ -282,6 +285,9 @@ export const bulkEmailTemplateDeletePage = (
   );
 
 export type BulkEmailPreviewState = {
+  /** Flash messages surfaced after a redirect to the preview page. */
+  error?: string;
+  success?: string;
   draft: BulkEmailDraft;
   /** Human label for the target: audience label or listing name. */
   targetLabel: string;
@@ -329,7 +335,7 @@ export const bulkEmailPreviewPage = (
     <Layout title={t("bulk_email.preview_page_title")}>
       <AdminNav active={NAV_ACTIVE} session={session} />
       <SettingsSubNav />
-      <Flash />
+      <Flash error={state.error} success={state.success} />
 
       <div class="prose">
         <h1>{t("bulk_email.preview_page_title")}</h1>

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -309,6 +309,7 @@ export const adminGroupDetailPage = (
   phonePrefix?: string,
   successMessage?: string,
   questionData?: TableQuestionData,
+  error?: string,
 ): string => {
   const { columnKeys, filters } = resolveColumnLayout(
     settings.listingColumnOrder,
@@ -343,7 +344,7 @@ export const adminGroupDetailPage = (
   return String(
     <Layout title={group.name}>
       <AdminNav active="/admin/groups" session={session} />
-      <Flash success={successMessage} />
+      <Flash error={error} success={successMessage} />
       <nav>
         <ul>
           {!isReadOnly() && (

--- a/src/ui/templates/admin/login.tsx
+++ b/src/ui/templates/admin/login.tsx
@@ -13,10 +13,10 @@ import { Layout } from "#templates/layout.tsx";
 /**
  * Admin login page
  */
-export const adminLoginPage = (error?: string): string =>
+export const adminLoginPage = (error?: string, success?: string): string =>
   String(
     <Layout title={t("login.title")}>
-      <Flash error={error} />
+      <Flash error={error} success={success} />
       <CsrfForm action="/admin/login">
         <Raw html={renderFields(getLoginFields())} />
         <SubmitButton icon="log-in">{t("login.submit")}</SubmitButton>

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -87,6 +87,7 @@ export const adminQuestionsPage = (
   error?: string,
   listingNames: Map<number, string[]> = new Map(),
   totalListings = 0,
+  success?: string,
 ): string =>
   String(
     <Layout title={t("questions.title")}>
@@ -96,7 +97,7 @@ export const adminQuestionsPage = (
       <p class="actions">
         <GuideLink href="/admin/guide#questions">Questions guide</GuideLink>
       </p>
-      <Flash error={error} />
+      <Flash error={error} success={success} />
 
       <CsrfForm action="/admin/questions" id="new-question">
         <Raw html={questionTextForm.render()} />
@@ -154,6 +155,7 @@ export const adminQuestionPage = (
   answerCounts?: Map<number, number>,
   allListings: ListingWithCount[] = [],
   assignedListingIds: Set<number> = new Set(),
+  success?: string,
 ): string =>
   String(
     <Layout title={`Question: ${question.text}`}>
@@ -161,7 +163,7 @@ export const adminQuestionPage = (
       <SettingsSubNav />
 
       <h1>{question.text}</h1>
-      <Flash error={error} />
+      <Flash error={error} success={success} />
 
       <CsrfForm action={`/admin/questions/${question.id}/edit`}>
         <Raw html={questionTextForm.field("text").render(question.text)} />
@@ -371,6 +373,7 @@ export const adminAnswerEditPage = (
   aggregateRecalculation: AnswerAggregateRecalculation,
   modifiers: AnswerModifierOption[],
   modifierId: number | null,
+  success?: string,
 ): string =>
   String(
     <Layout title={t("questions.edit_answer.title")}>
@@ -389,7 +392,7 @@ export const adminAnswerEditPage = (
           {t("questions.edit_answer.question_context", { text: question.text })}
         </small>
       </p>
-      <Flash error={error} />
+      <Flash error={error} success={success} />
 
       <CsrfForm
         action={`/admin/questions/${question.id}/answers/${answer.id}/edit`}

--- a/src/ui/templates/layout.tsx
+++ b/src/ui/templates/layout.tsx
@@ -10,6 +10,8 @@ import {
 } from "#shared/asset-paths.ts";
 import { settings } from "#shared/db/settings.ts";
 import { DEMO_BANNER, isDemoMode } from "#shared/demo.ts";
+import { flashConsumed, getFlash } from "#shared/flash-context.ts";
+import { Flash } from "#shared/forms.tsx";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import type { Theme } from "#shared/types.ts";
 import { renderAdminFooter } from "#templates/admin/footer.tsx";
@@ -67,6 +69,19 @@ export const Layout = ({
                 alt=""
                 class="header-image"
                 src={getImageProxyUrl(headerImage)}
+              />
+            )}
+            {/* Backstop: render the request's flash here unless the page already
+                did (a targeted CsrfForm or an inline banner marked it consumed).
+                Evaluated after `children`, so the consumed flag is already set.
+                This is why no page needs to thread flash.success/error to be
+                shown — placing it once, structurally, removes the whole class of
+                "handler set the cookie but the page dropped it" bug. */}
+            {!flashConsumed() && (
+              <Flash
+                error={getFlash().error}
+                info={getFlash().info}
+                success={getFlash().success}
               />
             )}
             {children}

--- a/test/admin-built-sites-actions.test.ts
+++ b/test/admin-built-sites-actions.test.ts
@@ -17,7 +17,7 @@ import {
   createTestBuiltSite,
   createTestListing,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   provisionTestBuiltSite,
   testCookie,
 } from "#test-utils";
@@ -56,7 +56,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/rotate-renewal-token`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Renewal token rotated",
       )(response);
@@ -85,7 +85,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/rotate-renewal-token`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Renewal is not provisioned for this site",
         false,
@@ -244,7 +244,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
           `/admin/built-sites/${site.id}/bump-deadline`,
           { months: "1" },
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/built-sites/${site.id}/edit`,
           expect.stringContaining("could not be pushed"),
           false,
@@ -325,7 +325,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/override-deadline`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Choose a deadline date",
         false,
@@ -348,7 +348,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
         `/admin/built-sites/${site.id}/override-deadline`,
         { date: "2027-02-31" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Choose a valid deadline date",
         false,
@@ -372,7 +372,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
         `/admin/built-sites/${site.id}/override-deadline`,
         { date: "hello" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Choose a valid deadline date",
         false,
@@ -403,7 +403,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/re-sync-deadline`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Deadline re-synced",
       )(response);
@@ -450,7 +450,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/re-sync-deadline`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "No deadline to re-sync",
         false,
@@ -501,7 +501,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
         `/admin/built-sites/${site.id}/provision-renewal`,
         { months: "3" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Create a qualifying renewal tier listing before provisioning",
         false,
@@ -528,7 +528,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
         `/admin/built-sites/${site.id}/provision-renewal`,
         { months: "3" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         "Renewal is already provisioned for this site",
         false,
@@ -557,7 +557,7 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
           `/admin/built-sites/${site.id}/provision-renewal`,
           { months: "3" },
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/built-sites/${site.id}/edit`,
           "Renewal could not be pushed to the site",
           false,
@@ -643,7 +643,7 @@ describeWithEnv(
         const { response } = await adminFormPost(
           `/admin/built-sites/${site.id}/add-secrets`,
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/built-sites/${site.id}/edit`,
           expect.stringContaining("missing secret(s)"),
         )(response);
@@ -679,7 +679,7 @@ describeWithEnv(
         const { response } = await adminFormPost(
           `/admin/built-sites/${site.id}/add-secrets`,
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/built-sites/${site.id}/edit`,
           "Set 1 missing secret(s): NTFY_URL",
         )(response);
@@ -703,7 +703,7 @@ describeWithEnv(
         const { response } = await adminFormPost(
           `/admin/built-sites/${site.id}/add-secrets`,
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/built-sites/${site.id}/edit`,
           "No missing secrets — nothing to set",
         )(response);
@@ -728,7 +728,7 @@ describeWithEnv(
         const { response } = await adminFormPost(
           `/admin/built-sites/${site.id}/add-secrets`,
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/built-sites/${site.id}/edit`,
           expect.stringContaining("Secrets could not be set"),
           false,

--- a/test/e2e/duration-days.test.ts
+++ b/test/e2e/duration-days.test.ts
@@ -34,7 +34,7 @@ import {
   createTestGroup,
   createTestHoliday,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   makeTestEntry,
   mockFormRequest,
   rawListingRange,
@@ -837,7 +837,7 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
         `/admin/listing/${listingA.id}/edit`,
         dailyEditForm(listingA, 2, group.id),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listingA.id}`,
         "Listing updated Warning: group capacity exceeded on 2026-10-02",
       )(response);
@@ -866,7 +866,7 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
         `/admin/listing/${listing.id}/edit`,
         dailyEditForm(listing, 2),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -923,7 +923,7 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
           thank_you_url: "https://example.com",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);

--- a/test/integration/theme.test.ts
+++ b/test/integration/theme.test.ts
@@ -6,7 +6,7 @@ import {
   adminFormPost,
   adminGet,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   mockRequest,
 } from "#test-utils";
 
@@ -21,7 +21,7 @@ describeWithEnv("integration: theme settings", { db: true }, () => {
     const { response } = await adminFormPost("/admin/settings/theme", {
       theme: "dark",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings?form=settings-theme#settings-theme",
       "Theme set to dark",
     )(response);

--- a/test/lib/forms/flash.test.ts
+++ b/test/lib/forms/flash.test.ts
@@ -2,15 +2,27 @@ import { expect } from "@std/expect";
 import { afterEach, beforeAll, describe, it as test } from "@std/testing/bdd";
 import { getCurrentCsrfToken, signCsrfToken } from "#shared/csrf.ts";
 import {
-  CsrfForm,
-  Flash,
-  renderError,
-  renderSuccess,
-  setFormError,
-  setFormSuccess,
-} from "#shared/forms.tsx";
+  type Flash as FlashMessage,
+  runWithFlashContext,
+  setFlashContext,
+  setFlashFormId,
+} from "#shared/flash-context.ts";
+import { CsrfForm, Flash, renderError, renderSuccess } from "#shared/forms.tsx";
 import { detectIframeMode } from "#shared/iframe.ts";
 import { hasInputWithValue, setupTestEncryptionKey } from "#test-utils";
+
+/** Render a CsrfForm inside a flash context targeting `formId`, so the form's
+ *  inline-flash branch (id === target form) can be exercised. */
+const csrfFormInFlash = (
+  props: { action: string; id?: string },
+  flash: FlashMessage,
+  formId: string | null,
+): string =>
+  runWithFlashContext(() => {
+    setFlashContext(flash);
+    setFlashFormId(formId);
+    return String(CsrfForm(props));
+  });
 
 beforeAll(async () => {
   setupTestEncryptionKey();
@@ -97,8 +109,6 @@ describe("Flash", () => {
 
 describe("CsrfForm", () => {
   afterEach(() => {
-    setFormSuccess("", "");
-    setFormError("", "");
     detectIframeMode("https://example.com/");
   });
 
@@ -140,38 +150,49 @@ describe("CsrfForm", () => {
     expect(html).toContain("Submit here");
   });
 
-  test("shows success flash when id matches stored success state", () => {
-    setFormSuccess("my-form", "Saved");
-    const html = String(CsrfForm({ action: "/submit", id: "my-form" }));
+  test("shows success flash when id matches the targeted form", () => {
+    const html = csrfFormInFlash(
+      { action: "/submit", id: "my-form" },
+      { success: "Saved" },
+      "my-form",
+    );
     expect(html).toContain("Saved");
     expect(html).toContain('class="success"');
   });
 
   test("does not show success when id does not match", () => {
-    setFormSuccess("other-form", "Saved");
     expect(
-      String(CsrfForm({ action: "/submit", id: "my-form" })),
+      csrfFormInFlash(
+        { action: "/submit", id: "my-form" },
+        { success: "Saved" },
+        "other-form",
+      ),
     ).not.toContain('class="success"');
   });
 
   test("does not show success when no id on form", () => {
-    setFormSuccess("my-form", "Saved");
-    expect(String(CsrfForm({ action: "/submit" }))).not.toContain(
-      'class="success"',
-    );
+    expect(
+      csrfFormInFlash({ action: "/submit" }, { success: "Saved" }, "my-form"),
+    ).not.toContain('class="success"');
   });
 
-  test("shows error flash when id matches stored error state", () => {
-    setFormError("my-form", "Something went wrong");
-    const html = String(CsrfForm({ action: "/submit", id: "my-form" }));
+  test("shows error flash when id matches the targeted form", () => {
+    const html = csrfFormInFlash(
+      { action: "/submit", id: "my-form" },
+      { error: "Something went wrong" },
+      "my-form",
+    );
     expect(html).toContain("Something went wrong");
     expect(html).toContain('class="error"');
   });
 
   test("does not show error when id does not match", () => {
-    setFormError("other-form", "err");
     expect(
-      String(CsrfForm({ action: "/submit", id: "my-form" })),
+      csrfFormInFlash(
+        { action: "/submit", id: "my-form" },
+        { error: "err" },
+        "other-form",
+      ),
     ).not.toContain('class="error"');
   });
 

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -25,9 +25,9 @@ import {
   createTestListing,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
-  expectRedirectWithFlash,
   extractInputValue,
   FLASH_TEST_ID,
   flashCookieHeader,
@@ -214,7 +214,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         confirm_identifier: "john doe",
         release_bookings: "1",
       })();
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Attendee deleted",
       )(response);
@@ -232,7 +232,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const { response } = await deleteAction({
         confirm_identifier: "  John Doe  ",
       })();
-      expectRedirectWithFlash("/admin/listing/1", "Attendee deleted")(response);
+      await expectFlashRedirect(
+        "/admin/listing/1",
+        "Attendee deleted",
+      )(response);
     });
 
     test("can delete attendee without releasing bookings", async () => {
@@ -251,7 +254,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         { confirm_identifier: "Keep Pool" },
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Attendee deleted",
       )(response);
@@ -296,7 +299,10 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           },
         ),
       );
-      expectRedirectWithFlash("/admin/listing/1", "Attendee deleted")(response);
+      await expectFlashRedirect(
+        "/admin/listing/1",
+        "Attendee deleted",
+      )(response);
 
       // Verify attendee was deleted
       const { getAttendeeRaw } = await import("#shared/db/attendees.ts");
@@ -403,7 +409,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Incomplete registration removed",
       )(response);
@@ -434,7 +440,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         undefined,
         false,
@@ -465,7 +471,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         undefined,
         false,
@@ -497,7 +503,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Incomplete registration removed",
       )(response);
@@ -1352,7 +1358,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         form,
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/attendees/${attendee.id}#attendee-form`,
         "Updated Jane Doe",
       )(response);
@@ -1421,7 +1427,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         form,
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/attendees/${attendee.id}#attendee-form`,
         "Updated Jane Smith",
       )(response);
@@ -1609,7 +1615,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         form,
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/attendees/${attendee.id}#attendee-form`,
         "Updated Jane Smith",
       )(response);
@@ -1811,7 +1817,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
           webhookUrl: "https://example.com/webhook",
         });
         expect(response.status).toBe(302);
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${listing.id}`,
           "Notification re-sent",
         )(response);
@@ -2029,7 +2035,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         `/admin/attendees/${attendee.id}/refresh-payment`,
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/attendees/${attendee.id}`,
         "No payment to refresh",
         false,
@@ -2563,7 +2569,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         { merge_version: mergeVersion, source_token: sourceToken },
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/attendees/${target.id}`,
         expect.stringContaining("Merged"),
       )(response);

--- a/test/lib/server-auth.test.ts
+++ b/test/lib/server-auth.test.ts
@@ -12,8 +12,8 @@ import {
   createTestAgentSession,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   extractInputValue,
   FLASH_TEST_ID,
   flashCookieHeader,
@@ -54,7 +54,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       const { cookie } = await loginAsAdmin();
 
       const response = await awaitTestRequest("/admin/login", { cookie });
-      expectRedirectWithFlash("/admin", "Already logged in")(response);
+      await expectFlashRedirect("/admin", "Already logged in")(response);
     });
   });
 
@@ -91,7 +91,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       const response = await handleRequest(
         await mockAdminLoginRequest({ password, username: "testadmin" }),
       );
-      expectRedirectWithFlash("/admin", "Logged in")(response);
+      await expectFlashRedirect("/admin", "Logged in")(response);
       const sessionCookie = response.headers
         .getSetCookie()
         .find((c) => c.startsWith(`${getSessionCookieName()}=`));
@@ -226,7 +226,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       const response = await handleRequest(
         mockFormRequest("/admin/logout", { csrf_token: csrfToken }, cookie),
       );
-      expectRedirectWithFlash("/admin", "Logged out")(response);
+      await expectFlashRedirect("/admin", "Logged out")(response);
       const sessionCookie = response.headers
         .getSetCookie()
         .find((c) => c.startsWith(`${getSessionCookieName()}=`));
@@ -365,7 +365,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
       const response = await handleRequest(
         mockFormRequest("/admin/sessions", { csrf_token: csrfToken }, cookie),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/sessions",
         "Logged out of all other sessions",
       )(response);
@@ -511,7 +511,7 @@ describeWithEnv("server (admin auth)", { db: true }, () => {
         }),
       );
       const elapsed = Date.now() - start;
-      expectRedirectWithFlash("/admin", "Logged in")(response);
+      await expectFlashRedirect("/admin", "Logged in")(response);
       expect(elapsed).toBeGreaterThanOrEqual(100);
     });
   });

--- a/test/lib/server-backup.test.ts
+++ b/test/lib/server-backup.test.ts
@@ -12,8 +12,8 @@ import {
   createTestListing,
   createTestManagerSession,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   getTestSession,
   testRequiresAuth,
   withLocalStorageEnabled,
@@ -78,7 +78,10 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
       await withLocalStorageEnabled(async () => {
         await createTestListing({ name: "Backup Test" });
         const { response } = await adminFormPost("/admin/backup/create");
-        expectRedirectWithFlash("/admin/backup")(response);
+        await expectFlashRedirect(
+          "/admin/backup",
+          "Database backup created",
+        )(response);
       });
     });
 
@@ -263,7 +266,11 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
           confirm_identifier: RESTORE_CONFIRM_PHRASE,
         },
       );
-      expectRedirectWithFlash("/admin/backup")(response);
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Invalid backup reference",
+        false,
+      )(response);
     });
 
     test("rejects wrong confirmation phrase", async () => {
@@ -274,7 +281,11 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
           confirm_identifier: "WRONG",
         },
       );
-      expectRedirectWithFlash("/admin/backup")(response);
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Confirmation phrase does not match",
+        false,
+      )(response);
     });
 
     test("rejects missing backup file", async () => {
@@ -286,7 +297,11 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
             confirm_identifier: RESTORE_CONFIRM_PHRASE,
           },
         );
-        expectRedirectWithFlash("/admin/backup")(response);
+        await expectFlashRedirect(
+          "/admin/backup",
+          "Backup file expired or not found. Please upload again.",
+          false,
+        )(response);
       });
     });
 
@@ -312,7 +327,10 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
             confirm_identifier: RESTORE_CONFIRM_PHRASE,
           },
         );
-        expectRedirectWithFlash("/admin/backup")(response);
+        await expectFlashRedirect(
+          "/admin/backup",
+          "Database restored from backup",
+        )(response);
 
         const restored = (await getAllListings()).find(
           (e) => e.id === listing.id,
@@ -335,7 +353,7 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
             confirm_identifier: RESTORE_CONFIRM_PHRASE,
           },
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/admin/backup",
           "Invalid backup reference",
           false,

--- a/test/lib/server-built-sites-update.test.ts
+++ b/test/lib/server-built-sites-update.test.ts
@@ -11,7 +11,7 @@ import {
   adminFormPost,
   createTestBuiltSite,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   setTestEnv,
   testCookie,
 } from "#test-utils";
@@ -86,7 +86,7 @@ describeWithEnv("POST /admin/built-sites/:id/update", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/update`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         expect.stringContaining(
           "Updated 'Update Me' to 2099-01-01 - Big Update",
@@ -111,7 +111,7 @@ describeWithEnv("POST /admin/built-sites/:id/update", { db: true }, () => {
     const { response } = await adminFormPost(
       `/admin/built-sites/${site.id}/update`,
     );
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       `/admin/built-sites/${site.id}/edit`,
       expect.stringContaining("no Bunny script ID"),
       false,
@@ -133,7 +133,7 @@ describeWithEnv("POST /admin/built-sites/:id/update", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/update`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         expect.stringContaining("Update failed"),
         false,
@@ -159,7 +159,7 @@ describeWithEnv("POST /admin/built-sites/:id/update", { db: true }, () => {
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/update`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         expect.stringContaining("already in progress"),
         false,
@@ -180,7 +180,7 @@ describeWithEnv("POST /admin/built-sites/:id/update", { db: true }, () => {
     const { response } = await adminFormPost(
       `/admin/built-sites/${site.id}/update`,
     );
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       `/admin/built-sites/${site.id}/edit`,
       expect.stringContaining("No backup of this site in the last hour"),
       false,
@@ -226,7 +226,7 @@ describeWithEnv(
       const { response } = await adminFormPost(
         `/admin/built-sites/${site.id}/update`,
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/built-sites/${site.id}/edit`,
         expect.stringContaining("BUNNY_API_KEY is not configured"),
         false,

--- a/test/lib/server-built-sites.test.ts
+++ b/test/lib/server-built-sites.test.ts
@@ -8,8 +8,8 @@ import {
   deleteTestBuiltSite,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   FLASH_TEST_ID,
   flashCookieHeader,
@@ -184,7 +184,7 @@ describeWithEnv("server (admin built sites)", builtSitesTestEnv, () => {
         bunny_url: "https://nodb.b-cdn.net",
         name: "No DB Site",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/built-sites",
         expect.stringContaining("created"),
       )(response);
@@ -433,7 +433,7 @@ describeWithEnv("server (admin built sites)", builtSitesTestEnv, () => {
           confirm_identifier: "case test",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/built-sites",
         "Built site deleted",
       )(response);

--- a/test/lib/server-bulk-email.test.ts
+++ b/test/lib/server-bulk-email.test.ts
@@ -24,9 +24,9 @@ import {
   createTestManagerSession,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
-  expectRedirectWithFlash,
   getTestPrivateKey,
   testCookie,
   testRequiresAuth,
@@ -180,7 +180,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         body: "Hello everyone",
         subject: "News",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails/preview",
         "Review your email below before sending.",
       )(response);
@@ -211,7 +211,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         listing_id: "9999",
         subject: "Subject",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails",
         "That listing no longer exists.",
         false,
@@ -224,7 +224,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         listing_id: "0",
         subject: "Subject",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails",
         "That listing no longer exists.",
         false,
@@ -398,7 +398,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
 
     test("errors when there is no draft", async () => {
       const { response } = await adminFormPost("/admin/emails/send", {});
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails",
         "There's no email to send.",
         false,
@@ -413,7 +413,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         subject: "Subject",
       });
       const { response } = await adminFormPost("/admin/emails/send", {});
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails/preview",
         "Configure your own email provider before sending bulk email.",
         false,
@@ -432,7 +432,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
 
       const { response } = await adminFormPost("/admin/emails/send", {});
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails",
         "Sent to 2 recipients via Resend. The email provider responded with HTTP 200.",
       )(response);
@@ -459,7 +459,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
 
       const { response } = await adminFormPost("/admin/emails/send", {});
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails",
         'Sent to 2 recipients via Resend. The email provider responded with HTTP 200: {"data":[{"id":"msg_1"}]}.',
       )(response);
@@ -498,7 +498,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         subject: "Subject",
       });
       const { response } = await adminFormPost("/admin/emails/send", {});
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails/preview",
         "There are no recipients to send to.",
         false,
@@ -520,7 +520,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         subject: "Sale",
       });
       const { response } = await adminFormPost("/admin/emails/send", {});
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails/preview",
         "Everyone in this audience has unsubscribed.",
         false,
@@ -655,7 +655,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
 
       const { response } = await adminFormPost("/admin/emails/send", {});
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails",
         "Sent to 1 recipient via Resend. The email provider responded with HTTP 200.",
       )(response);
@@ -967,7 +967,7 @@ describeWithEnv("server (bulk email)", { db: true }, () => {
         `/admin/emails/templates/${id}/delete`,
         { confirm_identifier: "To delete" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/emails?audience=active",
         "Template deleted.",
       )(response);

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -18,8 +18,8 @@ import {
   deleteTestGroup,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   mockFormRequest,
   testCookie,
@@ -233,7 +233,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${group.id}`,
         "Group updated",
       )(response);
@@ -286,7 +286,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         slug: g1.slug,
         terms_and_conditions: "",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${g2.id}/edit`,
         expect.stringContaining("Slug is already in use"),
         false,
@@ -359,7 +359,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
           confirm_identifier: "Wrong Name",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${group.id}/delete`,
         expect.stringContaining("Group name does not match"),
         false,
@@ -423,7 +423,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
             cookie,
           ),
         );
-        expectRedirectWithFlash("/admin/groups", "Group deleted")(response);
+        await expectFlashRedirect("/admin/groups", "Group deleted")(response);
       } finally {
         findByIdStub.restore();
       }
@@ -855,7 +855,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${group.id}`,
         "Listings added to group",
       )(response);
@@ -884,7 +884,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${group.id}`,
         "Listings added to group",
       )(response);
@@ -917,7 +917,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${group.id}`,
         "This group already contains standard listings — all listings in a group must be the same type",
         false,
@@ -971,7 +971,7 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/groups/${group.id}`,
         "Group updated",
       )(response);

--- a/test/lib/server-groups.test.ts
+++ b/test/lib/server-groups.test.ts
@@ -233,9 +233,13 @@ describeWithEnv("server (admin groups)", { db: true }, () => {
         ),
       );
       expect(response.status).toBe(302);
+      // Follow as the manager who made the POST, so the render check verifies
+      // the landing page that role actually sees (not the default owner's).
       await expectFlashRedirect(
         `/admin/groups/${group.id}`,
         "Group updated",
+        true,
+        cookie,
       )(response);
     });
 

--- a/test/lib/server-holidays.test.ts
+++ b/test/lib/server-holidays.test.ts
@@ -10,8 +10,8 @@ import {
   deleteTestHoliday,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   mockAdminLoginRequest,
   mockFormRequest,
@@ -411,7 +411,7 @@ describeWithEnv("server (admin holidays)", { db: true }, () => {
           confirm_identifier: "christmas day",
         },
       );
-      expectRedirectWithFlash("/admin/holidays", "Holiday deleted")(response);
+      await expectFlashRedirect("/admin/holidays", "Holiday deleted")(response);
     });
 
     test("returns 404 for non-existent holiday", async () => {

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -13,8 +13,8 @@ import {
   cdnOkResponse,
   createTestListing,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   FLASH_TEST_ID,
   flashCookieHeader,
   installUrlHandler,
@@ -329,7 +329,7 @@ describeWithEnv(
             csrfToken,
             "photo.jpg",
           );
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             `/admin/listing/${listing.id}`,
             "Listing updated",
           )(response);
@@ -491,12 +491,11 @@ describeWithEnv(
       const expectImageDeleteRedirect = (
         response: Response,
         listingId: number,
-      ) => {
-        expectRedirectWithFlash(
+      ): Promise<Response> =>
+        expectFlashRedirect(
           `/admin/listing/${listingId}`,
           "Image removed",
         )(response);
-      };
 
       test("removes image from listing and storage", async () => {
         const { listing, cookie, csrfToken } = await setupListingAndLogin();
@@ -508,7 +507,7 @@ describeWithEnv(
             cookie,
             csrfToken,
           );
-          expectImageDeleteRedirect(response, listing.id);
+          await expectImageDeleteRedirect(response, listing.id);
 
           const updated = await getListingWithCount(listing.id);
           expect(updated?.image_url).toBe("");
@@ -519,7 +518,7 @@ describeWithEnv(
         const { listing, cookie, csrfToken } = await setupListingAndLogin();
 
         const response = await submitImageDelete(listing.id, cookie, csrfToken);
-        expectImageDeleteRedirect(response, listing.id);
+        await expectImageDeleteRedirect(response, listing.id);
       });
 
       test("returns 404 for non-existent listing", async () => {
@@ -649,7 +648,7 @@ describeWithEnv(
               cookie,
             ),
           );
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             `/admin/listing/${listing.id}`,
             "Listing updated",
           )(response);
@@ -700,7 +699,7 @@ describeWithEnv(
               name: "guide.pdf",
             },
           );
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             `/admin/listing/${listing.id}`,
             "Listing updated",
           )(response);
@@ -805,7 +804,7 @@ describeWithEnv(
               },
             ),
           );
-          expectRedirectWithFlash("/admin", "Listing created")(response);
+          await expectFlashRedirect("/admin", "Listing created")(response);
 
           const m = await import("#shared/db/listings.ts");
           const listings = await m.getAllListings();
@@ -830,7 +829,7 @@ describeWithEnv(
             cookie,
             csrfToken,
           );
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             `/admin/listing/${listing.id}`,
             "Attachment removed",
           )(response);
@@ -849,7 +848,7 @@ describeWithEnv(
           cookie,
           csrfToken,
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${listing.id}`,
           "Attachment removed",
         )(response);

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -30,8 +30,8 @@ import {
   deactivateTestListing,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   followRedirectWithFlash,
   mockFormRequest,
@@ -109,7 +109,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           await testCookie(),
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing created")(response);
+      await expectFlashRedirect("/admin", "Listing created")(response);
 
       // Verify listing was actually created
       const { getListing } = await import("#shared/db/listings.ts");
@@ -134,7 +134,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           await testCookie(),
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing created")(response);
+      await expectFlashRedirect("/admin", "Listing created")(response);
 
       // Verify webhook_url was cleared
       const { getListing } = await import("#shared/db/listings.ts");
@@ -162,7 +162,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           await testCookie(),
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing created")(response);
+      await expectFlashRedirect("/admin", "Listing created")(response);
 
       const { getListing } = await import("#shared/db/listings.ts");
       const listing = await getListing(1);
@@ -296,7 +296,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         ),
       );
       // Slug auto-generated so creation succeeds
-      expectRedirectWithFlash("/admin", "Listing created")(response);
+      await expectFlashRedirect("/admin", "Listing created")(response);
     });
   });
 
@@ -894,7 +894,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         `/admin/listings/recalculate/${listing.id}`,
         { recalculate_fields: "booked_quantity" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}/edit`,
         "Listing totals recalculated",
         true,
@@ -916,7 +916,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         `/admin/listings/recalculate/${listing.id}`,
         { recalculate_fields: "booked_quantity" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}/edit`,
         "Listing totals recalculated",
         true,
@@ -1048,7 +1048,10 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash("/admin/listing/1", "Listing updated")(response);
+      await expectFlashRedirect(
+        "/admin/listing/1",
+        "Listing updated",
+      )(response);
 
       // Verify the listing was updated
       const { getListingWithCount } = await import("#shared/db/listings.ts");
@@ -1081,7 +1084,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -1145,7 +1148,10 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash("/admin/listing/1", "Listing updated")(response);
+      await expectFlashRedirect(
+        "/admin/listing/1",
+        "Listing updated",
+      )(response);
 
       // Verify webhook_url was cleared
       const { getListingWithCount } = await import("#shared/db/listings.ts");
@@ -1181,7 +1187,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -1283,7 +1289,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -1310,7 +1316,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -1339,7 +1345,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -1451,7 +1457,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Listing updated",
       )(response);
@@ -1522,7 +1528,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/listing/1",
         "Listing deactivated",
       )(response);
@@ -1623,7 +1629,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/listing/1",
         "Listing reactivated",
       )(response);
@@ -1819,7 +1825,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing deleted")(response);
+      await expectFlashRedirect("/admin", "Listing deleted")(response);
 
       // Verify listing was deleted
       const { getListing } = await import("#shared/db/listings.ts");
@@ -1844,7 +1850,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing deleted")(response);
+      await expectFlashRedirect("/admin", "Listing deleted")(response);
     });
 
     test("deletes the listing and unlinks its attendees", async () => {
@@ -2373,7 +2379,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing deleted")(response);
+      await expectFlashRedirect("/admin", "Listing deleted")(response);
 
       const { getListing: getListingFn } = await import(
         "#shared/db/listings.ts"
@@ -2428,7 +2434,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash("/admin", "Listing deleted")(response);
+      await expectFlashRedirect("/admin", "Listing deleted")(response);
 
       const { getAttendeesRaw } = await import("#shared/db/attendees.ts");
       const attendees = await getAttendeesRaw(listing.id);

--- a/test/lib/server-logistics.test.ts
+++ b/test/lib/server-logistics.test.ts
@@ -18,8 +18,8 @@ import {
   createTestListing,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   testRequiresAuth,
 } from "#test-utils";
@@ -68,7 +68,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
           has_logistics: "true",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/logistics",
         "Logistics enabled",
       )(response);
@@ -83,7 +83,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
           has_logistics: "false",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/logistics",
         "Logistics disabled",
       )(response);
@@ -96,7 +96,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
       const { response } = await adminFormPost("/admin/logistics", {
         name: "Van 1",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/logistics",
         "Logistics agent created",
       )(response);
@@ -136,7 +136,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
       const { response } = await adminFormPost(`/admin/logistics/${id}/edit`, {
         name: "Van B",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/logistics",
         "Logistics agent updated",
       )(response);
@@ -153,7 +153,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
         name: "Crewed Van",
         user_ids: String(userId),
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/logistics",
         "Logistics agent updated",
       )(assigned.response);
@@ -186,7 +186,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
           confirm_identifier: "Doomed Van",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/logistics",
         "Logistics agent deleted",
       )(response);

--- a/test/lib/server-modifiers.test.ts
+++ b/test/lib/server-modifiers.test.ts
@@ -24,8 +24,8 @@ import {
   createTestListing,
   createTestManagerSession,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   followRedirectWithFlash,
   testRequiresAuth,
@@ -98,7 +98,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData(),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers",
         "Modifier created",
         true,
@@ -157,7 +157,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ min_subtotal: "-5" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Minimum order must be a positive number",
         false,
@@ -179,7 +179,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ calc_value: "abc" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Enter a valid number",
         false,
@@ -191,7 +191,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ calc_value: "150" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Percentage must be greater than 0 and at most 100",
         false,
@@ -203,7 +203,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ calc_value: "0" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Percentage must be greater than 0 and at most 100",
         false,
@@ -232,7 +232,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ calc_kind: "multiply", calc_value: "0" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Multiplier must be greater than 0",
         false,
@@ -244,7 +244,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ calc_kind: "fixed", calc_value: "0" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Amount must be greater than 0",
         false,
@@ -256,7 +256,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ calc_kind: "bogus" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Invalid modifier type",
         false,
@@ -268,7 +268,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ direction: "sideways" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Invalid direction",
         false,
@@ -315,7 +315,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         `/admin/modifiers/${id}/edit`,
         createData({ calc_value: "20", name: "After" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers",
         "Modifier updated",
         true,
@@ -334,7 +334,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         total_uses: "12",
         usage_count: "4",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers",
         "Modifier updated",
         true,
@@ -354,7 +354,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         total_uses: "-1",
         usage_count: "4",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/modifiers/${id}/edit`,
         "Total Uses must be 0 or greater",
         false,
@@ -378,7 +378,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         `/admin/modifiers/${id}/edit`,
         createData({ calc_value: "150" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/modifiers/${id}/edit`,
         "Percentage must be greater than 0 and at most 100",
         false,
@@ -456,7 +456,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         `/admin/modifiers/recalculate/${id}`,
         { recalculate_fields: "total_uses" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/modifiers/${id}/edit`,
         "Modifier totals recalculated",
         true,
@@ -476,7 +476,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         `/admin/modifiers/recalculate/${id}`,
         { recalculate_fields: "total_uses" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/modifiers/${id}/edit`,
         "Modifier totals recalculated",
         true,
@@ -527,7 +527,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
           confirm_identifier: "Doomed",
         },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers",
         "Modifier deleted",
         true,
@@ -550,7 +550,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ scope: "bogus" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Invalid scope",
         false,
@@ -629,7 +629,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         `/admin/modifiers/${id}/links`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/modifiers/${id}/edit`,
         "Scope updated",
         true,
@@ -690,7 +690,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         `/admin/modifiers/${id}/answers`,
         { answer_ids: String(answerId) },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/modifiers/${id}/edit`,
         "Answers updated",
         true,
@@ -737,7 +737,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ trigger: "magic" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Invalid trigger",
         false,
@@ -749,7 +749,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ code: "", trigger: "code" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "A promo-code modifier needs a code",
         false,
@@ -790,7 +790,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ min_visits: "1", trigger: "optional" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Optional add-ons cannot require previous bookings",
         false,
@@ -802,7 +802,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ min_visits: "-1" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Minimum previous bookings must be a whole number of 0 or more",
         false,
@@ -814,7 +814,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
         "/admin/modifiers",
         createData({ min_visits: "1.5" }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/modifiers/new",
         "Minimum previous bookings must be a whole number of 0 or more",
         false,

--- a/test/lib/server-privacy.test.ts
+++ b/test/lib/server-privacy.test.ts
@@ -29,8 +29,8 @@ import {
   awaitTestRequest,
   createTestManagerSession,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   testRequiresAuth,
 } from "#test-utils";
@@ -120,7 +120,7 @@ describeWithEnv("server (admin privacy)", { db: true }, () => {
         retention: "1825",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/privacy",
         "Saved your orphaned-record settings.",
       )(response);
@@ -148,7 +148,7 @@ describeWithEnv("server (admin privacy)", { db: true }, () => {
         retention: "182",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/privacy",
         "Deleted 1 orphaned record.",
       )(response);
@@ -161,7 +161,7 @@ describeWithEnv("server (admin privacy)", { db: true }, () => {
         retention: "abc",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/privacy",
         "Please choose how old records must be before they are deleted.",
         false,
@@ -184,7 +184,7 @@ describeWithEnv("server (admin privacy)", { db: true }, () => {
         identifier: "erase-me@example.com",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/privacy",
         "Deleted that contact's record.",
       )(response);
@@ -221,7 +221,7 @@ describeWithEnv("server (admin privacy)", { db: true }, () => {
         identifier: "   ",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/privacy",
         "Please enter the email address or phone number to delete.",
         false,
@@ -234,7 +234,7 @@ describeWithEnv("server (admin privacy)", { db: true }, () => {
         identifier: "123456",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/privacy",
         "Please choose whether you are entering an email or a phone number.",
         false,

--- a/test/lib/server-questions.test.ts
+++ b/test/lib/server-questions.test.ts
@@ -9,8 +9,8 @@ import {
   createTestManagerSession,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   expectStatus,
   mockFormRequest,
   testCookie,
@@ -107,7 +107,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       );
       const questions = await getAllQuestionsWithAnswers();
       const found = questions.find((q) => q.text === "Redirect target?")!;
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${found.id}`,
         "Question created",
       )(response);
@@ -138,7 +138,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         (q) => q.text === "Choose one?",
       );
       expect(question?.display_type).toBe("select");
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${question!.id}`,
         "Question created",
       )(response);
@@ -215,7 +215,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         display_type: "radio" as const,
         text: "After edit",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${id}`,
         "Question updated",
       )(response);
@@ -266,7 +266,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${q.id}/edit`,
         { display_type: "radio" as const, text: "Notes updated" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${q.id}`,
         "Question updated",
       )(response);
@@ -428,7 +428,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/listings`,
         { listing_ids: String(listing.id) },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Listings updated",
       )(response);
@@ -450,7 +450,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/listings`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Listings updated",
       )(response);
@@ -537,7 +537,10 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${id}/delete`,
         { confirm_identifier: "Confirm Delete" },
       );
-      expectRedirectWithFlash("/admin/questions", "Question deleted")(response);
+      await expectFlashRedirect(
+        "/admin/questions",
+        "Question deleted",
+      )(response);
 
       // Verify it's gone
       const { questionsTable } = await import("#shared/db/questions.ts");
@@ -577,7 +580,10 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${id}/delete`,
         { confirm_identifier: "case test" },
       );
-      expectRedirectWithFlash("/admin/questions", "Question deleted")(response);
+      await expectFlashRedirect(
+        "/admin/questions",
+        "Question deleted",
+      )(response);
     });
 
     test("rejects deletion when confirm_identifier is missing", async () => {
@@ -669,7 +675,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId}/delete`,
         { confirm_identifier: "Goodbye Answer" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Answer deleted",
       )(response);
@@ -774,7 +780,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId}/edit`,
         { modifier_id: "", text: "After" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Answer updated",
       )(response);
@@ -1036,7 +1042,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId}/recalculate`,
         { recalculate_fields: "times_selected" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}/answers/${aId}/edit`,
         "Selection total recalculated",
       )(response);
@@ -1143,7 +1149,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
           cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Questions updated",
       )(response);
@@ -1161,7 +1167,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/listing/${listing.id}/questions`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}`,
         "Questions updated",
       )(response);
@@ -1304,7 +1310,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId1}/move-down`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Answer moved",
       )(response);
@@ -1326,7 +1332,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId2}/move-up`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Answer moved",
       )(response);
@@ -1345,7 +1351,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId1}/move-up`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Answer moved",
       )(response);
@@ -1358,7 +1364,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}/answers/${aId1}/move-down`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/questions/${qId}`,
         "Answer moved",
       )(response);
@@ -1402,7 +1408,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${firstId}/move-down`,
         {},
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/questions",
         "Question moved",
       )(down.response);

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -13,8 +13,8 @@ import {
   createTestListing,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   mockFormRequest,
   mockProviderType,
   setupListingAndLogin,
@@ -248,7 +248,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       const response = await submitRefund(ctx, {
         confirm_identifier: "Wrong Name",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/refund`,
         expect.stringContaining("does not match"),
         false,
@@ -270,7 +270,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
           await testCookie(),
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}/attendee/${attendee.id}/refund`,
         expect.stringContaining("no payment to refund"),
         false,
@@ -280,7 +280,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
     test("returns error when no payment provider configured", async () => {
       const ctx = await setupRefundTest("pi_test_noprov");
       const response = await submitRefund(ctx);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/refund`,
         expect.stringContaining("No payment provider configured"),
         false,
@@ -292,7 +292,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
 
       await withRefundMock(true, async (mockRefund) => {
         const response = await submitRefund(ctx);
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${ctx.listing.id}`,
           "Refund issued",
         )(response);
@@ -305,7 +305,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
 
       await withRefundMock(false, async () => {
         const response = await submitRefund(ctx);
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/refund`,
           expect.stringContaining("Refund failed"),
           false,
@@ -322,7 +322,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
           ctx.cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/refund`,
         expect.stringContaining("does not match"),
         false,
@@ -418,7 +418,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       const response = await submitRefundAll(ctx, {
         confirm_identifier: "Wrong Listing Name",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/refund-all`,
         expect.stringContaining("does not match"),
         false,
@@ -434,7 +434,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
           ctx.cookie,
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/refund-all`,
         expect.stringContaining("does not match"),
         false,
@@ -459,7 +459,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
           await testCookie(),
         ),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${listing.id}/refund-all`,
         expect.stringContaining("No attendees have payments to refund"),
         false,
@@ -469,7 +469,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
     test("returns error when no payment provider configured", async () => {
       const ctx = await setupRefundTest("pi_noprov_all");
       const response = await submitRefundAll(ctx);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/refund-all`,
         expect.stringContaining("No payment provider configured"),
         false,
@@ -501,7 +501,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
             await testCookie(),
           ),
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${listing.id}`,
           "All attendees refunded",
         )(response);
@@ -531,7 +531,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
           ),
         );
         expect(mockRefund.calls.length).toBe(30);
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${listing.id}/refund-all`,
           expect.stringContaining("30 attendee(s) refunded"),
         )(response);
@@ -560,7 +560,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
             await testCookie(),
           ),
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${listing.id}/refund-all`,
           expect.stringContaining("30 failed"),
           false,
@@ -597,7 +597,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
               await testCookie(),
             ),
           );
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             `/admin/listing/${listing.id}/refund-all`,
             expect.stringContaining("1 refund(s) succeeded"),
             false,
@@ -639,7 +639,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
               await testCookie(),
             ),
           );
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             `/admin/listing/${listing.id}/refund-all`,
             expect.stringContaining("1 refund(s) succeeded"),
             false,
@@ -668,7 +668,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       await markAsRefunded(ctx.attendee.id, ctx.listing.id);
 
       const response = await submitRefund(ctx);
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/refund`,
         expect.stringContaining("already been refunded"),
         false,
@@ -706,7 +706,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
 
         // Verify attendee is marked as refunded by trying to refund again
         const retryResponse = await submitRefund(ctx);
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/refund`,
           expect.stringContaining("already been refunded"),
           false,

--- a/test/lib/server-seeds.test.ts
+++ b/test/lib/server-seeds.test.ts
@@ -12,7 +12,7 @@ import {
   awaitTestRequest,
   createTestManagerSession,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   extractCsrfToken,
   mockFormRequest,
   mockRequest,
@@ -86,7 +86,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         "Created 2 listing(s) with 0 attendee(s) total.",
       )(response);
@@ -108,7 +108,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         expect.stringContaining("Created 2 listing"),
       )(response);
@@ -153,7 +153,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         expect.stringContaining(`Created ${MAX_SEED_LISTINGS} listing`),
       )(response);
@@ -172,7 +172,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         expect.stringContaining("Created 1 listing"),
       )(response);
@@ -230,7 +230,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         "Failed to create seed data. Ensure setup is complete.",
         false,
@@ -250,7 +250,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         expect.stringContaining("Created 1 listing"),
       )(response);
@@ -269,7 +269,7 @@ describeWithEnv("server (admin seeds)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/seeds",
         expect.stringContaining("Created 1 listing"),
       )(response);

--- a/test/lib/server-settings/apple-wallet.test.ts
+++ b/test/lib/server-settings/apple-wallet.test.ts
@@ -7,7 +7,7 @@ import {
   awaitTestRequest,
   createTestAttendeeWithToken,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   getHeader,
   mockFormRequest,
   setTestEnv,
@@ -272,7 +272,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_pass_type_id: "",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining("Pass Type ID is required"),
       false,
@@ -283,7 +283,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_team_id: "",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining("Team ID is required"),
       false,
@@ -294,7 +294,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_signing_cert: "",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining("Signing certificate is required"),
       false,
@@ -305,7 +305,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_signing_key: "",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining("Signing private key is required"),
       false,
@@ -316,7 +316,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_wwdr_cert: "",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining("WWDR certificate is required"),
       false,
@@ -327,7 +327,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_signing_cert: "not a valid cert",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining(
         "Signing certificate is not a valid PEM certificate",
@@ -340,7 +340,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_signing_key: "not a valid key",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining(
         "Signing private key is not a valid PEM private key",
@@ -353,7 +353,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
     const response = await submitWalletSettingsForm({
       apple_wallet_wwdr_cert: "not a valid cert",
     });
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       expect.stringContaining(
         "WWDR certificate is not a valid PEM certificate",
@@ -367,7 +367,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
       apple_wallet_pass_type_id: "pass.com.test.tickets",
     });
 
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       "Apple Wallet configuration updated",
     )(response);
@@ -389,7 +389,7 @@ describeWithEnv("POST /admin/settings/apple-wallet", { db: true }, () => {
       apple_wallet_wwdr_cert: "",
     });
 
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-apple-wallet#settings-apple-wallet",
       "Apple Wallet configuration cleared",
     )(response);

--- a/test/lib/server-settings/column-order.test.ts
+++ b/test/lib/server-settings/column-order.test.ts
@@ -4,7 +4,7 @@ import { settings } from "#shared/db/settings.ts";
 import {
   adminFormPost,
   describeWithEnv,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
 } from "#test-utils";
 
 describeWithEnv("server (admin settings: column order)", { db: true }, () => {
@@ -17,7 +17,7 @@ describeWithEnv("server (admin settings: column order)", { db: true }, () => {
         "/admin/settings/listing-column-order",
         { column_order: "{{name}}, {{status}}" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         formUrl,
         "Listing column order updated",
       )(response);
@@ -29,7 +29,7 @@ describeWithEnv("server (admin settings: column order)", { db: true }, () => {
         "/admin/settings/listing-column-order",
         { column_order: "{{invalid}}" },
       );
-      expectRedirectWithFlash(formUrl, undefined, false)(response);
+      await expectFlashRedirect(formUrl, undefined, false)(response);
       const msg = decodeURIComponent(response.headers.get("set-cookie") ?? "");
       expect(msg).toContain("invalid");
       expect(msg).toContain("Available columns");
@@ -41,7 +41,7 @@ describeWithEnv("server (admin settings: column order)", { db: true }, () => {
         "/admin/settings/listing-column-order",
         { column_order: "" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         formUrl,
         "Listing column order updated",
       )(response);
@@ -58,7 +58,7 @@ describeWithEnv("server (admin settings: column order)", { db: true }, () => {
         "/admin/settings/attendee-column-order",
         { column_order: "{{name}}, {{qty}}, {{ticket}}" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         formUrl,
         "Attendee column order updated",
       )(response);
@@ -72,7 +72,7 @@ describeWithEnv("server (admin settings: column order)", { db: true }, () => {
         "/admin/settings/attendee-column-order",
         { column_order: "{{bogus}}" },
       );
-      expectRedirectWithFlash(formUrl, undefined, false)(response);
+      await expectFlashRedirect(formUrl, undefined, false)(response);
       const msg = decodeURIComponent(response.headers.get("set-cookie") ?? "");
       expect(msg).toContain("bogus");
       expect(msg).toContain("Available columns");
@@ -84,7 +84,7 @@ describeWithEnv("server (admin settings: column order)", { db: true }, () => {
         "/admin/settings/attendee-column-order",
         { column_order: "" },
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         formUrl,
         "Attendee column order updated",
       )(response);

--- a/test/lib/server-settings/domains.test.ts
+++ b/test/lib/server-settings/domains.test.ts
@@ -9,6 +9,7 @@ import {
   awaitTestRequest,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectRedirectWithFlash,
   followRedirectWithFlash,
   mockFormRequest,
@@ -395,7 +396,7 @@ describeWithEnv("server (admin settings: domains)", { db: true }, () => {
               "/admin/settings/custom-domain",
               { custom_domain: "tickets.example.com" },
             );
-            expectRedirectWithFlash(
+            await expectFlashRedirect(
               "/admin/settings-advanced?form=settings-custom-domain#settings-custom-domain",
               expect.stringContaining("Another task is already in progress"),
               false,
@@ -413,7 +414,7 @@ describeWithEnv("server (admin settings: domains)", { db: true }, () => {
             const { response } = await adminFormPost(
               "/admin/settings/custom-domain/validate",
             );
-            expectRedirectWithFlash(
+            await expectFlashRedirect(
               "/admin/settings-advanced?form=settings-custom-domain-validate#settings-custom-domain-validate",
               expect.stringContaining("Another task is already in progress"),
               false,
@@ -773,6 +774,8 @@ describeWithEnv("server (admin settings: domains)", { db: true }, () => {
                   await testCookie(),
                 ),
               );
+              // Cookie-only: following re-renders settings-advanced, which
+              // re-issues the Bunny CDN calls only mocked for this POST.
               expectRedirectWithFlash(
                 "/admin/settings-advanced?form=settings-host-subdomain#settings-host-subdomain",
                 "Subdomain registered: mylisting.tickets.example.com",
@@ -836,7 +839,7 @@ describeWithEnv("server (admin settings: domains)", { db: true }, () => {
                 await testCookie(),
               ),
             );
-            expectRedirectWithFlash(
+            await expectFlashRedirect(
               "/admin/settings-advanced?form=settings-host-subdomain#settings-host-subdomain",
               expect.stringContaining("Another task is already in progress"),
               false,

--- a/test/lib/server-settings/embed-hosts.test.ts
+++ b/test/lib/server-settings/embed-hosts.test.ts
@@ -8,8 +8,8 @@ import {
   awaitTestRequest,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   getEmbeddableTicketResponse,
   getHeader,
   mockFormRequest,
@@ -25,7 +25,7 @@ async function postInvalidEmbedHosts(
   const { response } = await adminFormPost("/admin/settings/embed-hosts", {
     embed_hosts: hosts,
   });
-  expectRedirectWithFlash(
+  await expectFlashRedirect(
     "/admin/settings?form=settings-embed-hosts#settings-embed-hosts",
     expect.stringContaining(expectedError),
     false,
@@ -41,7 +41,7 @@ async function postEmbedHostsExpectRedirect(
     "/admin/settings/embed-hosts",
     fields,
   );
-  expectRedirectWithFlash(
+  await expectFlashRedirect(
     "/admin/settings?form=settings-embed-hosts#settings-embed-hosts",
     expectedMessage,
   )(response);
@@ -134,7 +134,7 @@ describeWithEnv("server (embed hosts)", { db: true }, () => {
         ),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/settings?form=settings-embed-hosts#settings-embed-hosts",
         "Embed host restrictions removed",
       )(response);

--- a/test/lib/server-settings/google-wallet.test.ts
+++ b/test/lib/server-settings/google-wallet.test.ts
@@ -6,8 +6,8 @@ import {
   awaitTestRequest,
   createTestAttendeeWithToken,
   describeWithEnv,
+  expectFlashRedirect,
   expectRedirect,
-  expectRedirectWithFlash,
   loginAsAdmin,
   mockFormRequest,
   setTestEnv,
@@ -169,7 +169,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
         cookie,
       ),
     );
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
       expect.stringContaining("Issuer ID is required"),
       false,
@@ -192,7 +192,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
         cookie,
       ),
     );
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
       expect.stringContaining("Service account email is required"),
       false,
@@ -215,7 +215,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
         cookie,
       ),
     );
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
       expect.stringContaining("Service account private key is required"),
       false,
@@ -238,7 +238,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
         cookie,
       ),
     );
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
       expect.stringContaining(
         "Service account private key is not a valid PEM private key",
@@ -265,7 +265,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
       ),
     );
 
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
       "Google Wallet configuration updated",
     )(response);
@@ -295,7 +295,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
       ),
     );
 
-    expectRedirectWithFlash(
+    await expectFlashRedirect(
       "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
       "Google Wallet configuration cleared",
     )(response);

--- a/test/lib/server-settings/header-image.test.ts
+++ b/test/lib/server-settings/header-image.test.ts
@@ -8,6 +8,7 @@ import {
   assertAdminHtml,
   createTestManagerSession,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirectWithFlash,
   JPEG_HEADER,
@@ -129,7 +130,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
           data: PDF_BYTES,
           name: "doc.pdf",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_FORM_REDIRECT,
           expect.stringContaining("JPEG, PNG, GIF, or WebP"),
           false,
@@ -147,7 +148,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
           data: oversized,
           name: "big.jpg",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_FORM_REDIRECT,
           expect.stringContaining("256KB"),
           false,
@@ -180,7 +181,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
           await testCookie(),
         );
         const response = await handleRequest(request);
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_FORM_REDIRECT,
           expect.stringContaining("No image file provided"),
           false,
@@ -191,6 +192,8 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
     test("reports error when storage is not configured", async () => {
       await withStorageDisabled(async () => {
         const response = await submitHeaderJpeg("logo.jpg");
+        // Cookie-only: with storage disabled the upload form is hidden, so the
+        // settings page the error redirects to has no field to render it under.
         expectRedirectWithFlash(
           HEADER_IMAGE_FORM_REDIRECT,
           expect.stringContaining("Image storage is not configured"),
@@ -217,7 +220,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
     test("reports error when CDN upload fails", async () => {
       await withCdnRejecting(new Error("CDN unreachable"), async () => {
         const response = await submitHeaderJpeg("logo.jpg");
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_FORM_REDIRECT,
           "Header image upload failed",
           false,
@@ -232,7 +235,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
           data: new Uint8Array([0x00, 0x00, 0x00, 0x00]),
           name: "fake.jpg",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_FORM_REDIRECT,
           expect.stringContaining("valid image"),
           false,
@@ -255,7 +258,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
     test("reports error when there is no header image to remove", async () => {
       await withStorageEnabled(async () => {
         const response = await submitHeaderImageDelete();
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_FORM_REDIRECT,
           expect.stringContaining("No header image to remove"),
           false,
@@ -268,7 +271,7 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
 
       await withCdnRejecting(new Error("CDN unreachable"), async () => {
         const response = await submitHeaderImageDelete();
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           HEADER_IMAGE_DELETE_FORM_REDIRECT,
           "Header image removal failed",
           false,

--- a/test/lib/server-settings/settings-page.test.ts
+++ b/test/lib/server-settings/settings-page.test.ts
@@ -28,7 +28,7 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       await expectHtmlResponse(response, 200, "Settings", "Change Password");
     });
 
-    test("does not display success when form param is missing", async () => {
+    test("shows a flash with no form target as a page-level banner", async () => {
       const response = await awaitTestRequest(
         `/admin/settings?flash=${FLASH_TEST_ID}`,
         {
@@ -38,7 +38,11 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         },
       );
       const html = await response.text();
-      expect(html).not.toContain('class="success"');
+      // With no ?form= target, no CsrfForm claims the flash, so the Layout
+      // backstop renders it — surfacing it rather than the old behavior of
+      // silently swallowing an unattributed flash.
+      expect(html).toContain('class="success"');
+      expect(html).toContain("Test success message");
     });
 
     test("displays success message on the matching form when form param is provided", async () => {

--- a/test/lib/server-settings/statuses.test.ts
+++ b/test/lib/server-settings/statuses.test.ts
@@ -12,8 +12,8 @@ import {
   adminFormPost,
   adminGet,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   testRequiresAuth,
 } from "#test-utils";
 
@@ -70,7 +70,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         name: "Reserved",
         reservation_amount: "10%",
       });
-      expectRedirectWithFlash(PATH, "Status created")(response);
+      await expectFlashRedirect(PATH, "Status created")(response);
 
       const statuses = await getAllAttendeeStatuses();
       const created = statuses.find((s) => s.name === "Reserved")!;
@@ -82,7 +82,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
 
     test("rejects a missing name", async () => {
       const { response } = await adminFormPost(PATH, { name: "" });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/new`,
         "Please enter a name",
         false,
@@ -95,7 +95,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         name: "Bad",
         reservation_amount: "lots",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/new`,
         RESERVATION_AMOUNT_HINT,
         false,
@@ -109,7 +109,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         name: "Contradiction",
         reservation_amount: "10",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/new`,
         "A paid status can't also be a reservation",
         false,
@@ -124,7 +124,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         is_public_default: "1",
         name: "New Default",
       });
-      expectRedirectWithFlash(PATH, "Status created")(response);
+      await expectFlashRedirect(PATH, "Status created")(response);
 
       const newDefault = await getPublicDefaultStatus();
       expect(newDefault?.name).toBe("New Default");
@@ -138,7 +138,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         is_paid_default: "1",
         name: "Settled",
       });
-      expectRedirectWithFlash(PATH, "Status created")(response);
+      await expectFlashRedirect(PATH, "Status created")(response);
       expect((await getAttendeeStatus(seed.id))?.is_paid_default).toBe(false);
     });
   });
@@ -149,7 +149,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${created.id}/edit`, {
         name: "Renamed",
       });
-      expectRedirectWithFlash(PATH, "Status updated")(response);
+      await expectFlashRedirect(PATH, "Status updated")(response);
       expect((await getAttendeeStatus(created.id))?.name).toBe("Renamed");
     });
 
@@ -160,7 +160,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         is_paid_default: "1",
         name: "Confirmed",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${seed.id}/edit`,
         "Choose another public default before clearing this one",
         false,
@@ -204,7 +204,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${seed.id}/edit`, {
         name: "",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${seed.id}/edit`,
         "Please enter a name",
         false,
@@ -217,7 +217,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         is_public_default: "1",
         name: "Confirmed",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${seed.id}/edit`,
         "Choose another paid default before clearing this one",
         false,
@@ -252,7 +252,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${spare.id}/delete`, {
         confirm_identifier: "wrong",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${spare.id}/delete`,
         "Name does not match. Please type the exact name to confirm deletion.",
         false,
@@ -265,7 +265,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${seed.id}/delete`, {
         confirm_identifier: seed.name,
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${seed.id}/delete`,
         "You must keep at least one status",
         false,
@@ -278,7 +278,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${seed.id}/delete`, {
         confirm_identifier: seed.name,
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${seed.id}/delete`,
         "Choose another public default before deleting this status",
         false,
@@ -296,7 +296,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${inUse.id}/delete`, {
         confirm_identifier: "Active",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${inUse.id}/delete`,
         "This status is in use by attendees",
         false,
@@ -308,7 +308,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${spare.id}/delete`, {
         confirm_identifier: "Disposable",
       });
-      expectRedirectWithFlash(PATH, "Status deleted")(response);
+      await expectFlashRedirect(PATH, "Status deleted")(response);
       expect(await getAttendeeStatus(spare.id)).toBeNull();
     });
 
@@ -328,7 +328,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
       const { response } = await adminFormPost(`${PATH}/${settled.id}/delete`, {
         confirm_identifier: "Settled",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `${PATH}/${settled.id}/delete`,
         "Choose another paid default before deleting this status",
         false,
@@ -348,7 +348,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
         sortOrder: 2,
       });
       const { response } = await adminFormPost(`${PATH}/${second.id}/move-up`);
-      expectRedirectWithFlash(PATH, "Status moved")(response);
+      await expectFlashRedirect(PATH, "Status moved")(response);
 
       const order = (await getAllAttendeeStatuses()).map((s) => s.name);
       const firstIdx = order.indexOf("First");
@@ -361,7 +361,7 @@ describeWithEnv("server (admin attendee statuses)", { db: true }, () => {
     test("move at the boundary is a no-op", async () => {
       const seed = await seedStatus();
       const { response } = await adminFormPost(`${PATH}/${seed.id}/move-up`);
-      expectRedirectWithFlash(PATH, "Status moved")(response);
+      await expectFlashRedirect(PATH, "Status moved")(response);
     });
 
     test("returns 404 moving a missing status", async () => {

--- a/test/lib/server-settings/superuser.test.ts
+++ b/test/lib/server-settings/superuser.test.ts
@@ -21,7 +21,7 @@ import {
   createTestManagerSession,
   describeWithEnv,
   expectFlash,
-  expectRedirectWithFlash,
+  expectFlashRedirect,
   mockFormRequest,
   setTestEnv,
   testCookie,
@@ -102,7 +102,7 @@ describeWithEnv("server (admin settings superuser)", { db: true }, () => {
       const { response } = await adminFormPost(SUPERUSER_ROUTE, {
         superuser_choice: "self-managed",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/settings?form=settings-superuser#settings-superuser",
         "Superuser recovery declined",
       )(response);
@@ -288,7 +288,7 @@ describeWithEnv("server (admin settings superuser)", { db: true }, () => {
           const { response } = await adminFormPost(SUPERUSER_ROUTE, {
             superuser_choice: "enable-superuser",
           });
-          expectRedirectWithFlash(
+          await expectFlashRedirect(
             "/admin/settings?form=settings-superuser#settings-superuser",
             "Superuser enabled and credentials sent",
           )(response);

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -11,9 +11,9 @@ import {
   awaitTestRequest,
   createTestDb,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
-  expectRedirectWithFlash,
   getSetupCsrfToken,
   invalidateTestDbCache,
   mockFormRequest,
@@ -268,7 +268,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
             country: "US",
           }),
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("Invalid or expired form"),
           false,
@@ -286,7 +286,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
             csrf_token: "wrong-token-in-form",
           }),
         );
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("Invalid or expired form"),
           false,
@@ -298,7 +298,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
           admin_password: "",
           admin_password_confirm: "",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("Admin Password"),
           false,
@@ -309,7 +309,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
         const response = await submitSetupFormWithDefaults({
           admin_password_confirm: "different",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("Passwords do not match"),
           false,
@@ -321,7 +321,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
           admin_password: "short",
           admin_password_confirm: "short",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("at least 8 characters"),
           false,
@@ -332,7 +332,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
         const response = await submitSetupFormWithDefaults({
           country: "XX",
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("valid country"),
           false,
@@ -343,7 +343,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
         const response = await submitSetupFormWithDefaults({
           accept_agreement: "", // Explicitly not accepting
         });
-        expectRedirectWithFlash(
+        await expectFlashRedirect(
           "/setup/",
           expect.stringContaining("must accept the Data Controller Agreement"),
           false,

--- a/test/lib/server-site.test.ts
+++ b/test/lib/server-site.test.ts
@@ -8,9 +8,9 @@ import {
   awaitTestRequest,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
-  expectRedirectWithFlash,
   FLASH_TEST_ID,
   flashCookieHeader,
   hasCheckedInput,
@@ -127,7 +127,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         homepage_text: "",
         website_title: "x".repeat(MAX_WEBSITE_TITLE_LENGTH + 1),
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/site",
         expect.stringContaining(
           `${MAX_WEBSITE_TITLE_LENGTH} characters or fewer`,
@@ -141,7 +141,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
         homepage_text: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
         website_title: "",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/site",
         expect.stringContaining(`${MAX_TEXTAREA_LENGTH} characters or fewer`),
         false,
@@ -257,7 +257,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
       const { response } = await adminFormPost("/admin/site/contact", {
         contact_page_text: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/site/contact",
         expect.stringContaining(`${MAX_TEXTAREA_LENGTH} characters or fewer`),
         false,
@@ -365,7 +365,7 @@ describeWithEnv("server (admin site)", { db: true }, () => {
       const { response } = await adminFormPost("/admin/site/order", {
         order_intro_text: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/site/order",
         expect.stringContaining(`${MAX_TEXTAREA_LENGTH} characters or fewer`),
         false,

--- a/test/lib/server-users-invite.test.ts
+++ b/test/lib/server-users-invite.test.ts
@@ -5,9 +5,9 @@ import {
   adminFormPost,
   awaitTestRequest,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
-  expectRedirectWithFlash,
   FLASH_TEST_ID,
   flashCookieHeader,
   TEST_ADMIN_USERNAME,
@@ -106,7 +106,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         username: TEST_ADMIN_USERNAME,
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/user/new",
         expect.stringContaining("already taken"),
         false,
@@ -119,7 +119,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         username: "newuser",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/user/new",
         expect.stringContaining("Invalid role"),
         false,

--- a/test/lib/server-users-join.test.ts
+++ b/test/lib/server-users-join.test.ts
@@ -7,6 +7,7 @@ import {
   assertPublicHtml,
   createTestInvite,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
   expectRedirectWithFlash,
   mockAdminLoginRequest,
@@ -27,7 +28,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
           username: TEST_ADMIN_USERNAME,
         }),
       );
-      expectRedirectWithFlash("/admin", "Logged in")(response);
+      await expectFlashRedirect("/admin", "Logged in")(response);
       const sessionCookie = response.headers
         .getSetCookie()
         .find((c) => c.startsWith(`${getSessionCookieName()}=`));
@@ -41,7 +42,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
           username: "nonexistent",
         }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin",
         expect.stringContaining("Username or password was wrong"),
         false,
@@ -55,7 +56,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
           username: TEST_ADMIN_USERNAME,
         }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin",
         expect.stringContaining("Username or password was wrong"),
         false,
@@ -97,6 +98,8 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         password_confirm: "newpassword123",
       });
 
+      // Cookie-only: /join/complete is a public confirmation page (shown to the
+      // freshly-activated user, not the admin session) and states its own result.
       expectRedirectWithFlash(
         "/join/complete",
         "Password set successfully",
@@ -142,7 +145,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         }),
       );
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/join/${inviteCode}`,
         expect.stringContaining("invalid"),
         false,
@@ -161,7 +164,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         password_confirm: "differentpassword",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/join/${inviteCode}`,
         expect.stringContaining("do not match"),
         false,
@@ -176,7 +179,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         password_confirm: "short",
       });
 
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/join/${inviteCode}`,
         expect.stringContaining("8 characters"),
         false,
@@ -225,7 +228,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
           password_confirm: "newpassword123",
         }),
       );
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         `/join/${inviteCode}`,
         expect.stringContaining("try again"),
         false,

--- a/test/lib/server-users-manage.test.ts
+++ b/test/lib/server-users-manage.test.ts
@@ -5,8 +5,8 @@ import {
   adminFormPost,
   awaitTestRequest,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   TEST_ADMIN_USERNAME,
   testCookie,
 } from "#test-utils";
@@ -59,7 +59,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       const { response } = await adminFormPost("/admin/users/2/delete", {
         confirm_identifier: "deleteme",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/users",
         expect.stringContaining("deleted"),
       )(response);
@@ -77,7 +77,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       const { response } = await adminFormPost("/admin/users/2/delete", {
         confirm_identifier: "wrongname",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/users/2/delete",
         expect.stringContaining("Username does not match"),
         false,
@@ -94,7 +94,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       });
 
       const { response } = await adminFormPost("/admin/users/2/delete");
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/users/2/delete",
         expect.stringContaining("Username does not match"),
         false,
@@ -120,7 +120,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       const { response } = await adminFormPost("/admin/users/2/delete", {
         confirm_identifier: "otheradmin",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/users",
         expect.stringContaining("deleted"),
       )(response);

--- a/test/lib/server-users-roles.test.ts
+++ b/test/lib/server-users-roles.test.ts
@@ -13,8 +13,8 @@ import {
   awaitTestRequest,
   createTestManagerSession,
   describeWithEnv,
+  expectFlashRedirect,
   expectHtmlResponse,
-  expectRedirectWithFlash,
   mockFormRequest,
   mockRequest,
   TEST_ADMIN_PASSWORD,
@@ -124,7 +124,7 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
         new_password: "newpassword123",
         new_password_confirm: "newpassword123",
       });
-      expectRedirectWithFlash(
+      await expectFlashRedirect(
         "/admin/settings?form=settings-password#settings-password",
         expect.stringContaining("Failed to update password"),
         false,

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
+import { renderSuccess } from "#shared/forms.tsx";
 import {
   adminListingPage,
   buildAnswerSummaryRows,
@@ -112,6 +113,18 @@ describe("adminQuestionsPage", () => {
     const html = adminQuestionsPage([], TEST_SESSION, "Something went wrong");
     expect(html).toContain("Something went wrong");
   });
+
+  test("renders success flash when provided", () => {
+    const html = adminQuestionsPage(
+      [],
+      TEST_SESSION,
+      undefined,
+      undefined,
+      undefined,
+      "Question deleted",
+    );
+    expect(html).toContain(renderSuccess("Question deleted"));
+  });
 });
 
 describe("adminQuestionPage", () => {
@@ -152,6 +165,19 @@ describe("adminQuestionPage", () => {
   test("renders error message when provided", () => {
     const html = adminQuestionPage(question, TEST_SESSION, "Error!");
     expect(html).toContain("Error!");
+  });
+
+  test("renders success flash when provided", () => {
+    const html = adminQuestionPage(
+      question,
+      TEST_SESSION,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "Question updated",
+    );
+    expect(html).toContain(renderSuccess("Question updated"));
   });
 
   test("renders empty answers state", () => {
@@ -485,6 +511,20 @@ describe("adminAnswerEditPage", () => {
       null,
     );
     expect(html).toContain("Invalid modifier");
+  });
+
+  test("renders success flash when provided", () => {
+    const html = adminAnswerEditPage(
+      question,
+      answer,
+      TEST_SESSION,
+      undefined,
+      aligned,
+      modifiers,
+      null,
+      "Selection total recalculated",
+    );
+    expect(html).toContain(renderSuccess("Selection total recalculated"));
   });
 });
 

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -231,11 +231,12 @@ export const expectFlashRedirect =
     const actual = succeeded ? parsed.success : parsed.error;
     // A verified flash redirect must carry a non-empty message at the asserted
     // level; without this, renderSuccess("")/renderError("") is "" and
-    // toContain("") would pass vacuously without proving any banner rendered.
+    // counting "" occurrences would pass vacuously without proving any banner.
     expect(actual).toBeTruthy();
-    expect(html).toContain(
-      succeeded ? renderSuccess(actual) : renderError(actual),
-    );
+    // Exactly once: catches both the dropped-flash bug (zero) and double-render
+    // (two), e.g. a page banner plus a structural Layout/CsrfForm one.
+    const banner = succeeded ? renderSuccess(actual) : renderError(actual);
+    expect(html.split(banner).length - 1).toBe(1);
     return response;
   };
 

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -39,6 +39,8 @@ export const assertFormRedirect = async (
 ): Promise<Response> => {
   const { adminFormPost } = await import("#test-utils/session.ts");
   const { response } = await adminFormPost(path, data);
+  // Cookie-only: callers include the database-reset flow, whose redirect target
+  // can't be followed (the reset wipes the DB and the admin session).
   expectRedirectWithFlash(redirectTo, flashMessage)(response);
   return response;
 };
@@ -122,17 +124,24 @@ export const expectRedirect = (
 export const expectAdminRedirect = (response: Response): string =>
   expectRedirect(response, "/admin");
 
+/** Parse the `flash_*` cookie off a redirect response into its message fields. */
+const parseFlashCookie = (
+  response: Response,
+): ReturnType<typeof parseFlashValue> => {
+  const cookies = response.headers.getSetCookie();
+  const flash = cookies.find((c) => c.startsWith("flash_"))!;
+  const cookiePart = flash.split(";")[0]!;
+  const value = cookiePart.split("=").slice(1).join("=");
+  return parseFlashValue(value);
+};
+
 export const expectFlash = (
   response: Response,
   // deno-lint-ignore no-explicit-any
   message: string | any,
   succeeded = true,
 ): Response => {
-  const cookies = response.headers.getSetCookie();
-  const flash = cookies.find((c) => c.startsWith("flash_"))!;
-  const cookiePart = flash.split(";")[0]!;
-  const value = cookiePart.split("=").slice(1).join("=");
-  const parsed = parseFlashValue(value);
+  const parsed = parseFlashCookie(response);
   const actual = succeeded ? parsed.success : parsed.error;
   if (message !== undefined) expect(actual).toEqual(message);
   return response;
@@ -152,6 +161,61 @@ export const expectRedirectWithFlash =
       expectFlash(response, message, succeeded);
       return response;
     };
+
+/** Lazy default follow cookie: the owner test session, which can GET any admin
+ *  page, so the destination renders for the common admin case without the
+ *  caller threading a cookie through. */
+const defaultFollowCookie = async (): Promise<string> => {
+  const { testCookie } = await import("#test-utils/session.ts");
+  return testCookie();
+};
+
+/**
+ * Curried, mandatory-flash redirect assertion — reach for this after almost
+ * every admin action that ends in a redirect. Asserts that `response`:
+ *   1. is a 302 to `location` (the `?flash=<id>` tracking param is ignored),
+ *   2. carries a flash cookie whose message satisfies `message` (a string or an
+ *      asymmetric matcher such as `expect.stringContaining(...)`), and
+ *   3. RENDERS that flash where the operator lands: it follows the redirect,
+ *      carrying the flash cookie + a session cookie, and asserts the rendered
+ *      banner (built from the real cookie message) is in the returned HTML.
+ *
+ * Step 3 is the whole point — a handler can set a perfect flash cookie that the
+ * destination page silently drops, which a cookie-only assertion never catches.
+ * The message is mandatory: "we were just redirected" verifies almost nothing.
+ * For the genuinely flash-less redirects — payment/checkout hops, the public
+ * success page, API responses, and auth bounces to /admin/login — use
+ * `expectRedirect` instead.
+ *
+ * `cookie` defaults to the owner test session. Pass an explicit cookie for
+ * role-scoped destinations whose page differs for that role, or a public one.
+ */
+export const expectFlashRedirect =
+  (
+    location: string,
+    // deno-lint-ignore no-explicit-any
+    message: string | any,
+    succeeded = true,
+    cookie?: string,
+  ) =>
+  async (response: Response): Promise<Response> => {
+    expectRedirectWithFlash(location, message, succeeded)(response);
+
+    const [{ handleRequest }, { renderError, renderSuccess }] =
+      await Promise.all([import("#routes"), import("#shared/forms.tsx")]);
+    const followed = await followRedirectWithFlash(
+      response,
+      handleRequest,
+      cookie ?? (await defaultFollowCookie()),
+    );
+    const html = await followed.text();
+    const parsed = parseFlashCookie(response);
+    const actual = (succeeded ? parsed.success : parsed.error) ?? "";
+    expect(html).toContain(
+      succeeded ? renderSuccess(actual) : renderError(actual),
+    );
+    return response;
+  };
 
 export const flashCookieHeader = (
   message: string,

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { it } from "@std/testing/bdd";
-import { parseFlashValue } from "#shared/cookies.ts";
+import { getSessionCookieName, parseFlashValue } from "#shared/cookies.ts";
 
 export const FLASH_TEST_ID = "t001";
 
@@ -170,6 +170,20 @@ const defaultFollowCookie = async (): Promise<string> => {
   return testCookie();
 };
 
+/** The session cookie this response sets or clears (login establishes a new one,
+ *  logout clears it), or null when the redirect leaves the session untouched.
+ *  Lets the follow use the session the action actually establishes — so a
+ *  logout is followed logged-out, matching what the browser would render —
+ *  instead of a stale default owner session. */
+const sessionCookieFromResponse = (response: Response): string | null => {
+  const prefix = `${getSessionCookieName()}=`;
+  const match = response.headers
+    .getSetCookie()
+    .map((c) => c.split(";")[0])
+    .find((c) => c?.startsWith(prefix));
+  return match ?? null;
+};
+
 /**
  * Curried, mandatory-flash redirect assertion — reach for this after almost
  * every admin action that ends in a redirect. Asserts that `response`:
@@ -187,8 +201,10 @@ const defaultFollowCookie = async (): Promise<string> => {
  * success page, API responses, and auth bounces to /admin/login — use
  * `expectRedirect` instead.
  *
- * `cookie` defaults to the owner test session. Pass an explicit cookie for
- * role-scoped destinations whose page differs for that role, or a public one.
+ * The follow uses, in order: an explicit `cookie`; the session the response
+ * itself sets or clears (so a login is followed as the new user and a logout as
+ * logged-out, matching the browser); otherwise the owner test session. So even
+ * an auth-mutating redirect renders the page the real user would land on.
  */
 export const expectFlashRedirect =
   (
@@ -206,11 +222,17 @@ export const expectFlashRedirect =
     const followed = await followRedirectWithFlash(
       response,
       handleRequest,
-      cookie ?? (await defaultFollowCookie()),
+      cookie ??
+        sessionCookieFromResponse(response) ??
+        (await defaultFollowCookie()),
     );
     const html = await followed.text();
     const parsed = parseFlashCookie(response);
-    const actual = (succeeded ? parsed.success : parsed.error) ?? "";
+    const actual = succeeded ? parsed.success : parsed.error;
+    // A verified flash redirect must carry a non-empty message at the asserted
+    // level; without this, renderSuccess("")/renderError("") is "" and
+    // toContain("") would pass vacuously without proving any banner rendered.
+    expect(actual).toBeTruthy();
     expect(html).toContain(
       succeeded ? renderSuccess(actual) : renderError(actual),
     );


### PR DESCRIPTION
## The bug

Saving a question showed no flash message. The question pages rendered `<Flash error={error} />` but the handlers never passed `flash.success` (and the templates had no success slot), so the "Question created/updated" message set on the PRG redirect was silently dropped on the page the operator landed on.

## Why no test caught it

Every redirect test asserted the flash **cookie** on the 302 (`expectRedirectWithFlash` / `expectFlash`) but never followed the redirect to check the destination page actually **rendered** it. The cookie was always set correctly — the rendering was what broke. So the whole class of bug was invisible to the suite.

## The fix + the new assertion

- **Questions**: thread `flash.success` / `flash.error` through the list, detail, and answer-edit pages.
- **`expectFlashRedirect(location, message, succeeded?, cookie?)`** — a curried assertion that checks the 302 + the flash cookie (**message is mandatory**) **and** follows the redirect, carrying the flash cookie + a session cookie, to assert the rendered banner is in the HTML the operator receives. It defaults to the owner session, so the follow is free for the common admin case.
- The suite is swept onto it. `expectRedirectWithFlash` stays as the cookie-only check for redirect-builder unit tests and the genuinely non-followable cases: DB reset wipes the session, password change rotates it, external-API mocks scoped to the POST, the public `/join/complete` page, and the calendar view (which has no flash banner). Each is commented at the call site.

## Bugs the render check then surfaced (all fixed the same way)

The sweep proved the questions bug was **systemic**, not isolated:

| Feature | What was wrong |
| --- | --- |
| **refunds** | single + bulk refund pages rendered with `undefined` instead of the flash; bulk continuation success had no success slot |
| **bulk-email** | compose + preview rendered a bare `<Flash />` with no props |
| **groups** | detail page rendered success but not error |
| **users** | invite form and the confirmed-delete render callback dropped the error |
| **owner-crud** | the shared edit-page helper applied the flash but never passed it to the renderer — fixes every CRUD resource's edit page |

## Verification

`deno task precommit` passes in full: lint, typecheck, **0% duplication**, build, and the complete test suite at **100% coverage**.

## Known follow-up (out of scope here)

The API-keys delete-confirmation page has no `error` slot at all, so a wrong-confirmation there shows nothing. It wasn't in the swept set; left for a focused follow-up rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt8AhchP2za2oCAgcYJ3Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt8AhchP2za2oCAgcYJ3Ac)_