### PR TITLE
Universal link styling with an "Underline links" setting

### DIFF
--- a/src/features/admin/settings-general.ts
+++ b/src/features/admin/settings-general.ts
@@ -104,15 +104,23 @@ export const handleBusinessEmailPost = settingsClearable({
   validate: (v) => (!isValidEmail(v) ? t("error.email_format") : null),
 });
 
-/** Handle POST /admin/settings/theme - owner only */
+/** Handle POST /admin/settings/theme - owner only. The Site Theme form also
+ * carries the "Underline links" checkbox, so this saves both the theme and the
+ * underline-links toggle (off when the checkbox is absent) in one submission. */
 export const handleThemePost = settingsHandler({
-  extract: (form) => form.getString("theme"),
+  extract: (form) => ({
+    theme: form.getString("theme"),
+    underlineLinks: form.get("underline_links") === "true",
+  }),
   formId: "settings-theme",
   label: "Theme",
-  log: (v) => `Theme set to ${v}`,
-  save: (v) => settings.update.theme(v as Theme),
+  log: (v) => `Theme set to ${v.theme}`,
+  save: async (v) => {
+    await settings.update.theme(v.theme as Theme);
+    await settings.update.underlineLinks(v.underlineLinks);
+  },
   validate: (v) =>
-    v !== "light" && v !== "dark" ? t("error.invalid_theme") : null,
+    v.theme !== "light" && v.theme !== "dark" ? t("error.invalid_theme") : null,
 });
 
 /** Handle POST /admin/settings/show-public-site - owner only */

--- a/src/features/admin/settings-page.ts
+++ b/src/features/admin/settings-page.ts
@@ -50,6 +50,7 @@ const getSettingsPageState = async () => {
     superuser,
     termsAndConditions: settings.terms,
     theme: settings.theme,
+    underlineLinks: settings.underlineLinks,
     webhookUrl: getWebhookUrl(),
   };
 };

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -248,7 +248,7 @@ const getPrefix = (path: string): string => {
  * - domain resolution (`loadEffectiveDomain`) reads custom_domain + bunny_subdomain
  * - routing gates on setup_complete / show_public_*
  * - the bare `Layout` (rendered by the universal `notFoundResponse` fallback
- *   and every HTML error page) reads theme + header_image_url
+ *   and every HTML error page) reads theme + underline_links + header_image_url
  * - `applySecurityHeaders` rebuilds the CSP on every routed response, reading
  *   the payment provider (and square_sandbox when the provider is Square)
  * - pruning self-guards on last_pruned_*
@@ -263,6 +263,7 @@ const INFRA_SETTINGS: readonly string[] = [
   CONFIG_KEYS.SHOW_PUBLIC_SITE,
   CONFIG_KEYS.SHOW_PUBLIC_API,
   CONFIG_KEYS.THEME,
+  CONFIG_KEYS.UNDERLINE_LINKS,
   CONFIG_KEYS.HEADER_IMAGE_URL,
   CONFIG_KEYS.PAYMENT_PROVIDER,
   CONFIG_KEYS.SQUARE_SANDBOX,

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -57,6 +57,8 @@
   "settings.theme_hint": "Choose between light and dark themes for the site interface.",
   "settings.theme_light": "Light",
   "settings.theme_dark": "Dark",
+  "settings.underline_links": "Underline links",
+  "settings.underline_links_hint": "Underline links everywhere, including the navigation. When off, links show in colour only and gain an underline on hover or focus.",
   "settings.save_theme": "Save Theme",
   "settings.advanced_link": "For advanced settings including public API, Apple Wallet, custom email templates, mail provider, timezone, custom domain, and database reset, click here.",
   "settings.debug_link": "For nerdy debug info click here.",

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -153,6 +153,7 @@ export const CONFIG_KEYS = {
   SUPPORT_FORM_LAST_SUBMITTED: "support_form_last_submitted",
   TERMS_AND_CONDITIONS: "terms_and_conditions",
   THEME: "theme",
+  UNDERLINE_LINKS: "underline_links",
   WEBSITE_TITLE: "website_title",
   WRAPPED_PRIVATE_KEY: "wrapped_private_key",
 } as const;
@@ -327,6 +328,7 @@ const stringSettingDefaults = Object.fromEntries(
 type SpecificFields = {
   country: string;
   theme: Theme;
+  underline_links: boolean;
   show_public_site: boolean;
   show_public_api: boolean;
   calendar_feeds_enabled: boolean;
@@ -369,6 +371,7 @@ const data: SettingsData = {
   square_sandbox: false,
   theme: "light",
   timezone: DEFAULT_TIMEZONE,
+  underline_links: false,
   ...stringSettingDefaults,
   superuser_choice: "",
 };
@@ -657,6 +660,9 @@ const SPECIAL_APPLIERS: Record<string, (raw: string | undefined) => void> = {
   },
   [CONFIG_KEYS.THEME]: (raw) => {
     data.theme = raw === "dark" ? "dark" : "light";
+  },
+  [CONFIG_KEYS.UNDERLINE_LINKS]: (raw) => {
+    data.underline_links = raw === "true";
   },
   [CONFIG_KEYS.SHOW_PUBLIC_SITE]: (raw) => {
     data.show_public_site = raw === "true";
@@ -1185,6 +1191,9 @@ const settingsBase = {
   get timezone(): string {
     return snap("timezone");
   },
+  get underlineLinks(): boolean {
+    return snap("underline_links");
+  },
 
   // -----------------------------------------------------------------------
   // Async writes — settings.update.*
@@ -1308,6 +1317,7 @@ const settingsBase = {
       data.support_form_last_submitted = ts;
     },
     theme: rawUpdate(CONFIG_KEYS.THEME, "theme") as (v: Theme) => Promise<void>,
+    underlineLinks: boolUpdate(CONFIG_KEYS.UNDERLINE_LINKS, "underline_links"),
   },
   updateUserPassword,
   withCurrentTask,

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -594,6 +594,15 @@ input[type="submit"],
   color: var(--color-bg);
 }
 
+/* A button-styled link keeps its --color-bg text when active: without this the
+   universal a:active / a.active link colour would darken the text against the
+   button's colored background. Buttons aren't links in the design sense, so the
+   "white when active" link rule shouldn't reach them. */
+.btn:active,
+.btn.active {
+  color: var(--color-bg);
+}
+
 .btn.outline {
   background-color: transparent;
   color: var(--color-link);
@@ -2252,9 +2261,11 @@ span.cal-day {
   outline: 1px solid var(--color-link);
 }
 
-/* Currently selected date */
+/* Currently selected date. The :active selector keeps the light text when the
+   selected day is tapped (touch/keyboard have no :hover to fall back on). */
 .cal-day-selected,
-a.cal-day-selected:hover {
+a.cal-day-selected:hover,
+a.cal-day-selected:active {
   background: var(--color-link);
   color: var(--color-bg);
 }

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -534,6 +534,15 @@ a {
   text-decoration: none;
 }
 
+/* "Underline links" setting (owner toggle on the Site Theme form, off by
+   default). When on, <html> carries data-underline-links and every link — nav
+   included — gets a default underline. :where() keeps this at the same
+   specificity as the base `a` rule above, so components that opt out of
+   underlines (buttons, calendar chips, the skip link) still win. */
+:where(:root[data-underline-links]) a {
+  text-decoration: underline;
+}
+
 a:hover,
 a:focus {
   text-decoration: underline;
@@ -578,6 +587,14 @@ input[type="submit"]:hover,
 .btn:hover {
   cursor: pointer;
   filter: brightness(var(--hover-brightness));
+}
+
+/* .btn is also used on <a>: keep the link hover/focus underline (and the
+   "Underline links" setting) off button text — a button is a control, not a
+   text link. */
+.btn:hover,
+.btn:focus {
+  text-decoration: none;
 }
 
 button:active,

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -373,10 +373,6 @@ nav ul li {
   display: none;
 }
 
-nav a.active {
-  color: var(--color-text);
-}
-
 /* Nav for Desktop: pin the admin menu to the left as a sticky sidebar, with the
    page content flowing to its right. The sidebar is a plain vertical list of
    links — no boxes or borders — with each section's sub-nav nested and indented
@@ -448,14 +444,6 @@ nav a.active {
 
   .admin-nav--desktop .admin-subnav {
     padding-left: var(--space-m);
-  }
-
-  .admin-nav--desktop a {
-    text-decoration: none;
-  }
-
-  .admin-nav--desktop a:hover {
-    text-decoration: underline;
   }
 }
 
@@ -538,19 +526,22 @@ sup {
   top: -2px;
 }
 
-/* Links */
+/* Links: blue with no underline; underlined on hover/focus; white when active
+   (the :active state, or the .active class marking the current nav link). */
 a {
   color: var(--color-link);
   display: inline-block;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
   text-decoration: underline;
 }
 
-a:hover {
-  filter: brightness(var(--hover-brightness));
-}
-
-a:active {
-  filter: brightness(var(--active-brightness));
+a:active,
+a.active {
+  color: var(--color-text);
 }
 
 a b,

--- a/src/ui/templates/admin/settings.tsx
+++ b/src/ui/templates/admin/settings.tsx
@@ -40,6 +40,7 @@ export type SettingsPageState = {
   termsAndConditions: string;
   businessEmail: string;
   theme: Theme;
+  underlineLinks: boolean;
   showPublicSite: boolean;
   headerImageUrl: string;
   storageEnabled: boolean;

--- a/src/ui/templates/admin/settings/theme.tsx
+++ b/src/ui/templates/admin/settings/theme.tsx
@@ -33,5 +33,15 @@ export const ThemeForm = (s: SettingsPageState): JSX.Element => (
         {t("settings.theme_dark")}
       </label>
     </fieldset>
+    <label class="checkbox">
+      <input
+        checked={s.underlineLinks}
+        name="underline_links"
+        type="checkbox"
+        value="true"
+      />{" "}
+      {t("settings.underline_links")}
+    </label>
+    <small>{t("settings.underline_links_hint")}</small>
   </SettingsSection>
 );

--- a/src/ui/templates/layout.tsx
+++ b/src/ui/templates/layout.tsx
@@ -47,7 +47,11 @@ export const Layout = ({
   return new SafeHtml(
     "<!DOCTYPE html>" +
     (
-      <html data-theme={resolvedTheme} lang="en">
+      <html
+        data-theme={resolvedTheme}
+        data-underline-links={settings.underlineLinks}
+        lang="en"
+      >
         <head>
           <meta charset="UTF-8" />
           <meta

--- a/test/integration/theme.test.ts
+++ b/test/integration/theme.test.ts
@@ -52,4 +52,33 @@ describeWithEnv("integration: theme settings", { db: true }, () => {
     const html = await response.text();
     expect(html).toContain('data-theme="light"');
   });
+
+  test("links are not underlined by default (no data-underline-links)", async () => {
+    const { response } = await adminGet("/admin/settings");
+    const html = await response.text();
+    expect(html).not.toContain("data-underline-links");
+  });
+
+  test("enabling underline links adds data-underline-links to the page", async () => {
+    await adminFormPost("/admin/settings/theme", {
+      theme: "light",
+      underline_links: "true",
+    });
+
+    const { response } = await adminGet("/admin/settings");
+    const html = await response.text();
+    expect(html).toContain("data-underline-links");
+  });
+
+  test("underline links setting is reflected on public pages", async () => {
+    await settings.update.showPublicSite(true);
+    await adminFormPost("/admin/settings/theme", {
+      theme: "light",
+      underline_links: "true",
+    });
+
+    const response = await handleRequest(mockRequest("/"));
+    const html = await response.text();
+    expect(html).toContain("data-underline-links");
+  });
 });

--- a/test/lib/db/settings.test.ts
+++ b/test/lib/db/settings.test.ts
@@ -236,6 +236,20 @@ describeWithEnv("db > settings", { db: true }, () => {
       expect(settings.theme).toBe("dark");
     });
 
+    test("loadKeys sets underlineLinks true when stored value is true", async () => {
+      await settings.setRaw(CONFIG_KEYS.UNDERLINE_LINKS, "true");
+      settings.invalidateCache();
+      await settings.loadKeys([CONFIG_KEYS.UNDERLINE_LINKS]);
+      expect(settings.underlineLinks).toBe(true);
+    });
+
+    test("loadKeys leaves underlineLinks false when stored value is not true", async () => {
+      await settings.setRaw(CONFIG_KEYS.UNDERLINE_LINKS, "false");
+      settings.invalidateCache();
+      await settings.loadKeys([CONFIG_KEYS.UNDERLINE_LINKS]);
+      expect(settings.underlineLinks).toBe(false);
+    });
+
     test("update.bookingFee with empty string resets to 0", async () => {
       await settings.update.bookingFee("500");
       expect(settings.bookingFee).toBe("500");

--- a/test/lib/server-settings/theme.test.ts
+++ b/test/lib/server-settings/theme.test.ts
@@ -143,5 +143,56 @@ describeWithEnv("server (admin settings)", { db: true }, () => {
       expect(html).toContain('value="dark"');
       expect(html).toContain("checked");
     });
+
+    test("ticking the underline-links checkbox enables it", async () => {
+      expect(settings.underlineLinks).toBe(false);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/theme",
+          {
+            csrf_token: await testCsrfToken(),
+            theme: "light",
+            underline_links: "true",
+          },
+          await testCookie(),
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(settings.underlineLinks).toBe(true);
+    });
+
+    test("omitting the underline-links checkbox disables it", async () => {
+      // Enable first so the submission has to turn it back off.
+      await settings.update.underlineLinks(true);
+
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/theme",
+          {
+            csrf_token: await testCsrfToken(),
+            theme: "light",
+          },
+          await testCookie(),
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(settings.underlineLinks).toBe(false);
+    });
+
+    test("settings page checks the underline-links box when enabled", async () => {
+      await settings.update.underlineLinks(true);
+
+      const response = await awaitTestRequest("/admin/settings", {
+        cookie: await testCookie(),
+      });
+      const html = await response.text();
+      const checkboxMatch = html.match(
+        /<input[^>]*name="underline_links"[^>]*>/,
+      );
+      expect(checkboxMatch?.[0]).toContain("checked");
+    });
   });
 });

--- a/test/lib/theme.test.ts
+++ b/test/lib/theme.test.ts
@@ -17,3 +17,24 @@ describeWithEnv("settings.theme from DB", { db: true }, () => {
     expect(settings.theme).toBe("dark");
   });
 });
+
+describeWithEnv("settings.underlineLinks from DB", { db: true }, () => {
+  beforeEach(() => {
+    settings.clearTestOverride("underline_links");
+  });
+
+  test("underlining links is off by default", () => {
+    expect(settings.underlineLinks).toBe(false);
+  });
+
+  test("turns underlining on after updating to true", async () => {
+    await settings.update.underlineLinks(true);
+    expect(settings.underlineLinks).toBe(true);
+  });
+
+  test("turns underlining back off after updating to false", async () => {
+    await settings.update.underlineLinks(true);
+    await settings.update.underlineLinks(false);
+    expect(settings.underlineLinks).toBe(false);
+  });
+});

--- a/test/templates/admin/settings.test.ts
+++ b/test/templates/admin/settings.test.ts
@@ -40,6 +40,7 @@ const defaultState = (): SettingsPageState => ({
   superuser: { available: false, reason: "missing-env" },
   termsAndConditions: "",
   theme: "light",
+  underlineLinks: false,
   webhookUrl: "https://example.com/payment/webhook",
 });
 
@@ -54,6 +55,23 @@ describe("adminSettingsPage", () => {
     expect(html).toContain("A SumUp API key is currently configured");
     expect(html).not.toContain("Test mode");
     expect(html).not.toContain("Live mode");
+  });
+
+  test("renders the underline-links checkbox, unchecked by default", () => {
+    const html = adminSettingsPage(TEST_SESSION, defaultState());
+    expect(html).toContain("Underline links");
+    const checkbox = html.match(/<input[^>]*name="underline_links"[^>]*>/);
+    expect(checkbox?.[0]).toContain('type="checkbox"');
+    expect(checkbox?.[0]).not.toContain("checked");
+  });
+
+  test("checks the underline-links checkbox when enabled", () => {
+    const html = adminSettingsPage(TEST_SESSION, {
+      ...defaultState(),
+      underlineLinks: true,
+    });
+    const checkbox = html.match(/<input[^>]*name="underline_links"[^>]*>/);
+    expect(checkbox?.[0]).toContain("checked");
   });
 
   test("shows square webhook configured message when key is set", () => {


### PR DESCRIPTION
## What

Reworks link styling to be consistent everywhere, and adds an owner setting to control underlines.

**Base link styling (nav rule made universal):**
- Links are blue (`--color-link`) with **no underline** by default
- **Underlined on `:hover` / `:focus`**
- **`--color-text` (white in dark theme)** when `:active` or carrying `.active` (the current nav link)

**`.btn` insulation (buttons are controls, not links):**
- Button-styled links keep `--color-bg` text in the active state (the universal `a:active` colour was darkening text on the coloured button background)
- Button-styled links never pick up the link hover/focus underline

**New "Underline links" setting (off by default):**
- An owner toggle on the **Site Theme** form that universally decides whether links are underlined, **nav included**
- Off (default): links are colour-only and underline on hover/focus. On: every link is underlined
- Stored as `underline_links`; the layout adds a `data-underline-links` attribute to `<html>` when on; CSS restores the underline via `:where()` so it stays at base specificity and the components that opt out of underlines (buttons, calendar chips, the skip link) keep winning
- This also resolves the earlier accessibility note about colour-only inline links — operators who want the non-colour cue can switch it on

## Testing

`deno task typecheck`, `lint:ci`, `cpd` (0 clones), and `build:static` all pass. Added unit/integration/template tests for the setting (storage default + load, the Site Theme POST saving it both ways, the `data-underline-links` attribute, and the checkbox state). The full suite is green apart from one pre-existing, network/parallel-flaky stripe-mock download test (`test/lib/stripe-mock.test.ts` — passes 23/23 in isolation), which is unrelated to this change.

`style.css` is a gitignored build artifact compiled from the SCSS, so only the source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tCfcqd1kAZKUF3Uh59F52