### PR TITLE
Harden the oldest-untouched test files against mutation

### DIFF
--- a/src/shared/jsx/jsx-runtime.ts
+++ b/src/shared/jsx/jsx-runtime.ts
@@ -83,7 +83,7 @@ export const escapeHtml = (str: string): string =>
     .replace(/"/g, "&quot;");
 
 /** Void elements that should not have closing tags */
-const VOID_ELEMENTS: Record<string, true> = {
+export const VOID_ELEMENTS: Record<string, true> = {
   area: true,
   base: true,
   br: true,

--- a/src/shared/jsx/jsx-runtime.ts
+++ b/src/shared/jsx/jsx-runtime.ts
@@ -82,8 +82,10 @@ export const escapeHtml = (str: string): string =>
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
 
-/** Void elements that should not have closing tags */
-export const VOID_ELEMENTS: Record<string, true> = {
+/** Void elements that should not have closing tags.
+ * Frozen so the renderer's global void-element rules can't be mutated by an
+ * importer (the table is exported only so tests can enumerate it). */
+export const VOID_ELEMENTS: Readonly<Record<string, true>> = Object.freeze({
   area: true,
   base: true,
   br: true,
@@ -98,7 +100,7 @@ export const VOID_ELEMENTS: Record<string, true> = {
   source: true,
   track: true,
   wbr: true,
-};
+});
 
 const isSafeHtml = (value: unknown): value is SafeHtml =>
   value instanceof SafeHtml;

--- a/test/lib/csrf.test.ts
+++ b/test/lib/csrf.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import {
   isSignedCsrfToken,
   signCsrfToken,
@@ -89,6 +90,37 @@ describe("verifySignedCsrfToken", () => {
     const token = await signCsrfToken();
     // Verify with maxAge=-1 so the token is already expired
     expect(await verifySignedCsrfToken(token, -1)).toBe(false);
+  });
+
+  test("rejects a token once real elapsed time exceeds maxAge", async () => {
+    using time = new FakeTime(1_000_000_000_000);
+    const token = await signCsrfToken();
+    // Accepted while still inside the window...
+    expect(await verifySignedCsrfToken(token, 60)).toBe(true);
+    // ...then advance real time past maxAge so age (120s) > maxAge (60s).
+    time.tick(120_000);
+    expect(await verifySignedCsrfToken(token, 60)).toBe(false);
+  });
+
+  test("rejects a token dated more than 60s in the future", async () => {
+    // Sign under a far-future clock so the token's timestamp is well ahead
+    // of "now"; FakeTime cannot move backwards, so verify under a separate
+    // present-time clock. The gap (decades) far exceeds the 60s skew window.
+    const signedInFuture = await (async () => {
+      const future = new FakeTime(4_000_000_000_000);
+      try {
+        return await signCsrfToken();
+      } finally {
+        future.restore();
+      }
+    })();
+
+    const present = new FakeTime(1_700_000_000_000);
+    try {
+      expect(await verifySignedCsrfToken(signedInFuture)).toBe(false);
+    } finally {
+      present.restore();
+    }
   });
 
   test("rejects a plain (unsigned) token", async () => {

--- a/test/lib/db/sessions.test.ts
+++ b/test/lib/db/sessions.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+import { getAllCacheStats } from "#shared/cache-registry.ts";
+import { execute } from "#shared/db/client.ts";
 import {
   createSession,
   deleteAllSessions,
@@ -8,6 +10,7 @@ import {
   deleteSession,
   getAllSessions,
   getSession,
+  resetSessionCache,
 } from "#shared/db/sessions.ts";
 import { describeWithEnv } from "#test-utils";
 
@@ -113,5 +116,90 @@ describeWithEnv("db > sessions", { db: true }, () => {
     } finally {
       time.restore();
     }
+  });
+
+  // The following tests observe the cache's *effect* by mutating the DB row
+  // behind the cache's back: a cached read returns the stale in-memory value,
+  // while a cache miss reflects the changed DB.
+
+  test("createSession pre-caches so a later read skips the DB", async () => {
+    await createSession("precache", "csrf-pre", Date.now() + 60000, null, 1);
+    // Remove the row from the DB; the cache still holds the session.
+    await execute("DELETE FROM sessions");
+
+    const session = await getSession("precache");
+    expect(session).not.toBeNull();
+    expect(session?.csrf_token).toBe("csrf-pre");
+  });
+
+  test("getSession caches the DB result so a second read skips the DB", async () => {
+    await createSession("dbcache", "csrf-db", Date.now() + 60000, null, 1);
+    resetSessionCache(); // drop the pre-cache; the DB row remains
+
+    const first = await getSession("dbcache"); // cache miss → DB → caches
+    expect(first?.csrf_token).toBe("csrf-db");
+
+    await execute("DELETE FROM sessions"); // remove DB row; cache retains it
+    const second = await getSession("dbcache");
+    expect(second).not.toBeNull();
+    expect(second?.csrf_token).toBe("csrf-db");
+  });
+
+  test("getSession re-queries the DB once the cache TTL expires", async () => {
+    const start = Date.now();
+    const time = new FakeTime(start);
+    try {
+      await createSession("ttl-requery", "csrf-old", start + 60000, null, 1);
+      // Within TTL: cached (stale) value is served even after the DB changes.
+      await execute("UPDATE sessions SET csrf_token = 'csrf-new'");
+      expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-old");
+
+      // Past the 10s TTL: the cache entry expires and the DB is re-read.
+      time.now = start + 11000;
+      expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-new");
+    } finally {
+      time.restore();
+    }
+  });
+
+  test("repeated reads of a missing session stay null (cached null is safe)", async () => {
+    expect(await getSession("ghost")).toBeNull();
+    // Second read hits the cached null entry; must not throw or resurrect a row.
+    expect(await getSession("ghost")).toBeNull();
+  });
+
+  test("resetSessionCache clears cached sessions", async () => {
+    await createSession("reset-me", "csrf-reset", Date.now() + 60000, null, 1);
+    await execute("DELETE FROM sessions"); // DB empty; cache still holds it
+
+    resetSessionCache();
+
+    // With the cache cleared, the read falls through to the (empty) DB.
+    expect(await getSession("reset-me")).toBeNull();
+  });
+
+  test("deleteOtherSessions keeps the current session cached", async () => {
+    const expires = Date.now() + 60000;
+    await createSession("keep", "csrf-keep", expires, null, 1);
+    await createSession("drop", "csrf-drop", expires, null, 1);
+
+    await deleteOtherSessions("keep");
+
+    // The kept session should still be cached: deleting all DB rows leaves a
+    // cached read returning it, while the dropped one is gone.
+    await execute("DELETE FROM sessions");
+    const kept = await getSession("keep");
+    expect(kept).not.toBeNull();
+    expect(kept?.csrf_token).toBe("csrf-keep");
+  });
+
+  test("registers a 'sessions' cache stat reflecting cached entries", async () => {
+    resetSessionCache();
+    const before = getAllCacheStats().find((s) => s.name === "sessions");
+    expect(before?.entries).toBe(0);
+
+    await createSession("stat", "csrf-stat", Date.now() + 60000, null, 1);
+    const after = getAllCacheStats().find((s) => s.name === "sessions");
+    expect(after?.entries).toBe(1);
   });
 });

--- a/test/lib/db/token-attempts.test.ts
+++ b/test/lib/db/token-attempts.test.ts
@@ -9,6 +9,8 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+import { hmacHash } from "#shared/crypto/hashing.ts";
+import { queryOne } from "#shared/db/client.ts";
 import {
   clearTokenAttempts,
   isTokenRateLimited,
@@ -23,6 +25,11 @@ import { describeWithEnv } from "#test-utils";
 
 const makeTokens = (prefix: string, count: number): string[] =>
   Array.from({ length: count }, (_, i) => `${prefix}-${i}`);
+
+const rawRow = async (ip: string): Promise<{ ip: string } | null> =>
+  queryOne<{ ip: string }>("SELECT ip FROM token_attempts WHERE ip = ?", [
+    await hmacHash(ip),
+  ]);
 
 describeWithEnv("db > token-attempts", { db: true }, () => {
   describe("isTokenRateLimited", () => {
@@ -50,6 +57,25 @@ describeWithEnv("db > token-attempts", { db: true }, () => {
 
         time.tick(TOKEN_LOCKOUT_MS + 1);
         expect(await isTokenRateLimited(ip)).toBe(false);
+      } finally {
+        time.restore();
+      }
+    });
+
+    test("deletes the stored row when an expired lockout is checked", async () => {
+      const ip = "10.0.0.11";
+      const time = new FakeTime(1_800_000_000_000);
+      try {
+        await recordTokenFailure(ip, makeTokens("exp", MAX_TOKEN_404S));
+        // While locked, the row persists.
+        expect(await rawRow(ip)).not.toBeNull();
+
+        time.tick(TOKEN_LOCKOUT_MS + 1);
+        expect(await isTokenRateLimited(ip)).toBe(false);
+
+        // Checking an expired lockout must clear the row so the next attempt
+        // starts fresh (and no fingerprint is left behind).
+        expect(await rawRow(ip)).toBeNull();
       } finally {
         time.restore();
       }

--- a/test/lib/fetch.test.ts
+++ b/test/lib/fetch.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { fetchText } from "#shared/fetch.ts";
+import { fetchText, parseApiError } from "#shared/fetch.ts";
 
 describe("fetchText", () => {
   let fetchStub: ReturnType<typeof stub<typeof globalThis, "fetch">>;
@@ -81,5 +81,59 @@ describe("fetchText", () => {
     await expect(fetchText("https://example.com/fail")).rejects.toThrow(
       "Network error",
     );
+  });
+});
+
+describe("parseApiError", () => {
+  test("extracts the 'message' field and reports ok:false", () => {
+    const result = parseApiError(
+      { status: 400, text: '{"message":"Bad input"}' },
+      "Turso",
+    );
+    expect(result).toEqual({
+      error: "Turso failed (400): Bad input",
+      ok: false,
+    });
+  });
+
+  test("falls back to the 'error' field when 'message' is absent", () => {
+    const result = parseApiError(
+      { status: 500, text: '{"error":"boom"}' },
+      "Deploy",
+    );
+    expect(result).toEqual({ error: "Deploy failed (500): boom", ok: false });
+  });
+
+  test("prefers 'message' over 'error' (first matching key wins)", () => {
+    const result = parseApiError(
+      { status: 422, text: '{"message":"primary","error":"secondary"}' },
+      "Bunny",
+    );
+    expect(result.error).toBe("Bunny failed (422): primary");
+  });
+
+  test("honours a custom key list", () => {
+    const result = parseApiError(
+      { status: 403, text: '{"detail":"nope","message":"ignored"}' },
+      "Custom",
+      ["detail"],
+    );
+    expect(result.error).toBe("Custom failed (403): nope");
+  });
+
+  test("uses the raw text when the body is not JSON", () => {
+    const result = parseApiError(
+      { status: 502, text: "Bad Gateway" },
+      "Upstream",
+    );
+    expect(result.error).toBe("Upstream failed (502): Bad Gateway");
+  });
+
+  test("uses the raw text when JSON has no matching key", () => {
+    const result = parseApiError(
+      { status: 400, text: '{"unexpected":"shape"}' },
+      "Api",
+    );
+    expect(result.error).toBe('Api failed (400): {"unexpected":"shape"}');
   });
 });

--- a/test/lib/forms/components.test.ts
+++ b/test/lib/forms/components.test.ts
@@ -1,0 +1,111 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { flashConsumed, runWithFlashContext } from "#shared/flash-context.ts";
+import { ConfirmForm, Flash } from "#shared/forms.tsx";
+
+describe("Flash", () => {
+  // Rendering any banner must mark the request's flash consumed so the Layout
+  // backstop doesn't render it a second time. Each banner type triggers it.
+  const consumesFor = (props: {
+    error?: string;
+    success?: string;
+    info?: string;
+  }) =>
+    runWithFlashContext(() => {
+      expect(flashConsumed()).toBe(false);
+      String(Flash(props));
+      return flashConsumed();
+    });
+
+  test("consumes the flash when rendering an error banner", () => {
+    expect(consumesFor({ error: "boom" })).toBe(true);
+  });
+
+  test("consumes the flash when rendering a success banner", () => {
+    expect(consumesFor({ success: "yay" })).toBe(true);
+  });
+
+  test("consumes the flash when rendering an info banner", () => {
+    expect(consumesFor({ info: "fyi" })).toBe(true);
+  });
+
+  test("does not consume the flash when there is no message", () => {
+    const consumed = runWithFlashContext(() => {
+      String(Flash({}));
+      return flashConsumed();
+    });
+    expect(consumed).toBe(false);
+  });
+});
+
+describe("ConfirmForm", () => {
+  test("defaults to danger styling", () => {
+    const html = String(
+      ConfirmForm({
+        action: "/x",
+        buttonText: "Delete",
+        label: "L",
+        name: "n",
+      }),
+    );
+    expect(html).toContain('class="danger"');
+  });
+
+  test("renders the confirm_identifier input by default", () => {
+    const html = String(
+      ConfirmForm({
+        action: "/x",
+        buttonText: "Delete",
+        label: "L",
+        name: "n",
+      }),
+    );
+    expect(html).toContain('name="confirm_identifier"');
+  });
+
+  test("omits the confirm input when confirmName is false", () => {
+    const html = String(
+      ConfirmForm({ action: "/x", buttonText: "OK", confirmName: false }),
+    );
+    expect(html).not.toContain('name="confirm_identifier"');
+  });
+
+  test("wraps children in a prose div", () => {
+    const html = String(
+      ConfirmForm({
+        action: "/x",
+        buttonText: "OK",
+        children: "Warning text",
+        confirmName: false,
+      }),
+    );
+    expect(html).toContain('class="prose"');
+    expect(html).toContain("Warning text");
+  });
+
+  test("renders a hidden return_url input when returnUrl is given", () => {
+    const html = String(
+      ConfirmForm({
+        action: "/x",
+        buttonText: "OK",
+        confirmName: false,
+        returnUrl: "/back",
+      }),
+    );
+    expect(html).toContain('name="return_url"');
+    expect(html).toContain('value="/back"');
+  });
+
+  test("renders hidden inputs for each hiddenFields entry", () => {
+    const html = String(
+      ConfirmForm({
+        action: "/x",
+        buttonText: "OK",
+        confirmName: false,
+        hiddenFields: { foo: "bar" },
+      }),
+    );
+    expect(html).toContain('name="foo"');
+    expect(html).toContain('value="bar"');
+  });
+});

--- a/test/lib/forms/define-form.test.ts
+++ b/test/lib/forms/define-form.test.ts
@@ -81,6 +81,19 @@ describe("defineForm", () => {
     if (result.valid) expect(result.values.qty).toBe(5);
   });
 
+  test("optional number field preserves a zero value (not coerced to null)", () => {
+    const form = defineForm({
+      fields: [{ label: "Qty", name: "qty", type: "number" }] as const,
+      id: "test",
+    });
+
+    const result = form.validate(new FormParams({ qty: "0" }));
+    expect(result.valid).toBe(true);
+    // 0 is a real value: it must survive the `?? null` normalisation rather
+    // than being treated as "missing" (which `|| null` would do).
+    if (result.valid) expect(result.values.qty).toBe(0);
+  });
+
   test("runs custom validate when provided", () => {
     const form = defineForm({
       fields: [

--- a/test/lib/forms/rendering.test.ts
+++ b/test/lib/forms/rendering.test.ts
@@ -46,6 +46,33 @@ describe("renderField", () => {
     expect(html).toContain('placeholder="Enter your name"');
   });
 
+  test("marks a markdown textarea for preview, plain textarea is not marked", () => {
+    const withPreview = rendered({
+      label: "Bio",
+      markdown: true,
+      name: "bio",
+      type: "textarea",
+    });
+    expect(withPreview).toContain("data-markdown-preview");
+
+    const plain = rendered({ label: "Bio", name: "bio", type: "textarea" });
+    expect(plain).not.toContain("data-markdown-preview");
+  });
+
+  test("renders a checkbox group only for the checkbox-group type", () => {
+    // A non-checkbox field that happens to carry options must still render its
+    // normal input — the checkbox-group branch is gated on the type, not just
+    // the presence of options.
+    const html = rendered({
+      label: "Name",
+      name: "name",
+      options: [{ label: "A", value: "a" }],
+      type: "text",
+    });
+    expect(html).toContain('type="text"');
+    expect(html).not.toContain('type="checkbox"');
+  });
+
   test("renders hint text", () => {
     const html = rendered({
       hint: "Minimum 8 characters",

--- a/test/lib/forms/saved-data.test.ts
+++ b/test/lib/forms/saved-data.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { FormParams } from "#shared/form-data.ts";
 import {
   clearSavedFormData,
+  entityToFieldValues,
   type Field,
   getSavedFormData,
   renderFields,
@@ -12,6 +13,46 @@ import {
 const field = (
   overrides: Partial<Field> & { name: string; label: string },
 ): Field => ({ type: "text", ...overrides });
+
+describe("entityToFieldValues", () => {
+  const fields = [
+    field({ label: "A", name: "a" }),
+    field({ label: "B", name: "b" }),
+  ];
+
+  test("derives field values from the entity", () => {
+    const values = entityToFieldValues({ a: "1", b: "2" }, fields, {});
+    expect(values).toEqual({ a: "1", b: "2" });
+  });
+
+  test("applies a formatter when one is supplied for the field", () => {
+    const values = entityToFieldValues({ a: "1", b: "2" }, fields, {
+      a: (e) => `formatted-${e.a}`,
+    });
+    expect(values.a).toBe("formatted-1");
+    expect(values.b).toBe("2");
+  });
+
+  test("yields empty strings when there is no entity", () => {
+    const values = entityToFieldValues(undefined, fields, {});
+    expect(values).toEqual({ a: "", b: "" });
+  });
+
+  test("merges extra values over the entity-derived fields", () => {
+    const values = entityToFieldValues(
+      { a: "1", b: "2" },
+      fields,
+      {},
+      {
+        b: "override",
+        c: "extra",
+      },
+    );
+    expect(values.a).toBe("1");
+    expect(values.b).toBe("override");
+    expect(values.c).toBe("extra");
+  });
+});
 
 describe("saved form data", () => {
   afterEach(() => clearSavedFormData());

--- a/test/lib/jsx-runtime.test.ts
+++ b/test/lib/jsx-runtime.test.ts
@@ -1,6 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { Fragment, jsx, Raw, SafeHtml } from "#jsx/jsx-runtime.ts";
+import {
+  Fragment,
+  jsx,
+  Raw,
+  SafeHtml,
+  VOID_ELEMENTS,
+} from "#jsx/jsx-runtime.ts";
 
 describe("jsx-runtime", () => {
   describe("jsx", () => {
@@ -34,14 +40,21 @@ describe("jsx-runtime", () => {
       expect(result.toString()).toBe("<div></div>");
     });
 
-    test("renders void element without closing tag", () => {
-      const result = jsx("br", null);
-      expect(result.toString()).toBe("<br>");
-    });
+    for (const tag of Object.keys(VOID_ELEMENTS)) {
+      test(`renders <${tag}> self-closing without a closing tag`, () => {
+        const result = jsx(tag, null);
+        expect(result.toString()).toBe(`<${tag}>`);
+      });
+    }
 
     test("renders void element with attributes", () => {
       const result = jsx("input", { name: "foo", type: "text" });
       expect(result.toString()).toBe('<input name="foo" type="text">');
+    });
+
+    test("renders a non-void element with an explicit closing tag", () => {
+      const result = jsx("div", null);
+      expect(result.toString()).toBe("<div></div>");
     });
 
     test("renders boolean attribute as name only when true", () => {
@@ -51,6 +64,16 @@ describe("jsx-runtime", () => {
 
     test("omits boolean attribute when false", () => {
       const result = jsx("input", { required: false });
+      expect(result.toString()).toBe("<input>");
+    });
+
+    test("omits attribute when value is null", () => {
+      const result = jsx("input", { name: null });
+      expect(result.toString()).toBe("<input>");
+    });
+
+    test("omits attribute when value is undefined", () => {
+      const result = jsx("input", { name: undefined });
       expect(result.toString()).toBe("<input>");
     });
 

--- a/test/lib/jsx-runtime.test.ts
+++ b/test/lib/jsx-runtime.test.ts
@@ -8,6 +8,27 @@ import {
   VOID_ELEMENTS,
 } from "#jsx/jsx-runtime.ts";
 
+// The HTML void elements, as a fixed spec list independent of the production
+// table. Driving the render tests from this (rather than from VOID_ELEMENTS
+// itself) means dropping a tag from VOID_ELEMENTS makes jsx() render it with a
+// closing tag and these tests FAIL — instead of silently no longer testing it.
+const EXPECTED_VOID_ELEMENTS = [
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+] as const;
+
 describe("jsx-runtime", () => {
   describe("jsx", () => {
     test("renders element with text child", () => {
@@ -40,12 +61,20 @@ describe("jsx-runtime", () => {
       expect(result.toString()).toBe("<div></div>");
     });
 
-    for (const tag of Object.keys(VOID_ELEMENTS)) {
+    for (const tag of EXPECTED_VOID_ELEMENTS) {
       test(`renders <${tag}> self-closing without a closing tag`, () => {
         const result = jsx(tag, null);
         expect(result.toString()).toBe(`<${tag}>`);
       });
     }
+
+    test("VOID_ELEMENTS table matches the HTML void-element spec exactly", () => {
+      // Pin the production table to the spec list: adding or removing a tag
+      // here (or there) is a deliberate change that must update both.
+      expect(Object.keys(VOID_ELEMENTS).sort()).toEqual(
+        [...EXPECTED_VOID_ELEMENTS].sort(),
+      );
+    });
 
     test("renders void element with attributes", () => {
       const result = jsx("input", { name: "foo", type: "text" });

--- a/test/lib/logger/log-output.test.ts
+++ b/test/lib/logger/log-output.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { type Spy, spy } from "@std/testing/mock";
+import { type Spy, spy, stub } from "@std/testing/mock";
 import {
   createRequestTimer,
   logDebug,
@@ -119,5 +119,19 @@ describe("createRequestTimer", () => {
     const first = getElapsed();
     const second = getElapsed();
     expect(second).toBeGreaterThanOrEqual(first);
+  });
+
+  test("reports elapsed as now minus start, not a ratio", () => {
+    // Drive performance.now() deterministically so the elapsed value is the
+    // exact difference (subtraction), not now/start (which would round to ~1).
+    let clock = 1000;
+    const perfStub = stub(performance, "now", () => clock);
+    try {
+      const getElapsed = createRequestTimer(); // start = 1000
+      clock = 1500;
+      expect(getElapsed()).toBe(500);
+    } finally {
+      perfStub.restore();
+    }
   });
 });

--- a/test/lib/rest.test.ts
+++ b/test/lib/rest.test.ts
@@ -481,6 +481,25 @@ describeWithEnv("rest/handlers", { db: true }, () => {
       await expectExists(resource, 1);
     });
 
+    test("skips verification when no onVerifyFailed is configured, even with a wrong name", async () => {
+      // Name verification is only enforced when the caller supplies an
+      // onVerifyFailed handler. Without it, a wrong name must NOT block the
+      // delete (and must not try to call the absent handler).
+      const resource = await insertRow(
+        createTestResource(true),
+        importantItemData,
+      );
+      const handler = deleteHandler(resource, deleteOpts());
+      const response = await handler(
+        await createAuthRequest("/items/1", {
+          confirm_identifier: "Wrong Name",
+        }),
+        1,
+      );
+      expect(response.status).toBe(204);
+      await expectDeleted(resource, 1);
+    });
+
     const setupDeleteWithVerify = async () => {
       const resource = await insertRow(
         createTestResource(true),

--- a/test/lib/server-backup.test.ts
+++ b/test/lib/server-backup.test.ts
@@ -151,6 +151,8 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
         );
         expect(response.status).toBe(200);
         expect(response.headers.get("content-type")).toBe("application/zip");
+        // The response body must be the actual zip bytes, not an empty slice.
+        expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
       });
     });
   });
@@ -192,6 +194,14 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
         expect(response.status).toBe(200);
         const html = await response.text();
         expect(html).toContain("Confirm Database Restore");
+        // The statement count must be a real number, not NaN.
+        expect(html).not.toContain("NaN");
+        // A backup whose schema matches must NOT show the mismatch warning.
+        expect(html).not.toContain("Schema mismatch");
+        // The uploaded zip must be stored so the confirm step can read it back.
+        const pending = html.match(/value="(restore-pending-[^"]+\.zip)"/);
+        expect(pending).toBeTruthy();
+        expect(await downloadRaw(pending![1])).not.toBeNull();
       });
     });
 
@@ -222,7 +232,11 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
       await withLocalStorageEnabled(async () => {
         const { cookie, csrfToken } = await getTestSession();
         const response = await postRestore(cookie, csrfToken);
-        expect(response.status).toBe(302);
+        await expectFlashRedirect(
+          "/admin/backup",
+          "Please select a backup file",
+          false,
+        )(response);
       });
     });
 
@@ -232,7 +246,11 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
         const response = await postRestore(cookie, csrfToken, {
           backup_file: new File([new ArrayBuffer(100)], "bad.zip"),
         });
-        expect(response.status).toBe(302);
+        await expectFlashRedirect(
+          "/admin/backup",
+          expect.stringContaining("Invalid backup file"),
+          false,
+        )(response);
       });
     });
   });
@@ -248,6 +266,23 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
         "/admin/backup/restore/confirm",
         {
           backup_filename: "bad.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Invalid backup reference",
+        false,
+      )(response);
+    });
+
+    test("rejects a path-traversal filename that passes the prefix check", async () => {
+      // The leaf has the restore-pending prefix and .zip suffix, so only the
+      // isSafeBackupFilename guard (no "/", "\\", or "..") rejects it.
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-a/b.zip",
           confirm_identifier: RESTORE_CONFIRM_PHRASE,
         },
       );

--- a/test/lib/server-backup.test.ts
+++ b/test/lib/server-backup.test.ts
@@ -199,7 +199,9 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
         // A backup whose schema matches must NOT show the mismatch warning.
         expect(html).not.toContain("Schema mismatch");
         // The uploaded zip must be stored so the confirm step can read it back.
-        const tempName = html.match(/value="(restore-pending-[^"]+\.zip)"/)?.[1];
+        const tempName = html.match(
+          /value="(restore-pending-[^"]+\.zip)"/,
+        )?.[1];
         expect(tempName).toBeDefined();
         expect(await downloadRaw(tempName!)).not.toBeNull();
       });

--- a/test/lib/server-backup.test.ts
+++ b/test/lib/server-backup.test.ts
@@ -199,9 +199,9 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
         // A backup whose schema matches must NOT show the mismatch warning.
         expect(html).not.toContain("Schema mismatch");
         // The uploaded zip must be stored so the confirm step can read it back.
-        const pending = html.match(/value="(restore-pending-[^"]+\.zip)"/);
-        expect(pending).toBeTruthy();
-        expect(await downloadRaw(pending![1])).not.toBeNull();
+        const tempName = html.match(/value="(restore-pending-[^"]+\.zip)"/)?.[1];
+        expect(tempName).toBeDefined();
+        expect(await downloadRaw(tempName!)).not.toBeNull();
       });
     });
 

--- a/test/lib/server-settings/square.test.ts
+++ b/test/lib/server-settings/square.test.ts
@@ -76,6 +76,20 @@ describeAdminSettings(() => {
         response,
         expect.stringContaining("Square credentials updated"),
       );
+      // No sandbox checkbox submitted → production mode persisted.
+      expect(settings.square.sandbox).toBe(false);
+    });
+
+    test("persists sandbox mode when the sandbox checkbox is checked", async () => {
+      const { response } = await adminFormPost("/admin/settings/square", {
+        square_access_token: "EAAAl_test_new",
+        square_location_id: "L_test_456",
+        square_sandbox: "on",
+      });
+
+      expect(response.status).toBe(302);
+      // The checkbox ("on") must be stored as sandbox=true, not just accepted.
+      expect(settings.square.sandbox).toBe(true);
     });
 
     test("rejects an access token that looks like an application ID", async () => {

--- a/test/lib/server-settings/stripe.test.ts
+++ b/test/lib/server-settings/stripe.test.ts
@@ -143,6 +143,10 @@ describeAdminSettings(() => {
           expectRedirect(response, "/admin/settings");
           expectFlash(response, expect.stringContaining("Stripe key updated"));
           expectFlash(response, expect.stringContaining("webhook configured"));
+          // The webhook config returned by setupWebhookEndpoint must be
+          // persisted, not just acknowledged in the flash.
+          expect(settings.stripe.webhookSecret).toBe("whsec_test_secret");
+          expect(settings.stripe.webhookEndpointId).toBe("we_test_123");
         },
       );
     });

--- a/test/lib/stripe-mock.test.ts
+++ b/test/lib/stripe-mock.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 
 import {
+  BIN_DIR,
   downloadStripeMock,
   getArch,
   getPlatform,
@@ -145,6 +146,40 @@ describe("stripe-mock utilities", () => {
       }
     });
 
+    test("start downloads the binary when it is missing before spawning", async () => {
+      const testPort = 12113;
+      // Skip if something is already on that port
+      if (await isStripeMockRunning(testPort)) return;
+
+      const realPath = STRIPE_MOCK_PATH;
+      const backupPath = `${realPath}.bak-mgr`;
+      const manager = new StripeMockManager(testPort);
+      let renamed = false;
+
+      try {
+        // Remove the binary so start() must download it before spawning;
+        // if start() skipped the download, spawn would fail with NotFound.
+        await Deno.rename(realPath, backupPath);
+        renamed = true;
+
+        await manager.start();
+
+        expect(manager.isManaged()).toBe(true);
+        expect(await isStripeMockRunning(testPort)).toBe(true);
+      } finally {
+        manager.stop();
+        if (renamed) {
+          // Discard the downloaded binary and restore the original.
+          try {
+            await Deno.remove(realPath);
+          } catch {
+            // May not exist if download failed
+          }
+          await Deno.rename(backupPath, realPath);
+        }
+      }
+    });
+
     test("start throws when stripe-mock fails to become ready", async () => {
       // Temporarily replace STRIPE_MOCK_PATH-referenced binary with a no-op script
       // that exits immediately, so the process starts but never listens on the port
@@ -198,31 +233,36 @@ describe("stripe-mock utilities", () => {
   });
 
   describe("downloadStripeMock with missing binary", () => {
-    test("enters download path when binary does not exist", async () => {
-      const realPath = STRIPE_MOCK_PATH;
-      const backupPath = `${realPath}.bak-dl`;
-      let renamed = false;
+    test("creates the bin dir, downloads an executable binary, and cleans up the tarball", async () => {
+      // Move the whole bin dir aside so downloadStripeMock must recreate it
+      // (the already-running stripe-mock keeps its open file handle).
+      const backupDir = `${BIN_DIR}.bak-dl`;
+      const tarPath = `${BIN_DIR}/stripe-mock.tar.gz`;
+      let movedAway = false;
 
       try {
-        await Deno.rename(realPath, backupPath);
-        renamed = true;
+        await Deno.rename(BIN_DIR, backupDir);
+        movedAway = true;
 
-        // Call downloadStripeMock - it should detect file is missing and download
+        // Bin dir is gone: download must mkdir it, fetch, extract, chmod, clean up.
         await downloadStripeMock();
 
-        // Verify the binary was downloaded
-        const stat = await Deno.stat(realPath);
+        // Binary was downloaded as a real file...
+        const stat = await Deno.stat(STRIPE_MOCK_PATH);
         expect(stat.isFile).toBe(true);
+        // ...and made executable (owner execute bit set by chmod +x).
+        expect((stat.mode ?? 0) & 0o100).toBe(0o100);
+        // ...and the intermediate tarball was removed.
+        await expect(Deno.stat(tarPath)).rejects.toThrow(Deno.errors.NotFound);
       } finally {
-        // Restore the original binary
-        if (renamed) {
+        // Discard the freshly downloaded dir and restore the original.
+        if (movedAway) {
           try {
-            // Remove the downloaded one if it exists
-            await Deno.remove(realPath);
+            await Deno.remove(BIN_DIR, { recursive: true });
           } catch {
             // May not exist if download failed
           }
-          await Deno.rename(backupPath, realPath);
+          await Deno.rename(backupDir, BIN_DIR);
         }
       }
     });

--- a/test/scripts/build-tag.test.ts
+++ b/test/scripts/build-tag.test.ts
@@ -78,4 +78,36 @@ describe("isoToTag / parseReleaseTag roundtrip", () => {
       setBuildTimestampForTest(null);
     }
   });
+
+  test("isNewerVersion treats an earlier tag as not newer", () => {
+    setBuildTimestampForTest("2026-03-01T00:00:00.000Z");
+    try {
+      const olderTag = isoToTag("2026-01-01T00:00:00.000Z");
+      expect(isNewerVersion(olderTag)).toBe(false);
+    } finally {
+      setBuildTimestampForTest(null);
+    }
+  });
+
+  test("isNewerVersion returns false (never throws) for an unparseable tag", () => {
+    // Guard must short-circuit before dereferencing the null parsed date, even
+    // when a real build timestamp is present.
+    setBuildTimestampForTest("2026-01-01T00:00:00.000Z");
+    try {
+      expect(isNewerVersion("not-a-release-tag")).toBe(false);
+    } finally {
+      setBuildTimestampForTest(null);
+    }
+  });
+
+  test("isNewerVersion returns false when the build timestamp is empty", () => {
+    // Development/source builds carry no timestamp; nothing is ever "newer".
+    setBuildTimestampForTest("");
+    try {
+      const tag = isoToTag("2026-02-01T00:00:00.000Z");
+      expect(isNewerVersion(tag)).toBe(false);
+    } finally {
+      setBuildTimestampForTest(null);
+    }
+  });
 });

--- a/test/templates/admin/sessions.test.ts
+++ b/test/templates/admin/sessions.test.ts
@@ -1,10 +1,19 @@
 import { expect } from "@std/expect";
 import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
+import type { Session } from "#shared/types.ts";
 import { adminSessionsPage } from "#templates/admin/sessions.tsx";
 import { setupTestEncryptionKey } from "#test-utils";
 
 const TEST_SESSION = { adminLevel: "owner" as const };
+
+const mkSession = (token: string): Session => ({
+  csrf_token: "csrf",
+  expires: Date.now() + 86400000,
+  token,
+  user_id: 1,
+  wrapped_data_key: null,
+});
 
 beforeAll(async () => {
   setupTestEncryptionKey();
@@ -43,5 +52,35 @@ describe("adminSessionsPage", () => {
   test("renders empty state when no sessions", () => {
     const html = adminSessionsPage([], "some-token", TEST_SESSION, "");
     expect(html).toContain("No sessions");
+  });
+
+  test("marks the row that matches the current token as current", () => {
+    const s = mkSession("abcdefghijklmnop");
+    const html = adminSessionsPage([s], s.token, TEST_SESSION, "");
+    expect(html).toContain("Current");
+  });
+
+  test("does not mark a row whose token is not the current one", () => {
+    const s = mkSession("abcdefghijklmnop");
+    const html = adminSessionsPage([s], "a-different-token", TEST_SESSION, "");
+    expect(html).not.toContain("Current");
+  });
+
+  test("shows the logout-others control with the count of other sessions", () => {
+    const current = mkSession("aaaaaaaaaaaaaaaa");
+    const html = adminSessionsPage(
+      [current, mkSession("bbbbbbbbbbbbbbbb"), mkSession("cccccccccccccccc")],
+      current.token,
+      TEST_SESSION,
+      "",
+    );
+    // Two sessions other than the current one.
+    expect(html).toContain("Log out of all other sessions (2)");
+  });
+
+  test("hides the logout-others control when there are no other sessions", () => {
+    const s = mkSession("aaaaaaaaaaaaaaaa");
+    const html = adminSessionsPage([s], s.token, TEST_SESSION, "");
+    expect(html).not.toContain("Log out of all other sessions");
   });
 });


### PR DESCRIPTION
## What

Working through the test files that have gone the longest without an update and closing the gaps mutation testing exposes in each.

| File / module | Source | Before → After |
| --- | --- | --- |
| `jsx-runtime.test.ts` | `src/shared/jsx/jsx-runtime.ts` | 57.6% → 97.0% |
| `stripe-mock.ts` | (same, `--harness`) | 72.0% → 84.0% |
| `csrf.test.ts` | `src/shared/csrf.ts` | 80.0% → 90.0% |
| `db/sessions.test.ts` | `src/shared/db/sessions.ts` | 47.8% → 91.3% |
| `db/token-attempts.test.ts` | `src/shared/db/token-attempts.ts` | 94.4% → 100% |
| `fetch.test.ts` | `src/shared/fetch.ts` | 0% → 100% |
| `forms/*.test.ts` | `src/shared/forms.tsx` | 80.2% → 96.3% |
| `logger/*.test.ts` | `src/shared/logger.ts` | 85.3% → 88.2% |
| `build-tag.test.ts` | `src/shared/update.ts` (tag region) | guard now killed |
| `rest.test.ts` | `src/shared/rest/{handlers,resource}.ts` | handlers 66.7% → 77.8% |

`embed-hosts` and `ntfy` were already mutation-clean; `payment-crypto`'s lone survivor is unobservable (non-extractable `importKey` flag). Remaining survivors elsewhere are equivalent mutants or owned by another test file's domain (documented per commit).

---

### Highlights

- **jsx-runtime** — exported + froze `VOID_ELEMENTS` (per review), table test, null/undefined attribute tests.
- **stripe-mock** — killed the 3 download-path gaps; found `chmod +x` redundant.
- **csrf** — `FakeTime` tests for real expiry and future-dated-token rejection.
- **db/sessions** — cache-observability tests (mutate the DB behind the cache).
- **db/token-attempts** — DB-row inspection proving expired-lockout deletion.
- **fetch** — `parseApiError` had no direct test; added full coverage.
- **forms** — number-zero in `defineForm`, markdown/type-gated rendering, `entityToFieldValues`, and a new `components.test.ts` for the previously-untested `Flash`/`ConfirmForm`.
- **logger** — `performance.now`-stubbed test pinning `createRequestTimer`'s exact elapsed difference.
- **build-tag** — `isNewerVersion` guard (unparseable tag / empty timestamp) was untested.
- **rest** — name verification is opt-in via `onVerifyFailed`; added the named-resource-without-handler case.

---

## Verification

- `deno task test:files` on each changed test file → all pass
- `deno task lint:ci` → clean
- `deno check` on each changed file → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKBx6n4U1G5DdzhZYFPBZZ