### PR TITLE
Retry migration verify() on read-your-writes schema lag

### DIFF
--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -17,7 +17,7 @@ import { ensureDefaultAttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import { getDb } from "#shared/db/client.ts";
 import { getEnv } from "#shared/env.ts";
 import { logDebug } from "#shared/logger.ts";
-import { nowIso } from "#shared/now.ts";
+import { delay, nowIso } from "#shared/now.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
 import { recordScriptVersion } from "#shared/update.ts";
 import currentSchemaMigration from "./migrations/2026-06-11_current_schema.ts";
@@ -330,11 +330,53 @@ const pendingMigrations = async (): Promise<Migration[]> => {
   return MIGRATIONS.filter((migration) => !applied.has(migration.id));
 };
 
+/**
+ * Backoff (ms) before each re-attempt of a migration's verify(). Its length is
+ * the number of retries, so four verify attempts in total.
+ *
+ * A migration applies DDL in up() and then verify() reads the live schema back
+ * to confirm it landed. The snapshot is already pinned to the primary
+ * (queryBatchPrimary, "write" mode) to dodge replica lag, but a freshly-opened
+ * primary connection can still briefly observe the pre-DDL schema —
+ * read-your-writes propagation lag — so a column the ALTER just added reads as
+ * missing and verify() throws spuriously. (Observed in production: a column-add
+ * migration failed verification on one request and passed on the retry moments
+ * later.) verify() re-snapshots on every call, so retrying after a short backoff
+ * lets the schema settle within the same request rather than 503-ing it. A
+ * genuine schema defect stays missing across every attempt and still throws, so
+ * this never masks a real bug.
+ */
+export const VERIFY_RETRY_BACKOFF_MS = [50, 150, 350] as const;
+
+/**
+ * Run a migration's verify(), retrying a transient failure (read-your-writes
+ * lag on the just-applied DDL) on a fresh schema snapshot before giving up.
+ */
+export const verifyMigrationWithRetry = async (
+  migration: Migration,
+): Promise<void> => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await migration.verify();
+      return;
+    } catch (error) {
+      if (attempt >= VERIFY_RETRY_BACKOFF_MS.length) throw error;
+      logDebug(
+        "Migration",
+        `verify ${migration.id} failed on attempt ${
+          attempt + 1
+        }, retrying: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      await delay(VERIFY_RETRY_BACKOFF_MS[attempt]!);
+    }
+  }
+};
+
 const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
   for (const migration of pending) {
     logDebug("Migration", `Running ${migration.id}: ${migration.description}`);
     await migration.up();
-    await migration.verify();
+    await verifyMigrationWithRetry(migration);
     await markMigrationApplied(migration);
   }
 };

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -6,9 +6,12 @@ import {
   initDb,
   invalidateInitDbCache,
   MIGRATION_LOCK_TTL_MS,
+  type Migration,
   MigrationInProgressError,
   resetDatabase,
   SCHEMA_HASH,
+  VERIFY_RETRY_BACKOFF_MS,
+  verifyMigrationWithRetry,
 } from "#shared/db/migrations.ts";
 import { createSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -176,6 +179,45 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
           sql: "UPDATE settings SET value = ? WHERE key = 'db_schema_hash'",
         });
       }
+    });
+  });
+
+  describe("verify retry on read-your-writes lag", () => {
+    const fakeMigration = (verify: () => Promise<void>): Migration => ({
+      description: "fake migration for verify-retry tests",
+      id: "fake-verify-retry",
+      up: () => Promise.resolve(),
+      verify,
+    });
+
+    test("retries a transient verify failure and then resolves", async () => {
+      let attempts = 0;
+      await verifyMigrationWithRetry(
+        fakeMigration(() => {
+          attempts++;
+          // Fail on the first two snapshots (stale schema), succeed on the third.
+          return attempts < 3
+            ? Promise.reject(
+                new Error("Migration verification failed: missing column(s)"),
+              )
+            : Promise.resolve();
+        }),
+      );
+      expect(attempts).toBe(3);
+    });
+
+    test("rethrows after exhausting every retry", async () => {
+      let attempts = 0;
+      await expect(
+        verifyMigrationWithRetry(
+          fakeMigration(() => {
+            attempts++;
+            return Promise.reject(new Error("genuine schema defect"));
+          }),
+        ),
+      ).rejects.toThrow("genuine schema defect");
+      // One initial attempt plus one per backoff entry.
+      expect(attempts).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
     });
   });
 


### PR DESCRIPTION
## Problem

A site failed to boot with a 503 during a migration run:

```
[dc0d] [Migration] Running 2026-06-22_listing_attendee_ledger_event_group: Add a ledger_event_group column …
[dc0d] [Error] E_CDN_REQUEST detail="GET /: Migration verification failed: listing_attendees missing column(s): ledger_event_group"
[dc0d] [Request] GET / 503 561ms
…
[5d06] [Migration] Running 2026-06-22_listing_attendee_ledger_event_group: …   ← re-ran moments later and PASSED
```

The migration's `up()` issues `ALTER TABLE listing_attendees ADD COLUMN ledger_event_group`, then `verify()` reads the live schema back to confirm it landed. That snapshot is already pinned to the primary (`queryBatchPrimary`, `"write"` mode) to dodge replica lag — but on libsql/Turso a **freshly-opened primary connection can still briefly observe the pre-DDL schema** (read-your-writes propagation lag). So the just-added column reads as missing, `verify()` throws, and the request 503s — even though the migration actually succeeded. The next request re-ran the same (unrecorded) migration once the schema had settled, which is exactly the fail-then-pass pattern in the log.

## Fix

`runPendingMigrations` now calls a new `verifyMigrationWithRetry`, which re-runs `verify()` (re-snapshotting on each call) with short backoffs `[50, 150, 350]ms` before giving up. The transient lag is absorbed **within the same request** instead of surfacing as a user-visible 503 + an implicit retry on the next request.

Verification is a side-effect-free read, so retrying is safe. A genuine schema defect stays missing across all four attempts and still throws, so this never masks a real bug.

## Tests

Added direct unit tests for `verifyMigrationWithRetry` covering both branches: a transient failure that resolves on a later snapshot, and a permanent failure that rethrows after exhausting every retry.

Full `deno task precommit` is green (typecheck, lint, jscpd 0%, edge build, 100% coverage / 10,425 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezdmsysYVywQniU4czkbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KezdmsysYVywQniU4czkbC)_