### PR TITLE
Harden code-quality tests: 35.8% → 100% mutation score

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -128,6 +128,16 @@
       "linter": {
         "enabled": false
       }
+    },
+    {
+      "includes": ["test/lib/code-quality/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noTemplateCurlyInString": "off"
+          }
+        }
+      }
     }
   ],
   "vcs": {

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -2,34 +2,33 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import {
+  detectAliasing,
+  detectModuleLevelLet,
+  detectThenUsage,
+  extractCallSites,
+  findInMemoryStateViolations,
+  findRawDbViolation,
+  findRedundantArg,
+  findTestOnlyExportViolations,
+  getAllFilesWithExt,
+  type Site,
+} from "./code-quality/detectors.ts";
+
+/**
+ * Integration guard for the code-quality rules: it scans the real `src/`+`test/`
+ * tree and asserts there are zero violations. The detection logic itself lives
+ * in `./code-quality/detectors.ts` and is proven with crafted fixtures in
+ * `./code-quality/detectors.test.ts` — this file is only the "is the live
+ * codebase clean?" half. The policy allow-lists (which existing files are
+ * exempt, which test hooks are intentional) live here, since they describe this
+ * codebase rather than the rules.
+ */
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(currentDir, "../..");
 const SRC_DIR = join(currentDir, "../../src");
 const TEST_DIR = join(currentDir, "../../test");
-
-/**
- * Patterns that indicate in-memory state storage at module level.
- * These should be stored in the database instead to survive restarts.
- */
-const FORBIDDEN_PATTERNS = [
-  {
-    description: "Module-level Map (use database instead)",
-    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*=\s*new\s+Map\s*[<(]/m,
-  },
-  {
-    description: "Module-level Set (use database instead)",
-    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*=\s*new\s+Set\s*[<(]/m,
-  },
-  {
-    description: "Module-level typed Map (use database instead)",
-    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*:\s*Map\s*</m,
-  },
-  {
-    description: "Module-level typed Set (use database instead)",
-    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*:\s*Set\s*</m,
-  },
-];
 
 /**
  * src/ files allowed to hold module-level Map/Set state (the in-memory-state
@@ -53,37 +52,160 @@ const ALLOWED_FILES_STATE = [
   "shared/i18n.ts",
 ];
 
-/**
- * Pattern to detect function/variable aliasing at module level.
- * Forces use of `import { x as y }` instead of post-import aliasing.
- * Example violation: const myFunc = someImportedFunc;
- * Only matches identifiers (starts with letter/underscore), not literals.
- */
-const ALIASING_PATTERN =
-  /^(?:export\s+)?const\s+(\w+)\s*=\s*([a-zA-Z_]\w*)\s*;?\s*(?:\/\/.*)?$/;
+// Direct getDb().execute / .batch calls bypass the single client choke
+// point that drives automatic, table-scoped cache invalidation, so a write
+// through them can silently leave a cache stale. All callers must use
+// execute()/queryOne()/queryAll()/executeBatch() instead. Only the client
+// itself and the migrator (which runs DDL/backfill before caches matter)
+// may touch the raw connection.
+const ALLOWED_RAW_DB = [
+  "shared/db/client.ts",
+  // The migrator runs DDL / schema setup / backfill before the app serves
+  // requests, so cache invalidation does not apply to it.
+  "shared/db/migrations.ts",
+  "shared/db/migrations/",
+];
+
+/** Library/infrastructure modules - okay to have unused exports */
+const LIBRARY_PATHS = [
+  "fp.ts", // FP utility library
+  "shared/jsx/jsx-runtime.ts", // JSX compiler runtime
+  "shared/jsx/jsx-dev-runtime.ts", // JSX dev runtime
+  "shared/asset-paths.ts", // Build-time config consumed by .tsx templates
+  // The transfer ledger (src/shared/ledger + src/shared/accounting) is being
+  // wired in incrementally; like fp.ts, some exports have no production
+  // caller yet. account.ts and validate.ts are already consumed by the store
+  // adapter, so they are no longer exempt — the remaining modules lose their
+  // exemption as the event mappers and checkout wiring land.
+  "shared/ledger/project.ts",
+  "shared/ledger/reverse.ts",
+  "shared/ledger/reconcile.ts",
+  "shared/checkout-ledger.ts",
+  "shared/accounting/store.ts",
+  "shared/accounting/queries.ts",
+  "shared/accounting/mappers.ts",
+];
+
+/** Index modules that only re-export from sub-modules */
+const AGGREGATION_MODULES = [
+  "shared/db/index.ts",
+  "shared/rest/index.ts",
+  "templates/index.ts",
+];
 
 /**
- * Pattern to detect .then() usage - prefer async/await
+ * Test hooks - functions that are intentionally exported for test setup/cleanup.
+ * These are necessary for testing but should not be used in production code.
+ * Format: "file:exportName"
  */
-const THEN_PATTERN = /\.then\s*\(/g;
-
-const getAllFilesWithExt = async (
-  dir: string,
-  ext: string,
-): Promise<string[]> => {
-  const files: string[] = [];
-
-  for await (const entry of Deno.readDir(dir)) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory) {
-      files.push(...(await getAllFilesWithExt(fullPath, ext)));
-    } else if (entry.name.endsWith(ext)) {
-      files.push(fullPath);
-    }
-  }
-
-  return files;
-};
+const ALLOWED_TEST_HOOKS: string[] = [
+  // Database injection for test isolation
+  "shared/db/client.ts:setDb",
+  // Set encryption key directly to avoid env var races between parallel tests
+  "shared/crypto/encryption.ts:setEncryptionKeyForTest",
+  // Set fast PBKDF2 directly to avoid env var races between parallel tests
+  "shared/crypto/hashing.ts:setFastPbkdf2ForTest",
+  // Set RSA key size directly to avoid env var races between parallel tests
+  "shared/crypto/keys.ts:setRsaKeySizeForTest",
+  // Reset cached Stripe client between tests
+  "shared/stripe.ts:resetStripeClient",
+  // TTL constant used by page-cache tests to verify caching behaviour
+  "shared/db/settings.ts:SETTINGS_CACHE_TTL_MS",
+  // Dev/test-only switch for the settings read audit (no-op in production)
+  "shared/db/settings-audit.ts:setSettingsAuditEnabled",
+  // (settings.ts functions now accessed via settings namespace, not individual exports)
+  // Reset cached sessions between tests
+  "shared/db/sessions.ts:resetSessionCache",
+  // Reset cached I18N_REPLACEMENTS replacer + compiled formats between tests
+  "shared/i18n.ts:resetI18nForTest",
+  // DB version/hash constants used in production but test pattern doesn't detect constant comparison
+  "shared/db/migrations.ts:LATEST_UPDATE",
+  "shared/db/migrations.ts:SCHEMA_HASH",
+  // Migration lock TTL used in production (same-file) but test pattern doesn't detect same-file usage
+  "shared/db/migrations.ts:MIGRATION_LOCK_TTL_MS",
+  // Backup freshness window used in production (same-file) but test pattern doesn't detect same-file usage
+  "shared/db/backup.ts:BACKUP_FRESHNESS_WINDOW_MS",
+  // Attendees page size used in production (same-file) but test pattern doesn't detect same-file usage
+  "shared/db/attendees/queries.ts:ATTENDEES_PAGE_SIZE",
+  // Payments-retention floor guard used in production (same-file: validates
+  // PRUNE_PAYMENTS_RETENTION_DAYS at import) but test pattern doesn't detect same-file usage
+  "shared/limits.ts:assertPaymentsRetentionSafe",
+  // Test helper for creating signed webhook payloads
+  "shared/stripe.ts:constructTestWebhookEvent",
+  // Reset cached Square client between tests
+  "shared/square.ts:resetSquareClient",
+  // Test helper for creating signed Square webhook payloads
+  "shared/square.ts:constructTestWebhookEvent",
+  // Convenience wrapper for idempotency checks (production uses isSessionProcessed directly)
+  "shared/db/processed-payments.ts:getProcessedAttendeeId",
+  // Raw attendee fetch for testing encrypted data (production uses batched getListingWithAttendeesRaw)
+  "shared/db/attendees/queries.ts:getAttendeesRaw",
+  // Single attendee fetch for tests (production uses batched getListingWithAttendeeRaw)
+  "shared/db/attendees/queries.ts:getAttendee",
+  // Listing activity log fetch for tests (production uses batched getListingWithActivityLog)
+  "shared/db/activityLog.ts:getListingActivityLog",
+  // Token format check used by CSRF tests (production verifies via verifySignedCsrfToken)
+  "shared/csrf.ts:isSignedCsrfToken",
+  // Response cookie helper used by auth tests (production sets cookies directly)
+  "features/utils.ts:withCookie",
+  // Reset cache registry between tests
+  "shared/cache-registry.ts:resetCacheRegistry",
+  // Request-cache invalidators kept for test cleanup only; in production
+  // writes auto-invalidate through cachedTable's wrapped table, so these
+  // have no production caller (groups/holidays have no raw-SQL writers).
+  "shared/db/groups.ts:invalidateGroupsCache",
+  "shared/db/holidays.ts:invalidateHolidaysCache",
+  "shared/db/logistics-agents.ts:invalidateLogisticsAgentsCache",
+  // Reset cached effective domain between tests
+  "shared/config.ts:resetEffectiveDomain",
+  "shared/config.ts:setEffectiveDomainForTest",
+  // Reset cached demo mode between tests
+  "shared/demo.ts:resetDemoMode",
+  "shared/demo.ts:setDemoModeForTest",
+  // Reset cached Liquid engine between tests (currency changes need fresh filters)
+  "shared/email-renderer.ts:resetEngine",
+  // Skip login delay in tests without env var races
+  "shared/test-overrides.ts:setSkipLoginDelayForTest",
+  // Reset/set host email config between tests without env var races
+  "shared/email.ts:setHostEmailConfigForTest",
+  "shared/email.ts:resetHostEmailConfig",
+  // Timezone validation utility (timezone now derived from country, but still useful for tests)
+  "shared/timezone.ts:isValidTimezone",
+  // Attachment size constant (now re-exported from limits.ts, not detected by export patterns)
+  "shared/storage.ts:MAX_ATTACHMENT_SIZE",
+  // AsyncLocalStorage-based storage config for concurrent test isolation
+  "shared/storage.ts:runWithStorageConfig",
+  // readLimit used in production (module-level constants) but test pattern doesn't detect same-file usage
+  "shared/limits.ts:readLimit",
+  // Settings cache TTL constant used by tests to verify caching behavior
+  "shared/db/settings.ts:SETTINGS_CACHE_TTL_MS",
+  // Set log suppression directly to avoid env var races between parallel tests
+  "shared/logger.ts:setSuppressRequestLogs",
+  "shared/logger.ts:setSuppressDebugLogs",
+  // Rethrow errors in tests without env var races
+  "shared/test-overrides.ts:setRethrowErrorsForTest",
+  // Override BUILD_TIMESTAMP / BUILD_COMMIT in tests (compile-time constants can't be changed otherwise)
+  "shared/update.ts:setBuildTimestampForTest",
+  "shared/update.ts:setBuildCommitForTest",
+  // Route maps used by API documentation tests (production uses via dynamic import / createRouter)
+  "features/api/index.ts:apiRoutes",
+  "features/admin/api.ts:adminApiRoutes",
+  // Storage delete override for testing fire-and-forget error handling
+  "shared/test-overrides.ts:getDeleteOverride",
+  "shared/test-overrides.ts:setDeleteOverride",
+  "shared/test-overrides.ts:setDeleteOverrideForTest",
+  // API key touch override for testing fire-and-forget error handling
+  "shared/test-overrides.ts:getTouchOverride",
+  "shared/test-overrides.ts:setTouchOverride",
+  "shared/test-overrides.ts:setTouchOverrideForTest",
+  // Reset the in-memory form re-fill stash between tests
+  "shared/form-stash.ts:clearFormStash",
+  // Backward-compat wrapper: fires all invalidators unconditionally (no production caller now
+  // that client.ts uses invalidateCachesForWrite, but kept for external callers and tests)
+  "shared/cache-registry.ts:invalidateCachesForTable",
+  // SET-clause column extractor: internal parser exposed for unit testing only
+  "shared/db/client.ts:extractUpdateColumns",
+];
 
 const getAllTsFiles = (dir: string): Promise<string[]> =>
   getAllFilesWithExt(dir, ".ts");
@@ -94,7 +216,7 @@ const getRelativePath = (fullPath: string): string =>
 /**
  * Path relative to the repo root, e.g. "src/foo.ts" or "test/foo.ts". Used by
  * the rules that scan both src and test files (aliasing, module-level let,
- * .then(), redundant constant args) so their violation paths are unambiguous.
+ * .then()) so their violation paths are unambiguous.
  */
 const repoRelative = (fullPath: string): string =>
   fullPath.replace(`${REPO_ROOT}/`, "");
@@ -107,204 +229,14 @@ const readAllFiles = async (files: string[]): Promise<Map<string, string>> => {
   return new Map(entries);
 };
 
-/* -------------------------------------------------------------------------- *
- * Lightweight call-site scanner (used by the "redundant constant argument"   *
- * check). It is intentionally a small hand-written lexer rather than a full  *
- * AST parser, matching the regex-driven style of the rest of this file. It   *
- * skips comments and string/template literals so callee names and argument   *
- * text are never matched inside them.                                        *
- * -------------------------------------------------------------------------- */
-
-/** A single call expression discovered in a source file. */
-type CallSite = { name: string; args: string[]; line: number };
-
-/** Keywords that are followed by `(` but are not function calls. */
-const NON_CALL_KEYWORDS = new Set([
-  "if",
-  "for",
-  "while",
-  "switch",
-  "catch",
-  "with",
-  "return",
-  "await",
-  "typeof",
-  "delete",
-  "void",
-  "new",
-  "do",
-  "yield",
-  "super",
-  "constructor",
-]);
-
-const isIdentChar = (c: string | undefined): boolean => !!c && /[\w$]/.test(c);
-const isIdentStart = (c: string | undefined): boolean =>
-  !!c && /[A-Za-z_$]/.test(c);
-const isWhitespace = (c: string | undefined): boolean => !!c && /\s/.test(c);
-
 /**
- * Skip a string or template literal starting at the opening quote `start`.
- * Returns the index immediately after the closing quote. Template `${...}`
- * substitutions are skipped wholesale (including nested strings) so a `)` or
- * `,` inside them never leaks into argument parsing.
+ * Files that *define* the code-quality patterns (in comments, regexes and
+ * fixture strings) and so would flag themselves under the line-level scans.
+ * They have no real line-level violations of their own.
  */
-const skipString = (content: string, start: number): number => {
-  const quote = content[start];
-  let j = start + 1;
-  while (j < content.length) {
-    const c = content[j];
-    if (c === "\\") {
-      j += 2;
-      continue;
-    }
-    if (c === quote) return j + 1;
-    if (quote === "`" && c === "$" && content[j + 1] === "{") {
-      let depth = 1;
-      j += 2;
-      while (j < content.length && depth > 0) {
-        const d = content[j];
-        if (d === "{") depth++;
-        else if (d === "}") depth--;
-        else if (d === '"' || d === "'" || d === "`") {
-          j = skipString(content, j);
-          continue;
-        }
-        j++;
-      }
-      continue;
-    }
-    j++;
-  }
-  return j;
-};
-
-/** If `i` points at the start of a comment, return the index past it, else i. */
-const skipComment = (content: string, i: number): number => {
-  if (content[i] === "/" && content[i + 1] === "/") {
-    let j = i;
-    while (j < content.length && content[j] !== "\n") j++;
-    return j;
-  }
-  if (content[i] === "/" && content[i + 1] === "*") {
-    let j = i + 2;
-    while (
-      j < content.length &&
-      !(content[j] === "*" && content[j + 1] === "/")
-    )
-      j++;
-    return j + 2;
-  }
-  return i;
-};
-
-/**
- * Parse a comma-separated argument list whose opening `(` is at `open`.
- * Returns the trimmed top-level arguments and the index of the closing `)`.
- * Nested brackets, strings and comments are skipped so only top-level commas
- * split arguments.
- */
-const parseArgList = (
-  content: string,
-  open: number,
-): { args: string[]; end: number } => {
-  const args: string[] = [];
-  let depth = 1;
-  let cur = open + 1;
-  let p = open + 1;
-  while (p < content.length && depth > 0) {
-    const skipped = skipComment(content, p);
-    if (skipped !== p) {
-      p = skipped;
-      continue;
-    }
-    const d = content[p];
-    if (d === '"' || d === "'" || d === "`") {
-      p = skipString(content, p);
-      continue;
-    }
-    if (d === "(" || d === "[" || d === "{") depth++;
-    else if (d === ")" || d === "]" || d === "}") {
-      depth--;
-      if (depth === 0) {
-        args.push(content.slice(cur, p).trim());
-        break;
-      }
-    } else if (d === "," && depth === 1) {
-      args.push(content.slice(cur, p).trim());
-      cur = p + 1;
-    }
-    p++;
-  }
-  return { args: args.filter((a) => a.length > 0), end: p };
-};
-
-/** A call site keyed by character offset, before line numbers are resolved. */
-type RawCall = { name: string; args: string[]; offset: number };
-
-/**
- * Try to read an identifier-followed-by-`(` call starting at `i`.
- * Returns the parsed call (if any) and the index to continue scanning from.
- */
-const readCallAt = (
-  content: string,
-  i: number,
-  prevWord: string,
-): { call: RawCall | null; word: string; next: number } => {
-  let j = i;
-  while (j < content.length && isIdentChar(content[j])) j++;
-  const word = content.slice(i, j);
-  let k = j;
-  while (k < content.length && isWhitespace(content[k])) k++;
-  const isCall =
-    content[k] === "(" &&
-    !NON_CALL_KEYWORDS.has(word) &&
-    prevWord !== "function";
-  const call = isCall
-    ? { args: parseArgList(content, k).args, name: word, offset: i }
-    : null;
-  return { call, next: j, word };
-};
-
-/** Resolve byte offsets (in ascending order) to 1-based line numbers. */
-const resolveLines = (content: string, calls: RawCall[]): CallSite[] => {
-  let line = 1;
-  let idx = 0;
-  return calls.map((call) => {
-    for (; idx < call.offset; idx++) if (content[idx] === "\n") line++;
-    return { args: call.args, line, name: call.name };
-  });
-};
-
-/** Extract every `name(...)` call site from a source file. */
-const extractCallSites = (content: string): CallSite[] => {
-  const calls: RawCall[] = [];
-  let prevWord = "";
-  let i = 0;
-  while (i < content.length) {
-    const c = content[i];
-    const pastComment = skipComment(content, i);
-    if (pastComment !== i) {
-      i = pastComment;
-      continue;
-    }
-    if (c === '"' || c === "'" || c === "`") {
-      i = skipString(content, i);
-      prevWord = "";
-      continue;
-    }
-    if (isIdentStart(c)) {
-      const { call, word, next } = readCallAt(content, i, prevWord);
-      if (call) calls.push(call);
-      prevWord = word;
-      i = next;
-      continue;
-    }
-    if (!isWhitespace(c)) prevWord = "";
-    i++;
-  }
-  return resolveLines(content, calls);
-};
+const isCodeQualityFile = (relativePath: string): boolean =>
+  relativePath === "test/lib/code-quality.test.ts" ||
+  relativePath.startsWith("test/lib/code-quality/");
 
 describe("code quality", () => {
   /** Cached file lists and contents, populated once on first use */
@@ -342,18 +274,13 @@ describe("code quality", () => {
 
       for (const file of srcFiles) {
         const relativePath = getRelativePath(file);
-
-        if (ALLOWED_FILES_STATE.includes(relativePath)) {
-          continue;
-        }
-
-        const content = srcContents.get(file)!;
-
-        for (const { pattern, description } of FORBIDDEN_PATTERNS) {
-          if (pattern.test(content)) {
-            violations.push(`${relativePath}: ${description}`);
-          }
-        }
+        violations.push(
+          ...findInMemoryStateViolations(
+            relativePath,
+            srcContents.get(file)!,
+            ALLOWED_FILES_STATE,
+          ),
+        );
       }
 
       expect(violations).toEqual([]);
@@ -361,37 +288,17 @@ describe("code quality", () => {
   });
 
   describe("db writes go through the client", () => {
-    // Direct getDb().execute / .batch calls bypass the single client choke
-    // point that drives automatic, table-scoped cache invalidation, so a write
-    // through them can silently leave a cache stale. All callers must use
-    // execute()/queryOne()/queryAll()/executeBatch() instead. Only the client
-    // itself and the migrator (which runs DDL/backfill before caches matter)
-    // may touch the raw connection.
-    const ALLOWED_RAW_DB = [
-      "shared/db/client.ts",
-      // The migrator runs DDL / schema setup / backfill before the app serves
-      // requests, so cache invalidation does not apply to it.
-      "shared/db/migrations.ts",
-      "shared/db/migrations/",
-    ];
-    const RAW_DB_PATTERN = /getDb\(\)\.(?:execute|batch)\s*\(/;
-
     test("no source file calls getDb().execute/.batch directly", async () => {
       await ensureLoaded();
       const violations: string[] = [];
 
       for (const file of srcFiles) {
-        const relativePath = getRelativePath(file);
-        if (
-          ALLOWED_RAW_DB.some((allowed) => relativePath.startsWith(allowed))
-        ) {
-          continue;
-        }
-        if (RAW_DB_PATTERN.test(srcContents.get(file)!)) {
-          violations.push(
-            `${relativePath}: use execute()/queryOne()/queryAll()/executeBatch() from #shared/db/client.ts instead of getDb().execute/.batch`,
-          );
-        }
+        const violation = findRawDbViolation(
+          getRelativePath(file),
+          srcContents.get(file)!,
+          ALLOWED_RAW_DB,
+        );
+        if (violation) violations.push(violation);
       }
 
       expect(violations).toEqual([]);
@@ -399,31 +306,28 @@ describe("code quality", () => {
   });
 
   /**
-   * Scan src and test files line by line, collecting violations via a callback.
+   * Scan src and test files line by line, collecting violations via a detector.
    * Test code is held to the same line-level standards as production code.
    * Returns the combined violation list.
    */
   const scanSourceLines = async (
-    check: (ctx: {
-      relativePath: string;
-      line: string;
-      lineNum: number;
-    }) => string | null,
+    detect: (
+      relativePath: string,
+      line: string,
+      lineNum: number,
+    ) => string | null,
   ): Promise<string[]> => {
     await ensureLoaded();
     const violations: string[] = [];
     const scan = (files: string[], contents: Map<string, string>): void => {
       for (const file of files) {
         const relativePath = repoRelative(file);
-        // This file defines the patterns it checks for (in comments, regexes
-        // and test names), so it would flag itself. It has no real line-level
-        // violations of its own, so skip it from the line scans.
-        if (relativePath === "test/lib/code-quality.test.ts") continue;
+        if (isCodeQualityFile(relativePath)) continue;
         const lines = contents.get(file)!.split("\n");
         let lineNum = 0;
         for (const line of lines) {
           lineNum++;
-          const v = check({ line, lineNum, relativePath });
+          const v = detect(relativePath, line, lineNum);
           if (v) violations.push(v);
         }
       }
@@ -435,48 +339,21 @@ describe("code quality", () => {
 
   describe("no aliasing", () => {
     test("should not alias functions or variables at module level", async () => {
-      const violations = await scanSourceLines(
-        ({ relativePath, line, lineNum }) => {
-          const match = line.match(ALIASING_PATTERN);
-          if (!match) return null;
-          const [, varName, value] = match;
-          return `${relativePath}:${lineNum}: const ${varName} = ${value} (use import { ${value} as ${varName} } instead)`;
-        },
-      );
-
+      const violations = await scanSourceLines(detectAliasing);
       expect(violations).toEqual([]);
     });
   });
 
   describe("no module-level let", () => {
     test("should use const with once()/lazyRef() instead of let", async () => {
-      const violations = await scanSourceLines(
-        ({ relativePath, line, lineNum }) => {
-          if (!line.match(/^(export\s+)?let\s+/)) return null;
-          return `${relativePath}:${lineNum}: ${line.slice(
-            0,
-            50,
-          )}... (use const with once()/lazyRef())`;
-        },
-      );
-
+      const violations = await scanSourceLines(detectModuleLevelLet);
       expect(violations).toEqual([]);
     });
   });
 
   describe("no .then() usage", () => {
     test("should use async/await instead of .then()", async () => {
-      const violations = await scanSourceLines(
-        ({ relativePath, line, lineNum }) => {
-          THEN_PATTERN.lastIndex = 0;
-          if (!THEN_PATTERN.test(line)) return null;
-          THEN_PATTERN.lastIndex = 0;
-          return `${relativePath}:${lineNum}: ${line
-            .trim()
-            .slice(0, 50)}... (use async/await instead)`;
-        },
-      );
-
+      const violations = await scanSourceLines(detectThenUsage);
       expect(violations).toEqual([]);
     });
   });
@@ -484,312 +361,13 @@ describe("code quality", () => {
   describe("no test-only exports", () => {
     /**
      * Detects exports that exist solely to be tested, violating the principle of
-     * testing outcomes rather than implementation. These typically include:
-     * - Reset/clear functions only used in test cleanup (e.g., resetFooClient)
-     * - Internal helper functions exported just to unit test them
-     * - Config getters that are never actually called in production
-     *
-     * Excluded from checking:
-     * - Library modules (fp/*) - reusable utilities, may not all be used yet
-     * - JSX runtime modules (shared/jsx/*) - used implicitly by JSX compiler
-     * - Index files that only re-export (shared/db/index.ts) - aggregation modules
-     *
+     * testing outcomes rather than implementation. Excluded from checking:
+     * library modules (fp/*), JSX runtimes, and index files that only re-export.
      * (Test utilities live under test/, so this src-only rule never sees them.)
      */
-
-    /** Library/infrastructure modules - okay to have unused exports */
-    const LIBRARY_PATHS = [
-      "fp.ts", // FP utility library
-      "shared/jsx/jsx-runtime.ts", // JSX compiler runtime
-      "shared/jsx/jsx-dev-runtime.ts", // JSX dev runtime
-      "shared/asset-paths.ts", // Build-time config consumed by .tsx templates
-      // The transfer ledger (src/shared/ledger + src/shared/accounting) is being
-      // wired in incrementally; like fp.ts, some exports have no production
-      // caller yet. account.ts and validate.ts are already consumed by the store
-      // adapter, so they are no longer exempt — the remaining modules lose their
-      // exemption as the event mappers and checkout wiring land.
-      "shared/ledger/project.ts",
-      "shared/ledger/reverse.ts",
-      "shared/ledger/reconcile.ts",
-      "shared/checkout-ledger.ts",
-      "shared/accounting/store.ts",
-      "shared/accounting/queries.ts",
-      "shared/accounting/mappers.ts",
-    ];
-
-    /** Index modules that only re-export from sub-modules */
-    const AGGREGATION_MODULES = [
-      "shared/db/index.ts",
-      "shared/rest/index.ts",
-      "templates/index.ts",
-    ];
-
-    /**
-     * Test hooks - functions that are intentionally exported for test setup/cleanup.
-     * These are necessary for testing but should not be used in production code.
-     * Format: "file:exportName"
-     */
-    const ALLOWED_TEST_HOOKS: string[] = [
-      // Database injection for test isolation
-      "shared/db/client.ts:setDb",
-      // Set encryption key directly to avoid env var races between parallel tests
-      "shared/crypto/encryption.ts:setEncryptionKeyForTest",
-      // Set fast PBKDF2 directly to avoid env var races between parallel tests
-      "shared/crypto/hashing.ts:setFastPbkdf2ForTest",
-      // Set RSA key size directly to avoid env var races between parallel tests
-      "shared/crypto/keys.ts:setRsaKeySizeForTest",
-      // Reset cached Stripe client between tests
-      "shared/stripe.ts:resetStripeClient",
-      // TTL constant used by page-cache tests to verify caching behaviour
-      "shared/db/settings.ts:SETTINGS_CACHE_TTL_MS",
-      // Dev/test-only switch for the settings read audit (no-op in production)
-      "shared/db/settings-audit.ts:setSettingsAuditEnabled",
-      // (settings.ts functions now accessed via settings namespace, not individual exports)
-      // Reset cached sessions between tests
-      "shared/db/sessions.ts:resetSessionCache",
-      // Reset cached I18N_REPLACEMENTS replacer + compiled formats between tests
-      "shared/i18n.ts:resetI18nForTest",
-      // DB version/hash constants used in production but test pattern doesn't detect constant comparison
-      "shared/db/migrations.ts:LATEST_UPDATE",
-      "shared/db/migrations.ts:SCHEMA_HASH",
-      // Migration lock TTL used in production (same-file) but test pattern doesn't detect same-file usage
-      "shared/db/migrations.ts:MIGRATION_LOCK_TTL_MS",
-      // Backup freshness window used in production (same-file) but test pattern doesn't detect same-file usage
-      "shared/db/backup.ts:BACKUP_FRESHNESS_WINDOW_MS",
-      // Attendees page size used in production (same-file) but test pattern doesn't detect same-file usage
-      "shared/db/attendees/queries.ts:ATTENDEES_PAGE_SIZE",
-      // Payments-retention floor guard used in production (same-file: validates
-      // PRUNE_PAYMENTS_RETENTION_DAYS at import) but test pattern doesn't detect same-file usage
-      "shared/limits.ts:assertPaymentsRetentionSafe",
-      // Test helper for creating signed webhook payloads
-      "shared/stripe.ts:constructTestWebhookEvent",
-      // Reset cached Square client between tests
-      "shared/square.ts:resetSquareClient",
-      // Test helper for creating signed Square webhook payloads
-      "shared/square.ts:constructTestWebhookEvent",
-      // Convenience wrapper for idempotency checks (production uses isSessionProcessed directly)
-      "shared/db/processed-payments.ts:getProcessedAttendeeId",
-      // Raw attendee fetch for testing encrypted data (production uses batched getListingWithAttendeesRaw)
-      "shared/db/attendees/queries.ts:getAttendeesRaw",
-      // Single attendee fetch for tests (production uses batched getListingWithAttendeeRaw)
-      "shared/db/attendees/queries.ts:getAttendee",
-      // Listing activity log fetch for tests (production uses batched getListingWithActivityLog)
-      "shared/db/activityLog.ts:getListingActivityLog",
-      // Token format check used by CSRF tests (production verifies via verifySignedCsrfToken)
-      "shared/csrf.ts:isSignedCsrfToken",
-      // Response cookie helper used by auth tests (production sets cookies directly)
-      "features/utils.ts:withCookie",
-      // Reset cache registry between tests
-      "shared/cache-registry.ts:resetCacheRegistry",
-      // Request-cache invalidators kept for test cleanup only; in production
-      // writes auto-invalidate through cachedTable's wrapped table, so these
-      // have no production caller (groups/holidays have no raw-SQL writers).
-      "shared/db/groups.ts:invalidateGroupsCache",
-      "shared/db/holidays.ts:invalidateHolidaysCache",
-      "shared/db/logistics-agents.ts:invalidateLogisticsAgentsCache",
-      // Reset cached effective domain between tests
-      "shared/config.ts:resetEffectiveDomain",
-      "shared/config.ts:setEffectiveDomainForTest",
-      // Reset cached demo mode between tests
-      "shared/demo.ts:resetDemoMode",
-      "shared/demo.ts:setDemoModeForTest",
-      // Reset cached Liquid engine between tests (currency changes need fresh filters)
-      "shared/email-renderer.ts:resetEngine",
-      // Skip login delay in tests without env var races
-      "shared/test-overrides.ts:setSkipLoginDelayForTest",
-      // Reset/set host email config between tests without env var races
-      "shared/email.ts:setHostEmailConfigForTest",
-      "shared/email.ts:resetHostEmailConfig",
-      // Timezone validation utility (timezone now derived from country, but still useful for tests)
-      "shared/timezone.ts:isValidTimezone",
-      // Attachment size constant (now re-exported from limits.ts, not detected by export patterns)
-      "shared/storage.ts:MAX_ATTACHMENT_SIZE",
-      // AsyncLocalStorage-based storage config for concurrent test isolation
-      "shared/storage.ts:runWithStorageConfig",
-      // readLimit used in production (module-level constants) but test pattern doesn't detect same-file usage
-      "shared/limits.ts:readLimit",
-      // Settings cache TTL constant used by tests to verify caching behavior
-      "shared/db/settings.ts:SETTINGS_CACHE_TTL_MS",
-      // Set log suppression directly to avoid env var races between parallel tests
-      "shared/logger.ts:setSuppressRequestLogs",
-      "shared/logger.ts:setSuppressDebugLogs",
-      // Rethrow errors in tests without env var races
-      "shared/test-overrides.ts:setRethrowErrorsForTest",
-      // Override BUILD_TIMESTAMP / BUILD_COMMIT in tests (compile-time constants can't be changed otherwise)
-      "shared/update.ts:setBuildTimestampForTest",
-      "shared/update.ts:setBuildCommitForTest",
-      // Route maps used by API documentation tests (production uses via dynamic import / createRouter)
-      "features/api/index.ts:apiRoutes",
-      "features/admin/api.ts:adminApiRoutes",
-      // Storage delete override for testing fire-and-forget error handling
-      "shared/test-overrides.ts:getDeleteOverride",
-      "shared/test-overrides.ts:setDeleteOverride",
-      "shared/test-overrides.ts:setDeleteOverrideForTest",
-      // API key touch override for testing fire-and-forget error handling
-      "shared/test-overrides.ts:getTouchOverride",
-      "shared/test-overrides.ts:setTouchOverride",
-      "shared/test-overrides.ts:setTouchOverrideForTest",
-      // Reset the in-memory form re-fill stash between tests
-      "shared/form-stash.ts:clearFormStash",
-      // Backward-compat wrapper: fires all invalidators unconditionally (no production caller now
-      // that client.ts uses invalidateCachesForWrite, but kept for external callers and tests)
-      "shared/cache-registry.ts:invalidateCachesForTable",
-      // SET-clause column extractor: internal parser exposed for unit testing only
-      "shared/db/client.ts:extractUpdateColumns",
-    ];
-
-    /**
-     * Patterns to extract exported symbols from source files.
-     * Only captures direct exports, not re-exports.
-     */
-    const EXPORT_PATTERNS = [
-      // export const/let name = ...
-      /^export\s+(?:const|let)\s+(\w+)/gm,
-      // export function name(...) or export async function name(...)
-      /^export\s+(?:async\s+)?function\s+(\w+)/gm,
-      // export class name
-      /^export\s+class\s+(\w+)/gm,
-    ];
-
-    /** Pattern to detect re-export statements (export { x } from "y") */
-    const RE_EXPORT_PATTERN = /^export\s+\{[^}]+\}\s+from\s+['"]/m;
-
-    const extractExports = (content: string): string[] => {
-      const exports: string[] = [];
-
-      for (const pattern of EXPORT_PATTERNS) {
-        pattern.lastIndex = 0;
-        for (const match of content.matchAll(pattern)) {
-          const captured = match[1];
-          if (captured) {
-            exports.push(captured.trim());
-          }
-        }
-      }
-
-      return exports;
-    };
-
-    /**
-     * Check if a symbol is used within the same file (not just defined).
-     * Looks for patterns like `symbolName(` (function calls) or `symbolName.` (property access).
-     */
-    const isUsedInSameFile = (symbolName: string, content: string): boolean => {
-      const lines = content.split("\n");
-      let usageCount = 0;
-
-      for (const line of lines) {
-        // Skip the export definition line
-        if (
-          line.match(
-            new RegExp(
-              `^export\\s+.*(const|let|function|async).*\\b${symbolName}\\b\\s*[=({]`,
-            ),
-          )
-        ) {
-          continue;
-        }
-        // Count usages: function calls, property access, or object shorthand
-        // Matches: name(, name., name, (in objects), name: (with type),
-        // and name } (when symbol is the trailing entry of an object literal)
-        const usagePattern = new RegExp(`\\b${symbolName}\\s*[.(,:}]`);
-        if (usagePattern.test(line)) {
-          usageCount++;
-        }
-      }
-
-      return usageCount > 0;
-    };
-
-    const isUsedInProductionCode = (
-      symbolName: string,
-      sourceFile: string,
-    ): boolean => {
-      // Check if it's used within the same file
-      const sourceContent = srcContents.get(sourceFile)!;
-      if (isUsedInSameFile(symbolName, sourceContent)) {
-        return true;
-      }
-
-      // Pattern to find imports of this symbol
-      const importPattern = new RegExp(
-        `import\\s*\\{[^}]*\\b${symbolName}\\b[^}]*\\}`,
-      );
-
-      // Check .ts files
-      for (const file of srcFiles) {
-        if (file === sourceFile) continue;
-        if (importPattern.test(srcContents.get(file)!)) {
-          return true;
-        }
-      }
-
-      // Also check .tsx files as importers
-      for (const file of tsxFiles) {
-        if (importPattern.test(tsxContents.get(file)!)) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
-    /** Check if a symbol is imported in any test file */
-    const isUsedInTests = (symbolName: string): boolean => {
-      const importPattern = new RegExp(
-        `import\\s*\\{[^}]*\\b${symbolName}\\b[^}]*\\}`,
-      );
-
-      for (const testFile of testFiles) {
-        if (importPattern.test(testContents.get(testFile)!)) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-    /** Check if a file should be skipped (test utils, libraries, aggregation modules) */
     const shouldSkipFile = (relativePath: string): boolean =>
       LIBRARY_PATHS.includes(relativePath) ||
       AGGREGATION_MODULES.includes(relativePath);
-
-    /** Check if a file is primarily a re-export module */
-    const isPrimarilyReExportModule = (content: string): boolean => {
-      if (!RE_EXPORT_PATTERN.test(content)) return false;
-
-      const lines = content.split("\n");
-      const exportLines = lines.filter((l) => l.startsWith("export"));
-      const reExportLines = lines.filter((l) =>
-        /^export\s+\{[^}]+\}\s+from\s+['"]/.test(l),
-      );
-      return reExportLines.length > exportLines.length / 2;
-    };
-
-    /** Find test-only violations for a single file */
-    const findFileViolations = (file: string): string[] => {
-      const relativePath = getRelativePath(file);
-      const violations: string[] = [];
-
-      const content = srcContents.get(file)!;
-      if (isPrimarilyReExportModule(content)) return violations;
-
-      const exports = extractExports(content);
-
-      for (const exportName of exports) {
-        const hookKey = `${relativePath}:${exportName}`;
-        if (ALLOWED_TEST_HOOKS.includes(hookKey)) continue;
-
-        const usedInProduction = isUsedInProductionCode(exportName, file);
-
-        if (!usedInProduction && isUsedInTests(exportName)) {
-          violations.push(
-            `${relativePath}: "${exportName}" is exported but only used in tests`,
-          );
-        }
-      }
-
-      return violations;
-    };
 
     test("exports from src/ should be used in production code, not just tests", async () => {
       await ensureLoaded();
@@ -799,8 +377,16 @@ describe("code quality", () => {
         const relativePath = getRelativePath(file);
         if (shouldSkipFile(relativePath)) continue;
 
-        const fileViolations = findFileViolations(file);
-        violations.push(...fileViolations);
+        violations.push(
+          ...findTestOnlyExportViolations(
+            file,
+            relativePath,
+            srcContents,
+            tsxContents,
+            testContents,
+            ALLOWED_TEST_HOOKS,
+          ),
+        );
       }
 
       expect(violations).toEqual([]);
@@ -809,71 +395,13 @@ describe("code quality", () => {
 
   describe("no redundant constant arguments", () => {
     /**
-     * Detects functions where a given positional argument is *always* passed
-     * the same constant literal across every call site. When a parameter never
-     * varies it is dead flexibility — the value belongs in a default parameter
-     * or a module constant, not repeated at every call.
-     *
-     * Example violation: `fooMethod("foo", bar)` and `fooMethod("foo", baz)`
-     * everywhere → arg #0 is always "foo" and should be a default.
-     *
-     * Only literal arguments are considered (strings, numbers, booleans, null,
-     * undefined, template literals). Variable/expression arguments are ignored
-     * because identical *names* rarely mean identical *values*.
+     * Pool call sites across all production source (src + tsx) by callee name.
+     * This rule is about production API design — pooling test call sites would
+     * flag production functions for constants only tests happen to pass, so it
+     * stays src-scoped (like in-memory-state and test-only exports).
      */
-
-    /** Minimum number of call sites before a constant argument is suspicious. */
-    const MIN_CALL_SITES = 3;
-
-    /**
-     * Built-in string/array/number methods whose constant literal arguments are
-     * idiomatic, not redundant (e.g. `padStart(2, "0")`, `toFixed(2)`). These
-     * share names with no application function, so ignoring them is safe.
-     */
-    const IGNORED_CALLEES = new Set([
-      "padStart",
-      "padEnd",
-      "toFixed",
-      "toString",
-      "repeat",
-      "indexOf",
-      "lastIndexOf",
-      "charAt",
-      "codePointAt",
-      "localeCompare",
-    ]);
-
-    /**
-     * Intentional constant arguments that should not be flagged.
-     * Format: "calleeName#position" with a justifying comment.
-     */
-    const ALLOWED_CONSTANT_ARGS = [
-      // Built-in parseInt/Number.parseInt should always pass an explicit radix.
-      "parseInt#1",
-    ];
-
-    /** True for arguments that are constant literals (not variables/expressions). */
-    const isConstantLiteral = (arg: string): boolean => {
-      if (/^["'`]/.test(arg)) return true;
-      if (/^-?\d/.test(arg)) return true;
-      return (
-        arg === "true" ||
-        arg === "false" ||
-        arg === "null" ||
-        arg === "undefined"
-      );
-    };
-
-    type Site = { args: string[]; file: string; line: number };
-
-    /** Collect call sites keyed by callee name across all production source. */
     const collectCallSites = (): Map<string, Site[]> => {
       const byName = new Map<string, Site[]>();
-      // Production call sites only (src + tsx). This rule is about production
-      // API design — pooling test call sites would flag production functions
-      // for constants only tests happen to pass, forcing production default
-      // params from test patterns. So, like in-memory-state and test-only
-      // exports, it stays src-scoped.
       const record = (file: string, content: string): void => {
         const relativePath = getRelativePath(file);
         for (const call of extractCallSites(content)) {
@@ -885,29 +413,6 @@ describe("code quality", () => {
       for (const file of srcFiles) record(file, srcContents.get(file)!);
       for (const file of tsxFiles) record(file, tsxContents.get(file)!);
       return byName;
-    };
-
-    /** Describe a single redundant-argument violation for a callee. */
-    const findRedundantArg = (name: string, sites: Site[]): string | null => {
-      if (IGNORED_CALLEES.has(name)) return null;
-      if (sites.length < MIN_CALL_SITES) return null;
-      // Only positions present in *every* call site count as "always passed".
-      const sharedArity = Math.min(...sites.map((s) => s.args.length));
-      for (let pos = 0; pos < sharedArity; pos++) {
-        if (ALLOWED_CONSTANT_ARGS.includes(`${name}#${pos}`)) continue;
-        // `pos < sharedArity` guarantees every site has an argument here.
-        const values = sites.map((s) => s.args[pos] as string);
-        if (!values.every(isConstantLiteral)) continue;
-        const first = values[0] as string;
-        if (!values.every((v) => v === first)) continue;
-        const where = sites
-          .map((s) => `${s.file}:${s.line}`)
-          .slice(0, 4)
-          .join(", ");
-        const more = sites.length > 4 ? ", ..." : "";
-        return `${name}() arg #${pos} is always ${first} across ${sites.length} calls (${where}${more}) — use a default parameter or constant`;
-      }
-      return null;
     };
 
     test("functions should not always receive the same constant argument", async () => {

--- a/test/lib/code-quality/detectors.test.ts
+++ b/test/lib/code-quality/detectors.test.ts
@@ -1,0 +1,872 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  detectAliasing,
+  detectModuleLevelLet,
+  detectThenUsage,
+  extractCallSites,
+  extractExports,
+  findInMemoryStateViolations,
+  findRawDbViolation,
+  findRedundantArg,
+  findTestOnlyExportViolations,
+  getAllFilesWithExt,
+  isConstantLiteral,
+  isPrimarilyReExportModule,
+  isSymbolImported,
+  isUsedInProductionCode,
+  isUsedInSameFile,
+  isUsedInTests,
+  parseArgList,
+  type Site,
+  skipComment,
+  skipString,
+} from "./detectors.ts";
+
+/**
+ * Fixture-driven tests for the code-quality detectors. The integration test
+ * (`../code-quality.test.ts`) only asserts the *live* tree is clean, which
+ * cannot distinguish a working detector from a broken one. These tests feed each
+ * detector a known-bad input and assert it fires, and a known-good input and
+ * assert it stays quiet — so a regression in the detection logic fails here.
+ */
+
+const mapOf = (entries: [string, string][]): Map<string, string> =>
+  new Map(entries);
+
+describe("getAllFilesWithExt", () => {
+  test("collects matching files recursively and ignores other extensions", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await Deno.mkdir(join(dir, "sub"));
+      await Deno.writeTextFile(join(dir, "a.ts"), "");
+      await Deno.writeTextFile(join(dir, "b.tsx"), "");
+      await Deno.writeTextFile(join(dir, "c.txt"), "");
+      await Deno.writeTextFile(join(dir, "sub", "d.ts"), "");
+      await Deno.writeTextFile(join(dir, "sub", "e.tsx"), "");
+
+      const ts = await getAllFilesWithExt(dir, ".ts");
+      expect(ts.sort()).toEqual([join(dir, "a.ts"), join(dir, "sub", "d.ts")]);
+
+      const tsx = await getAllFilesWithExt(dir, ".tsx");
+      expect(tsx.sort()).toEqual([
+        join(dir, "b.tsx"),
+        join(dir, "sub", "e.tsx"),
+      ]);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  test("returns an empty list for a directory with no matches", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(join(dir, "only.md"), "");
+      expect(await getAllFilesWithExt(dir, ".ts")).toEqual([]);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+});
+
+describe("findInMemoryStateViolations", () => {
+  test("flags a module-level Map assignment", () => {
+    expect(
+      findInMemoryStateViolations(
+        "shared/x.ts",
+        "const cache = new Map();",
+        [],
+      ),
+    ).toEqual(["shared/x.ts: Module-level Map (use database instead)"]);
+  });
+
+  test("flags a module-level Set assignment", () => {
+    expect(
+      findInMemoryStateViolations("shared/x.ts", "let seen = new Set();", []),
+    ).toEqual(["shared/x.ts: Module-level Set (use database instead)"]);
+  });
+
+  test("flags a module-level typed Map declaration", () => {
+    expect(
+      findInMemoryStateViolations(
+        "shared/x.ts",
+        "const cache: Map<string, number> = build();",
+        [],
+      ),
+    ).toEqual(["shared/x.ts: Module-level typed Map (use database instead)"]);
+  });
+
+  test("flags a module-level typed Set declaration", () => {
+    expect(
+      findInMemoryStateViolations(
+        "shared/x.ts",
+        "export const seen: Set<string> = build();",
+        [],
+      ),
+    ).toEqual(["shared/x.ts: Module-level typed Set (use database instead)"]);
+  });
+
+  test("does not flag clean content", () => {
+    expect(
+      findInMemoryStateViolations("shared/x.ts", "const x = 1;", []),
+    ).toEqual([]);
+  });
+
+  test("does not flag an indented (non-module-level) Map", () => {
+    expect(
+      findInMemoryStateViolations(
+        "shared/x.ts",
+        "function f() {\n  const m = new Map();\n}",
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  test("skips files on the allow-list even when they match", () => {
+    expect(
+      findInMemoryStateViolations("shared/x.ts", "const cache = new Map();", [
+        "shared/x.ts",
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("findRawDbViolation", () => {
+  test("flags a direct getDb().execute call", () => {
+    expect(
+      findRawDbViolation("features/y.ts", "await getDb().execute(sql);", []),
+    ).toBe(
+      "features/y.ts: use execute()/queryOne()/queryAll()/executeBatch() from #shared/db/client.ts instead of getDb().execute/.batch",
+    );
+  });
+
+  test("flags a direct getDb().batch call", () => {
+    expect(
+      findRawDbViolation("features/y.ts", "await getDb().batch(stmts);", []),
+    ).toContain("instead of getDb().execute/.batch");
+  });
+
+  test("returns null for clean content", () => {
+    expect(findRawDbViolation("features/y.ts", "await execute(sql);", [])).toBe(
+      null,
+    );
+  });
+
+  test("returns null for a file under an allowed prefix", () => {
+    expect(
+      findRawDbViolation("shared/db/migrations/001.ts", "getDb().execute(x);", [
+        "shared/db/migrations/",
+      ]),
+    ).toBe(null);
+  });
+});
+
+describe("detectAliasing", () => {
+  test("flags an identifier-to-identifier const alias", () => {
+    expect(detectAliasing("src/a.ts", "const myFn = someFn;", 7)).toBe(
+      "src/a.ts:7: const myFn = someFn (use import { someFn as myFn } instead)",
+    );
+  });
+
+  test("flags an exported alias", () => {
+    expect(detectAliasing("src/a.ts", "export const a = b;", 3)).toBe(
+      "src/a.ts:3: const a = b (use import { b as a } instead)",
+    );
+  });
+
+  test("does not flag assignment of a literal", () => {
+    expect(detectAliasing("src/a.ts", "const n = 123;", 1)).toBe(null);
+  });
+
+  test("does not flag a call expression", () => {
+    expect(detectAliasing("src/a.ts", "const x = build();", 1)).toBe(null);
+  });
+
+  test("does not flag a let binding", () => {
+    expect(detectAliasing("src/a.ts", "let x = y;", 1)).toBe(null);
+  });
+});
+
+describe("detectModuleLevelLet", () => {
+  test("flags a module-level let", () => {
+    expect(detectModuleLevelLet("src/a.ts", "let counter = 0;", 7)).toBe(
+      "src/a.ts:7: let counter = 0;... (use const with once()/lazyRef())",
+    );
+  });
+
+  test("flags an exported let", () => {
+    expect(detectModuleLevelLet("src/a.ts", "export let x = 1;", 2)).toBe(
+      "src/a.ts:2: export let x = 1;... (use const with once()/lazyRef())",
+    );
+  });
+
+  test("truncates the reported line to 50 characters", () => {
+    const long = `let x = ${"a".repeat(80)};`;
+    expect(detectModuleLevelLet("src/a.ts", long, 1)).toBe(
+      `src/a.ts:1: ${long.slice(0, 50)}... (use const with once()/lazyRef())`,
+    );
+  });
+
+  test("does not flag an indented let", () => {
+    expect(detectModuleLevelLet("src/a.ts", "  let x = 1;", 1)).toBe(null);
+  });
+
+  test("does not flag const", () => {
+    expect(detectModuleLevelLet("src/a.ts", "const x = 1;", 1)).toBe(null);
+  });
+
+  test("does not flag an identifier that merely starts with 'let'", () => {
+    expect(detectModuleLevelLet("src/a.ts", "letter = 1;", 1)).toBe(null);
+  });
+});
+
+describe("detectThenUsage", () => {
+  test("flags a .then() call and trims leading whitespace", () => {
+    expect(detectThenUsage("src/a.ts", "  promise.then(handle);", 4)).toBe(
+      "src/a.ts:4: promise.then(handle);... (use async/await instead)",
+    );
+  });
+
+  test("flags .then with whitespace before the paren", () => {
+    expect(detectThenUsage("src/a.ts", "p.then ();", 1)).toBe(
+      "src/a.ts:1: p.then ();... (use async/await instead)",
+    );
+  });
+
+  test("returns null for async/await code", () => {
+    expect(detectThenUsage("src/a.ts", "await promise;", 1)).toBe(null);
+  });
+
+  test("returns null when 'then' is not a method call", () => {
+    expect(detectThenUsage("src/a.ts", "const then = 1;", 1)).toBe(null);
+  });
+});
+
+describe("extractExports", () => {
+  test("captures const, let, function, async function and class exports", () => {
+    const content = [
+      "export const foo = 1;",
+      "export let bar = 2;",
+      "export function baz() {}",
+      "export async function qux() {}",
+      "export class Cls {}",
+    ].join("\n");
+    expect(extractExports(content)).toEqual([
+      "foo",
+      "bar",
+      "baz",
+      "qux",
+      "Cls",
+    ]);
+  });
+
+  test("ignores re-exports", () => {
+    expect(extractExports('export { x } from "./y.ts";')).toEqual([]);
+  });
+
+  test("returns an empty list when there are no exports", () => {
+    expect(extractExports("const internal = 1;")).toEqual([]);
+  });
+});
+
+describe("isUsedInSameFile", () => {
+  test("detects a usage beyond the export definition line", () => {
+    const content = "export const foo = 1;\nfoo();\nconst other = 2;";
+    expect(isUsedInSameFile("foo", content)).toBe(true);
+  });
+
+  test("detects property-access usage", () => {
+    expect(isUsedInSameFile("foo", "export const foo = {};\nfoo.bar;")).toBe(
+      true,
+    );
+  });
+
+  test("returns false when only the definition line mentions the symbol", () => {
+    expect(isUsedInSameFile("foo", "export const foo = 1;")).toBe(false);
+  });
+
+  test("returns false when the symbol never appears", () => {
+    expect(isUsedInSameFile("foo", "const bar = 1;\nbar();")).toBe(false);
+  });
+});
+
+describe("isSymbolImported", () => {
+  test("detects a named import", () => {
+    expect(isSymbolImported("foo", 'import { foo, bar } from "./x.ts";')).toBe(
+      true,
+    );
+  });
+
+  test("returns false when the symbol is only defined, not imported", () => {
+    expect(isSymbolImported("foo", "const foo = 1;")).toBe(false);
+  });
+
+  test("returns false when a different symbol is imported", () => {
+    expect(isSymbolImported("foo", 'import { bar } from "./x.ts";')).toBe(
+      false,
+    );
+  });
+});
+
+describe("isUsedInProductionCode", () => {
+  test("true when used within the same source file", () => {
+    expect(
+      isUsedInProductionCode(
+        "foo",
+        "a.ts",
+        mapOf([["a.ts", "export const foo = 1;\nfoo();"]]),
+        mapOf([]),
+      ),
+    ).toBe(true);
+  });
+
+  test("true when imported by another .ts source", () => {
+    expect(
+      isUsedInProductionCode(
+        "foo",
+        "a.ts",
+        mapOf([
+          ["a.ts", "export const foo = 1;"],
+          ["b.ts", 'import { foo } from "./a.ts";'],
+        ]),
+        mapOf([]),
+      ),
+    ).toBe(true);
+  });
+
+  test("true when imported by a .tsx template", () => {
+    expect(
+      isUsedInProductionCode(
+        "foo",
+        "a.ts",
+        mapOf([["a.ts", "export const foo = 1;"]]),
+        mapOf([["t.tsx", 'import { foo } from "./a.ts";']]),
+      ),
+    ).toBe(true);
+  });
+
+  test("false when used nowhere in production", () => {
+    expect(
+      isUsedInProductionCode(
+        "foo",
+        "a.ts",
+        mapOf([
+          ["a.ts", "export const foo = 1;"],
+          ["b.ts", "const unrelated = 1;"],
+        ]),
+        mapOf([["t.tsx", "const x = 1;"]]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isUsedInTests", () => {
+  test("true when a test file imports the symbol", () => {
+    expect(
+      isUsedInTests(
+        "foo",
+        mapOf([["x.test.ts", 'import { foo } from "../a.ts";']]),
+      ),
+    ).toBe(true);
+  });
+
+  test("false when no test imports the symbol", () => {
+    expect(isUsedInTests("foo", mapOf([["x.test.ts", "const y = 1;"]]))).toBe(
+      false,
+    );
+  });
+});
+
+describe("isPrimarilyReExportModule", () => {
+  test("false when there are no re-exports", () => {
+    expect(isPrimarilyReExportModule("export const x = 1;")).toBe(false);
+  });
+
+  test("true when re-exports dominate", () => {
+    const content = 'export { a } from "./a.ts";\nexport { b } from "./b.ts";';
+    expect(isPrimarilyReExportModule(content)).toBe(true);
+  });
+
+  test("false when direct exports tie the re-export count", () => {
+    const content = 'export { a } from "./a.ts";\nexport const b = 1;';
+    expect(isPrimarilyReExportModule(content)).toBe(false);
+  });
+});
+
+describe("findTestOnlyExportViolations", () => {
+  const src = (content: string): Map<string, string> =>
+    mapOf([["a.ts", content]]);
+
+  test("flags an export used only by tests", () => {
+    expect(
+      findTestOnlyExportViolations(
+        "a.ts",
+        "shared/a.ts",
+        src("export const helper = 1;"),
+        mapOf([]),
+        mapOf([["x.test.ts", 'import { helper } from "../a.ts";']]),
+        [],
+      ),
+    ).toEqual(['shared/a.ts: "helper" is exported but only used in tests']);
+  });
+
+  test("does not flag an export also used in production", () => {
+    expect(
+      findTestOnlyExportViolations(
+        "a.ts",
+        "shared/a.ts",
+        mapOf([
+          ["a.ts", "export const helper = 1;"],
+          ["b.ts", 'import { helper } from "./a.ts";\nhelper();'],
+        ]),
+        mapOf([]),
+        mapOf([["x.test.ts", 'import { helper } from "../a.ts";']]),
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  test("does not flag an export used nowhere", () => {
+    expect(
+      findTestOnlyExportViolations(
+        "a.ts",
+        "shared/a.ts",
+        src("export const helper = 1;"),
+        mapOf([]),
+        mapOf([["x.test.ts", "const y = 1;"]]),
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  test("respects the allowed-test-hooks list", () => {
+    expect(
+      findTestOnlyExportViolations(
+        "a.ts",
+        "shared/a.ts",
+        src("export const setFooForTest = 1;"),
+        mapOf([]),
+        mapOf([["x.test.ts", 'import { setFooForTest } from "../a.ts";']]),
+        ["shared/a.ts:setFooForTest"],
+      ),
+    ).toEqual([]);
+  });
+
+  test("returns nothing for a re-export aggregation module", () => {
+    expect(
+      findTestOnlyExportViolations(
+        "a.ts",
+        "shared/a.ts",
+        src('export { x } from "./x.ts";\nexport { z } from "./z.ts";'),
+        mapOf([]),
+        mapOf([["x.test.ts", 'import { x } from "../a.ts";']]),
+        [],
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("isConstantLiteral", () => {
+  const cases: [string, boolean][] = [
+    ['"str"', true],
+    ["'str'", true],
+    ["`tpl`", true],
+    ["123", true],
+    ["-5", true],
+    ["0", true],
+    ["true", true],
+    ["false", true],
+    ["null", true],
+    ["undefined", true],
+    ["variable", false],
+    ["build()", false],
+    ["a + b", false],
+  ];
+  for (const [arg, expected] of cases) {
+    test(`${arg} -> ${expected}`, () => {
+      expect(isConstantLiteral(arg)).toBe(expected);
+    });
+  }
+});
+
+describe("extractCallSites", () => {
+  const cases: {
+    name: string;
+    src: string;
+    expected: ReturnType<typeof extractCallSites>;
+  }[] = [
+    {
+      expected: [{ args: ["1", "2"], line: 1, name: "foo" }],
+      name: "a simple call with two arguments",
+      src: "foo(1, 2)",
+    },
+    {
+      expected: [{ args: ['"a, b"', "c"], line: 1, name: "foo" }],
+      name: "a comma inside a double-quoted string (not an arg separator)",
+      src: 'foo("a, b", c)',
+    },
+    {
+      expected: [{ args: ["'x'", "`y`"], line: 1, name: "foo" }],
+      name: "single-quoted and template-literal arguments",
+      src: "foo('x', `y`)",
+    },
+    {
+      expected: [{ args: ['"a\\"b"'], line: 1, name: "foo" }],
+      name: "an escaped quote inside a string",
+      src: 'foo("a\\"b")',
+    },
+    {
+      expected: [{ args: ['"a$b"'], line: 1, name: "foo" }],
+      name: "a double-quoted string containing a lone $",
+      src: 'foo("a$b")',
+    },
+    {
+      expected: [
+        { args: ["bar(1, 2)", "[3, 4]", "{a: 5}"], line: 1, name: "foo" },
+        { args: ["1", "2"], line: 1, name: "bar" },
+      ],
+      // The nested `bar(...)` call is also discovered; foo's own arguments keep
+      // their nested commas because brackets bump the depth past the top level.
+      name: "nested calls, arrays and objects (depth tracking)",
+      src: "foo(bar(1, 2), [3, 4], {a: 5})",
+    },
+    {
+      expected: [{ args: ["1"], line: 1, name: "foo" }],
+      name: "a keyword followed by a paren is not a call",
+      src: "if (cond) foo(1)",
+    },
+    {
+      expected: [{ args: ["a"], line: 1, name: "bar" }],
+      name: "a function declaration name is not a call",
+      src: "function foo(a) { bar(a); }",
+    },
+    {
+      expected: [{ args: ["1"], line: 1, name: "bar" }],
+      name: "an identifier not followed by a paren is not a call",
+      src: "const x = foo; bar(1)",
+    },
+    {
+      expected: [{ args: [], line: 1, name: "foo" }],
+      name: "whitespace between the name and the paren",
+      src: "foo ()",
+    },
+    {
+      expected: [{ args: [], line: 1, name: "foo" }],
+      name: "an empty argument list",
+      src: "foo()",
+    },
+    {
+      expected: [{ args: ["a"], line: 1, name: "foo" }],
+      name: "a trailing empty argument is dropped",
+      src: "foo(a, )",
+    },
+    {
+      expected: [{ args: ["2"], line: 2, name: "bar" }],
+      name: "a line comment hides a call; line numbers are resolved",
+      src: "// foo(1)\nbar(2)",
+    },
+    {
+      expected: [{ args: ["2"], line: 1, name: "bar" }],
+      name: "a block comment hides a call",
+      src: "/* foo(1) */ bar(2)",
+    },
+    {
+      expected: [{ args: ["x /* , */", "y"], line: 1, name: "foo" }],
+      // A comma inside a comment must not split the argument list: the comment
+      // text stays in the arg slice, but there are still exactly two arguments.
+      name: "a comma inside a comment does not split arguments",
+      src: "foo(x /* , */, y)",
+    },
+    {
+      expected: [
+        { args: ["1"], line: 2, name: "foo" },
+        { args: ["2"], line: 4, name: "bar" },
+      ],
+      name: "two calls on different lines",
+      src: "\nfoo(1)\n\nbar(2)",
+    },
+    {
+      expected: [{ args: [], line: 1, name: "foo" }],
+      name: "an unterminated string stops cleanly",
+      src: 'foo("abc',
+    },
+    {
+      expected: [{ args: [], line: 1, name: "foo" }],
+      name: "an unterminated argument list stops cleanly",
+      src: "foo(a",
+    },
+    {
+      expected: [],
+      name: "an unterminated line comment yields no calls",
+      src: "// foo(1)",
+    },
+    {
+      expected: [],
+      name: "an unterminated block comment yields no calls",
+      src: "/* foo(1)",
+    },
+    {
+      expected: [{ args: ['"bar()"'], line: 1, name: "foo" }],
+      // A call-like sequence inside a double-quoted string must stay hidden.
+      name: "a call inside a double-quoted string is not detected",
+      src: 'foo("bar()")',
+    },
+    {
+      expected: [{ args: ["'baz()'"], line: 1, name: "foo" }],
+      name: "a call inside a single-quoted string is not detected",
+      src: "foo('baz()')",
+    },
+    {
+      expected: [{ args: ["`qux()`"], line: 1, name: "foo" }],
+      name: "a call inside a template literal is not detected",
+      src: "foo(`qux()`)",
+    },
+    {
+      expected: [{ args: ["1"], line: 1, name: "foo" }],
+      // Scanning must resume *at* the end of a comment, not be advanced past it:
+      // an off-by addition here would land mid-token and miss the real call.
+      name: "scanning resumes exactly after a mid-line comment",
+      src: "ab /* c */ foo(1)",
+    },
+    {
+      expected: [{ args: ["1"], line: 1, name: "foo" }],
+      name: "scanning resumes exactly after a mid-line string",
+      src: "ab 'xxxx' foo(1)",
+    },
+    {
+      expected: [{ args: [], line: 1, name: "foo" }],
+      // The "function" guard must be cleared after a string, or the following
+      // call would be wrongly treated as a function declaration name.
+      name: "a string clears the preceding-word guard",
+      src: 'function "s" foo()',
+    },
+    {
+      expected: [],
+      // The preceding word is replaced, not accumulated: with replacement the
+      // most recent word is "function", which suppresses this call (no calls).
+      // Under an accumulating mutant the guard reads "afunction" and the call
+      // would wrongly be reported.
+      name: "the preceding-word guard is replaced, not accumulated",
+      src: "a function foo()",
+    },
+    {
+      expected: [{ args: [], line: 1, name: "foo" }],
+      // A punctuation token clears the guard: `function;` does not suppress the
+      // following call the way `function foo()` would.
+      name: "punctuation clears the preceding-word guard",
+      src: "function; foo()",
+    },
+  ];
+  for (const { name, src, expected } of cases) {
+    test(name, () => {
+      expect(extractCallSites(src)).toEqual(expected);
+    });
+  }
+
+  test("skips template substitutions: nested braces, strings and templates", () => {
+    // Source text:  foo(`a$b${ {x:"q"} }${'s'}${`t`}`)
+    // The whole backtick template is one argument; the `bar` call and comma-like
+    // characters inside `${...}` must NOT leak out as separate calls/args.
+    const template = "`a$b${ {x:\"q\"} }${'s'}${`t`}`";
+    const src = `foo(${template})`;
+    expect(extractCallSites(src)).toEqual([
+      { args: [template], line: 1, name: "foo" },
+    ]);
+  });
+
+  test("handles an unterminated template substitution", () => {
+    // Source text:  foo(`${x`)   — the inner backtick opens a nested template
+    // that never closes, so the whole thing is consumed as one (empty) call.
+    const src = "foo(`${x`)";
+    expect(extractCallSites(src)).toEqual([{ args: [], line: 1, name: "foo" }]);
+  });
+});
+
+describe("findRedundantArg", () => {
+  const site = (args: string[], line = 1, file = "a.ts"): Site => ({
+    args,
+    file,
+    line,
+  });
+
+  test("ignores built-in callees like padStart", () => {
+    const sites = [site(["2", "'0'"]), site(["2", "'0'"]), site(["2", "'0'"])];
+    expect(findRedundantArg("padStart", sites)).toBe(null);
+  });
+
+  test("ignores callees with fewer than three call sites", () => {
+    expect(findRedundantArg("foo", [site(["1"]), site(["1"])])).toBe(null);
+  });
+
+  test("flags a position that is always the same constant", () => {
+    const sites = [
+      site(["1"], 10, "a.ts"),
+      site(["1"], 20, "b.ts"),
+      site(["1"], 30, "c.ts"),
+    ];
+    expect(findRedundantArg("foo", sites)).toBe(
+      "foo() arg #0 is always 1 across 3 calls (a.ts:10, b.ts:20, c.ts:30) — use a default parameter or constant",
+    );
+  });
+
+  test("respects the allowed-constant-args list (parseInt radix)", () => {
+    const sites = [site(["x", "10"]), site(["y", "10"]), site(["z", "10"])];
+    expect(findRedundantArg("parseInt", sites)).toBe(null);
+  });
+
+  test("does not flag a position holding non-literal arguments", () => {
+    const sites = [site(["a"]), site(["b"]), site(["c"])];
+    expect(findRedundantArg("foo", sites)).toBe(null);
+  });
+
+  test("does not flag constants that differ across call sites", () => {
+    const sites = [site(["1"]), site(["2"]), site(["3"])];
+    expect(findRedundantArg("foo", sites)).toBe(null);
+  });
+
+  test("checks later positions when an earlier one varies", () => {
+    const sites = [
+      site(["a", "9"], 1, "a.ts"),
+      site(["b", "9"], 2, "a.ts"),
+      site(["c", "9"], 3, "a.ts"),
+    ];
+    expect(findRedundantArg("foo", sites)).toBe(
+      "foo() arg #1 is always 9 across 3 calls (a.ts:1, a.ts:2, a.ts:3) — use a default parameter or constant",
+    );
+  });
+
+  test("only inspects positions present in every call site", () => {
+    // shared arity is 1, so the differing second arg of the wider sites is
+    // never considered; arg #0 is always "1" and is flagged.
+    const sites = [site(["1", "2"]), site(["1"]), site(["1", "9"])];
+    expect(findRedundantArg("foo", sites)).toContain("arg #0 is always 1");
+  });
+
+  test("appends an ellipsis when there are more than four call sites", () => {
+    const sites = [
+      site(["1"], 1, "f1.ts"),
+      site(["1"], 1, "f2.ts"),
+      site(["1"], 1, "f3.ts"),
+      site(["1"], 1, "f4.ts"),
+      site(["1"], 1, "f5.ts"),
+    ];
+    expect(findRedundantArg("foo", sites)).toBe(
+      "foo() arg #0 is always 1 across 5 calls (f1.ts:1, f2.ts:1, f3.ts:1, f4.ts:1, ...) — use a default parameter or constant",
+    );
+  });
+});
+
+/**
+ * Direct tokenizer tests. `extractCallSites` is too forgiving to expose these
+ * helpers' internal edge cases — it always recovers at the next closing quote —
+ * so the index/argument contracts are asserted here. (Same rationale as the
+ * codebase's other "internal parser exposed for unit testing only".)
+ */
+describe("skipString", () => {
+  test("returns the index just past a simple string", () => {
+    expect(skipString('"abc"', 0)).toBe(5);
+  });
+
+  test("skips an escaped character rather than closing on it", () => {
+    // The backslash escapes the next char; without skipping two, the closing
+    // quote would be misread (and the index would be wrong).
+    expect(skipString('"a\\nb"', 0)).toBe(6);
+  });
+
+  test("skips a template substitution", () => {
+    expect(skipString("`${x}`", 0)).toBe(6);
+  });
+
+  test("ends a template at its closing backtick, leaving trailing code", () => {
+    // Stops just past the closing backtick (index 6) rather than treating the
+    // substitution's contents as nested strings and running into `bar`.
+    expect(skipString("`${a}`bar", 0)).toBe(6);
+  });
+
+  test("tracks brace depth inside a substitution", () => {
+    // The inner `{ ... }` must raise the depth so the substitution ends at the
+    // outer `}`, not the inner one (which would expose the inner backtick).
+    expect(skipString("`${ { `x` } }`", 0)).toBe(14);
+  });
+
+  test("skips a double-quoted nested string inside a substitution", () => {
+    expect(skipString('`${ "}" + `x` }`', 0)).toBe(16);
+  });
+
+  test("skips a single-quoted nested string inside a substitution", () => {
+    expect(skipString("`${ '}' }`", 0)).toBe(10);
+  });
+
+  test("skips a backtick nested string inside a substitution", () => {
+    expect(skipString("`${ `}` }`", 0)).toBe(10);
+  });
+
+  test("treats a lone $ in a template as literal", () => {
+    expect(skipString("`a$b`", 0)).toBe(5);
+  });
+
+  test("treats $ in a non-template string as literal", () => {
+    expect(skipString('"a$b"', 0)).toBe(5);
+  });
+
+  test("returns past the end for an unterminated string", () => {
+    expect(skipString('"abc', 0)).toBe(4);
+  });
+});
+
+describe("skipComment", () => {
+  test("skips a line comment up to the newline", () => {
+    expect(skipComment("// x\ny", 0)).toBe(4);
+  });
+
+  test("skips a line comment running to end of input", () => {
+    expect(skipComment("// x", 0)).toBe(4);
+  });
+
+  test("skips a block comment", () => {
+    expect(skipComment("/* x */y", 0)).toBe(7);
+  });
+
+  test("ends a block comment only at star-slash, not a bare slash", () => {
+    expect(skipComment("/* a/ */", 0)).toBe(8);
+  });
+
+  test("does not treat a lone slash as the start of a comment", () => {
+    expect(skipComment("/x", 0)).toBe(0);
+  });
+
+  test("returns the index unchanged for a non-comment slash", () => {
+    expect(skipComment("x/y", 1)).toBe(1);
+  });
+});
+
+describe("parseArgList", () => {
+  test("splits top-level comma-separated arguments", () => {
+    expect(parseArgList("(a, b)", 0).args).toEqual(["a", "b"]);
+  });
+
+  test("does not split on a comma inside a single-quoted string", () => {
+    expect(parseArgList("('a,b')", 0).args).toEqual(["'a,b'"]);
+  });
+
+  test("does not split on a comma inside a double-quoted string", () => {
+    expect(parseArgList('("a,b")', 0).args).toEqual(['"a,b"']);
+  });
+
+  test("keeps nested-bracket contents as a single argument", () => {
+    expect(parseArgList("(f(1, 2), [3])", 0).args).toEqual(["f(1, 2)", "[3]"]);
+  });
+
+  test("reports the closing-paren index as the end", () => {
+    expect(parseArgList("(a)", 0).end).toBe(2);
+  });
+
+  test("drops an empty trailing argument", () => {
+    expect(parseArgList("(a, )", 0).args).toEqual(["a"]);
+  });
+
+  test("stops cleanly on an unterminated list", () => {
+    expect(parseArgList("(a", 0).args).toEqual([]);
+  });
+});

--- a/test/lib/code-quality/detectors.ts
+++ b/test/lib/code-quality/detectors.ts
@@ -1,0 +1,627 @@
+/**
+ * Pure detection logic for the "code quality" test suite.
+ *
+ * This module exists so the rules enforced by `test/lib/code-quality.test.ts`
+ * can be exercised directly with crafted fixtures — feeding each detector a
+ * known-bad input and asserting it fires, and a known-good input and asserting
+ * it stays quiet. The integration test that scans the real `src/`+`test/` tree
+ * only ever asserts "no violations" against an already-clean codebase, so on its
+ * own it cannot tell a working detector apart from a broken one (mutation
+ * testing scored it 35.8%). Splitting the pure logic out here, behind explicit
+ * inputs, makes every branch reachable and every regression catchable.
+ *
+ * Everything here is a pure function of its arguments (the file lists, contents,
+ * and policy allow-lists are passed in by the caller), with the lone exception
+ * of `getAllFilesWithExt`, which walks the filesystem.
+ */
+
+import { join } from "node:path";
+
+/* -------------------------------------------------------------------------- *
+ * File discovery                                                             *
+ * -------------------------------------------------------------------------- */
+
+/** Recursively collect every file under `dir` whose name ends with `ext`. */
+export const getAllFilesWithExt = async (
+  dir: string,
+  ext: string,
+): Promise<string[]> => {
+  const files: string[] = [];
+
+  for await (const entry of Deno.readDir(dir)) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory) {
+      files.push(...(await getAllFilesWithExt(fullPath, ext)));
+    } else if (entry.name.endsWith(ext)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
+/* -------------------------------------------------------------------------- *
+ * No in-memory state: module-level Map/Set should be in the database         *
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Patterns that indicate in-memory state storage at module level.
+ * These should be stored in the database instead to survive restarts.
+ */
+export const FORBIDDEN_PATTERNS = [
+  {
+    description: "Module-level Map (use database instead)",
+    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*=\s*new\s+Map\s*[<(]/m,
+  },
+  {
+    description: "Module-level Set (use database instead)",
+    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*=\s*new\s+Set\s*[<(]/m,
+  },
+  {
+    description: "Module-level typed Map (use database instead)",
+    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*:\s*Map\s*</m,
+  },
+  {
+    description: "Module-level typed Set (use database instead)",
+    pattern: /^(?:export\s+)?(?:const|let)\s+\w+\s*:\s*Set\s*</m,
+  },
+];
+
+/**
+ * Violations of the in-memory-state rule for a single source file. `allowedFiles`
+ * is the src-relative allow-list of files permitted to hold module-level state.
+ */
+export const findInMemoryStateViolations = (
+  relativePath: string,
+  content: string,
+  allowedFiles: string[],
+): string[] => {
+  if (allowedFiles.includes(relativePath)) return [];
+  const violations: string[] = [];
+  for (const { pattern, description } of FORBIDDEN_PATTERNS) {
+    if (pattern.test(content)) {
+      violations.push(`${relativePath}: ${description}`);
+    }
+  }
+  return violations;
+};
+
+/* -------------------------------------------------------------------------- *
+ * DB writes must go through the client choke point                           *
+ * -------------------------------------------------------------------------- */
+
+export const RAW_DB_PATTERN = /getDb\(\)\.(?:execute|batch)\s*\(/;
+
+/**
+ * The violation message for a file that calls `getDb().execute/.batch` directly,
+ * or `null` when the file is clean or on the `allowed` prefix list.
+ */
+export const findRawDbViolation = (
+  relativePath: string,
+  content: string,
+  allowed: string[],
+): string | null => {
+  if (allowed.some((prefix) => relativePath.startsWith(prefix))) return null;
+  if (RAW_DB_PATTERN.test(content)) {
+    return `${relativePath}: use execute()/queryOne()/queryAll()/executeBatch() from #shared/db/client.ts instead of getDb().execute/.batch`;
+  }
+  return null;
+};
+
+/* -------------------------------------------------------------------------- *
+ * Line-level rules: aliasing, module-level let, .then()                       *
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Pattern to detect function/variable aliasing at module level.
+ * Forces use of `import { x as y }` instead of post-import aliasing.
+ * Example violation: const myFunc = someImportedFunc;
+ * Only matches identifiers (starts with letter/underscore), not literals.
+ */
+export const ALIASING_PATTERN =
+  /^(?:export\s+)?const\s+(\w+)\s*=\s*([a-zA-Z_]\w*)\s*;?\s*(?:\/\/.*)?$/;
+
+/** A single line's aliasing violation, or `null` when the line is fine. */
+export const detectAliasing = (
+  relativePath: string,
+  line: string,
+  lineNum: number,
+): string | null => {
+  const match = line.match(ALIASING_PATTERN);
+  if (!match) return null;
+  const [, varName, value] = match;
+  return `${relativePath}:${lineNum}: const ${varName} = ${value} (use import { ${value} as ${varName} } instead)`;
+};
+
+/** Module-level `let` / `export let` (should be `const` with once()/lazyRef()). */
+export const MODULE_LET_PATTERN = /^(export\s+)?let\s+/;
+
+/** A single line's module-level-let violation, or `null`. */
+export const detectModuleLevelLet = (
+  relativePath: string,
+  line: string,
+  lineNum: number,
+): string | null => {
+  if (!line.match(MODULE_LET_PATTERN)) return null;
+  return `${relativePath}:${lineNum}: ${line.slice(
+    0,
+    50,
+  )}... (use const with once()/lazyRef())`;
+};
+
+/**
+ * Pattern to detect `.then()` usage — prefer async/await. Non-global so `.test()`
+ * is stateless (the global form needed a `lastIndex` reset around every call).
+ */
+export const THEN_PATTERN = /\.then\s*\(/;
+
+/** A single line's `.then()` violation, or `null`. */
+export const detectThenUsage = (
+  relativePath: string,
+  line: string,
+  lineNum: number,
+): string | null => {
+  if (!THEN_PATTERN.test(line)) return null;
+  return `${relativePath}:${lineNum}: ${line
+    .trim()
+    .slice(0, 50)}... (use async/await instead)`;
+};
+
+/* -------------------------------------------------------------------------- *
+ * No test-only exports                                                       *
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Patterns to extract exported symbols from source files.
+ * Only captures direct exports, not re-exports.
+ */
+export const EXPORT_PATTERNS = [
+  // export const/let name = ...
+  /^export\s+(?:const|let)\s+(\w+)/gm,
+  // export function name(...) or export async function name(...)
+  /^export\s+(?:async\s+)?function\s+(\w+)/gm,
+  // export class name
+  /^export\s+class\s+(\w+)/gm,
+];
+
+/** Pattern to detect re-export statements (export { x } from "y") */
+export const RE_EXPORT_PATTERN = /^export\s+\{[^}]+\}\s+from\s+['"]/m;
+
+/** Every directly-exported symbol name declared in `content`. */
+export const extractExports = (content: string): string[] => {
+  const exports: string[] = [];
+
+  for (const pattern of EXPORT_PATTERNS) {
+    // No lastIndex reset is needed: String.prototype.matchAll clones the regex
+    // and never advances the original's lastIndex, so it stays 0 between calls.
+    // Group 1 is the `(\w+)` name, always present and non-empty on a match.
+    for (const match of content.matchAll(pattern)) {
+      exports.push(match[1]!.trim());
+    }
+  }
+
+  return exports;
+};
+
+/**
+ * Whether `symbolName` is referenced within `content` (beyond its own export
+ * definition). Looks for calls (`name(`), property access (`name.`), object
+ * shorthand, type position, or as the trailing entry of an object literal.
+ */
+export const isUsedInSameFile = (
+  symbolName: string,
+  content: string,
+): boolean => {
+  const lines = content.split("\n");
+  let usageCount = 0;
+
+  for (const line of lines) {
+    // Skip the export definition line
+    if (
+      line.match(
+        new RegExp(
+          `^export\\s+.*(const|let|function|async).*\\b${symbolName}\\b\\s*[=({]`,
+        ),
+      )
+    ) {
+      continue;
+    }
+    // Count usages: function calls, property access, or object shorthand
+    // Matches: name(, name., name, (in objects), name: (with type),
+    // and name } (when symbol is the trailing entry of an object literal)
+    const usagePattern = new RegExp(`\\b${symbolName}\\s*[.(,:}]`);
+    if (usagePattern.test(line)) {
+      usageCount++;
+    }
+  }
+
+  return usageCount > 0;
+};
+
+/** Whether `content` imports `symbolName` via a named `import { … }` clause. */
+export const isSymbolImported = (
+  symbolName: string,
+  content: string,
+): boolean => {
+  const importPattern = new RegExp(
+    `import\\s*\\{[^}]*\\b${symbolName}\\b[^}]*\\}`,
+  );
+  return importPattern.test(content);
+};
+
+/**
+ * Whether `symbolName` (exported from `sourceFile`) is used anywhere in
+ * production code: within the same file, imported by another `.ts` source, or
+ * imported by a `.tsx` template. `srcContents`/`tsxContents` map an absolute
+ * path to its contents.
+ */
+export const isUsedInProductionCode = (
+  symbolName: string,
+  sourceFile: string,
+  srcContents: Map<string, string>,
+  tsxContents: Map<string, string>,
+): boolean => {
+  // Check if it's used within the same file
+  const sourceContent = srcContents.get(sourceFile)!;
+  if (isUsedInSameFile(symbolName, sourceContent)) {
+    return true;
+  }
+
+  // Check other .ts source files
+  for (const [file, content] of srcContents) {
+    if (file === sourceFile) continue;
+    if (isSymbolImported(symbolName, content)) {
+      return true;
+    }
+  }
+
+  // Also check .tsx files as importers
+  for (const content of tsxContents.values()) {
+    if (isSymbolImported(symbolName, content)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/** Whether `symbolName` is imported by any test file in `testContents`. */
+export const isUsedInTests = (
+  symbolName: string,
+  testContents: Map<string, string>,
+): boolean => {
+  for (const content of testContents.values()) {
+    if (isSymbolImported(symbolName, content)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** Whether `content` is primarily a re-export (aggregation) module. */
+export const isPrimarilyReExportModule = (content: string): boolean => {
+  if (!RE_EXPORT_PATTERN.test(content)) return false;
+
+  const lines = content.split("\n");
+  const exportLines = lines.filter((l) => l.startsWith("export"));
+  const reExportLines = lines.filter((l) =>
+    /^export\s+\{[^}]+\}\s+from\s+['"]/.test(l),
+  );
+  return reExportLines.length > exportLines.length / 2;
+};
+
+/**
+ * Test-only-export violations for one source file: exports that are imported by
+ * tests but never used in production. `allowedHooks` is the `file:exportName`
+ * allow-list of intentional test hooks.
+ */
+export const findTestOnlyExportViolations = (
+  sourceFile: string,
+  relativePath: string,
+  srcContents: Map<string, string>,
+  tsxContents: Map<string, string>,
+  testContents: Map<string, string>,
+  allowedHooks: string[],
+): string[] => {
+  const violations: string[] = [];
+
+  const content = srcContents.get(sourceFile)!;
+  if (isPrimarilyReExportModule(content)) return violations;
+
+  const exports = extractExports(content);
+
+  for (const exportName of exports) {
+    const hookKey = `${relativePath}:${exportName}`;
+    if (allowedHooks.includes(hookKey)) continue;
+
+    const usedInProduction = isUsedInProductionCode(
+      exportName,
+      sourceFile,
+      srcContents,
+      tsxContents,
+    );
+
+    if (!usedInProduction && isUsedInTests(exportName, testContents)) {
+      violations.push(
+        `${relativePath}: "${exportName}" is exported but only used in tests`,
+      );
+    }
+  }
+
+  return violations;
+};
+
+/* -------------------------------------------------------------------------- *
+ * Lightweight call-site scanner (used by the redundant-constant-argument      *
+ * check). A small hand-written lexer rather than a full AST parser, matching  *
+ * the regex-driven style of the rest of this file. It skips comments and      *
+ * string/template literals so callee names and argument text are never        *
+ * matched inside them. The tokenizer helpers (skipString/skipComment/         *
+ * parseArgList) are exported so their index/argument contracts can be unit-   *
+ * tested directly — `extractCallSites` alone hides their internal edge cases. *
+ * -------------------------------------------------------------------------- */
+
+/** A single call expression discovered in a source file. */
+export type CallSite = { name: string; args: string[]; line: number };
+
+/** Keywords that are followed by `(` but are not function calls. */
+const NON_CALL_KEYWORDS = new Set([
+  "if",
+  "for",
+  "while",
+  "switch",
+  "catch",
+  "with",
+  "return",
+  "await",
+  "typeof",
+  "delete",
+  "void",
+  "new",
+  "do",
+  "yield",
+  "super",
+  "constructor",
+]);
+
+// These receive a single character the caller has already confirmed is in
+// range (every call site is guarded by `< content.length`), so they take a
+// definite `string` — no `undefined` guard, which would be a dead branch here.
+const isIdentChar = (c: string): boolean => /[\w$]/.test(c);
+const isIdentStart = (c: string): boolean => /[A-Za-z_$]/.test(c);
+const isWhitespace = (c: string): boolean => /\s/.test(c);
+
+/**
+ * Skip a string or template literal starting at the opening quote `start`.
+ * Returns the index immediately after the closing quote. Template `${...}`
+ * substitutions are skipped wholesale (including nested strings) so a `)` or
+ * `,` inside them never leaks into argument parsing.
+ */
+export const skipString = (content: string, start: number): number => {
+  const quote = content[start];
+  let j = start + 1;
+  while (j < content.length) {
+    const c = content[j];
+    if (c === "\\") {
+      j += 2;
+      continue;
+    }
+    if (c === quote) return j + 1;
+    if (quote === "`" && c === "$" && content[j + 1] === "{") {
+      let depth = 1;
+      j += 2;
+      while (j < content.length && depth > 0) {
+        const d = content[j];
+        if (d === "{") depth++;
+        else if (d === "}") depth--;
+        else if (d === '"' || d === "'" || d === "`") {
+          j = skipString(content, j);
+          continue;
+        }
+        j++;
+      }
+      continue;
+    }
+    j++;
+  }
+  return j;
+};
+
+/** If `i` points at the start of a comment, return the index past it, else i. */
+export const skipComment = (content: string, i: number): number => {
+  if (content[i] === "/" && content[i + 1] === "/") {
+    let j = i;
+    while (j < content.length && content[j] !== "\n") j++;
+    return j;
+  }
+  if (content[i] === "/" && content[i + 1] === "*") {
+    let j = i + 2;
+    while (
+      j < content.length &&
+      !(content[j] === "*" && content[j + 1] === "/")
+    )
+      j++;
+    return j + 2;
+  }
+  return i;
+};
+
+/**
+ * Parse a comma-separated argument list whose opening `(` is at `open`.
+ * Returns the trimmed top-level arguments and the index of the closing `)`.
+ * Nested brackets, strings and comments are skipped so only top-level commas
+ * split arguments.
+ */
+export const parseArgList = (
+  content: string,
+  open: number,
+): { args: string[]; end: number } => {
+  const args: string[] = [];
+  let depth = 1;
+  let cur = open + 1;
+  let p = open + 1;
+  while (p < content.length && depth > 0) {
+    const skipped = skipComment(content, p);
+    if (skipped !== p) {
+      p = skipped;
+      continue;
+    }
+    const d = content[p];
+    if (d === '"' || d === "'" || d === "`") {
+      p = skipString(content, p);
+      continue;
+    }
+    if (d === "(" || d === "[" || d === "{") depth++;
+    else if (d === ")" || d === "]" || d === "}") {
+      depth--;
+      if (depth === 0) {
+        args.push(content.slice(cur, p).trim());
+        break;
+      }
+    } else if (d === "," && depth === 1) {
+      args.push(content.slice(cur, p).trim());
+      cur = p + 1;
+    }
+    p++;
+  }
+  return { args: args.filter((a) => a.length > 0), end: p };
+};
+
+/** A call site keyed by character offset, before line numbers are resolved. */
+type RawCall = { name: string; args: string[]; offset: number };
+
+/**
+ * Try to read an identifier-followed-by-`(` call starting at `i`.
+ * Returns the parsed call (if any) and the index to continue scanning from.
+ */
+const readCallAt = (
+  content: string,
+  i: number,
+  prevWord: string,
+): { call: RawCall | null; word: string; next: number } => {
+  let j = i;
+  while (j < content.length && isIdentChar(content[j]!)) j++;
+  const word = content.slice(i, j);
+  let k = j;
+  while (k < content.length && isWhitespace(content[k]!)) k++;
+  const isCall =
+    content[k] === "(" &&
+    !NON_CALL_KEYWORDS.has(word) &&
+    prevWord !== "function";
+  const call = isCall
+    ? { args: parseArgList(content, k).args, name: word, offset: i }
+    : null;
+  return { call, next: j, word };
+};
+
+/** Resolve byte offsets (in ascending order) to 1-based line numbers. */
+const resolveLines = (content: string, calls: RawCall[]): CallSite[] => {
+  let line = 1;
+  let idx = 0;
+  return calls.map((call) => {
+    for (; idx < call.offset; idx++) if (content[idx] === "\n") line++;
+    return { args: call.args, line, name: call.name };
+  });
+};
+
+/** Extract every `name(...)` call site from a source file. */
+export const extractCallSites = (content: string): CallSite[] => {
+  const calls: RawCall[] = [];
+  let prevWord = "";
+  let i = 0;
+  while (i < content.length) {
+    const c = content[i]!;
+    const pastComment = skipComment(content, i);
+    if (pastComment !== i) {
+      i = pastComment;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      i = skipString(content, i);
+      prevWord = "";
+      continue;
+    }
+    if (isIdentStart(c)) {
+      const { call, word, next } = readCallAt(content, i, prevWord);
+      if (call) calls.push(call);
+      prevWord = word;
+      i = next;
+      continue;
+    }
+    if (!isWhitespace(c)) prevWord = "";
+    i++;
+  }
+  return resolveLines(content, calls);
+};
+
+/* -------------------------------------------------------------------------- *
+ * No redundant constant arguments                                            *
+ * -------------------------------------------------------------------------- */
+
+/** Minimum number of call sites before a constant argument is suspicious. */
+export const MIN_CALL_SITES = 3;
+
+/**
+ * Built-in string/array/number methods whose constant literal arguments are
+ * idiomatic, not redundant (e.g. `padStart(2, "0")`, `toFixed(2)`). These
+ * share names with no application function, so ignoring them is safe.
+ */
+export const IGNORED_CALLEES = new Set([
+  "padStart",
+  "padEnd",
+  "toFixed",
+  "toString",
+  "repeat",
+  "indexOf",
+  "lastIndexOf",
+  "charAt",
+  "codePointAt",
+  "localeCompare",
+]);
+
+/**
+ * Intentional constant arguments that should not be flagged.
+ * Format: "calleeName#position" with a justifying comment.
+ */
+export const ALLOWED_CONSTANT_ARGS = [
+  // Built-in parseInt/Number.parseInt should always pass an explicit radix.
+  "parseInt#1",
+];
+
+/** True for arguments that are constant literals (not variables/expressions). */
+export const isConstantLiteral = (arg: string): boolean => {
+  if (/^["'`]/.test(arg)) return true;
+  if (/^-?\d/.test(arg)) return true;
+  return (
+    arg === "true" || arg === "false" || arg === "null" || arg === "undefined"
+  );
+};
+
+/** A call site enriched with the file it was found in (for reporting). */
+export type Site = { args: string[]; file: string; line: number };
+
+/** Describe a single redundant-argument violation for a callee, or `null`. */
+export const findRedundantArg = (
+  name: string,
+  sites: Site[],
+): string | null => {
+  if (IGNORED_CALLEES.has(name)) return null;
+  if (sites.length < MIN_CALL_SITES) return null;
+  // Only positions present in *every* call site count as "always passed".
+  const sharedArity = Math.min(...sites.map((s) => s.args.length));
+  for (let pos = 0; pos < sharedArity; pos++) {
+    if (ALLOWED_CONSTANT_ARGS.includes(`${name}#${pos}`)) continue;
+    // `pos < sharedArity` guarantees every site has an argument here.
+    const values = sites.map((s) => s.args[pos] as string);
+    if (!values.every(isConstantLiteral)) continue;
+    const first = values[0] as string;
+    if (!values.every((v) => v === first)) continue;
+    const where = sites
+      .map((s) => `${s.file}:${s.line}`)
+      .slice(0, 4)
+      .join(", ");
+    const more = sites.length > 4 ? ", ..." : "";
+    return `${name}() arg #${pos} is always ${first} across ${sites.length} calls (${where}${more}) — use a default parameter or constant`;
+  }
+  return null;
+};


### PR DESCRIPTION
## What & why

Running `deno task mutation` against the **code quality** suite (`test/lib/code-quality.test.ts`) revealed it scored only **35.8%** — 138 of 215 mutants survived.

The root cause was uniform: every check scanned the live, already-clean tree and asserted `expect(violations).toEqual([])`. With no positive fixtures, the suite couldn't tell a working detector from a broken one. Two survivor families proved it:

- **Phantom-green** — deleting the `expect(...)` assertion, a `violations.push(...)`, or a `scan(...)` call all left the list empty and the test green.
- **Broken detector internals** — operator flips throughout the hand-written lexer (`skipString`/`skipComment`/`parseArgList`) and the export/redundant-arg logic survived, because the lexer is only ever run over a tree with no violations either way.

## Changes

- **Extracted the pure detection logic** into `test/lib/code-quality/detectors.ts`, behind explicit inputs (policy allow-lists are injected by the caller), so every branch is reachable.
- **Added `test/lib/code-quality/detectors.test.ts`** — positive + negative fixtures that feed each detector known-bad input and assert the exact violation, and known-good input and assert silence.
- The tokenizer helpers (`skipString`/`skipComment`/`parseArgList`) are exported and unit-tested directly with exact index/argument assertions — `extractCallSites` alone is too forgiving to expose their edge cases. This mirrors the existing "internal parser exposed for unit testing only" pattern already in the repo.
- **`test/lib/code-quality.test.ts` stays as the real-tree guard**, now importing the shared detectors and holding only the policy allow-lists.
- Removed two coverage traps introduced by moving code out of a test file (an always-true `if (captured)` and the dead `!!c` guards in the lexer predicates).
- Scoped a biome override disabling `noTemplateCurlyInString` for the fixtures, which legitimately embed `${...}` as lexer **source text**.

## Result

- `detectors.ts`: **100% line + branch coverage** and a **100% mutation score (155/155 mutants killed)**.
- Behaviour of the real-tree scan is unchanged (same regexes/logic, just relocated).
- `deno task precommit` passes in full: lint, typecheck, cpd (0%), build:edge, and the whole suite at 100% coverage.

```
deno task mutation test/lib/code-quality/detectors.ts test/lib/code-quality/detectors.test.ts
  mutants: 155  killed: 155  survived: 0  score: 100.0%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiTon9jkJJNCDupFoYuPsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiTon9jkJJNCDupFoYuPsu)_