### PR TITLE
test: harden reservation-amount and balance tests against surviving mutants

### DIFF
--- a/test/lib/balance-link.test.ts
+++ b/test/lib/balance-link.test.ts
@@ -12,6 +12,22 @@ describe("balance-link", () => {
     setupTestEncryptionKey();
   });
 
+  // Build a correctly-signed "bal1." token wrapping an arbitrary payload, so a
+  // test can exercise the shape validation with a signature that already passes.
+  const signRawPayload = async (payload: unknown): Promise<string> => {
+    const { buildSignedToken, encodeTokenPayload } = await import(
+      "#shared/crypto/signed-token.ts"
+    );
+    const encoded = encodeTokenPayload(payload);
+    return buildSignedToken("bal1.", encoded, `balance:${encoded}`);
+  };
+
+  test("a balance link is valid for 90 days", () => {
+    // Pins the link lifetime to 90 days, expressed in seconds (90 × 86,400).
+    // Lengthening or shortening the window is a behaviour change to catch here.
+    expect(BALANCE_LINK_MAX_AGE_S).toBe(7_776_000);
+  });
+
   test("signs and verifies a token for an attendee", async () => {
     const token = await signBalanceToken(42);
     expect(token.startsWith("bal1.")).toBe(true);
@@ -51,15 +67,23 @@ describe("balance-link", () => {
   test("rejects a correctly-signed token whose payload is the wrong shape", async () => {
     // Sign a non-conforming payload with a valid HMAC, so the signature passes
     // but the field validation rejects it.
-    const { buildSignedToken, encodeTokenPayload } = await import(
-      "#shared/crypto/signed-token.ts"
-    );
-    const encoded = encodeTokenPayload({ not: "a balance" });
-    const token = await buildSignedToken(
-      "bal1.",
-      encoded,
-      `balance:${encoded}`,
-    );
+    const token = await signRawPayload({ not: "a balance" });
+    expect(await verifyBalanceToken(token)).toBeNull();
+  });
+
+  test("rejects a correctly-signed token whose attendee id is not a number", async () => {
+    // Signature and expiry are valid (a plausible near-future second), but `a`
+    // is a string. The id field must be validated independently of the expiry,
+    // and reach this check before the expiry/skew bounds can rescue it.
+    const validExpiry = Math.floor(Date.now() / 1000) + 1000;
+    const token = await signRawPayload({ a: "42", e: validExpiry });
+    expect(await verifyBalanceToken(token)).toBeNull();
+  });
+
+  test("rejects a correctly-signed token whose expiry is not a number", async () => {
+    // Signature is valid and `a` is a number, but `e` is a string. The expiry
+    // field must be validated independently of the id field.
+    const token = await signRawPayload({ a: 42, e: "soon" });
     expect(await verifyBalanceToken(token)).toBeNull();
   });
 

--- a/test/lib/reservation-amount.test.ts
+++ b/test/lib/reservation-amount.test.ts
@@ -248,6 +248,33 @@ describe("reservation-amount", () => {
     );
 
     testWithSetting(
+      "breaks leftover ties by cart order across items, not by item alone",
+      { currency: "GBP" },
+      () => {
+        // Deposit of 20 minor units across 4 units priced [90, 70, 70, 70]
+        // (item0 ×1, item1 ×2, item2 ×1; subtotal 300). Proportional floors are
+        // [6, 4, 4, 4] (18) leaving 2 leftover minor units. The three 70-priced
+        // units share the same fractional remainder, so the two leftovers must
+        // go to the *earliest* units in cart order — both of item1's units —
+        // never to item2's later unit. This pins down that each unit's tie-break
+        // key is its absolute cart position (prefix quantity + unit index), so
+        // item1's second unit outranks item2's first unit.
+        const allocation = allocateReservationDeposit("0.20", [
+          { quantity: 1, unitPrice: 90 },
+          { quantity: 2, unitPrice: 70 },
+          { quantity: 1, unitPrice: 70 },
+        ]);
+        expect(allocation.total).toBe(20);
+        expect(allocation.perItemTotals).toEqual([6, 10, 4]);
+        expect(allocation.lines).toEqual([
+          { chargedUnitAmount: 6, itemIndex: 0, quantity: 1 },
+          { chargedUnitAmount: 5, itemIndex: 1, quantity: 2 },
+          { chargedUnitAmount: 4, itemIndex: 2, quantity: 1 },
+        ]);
+      },
+    );
+
+    testWithSetting(
       "percent and per-item totals preserve their order-level semantics",
       { currency: "GBP" },
       () => {

--- a/test/lib/server-balance.test.ts
+++ b/test/lib/server-balance.test.ts
@@ -113,6 +113,16 @@ describeWithEnv("server (public balance page)", { db: true }, () => {
     expect(html).toContain("not valid");
   });
 
+  test("GET rejects a validly-signed token for a missing attendee", async () => {
+    // The token verifies, but no attendee row matches, so the balance state is
+    // null. The handler must short-circuit to the not-valid page rather than
+    // dereference the absent state.
+    const token = await signBalanceToken(999_999);
+    const response = await handleRequest(mockRequest(`/pay/${token}`));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("not valid");
+  });
+
   test("GET treats a balance with no status as settled", async () => {
     const attendeeId = await insertBareAttendee(null, 1500);
     const token = await signBalanceToken(attendeeId);


### PR DESCRIPTION
## What

Ran `deno task mutation` over the modules dealing with reservation amounts and balances, and closed the **real** (non-equivalent) gaps the surviving mutants exposed. Test-only changes — no production code was touched.

## Modules & results

| Module | Before | After | Action |
| --- | --- | --- | --- |
| `src/shared/reservation-amount.ts` | 81.0% | 85.7% | killed the cart-order tie-break mutant |
| `src/shared/balance-link.ts` | 80.0% | **100%** | pinned link lifetime + per-field validation |
| `src/features/public/balance.ts` | 71.4% | 85.7% | killed the null-state dereference mutant |
| `src/shared/db/attendees/balance.ts` | 70.0% | 70.0% | all survivors equivalent — no change |
| `src/features/admin/attendee-balance.ts` | — | — | no mutable operators |

## New / strengthened tests

- **reservation-amount**: a cross-item leftover-allocation case pinning the cart-order tie-breaker — each ticket unit's tie key is its absolute cart position (`prefix quantity + unit index`), so an item's later unit outranks a following item's first unit. Kills the `originalIndex` `+ unitIndex` → `* unitIndex` survivor.
- **balance-link**: pin the 90-day link lifetime (`7,776,000s`), and reject a correctly-signed token whose `a` (attendee id) or `e` (expiry) field is non-numeric — validating each field independently. Takes the file to 100%.
- **public/balance**: reject a validly-signed token for an attendee that no longer exists, so the handler short-circuits to the not-valid page instead of dereferencing a null balance state.

## Survivors left in place (equivalent mutants)

These cannot be killed without asserting impossible DB states (which `AGENTS.md` forbids designing tests around), verified both analytically and by brute-forcing 27k+ inputs:

- `reservation-amount.ts:140` `|| → &&` — `fullSubtotal === 0` always forces `total === 0`, so the branch is redundant.
- `reservation-amount.ts:169` (×2) `- → /` — the sort always receives data already ordered by `(itemIndex asc, amount desc)`.
- `balance.ts:91` `|| → &&` — `name` is `NOT NULL`; a present listing's `unit_price` defaults to `0`, never null, so the redundant check never diverges.
- `balance.ts:119` / `balance.ts:189`, `public/balance.ts:92` `?? → ||` — the guarded values are either `INTEGER NOT NULL` (only falsy value `0` yields the same result) or `AUTOINCREMENT` ids ≥ 1.

## Verification

`deno check`, `deno task lint:ci`, and the affected test files (`reservation-amount`, `balance-link`, `server-balance` — 62 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxJEd8h3Uf19yeHLCcLcLt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxJEd8h3Uf19yeHLCcLcLt)_