### PR TITLE
Pin lineListPrice and the reservation feeSubtotal branch (mutation gaps)

### DIFF
--- a/test/lib/checkout-pricing.test.ts
+++ b/test/lib/checkout-pricing.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   allocateDiscount,
   applyModifiers,
+  lineListPrice,
   type PricedLine,
   priceCheckout,
   ticketPaymentBreakdown,
@@ -232,6 +233,27 @@ describe("priceCheckout", () => {
       expect(order.extras[0]!.amount).toBe(100);
       // Deposit (2 × £1) + fee (£1) = £3.
       expect(order.total).toBe(300);
+    },
+  );
+
+  testWithSetting(
+    "takes the percentage deposit from the feeSubtotal override, not the items",
+    { booking_fee: "5" },
+    () => {
+      // feeSubtotal override (£50) differs from the item subtotal (2 × £10 =
+      // £20), so a 10% deposit is 10% of £50 = £5 (£2.50/unit), not 10% of £20.
+      // The ?:-branch must keep the override path; collapsing it to the
+      // "unmodified" path would deposit 10% of the items instead.
+      const order = priceCheckout(
+        intentWith([item({ quantity: 2 })], {
+          feeSubtotal: 5000,
+          reservationAmount: "10%",
+        }),
+      );
+      expect(order.lines[0]!.chargedUnitAmount).toBe(250);
+      expect(order.fullSubtotal).toBe(5000);
+      // Deposit (2 × £2.50 = £5) + fee (5% of £50 = £2.50) = £7.50.
+      expect(order.total).toBe(750);
     },
   );
 
@@ -599,5 +621,13 @@ describe("allocateDiscount", () => {
 
   test("clamps a discount larger than the total to zero", () => {
     expect(allocateDiscount([100, 100], 500)).toEqual([0, 0]);
+  });
+});
+
+describe("lineListPrice", () => {
+  test("is unit price multiplied by quantity (gross list price)", () => {
+    expect(
+      lineListPrice(line({ item: item({ unitPrice: 500 }), quantity: 4 })),
+    ).toBe(2000);
   });
 });


### PR DESCRIPTION
Follow-up to the mutation-tester work (#1383): kill the two **real, killable** survivors it surfaced in `checkout-pricing.ts`. Same shape as #1382 did for site-assignment — pure test hardening, no production change.

| Survivor | Gap | Fix |
|---|---|---|
| `92:22  * → -` | `lineListPrice` (`unitPrice * quantity`) — a ledger function with **no test at all** | Direct test: `500 × 4 = 2000` (the mutant gives `496`) |
| `342:55  === → !=` | the `feeSubtotal === undefined` reservation branch | A reservation test where the override **differs** from the item subtotal |

The interesting one is `342:55`. When a caller passes `reservationAmount` **and** a `feeSubtotal` override, the deposit must be taken from the override (`reservationLines(…, fullSubtotal)`), not the items (`unmodifiedReservationLines`). The existing override test happened to use `feeSubtotal == subtotal` (£20 == £20), so both paths produced the same numbers and the mutant survived. The new test uses `feeSubtotal` £50 ≠ item subtotal £20, so a 10% deposit is £5 (£2.50/unit) — which the collapsed path would get wrong (£2, from 10% of the items).

> The third survivor the tester reports, `176:16  - → /` (the `toLines` index sort), is left alone — it's a **genuine equivalent**: `toUnits` assigns `lineIdx` as the flatMap array index, so the sort's input is always already ascending, and `sort((a,b)=>a/b)` is identity on already-ascending input. It belongs in the ignore-list (being re-added on #1383), not killed here.

Verified: both mutants now die; the only remaining checkout-pricing survivors are the three equivalents (two `?? → ||` and the sort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqYJUBqzMP9QmVa7nVUDAF)_