### PR TITLE
Unify ledger balance, post guards, and row-account builders

### DIFF
--- a/src/shared/accounting/accounts.ts
+++ b/src/shared/accounting/accounts.ts
@@ -20,29 +20,29 @@ export const WORLD: AccountRef = account(EXTERNAL, "world");
 export const BOOKING_FEE_INCOME: AccountRef = account(FEE_INCOME, "booking");
 
 /**
- * Row-backed accounts key off a real table id. A zero, negative, fractional, or
- * unsafe-integer id would mint a phantom account (e.g. `attendee:1.5`) that the
- * ledger accepts — its account ids are only checked for non-emptiness — silently
- * diverting money from the real row's balance, statements, and refunds. Reject
- * such ids at construction.
+ * Build the account constructor for one type of row-backed account. The row id
+ * must be a positive safe integer: a zero, negative, fractional, or unsafe id
+ * would mint a phantom account (e.g. `attendee:1.5`) that the ledger accepts —
+ * its account ids are only checked for non-emptiness — silently diverting money
+ * from the real row's balance, statements, and refunds. Reject such ids at
+ * construction, so every row-backed type validates identically.
  */
-const rowId = (kind: string, id: number): number => {
-  if (!Number.isSafeInteger(id) || id <= 0) {
-    throw new Error(
-      `${kind} account id must be a positive safe integer: ${id}`,
-    );
-  }
-  return id;
-};
+const rowAccount =
+  (kind: string) =>
+  (id: number): AccountRef => {
+    if (!Number.isSafeInteger(id) || id <= 0) {
+      throw new Error(
+        `${kind} account id must be a positive safe integer: ${id}`,
+      );
+    }
+    return account(kind, id);
+  };
 
 /** One attendee's receivable/clearing account; its balance is what they owe. */
-export const attendeeAccount = (id: number): AccountRef =>
-  account(ATTENDEE, rowId(ATTENDEE, id));
+export const attendeeAccount = rowAccount(ATTENDEE);
 
 /** Gross ticket revenue for one listing. */
-export const revenueAccount = (listingId: number): AccountRef =>
-  account(REVENUE, rowId(REVENUE, listingId));
+export const revenueAccount = rowAccount(REVENUE);
 
 /** One discount/surcharge modifier's net effect. */
-export const modifierAccount = (modifierId: number): AccountRef =>
-  account(MODIFIER, rowId(MODIFIER, modifierId));
+export const modifierAccount = rowAccount(MODIFIER);

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -40,6 +40,18 @@ export type PostResult = {
   readonly skipped: number;
 };
 
+/** Every leg of one event must agree on `label`; name the offending values if not. */
+const assertShared = (label: string, values: string[]): void => {
+  const distinct = new Set(values);
+  if (distinct.size > 1) {
+    throw new Error(
+      `postTransfers: every leg must share one ${label} (got ${[
+        ...distinct,
+      ].join(", ")})`,
+    );
+  }
+};
+
 /**
  * Checks that need no database, run before any DB work so a malformed batch never
  * opens a transaction: every leg is valid on its own, the batch shares one event
@@ -55,20 +67,14 @@ const assertPostable = (inputs: TransferInput[]): void => {
       throw new Error(`invalid transfer (${input.reference}): ${codes}`);
     }
   }
-  const eventGroups = new Set(inputs.map((t) => t.eventGroup));
-  if (eventGroups.size > 1) {
-    throw new Error(
-      `postTransfers: every leg must share one eventGroup (got ${eventGroups.size})`,
-    );
-  }
-  const currencies = new Set(inputs.map((t) => t.currency));
-  if (currencies.size > 1) {
-    throw new Error(
-      `postTransfers: every leg must share one currency (got ${[
-        ...currencies,
-      ].join(", ")})`,
-    );
-  }
+  assertShared(
+    "eventGroup",
+    inputs.map((t) => t.eventGroup),
+  );
+  assertShared(
+    "currency",
+    inputs.map((t) => t.currency),
+  );
   const references = inputs.map((t) => t.reference);
   if (new Set(references).size !== references.length) {
     throw new Error("postTransfers: duplicate reference within one event");

--- a/src/shared/ledger/project.ts
+++ b/src/shared/ledger/project.ts
@@ -25,23 +25,6 @@ export const assertSingleCurrency = (transfers: Transfer[]): void => {
   }
 };
 
-/**
- * Net balance of one account: money in (as destination) minus money out (as
- * source). Positive ⇒ the account holds value; negative ⇒ it owes.
- */
-export const balanceOf =
-  (acct: AccountRef) =>
-  (transfers: Transfer[]): number => {
-    assertSingleCurrency(transfers);
-    const into = sumOf((t: Transfer) =>
-      sameAccount(t.destination, acct) ? t.amount : 0,
-    )(transfers);
-    const outOf = sumOf((t: Transfer) =>
-      sameAccount(t.source, acct) ? t.amount : 0,
-    )(transfers);
-    return into - outOf;
-  };
-
 /** Every account's balance, keyed by {@link accountKey}. */
 export const allBalances = (transfers: Transfer[]): Map<string, number> => {
   assertSingleCurrency(transfers);
@@ -56,6 +39,17 @@ export const allBalances = (transfers: Transfer[]): Map<string, number> => {
   }
   return balances;
 };
+
+/**
+ * Net balance of one account: money in (as destination) minus money out (as
+ * source). Positive ⇒ the account holds value; negative ⇒ it owes. Reads the
+ * one balance algorithm in {@link allBalances}, so a single account is never
+ * summed a second, different way.
+ */
+export const balanceOf =
+  (acct: AccountRef) =>
+  (transfers: Transfer[]): number =>
+    allBalances(transfers).get(accountKey(acct)) ?? 0;
 
 /** Total amount across transfers of one kind (e.g. cash refunded). */
 export const sumOfKind =

--- a/test/lib/ledger/project.test.ts
+++ b/test/lib/ledger/project.test.ts
@@ -35,6 +35,11 @@ describe("balanceOf", () => {
     ];
     expect(balanceOf(attendee)(ts)).toBe(-8000);
   });
+
+  it("is zero for an account with no transfers in the slice", () => {
+    const ts = [makeTransfer({ destination: revenue, source: attendee })];
+    expect(balanceOf(account("modifier", 99))(ts)).toBe(0);
+  });
 });
 
 describe("allBalances", () => {


### PR DESCRIPTION
## What

Three deep-dive consolidations in the ledger/accounting code (continuing the LOC-reduction work from #1380 and #1384).

### 1. One in-memory balance algorithm

`balanceOf` had its own two `sumOf` passes (money-in minus money-out) — a second implementation of the rule `allBalances` already encodes. It now reads from `allBalances`:

```ts
export const balanceOf =
  (acct: AccountRef) =>
  (transfers: Transfer[]): number =>
    allBalances(transfers).get(accountKey(acct)) ?? 0;
```

So a single account and the whole set can never be summed two different ways. The currency guard is preserved (`allBalances` calls `assertSingleCurrency`). Added a test for the absent-account (`?? 0`) path.

### 2. Shared "every leg must share one X" guard

`assertPostable`'s two near-identical event-group / currency checks collapse into one helper that names the offending values for both:

```ts
const assertShared = (label: string, values: string[]): void => { … };
assertShared("eventGroup", inputs.map((t) => t.eventGroup));
assertShared("currency", inputs.map((t) => t.currency));
```

The duplicate-reference check stays separate (it compares set size to array length, not `> 1`). Messages keep the `"one eventGroup"` / `"one currency"` phrasing the tests assert.

### 3. One row-backed account factory

`attendeeAccount` / `revenueAccount` / `modifierAccount` were three identical `account(KIND, rowId(KIND, id))` bodies. The `rowId` guard and the three builders fold into a single curried `rowAccount(kind)` factory, so every row-backed type validates its id (positive safe integer) the same way and the builders become one-line bindings.

## Verification

`deno task precommit` passes in full: lint, typecheck, **cpd (0% duplication)**, build, **test:coverage (100%)**. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)