### PR TITLE
Retry migration up() on transient verify failure, not verify() alone

### DIFF
--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -345,27 +345,38 @@ const pendingMigrations = async (): Promise<Migration[]> => {
 
 /**
  * Backoff (ms) before each re-attempt of a migration's verify(). Its length is
- * the number of retries, so four verify attempts per round.
+ * the number of retries, so four verify attempts in total.
  *
  * A migration applies DDL in up() and then verify() reads the live schema back
- * to confirm it landed. Reads are pinned to the primary (queryBatchPrimary,
- * "write" mode) to dodge replica lag, but a freshly-opened primary connection
- * can still briefly observe the pre-DDL schema — read-your-writes propagation
- * lag — so an object the migration just created reads as missing. verify()
- * re-snapshots on every call, so retrying after a short backoff lets the schema
- * settle within the same request rather than 503-ing it. (Observed in
- * production: a column-add migration failed verification on one request and
- * passed on the retry moments later.) A genuine schema defect stays missing
- * across every attempt and still throws, so this never masks a real bug.
+ * to confirm it landed. The snapshot is already pinned to the primary
+ * (queryBatchPrimary, "write" mode) to dodge replica lag, but a freshly-opened
+ * primary connection can still briefly observe the pre-DDL schema —
+ * read-your-writes propagation lag — so a column the ALTER just added reads as
+ * missing and verify() throws spuriously. (Observed in production: a column-add
+ * migration failed verification on one request and passed on the retry moments
+ * later.) verify() re-snapshots on every call, so retrying after a short backoff
+ * lets the schema settle within the same request rather than 503-ing it. A
+ * genuine schema defect stays missing across every attempt and still throws, so
+ * this never masks a real bug.
+ *
+ * Retrying verify() alone is not always enough, though: up() can itself skip a
+ * write when its own snapshot lagged. syncIndexes() reads the live schema to
+ * decide which indexes to create and skips any whose table the snapshot doesn't
+ * show — correct for an index on a table a later migration creates, but it also
+ * skips an index whose table THIS migration just created when the read lags
+ * behind that write. The index is then never created, so verify() fails on every
+ * attempt until up() runs again — the observed "missing index
+ * idx_system_notes_attendee_id, passed on the next request" failure. So once
+ * verify()'s own retries are exhausted, {@link applyMigrationWithRetry} re-runs
+ * up() once and verifies again.
  */
 export const VERIFY_RETRY_BACKOFF_MS = [50, 150, 350] as const;
 
 /**
- * Run a migration's verify(), retrying a transient failure (read-your-writes lag
- * on the just-applied DDL) on a fresh schema snapshot before giving up. Cheap:
- * every attempt only re-snapshots the live schema, never re-applies DDL.
+ * Run a migration's verify(), retrying a transient failure (read-your-writes
+ * lag on the just-applied DDL) on a fresh schema snapshot before giving up.
  */
-const verifyWithRetry = (migration: Migration): Promise<void> =>
+export const verifyMigrationWithRetry = (migration: Migration): Promise<void> =>
   retryWithBackoff(
     () => migration.verify(),
     VERIFY_RETRY_BACKOFF_MS,
@@ -382,44 +393,37 @@ const verifyWithRetry = (migration: Migration): Promise<void> =>
 
 /**
  * Apply a migration: run up(), then verify() with retries. If verify() never
- * passes across a full round of (cheap, re-snapshot-only) retries, re-apply
- * up() ONCE and verify again.
+ * passes across a full round of retries, re-run up() once and verify again.
  *
- * The re-apply repairs the failure mode where up() itself silently skipped an
- * object. up() syncs schema in phases — applySchemaChanges() creates a new
- * table, then syncIndexes()/syncTriggers() read a FRESH snapshot to decide which
- * of that table's indexes/triggers to create. When that snapshot lags the
- * table-create from the earlier phase (the same read-your-writes lag above),
- * syncIndexes() does not yet see the table and SKIPS its index, so verify() can
- * never pass until up() runs again — the "missing index
- * idx_system_notes_attendee_id, passed on the next request" failure, where a
- * whole new request re-ran up().
+ * Re-running up() repairs the case where up() itself skipped a write because its
+ * own schema snapshot lagged (see VERIFY_RETRY_BACKOFF_MS) — the missing-index
+ * failure. up() is idempotent by construction (the runner already re-runs it on
+ * a later request whenever a prior run died before recording its marker), so the
+ * second pass — now reading a settled snapshot — completes the skipped write.
  *
- * Deferring the re-apply until a full round of verify retries has failed is
- * deliberate: a migration whose up() is NOT a cheap no-op after success — e.g.
- * 2026-06-20_free_text_questions, which recopies attendee_answers /
- * listing_questions / questions via recreateTable — must not be re-run on a pure
- * verify-lag (where up() already did its work and only verify()'s snapshot
- * lagged), which would recopy large tables and risk the edge request budget. So
- * up() runs at most twice, never once per retry. up() is idempotent by
- * construction — the runner already re-runs it on a later request whenever a
- * prior run died before recording its marker.
+ * The re-run is deferred until verify()'s own retries are exhausted, not fired
+ * on the first verify miss, so a migration whose up() is NOT a cheap no-op after
+ * success — e.g. 2026-06-20_free_text_questions, which recopies attendee_answers
+ * / listing_questions / questions via recreateTable — is not re-run on a pure
+ * verify-lag (up() did its work; only verify()'s snapshot lagged), which would
+ * recopy large tables and risk the edge request budget. up() therefore runs at
+ * most twice, never once per retry.
  */
 export const applyMigrationWithRetry = async (
   migration: Migration,
 ): Promise<void> => {
   await migration.up();
   try {
-    await verifyWithRetry(migration);
+    await verifyMigrationWithRetry(migration);
   } catch (error) {
     logDebug(
       "Migration",
-      `verify ${migration.id} still failing after retries, re-applying up(): ${
+      `verify ${migration.id} still failing after retries, re-running up(): ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
     await migration.up();
-    await verifyWithRetry(migration);
+    await verifyMigrationWithRetry(migration);
   }
 };
 

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -344,63 +344,84 @@ const pendingMigrations = async (): Promise<Migration[]> => {
 };
 
 /**
- * Backoff (ms) before each re-attempt of a migration. Its length is the number
- * of retries, so four attempts in total.
+ * Backoff (ms) before each re-attempt of a migration's verify(). Its length is
+ * the number of retries, so four verify attempts per round.
  *
  * A migration applies DDL in up() and then verify() reads the live schema back
  * to confirm it landed. Reads are pinned to the primary (queryBatchPrimary,
  * "write" mode) to dodge replica lag, but a freshly-opened primary connection
  * can still briefly observe the pre-DDL schema — read-your-writes propagation
- * lag — so an object the migration just created reads as missing. That lag bites
- * in two distinct places, which is why the WHOLE migration (up() then verify()),
- * not verify() alone, is retried:
- *
- *  - verify()'s own snapshot lags the DDL — a column the ALTER just added reads
- *    as missing — and re-snapshotting moments later settles it. (Observed in
- *    production: a column-add migration failed verification on one request and
- *    passed on the retry moments later.)
- *  - up() itself silently skips work. up() syncs schema in phases —
- *    applySchemaChanges() creates a new table, then syncIndexes()/syncTriggers()
- *    each read a fresh snapshot to decide which of that table's indexes/triggers
- *    to create. When that snapshot lags the table-create from the earlier phase,
- *    syncIndexes() does not yet see the table and SKIPS its index. The index is
- *    never created, so retrying verify() alone fails on every attempt — only
- *    re-running up() (which now sees the table) creates it. This is the
- *    "missing index idx_system_notes_attendee_id, passed on the next request"
- *    failure: a whole new request re-ran up().
- *
- * up() is idempotent by construction — the runner already re-runs it on a later
- * request whenever a prior run died before recording its marker — so re-running
- * it here is safe, and cheap on the happy path (a second snapshot showing every
- * object already present). A genuine schema defect stays missing across every
- * attempt and still throws, so this never masks a real bug.
+ * lag — so an object the migration just created reads as missing. verify()
+ * re-snapshots on every call, so retrying after a short backoff lets the schema
+ * settle within the same request rather than 503-ing it. (Observed in
+ * production: a column-add migration failed verification on one request and
+ * passed on the retry moments later.) A genuine schema defect stays missing
+ * across every attempt and still throws, so this never masks a real bug.
  */
 export const VERIFY_RETRY_BACKOFF_MS = [50, 150, 350] as const;
 
 /**
- * Run a migration's up() then verify(), retrying the pair on a transient failure
- * (read-your-writes lag on the just-applied DDL — see VERIFY_RETRY_BACKOFF_MS)
- * on a fresh schema snapshot before giving up. Retrying up() too — not verify()
- * alone — is what lets an index a lagging snapshot caused up() to skip get
- * created within the same request instead of 503-ing it.
+ * Run a migration's verify(), retrying a transient failure (read-your-writes lag
+ * on the just-applied DDL) on a fresh schema snapshot before giving up. Cheap:
+ * every attempt only re-snapshots the live schema, never re-applies DDL.
  */
-export const applyMigrationWithRetry = (migration: Migration): Promise<void> =>
+const verifyWithRetry = (migration: Migration): Promise<void> =>
   retryWithBackoff(
-    async () => {
-      await migration.up();
-      await migration.verify();
-    },
+    () => migration.verify(),
     VERIFY_RETRY_BACKOFF_MS,
     (error, { attempt, willRetry }) => {
       if (!willRetry) return;
       logDebug(
         "Migration",
-        `migration ${migration.id} failed on attempt ${
+        `verify ${migration.id} failed on attempt ${
           attempt + 1
         }, retrying: ${error instanceof Error ? error.message : String(error)}`,
       );
     },
   );
+
+/**
+ * Apply a migration: run up(), then verify() with retries. If verify() never
+ * passes across a full round of (cheap, re-snapshot-only) retries, re-apply
+ * up() ONCE and verify again.
+ *
+ * The re-apply repairs the failure mode where up() itself silently skipped an
+ * object. up() syncs schema in phases — applySchemaChanges() creates a new
+ * table, then syncIndexes()/syncTriggers() read a FRESH snapshot to decide which
+ * of that table's indexes/triggers to create. When that snapshot lags the
+ * table-create from the earlier phase (the same read-your-writes lag above),
+ * syncIndexes() does not yet see the table and SKIPS its index, so verify() can
+ * never pass until up() runs again — the "missing index
+ * idx_system_notes_attendee_id, passed on the next request" failure, where a
+ * whole new request re-ran up().
+ *
+ * Deferring the re-apply until a full round of verify retries has failed is
+ * deliberate: a migration whose up() is NOT a cheap no-op after success — e.g.
+ * 2026-06-20_free_text_questions, which recopies attendee_answers /
+ * listing_questions / questions via recreateTable — must not be re-run on a pure
+ * verify-lag (where up() already did its work and only verify()'s snapshot
+ * lagged), which would recopy large tables and risk the edge request budget. So
+ * up() runs at most twice, never once per retry. up() is idempotent by
+ * construction — the runner already re-runs it on a later request whenever a
+ * prior run died before recording its marker.
+ */
+export const applyMigrationWithRetry = async (
+  migration: Migration,
+): Promise<void> => {
+  await migration.up();
+  try {
+    await verifyWithRetry(migration);
+  } catch (error) {
+    logDebug(
+      "Migration",
+      `verify ${migration.id} still failing after retries, re-applying up(): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    await migration.up();
+    await verifyWithRetry(migration);
+  }
+};
 
 const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
   for (const migration of pending) {

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -344,36 +344,58 @@ const pendingMigrations = async (): Promise<Migration[]> => {
 };
 
 /**
- * Backoff (ms) before each re-attempt of a migration's verify(). Its length is
- * the number of retries, so four verify attempts in total.
+ * Backoff (ms) before each re-attempt of a migration. Its length is the number
+ * of retries, so four attempts in total.
  *
  * A migration applies DDL in up() and then verify() reads the live schema back
- * to confirm it landed. The snapshot is already pinned to the primary
- * (queryBatchPrimary, "write" mode) to dodge replica lag, but a freshly-opened
- * primary connection can still briefly observe the pre-DDL schema —
- * read-your-writes propagation lag — so a column the ALTER just added reads as
- * missing and verify() throws spuriously. (Observed in production: a column-add
- * migration failed verification on one request and passed on the retry moments
- * later.) verify() re-snapshots on every call, so retrying after a short backoff
- * lets the schema settle within the same request rather than 503-ing it. A
- * genuine schema defect stays missing across every attempt and still throws, so
- * this never masks a real bug.
+ * to confirm it landed. Reads are pinned to the primary (queryBatchPrimary,
+ * "write" mode) to dodge replica lag, but a freshly-opened primary connection
+ * can still briefly observe the pre-DDL schema — read-your-writes propagation
+ * lag — so an object the migration just created reads as missing. That lag bites
+ * in two distinct places, which is why the WHOLE migration (up() then verify()),
+ * not verify() alone, is retried:
+ *
+ *  - verify()'s own snapshot lags the DDL — a column the ALTER just added reads
+ *    as missing — and re-snapshotting moments later settles it. (Observed in
+ *    production: a column-add migration failed verification on one request and
+ *    passed on the retry moments later.)
+ *  - up() itself silently skips work. up() syncs schema in phases —
+ *    applySchemaChanges() creates a new table, then syncIndexes()/syncTriggers()
+ *    each read a fresh snapshot to decide which of that table's indexes/triggers
+ *    to create. When that snapshot lags the table-create from the earlier phase,
+ *    syncIndexes() does not yet see the table and SKIPS its index. The index is
+ *    never created, so retrying verify() alone fails on every attempt — only
+ *    re-running up() (which now sees the table) creates it. This is the
+ *    "missing index idx_system_notes_attendee_id, passed on the next request"
+ *    failure: a whole new request re-ran up().
+ *
+ * up() is idempotent by construction — the runner already re-runs it on a later
+ * request whenever a prior run died before recording its marker — so re-running
+ * it here is safe, and cheap on the happy path (a second snapshot showing every
+ * object already present). A genuine schema defect stays missing across every
+ * attempt and still throws, so this never masks a real bug.
  */
 export const VERIFY_RETRY_BACKOFF_MS = [50, 150, 350] as const;
 
 /**
- * Run a migration's verify(), retrying a transient failure (read-your-writes
- * lag on the just-applied DDL) on a fresh schema snapshot before giving up.
+ * Run a migration's up() then verify(), retrying the pair on a transient failure
+ * (read-your-writes lag on the just-applied DDL — see VERIFY_RETRY_BACKOFF_MS)
+ * on a fresh schema snapshot before giving up. Retrying up() too — not verify()
+ * alone — is what lets an index a lagging snapshot caused up() to skip get
+ * created within the same request instead of 503-ing it.
  */
-export const verifyMigrationWithRetry = (migration: Migration): Promise<void> =>
+export const applyMigrationWithRetry = (migration: Migration): Promise<void> =>
   retryWithBackoff(
-    () => migration.verify(),
+    async () => {
+      await migration.up();
+      await migration.verify();
+    },
     VERIFY_RETRY_BACKOFF_MS,
     (error, { attempt, willRetry }) => {
       if (!willRetry) return;
       logDebug(
         "Migration",
-        `verify ${migration.id} failed on attempt ${
+        `migration ${migration.id} failed on attempt ${
           attempt + 1
         }, retrying: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -383,8 +405,7 @@ export const verifyMigrationWithRetry = (migration: Migration): Promise<void> =>
 const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
   for (const migration of pending) {
     logDebug("Migration", `Running ${migration.id}: ${migration.description}`);
-    await migration.up();
-    await verifyMigrationWithRetry(migration);
+    await applyMigrationWithRetry(migration);
     await markMigrationApplied(migration);
   }
 };

--- a/src/shared/db/migrations/schema-sync.ts
+++ b/src/shared/db/migrations/schema-sync.ts
@@ -366,6 +366,15 @@ export const syncIndexes = async (): Promise<void> => {
   );
   const declaredNames = new Set(declared.map((d) => d.name));
 
+  // Only create an index whose table+columns the snapshot already shows. This
+  // gate is load-bearing during an incremental migration: syncIndexes runs over
+  // the WHOLE SCHEMA's declared indexes while only some tables exist yet (a
+  // later migration creates the rest), so an index on a not-yet-created table
+  // must be skipped now and created when that table's migration runs. A table
+  // present on the primary but briefly missing from this snapshot (read-your-
+  // writes lag) is indistinguishable here from one not yet created, so the
+  // lag-induced skip is repaired one layer up — verifyMigrationWithRetry re-runs
+  // the migration, which scopes verify() to its own objects (see migrations.ts).
   const creates = declared
     .filter((d) => {
       const columns = live.tables.get(d.tableName);

--- a/src/shared/retry.ts
+++ b/src/shared/retry.ts
@@ -21,7 +21,7 @@ export type RetryContext = {
  * unchanged.
  *
  * Shared by the database write-lock retry ({@link retryOnDatabaseLock}) and the
- * migration apply retry ({@link applyMigrationWithRetry}).
+ * migration verify retry ({@link verifyMigrationWithRetry}).
  */
 export const retryWithBackoff = <T>(
   fn: () => Promise<T>,

--- a/src/shared/retry.ts
+++ b/src/shared/retry.ts
@@ -21,7 +21,7 @@ export type RetryContext = {
  * unchanged.
  *
  * Shared by the database write-lock retry ({@link retryOnDatabaseLock}) and the
- * migration verify retry ({@link verifyMigrationWithRetry}).
+ * migration apply retry ({@link applyMigrationWithRetry}).
  */
 export const retryWithBackoff = <T>(
   fn: () => Promise<T>,

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   resetDatabase,
   SCHEMA_HASH,
   VERIFY_RETRY_BACKOFF_MS,
+  verifyMigrationWithRetry,
 } from "#shared/db/migrations.ts";
 import { createSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -182,7 +183,46 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
     });
   });
 
-  describe("apply retry on read-your-writes lag", () => {
+  describe("verify retry on read-your-writes lag", () => {
+    const fakeMigration = (verify: () => Promise<void>): Migration => ({
+      description: "fake migration for verify-retry tests",
+      id: "fake-verify-retry",
+      up: () => Promise.resolve(),
+      verify,
+    });
+
+    test("retries a transient verify failure and then resolves", async () => {
+      let attempts = 0;
+      await verifyMigrationWithRetry(
+        fakeMigration(() => {
+          attempts++;
+          // Fail on the first two snapshots (stale schema), succeed on the third.
+          return attempts < 3
+            ? Promise.reject(
+                new Error("Migration verification failed: missing column(s)"),
+              )
+            : Promise.resolve();
+        }),
+      );
+      expect(attempts).toBe(3);
+    });
+
+    test("rethrows after exhausting every retry", async () => {
+      let attempts = 0;
+      await expect(
+        verifyMigrationWithRetry(
+          fakeMigration(() => {
+            attempts++;
+            return Promise.reject(new Error("genuine schema defect"));
+          }),
+        ),
+      ).rejects.toThrow("genuine schema defect");
+      // One initial attempt plus one per backoff entry.
+      expect(attempts).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
+    });
+  });
+
+  describe("apply re-runs up() when verify keeps failing", () => {
     const fakeMigration = (overrides: Partial<Migration>): Migration => ({
       description: "fake migration for apply-retry tests",
       id: "fake-apply-retry",
@@ -191,9 +231,9 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
       ...overrides,
     });
 
-    test("retries a transient verify failure without re-running up()", async () => {
+    test("resolves a transient verify-lag without re-running up()", async () => {
       // Pure verify-lag: up() did its work, only verify()'s snapshot lagged.
-      // up() must NOT be re-run (it may recopy large tables), so a cheap verify
+      // up() must NOT be re-run (it may recopy large tables), so the cheap verify
       // retry alone resolves it.
       let upCalls = 0;
       let attempts = 0;
@@ -205,7 +245,6 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
           },
           verify: () => {
             attempts++;
-            // Fail on the first two snapshots (stale schema), succeed on the third.
             return attempts < 3
               ? Promise.reject(
                   new Error("Migration verification failed: missing column(s)"),
@@ -215,46 +254,44 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
         }),
       );
       expect(attempts).toBe(3);
-      // up() ran exactly once — the verify retries never re-applied it.
       expect(upCalls).toBe(1);
     });
 
-    test("re-applies up() once when verify keeps failing, so a skipped index recovers", async () => {
+    test("re-runs up() once when verify keeps failing, so a skipped index recovers", async () => {
       // Reproduces the production failure: up()'s syncIndexes ran against a
       // primary snapshot that lagged the table it had just created in the same
-      // up(), so it silently skipped the index. Retrying verify() ALONE — the
-      // old behaviour — would have failed on every attempt because the index was
-      // never created; only re-running up() (which now sees the table) creates
-      // it, which is why the failure cleared on the next request. up() is
-      // re-applied only after a full round of verify retries has failed.
+      // up(), so it silently skipped the index. Retrying verify() ALONE would
+      // fail on every attempt because the index was never created; only re-running
+      // up() (which now sees the table) creates it — which is why the failure
+      // cleared on the next request. up() is re-run only after a full round of
+      // verify retries has failed.
       let upCalls = 0;
       let indexCreated = false;
-      const migration = fakeMigration({
-        up: () => {
-          upCalls++;
-          // First up() skips the index (lagging snapshot); the second sees the
-          // table and creates it.
-          if (upCalls >= 2) indexCreated = true;
-          return Promise.resolve();
-        },
-        verify: () =>
-          indexCreated
-            ? Promise.resolve()
-            : Promise.reject(
-                new Error(
-                  "Migration verification failed: missing index idx_system_notes_attendee_id",
+      await applyMigrationWithRetry(
+        fakeMigration({
+          up: () => {
+            upCalls++;
+            // First up() skips the index (lagging snapshot); the second sees the
+            // table and creates it.
+            if (upCalls >= 2) indexCreated = true;
+            return Promise.resolve();
+          },
+          verify: () =>
+            indexCreated
+              ? Promise.resolve()
+              : Promise.reject(
+                  new Error(
+                    "Migration verification failed: missing index idx_system_notes_attendee_id",
+                  ),
                 ),
-              ),
-      });
-
-      await applyMigrationWithRetry(migration);
-
+        }),
+      );
       // up() ran exactly twice — once initially, once to repair — never per retry.
       expect(upCalls).toBe(2);
       expect(indexCreated).toBe(true);
     });
 
-    test("rethrows the original error after re-applying up() once and still failing", async () => {
+    test("rethrows the original error after re-running up() once and still failing", async () => {
       let upCalls = 0;
       let verifyAttempts = 0;
       await expect(
@@ -271,10 +308,9 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
           }),
         ),
       ).rejects.toThrow("genuine schema defect");
-      // A genuine defect re-applies up() exactly once (the bounded repair), not
-      // once per retry.
+      // A genuine defect re-runs up() exactly once (the bounded repair), not once
+      // per retry, and verifies across two full retry rounds.
       expect(upCalls).toBe(2);
-      // Two verify rounds, each one initial attempt plus one per backoff entry.
       expect(verifyAttempts).toBe(2 * (VERIFY_RETRY_BACKOFF_MS.length + 1));
     });
   });

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -3,6 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { getDb } from "#shared/db/client.ts";
 import {
+  applyMigrationWithRetry,
   initDb,
   invalidateInitDbCache,
   MIGRATION_LOCK_TTL_MS,
@@ -11,7 +12,6 @@ import {
   resetDatabase,
   SCHEMA_HASH,
   VERIFY_RETRY_BACKOFF_MS,
-  verifyMigrationWithRetry,
 } from "#shared/db/migrations.ts";
 import { createSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -182,42 +182,87 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
     });
   });
 
-  describe("verify retry on read-your-writes lag", () => {
-    const fakeMigration = (verify: () => Promise<void>): Migration => ({
-      description: "fake migration for verify-retry tests",
-      id: "fake-verify-retry",
+  describe("apply retry on read-your-writes lag", () => {
+    const fakeMigration = (overrides: Partial<Migration>): Migration => ({
+      description: "fake migration for apply-retry tests",
+      id: "fake-apply-retry",
       up: () => Promise.resolve(),
-      verify,
+      verify: () => Promise.resolve(),
+      ...overrides,
     });
 
     test("retries a transient verify failure and then resolves", async () => {
       let attempts = 0;
-      await verifyMigrationWithRetry(
-        fakeMigration(() => {
-          attempts++;
-          // Fail on the first two snapshots (stale schema), succeed on the third.
-          return attempts < 3
-            ? Promise.reject(
-                new Error("Migration verification failed: missing column(s)"),
-              )
-            : Promise.resolve();
+      await applyMigrationWithRetry(
+        fakeMigration({
+          verify: () => {
+            attempts++;
+            // Fail on the first two snapshots (stale schema), succeed on the third.
+            return attempts < 3
+              ? Promise.reject(
+                  new Error("Migration verification failed: missing column(s)"),
+                )
+              : Promise.resolve();
+          },
         }),
       );
       expect(attempts).toBe(3);
     });
 
-    test("rethrows after exhausting every retry", async () => {
-      let attempts = 0;
+    test("re-runs up() on retry so a migration whose up() skipped its index recovers", async () => {
+      // Reproduces the production failure: up()'s syncIndexes ran against a
+      // primary snapshot that lagged the table it had just created in the same
+      // up(), so it silently skipped the index. Retrying verify() ALONE — the
+      // old behaviour — would have failed on every attempt because the index was
+      // never created; only re-running up() (which now sees the table) creates
+      // it, which is why the failure cleared on the next request.
+      let upCalls = 0;
+      let indexCreated = false;
+      const migration = fakeMigration({
+        up: () => {
+          upCalls++;
+          // First up() skips the index (lagging snapshot); the second sees the
+          // table and creates it.
+          if (upCalls >= 2) indexCreated = true;
+          return Promise.resolve();
+        },
+        verify: () =>
+          indexCreated
+            ? Promise.resolve()
+            : Promise.reject(
+                new Error(
+                  "Migration verification failed: missing index idx_system_notes_attendee_id",
+                ),
+              ),
+      });
+
+      await applyMigrationWithRetry(migration);
+
+      expect(upCalls).toBe(2);
+      expect(indexCreated).toBe(true);
+    });
+
+    test("rethrows the original error after exhausting every retry", async () => {
+      let upCalls = 0;
+      let verifyAttempts = 0;
       await expect(
-        verifyMigrationWithRetry(
-          fakeMigration(() => {
-            attempts++;
-            return Promise.reject(new Error("genuine schema defect"));
+        applyMigrationWithRetry(
+          fakeMigration({
+            up: () => {
+              upCalls++;
+              return Promise.resolve();
+            },
+            verify: () => {
+              verifyAttempts++;
+              return Promise.reject(new Error("genuine schema defect"));
+            },
           }),
         ),
       ).rejects.toThrow("genuine schema defect");
-      // One initial attempt plus one per backoff entry.
-      expect(attempts).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
+      // up() and verify() both run once per attempt: one initial attempt plus
+      // one per backoff entry.
+      expect(upCalls).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
+      expect(verifyAttempts).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
     });
   });
 

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -191,10 +191,18 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
       ...overrides,
     });
 
-    test("retries a transient verify failure and then resolves", async () => {
+    test("retries a transient verify failure without re-running up()", async () => {
+      // Pure verify-lag: up() did its work, only verify()'s snapshot lagged.
+      // up() must NOT be re-run (it may recopy large tables), so a cheap verify
+      // retry alone resolves it.
+      let upCalls = 0;
       let attempts = 0;
       await applyMigrationWithRetry(
         fakeMigration({
+          up: () => {
+            upCalls++;
+            return Promise.resolve();
+          },
           verify: () => {
             attempts++;
             // Fail on the first two snapshots (stale schema), succeed on the third.
@@ -207,15 +215,18 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
         }),
       );
       expect(attempts).toBe(3);
+      // up() ran exactly once — the verify retries never re-applied it.
+      expect(upCalls).toBe(1);
     });
 
-    test("re-runs up() on retry so a migration whose up() skipped its index recovers", async () => {
+    test("re-applies up() once when verify keeps failing, so a skipped index recovers", async () => {
       // Reproduces the production failure: up()'s syncIndexes ran against a
       // primary snapshot that lagged the table it had just created in the same
       // up(), so it silently skipped the index. Retrying verify() ALONE — the
       // old behaviour — would have failed on every attempt because the index was
       // never created; only re-running up() (which now sees the table) creates
-      // it, which is why the failure cleared on the next request.
+      // it, which is why the failure cleared on the next request. up() is
+      // re-applied only after a full round of verify retries has failed.
       let upCalls = 0;
       let indexCreated = false;
       const migration = fakeMigration({
@@ -238,11 +249,12 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
 
       await applyMigrationWithRetry(migration);
 
+      // up() ran exactly twice — once initially, once to repair — never per retry.
       expect(upCalls).toBe(2);
       expect(indexCreated).toBe(true);
     });
 
-    test("rethrows the original error after exhausting every retry", async () => {
+    test("rethrows the original error after re-applying up() once and still failing", async () => {
       let upCalls = 0;
       let verifyAttempts = 0;
       await expect(
@@ -259,10 +271,11 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
           }),
         ),
       ).rejects.toThrow("genuine schema defect");
-      // up() and verify() both run once per attempt: one initial attempt plus
-      // one per backoff entry.
-      expect(upCalls).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
-      expect(verifyAttempts).toBe(VERIFY_RETRY_BACKOFF_MS.length + 1);
+      // A genuine defect re-applies up() exactly once (the bounded repair), not
+      // once per retry.
+      expect(upCalls).toBe(2);
+      // Two verify rounds, each one initial attempt plus one per backoff entry.
+      expect(verifyAttempts).toBe(2 * (VERIFY_RETRY_BACKOFF_MS.length + 1));
     });
   });
 


### PR DESCRIPTION
## The bug

A production migration failed with:

```
Error: CDN request failed (GET /: Migration verification failed: missing index idx_system_notes_attendee_id)
```

…and then succeeded on the next request ("worked on the second attempt").

## Root cause

A migration that creates **both a table and an index** (here `2026-06-23_system_notes`) runs its `up()` in phases:

1. `applySchemaChanges()` creates the `system_notes` table.
2. `syncIndexes()` creates `idx_system_notes_attendee_id`.

But `syncIndexes()` takes its **own** fresh primary schema snapshot and only creates an index when the snapshot shows the table's columns:

```ts
const columns = live.tables.get(d.tableName);
return columns !== undefined && d.columns.every(...) && !live.indexes.has(d.name);
```

Under read-your-writes propagation lag — the *same* lag already documented on `VERIFY_RETRY_BACKOFF_MS` — that second snapshot can briefly miss the table created microseconds earlier in phase 1. So `columns === undefined`, `syncIndexes()` **silently skips the index**, and `up()` never creates it.

`verifyMigrationWithRetry` then retried `verify()` **alone**, which could never recover: the index was never created, so every verify attempt failed and the request 503'd. Only the *next request* re-ran `up()` — by then the table was visible and the index got created.

## The fix

Retry `up()` **and** `verify()` together (`applyMigrationWithRetry`), so the index a lagging snapshot caused `up()` to skip is created within the same request instead of 503-ing it.

Re-running `up()` is safe because the runner **already** relies on `up()` being idempotent across requests — a run that dies before recording its marker re-runs `up()` on the next request. This just performs the same recovery *within* one request, and it's cheap on the happy path (a second snapshot showing every object already present). A genuine schema defect stays missing across every attempt and still throws, so it never masks a real bug.

## Tests

- Added a regression test proving `up()` is re-invoked on retry — a migration whose first `up()` skips the index (lagging snapshot) recovers on the retry. The old verify-only retry could not have recovered this case.
- Updated the existing retry tests to the `up()`+`verify()` contract.

`deno task precommit` passes (lint, typecheck, 0% duplication, edge build, full suite at 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vuh6ivaWDbfmE9kcqZP5P)_