### PR TITLE
Reverse attendee ledger statement figures for readability

### DIFF
--- a/src/ui/templates/admin/ledger.tsx
+++ b/src/ui/templates/admin/ledger.tsx
@@ -192,6 +192,24 @@ export const LedgerTable = ({
 const signedAmount = (signed: number): string =>
   `${signed < 0 ? "-" : "+"}${formatCurrency(Math.abs(signed))}`;
 
+/**
+ * Whether an account's statement figures should be shown with their sign
+ * flipped. The ledger stores an attendee's account as a liability — a booking
+ * debits it negative, a payment credits it back toward zero — which is correct
+ * double-entry but reads backwards to a non-accountant: they expect a charge to
+ * show as a positive amount owed and a payment to bring it down. So an attendee
+ * statement negates its signed deltas and running balance; every other account
+ * (revenue, modifier, the singletons) keeps its native ledger sign. */
+const isReversedAccount = (account: AccountRef): boolean =>
+  account.type === "attendee";
+
+/** A statement figure (signed delta or running balance) as shown for an account,
+ * flipping its sign for the {@link isReversedAccount reversed} attendee view. The
+ * `value !== 0` guard keeps a zero figure from becoming negative zero, which
+ * would render as a stray "-£0". */
+const shownFigure = (value: number, account: AccountRef): number =>
+  isReversedAccount(account) && value !== 0 ? -value : value;
+
 /** The counterparty on a statement line: the OTHER account on the leg (the
  * source when this account received, else the destination). */
 const counterparty = (line: StatementLine, account: AccountRef): AccountRef =>
@@ -215,8 +233,12 @@ const StatementRow = ({
       <td>{formatDatetimeShort(line.transfer.occurredAt)}</td>
       <td>{kindLabel(line.transfer)}</td>
       <td>{accountCell(counterparty(line, account), names)}</td>
-      <td class={colClass("amount")}>{signedAmount(line.signed)}</td>
-      <td class={colClass("amount")}>{formatCurrency(line.running)}</td>
+      <td class={colClass("amount")}>
+        {signedAmount(shownFigure(line.signed, account))}
+      </td>
+      <td class={colClass("amount")}>
+        {formatCurrency(shownFigure(line.running, account))}
+      </td>
     </tr>,
   );
 
@@ -291,7 +313,9 @@ export const AccountStatementHeading = ({
   return (
     <p class="ledger-balance">
       <strong>{accountLabelText(account, names)}</strong>{" "}
-      {t("admin.ledger.balance", { amount: formatCurrency(balance) })}
+      {t("admin.ledger.balance", {
+        amount: formatCurrency(shownFigure(balance, account)),
+      })}
     </p>
   );
 };

--- a/test/templates/admin/attendee-detail.test.ts
+++ b/test/templates/admin/attendee-detail.test.ts
@@ -281,18 +281,19 @@ describe("AttendeeLedgerSection", () => {
   const acct = account("attendee", 7);
 
   test("embeds the shared statement in a collapsed Ledger disclosure with the balance and a full-ledger action", () => {
-    // A single payment credits the attendee account, so its balance is +5000.
+    // A single sale debits the attendee account, so the ledger holds -5000; the
+    // attendee view flips it to show the +5000 they owe as the balance.
     const lines = statementFor(acct)([
       {
         amount: 5000,
-        destination: acct,
+        destination: account("revenue", 1),
         eventGroup: "evt",
         id: 1,
-        kind: "payment",
+        kind: "sale",
         occurredAt: "2026-06-21T10:00:00.000Z",
         recordedAt: "2026-06-21T10:00:00.000Z",
-        reference: "pay-1",
-        source: account("external", "world"),
+        reference: "sale-1",
+        source: acct,
       },
     ]);
     const html = String(
@@ -308,9 +309,11 @@ describe("AttendeeLedgerSection", () => {
     expect(html).toContain('class="table-header-actions"');
     expect(html).toContain('href="/admin/ledger/attendee/7"');
     expect(html).toContain("View full ledger");
-    // The counterparty singleton and the running balance both render.
-    expect(html).toContain("Card / bank");
+    // The counterparty (the listing, unnamed here) and the running balance both
+    // render; the reversed balance is the +5000 the attendee owes.
+    expect(html).toContain("Listing #1");
     expect(html).toContain(`Balance: ${formatCurrency(5000)}`);
+    expect(html).not.toContain(`Balance: -${formatCurrency(5000)}`);
     expect(html).toContain('<th class="col-amount">Balance</th>');
   });
 

--- a/test/templates/admin/ledger.test.ts
+++ b/test/templates/admin/ledger.test.ts
@@ -178,7 +178,7 @@ describe("AccountStatementTable", () => {
       }),
     ]);
 
-  test("shows the counterparty, signed change, and running balance per leg", () => {
+  test("reverses the attendee figures so a charge reads positive and a payment brings it down", () => {
     const refs = names({ listings: new Map([[1, "Concert"]]) });
     const html = String(
       AccountStatementTable({ account: acct, lines: lines(), names: refs }),
@@ -188,11 +188,39 @@ describe("AccountStatementTable", () => {
     expect(html).toContain('<a href="/admin/listing/1">Concert</a>');
     // Leg 2: counterparty is the card/bank singleton (this account received).
     expect(html).toContain("Card / bank");
-    // Signed deltas carry an explicit sign; the sale debits, the payment credits.
+    // The ledger stores the sale as a -5000 debit and the payment as a +5000
+    // credit against the attendee. The attendee view flips both: the sale reads
+    // as a +5000 charge and the payment as a -5000 reduction.
+    const rows = html.split("<tr>");
+    expect(rows[2]).toContain(`+${formatCurrency(5000)}`); // sale: charge owed
+    expect(rows[3]).toContain(`-${formatCurrency(5000)}`); // payment: brings it down
+    // Running balance climbs to the +5000 owed after the sale, then settles at 0.
+    expect(rows[2]).toContain(`>${formatCurrency(5000)}<`);
+    expect(rows[3]).toContain(`>${formatCurrency(0)}<`);
+  });
+
+  test("keeps native ledger signs for a non-attendee (revenue) account", () => {
+    // Reversal is attendee-only: a revenue account's statement still shows the
+    // ledger's own signs, so the convention isn't flipped for every account.
+    const revenue = account("revenue", 1);
+    const html = String(
+      AccountStatementTable({
+        account: revenue,
+        lines: statementFor(revenue)([
+          transfer({
+            amount: 5000,
+            destination: account("revenue", 1),
+            kind: "sale",
+            source: account("attendee", 1),
+          }),
+        ]),
+        names: names(),
+      }),
+    );
+    // Revenue received the sale: a +5000 credit and a +5000 running balance,
+    // unflipped.
     expect(html).toContain(`+${formatCurrency(5000)}`);
-    expect(html).toContain(`-${formatCurrency(5000)}`);
-    // Running balance reaches 5000 after the sale, 0 after the payment.
-    expect(html).toContain(formatCurrency(0));
+    expect(html).not.toContain(`-${formatCurrency(5000)}`);
   });
 
   test("renders the empty state row spanning all five columns", () => {
@@ -282,20 +310,22 @@ describe("adminLedgerPage", () => {
 describe("adminAccountStatementPage", () => {
   const acct = account("attendee", 7);
 
-  test("shows the account label, its balance, a back link, and the statement", () => {
+  test("shows the account label, its reversed balance, a back link, and the statement", () => {
     const refs = names({ attendees: new Map([[7, "Ada Lovelace"]]) });
-    // A single payment credits the attendee account, so its final balance is
-    // +5000; the heading must show the account's own label and that balance.
+    // A single sale debits the attendee account, so the ledger holds -5000; the
+    // attendee view flips it, showing the heading balance as the +5000 they owe.
     const lines = statementFor(acct)([
       transfer({
         amount: 5000,
-        destination: acct,
-        source: account("external", "world"),
+        destination: account("revenue", 1),
+        kind: "sale",
+        source: acct,
       }),
     ]);
     const html = adminAccountStatementPage(acct, lines, refs, SESSION);
     expect(html).toContain("Ada Lovelace");
     expect(html).toContain(`Balance: ${formatCurrency(5000)}`);
+    expect(html).not.toContain(`Balance: -${formatCurrency(5000)}`);
     // The nav links back to the ledger; no separate back-link arrow is shown.
     expect(html).toContain('href="/admin/ledger"');
     expect(html).not.toContain("&larr;");


### PR DESCRIPTION
## What

On the attendee view of the ledger, the signed change, running balance, and heading balance are now shown with their sign flipped.

## Why

An attendee's ledger account is stored as a **liability**: a booking debits it negative and a payment credits it back toward zero. That's correct double-entry, but it reads backwards to a normal person — they expect a charge to show as a positive amount owed and a payment to bring it down.

## How

`src/ui/templates/admin/ledger.tsx` now negates the signed delta and running balance (and the heading balance) whenever the statement's account is an **attendee** account. Because the reversal is derived from the account type inside the shared statement components, both surfaces stay consistent:

- the embedded statement panel on the edit-attendee page, and
- the standalone `/admin/ledger/attendee/:id` page reached via "View full ledger".

Every other account (revenue, modifier, the singletons) keeps its native ledger sign. A zero figure is left unflipped so it never renders as a stray `-£0`.

## Tests

- Updated the `AccountStatementTable` / `AccountStatementHeading` / page tests to assert the reversed attendee figures, and added a test that a non-attendee (revenue) account keeps its native signs.
- `deno task test:files` on the ledger, attendee-detail, and server-ledger suites all pass; `lint:ci` and `typecheck` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1LsNYTYqQqqbePG6HJESH)_