### PR TITLE
Remove flash boilerplate the Layout backstop made redundant; fix bulk-email form-targeting

### DIFF
--- a/src/features/admin/attendee-refunds.ts
+++ b/src/features/admin/attendee-refunds.ts
@@ -141,13 +141,7 @@ const handleAdminRefundAllGet = (
           400,
         )
       : htmlResponse(
-          adminRefundAllAttendeesPage(
-            listing,
-            count,
-            session,
-            flash.error,
-            flash.success,
-          ),
+          adminRefundAllAttendeesPage(listing, count, session, flash.error),
         );
   });
 

--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -75,7 +75,6 @@ import {
   getEmailConfig,
   sendBulkEmails,
 } from "#shared/email.ts";
-import type { Flash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { MAX_EMAIL_TEMPLATES } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
@@ -148,20 +147,16 @@ const saveDraft = async (
   await settings.update.bulkEmailDraft(encrypted);
 };
 
-/** Wrap an owner-only page builder: gate on owner, apply flash, then build.
- * The flash is handed to the builder so the page can render it as a banner. */
+/** Wrap an owner-only page builder: gate on owner, record the flash's target
+ * form (so a matching CsrfForm renders it inline), then build. The flash itself
+ * is rendered by the targeted form or the Layout backstop — not threaded here. */
 const ownerEmailPage =
-  (
-    build: (
-      request: Request,
-      session: AuthSession,
-      flash: Flash,
-    ) => Promise<Response>,
-  ) =>
+  (build: (request: Request, session: AuthSession) => Promise<Response>) =>
   (request: Request): Promise<Response> =>
-    requireOwnerOr(request, (session) =>
-      build(request, session, applyFlash(request)),
-    );
+    requireOwnerOr(request, (session) => {
+      applyFlash(request);
+      return build(request, session);
+    });
 
 /** Split recipients into those who'll be sent to and a skipped (unsubscribed) count. */
 const partitionRecipients = async (
@@ -193,7 +188,7 @@ const decryptTemplateSubjects = async (
 };
 
 /** GET /admin/emails — compose form. */
-const handleComposeGet = ownerEmailPage(async (request, session, flash) => {
+const handleComposeGet = ownerEmailPage(async (request, session) => {
   const params = new URL(request.url).searchParams;
   const target = await targetFromQuery(params);
   if (!target) return notFoundResponse();
@@ -234,11 +229,9 @@ const handleComposeGet = ownerEmailPage(async (request, session, flash) => {
       copy: targetComposeCopy(target),
       disabledReason,
       draft,
-      error: flash.error,
       recipientCount: recipients.length,
       selectedTemplateId,
       single: targetIsSingleRecipient(target),
-      success: flash.success,
       targetLabel,
       templateLinkBase: `${COMPOSE_PATH}${targetQuery(target)}`,
       templates,
@@ -295,7 +288,7 @@ const handlePreviewPost = (request: Request): Promise<Response> =>
 /* jscpd:ignore-end */
 
 /** GET /admin/emails/preview — render the saved draft for confirmation. */
-const handlePreviewGet = ownerEmailPage(async (_request, session, flash) => {
+const handlePreviewGet = ownerEmailPage(async (_request, session) => {
   const privateKey = await requirePrivateKey(session);
   const draft = await parseSavedDraft(privateKey);
   if (!draft) return redirectResponse(COMPOSE_PATH);
@@ -317,7 +310,6 @@ const handlePreviewGet = ownerEmailPage(async (_request, session, flash) => {
       contactSummary: contactFrequencySummary(counts),
       disabledReason,
       draft,
-      error: flash.error,
       mailtoLink: buildMailtoLink(
         sendable,
         draft.subject,
@@ -330,7 +322,6 @@ const handlePreviewGet = ownerEmailPage(async (_request, session, flash) => {
       sendableCount: sendable.length,
       sendableEmails: sendable,
       skippedCount: skipped,
-      success: flash.success,
       targetLabel,
     }),
   );

--- a/src/features/admin/dashboard.ts
+++ b/src/features/admin/dashboard.ts
@@ -40,7 +40,8 @@ export const loginResponse = async (
 ): Promise<Response> => {
   const flash = applyFlash(request);
   await signCsrfToken();
-  return htmlResponse(adminLoginPage(flash.error, flash.success), status);
+  // success (e.g. "Logged out") is rendered by the Layout backstop from context.
+  return htmlResponse(adminLoginPage(flash.error), status);
 };
 
 /** Maximum number of newest attendees to show on dashboard */

--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -148,7 +148,6 @@ const handleQuestionsGet = ownerPage(async (session) => {
     flash.error,
     listingNames,
     allListings.length,
-    flash.success,
   );
 });
 
@@ -190,7 +189,6 @@ const handleQuestionGet = ownerGetById(
         answerCounts,
         allListings,
         new Set(assignedListingIds),
-        flash.success,
       ),
     );
   },
@@ -390,7 +388,6 @@ const handleEditAnswerGet = answerRoute(async (question, answer, session) => {
       aggregateRecalculation,
       modifiers,
       modifierId,
-      flash.success,
     ),
   );
 });

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -138,12 +138,11 @@ export const adminRefundAllAttendeesPage = (
   refundableCount: number,
   session: AdminSession,
   error?: string,
-  success?: string,
 ): string =>
   String(
     <Layout title={`Refund All: ${listing.name}`}>
       <AdminNav active="/admin/" session={session} />
-      <Flash error={error} success={success} />
+      <Flash error={error} />
 
       <ConfirmForm
         action={`/admin/listing/${listing.id}/refund-all`}

--- a/src/ui/templates/admin/bulk-email.tsx
+++ b/src/ui/templates/admin/bulk-email.tsx
@@ -25,9 +25,6 @@ const NAV_ACTIVE = "/admin/settings";
 const EMAIL_SETTINGS_LINK = "/admin/settings-advanced#settings-email";
 
 export type BulkEmailComposeState = {
-  /** Flash messages surfaced after a redirect back to the compose form. */
-  error?: string;
-  success?: string;
   /** How to render the recipient control (spec-driven: selector or fixed). */
   control: ComposeControl;
   /** Heading + intro for this kind of target (spec-driven). */
@@ -111,7 +108,6 @@ export const bulkEmailComposePage = (
     <Layout title={copy.heading}>
       <AdminNav active={NAV_ACTIVE} session={session} />
       <SettingsSubNav />
-      <Flash error={state.error} success={state.success} />
 
       <div class="prose">
         <h1>{copy.heading}</h1>
@@ -285,9 +281,6 @@ export const bulkEmailTemplateDeletePage = (
   );
 
 export type BulkEmailPreviewState = {
-  /** Flash messages surfaced after a redirect to the preview page. */
-  error?: string;
-  success?: string;
   draft: BulkEmailDraft;
   /** Human label for the target: audience label or listing name. */
   targetLabel: string;
@@ -335,7 +328,6 @@ export const bulkEmailPreviewPage = (
     <Layout title={t("bulk_email.preview_page_title")}>
       <AdminNav active={NAV_ACTIVE} session={session} />
       <SettingsSubNav />
-      <Flash error={state.error} success={state.success} />
 
       <div class="prose">
         <h1>{t("bulk_email.preview_page_title")}</h1>

--- a/src/ui/templates/admin/login.tsx
+++ b/src/ui/templates/admin/login.tsx
@@ -13,10 +13,10 @@ import { Layout } from "#templates/layout.tsx";
 /**
  * Admin login page
  */
-export const adminLoginPage = (error?: string, success?: string): string =>
+export const adminLoginPage = (error?: string): string =>
   String(
     <Layout title={t("login.title")}>
-      <Flash error={error} success={success} />
+      <Flash error={error} />
       <CsrfForm action="/admin/login">
         <Raw html={renderFields(getLoginFields())} />
         <SubmitButton icon="log-in">{t("login.submit")}</SubmitButton>

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -87,7 +87,6 @@ export const adminQuestionsPage = (
   error?: string,
   listingNames: Map<number, string[]> = new Map(),
   totalListings = 0,
-  success?: string,
 ): string =>
   String(
     <Layout title={t("questions.title")}>
@@ -97,7 +96,7 @@ export const adminQuestionsPage = (
       <p class="actions">
         <GuideLink href="/admin/guide#questions">Questions guide</GuideLink>
       </p>
-      <Flash error={error} success={success} />
+      <Flash error={error} />
 
       <CsrfForm action="/admin/questions" id="new-question">
         <Raw html={questionTextForm.render()} />
@@ -155,7 +154,6 @@ export const adminQuestionPage = (
   answerCounts?: Map<number, number>,
   allListings: ListingWithCount[] = [],
   assignedListingIds: Set<number> = new Set(),
-  success?: string,
 ): string =>
   String(
     <Layout title={`Question: ${question.text}`}>
@@ -163,7 +161,7 @@ export const adminQuestionPage = (
       <SettingsSubNav />
 
       <h1>{question.text}</h1>
-      <Flash error={error} success={success} />
+      <Flash error={error} />
 
       <CsrfForm action={`/admin/questions/${question.id}/edit`}>
         <Raw html={questionTextForm.field("text").render(question.text)} />
@@ -373,7 +371,6 @@ export const adminAnswerEditPage = (
   aggregateRecalculation: AnswerAggregateRecalculation,
   modifiers: AnswerModifierOption[],
   modifierId: number | null,
-  success?: string,
 ): string =>
   String(
     <Layout title={t("questions.edit_answer.title")}>
@@ -392,7 +389,7 @@ export const adminAnswerEditPage = (
           {t("questions.edit_answer.question_context", { text: question.text })}
         </small>
       </p>
-      <Flash error={error} success={success} />
+      <Flash error={error} />
 
       <CsrfForm
         action={`/admin/questions/${question.id}/answers/${answer.id}/edit`}

--- a/test/api-keys.test.ts
+++ b/test/api-keys.test.ts
@@ -27,6 +27,7 @@ import {
   createTestListing,
   describeWithEnv,
   expectFlash,
+  expectFlashRedirect,
   expectRedirect,
   extractCsrfToken,
   FLASH_TEST_ID,
@@ -432,8 +433,13 @@ describeWithEnv("API Keys", { db: true }, () => {
         }),
       );
 
-      expect(response.status).toBe(302);
-      expectFlash(response, expect.stringContaining("does not match"), false);
+      // The delete-confirmation page has no error slot of its own; the Layout
+      // backstop renders the mismatch error, so the operator actually sees it.
+      await expectFlashRedirect(
+        `/admin/api-keys/${id}/delete`,
+        expect.stringContaining("does not match"),
+        false,
+      )(response);
       expect(await countApiKeysForUser(1)).toBe(1);
     });
 

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
-import { renderSuccess } from "#shared/forms.tsx";
 import {
   adminListingPage,
   buildAnswerSummaryRows,
@@ -113,18 +112,6 @@ describe("adminQuestionsPage", () => {
     const html = adminQuestionsPage([], TEST_SESSION, "Something went wrong");
     expect(html).toContain("Something went wrong");
   });
-
-  test("renders success flash when provided", () => {
-    const html = adminQuestionsPage(
-      [],
-      TEST_SESSION,
-      undefined,
-      undefined,
-      undefined,
-      "Question deleted",
-    );
-    expect(html).toContain(renderSuccess("Question deleted"));
-  });
 });
 
 describe("adminQuestionPage", () => {
@@ -165,19 +152,6 @@ describe("adminQuestionPage", () => {
   test("renders error message when provided", () => {
     const html = adminQuestionPage(question, TEST_SESSION, "Error!");
     expect(html).toContain("Error!");
-  });
-
-  test("renders success flash when provided", () => {
-    const html = adminQuestionPage(
-      question,
-      TEST_SESSION,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "Question updated",
-    );
-    expect(html).toContain(renderSuccess("Question updated"));
   });
 
   test("renders empty answers state", () => {
@@ -511,20 +485,6 @@ describe("adminAnswerEditPage", () => {
       null,
     );
     expect(html).toContain("Invalid modifier");
-  });
-
-  test("renders success flash when provided", () => {
-    const html = adminAnswerEditPage(
-      question,
-      answer,
-      TEST_SESSION,
-      undefined,
-      aligned,
-      modifiers,
-      null,
-      "Selection total recalculated",
-    );
-    expect(html).toContain(renderSuccess("Selection total recalculated"));
   });
 });
 


### PR DESCRIPTION
Follow-up to #1370. Now that the `Layout` renders the request's flash structurally, the per-page threading is redundant. This removes the clean cases, fixes the one spot where a page-level banner fought the new form-targeting, and closes the api-keys follow-up with a test.

## 1. bulk-email — fixes Codex review thread on #1370 (form-targeted flash)

The compose validation error redirects with `form=bulk-email#bulk-email`, so the `<CsrfForm id="bulk-email">` should render it inline. But the top-level `<Flash error={state.error}>` I'd added rendered it at the top **and consumed it**, pre-empting the inline form — and since the browser jumps to the `#bulk-email` anchor, a user could land *past* the error.

Fix: drop the redundant compose/preview banners. Form-targeted errors now render **inline at the form**; non-targeted flashes render via the Layout backstop. (`applyFlash` is still called, to record the target form for the CsrfForm.)

## 2. Success-side boilerplate removal

Success is always cookie-derived (no dual-duty), so the backstop fully covers it. Removed the success params + handler threadings from:
- questions list / detail / answer-edit pages
- the login page (`"Logged out"` now via the backstop)
- the bulk-refund page

…plus the now-obsolete template-level success tests.

## 3. api-keys — closes the known follow-up with a test

The delete-confirmation page never had an `error` slot. The backstop now renders its mismatch error, so the operator actually sees "…does not match". Converted the test to `expectFlashRedirect` to prove the rendered banner is there — **no code change needed**, the backstop already fixed it.

## Deliberately kept

`error` params are retained where a page **also** renders a *direct, computed* error at 400 (refunds' "no payment", recalculate's "choose a field", the settings `errorPage` sites) or feeds a **shared** template. The backstop already makes a forgotten error thread safe, so removing those would be lower-value churn that reorders positional args across many call sites — better as a separate, deliberate pass if wanted.

## Verification

Net **−63 lines**. `deno task precommit` passes: lint, typecheck, **0% duplication**, build, full suite at **100% coverage**. The `expectFlashRedirect` exactly-once assertion guarantees each removed page still shows its flash once (now via the backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt8AhchP2za2oCAgcYJ3Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt8AhchP2za2oCAgcYJ3Ac)_