### PR TITLE
Extract shared retryWithBackoff helper

### DIFF
--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -26,7 +26,7 @@ import {
   trackQuery,
 } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
-import { delay } from "#shared/now.ts";
+import { retryWithBackoff } from "#shared/retry.ts";
 
 /**
  * Match the target table of a mutating statement (INSERT/UPDATE/DELETE/REPLACE),
@@ -150,7 +150,6 @@ export class DatabaseBusyError extends Error {
 /** Backoff before each retry of a contended database lock; its length is the
  *  number of retries, so four attempts in total. */
 const WRITE_LOCK_RETRY_BACKOFF_MS = [50, 150, 350] as const;
-const WRITE_LOCK_ATTEMPTS = WRITE_LOCK_RETRY_BACKOFF_MS.length + 1;
 
 /** SQLite has a single writer, so a contended write surfaces as SQLITE_BUSY —
  *  thrown immediately by the local driver as "database is locked" when a bare
@@ -167,17 +166,11 @@ const isDatabaseLocked = (error: unknown): boolean =>
  * loser. A lock that outlasts the retries surfaces as {@link DatabaseBusyError}
  * (the request layer's friendly busy page); every other error propagates at once.
  */
-const retryOnDatabaseLock = async <T>(run: () => Promise<T>): Promise<T> => {
-  for (let attempt = 0; attempt < WRITE_LOCK_ATTEMPTS; attempt++) {
-    if (attempt > 0) await delay(WRITE_LOCK_RETRY_BACKOFF_MS[attempt - 1]!);
-    try {
-      return await run();
-    } catch (error) {
-      if (!isDatabaseLocked(error)) throw error;
-    }
-  }
-  throw new DatabaseBusyError();
-};
+const retryOnDatabaseLock = <T>(run: () => Promise<T>): Promise<T> =>
+  retryWithBackoff(run, WRITE_LOCK_RETRY_BACKOFF_MS, (error, { willRetry }) => {
+    if (!isDatabaseLocked(error)) throw error;
+    if (!willRetry) throw new DatabaseBusyError();
+  });
 
 const executeTrackedStatement = (
   sql: string,

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -17,8 +17,9 @@ import { ensureDefaultAttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import { getDb } from "#shared/db/client.ts";
 import { getEnv } from "#shared/env.ts";
 import { logDebug } from "#shared/logger.ts";
-import { delay, nowIso } from "#shared/now.ts";
+import { nowIso } from "#shared/now.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
+import { retryWithBackoff } from "#shared/retry.ts";
 import { recordScriptVersion } from "#shared/update.ts";
 import currentSchemaMigration from "./migrations/2026-06-11_current_schema.ts";
 import sumupCheckoutsMigration from "./migrations/2026-06-12_sumup_checkouts.ts";
@@ -352,25 +353,20 @@ export const VERIFY_RETRY_BACKOFF_MS = [50, 150, 350] as const;
  * Run a migration's verify(), retrying a transient failure (read-your-writes
  * lag on the just-applied DDL) on a fresh schema snapshot before giving up.
  */
-export const verifyMigrationWithRetry = async (
-  migration: Migration,
-): Promise<void> => {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      await migration.verify();
-      return;
-    } catch (error) {
-      if (attempt >= VERIFY_RETRY_BACKOFF_MS.length) throw error;
+export const verifyMigrationWithRetry = (migration: Migration): Promise<void> =>
+  retryWithBackoff(
+    () => migration.verify(),
+    VERIFY_RETRY_BACKOFF_MS,
+    (error, { attempt, willRetry }) => {
+      if (!willRetry) return;
       logDebug(
         "Migration",
         `verify ${migration.id} failed on attempt ${
           attempt + 1
         }, retrying: ${error instanceof Error ? error.message : String(error)}`,
       );
-      await delay(VERIFY_RETRY_BACKOFF_MS[attempt]!);
-    }
-  }
-};
+    },
+  );
 
 const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
   for (const migration of pending) {

--- a/src/shared/retry.ts
+++ b/src/shared/retry.ts
@@ -1,0 +1,43 @@
+import { delay } from "#shared/now.ts";
+
+/** Passed to a {@link retryWithBackoff} error handler for each failed attempt. */
+export type RetryContext = {
+  /** Zero-based attempt index that just failed. */
+  attempt: number;
+  /** Whether another attempt follows (false once the backoffs are exhausted). */
+  willRetry: boolean;
+};
+
+/**
+ * Run `fn`, retrying after each failure with the matching delay from
+ * `backoffMs`. The array's length is the number of retries, so there are
+ * `backoffMs.length + 1` attempts in total.
+ *
+ * After every failed attempt, `onError(error, { attempt, willRetry })` runs. It
+ * may throw to abort immediately — to propagate a non-retryable error, or to
+ * swap in a friendlier one once the retries are exhausted (`willRetry` false) —
+ * otherwise the loop waits `backoffMs[attempt]` and tries again. When the
+ * retries are exhausted and `onError` did not throw, the last error is rethrown
+ * unchanged.
+ *
+ * Shared by the database write-lock retry ({@link retryOnDatabaseLock}) and the
+ * migration verify retry ({@link verifyMigrationWithRetry}).
+ */
+export const retryWithBackoff = <T>(
+  fn: () => Promise<T>,
+  backoffMs: readonly number[],
+  onError: (error: unknown, context: RetryContext) => void,
+): Promise<T> => {
+  const attemptFrom = async (attempt: number): Promise<T> => {
+    try {
+      return await fn();
+    } catch (error) {
+      const willRetry = attempt < backoffMs.length;
+      onError(error, { attempt, willRetry });
+      if (!willRetry) throw error;
+      await delay(backoffMs[attempt]!);
+      return attemptFrom(attempt + 1);
+    }
+  };
+  return attemptFrom(0);
+};

--- a/test/lib/retry.test.ts
+++ b/test/lib/retry.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { retryWithBackoff } from "#shared/retry.ts";
+
+describe("retryWithBackoff", () => {
+  test("returns the result without invoking onError when fn succeeds first try", async () => {
+    let onErrorCalls = 0;
+    const result = await retryWithBackoff(
+      () => Promise.resolve("ok"),
+      [1, 1],
+      () => {
+        onErrorCalls++;
+      },
+    );
+    expect(result).toBe("ok");
+    expect(onErrorCalls).toBe(0);
+  });
+
+  test("retries after a failure and resolves, reporting willRetry", async () => {
+    let attempts = 0;
+    const seen: boolean[] = [];
+    const result = await retryWithBackoff(
+      () => {
+        attempts++;
+        return attempts < 3
+          ? Promise.reject(new Error("transient"))
+          : Promise.resolve("recovered");
+      },
+      [1, 1],
+      (_error, { willRetry }) => {
+        seen.push(willRetry);
+      },
+    );
+    expect(result).toBe("recovered");
+    expect(attempts).toBe(3);
+    expect(seen).toEqual([true, true]);
+  });
+
+  test("rethrows the last error once the backoffs are exhausted", async () => {
+    let attempts = 0;
+    await expect(
+      retryWithBackoff(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("never settles"));
+        },
+        [1, 1],
+        () => {},
+      ),
+    ).rejects.toThrow("never settles");
+    // One initial attempt plus one per backoff entry.
+    expect(attempts).toBe(3);
+  });
+
+  test("aborts immediately when onError throws", async () => {
+    let attempts = 0;
+    await expect(
+      retryWithBackoff(
+        () => {
+          attempts++;
+          return Promise.reject(new Error("non-retryable"));
+        },
+        [1, 1],
+        (error) => {
+          throw error;
+        },
+      ),
+    ).rejects.toThrow("non-retryable");
+    expect(attempts).toBe(1);
+  });
+
+  test("lets onError swap in a different error on the final attempt", async () => {
+    await expect(
+      retryWithBackoff(
+        () => Promise.reject(new Error("raw")),
+        [],
+        (_error, { willRetry }) => {
+          if (!willRetry) throw new Error("friendly");
+        },
+      ),
+    ).rejects.toThrow("friendly");
+  });
+});


### PR DESCRIPTION
Follow-up to #1402. That PR added a migration verify retry whose backoff loop duplicated the existing database write-lock retry (`retryOnDatabaseLock`). This DRYs them up.

## Change

Adds `retryWithBackoff(fn, backoffMs, onError)` in `src/shared/retry.ts` and routes both retry sites through it:

- **`retryOnDatabaseLock`** (client.ts) — `onError` rethrows a non-lock error immediately, and throws `DatabaseBusyError` once the backoffs are exhausted (`willRetry === false`).
- **`verifyMigrationWithRetry`** (migrations.ts) — `onError` logs each transient failure while retrying, and lets the original error propagate after the final attempt.

The `onError(error, { attempt, willRetry })` callback is what lets one helper serve both policies: it may throw to abort/replace the error, or return to allow a backoff-and-retry.

The helper is written as a small recursion rather than an infinite `for (;;)` loop, because the loop form leaves an uncoverable loop-exit branch (the empty condition can never be false) — the recursion has only genuinely-reachable branches.

## Tests

New `test/lib/retry.test.ts` covers the helper directly: first-try success, retry-then-succeed, exhaustion (rethrows the last error), immediate abort when `onError` throws, and swapping in a different error on the final attempt. The existing DB-lock contention tests and migration verify-retry tests continue to exercise both call sites unchanged.

Full `deno task precommit` is green (typecheck, lint, jscpd 0%, edge build, 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezdmsysYVywQniU4czkbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KezdmsysYVywQniU4czkbC)_