### PR TITLE
Log completed SQL statements to system logs

### DIFF
--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -22,6 +22,7 @@ import {
 import {
   addQueryLogEntry,
   isQueryLogEnabled,
+  logCompletedSql,
   trackQuery,
 } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
@@ -300,7 +301,10 @@ const trackedBatch = async (
     // so the footer's wall-clock union counts that time once (not N times).
     for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed, start);
   }
-  for (const stmt of statements) invalidateForSql(stmt.sql);
+  for (const stmt of statements) {
+    logCompletedSql(stmt.sql);
+    invalidateForSql(stmt.sql);
+  }
   return results;
 };
 

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -302,7 +302,7 @@ const trackedBatch = async (
     for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed, start);
   }
   for (const stmt of statements) {
-    logCompletedSql(stmt.sql);
+    void logCompletedSql(stmt.sql);
     invalidateForSql(stmt.sql);
   }
   return results;

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -179,6 +179,23 @@ const notifyN1Violation = async (detail: string): Promise<void> => {
 };
 
 /**
+ * Mirror the debug footer to the system logs: emit each SQL statement as it
+ * completes, with its bound values omitted. The statement is parameterised, so
+ * the string carries only `?` placeholders — never PII or secrets — exactly the
+ * value-free view the admin footer renders. Whitespace is collapsed so a
+ * multi-line statement logs on one line. Routed through `logDebug` (category
+ * "SQL") so it honours the same debug-log suppression as other debug output;
+ * the dynamic import avoids the static cycle (query-log is imported by the db
+ * client, which the logger transitively depends on), mirroring
+ * {@link notifyN1Violation}.
+ */
+export const logCompletedSql = (sql: string): void => {
+  void import("#shared/logger.ts").then(({ logDebug }) =>
+    logDebug("SQL", sql.replace(/\s+/g, " ").trim()),
+  );
+};
+
+/**
  * Count a read round-trip within a request and fire once, exactly when the
  * count crosses the threshold. Writes and queries outside a request scope (the
  * fallback state, e.g. startup migrations) are never counted.
@@ -207,13 +224,15 @@ export const trackQuery = async <T>(
   const store = asyncLocalStorage.getStore();
   if (store) enforceN1Guard(store, sql);
   const state = store ?? fallbackState;
-  if (!state.enabled) return fn();
   const start = performance.now();
   const result = await fn();
-  state.entries.push({
-    durationMs: performance.now() - start,
-    sql,
-    startedAtMs: start,
-  });
+  if (state.enabled) {
+    state.entries.push({
+      durationMs: performance.now() - start,
+      sql,
+      startedAtMs: start,
+    });
+  }
+  logCompletedSql(sql);
   return result;
 };

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -189,10 +189,9 @@ const notifyN1Violation = async (detail: string): Promise<void> => {
  * client, which the logger transitively depends on), mirroring
  * {@link notifyN1Violation}.
  */
-export const logCompletedSql = (sql: string): void => {
-  void import("#shared/logger.ts").then(({ logDebug }) =>
-    logDebug("SQL", sql.replace(/\s+/g, " ").trim()),
-  );
+export const logCompletedSql = async (sql: string): Promise<void> => {
+  const { logDebug } = await import("#shared/logger.ts");
+  logDebug("SQL", sql.replace(/\s+/g, " ").trim());
 };
 
 /**
@@ -233,6 +232,6 @@ export const trackQuery = async <T>(
       startedAtMs: start,
     });
   }
-  logCompletedSql(sql);
+  void logCompletedSql(sql);
   return result;
 };

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -373,6 +373,7 @@ export const createRequestTimer = (): (() => number) => {
  */
 export type LogCategory =
   | "Setup"
+  | "SQL"
   | "Webhook"
   | "Payment"
   | "Auth"

--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -13,9 +13,11 @@ import {
   sqlWallClockMs,
   trackQuery,
 } from "#shared/db/query-log.ts";
-// Preloaded so the guard's dynamic `import("#shared/logger.ts")` is a cache hit,
-// making the notify-mode test's flush deterministic rather than time-dependent.
-import "#shared/logger.ts";
+// Importing logger eagerly also preloads it, so the dynamic
+// `import("#shared/logger.ts")` in the N+1 guard and the SQL system-log
+// mirror is a cache hit — keeping their fire-and-forget flush deterministic
+// rather than time-dependent.
+import { setSuppressDebugLogs } from "#shared/logger.ts";
 
 describe("query-log", () => {
   describe("enableQueryLog", () => {
@@ -178,6 +180,47 @@ describe("query-log", () => {
         expect(logged!.startedAtMs).toBeLessThanOrEqual(after);
         expect(logged!.durationMs).toBeGreaterThanOrEqual(0);
       });
+    });
+  });
+
+  describe("system-log mirroring", () => {
+    // A completed query is mirrored to the system logs via console.debug; let the
+    // fire-and-forget dynamic import + logDebug settle before asserting.
+    const captureSqlLogs = async (
+      run: () => Promise<void>,
+    ): Promise<string[]> => {
+      setSuppressDebugLogs(false);
+      const debugSpy = stub(console, "debug");
+      try {
+        await run();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return debugSpy.calls.map((call) => call.args.join(" "));
+      } finally {
+        debugSpy.restore();
+        setSuppressDebugLogs(null);
+      }
+    };
+
+    test("mirrors a completed statement, omitting bound values", async () => {
+      const logs = await captureSqlLogs(() =>
+        trackQuery("SELECT name FROM users WHERE id = ?", () =>
+          Promise.resolve("ok"),
+        ),
+      );
+      expect(
+        logs.some((line) =>
+          line.includes("[SQL] SELECT name FROM users WHERE id = ?"),
+        ),
+      ).toBe(true);
+    });
+
+    test("collapses whitespace so a multi-line statement logs on one line", async () => {
+      const logs = await captureSqlLogs(() =>
+        trackQuery("SELECT\n  id\nFROM   users", () => Promise.resolve("ok")),
+      );
+      expect(
+        logs.some((line) => line.includes("[SQL] SELECT id FROM users")),
+      ).toBe(true);
     });
   });
 

--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -187,7 +187,7 @@ describe("query-log", () => {
     // A completed query is mirrored to the system logs via console.debug; let the
     // fire-and-forget dynamic import + logDebug settle before asserting.
     const captureSqlLogs = async (
-      run: () => Promise<void>,
+      run: () => Promise<unknown>,
     ): Promise<string[]> => {
       setSuppressDebugLogs(false);
       const debugSpy = stub(console, "debug");


### PR DESCRIPTION
## What

Mirror the value-free SQL that the admin debug footer renders to the system logs, emitting each statement as it completes.

## Why

The debug footer already shows every query a request ran with values omitted. This surfaces the same information in the system logs (`console.debug`), so SQL activity is visible operationally — not just in the per-request admin footer.

## How

- Added a `logCompletedSql` helper in `query-log.ts` that routes the completed statement through `logDebug` under a new `"SQL"` log category. Because the SQL is parameterised, the string carries only `?` placeholders — never bound values, PII, or secrets — exactly the footer's value-free view.
- Wired it into the two completion chokepoints:
  - `trackQuery` — single statements and interactive-transaction statements.
  - `trackedBatch` — batch statements (logged per statement once the round-trip resolves).
- Whitespace is collapsed so a multi-line statement logs on one line.
- Routing through `logDebug` means it honours the existing debug-log suppression (`TEST_SUPPRESS_DEBUG_LOGS` / `setSuppressDebugLogs`), so the test suite stays quiet.
- A dynamic `import("#shared/logger.ts")` avoids the db-client ↔ logger import cycle, mirroring the existing `notifyN1Violation` pattern.

## Tests

Added `system-log mirroring` tests in `test/lib/query-log.test.ts` covering that a completed statement is logged with bound values omitted and that multi-line whitespace is collapsed. Lint, typecheck, and the query-log + with-transaction suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do9As9RJARUsDAq4a86SV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Do9As9RJARUsDAq4a86SV1)_