### PR TITLE
Mutation tester: treat zero-mutant runs as inconclusive

### DIFF
--- a/scripts/mutation/runner.ts
+++ b/scripts/mutation/runner.ts
@@ -130,11 +130,17 @@ const evaluateMutant = async (
   }
 };
 
-/** Print the report (and the CI step summary), returning the exit code. */
+/**
+ * Print the report (and the CI step summary), returning the exit code:
+ * 0 = every mutant detected, 1 = survivors, 2 = inconclusive (no mutants, so
+ * the run proved nothing — fail rather than report a vacuous 100% that would
+ * let CI go green on a module with nothing to test).
+ */
 const report = (results: MutantResult[]): number => {
   const summary = summarize(results);
   for (const line of formatSummaryLines(summary)) console.log(line);
   writeStepSummary(summary);
+  if (summary.total === 0) return 2;
   return summary.survived === 0 ? 0 : 1;
 };
 

--- a/scripts/mutation/summary.ts
+++ b/scripts/mutation/summary.ts
@@ -90,16 +90,25 @@ const survivorLine = (result: MutantResult): string => {
 };
 
 /** The full terminal report as lines, ready for the runner to print. Pure. */
-export const formatSummaryLines = (s: Summary): string[] => [
-  bold("\nMutation testing summary"),
-  ...countRows(s).map(renderRow),
-  ...(s.survivors.length === 0
-    ? [green("\nAll mutants were detected.")]
-    : [
-        red("\nSurvivors — these mutations did not fail any test:"),
-        ...s.survivors.map(survivorLine),
-      ]),
-];
+export const formatSummaryLines = (s: Summary): string[] => {
+  if (s.total === 0) {
+    return [
+      bold("\nMutation testing summary"),
+      yellow("  No mutable operators were found — nothing to mutate."),
+      yellow("  Result is INCONCLUSIVE (a mutation score needs ≥1 mutant)."),
+    ];
+  }
+  return [
+    bold("\nMutation testing summary"),
+    ...countRows(s).map(renderRow),
+    ...(s.survivors.length === 0
+      ? [green("\nAll mutants were detected.")]
+      : [
+          red("\nSurvivors — these mutations did not fail any test:"),
+          ...s.survivors.map(survivorLine),
+        ]),
+  ];
+};
 
 // --- GitHub step summary (Markdown) --------------------------------------
 
@@ -109,6 +118,15 @@ const survivorRow = (result: MutantResult): string => {
 };
 
 const markdownSummary = (s: Summary): string => {
+  if (s.total === 0) {
+    return [
+      "## 🧬 Mutation testing",
+      "",
+      "⚠️ **Inconclusive** — no mutable operators were found, so nothing was" +
+        " mutated. A mutation score needs at least one mutant.",
+      "",
+    ].join("\n");
+  }
   const headline =
     s.survived === 0
       ? `✅ **All ${s.total} mutants detected** — score ${s.score.toFixed(1)}%`


### PR DESCRIPTION
Follow-up to #1376 (now merged), addressing one of the two Codex review findings on that PR.

## Fix: zero-mutant runs are now inconclusive (Codex finding 2)

If the matched source files contain no operators the tool mutates, `results` is empty — but `summarize` reported a **100% score** and `report` exited `0` because there were no survivors. A workflow could therefore go **green having mutation-tested nothing at all**.

Now `total === 0` is surfaced as **INCONCLUSIVE** in both the terminal report and the Markdown step summary, and `report` returns exit code **2** (distinct from `1` = survivors) so CI fails rather than passing vacuously.

Verified end-to-end: running against an operator-free source prints the inconclusive notice and exits `2`; normal runs are byte-for-byte unchanged.

## Context: the other two findings need no code change

- **Codex finding 1 ("oxc spans are byte offsets")** — **false positive.** Tested empirically with a Latin-1 char and an astral emoji (surrogate pair) before an operator: oxc-parser@0.132.0 reports the exact **UTF-16** index and both mutants apply correctly. The existing `string.slice` usage is right.
- **`checkout-pricing.ts` mutation run (separate exploration)** — 85.2% raw score, 4 survivors, but on analysis **all four are equivalent mutants** (e.g. `?? → ||` where the fallback equals the only falsy value or the operand is always-truthy; `a - b → a / b` on an index array that is always already-ascending). No tests are warranted — chasing equivalent mutants would mean asserting non-production inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF)_