### PR TITLE
Address Codex review on markdown questions

### DIFF
--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -75,6 +75,7 @@ import {
   adminQuestionDeletePage,
   adminQuestionPage,
   adminQuestionsPage,
+  questionTextFlat,
 } from "#templates/admin/questions.tsx";
 import {
   type AnswerAggregateFormValues,
@@ -279,7 +280,10 @@ const handleAddAnswer = createAuthedFormRoute<
 
 /** Confirmed-delete handlers for questions */
 const questionDelete = createConfirmedHandlers<QuestionWithAnswers>({
-  identifier: (q) => q.text,
+  // The confirmation page shows the flattened text (newlines → " / "), and a
+  // single-line input can't carry the raw newlines, so verify against the same
+  // flattened form the operator can actually type.
+  identifier: (q) => questionTextFlat(q.text),
   identifierLabel: "Question text",
   load: (id) => getQuestionWithAnswers(id),
   onConfirm: async (q) => {

--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -397,6 +397,16 @@ const validateSingleField = (
     if (error) return { error, valid: false };
   }
 
+  // Enforce the field's maxlength server-side (the rendered input's maxlength is
+  // only a browser hint). Runs after any custom validator so a field with its
+  // own length rule keeps its domain-specific message.
+  if (field.maxlength && trimmed.length > field.maxlength) {
+    return {
+      error: `${field.label} must be ${field.maxlength} characters or fewer`,
+      valid: false,
+    };
+  }
+
   return { valid: true, value: parseFieldValue(field, trimmed) };
 };
 

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -245,21 +245,18 @@ export const EditQuestions = ({
   <>
     {questions.map((q) =>
       q.display_type === "free_text"
-        ? questionWrapper(
-            q,
-            undefined,
+        ? questionWrapper(q, undefined, (labelledBy) => (
             <input
+              aria-labelledby={labelledBy}
               maxlength={MAX_TEXTAREA_LENGTH}
               name={`question_${q.id}`}
               type="text"
               value={selectedTextAnswers.get(q.id) ?? ""}
-            />,
-          )
+            />
+          ))
         : q.display_type === "select"
-          ? questionWrapper(
-              q,
-              undefined,
-              <select name={`question_${q.id}`}>
+          ? questionWrapper(q, undefined, (labelledBy) => (
+              <select aria-labelledby={labelledBy} name={`question_${q.id}`}>
                 <option value="">No answer</option>
                 {q.answers
                   .filter((a) => a.active || selectedAnswerIds.includes(a.id))
@@ -271,8 +268,8 @@ export const EditQuestions = ({
                       {a.text}
                     </option>
                   ))}
-              </select>,
-            )
+              </select>
+            ))
           : questionFieldset(
               q,
               undefined,

--- a/src/ui/templates/components/question-text.tsx
+++ b/src/ui/templates/components/question-text.tsx
@@ -9,9 +9,18 @@ import type { Child } from "#shared/jsx/jsx-runtime.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { isSimpleMarkdown, renderMarkdown } from "#shared/markdown.ts";
 
-/** The prose-HTML for a complex question text, wrapped in a styling div. */
-const questionProse = (text: string): string =>
-  `<div class="prose">${renderMarkdown(text)}</div>`;
+/**
+ * Stable id for a question's rendered prose block. A complex-markdown question
+ * renders its text outside a `<label>`, so the control (or radio fieldset)
+ * points its `aria-labelledby` at this id to stay named for assistive tech.
+ */
+const questionProseId = (q: QuestionWithAnswers): string =>
+  `question-${q.id}-prose`;
+
+/** The prose-HTML for a complex question text, wrapped in a styling div that
+ * carries the id its control references via `aria-labelledby`. */
+const questionProse = (q: QuestionWithAnswers): string =>
+  `<div class="prose" id="${questionProseId(q)}">${renderMarkdown(q.text)}</div>`;
 
 /**
  * True when the question text is simple enough to label a control inline
@@ -25,48 +34,59 @@ export const hasSimpleQuestionText = (q: QuestionWithAnswers): boolean =>
  * escaped by JSX) when simple, or a prose div (Raw HTML) when complex.
  */
 export const questionTextContent = (q: QuestionWithAnswers): Child =>
-  hasSimpleQuestionText(q) ? q.text : <Raw html={questionProse(q.text)} />;
+  hasSimpleQuestionText(q) ? q.text : <Raw html={questionProse(q)} />;
 
 /**
- * Wrap a single-control question (free-text input or select) with its question
- * text. When the text is simple markdown it sits inside a `<label>` so clicking
- * it focuses the control. When complex it sits in a `<div class="prose">` above
- * the control inside a plain `<div>` wrapper. Both carry .custom-question (plus
- * any data-listing-ids) so the visibility script can show/hide them.
+ * Build a single-control question (free-text input or select). The control is a
+ * factory so the wrapper can name it correctly in both layouts: when the text
+ * is simple markdown the control sits inside a `<label>` (clicking it focuses
+ * the control, and the label names it implicitly, so no extra prop is passed);
+ * when complex the prose sits in a `<div class="prose">` above the control
+ * inside a plain `<div>` wrapper, and the control receives the prose's id as
+ * `aria-labelledby` so it stays named for assistive tech. Both carry
+ * .custom-question (plus any data-listing-ids) so the visibility script can
+ * show/hide them.
  */
 export const questionWrapper = (
   q: QuestionWithAnswers,
   listingIds: string | undefined,
-  control: JSX.Element,
+  control: (labelledBy?: string) => JSX.Element,
 ): JSX.Element =>
   hasSimpleQuestionText(q) ? (
     <label class="custom-question" data-listing-ids={listingIds}>
       {q.text}
-      {control}
+      {control()}
     </label>
   ) : (
     <div class="custom-question" data-listing-ids={listingIds}>
-      <Raw html={questionProse(q.text)} />
-      {control}
+      <Raw html={questionProse(q)} />
+      {control(questionProseId(q))}
     </div>
   );
 
 /**
  * Wrap a multi-control question (radio answers) in a fieldset. Simple question
  * text becomes a `<legend>`; complex markdown is rendered as prose before the
- * answer controls.
+ * answer controls and the fieldset is named by it via `aria-labelledby`, so the
+ * radio group stays labelled even without a `<legend>`.
  */
 export const questionFieldset = (
   q: QuestionWithAnswers,
   listingIds: string | undefined,
   controls: JSX.Element[],
-): JSX.Element => (
-  <fieldset class="custom-question" data-listing-ids={listingIds}>
-    {hasSimpleQuestionText(q) ? (
+): JSX.Element =>
+  hasSimpleQuestionText(q) ? (
+    <fieldset class="custom-question" data-listing-ids={listingIds}>
       <legend>{q.text}</legend>
-    ) : (
-      questionTextContent(q)
-    )}
-    {controls}
-  </fieldset>
-);
+      {controls}
+    </fieldset>
+  ) : (
+    <fieldset
+      aria-labelledby={questionProseId(q)}
+      class="custom-question"
+      data-listing-ids={listingIds}
+    >
+      {questionTextContent(q)}
+      {controls}
+    </fieldset>
+  );

--- a/src/ui/templates/public/reservations.tsx
+++ b/src/ui/templates/public/reservations.tsx
@@ -289,31 +289,32 @@ const renderQuestion = (
   const answered = savedFormValue(`question_${q.id}`);
   const options = q.answers.filter((a) => a.active);
   if (q.display_type === "free_text") {
-    return questionWrapper(
-      q,
-      listingIds,
+    return questionWrapper(q, listingIds, (labelledBy) => (
       <input
+        aria-labelledby={labelledBy}
         maxlength={MAX_TEXTAREA_LENGTH}
         name={`question_${q.id}`}
         required={required}
         type="text"
         value={answered}
-      />,
-    );
+      />
+    ));
   }
   if (q.display_type === "select") {
-    return questionWrapper(
-      q,
-      listingIds,
-      <select name={`question_${q.id}`} required={required}>
+    return questionWrapper(q, listingIds, (labelledBy) => (
+      <select
+        aria-labelledby={labelledBy}
+        name={`question_${q.id}`}
+        required={required}
+      >
         <option value="">{t("public.ticket.select_answer_placeholder")}</option>
         {options.map((a) => (
           <option selected={answered === String(a.id)} value={String(a.id)}>
             {a.text}
           </option>
         ))}
-      </select>,
-    );
+      </select>
+    ));
   }
   return questionFieldset(
     q,

--- a/test/lib/forms/validate-form.test.ts
+++ b/test/lib/forms/validate-form.test.ts
@@ -72,6 +72,26 @@ describe("validateForm", () => {
     if (!result.valid) expect(result.error).toBe("Code must be 3 characters");
   });
 
+  test("rejects a value longer than the field's maxlength", () => {
+    const fields: Field[] = [
+      field({ label: "Bio", maxlength: 5, name: "bio" }),
+    ];
+    const result = validateForm(new FormParams({ bio: "abcdef" }), fields);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Bio must be 5 characters or fewer");
+    }
+  });
+
+  test("accepts a value exactly at the field's maxlength", () => {
+    const fields: Field[] = [
+      field({ label: "Bio", maxlength: 5, name: "bio" }),
+    ];
+    const result = validateForm(new FormParams({ bio: "abcde" }), fields);
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.values.bio).toBe("abcde");
+  });
+
   test("skips custom validate for empty optional field", () => {
     const fields: Field[] = [
       field({

--- a/test/lib/render-questions.test.ts
+++ b/test/lib/render-questions.test.ts
@@ -232,7 +232,8 @@ describe("renderQuestions", () => {
     ]).toString();
 
     expect(html).toContain('<div class="custom-question">');
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
+    expect(html).toContain('aria-labelledby="question-1-prose"');
     expect(html).toContain("<strong>more</strong>");
     expect(html).not.toContain("**more**");
   });
@@ -257,7 +258,8 @@ describe("renderQuestions", () => {
     ]).toString();
 
     expect(html).toContain('<div class="custom-question">');
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
+    expect(html).toContain('aria-labelledby="question-1-prose"');
     expect(html).toContain('<a href="https://example.com">a colour</a>');
   });
 
@@ -280,7 +282,10 @@ describe("renderQuestions", () => {
       },
     ]).toString();
 
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain(
+      '<fieldset aria-labelledby="question-1-prose" class="custom-question">',
+    );
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
     expect(html).toContain("<h1>Heading</h1>");
     expect(html).not.toContain("<legend>");
   });

--- a/test/lib/server-questions.test.ts
+++ b/test/lib/server-questions.test.ts
@@ -171,6 +171,30 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         false,
       );
     });
+
+    test("rejects text longer than MAX_TEXTAREA_LENGTH server-side", async () => {
+      // The browser maxlength is only a UI hint; a direct POST must not be able
+      // to persist markdown beyond the cap (it would later be encrypted and
+      // rendered on public booking pages).
+      const { MAX_TEXTAREA_LENGTH } = await import("#shared/limits.ts");
+      const { response } = await adminFormPost("/admin/questions", {
+        display_type: "radio" as const,
+        text: "a".repeat(MAX_TEXTAREA_LENGTH + 1),
+      });
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining(
+          `Question text must be ${MAX_TEXTAREA_LENGTH} characters or fewer`,
+        ),
+        false,
+      );
+
+      const { getAllQuestionsWithAnswers } = await import(
+        "#shared/db/questions.ts"
+      );
+      expect(await getAllQuestionsWithAnswers()).toHaveLength(0);
+    });
   });
 
   describe("GET /admin/questions/:id", () => {
@@ -546,6 +570,25 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       const { questionsTable } = await import("#shared/db/questions.ts");
       const found = await questionsTable.findById(id);
       expect(found).toBeNull();
+    });
+
+    test("deletes a multiline question via its flattened confirmation text", async () => {
+      // A question editor is a textarea, so the text can contain newlines. The
+      // confirmation page (and the single-line confirm input) shows the
+      // flattened "Line 1 / Line 2" form, so deletion must verify against that
+      // — not the raw newline text the operator cannot type.
+      const id = await createQuestion("Line 1\nLine 2");
+      const { response } = await adminFormPost(
+        `/admin/questions/${id}/delete`,
+        { confirm_identifier: "Line 1 / Line 2" },
+      );
+      await expectFlashRedirect(
+        "/admin/questions",
+        "Question deleted",
+      )(response);
+
+      const { questionsTable } = await import("#shared/db/questions.ts");
+      expect(await questionsTable.findById(id)).toBeNull();
     });
 
     test("rejects deletion with wrong text", async () => {

--- a/test/templates/admin/attendees.test.tsx
+++ b/test/templates/admin/attendees.test.tsx
@@ -172,7 +172,8 @@ describe("EditQuestions", () => {
       { textAnswers: new Map([[1, "done"]]) },
     );
 
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
+    expect(html).toContain('aria-labelledby="question-1-prose"');
     expect(html).toContain("<strong>more</strong>");
     expect(html).not.toContain('<label class="custom-question">');
   });
@@ -198,7 +199,8 @@ describe("EditQuestions", () => {
       { answerIds: [10] },
     );
 
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
+    expect(html).toContain('aria-labelledby="question-1-prose"');
     expect(html).toContain('<a href="https://example.com">a colour</a>');
     expect(html).not.toContain('<label class="custom-question">');
   });
@@ -224,7 +226,10 @@ describe("EditQuestions", () => {
       { answerIds: [10] },
     );
 
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain(
+      '<fieldset aria-labelledby="question-1-prose" class="custom-question">',
+    );
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
     expect(html).toContain("<h1>Heading</h1>");
     expect(html).not.toContain("<legend>");
   });

--- a/test/templates/components/question-text.test.tsx
+++ b/test/templates/components/question-text.test.tsx
@@ -40,11 +40,11 @@ describe("questionTextContent", () => {
     expect(content).toBe("What size?");
   });
 
-  test("returns a prose div for complex markdown", () => {
+  test("returns a prose div with a stable id for complex markdown", () => {
     const content = String(
       questionTextContent(radioQuestion("What **size**?")),
     );
-    expect(content).toContain('<div class="prose">');
+    expect(content).toContain('<div class="prose" id="question-1-prose">');
     expect(content).toContain("<strong>size</strong>");
   });
 });
@@ -52,11 +52,9 @@ describe("questionTextContent", () => {
 describe("questionWrapper", () => {
   test("wraps a control in a label for simple text", () => {
     const html = String(
-      questionWrapper(
-        radioQuestion("What size?"),
-        undefined,
-        <input name="q1" type="text" />,
-      ),
+      questionWrapper(radioQuestion("What size?"), undefined, () => (
+        <input name="q1" type="text" />
+      )),
     );
     expect(html).toContain('<label class="custom-question">');
     expect(html).toContain("What size?");
@@ -64,20 +62,45 @@ describe("questionWrapper", () => {
     expect(html).toContain('type="text"');
   });
 
+  test("does not pass a labelledBy id when the control is inside a label", () => {
+    // Simple text labels the control implicitly via the wrapping <label>, so no
+    // aria-labelledby is needed — the factory is called with no id.
+    const html = String(
+      questionWrapper(radioQuestion("What size?"), undefined, (labelledBy) => (
+        <input aria-labelledby={labelledBy} name="q1" type="text" />
+      )),
+    );
+    expect(html).not.toContain("aria-labelledby");
+  });
+
   test("wraps a control in a div with prose for complex markdown", () => {
     const html = String(
-      questionWrapper(
-        radioQuestion("What **size**?"),
-        "100 200",
-        <input name="q1" type="text" />,
-      ),
+      questionWrapper(radioQuestion("What **size**?"), "100 200", () => (
+        <input name="q1" type="text" />
+      )),
     );
     expect(html).toContain(
       '<div class="custom-question" data-listing-ids="100 200">',
     );
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
     expect(html).toContain("<strong>size</strong>");
     expect(html).not.toContain('<label class="custom-question">');
+  });
+
+  test("names the control via aria-labelledby for complex markdown", () => {
+    // The control sits outside any <label>, so it must reference the prose id to
+    // stay named for assistive tech.
+    const html = String(
+      questionWrapper(
+        radioQuestion("What **size**?"),
+        undefined,
+        (labelledBy) => (
+          <input aria-labelledby={labelledBy} name="q1" type="text" />
+        ),
+      ),
+    );
+    expect(html).toContain('aria-labelledby="question-1-prose"');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
   });
 });
 
@@ -95,9 +118,10 @@ describe("questionFieldset", () => {
     expect(html).toContain("<legend>What size?</legend>");
     expect(html).toContain('type="radio"');
     expect(html).not.toContain('<div class="prose">');
+    expect(html).not.toContain("aria-labelledby");
   });
 
-  test("renders complex fieldset text as prose before controls", () => {
+  test("renders complex fieldset text as prose and names the group by it", () => {
     const html = String(
       questionFieldset(radioQuestion("What **size**?"), "100 200", [
         <label>
@@ -107,9 +131,9 @@ describe("questionFieldset", () => {
     );
 
     expect(html).toContain(
-      '<fieldset class="custom-question" data-listing-ids="100 200">',
+      '<fieldset aria-labelledby="question-1-prose" class="custom-question" data-listing-ids="100 200">',
     );
-    expect(html).toContain('<div class="prose">');
+    expect(html).toContain('<div class="prose" id="question-1-prose">');
     expect(html).toContain("<strong>size</strong>");
     expect(html).not.toContain("<legend>");
   });


### PR DESCRIPTION
Addresses the three Codex P2 comments on #1463 ("Let questions be markdown"). Stacked on `question-descriptions` so it lands on that PR.

## Changes

1. **Keep the delete confirmation verifiable for multiline questions.** The question editor is now a textarea, so the text can contain newlines. The confirmation page (and its single-line confirm input) shows the flattened `Line 1 / Line 2` form, but the delete handler verified against the raw `q.text`, making multiline questions impossible to delete. `questionDelete.identifier` now uses `questionTextFlat(q.text)` so it matches what the operator sees and can type.

2. **Enforce the text cap server-side.** The rendered `maxlength` was only a browser hint — a direct/admin POST could persist question markdown far beyond `MAX_TEXTAREA_LENGTH`. `validateSingleField` now enforces a field's `maxlength` server-side. It runs after any custom validator, so fields with their own length rules (username, address, …) keep their domain-specific messages; this is a general fix, not just for the question form.

3. **Preserve labels for complex-markdown questions.** When a free-text/select/radio question's text contains complex markdown it renders outside a `<label>`, leaving the control unnamed for assistive tech. The prose block now carries a stable id and the control references it via `aria-labelledby` (single controls receive the id; the radio `<fieldset>` carries `aria-labelledby`).

## Tests

- `test/lib/server-questions.test.ts` — a multiline question can be deleted via its flattened confirmation text; an over-cap POST is rejected and persists nothing.
- `test/lib/forms/validate-form.test.ts` — `maxlength` is enforced (rejects over, accepts at boundary).
- `test/lib/render-questions.test.ts`, `test/templates/admin/attendees.test.tsx`, `test/templates/components/question-text.test.tsx` — complex-markdown controls/fieldsets are named via `aria-labelledby`.

`deno task precommit` passes (lint, typecheck, cpd, build:edge, full coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzsST1EjTzW4WJrADZdSFt)_