### PR TITLE
Extract a shared queryIdColumn db helper (dedup)

### DIFF
--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -224,6 +224,15 @@ export const queryAll = async <T>(
   args?: InValue[],
 ): Promise<T[]> => resultRows<T>(await execute(sql, args));
 
+/** Run a query whose single selected column is aliased `id` and return the ids. */
+export const queryIdColumn = async (
+  sql: string,
+  args?: InValue[],
+): Promise<number[]> => {
+  const rows = await queryAll<{ id: number }>(sql, args);
+  return rows.map((r) => r.id);
+};
+
 /** Count all rows in a table. `table` must be a trusted constant, not input. */
 export const countRows = async (table: string): Promise<number> => {
   // COUNT(*) always returns exactly one row, so the result is never null.

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -15,6 +15,7 @@ import {
   executeBatch,
   inPlaceholders,
   queryAll,
+  queryIdColumn,
   queryOne,
   resetAggregates,
 } from "#shared/db/client.ts";
@@ -208,20 +209,11 @@ export const resetModifierAggregateFields = async (
   await resetAggregates("modifiers", modifierId, fields, aggregateResetSql);
 };
 
-/** Run a single-column `id` query for a modifier and return the ids. */
-const modifierIdColumn = async (
-  sql: string,
-  modifierId: number,
-): Promise<number[]> => {
-  const rows = await queryAll<{ id: number }>(sql, [modifierId]);
-  return rows.map((r) => r.id);
-};
-
 /** Listing ids a modifier is directly linked to (scope = "listings"). */
 export const getModifierListingIds = (modifierId: number): Promise<number[]> =>
-  modifierIdColumn(
+  queryIdColumn(
     "SELECT listing_id AS id FROM modifier_listings WHERE modifier_id = ?",
-    modifierId,
+    [modifierId],
   );
 
 type ModifierListingLinkRow = { listing_id: number; modifier_id: number };
@@ -272,15 +264,15 @@ export const getModifierGroupListingIdsByModifierId =
 
 /** Group ids a modifier is linked to (for the admin scope editor). */
 export const getModifierGroupIds = (modifierId: number): Promise<number[]> =>
-  modifierIdColumn(
+  queryIdColumn(
     "SELECT group_id AS id FROM modifier_groups WHERE modifier_id = ?",
-    modifierId,
+    [modifierId],
   );
 
 /** Answer ids an "answer"-triggered modifier is linked to (for the admin
  * editor) — i.e. the answers whose modifier_id points at this modifier. */
 export const getModifierAnswerIds = (modifierId: number): Promise<number[]> =>
-  modifierIdColumn("SELECT id FROM answers WHERE modifier_id = ?", modifierId);
+  queryIdColumn("SELECT id FROM answers WHERE modifier_id = ?", [modifierId]);
 
 /** Run a "clear, then re-add" batch idempotently: one reset statement (bound to
  * `[modifierId]`), then one write per id (bound to `[modifierId, id]`). Shared


### PR DESCRIPTION
## What

Promotes the `queryAll<{ id }>(...).map(r => r.id)` pattern — currently a private `modifierIdColumn` helper in `modifiers.ts` — to a generic `queryIdColumn(sql, args?)` in the db client, and uses it for the three modifier id-column lookups (`getModifierListingIds`, `getModifierGroupIds`, `getModifierAnswerIds`).

## Why

Pure refactor, no behaviour change. It's the first, fully-independent chunk carved out of the large parent/child listings branch (#1363) — `queryIdColumn` is also used by the parent/child relationship accessors, so landing it on its own shrinks the later feature PRs and removes an existing duplicate today.

## Notes

`deno task precommit` is green (lint, typecheck, 0% duplication, build, 100% coverage). The modifier id lookups are already covered by the existing modifier tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXtrnQgnP2uiUDLF2C3oU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXtrnQgnP2uiUDLF2C3oU1)_