### PR TITLE
Copy SENTRY_URL to built sites

### DIFF
--- a/src/shared/builder.ts
+++ b/src/shared/builder.ts
@@ -32,6 +32,7 @@ type HostSecret = { name: string; hostInfra?: boolean };
 
 const HOST_SECRETS: readonly HostSecret[] = [
   { name: "NTFY_URL" },
+  { name: "SENTRY_URL" },
   { name: "ADMIN_EMAIL_ADDRESS" },
   { hostInfra: true, name: "STORAGE_ZONE_NAME" },
   { hostInfra: true, name: "STORAGE_ZONE_KEY" },

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -119,6 +119,7 @@ describeWithEnv(
     env: {
       ADMIN_EMAIL_ADDRESS: "admin@example.com",
       NTFY_URL: "https://ntfy.example.com/test",
+      SENTRY_URL: "https://k@bugs.example.com/2",
     },
   },
   () => {
@@ -160,6 +161,7 @@ describeWithEnv(
 
         const secretsSet = secretsFrom(secretStub);
         expectSecret(secretsSet, "NTFY_URL", "https://ntfy.example.com/test");
+        expectSecret(secretsSet, "SENTRY_URL", "https://k@bugs.example.com/2");
         expectSecret(secretsSet, "ADMIN_EMAIL_ADDRESS", "admin@example.com");
       }));
 


### PR DESCRIPTION
## What

Adds `SENTRY_URL` to the `HOST_SECRETS` list in `src/shared/builder.ts`, so the host's Sentry DSN is **copied to every freshly built site** and **backfilled onto existing sites** when their secrets are synced — exactly the treatment `NTFY_URL` already gets.

Follow-up to #1429 (which added Sentry support). Without this, a built site never sees `SENTRY_URL`, so it never initializes Sentry and its server-side errors go unreported.

## Why this list

`HOST_SECRETS` is the single source of truth for secrets propagated to built sites — it feeds both the initial `buildSite` secret-set and the `add-secrets` backfill UI (`#shared/site-secrets.ts`), and the infra/non-infra split is derived from it so it can't drift.

`SENTRY_URL` is tagged **non-infra** (no `hostInfra: true`), matching `NTFY_URL`: a DSN only authorizes *submitting* events (it can't read project data), so the backfill UI shouldn't flag it as a host-level infrastructure credential alongside the Bunny account key / storage / wallet signing material.

## Testing

- Extended the existing `builder.test.ts` "copies host secrets when env vars are set" case to set `SENTRY_URL` in the env and assert it's among the secrets written to the new site — a direct regression guard against it being dropped from the list.
- `deno task precommit` passes against current `main` (lint, typecheck, cpd, build:edge, full suite + 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8r9VhGLHqp1JwjsYvn5TN

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8r9VhGLHqp1JwjsYvn5TN)_