### PR TITLE
Replace DELETE with upsert when clearing stale commit marker

### DIFF
--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -146,8 +146,9 @@ const syncCommitMarker = async (
 ): Promise<void> => {
   if (commit) return recordSettingMarker(CURRENT_SCRIPT_COMMIT_KEY, commit);
   if (!version) return;
-  await execute("DELETE FROM settings WHERE key = ?", [
+  await execute("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", [
     CURRENT_SCRIPT_COMMIT_KEY,
+    "",
   ]);
 };
 


### PR DESCRIPTION
The `syncCommitMarker` function used a bare `DELETE` to clear the `current_script_commit` setting when a built bundle ships without a commit hash. This made the write path inconsistent — everywhere else in the settings table uses `INSERT OR REPLACE`.

Replace the `DELETE` with `INSERT OR REPLACE ... VALUES (?, "")`. `readRecordedScriptCommit()` already returns `""` for both a missing row and an empty-value row (via `row?.value ?? ""`), so behaviour is unchanged. The backup display code checks for a valid 40-char SHA before surfacing the commit to the operator, so an empty-string row is handled correctly there too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYZddMNweckaxQopwqg8yK)_