### PR TITLE
Add login links to setup-complete and account-activated pages

### DIFF
--- a/src/locales/en/login.json
+++ b/src/locales/en/login.json
@@ -14,6 +14,7 @@
   "join.success.heading": "Password Set",
   "join.success.message": "Your password has been set successfully.",
   "join.success.ready": "Your account is ready — you can log in now.",
+  "join.success.login_link": "Log In",
   "join.invalid.title": "Invalid Invite",
   "join.invalid.heading": "Invalid Invite",
   "password.current": "Current Password",

--- a/src/locales/en/setup.json
+++ b/src/locales/en/setup.json
@@ -24,5 +24,6 @@
   "setup.complete.title": "Setup Complete",
   "setup.complete.heading": "Setup Complete!",
   "setup.complete.message": "Your ticket reservation system has been configured successfully.",
-  "setup.complete.dashboard_link": "Go to Admin Dashboard"
+  "setup.complete.dashboard_link": "Go to Admin Dashboard",
+  "setup.complete.login_link": "Log In"
 }

--- a/src/ui/templates/join.tsx
+++ b/src/ui/templates/join.tsx
@@ -6,6 +6,7 @@ import { t } from "#i18n";
 import { joinForm } from "#routes/join.ts";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import { ActionButton } from "#templates/components/actions.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 /**
@@ -41,6 +42,11 @@ export const joinCompletePage = (): string =>
         <p>{t("join.success.message")}</p>
         <p>{t("join.success.ready")}</p>
       </div>
+      <p class="actions">
+        <ActionButton href="/admin/login" icon="log-in">
+          {t("join.success.login_link")}
+        </ActionButton>
+      </p>
     </Layout>,
   );
 

--- a/src/ui/templates/setup.tsx
+++ b/src/ui/templates/setup.tsx
@@ -105,8 +105,8 @@ export const setupCompletePage = (): string =>
         <p>{t("setup.complete.message")}</p>
       </div>
       <p class="actions">
-        <ActionButton href="/admin/" icon="arrow-right">
-          {t("setup.complete.dashboard_link")}
+        <ActionButton href="/admin/login" icon="log-in">
+          {t("setup.complete.login_link")}
         </ActionButton>
       </p>
     </Layout>,

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -461,7 +461,12 @@ describeWithEnv("server (setup)", { db: true }, () => {
       });
 
       test("GET /setup/complete shows success page when setup is done", async () => {
-        await assertPublicHtml("/setup/complete", "Setup Complete");
+        await assertPublicHtml(
+          "/setup/complete",
+          "Setup Complete",
+          'href="/admin/login"',
+          "Log In",
+        );
       });
     });
   });

--- a/test/lib/server-users-join.test.ts
+++ b/test/lib/server-users-join.test.ts
@@ -83,7 +83,12 @@ describeWithEnv("server (multi-user admin)", { db: true }, () => {
     });
 
     test("GET /join/complete shows confirmation page", async () => {
-      await assertPublicHtml("/join/complete", "Password Set");
+      await assertPublicHtml(
+        "/join/complete",
+        "Password Set",
+        'href="/admin/login"',
+        "Log In",
+      );
     });
 
     test("POST /join/:code self-activates the invited user", async () => {

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -1623,7 +1623,7 @@ describe("test-utils", () => {
       expect(actions).toEqual([
         "visit:/setup/",
         "submit:Complete Setup",
-        "click:Go to Admin Dashboard",
+        "click:Log In",
         "submit:Login",
         "click:Back to dashboard",
       ]);

--- a/test/test-utils/e2e.ts
+++ b/test/test-utils/e2e.ts
@@ -43,7 +43,7 @@ export const setupAndLogin = async (browser: TestBrowser): Promise<void> => {
     "Complete Setup",
   );
   invalidateAllCaches();
-  await browser.clickLink("Go to Admin Dashboard");
+  await browser.clickLink("Log In");
   await browser.submitForm(
     { password: "password", username: "admin" },
     "Login",


### PR DESCRIPTION
## Summary

On both the "Setup Complete" and "Password Set" (account activated) success pages, the next thing the user wants to do is log in — but neither page offered a link to do so. This adds a login button to each.

## Changes

- **`/setup/complete`**: replaced the "Go to Admin Dashboard" button (which only redirected through the login form anyway, since setup doesn't log you in) with a direct "Log In" button pointing at `/admin/login`.
- **`/join/complete`**: added a matching "Log In" button below the success message.
- Added the `setup.complete.login_link` and `join.success.login_link` locale strings.
- Updated the `setupAndLogin` e2e helper and its unit test to click the new "Log In" link, and extended the `/setup/complete` and `/join/complete` page tests to assert the login link is rendered.

## Testing

- `deno task test` — all 12246 tests pass
- `deno task lint:ci`, `deno task typecheck`, `deno task cpd` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEpHZN8m2mmeogm5DNQ4GG)_