### PR TITLE
Make table rebuilds atomic with a Bunny interactive transaction

### DIFF
--- a/src/shared/db/migrations/schema-sync.ts
+++ b/src/shared/db/migrations/schema-sync.ts
@@ -1,5 +1,10 @@
 import type { InValue } from "@libsql/client";
-import { executeBatch, getDb, queryBatchPrimary } from "#shared/db/client.ts";
+import {
+  executeBatch,
+  getDb,
+  queryBatchPrimary,
+  withTransaction,
+} from "#shared/db/client.ts";
 import { logDebug } from "#shared/logger.ts";
 import {
   APP_SCHEMA,
@@ -112,28 +117,6 @@ const createIndexSql = (tableName: string, idx: Index): string => {
   )})`;
 };
 
-/** Create indexes for a named table from SCHEMA */
-const createIndexesForTable = async (
-  tableName: string,
-  indexes: Index[],
-): Promise<void> => {
-  for (const idx of indexes) {
-    await runMigration(createIndexSql(tableName, idx));
-  }
-};
-
-/**
- * (Re)create every declared trigger that fires on a named table. Called after
- * {@link recreateTable} rebuilds a table, since dropping the old table also
- * drops its triggers. Statements are `CREATE TRIGGER IF NOT EXISTS`, so this is
- * idempotent.
- */
-const createTriggersForTable = async (tableName: string): Promise<void> => {
-  for (const trg of TRIGGERS) {
-    if (trg.table === tableName) await runMigration(trg.sql);
-  }
-};
-
 const currentSchemaTable = (tableName: string): Table => {
   const table = SCHEMA.find(([name]) => name === tableName)?.[1];
   if (!table) throw new Error(`Unknown schema table ${tableName}`);
@@ -153,38 +136,62 @@ const copyExpressionFor = ([column, type]: Column): string => {
   return defaultMatch ? `COALESCE(${column}, '${defaultMatch[1]}')` : column;
 };
 
-export const rebuildTableWithColumns = async ({
-  columns,
-  tableName,
-  tmpName = `${tableName}_new`,
-}: {
+type RebuildParams = {
   columns: readonly Column[];
   tableName: string;
   tmpName?: string;
-}): Promise<void> => {
-  const colNames = columns.map(([col]) => col).join(", ");
-  const colDefs = columns.map(([col, type]) => `${col} ${type}`).join(", ");
-  const selectExprs = columns.map(copyExpressionFor).join(", ");
-
-  await executeBatch([
-    { args: [], sql: `DROP TABLE IF EXISTS ${tmpName}` },
-    { args: [], sql: `CREATE TABLE ${tmpName} (${colDefs})` },
-    {
-      args: [],
-      sql:
-        `INSERT INTO ${tmpName} (${colNames}) ` +
-        `SELECT ${selectExprs} FROM ${tableName}`,
-    },
-    { args: [], sql: `DROP TABLE ${tableName}` },
-    { args: [], sql: `ALTER TABLE ${tmpName} RENAME TO ${tableName}` },
-  ]);
 };
 
 /**
- * Recreate a table from its SCHEMA definition, preserving data for matching columns.
+ * The ordered statements that rebuild a table from a column list, preserving
+ * data for the listed columns: stage a fresh table, copy the rows across, drop
+ * the original, then rename the staged table into its place. Shared by the
+ * batch rebuild ({@link rebuildTableWithColumns}) and the atomic
+ * {@link recreateTable}.
+ */
+const rebuildStatements = ({
+  columns,
+  tableName,
+  tmpName = `${tableName}_new`,
+}: RebuildParams): string[] => {
+  const colNames = columns.map(([col]) => col).join(", ");
+  const colDefs = columns.map(([col, type]) => `${col} ${type}`).join(", ");
+  const selectExprs = columns.map(copyExpressionFor).join(", ");
+  return [
+    `DROP TABLE IF EXISTS ${tmpName}`,
+    `CREATE TABLE ${tmpName} (${colDefs})`,
+    `INSERT INTO ${tmpName} (${colNames}) SELECT ${selectExprs} FROM ${tableName}`,
+    `DROP TABLE ${tableName}`,
+    `ALTER TABLE ${tmpName} RENAME TO ${tableName}`,
+  ];
+};
+
+export const rebuildTableWithColumns = async (
+  params: RebuildParams,
+): Promise<void> => {
+  await executeBatch(
+    rebuildStatements(params).map((sql) => ({ args: [], sql })),
+  );
+};
+
+/**
+ * Recreate a table from its SCHEMA definition, preserving data for matching
+ * columns.
  *
- * The new table is created WITHOUT foreign keys (only column definitions).
- * This means any FKs the original table had are removed after recreation.
+ * The rebuild (copy into a fresh table), its indexes, and its triggers all run
+ * inside ONE interactive transaction, so the table is never committed without
+ * the indexes and triggers that enforce its invariants. Any failure rolls the
+ * whole rebuild back and leaves the original table untouched, instead of
+ * leaving a live table missing (say) a UNIQUE index until the migration is
+ * retried — a window in which duplicate rows could land and then permanently
+ * break the index re-creation. An interactive transaction (rather than a batch)
+ * is what makes this possible: a compound `CREATE TRIGGER … BEGIN … END`
+ * carries internal semicolons that some batch transports mis-split, so triggers
+ * cannot ride in a batch — but each is sent through its own `tx.execute()` here
+ * and still commits atomically with the rebuild.
+ *
+ * The new table is created WITHOUT foreign keys (only column definitions), so
+ * any FKs the original table had are removed after recreation.
  *
  * IMPORTANT: If other tables have FKs referencing this table and contain data,
  * those tables must be recreated FIRST (to remove their FK constraints).
@@ -194,14 +201,16 @@ export const rebuildTableWithColumns = async ({
  */
 export const recreateTable = async (tableName: string): Promise<void> => {
   const tableSchema = currentSchemaTable(tableName);
-  await rebuildTableWithColumns({
-    columns: tableSchema.columns,
-    tableName,
+  const statements = [
+    ...rebuildStatements({ columns: tableSchema.columns, tableName }),
+    ...(tableSchema.indexes ?? []).map((idx) => createIndexSql(tableName, idx)),
+    // Triggers on this table were dropped with the old table — re-create them
+    // in the same transaction so the rebuilt table is never live without them.
+    ...TRIGGERS.filter((trg) => trg.table === tableName).map((trg) => trg.sql),
+  ];
+  await withTransaction(async (tx) => {
+    for (const sql of statements) await tx.execute(sql);
   });
-
-  await createIndexesForTable(tableName, tableSchema.indexes ?? []);
-  // Triggers on this table were dropped with the old table — re-create them.
-  await createTriggersForTable(tableName);
 };
 
 export const getAppSchemaColumns = (tableName: string): Set<string> =>

--- a/test/lib/db/free-text-migration.test.ts
+++ b/test/lib/db/free-text-migration.test.ts
@@ -16,13 +16,23 @@ import { resetDb } from "#test-utils";
  * both tables, which is what this verifies.
  */
 describe("db > free-text migration constraint relaxation", () => {
-  afterEach(() => {
+  // recreateTable rebuilds inside an interactive transaction, which opens a
+  // second connection — so this uses a temp file rather than ":memory:" (each
+  // ":memory:" connection is its own empty database; see test-utils/db.ts).
+  let dbPath: string | undefined;
+
+  afterEach(async () => {
     resetDb();
+    if (dbPath) {
+      await Deno.remove(dbPath).catch(() => {});
+      dbPath = undefined;
+    }
   });
 
   /** A database shaped as it was before the free-text feature shipped. */
   const seedLegacyDb = async () => {
-    const db = createClient({ url: ":memory:" });
+    dbPath = await Deno.makeTempFile({ suffix: ".db" });
+    const db = createClient({ url: `file:${dbPath}` });
     setDb(db);
     await db.execute(
       `CREATE TABLE attendee_answers (

--- a/test/lib/db/legacy-migration.test.ts
+++ b/test/lib/db/legacy-migration.test.ts
@@ -15,8 +15,31 @@ import { resetDb, setupTestEncryptionKey } from "#test-utils";
  * HTTP requests).
  */
 describe("db > listing_attendees migration from legacy schema", () => {
-  afterEach(() => {
+  // recreateTable now rebuilds inside an interactive transaction, which opens a
+  // second connection — so these tests use a temp file rather than ":memory:"
+  // (each ":memory:" connection is its own empty database; see test-utils/db.ts).
+  const openFileDbs: Array<{
+    client: ReturnType<typeof createClient>;
+    path: string;
+  }> = [];
+
+  const newFileDb = async (): Promise<ReturnType<typeof createClient>> => {
+    const path = await Deno.makeTempFile({ suffix: ".db" });
+    const client = createClient({ url: `file:${path}` });
+    openFileDbs.push({ client, path });
+    return client;
+  };
+
+  afterEach(async () => {
     resetDb();
+    for (const { client, path } of openFileDbs.splice(0)) {
+      try {
+        client.close();
+      } catch {
+        // already closed
+      }
+      await Deno.remove(path).catch(() => {});
+    }
   });
 
   const LEGACY_DB_UPDATE = "legacy-update";
@@ -194,7 +217,7 @@ describe("db > listing_attendees migration from legacy schema", () => {
   /** Create the legacy schema and return the client */
   const createLegacyDb = async () => {
     setupTestEncryptionKey();
-    const client = createClient({ url: ":memory:" });
+    const client = await newFileDb();
     setDb(client);
     for (const sql of LEGACY_SCHEMA_SQL) {
       await client.execute(sql);
@@ -414,7 +437,7 @@ describe("db > listing_attendees migration from legacy schema", () => {
 
   test("drops PII columns when listing_id was dropped in a prior partial run", async () => {
     setupTestEncryptionKey();
-    const client = createClient({ url: ":memory:" });
+    const client = await newFileDb();
     setDb(client);
 
     // Simulate a DB in the intermediate state: listing_id and its relatives
@@ -470,7 +493,7 @@ describe("db > listing_attendees migration from legacy schema", () => {
 
   test("fails instead of marking progress for unknown legacy attendee shape", async () => {
     setupTestEncryptionKey();
-    const client = createClient({ url: ":memory:" });
+    const client = await newFileDb();
     setDb(client);
 
     await client.execute(
@@ -508,7 +531,7 @@ describe("db > listing_attendees migration from legacy schema", () => {
 
   test("skips table recreation when attendees already matches schema", async () => {
     setupTestEncryptionKey();
-    const client = createClient({ url: ":memory:" });
+    const client = await newFileDb();
     setDb(client);
 
     // Run initDb on a fresh DB so everything is created and up to date

--- a/test/lib/db/recreate-table-atomic.test.ts
+++ b/test/lib/db/recreate-table-atomic.test.ts
@@ -1,0 +1,102 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { getDb } from "#shared/db/client.ts";
+import { recreateTable } from "#shared/db/migrations/schema-sync.ts";
+import { setupTransactionalTestDb } from "#test-utils";
+
+/**
+ * recreateTable rebuilds a table, then (re)creates its indexes and triggers, all
+ * inside one interactive transaction. This guards the safety property that buys:
+ * if a post-rebuild step fails — e.g. a UNIQUE index cannot be built because the
+ * live data has duplicates — the whole rebuild rolls back and the original table
+ * is left exactly as it was, rather than committed in a half-migrated shape (the
+ * renamed table missing the very index that enforces its invariant).
+ *
+ * `users` is used as the subject: it has a UNIQUE index (idx_users_username_index)
+ * and is referenced by no triggers, so it can be rebuilt in isolation.
+ */
+describe("db > recreateTable atomicity", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeEach(async () => {
+    cleanup = await setupTransactionalTestDb();
+  });
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  /**
+   * Bend the live `users` table into a legacy shape recreateTable must repair:
+   * drop the UNIQUE index, add a column that is NOT in the current SCHEMA (so the
+   * rebuild would drop it), and insert `extraRows` whose username_index values
+   * decide whether the index can be rebuilt.
+   */
+  const seedLegacyUsers = async (usernameIndexes: string[]): Promise<void> => {
+    const db = getDb();
+    await db.execute("DROP INDEX idx_users_username_index");
+    await db.execute(
+      "ALTER TABLE users ADD COLUMN legacy_extra TEXT NOT NULL DEFAULT 'keep'",
+    );
+    for (const usernameIndex of usernameIndexes) {
+      await db.execute({
+        args: [usernameIndex],
+        sql: "INSERT INTO users (username_hash, username_index, admin_level) VALUES ('h', ?, 'owner')",
+      });
+    }
+  };
+
+  const columnNames = async (table: string): Promise<string[]> =>
+    (await getDb().execute(`PRAGMA table_info(${table})`)).rows.map((row) =>
+      String(row.name),
+    );
+
+  const indexNames = async (table: string): Promise<string[]> =>
+    (
+      await getDb().execute({
+        args: [table],
+        sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?",
+      })
+    ).rows.map((row) => String(row.name));
+
+  test("rolls the entire rebuild back when the UNIQUE index cannot be built", async () => {
+    // Two rows share a username_index, so re-creating the UNIQUE index fails.
+    await seedLegacyUsers(["dup", "dup"]);
+
+    await expect(recreateTable("users")).rejects.toThrow();
+
+    // The rebuild dropped `legacy_extra` on the staged table; its survival proves
+    // the DROP/CREATE/RENAME were rolled back, not committed-then-failed.
+    expect(await columnNames("users")).toContain("legacy_extra");
+
+    // Both duplicate rows are still present and untouched.
+    const rows = await getDb().execute(
+      "SELECT username_index FROM users ORDER BY id",
+    );
+    expect(rows.rows.map((row) => row.username_index)).toEqual(["dup", "dup"]);
+
+    // The UNIQUE index never landed — its creation is what failed and rolled back.
+    expect(await indexNames("users")).not.toContain("idx_users_username_index");
+
+    // The staged rebuild table must not be left behind either.
+    const staged = await getDb().execute(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users_new'",
+    );
+    expect(staged.rows.length).toBe(0);
+  });
+
+  test("commits the rebuilt table together with its UNIQUE index on success", async () => {
+    await seedLegacyUsers(["only"]);
+
+    await recreateTable("users");
+
+    // The extra column is gone (rebuilt from SCHEMA) and the row survived.
+    expect(await columnNames("users")).not.toContain("legacy_extra");
+    const rows = await getDb().execute("SELECT username_index FROM users");
+    expect(rows.rows.map((row) => row.username_index)).toEqual(["only"]);
+
+    // The SCHEMA's UNIQUE index was (re)created in the same transaction.
+    expect(await indexNames("users")).toContain("idx_users_username_index");
+  });
+});


### PR DESCRIPTION
## What & why

You asked to make migrations safer using Bunny's [interactive transactions](https://docs.bunny.net/) (the libSQL `client.transaction("write")` API). This applies them to the riskiest part of the migration runner: **`recreateTable`**, the routine that rebuilds a table from its current `SCHEMA` (to drop columns or relax constraints SQLite can't `ALTER`).

### The gap this closes

`recreateTable` used to commit the data copy as one atomic batch, then create the table's indexes and triggers as **separate, auto-committed statements**:

```
batch: DROP tmp · CREATE tmp · INSERT…SELECT · DROP orig · RENAME tmp→orig   ← commits here
then:  CREATE INDEX …   (separate)
then:  CREATE TRIGGER … (separate)
```

If anything after the rebuild failed, the renamed table was already live — but missing the very `UNIQUE` index that enforces its invariant. Until the migration retried, duplicate rows could land, after which the index could **never** be rebuilt. The trigger steps also can't safely ride in a batch: a compound `CREATE TRIGGER … BEGIN … END` carries internal semicolons that some batch transports mis-split (this is exactly why `syncTriggers` runs them one-by-one).

### The fix

The rebuild, its indexes, and its triggers now all run inside **one interactive transaction** (the project's existing `withTransaction` wrapper). The operation is all-or-nothing — any failure rolls back and leaves the original table exactly as it was — and each trigger is sent through its own `tx.execute()`, so compound triggers commit atomically with the rebuild.

## Scope notes

- **Only `recreateTable`.** `applySchemaChanges` is deliberately left as sequential idempotent DDL (it's intentionally tolerant of a concurrent isolate winning the same additive race), and the full-table backfills are not wrapped — interactive transactions hold a write lock with a 5s timeout, so wrapping a long backfill would make it *less* reliable, not more.
- `rebuildTableWithColumns` (the standalone legacy-rename path) keeps its single atomic batch; both paths now share one `rebuildStatements` builder.

## Tests

- New `recreate-table-atomic.test.ts` proves the rollback guarantee: a `UNIQUE` index that can't be built (duplicate rows) rolls the **entire** rebuild back — a non-schema column survives, both rows remain, and no half-built table/index is left behind — plus the happy path commits the table and index together.
- Interactive transactions open a second connection, so the migration tests that drive `recreateTable` move from `":memory:"` (each connection is its own empty database) to temp files.
- `deno task precommit` is green: lint, typecheck, cpd (0%), edge build, and full `test:coverage` (100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKRpb9rnpjMbF1pdp3s3XF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKRpb9rnpjMbF1pdp3s3XF)_