### PR TITLE
Cross-fade between page loads with cross-document view transitions

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -77,6 +77,16 @@ html[data-theme="dark"] {
   color-scheme: dark;
 }
 
+/* Cross-document view transitions: cross-fade between same-origin page loads so
+   moving around feels like one fluid app rather than discrete document loads.
+   Pure progressive enhancement — every page links this one stylesheet and shares
+   the single Layout, so both sides of a navigation opt in automatically; browsers
+   without support just navigate instantly as before, and external links (a
+   different origin) are left alone. Neutralised under prefers-reduced-motion below. */
+@view-transition {
+  navigation: auto;
+}
+
 /* Dark mode form enhancements */
 [data-theme="dark"] form {
   border-width: 2px;
@@ -148,6 +158,13 @@ html[data-theme="dark"] {
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+
+  /* Skip the cross-document cross-fade too: the page still swaps, just instantly. */
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
   }
 }
 


### PR DESCRIPTION
## What

Make navigating between pages feel like one fluid app rather than discrete document loads, by opting into the browser-native **cross-document View Transitions API** — a single CSS at-rule in `src/ui/static/style.scss`:

```scss
@view-transition {
  navigation: auto;
}
```

Same-origin navigations now cross-fade instead of hard-cutting.

## Why this approach

The ask was for the most minimal, progressive, ideally CSS-only way to make page loads feel snappier/more fluid — "in the least hacky way possible". This is exactly that:

- **Genuinely CSS-only** — no JS, no client-side router, no `<meta>` tag, no markup change, no new dependency. It's a native browser feature, not a library emulating one. Stays friendly to the strict, no-inline CSP this project already targets.
- **Pure progressive enhancement** — cross-document transitions only fire when *both* pages opt in. Because every page links the one `style.css` and shares the single `Layout`, that's satisfied site-wide for free. Browsers without support just navigate instantly as they do today (zero penalty), and cross-origin links are unaffected by design.
- **Fits existing conventions** — the opt-in sits next to the existing `scroll-behavior: smooth` "navigation feel" rules, and the reduced-motion guard is folded into the **existing** `@media (prefers-reduced-motion: reduce)` block rather than adding a second one. Under reduced motion the page still swaps, just instantly.

## Verification

- Confirmed the at-rule survives **both** build stages intact, with no warnings: Dart Sass (`expanded`) for the served file, and esbuild's CSS minifier for the inlined edge build. `deno task build:static` and `deno task build:edge` both pass and the rule is present in the output.
- Full `deno task precommit` is green: lint ✓ · typecheck ✓ · cpd ✓ · build:edge ✓ · test:coverage ✓.
- Only `style.scss` is touched; compiled artifacts remain gitignored. No TypeScript changed, so coverage is unaffected.

## Possible follow-up (not included)

The default transition is a whole-page cross-fade. Since the admin sidebar is near-identical between admin pages it already reads as "only the content updates". If we later want the chrome explicitly pinned while content slides, the next step would be giving the nav a `view-transition-name` — deliberately left out here to keep this pass minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtB4XCRTMyN1WPGqYstqCh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtB4XCRTMyN1WPGqYstqCh)_