### PR TITLE
Surface paid-line no-quantity block at top of page, disable the box

### DIFF
--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -135,6 +135,9 @@ export type ValidationResult =
       valid: false;
       attendeeError: AttendeeFieldError | null;
       dateError: string | null;
+      /** Form-wide error surfaced at the top of the page (e.g. a paid line was
+       * marked no-quantity), as opposed to a per-line error shown in the table. */
+      formError: string | null;
       lineErrors: Map<number, string>;
       values: ParsedAttendeeForm;
     };
@@ -164,6 +167,20 @@ export const isBookedLine = (line: AttendeeFormLine): boolean =>
  * deliberate quantity-0 sentinel line to keep, not a real booking. */
 export const isNoQuantityLine = (line: AttendeeFormLine): boolean =>
   line.noQuantity && line.listing !== null;
+
+/** True when a line carries a captured payment (price_paid > 0 on its existing
+ * booking). Such a line can't be marked no-quantity until the charge is
+ * refunded — silently clearing price_paid would drop listing income and strand
+ * the charge behind the quantity-0 refund guards — so the editor disables its
+ * "no quantity" box ({@link PAID_NO_QUANTITY_MESSAGE} as the tooltip) and the
+ * validator rejects a hand-crafted tick. */
+export const isPaymentLockedLine = (line: AttendeeFormLine): boolean =>
+  (line.existingBooking?.price_paid ?? 0) > 0;
+
+/** Why a paid line can't be marked no-quantity: shown at the top of the page on
+ * a (hand-crafted) submission and as the disabled box's hover tooltip. */
+export const PAID_NO_QUANTITY_MESSAGE =
+  "Refund this line's payment before marking it no quantity.";
 
 /** True when the line should be persisted at all: a real booking OR a deliberate
  * no-quantity line. The persistence + no-lines paths use THIS (so a checked
@@ -364,15 +381,10 @@ const isBookedDaily = (line: AttendeeFormLine): boolean =>
   isBookedLine(line) && line.listing!.listing_type === "daily";
 
 /** Validate one line. Date/duration/overbooking concerns are surfaced as
- * non-blocking warnings elsewhere, not as errors. */
+ * non-blocking warnings elsewhere, not as errors. The paid-line no-quantity rule
+ * is enforced form-wide ({@link validatePaidNoQuantity}) so its message lands at
+ * the top of the page, not buried in the quantity table. */
 const validateLine = (line: AttendeeFormLine): string | null => {
-  // Forbid marking a PAID line no-quantity: the charge must be refunded or
-  // retargeted to a real line first. Silently clearing price_paid would drop
-  // listing income and strand the charge behind the (now quantity-0) refund
-  // guards, so reject rather than normalise (enforces the §1 invariant).
-  if (isNoQuantityLine(line) && (line.existingBooking?.price_paid ?? 0) > 0) {
-    return "Refund this line's payment before marking it no quantity.";
-  }
   // isBookedLine already guarantees an integer quantity ≥ 1; the only quantity
   // error left is exceeding the listing's per-booking maximum.
   if (!isBookedLine(line)) return null;
@@ -381,6 +393,15 @@ const validateLine = (line: AttendeeFormLine): string | null => {
   }
   return null;
 };
+
+/** Form-wide guard: forbid marking a PAID line no-quantity — the charge must be
+ * refunded or retargeted to a real line first (enforces the §1 invariant). The
+ * editor already disables the box for these lines, so this only fires on a
+ * hand-crafted submission; its message is shown at the top of the page. */
+const validatePaidNoQuantity = (parsed: ParsedAttendeeForm): string | null =>
+  parsed.lines.some((l) => isNoQuantityLine(l) && isPaymentLockedLine(l))
+    ? PAID_NO_QUANTITY_MESSAGE
+    : null;
 
 /**
  * Validate the attendee block, the shared date, and each booked line. A daily
@@ -396,6 +417,7 @@ export const validateParsedForm = (
     hasDailyBooking && !isIsoDate(parsed.startDate)
       ? "A start date is required for the booked daily listings"
       : null;
+  const formError = validatePaidNoQuantity(parsed);
 
   const lineErrors = new Map<number, string>();
   for (let i = 0; i < parsed.lines.length; i++) {
@@ -404,10 +426,11 @@ export const validateParsedForm = (
     if (error) lineErrors.set(i, error);
   }
 
-  if (attendeeError || dateError || lineErrors.size > 0) {
+  if (attendeeError || dateError || formError || lineErrors.size > 0) {
     return {
       attendeeError,
       dateError,
+      formError,
       lineErrors,
       valid: false,
       values: parsed,

--- a/src/features/admin/attendee-form-routes.ts
+++ b/src/features/admin/attendee-form-routes.ts
@@ -352,6 +352,7 @@ const buildTemplateData = async (
     dateError?: string | null;
     flashError?: string;
     flashSuccess?: string;
+    formError?: string | null;
     hasMixedTimings?: boolean;
     returnUrl?: string;
     questions?: QuestionWithAnswers[];
@@ -393,6 +394,7 @@ const buildTemplateData = async (
     dateError: opts.dateError ?? null,
     flashError: opts.flashError,
     flashSuccess: opts.flashSuccess,
+    formError: opts.formError ?? null,
     // The shared date range only affects daily listings; the form's rendered
     // lines cover every active listing plus any inactive one this attendee
     // already books, so a daily line here is exactly when the dates matter.
@@ -693,6 +695,7 @@ const handleSubmitInner = async (
       ...dataForRerender,
       attendeeError: result.attendeeError?.message ?? null,
       dateError: result.dateError,
+      formError: result.formError,
     });
   }
 

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -20,9 +20,11 @@ import {
   type AttendeeFormLine,
   type BalanceNotice,
   DAY_COUNT_FIELD,
+  isPaymentLockedLine,
   isRetainedLine,
   LINE_KEY_PREFIX,
   NO_QUANTITY_PREFIX,
+  PAID_NO_QUANTITY_MESSAGE,
   type ParsedAttendeeForm,
   QTY_PREFIX,
   REMAINING_BALANCE_FIELD,
@@ -115,6 +117,9 @@ export type AttendeeFormTemplateData = {
   attendeeError: string | null;
   /** Shared-date error (e.g. missing start date for a booked daily listing). */
   dateError: string | null;
+  /** Form-wide error shown at the top of the page (e.g. a paid line was marked
+   * no-quantity), kept out of the per-line quantity table. */
+  formError: string | null;
   /** Save outcome shown inside the form. */
   flashError?: string;
   flashSuccess?: string;
@@ -164,6 +169,9 @@ const ListingRow = ({
   const listing = line.listing!;
   const booked = isRetainedLine(line) || Boolean(line.existingBooking);
   const isDaily = listing.listing_type === "daily";
+  // A paid line can't be marked no-quantity until its charge is refunded, so the
+  // box is disabled with an explaining tooltip rather than left to fail on save.
+  const paymentLocked = isPaymentLockedLine(line);
   return (
     <tr class={booked ? "attendee-line" : "attendee-line attendee-line-empty"}>
       <td>
@@ -196,7 +204,9 @@ const ListingRow = ({
           <input
             checked={line.noQuantity}
             class="no-quantity-toggle"
+            disabled={paymentLocked}
             name={`${NO_QUANTITY_PREFIX}${listing.id}`}
+            title={paymentLocked ? PAID_NO_QUANTITY_MESSAGE : undefined}
             type="checkbox"
             value="1"
           />
@@ -882,6 +892,12 @@ export const attendeeFormPage = (
 
       {isEdit && a && (
         <AttendeeNotesSection attendeeId={a.id} notes={data.systemNotes} />
+      )}
+
+      {data.formError && (
+        <output class="error" role="alert">
+          {data.formError}
+        </output>
       )}
 
       {data.topWarnings.length > 0 && (

--- a/test/lib/attendee-form-model.test.ts
+++ b/test/lib/attendee-form-model.test.ts
@@ -585,12 +585,15 @@ describe("no-quantity persistence + paid-line guard", () => {
     });
     const result = validateParsedForm(parsed);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.lineErrors.get(0)).toContain("Refund");
-    // The per-line error field (rendered inline against the row) carries the
-    // exact message, not a concatenation onto its prior value.
-    expect(parsed.lines[0]!.error).toBe(
-      "Refund this line's payment before marking it no quantity.",
-    );
+    // The paid-line block is a form-wide error (shown at the top of the page),
+    // not a per-line error buried in the quantity table.
+    if (!result.valid) {
+      expect(result.formError).toBe(
+        "Refund this line's payment before marking it no quantity.",
+      );
+      expect(result.lineErrors.size).toBe(0);
+    }
+    expect(parsed.lines[0]!.error).toBe(null);
   });
 
   test("validateParsedForm allows marking an unpaid line no-quantity", () => {

--- a/test/lib/server-attendee-form.test.ts
+++ b/test/lib/server-attendee-form.test.ts
@@ -635,7 +635,15 @@ describeWithEnv("server (unified attendee form)", { db: true }, () => {
 
       // Re-renders the form in place (200) with the line untouched.
       const html = await expectHtmlResponse(response, 200);
-      expect(html).toContain("Refund this line's payment");
+      // The block is surfaced as a top-of-page error, not buried in the table.
+      expect(html).toContain(
+        `<output class="error" role="alert">Refund this line's payment before marking it no quantity.</output>`,
+      );
+      // The paid line's "no quantity" box is disabled with an explaining tooltip
+      // so it can't be ticked in the first place.
+      expect(html).toContain(
+        `class="no-quantity-toggle" disabled name="noqty_${listing.id}" title="Refund this line's payment before marking it no quantity."`,
+      );
       expect(await readLine(attendeeId, listing.id)).toMatchObject({
         price_paid: 1500,
         quantity: 2,


### PR DESCRIPTION
## Why

When saving an attendee with a product set to "no quantity" (quantity 0), a line that still carries a captured payment can't become a quantity-0 sentinel until the charge is refunded. Two UX problems with the old behaviour:

1. The block was reported as a **per-line error inside the quantity table**, which is easy to miss.
2. The **"no quantity" box stayed enabled**, so an operator could tick it and only discover on save that it was rejected.

## What changed

- The paid-line guard is now a **form-wide error rendered at the top of the page** (`formError`) instead of a per-line error buried in the table. The per-line error mechanism is kept for genuinely line-scoped errors (e.g. "Quantity must be at most N").
- The **"no quantity" checkbox is disabled** for any line with a captured payment, with a `title` tooltip — `"Refund this line's payment before marking it no quantity."` — explaining why, so it can't be ticked in the first place.
- The server-side validator still rejects a hand-crafted submission and surfaces the same message at the top; the existing stale-key safety net in `applyEdit` is unchanged.

A shared `isPaymentLockedLine` predicate and `PAID_NO_QUANTITY_MESSAGE` constant back both the template (disable + tooltip) and the validator, so the rule has a single source of truth.

## Tests

- Updated the model unit test to assert the block is now a form-wide `formError` with no per-line error.
- Strengthened the server test to assert the top-of-page error output and the disabled box with its tooltip.
- Typecheck, lint, jscpd (0 clones), model/server/e2e no-quantity suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sqgf8WaU1moZf1S1vywgxG)_