### PR TITLE
Add workflow to clean up workflow runs older than 7 days

### DIFF
--- a/.github/workflows/clean-workflow-runs.yml
+++ b/.github/workflows/clean-workflow-runs.yml
@@ -1,0 +1,17 @@
+name: Clean Workflow Runs
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: igorjs/gh-actions-clean-workflow@v7
+        with:
+          runs_older_than: 7


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/clean-workflow-runs.yml` using the [`igorjs/gh-actions-clean-workflow@v7`](https://github.com/marketplace/actions/clean-workflow-action) action
- Runs daily at 03:00 UTC on a cron schedule, and can also be triggered manually via `workflow_dispatch`
- Deletes any workflow runs older than 7 days, keeping the Actions history tidy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyaVquF8q6SqRMc41gUDLd)_