### PR TITLE
Pin error signalling + syncReadOnlyFrom to close site-assignment mutation gaps

### DIFF
--- a/test/lib/site-assignment.test.ts
+++ b/test/lib/site-assignment.test.ts
@@ -13,11 +13,13 @@ import {
   resetHostEmailConfig,
   setHostEmailConfigForTest,
 } from "#shared/email.ts";
+import { ErrorCode } from "#shared/logger.ts";
 import { nowIso } from "#shared/now.ts";
 import {
   assignAndNotifyBuiltSites,
   parseReadOnlyFromMs,
   pickTierListing,
+  syncReadOnlyFrom,
   validateSiteAssignmentConfig,
 } from "#shared/site-assignment.ts";
 import {
@@ -379,14 +381,36 @@ describeWithEnv(
 
       test("skips assignment and logs DATA_INVALID when initial_site_months is 0", async () => {
         await insertBuiltSite("Site A", "a.test.net", "", "", true);
+        const restoreEnv = setTestEnv({ NTFY_URL: "https://ntfy.test/topic" });
+        const errorSpy = stub(console, "error", () => {});
 
-        await assignAndNotifyBuiltSites([siteEntry({ initialSiteMonths: 0 })]);
+        try {
+          await assignAndNotifyBuiltSites([
+            siteEntry({ initialSiteMonths: 0 }),
+          ]);
+        } finally {
+          errorSpy.restore();
+          restoreEnv();
+        }
 
         const sites = await getAllBuiltSites();
         const site = sites.find((s) => s.name === "Site A")!;
         expect(site.assignedAttendeeId).toBeNull();
         expect(site.renewalTokenIndex).toBeNull();
         expect(secretStub.calls.length).toBe(0);
+        // The blocked reason "initial_months" maps to DATA_INVALID, not the
+        // CONFIG_MISSING fallback — assert both the logged code and the ntfy ping.
+        expect(
+          errorSpy.calls.some((c) =>
+            String(c.args[0]).includes(ErrorCode.DATA_INVALID),
+          ),
+        ).toBe(true);
+        expect(
+          fetchStub.calls.some(
+            (c: { args: [string, RequestInit] }) =>
+              c.args[1]?.body === "DATA_INVALID",
+          ),
+        ).toBe(true);
       });
 
       test("skips assignment and logs CONFIG_MISSING when no qualifying tier listings exist", async () => {
@@ -405,6 +429,8 @@ describeWithEnv(
         }
 
         const buildStub = stubBuildSiteSuccess();
+        const restoreEnv = setTestEnv({ NTFY_URL: "https://ntfy.test/topic" });
+        const errorSpy = stub(console, "error", () => {});
         try {
           await assignAndNotifyBuiltSites([siteEntry()]);
 
@@ -412,7 +438,21 @@ describeWithEnv(
           const assigned = sites.filter((s) => s.assignedAttendeeId !== null);
           expect(assigned).toHaveLength(0);
           expect(secretStub.calls.length).toBe(0);
+          // A missing renewal tier maps to CONFIG_MISSING (the fallback branch).
+          expect(
+            errorSpy.calls.some((c) =>
+              String(c.args[0]).includes(ErrorCode.CONFIG_MISSING),
+            ),
+          ).toBe(true);
+          expect(
+            fetchStub.calls.some(
+              (c: { args: [string, RequestInit] }) =>
+                c.args[1]?.body === "CONFIG_MISSING",
+            ),
+          ).toBe(true);
         } finally {
+          errorSpy.restore();
+          restoreEnv();
           buildStub.restore();
         }
       });
@@ -560,6 +600,52 @@ describeWithEnv(
         } finally {
           failStub.restore();
         }
+      });
+    });
+
+    describe("syncReadOnlyFrom", () => {
+      test("pushes RENEWAL_URL alongside READ_ONLY_FROM when given a renewalUrl", async () => {
+        await insertBuiltSite(
+          "Sync A",
+          "sync-a.test.net",
+          "",
+          "",
+          false,
+          "5001",
+        );
+        const site = (await getAllBuiltSites()).find(
+          (s) => s.name === "Sync A",
+        )!;
+
+        await syncReadOnlyFrom(
+          site,
+          addMonthsIso(nowIso(), 3),
+          "https://example.test/renew/?t=abc",
+        );
+
+        const keys = secretStub.calls.map((c) => c.args[1]);
+        expect(keys).toContain("RENEWAL_URL");
+        expect(keys).toContain("READ_ONLY_FROM");
+      });
+
+      test("pushes only READ_ONLY_FROM when no renewalUrl is given", async () => {
+        await insertBuiltSite(
+          "Sync B",
+          "sync-b.test.net",
+          "",
+          "",
+          false,
+          "5002",
+        );
+        const site = (await getAllBuiltSites()).find(
+          (s) => s.name === "Sync B",
+        )!;
+
+        await syncReadOnlyFrom(site, addMonthsIso(nowIso(), 3));
+
+        const keys = secretStub.calls.map((c) => c.args[1]);
+        expect(keys).not.toContain("RENEWAL_URL");
+        expect(keys).toContain("READ_ONLY_FROM");
       });
     });
 


### PR DESCRIPTION
Mutation-testing `src/shared/site-assignment.ts` scored 68.2% (7 survivors). **Three were real gaps; the other four are equivalent `?? → ||` mutants** (operands that can never be falsy-non-null, so no test can distinguish them).

| Survivor | Gap | Fix |
|---|---|---|
| `250:19 !== → ==` | `syncReadOnlyFrom`'s conditional `renewalUrl` spread — and the function had **no direct test at all** | New suite: `RENEWAL_URL` is pushed when a `renewalUrl` is given, and not when omitted |
| `352:22 === → !=` | the blocked-reason → `ErrorCode` mapping was never asserted | Spy `console.error`, assert the logged code for both branches |
| `358:20 === → !=` | same for the `sendNtfyError` code | Assert the ntfy ping body for both branches |

The kicker: the two tests **named** "logs DATA_INVALID" / "logs CONFIG_MISSING" only asserted that assignment was *skipped* — they never checked which code was emitted. This makes them live up to their names (`initial_months → DATA_INVALID`, `missing_tier → CONFIG_MISSING`).

Re-running the mutation tester now kills all three; only the four equivalent `?? → ||` mutants remain (81.8%, which is 100% of the *non-equivalent* mutants). **Production code is unchanged** — pure test hardening.

> Note: a follow-up PR will add a known-equivalent ignore-list to the mutation tester so those four stop being re-reported and the tool becomes CI-gateable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF)_