### PR TITLE
Encrypt the activity log with the owner key, not DB_ENCRYPTION_KEY

### DIFF
--- a/src/features/admin/dashboard.ts
+++ b/src/features/admin/dashboard.ts
@@ -141,9 +141,11 @@ const LOG_DISPLAY_LIMIT = 200;
 
 /**
  * Attendee id → name for the log's Attendee column. The session private key is
- * unwrapped only when an entry actually links an attendee, so a system- or
- * listing-only log still renders for a session whose key is unavailable (its
- * messages and listing names decrypt with the DB key, not the session key).
+ * unwrapped here only when an entry actually links an attendee; listing names
+ * come from the listings cache (env-key), so a system- or listing-only log
+ * needs no attendee-name decryption. The log *messages* are decrypted in
+ * decryptLogRows, which pulls the same request-scoped session key whenever an
+ * entry is in the owner-key format.
  */
 const loadAttendeeNames = async (
   attendeeIds: number[],

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -11,10 +11,7 @@ import {
 import { parseCookies } from "#routes/url.ts";
 import { getRequestClientIp } from "#shared/client-context.ts";
 import { getSessionCookieName } from "#shared/cookies.ts";
-import {
-  getPrivateKeyFromSession,
-  unwrapKeyWithToken,
-} from "#shared/crypto/keys.ts";
+import { unwrapKeyWithToken } from "#shared/crypto/keys.ts";
 import { generateSecureToken } from "#shared/crypto/utils.ts";
 import { signCsrfToken, verifySignedCsrfToken } from "#shared/csrf.ts";
 import {
@@ -23,7 +20,6 @@ import {
 } from "#shared/db/api-key-attempts.ts";
 import { getApiKeyByToken, touchApiKeyLastUsed } from "#shared/db/api-keys.ts";
 import { deleteSession, getSession } from "#shared/db/sessions.ts";
-import { settings } from "#shared/db/settings.ts";
 import { decryptAdminLevel, getUserAuthFieldsById } from "#shared/db/users.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { setSavedFormData } from "#shared/forms.tsx";
@@ -39,15 +35,18 @@ import {
   STAFF_ADMIN_LEVELS,
 } from "#shared/types.ts";
 
+// SessionKeyError and the session→private-key derivation live in #shared so
+// shared-layer modules (e.g. the activity log) can reach them without importing
+// the feature layer. Re-exported here for the many route callers that import
+// them from #routes/auth.ts. getPrivateKey is the explicit-session form;
+// requireRequestPrivateKey (#shared/session-private-key.ts) is the
+// request-scoped, thread-free form that needs no session argument.
+export {
+  getSessionPrivateKey as getPrivateKey,
+  SessionKeyError,
+} from "#shared/session-private-key.ts";
 // Re-export for callers that need it
 export { generateSecureToken };
-
-/** Thrown when a session's private key cannot be derived (e.g. wrappedDataKey missing or unwrap failure) */
-export class SessionKeyError extends Error {
-  constructor() {
-    super("Private key unavailable for session");
-  }
-}
 
 /** Session with wrapped data key for private key derivation, and user role */
 export type AuthSession = {
@@ -206,29 +205,6 @@ export const getAuthenticatedApiKey = async (
   };
   setCachedSession(result);
   return result;
-};
-
-/**
- * Get private key for decrypting attendee PII from an authenticated session
- * Returns null if session doesn't have wrapped_data_key
- */
-export const getPrivateKey = async (session: {
-  token: string;
-  wrappedDataKey: string | null;
-}): Promise<CryptoKey | null> => {
-  if (!session.wrappedDataKey) return null;
-
-  if (!settings.wrappedPrivateKey) return null;
-
-  try {
-    return await getPrivateKeyFromSession(
-      session.token,
-      session.wrappedDataKey,
-      settings.wrappedPrivateKey,
-    );
-  } catch {
-    return null;
-  }
 };
 
 /** How the request was authenticated */

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -44,6 +44,7 @@ import {
   clearSessionCookie,
   parseFlashValue,
 } from "#shared/cookies.ts";
+import { maybeBackfillActivityLog } from "#shared/db/activity-log-backfill.ts";
 import { DatabaseBusyError } from "#shared/db/client.ts";
 import {
   initDb,
@@ -251,6 +252,7 @@ const getPrefix = (path: string): string => {
  * - `applySecurityHeaders` rebuilds the CSP on every routed response, reading
  *   the payment provider (and square_sandbox when the provider is Square)
  * - pruning self-guards on last_pruned_*
+ * - the activity-log backfill self-guards on its done flag + last-run stamp
  * - session auth + PII decryption read the key material
  */
 const INFRA_SETTINGS: readonly string[] = [
@@ -278,6 +280,10 @@ const INFRA_SETTINGS: readonly string[] = [
   CONFIG_KEYS.LAST_PRUNED_ORPHANS,
   CONFIG_KEYS.AUTO_PURGE_ORPHANS,
   CONFIG_KEYS.ORPHAN_PURGE_RETENTION,
+  // The activity-log backfill runs from the same fire-and-forget scheduler and
+  // self-guards on these every request until it has converted every legacy row.
+  CONFIG_KEYS.ACTIVITY_LOG_BACKFILL_DONE,
+  CONFIG_KEYS.LAST_ACTIVITY_LOG_BACKFILL,
   CONFIG_KEYS.PUBLIC_KEY,
   CONFIG_KEYS.WRAPPED_PRIVATE_KEY,
 ];
@@ -783,6 +789,10 @@ const prepareRequestEnvironment = async (
   if (!(method === "POST" && path === "/admin/privacy/orphans")) {
     addPendingWork(maybeRunPrunes());
   }
+
+  // Drain the legacy-format activity-log backfill a batch at a time. Like the
+  // prunes it self-gates on an interval and is a no-op once complete.
+  addPendingWork(maybeBackfillActivityLog());
 
   // Load effective domain (custom_domain from DB if set, else request hostname)
   loadEffectiveDomain(request.url);

--- a/src/shared/crypto/encryption.ts
+++ b/src/shared/crypto/encryption.ts
@@ -10,8 +10,12 @@ import { fromBase64, getRandomBytes, toBase64 } from "./utils.ts";
 /**
  * Encryption format version prefix
  * Format: enc:1:$base64iv:$base64ciphertext
+ *
+ * Tags symmetric DB_ENCRYPTION_KEY ciphertext, distinguishing it from hybrid
+ * owner-key values (see HYBRID_PREFIX in keys.ts) — the activity-log backfill
+ * keys off this prefix to find legacy rows still to re-encrypt.
  */
-const ENCRYPTION_PREFIX = "enc:1:";
+export const ENCRYPTION_PREFIX = "enc:1:";
 
 export const decodeKeyBytes = (keyString: string): Uint8Array => {
   const keyBytes = fromBase64(keyString);

--- a/src/shared/crypto/keys.ts
+++ b/src/shared/crypto/keys.ts
@@ -308,7 +308,10 @@ export const importPublicKey = (jwkString: string): Promise<CryptoKey> =>
 export const importPrivateKey = (jwkString: string): Promise<CryptoKey> =>
   importRsaKey(jwkString, "decrypt");
 
-const HYBRID_PREFIX = "hyb:1:";
+/** Prefix tagging a hybrid (RSA+AES) ciphertext, e.g. owner-key activity-log
+ * messages and attendee PII. Distinguishes them from env-key {@link
+ * ENCRYPTION_PREFIX} values so a decrypt path can route by format. */
+export const HYBRID_PREFIX = "hyb:1:";
 
 /**
  * Encrypt data using hybrid encryption (RSA + AES)

--- a/src/shared/db/activity-log-backfill.ts
+++ b/src/shared/db/activity-log-backfill.ts
@@ -1,0 +1,92 @@
+/**
+ * Activity-log backfill — re-encrypt legacy env-key messages to the owner key.
+ *
+ * Before the owner-key switch, `activity_log.message` was encrypted with
+ * DB_ENCRYPTION_KEY, so a database dump plus that key could read the whole
+ * history. This converts those rows in bounded batches: decrypt each `enc:` row
+ * with the env key, re-encrypt under the owner's public key, write it back.
+ * Only the public key is needed (no password), so it runs unattended.
+ *
+ * It is resumable without a cursor: a converted row no longer matches the
+ * `enc:` prefix, so each batch shrinks the remaining set. A batch that finds
+ * nothing flips a done flag so the scan stops permanently. Scheduling mirrors
+ * the prune tasks — fire-and-forget from the request handler, interval-gated by
+ * a `last_run` timestamp — to stay within the edge subrequest budget while
+ * converging over successive requests.
+ */
+
+import type { InValue } from "@libsql/client";
+import { decrypt, ENCRYPTION_PREFIX } from "#shared/crypto/encryption.ts";
+import { encryptWithOwnerKey } from "#shared/crypto/keys.ts";
+import { executeBatch, queryAll } from "#shared/db/client.ts";
+import { settings } from "#shared/db/settings.ts";
+import {
+  ACTIVITY_LOG_BACKFILL_BATCH,
+  ACTIVITY_LOG_BACKFILL_INTERVAL_MS,
+  parsePositiveInt,
+} from "#shared/limits.ts";
+import { logDebug } from "#shared/logger.ts";
+import { nowMs } from "#shared/now.ts";
+
+/** Legacy env-key row awaiting re-encryption. */
+type LegacyRow = { id: number; message: string };
+
+/**
+ * Re-encrypt one batch of legacy env-key rows to the owner key. Returns the
+ * number of rows converted (0 when none remain). All the rewrites land in a
+ * single transactional `executeBatch`, so a batch costs two subrequests (the
+ * SELECT and the batched write) however large it is.
+ */
+export const backfillActivityLogBatch = async (
+  publicKey: string,
+): Promise<number> => {
+  const rows = await queryAll<LegacyRow>(
+    "SELECT id, message FROM activity_log WHERE message LIKE ? LIMIT ?",
+    [`${ENCRYPTION_PREFIX}%`, ACTIVITY_LOG_BACKFILL_BATCH],
+  );
+  if (rows.length === 0) return 0;
+  const updates = await Promise.all(
+    rows.map(async (row) => ({
+      args: [
+        await encryptWithOwnerKey(await decrypt(row.message), publicKey),
+        row.id,
+      ] as InValue[],
+      sql: "UPDATE activity_log SET message = ? WHERE id = ?",
+    })),
+  );
+  await executeBatch(updates);
+  return rows.length;
+};
+
+/** Backfill is finished, or cannot run yet because no key pair is configured. */
+const backfillIdle = (): boolean =>
+  settings.activityLogBackfillDone === "true" || !settings.publicKey;
+
+/** Due when at least the backfill interval has elapsed since the last batch. */
+const isDue = (lastMs: number, now: number): boolean =>
+  now - lastMs >= ACTIVITY_LOG_BACKFILL_INTERVAL_MS;
+
+/**
+ * Run one backfill batch if due. Safe to call fire-and-forget
+ * (`addPendingWork`); never throws. Writes the run timestamp before working
+ * (claiming the interval so concurrent requests don't double-run) and marks the
+ * job done once a batch finds no remaining legacy rows.
+ */
+export const maybeBackfillActivityLog = async (): Promise<void> => {
+  if (backfillIdle()) return;
+  const now = nowMs();
+  if (!isDue(parsePositiveInt(settings.lastActivityLogBackfill, 0), now)) {
+    return;
+  }
+  try {
+    await settings.update.lastActivityLogBackfill(String(now));
+    const converted = await backfillActivityLogBatch(settings.publicKey);
+    if (converted === 0) {
+      await settings.update.activityLogBackfillDone("true");
+    } else {
+      logDebug("Backfill", `activity_log: re-encrypted ${converted} rows`);
+    }
+  } catch (e) {
+    logDebug("Backfill", `activity_log failed: ${String(e)}`);
+  }
+};

--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -4,17 +4,18 @@
  * Activity logging for admin visibility. Messages are encrypted with the site
  * owner's public key (hybrid RSA+AES), so a database dump plus DB_ENCRYPTION_KEY
  * cannot read them — only an authenticated admin, whose password unwraps the
- * private key, can. Writing needs only the always-available public key, so the
- * many unauthenticated callers (webhooks, the error logger) still log; reading
- * pulls the private key from the current request's session with no threading.
+ * private key, can. Writing needs only the public key (which a set-up site
+ * always has), so the many unauthenticated callers (webhooks, the error logger)
+ * still log; reading pulls the private key from the current request's session
+ * with no threading.
  *
- * Rows written before this change (and any written before setup configured a
- * key pair) carry the legacy DB_ENCRYPTION_KEY format and are still readable —
- * {@link decryptLogMessage} routes by prefix. The activity-log backfill job
- * re-encrypts those legacy rows to the owner key over time.
+ * Rows written before this change carry the legacy DB_ENCRYPTION_KEY format and
+ * are still readable — {@link decryptLogMessage} routes by prefix. The
+ * activity-log backfill job re-encrypts those legacy rows to the owner key over
+ * time.
  */
 
-import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
+import { decrypt } from "#shared/crypto/encryption.ts";
 import {
   decryptWithOwnerKey,
   encryptWithOwnerKey,
@@ -26,7 +27,7 @@ import {
   LISTING_COUNT_GROUP_BY,
   LISTING_COUNT_SELECT,
 } from "#shared/db/listings.ts";
-import { settings } from "#shared/db/settings.ts";
+import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
 import { col, defineTable } from "#shared/db/table.ts";
 import { nowIso } from "#shared/now.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
@@ -71,21 +72,6 @@ export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
 );
 
 /**
- * Encrypt a log message for storage with the owner's public key (hybrid), so
- * the entry is unreadable from a DB dump plus DB_ENCRYPTION_KEY. When no public
- * key is in scope it falls back to the env key, keeping logging alive — but the
- * caller must then re-arm the backfill (see {@link logActivity}), because that
- * happens not only genuinely pre-setup but also when the settings snapshot
- * simply hasn't loaded yet (e.g. an error logged early in a cold request on an
- * already-configured site).
- */
-const encryptLogMessage = (
-  message: string,
-  publicKey: string,
-): Promise<string> =>
-  publicKey ? encryptWithOwnerKey(message, publicKey) : encrypt(message);
-
-/**
  * Decrypt a stored log message, routing by format prefix: owner-key (hybrid)
  * rows need the session private key; legacy env-key rows decrypt without it.
  */
@@ -96,6 +82,19 @@ const decryptLogMessage = (
   message.startsWith(HYBRID_PREFIX)
     ? decryptWithOwnerKey(message, privateKey as CryptoKey)
     : decrypt(message);
+
+/**
+ * The owner public key, loading it into the settings snapshot on demand if a
+ * mid-request cache reset (setup, restore, database reset) blanked it. A set-up
+ * site always has one in the DB, so this trusts that rather than falling back to
+ * the env key; only genuinely pre-setup does it stay empty (and encryption then
+ * throws, which the error logger swallows).
+ */
+const ownerPublicKey = async (): Promise<string> => {
+  if (settings.publicKey) return settings.publicKey;
+  await settings.loadKeys([CONFIG_KEYS.PUBLIC_KEY]);
+  return settings.publicKey;
+};
 
 /** Accept an listing ID as a number or an object with `.id` */
 type ListingRef = number | { id: number };
@@ -113,18 +112,14 @@ export const logActivity = async (
   listing?: ListingRef | null,
   attendeeId?: number | null,
 ): Promise<ActivityLogEntry> => {
-  const publicKey = settings.publicKey;
   const row = await activityLogTable.insert({
     attendeeId: attendeeId ?? null,
     listingId: toListingId(listing),
-    message: await encryptLogMessage(message, publicKey),
+    // Encrypt with the owner's public key — a set-up site always has one, so
+    // there is no env-key fallback (ownerPublicKey loads it if the snapshot was
+    // reset earlier this request).
+    message: await encryptWithOwnerKey(message, await ownerPublicKey()),
   });
-  // No public key in scope means the row was stored in the legacy env-key
-  // format. Re-arm the backfill so it re-encrypts this row to the owner key
-  // once the key is available — clearing the done flag unconditionally, since a
-  // snapshot that hasn't loaded would wrongly read it as already cleared and a
-  // completed backfill would otherwise never revisit this straggler.
-  if (!publicKey) await settings.update.activityLogBackfillDone("");
   // insert() echoes the (encrypted) input back; restore the plaintext so the
   // returned entry stays human-readable for callers and tests.
   return { ...row, message };

--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -71,16 +71,19 @@ export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
 );
 
 /**
- * Encrypt a log message for storage. Prefers the site owner's public key
- * (hybrid) so the entry is unreadable from a DB dump plus DB_ENCRYPTION_KEY.
- * Before setup configures a key pair there is no public key, so it falls back
- * to the env key — keeping pre-setup error logging working; the backfill job
- * later re-encrypts any such legacy rows.
+ * Encrypt a log message for storage with the owner's public key (hybrid), so
+ * the entry is unreadable from a DB dump plus DB_ENCRYPTION_KEY. When no public
+ * key is in scope it falls back to the env key, keeping logging alive — but the
+ * caller must then re-arm the backfill (see {@link logActivity}), because that
+ * happens not only genuinely pre-setup but also when the settings snapshot
+ * simply hasn't loaded yet (e.g. an error logged early in a cold request on an
+ * already-configured site).
  */
-const encryptLogMessage = (message: string): Promise<string> => {
-  const publicKey = settings.publicKey;
-  return publicKey ? encryptWithOwnerKey(message, publicKey) : encrypt(message);
-};
+const encryptLogMessage = (
+  message: string,
+  publicKey: string,
+): Promise<string> =>
+  publicKey ? encryptWithOwnerKey(message, publicKey) : encrypt(message);
 
 /**
  * Decrypt a stored log message, routing by format prefix: owner-key (hybrid)
@@ -110,11 +113,18 @@ export const logActivity = async (
   listing?: ListingRef | null,
   attendeeId?: number | null,
 ): Promise<ActivityLogEntry> => {
+  const publicKey = settings.publicKey;
   const row = await activityLogTable.insert({
     attendeeId: attendeeId ?? null,
     listingId: toListingId(listing),
-    message: await encryptLogMessage(message),
+    message: await encryptLogMessage(message, publicKey),
   });
+  // No public key in scope means the row was stored in the legacy env-key
+  // format. Re-arm the backfill so it re-encrypts this row to the owner key
+  // once the key is available — clearing the done flag unconditionally, since a
+  // snapshot that hasn't loaded would wrongly read it as already cleared and a
+  // completed backfill would otherwise never revisit this straggler.
+  if (!publicKey) await settings.update.activityLogBackfillDone("");
   // insert() echoes the (encrypted) input back; restore the plaintext so the
   // returned entry stays human-readable for callers and tests.
   return { ...row, message };

--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -1,19 +1,35 @@
 /**
  * Activity log operations
  *
- * Activity logging for admin visibility.
- * Messages are encrypted - only admins can read them.
+ * Activity logging for admin visibility. Messages are encrypted with the site
+ * owner's public key (hybrid RSA+AES), so a database dump plus DB_ENCRYPTION_KEY
+ * cannot read them — only an authenticated admin, whose password unwraps the
+ * private key, can. Writing needs only the always-available public key, so the
+ * many unauthenticated callers (webhooks, the error logger) still log; reading
+ * pulls the private key from the current request's session with no threading.
+ *
+ * Rows written before this change (and any written before setup configured a
+ * key pair) carry the legacy DB_ENCRYPTION_KEY format and are still readable —
+ * {@link decryptLogMessage} routes by prefix. The activity-log backfill job
+ * re-encrypts those legacy rows to the owner key over time.
  */
 
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
+import {
+  decryptWithOwnerKey,
+  encryptWithOwnerKey,
+  HYBRID_PREFIX,
+} from "#shared/crypto/keys.ts";
 import { queryAll, queryBatch, resultRows } from "#shared/db/client.ts";
 import {
   decryptListingWithCount,
   LISTING_COUNT_GROUP_BY,
   LISTING_COUNT_SELECT,
 } from "#shared/db/listings.ts";
+import { settings } from "#shared/db/settings.ts";
 import { col, defineTable } from "#shared/db/table.ts";
 import { nowIso } from "#shared/now.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 
 /** Activity log entry */
@@ -33,8 +49,12 @@ export type ActivityLogInput = {
 };
 
 /**
- * Activity log table definition
- * message is encrypted - decrypted only for admin view
+ * Activity log table definition.
+ *
+ * `message` is a plain column here because its crypto can't be expressed as a
+ * static transform: the write key is resolved at runtime (owner public key when
+ * configured, else the env key) and the read key is the per-request private key.
+ * {@link logActivity} and {@link decryptLogRows} own those two steps.
  */
 export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
   {
@@ -45,10 +65,34 @@ export const activityLogTable = defineTable<ActivityLogEntry, ActivityLogInput>(
       created: col.withDefault(() => nowIso()),
       id: col.generated<number>(),
       listing_id: col.simple<number | null>(),
-      message: col.encrypted<string>(encrypt, decrypt),
+      message: col.simple<string>(),
     },
   },
 );
+
+/**
+ * Encrypt a log message for storage. Prefers the site owner's public key
+ * (hybrid) so the entry is unreadable from a DB dump plus DB_ENCRYPTION_KEY.
+ * Before setup configures a key pair there is no public key, so it falls back
+ * to the env key — keeping pre-setup error logging working; the backfill job
+ * later re-encrypts any such legacy rows.
+ */
+const encryptLogMessage = (message: string): Promise<string> => {
+  const publicKey = settings.publicKey;
+  return publicKey ? encryptWithOwnerKey(message, publicKey) : encrypt(message);
+};
+
+/**
+ * Decrypt a stored log message, routing by format prefix: owner-key (hybrid)
+ * rows need the session private key; legacy env-key rows decrypt without it.
+ */
+const decryptLogMessage = (
+  message: string,
+  privateKey: CryptoKey | null,
+): Promise<string> =>
+  message.startsWith(HYBRID_PREFIX)
+    ? decryptWithOwnerKey(message, privateKey as CryptoKey)
+    : decrypt(message);
 
 /** Accept an listing ID as a number or an object with `.id` */
 type ListingRef = number | { id: number };
@@ -61,22 +105,39 @@ const toListingId = (listing?: ListingRef | null): number | null =>
  * Log an activity. Optionally associate it with a listing and/or attendee so
  * admin views can filter the log by either.
  */
-export const logActivity = (
+export const logActivity = async (
   message: string,
   listing?: ListingRef | null,
   attendeeId?: number | null,
-): Promise<ActivityLogEntry> =>
-  activityLogTable.insert({
+): Promise<ActivityLogEntry> => {
+  const row = await activityLogTable.insert({
     attendeeId: attendeeId ?? null,
     listingId: toListingId(listing),
-    message,
+    message: await encryptLogMessage(message),
   });
+  // insert() echoes the (encrypted) input back; restore the plaintext so the
+  // returned entry stays human-readable for callers and tests.
+  return { ...row, message };
+};
 
-/** Decrypt the messages of a batch of raw activity log rows. */
-const decryptLogRows = (
+/**
+ * Decrypt the messages of a batch of raw activity log rows. The session private
+ * key is pulled from the current request only when at least one row is in the
+ * owner-key format; a batch of purely legacy env-key rows (or an empty result)
+ * decrypts without a key, so such pages still render where none is in scope.
+ */
+const decryptLogRows = async (
   rows: ActivityLogEntry[],
-): Promise<ActivityLogEntry[]> =>
-  Promise.all(rows.map((row) => activityLogTable.fromDb(row)));
+): Promise<ActivityLogEntry[]> => {
+  const needsKey = rows.some((row) => row.message.startsWith(HYBRID_PREFIX));
+  const privateKey = needsKey ? await requireRequestPrivateKey() : null;
+  return Promise.all(
+    rows.map(async (row) => ({
+      ...row,
+      message: await decryptLogMessage(row.message, privateKey),
+    })),
+  );
+};
 
 /** Query activity log with optional listing filter, decrypts messages */
 const queryActivityLog = async (

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -74,6 +74,7 @@ import type { EncryptedUpdateFn } from "#shared/wallets/wallet-settings-types.ts
 // ---------------------------------------------------------------------------
 
 export const CONFIG_KEYS = {
+  ACTIVITY_LOG_BACKFILL_DONE: "activity_log_backfill_done",
   APPLE_WALLET_PASS_TYPE_ID: "apple_wallet_pass_type_id",
   APPLE_WALLET_SIGNING_CERT: "apple_wallet_signing_cert",
   APPLE_WALLET_SIGNING_KEY: "apple_wallet_signing_key",
@@ -109,6 +110,7 @@ export const CONFIG_KEYS = {
   HAS_LOGISTICS: "has_logistics",
   HEADER_IMAGE_URL: "header_image_url",
   HOMEPAGE_TEXT: "homepage_text",
+  LAST_ACTIVITY_LOG_BACKFILL: "last_activity_log_backfill",
   LAST_PRUNED_CONTACTS: "last_pruned_contacts",
   LAST_PRUNED_INVITES: "last_pruned_invites",
   LAST_PRUNED_LOGINS: "last_pruned_logins",
@@ -260,6 +262,8 @@ const PLAINTEXT_KEYS = [
   CONFIG_KEYS.LAST_PRUNED_INVITES,
   CONFIG_KEYS.LAST_PRUNED_ORPHANS,
   CONFIG_KEYS.SMS_GATEWAY_BASE_URL,
+  CONFIG_KEYS.ACTIVITY_LOG_BACKFILL_DONE,
+  CONFIG_KEYS.LAST_ACTIVITY_LOG_BACKFILL,
 ] as const;
 
 /** Encrypted string config keys (decrypted during loadKeys, default ""). */
@@ -489,6 +493,7 @@ const plaintextUpdate: EncryptedUpdateFn = stringUpdate(writeOrDelete);
 type AccessorSpec = { key: StringSettingKey; readOnly?: true };
 
 const STRING_ACCESSORS = {
+  activityLogBackfillDone: { key: CONFIG_KEYS.ACTIVITY_LOG_BACKFILL_DONE },
   attendeeColumnOrder: { key: CONFIG_KEYS.ATTENDEE_COLUMN_ORDER },
   bulkEmailDraft: { key: CONFIG_KEYS.BULK_EMAIL_DRAFT },
   bunnySubdomain: { key: CONFIG_KEYS.BUNNY_SUBDOMAIN },
@@ -504,6 +509,7 @@ const STRING_ACCESSORS = {
   embedHosts: { key: CONFIG_KEYS.EMBED_HOSTS },
   headerImageUrl: { key: CONFIG_KEYS.HEADER_IMAGE_URL },
   homepageText: { key: CONFIG_KEYS.HOMEPAGE_TEXT },
+  lastActivityLogBackfill: { key: CONFIG_KEYS.LAST_ACTIVITY_LOG_BACKFILL },
   lastPrunedContacts: { key: CONFIG_KEYS.LAST_PRUNED_CONTACTS },
   lastPrunedInvites: { key: CONFIG_KEYS.LAST_PRUNED_INVITES },
   lastPrunedLogins: { key: CONFIG_KEYS.LAST_PRUNED_LOGINS },

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -245,6 +245,25 @@ export const PRUNE_CONTACTS_RETENTION_DAYS = readLimit(
 /** How often (hours) to re-run each prune task (default: 24 = daily) */
 export const PRUNE_INTERVAL_HOURS = readLimit("PRUNE_INTERVAL_HOURS", 24);
 
+/**
+ * Rows re-encrypted per activity-log backfill batch (default: 200). The whole
+ * batch is written in one `executeBatch` (a single subrequest) after one SELECT,
+ * so the per-request subrequest cost is fixed at two regardless of batch size.
+ */
+export const ACTIVITY_LOG_BACKFILL_BATCH = readLimit(
+  "ACTIVITY_LOG_BACKFILL_BATCH",
+  200,
+);
+
+/**
+ * Minimum gap (seconds) between activity-log backfill batches (default: 60).
+ * Throttles the fire-and-forget scheduler so one batch runs per minute of
+ * traffic while draining, rather than once per request — fast enough to clear a
+ * typical log within the hour, then it self-marks done and stops.
+ */
+export const ACTIVITY_LOG_BACKFILL_INTERVAL_MS =
+  readLimit("ACTIVITY_LOG_BACKFILL_INTERVAL_SECONDS", 60) * 1000;
+
 // ---------------------------------------------------------------------------
 // Email templates
 // ---------------------------------------------------------------------------

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -382,7 +382,8 @@ export type LogCategory =
   | "Storage"
   | "Wallet"
   | "Migration"
-  | "Prune";
+  | "Prune"
+  | "Backfill";
 
 /**
  * Log a debug message with category prefix

--- a/src/shared/session-private-key.ts
+++ b/src/shared/session-private-key.ts
@@ -1,0 +1,78 @@
+/**
+ * Request-scoped access to the site's private key.
+ *
+ * The owner key pair decrypts attendee PII (and now the activity log). Deriving
+ * the private key needs the authenticated session: its token unwraps the
+ * DATA_KEY, which decrypts the stored private key. Historically every caller
+ * had to thread the derived key (or the session) down through its call stack.
+ *
+ * {@link getRequestPrivateKey} removes that threading: it reads the
+ * AsyncLocalStorage-scoped session for the *current request* (see
+ * session-context.ts) and derives the key on demand (memoised per token by
+ * getPrivateKeyFromSession). Because the session store is bound to the current
+ * request's async context, the accessor can only ever return *this* request's
+ * own session, and the derivation is keyed by that session's unique token — so
+ * there is no path by which one request can obtain another session's key.
+ *
+ * Outside a request (background jobs, webhooks that only write, unit tests that
+ * don't establish a context) there is no session, so the accessor returns null
+ * / throws — fail-closed, never falling back to another session.
+ */
+
+import { getPrivateKeyFromSession } from "#shared/crypto/keys.ts";
+import { settings } from "#shared/db/settings.ts";
+import { getCachedSession } from "#shared/session-context.ts";
+
+/** Minimal session shape needed to derive the private key. */
+type KeyedSession = { token: string; wrappedDataKey: string | null };
+
+/** Thrown when the current session's private key cannot be derived (e.g.
+ * wrappedDataKey missing, no key pair configured, or unwrap failure). */
+export class SessionKeyError extends Error {
+  constructor() {
+    super("Private key unavailable for session");
+  }
+}
+
+/**
+ * Derive the private key for an explicit session, or null when it cannot be
+ * derived (no wrapped data key, no stored private key, or an unwrap failure —
+ * e.g. after a DB_ENCRYPTION_KEY rotation invalidates an old session).
+ */
+export const getSessionPrivateKey = async (
+  session: KeyedSession,
+): Promise<CryptoKey | null> => {
+  if (!session.wrappedDataKey) return null;
+  if (!settings.wrappedPrivateKey) return null;
+
+  try {
+    return await getPrivateKeyFromSession(
+      session.token,
+      session.wrappedDataKey,
+      settings.wrappedPrivateKey,
+    );
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Private key for the current request's session, or null when there is no
+ * session in scope or its key cannot be derived.
+ */
+export const getRequestPrivateKey = (): Promise<CryptoKey | null> => {
+  const session = getCachedSession();
+  return session ? getSessionPrivateKey(session) : Promise.resolve(null);
+};
+
+/**
+ * Private key for the current request's session, throwing {@link SessionKeyError}
+ * when unavailable. Use this where decryption must succeed for the page to
+ * render (the activity log, attendee PII) — the central request error handler
+ * special-cases SessionKeyError into a re-authenticate response.
+ */
+export const requireRequestPrivateKey = async (): Promise<CryptoKey> => {
+  const key = await getRequestPrivateKey();
+  if (!key) throw new SessionKeyError();
+  return key;
+};

--- a/test/admin-built-sites-actions.test.ts
+++ b/test/admin-built-sites-actions.test.ts
@@ -6,7 +6,6 @@ import { FakeTime } from "@std/testing/time";
 import { handleRequest } from "#routes";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { addMonthsIso } from "#shared/dates.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import {
   getAllBuiltSites,
   updateBuiltSiteRenewalState,
@@ -18,6 +17,7 @@ import {
   createTestListing,
   describeWithEnv,
   expectFlashRedirect,
+  getAllActivityLog,
   provisionTestBuiltSite,
   testCookie,
 } from "#test-utils";

--- a/test/e2e/duration-days.test.ts
+++ b/test/e2e/duration-days.test.ts
@@ -12,7 +12,6 @@ import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { generateAttendeesCsv } from "#routes/admin/attendees-csv.ts";
 import { addDays, getAvailableDates } from "#shared/dates.ts";
-import { getListingActivityLog } from "#shared/db/activityLog.ts";
 import {
   checkBatchAvailability,
   checkGroupCapAfterDurationChange,
@@ -35,6 +34,7 @@ import {
   createTestHoliday,
   describeWithEnv,
   expectFlashRedirect,
+  getListingActivityLog,
   makeTestEntry,
   mockFormRequest,
   rawListingRange,

--- a/test/lib/admin/sms.test.ts
+++ b/test/lib/admin/sms.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { it } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { getAttendeeActivityLog } from "#shared/db/activityLog.ts";
 import { getDb } from "#shared/db/client.ts";
 import { getContactRecord, hashPhone } from "#shared/db/contact-preferences.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -15,6 +14,7 @@ import {
   createTestAttendeeDirect,
   createTestListing,
   describeWithEnv,
+  getAttendeeActivityLog,
   getTestPrivateKey,
 } from "#test-utils";
 

--- a/test/lib/crypto/encryption.test.ts
+++ b/test/lib/crypto/encryption.test.ts
@@ -38,16 +38,20 @@ describeWithEnv("encryption", { encryptionKey: true }, () => {
       );
     });
 
-    it("re-runs the key initializer and reads the env when the override is cleared to null", () => {
+    it("re-runs the key initializer when the override is cleared to null", () => {
       // Clearing to null (not "") resets the lazyRef holding the override, so
-      // the next read re-runs its initializer and falls through to the
-      // DB_ENCRYPTION_KEY env var — unset under test, so it reports the missing
-      // key. Exercises the env-lookup branch that otherwise only the e2e
-      // subprocess hits.
+      // the next read re-runs its initializer and falls through to
+      // DB_ENCRYPTION_KEY. That env var is set in CI but not locally, so assert
+      // against whatever it holds — either way this exercises the env-lookup
+      // branch that otherwise only the e2e subprocess covers.
       setEncryptionKeyForTest(null);
-      expect(() => validateEncryptionKey()).toThrow(
-        "DB_ENCRYPTION_KEY environment variable is required",
-      );
+      if (Deno.env.get("DB_ENCRYPTION_KEY")) {
+        expect(() => validateEncryptionKey()).not.toThrow();
+      } else {
+        expect(() => validateEncryptionKey()).toThrow(
+          "DB_ENCRYPTION_KEY environment variable is required",
+        );
+      }
       setupTestEncryptionKey(); // restore the override for sibling tests
     });
   });

--- a/test/lib/crypto/encryption.test.ts
+++ b/test/lib/crypto/encryption.test.ts
@@ -37,6 +37,19 @@ describeWithEnv("encryption", { encryptionKey: true }, () => {
         "DB_ENCRYPTION_KEY must be 32 bytes",
       );
     });
+
+    it("re-runs the key initializer and reads the env when the override is cleared to null", () => {
+      // Clearing to null (not "") resets the lazyRef holding the override, so
+      // the next read re-runs its initializer and falls through to the
+      // DB_ENCRYPTION_KEY env var — unset under test, so it reports the missing
+      // key. Exercises the env-lookup branch that otherwise only the e2e
+      // subprocess hits.
+      setEncryptionKeyForTest(null);
+      expect(() => validateEncryptionKey()).toThrow(
+        "DB_ENCRYPTION_KEY environment variable is required",
+      );
+      setupTestEncryptionKey(); // restore the override for sibling tests
+    });
   });
 
   describe("encrypt and decrypt", () => {

--- a/test/lib/db/activity-log-backfill.test.ts
+++ b/test/lib/db/activity-log-backfill.test.ts
@@ -66,13 +66,19 @@ describeWithEnv("db > activity log backfill", { db: true }, () => {
 
   test("scheduler converts a due batch and records the run timestamp", async () => {
     const id = await insertLegacyRow("convert me");
+    // A last-run a full day ago is unambiguously past the interval, so the run
+    // is due — pinning the elapsed-time subtraction in the interval check
+    // (now - last >= interval), not merely the last=0 boundary.
+    const dayAgo = Date.now() - 24 * 60 * 60 * 1000;
+    await settings.update.lastActivityLogBackfill(String(dayAgo));
 
     await maybeBackfillActivityLog();
 
     expect((await rawMessage(id)).startsWith(HYBRID_PREFIX)).toBe(true);
     // Work may remain, so it is not marked done after a non-empty batch.
     expect(settings.activityLogBackfillDone).not.toBe("true");
-    expect(Number(settings.lastActivityLogBackfill)).toBeGreaterThan(0);
+    // The run stamped a fresh, newer timestamp over the day-old one.
+    expect(Number(settings.lastActivityLogBackfill)).toBeGreaterThan(dayAgo);
   });
 
   test("scheduler marks itself done once nothing remains", async () => {

--- a/test/lib/db/activity-log-backfill.test.ts
+++ b/test/lib/db/activity-log-backfill.test.ts
@@ -1,0 +1,123 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { ENCRYPTION_PREFIX, encrypt } from "#shared/crypto/encryption.ts";
+import { HYBRID_PREFIX } from "#shared/crypto/keys.ts";
+import {
+  backfillActivityLogBatch,
+  maybeBackfillActivityLog,
+} from "#shared/db/activity-log-backfill.ts";
+import { getAllActivityLog, logActivity } from "#shared/db/activityLog.ts";
+import { execute, queryOne } from "#shared/db/client.ts";
+import { settings } from "#shared/db/settings.ts";
+import { nowIso } from "#shared/now.ts";
+import { describeWithEnv, withTestSession } from "#test-utils";
+
+/** Insert a row encrypted with DB_ENCRYPTION_KEY (the pre-migration format). */
+const insertLegacyRow = async (message: string): Promise<number> => {
+  const result = await execute(
+    "INSERT INTO activity_log (message, created, listing_id, attendee_id) VALUES (?, ?, NULL, NULL)",
+    [await encrypt(message), nowIso()],
+  );
+  return Number(result.lastInsertRowid);
+};
+
+/** Raw (still-encrypted) stored message for a row. */
+const rawMessage = async (id: number): Promise<string> =>
+  (await queryOne<{ message: string }>(
+    "SELECT message FROM activity_log WHERE id = ?",
+    [id],
+  ))!.message;
+
+describeWithEnv("db > activity log backfill", { db: true }, () => {
+  test("re-encrypts legacy rows to the owner key, preserving the plaintext", async () => {
+    const id1 = await insertLegacyRow("legacy one");
+    const id2 = await insertLegacyRow("legacy two");
+    expect((await rawMessage(id1)).startsWith(ENCRYPTION_PREFIX)).toBe(true);
+
+    const converted = await backfillActivityLogBatch(settings.publicKey);
+
+    expect(converted).toBe(2);
+    expect((await rawMessage(id1)).startsWith(HYBRID_PREFIX)).toBe(true);
+    expect((await rawMessage(id2)).startsWith(HYBRID_PREFIX)).toBe(true);
+    // Re-encrypted rows still read back as the original plaintext for an admin.
+    const messages = (await withTestSession(() => getAllActivityLog())).map(
+      (e) => e.message,
+    );
+    expect(messages).toContain("legacy one");
+    expect(messages).toContain("legacy two");
+  });
+
+  test("leaves owner-key rows untouched", async () => {
+    const legacyId = await insertLegacyRow("legacy");
+    const owner = await logActivity("already owner-key");
+    const ownerBefore = await rawMessage(owner.id);
+
+    const converted = await backfillActivityLogBatch(settings.publicKey);
+
+    expect(converted).toBe(1); // only the legacy row matched
+    expect(await rawMessage(owner.id)).toBe(ownerBefore); // byte-for-byte
+    expect((await rawMessage(legacyId)).startsWith(HYBRID_PREFIX)).toBe(true);
+  });
+
+  test("returns 0 when no legacy rows remain", async () => {
+    await logActivity("owner-key only");
+    expect(await backfillActivityLogBatch(settings.publicKey)).toBe(0);
+  });
+
+  test("scheduler converts a due batch and records the run timestamp", async () => {
+    const id = await insertLegacyRow("convert me");
+
+    await maybeBackfillActivityLog();
+
+    expect((await rawMessage(id)).startsWith(HYBRID_PREFIX)).toBe(true);
+    // Work may remain, so it is not marked done after a non-empty batch.
+    expect(settings.activityLogBackfillDone).not.toBe("true");
+    expect(Number(settings.lastActivityLogBackfill)).toBeGreaterThan(0);
+  });
+
+  test("scheduler marks itself done once nothing remains", async () => {
+    await maybeBackfillActivityLog();
+
+    expect(settings.activityLogBackfillDone).toBe("true");
+  });
+
+  test("scheduler is a no-op once done", async () => {
+    await settings.update.activityLogBackfillDone("true");
+    const id = await insertLegacyRow("should stay legacy");
+
+    await maybeBackfillActivityLog();
+
+    expect((await rawMessage(id)).startsWith(ENCRYPTION_PREFIX)).toBe(true);
+  });
+
+  test("scheduler is a no-op before a key pair is configured", async () => {
+    const id = await insertLegacyRow("no key yet");
+    settings.setForTest({ public_key: "" });
+
+    await maybeBackfillActivityLog();
+
+    expect((await rawMessage(id)).startsWith(ENCRYPTION_PREFIX)).toBe(true);
+    expect(settings.activityLogBackfillDone).not.toBe("true");
+  });
+
+  test("scheduler skips when the interval has not elapsed", async () => {
+    await settings.update.lastActivityLogBackfill(String(Date.now()));
+    const id = await insertLegacyRow("too soon");
+
+    await maybeBackfillActivityLog();
+
+    expect((await rawMessage(id)).startsWith(ENCRYPTION_PREFIX)).toBe(true);
+  });
+
+  test("scheduler swallows a failing batch without marking done", async () => {
+    // A corrupt env-key payload makes decrypt throw partway through the batch.
+    await execute(
+      "INSERT INTO activity_log (message, created, listing_id, attendee_id) VALUES (?, ?, NULL, NULL)",
+      [`${ENCRYPTION_PREFIX}AAAA:BBBB`, nowIso()],
+    );
+
+    await maybeBackfillActivityLog(); // must not throw
+
+    expect(settings.activityLogBackfillDone).not.toBe("true");
+  });
+});

--- a/test/lib/db/activity-log.test.ts
+++ b/test/lib/db/activity-log.test.ts
@@ -1,5 +1,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { decrypt, ENCRYPTION_PREFIX } from "#shared/crypto/encryption.ts";
+import { HYBRID_PREFIX } from "#shared/crypto/keys.ts";
 import {
   getAllActivityLog,
   getAttendeeActivityLog,
@@ -7,7 +9,20 @@ import {
   getListingWithActivityLog,
   logActivity,
 } from "#shared/db/activityLog.ts";
-import { createTestListing, describeWithEnv } from "#test-utils";
+import { queryOne } from "#shared/db/client.ts";
+import { settings } from "#shared/db/settings.ts";
+import {
+  createTestListing,
+  describeWithEnv,
+  withTestSession,
+} from "#test-utils";
+
+/** Raw (still-encrypted) stored message for an activity-log row. */
+const rawMessage = async (id: number): Promise<string> =>
+  (await queryOne<{ message: string }>(
+    "SELECT message FROM activity_log WHERE id = ?",
+    [id],
+  ))!.message;
 
 describeWithEnv("db > activity log", { db: true }, () => {
   test("logActivity creates log entry with message", async () => {
@@ -33,12 +48,47 @@ describeWithEnv("db > activity log", { db: true }, () => {
     expect(entry.message).toBe("Created listing 'Test Listing'");
   });
 
+  test("stores messages encrypted with the owner key, not DB_ENCRYPTION_KEY", async () => {
+    const entry = await logActivity("Sensitive note");
+    const stored = await rawMessage(entry.id);
+
+    // Owner-key (hybrid RSA+AES) format, not the env-key (enc:) format.
+    expect(stored.startsWith(HYBRID_PREFIX)).toBe(true);
+    expect(stored.startsWith(ENCRYPTION_PREFIX)).toBe(false);
+    // A database dump plus DB_ENCRYPTION_KEY cannot read it: the env-key
+    // decrypt rejects an owner-key payload outright.
+    await expect(decrypt(stored)).rejects.toThrow();
+  });
+
+  test("reading owner-key entries fails closed without a session", async () => {
+    await logActivity("Owner-key entry");
+
+    await expect(getAllActivityLog()).rejects.toThrow(
+      "Private key unavailable for session",
+    );
+  });
+
+  test("falls back to the env key before a key pair is configured", async () => {
+    // No public key yet (pre-setup); the error logger must still record.
+    settings.setForTest({ public_key: "" });
+    const entry = await logActivity("Pre-setup error");
+    const stored = await rawMessage(entry.id);
+
+    expect(stored.startsWith(ENCRYPTION_PREFIX)).toBe(true);
+    expect(await decrypt(stored)).toBe("Pre-setup error");
+
+    // Legacy env-key rows decrypt without a session in scope.
+    const entries = await getAllActivityLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.message).toBe("Pre-setup error");
+  });
+
   test("logActivity records an attendee_id and getAttendeeActivityLog filters by it", async () => {
     await logActivity("Unrelated entry");
     await logActivity("Balance paid", null, 42);
     await logActivity("Other attendee", null, 99);
 
-    const entries = await getAttendeeActivityLog(42);
+    const entries = await withTestSession(() => getAttendeeActivityLog(42));
     expect(entries).toHaveLength(1);
     expect(entries[0]!.message).toBe("Balance paid");
     expect(entries[0]!.attendee_id).toBe(42);
@@ -60,7 +110,9 @@ describeWithEnv("db > activity log", { db: true }, () => {
     await logActivity("Another action for listing 1", listing1.id);
     await logActivity("Action for listing 2", listing2.id);
 
-    const listing1Log = await getListingActivityLog(listing1.id);
+    const listing1Log = await withTestSession(() =>
+      getListingActivityLog(listing1.id),
+    );
     // REST API also logs listing creation, so we have 3 entries for listing 1
     expect(listing1Log.length).toBe(3);
     expect(listing1Log[0]?.message).toBe("Another action for listing 1");
@@ -82,7 +134,9 @@ describeWithEnv("db > activity log", { db: true }, () => {
     await logActivity("Action 2", listing.id);
     await logActivity("Action 3", listing.id);
 
-    const entries = await getListingActivityLog(listing.id, 2);
+    const entries = await withTestSession(() =>
+      getListingActivityLog(listing.id, 2),
+    );
     expect(entries.length).toBe(2);
   });
 
@@ -96,7 +150,7 @@ describeWithEnv("db > activity log", { db: true }, () => {
     await logActivity("Global action");
     await logActivity("Listing action", listing.id);
 
-    const entries = await getAllActivityLog();
+    const entries = await withTestSession(() => getAllActivityLog());
     // REST API logs listing creation, so we have 3 entries total
     expect(entries.length).toBe(3);
   });
@@ -106,7 +160,7 @@ describeWithEnv("db > activity log", { db: true }, () => {
     await logActivity("Second action");
     await logActivity("Third action");
 
-    const entries = await getAllActivityLog();
+    const entries = await withTestSession(() => getAllActivityLog());
     expect(entries[0]?.message).toBe("Third action");
     expect(entries[1]?.message).toBe("Second action");
     expect(entries[2]?.message).toBe("First action");
@@ -117,7 +171,7 @@ describeWithEnv("db > activity log", { db: true }, () => {
     await logActivity("Action 2");
     await logActivity("Action 3");
 
-    const entries = await getAllActivityLog(2);
+    const entries = await withTestSession(() => getAllActivityLog(2));
     expect(entries.length).toBe(2);
   });
 
@@ -131,7 +185,9 @@ describeWithEnv("db > activity log", { db: true }, () => {
     await logActivity("First action", listing.id);
     await logActivity("Second action", listing.id);
 
-    const result = await getListingWithActivityLog(listing.id);
+    const result = await withTestSession(() =>
+      getListingWithActivityLog(listing.id),
+    );
     expect(result).not.toBeNull();
     expect(result?.listing.id).toBe(listing.id);
     expect(result?.listing.name).toBe("Batch Test Listing");

--- a/test/lib/db/activity-log.test.ts
+++ b/test/lib/db/activity-log.test.ts
@@ -83,6 +83,19 @@ describeWithEnv("db > activity log", { db: true }, () => {
     expect(entries[0]!.message).toBe("Pre-setup error");
   });
 
+  test("env-key fallback re-arms an already-completed backfill", async () => {
+    // A configured site whose backfill finished, then an early error logs
+    // before the public key snapshot loaded — storing an enc: row.
+    await settings.update.activityLogBackfillDone("true");
+    settings.setForTest({ public_key: "" });
+
+    await logActivity("late error on a cold request");
+
+    // The backfill must re-engage to re-encrypt that straggler, so the done
+    // flag is cleared rather than left orphaning the row forever.
+    expect(settings.activityLogBackfillDone).not.toBe("true");
+  });
+
   test("logActivity records an attendee_id and getAttendeeActivityLog filters by it", async () => {
     await logActivity("Unrelated entry");
     await logActivity("Balance paid", null, 42);

--- a/test/lib/db/activity-log.test.ts
+++ b/test/lib/db/activity-log.test.ts
@@ -1,6 +1,10 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { decrypt, ENCRYPTION_PREFIX } from "#shared/crypto/encryption.ts";
+import {
+  decrypt,
+  ENCRYPTION_PREFIX,
+  encrypt,
+} from "#shared/crypto/encryption.ts";
 import { HYBRID_PREFIX } from "#shared/crypto/keys.ts";
 import {
   getAllActivityLog,
@@ -9,8 +13,9 @@ import {
   getListingWithActivityLog,
   logActivity,
 } from "#shared/db/activityLog.ts";
-import { queryOne } from "#shared/db/client.ts";
+import { execute, queryOne } from "#shared/db/client.ts";
 import { settings } from "#shared/db/settings.ts";
+import { nowIso } from "#shared/now.ts";
 import {
   createTestListing,
   describeWithEnv,
@@ -68,32 +73,28 @@ describeWithEnv("db > activity log", { db: true }, () => {
     );
   });
 
-  test("falls back to the env key before a key pair is configured", async () => {
-    // No public key yet (pre-setup); the error logger must still record.
-    settings.setForTest({ public_key: "" });
-    const entry = await logActivity("Pre-setup error");
-    const stored = await rawMessage(entry.id);
+  test("loads the public key on demand when the snapshot was reset", async () => {
+    // A mid-request cache reset (setup, restore, database reset) blanks the
+    // snapshot while the key is still in the DB; logActivity must reload it
+    // rather than fall back to the env key.
+    settings.invalidateCache();
+    const entry = await logActivity("after a cache reset");
 
-    expect(stored.startsWith(ENCRYPTION_PREFIX)).toBe(true);
-    expect(await decrypt(stored)).toBe("Pre-setup error");
-
-    // Legacy env-key rows decrypt without a session in scope.
-    const entries = await getAllActivityLog();
-    expect(entries).toHaveLength(1);
-    expect(entries[0]!.message).toBe("Pre-setup error");
+    // Stored owner-key (hybrid), not env-key — the reload found the DB key.
+    expect((await rawMessage(entry.id)).startsWith(HYBRID_PREFIX)).toBe(true);
   });
 
-  test("env-key fallback re-arms an already-completed backfill", async () => {
-    // A configured site whose backfill finished, then an early error logs
-    // before the public key snapshot loaded — storing an enc: row.
-    await settings.update.activityLogBackfillDone("true");
-    settings.setForTest({ public_key: "" });
+  test("reads legacy env-key rows without a session", async () => {
+    // A row written before the owner-key switch (env-key format). Such rows
+    // decrypt with the env key, so they still render with no session in scope.
+    await execute(
+      "INSERT INTO activity_log (message, created, listing_id, attendee_id) VALUES (?, ?, NULL, NULL)",
+      [await encrypt("legacy entry"), nowIso()],
+    );
 
-    await logActivity("late error on a cold request");
-
-    // The backfill must re-engage to re-encrypt that straggler, so the done
-    // flag is cleared rather than left orphaning the row forever.
-    expect(settings.activityLogBackfillDone).not.toBe("true");
+    const entries = await getAllActivityLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.message).toBe("legacy entry");
   });
 
   test("logActivity records an attendee_id and getAttendeeActivityLog filters by it", async () => {

--- a/test/lib/db/listings.test.ts
+++ b/test/lib/db/listings.test.ts
@@ -47,6 +47,7 @@ import {
   createTestListing,
   describeWithEnv,
   getTestPrivateKey,
+  withTestSession,
 } from "#test-utils";
 
 describeWithEnv("db > listings", { db: true, triggers: true }, () => {
@@ -331,7 +332,7 @@ describeWithEnv("db > listings", { db: true, triggers: true }, () => {
       const listingLog = await getListingActivityLog(listing.id);
       expect(listingLog).toEqual([]);
 
-      const allLog = await getAllActivityLog();
+      const allLog = await withTestSession(() => getAllActivityLog());
       const messages = allLog.map((e) => e.message);
       expect(messages).not.toContain("Action for listing");
       expect(messages).not.toContain("Another action");

--- a/test/lib/db/settle-balance.test.ts
+++ b/test/lib/db/settle-balance.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { getAttendeeActivityLog } from "#shared/db/activityLog.ts";
 import {
   attendeeStatusesTable,
   getPaidDefaultStatus,
@@ -18,7 +17,11 @@ import {
   getQueryLog,
   runWithQueryLogContext,
 } from "#shared/db/query-log.ts";
-import { createTestListing, describeWithEnv } from "#test-utils";
+import {
+  createTestListing,
+  describeWithEnv,
+  getAttendeeActivityLog,
+} from "#test-utils";
 
 /** Create a reserved attendee with an outstanding balance. */
 const createReservedAttendee = async (remainingBalance: number) => {

--- a/test/lib/logger/log-error.test.ts
+++ b/test/lib/logger/log-error.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { type Spy, spy, stub } from "@std/testing/mock";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import {
   bestEffort,
   ErrorCode,
@@ -12,6 +11,7 @@ import { flushPendingWork, runWithPendingWork } from "#shared/pending-work.ts";
 import {
   createTestDbWithSetup,
   createTestListing,
+  getAllActivityLog,
   resetDb,
   setTestEnv,
 } from "#test-utils";

--- a/test/lib/renewals.test.ts
+++ b/test/lib/renewals.test.ts
@@ -4,12 +4,12 @@ import { stub } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { addMonthsIso } from "#shared/dates.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { getAllBuiltSites, insertBuiltSite } from "#shared/db/built-sites.ts";
 import { applyRenewalsForEntries } from "#shared/webhook.ts";
 import {
   createTestListing,
   describeWithEnv,
+  getAllActivityLog,
   makeTestEntry,
   provisionTestBuiltSite,
 } from "#test-utils";

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1843,9 +1843,7 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         expect(response.status).toBe(302);
 
         // Verify activity was logged
-        const { getListingActivityLog } = await import(
-          "#shared/db/activityLog.ts"
-        );
+        const { getListingActivityLog } = await import("#test-utils");
         const logs = await getListingActivityLog(listing.id);
         const resendLog = logs.find((l: { message: string }) =>
           l.message.includes("Notification re-sent"),

--- a/test/lib/server-built-sites-update.test.ts
+++ b/test/lib/server-built-sites-update.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { backupKey, backupTimestamp, dbName } from "#shared/db/backup.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
 import { uploadRaw } from "#shared/storage.ts";
@@ -12,6 +11,7 @@ import {
   createTestBuiltSite,
   describeWithEnv,
   expectFlashRedirect,
+  getAllActivityLog,
   setTestEnv,
   testCookie,
 } from "#test-utils";

--- a/test/lib/server-bulk-email.test.ts
+++ b/test/lib/server-bulk-email.test.ts
@@ -2,10 +2,6 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { type BulkEmailDraft, serializeDraft } from "#shared/bulk-email.ts";
 import { encryptWithOwnerKey } from "#shared/crypto/keys.ts";
-import {
-  getAllActivityLog,
-  getListingActivityLog,
-} from "#shared/db/activityLog.ts";
 import { getDb } from "#shared/db/client.ts";
 import {
   getContactRecord,
@@ -27,6 +23,8 @@ import {
   expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
+  getAllActivityLog,
+  getListingActivityLog,
   getTestPrivateKey,
   testCookie,
   testRequiresAuth,

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -5,7 +5,6 @@ import { handleRequest } from "#routes";
 import { formatCountdown } from "#routes/format.ts";
 import { withCookie } from "#routes/response.ts";
 import { addDays } from "#shared/dates.ts";
-import { logActivity } from "#shared/db/activityLog.ts";
 import { getDb, insert } from "#shared/db/client.ts";
 import {
   getListingWithCount,
@@ -34,6 +33,7 @@ import {
   expectHtmlResponse,
   expectStatus,
   followRedirectWithFlash,
+  logActivity,
   mockFormRequest,
   mockMultipartRequest,
   setTestEnv,
@@ -3190,9 +3190,7 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         ),
       );
 
-      const { getListingActivityLog } = await import(
-        "#shared/db/activityLog.ts"
-      );
+      const { getListingActivityLog } = await import("#test-utils");
       const logs = await getListingActivityLog(listing.id);
       const updateLog = logs.find((l: { message: string }) =>
         l.message.includes("updated"),

--- a/test/lib/server-misc-admin-handlers.test.ts
+++ b/test/lib/server-misc-admin-handlers.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { FormParams } from "#shared/form-data.ts";
 import {
   createTestListing,
   describeWithEnv,
   expectFlash,
+  getAllActivityLog,
   mockFormRequest,
   mockMultipartRequest,
   mockRequest,

--- a/test/lib/server-settings/booking-fee.test.ts
+++ b/test/lib/server-settings/booking-fee.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import {
@@ -9,6 +8,7 @@ import {
   describeWithEnv,
   expectFlash,
   expectHtmlResponse,
+  getAllActivityLog,
   mockFormRequest,
   testCookie,
   testCsrfToken,

--- a/test/lib/server-settings/business-email.test.ts
+++ b/test/lib/server-settings/business-email.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import {
@@ -9,6 +8,7 @@ import {
   describeWithEnv,
   expectFlash,
   expectHtmlResponse,
+  getAllActivityLog,
   mockFormRequest,
   testCookie,
   testRequiresAuth,

--- a/test/lib/server-settings/domains.test.ts
+++ b/test/lib/server-settings/domains.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   adminFormPost,
@@ -12,6 +11,7 @@ import {
   expectFlashRedirect,
   expectRedirectWithFlash,
   followRedirectWithFlash,
+  getAllActivityLog,
   mockFormRequest,
   mockRequestWithHost,
   testCookie,

--- a/test/lib/server-settings/email.test.ts
+++ b/test/lib/server-settings/email.test.ts
@@ -1,13 +1,13 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import {
   adminFormPost,
   awaitTestRequest,
   describeWithEnv,
   expectFlash,
+  getAllActivityLog,
   testCookie,
   testRequiresAuth,
   withMocks,

--- a/test/lib/server-settings/password.test.ts
+++ b/test/lib/server-settings/password.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { getSessionCookieName } from "#shared/cookies.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { invalidateUsersCache } from "#shared/db/users.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import {
@@ -13,8 +12,10 @@ import {
   expectHtmlResponse,
   expectRedirect,
   expectRedirectWithFlash,
+  getAllActivityLog,
   mockAdminLoginRequest,
   mockFormRequest,
+  reloginAsAdmin,
   TEST_ADMIN_PASSWORD,
   testCookie,
   testRequiresAuth,
@@ -161,6 +162,9 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
         new_password_confirm: "newpassword123",
       });
 
+      // Changing the password deletes existing sessions; re-authenticate with
+      // the new password so the owner-key log can be read back.
+      await reloginAsAdmin("newpassword123");
       const logs = await getAllActivityLog();
       expect(logs.some((l) => l.message.includes("Password changed"))).toBe(
         true,

--- a/test/lib/server-settings/payment-provider.test.ts
+++ b/test/lib/server-settings/payment-provider.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import {
   adminFormPost,
   describeWithEnv,
   expectFlash,
+  getAllActivityLog,
   testRequiresAuth,
 } from "#test-utils";
 

--- a/test/lib/server-settings/square.test.ts
+++ b/test/lib/server-settings/square.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import { squareApi } from "#shared/square.ts";
@@ -13,6 +12,7 @@ import {
   describeWithEnv,
   expectFlash,
   expectHtmlResponse,
+  getAllActivityLog,
   mockFormRequest,
   testCookie,
   testRequiresAuth,

--- a/test/lib/server-settings/stripe.test.ts
+++ b/test/lib/server-settings/stripe.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import { stripeApi } from "#shared/stripe.ts";
@@ -14,6 +13,7 @@ import {
   expectFlash,
   expectHtmlResponse,
   expectRedirect,
+  getAllActivityLog,
   mockFormRequest,
   testCookie,
   testRequiresAuth,

--- a/test/lib/server-settings/superuser.test.ts
+++ b/test/lib/server-settings/superuser.test.ts
@@ -6,7 +6,6 @@ import { buildSessionCookie } from "#shared/cookies.ts";
 import { hashPassword } from "#shared/crypto/hashing.ts";
 import { generateSecureToken } from "#shared/crypto/utils.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { createSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
@@ -22,6 +21,7 @@ import {
   describeWithEnv,
   expectFlash,
   expectFlashRedirect,
+  getAllActivityLog,
   mockFormRequest,
   setTestEnv,
   testCookie,

--- a/test/lib/server-settings/terms.test.ts
+++ b/test/lib/server-settings/terms.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
@@ -11,6 +10,7 @@ import {
   describeWithEnv,
   expectFlash,
   expectHtmlResponse,
+  getAllActivityLog,
   mockFormRequest,
   testCookie,
   testRequiresAuth,

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -18,6 +18,7 @@ import {
   mockFormRequest,
   mockRequest,
   mockSetupFormRequest,
+  reloginAsAdmin,
   resetDb,
   withExpectedError,
   withMocks,
@@ -505,6 +506,9 @@ describeWithEnv("server (setup)", { db: true }, () => {
         ),
       );
 
+      // The setup-completion entry is owner-key encrypted, so read it back as
+      // the newly-created owner (whose password is non-default here).
+      await reloginAsAdmin("mypassword123");
       const logs = await getAllActivityLog();
       expect(
         logs.some((l) => l.message.includes("Initial setup completed")),

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { getDb } from "#shared/db/client.ts";
 import { invalidateInitDbCache, resetDatabase } from "#shared/db/migrations.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -13,6 +12,7 @@ import {
   expectFlashRedirect,
   expectHtmlResponse,
   expectRedirect,
+  getAllActivityLog,
   getSetupCsrfToken,
   invalidateTestDbCache,
   mockFormRequest,

--- a/test/lib/server-users-ui.test.ts
+++ b/test/lib/server-users-ui.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { encrypt } from "#shared/crypto/encryption.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { getDb } from "#shared/db/client.ts";
 import { invalidateUsersCache } from "#shared/db/users.ts";
 import {
@@ -10,6 +9,7 @@ import {
   awaitTestRequest,
   createTestManagerSession,
   describeWithEnv,
+  getAllActivityLog,
   testCookie,
 } from "#test-utils";
 

--- a/test/lib/server-webhooks.test.ts
+++ b/test/lib/server-webhooks.test.ts
@@ -4,7 +4,6 @@ import { spy, stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { priceCheckout } from "#shared/checkout-pricing.ts";
 import { setEffectiveDomainForTest } from "#shared/config.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { getDb } from "#shared/db/client.ts";
 import {
   modifiersTable,
@@ -38,6 +37,7 @@ import {
   describeWithEnv,
   expectHtmlResponse,
   followRedirect,
+  getAllActivityLog,
   mockRequest,
   mockWebhookRequest,
   setupStripe,
@@ -4922,9 +4922,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         expect(refundLog).toBeDefined();
 
         // Verify refund was logged to activity log tagged to listing
-        const { getListingActivityLog } = await import(
-          "#shared/db/activityLog.ts"
-        );
+        const { getListingActivityLog } = await import("#test-utils");
         const entries = await getListingActivityLog(listing.id);
         const refundEntry = entries.find((e) =>
           e.message.includes("Automatic refund"),
@@ -4994,9 +4992,7 @@ describeWithEnv("server (webhooks)", { db: true }, () => {
         );
         expect(response.status).toBe(200);
 
-        const { getListingActivityLog } = await import(
-          "#shared/db/activityLog.ts"
-        );
+        const { getListingActivityLog } = await import("#test-utils");
         const entries = await getListingActivityLog(listing.id);
         const refundEntry = entries.find((e) =>
           e.message.includes("Automatic refund"),

--- a/test/lib/session-private-key.test.ts
+++ b/test/lib/session-private-key.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import {
+  decryptWithOwnerKey,
+  encryptWithOwnerKey,
+} from "#shared/crypto/keys.ts";
+import { settings } from "#shared/db/settings.ts";
+import {
+  getRequestPrivateKey,
+  requireRequestPrivateKey,
+  SessionKeyError,
+} from "#shared/session-private-key.ts";
+import { describeWithEnv, withTestSession } from "#test-utils";
+
+describeWithEnv("shared > session private key", { db: true }, () => {
+  test("getRequestPrivateKey returns null with no session in scope", async () => {
+    expect(await getRequestPrivateKey()).toBeNull();
+  });
+
+  test("requireRequestPrivateKey throws SessionKeyError with no session in scope", async () => {
+    await expect(requireRequestPrivateKey()).rejects.toBeInstanceOf(
+      SessionKeyError,
+    );
+  });
+
+  test("resolves the current request's key, which decrypts owner-key data", async () => {
+    const sealed = await encryptWithOwnerKey("top secret", settings.publicKey);
+
+    const opened = await withTestSession(async () => {
+      const key = await requireRequestPrivateKey();
+      return decryptWithOwnerKey(sealed, key);
+    });
+
+    expect(opened).toBe("top secret");
+  });
+
+  test("the key is scoped to the request: unavailable once the context exits", async () => {
+    await withTestSession(async () => {
+      expect(await getRequestPrivateKey()).not.toBeNull();
+    });
+    // Outside the request context the accessor fails closed — no key lingers
+    // in scope to leak into an unrelated caller.
+    expect(await getRequestPrivateKey()).toBeNull();
+  });
+});

--- a/test/lib/settings-helpers/clearable.test.ts
+++ b/test/lib/settings-helpers/clearable.test.ts
@@ -4,9 +4,13 @@ import { beforeEach, it as test } from "@std/testing/bdd";
 import type { ErrorPageFn } from "#routes/admin/settings-helpers.ts";
 import { clearableFieldHandler } from "#routes/admin/settings-helpers.ts";
 import type { AuthSession } from "#routes/auth.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { FormParams } from "#shared/form-data.ts";
-import { describeWithEnv, expectFlash, expectRedirect } from "#test-utils";
+import {
+  describeWithEnv,
+  expectFlash,
+  expectRedirect,
+  getAllActivityLog,
+} from "#test-utils";
 
 const formFrom = (data: Record<string, string>): FormParams =>
   new FormParams(new URLSearchParams(data));

--- a/test/lib/settings-helpers/create.test.ts
+++ b/test/lib/settings-helpers/create.test.ts
@@ -4,9 +4,13 @@ import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import type { ErrorPageFn } from "#routes/admin/settings-helpers.ts";
 import { createSettingsHandler } from "#routes/admin/settings-helpers.ts";
 import type { AuthSession } from "#routes/auth.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { FormParams } from "#shared/form-data.ts";
-import { describeWithEnv, expectFlash, expectRedirect } from "#test-utils";
+import {
+  describeWithEnv,
+  expectFlash,
+  expectRedirect,
+  getAllActivityLog,
+} from "#test-utils";
 
 const formFrom = (data: Record<string, string>): FormParams =>
   new FormParams(new URLSearchParams(data));

--- a/test/lib/settings-helpers/secret.test.ts
+++ b/test/lib/settings-helpers/secret.test.ts
@@ -7,10 +7,14 @@ import {
   secretFieldHandler,
 } from "#routes/admin/settings-helpers.ts";
 import type { AuthSession } from "#routes/auth.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { MASK_SENTINEL } from "#shared/db/settings.ts";
 import { FormParams } from "#shared/form-data.ts";
-import { describeWithEnv, expectFlash, expectRedirect } from "#test-utils";
+import {
+  describeWithEnv,
+  expectFlash,
+  expectRedirect,
+  getAllActivityLog,
+} from "#test-utils";
 
 const formFrom = (data: Record<string, string>): FormParams =>
   new FormParams(new URLSearchParams(data));

--- a/test/lib/settings-helpers/toggle.test.ts
+++ b/test/lib/settings-helpers/toggle.test.ts
@@ -4,9 +4,13 @@ import { beforeEach, it as test } from "@std/testing/bdd";
 import type { ErrorPageFn } from "#routes/admin/settings-helpers.ts";
 import { toggleHandler } from "#routes/admin/settings-helpers.ts";
 import type { AuthSession } from "#routes/auth.ts";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { FormParams } from "#shared/form-data.ts";
-import { describeWithEnv, expectFlash, expectRedirect } from "#test-utils";
+import {
+  describeWithEnv,
+  expectFlash,
+  expectRedirect,
+  getAllActivityLog,
+} from "#test-utils";
 
 const formFrom = (data: Record<string, string>): FormParams =>
   new FormParams(new URLSearchParams(data));

--- a/test/lib/sms/webhook.test.ts
+++ b/test/lib/sms/webhook.test.ts
@@ -2,10 +2,6 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import {
-  getAllActivityLog,
-  getAttendeeActivityLog,
-} from "#shared/db/activityLog.ts";
-import {
   findAttendeeIdByPhoneIndex,
   setAttendeePhoneIndexIfEmpty,
 } from "#shared/db/attendee-phone-index.ts";
@@ -23,6 +19,8 @@ import {
   createTestAttendeeDirect,
   createTestListing,
   describeWithEnv,
+  getAllActivityLog,
+  getAttendeeActivityLog,
 } from "#test-utils";
 
 const SECRET = "whsec-123";

--- a/test/lib/webhook.test.ts
+++ b/test/lib/webhook.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy, stub } from "@std/testing/mock";
 import { bracket, map } from "#fp";
-import { getAllActivityLog } from "#shared/db/activityLog.ts";
 import { flushPendingWork, runWithPendingWork } from "#shared/pending-work.ts";
 import {
   buildWebhookPayload,
@@ -17,6 +16,7 @@ import {
   createTestListing,
   describeWithEnv,
   type EmailEntry,
+  getAllActivityLog,
   makeTestAttendee as makeAttendee,
   makeTestEntry as makeEntry,
   makeTestListing as makeListing,

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,3 +1,4 @@
+export * from "./test-utils/activity-log.ts";
 export * from "./test-utils/api-schemas.ts";
 export * from "./test-utils/assertions.ts";
 export { getTestDataKey, getTestPrivateKey } from "./test-utils/crypto.ts";

--- a/test/test-utils/activity-log.ts
+++ b/test/test-utils/activity-log.ts
@@ -1,0 +1,54 @@
+/**
+ * Session-bound activity-log readers for tests.
+ *
+ * Activity-log messages are encrypted with the owner key, so reading them needs
+ * the request's private key. In production those reads happen inside an
+ * authenticated admin session; these wrappers reproduce that by running the
+ * real reader inside the test owner's session context (see {@link
+ * withTestSession}). A test that merely wants to assert "this action was
+ * logged" can therefore call them exactly like the real functions — just
+ * import from `#test-utils` instead of `#shared/db/activityLog.ts`.
+ *
+ * `logActivity` (a write) needs no session, so it is re-exported unchanged for
+ * the convenience of files that both write and read the log.
+ *
+ * Tests that exercise the encryption itself, or the no-session fail-closed
+ * path, should import the real readers from `#shared/db/activityLog.ts`.
+ */
+
+import type {
+  ActivityLogEntry,
+  ListingWithActivityLog,
+} from "#shared/db/activityLog.ts";
+import {
+  getAllActivityLog as realGetAllActivityLog,
+  getAttendeeActivityLog as realGetAttendeeActivityLog,
+  getListingActivityLog as realGetListingActivityLog,
+  getListingWithActivityLog as realGetListingWithActivityLog,
+} from "#shared/db/activityLog.ts";
+import { withTestSession } from "#test-utils/session.ts";
+
+export { logActivity } from "#shared/db/activityLog.ts";
+
+export const getAllActivityLog = (
+  limit?: number,
+): Promise<ActivityLogEntry[]> =>
+  withTestSession(() => realGetAllActivityLog(limit));
+
+export const getListingActivityLog = (
+  listingId: number,
+  limit?: number,
+): Promise<ActivityLogEntry[]> =>
+  withTestSession(() => realGetListingActivityLog(listingId, limit));
+
+export const getAttendeeActivityLog = (
+  attendeeId: number,
+  limit?: number,
+): Promise<ActivityLogEntry[]> =>
+  withTestSession(() => realGetAttendeeActivityLog(attendeeId, limit));
+
+export const getListingWithActivityLog = (
+  listingId: number,
+  limit?: number,
+): Promise<ListingWithActivityLog | null> =>
+  withTestSession(() => realGetListingWithActivityLog(listingId, limit));

--- a/test/test-utils/session.ts
+++ b/test/test-utils/session.ts
@@ -1,10 +1,15 @@
 import type { Row } from "@libsql/client";
+import type { AuthSession } from "#routes/auth.ts";
 import { getSessionCookieName } from "#shared/cookies.ts";
 import { generateSecureToken } from "#shared/crypto/utils.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
 import { createApiKey } from "#shared/db/api-keys.ts";
 import type { ListingInput } from "#shared/db/listings.ts";
 import { getSession } from "#shared/db/sessions.ts";
+import {
+  runWithSessionContext,
+  setCachedSession,
+} from "#shared/session-context.ts";
 import type { Listing } from "#shared/types.ts";
 import type { AdminTestContext } from "#test-utils/internal.ts";
 import {
@@ -15,7 +20,10 @@ import {
   TEST_ADMIN_USERNAME,
 } from "#test-utils/internal.ts";
 
-export const loginAsAdmin = async (): Promise<{
+export const loginAsAdmin = async (
+  username: string = TEST_ADMIN_USERNAME,
+  password: string = TEST_ADMIN_PASSWORD,
+): Promise<{
   cookie: string;
   csrfToken: string;
 }> => {
@@ -35,7 +43,7 @@ export const loginAsAdmin = async (): Promise<{
 
   const loginResponse = await handleRequest(
     await mockAdminLoginRequest(
-      { password: TEST_ADMIN_PASSWORD, username: TEST_ADMIN_USERNAME },
+      { password, username },
       loginCsrfToken,
     ),
   );
@@ -85,6 +93,50 @@ export const testCookie = async (): Promise<string> =>
 
 export const testCsrfToken = async (): Promise<string> =>
   (await getTestSession()).csrfToken;
+
+/** Build an owner AuthSession from the live test admin session row. */
+const getTestAuthSession = async (): Promise<AuthSession> => {
+  const cookie = await testCookie();
+  const token = cookie.match(
+    new RegExp(`${getSessionCookieName()}=([^;]+)`),
+  )![1]!;
+  const session = await getSession(token);
+  if (!session) throw new Error("Test admin session row not found");
+  return {
+    adminLevel: "owner",
+    token,
+    userId: session.user_id!,
+    wrappedDataKey: session.wrapped_data_key,
+  };
+};
+
+/**
+ * Run `fn` inside a request-scoped session context for the test admin owner,
+ * mirroring the server's per-request `runWithSessionContext` wrapper. Use this
+ * around direct calls to code that reads the private key from the current
+ * request (e.g. activity-log decryption via `requireRequestPrivateKey`), which
+ * otherwise has no session in scope in a unit test and fails closed.
+ */
+export const withTestSession = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const session = await getTestAuthSession();
+  return runWithSessionContext(() => {
+    setCachedSession(session);
+    return fn();
+  });
+};
+
+/**
+ * Re-establish the cached test admin session after an action that logged the
+ * owner out (e.g. a password change deletes existing sessions). Logs in fresh
+ * with the given password and replaces the cached session, so subsequent
+ * `withTestSession` / `getTestSession` calls resolve a valid session.
+ */
+export const reloginAsAdmin = async (
+  password: string,
+  username: string = TEST_ADMIN_USERNAME,
+): Promise<void> => {
+  setTestSession(await loginAsAdmin(username, password));
+};
 
 export const createTestManagerSession = async (
   token = "mgr-session",

--- a/test/test-utils/session.ts
+++ b/test/test-utils/session.ts
@@ -42,10 +42,7 @@ export const loginAsAdmin = async (
   }
 
   const loginResponse = await handleRequest(
-    await mockAdminLoginRequest(
-      { password, username },
-      loginCsrfToken,
-    ),
+    await mockAdminLoginRequest({ password, username }, loginCsrfToken),
   );
   loginResponse.body?.cancel();
   const cookie = loginResponse.headers


### PR DESCRIPTION
## What & why

Activity-log messages were encrypted symmetrically with `DB_ENCRYPTION_KEY`, so a database dump **plus the env key** could read the entire log. This moves them to the site owner's hybrid RSA key — the same scheme attendee PII already uses — so only an authenticated admin (whose password unwraps the private key) can read them. It closes the same gap the `user_kek_v2` work closed for PII.

- **Writing** needs only the public key, which a set-up site always has, so the unauthenticated callers (Stripe/SumUp/Square webhooks, the SMS webhook, the error logger) keep logging. There is no env-key fallback; the setup handler reloads the freshly-generated key before logging "Initial setup completed", so even the first entry is owner-key encrypted.
- **Reading** routes by format prefix (`hyb:` vs `enc:`), so legacy env-key rows stay readable alongside new owner-key ones — no big-bang cutover.

## Reading the private key without threading it

Threading the private key (or the session) down through call stacks is a recurring papercut. Instead of adding another parameter everywhere, a new `#shared/session-private-key.ts` derives the key from the **request-scoped session** via `AsyncLocalStorage` — the same mechanism the codebase already uses for the cached session, flash, locale, request id, etc.

- `requireRequestPrivateKey()` reads the current request's session and derives the key. It is bound to that request's async context, so it can only ever return *this* request's own session, and the derivation is keyed by that session's unique token — there is no path for one request to obtain another's key.
- Outside a request (background jobs, unit tests with no context) it **fails closed** rather than falling back to any other session.
- Because the activity-log readers call it internally, **their signatures and every call site are unchanged** — the threading simply disappeared.

The existing session→key derivation and `SessionKeyError` moved into this shared module (re-exported from `auth.ts` for current callers), removing a duplication.

## Backfilling the history

The activity log is never pruned, so legacy `enc:` rows would otherwise stay env-key-readable forever. A fire-and-forget job — scheduled from the request handler alongside the prunes — re-encrypts them to the owner key a batch at a time:

- Re-encryption needs only the public key and the env key (**no password**), so it runs unattended.
- Resumable without a cursor: a converted row no longer matches the `enc:` prefix, so each batch shrinks the remaining set; it self-marks **done** once a batch finds nothing and never scans again.
- Each batch is one `SELECT` plus one `executeBatch` write, so its subrequest cost is fixed (two) regardless of batch size, and an interval gate throttles it to one batch per minute of traffic while draining.
- The scheduler reads its done flag + last-run stamp every request, so both are declared in `INFRA_SETTINGS` (like the prune timestamps).

## Decisions baked in
- **Backfill all existing rows** (no new pruning).
- **Inline, resumable** scheduler (not an out-of-band CLI task).
- **Require the key** on read — the log gates exactly like the attendee PII pages (a `SessionKeyError` surfaces the re-authenticate response); no per-row "locked" placeholder.

## Testing
- New security-focused tests assert messages are stored owner-key-encrypted (not env-key, not plaintext) and that reads **fail closed** without a session.
- New tests for the request-scoped accessor (including that the key is unavailable once the request context exits) and full branch coverage of the backfill (convert / skip owner-key rows / done-flag / no-key / interval gate / error path).
- Black-box "this action was logged" tests read via session-bound wrappers re-exported from `#test-utils`, so their call sites are unchanged.
- Full `precommit` passes: lint, typecheck, **0% duplication**, edge build, and the whole suite at **100% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FduygyaziVoVyMqgQvBHj)_