### PR TITLE
Fix flaky CLI e2e test: pin subprocess cwd, drop global chdir

### DIFF
--- a/cli/api.ts
+++ b/cli/api.ts
@@ -19,5 +19,5 @@ if (!request) {
   Deno.exit(2);
 }
 
-const config = await loadConfig();
+const config = await loadConfig(Deno.cwd());
 await writeOut(`${JSON.stringify(await curlJson(config, request), null, 2)}\n`);

--- a/cli/config.ts
+++ b/cli/config.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 export type CliConfig = Readonly<{ apiHostname: string; apiKey: string }>;
 
 const ENV_HOST = "API_HOSTNAME";
@@ -17,9 +19,9 @@ const parseDotEnv = (text: string): Record<string, string> => {
   return values;
 };
 
-const readDotEnv = async (): Promise<Record<string, string>> => {
+const readDotEnv = async (envDir: string): Promise<Record<string, string>> => {
   try {
-    return parseDotEnv(await Deno.readTextFile(".env"));
+    return parseDotEnv(await Deno.readTextFile(join(envDir, ".env")));
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) return {};
     throw error;
@@ -38,8 +40,8 @@ const requiredPrompt = (label: string): string => {
   return value;
 };
 
-export const loadConfig = async (): Promise<CliConfig> => {
-  const envFile = await readDotEnv();
+export const loadConfig = async (envDir: string): Promise<CliConfig> => {
+  const envFile = await readDotEnv(envDir);
   const apiHostname = cleanHost(
     Deno.env.get(ENV_HOST) ?? envFile[ENV_HOST] ?? requiredPrompt("API host"),
   );

--- a/cli/tui.ts
+++ b/cli/tui.ts
@@ -11,7 +11,7 @@ import {
 
 type State = { resource: ResourceName; last: unknown };
 
-const config = await loadConfig();
+const config = await loadConfig(Deno.cwd());
 const state: State = { last: null, resource: "listings" };
 
 const helpText = `\nTickets CLI (Rezi-style Deno TUI, curl-backed)\nCommands:\n  resource <${resources.join("|")}>\n  list\n  get <id>\n  create <json>\n  update <id> <json>\n  delete <id> <json-confirmation>\n  help\n  quit\n`;

--- a/test/e2e/cli-api.test.ts
+++ b/test/e2e/cli-api.test.ts
@@ -1,3 +1,5 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
@@ -6,6 +8,11 @@ import {
   createTestListing,
   describeWithEnv,
 } from "#test-utils";
+
+// Absolute project root, derived from this file's location rather than the
+// process cwd. The suite runs with --parallel, so the cwd is shared mutable
+// state: another test file may Deno.chdir() into a temp dir it then deletes.
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 const decode = (bytes: Uint8Array): string => new TextDecoder().decode(bytes);
 
@@ -39,6 +46,10 @@ const runCliApiRaw = async (
       "cli/api.ts",
       ...args,
     ],
+    // Pin the spawn's cwd to the project root so it never inherits whatever
+    // transient directory a parallel test left behind (which would fail with
+    // "No such cwd"), and so the relative cli/api.ts path always resolves.
+    cwd: projectRoot,
     env: { API_HOSTNAME: hostname, API_KEY: apiKey },
     stderr: "piped",
     stdout: "piped",

--- a/test/lib/cli.test.ts
+++ b/test/lib/cli.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
@@ -9,15 +10,18 @@ import { buildCurlArgs, curlFailureMessage, curlJson } from "../../cli/curl.ts";
 import { clearScreen, writeErr, writeOut } from "../../cli/io.ts";
 import { parseResource, resourcePath, resources } from "../../cli/resources.ts";
 
-const withTempCwd = async <T>(fn: () => Promise<T>): Promise<T> => {
-  const original = Deno.cwd();
-  const dir = await Deno.makeTempDir();
+// Run `fn` against a throwaway directory it can populate with a `.env`. The
+// directory is passed in explicitly rather than via Deno.chdir, because the cwd
+// is process-global: changing it here would race with parallel test files that
+// spawn subprocesses inheriting that cwd (see test/e2e/cli-api.test.ts).
+const withTempEnvDir = async <T>(
+  fn: (envDir: string) => Promise<T>,
+): Promise<T> => {
+  const envDir = await Deno.makeTempDir();
   try {
-    Deno.chdir(dir);
-    return await fn();
+    return await fn(envDir);
   } finally {
-    Deno.chdir(original);
-    await Deno.remove(dir, { recursive: true });
+    await Deno.remove(envDir, { recursive: true });
   }
 };
 
@@ -28,12 +32,12 @@ describe("CLI config", () => {
       API_KEY: "env-key",
     });
     try {
-      await withTempCwd(async () => {
-        await expect(loadConfig()).resolves.toEqual({
+      await withTempEnvDir((envDir) =>
+        expect(loadConfig(envDir)).resolves.toEqual({
           apiHostname: "https://tickets.example.com",
           apiKey: "env-key",
-        });
-      });
+        }),
+      );
     } finally {
       restore();
     }
@@ -45,9 +49,9 @@ describe("CLI config", () => {
       API_KEY: undefined,
     });
     try {
-      await withTempCwd(async () => {
+      await withTempEnvDir(async (envDir) => {
         await Deno.writeTextFile(
-          ".env",
+          join(envDir, ".env"),
           [
             "# local CLI config",
             "not valid",
@@ -56,7 +60,7 @@ describe("CLI config", () => {
           ].join("\n"),
         );
 
-        await expect(loadConfig()).resolves.toEqual({
+        await expect(loadConfig(envDir)).resolves.toEqual({
           apiHostname: "http://localhost:4567",
           apiKey: "dot-key",
         });
@@ -75,12 +79,12 @@ describe("CLI config", () => {
       label === "API host" ? "prompt.test" : "prompt-key",
     );
     try {
-      await withTempCwd(async () => {
-        await expect(loadConfig()).resolves.toEqual({
+      await withTempEnvDir((envDir) =>
+        expect(loadConfig(envDir)).resolves.toEqual({
           apiHostname: "https://prompt.test",
           apiKey: "prompt-key",
-        });
-      });
+        }),
+      );
     } finally {
       prompt.restore();
       restore();
@@ -94,9 +98,9 @@ describe("CLI config", () => {
     });
     const prompt = stub(globalThis, "prompt", () => "");
     try {
-      await withTempCwd(async () => {
-        await expect(loadConfig()).rejects.toThrow("API host is required");
-      });
+      await withTempEnvDir((envDir) =>
+        expect(loadConfig(envDir)).rejects.toThrow("API host is required"),
+      );
     } finally {
       prompt.restore();
       restore();
@@ -110,9 +114,9 @@ describe("CLI config", () => {
     });
     const prompt = stub(globalThis, "prompt", () => null);
     try {
-      await withTempCwd(async () => {
-        await expect(loadConfig()).rejects.toThrow("API host is required");
-      });
+      await withTempEnvDir((envDir) =>
+        expect(loadConfig(envDir)).rejects.toThrow("API host is required"),
+      );
     } finally {
       prompt.restore();
       restore();
@@ -125,12 +129,12 @@ describe("CLI config", () => {
       API_KEY: "env-key",
     });
     try {
-      await withTempCwd(async () => {
-        await expect(loadConfig()).resolves.toEqual({
+      await withTempEnvDir((envDir) =>
+        expect(loadConfig(envDir)).resolves.toEqual({
           apiHostname: "",
           apiKey: "env-key",
-        });
-      });
+        }),
+      );
     } finally {
       restore();
     }
@@ -142,9 +146,9 @@ describe("CLI config", () => {
       API_KEY: "env-key",
     });
     try {
-      await withTempCwd(async () => {
-        await Deno.mkdir(".env");
-        await expect(loadConfig()).rejects.toThrow();
+      await withTempEnvDir(async (envDir) => {
+        await Deno.mkdir(join(envDir, ".env"));
+        await expect(loadConfig(envDir)).rejects.toThrow();
       });
     } finally {
       restore();


### PR DESCRIPTION
## Problem

`test/e2e/cli-api.test.ts` (e.g. line 179, "prints usage when arguments are missing") was intermittently failing with `No such cwd '/tmp/...'` when spawning the `cli/api.ts` subprocess.

## Root cause — a shared-cwd race under `--parallel`

The runner executes the suite with `--parallel` (`scripts/test-harness.ts`), so test files share one OS process and therefore one process-global working directory.

- `test/lib/cli.test.ts` mutated that shared cwd: its `withTempCwd` helper did `Deno.chdir(tempDir)` … `Deno.remove(tempDir)`.
- `test/e2e/cli-api.test.ts` spawned `cli/api.ts` via `Deno.Command` with **no `cwd`**, so it inherited whatever ambient cwd the process happened to have.

When the two overlapped, the e2e spawn could inherit the temp dir that `cli.test.ts` had already deleted → `No such cwd`.

## Fix — both sides of the race

1. **Direct fix** (`test/e2e/cli-api.test.ts`): pin the `Deno.Command` `cwd` to an absolute project root derived from `import.meta.url` (not `Deno.cwd()`, which is the unstable value). The spawn no longer depends on ambient cwd, and the relative `cli/api.ts` arg always resolves.
2. **Root cause** (`cli/config.ts`, `cli/api.ts`, `cli/tui.ts`, `test/lib/cli.test.ts`): remove the only process-global `Deno.chdir` in the suite. `loadConfig` now takes an explicit `envDir` (production callers pass `Deno.cwd()`), so `cli.test.ts` points at a temp `.env` directory directly instead of `chdir`-ing into it. No test mutates the shared cwd anymore.

## Verification

- `deno task lint:ci` ✓
- `deno task typecheck` ✓
- `deno task test:files test/lib/cli.test.ts test/e2e/cli-api.test.ts` → 41/41 ✓
- `deno task test:coverage` → full suite green, **100% line & branch coverage** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6Pt6kxSG3bc15FvUAkFb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR6Pt6kxSG3bc15FvUAkFb)_