### PR TITLE
Batch mutation test runs to bound open file descriptors

### DIFF
--- a/scripts/mutation/batch.ts
+++ b/scripts/mutation/batch.ts
@@ -1,0 +1,36 @@
+/**
+ * Split the test files for one mutation run into batches that each execute in
+ * their own `deno test` process.
+ *
+ * Why batch at all: the local libsql sqlite3 driver strands one file descriptor
+ * per interactive transaction — its `Client.transaction()` detaches a
+ * connection that nothing ever closes (commit/rollback only issue SQL, and the
+ * later `Client.close()` reclaims a different, lazily-recreated connection), so
+ * the fd is only released when V8 finalizes the orphaned handle during GC. A
+ * single process that loads many test files can therefore spike past its
+ * open-file ceiling before GC catches up, which surfaces as "Too many open
+ * files". The full suite avoids this by sharding across `--parallel` workers;
+ * the mutation runner runs each set in one process (so a mutant binds through
+ * the `#…` import map), so it instead caps how many files a process loads and
+ * runs the rest in a fresh process — process exit releases every fd it held.
+ */
+
+/**
+ * Files per `deno test` process. Small enough that one process's transaction
+ * churn stays well under the open-file ceiling on every platform (macOS
+ * defaults its hard limit far lower than Linux), large enough that process
+ * startup stays negligible for the common, small changed-file set.
+ */
+export const TEST_FILE_BATCH_SIZE = 24;
+
+/** Chunk `testFiles` into runs of at most `size`, preserving order. */
+export const batchTestFiles = (
+  testFiles: string[],
+  size = TEST_FILE_BATCH_SIZE,
+): string[][] => {
+  const batches: string[][] = [];
+  for (let i = 0; i < testFiles.length; i += size) {
+    batches.push(testFiles.slice(i, i + size));
+  }
+  return batches;
+};

--- a/scripts/mutation/runner.ts
+++ b/scripts/mutation/runner.ts
@@ -19,6 +19,7 @@ import {
   withTestHarness,
 } from "../test-harness.ts";
 import { type AssetRebuilder, createAssetRebuilder } from "./assets.ts";
+import { batchTestFiles } from "./batch.ts";
 import { applyMutant, generateMutants, type Mutant } from "./generate.ts";
 import {
   type IgnoreList,
@@ -56,7 +57,35 @@ const testEnv = (): Record<string, string> => ({
   STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
 });
 
-/** Run the test files once, returning the outcome and how long it took. */
+/** Run one `deno test` process over `batch`, returning its exit code. */
+const runTestBatch = async (
+  batch: string[],
+  signal: AbortSignal,
+): Promise<number> => {
+  const { code } = await new Deno.Command(Deno.execPath(), {
+    args: ["test", "--no-check", "--allow-all", ...batch],
+    cwd: projectRoot,
+    env: testEnv(),
+    signal,
+    stderr: "null",
+    stdout: "null",
+  }).output();
+  return code;
+};
+
+/**
+ * Run the test files once, returning the outcome and how long it took.
+ *
+ * The files are run in batches, each in its own `deno test` process, to cap how
+ * many test files a single process loads at a time — see ./batch.ts for why the
+ * local libsql driver's per-transaction fd leak makes a one-big-process run
+ * spike past the open-file ceiling ("Too many open files"). A fresh process per
+ * batch releases every fd on exit, so the peak stays bounded by one batch.
+ *
+ * A non-zero batch is enough to decide the run: it fails the baseline, or kills
+ * a mutant, so the remaining batches are skipped. All batches share one timeout
+ * and abort signal, so a mutant that hangs is still caught as "timed-out".
+ */
 const runTests = async (
   testFiles: string[],
   timeoutMs: number,
@@ -68,21 +97,15 @@ const runTests = async (
   if (abortSignal?.aborted) controller.abort();
   else abortSignal?.addEventListener("abort", onAbort, { once: true });
   const startedAt = performance.now();
+  const elapsed = (): number => performance.now() - startedAt;
   try {
-    const { code } = await new Deno.Command(Deno.execPath(), {
-      args: ["test", "--no-check", "--allow-all", ...testFiles],
-      cwd: projectRoot,
-      env: testEnv(),
-      signal: controller.signal,
-      stderr: "null",
-      stdout: "null",
-    }).output();
-    return {
-      durationMs: performance.now() - startedAt,
-      outcome: code === 0 ? "passed" : "failed",
-    };
+    for (const batch of batchTestFiles(testFiles)) {
+      const code = await runTestBatch(batch, controller.signal);
+      if (code !== 0) return { durationMs: elapsed(), outcome: "failed" };
+    }
+    return { durationMs: elapsed(), outcome: "passed" };
   } catch {
-    return { durationMs: performance.now() - startedAt, outcome: "timed-out" };
+    return { durationMs: elapsed(), outcome: "timed-out" };
   } finally {
     clearTimeout(timer);
     abortSignal?.removeEventListener("abort", onAbort);

--- a/test/scripts/mutation-batch.test.ts
+++ b/test/scripts/mutation-batch.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "@std/expect";
+import {
+  batchTestFiles,
+  TEST_FILE_BATCH_SIZE,
+} from "../../scripts/mutation/batch.ts";
+
+Deno.test("batchTestFiles returns no batches for an empty list", () => {
+  expect(batchTestFiles([])).toEqual([]);
+});
+
+Deno.test("batchTestFiles keeps a sub-size list as a single batch", () => {
+  const files = ["a.test.ts", "b.test.ts"];
+  expect(batchTestFiles(files, 5)).toEqual([files]);
+});
+
+Deno.test("batchTestFiles splits into ordered batches with a partial tail", () => {
+  expect(batchTestFiles(["a", "b", "c", "d", "e"], 2)).toEqual([
+    ["a", "b"],
+    ["c", "d"],
+    ["e"],
+  ]);
+});
+
+Deno.test("batchTestFiles defaults to TEST_FILE_BATCH_SIZE per process", () => {
+  const files = Array.from(
+    { length: TEST_FILE_BATCH_SIZE + 1 },
+    (_unused, i) => `f${i}.test.ts`,
+  );
+  const batches = batchTestFiles(files);
+  expect(batches.length).toBe(2);
+  expect(batches[0]?.length).toBe(TEST_FILE_BATCH_SIZE);
+  expect(batches[1]?.length).toBe(1);
+});


### PR DESCRIPTION
## Problem

Agents kept hitting **"Too many open files"** during mutation testing.

I reproduced and traced it to a file-descriptor leak in the **local** libsql `sqlite3` driver (used only by tests and `deno task start`, never by the remote/edge path production runs on):

- `Client.transaction()` detaches its connection from the client and hands it to a transaction object that **never closes it** — `commit()`/`rollback()` only issue SQL, and the later `Client.close()` reclaims a *different*, lazily-recreated connection.
- So every `withTransaction` (and the transaction-backed setup paths) strands one fd against its since-deleted temp DB file. The fd is only released when V8 finalizes the orphaned handle on **GC**.

Measured on the full suite in a single process, live fds climbed monotonically (1555 → 2147 → …), of which ~1700 were `(deleted)` `.db` handles. Because reclamation is GC-timed, a run that loads many test files at once can spike past the process's open-file ceiling *before* GC catches up.

Two facts shape the fix:

1. **The full suite escapes this** only because it shards across `--parallel` workers — each worker is a separate process with its own ceiling. The mutation runner deliberately runs each set in **one** process (so a mutant binds through the `#…` import map), so it has no such relief.
2. **Raising the soft limit is a no-op** — Deno already auto-raises the soft `NOFILE` limit to the hard cap on startup (verified: launched with soft=200, the deno process and its children see soft=4096). The real ceiling is the hard limit, which is platform-dependent and low by default on macOS (256).

## Fix

Cap how many test files a single `deno test` process loads by running them in **batches** (`scripts/mutation/batch.ts`), each in a fresh process that releases every fd on exit — so peak fd usage stays bounded by one batch regardless of GC timing or platform limit.

- A non-zero batch is enough to fail the baseline or kill a mutant, so the remaining batches are skipped (early exit).
- All batches share one timeout and abort signal, so a hanging mutant is still caught as `timed-out`, and SIGINT/SIGTERM still unwinds cleanly.
- Batch size 24: small enough to stay well under the fd ceiling on every platform, large enough that process startup stays negligible for the common small changed-file set (so `precommit:mutation` is unaffected).

## Tests

- `test/scripts/mutation-batch.test.ts` — covers `batchTestFiles`: empty list, sub-size single batch, ordered split with a partial tail, and the default size boundary.
- Verified end-to-end: single-batch and multi-batch (39 files → 2 batches) mutation runs both produce a green baseline and 100% mutant detection; the existing `test/scripts/` suite, `lint:ci`, and `cpd` (0% duplication) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F11tC7fmmZg56rdNt25K22)_