### PR TITLE
Test validatePrice directly to close its mutation gaps

### DIFF
--- a/test/lib/currency.test.ts
+++ b/test/lib/currency.test.ts
@@ -5,6 +5,7 @@ import {
   getDecimalPlaces,
   toMajorUnits,
   toMinorUnits,
+  validatePrice,
 } from "#shared/currency.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
 import {
@@ -152,6 +153,86 @@ describe("currency", () => {
     testWithSetting("converts KWD (3 decimals)", { currency: "KWD" }, () => {
       expect(toMajorUnits(1050)).toBe("1.050");
     });
+  });
+
+  describe("validatePrice", () => {
+    // GBP → 2 decimal places, so toMinorUnits multiplies major units by 100.
+    testWithSetting(
+      "accepts empty input as 0 when the minimum is 0 (pay-what-you-want)",
+      { currency: "GBP" },
+      () => {
+        expect(validatePrice("", 0, 100_000)).toEqual({ ok: true, price: 0 });
+      },
+    );
+
+    testWithSetting(
+      "rejects empty input when a minimum is required",
+      { currency: "GBP" },
+      () => {
+        expect(validatePrice("", 500, 100_000)).toEqual({
+          error: "Please enter a price",
+          ok: false,
+        });
+      },
+    );
+
+    testWithSetting("rejects non-numeric input", { currency: "GBP" }, () => {
+      expect(validatePrice("abc", 0, 100_000)).toEqual({
+        error: "Please enter a valid price",
+        ok: false,
+      });
+    });
+
+    testWithSetting("rejects a negative price", { currency: "GBP" }, () => {
+      expect(validatePrice("-5", 0, 100_000)).toEqual({
+        error: "Please enter a valid price",
+        ok: false,
+      });
+    });
+
+    testWithSetting(
+      "accepts an in-range price and converts it to minor units",
+      { currency: "GBP" },
+      () => {
+        expect(validatePrice("10", 0, 100_000)).toEqual({
+          ok: true,
+          price: 1000,
+        });
+      },
+    );
+
+    testWithSetting(
+      "rejects a price below the minimum",
+      { currency: "GBP" },
+      () => {
+        // £1 = 100 minor units, below the 500 minimum.
+        expect(validatePrice("1", 500, 100_000)).toEqual({
+          error: "Price must be at least the minimum ticket price",
+          ok: false,
+        });
+      },
+    );
+
+    testWithSetting(
+      "rejects a price above the maximum",
+      { currency: "GBP" },
+      () => {
+        // £2000 = 200000 minor units, above the 100000 maximum.
+        expect(validatePrice("2000", 0, 100_000)).toEqual({
+          error: "Price exceeds the maximum allowed",
+          ok: false,
+        });
+      },
+    );
+
+    testWithSetting(
+      "accepts a price exactly on the minimum and maximum bounds",
+      { currency: "GBP" },
+      () => {
+        // The guards are strict (< / >), so priceMinor === min === max passes.
+        expect(validatePrice("5", 500, 500)).toEqual({ ok: true, price: 500 });
+      },
+    );
   });
 
   describe("settings.currency integration", () => {


### PR DESCRIPTION
Found by running the in-house mutation tester against a randomly-picked module:

```
deno task mutation src/shared/currency.ts test/lib/currency.test.ts
→ 12 mutants, 5 survived (58.3%)
```

All five survivors were guards inside **`validatePrice`** — a money-input validator that had **no direct tests at all**. It was only line-covered *incidentally* (via the `listing-qr` and `ticket-form` feature tests), so its branches were never pinned by assertions — exactly the blind spot 100% line coverage hides and mutation testing exposes.

| Survivor | Guard | Effect of the mutation |
|---|---|---|
| `66:20 === → !=` | `minPrice === 0` | inverts the empty-input / pay-what-you-want case |
| `71:27 \|\| → &&` | `isNaN(parsed) \|\| parsed < 0` | rejection becomes unreachable — NaN/negative slip through |
| `71:37 < → >=` | `parsed < 0` | negative-price guard |
| `75:17 < → >=` | `priceMinor < minPrice` | minimum-price boundary |
| `81:17 > → <=` | `priceMinor > maxPrice` | maximum-price boundary |

This adds a `validatePrice` suite (empty/required, non-numeric, negative, in-range, below-min, above-max, and the exact min/max boundary). Re-running the mutation tester now reports **12/12 killed (100%)**.

**Production code is unchanged** — these were test gaps, not bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF)_