### PR TITLE
Drop jscpd test minTokens to 48 and fix all raised duplications

### DIFF
--- a/.jscpd.test.json
+++ b/.jscpd.test.json
@@ -18,7 +18,7 @@
   "gitignore": true,
   "exitCode": 1,
   "minLines": 1,
-  "minTokens": 49,
+  "minTokens": 48,
   "path": [
     "test"
   ]

--- a/test/admin-api-groups.test.ts
+++ b/test/admin-api-groups.test.ts
@@ -8,6 +8,7 @@ import {
 } from "#shared/db/groups.ts";
 import {
   apiRequest,
+  assertApiDeleteOk,
   assertJson,
   createTestGroup,
   createTestListing,
@@ -360,16 +361,7 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
     test("deletes group with correct confirmation", async () => {
       const group = await createTestGroup({ name: "To Delete" });
 
-      await assertJson(
-        apiRequest(`/api/admin/groups/${group.id}`, {
-          body: { confirm_identifier: "To Delete" },
-          method: "DELETE",
-        }),
-        200,
-        (body) => {
-          expect(body.status).toBe("ok");
-        },
-      );
+      await assertApiDeleteOk(`/api/admin/groups/${group.id}`, "To Delete");
 
       const all = await getAllGroups();
       expect(all.find((g) => g.id === group.id)).toBeUndefined();

--- a/test/admin-api-holidays.test.ts
+++ b/test/admin-api-holidays.test.ts
@@ -4,6 +4,7 @@ import { handleRequest } from "#routes";
 import { getAllHolidays, holidaysTable } from "#shared/db/holidays.ts";
 import {
   apiRequest,
+  assertApiDeleteOk,
   assertJson,
   createTestHoliday,
   createTestManagerSession,
@@ -242,16 +243,7 @@ describeWithEnv("Admin API - Holidays", { db: true }, () => {
     test("deletes holiday with correct confirmation", async () => {
       const holiday = await createTestHoliday({ name: "To Delete" });
 
-      await assertJson(
-        apiRequest(`/api/admin/holidays/${holiday.id}`, {
-          body: { confirm_identifier: "To Delete" },
-          method: "DELETE",
-        }),
-        200,
-        (body) => {
-          expect(body.status).toBe("ok");
-        },
-      );
+      await assertApiDeleteOk(`/api/admin/holidays/${holiday.id}`, "To Delete");
 
       const all = await getAllHolidays();
       expect(all.find((h) => h.id === holiday.id)).toBeUndefined();

--- a/test/bulk-actions/deactivate.test.ts
+++ b/test/bulk-actions/deactivate.test.ts
@@ -8,10 +8,13 @@ import {
   createTestGroup,
   createTestListing,
   describeWithEnv,
+  getBulkActionForm,
   insertModifier,
   linkModifierListing,
   patchModifier,
 } from "#test-utils";
+
+const getDeactivateForm = getBulkActionForm("deactivate");
 
 /** Insert an active opt-in add-on scoped to the given listing ids. */
 const optInAddOnForListings = async (
@@ -31,12 +34,8 @@ describeWithEnv("Admin bulk actions — deactivate", { db: true }, () => {
       const group = await createTestGroup({ name: "To Deactivate" });
       await createTestListing({ groupId: group.id, name: "Listing" });
 
-      const response = await adminGet(
-        `/admin/groups/${group.id}/bulk-actions/deactivate`,
-      );
-      const html = await response.text();
+      const html = await getDeactivateForm(group.id);
 
-      expect(response.status).toBe(200);
       expect(html).toContain("Deactivate Group");
       expect(html).toContain('name="confirm_identifier"');
       expect(html).toContain("deactivate 1 active listing");
@@ -48,12 +47,8 @@ describeWithEnv("Admin bulk actions — deactivate", { db: true }, () => {
       await createTestListing({ groupId: group.id, name: "A" });
       await createTestListing({ groupId: group.id, name: "B" });
 
-      const response = await adminGet(
-        `/admin/groups/${group.id}/bulk-actions/deactivate`,
-      );
-      const html = await response.text();
+      const html = await getDeactivateForm(group.id);
 
-      expect(response.status).toBe(200);
       expect(html).toContain("deactivate 2 active listings");
     });
 

--- a/test/bulk-actions/duplicate.test.ts
+++ b/test/bulk-actions/duplicate.test.ts
@@ -4,11 +4,13 @@ import { getAllGroups, getListingsByGroupId } from "#shared/db/groups.ts";
 import { getAllListings, getListingWithCount } from "#shared/db/listings.ts";
 import {
   adminFormPost,
-  adminGet,
   createTestGroup,
   createTestListing,
   describeWithEnv,
+  getBulkActionForm,
 } from "#test-utils";
+
+const getDuplicateForm = getBulkActionForm("duplicate");
 
 describeWithEnv("Admin bulk actions — duplicate", { db: true }, () => {
   describe("GET /admin/groups/:id/bulk-actions/duplicate", () => {
@@ -16,12 +18,8 @@ describeWithEnv("Admin bulk actions — duplicate", { db: true }, () => {
       const group = await createTestGroup({ name: "Original" });
       await createTestListing({ groupId: group.id, name: "Spring Workshop" });
 
-      const response = await adminGet(
-        `/admin/groups/${group.id}/bulk-actions/duplicate`,
-      );
-      const html = await response.text();
+      const html = await getDuplicateForm(group.id);
 
-      expect(response.status).toBe(200);
       expect(html).toContain("Duplicate Group");
       expect(html).toContain("Spring Workshop");
       expect(html).toContain('id="duplicate-preview-listings"');
@@ -32,12 +30,8 @@ describeWithEnv("Admin bulk actions — duplicate", { db: true }, () => {
     test("shows an empty-state message when the group has no listings", async () => {
       const group = await createTestGroup({ name: "Empty" });
 
-      const response = await adminGet(
-        `/admin/groups/${group.id}/bulk-actions/duplicate`,
-      );
-      const html = await response.text();
+      const html = await getDuplicateForm(group.id);
 
-      expect(response.status).toBe(200);
       expect(html).toContain("This group has no listings");
     });
   });

--- a/test/e2e/accounting.test.ts
+++ b/test/e2e/accounting.test.ts
@@ -213,7 +213,9 @@ const mergePreview = async (
   sourceToken: string,
 ): Promise<{ version: string; bookingField: string }> => {
   const page = await adminGet(
-    `/admin/attendees/${targetId}/merge?token=${encodeURIComponent(sourceToken)}`,
+    `/admin/attendees/${targetId}/merge?token=${encodeURIComponent(
+      sourceToken,
+    )}`,
   );
   expect(page.status).toBe(200);
   const html = await page.text();
@@ -1449,7 +1451,9 @@ describeWithEnv("e2e: accounting lifecycle", { db: true }, () => {
 
     // The preview shows the conflict row but NOT the money-decision UI.
     const preview = await adminGet(
-      `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(sourceToken)}`,
+      `/admin/attendees/${target.id}/merge?token=${encodeURIComponent(
+        sourceToken,
+      )}`,
     );
     const previewHtml = await preview.text();
     expect(previewHtml).toContain('name="booking_');

--- a/test/e2e/duration-days.test.ts
+++ b/test/e2e/duration-days.test.ts
@@ -1174,7 +1174,9 @@ describeWithEnv("e2e: multi-day bookings", { db: true }, () => {
 
       const response = await handleRequest(
         mockFormRequest(
-          `/admin/listing/${listing.id}/attendee/${result.attendees[0]!.id}/checkin`,
+          `/admin/listing/${listing.id}/attendee/${
+            result.attendees[0]!.id
+          }/checkin`,
           { csrf_token: csrfToken },
           cookie,
         ),

--- a/test/e2e/n-plus-one-guard.test.ts
+++ b/test/e2e/n-plus-one-guard.test.ts
@@ -161,10 +161,12 @@ const createProtectedFixture = async (): Promise<ProtectedFixture> => {
     trigger: "answer",
   });
 
-  for (const listing of listings)
+  for (const listing of listings) {
     await linkModifierListing(modifier.id, listing.id);
-  for (const answerId of answerIds)
+  }
+  for (const answerId of answerIds) {
     await linkModifierAnswer(modifier.id, answerId);
+  }
 
   const groupModifier = await insertModifier({
     name: "N+1 protected group discount",

--- a/test/lib/admin-api-security.test.ts
+++ b/test/lib/admin-api-security.test.ts
@@ -116,20 +116,43 @@ describeWithEnv("admin API security", { db: true }, () => {
       expect(response.status).toBe(400);
     });
 
-    const assertListingRequestRejects400 = async (
+    type ListingShape = { id: number; name: string };
+
+    const makeListingRequest = async (
       method: string,
-      bodyFn: (listing: { id: number; name: string }) => string,
-      urlFn: (listing: { id: number; name: string }) => string,
-    ): Promise<void> => {
+      bodyFn: (listing: ListingShape) => string,
+      urlFn: (listing: ListingShape) => string,
+      extraHeaders?: Record<string, string>,
+    ): Promise<Response> => {
       const listing = await createTestListing();
       const apiKey = await createTestApiKeyToken();
-      const response = await handleRequest(
+      return handleRequest(
         requestAsApiKey(urlFn(listing), apiKey, {
           body: bodyFn(listing),
           method,
+          ...(extraHeaders ? { headers: extraHeaders } : {}),
         }),
       );
+    };
+
+    const assertListingRequestRejects400 = async (
+      method: string,
+      bodyFn: (listing: ListingShape) => string,
+      urlFn: (listing: ListingShape) => string,
+    ): Promise<void> => {
+      const response = await makeListingRequest(method, bodyFn, urlFn);
       expect(response.status).toBe(400);
+    };
+
+    const assertListingRequestWithJsonAccepted = async (
+      method: string,
+      bodyFn: (listing: ListingShape) => string,
+      urlFn: (listing: ListingShape) => string,
+    ): Promise<void> => {
+      const response = await makeListingRequest(method, bodyFn, urlFn, {
+        "content-type": "application/json",
+      });
+      expect(response.status).not.toBe(400);
     };
 
     test("PUT /api/admin/listings/:id without content-type returns 400", () =>
@@ -160,31 +183,19 @@ describeWithEnv("admin API security", { db: true }, () => {
 
     // Regression: confirm the 400s above come from missing content-type, not
     // from some other validation. Adding the header must make each request pass.
-    test("PUT /api/admin/listings/:id with content-type is not rejected for missing content-type", async () => {
-      const listing = await createTestListing();
-      const apiKey = await createTestApiKeyToken();
-      const response = await handleRequest(
-        requestAsApiKey(`/api/admin/listings/${listing.id}`, apiKey, {
-          body: JSON.stringify({ name: "Updated" }),
-          headers: { "content-type": "application/json" },
-          method: "PUT",
-        }),
-      );
-      expect(response.status).not.toBe(400);
-    });
+    test("PUT /api/admin/listings/:id with content-type is not rejected for missing content-type", () =>
+      assertListingRequestWithJsonAccepted(
+        "PUT",
+        () => JSON.stringify({ name: "Updated" }),
+        ({ id }) => `/api/admin/listings/${id}`,
+      ));
 
-    test("DELETE /api/admin/listings/:id with content-type is not rejected for missing content-type", async () => {
-      const listing = await createTestListing();
-      const apiKey = await createTestApiKeyToken();
-      const response = await handleRequest(
-        requestAsApiKey(`/api/admin/listings/${listing.id}`, apiKey, {
-          body: JSON.stringify({ confirm_identifier: listing.name }),
-          headers: { "content-type": "application/json" },
-          method: "DELETE",
-        }),
-      );
-      expect(response.status).not.toBe(400);
-    });
+    test("DELETE /api/admin/listings/:id with content-type is not rejected for missing content-type", () =>
+      assertListingRequestWithJsonAccepted(
+        "DELETE",
+        ({ name }) => JSON.stringify({ confirm_identifier: name }),
+        ({ id }) => `/api/admin/listings/${id}`,
+      ));
 
     test("treats uppercase Content-Type the same as lowercase (RFC 7231)", async () => {
       const apiKey = await createTestApiKeyToken();

--- a/test/lib/admin-api-security.test.ts
+++ b/test/lib/admin-api-security.test.ts
@@ -116,17 +116,28 @@ describeWithEnv("admin API security", { db: true }, () => {
       expect(response.status).toBe(400);
     });
 
-    test("PUT /api/admin/listings/:id without content-type returns 400", async () => {
+    const assertListingRequestRejects400 = async (
+      method: string,
+      bodyFn: (listingId: number) => string,
+      urlFn: (listingId: number) => string,
+    ): Promise<void> => {
       const listing = await createTestListing();
       const apiKey = await createTestApiKeyToken();
       const response = await handleRequest(
-        requestAsApiKey(`/api/admin/listings/${listing.id}`, apiKey, {
-          body: JSON.stringify({ name: "Updated" }),
-          method: "PUT",
+        requestAsApiKey(urlFn(listing.id), apiKey, {
+          body: bodyFn(listing.id),
+          method,
         }),
       );
       expect(response.status).toBe(400);
-    });
+    };
+
+    test("PUT /api/admin/listings/:id without content-type returns 400", () =>
+      assertListingRequestRejects400(
+        "PUT",
+        () => JSON.stringify({ name: "Updated" }),
+        (id) => `/api/admin/listings/${id}`,
+      ));
 
     test("POST /api/admin/listings with text/plain content-type returns 400", async () => {
       const apiKey = await createTestApiKeyToken();
@@ -140,17 +151,12 @@ describeWithEnv("admin API security", { db: true }, () => {
       expect(response.status).toBe(400);
     });
 
-    test("body-bearing DELETE without content-type is rejected", async () => {
-      const listing = await createTestListing();
-      const apiKey = await createTestApiKeyToken();
-      const response = await handleRequest(
-        requestAsApiKey(`/api/admin/listings/${listing.id}`, apiKey, {
-          body: JSON.stringify({ confirm_identifier: listing.name }),
-          method: "DELETE",
-        }),
-      );
-      expect(response.status).toBe(400);
-    });
+    test("body-bearing DELETE without content-type is rejected", () =>
+      assertListingRequestRejects400(
+        "DELETE",
+        (id) => JSON.stringify({ confirm_identifier: String(id) }),
+        (id) => `/api/admin/listings/${id}`,
+      ));
 
     test("treats uppercase Content-Type the same as lowercase (RFC 7231)", async () => {
       const apiKey = await createTestApiKeyToken();

--- a/test/lib/admin-api-security.test.ts
+++ b/test/lib/admin-api-security.test.ts
@@ -158,6 +158,34 @@ describeWithEnv("admin API security", { db: true }, () => {
         ({ id }) => `/api/admin/listings/${id}`,
       ));
 
+    // Regression: confirm the 400s above come from missing content-type, not
+    // from some other validation. Adding the header must make each request pass.
+    test("PUT /api/admin/listings/:id with content-type is not rejected for missing content-type", async () => {
+      const listing = await createTestListing();
+      const apiKey = await createTestApiKeyToken();
+      const response = await handleRequest(
+        requestAsApiKey(`/api/admin/listings/${listing.id}`, apiKey, {
+          body: JSON.stringify({ name: "Updated" }),
+          headers: { "content-type": "application/json" },
+          method: "PUT",
+        }),
+      );
+      expect(response.status).not.toBe(400);
+    });
+
+    test("DELETE /api/admin/listings/:id with content-type is not rejected for missing content-type", async () => {
+      const listing = await createTestListing();
+      const apiKey = await createTestApiKeyToken();
+      const response = await handleRequest(
+        requestAsApiKey(`/api/admin/listings/${listing.id}`, apiKey, {
+          body: JSON.stringify({ confirm_identifier: listing.name }),
+          headers: { "content-type": "application/json" },
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).not.toBe(400);
+    });
+
     test("treats uppercase Content-Type the same as lowercase (RFC 7231)", async () => {
       const apiKey = await createTestApiKeyToken();
       const body = JSON.stringify({ max_attendees: 10, name: "Case Test" });

--- a/test/lib/admin-api-security.test.ts
+++ b/test/lib/admin-api-security.test.ts
@@ -118,14 +118,14 @@ describeWithEnv("admin API security", { db: true }, () => {
 
     const assertListingRequestRejects400 = async (
       method: string,
-      bodyFn: (listingId: number) => string,
-      urlFn: (listingId: number) => string,
+      bodyFn: (listing: { id: number; name: string }) => string,
+      urlFn: (listing: { id: number; name: string }) => string,
     ): Promise<void> => {
       const listing = await createTestListing();
       const apiKey = await createTestApiKeyToken();
       const response = await handleRequest(
-        requestAsApiKey(urlFn(listing.id), apiKey, {
-          body: bodyFn(listing.id),
+        requestAsApiKey(urlFn(listing), apiKey, {
+          body: bodyFn(listing),
           method,
         }),
       );
@@ -136,7 +136,7 @@ describeWithEnv("admin API security", { db: true }, () => {
       assertListingRequestRejects400(
         "PUT",
         () => JSON.stringify({ name: "Updated" }),
-        (id) => `/api/admin/listings/${id}`,
+        ({ id }) => `/api/admin/listings/${id}`,
       ));
 
     test("POST /api/admin/listings with text/plain content-type returns 400", async () => {
@@ -154,8 +154,8 @@ describeWithEnv("admin API security", { db: true }, () => {
     test("body-bearing DELETE without content-type is rejected", () =>
       assertListingRequestRejects400(
         "DELETE",
-        (id) => JSON.stringify({ confirm_identifier: String(id) }),
-        (id) => `/api/admin/listings/${id}`,
+        ({ name }) => JSON.stringify({ confirm_identifier: name }),
+        ({ id }) => `/api/admin/listings/${id}`,
       ));
 
     test("treats uppercase Content-Type the same as lowercase (RFC 7231)", async () => {

--- a/test/lib/builder.test.ts
+++ b/test/lib/builder.test.ts
@@ -280,59 +280,58 @@ describeWithEnv(
         },
       ));
 
-    test("buildSite returns error when Deno app creation fails", () =>
-      withMocks(
-        () =>
+    const DENO_ERROR_CASES: {
+      name: string;
+      mocks: () => Restorable | Record<string, Restorable>;
+      error: string;
+    }[] = [
+      {
+        error: "Create app failed",
+        mocks: () =>
           stubDenoBuilderApis({
             createAppResult: {
               error: "Create app failed (500): Error",
               ok: false as const,
             },
           }),
-        async () => {
-          const result = await builderApi.buildSite({
-            dbToken: "tok",
-            dbUrl: "libsql://test.io",
-            hostingProvider: "deno",
-            siteName: "Fail",
-          });
-          expectBuildError(result, "Create app failed");
-        },
-      ));
-
-    test("buildSite returns error when Deno setEnvVars fails", () =>
-      withMocks(
-        () =>
+        name: "buildSite returns error when Deno app creation fails",
+      },
+      {
+        error: "Failed to set secrets",
+        mocks: () =>
           stubDenoBuilderApis({
-            setEnvResult: { error: "Set env failed (403)", ok: false as const },
+            setEnvResult: {
+              error: "Set env failed (403)",
+              ok: false as const,
+            },
           }),
-        async () => {
-          const result = await builderApi.buildSite({
-            dbToken: "tok",
-            dbUrl: "libsql://test.io",
-            hostingProvider: "deno",
-            siteName: "Fail",
-          });
-          expectBuildError(result, "Failed to set secrets");
-        },
-      ));
-
-    test("buildSite returns error when Deno deployCode fails", () =>
-      withMocks(
-        () =>
+        name: "buildSite returns error when Deno setEnvVars fails",
+      },
+      {
+        error: "Deploy failed",
+        mocks: () =>
           stubDenoBuilderApis({
-            deployResult: { error: "Deploy failed (500)", ok: false as const },
+            deployResult: {
+              error: "Deploy failed (500)",
+              ok: false as const,
+            },
           }),
-        async () => {
+        name: "buildSite returns error when Deno deployCode fails",
+      },
+    ];
+    for (const { name, mocks, error } of DENO_ERROR_CASES) {
+      test(name, () =>
+        withMocks(mocks, async () => {
           const result = await builderApi.buildSite({
             dbToken: "tok",
             dbUrl: "libsql://test.io",
             hostingProvider: "deno",
             siteName: "Fail",
           });
-          expectBuildError(result, "Deploy failed");
-        },
-      ));
+          expectBuildError(result, error);
+        }),
+      );
+    }
 
     test("createDatabase dispatches to tursoApi when provider is turso", () =>
       withMocks(

--- a/test/lib/code-quality/detectors.ts
+++ b/test/lib/code-quality/detectors.ts
@@ -439,8 +439,9 @@ export const skipComment = (content: string, i: number): number => {
     while (
       j < content.length &&
       !(content[j] === "*" && content[j + 1] === "/")
-    )
+    ) {
       j++;
+    }
     return j + 2;
   }
   return i;

--- a/test/lib/custom-question-visibility.test.ts
+++ b/test/lib/custom-question-visibility.test.ts
@@ -49,6 +49,14 @@ describe("custom question visibility", () => {
     expect(listenerAttached).toBe(false);
   });
 
+  const assertHiddenAndDeRequired = (
+    roots: ReturnType<typeof installFakeDom>,
+    text: { required: boolean },
+  ): void => {
+    expect(roots[0]!.hidden).toBe(true);
+    expect(text.required).toBe(false);
+  };
+
   test("hides and de-requires a question with no active listing", () => {
     const control = textControl();
     const roots = installFakeDom([
@@ -59,8 +67,7 @@ describe("custom question visibility", () => {
 
     initQuestionVisibility();
 
-    expect(roots[0]!.hidden).toBe(true);
-    expect(text.required).toBe(false);
+    assertHiddenAndDeRequired(roots, text);
   });
 
   test("shows and requires a question for a child given a positive quantity under an in-cart parent", () => {
@@ -134,7 +141,6 @@ describe("custom question visibility", () => {
 
     initQuestionVisibility();
 
-    expect(roots[0]!.hidden).toBe(true);
-    expect(text.required).toBe(false);
+    assertHiddenAndDeRequired(roots, text);
   });
 });

--- a/test/lib/db/attendees/create-attendee-ledger.test.ts
+++ b/test/lib/db/attendees/create-attendee-ledger.test.ts
@@ -92,19 +92,29 @@ describeWithEnv(
       expect((await allTransfers()).length).toBe(0);
     });
 
+    const makeTrackingPostLedger = (
+      listingId: number,
+    ): {
+      posted: { value: boolean };
+      postLedger: (tx: TxScope, attendeeId: number) => Promise<void>;
+    } => {
+      const posted = { value: false };
+      const postLedger = async (
+        tx: TxScope,
+        attendeeId: number,
+      ): Promise<void> => {
+        posted.value = true;
+        await postTransfersTx(tx, saleAndPayment(listingId, attendeeId));
+      };
+      return { posted, postLedger };
+    };
+
     test("rolls back the whole order (and posts nothing) on a partial create", async () => {
       // Two listings, one already full: the paid path is all-or-nothing, so the
       // create must roll back rather than post legs for the line that did book.
       const open = await createTestListing({ maxAttendees: 5 });
       const full = await createTestListing({ maxAttendees: 1 });
-      let posted = false;
-      const postLedger = async (
-        tx: TxScope,
-        attendeeId: number,
-      ): Promise<void> => {
-        posted = true;
-        await postTransfersTx(tx, saleAndPayment(open.id, attendeeId));
-      };
+      const { posted, postLedger } = makeTrackingPostLedger(open.id);
 
       const result = await createAttendeeAtomic(
         {
@@ -119,21 +129,14 @@ describeWithEnv(
       );
 
       expect(result.success).toBe(false);
-      expect(posted).toBe(false);
+      expect(posted.value).toBe(false);
       expect((await getAttendeesRaw(open.id)).length).toBe(0);
       expect((await allTransfers()).length).toBe(0);
     });
 
     test("returns capacity_exceeded without posting when no booking fits", async () => {
       const listing = await createTestListing({ maxAttendees: 1 });
-      let posted = false;
-      const postLedger = async (
-        tx: TxScope,
-        attendeeId: number,
-      ): Promise<void> => {
-        posted = true;
-        await postTransfersTx(tx, saleAndPayment(listing.id, attendeeId));
-      };
+      const { posted, postLedger } = makeTrackingPostLedger(listing.id);
 
       const result = await createAttendeeAtomic(
         {
@@ -147,7 +150,7 @@ describeWithEnv(
       expect(result.success).toBe(false);
       if (result.success) return;
       expect(result.reason).toBe("capacity_exceeded");
-      expect(posted).toBe(false);
+      expect(posted.value).toBe(false);
       expect((await getAttendeesRaw(listing.id)).length).toBe(0);
       expect((await allTransfers()).length).toBe(0);
     });

--- a/test/lib/db/attendees/create-booking-batch.test.ts
+++ b/test/lib/db/attendees/create-booking-batch.test.ts
@@ -144,8 +144,9 @@ describeWithEnv("db > createBookingAtomic", { db: true }, () => {
     const result = await createBookingAtomic(paidInput(listing.id, 600), plan);
 
     expect(result).not.toBe("sold-out");
-    if (result === "sold-out" || !result.success)
+    if (result === "sold-out" || !result.success) {
       throw new Error("expected ok");
+    }
     const attendeeId = result.attendees[0]!.id;
     // Gross revenue recognised, surcharge billed, and the £6 paid clears the
     // balance to zero — the legs were posted with the real attendee id.
@@ -224,8 +225,9 @@ describeWithEnv("db > createBookingAtomic", { db: true }, () => {
       plan,
     );
 
-    if (result === "sold-out" || !result.success)
+    if (result === "sold-out" || !result.success) {
       throw new Error("expected ok");
+    }
     expect(result.attendees.length).toBe(1);
     // No money moved, no event-group stamp written.
     expect((await allTransfers()).length).toBe(0);
@@ -313,8 +315,9 @@ describeWithEnv("db > createBookingAtomic", { db: true }, () => {
     );
 
     // Greedy create: the open listing's booking landed, the full one didn't.
-    if (result === "sold-out" || !result.success)
+    if (result === "sold-out" || !result.success) {
       throw new Error("expected ok");
+    }
     expect(result.attendees.length).toBe(1);
     // The all-bookings-landed guard held back every leg and the finalize, so the
     // caller's ensureAllBookings can roll the partial booking back cleanly.

--- a/test/lib/db/auth.test.ts
+++ b/test/lib/db/auth.test.ts
@@ -17,6 +17,8 @@ import { createSession, getSession } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getUserByUsername, verifyUserPassword } from "#shared/db/users.ts";
 import {
+  assertAdminPasswordRejects,
+  assertAdminPasswordVerifies,
   bookAttendee,
   createTestListing,
   describeWithEnv,
@@ -26,20 +28,11 @@ import {
 
 describeWithEnv("db > auth", { db: true }, () => {
   describe("admin password", () => {
-    test("verifyUserPassword returns hash for correct password", async () => {
-      const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-      expect(user).not.toBeNull();
-      const result = await verifyUserPassword(user!, TEST_ADMIN_PASSWORD);
-      expect(result).toBeTruthy();
-      expect(result).toContain("pbkdf2:");
-    });
+    test("verifyUserPassword returns hash for correct password", () =>
+      assertAdminPasswordVerifies());
 
-    test("verifyUserPassword returns null for wrong password", async () => {
-      const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-      expect(user).not.toBeNull();
-      const result = await verifyUserPassword(user!, "wrong");
-      expect(result).toBeNull();
-    });
+    test("verifyUserPassword returns null for wrong password", () =>
+      assertAdminPasswordRejects());
 
     test("updateUserPassword re-wraps DATA_KEY with new KEK", async () => {
       const user = await getUserByUsername(TEST_ADMIN_USERNAME);

--- a/test/lib/db/keyed-cache.test.ts
+++ b/test/lib/db/keyed-cache.test.ts
@@ -42,24 +42,19 @@ describe("db > keyed-cache", () => {
     clock = 1000;
   });
 
-  const build = (
-    rows: Row[],
-  ): {
+  type CacheFixture = {
     cache: KeyedCache<Row>;
     calls: ReturnType<typeof makeFetchers>["calls"];
-  } => {
+  };
+
+  const build = (rows: Row[]): CacheFixture => {
     const { base, calls } = makeFetchers(rows);
     return { cache: createKeyedCache({ ...base, now, ttlMs: 1000 }), calls };
   };
 
   // A "small table" cache that omits the single-row fetchers, so by-id and
   // by-key reads fall back to the whole-set load.
-  const buildLite = (
-    rows: Row[],
-  ): {
-    cache: KeyedCache<Row>;
-    calls: ReturnType<typeof makeFetchers>["calls"];
-  } => {
+  const buildLite = (rows: Row[]): CacheFixture => {
     const { base, calls } = makeFetchers(rows);
     return {
       cache: createKeyedCache<Row>({

--- a/test/lib/db/migration-test-helpers.ts
+++ b/test/lib/db/migration-test-helpers.ts
@@ -268,7 +268,9 @@ END`,
 FOR EACH ROW BEGIN
   ${spec.contribution("+", "NEW")}
 END`,
-    [updateName]: `AFTER UPDATE OF ${spec.updateOfColumns.join(", ")} ON ${spec.usageTable}
+    [updateName]: `AFTER UPDATE OF ${spec.updateOfColumns.join(
+      ", ",
+    )} ON ${spec.usageTable}
 FOR EACH ROW BEGIN
   ${spec.contribution("-", "OLD")}
   ${spec.contribution("+", "NEW")}

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -20,9 +20,13 @@ import {
   SCHEMA_HASH,
 } from "#shared/db/migrations.ts";
 import {
+  assertSchemaEmpty,
   describeWithEnv,
   invalidateTestDbCache,
+  schemaMarkerKeys,
+  settingsTableExists,
   stubNtfyFetch,
+  tableExists,
 } from "#test-utils";
 import {
   markCurrentSchemaMigrationPending,
@@ -94,32 +98,10 @@ describeWithEnv("db > migrations", { db: true }, () => {
       }
     };
 
-    const settingsTableExists = async (): Promise<boolean> => {
-      const result = await getDb().execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='settings'",
-      );
-      return result.rows.length > 0;
-    };
-
-    const tableExists = async (table: string): Promise<boolean> => {
-      const result = await getDb().execute({
-        args: [table],
-        sql: "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-      });
-      return result.rows.length > 0;
-    };
-
     const createEmptySettingsTable = () =>
       getDb().execute(
         "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
       );
-
-    const schemaMarkerKeys = async (): Promise<string[]> => {
-      const result = await getDb().execute(
-        "SELECT key FROM settings WHERE key IN ('latest_db_update', 'db_schema_hash') ORDER BY key",
-      );
-      return result.rows.map((row) => String(row.key));
-    };
 
     const schemaMigrationsTableExists = async (): Promise<boolean> => {
       const result = await getDb().execute(
@@ -389,9 +371,7 @@ describeWithEnv("db > migrations", { db: true }, () => {
 
       await expect(initDb()).rejects.toThrow("settings table is uninitialized");
 
-      expect(await settingsTableExists()).toBe(true);
-      expect(await tableExists("listings")).toBe(false);
-      expect(await schemaMarkerKeys()).toEqual([]);
+      await assertSchemaEmpty();
     });
 
     test("initDb bootstraps a missing settings table when explicitly allowed", async () => {
@@ -403,59 +383,44 @@ describeWithEnv("db > migrations", { db: true }, () => {
       expect(await tableExists("listings")).toBe(true);
     });
 
-    test("named legacy migration drops legacy indexes not in declarative schema", async () => {
-      await getDb().execute(
-        `CREATE INDEX IF NOT EXISTS
-         idx_attendees_legacy_created
-         ON attendees(created)`,
-      );
-
-      const before = await getDb().execute(
-        `SELECT name FROM sqlite_master
-         WHERE type = 'index'
-           AND name = 'idx_attendees_legacy_created'`,
-      );
+    const assertLegacyObjectDropped = async (
+      type: string,
+      name: string,
+      createSql: string,
+    ): Promise<void> => {
+      await getDb().execute(createSql);
+      const before = await getDb().execute({
+        args: [type, name],
+        sql: "SELECT name FROM sqlite_master WHERE type = ? AND name = ?",
+      });
       expect(before.rows.length).toBe(1);
-
       await getDb().execute(
         "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
       );
       await markCurrentSchemaMigrationPending();
       await initDb();
-
-      const after = await getDb().execute(
-        `SELECT name FROM sqlite_master
-         WHERE type = 'index'
-           AND name = 'idx_attendees_legacy_created'`,
-      );
+      const after = await getDb().execute({
+        args: [type, name],
+        sql: "SELECT name FROM sqlite_master WHERE type = ? AND name = ?",
+      });
       expect(after.rows.length).toBe(0);
-    });
+    };
 
-    test("named legacy migration drops legacy triggers not in declarative schema", async () => {
-      await getDb().execute(
+    test("named legacy migration drops legacy indexes not in declarative schema", () =>
+      assertLegacyObjectDropped(
+        "index",
+        "idx_attendees_legacy_created",
+        "CREATE INDEX IF NOT EXISTS idx_attendees_legacy_created ON attendees(created)",
+      ));
+
+    test("named legacy migration drops legacy triggers not in declarative schema", () =>
+      assertLegacyObjectDropped(
+        "trigger",
+        "trg_legacy_noop",
         `CREATE TRIGGER IF NOT EXISTS trg_legacy_noop
          AFTER INSERT ON attendees
          FOR EACH ROW BEGIN SELECT 1; END`,
-      );
-
-      const before = await getDb().execute(
-        `SELECT name FROM sqlite_master
-         WHERE type = 'trigger' AND name = 'trg_legacy_noop'`,
-      );
-      expect(before.rows.length).toBe(1);
-
-      await getDb().execute(
-        "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
-      );
-      await markCurrentSchemaMigrationPending();
-      await initDb();
-
-      const after = await getDb().execute(
-        `SELECT name FROM sqlite_master
-         WHERE type = 'trigger' AND name = 'trg_legacy_noop'`,
-      );
-      expect(after.rows.length).toBe(0);
-    });
+      ));
   });
 
   describe("initDb ready cache", () => {

--- a/test/lib/form-stash.test.ts
+++ b/test/lib/form-stash.test.ts
@@ -21,8 +21,9 @@ const stashRequired = (data: string): string => {
 
 const formStashStat = () => {
   const stat = getAllCacheStats().find((s) => s.name === "form-stash");
-  if (stat === undefined)
+  if (stat === undefined) {
     throw new Error("form-stash stats are not registered");
+  }
   return stat;
 };
 

--- a/test/lib/google-wallet.test.ts
+++ b/test/lib/google-wallet.test.ts
@@ -25,6 +25,12 @@ const makePassData = (
   ...overrides,
 });
 
+const findTextModule = (
+  obj: { textModulesData: Array<Record<string, string>> },
+  id: string,
+): Record<string, string> =>
+  obj.textModulesData.find((m) => m.id === id) as Record<string, string>;
+
 describe("google-wallet", () => {
   // generateGoogleTestCreds() is memoized, so one call yields the shared creds
   // for every test.
@@ -106,9 +112,7 @@ describe("google-wallet", () => {
     test("includes quantity when greater than 1", async () => {
       const decoded = await extractPayload(makePassData({ quantity: 3 }));
       const obj = decoded.payload.listingTicketObjects[0];
-      const qty = obj.textModulesData.find(
-        (m: Record<string, string>) => m.id === "qty",
-      );
+      const qty = findTextModule(obj, "qty");
       expect(qty).toBeDefined();
       expect(qty.body).toBe("3");
     });
@@ -124,9 +128,7 @@ describe("google-wallet", () => {
         makePassData({ currencyCode: "EUR", pricePaid: 2500 }),
       );
       const obj = decoded.payload.listingTicketObjects[0];
-      const price = obj.textModulesData.find(
-        (m: Record<string, string>) => m.id === "price",
-      );
+      const price = findTextModule(obj, "price");
       expect(price).toBeDefined();
       expect(price.body).toBe("25 EUR");
     });
@@ -142,9 +144,7 @@ describe("google-wallet", () => {
         makePassData({ currencyCode: "JPY", pricePaid: 1000 }),
       );
       const obj = decoded.payload.listingTicketObjects[0];
-      const price = obj.textModulesData.find(
-        (m: Record<string, string>) => m.id === "price",
-      );
+      const price = findTextModule(obj, "price");
       expect(price.body).toBe("1000 JPY");
     });
   });

--- a/test/lib/server-ledger.test.ts
+++ b/test/lib/server-ledger.test.ts
@@ -431,7 +431,9 @@ describeWithEnv("server (admin ledger)", { db: true }, () => {
     await postAttendeePayment(attendeeId);
     const [entry] = await allTransfers();
     const response = await adminGet(
-      `/admin/ledger/entries/${entry!.id}/edit?return_url=%2Fadmin%2Fattendees%2F${attendeeId}`,
+      `/admin/ledger/entries/${
+        entry!.id
+      }/edit?return_url=%2Fadmin%2Fattendees%2F${attendeeId}`,
     );
     expect(response.status).toBe(200);
     const html = await response.text();

--- a/test/lib/server-listing-qr-admin.test.ts
+++ b/test/lib/server-listing-qr-admin.test.ts
@@ -29,6 +29,13 @@ const extractToken = (html: string): string | null => {
   return match ? decodeURIComponent(match[1]!) : null;
 };
 
+const extractAndVerifyToken = async (html: string, slug: string) => {
+  const token = extractToken(html);
+  expect(token).not.toBeNull();
+  const payload = await verifyQrBookToken(slug, token!);
+  return { payload, token };
+};
+
 /** Parent with a Monday-only child: computes bookable start dates for each.
  * Shared by two tests that exercise the child-date-constrained QR flow. */
 const setupParentWithMondayChild = async () => {
@@ -307,9 +314,7 @@ describeWithEnv("admin listing-qr route", { db: true }, () => {
         },
       );
       const body = await response.text();
-      const token = extractToken(body);
-      expect(token).not.toBeNull();
-      const payload = await verifyQrBookToken(listing.slug, token!);
+      const { payload } = await extractAndVerifyToken(body, listing.slug);
       expect(payload).not.toBeNull();
       expect(payload!.n).toBe("Ada Lovelace");
       expect(payload!.v).toBe(1250);
@@ -329,9 +334,7 @@ describeWithEnv("admin listing-qr route", { db: true }, () => {
       );
       expect(response.status).toBe(200);
       const body = await response.text();
-      const token = extractToken(body);
-      expect(token).not.toBeNull();
-      const payload = await verifyQrBookToken(listing.slug, token!);
+      const { payload } = await extractAndVerifyToken(body, listing.slug);
       expect(payload!.n).toBe("");
       expect(payload!.q).toBe(1);
       expect(payload!.v).toBe(-1);

--- a/test/lib/server-qr-book.test.ts
+++ b/test/lib/server-qr-book.test.ts
@@ -85,6 +85,15 @@ const withStripe = async (
   }
 };
 
+const expectStripeRedirect = (
+  response: Response,
+  stripe: ReturnType<typeof stubStripe>,
+): void => {
+  expect(response.status).toBe(302);
+  expect(response.headers.get("location")).toContain("stripe.example");
+  expect(stripe.checkoutStub.calls.length).toBe(1);
+};
+
 /** Assert the most recent Stripe checkout session was created with a single
  *  line at `expectedUnitPrice`, after the form redirected (302). Two
  *  qr-book-vs-`custom_price` tests share this exact assertion pair. */
@@ -429,9 +438,7 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
           const response = await awaitTestRequest(
             qrBookPath(listing.slug, token),
           );
-          expect(response.status).toBe(302);
-          expect(response.headers.get("location")).toContain("stripe.example");
-          expect(stripe.checkoutStub.calls.length).toBe(1);
+          expectStripeRedirect(response, stripe);
         });
       } finally {
         await settings.update.terms("");
@@ -568,9 +575,7 @@ describeWithEnv("qr-book scan handler > parent gate", { db: true }, () => {
     const stripe = stubStripe();
     try {
       const response = await awaitTestRequest(qrBookPath(listing.slug, token));
-      expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toContain("stripe.example");
-      expect(stripe.checkoutStub.calls.length).toBe(1);
+      expectStripeRedirect(response, stripe);
     } finally {
       stripe.restore();
     }

--- a/test/lib/server-settings/google-wallet.test.ts
+++ b/test/lib/server-settings/google-wallet.test.ts
@@ -9,6 +9,7 @@ import {
   expectFlashRedirect,
   expectHtml,
   expectRedirect,
+  fetchAliceTicketPageBody,
   loginAsAdmin,
   mockFormRequest,
   setTestEnv,
@@ -119,12 +120,7 @@ describeWithEnv("ticket view google wallet link", { db: true }, () => {
   });
 
   test("does not show google wallet link when not configured", async () => {
-    const { token } = await createTestAttendeeWithToken(
-      "Alice",
-      "alice@test.com",
-    );
-    const response = await awaitTestRequest(`/t/${token}`);
-    const body = await response.text();
+    const { body } = await fetchAliceTicketPageBody();
     expect(body).not.toContain("Google Wallet");
   });
 

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -6,6 +6,7 @@ import { invalidateInitDbCache, resetDatabase } from "#shared/db/migrations.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   assertPublicHtml,
+  assertSchemaEmpty,
   awaitTestRequest,
   createTestDb,
   describeWithEnv,
@@ -20,6 +21,9 @@ import {
   mockSetupFormRequest,
   reloginAsAdmin,
   resetDb,
+  schemaMarkerKeys,
+  settingsTableExists,
+  tableExists,
   withExpectedError,
   withMocks,
 } from "#test-utils";
@@ -55,34 +59,12 @@ describeWithEnv("server (setup)", { db: true }, () => {
     settings.setup.clearCache();
   }
 
-  async function settingsTableExists(): Promise<boolean> {
-    const result = await getDb().execute(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='settings'",
-    );
-    return result.rows.length > 0;
-  }
-
-  async function tableExists(table: string): Promise<boolean> {
-    const result = await getDb().execute({
-      args: [table],
-      sql: "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-    });
-    return result.rows.length > 0;
-  }
-
   async function createEmptySettingsTable(): Promise<void> {
     await getDb().execute(
       "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
     );
     settings.invalidateCache();
     settings.setup.clearCache();
-  }
-
-  async function schemaMarkerKeys(): Promise<string[]> {
-    const result = await getDb().execute(
-      "SELECT key FROM settings WHERE key IN ('latest_db_update', 'db_schema_hash') ORDER BY key",
-    );
-    return result.rows.map((row) => String(row.key));
   }
 
   describe("setup routes", () => {
@@ -127,9 +109,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
           "This site has not been activated yet",
         );
 
-        expect(await settingsTableExists()).toBe(true);
-        expect(await tableExists("listings")).toBe(false);
-        expect(await schemaMarkerKeys()).toEqual([]);
+        await assertSchemaEmpty();
       });
 
       test("returns not-activated page for admin when setup is incomplete", async () => {

--- a/test/lib/server-tickets.test.ts
+++ b/test/lib/server-tickets.test.ts
@@ -15,6 +15,7 @@ import {
   describeWithEnv,
   expectHtml,
   expectHtmlResponse,
+  fetchAliceTicketPageBody,
   getAttendeesRaw,
 } from "#test-utils";
 
@@ -296,13 +297,7 @@ describeWithEnv("ticket view (/t/:tokens)", { db: true }, () => {
   });
 
   test("displays ticket token on ticket page", async () => {
-    const { token } = await createTestAttendeeWithToken(
-      "Alice",
-      "alice@test.com",
-    );
-
-    const response = await awaitTestRequest(`/t/${token}`);
-    const body = await response.text();
+    const { body, token } = await fetchAliceTicketPageBody();
     expect(body).toContain("ticket-card-token");
     expect(body).toContain(token);
   });

--- a/test/lib/sumup.test.ts
+++ b/test/lib/sumup.test.ts
@@ -317,9 +317,13 @@ describe("sumup", () => {
       expect(result.merchant.error).toBe("No merchant code configured");
     });
 
-    test("reports success with key mode, merchant, and currency", async () => {
+    const withMerchantClient = (fn: () => Promise<void>): Promise<void> => {
       const client = makeClient({ merchantGet: () => Promise.resolve({}) });
-      await withClient(client, async () => {
+      return withClient(client, fn);
+    };
+
+    test("reports success with key mode, merchant, and currency", () =>
+      withMerchantClient(async () => {
         const result = await testSumupConnection();
         expect(result.ok).toBe(true);
         expect(result.apiKey).toEqual({ mode: "test", valid: true });
@@ -328,13 +332,11 @@ describe("sumup", () => {
           merchantCode: "MC123",
         });
         expect(result.currency).toEqual({ code: "GBP", supported: true });
-      });
-    });
+      }));
 
     test("fails overall when the site currency is unsupported", async () => {
       settings.setForTest({ currency: "AUD" });
-      const client = makeClient({ merchantGet: () => Promise.resolve({}) });
-      await withClient(client, async () => {
+      await withMerchantClient(async () => {
         const result = await testSumupConnection();
         expect(result.ok).toBe(false);
         expect(result.apiKey.valid).toBe(true);
@@ -344,8 +346,7 @@ describe("sumup", () => {
 
     test("reports the key mode as unknown for an unrecognized key prefix", async () => {
       settings.setForTest({ sumup_api_key: "plainkey" });
-      const client = makeClient({ merchantGet: () => Promise.resolve({}) });
-      await withClient(client, async () => {
+      await withMerchantClient(async () => {
         const result = await testSumupConnection();
         expect(result.apiKey.mode).toBe("unknown");
       });

--- a/test/lib/update.test.ts
+++ b/test/lib/update.test.ts
@@ -103,7 +103,10 @@ describe("deployLatestReleaseToDeno", () => {
   test("fetches the latest release and deploys it to a Deno app", async () => {
     const fetchStub = stubReleaseFetch();
     const deployStub = stub(denoDeployApi, "deployCode", () =>
-      Promise.resolve({ hostname: "https://app.deno.dev", ok: true as const }),
+      Promise.resolve({
+        hostname: "https://app.deno.dev",
+        ok: true as const,
+      }),
     );
     try {
       const release = await deployLatestReleaseToDeno("app_123");

--- a/test/lib/users-db.test.ts
+++ b/test/lib/users-db.test.ts
@@ -15,8 +15,9 @@ import {
   verifyUserPassword,
 } from "#shared/db/users.ts";
 import {
+  assertAdminPasswordRejects,
+  assertAdminPasswordVerifies,
   describeWithEnv,
-  TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
 } from "#test-utils";
 
@@ -35,20 +36,11 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
       expect(username).toBe(TEST_ADMIN_USERNAME);
     });
 
-    test("verifyUserPassword returns hash for correct password", async () => {
-      const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-      expect(user).not.toBeNull();
-      const hash = await verifyUserPassword(user!, TEST_ADMIN_PASSWORD);
-      expect(hash).toBeTruthy();
-      expect(hash).toContain("pbkdf2:");
-    });
+    test("verifyUserPassword returns hash for correct password", () =>
+      assertAdminPasswordVerifies());
 
-    test("verifyUserPassword returns null for wrong password", async () => {
-      const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-      expect(user).not.toBeNull();
-      const result = await verifyUserPassword(user!, "wrongpassword");
-      expect(result).toBeNull();
-    });
+    test("verifyUserPassword returns null for wrong password", () =>
+      assertAdminPasswordRejects());
 
     test("getUserByUsername returns null for nonexistent user", async () => {
       const user = await getUserByUsername("nonexistent");

--- a/test/scripts/test-durations.test.ts
+++ b/test/scripts/test-durations.test.ts
@@ -14,9 +14,7 @@ import {
 
 /** Build a minimal JUnit document wrapping the given `<testcase>` fragments. */
 const junit = (cases: string): string =>
-  `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="deno test" tests="0" failures="0" errors="0" time="0.0">\n${
-    cases
-  }\n</testsuites>`;
+  `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="deno test" tests="0" failures="0" errors="0" time="0.0">\n${cases}\n</testsuites>`;
 
 const testcase = (attrs: Record<string, string>, body = ""): string =>
   `<testcase ${Object.entries(attrs)

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -18,6 +18,7 @@ import {
   setupTestEncryptionKey,
   singleAnswerSizeQuestionData,
   sizeQuestionAnswerData,
+  smallLargeAnswers,
   testAnswer,
   testListingWithCount,
   testQuestion,
@@ -36,10 +37,7 @@ const TEST_SESSION = { adminLevel: "owner" as const };
  *  Built once so each describe shares the same fixture instead of re-spelling
  *  the literal three times. */
 const tShirtQuestion = testQuestion({
-  answers: [
-    testAnswer({ id: 10, sort_order: 0, text: "Small" }),
-    testAnswer({ id: 11, sort_order: 1, text: "Large" }),
-  ],
+  answers: smallLargeAnswers,
   id: 1,
   text: "T-shirt size?",
 });

--- a/test/templates/admin/settings-nag-banner.test.ts
+++ b/test/templates/admin/settings-nag-banner.test.ts
@@ -51,14 +51,14 @@ describeWithEnv(
       );
     });
 
+    const superuserItem = {
+      href: "/admin/settings#settings-superuser",
+      id: "superuser" as const,
+      label: "Choose whether to enable a superuser recovery account.",
+    };
+
     test("renders superuser nag link when items contain the superuser item", () => {
-      const items = [
-        {
-          href: "/admin/settings#settings-superuser",
-          id: "superuser" as const,
-          label: "Choose whether to enable a superuser recovery account.",
-        },
-      ];
+      const items = [superuserItem];
       const html = String(SettingsNagBanner({ items }));
       expect(html).toContain('href="/admin/settings#settings-superuser"');
       expect(html).toContain(
@@ -76,14 +76,7 @@ describeWithEnv(
         },
         () => {
           const baseNags = getSettingsNagItems();
-          const items = [
-            ...baseNags,
-            {
-              href: "/admin/settings#settings-superuser",
-              id: "superuser" as const,
-              label: "Choose whether to enable a superuser recovery account.",
-            },
-          ];
+          const items = [...baseNags, superuserItem];
           const html = String(SettingsNagBanner({ items }));
           expect(html).toContain(
             'href="/admin/settings#settings-payment-provider"',
@@ -105,13 +98,7 @@ describeWithEnv(
     });
 
     test("superuser nag label text matches exactly", () => {
-      const items = [
-        {
-          href: "/admin/settings#settings-superuser",
-          id: "superuser" as const,
-          label: "Choose whether to enable a superuser recovery account.",
-        },
-      ];
+      const items = [superuserItem];
       const html = String(SettingsNagBanner({ items }));
       expect(html).toContain(
         "Choose whether to enable a superuser recovery account.",

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -86,6 +86,25 @@ export const expectRejectsEmptyName = async (path: string): Promise<void> => {
   );
 };
 
+/** DELETE a named resource via the admin JSON API with a confirmation and
+ *  assert the standard `{ status: "ok" }` 200 response. */
+export const assertApiDeleteOk = async (
+  url: string,
+  confirmationName: string,
+): Promise<void> => {
+  const { apiRequest } = await import("#test-utils/session.ts");
+  await assertJson(
+    apiRequest(url, {
+      body: { confirm_identifier: confirmationName },
+      method: "DELETE",
+    }),
+    200,
+    (body) => {
+      expect(body.status).toBe("ok");
+    },
+  );
+};
+
 export const assertFormRedirect = async (
   path: string,
   data: Record<string, string>,

--- a/test/test-utils/db-helpers.ts
+++ b/test/test-utils/db-helpers.ts
@@ -585,6 +585,53 @@ export const createTestAttendeeWithToken = async (
   return { attendee, listing, token };
 };
 
+/** Create a test attendee for "Alice" and fetch her ticket page body.
+ *  Returns both the token (for further URL assertions) and the HTML body. */
+export const fetchAliceTicketPageBody = async (): Promise<{
+  token: string;
+  body: string;
+}> => {
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  const { token } = await createTestAttendeeWithToken(
+    "Alice",
+    "alice@test.com",
+  );
+  const response = await awaitTestRequest(`/t/${token}`);
+  const body = await response.text();
+  return { body, token };
+};
+
+/** Assert that the admin password can be verified against the stored hash,
+ *  and that the hash uses the pbkdf2 scheme. Shared by the users-db and auth
+ *  tests which both verify this same invariant. */
+export const assertAdminPasswordVerifies = async (): Promise<void> => {
+  const { expect } = await import("@std/expect");
+  const { getUserByUsername, verifyUserPassword } = await import(
+    "#shared/db/users.ts"
+  );
+  const { TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } = await import(
+    "#test-utils/internal.ts"
+  );
+  const user = await getUserByUsername(TEST_ADMIN_USERNAME);
+  expect(user).not.toBeNull();
+  const result = await verifyUserPassword(user!, TEST_ADMIN_PASSWORD);
+  expect(result).toBeTruthy();
+  expect(result).toContain("pbkdf2:");
+};
+
+/** Assert that verifyUserPassword returns null for an incorrect password. */
+export const assertAdminPasswordRejects = async (): Promise<void> => {
+  const { expect } = await import("@std/expect");
+  const { getUserByUsername, verifyUserPassword } = await import(
+    "#shared/db/users.ts"
+  );
+  const { TEST_ADMIN_USERNAME } = await import("#test-utils/internal.ts");
+  const user = await getUserByUsername(TEST_ADMIN_USERNAME);
+  expect(user).not.toBeNull();
+  const result = await verifyUserPassword(user!, "wrongpassword");
+  expect(result).toBeNull();
+};
+
 export const createDailyTestListing = (
   overrides: Partial<Omit<ListingInput, "slug" | "slugIndex">> = {},
 ) =>

--- a/test/test-utils/factories.ts
+++ b/test/test-utils/factories.ts
@@ -360,6 +360,14 @@ export const pricedOrder = (
   ...overrides,
 });
 
+/** The canonical Small/Large answer pair (ids 10 and 11) reused by both the
+ *  factories and the questions template tests so the answer array lives in
+ *  one place. */
+export const smallLargeAnswers = [
+  testAnswer({ id: 10, sort_order: 0, text: "Small" }),
+  testAnswer({ id: 11, sort_order: 1, text: "Large" }),
+];
+
 /** The canonical "Size?" question answer-data fixture used by both the
  *  detail-rows unit tests and the admin questions template tests: three
  *  attendees (ids 1, 2, 3) answering a single "Size?" question (id 1) with
@@ -374,10 +382,7 @@ export const sizeQuestionAnswerData = (): AttendeeQuestionData => ({
   ]),
   questions: [
     testQuestion({
-      answers: [
-        testAnswer({ id: 10, sort_order: 0, text: "Small" }),
-        testAnswer({ id: 11, sort_order: 1, text: "Large" }),
-      ],
+      answers: smallLargeAnswers,
       id: 1,
       text: "Size?",
     }),

--- a/test/test-utils/migrations.ts
+++ b/test/test-utils/migrations.ts
@@ -1,3 +1,4 @@
+import { expect } from "@std/expect";
 import { getDb } from "#shared/db/client.ts";
 import type {
   AdditiveMigration,
@@ -24,6 +25,32 @@ export const indexExists = async (name: string): Promise<boolean> => {
     sql: "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
   });
   return result.rows.length > 0;
+};
+
+export const tableExists = async (table: string): Promise<boolean> => {
+  const result = await getDb().execute({
+    args: [table],
+    sql: "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+  });
+  return result.rows.length > 0;
+};
+
+export const settingsTableExists = (): Promise<boolean> =>
+  tableExists("settings");
+
+export const schemaMarkerKeys = async (): Promise<string[]> => {
+  const result = await getDb().execute(
+    "SELECT key FROM settings WHERE key IN ('latest_db_update', 'db_schema_hash') ORDER BY key",
+  );
+  return result.rows.map((row) => String(row.key));
+};
+
+/** Assert the "empty but initialized settings table" state: settings table
+ *  exists, listings table absent, no schema-version markers recorded yet. */
+export const assertSchemaEmpty = async (): Promise<void> => {
+  expect(await settingsTableExists()).toBe(true);
+  expect(await tableExists("listings")).toBe(false);
+  expect(await schemaMarkerKeys()).toEqual([]);
 };
 
 const additive = (migration: AdditiveMigration): Migration => ({

--- a/test/test-utils/session.ts
+++ b/test/test-utils/session.ts
@@ -448,6 +448,22 @@ export const adminGet = async (path: string): Promise<Response> => {
   return awaitTestRequest(path, { cookie });
 };
 
+/** Curried helper for bulk-action GET pages: returns a function that fetches
+ *  `/admin/groups/:id/bulk-actions/<action>`, asserts 200, and returns the
+ *  HTML body. The two concrete actions (duplicate, deactivate) share this
+ *  structure — curry with the action name to create each specialisation. */
+export const getBulkActionForm =
+  (action: string) =>
+  async (groupId: number): Promise<string> => {
+    const { expect } = await import("@std/expect");
+    const response = await adminGet(
+      `/admin/groups/${groupId}/bulk-actions/${action}`,
+    );
+    const html = await response.text();
+    expect(response.status).toBe(200);
+    return html;
+  };
+
 export const setupAdminTest = async (
   listingOverrides: Partial<Omit<ListingInput, "slug" | "slugIndex">> = {},
 ): Promise<AdminTestContext> => {

--- a/test/test-utils/test-browser.test.ts
+++ b/test/test-utils/test-browser.test.ts
@@ -145,7 +145,9 @@ describe("TestBrowser navigation", () => {
     useHandler(browser, (request) => {
       const url = new URL(request.url);
       seen.push(
-        `${request.method} ${url.pathname} ${request.headers.get("cookie") ?? ""}`,
+        `${request.method} ${url.pathname} ${
+          request.headers.get("cookie") ?? ""
+        }`,
       );
       if (url.pathname === "/start") {
         return new Response(null, {


### PR DESCRIPTION
## Summary

- Drops `.jscpd.test.json` `minTokens` from 49 to 48, exposing 18 clones
- Fixes all 18 clones by extracting shared helpers — no functionality lost
- Two structurally similar bulk-action helpers merged via currying (`getBulkActionForm`)

## New shared helpers

**`test/test-utils/`**
- `getBulkActionForm(action)` — curried factory used by both `duplicate.test.ts` and `deactivate.test.ts`
- `assertApiDeleteOk(url, name)` — shared by groups and holidays DELETE tests
- `assertAdminPasswordVerifies()` / `assertAdminPasswordRejects()` — shared by `users-db` and `auth` tests
- `fetchAliceTicketPageBody()` — shared by `server-tickets` and `google-wallet` tests
- `tableExists`, `settingsTableExists`, `schemaMarkerKeys`, `assertSchemaEmpty` — shared by migrations and server-setup tests
- `smallLargeAnswers` — shared by factories and questions template tests

**Inline helpers (within-file)**
- `CacheFixture` type alias in `keyed-cache.test.ts`
- `makeTrackingPostLedger` factory in `create-attendee-ledger.test.ts`
- `assertLegacyObjectDropped` in `migrations.test.ts`
- `superuserItem` const in `settings-nag-banner.test.ts`
- `DENO_ERROR_CASES` array in `builder.test.ts`
- `assertListingRequestRejects400` in `admin-api-security.test.ts`
- `assertHiddenAndDeRequired` in `custom-question-visibility.test.ts`
- `withMerchantClient` in `sumup.test.ts`
- `extractAndVerifyToken` in `server-listing-qr-admin.test.ts`
- `expectStripeRedirect` in `server-qr-book.test.ts`
- `findTextModule` in `google-wallet.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_018pdjtDRFePJi2Sm6ryaakC)_