### PR TITLE
Unify table action rows under .table-actions; left-align; table width: fit-content

### DIFF
--- a/src/shared/filter-bar.ts
+++ b/src/shared/filter-bar.ts
@@ -19,8 +19,7 @@ export type FilterBarOption = {
 };
 
 /**
- * Render a labelled filter bar as the `.table-header-actions` paragraph shown
- * above a table.
+ * Render a labelled filter bar as the `.table-actions` div shown above a table.
  */
 export const renderFilterBar = (
   label: string,
@@ -33,5 +32,5 @@ export const renderFilterBar = (
         : `<a href="${o.href}">${o.label}</a>`,
     )
     .join(" / ");
-  return `<p class="table-header-actions">${label}: ${links}</p>`;
+  return `<div class="table-actions">${label}: ${links}</div>`;
 };

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1059,6 +1059,7 @@ table {
   border-spacing: 0;
   padding: 0;
   white-space: nowrap;
+  width: fit-content;
 }
 
 table td,
@@ -2375,22 +2376,10 @@ a.cal-day-selected:active {
   gap: var(--space-m);
 }
 
-/* Action rows attached to a table: filters above (left-aligned), table-wide
-   utilities (CSV export, …) below — right-aligned on desktop, left on mobile.
+/* Action rows attached to a table: filters above or below.
    No margin of their own; the surrounding flex container supplies the gap. */
-.table-header-actions,
-.table-footer-actions {
+.table-actions {
   margin: 0;
-}
-
-.table-footer-actions {
-  text-align: left;
-}
-
-@media (min-width: 769px) {
-  .table-footer-actions {
-    text-align: right;
-  }
 }
 
 /* Previous/next pagination */

--- a/src/ui/templates/admin/attendees-list.tsx
+++ b/src/ui/templates/admin/attendees-list.tsx
@@ -227,11 +227,11 @@ export const adminAttendeesListPage = (props: AttendeesListPageProps): string =>
           />
         </div>
 
-        <p class="table-footer-actions">
+        <div class="table-actions">
           <a href={csvHref(props.listingId, props.type)}>
             {t("listings_table.export_csv")}
           </a>
-        </p>
+        </div>
       </div>
 
       <Pagination

--- a/src/ui/templates/admin/calendar.tsx
+++ b/src/ui/templates/admin/calendar.tsx
@@ -156,9 +156,9 @@ export const adminCalendarPage = (
           />
         </div>
         {dateFilter && attendees.length > 0 && (
-          <p class="table-footer-actions">
+          <div class="table-actions">
             <a href={exportHref}>{t("admin.calendar.export_csv")}</a>
-          </p>
+          </div>
         )}
       </article>
     </Layout>,

--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -248,9 +248,9 @@ const ListingsTableBlock = ({
     <Raw html={headerHtml} />
     <Raw html={renderListingsTableSection(listings, columnKeys, filters)} />
     {csvExport && (
-      <p class="table-footer-actions">
+      <div class="table-actions">
         <a href="/admin/listings/csv">{t("listings_table.export_csv")}</a>
-      </p>
+      </div>
     )}
   </div>
 );

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -1123,9 +1123,9 @@ const AttendeesSection = ({
           })}
         />
       </div>
-      <p class="table-footer-actions">
+      <div class="table-actions">
         <a href={exportHref}>{t("listings_table.export_csv")}</a>
-      </p>
+      </div>
     </article>
   );
 };

--- a/test/templates/admin/attendees-list.test.ts
+++ b/test/templates/admin/attendees-list.test.ts
@@ -93,7 +93,7 @@ describe("adminAttendeesListPage", () => {
 
   test("renders a plain CSV export link when no filters are active", () => {
     const html = adminAttendeesListPage(buildProps());
-    expect(html).toContain('class="table-footer-actions"');
+    expect(html).toContain('class="table-actions"');
     expect(html).toContain('href="/admin/attendees/csv"');
     expect(html).toContain("Export CSV");
   });
@@ -242,7 +242,7 @@ describe("adminAttendeesListPage", () => {
 
     test("renders the bar with the active type bold and the rest as links", () => {
       const html = adminAttendeesListPage(multiCategory({ type: "daily" }));
-      expect(html).toContain('class="table-header-actions"');
+      expect(html).toContain('class="table-actions"');
       expect(html).toContain("<strong><u>Daily</u></strong>");
       expect(html).toContain(">Standard</a>");
       expect(html).toContain(">All</a>");
@@ -252,7 +252,7 @@ describe("adminAttendeesListPage", () => {
       const html = adminAttendeesListPage(
         buildProps({ categories: ["standard"] }),
       );
-      expect(html).not.toContain('class="table-header-actions"');
+      expect(html).not.toContain("Showing:");
     });
 
     test("type links reset the listing and page filters but keep the sort", () => {
@@ -268,7 +268,7 @@ describe("adminAttendeesListPage", () => {
       // Scope assertions to the filter-bar fragment: the pagination links below
       // legitimately keep the listing/page, which would otherwise mask the reset.
       const bar =
-        html.match(/<p class="table-header-actions">.*?<\/p>/s)?.[0] ?? "";
+        html.match(/<div class="table-actions">.*?<\/div>/s)?.[0] ?? "";
       // The bar is injected via <Raw>, so its ampersands stay unescaped.
       expect(bar).toContain('href="/admin/attendees?type=daily&sort=oldest"');
       expect(bar).not.toContain("listing=7"); // specific-listing filter dropped

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -484,7 +484,6 @@ describe("adminDashboardPage type filter", () => {
   test("does not show a CSV export footer (the dashboard table is active-only)", () => {
     const html = adminDashboardPage([standard, daily], TEST_SESSION);
     expect(html).not.toContain("/admin/listings/csv");
-    expect(html).not.toContain("table-footer-actions");
   });
 });
 
@@ -542,7 +541,7 @@ describe("adminListingsPage", () => {
       [testListingWithCount({ name: "Active Show" })],
       TEST_SESSION,
     );
-    expect(html).toContain('class="table-footer-actions"');
+    expect(html).toContain('class="table-actions"');
     expect(html).toContain('href="/admin/listings/csv"');
     expect(html).toContain("Export CSV");
   });


### PR DESCRIPTION
## Summary

- Rename `.table-header-actions` and `.table-footer-actions` → `.table-actions` in CSS, `filter-bar.ts`, and all four admin templates (dashboard, calendar, listings, attendees-list), changing `<p>` wrappers to `<div>`
- Remove the desktop right-align rule that was on `.table-footer-actions`; all action rows (filters above, export links below) are now consistently left-aligned
- Add `width: fit-content` to the `table` CSS rule so tables shrink to their content width
- Update tests to match the new class name; the "omits the bar" test now checks for content (`"Showing:"`) rather than the class, since `.table-actions` is shared between filter bars and export links

## Test plan

- [ ] `deno task precommit` passes (lint, typecheck, cpd, build, coverage all green)
- [ ] Admin pages with tables (dashboard, attendees list, calendar, listings) show Export CSV left-aligned below the table
- [ ] Filter bars above tables remain left-aligned
- [ ] Tables shrink to fit their content rather than stretching full-width

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPfwpbfieojbzQ1Lsdx7QT)_