### PR TITLE
Decision 17: require a money decision when a merge discards a paid booking (+ eventGroup batch guard)

### DIFF
--- a/accounting-plan.md
+++ b/accounting-plan.md
@@ -380,12 +380,18 @@ tests) before the corresponding path goes live.
 
 ### Merge
 
-- [ ] **A merge conflict requires an explicit operator decision** — a *required*
-  field resolves each conflicting booking (keep both records' payments as the
-  person's credit, or route the losing side to a manual adjustment). A clean merge
-  still moves every leg wholesale; a conflict never auto-moves a discarded order's
-  money onto the target by a silent default (decision 17; AGENTS.md "Operator
-  decides genuine conflicts").
+- [x] **A merge conflict requires an explicit operator decision** — when the
+  booking the operator discards carries a recognised `sale`, a *required* money
+  field resolves it (no silent default): `credit` keeps the over-collected cash as
+  the merged person's credit (`writeoff → attendee`), `writeoff` parks it in the
+  `writeoff` contra account. Either way the discarded `sale` is un-billed
+  (`revenue → writeoff`) so the listing's income counts the kept ticket once
+  instead of double-counting the duplicate. A clean (moveable) booking still moves
+  every leg wholesale with no decision; a conflict never auto-moves a discarded
+  order's money onto the target. `validateAttendeeMergeDecision` rejects a merge
+  that omits the choice, and the un-bill/credit legs post in the same write
+  transaction as the repoint (decision 17; AGENTS.md "Operator decides genuine
+  conflicts").
 
 ### PSP modelling (later)
 

--- a/src/features/admin/attendees-merge.ts
+++ b/src/features/admin/attendees-merge.ts
@@ -26,8 +26,8 @@ import { getQuestionsWithListingIds } from "#shared/db/questions.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import {
   applyAttendeeMerge,
-  bookingKey,
   buildAttendeeMergeDiff,
+  conflictBookingEntries,
   validateAttendeeMergeDecision,
 } from "#shared/merge/attendee-merge.ts";
 import type {
@@ -35,6 +35,7 @@ import type {
   AttendeeMergeDiff,
   MergeAnswerChoice,
   MergeBookingChoice,
+  MergeMoneyChoice,
   MergeValueChoice,
 } from "#shared/merge/attendee-merge-types.ts";
 import type { Attendee } from "#shared/types.ts";
@@ -209,6 +210,13 @@ const mergeCountParts = (fields: Array<[number, string]>): string[] =>
     map(([count, label]: [number, string]) => `${count} ${label}`),
   )(fields);
 
+/** The booking-movement counts every merge message leads with, before each
+ *  surface adds its own (the log is fuller; the flash is a short confirmation). */
+const bookingMoveParts = (summary: MergeSummary): Array<[number, string]> => [
+  [summary.bookingsMoved, "booking(s) moved"],
+  [summary.bookingsSkipped, "booking(s) skipped"],
+];
+
 /** Build activity log message parts for a merge summary */
 const buildMergeLogParts = (
   summary: MergeSummary,
@@ -217,9 +225,10 @@ const buildMergeLogParts = (
 ): string[] => [
   `Attendee '${sourceName}' merged into '${mergedPiiName}'`,
   ...mergeCountParts([
-    [summary.bookingsMoved, "booking(s) moved"],
-    [summary.bookingsSkipped, "booking(s) skipped"],
+    ...bookingMoveParts(summary),
     [summary.bookingsReplacedTarget, "booking(s) replaced"],
+    [summary.bookingsCredited, "payment(s) kept as credit"],
+    [summary.bookingsWrittenOff, "payment(s) written off"],
     [summary.answersTakenFromSource, "answer(s) from source"],
     [summary.answersCleared, "answer(s) cleared"],
   ]),
@@ -233,8 +242,9 @@ const buildMergeFlashParts = (
 ): string[] => [
   `Merged ${sourceName} into ${mergedPiiName}`,
   ...mergeCountParts([
-    [summary.bookingsMoved, "booking(s) moved"],
-    [summary.bookingsSkipped, "booking(s) skipped"],
+    ...bookingMoveParts(summary),
+    [summary.bookingsCredited, "payment(s) credited"],
+    [summary.bookingsWrittenOff, "payment(s) written off"],
   ]),
 ];
 
@@ -367,21 +377,49 @@ const toBookingChoice = (raw: string): MergeBookingChoice => {
   return "keep_target";
 };
 
+/** Build a per-conflict decision Record by parsing each NON-moveable booking's
+ *  form field (keyed by "listingId:startAt"). A `parse` result of `undefined`
+ *  leaves the entry out — so a blank money choice stays absent and validation can
+ *  demand it, while `toBookingChoice` (which always resolves) fills every row. */
+const parseConflictDecisions = <T>(
+  diff: AttendeeMergeDiff,
+  parse: (key: string) => T | undefined,
+): Record<string, T> => {
+  const out: Record<string, T> = {};
+  for (const { key } of conflictBookingEntries(diff)) {
+    const value = parse(key);
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+};
+
 /** Parse booking decisions from form (only non-moveable items) */
 const parseBookingDecisions = (
   form: FormParams,
   diff: AttendeeMergeDiff,
-): Record<string, MergeBookingChoice> => {
-  const bookings: Record<string, MergeBookingChoice> = {};
-  for (const item of diff.bookingItems) {
-    if (item.conflictClass !== "moveable") {
-      const key = bookingKey(item.listingId, item.startAt);
-      const val = form.getString(`booking_${key}`);
-      bookings[key] = toBookingChoice(val);
-    }
-  }
-  return bookings;
+): Record<string, MergeBookingChoice> =>
+  parseConflictDecisions(diff, (key) =>
+    toBookingChoice(form.getString(`booking_${key}`)),
+  );
+
+/** Normalize a raw money choice; an empty/unknown value is left ABSENT so
+ *  validation can require an explicit decision (decision 17 — never defaulted). */
+const toMoneyChoice = (raw: string): MergeMoneyChoice | undefined => {
+  if (raw === "credit") return "credit";
+  if (raw === "writeoff") return "writeoff";
+  return undefined;
 };
+
+/** Parse money decisions from form (only conflicting items); a blank choice is
+ *  omitted so validateAttendeeMergeDecision rejects the merge until the operator
+ *  decides what happens to the discarded booking's money. */
+const parseMoneyDecisions = (
+  form: FormParams,
+  diff: AttendeeMergeDiff,
+): Record<string, MergeMoneyChoice> =>
+  parseConflictDecisions(diff, (key) =>
+    toMoneyChoice(form.getString(`money_${key}`)),
+  );
 
 /** Parse merge decision form data into AttendeeMergeDecisionInput */
 const parseMergeDecisionForm = (
@@ -390,6 +428,7 @@ const parseMergeDecisionForm = (
 ): AttendeeMergeDecisionInput => ({
   answers: parseAnswerDecisions(form, diff),
   bookings: parseBookingDecisions(form, diff),
+  money: parseMoneyDecisions(form, diff),
   pii: parsePiiDecisions(form, diff),
   version: form.getString("merge_version"),
 });

--- a/src/locales/en/attendees.json
+++ b/src/locales/en/attendees.json
@@ -56,6 +56,7 @@
   "attendee_form.no_email_disabled_title": "This attendee has no email address on file",
   "attendee_form.merge_attendee_title": "Merge Attendee",
   "attendee_form.merge_attendee_description": "Search for another attendee by their ticket token and merge their listing registrations into this attendee.",
+  "attendee_form.merge_discarded_payment_label": "Discarded payment",
   "attendee_form.ticket_token_label": "Ticket token",
   "attendee_form.enter_ticket_token_placeholder": "Enter ticket token…",
   "attendee_form.search_button": "Search",

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -281,6 +281,18 @@ export const postTransferGroups = async (
   // writes: each group valid on its own, and across the batch no repeated
   // reference (which would silently under-post or collide two events).
   for (const inputs of nonEmpty) assertPostable(inputs);
+  // Each element of `groups` must be ONE event — distinct event groups. Two
+  // elements sharing an eventGroup would both plan against the same pre-write
+  // snapshot (neither sees the other), both insert, and the event would end up
+  // holding the UNION of their legs — after which an idempotent replay of either
+  // original fails `assertEventMatches`. Reject up front (chunks for one event
+  // must be combined into a single group before calling this).
+  const eventGroups = nonEmpty.map((inputs) => inputs[0]!.eventGroup);
+  if (new Set(eventGroups).size !== eventGroups.length) {
+    throw new Error(
+      "postTransferGroups: duplicate eventGroup across the batch",
+    );
+  }
   const allRefs = nonEmpty.flatMap((inputs) => inputs.map((t) => t.reference));
   if (new Set(allRefs).size !== allRefs.length) {
     throw new Error("postTransferGroups: duplicate reference across the batch");

--- a/src/shared/merge/attendee-merge-types.ts
+++ b/src/shared/merge/attendee-merge-types.ts
@@ -22,6 +22,18 @@ export type MergeAnswerChoice = "target" | "source" | "clear";
 /** How to handle a source booking conflict */
 export type MergeBookingChoice = "keep_target" | "take_source" | "skip_source";
 
+/**
+ * What happens to a CONFLICTING booking's money when its row is discarded by the
+ * booking choice (decision 17 — a required operator choice, never a silent
+ * default). The losing booking's `sale` is always un-billed (so the listing's
+ * income counts the kept ticket once); the choice decides the over-collected
+ * cash:
+ * - `credit` — keep it as the merged person's credit (they show a negative owed).
+ * - `writeoff` — park it in the `writeoff` contra account (they owe nothing; the
+ *   cash is written off transparently).
+ */
+export type MergeMoneyChoice = "credit" | "writeoff";
+
 // ---------------------------------------------------------------------------
 // Diff (output of analyze step)
 // ---------------------------------------------------------------------------
@@ -60,6 +72,14 @@ export type AttendeeMergeDiffBookingItem = {
   sourceBooking: ListingAttendeeRow;
   targetBooking: ListingAttendeeRow | null;
   conflictClass: BookingConflictClass;
+  /** The source booking's recognised `sale` amount (gross ticket price) in the
+   *  ledger, 0 when it carries no money. Decision 17 requires a money choice when
+   *  the booking the operator discards has an amount > 0. */
+  sourceSaleAmount: number;
+  /** The conflicting target booking's `sale` amount; 0 for a moveable source
+   *  booking (no target) or a free target. (`targetBooking === null` is the
+   *  signal for "no target", so this stays a plain number.) */
+  targetSaleAmount: number;
 };
 
 /** Full diff result from analyze step */
@@ -86,11 +106,16 @@ export type AttendeeMergeDecisionAnswers = Record<string, MergeAnswerChoice>;
 /** Per-booking decision (keyed by "listingId:startAt") */
 export type AttendeeMergeDecisionBookings = Record<string, MergeBookingChoice>;
 
+/** Per-conflict money decision (keyed by "listingId:startAt"), required when the
+ *  booking the operator discards carries money (decision 17). */
+export type AttendeeMergeDecisionMoney = Record<string, MergeMoneyChoice>;
+
 /** Full decision payload from the form */
 export type AttendeeMergeDecisionInput = {
   pii: AttendeeMergeDecisionPii;
   answers: AttendeeMergeDecisionAnswers;
   bookings: AttendeeMergeDecisionBookings;
+  money: AttendeeMergeDecisionMoney;
   version: string;
 };
 
@@ -115,6 +140,10 @@ export type AttendeeMergeApplySummary = {
   bookingsMoved: number;
   bookingsSkipped: number;
   bookingsReplacedTarget: number;
+  /** Conflicting bookings whose money was kept as the person's credit. */
+  bookingsCredited: number;
+  /** Conflicting bookings whose money was written off (decision 17). */
+  bookingsWrittenOff: number;
 };
 
 /** Result of applying a merge */

--- a/src/shared/merge/attendee-merge.ts
+++ b/src/shared/merge/attendee-merge.ts
@@ -6,16 +6,24 @@
  * 2. applyAttendeeMerge: apply explicit decisions from the admin
  */
 
-import { filter, map, reduce } from "#fp";
+import type { InValue } from "@libsql/client";
+import { filter, map, mapParallel, reduce } from "#fp";
+import {
+  attendeeAccount,
+  revenueAccount,
+} from "#shared/accounting/accounts.ts";
+import { ledgerTx } from "#shared/accounting/ledger-tx.ts";
+import { transfersByEventGroup } from "#shared/accounting/queries.ts";
 import { repointAttendeeStatements } from "#shared/accounting/repoint.ts";
 import type { ListingAttendeeRow } from "#shared/db/attendee-types.ts";
-import { executeBatch, insert } from "#shared/db/client.ts";
+import { insert, withTransaction } from "#shared/db/client.ts";
 import type { QuestionWithAnswers } from "#shared/db/questions.ts";
 import {
   getAttendeeAnswersByQuestion,
   getAttendeeTextAnswers,
   saveAttendeeAnswers,
 } from "#shared/db/questions.ts";
+import type { AccountRef } from "#shared/ledger/types.ts";
 import type {
   ApplyAttendeeMergeInput,
   AttendeeMergeApplyResult,
@@ -28,6 +36,7 @@ import type {
   AttendeeMergeValidationResult,
   BookingConflictClass,
   BuildAttendeeMergeDiffInput,
+  MergeBookingChoice,
 } from "#shared/merge/attendee-merge-types.ts";
 
 // ---------------------------------------------------------------------------
@@ -65,15 +74,26 @@ export const bookingKey = (listingId: number, startAt: string | null): string =>
 const itemBookingKey = (item: AttendeeMergeDiffBookingItem): string =>
   bookingKey(item.listingId, item.startAt);
 
+/** The NON-moveable conflict booking items paired with their decision key
+ *  ("listingId:startAt") — the rows the operator must decide on. The single place
+ *  the "skip moveable rows, key the rest" walk lives, shared by validation, the
+ *  decision-17 money legs, and the admin form parser, so they can never drift. */
+export const conflictBookingEntries = (
+  diff: AttendeeMergeDiff,
+): Array<{ item: AttendeeMergeDiffBookingItem; key: string }> =>
+  diff.bookingItems
+    .filter((item) => item.conflictClass !== "moveable")
+    .map((item) => ({ item, key: itemBookingKey(item) }));
+
 /** Determine the conflict label for a non-moveable booking item */
 export const bookingConflictLabel = (
-  item: AttendeeMergeDiffBookingItem,
+  item: Pick<AttendeeMergeDiffBookingItem, "conflictClass">,
 ): string =>
   item.conflictClass === "duplicate" ? "Duplicate" : "Conflicting metadata";
 
 /** Whether a set of booking items contains any non-moveable conflicts */
 export const hasBookingConflicts = (
-  items: AttendeeMergeDiffBookingItem[],
+  items: Pick<AttendeeMergeDiffBookingItem, "conflictClass">[],
 ): boolean => items.some((b) => b.conflictClass !== "moveable");
 
 /** Determine display label for a non-conflicting answer item */
@@ -171,7 +191,12 @@ export const buildAttendeeMergeDiff = async (
   );
 
   // --- Bookings ---
-  const bookingItems = buildBookingDiffItems(targetBookings, sourceBookings);
+  const bookingItems = await buildBookingDiffItems(
+    targetId,
+    sourceId,
+    targetBookings,
+    sourceBookings,
+  );
 
   const version = computeVersion(
     targetId,
@@ -217,12 +242,65 @@ const buildAnswerDiffItems = (
   }, [] as AttendeeMergeDiffAnswerItem[])([...relevantQuestionIds]);
 };
 
-/** Build booking diff items comparing source bookings against target */
+/**
+ * One booking's recognised `sale` amount (its gross ticket price) in the ledger:
+ * the `sale` legs of its order (`ledger_event_group`) that bill THIS attendee for
+ * THIS listing. 0 for a free or pre-ledger booking. This is the money decision 17
+ * has to resolve when the operator discards the booking — un-billing it removes
+ * the double-counted income, and the same amount is the over-collected cash to
+ * credit or write off.
+ */
+const bookingSaleAmount = async (
+  attendeeId: number,
+  listingId: number,
+  eventGroup: string,
+): Promise<number> => {
+  if (!eventGroup) return 0;
+  const account = attendeeAccount(attendeeId);
+  const revenue = revenueAccount(listingId);
+  const legs = await transfersByEventGroup(eventGroup);
+  return legs
+    .filter(
+      (leg) =>
+        leg.kind === "sale" &&
+        leg.source.type === account.type &&
+        leg.source.id === account.id &&
+        leg.destination.type === revenue.type &&
+        leg.destination.id === revenue.id,
+    )
+    .reduce((sum, leg) => sum + leg.amount, 0);
+};
+
+/** Classify a source booking against the target's bookings at the same key. */
+const classifyBooking = (
+  sb: ListingAttendeeRow,
+  tb: ListingAttendeeRow | null,
+): BookingConflictClass => {
+  if (!tb) return "moveable";
+  // `refunded` is now ledger-fed (order-level: every booking of an attendee
+  // shares it), so this compares the target attendee's refund status against the
+  // source's. Kept in the duplicate test so a row that differs only in refund
+  // status is still surfaced as conflicting metadata, not a silent duplicate.
+  if (
+    tb.quantity === sb.quantity &&
+    tb.price_paid === sb.price_paid &&
+    tb.checked_in === sb.checked_in &&
+    tb.refunded === sb.refunded
+  ) {
+    return "duplicate";
+  }
+  return "conflicting_metadata";
+};
+
+/** Build booking diff items comparing source bookings against target, loading the
+ *  ledger `sale` amount for each conflict so decision 17 can require a money
+ *  choice and the UI can show what is at stake. */
 const buildBookingDiffItems = (
+  targetId: number,
+  sourceId: number,
   targetBookings: ListingAttendeeRow[],
   sourceBookings: ListingAttendeeRow[],
-): AttendeeMergeDiffBookingItem[] => {
-  // Index target bookings by key
+): Promise<AttendeeMergeDiffBookingItem[]> => {
   const targetByKey = new Map(
     map(
       (b: ListingAttendeeRow) =>
@@ -230,37 +308,40 @@ const buildBookingDiffItems = (
     )(targetBookings),
   );
 
-  return map((sb: ListingAttendeeRow): AttendeeMergeDiffBookingItem => {
-    const key = bookingKey(sb.listing_id, sb.start_at);
-    const tb = targetByKey.get(key) ?? null;
-    let conflictClass: BookingConflictClass;
-
-    if (!tb) {
-      conflictClass = "moveable";
-    } else if (
-      tb.quantity === sb.quantity &&
-      tb.price_paid === sb.price_paid &&
-      tb.checked_in === sb.checked_in &&
-      // `refunded` is now ledger-fed (order-level: every booking of an attendee
-      // shares it), so this compares the target attendee's refund status against
-      // the source's. Kept in the duplicate test so a row that differs only in
-      // refund status is still surfaced as conflicting metadata, not a silent
-      // duplicate.
-      tb.refunded === sb.refunded
-    ) {
-      conflictClass = "duplicate";
-    } else {
-      conflictClass = "conflicting_metadata";
-    }
-
-    return {
-      conflictClass,
-      listingId: sb.listing_id,
-      sourceBooking: sb,
-      startAt: sb.start_at,
-      targetBooking: tb,
-    };
-  })(sourceBookings);
+  return mapParallel(
+    async (sb: ListingAttendeeRow): Promise<AttendeeMergeDiffBookingItem> => {
+      const tb =
+        targetByKey.get(bookingKey(sb.listing_id, sb.start_at)) ?? null;
+      const conflictClass = classifyBooking(sb, tb);
+      // A moveable booking moves with its own money (no decision, no
+      // double-count); only a conflict needs the amounts at stake.
+      const sourceSaleAmount =
+        conflictClass === "moveable"
+          ? 0
+          : await bookingSaleAmount(
+              sourceId,
+              sb.listing_id,
+              sb.ledger_event_group,
+            );
+      const targetSaleAmount =
+        tb === null
+          ? 0
+          : await bookingSaleAmount(
+              targetId,
+              tb.listing_id,
+              tb.ledger_event_group,
+            );
+      return {
+        conflictClass,
+        listingId: sb.listing_id,
+        sourceBooking: sb,
+        sourceSaleAmount,
+        startAt: sb.start_at,
+        targetBooking: tb,
+        targetSaleAmount,
+      };
+    },
+  )(sourceBookings);
 };
 
 // ---------------------------------------------------------------------------
@@ -294,21 +375,35 @@ export const validateAttendeeMergeDecision = (
     }
   }
 
-  // Check booking decisions for conflicts
-  const conflictingBookings = filter(
-    (b: AttendeeMergeDiffBookingItem) => b.conflictClass !== "moveable",
-  )(diff.bookingItems);
-  for (const item of conflictingBookings) {
-    if (!decision.bookings[itemBookingKey(item)]) {
-      errors.push(
-        `Missing decision for booking: Listing #${item.listingId}${
-          item.startAt ? ` (${item.startAt.slice(0, 10)})` : ""
-        }`,
-      );
+  // Check booking decisions for conflicts — both the row choice AND, when the
+  // booking the operator discards carries money, the decision-17 money choice
+  // (credit vs write-off). Neither is ever defaulted silently.
+  for (const { item, key } of conflictBookingEntries(diff)) {
+    const label = `Listing #${item.listingId}${
+      item.startAt ? ` (${item.startAt.slice(0, 10)})` : ""
+    }`;
+    const bookingChoice = decision.bookings[key];
+    if (!bookingChoice) {
+      errors.push(`Missing decision for booking: ${label}`);
+      continue;
+    }
+    if (discardedSaleAmount(item, bookingChoice) > 0 && !decision.money[key]) {
+      errors.push(`Missing money decision for booking: ${label}`);
     }
   }
 
   return errors.length > 0 ? { errors, valid: false } : { valid: true };
+};
+
+/** The `sale` amount the booking choice DISCARDS — the source booking for
+ *  keep_target/skip_source, the target booking for take_source — so decision 17
+ *  only demands a money choice when real money is being set aside. */
+const discardedSaleAmount = (
+  item: AttendeeMergeDiffBookingItem,
+  bookingChoice: MergeBookingChoice,
+): number => {
+  if (bookingChoice === "take_source") return item.targetSaleAmount;
+  return item.sourceSaleAmount;
 };
 
 // ---------------------------------------------------------------------------
@@ -484,6 +579,60 @@ const applyBookingDecisions = (
   };
 };
 
+/** One decision-17 reversal: a `writeoff` adjustment moving `account`'s balance
+ *  by `delta` (credit-the-account terms). */
+type MoneyReversal = {
+  account: AccountRef;
+  delta: number;
+  keyParts: (string | number)[];
+};
+
+/**
+ * Decision 17 — the `writeoff`-adjustment legs that resolve the money of each
+ * CONFLICTING booking the operator discards. Both choices UN-BILL the discarded
+ * `sale` (`revenue:L → writeoff`), so the listing's income counts the kept ticket
+ * once instead of double-counting the duplicate; `credit` then hands the
+ * over-collected cash back to the merged person (`writeoff → attendee:target`,
+ * surfacing it as a credit), while `writeoff` leaves it parked in the contra
+ * account so cash reports stay honest. Posted against the TARGET, onto which the
+ * source's legs were just repointed. A free/0-amount conflict produces no legs.
+ */
+const moneyReversalLegs = (
+  targetId: number,
+  diff: AttendeeMergeDiff,
+  decision: AttendeeMergeDecisionInput,
+): { legs: MoneyReversal[]; credited: number; writtenOff: number } => {
+  const legs: MoneyReversal[] = [];
+  let credited = 0;
+  let writtenOff = 0;
+  for (const { item, key } of conflictBookingEntries(diff)) {
+    // Every conflict carries a booking choice by the time apply runs — the form
+    // parser fills `keep_target` by default and validateAttendeeMergeDecision
+    // rejects a missing one — so this read always resolves.
+    const amount = discardedSaleAmount(item, decision.bookings[key]!);
+    if (amount <= 0) continue;
+    // Un-bill the discarded booking so the listing's income counts the kept ticket
+    // once (revenue:L → writeoff).
+    legs.push({
+      account: revenueAccount(item.listingId),
+      delta: -amount,
+      keyParts: ["merge-unbill", targetId, key],
+    });
+    if (decision.money[key] === "credit") {
+      // Hand the over-collected cash to the merged person (writeoff → attendee).
+      legs.push({
+        account: attendeeAccount(targetId),
+        delta: amount,
+        keyParts: ["merge-credit", targetId, key],
+      });
+      credited++;
+    } else {
+      writtenOff++;
+    }
+  }
+  return { credited, legs, writtenOff };
+};
+
 /** Apply a validated merge with explicit decisions */
 export const applyAttendeeMerge = async (
   input: ApplyAttendeeMergeInput,
@@ -533,8 +682,18 @@ export const applyAttendeeMerge = async (
     ...targetTextAnswers,
   ]);
 
-  // --- 4. Execute all DB changes atomically ---
-  await executeBatch([
+  // --- 4. Resolve decision-17 money for the discarded conflicting bookings ---
+  const {
+    legs: moneyLegs,
+    credited: bookingsCredited,
+    writtenOff: bookingsWrittenOff,
+  } = moneyReversalLegs(targetId, diff, decision);
+
+  // --- 5. Execute all DB changes atomically ---
+  // One interactive write transaction so the row changes, the ledger repoint, and
+  // the decision-17 reversal legs commit or roll back together — a half-merge
+  // would strand money or leave income double-counted.
+  const rowStatements: { args: InValue[]; sql: string }[] = [
     // Delete target bookings that are being replaced
     ...deleteTargetBookingStatements,
     // Insert moved/replaced source bookings
@@ -557,7 +716,15 @@ export const applyAttendeeMerge = async (
     // account-id mutation — so its financial history follows the merged person
     // rather than stranding on the deleted source (plan §5.17).
     ...repointAttendeeStatements(sourceId, targetId),
-  ]);
+  ];
+  await withTransaction(async (tx) => {
+    for (const statement of rowStatements) await tx.execute(statement);
+    // After the repoint (the discarded booking's legs now sit on the target),
+    // post the reversal legs that un-bill it and credit / write off its cash.
+    for (const leg of moneyLegs) {
+      await ledgerTx.adjust(tx, leg.account, leg.delta, leg.keyParts);
+    }
+  });
 
   // Save merged answers for target. The choice decisions reduce to one answer
   // per question; re-supplying the merged free-text plaintext lets
@@ -582,9 +749,11 @@ export const applyAttendeeMerge = async (
     answersCleared,
     answersKept,
     answersTakenFromSource,
+    bookingsCredited,
     bookingsMoved,
     bookingsReplacedTarget,
     bookingsSkipped,
+    bookingsWrittenOff,
     piiFieldsFromSource,
   };
 

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -464,6 +464,12 @@ const MergeBookingsDecisionTable = ({
               const conflictLabel = bookingConflictLabel(item);
               const targetQty = item.targetBooking!.quantity;
               const sourceQty = item.sourceBooking.quantity;
+              // The most either side's discarded ticket could be worth; >0 means
+              // a payment is at stake, so decision 17 demands a credit/write-off.
+              const moneyAtStake = Math.max(
+                item.sourceSaleAmount,
+                item.targetSaleAmount,
+              );
 
               return (
                 <tr>
@@ -495,6 +501,35 @@ const MergeBookingsDecisionTable = ({
                       <input name={name} type="radio" value="skip_source" />{" "}
                       Skip source
                     </label>
+                    {moneyAtStake > 0 && (
+                      <div class="merge-money-decision">
+                        <p class="muted">
+                          <strong>
+                            {t("attendee_form.merge_discarded_payment_label")}
+                          </strong>{" "}
+                          (source {formatCurrency(item.sourceSaleAmount)},
+                          target {formatCurrency(item.targetSaleAmount)}) — this
+                          can't be undone, so choose explicitly:
+                        </p>
+                        <label>
+                          <input
+                            name={`money_${key}`}
+                            type="radio"
+                            value="credit"
+                          />{" "}
+                          Keep as the person's credit
+                        </label>
+                        <br />
+                        <label>
+                          <input
+                            name={`money_${key}`}
+                            type="radio"
+                            value="writeoff"
+                          />{" "}
+                          Write it off
+                        </label>
+                      </div>
+                    )}
                   </td>
                 </tr>
               );

--- a/test/e2e/accounting.test.ts
+++ b/test/e2e/accounting.test.ts
@@ -243,6 +243,56 @@ const mergePost = async (
   );
 };
 
+/** Build a listing with two fully-PAID duplicate bookings (a target and a
+ *  token-bearing source) on it — the same-listing conflict decision 17 must
+ *  resolve. Income counts BOTH £50 tickets (£100) until the merge un-bills the
+ *  discarded one. Returns the ids plus the source's merge token. */
+const twoPaidDuplicates = async (
+  name: string,
+): Promise<{
+  listingId: number;
+  targetId: number;
+  sourceId: number;
+  sourceToken: string;
+}> => {
+  const listing = await createTestListing({
+    maxAttendees: 10,
+    name,
+    unitPrice: 5000,
+  });
+  const { attendee: target } = await createTestAttendeeDirect(
+    listing.id,
+    `${name} Target`,
+    `target-${name}@example.com`,
+  );
+  const { attendee: source, token: sourceToken } =
+    await createTestAttendeeDirect(
+      listing.id,
+      `${name} Source`,
+      `source-${name}@example.com`,
+    );
+  await postListingSale({
+    attendeeId: target.id,
+    gross: 5000,
+    listingId: listing.id,
+  });
+  await postListingSale({
+    attendeeId: source.id,
+    gross: 5000,
+    listingId: listing.id,
+  });
+  return {
+    listingId: listing.id,
+    sourceId: source.id,
+    sourceToken,
+    targetId: target.id,
+  };
+};
+
+/** The money-decision form field paired with a scraped `booking_<key>` field. */
+const moneyFieldFor = (bookingField: string): string =>
+  bookingField.replace("booking_", "money_");
+
 // -- Public-payment driver (mirrors server-payments-success.test.ts) ------ //
 
 /** A compact modifier ref as it rides the signed metadata (`{ i: id, q: qty }`). */
@@ -1283,64 +1333,149 @@ describeWithEnv("e2e: accounting lifecycle", { db: true }, () => {
     expect(await sumOfAllBalances()).toBe(0);
   });
 
-  // 17. Merging two attendees moves the money with them: the operator resolves the
-  //     conflicting same-listing booking (decision 17 — an explicit choice from the
-  //     form), then the source's ledger rows repoint onto the surviving target, so
-  //     what was owed follows the survivor and conservation holds.
-  test("a merge repoints the source's owed balance onto the surviving attendee", async () => {
-    const listing = await createTestListing({
-      maxAttendees: 10,
-      name: "Reunion",
-      unitPrice: 5000,
-    });
-    const { attendee: target } = await createTestAttendeeDirect(
-      listing.id,
-      "Jane Doe",
-      "jane@example.com",
-    );
-    const { attendee: source, token: sourceToken } =
-      await createTestAttendeeDirect(
-        listing.id,
-        "John Smith",
-        "john@example.com",
-      );
-    // Each owes £50 in the ledger (a gross sale with nothing paid).
-    await postListingSale({
-      amountPaid: 0,
-      attendeeId: target.id,
-      gross: 5000,
-      listingId: listing.id,
-    });
-    await postListingSale({
-      amountPaid: 0,
-      attendeeId: source.id,
-      gross: 5000,
-      listingId: listing.id,
-    });
-    expect(await owedBy(target.id)).toBe(5000);
-    expect(await owedBy(source.id)).toBe(5000);
+  // 17. Merging two PAID duplicate bookings, CREDIT choice (decision 17 — an
+  //     explicit operator choice, never a silent default): the survivor keeps ONE
+  //     ticket, the discarded duplicate's recognised sale is un-billed (so the
+  //     listing's income counts the kept ticket once, not twice), and the £50 the
+  //     duplicate paid is handed back as the survivor's CREDIT. The source account
+  //     empties, conservation holds, and the credit is shown on the balance page.
+  test("a merge crediting a paid duplicate shows the survivor's credit", async () => {
+    const { listingId, targetId, sourceId, sourceToken } =
+      await twoPaidDuplicates("Reunion");
+    // Both tickets recognised: income counts £100 before the merge resolves it.
+    expect(await incomeOf(listingId)).toBe(10000);
+    expect(await owedBy(targetId)).toBe(0);
+    expect(await owedBy(sourceId)).toBe(0);
 
-    // The operator resolves the conflicting same-listing booking (the decision is
-    // scraped from the rendered form), then applies the merge.
-    const { version, bookingField } = await mergePreview(
-      target.id,
-      sourceToken,
-    );
-    const merged = await mergePost(target.id, {
+    // Keep the target ticket; CREDIT the discarded source payment (both decisions
+    // are scraped from the rendered form, then applied).
+    const { version, bookingField } = await mergePreview(targetId, sourceToken);
+    const merged = await mergePost(targetId, {
       [bookingField]: "keep_target",
+      [moneyFieldFor(bookingField)]: "credit",
       merge_version: version,
       source_token: sourceToken,
     });
     expect(merged.status).toBe(302);
 
-    // The money follows the survivor: the source account is emptied (its ledger
-    // rows moved) and the target now holds both owed balances; conservation holds.
-    expect(norm(await accountBalance(attendeeAccount(source.id)))).toBe(0);
-    expect(await owedBy(target.id)).toBe(10000);
+    // Income now counts the ONE kept ticket; the survivor holds the over-paid £50
+    // as a credit (negative owed); the source account is emptied; conservation holds.
+    expect(await incomeOf(listingId)).toBe(5000);
+    expect(await owedBy(targetId)).toBe(-5000);
+    expect(norm(await accountBalance(attendeeAccount(sourceId)))).toBe(0);
+    expect(await sumOfAllBalances()).toBe(0);
+
+    // Transparency: the survivor's balance page renders the £50 credit figure.
+    const balancePage = await adminPageHtml(
+      `/admin/attendees/${targetId}/balance`,
+    );
+    expect(balancePage).toContain(formatCurrency(-5000));
+  });
+
+  // 18. The same paid duplicate, WRITE-OFF choice: income still counts the one kept
+  //     ticket, but the over-paid £50 is parked in the `writeoff` contra account
+  //     rather than credited — the survivor owes nothing and cash reports stay
+  //     honest. Conservation still holds.
+  test("a merge writing off a paid duplicate parks the cash in writeoff", async () => {
+    const { listingId, targetId, sourceId, sourceToken } =
+      await twoPaidDuplicates("Gala");
+    const writeoffBefore = norm(await accountBalance(WRITEOFF));
+
+    const { version, bookingField } = await mergePreview(targetId, sourceToken);
+    const merged = await mergePost(targetId, {
+      [bookingField]: "keep_target",
+      [moneyFieldFor(bookingField)]: "writeoff",
+      merge_version: version,
+      source_token: sourceToken,
+    });
+    expect(merged.status).toBe(302);
+
+    // One ticket's income survives; the survivor owes nothing; the un-billed £50
+    // lands in writeoff (not returned); the source empties; conservation holds.
+    expect(await incomeOf(listingId)).toBe(5000);
+    expect(await owedBy(targetId)).toBe(0);
+    expect(norm(await accountBalance(WRITEOFF))).toBe(writeoffBefore + 5000);
+    expect(norm(await accountBalance(attendeeAccount(sourceId)))).toBe(0);
     expect(await sumOfAllBalances()).toBe(0);
   });
 
-  // 18. A pay-what-you-want (can_pay_more) order recognises the FULL chosen price
+  // 19. The decision-17 GUARD: a paid duplicate may NOT be discarded without an
+  //     explicit money choice. Omitting it REFUSES the merge (the form re-renders
+  //     with the error instead of redirecting) and mutates NOTHING — income still
+  //     counts both tickets and the source still exists — so no silent double-count
+  //     or stranded money can slip through.
+  test("a merge refuses to discard a paid booking with no money decision", async () => {
+    const { listingId, sourceToken, targetId } =
+      await twoPaidDuplicates("Summit");
+
+    const { version, bookingField } = await mergePreview(targetId, sourceToken);
+    // Submit the booking choice but OMIT the money decision.
+    const refused = await mergePost(targetId, {
+      [bookingField]: "keep_target",
+      merge_version: version,
+      source_token: sourceToken,
+    });
+    // Re-rendered (200), not redirected (302); the apply never ran.
+    expect(refused.status).toBe(200);
+    expect(await refused.text()).toContain("money decision");
+
+    // Nothing changed: both tickets' income still counts and both attendees survive.
+    expect(await incomeOf(listingId)).toBe(10000);
+    expect((await getAttendeesRaw(listingId)).length).toBe(2);
+    expect(await sumOfAllBalances()).toBe(0);
+  });
+
+  // 20. A FREE duplicate (no money on either side) needs NO money decision: the
+  //     preview surfaces the conflicting booking row but hides the credit/write-off
+  //     UI, and the merge applies straight through posting no reversal legs — the
+  //     "nothing at stake" path decision 17 must keep one-click.
+  test("a free duplicate merges with no money decision and no reversal legs", async () => {
+    const listing = await createTestListing({
+      maxAttendees: 10,
+      name: "Freebie",
+      unitPrice: 0,
+    });
+    const { attendee: target } = await createTestAttendeeDirect(
+      listing.id,
+      "Free A",
+      "free-a@example.com",
+    );
+    const { attendee: source, token: sourceToken } =
+      await createTestAttendeeDirect(
+        listing.id,
+        "Free B",
+        "free-b@example.com",
+      );
+    // Nothing paid on either side — £0 at stake.
+    expect(await incomeOf(listing.id)).toBe(0);
+
+    // The preview shows the conflict row but NOT the money-decision UI.
+    const preview = await awaitTestRequest(
+      `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+      { cookie: await testCookie() },
+    );
+    const previewHtml = await preview.text();
+    expect(previewHtml).toContain('name="booking_');
+    expect(previewHtml).not.toContain("merge-money-decision");
+    expect(previewHtml).not.toContain("Discarded payment");
+
+    const version = extractInputValue(previewHtml, "merge_version")!;
+    const bookingField = previewHtml.match(/name="(booking_[^"]+)"/)![1]!;
+    const merged = await mergePost(target.id, {
+      [bookingField]: "keep_target",
+      merge_version: version,
+      source_token: sourceToken,
+    });
+    // No money decision required, so the merge redirects straight through.
+    expect(merged.status).toBe(302);
+
+    // The merge went through with no money moved and the source folded in.
+    expect(await incomeOf(listing.id)).toBe(0);
+    expect((await getAttendeesRaw(listing.id)).length).toBe(1);
+    expect(await sumOfAllBalances()).toBe(0);
+  });
+
+  // 21. A pay-what-you-want (can_pay_more) order recognises the FULL chosen price
   //     as income — the figure shown is exactly what the buyer paid, not the base
   //     price — and they owe nothing.
   test("a pay-what-you-want order recognises the chosen price as income", async () => {

--- a/test/lib/accounting/store.test.ts
+++ b/test/lib/accounting/store.test.ts
@@ -217,6 +217,26 @@ describe("db > accounting > store", () => {
       expect((await allTransfers()).length).toBe(0);
     });
 
+    test("rejects two groups that share an eventGroup in the batch", async () => {
+      // Each group is meant to be one event; two sharing a group would both plan
+      // against the same snapshot and merge into one event's legs, breaking a
+      // later idempotent replay of either.
+      const error = await rejection(
+        postTransferGroups([
+          [tx({ eventGroup: "evt-shared", reference: "a" })],
+          [
+            tx({
+              destination: account("fee_income", "booking"),
+              eventGroup: "evt-shared",
+              reference: "b",
+            }),
+          ],
+        ]),
+      );
+      expect(error.message).toContain("duplicate eventGroup across the batch");
+      expect((await allTransfers()).length).toBe(0);
+    });
+
     test("validates every group up front, rejecting the whole batch before any write", async () => {
       const error = await rejection(
         postTransferGroups([

--- a/test/lib/attendee-merge.test.ts
+++ b/test/lib/attendee-merge.test.ts
@@ -153,7 +153,13 @@ describeWithEnv("attendee merge service", { db: true }, () => {
     );
 
     const result = await applyAttendeeMerge({
-      decision: { answers: {}, bookings: {}, pii: {}, version: diff.version },
+      decision: {
+        answers: {},
+        bookings: {},
+        money: {},
+        pii: {},
+        version: diff.version,
+      },
       diff,
       privateKey: await getTestPrivateKey(),
       sourceId: source.id,
@@ -585,6 +591,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const decision: AttendeeMergeDecisionInput = {
         answers: {},
         bookings: {},
+        money: {},
         pii: {},
         version: "v2",
       };
@@ -617,6 +624,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const decision: AttendeeMergeDecisionInput = {
         answers: {},
         bookings: {},
+        money: {},
         pii: {},
         version: "v1",
       };
@@ -645,6 +653,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
               refunded: 0,
               start_at: null,
             },
+            sourceSaleAmount: 0,
             startAt: null,
             targetBooking: {
               attachment_downloads: 0,
@@ -657,6 +666,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
               refunded: 0,
               start_at: null,
             },
+            targetSaleAmount: 0,
           },
         ],
         piiFields: [],
@@ -667,6 +677,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const decision: AttendeeMergeDecisionInput = {
         answers: {},
         bookings: {},
+        money: {},
         pii: {},
         version: "v1",
       };
@@ -695,6 +706,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
               refunded: 0,
               start_at: "2026-06-15T10:00:00Z",
             },
+            sourceSaleAmount: 0,
             startAt: "2026-06-15T10:00:00Z",
             targetBooking: {
               attachment_downloads: 0,
@@ -707,6 +719,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
               refunded: 0,
               start_at: "2026-06-15T10:00:00Z",
             },
+            targetSaleAmount: 0,
           },
         ],
         piiFields: [],
@@ -717,6 +730,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const decision: AttendeeMergeDecisionInput = {
         answers: {},
         bookings: {},
+        money: {},
         pii: {},
         version: "v1",
       };
@@ -755,6 +769,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
               refunded: 0,
               start_at: null,
             },
+            sourceSaleAmount: 0,
             startAt: null,
             targetBooking: {
               attachment_downloads: 0,
@@ -767,6 +782,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
               refunded: 0,
               start_at: null,
             },
+            targetSaleAmount: 0,
           },
         ],
         piiFields: [],
@@ -777,11 +793,105 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const decision: AttendeeMergeDecisionInput = {
         answers: { "10": "source" },
         bookings: { "5:null": "keep_target" },
+        money: {},
         pii: { name: "target" },
         version: "v1",
       };
       const result = validateAttendeeMergeDecision(diff, decision);
       expect(result.valid).toBe(true);
+    });
+
+    // --- Decision 17: a discarded booking that carries money needs a choice --- //
+
+    const bookingRow =
+      (): import("#shared/db/attendee-types.ts").ListingAttendeeRow => ({
+        attachment_downloads: 0,
+        checked_in: 0,
+        end_at: null,
+        ledger_event_group: "grp",
+        listing_id: 5,
+        price_paid: 5000,
+        quantity: 1,
+        refunded: 0,
+        start_at: null,
+      });
+
+    /** A single same-listing duplicate conflict carrying the given ledger sale
+     *  amounts on each side. */
+    const moneyConflictDiff = (
+      sourceSaleAmount: number,
+      targetSaleAmount: number,
+    ): AttendeeMergeDiff => ({
+      answerItems: [],
+      bookingItems: [
+        {
+          conflictClass: "duplicate",
+          listingId: 5,
+          sourceBooking: bookingRow(),
+          sourceSaleAmount,
+          startAt: null,
+          targetBooking: bookingRow(),
+          targetSaleAmount,
+        },
+      ],
+      piiFields: [],
+      sourceId: 2,
+      targetId: 1,
+      version: "v1",
+    });
+
+    const decisionWith = (
+      money: AttendeeMergeDecisionInput["money"],
+      booking: "keep_target" | "take_source" = "keep_target",
+    ): AttendeeMergeDecisionInput => ({
+      answers: {},
+      bookings: { "5:null": booking },
+      money,
+      pii: {},
+      version: "v1",
+    });
+
+    test("rejects a discarded paid booking with no money decision", () => {
+      // keep_target discards the SOURCE booking (£50 of recognised sale), so the
+      // operator must choose credit vs write-off — never a silent default.
+      const result = validateAttendeeMergeDecision(
+        moneyConflictDiff(5000, 5000),
+        decisionWith({}),
+      );
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors[0]).toContain("money decision");
+      }
+    });
+
+    test("accepts a discarded paid booking once a money choice is given", () => {
+      const result = validateAttendeeMergeDecision(
+        moneyConflictDiff(5000, 5000),
+        decisionWith({ "5:null": "credit" }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    test("needs no money decision when the discarded booking is free", () => {
+      // A £0 conflict carries no money, so only the row choice is required.
+      const result = validateAttendeeMergeDecision(
+        moneyConflictDiff(0, 0),
+        decisionWith({}),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    test("take_source weighs the TARGET amount it discards, not the source", () => {
+      // Replacing with the source discards the TARGET booking; its £50 is what
+      // needs a decision even though the source booking is free.
+      const result = validateAttendeeMergeDecision(
+        moneyConflictDiff(0, 5000),
+        decisionWith({}, "take_source"),
+      );
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors[0]).toContain("money decision");
+      }
     });
   });
 
@@ -842,6 +952,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       const decision: AttendeeMergeDecisionInput = {
         answers: { [String(question.id)]: "source" },
         bookings: {},
+        money: {},
         pii: { email: "target", name: "source" },
         version: diff.version,
       };
@@ -952,7 +1063,13 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       );
 
       const result = await applyAttendeeMerge({
-        decision: { answers: {}, bookings: {}, pii: {}, version: diff.version },
+        decision: {
+          answers: {},
+          bookings: {},
+          money: {},
+          pii: {},
+          version: diff.version,
+        },
         diff,
         privateKey: await getTestPrivateKey(),
         sourceId: source.id,
@@ -1039,7 +1156,13 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       );
 
       const result = await applyAttendeeMerge({
-        decision: { answers: {}, bookings: {}, pii: {}, version: diff.version },
+        decision: {
+          answers: {},
+          bookings: {},
+          money: {},
+          pii: {},
+          version: diff.version,
+        },
         diff,
         privateKey: await getTestPrivateKey(),
         sourceId: source.id,
@@ -1119,6 +1242,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
         decision: {
           answers: { [String(question.id)]: "clear" },
           bookings: {},
+          money: {},
           pii: {},
           version: diff.version,
         },
@@ -1198,6 +1322,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
         decision: {
           answers: {},
           bookings: {},
+          money: {},
           pii: {},
           version: diff.version,
         },
@@ -1268,6 +1393,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
         decision: {
           answers: {},
           bookings: { [key]: "keep_target" },
+          money: {},
           pii: {},
           version: diff.version,
         },
@@ -1350,6 +1476,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
         decision: {
           answers: {},
           bookings: { [key]: "take_source" },
+          money: {},
           pii: {},
           version: diff.version,
         },
@@ -1434,6 +1561,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
         decision: {
           answers: {},
           bookings: {},
+          money: {},
           pii: { name: "source" },
           version: diff.version,
         },


### PR DESCRIPTION
## Why this PR exists

This is a **follow-up to #1381** (the double-entry ledger migration). Two fixes were ready when #1381 reached the merge queue but didn't make it into the squash that merged, so they're not on `main`. This PR lands them on top of the merged ledger work. Both were called out in the pre-merge review.

Nothing here is a re-run of #1381 — it's branched from the merged `main`, so the diff is only these two fixes.

---

## Fix 1 — A merge must not silently move money around (the important one)

### The problem

When you merge two attendees, the surviving person inherits all of the other one's ledger history. That's correct when the two people booked *different* things. But when they **both paid for the same booking** (a genuine duplicate — e.g. someone paid twice, or two records for one person), the old merge just moved both payments onto the survivor. The result:

- The listing's **income counted the ticket twice** (two "sale" entries for one ticket that's actually kept once).
- The **extra payment had nowhere sensible to go** — it was left stranded on the survivor's account.

So two figures on the site could quietly disagree, with no explanation. That's exactly the thing we don't want.

### The fix

Now, when the booking the merge is about to throw away has money on it, the operator **must choose** what happens to it — there's no silent default, and the merge is **refused** (the form re-loads with an error) until they pick:

- **Keep as the person's credit** — the extra payment becomes a credit on the merged person's account (they show a negative balance owing, i.e. we owe them).
- **Write it off** — the extra payment is parked in the `writeoff` account, so the survivor owes nothing and our cash reports stay honest.

Either way, the **discarded ticket's sale is un-billed** so the listing's income counts the kept ticket exactly **once** instead of twice.

A couple of guarantees:

- The un-bill + credit/write-off entries are written in the **same database transaction** as the rest of the merge, so you can never get a half-finished state with money stranded or income double-counted.
- A **clean merge** (the two people booked different things) still moves everything across in one click with no extra questions. A **free booking** (nothing paid) also needs no decision — there's no money at stake.

### What the operator sees

On the merge preview, each conflicting booking that carries a payment now shows a short "Discarded payment (source £X, target £Y) — this can't be undone, so choose explicitly:" block with the two radio options. If they skip it, the merge won't go through.

---

## Fix 2 — Reject duplicate event groups in one ledger batch

A smaller data-integrity guard in the ledger's batch writer (`postTransferGroups`). Each item in a batch is meant to be one self-contained event. If two items in the same batch accidentally shared an event group, they'd both plan against the same "before" snapshot, both write, and the event would end up holding the combined legs of both — which then breaks an idempotent replay. The writer now rejects that up front, before touching the database, alongside the existing duplicate-reference check.

---

## Tests

- **Unit** (`attendee-merge.test.ts`): the validation gate — rejects a discarded paid booking with no money choice, accepts once a choice is given, needs no choice for a free booking, and weighs the *target* amount when the operator replaces with the source.
- **End-to-end** (`accounting.test.ts`): full HTTP merge flow for the **credit** path (survivor shows the £50 credit, income counts one ticket), the **write-off** path (£50 lands in `writeoff`, survivor owes nothing), the **refusal** (no money choice → 200 re-render, nothing changed), and a **free duplicate** (no decision asked, no legs posted). Every case asserts double-entry conservation still holds.
- **Unit** (`store.test.ts`): the batch writer rejects two groups sharing an event group.

All precommit gates pass locally: lint, typecheck, 0% duplication, edge build, and 100% line/branch coverage.

## A note on scope

Production has only ever had bookings that are paid-in-full, refunded-in-full, or free — no deposits or part-payments — so this targets the paid-duplicate case, which is the one that can actually occur. Free duplicates stay one-click; clean (different-booking) merges are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUuSQUGHmPkZcHGfRTjskL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUuSQUGHmPkZcHGfRTjskL)_