### PR TITLE
Add view-transition-name to admin sidebar

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -401,6 +401,10 @@ nav ul li {
        the lower links stay reachable while the sidebar is stuck. */
     max-height: calc(100dvh - 2 * var(--space-m));
     overflow-y: auto;
+    /* Pin the sidebar visually across cross-document navigations: the browser
+       matches this name on both the old and new page and keeps the element in
+       place while only column-2 content transitions. */
+    view-transition-name: admin-sidebar;
   }
 
   /* Everything that isn't the sidebar flows down column 2... */


### PR DESCRIPTION
## Summary

- Names the desktop `.admin-nav-group` with `view-transition-name: admin-sidebar` inside the `min-width: 769px` breakpoint
- The browser matches the name on both the old and new page during cross-document navigation, holding the sidebar visually in place while only the column-2 content transitions
- Mobile is unaffected — `.admin-nav-group` has `display: contents` there, so it has no box to name
- The existing `prefers-reduced-motion` rule already suppresses all view-transition animations globally, so reduced-motion users are unaffected

## Test plan

- [ ] Navigate between admin pages on desktop and confirm the sidebar stays pinned (no cross-fade or movement) while the content area transitions
- [ ] Confirm mobile layout is unchanged
- [ ] Confirm `prefers-reduced-motion` still disables all animations including the sidebar transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TYG8k8qcCsMRsBLfsmySu

---
_Generated by [Claude Code](https://claude.ai/code/session_012TYG8k8qcCsMRsBLfsmySu)_