### PR TITLE
Tidy-up: unify account-balance reads + harden transfer tests via mutation testing

### DIFF
--- a/src/shared/accounting/backfill.ts
+++ b/src/shared/accounting/backfill.ts
@@ -76,12 +76,15 @@ const ATTENDEE = "attendee";
 const ATTENDEE_PAGE = 5000;
 
 /** The next page of attendee ids holding a paid booking row, after `afterId`. */
-const nextPaidAttendeeIds = async (afterId: number): Promise<number[]> => {
+const nextPaidAttendeeIds = async (
+  afterId: number,
+  pageSize: number,
+): Promise<number[]> => {
   const rows = await queryAll<{ attendee_id: number | bigint }>(
     "SELECT DISTINCT attendee_id FROM listing_attendees" +
       " WHERE price_paid > 0 AND attendee_id > ?" +
       " ORDER BY attendee_id LIMIT ?",
-    [afterId, ATTENDEE_PAGE],
+    [afterId, pageSize],
   );
   return rows.map((row) => Number(row.attendee_id));
 };
@@ -188,12 +191,16 @@ const attendeeStatements = async (
 /**
  * Backfill the ledger from every existing paid booking. Idempotent:
  * already-ledgered attendees are skipped and the deterministic references plus
- * `INSERT OR IGNORE` make a re-run write nothing.
+ * `INSERT OR IGNORE` make a re-run write nothing. `pageSize` (the per-batch
+ * attendee count, defaulting to the edge-budget {@link ATTENDEE_PAGE}) is
+ * lowered in tests to exercise the multi-page cursor.
  */
-export const backfillTransfers = async (): Promise<void> => {
+export const backfillTransfers = async (
+  pageSize: number = ATTENDEE_PAGE,
+): Promise<void> => {
   let afterId = 0;
   for (;;) {
-    const attendeeIds = await nextPaidAttendeeIds(afterId);
+    const attendeeIds = await nextPaidAttendeeIds(afterId, pageSize);
     if (attendeeIds.length === 0) return;
     const ledgered = await alreadyLedgered(attendeeIds);
     const groups = groupBy(await paidRowsForAttendees(attendeeIds), (row) =>

--- a/src/shared/accounting/projection-sql.ts
+++ b/src/shared/accounting/projection-sql.ts
@@ -10,8 +10,10 @@
  * the parameterised `transfersByAccount` in `./queries.ts` instead.
  */
 
-/** Account type/id columns for one leg side of a `transfers` row. */
-const COLUMNS = {
+/** Account type/id columns for one leg side of a `transfers` row — the single
+ *  home for these names, so every projection (the interpolated subqueries here
+ *  AND the parameterised balance reads in `./queries.ts`) refers to them once. */
+export const LEG_COLUMNS = {
   dest: { id: "dest_id", type: "dest_type" },
   source: { id: "source_id", type: "source_type" },
 } as const;
@@ -28,7 +30,7 @@ export const accountPredicate = (
   type: string,
   idExpr: string,
 ): string => {
-  const col = COLUMNS[role];
+  const col = LEG_COLUMNS[role];
   return `${col.type} = '${type}' AND ${col.id} = CAST(${idExpr} AS TEXT)`;
 };
 

--- a/src/shared/accounting/queries.ts
+++ b/src/shared/accounting/queries.ts
@@ -15,6 +15,7 @@ import {
   accountBalanceSubquery,
   attendeeOwedSubquery,
   creditsLessWriteoffDebits,
+  LEG_COLUMNS,
 } from "#shared/accounting/projection-sql.ts";
 import {
   fromDb,
@@ -29,12 +30,17 @@ import {
 } from "#shared/db/client.ts";
 import type { AccountRef, Transfer } from "#shared/ledger/types.ts";
 
+/** A parameterised "this leg's <role> side IS the account" match — two bound `?`
+ *  for (type, id), built from the shared transfers column names so every balance
+ *  read filters accounts identically. */
+const legMatchesAccount = (role: "source" | "dest"): string =>
+  `${LEG_COLUMNS[role].type} = ? AND ${LEG_COLUMNS[role].id} = ?`;
+
 /** Every transfer touching `account`, as source or destination. */
 export const transfersByAccount = (acct: AccountRef): Promise<Transfer[]> =>
   selectTransfers(
     fromDb,
-    " WHERE (source_type = ? AND source_id = ?)" +
-      " OR (dest_type = ? AND dest_id = ?)",
+    ` WHERE (${legMatchesAccount("source")}) OR (${legMatchesAccount("dest")})`,
     [acct.type, acct.id, acct.type, acct.id],
   );
 
@@ -69,9 +75,9 @@ const groupedBalances = (
 ): Promise<BalanceRow[]> =>
   queryAll<BalanceRow>(
     `SELECT id, COALESCE(SUM(delta), 0) AS balance FROM (
-       SELECT dest_id AS id, amount AS delta FROM transfers WHERE ${whereDest}
+       SELECT ${LEG_COLUMNS.dest.id} AS id, amount AS delta FROM transfers WHERE ${whereDest}
        UNION ALL
-       SELECT source_id AS id, -amount AS delta FROM transfers WHERE ${whereSource}
+       SELECT ${LEG_COLUMNS.source.id} AS id, -amount AS delta FROM transfers WHERE ${whereSource}
      ) GROUP BY id`,
     args,
   );
@@ -88,7 +94,11 @@ export const accountBalancesOfType = async (
   type: string,
 ): Promise<Map<string, number>> =>
   toBalanceMap(
-    await groupedBalances("dest_type = ?", "source_type = ?", [type, type]),
+    await groupedBalances(
+      `${LEG_COLUMNS.dest.type} = ?`,
+      `${LEG_COLUMNS.source.type} = ?`,
+      [type, type],
+    ),
   );
 
 /**
@@ -104,17 +114,31 @@ export const accountBalancesForIds = async (
   const placeholders = inPlaceholders(ids);
   return toBalanceMap(
     await groupedBalances(
-      `dest_type = ? AND dest_id IN (${placeholders})`,
-      `source_type = ? AND source_id IN (${placeholders})`,
+      `${LEG_COLUMNS.dest.type} = ? AND ${LEG_COLUMNS.dest.id} IN (${placeholders})`,
+      `${LEG_COLUMNS.source.type} = ? AND ${LEG_COLUMNS.source.id} IN (${placeholders})`,
       [type, ...ids, type, ...ids],
     ),
   );
 };
 
 /** Balance of one account: money in (as destination) minus money out (as
- *  source). Zero when the account has no transfers. */
-export const accountBalance = async (acct: AccountRef): Promise<number> =>
-  (await accountBalancesForIds(acct.type, [acct.id])).get(acct.id) ?? 0;
+ *  source), summed in SQL. Zero when the account has no transfers — a direct
+ *  scalar read rather than the grouped many-account query, so it shares the same
+ *  `legMatchesAccount` filter the rest of this module uses. */
+export const accountBalance = async (acct: AccountRef): Promise<number> => {
+  const asDest = legMatchesAccount("dest");
+  const asSource = legMatchesAccount("source");
+  // Each predicate binds (type, id) and appears four times — both CASE arms and
+  // both WHERE arms — so the account's pair repeats four times, in that order.
+  const pair: InValue[] = [acct.type, acct.id];
+  const rows = await queryAll<{ balance: number | bigint }>(
+    `SELECT COALESCE(SUM(CASE WHEN ${asDest} THEN amount` +
+      ` WHEN ${asSource} THEN -amount ELSE 0 END), 0) AS balance` +
+      ` FROM transfers WHERE ${asDest} OR ${asSource}`,
+    [...pair, ...pair, ...pair, ...pair],
+  );
+  return Number(rows[0]!.balance);
+};
 
 /**
  * Read a single projected money figure (a scalar `transfers` subquery) THROUGH an

--- a/test/lib/accounting/backfill.test.ts
+++ b/test/lib/accounting/backfill.test.ts
@@ -105,6 +105,25 @@ describeWithEnv("accounting > backfill", { db: true }, () => {
     expect(await accountBalance(WORLD)).toBe(-5000); // cash in
   });
 
+  test("walks every page when paid attendees exceed the page size", async () => {
+    const listing = await createTestListing({ maxAttendees: 10 });
+    // Five historical paid bookings; with a page size of 2 the cursor must SET to
+    // each page's last id, not accumulate — an `afterId +=` cursor over-advances
+    // past the final page and silently skips its attendees.
+    for (let i = 0; i < 5; i++) {
+      await historicalBooking(
+        [{ listingId: listing.id, pricePaid: 5000 }],
+        `paid-${i}@b.c`,
+      );
+    }
+
+    await backfillTransfers(2); // 3 pages of [2, 2, 1]
+
+    // Every £50 sale is recognised; a broken cursor leaves income short of £250.
+    expect(await accountBalance(revenueAccount(listing.id))).toBe(25000);
+    expect(await accountBalance(WORLD)).toBe(-25000);
+  });
+
   test("stamps each row's ledger_event_group with its booking event group", async () => {
     // The per-row amount-paid projection keys on ledger_event_group, so the
     // backfill must stamp it with the order's booking event group (the sale leg's).

--- a/test/lib/accounting/rows.test.ts
+++ b/test/lib/accounting/rows.test.ts
@@ -1,8 +1,14 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { insertStatement } from "#shared/accounting/rows.ts";
+import {
+  fromDb,
+  insertStatement,
+  selectTransfers,
+} from "#shared/accounting/rows.ts";
+import { executeBatch } from "#shared/db/client.ts";
 import { account } from "#shared/ledger/account.ts";
 import type { TransferInput } from "#shared/ledger/types.ts";
+import { useTransactionalDb } from "#test-utils/ledger.ts";
 
 /** The value bound to `column` in a built INSERT, by pairing the SQL's leading
  *  column list with its positional args. */
@@ -42,5 +48,54 @@ describe("accounting > rows > insertStatement", () => {
     const absent = insertStatement(base, recordedAt);
     expect(boundValue(absent, "posted_by")).toBe("system");
     expect(boundValue(absent, "reverses_id")).toBe(null);
+  });
+});
+
+describe("accounting > rows > stored-row round-trip", () => {
+  useTransactionalDb();
+  const recordedAt = "2026-06-21T12:00:00.000Z";
+
+  test("selectTransfers reads every column back, reversesId present and absent", async () => {
+    const plain: TransferInput = {
+      amount: 5000,
+      destination: account("revenue", 7),
+      eventGroup: "evt-plain",
+      kind: "sale",
+      memo: "first",
+      occurredAt: "2026-06-21T00:00:00.000Z",
+      reference: "ref-plain",
+      source: account("attendee", 3),
+    };
+    // A void leg carrying a (non-FK) reverses_id, so the NULL vs real-id branch of
+    // the row→Transfer mapping is exercised both ways.
+    const voiding: TransferInput = {
+      ...plain,
+      eventGroup: "evt-void",
+      kind: "void",
+      reference: "ref-void",
+      reversesId: 999,
+    };
+    await executeBatch([
+      insertStatement(plain, recordedAt),
+      insertStatement(voiding, recordedAt),
+    ]);
+
+    const all = await selectTransfers(fromDb, " ORDER BY id", []);
+    expect(all.length).toBe(2);
+    const [first, second] = all;
+
+    // Full-fidelity round-trip — a corrupted SELECT column list loses these.
+    expect(first!.amount).toBe(5000);
+    expect(first!.source).toEqual(account("attendee", 3));
+    expect(first!.destination).toEqual(account("revenue", 7));
+    expect(first!.reference).toBe("ref-plain");
+    expect(first!.eventGroup).toBe("evt-plain");
+    expect(first!.kind).toBe("sale");
+    expect(first!.memo).toBe("first");
+    expect(first!.occurredAt).toBe("2026-06-21T00:00:00.000Z");
+
+    // NULL reverses_id maps to undefined; a real id maps to the Number.
+    expect(first!.reversesId).toBeUndefined();
+    expect(second!.reversesId).toBe(999);
   });
 });

--- a/test/lib/accounting/store.test.ts
+++ b/test/lib/accounting/store.test.ts
@@ -49,6 +49,40 @@ describe("db > accounting > store", () => {
       expect((await allTransfers()).length).toBe(2);
     });
 
+    test("rejects replaying an event group with a changed leg", async () => {
+      const original = saleAndPayment();
+      expect(await postTransfers(original)).toEqual({
+        inserted: 2,
+        skipped: 0,
+      });
+      // Same event group and references, but one leg's amount differs — not an
+      // idempotent replay, so the single-event guard must reject it.
+      const tampered = [
+        { ...original[0]!, amount: original[0]!.amount + 1 },
+        original[1]!,
+      ];
+      const error = await rejection(postTransfers(tampered));
+      expect(error).toBeInstanceOf(LedgerConflictError);
+      expect((await allTransfers()).length).toBe(2); // the original legs, untouched
+    });
+
+    test("rejects a reversal whose original transfer is absent", async () => {
+      // A reverses_id pointing at no stored transfer must be refused before the
+      // insert, so it never uses up the unique one-void-per-original slot.
+      const error = await rejection(
+        postTransfers([
+          tx({
+            eventGroup: "orphan-void",
+            reference: "orphan-void",
+            reversesId: 999,
+          }),
+        ]),
+      );
+      expect(error).toBeInstanceOf(LedgerConflictError);
+      expect(error.message).toContain("refers to no transfer");
+      expect((await allTransfers()).length).toBe(0);
+    });
+
     test("rejects duplicate references within one post", async () => {
       const error = await rejection(
         postTransfers([


### PR DESCRIPTION
## Why

The code companion to #1412 (the post-merge tidy-up). #1412 removed the merged design doc; this PR lands the two code-quality pieces from the same pass — the one unification worth doing, and the mutation-testing follow-up. (Branched off the merged `main`, so the diff is only these changes.)

---

## Part 1 — Unify the account-balance reads

There were two independent SQL spellings of "balance = money in − money out" in `accounting/queries.ts`:

- `accountBalance(acct)` (one account) read its balance by calling `accountBalancesForIds` — the grouped `UNION ALL … GROUP BY` query built for reading *many* accounts at once — then pulling the single id back out of the result map with `… ?? 0`. Using a set-aggregate to read one scalar.
- The column names (`dest_id`, `source_type`, …) were hardcoded in `queries.ts`, even though `projection-sql.ts` exists precisely to be their one home.

This PR:

- Reads `accountBalance` **directly as a scalar sum**, and factors the "this leg's source/destination side is the account" filter into one `legMatchesAccount()` helper shared by `accountBalance` and `transfersByAccount`.
- Exports the transfers column names (`LEG_COLUMNS`) from `projection-sql.ts` and references them from the grouped reads too, so a column rename can't skew the grouped reads against the scalar ones.

What's **deliberately left separate** (flagged so it isn't "unified" later by mistake): the interpolated `accountBalanceSubquery` (which embeds inside larger queries using a numeric id, and can't take an arbitrary account id like `world`), and the grouped many-account query (a different result shape for page reads). Those are genuine, load-bearing differences, not duplication.

## Part 2 — Harden the transfer tests with mutation testing

Ran `deno task mutation` across every transfer source file. The pure `ledger/` library was already 100%, but the `accounting/` glue had a handful of **surviving mutants** — code changes the tests didn't notice:

- **`rows.ts`** — the tests only built INSERT statements, never read a row back, so a corrupted SELECT column list or the `reverses_id` null→undefined mapping slipped through. Added a stored-row round-trip that asserts every field, with a `reverses_id` both present and absent.
- **`backfill.ts`** — the test only ever ran a single page, so the pagination cursor advancing by `afterId =` vs `afterId +=` was indistinguishable. Made the page size an injectable parameter (default unchanged in production) and added a five-attendee, two-per-page test that an accumulating cursor would leave short.
- **`store.ts`** — the single-event write path's replay-conflict and orphan-reversal guards were never exercised (only the batch path was). Added tests that posting a changed leg on a stored event group, and a reversal whose original doesn't exist, both reject.

**Every transfer source file now scores 100% under mutation**, and the `accountBalance` rewrite itself took `queries.ts` from 66.7% → 100%.

Full precommit passes: lint, typecheck, 0% duplication, edge build, 100% line/branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUuSQUGHmPkZcHGfRTjskL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUuSQUGHmPkZcHGfRTjskL)_