### PR TITLE
Show list prices before modifiers in the order summary

### DIFF
--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -784,7 +784,11 @@ const renderQuote = async (
   if (!available) {
     return htmlResponse(orderSummaryMessage(TICKETS_UNAVAILABLE_MESSAGE));
   }
-  if (isPaymentsEnabled()) return htmlResponse(orderSummary(pricedOrder));
+  if (isPaymentsEnabled()) {
+    return htmlResponse(
+      orderSummary(pricedOrder, Boolean(pricingParams.reservationAmount)),
+    );
+  }
   // No payment provider: the booking is taken without charging, but a paid order
   // still records its full value as the amount owed (see processSubmission), so
   // surface that figure instead of implying the order is free. fullSubtotal is

--- a/src/ui/templates/public/order-summary.tsx
+++ b/src/ui/templates/public/order-summary.tsx
@@ -1,10 +1,46 @@
+import { sumOf } from "#fp";
 import { t } from "#i18n";
-import type { PricedOrder } from "#shared/checkout-pricing.ts";
+import {
+  lineListPrice,
+  type PricedLine,
+  type PricedOrder,
+} from "#shared/checkout-pricing.ts";
 import { formatCurrency } from "#shared/currency.ts";
 
 /** Prefix a line label with its quantity when more than one was taken. */
 const quantityLabel = (quantity: number, name: string): string =>
   quantity > 1 ? `${quantity}× ${name}` : name;
+
+/** One name/amount pair to render as a ticket row in the summary table. */
+type TicketRow = { label: string; amount: number };
+
+/**
+ * The ticket rows to show above the modifiers.
+ *
+ * For a full-payment order each listing is shown at its gross list price
+ * (quantity × unit price), so a discount surfaces only on its own modifier row
+ * rather than being silently folded into the ticket line — otherwise the line
+ * and the modifier row would double-count the same reduction. Discounts split a
+ * listing into several priced lines, so those are regrouped into one row.
+ *
+ * For a deposit the charged amount IS the figure due now (the deposit already
+ * reflects every modifier), so each priced line is shown exactly as charged.
+ */
+const ticketRows = (lines: PricedLine[], isDeposit: boolean): TicketRow[] =>
+  isDeposit
+    ? lines.map((line) => ({
+        amount: line.chargedUnitAmount * line.quantity,
+        label: quantityLabel(line.quantity, line.item.name),
+      }))
+    : [...Map.groupBy(lines, (line) => line.item.listingId).values()].map(
+        (group) => ({
+          amount: sumOf(lineListPrice)(group),
+          label: quantityLabel(
+            sumOf((line: PricedLine) => line.quantity)(group),
+            group[0]!.item.name,
+          ),
+        }),
+      );
 
 /** A single name/amount row in the order-summary table. */
 const SummaryRow = ({
@@ -26,17 +62,18 @@ const SummaryRow = ({
  * Render a fully-priced order as a compact summary table. Returned as a bare
  * HTML fragment so the booking form's running-total script can drop it inline,
  * and so the no-JS `target="_blank"` fallback shows the same breakdown.
+ *
+ * Pass `isDeposit` for a reservation so the ticket rows show the deposit charged
+ * now; a full-payment order instead shows list prices before modifiers, with the
+ * modifiers itemised on their own rows.
  */
-export const orderSummary = (order: PricedOrder): string =>
+export const orderSummary = (order: PricedOrder, isDeposit = false): string =>
   String(
     <div class="table-scroll">
       <table class="order-summary">
         <tbody>
-          {order.lines.map((line) => (
-            <SummaryRow
-              amount={line.chargedUnitAmount * line.quantity}
-              label={quantityLabel(line.quantity, line.item.name)}
-            />
+          {ticketRows(order.lines, isDeposit).map((row) => (
+            <SummaryRow amount={row.amount} label={row.label} />
           ))}
           {order.extras.map((extra) => (
             <SummaryRow

--- a/test/lib/server-calculate.test.ts
+++ b/test/lib/server-calculate.test.ts
@@ -4,6 +4,8 @@ import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import { formatCurrency } from "#shared/currency.ts";
+import { invalidateAttendeeStatusesCache } from "#shared/db/attendee-statuses.ts";
+import { getDb } from "#shared/db/client.ts";
 import { modifiersTable, setModifierAnswers } from "#shared/db/modifiers.ts";
 import {
   answersTable,
@@ -290,6 +292,25 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     expect(html).toContain("order-summary-total");
   });
 
+  test("shows the listing price before modifiers, not the discounted line price", async () => {
+    const listing = await setupPromoListing();
+
+    const html = await (
+      await calculate(listing.slug, listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+        promo_code: "SAVE10",
+      })
+    ).text();
+
+    // The ticket line is the full £10.00 list price, so the discount isn't
+    // baked into it — the modifier is itemised separately on its own row...
+    expect(html).toContain(formatCurrency(1000));
+    expect(html).toContain("10% off");
+    expect(html).toContain(formatCurrency(-100));
+    // ...and only the total carries the £9.00 discounted figure.
+    expect(html).toContain(formatCurrency(900));
+  });
+
   test("does not apply a promo code discount when no code is submitted", async () => {
     const listing = await setupPromoListing();
 
@@ -319,6 +340,39 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     expect(html).toContain(formatCurrency(1000));
     expect(html).not.toContain(formatCurrency(900));
     expect(html).not.toContain("10% off");
+  });
+
+  /** Turn the seeded public-default status into a reservation charging `amount`,
+   * so the quote prices each line as a deposit rather than the full price. */
+  const setPublicReservation = async (amount: string): Promise<void> => {
+    await getDb().execute({
+      args: [amount],
+      sql: "UPDATE attendee_statuses SET is_reservation = 1, reservation_amount = ? WHERE is_public_default = 1",
+    });
+    invalidateAttendeeStatusesCache();
+  };
+
+  test("shows the deposit charged now for a reservation, not the full list price", async () => {
+    await setupStripe();
+    await setPublicReservation("10%");
+    const listing = await createTestListing({
+      maxQuantity: 5,
+      name: "Weekend Pass",
+      unitPrice: 2000,
+    });
+
+    const html = await (
+      await calculate(listing.slug, listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      })
+    ).text();
+
+    // A deposit summary shows what's due now (10% of £20.00 = £2.00), not the
+    // full £20.00 list price — the deposit already reflects the reservation.
+    expect(html).toContain("Weekend Pass");
+    expect(html).toContain(formatCurrency(200));
+    expect(html).not.toContain(formatCurrency(2000));
+    expect(html).toContain("order-summary-total");
   });
 
   test("applies a promo code discount case-insensitively", async () => {


### PR DESCRIPTION
## Problem

In `.order-summary`, each ticket line was rendered at its **charged** amount — which already had any discount modifier baked in — while the same discount was *also* shown on its own row. That double-counted the reduction: the listing line and the modifier row both reflected it, so the visible figures didn't reconcile to the total.

For example, a £10.00 ticket with a 10%-off code showed:

| | before |
| --- | --- |
| Workshop | £9.00 |
| 10% off | −£1.00 |
| **Total** | **£9.00** |

…where the line price already had the discount applied, so it read as £9.00 − £1.00 = £8.00 — confusing.

## Fix

Render each listing at its **gross list price** (quantity × unit price), so a modifier surfaces only on its own row:

| | after |
| --- | --- |
| Workshop | £10.00 |
| 10% off | −£1.00 |
| **Total** | **£9.00** |

A discount splits a listing into several priced lines internally, so those are regrouped into a single row at the full list price.

Reservations are unchanged: a deposit summary still shows the amount charged **now** (the deposit already reflects every modifier), so `orderSummary` takes an `isDeposit` flag and the `/calculate` caller passes it through based on the public reservation amount.

## Tests

- Regression test asserting the ticket line shows the full £10.00 list price (not the £9.00 discounted figure), with the discount on its own row — fails before the fix, passes after.
- New test covering the deposit branch: a reservation quote shows the deposit due now, not the full list price.
- `order-summary.tsx` stays at 100% branch/line coverage; lint, typecheck and jscpd (0% dupes) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpr4bv3RpjMjWiycJSBYYY)_