### PR TITLE
Add global boot checks and MAIN_INSTANCE_KEY validation

### DIFF
--- a/src/edge.ts
+++ b/src/edge.ts
@@ -7,7 +7,7 @@ import * as BunnySDK from "@bunny.net/edgescript-sdk";
 import { once } from "#fp";
 import { handleRequest } from "#routes";
 import { temporaryErrorResponse } from "#routes/response.ts";
-import { validateEncryptionKey } from "#shared/crypto/encryption.ts";
+import { validateBootChecks } from "#shared/boot-checks.ts";
 import { setN1GuardNotifyOnly } from "#shared/db/query-log.ts";
 import {
   ErrorCode,
@@ -18,7 +18,7 @@ import {
 import { initSentry } from "#shared/sentry.ts";
 
 const initialize = once((): void => {
-  validateEncryptionKey();
+  validateBootChecks();
   // Start Sentry error reporting (no-op unless SENTRY_URL is configured).
   initSentry();
   // In production a request must never be killed by the N+1 guard: report it

--- a/src/features/instance.ts
+++ b/src/features/instance.ts
@@ -15,8 +15,9 @@
  * whole fleet, exactly as before. An unrecognised tier is a 400.
  *
  * Security posture:
- * - Disabled unless MAIN_INSTANCE_KEY is set (a plain instance never exposes it,
- *   and a disabled builder returns 404 rather than advertising the route).
+ * - Disabled unless MAIN_INSTANCE_KEY is set (a plain instance returns 404
+ *   rather than advertising the route); boot checks fail fast if a configured
+ *   key is blank or too short.
  * - The bearer key is compared in constant time.
  * - Only the per-site READ-ONLY db token is returned — no write access, and the
  *   per-site DB_ENCRYPTION_KEY is never stored here, so field-level PII stays

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@
  */
 
 import { handleRequest } from "#routes/index.ts";
-import { validateEncryptionKey } from "#shared/crypto/encryption.ts";
+import { validateBootChecks } from "#shared/boot-checks.ts";
 import { logDebug } from "#shared/logger.ts";
 import { initSentry } from "#shared/sentry.ts";
 
 const startServer = (port = 3000): void => {
-  validateEncryptionKey();
+  validateBootChecks();
   initSentry();
   logDebug("Setup", `Server starting on http://localhost:${port}`);
 

--- a/src/shared/boot-checks.ts
+++ b/src/shared/boot-checks.ts
@@ -1,0 +1,44 @@
+/**
+ * Fail-fast validation for environment/configuration that must be sane before
+ * the app starts accepting requests. Keep checks here when they are global
+ * boot invariants rather than per-request validation concerns.
+ */
+
+import { validateEncryptionKey } from "#shared/crypto/encryption.ts";
+import { getEnv } from "#shared/env.ts";
+
+export type BootCheck = {
+  name: string;
+  run: () => void;
+};
+
+const MAIN_INSTANCE_KEY_MIN_BYTES = 32;
+
+const encodedLength = (value: string): number =>
+  new TextEncoder().encode(value).length;
+
+export const validateOptionalMainInstanceKey = (): void => {
+  const key = getEnv("MAIN_INSTANCE_KEY");
+  if (key === undefined) return;
+  if (key.trim().length === 0) {
+    throw new Error(
+      "MAIN_INSTANCE_KEY must be blank/unset or at least 32 bytes",
+    );
+  }
+  const byteLength = encodedLength(key);
+  if (byteLength < MAIN_INSTANCE_KEY_MIN_BYTES) {
+    throw new Error(
+      `MAIN_INSTANCE_KEY must be at least 32 bytes when set, got ${byteLength} bytes`,
+    );
+  }
+};
+
+export const BOOT_CHECKS: readonly BootCheck[] = [
+  { name: "DB_ENCRYPTION_KEY", run: validateEncryptionKey },
+  { name: "MAIN_INSTANCE_KEY", run: validateOptionalMainInstanceKey },
+];
+
+export const validateBootChecks = (): void => {
+  validateEncryptionKey();
+  validateOptionalMainInstanceKey();
+};

--- a/test/lib/boot-checks.test.ts
+++ b/test/lib/boot-checks.test.ts
@@ -1,0 +1,81 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import {
+  BOOT_CHECKS,
+  validateBootChecks,
+  validateOptionalMainInstanceKey,
+} from "#shared/boot-checks.ts";
+import {
+  clearTestEncryptionKey,
+  describeWithEnv,
+  setTestEnv,
+} from "#test-utils";
+
+describeWithEnv("boot checks", { encryptionKey: true }, () => {
+  test("lists the global checks run before serving requests", () => {
+    expect(BOOT_CHECKS.map((check) => check.name)).toEqual([
+      "DB_ENCRYPTION_KEY",
+      "MAIN_INSTANCE_KEY",
+    ]);
+  });
+
+  test("allows MAIN_INSTANCE_KEY to be absent", () => {
+    const restore = setTestEnv({ MAIN_INSTANCE_KEY: undefined });
+    try {
+      expect(() => validateOptionalMainInstanceKey()).not.toThrow();
+    } finally {
+      restore();
+    }
+  });
+
+  test("allows a high-entropy MAIN_INSTANCE_KEY", () => {
+    const restore = setTestEnv({
+      MAIN_INSTANCE_KEY: "instance-key-0123456789abcdef0123456789abcdef",
+    });
+    try {
+      expect(() => validateOptionalMainInstanceKey()).not.toThrow();
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails fast when MAIN_INSTANCE_KEY is blank", () => {
+    const restore = setTestEnv({ MAIN_INSTANCE_KEY: "   " });
+    try {
+      expect(() => validateOptionalMainInstanceKey()).toThrow(
+        "MAIN_INSTANCE_KEY must be blank/unset or at least 32 bytes",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails fast when MAIN_INSTANCE_KEY is too short", () => {
+    const restore = setTestEnv({ MAIN_INSTANCE_KEY: "short-key" });
+    try {
+      expect(() => validateOptionalMainInstanceKey()).toThrow(
+        "MAIN_INSTANCE_KEY must be at least 32 bytes when set, got 9 bytes",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("runs DB_ENCRYPTION_KEY validation during boot checks", () => {
+    clearTestEncryptionKey();
+    expect(() => validateBootChecks()).toThrow(
+      "DB_ENCRYPTION_KEY environment variable is required",
+    );
+  });
+
+  test("runs MAIN_INSTANCE_KEY validation during boot checks", () => {
+    const restore = setTestEnv({ MAIN_INSTANCE_KEY: "short-key" });
+    try {
+      expect(() => validateBootChecks()).toThrow(
+        "MAIN_INSTANCE_KEY must be at least 32 bytes when set, got 9 bytes",
+      );
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Centralize fail-fast environment validation that must hold before the app accepts requests so startup invariants are enforced consistently.
- Ensure `MAIN_INSTANCE_KEY` is either unset or meets a minimum entropy requirement instead of being silently accepted as a blank or short value.

### Description

- Add `src/shared/boot-checks.ts` which exposes `BOOT_CHECKS`, `validateOptionalMainInstanceKey`, and `validateBootChecks` and reuses the existing `validateEncryptionKey` check.
- Replace direct calls to `validateEncryptionKey()` in `src/edge.ts` and `src/index.ts` with `validateBootChecks()` so all global boot validations run during startup.
- Update the `features/instance` route documentation to note that boot checks now fail fast when `MAIN_INSTANCE_KEY` is blank or too short.
- Add unit tests in `test/lib/boot-checks.test.ts` covering the `BOOT_CHECKS` list, absence and presence of `MAIN_INSTANCE_KEY`, blank/short key failures, and that `validateBootChecks()` invokes `DB_ENCRYPTION_KEY` validation.

### Testing

- Ran the test suite with `deno test` which executed the new `test/lib/boot-checks.test.ts` cases and they passed.
- Tests verify `BOOT_CHECKS` contents, `validateOptionalMainInstanceKey` behavior for absent/high-entropy/blank/short keys, and that `validateBootChecks` fails when `DB_ENCRYPTION_KEY` is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8b3b6eb8832d96bd668c4d396fae)