### PR TITLE
Read the session private key from AsyncLocalStorage, not threaded args

### DIFF
--- a/src/features/admin/actions.ts
+++ b/src/features/admin/actions.ts
@@ -6,11 +6,9 @@ import type { AuthSession } from "#routes/auth.ts";
 import {
   AUTH_FORM,
   AUTH_MULTIPART,
-  getPrivateKey,
   OWNER_FORM,
   OWNER_MULTIPART,
   requireSessionOr,
-  SessionKeyError,
   withAuth,
 } from "#routes/auth.ts";
 import {
@@ -52,15 +50,6 @@ export const csvResponse = (csv: string, filename: string): Response =>
     },
   });
 
-/** Get the admin private key from session, throwing if unavailable */
-export const requirePrivateKey = async (
-  session: AuthSession,
-): Promise<CryptoKey> => {
-  const key = await getPrivateKey(session);
-  if (!key) throw new SessionKeyError();
-  return key;
-};
-
 /**
  * Bounded attendee id → name lookup for link labels (activity log, ledger). The
  * current request's private key is unwrapped only when at least one attendee is
@@ -90,7 +79,7 @@ export const withDecryptedAttendees = async (
   listingId: number,
   handler: ListingAttendeesHandler,
 ): Promise<Response> => {
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   const result = await getListingWithAttendeesRaw(listingId);
   if (!result) return notFoundResponse();
   const attendees = await decryptAttendees(result.attendeesRaw, pk);

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -404,11 +404,12 @@ const buildTemplateData = async (
 };
 
 /** Load custom questions + currently-selected answers across ALL of the
- * attendee's booked listings (edit mode only). */
+ * attendee's booked listings (edit mode only). The request's private key is
+ * only derived when there are questions whose free-text answers need
+ * decrypting, so an attendee with no questions never forces a key unwrap. */
 const loadQuestionsForExisting = async (
   attendeeId: number,
   existing: ExistingLine[],
-  privateKey: CryptoKey,
 ): Promise<{
   questions: QuestionWithAnswers[];
   selectedAnswerIds: number[];
@@ -426,18 +427,11 @@ const loadQuestionsForExisting = async (
   return {
     questions: data.questions,
     selectedAnswerIds: data.attendeeAnswerMap.get(attendeeId) ?? [],
-    selectedTextAnswers: await getAttendeeTextAnswers(attendeeId, privateKey),
+    selectedTextAnswers: await getAttendeeTextAnswers(
+      attendeeId,
+      await requireRequestPrivateKey(),
+    ),
   };
-};
-
-/** Resolve the session's private key and load the attendee's question context
- * with it — the two always pair up at the edit-form call sites. */
-const loadQuestionsForSession = async (
-  attendeeId: number,
-  existing: ExistingLine[],
-) => {
-  const privateKey = await requireRequestPrivateKey();
-  return loadQuestionsForExisting(attendeeId, existing, privateKey);
 };
 
 /** Render the attendee form page as an HTML response. */
@@ -501,7 +495,7 @@ export const handleAttendeeEditGet: TypedRouteHandler<
       renderListings,
     );
     const { questions, selectedAnswerIds, selectedTextAnswers } =
-      await loadQuestionsForSession(attendeeId, loaded.existing);
+      await loadQuestionsForExisting(attendeeId, loaded.existing);
     const contactRecords = await loadContactRecords(loaded.attendee);
     const ledger = await loadAttendeeLedgerForSession(session, attendeeId);
     const data = await buildTemplateData("edit", parsed, loaded.attendee, {
@@ -606,7 +600,7 @@ const loadEditContext = async (
   const loaded = await loadAttendeeForEdit(attendeeId);
   if (!loaded) return null;
   const { questions, selectedAnswerIds, selectedTextAnswers } =
-    await loadQuestionsForSession(attendeeId, loaded.existing);
+    await loadQuestionsForExisting(attendeeId, loaded.existing);
   return {
     attendee: loaded.attendee,
     existingByKey: new Map(

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -15,7 +15,6 @@
 
 /* jscpd:ignore-start */
 import { compact, filter, unique } from "#fp";
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import {
   ATTENDEE_FORM_ID,
   type AttendeeFormLine,
@@ -96,6 +95,7 @@ import {
   parseSelectedListingIds,
   START_DATE_FIELD,
 } from "#shared/order-select.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { Attendee, ListingWithCount } from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
@@ -433,11 +433,10 @@ const loadQuestionsForExisting = async (
 /** Resolve the session's private key and load the attendee's question context
  * with it — the two always pair up at the edit-form call sites. */
 const loadQuestionsForSession = async (
-  session: AuthSession,
   attendeeId: number,
   existing: ExistingLine[],
 ) => {
-  const privateKey = await requirePrivateKey(session);
+  const privateKey = await requireRequestPrivateKey();
   return loadQuestionsForExisting(attendeeId, existing, privateKey);
 };
 
@@ -493,7 +492,7 @@ export const handleAttendeeEditGet: TypedRouteHandler<
   "GET /admin/attendees/:attendeeId"
 > = (request, { attendeeId }) =>
   requireSessionOr(request, async (session) => {
-    const loaded = await loadAttendeeForEdit(session, attendeeId);
+    const loaded = await loadAttendeeForEdit(attendeeId);
     if (!loaded) return notFoundResponse();
     const renderListings = await getRenderListings(loaded.existing);
     const { parsed, hasMixedTimings } = buildEditFormFromAttendee(
@@ -502,8 +501,8 @@ export const handleAttendeeEditGet: TypedRouteHandler<
       renderListings,
     );
     const { questions, selectedAnswerIds, selectedTextAnswers } =
-      await loadQuestionsForSession(session, attendeeId, loaded.existing);
-    const contactRecords = await loadContactRecords(session, loaded.attendee);
+      await loadQuestionsForSession(attendeeId, loaded.existing);
+    const contactRecords = await loadContactRecords(loaded.attendee);
     const ledger = await loadAttendeeLedgerForSession(session, attendeeId);
     const data = await buildTemplateData("edit", parsed, loaded.attendee, {
       contactRecords,
@@ -558,13 +557,12 @@ const loadChannelRecord = async (
  * one contact value to decrypt, so an attendee with no email/phone never forces
  * a key prompt. */
 const loadContactRecords = async (
-  session: AuthSession,
   attendee: Attendee,
 ): Promise<ContactRecordsByChannel> => {
   if (!attendee.email.trim() && !attendee.phone.trim()) {
     return EMPTY_CONTACT_RECORDS;
   }
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   return {
     email: await loadChannelRecord(attendee.email, hashEmail, pk),
     phone: await loadChannelRecord(attendee.phone, hashPhone, pk),
@@ -573,10 +571,9 @@ const loadContactRecords = async (
 
 /** Load an attendee + all its listing_attendees rows for the edit page. */
 const loadAttendeeForEdit = async (
-  session: AuthSession,
   attendeeId: number,
 ): Promise<{ attendee: Attendee; existing: ExistingLine[] } | null> => {
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   const attendee = await getAttendee(attendeeId, pk);
   if (!attendee) return null;
   const existing = await loadExistingLines(attendeeId);
@@ -604,13 +601,12 @@ const EMPTY_EDIT_CONTEXT: EditContext = {
 /** Edit mode: load the attendee, its existing lines (indexed by key), and its
  * question/answer context. Returns null when the attendee does not exist. */
 const loadEditContext = async (
-  session: AuthSession,
   attendeeId: number,
 ): Promise<EditContext | null> => {
-  const loaded = await loadAttendeeForEdit(session, attendeeId);
+  const loaded = await loadAttendeeForEdit(attendeeId);
   if (!loaded) return null;
   const { questions, selectedAnswerIds, selectedTextAnswers } =
-    await loadQuestionsForSession(session, attendeeId, loaded.existing);
+    await loadQuestionsForSession(attendeeId, loaded.existing);
   return {
     attendee: loaded.attendee,
     existingByKey: new Map(
@@ -645,7 +641,7 @@ const handleSubmitInner = async (
 
   const edit =
     mode === "edit" && attendeeId !== null
-      ? await loadEditContext(session, attendeeId)
+      ? await loadEditContext(attendeeId)
       : EMPTY_EDIT_CONTEXT;
   if (edit === null) return notFoundResponse();
   const {

--- a/src/features/admin/attendees-edit.ts
+++ b/src/features/admin/attendees-edit.ts
@@ -9,8 +9,7 @@
  */
 
 import { t } from "#i18n";
-import { requirePrivateKey } from "#routes/admin/actions.ts";
-import { AUTH_FORM, type AuthSession, withAuth } from "#routes/auth.ts";
+import { AUTH_FORM, withAuth } from "#routes/auth.ts";
 import { errorRedirect, htmlResponse, redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
@@ -25,6 +24,7 @@ import { getListingWithCount } from "#shared/db/listings.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { getActivePaymentProvider } from "#shared/payments.ts";
 import { recordAttendeeRefund } from "#shared/refund-ledger.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { Attendee, ListingWithCount } from "#shared/types.ts";
 import { NO_PROVIDER_ERROR } from "./attendees-route-helpers.ts";
 
@@ -37,10 +37,9 @@ type RefreshPaymentContext = {
 
 /** Load the attendee + its first listing for the refresh-payment flow. */
 const loadRefreshContext = async (
-  session: AuthSession,
   attendeeId: number,
 ): Promise<RefreshPaymentContext | null> => {
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   const attendeeRaw = await queryOne<Attendee>(
     `SELECT ${ATTENDEE_LEFT_JOIN_SELECT}
      FROM attendees a
@@ -64,8 +63,8 @@ const loadRefreshContext = async (
 export const handleRefreshPayment: TypedRouteHandler<
   "POST /admin/attendees/:attendeeId/refresh-payment"
 > = (request, { attendeeId }) =>
-  withAuth(request, AUTH_FORM, async (session, _form) => {
-    const ctx = await loadRefreshContext(session, attendeeId);
+  withAuth(request, AUTH_FORM, async (_session, _form) => {
+    const ctx = await loadRefreshContext(attendeeId);
     if (!ctx) return htmlResponse("", 404);
 
     const { attendee, listing } = ctx;

--- a/src/features/admin/attendees-list.ts
+++ b/src/features/admin/attendees-list.ts
@@ -5,7 +5,7 @@
  */
 
 import { map, unique } from "#fp";
-import { csvResponse, requirePrivateKey } from "#routes/admin/actions.ts";
+import { csvResponse } from "#routes/admin/actions.ts";
 import {
   generateCalendarCsv,
   toCalendarAttendees,
@@ -28,6 +28,7 @@ import {
   listingCategory,
   listingTypeFromRequest,
 } from "#shared/listing-filter.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type {
   Attendee,
   AttendeeTableRow,
@@ -120,7 +121,7 @@ export const handleAttendeesListGet: TypedRouteHandler<
     const page = parsePage(request);
     const listingIds = resolveListingIds(listingId, type, listings);
 
-    const privateKey = await requirePrivateKey(session);
+    const privateKey = await requireRequestPrivateKey();
     const { rows, hasNext } = await getAttendeesPage({
       listingIds,
       page,
@@ -175,13 +176,13 @@ const allAttendeeBookings = async (
 export const handleAttendeesCsvExport: TypedRouteHandler<
   "GET /admin/attendees/csv"
 > = (request) =>
-  withListings(request, async (session, listings) => {
+  withListings(request, async (_session, listings) => {
     const listingIds = resolveListingIds(
       parseListingId(request, listings),
       listingTypeFromRequest(request),
       listings,
     );
-    const privateKey = await requirePrivateKey(session);
+    const privateKey = await requireRequestPrivateKey();
     const raw = await allAttendeeBookings(listingIds);
     const attendees = await decryptAttendees(raw, privateKey);
     const csv = generateCalendarCsv(

--- a/src/features/admin/attendees-merge.ts
+++ b/src/features/admin/attendees-merge.ts
@@ -4,7 +4,6 @@
 
 /* jscpd:ignore-start */
 import { filter, map, pipe } from "#fp";
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import { createEntityRouteHandlers } from "#routes/admin/entity-handlers.ts";
 import type { AuthSession } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
@@ -37,6 +36,7 @@ import type {
   MergeBookingChoice,
   MergeValueChoice,
 } from "#shared/merge/attendee-merge-types.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { Attendee } from "#shared/types.ts";
 import { adminMergeAttendeePage } from "#templates/admin/attendees.tsx";
 
@@ -44,10 +44,9 @@ import { adminMergeAttendeePage } from "#templates/admin/attendees.tsx";
 
 /** Load and decrypt a target attendee by ID for merge operations */
 const loadMergeTarget = async (
-  session: AuthSession,
   attendeeId: number,
 ): Promise<Attendee | null> => {
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   const raw = await queryOne<Attendee>(
     `SELECT ${ATTENDEE_LEFT_JOIN_SELECT}
      FROM attendees a
@@ -61,7 +60,6 @@ const loadMergeTarget = async (
 /** Look up and decrypt a source attendee by ticket token */
 const loadMergeSource = async (
   token: string,
-  session: AuthSession,
 ): Promise<{
   id: number;
   name: string;
@@ -72,7 +70,7 @@ const loadMergeSource = async (
   ticket_token: string;
   bookings: ListingAttendeeRow[];
 } | null> => {
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   const results = await getAttendeesByTokens([token]);
   const raw = results[0];
   if (!raw) return null;
@@ -242,7 +240,6 @@ const buildMergeFlashParts = (
 const validateMergePostInput = async (
   attendeeId: number,
   form: FormParams,
-  session: AuthSession,
 ): Promise<
   | { ok: true; source: MergeSource; sourceToken: string }
   | { ok: false; response: Response }
@@ -258,7 +255,7 @@ const validateMergePostInput = async (
     };
   }
 
-  const source = await loadMergeSource(sourceToken, session);
+  const source = await loadMergeSource(sourceToken);
   if (!source) {
     return {
       ok: false,
@@ -286,7 +283,6 @@ const validateMergePostInput = async (
 
 /** Apply merge decisions and return the success redirect response */
 const applyMergeDecisions = async (
-  session: AuthSession,
   attendeeId: number,
   target: Attendee,
   source: MergeSource,
@@ -296,7 +292,7 @@ const applyMergeDecisions = async (
   const result = await applyAttendeeMerge({
     decision,
     diff,
-    privateKey: await requirePrivateKey(session),
+    privateKey: await requireRequestPrivateKey(),
     sourceId: source.id,
     sourcePii: extractSourcePii(source),
     targetId: attendeeId,
@@ -404,7 +400,7 @@ export const handleMergeGet = handlers.get(async (request, session, target) => {
   const token = getSearchParam(request, "token");
   const flash = applyFlash(request);
   if (!token) return mergeAttendeePage(request, session)(target);
-  const source = await loadMergeSource(token, session);
+  const source = await loadMergeSource(token);
   if (!source) {
     return htmlResponse(
       adminMergeAttendeePage(
@@ -435,7 +431,7 @@ export const handleMergeGet = handlers.get(async (request, session, target) => {
 
 /** Handle POST /admin/attendees/:attendeeId/merge — validate + apply decisions */
 export const handleMergePost = handlers.post(async (session, form, target) => {
-  const input = await validateMergePostInput(target.id, form, session);
+  const input = await validateMergePostInput(target.id, form);
   if (!input.ok) return input.response;
   const { source, sourceToken } = input;
   const diff = await buildMergeDiffFor(target, source, target.id);
@@ -453,12 +449,5 @@ export const handleMergePost = handlers.post(async (session, form, target) => {
       ),
     );
   }
-  return applyMergeDecisions(
-    session,
-    target.id,
-    target,
-    source,
-    diff,
-    decision,
-  );
+  return applyMergeDecisions(target.id, target, source, diff, decision);
 });

--- a/src/features/admin/attendees-route-helpers.ts
+++ b/src/features/admin/attendees-route-helpers.ts
@@ -2,7 +2,7 @@
  * Shared utilities for admin attendee route handlers
  */
 
-import { requirePrivateKey } from "#routes/admin/actions.ts";
+/* jscpd:ignore-start */
 import { verifyOrRedirect } from "#routes/admin/confirmation.ts";
 import { withEntityLoader } from "#routes/admin/entity-handlers.ts";
 import {
@@ -15,7 +15,9 @@ import { getSearchParam } from "#routes/url.ts";
 import { decryptAttendeeOrNull } from "#shared/db/attendees.ts";
 import { getListingWithAttendeeRaw } from "#shared/db/listings.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { Attendee, ListingWithCount } from "#shared/types.ts";
+/* jscpd:ignore-end */
 
 /** Attendee with listing data */
 export type AttendeeWithListing = {
@@ -32,11 +34,10 @@ export const NO_PROVIDER_ERROR = "No payment provider configured.";
  * Decrypts attendee PII using the admin private key.
  */
 export const loadAttendeeForListing = async (
-  session: AuthSession,
   listingId: number,
   attendeeId: number,
 ): Promise<AttendeeWithListing | null> => {
-  const pk = await requirePrivateKey(session);
+  const pk = await requireRequestPrivateKey();
   const result = await getListingWithAttendeeRaw(listingId, attendeeId);
   if (!result) return null;
 
@@ -70,7 +71,6 @@ export const attendeeGetRoute =
   ): Promise<Response> =>
     requireSessionOr(request, (session) =>
       withAttendee(
-        session,
         listingId,
         attendeeId,
       )((data) => handler(data, session, request)),
@@ -88,11 +88,7 @@ const withAttendeeForm = (
   ) => Response | Promise<Response>,
 ): Promise<Response> =>
   withAuth(request, AUTH_FORM, (session, form) =>
-    withAttendee(
-      session,
-      listingId,
-      attendeeId,
-    )((data) => handler(data, session, form)),
+    withAttendee(listingId, attendeeId)((data) => handler(data, session, form)),
   );
 
 /** Read return_url from request query params */

--- a/src/features/admin/bulk-email.ts
+++ b/src/features/admin/bulk-email.ts
@@ -13,7 +13,6 @@
  * button (formaction="/admin/emails/templates") creates or updates a template.
  */
 
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import { createConfirmedHandlers } from "#routes/admin/confirmation.ts";
 import {
   type AuthSession,
@@ -79,6 +78,7 @@ import type { FormParams } from "#shared/form-data.ts";
 import { MAX_EMAIL_TEMPLATES } from "#shared/limits.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import { ok } from "#shared/response.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { parsePositiveIntId } from "#shared/validation/number.ts";
 import {
   bulkEmailComposePage,
@@ -110,12 +110,11 @@ const getBulkAvailability = (): BulkAvailability => {
 
 /** Recipients + the private key used + the owner's bulk-send availability. */
 const loadSendContext = async (
-  session: AuthSession,
   target: BulkEmailTarget,
 ): Promise<
   { privateKey: CryptoKey; recipients: string[] } & BulkAvailability
 > => {
-  const privateKey = await requirePrivateKey(session);
+  const privateKey = await requireRequestPrivateKey();
   return {
     privateKey,
     recipients: await resolveRecipientEmails(target, privateKey),
@@ -193,7 +192,7 @@ const handleComposeGet = ownerEmailPage(async (request, session) => {
   const target = await targetFromQuery(params);
   if (!target) return notFoundResponse();
   const { recipients, privateKey, canBulkSend, disabledReason } =
-    await loadSendContext(session, target);
+    await loadSendContext(target);
   // A listing or attendee target with no emailable recipient (an unknown
   // attendee token, or nobody with an email on file) has nothing to send to —
   // treat it as not found rather than rendering an empty compose page. Named
@@ -289,11 +288,11 @@ const handlePreviewPost = (request: Request): Promise<Response> =>
 
 /** GET /admin/emails/preview — render the saved draft for confirmation. */
 const handlePreviewGet = ownerEmailPage(async (_request, session) => {
-  const privateKey = await requirePrivateKey(session);
+  const privateKey = await requireRequestPrivateKey();
   const draft = await parseSavedDraft(privateKey);
   if (!draft) return redirectResponse(COMPOSE_PATH);
   const { recipients, canBulkSend, disabledReason, config } =
-    await loadSendContext(session, draft.target);
+    await loadSendContext(draft.target);
   const { sendable, skipped } = await partitionRecipients(
     recipients,
     draft.marketing,
@@ -329,13 +328,12 @@ const handlePreviewGet = ownerEmailPage(async (_request, session) => {
 
 /** POST /admin/emails/send — send the saved draft via the bulk provider. */
 const handleSendPost = (request: Request): Promise<Response> =>
-  withAuth(request, OWNER_FORM, async (session, _form) => {
-    const draft = await parseSavedDraft(await requirePrivateKey(session));
+  withAuth(request, OWNER_FORM, async (_session, _form) => {
+    const draft = await parseSavedDraft(await requireRequestPrivateKey());
     if (!draft) {
       return errorRedirect(COMPOSE_PATH, "There's no email to send.");
     }
     const { privateKey, recipients, config } = await loadSendContext(
-      session,
       draft.target,
     );
     if (!config) {
@@ -443,10 +441,10 @@ const templateDelete = createConfirmedHandlers<{ id: number; subject: string }>(
     auth: "owner",
     identifier: (template) => template.subject,
     identifierLabel: "Template subject",
-    load: async (id, session) => {
+    load: async (id) => {
       const raw = await getRawEmailTemplate(id);
       if (!raw) return null;
-      const privateKey = await requirePrivateKey(session);
+      const privateKey = await requireRequestPrivateKey();
       return {
         id,
         subject: await decryptWithOwnerKey(raw.subject, privateKey),

--- a/src/features/admin/calendar.ts
+++ b/src/features/admin/calendar.ts
@@ -15,7 +15,7 @@ import {
   generateCalendarCsv,
   toCalendarAttendees,
 } from "#routes/admin/calendar-csv.ts";
-import { getPrivateKey, requireSessionOr } from "#routes/auth.ts";
+import { requireSessionOr } from "#routes/auth.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { getSearchParam } from "#routes/url.ts";
@@ -52,6 +52,7 @@ import {
   assignmentMatchesAgentFilter,
   parseAgentFilter,
 } from "#shared/logistics-filter.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import {
   type Attendee,
@@ -316,7 +317,7 @@ const handleAdminCalendarGet = (request: Request) =>
       : { agentFilter: "all" as AgentFilter, agents: [] };
     let attendees: CalendarAttendeeRow[] = [];
     if (dateFilter) {
-      const privateKey = (await getPrivateKey(session))!;
+      const privateKey = await requireRequestPrivateKey();
       const [rawDailyAttendees, standardAttendees] = await Promise.all([
         getDailyListingAttendeesByDate(dateFilter),
         loadStandardListingAttendees(
@@ -352,7 +353,7 @@ const handleAdminCalendarGet = (request: Request) =>
     const questionData = await loadAttendeeQuestionData(
       attendees.map((a) => a.listingId),
       attendees.map((a) => a.id),
-      (await getPrivateKey(session))!,
+      await requireRequestPrivateKey(),
     );
 
     const hasPaidListing = allListings.some(isPaidListing);
@@ -380,12 +381,12 @@ const handleAdminCalendarGet = (request: Request) =>
  * Handle GET /admin/calendar/export (CSV export for calendar view)
  */
 const handleAdminCalendarExport = (request: Request) =>
-  withCalendarSession(request, async (session, dateFilter) => {
+  withCalendarSession(request, async (_session, dateFilter) => {
     if (!dateFilter) {
       return redirect("/admin/calendar", "Select a date to export", false);
     }
 
-    const privateKey = (await getPrivateKey(session))!;
+    const privateKey = await requireRequestPrivateKey();
     const [listingCtx, rawDailyAttendees] = await Promise.all([
       loadListingContext(),
       getDailyListingAttendeesByDate(dateFilter),

--- a/src/features/admin/contact-history.ts
+++ b/src/features/admin/contact-history.ts
@@ -10,7 +10,6 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import { AUTH_FORM, requireSessionOr, withAuth } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
@@ -26,6 +25,7 @@ import {
 import type { FormParams } from "#shared/form-data.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { contactHistoryPage } from "#templates/admin/contact-history.tsx";
 
 /* jscpd:ignore-end */
@@ -78,7 +78,7 @@ export const handleContactHistoryGet: TypedRouteHandler<
   requireSessionOr(request, async (session) => {
     const record = await loadForRepair(
       fromContactHashParam(hmac),
-      await requirePrivateKey(session),
+      await requireRequestPrivateKey(),
     );
     const flash = applyFlash(request);
     return htmlResponse(
@@ -97,7 +97,7 @@ export const handleContactHistoryPost: TypedRouteHandler<
   "POST /admin/history/:hmac"
 > = (request, { hmac }) =>
   withAuth(request, AUTH_FORM, async (session, form) => {
-    const pk = await requirePrivateKey(session);
+    const pk = await requireRequestPrivateKey();
     const hash = fromContactHashParam(hmac);
     const current = await loadForRepair(hash, pk);
     const updated = recordFromForm(form, current);

--- a/src/features/admin/dashboard.ts
+++ b/src/features/admin/dashboard.ts
@@ -3,11 +3,7 @@
  */
 
 import { compact, unique } from "#fp";
-import {
-  csvResponse,
-  loadAttendeeNames,
-  requirePrivateKey,
-} from "#routes/admin/actions.ts";
+import { csvResponse, loadAttendeeNames } from "#routes/admin/actions.ts";
 import { generateListingsCsv } from "#routes/admin/listings-csv.ts";
 import { requireSessionOr, sessionPage, withSession } from "#routes/auth.ts";
 import { applyFlash } from "#routes/csrf.ts";
@@ -33,6 +29,7 @@ import {
   filterListingsByType,
   listingTypeFromRequest,
 } from "#shared/listing-filter.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { sortListings } from "#shared/sort-listings.ts";
 /* jscpd:ignore-end */
 import {
@@ -85,7 +82,7 @@ const handleAdminGet = (request: Request): Promise<Response> =>
         getAllListings(),
         getActiveHolidays(),
         getNewestAttendeesRaw(NEWEST_ATTENDEES_LIMIT),
-        requirePrivateKey(session),
+        requireRequestPrivateKey(),
       ]);
       const newestAttendees = await decryptAttendees(newestRaw, privateKey);
       const sortedListings = sortListings(listings, holidays);

--- a/src/features/admin/deliveries.ts
+++ b/src/features/admin/deliveries.ts
@@ -8,14 +8,10 @@
  * the Calendar submenu and, unlike agents, keep the full staff navigation.
  */
 
+/* jscpd:ignore-start */
 import { unique } from "#fp";
 import { t } from "#i18n";
-import {
-  ANY_USER_FORM,
-  anyUserPage,
-  getPrivateKey,
-  withAuth,
-} from "#routes/auth.ts";
+import { ANY_USER_FORM, anyUserPage, withAuth } from "#routes/auth.ts";
 import { errorRedirect, redirect } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { addDays } from "#shared/dates.ts";
@@ -33,6 +29,7 @@ import {
 import { settings } from "#shared/db/settings.ts";
 import { getUserAgentIds } from "#shared/db/user-agents.ts";
 import { getFlash } from "#shared/flash-context.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { Attendee } from "#shared/types.ts";
 import {
@@ -40,6 +37,8 @@ import {
   type DeliveryBookingView,
   type DeliveryDayGroup,
 } from "#templates/admin/deliveries.tsx";
+
+/* jscpd:ignore-end */
 
 /** Lookups used to flesh out a bare run-sheet leg into a display row. */
 type LegLookups = {
@@ -155,7 +154,7 @@ const handleDeliveriesGet = anyUserPage(async (session) => {
   const tomorrow = addDays(today, 1);
   const legs = await getAgentRunSheet(agentIds, [today, tomorrow]);
 
-  const privateKey = (await getPrivateKey(session))!;
+  const privateKey = await requireRequestPrivateKey();
   const lookups = await loadLegLookups(legs, privateKey);
   const groups = buildGroups(legs, today, tomorrow, lookups);
   return agentDeliveriesPage(

--- a/src/features/admin/entity-handlers.ts
+++ b/src/features/admin/entity-handlers.ts
@@ -52,13 +52,13 @@ const createEntityHandler =
       ...rest: unknown[]
     ) => (session: AuthSession, entity: T) => Response | Promise<Response>,
   ) =>
-  (loader: (session: AuthSession, id: number) => Promise<T | null>) =>
+  (loader: (id: number) => Promise<T | null>) =>
   (request: Request, id: number) =>
   (handler: H): Promise<Response> =>
     authWrapper(request, (session, ...rest) =>
       withEntity((entity: T) =>
         adaptHandler(handler, request, ...rest)(session, entity),
-      )(() => loader(session, id)),
+      )(() => loader(id)),
     );
 
 /* jscpd:ignore-start */
@@ -67,7 +67,7 @@ const createEntityHandler =
  * Eliminates: `requireSessionOr(request, (session) => withLoader(session, id)(handler))`
  */
 export const withSessionAndEntity = <T>(
-  loader: (session: AuthSession, id: number) => Promise<T | null>,
+  loader: (id: number) => Promise<T | null>,
 ) =>
   createEntityHandler<T, GetEntityHandler<T>>(
     (request, cb) => requireSessionOr(request, cb as SessionHandler),
@@ -80,7 +80,7 @@ export const withSessionAndEntity = <T>(
  * Eliminates: `withAuth(request, AUTH_FORM, (session, form) => withLoader(session, id)(handler))`
  */
 export const withAuthAndEntity = <T>(
-  loader: (session: AuthSession, id: number) => Promise<T | null>,
+  loader: (id: number) => Promise<T | null>,
 ) =>
   createEntityHandler<T, PostEntityHandler<T>>(
     (request, cb) =>
@@ -98,7 +98,7 @@ export const withAuthAndEntity = <T>(
  * Returns { get, post } handlers that handle auth + entity loading.
  */
 export const withAuthEntityHandlers =
-  <T>(loader: (session: AuthSession, id: number) => Promise<T | null>) =>
+  <T>(loader: (id: number) => Promise<T | null>) =>
   (request: Request, id: number) => ({
     get: (
       handler: (
@@ -129,13 +129,13 @@ export const createEntityRouteHandlers = <
   T,
   TParams extends Record<string, unknown>,
 >(
-  loader: (session: AuthSession, id: number) => Promise<T | null>,
+  loader: (id: number) => Promise<T | null>,
   getId: (params: TParams) => number,
 ) => {
   const routeHandler =
     <H>(
       wrapper: (
-        l: (s: AuthSession, i: number) => Promise<T | null>,
+        l: (i: number) => Promise<T | null>,
       ) => (r: Request, i: number) => (h: H) => Promise<Response>,
       handler: H,
     ): ((request: Request, params: TParams) => Promise<Response>) =>

--- a/src/features/admin/groups.ts
+++ b/src/features/admin/groups.ts
@@ -4,7 +4,6 @@
 
 import { map } from "#fp";
 import { t } from "#i18n";
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import { createCrudHandlers } from "#routes/admin/owner-crud.ts";
 import { requireSessionOr } from "#routes/auth.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
@@ -33,6 +32,7 @@ import { GROUP_DEMO_FIELDS, wrapResourceForDemo } from "#shared/demo.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { generateUniqueSlug, normalizeSlug } from "#shared/slug.ts";
 import { sortListings } from "#shared/sort-listings.ts";
 import { type Attendee, type Group, isPaidListing } from "#shared/types.ts";
@@ -175,7 +175,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
       let attendees: Attendee[] = [];
       let phonePrefix: string | undefined;
       if (listingIds.length > 0) {
-        const privateKey = await requirePrivateKey(session);
+        const privateKey = await requireRequestPrivateKey();
         const hasPaidListing = sortedListings.some(isPaidListing);
         const [rawAttendees, prefix] = await Promise.all([
           getAttendeesByListingIds(listingIds),
@@ -193,7 +193,7 @@ const handleGroupDetail: TypedRouteHandler<"GET /admin/groups/:id"> = (
       const questionData = await loadAttendeeQuestionData(
         listingIds,
         attendees.map((a) => a.id),
-        await requirePrivateKey(session),
+        await requireRequestPrivateKey(),
       );
 
       return htmlResponse(

--- a/src/features/admin/listings-export.ts
+++ b/src/features/admin/listings-export.ts
@@ -42,7 +42,7 @@ export const handleAdminListingExport: TypedRouteHandler<
   )(
     filteredAttendeesHandler(
       request,
-      async ({ listing, session, dateFilter, filteredByDate }) => {
+      async ({ listing, dateFilter, filteredByDate }) => {
         const isDaily = listing.listing_type === "daily";
         // Mirror the on-screen attendee table: drop the failed-payment rows
         // that are split into the Failed Payments section, then apply the
@@ -56,7 +56,6 @@ export const handleAdminListingExport: TypedRouteHandler<
         const questionData = await loadListingQuestionData(
           listing.id,
           attendeeIds,
-          session,
         );
 
         const csv = generateAttendeesCsv(

--- a/src/features/admin/listings-view.ts
+++ b/src/features/admin/listings-view.ts
@@ -11,7 +11,6 @@ import { compact, filter, map, pipe, sort, unique } from "#fp";
 import {
   getDateFilter,
   listingAttendeesLoader,
-  requirePrivateKey,
 } from "#routes/admin/actions.ts";
 import type { AuthSession } from "#routes/auth.ts";
 import { htmlResponse } from "#routes/response.ts";
@@ -32,6 +31,7 @@ import {
 } from "#shared/db/questions.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getFlash } from "#shared/flash-context.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { Attendee, ListingWithCount } from "#shared/types.ts";
 import {
   type AttendeeFilter,
@@ -129,12 +129,11 @@ export const filteredAttendeesHandler =
 export const loadListingQuestionData = async (
   listingId: number,
   attendeeIds: number[],
-  session: AuthSession,
 ): Promise<AttendeeQuestionData | undefined> => {
   const [questions, answers] = await Promise.all([
     getQuestionsForListing(listingId),
     getAttendeeAnswersBatch(attendeeIds, {
-      privateKey: await requirePrivateKey(session),
+      privateKey: await requireRequestPrivateKey(),
       texts: true,
     }),
   ]);
@@ -199,7 +198,7 @@ const renderListingPage = async (
           ] = await Promise.all([
             Promise.resolve(getFlash()),
             Promise.resolve(settings.phonePrefix),
-            loadListingQuestionData(listing.id, attendeeIds, session),
+            loadListingQuestionData(listing.id, attendeeIds),
             loadGroupContext(listing, dateFilter),
             getListingAggregateRecalculation(listing),
             listingRevenueBreakdown(listing.id),

--- a/src/features/admin/scanner.ts
+++ b/src/features/admin/scanner.ts
@@ -5,14 +5,8 @@
  */
 
 import { filter, map, pipe } from "#fp";
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import { withEntityLoader } from "#routes/admin/entity-handlers.ts";
-import {
-  getPrivateKey,
-  requireSessionOr,
-  SCANNER_JSON,
-  withAuth,
-} from "#routes/auth.ts";
+import { requireSessionOr, SCANNER_JSON, withAuth } from "#routes/auth.ts";
 import type { IdRouteHandler } from "#routes/entity.ts";
 import { htmlResponse, jsonResponse } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
@@ -31,6 +25,10 @@ import {
 } from "#shared/db/attendees.ts";
 import { getListingWithCount } from "#shared/db/listings.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
+import {
+  getRequestPrivateKey,
+  requireRequestPrivateKey,
+} from "#shared/session-private-key.ts";
 import type { Attendee } from "#shared/types.ts";
 import { adminScannerPage } from "#templates/admin/scanner.tsx";
 
@@ -40,7 +38,7 @@ const withListing = withEntityLoader(getListingWithCount);
 const handleScannerGet: IdRouteHandler = (request, { id }) =>
   requireSessionOr(request, (session) =>
     withListing(id)(async (listing) => {
-      const privateKey = await requirePrivateKey(session);
+      const privateKey = await requireRequestPrivateKey();
       const rawAttendees = await getAttendeesRaw(listing.id);
       const attendees = await decryptAttendees(rawAttendees, privateKey);
       const uncheckedIn = pipe(
@@ -145,7 +143,7 @@ const performCheckIn = async (
  * accidental check-outs from double-scans during rapid door check-in.
  */
 const handleScanPost: IdRouteHandler = (request, { id }) =>
-  withAuth(request, SCANNER_JSON, async (session, body) => {
+  withAuth(request, SCANNER_JSON, async (_session, body) => {
     if (typeof body.token !== "string") {
       return jsonResponse({ error: "Missing token" }, 400);
     }
@@ -154,7 +152,7 @@ const handleScanPost: IdRouteHandler = (request, { id }) =>
     const force = body.force === true;
     const idVerified = body.id_verified === true;
 
-    const privateKey = await getPrivateKey(session);
+    const privateKey = await getRequestPrivateKey();
     if (!privateKey) {
       logError({
         code: ErrorCode.KEY_DERIVATION,

--- a/src/features/admin/sms.ts
+++ b/src/features/admin/sms.ts
@@ -13,7 +13,6 @@
  * gateway ids to attendees for status webhooks.
  */
 
-import { requirePrivateKey } from "#routes/admin/actions.ts";
 import {
   AUTH_FORM,
   type AuthSession,
@@ -30,6 +29,7 @@ import { countSmsMessages, recordSmsMessage } from "#shared/db/sms-messages.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { bestEffort } from "#shared/logger.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import {
   buildMessagePayload,
   getSmsGatewayConfig,
@@ -68,7 +68,6 @@ const handleSmsGet = (request: Request): Promise<Response> =>
     }
 
     return withAttendee(
-      session,
       listingId,
       attendeeId,
     )(async (data) =>
@@ -85,7 +84,10 @@ const handleSmsGet = (request: Request): Promise<Response> =>
   });
 
 /** Send the composed text to the targeted attendee. */
-const sendSms = (session: AuthSession, form: FormParams): Promise<Response> => {
+const sendSms = (
+  _session: AuthSession,
+  form: FormParams,
+): Promise<Response> => {
   const listingId = parsePositiveIntId(form.getString("listing"));
   const attendeeId = parsePositiveIntId(form.getString("attendee"));
   if (listingId === null || attendeeId === null) {
@@ -94,7 +96,6 @@ const sendSms = (session: AuthSession, form: FormParams): Promise<Response> => {
   const backUrl = smsUrl(listingId, attendeeId);
 
   return withAttendee(
-    session,
     listingId,
     attendeeId,
   )(async (data) => {
@@ -138,7 +139,7 @@ const sendSms = (session: AuthSession, form: FormParams): Promise<Response> => {
         recordContacts(
           [await hashPhone(phone)],
           message,
-          await requirePrivateKey(session),
+          await requireRequestPrivateKey(),
         ),
       );
       await logActivity(

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -37,14 +37,12 @@ import {
 
 // SessionKeyError and the session→private-key derivation live in #shared so
 // shared-layer modules (e.g. the activity log) can reach them without importing
-// the feature layer. Re-exported here for the many route callers that import
-// them from #routes/auth.ts. getPrivateKey is the explicit-session form;
-// requireRequestPrivateKey (#shared/session-private-key.ts) is the
-// request-scoped, thread-free form that needs no session argument.
-export {
-  getSessionPrivateKey as getPrivateKey,
-  SessionKeyError,
-} from "#shared/session-private-key.ts";
+// the feature layer. Re-exported here for the central request error handler
+// (#routes/index.ts), which special-cases it into a re-authenticate response.
+// Route handlers derive the key directly via requireRequestPrivateKey /
+// getRequestPrivateKey (#shared/session-private-key.ts) — the request-scoped,
+// thread-free form that needs no session argument.
+export { SessionKeyError } from "#shared/session-private-key.ts";
 // Re-export for callers that need it
 export { generateSecureToken };
 

--- a/src/features/checkin.ts
+++ b/src/features/checkin.ts
@@ -5,13 +5,7 @@
  */
 
 import { filter, map } from "#fp";
-import {
-  AUTH_FORM,
-  type AuthSession,
-  getAuthenticatedSession,
-  getPrivateKey,
-  withAuth,
-} from "#routes/auth.ts";
+import { AUTH_FORM, getAuthenticatedSession, withAuth } from "#routes/auth.ts";
 import {
   htmlResponse,
   notFoundResponse,
@@ -28,6 +22,7 @@ import { getSearchParam } from "#routes/url.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { updateCheckedIn } from "#shared/db/attendees.ts";
 import { settings } from "#shared/db/settings.ts";
+import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { Attendee } from "#shared/types.ts";
 import { checkinAdminPage, checkinPublicPage } from "#templates/checkin.tsx";
 
@@ -47,12 +42,9 @@ const sumTicketCount = (
   return total;
 };
 
-/** Decrypt entries' attendees using the session's private key */
-const decryptEntries = async (
-  entries: TokenEntry[],
-  session: AuthSession,
-): Promise<TokenEntry[]> => {
-  const privateKey = (await getPrivateKey(session))!;
+/** Decrypt entries' attendees using the current request's private key */
+const decryptEntries = async (entries: TokenEntry[]): Promise<TokenEntry[]> => {
+  const privateKey = await requireRequestPrivateKey();
   return decryptTokenEntries(entries, privateKey);
 };
 
@@ -76,7 +68,7 @@ const handleCheckinGet = (
     const session = await getAuthenticatedSession(request);
     if (!session) return htmlResponse(checkinPublicPage());
 
-    const decrypted = await decryptEntries(entries, session);
+    const decrypted = await decryptEntries(entries);
     const message = getSearchParam(request, "message");
     return htmlResponse(
       checkinAdminPage(
@@ -94,10 +86,10 @@ const handleCheckinPost = (
   request: Request,
   tokens: string[],
 ): Promise<Response> =>
-  withAuth(request, AUTH_FORM, (session, form) =>
+  withAuth(request, AUTH_FORM, (_session, form) =>
     withLookup(tokens, async (entries) => {
       const checkedIn = form.get("check_in") === "true";
-      const decrypted = await decryptEntries(entries, session);
+      const decrypted = await decryptEntries(entries);
       const eligible = filter((e: TokenEntry) => !e.attendee.refunded)(
         decrypted,
       ).map((e) => e.attendee);

--- a/src/features/feeds.ts
+++ b/src/features/feeds.ts
@@ -4,7 +4,7 @@
  */
 
 import { map, pipe } from "#fp";
-import { getPrivateKey, withAuth } from "#routes/auth.ts";
+import { withAuth } from "#routes/auth.ts";
 import { isRegistrationClosed } from "#routes/format.ts";
 import {
   icsResponse,
@@ -24,6 +24,7 @@ import {
 } from "#shared/db/logistics.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getUserAgentIds } from "#shared/db/user-agents.ts";
+import { getRequestPrivateKey } from "#shared/session-private-key.ts";
 import {
   type ListingWithCount,
   loadSortedListings,
@@ -233,7 +234,7 @@ const buildCalendarFeed = async (request: Request): Promise<Response> => {
     request,
     { allowApiKey: true, body: "json", roles: ["owner", "manager", "agent"] },
     async (session) => {
-      const privateKey = await getPrivateKey(session);
+      const privateKey = await getRequestPrivateKey();
       if (!privateKey) return new Response("Forbidden", { status: 403 });
       const listings = await getAllListings();
       const listingById = new Map(listings.map((l) => [l.id, l]));

--- a/test/lib/server-misc-admin-handlers.test.ts
+++ b/test/lib/server-misc-admin-handlers.test.ts
@@ -14,18 +14,6 @@ import {
 } from "#test-utils";
 
 describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
-  describe("routes/admin/utils.ts (requirePrivateKey)", () => {
-    test("throws SessionKeyError when private key is unavailable", async () => {
-      const { requirePrivateKey } = await import("#routes/admin/actions.ts");
-      const { SessionKeyError } = await import("#routes/auth.ts");
-      const session = {
-        token: "any-token",
-        wrappedDataKey: null,
-      } as Parameters<typeof requirePrivateKey>[0];
-      await expect(requirePrivateKey(session)).rejects.toThrow(SessionKeyError);
-    });
-  });
-
   describe("routes/admin/utils.ts (helper factories)", () => {
     test("withEntityLoader returns handler response when entity exists", async () => {
       const { withEntityLoader } = await import(
@@ -60,17 +48,14 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       );
       const cookie = await testCookie();
 
-      const response = await withSessionAndEntity((session, id) =>
-        Promise.resolve({
-          id,
-          userId: session.userId,
-        }),
+      const response = await withSessionAndEntity((id) =>
+        Promise.resolve({ id }),
       )(
         mockRequest("/admin/attendees/1", { headers: { cookie } }),
         123,
-      )((request, _session, entity) => {
+      )((request, session, entity) => {
         const path = new URL(request.url).pathname;
-        return new Response(`${path}:${entity.id}:${entity.userId}`);
+        return new Response(`${path}:${entity.id}:${session.userId}`);
       });
 
       expect(response.status).toBe(200);
@@ -84,7 +69,7 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       const cookie = await testCookie();
       const csrfToken = await testCsrfToken();
 
-      const response = await withAuthAndEntity((_session, id) =>
+      const response = await withAuthAndEntity((id) =>
         Promise.resolve({
           id,
         }),
@@ -112,7 +97,7 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       const csrfToken = await testCsrfToken();
 
       const handlers = createEntityRouteHandlers(
-        (_session, id) => Promise.resolve({ id }),
+        (id) => Promise.resolve({ id }),
         (params: { attendeeId: number }) => params.attendeeId,
       );
 
@@ -144,9 +129,7 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       const cookie = await testCookie();
       const csrfToken = await testCsrfToken();
 
-      const handlers = withAuthEntityHandlers((_session, id) =>
-        Promise.resolve({ id }),
-      );
+      const handlers = withAuthEntityHandlers((id) => Promise.resolve({ id }));
 
       const getResponse = await handlers(
         mockRequest("/admin/attendees/33", { headers: { cookie } }),

--- a/test/lib/server-misc-routing.test.ts
+++ b/test/lib/server-misc-routing.test.ts
@@ -332,10 +332,12 @@ describeWithEnv("server (misc: security and routing)", { db: true }, () => {
     });
   });
 
-  describe("routes/utils.ts (getPrivateKey)", () => {
+  describe("shared/session-private-key.ts (getSessionPrivateKey)", () => {
     test("returns null when wrappedDataKey is null", async () => {
-      const { getPrivateKey } = await import("#routes/auth.ts");
-      const result = await getPrivateKey({
+      const { getSessionPrivateKey } = await import(
+        "#shared/session-private-key.ts"
+      );
+      const result = await getSessionPrivateKey({
         token: "any-token",
         wrappedDataKey: null,
       });
@@ -351,8 +353,10 @@ describeWithEnv("server (misc: security and routing)", { db: true }, () => {
       });
       s.invalidateCache();
 
-      const { getPrivateKey } = await import("#routes/auth.ts");
-      const result = await getPrivateKey({
+      const { getSessionPrivateKey } = await import(
+        "#shared/session-private-key.ts"
+      );
+      const result = await getSessionPrivateKey({
         token: "any-token",
         wrappedDataKey: "some-wrapped-key",
       });
@@ -360,8 +364,10 @@ describeWithEnv("server (misc: security and routing)", { db: true }, () => {
     });
 
     test("returns null when crypto operation throws", async () => {
-      const { getPrivateKey } = await import("#routes/auth.ts");
-      const result = await getPrivateKey({
+      const { getSessionPrivateKey } = await import(
+        "#shared/session-private-key.ts"
+      );
+      const result = await getSessionPrivateKey({
         token: "any-token",
         wrappedDataKey: "corrupt-key-data",
       });

--- a/test/lib/session-context.test.ts
+++ b/test/lib/session-context.test.ts
@@ -71,5 +71,27 @@ describe("session-context", () => {
       const result = runWithSessionContext(() => 42);
       expect(result).toBe(42);
     });
+
+    test("isolates concurrent async flows that interleave their awaits", async () => {
+      // The security-critical property: two requests in flight at once must each
+      // only ever see their own session, even when their awaits interleave on
+      // the event loop. A leak here would let one request read another's
+      // session (and thus derive another user's private key).
+      const flow = (token: string, delayMs: number): Promise<string> =>
+        runWithSessionContext(async () => {
+          setCachedSession(makeSession(token));
+          // Yield control so the other flow runs between setup and read.
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          return getCachedSession()!.token;
+        });
+
+      const [first, second] = await Promise.all([
+        flow("request-a", 10),
+        flow("request-b", 1),
+      ]);
+
+      expect(first).toBe("request-a");
+      expect(second).toBe("request-b");
+    });
   });
 });


### PR DESCRIPTION
## What & why

We pass `session` (and derived `CryptoKey`s) down a lot of call stacks purely to unwrap owner-encrypted PII. The owner private key is already available request-scoped via `requireRequestPrivateKey` / `getRequestPrivateKey`, which read the current request's session from `AsyncLocalStorage` (`runWithSessionContext` wraps every request in `handleRequest`) and derive the key on demand (memoised per session token). This PR verifies that mechanism is sound and then adopts it widely so the threading can go away.

## Soundness verification (first half of the task)

- **Isolation:** `AsyncLocalStorage` binds the session store to each request's async context, so concurrent requests can never read each other's session. Key derivation is memoised by *session token*, so the accessor can only ever return *this* request's key.
- **Fail-closed:** outside a request scope the accessor returns `null` / throws `SessionKeyError`; it never falls back to another session.
- **Equivalence:** every site that derived the key did so from the request's own cached session — both `getAuthenticatedSession` and `getAuthenticatedApiKey` call `setCachedSession` — so the request-scoped accessor is provably equivalent at those sites. Bulk-email and calendar-feed decryption all run synchronously inside the request handler (not in background `pending-work`), so there is no deferred-context hazard.
- Added a `session-context` test that proves two concurrent async flows whose `await`s interleave each only ever see their own session.

## The migration (second half)

- Removed the duplicate `requirePrivateKey(session)` helper and the `getPrivateKey(session)` re-export; migrated all callers to the request-scoped accessors.
- Pruned `session` parameters that existed only to derive the key, cascading through their callers — including the `entity-handlers` loader contract, whose only loader (`loadMergeTarget`) no longer needs the session, so loaders are now `(id) => …`.
- Kept the **nullable** `getRequestPrivateKey` at the calendar-feed and scanner-JSON endpoints, which return their own `403`/`500` rather than the re-authenticate response `SessionKeyError` triggers — preserving behaviour exactly.

## Checks

`deno task precommit` passes: lint, typecheck, cpd (0%), build:edge, and tests at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EebEJ6T2oBiegd36qLkz7g)_