### PR TITLE
Don't clear the commit marker on a dev/source boot

### DIFF
--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -104,11 +104,6 @@ export const isNewerVersion = (
   return releaseDate.getTime() > new Date(buildTimestamp).getTime();
 };
 
-/**
- * Upsert a plaintext settings marker, writing only when the stored value
- * differs (so the unchanged path costs one indexed read and no write). A blank
- * value is a no-op, matching development/test builds where build info is empty.
- */
 /** Read a plaintext settings marker's value, or "" when the row is absent. */
 const readSettingMarker = async (key: string): Promise<string> => {
   const row = await queryOne<{ value: string }>(
@@ -118,6 +113,11 @@ const readSettingMarker = async (key: string): Promise<string> => {
   return row?.value ?? "";
 };
 
+/**
+ * Upsert a plaintext settings marker, writing only when the stored value
+ * differs (so the unchanged path costs one indexed read and no write). A blank
+ * value is a no-op, matching development/test builds where build info is empty.
+ */
 const recordSettingMarker = async (
   key: string,
   value: string,
@@ -132,14 +132,19 @@ const recordSettingMarker = async (
 
 /**
  * Sync the commit marker to the running build: upsert when the build embeds a
- * commit, but *clear* a previously-recorded one when it doesn't. Without the
- * clear, a local build path that ships without a commit (e.g.
- * `deno task deploy:edge`, which doesn't set BUILD_COMMIT) would leave a stale
- * commit from an earlier CI deploy behind — so a later backup/restore would name
- * the wrong commit for the data it captured. An honest "unknown" beats a lie.
+ * commit, but *clear* a previously-recorded one when a real built bundle ships
+ * without one (e.g. `deno task deploy:edge`, which doesn't set BUILD_COMMIT) —
+ * otherwise a stale commit from an earlier CI deploy would linger and a later
+ * backup/restore would name the wrong commit. "Real built bundle" is gated on a
+ * non-empty `version` (build timestamp): a dev/source boot has neither value,
+ * so it stays a pure no-op and never wipes a remote DB's commit.
  */
-const syncCommitMarker = async (commit: string): Promise<void> => {
+const syncCommitMarker = async (
+  version: string,
+  commit: string,
+): Promise<void> => {
   if (commit) return recordSettingMarker(CURRENT_SCRIPT_COMMIT_KEY, commit);
+  if (!version) return;
   await execute("DELETE FROM settings WHERE key = ?", [
     CURRENT_SCRIPT_COMMIT_KEY,
   ]);
@@ -155,11 +160,9 @@ const syncCommitMarker = async (commit: string): Promise<void> => {
  */
 export const recordScriptVersion = async (): Promise<void> => {
   try {
-    await recordSettingMarker(
-      CURRENT_SCRIPT_VERSION_KEY,
-      getEffectiveBuildTimestamp(),
-    );
-    await syncCommitMarker(getEffectiveBuildCommit());
+    const version = getEffectiveBuildTimestamp();
+    await recordSettingMarker(CURRENT_SCRIPT_VERSION_KEY, version);
+    await syncCommitMarker(version, getEffectiveBuildCommit());
   } catch (e) {
     logDebug(
       "Migration",

--- a/test/lib/site-update.test.ts
+++ b/test/lib/site-update.test.ts
@@ -181,18 +181,32 @@ describeWithEnv("recordScriptVersion", { db: true }, () => {
     expect(await readRecordedScriptCommit()).toBe("");
   });
 
-  test("clears a stale commit marker when the running build has no commit", async () => {
+  test("clears a stale commit marker when a built bundle ships without one", async () => {
     // A CI deploy records a commit…
     setBuildCommitForTest("abc123def4567890");
     await recordScriptVersion();
     expect(await readRecordedScriptCommit()).toBe("abc123def4567890");
 
-    // …then a local build that ships without a commit (e.g. deno task
-    // deploy:edge) must clear it, not leave the stale value to mislead a later
-    // restore into naming the wrong commit.
+    // …then a real built bundle that ships without a commit (e.g. deno task
+    // deploy:edge — it has a build timestamp but no embedded commit) must clear
+    // it, not leave the stale value to mislead a later restore.
     setBuildCommitForTest("");
+    setBuildTimestampForTest("2026-06-20T00:00:00Z");
     await recordScriptVersion();
     expect(await readRecordedScriptCommit()).toBe("");
+  });
+
+  test("preserves the commit marker on a dev/source boot with no build info", async () => {
+    // Seed a commit as a CI deploy would.
+    setBuildCommitForTest("abc123def4567890");
+    await recordScriptVersion();
+
+    // A dev/source boot has neither a timestamp nor a commit; it must NOT wipe
+    // the marker (e.g. running `deno task start` against a remote DB).
+    setBuildCommitForTest(null);
+    setBuildTimestampForTest(null);
+    await recordScriptVersion();
+    expect(await readRecordedScriptCommit()).toBe("abc123def4567890");
   });
 
   test("leaves the stored version untouched when it is unchanged", async () => {


### PR DESCRIPTION
Follow-up to #1390 review (the `update.ts:162` P2 we deferred when #1390 merged as-is).

## Problem
`recordScriptVersion`'s commit-marker sync cleared `current_script_commit` whenever the running build had **no** commit — but that includes a plain dev/source boot, where both `BUILD_TIMESTAMP` and `BUILD_COMMIT` are empty. So running `deno task start` against a real/remote DB would **wipe** the `current_script_commit` that a restore needs (low-impact and self-healing on the next CI deploy, but still wrong, and it contradicted the documented dev-build no-op).

## Fix
Gate the clear on a non-empty `version` (build timestamp): only a **real built bundle** that legitimately ships without a commit (e.g. `deno task deploy:edge`, which sets a timestamp but no `BUILD_COMMIT`) clears a stale marker. A dev/source boot has neither value, so it stays a pure no-op and never touches a remote DB's commit.

Also tidies an orphaned doc comment left over from an earlier dedup.

## Testing
- New: the marker is **preserved** on a dev/source boot with no build info.
- Updated: the stale-marker clear now requires a built bundle (timestamp present, commit absent).
- `typecheck`, `lint:ci`, `cpd` (0%), and the dead-code guard all green.

> The other open P2 from #1390 — isolating the rebuild's `github.token` via a multi-job restructure of `restore-deploy.yml` — is intentionally **not** in this PR; happy to do it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PQ3WhS414TJnwtZb9x9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2PQ3WhS414TJnwtZb9x9a)_