### PR TITLE
test(refund-ledger): extract expectSingleRefundCash helper

### DIFF
--- a/test/lib/refund-ledger.test.ts
+++ b/test/lib/refund-ledger.test.ts
@@ -45,6 +45,15 @@ const postBooking = async (
 const refundLegsOf = (legs: Transfer[]): Transfer[] =>
   legs.filter((leg) => (leg.kind ?? "").startsWith("refund_"));
 
+const expectSingleRefundCash = async (amount: number): Promise<Transfer> => {
+  const cash = refundLegsOf(
+    await transfersByAccount(attendeeAccount(ATTENDEE)),
+  ).filter((leg) => leg.kind === "refund_cash");
+  expect(cash.length).toBe(1);
+  expect(cash[0]!.amount).toBe(amount);
+  return cash[0]!;
+};
+
 // -- soleBookingOrder (pure) --------------------------------------------- //
 
 const leg = (overrides: Partial<Transfer>): Transfer => ({
@@ -120,12 +129,8 @@ describeWithEnv("refund-ledger > recordAttendeeRefund", { db: true }, () => {
 
     expect(await accountBalance(attendeeAccount(ATTENDEE))).toBe(0);
     expect(await accountBalance(revenueAccount(1))).toBe(0);
-    const cash = refundLegsOf(
-      await transfersByAccount(attendeeAccount(ATTENDEE)),
-    ).filter((l) => l.kind === "refund_cash");
-    expect(cash.length).toBe(1);
-    expect(cash[0]!.amount).toBe(5000);
-    expect(cash[0]!.destination).toEqual(WORLD);
+    const cash = await expectSingleRefundCash(5000);
+    expect(cash.destination).toEqual(WORLD);
   });
 
   test("reverses a sale-less paid order (surcharge with no sale leg)", async () => {
@@ -138,11 +143,7 @@ describeWithEnv("refund-ledger > recordAttendeeRefund", { db: true }, () => {
 
     expect(await accountBalance(modifierAccount(7))).toBe(0);
     expect(await accountBalance(attendeeAccount(ATTENDEE))).toBe(0);
-    const cash = refundLegsOf(
-      await transfersByAccount(attendeeAccount(ATTENDEE)),
-    ).filter((l) => l.kind === "refund_cash");
-    expect(cash.length).toBe(1);
-    expect(cash[0]!.amount).toBe(500);
+    await expectSingleRefundCash(500);
   });
 
   test("skips a balance-settled reservation (booking plus a balance payment)", async () => {


### PR DESCRIPTION
## What

Running `jscpd` over the ledger test files with `--min-tokens 50` surfaced one clone — a 6-line / 63-token block duplicated within `test/lib/refund-ledger.test.ts` (lines 123–127 and 141–145). Two adjacent `recordAttendeeRefund` tests repeated the same "assert exactly one `refund_cash` leg of amount N for the attendee" assertion verbatim.

This commit lifts that block into a small `expectSingleRefundCash(amount)` helper (placed next to the existing `refundLegsOf` helper). It returns the matched leg so the first test keeps its follow-up `destination` assertion, while the second test collapses to a single call.

## Why

The `test/` tree isn't covered by `deno task cpd` (that task only scans `src`), so this duplication had gone unflagged. Eliminating it keeps the test suite aligned with the project's 0%-duplication standard.

The two other `refund_cash` sites in the file (lines ~264 and ~377) only assert *count* for arbitrary attendee ids — a different, lighter check — so they were deliberately left untouched rather than forced through this amount-checking helper.

## Verification

- `jscpd` over the 5 ledger test files at `--min-tokens 50`: **0 clones** (was 1)
- `deno task test:files test/lib/refund-ledger.test.ts`: **22 passed**
- `deno task lint:ci`: clean
- `deno check test/lib/refund-ledger.test.ts`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSaENjGZWcdGEWUqM7mTqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSaENjGZWcdGEWUqM7mTqc)_