### PR TITLE
Bundle client assets with the deno-loader, like the edge build

### DIFF
--- a/scripts/build-static-assets.ts
+++ b/scripts/build-static-assets.ts
@@ -2,15 +2,18 @@
  * Build static client assets (admin, scanner, iframe-resizer, embed loader).
  */
 
+import { denoPlugins } from "@luca/esbuild-deno-loader";
 import { fromFileUrl } from "@std/path";
-import type { Plugin } from "esbuild";
 import * as esbuild from "esbuild";
 import * as sass from "sass";
 
-const denoConfig = JSON.parse(await Deno.readTextFile("./deno.json"));
-const denoImports: Record<string, string> = denoConfig.imports;
-
-const projectRoot = fromFileUrl(new URL("..", import.meta.url));
+/**
+ * deno.json path the deno-loader uses to resolve every bundle's imports —
+ * the `#` import map, npm/jsr specifiers, and each package's browser entry —
+ * exactly as the edge build (`build-edge.ts`) does. This replaces the
+ * per-package hand-rolled resolve plugins this file used to carry.
+ */
+const configPath = fromFileUrl(new URL("../deno.json", import.meta.url));
 
 const STATIC_DIR = "./src/ui/static";
 
@@ -64,73 +67,6 @@ const buildBundle = async (
   }
 };
 
-/** Resolve npm bare specifiers using Deno's import resolution */
-const denoNpmResolvePlugin: Plugin = {
-  name: "deno-npm-resolve",
-  setup(build) {
-    build.onResolve({ filter: /^jsqr$/ }, () => ({
-      path: fromFileUrl(import.meta.resolve("jsqr")),
-    }));
-  },
-};
-
-/** Match a single import map entry against a specifier */
-const matchImportEntry = (
-  specifier: string,
-  key: string,
-  value: unknown,
-): string | undefined => {
-  if (typeof value !== "string" || !value.startsWith("./")) return undefined;
-  if (key.endsWith("/") && specifier.startsWith(key)) {
-    return projectRoot + value.slice(2) + specifier.slice(key.length);
-  }
-  if (specifier === key) return projectRoot + value.slice(2);
-  return undefined;
-};
-
-/** Resolve a #-prefixed specifier using the deno.json import map */
-const resolveImportMap = (specifier: string): string | undefined => {
-  for (const [key, value] of Object.entries(denoImports)) {
-    const resolved = matchImportEntry(specifier, key, value);
-    if (resolved) return resolved;
-  }
-  return undefined;
-};
-
-/** Resolve #-prefixed imports using the deno.json import map */
-const denoImportMapPlugin: Plugin = {
-  name: "deno-import-map",
-  setup(build) {
-    build.onResolve({ filter: /^#/ }, (args) => {
-      const resolved = resolveImportMap(args.path);
-      return resolved ? { path: resolved } : undefined;
-    });
-  },
-};
-
-/** Resolve @iframe-resizer/* and auto-console-group using Deno's import resolution */
-const iframeResizerResolvePlugin: Plugin = {
-  name: "iframe-resizer-resolve",
-  setup(build) {
-    build.onResolve(
-      { filter: /^(@iframe-resizer\/|auto-console-group)/ },
-      (args) => ({
-        path: fromFileUrl(import.meta.resolve(args.path)),
-      }),
-    );
-  },
-};
-
-/** Resolve @botpoison/browser using Deno's import resolution */
-const botpoisonResolvePlugin: Plugin = {
-  name: "botpoison-resolve",
-  setup(build) {
-    build.onResolve({ filter: /^@botpoison\/browser$/ }, () => ({
-      path: fromFileUrl(import.meta.resolve("@botpoison/browser")),
-    }));
-  },
-};
-
 /**
  * The client JS bundles as data, so callers other than {@link buildStaticAssets}
  * can rebuild a single bundle with its exact esbuild config — entry point,
@@ -153,7 +89,7 @@ export const STATIC_JS_BUNDLES: StaticBundle[] = [
       minify: true,
       outfile: STATIC_ASSET_OUTFILES.scanner,
       platform: "browser",
-      plugins: [denoNpmResolvePlugin],
+      plugins: [...denoPlugins({ configPath })],
     },
   },
   {
@@ -165,7 +101,7 @@ export const STATIC_JS_BUNDLES: StaticBundle[] = [
       minify: true,
       outfile: STATIC_ASSET_OUTFILES.admin,
       platform: "browser",
-      plugins: [denoImportMapPlugin],
+      plugins: [...denoPlugins({ configPath })],
     },
   },
   {
@@ -177,6 +113,7 @@ export const STATIC_JS_BUNDLES: StaticBundle[] = [
       minify: true,
       outfile: STATIC_ASSET_OUTFILES.embed,
       platform: "browser",
+      plugins: [...denoPlugins({ configPath })],
     },
   },
   {
@@ -188,7 +125,7 @@ export const STATIC_JS_BUNDLES: StaticBundle[] = [
       minify: true,
       outfile: STATIC_ASSET_OUTFILES.contact,
       platform: "browser",
-      plugins: [botpoisonResolvePlugin],
+      plugins: [...denoPlugins({ configPath })],
     },
   },
   {
@@ -200,7 +137,7 @@ export const STATIC_JS_BUNDLES: StaticBundle[] = [
       minify: true,
       outfile: STATIC_ASSET_OUTFILES.iframeResizerParent,
       platform: "browser",
-      plugins: [iframeResizerResolvePlugin],
+      plugins: [...denoPlugins({ configPath })],
     },
   },
   {
@@ -213,7 +150,7 @@ export const STATIC_JS_BUNDLES: StaticBundle[] = [
       minify: true,
       outfile: STATIC_ASSET_OUTFILES.iframeResizerChild,
       platform: "browser",
-      plugins: [iframeResizerResolvePlugin],
+      plugins: [...denoPlugins({ configPath })],
     },
   },
 ];


### PR DESCRIPTION
## What

The client static-asset bundles in `build-static-assets.ts` each carried their own hand-rolled esbuild resolve plugin:

- `denoNpmResolvePlugin` — map `jsqr`
- `denoImportMapPlugin` (+ `resolveImportMap`/`matchImportEntry` helpers) — reimplement `#` import-map resolution
- `iframeResizerResolvePlugin` — `@iframe-resizer/*` + `auto-console-group`
- `botpoisonResolvePlugin` — `@botpoison/browser`

The edge build (`build-edge.ts`) already resolves its entire graph through `@luca/esbuild-deno-loader`. This points the client bundles at the same `denoPlugins({ configPath })` and deletes the bespoke plugins and helpers (**+14 / −77 lines**).

## Why it's safe

Verified the swap is behaviour-preserving by comparing the actual input files and string-literal fingerprints of each bundle, not just output size:

- **scanner, admin, embed, contact** — the deno-loader resolves the **identical source files**; output differs only in esbuild codegen (variable names, ordering).
- **iframe-resizer parent + child** — the deno-loader resolves the package's `browser` entry (`index.umd.js`) rather than the `main`/CJS entry. That's the vendor's own browser build (the one their `package.json` designates via the `browser` field), ~1.3KB smaller, with an **identical behavioural string fingerprint** apart from a dormant legacy-global `iFrameResize()` deprecation warning that this codebase's module-based usage never triggers. The GPLv3 license-global mechanism exists in both builds, so the injected `window.iframeResizer={license:'GPLv3'}` banner still applies.

## Verification

`deno task precommit` passes end to end:

| step | result |
| --- | --- |
| lint | ✓ |
| typecheck | ✓ |
| cpd (0% duplication) | ✓ |
| build:edge | ✓ |
| test:coverage (full suite, 100%) | ✓ |

All six bundles build with sizes matching the predicted deno-loader output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYQZNV5hGae5jwGYRQQbiM)_