### PR TITLE
Fix free-text answer string ids dropped by replica reads at checkout

### DIFF
--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -742,16 +742,21 @@ type CreatedEntry = { attendee: CreatedAttendee; listing: ListingWithCount };
 const textRefsWithStringId = (
   refs: TextAnswerRef[],
   listingId: number,
-): TextAnswerRef[] =>
-  refs.filter((ref) => {
-    if (Number.isInteger(ref.s)) return true;
-    logError({
-      code: ErrorCode.DATA_INVALID,
-      detail: `Text answer ref missing string id (question=${ref.q})`,
-      listingId,
-    });
-    return false;
-  });
+): TextAnswerRef[] => {
+  const resolved: TextAnswerRef[] = [];
+  for (const ref of refs) {
+    if (Number.isInteger(ref.s)) {
+      resolved.push(ref);
+    } else {
+      logError({
+        code: ErrorCode.DATA_INVALID,
+        detail: `Text answer ref missing string id (question=${ref.q})`,
+        listingId,
+      });
+    }
+  }
+  return resolved;
+};
 
 const saveSessionAnswers = async (
   createdEntries: CreatedEntry[],

--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -728,6 +728,31 @@ type CreatedAttendee = Extract<
 
 type CreatedEntry = { attendee: CreatedAttendee; listing: ListingWithCount };
 
+/**
+ * Keep only the text-answer refs that still carry a resolved string id (`s`).
+ *
+ * A ref without one is corrupt metadata: a checkout signed before string-id
+ * resolution was fixed to read its ids back from the primary could drop the `s`
+ * (a replica answered the read before the insert replicated, so the id resolved
+ * to undefined and JSON.stringify omitted the key). The referenced text is not
+ * recoverable from the metadata, so we drop that single answer and surface it
+ * loudly, rather than bind an undefined id — the payment is already captured, so
+ * the booking must still finalize instead of crash-looping the webhook.
+ */
+const textRefsWithStringId = (
+  refs: TextAnswerRef[],
+  listingId: number,
+): TextAnswerRef[] =>
+  refs.filter((ref) => {
+    if (Number.isInteger(ref.s)) return true;
+    logError({
+      code: ErrorCode.DATA_INVALID,
+      detail: `Text answer ref missing string id (question=${ref.q})`,
+      listingId,
+    });
+    return false;
+  });
+
 const saveSessionAnswers = async (
   createdEntries: CreatedEntry[],
   intent: BookingIntent,
@@ -751,13 +776,14 @@ const saveSessionAnswers = async (
   );
   for (const { attendee, listing } of createdEntries) {
     const refs = intent.listingTextAnswerIds?.[String(listing.id)] ?? [];
-    if (refs.length === 0) continue;
+    const resolvedRefs = textRefsWithStringId(refs, listing.id);
+    if (resolvedRefs.length === 0) continue;
     const existing = grouped.get(attendee.id) ?? { answerIds: [] };
     grouped.set(attendee.id, {
       ...existing,
       textAnswerIds: [
         ...(existing.textAnswerIds ?? []),
-        ...refs.map((ref) => ({ questionId: ref.q, stringId: ref.s })),
+        ...resolvedRefs.map((ref) => ({ questionId: ref.q, stringId: ref.s })),
       ],
     });
   }

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -204,6 +204,10 @@ const computeListingTextAnswerIdMap = async (
       ),
     ).map(([listingId, answers]) => [
       listingId,
+      // These answers are a subset of the texts handed to getOrCreateStringIds,
+      // which returns an id for every input text or throws — so `s` is always a
+      // real id here, never the undefined that JSON.stringify would silently
+      // drop from the signed metadata.
       answers.map((answer) => ({
         q: answer.questionId,
         s: stringIds.get(answer.text)!,

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -17,11 +17,13 @@ import {
 import {
   execute,
   executeBatch,
+  executeBatchWithResults,
   inPlaceholders,
   insert,
   queryAll,
   queryOne,
   resetAggregates,
+  resultRows,
 } from "#shared/db/client.ts";
 /* jscpd:ignore-end */
 import { columnMapByIds, swapSortOrder } from "#shared/db/query.ts";
@@ -555,14 +557,35 @@ export function parseQuestionAnswers(opts: { optional: boolean }) {
 }
 
 /**
- * Replace every listed attendee's answers in one atomic batch: each attendee's
- * existing answers are deleted, then their new answer set inserted. The
- * `Map<attendeeId, answerIds>` is the single shape every save situation reduces
- * to — one answer set shared across attendees, a by-question selection, or the
- * per-listing grouping from `groupListingAnswers` — so callers build the map and
- * this builds the SQL. Repeated question answers collapse to the last value
- * before insert, matching the single-answer-per-question invariant.
+ * Pair each just-written string (`text` + its `textIndex`) with the id the
+ * post-insert SELECT returned, keyed by text.
+ *
+ * Throws if any `textIndex` is missing from `found`. In `getOrCreateStringIds`
+ * the read runs in the same write-mode batch as the insert (one primary
+ * transaction), so every index we wrote must come back; a miss means that
+ * read-your-writes invariant broke. Returning an `undefined` id instead would
+ * corrupt every caller silently — a checkout would drop the `s` from its signed
+ * metadata and the webhook would later bind `undefined` into SQL ("Unsupported
+ * type of value"). Failing loudly here keeps the corruption from escaping.
  */
+export const pairStringIds = (
+  rows: readonly { text: string; textIndex: string }[],
+  found: readonly { id: number; text_index: string }[],
+): Map<string, number> => {
+  const idByIndex = new Map(found.map((row) => [row.text_index, row.id]));
+  return new Map(
+    rows.map((row) => {
+      const id = idByIndex.get(row.textIndex);
+      if (id === undefined) {
+        throw new Error(
+          `String id missing immediately after insert (text_index=${row.textIndex})`,
+        );
+      }
+      return [row.text, id];
+    }),
+  );
+};
+
 export const getOrCreateStringIds = async (
   texts: string[],
 ): Promise<Map<string, number>> => {
@@ -577,7 +600,13 @@ export const getOrCreateStringIds = async (
   );
   const created = nowIso();
   const textIndexes = rows.map((r) => r.textIndex);
-  await executeBatch([
+  // Insert, refresh `created`, and read the ids back in ONE write-mode batch.
+  // A write batch is a single transaction forwarded to the primary, so the
+  // trailing SELECT reads its own just-inserted rows. Reading the ids with a
+  // separate query would be a plain read the platform may serve from a replica
+  // that has not yet replicated the insert — for a brand-new string it returns
+  // no row, the id resolves to undefined, and the value is silently lost.
+  const results = await executeBatchWithResults([
     ...rows.map((row) => ({
       args: [row.textIndex, row.encrypted, created],
       sql: "INSERT OR IGNORE INTO strings (text_index, encrypted_text, created) VALUES (?, ?, ?)",
@@ -593,13 +622,13 @@ export const getOrCreateStringIds = async (
       args: [created, ...textIndexes],
       sql: `UPDATE strings SET created = ? WHERE text_index IN (${inPlaceholders(textIndexes)})`,
     },
+    {
+      args: textIndexes,
+      sql: `SELECT id, text_index FROM strings WHERE text_index IN (${inPlaceholders(textIndexes)})`,
+    },
   ]);
-  const found = await queryAll<{ id: number; text_index: string }>(
-    `SELECT id, text_index FROM strings WHERE text_index IN (${inPlaceholders(textIndexes)})`,
-    textIndexes,
-  );
-  const idByIndex = new Map(found.map((row) => [row.text_index, row.id]));
-  return new Map(rows.map((row) => [row.text, idByIndex.get(row.textIndex)!]));
+  const found = resultRows<{ id: number; text_index: string }>(results.at(-1)!);
+  return pairStringIds(rows, found);
 };
 
 export type AttendeeAnswerSet = {
@@ -666,6 +695,15 @@ const existingQuestionIds = async (
   return new Set(rows.map((row) => row.id));
 };
 
+/**
+ * Replace every listed attendee's answers in one atomic batch: each attendee's
+ * existing answers are deleted, then their new answer set inserted. The
+ * `Map<attendeeId, answerIds>` is the single shape every save situation reduces
+ * to — one answer set shared across attendees, a by-question selection, or the
+ * per-listing grouping from `groupListingAnswers` — so callers build the map and
+ * this builds the SQL. Repeated question answers collapse to the last value
+ * before insert, matching the single-answer-per-question invariant.
+ */
 export const saveAttendeeAnswers = async (
   answersByAttendee: Map<number, number[] | AttendeeAnswerSet>,
 ): Promise<void> => {

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { hmacHash } from "#shared/crypto/hashing.ts";
 import { createAttendeeAtomic } from "#shared/db/attendees.ts";
 import { execute, queryAll } from "#shared/db/client.ts";
 import { pruneUnusedStrings } from "#shared/db/prune.ts";
@@ -21,6 +22,7 @@ import {
   getQuestionsForListing,
   getQuestionsWithListingIds,
   getQuestionWithAnswers,
+  pairStringIds,
   questionDisplayTypeError,
   questionsTable,
   requireQuestionDisplayType,
@@ -880,6 +882,75 @@ describeWithEnv("custom questions", { db: true }, () => {
 
       const after = await getAttendeeAnswersBatch([att.id], { texts: false });
       expect(after.get(att.id)).toBeUndefined();
+    });
+  });
+
+  describe("getOrCreateStringIds", () => {
+    test("returns a complete map of real ids for brand-new texts", async () => {
+      const texts = ["Wheelchair access", "Vegan meal", "Front row"];
+      const ids = await getOrCreateStringIds(texts);
+
+      // Every input text resolves to a distinct, positive-integer id with no
+      // undefined slipping through. An undefined here is exactly what dropped
+      // the `s` from a checkout's signed metadata and later made the webhook
+      // bind an unsupported value, so this is the core read-your-writes guard.
+      expect([...ids.keys()].sort()).toEqual([...texts].sort());
+      // Distinct texts must resolve to distinct ids — no collision or reuse.
+      expect(new Set(ids.values()).size).toBe(texts.length);
+
+      // Each id must point at the row for that exact text, proven via the blind
+      // index — this also proves every id is a real row id (not undefined or a
+      // wrong number): a mutant id matches no row or a different text_index.
+      for (const text of texts) {
+        const rows = await queryAll<{ text_index: string }>(
+          "SELECT text_index FROM strings WHERE id = ?",
+          [ids.get(text)!],
+        );
+        expect(rows.length).toBe(1);
+        expect(rows[0]!.text_index).toBe(await hmacHash(text));
+      }
+    });
+
+    test("dedupes repeated input text to one id", async () => {
+      const ids = await getOrCreateStringIds(["Same", "Same", "Same"]);
+      expect([...ids.keys()]).toEqual(["Same"]);
+      expect(Number.isInteger(ids.get("Same"))).toBe(true);
+    });
+
+    test("returns an empty map for no texts", async () => {
+      const ids = await getOrCreateStringIds([]);
+      expect(ids.size).toBe(0);
+    });
+  });
+
+  describe("pairStringIds", () => {
+    test("pairs each text with the id matching its text_index", () => {
+      const rows = [
+        { text: "alpha", textIndex: "idx-a" },
+        { text: "beta", textIndex: "idx-b" },
+      ];
+      // Deliberately out of order to prove pairing is by index, not position.
+      const found = [
+        { id: 11, text_index: "idx-b" },
+        { id: 7, text_index: "idx-a" },
+      ];
+      expect(pairStringIds(rows, found)).toEqual(
+        new Map([
+          ["alpha", 7],
+          ["beta", 11],
+        ]),
+      );
+    });
+
+    test("throws naming the text_index when a written row is missing", () => {
+      const rows = [{ text: "ghost", textIndex: "idx-missing" }];
+      // A missing row is the read-your-writes failure that must fail loudly
+      // rather than yield an undefined id callers would bind into SQL.
+      expect(() => pairStringIds(rows, [])).toThrow("idx-missing");
+    });
+
+    test("returns an empty map for no rows", () => {
+      expect(pairStringIds([], []).size).toBe(0);
     });
   });
 

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -5935,5 +5935,199 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         mockVerify.restore();
       }
     });
+
+    test("a submitted free-text answer keeps its string id through checkout and the webhook", async () => {
+      await setupStripe();
+
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        name: "Round Trip Paid",
+        unitPrice: 1000,
+      });
+      const question = await questionsTable.insert({
+        displayType: "free_text",
+        text: "Access needs?",
+      });
+      await setListingQuestions(listing.id, [question.id]);
+
+      // Drive the REAL checkout so ticket-submit resolves the free-text answer
+      // to a string id and packs it into the intent. Capture that intent: its
+      // listingTextAnswerIds is exactly what gets serialized into the provider
+      // metadata, so a dropped `s` here is the production bug. The earlier
+      // free-text test hand-built this metadata and so could never catch it.
+      const { stripePaymentProvider } = await import(
+        "#shared/stripe-provider.ts"
+      );
+      const captured: CheckoutIntent[] = [];
+      const mockCreate = stub(
+        stripePaymentProvider,
+        "createCheckoutSession",
+        (intent: CheckoutIntent) => {
+          captured.push(intent);
+          return Promise.resolve({
+            checkoutUrl: "https://checkout.stripe.com/pay/cs_round_trip",
+            sessionId: "cs_round_trip",
+          });
+        },
+      );
+      const { submitTicketForm, expectCheckoutRedirect } = await import(
+        "#test-utils"
+      );
+      try {
+        expectCheckoutRedirect(
+          await submitTicketForm(listing.slug, {
+            email: "rt@example.com",
+            name: "Round Tripper",
+            [`question_${question.id}`]: "Step-free entrance",
+          }),
+        );
+      } finally {
+        mockCreate.restore();
+      }
+
+      // The resolved ref must carry a real numeric string id, never the
+      // undefined that JSON.stringify would silently drop from signed metadata.
+      const refs = captured[0]!.listingTextAnswerIds![String(listing.id)]!;
+      expect(refs.length).toBe(1);
+      expect(refs[0]!.q).toBe(question.id);
+      expect(Number.isInteger(refs[0]!.s)).toBe(true);
+
+      // Serialize those exact refs into webhook metadata the way production does
+      // and confirm the submitted text survives the full round-trip.
+      const mockVerify = await stubWebhookVerify({
+        data: {
+          object: {
+            amount_total: 1000,
+            id: "cs_round_trip",
+            metadata: signedMeta(
+              {
+                email: "rt@example.com",
+                items: singleItem(listing.id, 1, 1000),
+                name: "Round Tripper",
+                text_answer_ids: JSON.stringify(
+                  captured[0]!.listingTextAnswerIds,
+                ),
+              },
+              1000,
+            ),
+            payment_intent: "pi_round_trip",
+            payment_status: "paid",
+          },
+        },
+        id: "evt_round_trip",
+        type: "checkout.session.completed",
+      });
+
+      try {
+        await assertJson(
+          handleRequest(
+            mockWebhookRequest({}, { "stripe-signature": "sig_valid" }),
+          ),
+          200,
+          (json) => {
+            expect(json.received).toBe(true);
+            expect(json.processed).toBe(true);
+          },
+        );
+
+        const { getAttendeesRaw } = await import("#shared/db/attendees.ts");
+        const attendees = await getAttendeesRaw(listing.id);
+        expect(attendees.length).toBe(1);
+        const textAnswers = await getAttendeeTextAnswers(
+          attendees[0]!.id,
+          await getTestPrivateKey(),
+        );
+        expect(textAnswers.get(question.id)).toBe("Step-free entrance");
+      } finally {
+        mockVerify.restore();
+      }
+    });
+
+    test("finalizes a paid booking when a text-answer ref lost its string id, dropping only that answer", async () => {
+      await setupStripe();
+
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        name: "Corrupt Ref Paid",
+        unitPrice: 1000,
+      });
+      const goodQ = await questionsTable.insert({
+        displayType: "free_text",
+        text: "Access needs?",
+      });
+      const lostQ = await questionsTable.insert({
+        displayType: "free_text",
+        text: "Dietary needs?",
+      });
+      await setListingQuestions(listing.id, [goodQ.id, lostQ.id]);
+
+      const stringIds = await getOrCreateStringIds(["Step-free entrance"]);
+
+      // lostQ's ref carries no `s` — the corrupt shape a pre-fix checkout wrote
+      // when the string-id read raced replication and JSON.stringify dropped it.
+      const mockVerify = await stubWebhookVerify({
+        data: {
+          object: {
+            amount_total: 1000,
+            id: "cs_corrupt_ref",
+            metadata: signedMeta(
+              {
+                email: "corrupt@example.com",
+                items: singleItem(listing.id, 1, 1000),
+                name: "Corrupt Ref Buyer",
+                text_answer_ids: JSON.stringify({
+                  [String(listing.id)]: [
+                    { q: goodQ.id, s: stringIds.get("Step-free entrance") },
+                    { q: lostQ.id },
+                  ],
+                }),
+              },
+              1000,
+            ),
+            payment_intent: "pi_corrupt_ref",
+            payment_status: "paid",
+          },
+        },
+        id: "evt_corrupt_ref",
+        type: "checkout.session.completed",
+      });
+
+      try {
+        // The payment is already captured, so the booking must finalize (200,
+        // processed) rather than crash-loop on the unsupported undefined bind.
+        await assertJson(
+          handleRequest(
+            mockWebhookRequest({}, { "stripe-signature": "sig_valid" }),
+          ),
+          200,
+          (json) => {
+            expect(json.received).toBe(true);
+            expect(json.processed).toBe(true);
+          },
+        );
+
+        const { getAttendeesRaw } = await import("#shared/db/attendees.ts");
+        const attendees = await getAttendeesRaw(listing.id);
+        expect(attendees.length).toBe(1);
+
+        // The intact answer is saved; the ref with no id is dropped, not guessed.
+        const textAnswers = await getAttendeeTextAnswers(
+          attendees[0]!.id,
+          await getTestPrivateKey(),
+        );
+        expect(textAnswers.get(goodQ.id)).toBe("Step-free entrance");
+        expect(textAnswers.has(lostQ.id)).toBe(false);
+
+        // The dropped answer is surfaced loudly, not swallowed silently.
+        const log = await getAllActivityLog();
+        expect(
+          log.some((entry) =>
+            entry.message.includes("Text answer ref missing string id"),
+          ),
+        ).toBe(true);
+      } finally {
+        mockVerify.restore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## What broke

A paid checkout carrying a **free-text custom answer** could fail to finalize in the webhook with libsql's `Unsupported type of value`, while a duplicate redirect reported `Payment is being processed. Please wait a moment and refresh.` Both errors are the same incident — the webhook created the attendee, then crashed before finalizing.

## Root cause

`getOrCreateStringIds` inserted new `strings` rows in a **write**-mode batch (forwarded to the primary), then read their ids back with a **separate** query — a plain read the platform can serve from a **read replica that hasn't replicated the insert yet**. Bunny's docs confirm the split: write transactions go to the primary, read transactions can run on lagging replicas.

For a brand-new string the read missed the row, the id resolved to `undefined`, and `JSON.stringify` **silently dropped `s`** from the signed checkout metadata (`{"q":4,"s":…}` → `{"q":4}`). At webhook time the missing `s` was bound straight into the `attendee_answers` INSERT, libsql rejected it, and the already-captured booking never finalized.

It slipped past the suite because tests run on a single `:memory:` database (no replica, so read-your-writes always holds), and the existing round-trip test hand-built the webhook metadata with `getOrCreateStringIds` instead of asserting what the real checkout produced.

## Changes

- **`questions.ts`** — fold the id read into the *same* write-mode batch so it reads its own writes on the primary. Extract a `pairStringIds` guard that **throws** if a just-written row is missing rather than returning an `undefined` id that callers would bind into SQL.
- **`webhooks.ts`** — defense-in-depth: drop and **loudly log** any text-answer ref whose string id is missing, so a booking whose metadata was signed *before* this fix still finalizes instead of crash-looping the webhook (the payment is already captured).
- **`ticket-submit.ts`** — document why the resolved `s` is now always present.
- Move a stranded doc comment back onto `saveAttendeeAnswers` (good-citizen fixup).

## Tests

- `getOrCreateStringIds` read-your-writes contract — every text resolves to a real id, each tied to its row via the blind index.
- `pairStringIds` guard throws naming the missing index.
- **End-to-end round-trip** that drives the *real* checkout, asserts the resolved `s` is a real numeric id (the assertion the prior test skipped), and confirms the text survives checkout → webhook.
- Defense-in-depth: corrupt metadata finalizes the booking, drops only the unrecoverable answer, and logs the anomaly.

`deno task precommit` passes (lint, typecheck, cpd, build:edge, and the full `test:coverage` suite at 100%).

## ⚠️ Note on the existing stuck payment

This fixes the cause for *new* checkouts. The session that already failed created an attendee and then crashed before finalizing, so it likely left an **orphaned, unfinalized attendee** plus a held reservation. That one needs manual repair — happy to help diagnose/clean it up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176cfQQ5BeYpzvNPeTbzpMk

---
_Generated by [Claude Code](https://claude.ai/code/session_0176cfQQ5BeYpzvNPeTbzpMk)_