### PR TITLE
Harden query-log tests to kill mutation survivors

### DIFF
--- a/test/lib/query-log.test.ts
+++ b/test/lib/query-log.test.ts
@@ -1,11 +1,13 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
+import { returnsNext, stub } from "@std/testing/mock";
 import {
   addQueryLogEntry,
+  enableFooterDebug,
   enableQueryLog,
   getQueryLog,
   getQueryLogStartTime,
+  isFooterDebugEnabled,
   isQueryLogEnabled,
   N_PLUS_ONE_THRESHOLD,
   runWithQueryLogContext,
@@ -165,6 +167,35 @@ describe("query-log", () => {
         expect(second).toBeGreaterThanOrEqual(first);
       });
     });
+
+    test("each enable assigns the fresh clock value, never accumulates it", () => {
+      // Stubbing the clock pins the exact value the second enable must store:
+      // a re-assignment yields 2000, whereas an accumulating `+=` would carry
+      // the first reading forward to 3000.
+      runWithQueryLogContext(() => {
+        const nowStub = stub(performance, "now", returnsNext([1000, 2000]));
+        try {
+          enableQueryLog();
+          expect(getQueryLogStartTime()).toBe(1000);
+          enableQueryLog();
+          expect(getQueryLogStartTime()).toBe(2000);
+        } finally {
+          nowStub.restore();
+        }
+      });
+    });
+  });
+
+  describe("footer debug visibility", () => {
+    test("is hidden by default and shown only after enableFooterDebug", () => {
+      // A fresh request context must not expose the staff-only debug footer
+      // (default `false`); enabling it flips the flag to exactly `true`.
+      runWithQueryLogContext(() => {
+        expect(isFooterDebugEnabled()).toBe(false);
+        enableFooterDebug();
+        expect(isFooterDebugEnabled()).toBe(true);
+      });
+    });
   });
 
   describe("trackQuery recording", () => {
@@ -179,6 +210,24 @@ describe("query-log", () => {
         expect(logged!.startedAtMs).toBeGreaterThanOrEqual(before);
         expect(logged!.startedAtMs).toBeLessThanOrEqual(after);
         expect(logged!.durationMs).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    test("records the elapsed difference, not a ratio, of the clock readings", async () => {
+      // Pin the start/end clock readings so the recorded duration is the exact
+      // subtraction (1005 - 1000 = 5). A `now() / start` regression would log
+      // ~1.005 instead, so the precise value guards the arithmetic.
+      await runWithQueryLogContext(async () => {
+        enableQueryLog();
+        const nowStub = stub(performance, "now", returnsNext([1000, 1005]));
+        try {
+          await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+        } finally {
+          nowStub.restore();
+        }
+        const [logged] = getQueryLog();
+        expect(logged!.startedAtMs).toBe(1000);
+        expect(logged!.durationMs).toBe(5);
       });
     });
   });


### PR DESCRIPTION
## What

Strengthen the `test/lib/query-log.test.ts` assertions to kill mutation-testing survivors in `src/shared/db/query-log.ts`. These are pre-existing gaps (not introduced by any recent change) — surfaced while mutation-testing the module after #1403.

## Why

`deno task mutation src/shared/db/query-log.ts test/lib/query-log.test.ts` reported **8 surviving mutants (score 77.1%)** — code changes that no test would catch, all from weak/loose assertions (`>= 0`, `>= first`, no coverage of the footer-debug flag).

## Changes

This lifts the module's mutation score from **77.1% → 91.4%** by killing the 5 killable survivors:

| Survivor | Fix |
|----------|-----|
| `71:18` `= → +=` (enableQueryLog start time) | Stub the clock and assert the second enable stores the fresh reading (`2000`), not an accumulated one (`3000`). |
| `52:18` `false → true` (freshState `footerVisible`) | New test asserts the debug footer is hidden by default. |
| `79:27` `= → +=` & `79:30` `true → false` (enableFooterDebug) | Same test asserts the flag flips to exactly `true` after `enableFooterDebug`. |
| `230:36` `- → /` (trackQuery duration) | Stub the clock so the recorded duration is the exact subtraction (`1005 - 1000 = 5`), catching a `now() / start` regression. |

## Remaining survivors are equivalent mutants

The 3 still-surviving mutants are all `?? → ||` swaps where the left operand can never be a *defined-but-falsy* value, so the two operators are behaviourally identical and **no test can distinguish them**:

- `61:31` / `204:43` — `getStore() ?? fallbackState`: `getStore()` returns `QueryLogState | undefined`, never a falsy object.
- `225:22` — `readCounts.get(sql) ?? 0`: stored counts are always ≥ 1, never `0`.

These are left as-is rather than contorting the code/tests to chase an unreachable 100%.

## Verification

- `deno task mutation src/shared/db/query-log.ts test/lib/query-log.test.ts` → 32/35 killed (91.4%).
- `deno task lint:ci`, `deno check`, and the full `query-log` test file all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do9As9RJARUsDAq4a86SV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Do9As9RJARUsDAq4a86SV1)_