### PR TITLE
Unify ledger leg-identity into one shared field table

### DIFF
--- a/src/shared/accounting/conflicts.ts
+++ b/src/shared/accounting/conflicts.ts
@@ -9,7 +9,7 @@
  */
 
 import { type RowReader, selectById } from "#shared/accounting/rows.ts";
-import { sameAccount } from "#shared/ledger/account.ts";
+import { legIdentityDiff } from "#shared/ledger/reconcile.ts";
 import { isInverseOf } from "#shared/ledger/reverse.ts";
 import type { Transfer, TransferInput } from "#shared/ledger/types.ts";
 
@@ -23,32 +23,12 @@ export class LedgerConflictError extends Error {
   }
 }
 
-// Money-defining fields only: `memo` (non-deterministic ciphertext) and the
-// write-time `recorded_at`/`posted_by` metadata are not compared on replay.
-const kindOf = (t: { kind?: string }): string => t.kind ?? "";
-const reversesIdOf = (t: { reversesId?: number }): number | null =>
-  t.reversesId ?? null;
-
-const financialMismatches = (
-  prior: Transfer,
-  input: TransferInput,
-): string[] => {
-  const checks: [field: string, matches: boolean][] = [
-    ["amount", prior.amount === input.amount],
-    ["currency", prior.currency === input.currency],
-    ["source", sameAccount(prior.source, input.source)],
-    ["destination", sameAccount(prior.destination, input.destination)],
-    ["occurredAt", prior.occurredAt === input.occurredAt],
-    ["kind", kindOf(prior) === kindOf(input)],
-    ["reversesId", reversesIdOf(prior) === reversesIdOf(input)],
-  ];
-  return checks.filter(([, matches]) => !matches).map(([field]) => field);
-};
-
 /**
  * Check that a replayed event presents exactly the stored leg set. Throws if the
  * replay omits a stored leg, adds a leg that was never stored, or changes a
- * leg's money facts.
+ * leg's money facts. The per-leg comparison is {@link legIdentityDiff}, the same
+ * money-identity test reconciliation fingerprints use, so `memo` (non-deterministic
+ * ciphertext) and the write-time `recorded_at`/`posted_by` metadata are ignored.
  */
 export const assertEventMatches = (
   eventGroup: string,
@@ -73,7 +53,7 @@ export const assertEventMatches = (
         `event "${eventGroup}" is already posted without this leg`,
       );
     }
-    const mismatches = financialMismatches(prior, input);
+    const mismatches = legIdentityDiff(prior, input);
     if (mismatches.length > 0) {
       throw new LedgerConflictError(
         input.reference,

--- a/src/shared/accounting/mappers.ts
+++ b/src/shared/accounting/mappers.ts
@@ -47,6 +47,13 @@ type LegSpec = {
   refParts: RefPart[];
 };
 
+/** A single fixed-direction leg, dropped when its amount is zero (a free booking
+ *  posts no fee; a deposit-free reservation posts no payment). */
+const optionalLeg = (
+  amount: number,
+  spec: Omit<LegSpec, "amount">,
+): LegSpec[] => (amount > 0 ? [{ ...spec, amount }] : []);
+
 const modifierLeg = (
   attendee: AccountRef,
   modifier: { modifierId: number; delta: number },
@@ -98,30 +105,18 @@ const bookingLegSpecs = (
   const modifiers = facts.modifiers
     .filter((modifier) => modifier.delta !== 0)
     .map((modifier) => modifierLeg(attendee, modifier));
-  const fee: LegSpec[] =
-    facts.bookingFee > 0
-      ? [
-          {
-            amount: facts.bookingFee,
-            destination: BOOKING_FEE_INCOME,
-            kind: "fee",
-            refParts: ["fee"],
-            source: attendee,
-          },
-        ]
-      : [];
-  const payment: LegSpec[] =
-    facts.amountPaid > 0
-      ? [
-          {
-            amount: facts.amountPaid,
-            destination: attendee,
-            kind: "payment",
-            refParts: ["payment"],
-            source: WORLD,
-          },
-        ]
-      : [];
+  const fee = optionalLeg(facts.bookingFee, {
+    destination: BOOKING_FEE_INCOME,
+    kind: "fee",
+    refParts: ["fee"],
+    source: attendee,
+  });
+  const payment = optionalLeg(facts.amountPaid, {
+    destination: attendee,
+    kind: "payment",
+    refParts: ["payment"],
+    source: WORLD,
+  });
   return [...sales, ...modifiers, ...fee, ...payment];
 };
 

--- a/src/shared/ledger/reconcile.ts
+++ b/src/shared/ledger/reconcile.ts
@@ -56,16 +56,39 @@ type LegFacts = {
  */
 export type LegFingerprint = string;
 
+/**
+ * The money-defining facts of a leg, in a fixed order: change any one of them and
+ * it is a *different* transfer. Both the reconciliation fingerprint
+ * ({@link legFingerprint}) and the replay-equality guard ({@link legIdentityDiff},
+ * used by the store's conflict check) derive from this single table, so the two
+ * can never disagree on what "the same leg" means — adding a field here updates
+ * both at once.
+ */
+const IDENTITY_FIELDS: ReadonlyArray<
+  readonly [field: string, value: (leg: LegFacts) => string | number | null]
+> = [
+  ["kind", (leg) => leg.kind ?? ""],
+  ["source", (leg) => accountKey(leg.source)],
+  ["destination", (leg) => accountKey(leg.destination)],
+  ["amount", (leg) => leg.amount],
+  ["currency", (leg) => leg.currency],
+  ["occurredAt", (leg) => leg.occurredAt],
+  ["reversesId", (leg) => leg.reversesId ?? null],
+];
+
 export const legFingerprint = (leg: LegFacts): LegFingerprint =>
-  JSON.stringify([
-    leg.kind ?? "",
-    accountKey(leg.source),
-    accountKey(leg.destination),
-    leg.amount,
-    leg.currency,
-    leg.occurredAt,
-    leg.reversesId ?? null,
-  ]);
+  JSON.stringify(IDENTITY_FIELDS.map(([, value]) => value(leg)));
+
+/**
+ * The identity fields in which two legs differ, empty when they are the same
+ * money. Shares {@link IDENTITY_FIELDS} with {@link legFingerprint} so a replay's
+ * "stored leg differs in …" report and a reconciliation's fingerprint mismatch
+ * always agree on the set of fields that matter.
+ */
+export const legIdentityDiff = (a: LegFacts, b: LegFacts): string[] =>
+  IDENTITY_FIELDS.filter(([, value]) => value(a) !== value(b)).map(
+    ([field]) => field,
+  );
 
 /** A per-event mismatch between the legs an event should have and those actually
  *  present in the ledger, compared as {@link LegFingerprint}s. */


### PR DESCRIPTION
## What

A deep-dive cleanup of the double-entry accounting code, focused on collapsing two independent definitions of the same invariant into one source of truth.

### 1. One leg-identity field table (the headline)

The pure ledger's reconciliation fingerprint (`shared/ledger/reconcile.ts`) and the store's replay-equality guard (`shared/accounting/conflicts.ts`) each **independently enumerated the same seven money-defining fields** — `kind`, `source`, `destination`, `amount`, `currency`, `occurredAt`, `reversesId`.

That's a duplicated invariant that can silently drift: add a money-defining field to one list but not the other and a replay could be accepted as "matching" while reconciliation flags it (or vice versa) — a subtle accounting bug.

Both now derive from a single `IDENTITY_FIELDS` table in `reconcile.ts`:
- `legFingerprint` joins the field values (unchanged output),
- the new `legIdentityDiff` reports which field *names* differ.

`conflicts.ts` drops `financialMismatches`, `kindOf`, `reversesIdOf`, and the now-unused `sameAccount` import, calling `legIdentityDiff` instead. The "stored leg differs in …" messages are byte-for-byte the same.

### 2. `optionalLeg` helper in `accounting/mappers.ts`

The `fee` and `payment` legs repeated the same "emit one leg only if amount > 0" shape; extracted into a small `optionalLeg` helper.

## Verification

`deno task precommit` passes in full: lint, typecheck, **cpd (0% duplication)**, build, and **test:coverage (100%)** — no behaviour change.

## Note on a follow-up question (valibot / @std)

I also investigated whether `valibot` (already a project dependency) or `@std` could replace the ledger's hand-rolled validation. Conclusion: **not worth it for this code** — the pure ledger is deliberately dependency-free, and valibot's stock `isoTimestamp` matches neither ledger timestamp validator (it accepts millisecond-optional forms, non-UTC offsets, and overflow days like `2026-02-30` that the ledger rejects, so the custom `Date` round-trip check would still be needed), while `safeInteger` would collapse the deliberately-granular `non_positive`/`non_integer`/`unsafe` amount codes into one. Details in the chat thread. No code change made for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVbErPnX6LfoUACK2j7Zf3)_