### PR TITLE
Assert the retry backoff actually suspends between attempts

### DIFF
--- a/test/lib/retry.test.ts
+++ b/test/lib/retry.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import { retryWithBackoff } from "#shared/retry.ts";
 
 describe("retryWithBackoff", () => {
@@ -67,6 +68,33 @@ describe("retryWithBackoff", () => {
       ),
     ).rejects.toThrow("non-retryable");
     expect(attempts).toBe(1);
+  });
+
+  test("waits for the backoff delay before the next attempt", async () => {
+    const time = new FakeTime();
+    try {
+      let attempts = 0;
+      const promise = retryWithBackoff(
+        () => {
+          attempts++;
+          return attempts < 2
+            ? Promise.reject(new Error("transient"))
+            : Promise.resolve("ok");
+        },
+        [1000],
+        () => {},
+      );
+      // Flush microtasks: the first attempt has failed and is now parked on the
+      // 1000ms backoff, so the retry must not have run yet.
+      await time.tickAsync(0);
+      expect(attempts).toBe(1);
+      // Only once the backoff elapses does the next attempt fire.
+      await time.tickAsync(1000);
+      expect(await promise).toBe("ok");
+      expect(attempts).toBe(2);
+    } finally {
+      time.restore();
+    }
   });
 
   test("lets onError swap in a different error on the final attempt", async () => {


### PR DESCRIPTION
Follow-up to #1405. Mutation testing of the new `retryWithBackoff` helper surfaced one surviving mutant:

```
src/shared/retry.ts:38:7  await delay(backoffMs[attempt]!);  → (removed)
```

The existing tests only asserted *outcomes* (success / rethrow / abort), so removing the backoff `delay` between attempts changed nothing they checked — they'd still pass with the retries firing back-to-back.

## Change

Adds a `FakeTime` test that:
1. flushes microtasks after the first attempt fails and asserts the retry has **not** fired yet (it's parked on the backoff timer), then
2. advances fake time past the backoff and asserts the next attempt runs and resolves.

With the `delay` removed, the retry runs immediately, step 1's assertion fails, and the mutant is killed.

Mutation score for `src/shared/retry.ts` goes from **88.9% (8/9)** to **100% (9/9)**. No production code changes — test-only hardening.

Full `deno task precommit` is green (typecheck, lint, jscpd 0%, edge build, 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezdmsysYVywQniU4czkbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KezdmsysYVywQniU4czkbC)_