### PR TITLE
Add /order.js debug flag and make the widget hot path efficient

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -99,7 +99,12 @@
       }
     },
     {
-      "includes": ["src/index.ts", "src/app/index.ts", "src/shared/logger.ts"],
+      "includes": [
+        "src/index.ts",
+        "src/app/index.ts",
+        "src/shared/logger.ts",
+        "src/ui/client/order.ts"
+      ],
       "linter": {
         "rules": {
           "suspicious": {

--- a/deno.json
+++ b/deno.json
@@ -69,6 +69,7 @@
     "marked": "npm:marked@^18.0.0",
     "node-forge": "npm:node-forge@^1.4.0",
     "fflate": "npm:fflate@^0.8.2",
+    "happy-dom": "npm:happy-dom@^15.11.7",
     "auto-console-group": "npm:auto-console-group@^1.3.0",
     "valibot": "npm:valibot@^1.4.1",
     "temporal-polyfill": "npm:temporal-polyfill@^0.3.0",

--- a/deno.lock
+++ b/deno.lock
@@ -48,6 +48,8 @@
     "npm:esbuild@0.28.0": "0.28.0",
     "npm:fast-check@^3.23.0": "3.23.2",
     "npm:fflate@~0.8.2": "0.8.2",
+    "npm:happy-dom@15": "15.11.7",
+    "npm:happy-dom@^15.11.7": "15.11.7",
     "npm:intl-messageformat@10": "10.7.18",
     "npm:jscpd@*": "4.0.8",
     "npm:jsqr@^1.4.0": "1.4.0",
@@ -1137,6 +1139,9 @@
         "once"
       ]
     },
+    "entities@4.5.0": {
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
     "es-define-property@1.0.1": {
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
@@ -1333,6 +1338,14 @@
     },
     "graceful-fs@4.2.11": {
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "happy-dom@15.11.7": {
+      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "dependencies": [
+        "entities",
+        "webidl-conversions@7.0.0",
+        "whatwg-mimetype"
+      ]
     },
     "has-symbols@1.1.0": {
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
@@ -1925,11 +1938,17 @@
     "webidl-conversions@3.0.1": {
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
+    "webidl-conversions@7.0.0": {
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-mimetype@3.0.0": {
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+    },
     "whatwg-url@5.0.0": {
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": [
         "tr46",
-        "webidl-conversions"
+        "webidl-conversions@3.0.1"
       ]
     },
     "which@2.0.2": {
@@ -2013,6 +2032,7 @@
       "npm:esbuild@0.28",
       "npm:fast-check@^3.23.0",
       "npm:fflate@~0.8.2",
+      "npm:happy-dom@^15.11.7",
       "npm:intl-messageformat@10",
       "npm:jsqr@^1.4.0",
       "npm:liquidjs@^10.25.5",

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -127,3 +127,53 @@ src/ui/templates/admin/listing-defaults.tsx:90:19  ?? → ||  # UrlControl value
 src/ui/templates/admin/listing-defaults.tsx:119:42  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
 src/shared/listing-defaults.ts:95:52  === → ==  # hidden gate `months_per_unit === 0`: months_per_unit is a number (DB integer column), so === and == never disagree — there is no string/null operand to coerce
 src/shared/listing-defaults.ts:123:59  !== → !=  # setListingDefaultFields "is set" check: ListingDefaults values are boolean|number|string|string[]|undefined and never null, so `!== undefined` and `!= undefined` always agree
+
+# --- External order widget (src/ui/client/order.ts) ----------------------------
+# This is browser DOM-construction code; many operator swaps are provably
+# equivalent. Each `= → +=` below targets a property whose value before the
+# assignment is fixed, so `x = v` and `x += v` produce the same result:
+#  * a freshly created element's `.className`/`.textContent` is always "" (DOM
+#    spec), so `"" + literal === literal`;
+#  * the boolean flags (`memoryOnly`, `dropped`, `hasVariable`) are `false`
+#    before the swapped assignment and are only ever read for truthiness, so
+#    `false + true === 1` is truthy just like `true`.
+src/ui/client/order.ts:97:28  ?? → ||    # catalogEntry(): CatalogEntry|undefined; an object is truthy, undefined and "" never occur
+src/ui/client/order.ts:136:22  = → +=    # memoryOnly: false → 1, only read for truthiness
+src/ui/client/order.ts:152:24  = → +=    # memoryOnly: false → 1, only read for truthiness
+src/ui/client/order.ts:163:22  = → +=    # memoryOnly: false → 1, only read for truthiness
+src/ui/client/order.ts:177:16  = → +=    # dropped: false → 1, only read for truthiness
+src/ui/client/order.ts:180:51  ?? → ||   # merged.get(): merged values are summed positive quantities (>0), never 0
+src/ui/client/order.ts:183:18  = → +=    # this.notice was "" before this assignment
+src/ui/client/order.ts:261:24  = → +=    # heading.textContent: fresh element, "" before
+src/ui/client/order.ts:266:18  = → +=    # p.className: fresh element, "" before
+src/ui/client/order.ts:267:20  = → +=    # p.textContent: fresh element, "" before
+src/ui/client/order.ts:276:43  = → +=    # hasVariable: false → 1, only read for truthiness
+src/ui/client/order.ts:283:22  = → +=    # total.className: fresh element, "" before
+src/ui/client/order.ts:284:24  = → +=    # total.textContent: fresh element, "" before
+src/ui/client/order.ts:289:23  = → +=    # caveat.className: fresh element, "" before
+src/ui/client/order.ts:290:25  = → +=    # caveat.textContent: fresh element, "" before
+src/ui/client/order.ts:296:24  = → +=    # empty.textContent: fresh element, "" before
+src/ui/client/order.ts:305:18  = → +=    # row.className: fresh element, "" before
+src/ui/client/order.ts:307:19  = → +=    # name.className: fresh element, "" before
+src/ui/client/order.ts:308:21  = → +=    # name.textContent: fresh element, "" before
+src/ui/client/order.ts:312:20  = → +=    # price.className: fresh element, "" before
+src/ui/client/order.ts:313:22  = → +=    # price.textContent: fresh element, "" before
+src/ui/client/order.ts:328:21  = → +=    # continue button.className: fresh element, "" before
+src/ui/client/order.ts:329:23  = → +=    # continue button.textContent: fresh element, "" before
+src/ui/client/order.ts:346:19  = → +=    # cart button.className: fresh element, "" before
+src/ui/client/order.ts:347:16  = → +=    # button.hidden: false → 1 (truthy), and render() overwrites it with count===0 immediately
+src/ui/client/order.ts:347:19  true → false  # button.hidden is overwritten by render()'s `count === 0` on the next line of the constructor
+src/ui/client/order.ts:349:18  = → +=    # count span.className: fresh element, "" before
+src/ui/client/order.ts:350:20  = → +=    # count span.textContent: fresh element, "" before
+src/ui/client/order.ts:352:20  = → +=    # label.textContent: fresh element, "" before
+src/ui/client/order.ts:361:19  = → +=    # close button.className: fresh element, "" before
+src/ui/client/order.ts:362:21  = → +=    # close button.textContent: fresh element, "" before
+src/ui/client/order.ts:372:17  = → +=    # stepper wrap.className: fresh element, "" before
+src/ui/client/order.ts:375:18  = → +=    # dec.textContent: fresh element, "" before
+src/ui/client/order.ts:379:20  = → +=    # value span.textContent: fresh element, "" before
+src/ui/client/order.ts:382:18  = → +=    # inc.textContent: fresh element, "" before
+src/ui/client/order.ts:387:21  = → +=    # remove.textContent: fresh element, "" before
+src/ui/client/order.ts:395:20  = → +=    # style.textContent: fresh element, "" before
+src/ui/client/order.ts:429:27  = → +=    # registry[origin]: undefined → a truthy string; only read for the dedup truthiness check, the live controller is the local var
+src/ui/client/order.ts:433:48  ?? → ||   # link.dataset.addListing: string|undefined; the only falsy-non-null value "" equals the "" fallback
+src/ui/client/order.ts:443:59  ?? → ||   # link.dataset.addListing: string|undefined; the only falsy-non-null value "" equals the "" fallback

--- a/src/features/assets.ts
+++ b/src/features/assets.ts
@@ -3,6 +3,7 @@
  */
 
 import { dirname, fromFileUrl, join } from "@std/path";
+import { once } from "#fp";
 import { encodeBody } from "#routes/response.ts";
 
 const currentDir = dirname(fromFileUrl(import.meta.url));
@@ -50,6 +51,12 @@ export const handleIframeResizerChildJs = staticHandler(
 /** The raw ESM body of the external-order widget (`/order.js`). Exposed here —
  * rather than read in the handler — so the edge build inlines it the same way
  * it inlines the other static assets (the dynamic `/order.js` route prepends the
- * per-request catalog to this string). Returns the unencoded source text. */
-export const orderWidgetBody = (): string =>
-  Deno.readTextFileSync(join(staticDir, "order.js"));
+ * per-request catalog to this string). Returns the unencoded source text.
+ *
+ * The widget body never changes for the life of the process, and `/order.js` is
+ * hit on every embedding page load, so the file is read once and cached. (The
+ * edge build replaces this whole module with a pre-inlined constant; the cache
+ * only spares the per-request `readTextFileSync` on the Deno dev/Deploy path.) */
+export const orderWidgetBody = once((): string =>
+  Deno.readTextFileSync(join(staticDir, "order.js")),
+);

--- a/src/features/public/order-js.ts
+++ b/src/features/public/order-js.ts
@@ -40,17 +40,28 @@ const DISABLED_STUB =
 const DISALLOWED_STUB =
   'console.warn("Chobble Tickets: this site is not allowed to load the order library.");\nexport {};\n';
 
-const jsResponse = (body: string, headers: Record<string, string>): Response =>
-  // Pre-encode to bytes: Bunny Edge intermittently fails to decode raw string
-  // bodies, so all text responses go out as Uint8Array (see encodeBody).
-  new Response(encodeBody(body), {
+// Pre-encode the constant stub bodies once. `/order.js` is fetched on every
+// page that embeds the tag, and the no-catalog stubs (feature disabled, or a
+// denied origin) are the common case for a site that hasn't finished setup, so
+// the bytes are encoded at module load instead of on every request. The
+// encoded buffers are never mutated, so reusing them across responses is safe.
+const DISABLED_STUB_BODY = encodeBody(DISABLED_STUB);
+const DISALLOWED_STUB_BODY = encodeBody(DISALLOWED_STUB);
+
+// Pre-encode to bytes: Bunny Edge intermittently fails to decode raw string
+// bodies, so all text responses go out as Uint8Array (see encodeBody).
+const jsResponse = (
+  body: ArrayBuffer,
+  headers: Record<string, string>,
+): Response =>
+  new Response(body, {
     headers: { "content-type": JS_CONTENT_TYPE, ...headers },
   });
 
 /** Handle `GET /order.js`. */
 export const handleOrderJs = async (request: Request): Promise<Response> => {
   if (!settings.externalOrderEnabled) {
-    return jsResponse(DISABLED_STUB, {
+    return jsResponse(DISABLED_STUB_BODY, {
       "access-control-allow-origin": "*",
       "cache-control": "no-store",
     });
@@ -66,22 +77,29 @@ export const handleOrderJs = async (request: Request): Promise<Response> => {
   // evaluation, not the response body) and avoids the DB/decryption cost on
   // requests that could never use it.
   if (allowOrigin === null) {
-    return jsResponse(DISALLOWED_STUB, { "cache-control": "no-store" });
+    return jsResponse(DISALLOWED_STUB_BODY, { "cache-control": "no-store" });
   }
 
+  // Parse the request URL once: it supplies both the catalog origin and the
+  // `?debug=true` flag that turns on the widget's verbose console logging.
+  const url = new URL(request.url);
   const currency = settings.currency;
   const catalog = buildCatalog({
     currency,
+    debug: url.searchParams.get("debug") === "true",
     decimalPlaces: getDecimalPlaces(currency),
     generatedAt: nowIso(),
     listings: await getCatalogListings(),
-    origin: new URL(request.url).origin,
+    origin: url.origin,
   });
 
-  return jsResponse(`${serializeCatalog(catalog)}\n${orderWidgetBody()}`, {
-    "access-control-allow-origin": allowOrigin,
-    "cache-control": "no-store",
-    "cross-origin-resource-policy": "cross-origin",
-    vary: "Origin",
-  });
+  return jsResponse(
+    encodeBody(`${serializeCatalog(catalog)}\n${orderWidgetBody()}`),
+    {
+      "access-control-allow-origin": allowOrigin,
+      "cache-control": "no-store",
+      "cross-origin-resource-policy": "cross-origin",
+      vary: "Origin",
+    },
+  );
 };

--- a/src/shared/external-order.ts
+++ b/src/shared/external-order.ts
@@ -94,6 +94,10 @@ export interface Catalog {
   currency: string;
   decimalPlaces: number;
   generatedAt: string;
+  /** When true, the served widget emits verbose `console.debug` output so an
+   * integrator can see add-to-cart enhancement, cart state, and navigation as
+   * it happens. Toggled per request with `?debug=true` on `/order.js`. */
+  debug: boolean;
   listings: Record<string, CatalogListing>;
 }
 
@@ -133,9 +137,11 @@ export const buildCatalog = (params: {
   currency: string;
   decimalPlaces: number;
   generatedAt: string;
+  debug: boolean;
   listings: CatalogSourceListing[];
 }): Catalog => ({
   currency: params.currency,
+  debug: params.debug,
   decimalPlaces: params.decimalPlaces,
   generatedAt: params.generatedAt,
   listings: Object.fromEntries(

--- a/src/ui/client/order.ts
+++ b/src/ui/client/order.ts
@@ -27,6 +27,14 @@ import type {
 // Injected by the server immediately above this module body.
 declare const CATALOG: Catalog;
 
+/** Verbose console logging, gated on the `?debug=true` flag the server bakes
+ * into the catalog. Off by default so a production embed stays silent; on, it
+ * traces enhancement, cart mutations, and navigation to help an integrator see
+ * why their `data-add-listing` links aren't behaving. */
+const debugLog = (...args: unknown[]): void => {
+  if (CATALOG.debug) console.debug("[chobble-order]", ...args);
+};
+
 interface CartLine {
   slug: string;
   quantity: number;
@@ -126,6 +134,7 @@ class CartController {
       raw = sessionStorage.getItem(this.storageKey);
     } catch {
       this.memoryOnly = true;
+      debugLog("sessionStorage unavailable; cart is memory-only");
       return [];
     }
     if (!raw) return [];
@@ -136,6 +145,7 @@ class CartController {
       return Array.isArray(parsed) ? parsed.filter(isCartLine) : [];
     } catch {
       // Bad JSON from the host page — discard it but keep using storage.
+      debugLog("discarding corrupt stored cart");
       try {
         sessionStorage.removeItem(this.storageKey);
       } catch {
@@ -171,6 +181,7 @@ class CartController {
     }
     if (dropped) {
       this.notice = "Some items are no longer available and were removed.";
+      debugLog("reconcile dropped unavailable cart items");
     }
     return [...merged].map(([slug, quantity]) => ({ quantity, slug }));
   }
@@ -185,6 +196,7 @@ class CartController {
     this.save();
     this.render();
     this.bump();
+    debugLog("add", entry.slug, `x${quantity}`, "cart now", this.lines);
   }
 
   private setQuantity(slug: string, quantity: number): void {
@@ -316,6 +328,7 @@ class CartController {
     button.className = "continue";
     button.textContent = "Continue";
     button.addEventListener("click", () => {
+      debugLog("continue ->", url);
       if (url) globalThis.location.assign(url);
     });
     return button;
@@ -403,15 +416,26 @@ const init = (): void => {
     Record<string, unknown>
   >;
   const registry = (global[REGISTRY_KEY] ??= {});
-  if (registry[CATALOG.origin]) return;
+  if (registry[CATALOG.origin]) {
+    debugLog("already initialised for", CATALOG.origin);
+    return;
+  }
 
+  debugLog("init", {
+    listings: Object.keys(CATALOG.listings).length,
+    origin: CATALOG.origin,
+  });
   const controller = new CartController();
   registry[CATALOG.origin] = controller;
 
   const enhance = (link: HTMLAnchorElement): void => {
     if (link.dataset.chobbleEnhanced) return;
-    if (!resolveListing(link.dataset.addListing ?? "")) return;
+    if (!resolveListing(link.dataset.addListing ?? "")) {
+      debugLog("skipped un-enhanceable link", link.dataset.addListing);
+      return;
+    }
     link.dataset.chobbleEnhanced = "1";
+    debugLog("enhanced", link.dataset.addListing);
     link.addEventListener("click", (event) => {
       // Re-resolve at click time: an SPA may have repointed `data-add-listing`
       // since enhancement (re-scans skip already-enhanced links). If it now

--- a/test/lib/order-js.test.ts
+++ b/test/lib/order-js.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { spy } from "@std/testing/mock";
 import { handleRequest } from "#routes";
+import { orderWidgetBody } from "#routes/assets.ts";
 import { setChildIds } from "#shared/db/listing-parents.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -10,6 +12,9 @@ const orderJs = (origin?: string): Promise<Response> =>
   handleRequest(
     mockRequest("/order.js", origin ? { headers: { origin } } : {}),
   );
+
+const orderJsPath = (path: string): Promise<Response> =>
+  handleRequest(mockRequest(path));
 
 /** Slug of the created listing, looked up by name so the result is independent
  * of insertion order. */
@@ -43,6 +48,29 @@ describeWithEnv("order.js handler", { db: true, triggers: true }, () => {
     expect(body).toContain("const CATALOG");
     expect(body).toContain(slug);
     expect(body).toContain("isExternalOrderModule");
+  });
+
+  test("defaults the catalog debug flag off without the query param", async () => {
+    await settings.update.externalOrderEnabled(true);
+
+    const body = await (await orderJs()).text();
+    expect(body).toContain('"debug":false');
+    expect(body).not.toContain('"debug":true');
+  });
+
+  test("debug=true bakes the verbose-logging flag into the catalog", async () => {
+    await settings.update.externalOrderEnabled(true);
+
+    const body = await (await orderJsPath("/order.js?debug=true")).text();
+    expect(body).toContain('"debug":true');
+    expect(body).not.toContain('"debug":false');
+  });
+
+  test("a non-true debug value leaves verbose logging off", async () => {
+    await settings.update.externalOrderEnabled(true);
+
+    const body = await (await orderJsPath("/order.js?debug=1")).text();
+    expect(body).toContain('"debug":false');
   });
 
   test("marks a pay-what-you-want listing as variable-price in the catalog", async () => {
@@ -150,6 +178,21 @@ describeWithEnv("order.js handler", { db: true, triggers: true }, () => {
     expect(body).toContain("const CATALOG");
     expect(body).toContain(parent.slug);
     expect(body).not.toContain(child.slug);
+  });
+
+  test("caches the widget body so it is not re-read from disk per request", () => {
+    // The first call may or may not have already cached the body (test order is
+    // not fixed), so assert the invariant directly: a *subsequent* call must
+    // not hit the disk again. Without the cache, every call re-reads the file.
+    const readSpy = spy(Deno, "readTextFileSync");
+    try {
+      orderWidgetBody();
+      const afterFirst = readSpy.calls.length;
+      orderWidgetBody();
+      expect(readSpy.calls.length).toBe(afterFirst);
+    } finally {
+      readSpy.restore();
+    }
   });
 
   test("a non-/order.js path under the prefix is not handled (404)", async () => {

--- a/test/lib/order-widget.test.ts
+++ b/test/lib/order-widget.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Behavioural tests for the external-order widget (`src/ui/client/order.ts`,
+ * served as `/order.js`).
+ *
+ * The widget is browser code: it runs `init()` on load against `document`,
+ * `sessionStorage`, `MutationObserver`, etc. To exercise it in Deno we mirror
+ * exactly what the server does — prepend a `const CATALOG = …;` to the built
+ * bundle and run that script — but inside a fresh happy-dom `Window` per test,
+ * so each case starts from a clean DOM and storage. The bundle's trailing
+ * `export { … as isExternalOrderModule }` is rewritten to stash the function on
+ * a global so the test can still call it (a function body can't carry `export`).
+ *
+ * Running the real built bundle (not the TS source) is deliberate: the precommit
+ * mutation gate rebuilds that bundle per mutant, so these assertions bind to the
+ * code the browser actually receives.
+ */
+
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { spy } from "@std/testing/mock";
+import { Window } from "happy-dom";
+import { orderWidgetBody } from "#routes/assets.ts";
+import {
+  buildCatalog,
+  type CatalogSourceListing,
+  serializeCatalog,
+} from "#shared/external-order.ts";
+import { testListing } from "#test-utils/factories.ts";
+
+const ORIGIN = "https://tickets.test";
+const MODULE_MARKER = "__orderWidgetModule";
+
+/** The built bundle with its lone ESM export rewritten to a global assignment,
+ * so the otherwise module-only body runs under `new Function`. */
+const runnableBody = orderWidgetBody().replace(
+  /export\s*\{\s*(\w+)\s+as\s+isExternalOrderModule\s*\}\s*;?\s*$/,
+  `;globalThis.${MODULE_MARKER}=$1;`,
+);
+
+const makeCatalog = (listings: CatalogSourceListing[], debug: boolean) =>
+  buildCatalog({
+    currency: "GBP",
+    debug,
+    decimalPlaces: 2,
+    generatedAt: "2026-06-30T00:00:00Z",
+    listings,
+    origin: ORIGIN,
+  });
+
+interface AnimateCall {
+  keyframes: unknown;
+  options: unknown;
+}
+
+/** Per-test DOM + widget harness. Installs a fresh happy-dom into the globals
+ * the bundle reads, captures `console.debug`, navigation, animations, and focus,
+ * and runs the widget script. */
+const harness = () => {
+  const window = new Window({ url: `${ORIGIN}/` });
+  const document = window.document;
+  const logs: unknown[][] = [];
+  const navigations: string[] = [];
+  const animateCalls: AnimateCall[] = [];
+  const focusCalls: number[] = [];
+
+  // happy-dom has no Web Animations API; the widget's cart "bump" only needs the
+  // call to happen, so record it and return a benign stub.
+  (
+    window.HTMLElement.prototype as unknown as {
+      animate: (keyframes: unknown, options: unknown) => unknown;
+    }
+  ).animate = (keyframes: unknown, options: unknown) => {
+    animateCalls.push({ keyframes, options });
+    return {};
+  };
+  const realFocus = window.HTMLElement.prototype.focus;
+  window.HTMLElement.prototype.focus = function focusSpy(this: unknown) {
+    focusCalls.push(1);
+    return realFocus?.call(this);
+  };
+
+  const saved = new Map<string, PropertyDescriptor | undefined>();
+  const setGlobal = (key: string, value: unknown): void => {
+    if (!saved.has(key)) {
+      saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    }
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  };
+
+  setGlobal("document", document);
+  setGlobal("sessionStorage", window.sessionStorage);
+  setGlobal("MutationObserver", window.MutationObserver);
+  setGlobal("location", { assign: (url: string) => navigations.push(url) });
+
+  const origDebug = console.debug;
+  console.debug = (...args: unknown[]): void => {
+    logs.push(args);
+  };
+
+  const restore = (): void => {
+    console.debug = origDebug;
+    for (const [key, desc] of saved) {
+      if (desc) Object.defineProperty(globalThis, key, desc);
+      else delete (globalThis as Record<string, unknown>)[key];
+    }
+    delete (globalThis as Record<string, unknown>).__chobbleExternalOrder;
+    delete (globalThis as Record<string, unknown>)[MODULE_MARKER];
+  };
+
+  const setReadyState = (value: string): void => {
+    Object.defineProperty(document, "readyState", {
+      configurable: true,
+      get: () => value,
+    });
+  };
+
+  const run = (catalog: ReturnType<typeof makeCatalog>): void => {
+    new Function(`${serializeCatalog(catalog)}\n${runnableBody}`)();
+  };
+
+  // happy-dom delivers MutationObserver records via its async task manager;
+  // wait for those tasks to settle (and clear their timers) before asserting.
+  const flush = (): Promise<void> => window.happyDOM.waitUntilComplete();
+
+  const cleanup = async (): Promise<void> => {
+    await window.happyDOM.abort();
+    window.close();
+  };
+
+  return {
+    animateCalls,
+    cleanup,
+    document,
+    flush,
+    focusCalls,
+    logs,
+    navigations,
+    restore,
+    run,
+    setGlobal,
+    setReadyState,
+    window,
+  };
+};
+
+type Harness = ReturnType<typeof harness>;
+
+const listing = (
+  overrides: Partial<CatalogSourceListing> & { id: number; slug: string },
+): CatalogSourceListing => testListing(overrides);
+
+const setBody = (h: Harness, html: string): void => {
+  h.document.body.innerHTML = html;
+};
+
+const addLink = (slug: string, quantity?: string): string =>
+  `<a data-add-listing="${ORIGIN}/ticket/${slug}"${
+    quantity === undefined ? "" : ` data-add-quantity="${quantity}"`
+  }>Book ${slug}</a>`;
+
+// Minimal structural views of the happy-dom nodes the tests touch, so the file
+// needs neither the DOM lib (which would clash with happy-dom's own types) nor
+// `any`.
+interface Queryable {
+  querySelector(selector: string): QueryNode | null;
+  querySelectorAll(selector: string): ArrayLike<QueryNode>;
+}
+interface QueryNode extends Queryable {
+  textContent: string;
+  hidden: boolean;
+  open: boolean;
+  type: string;
+  getAttribute(name: string): string | null;
+  dispatchEvent(event: unknown): boolean;
+  click(): void;
+}
+
+const hostEl = (h: Harness) => h.document.querySelector("[data-chobble-order]");
+
+const shadow = (h: Harness): Queryable => {
+  const host = hostEl(h);
+  if (!host) throw new Error("widget host not mounted");
+  return (host as unknown as { shadowRoot: Queryable }).shadowRoot;
+};
+
+const cartButton = (h: Harness): QueryNode =>
+  shadow(h).querySelector(".cart-button") as QueryNode;
+
+const dialogEl = (h: Harness): QueryNode =>
+  shadow(h).querySelector("dialog") as QueryNode;
+
+const clickAnchor = (h: Harness, slug: string): boolean => {
+  const anchor = h.document.querySelector(
+    `a[data-add-listing="${ORIGIN}/ticket/${slug}"]`,
+  ) as unknown as QueryNode;
+  const event = new h.window.MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+  });
+  anchor.dispatchEvent(event);
+  return (event as unknown as { defaultPrevented: boolean }).defaultPrevented;
+};
+
+const clickIn = (root: Queryable, selector: string): void => {
+  (root.querySelector(selector) as QueryNode).click();
+};
+
+const openCart = (h: Harness): QueryNode => {
+  cartButton(h).click();
+  return dialogEl(h);
+};
+
+const logHas = (h: Harness, first: string): boolean =>
+  h.logs.some((entry) => entry[1] === first);
+
+/** The `type` property of a button matched in the shadow root. */
+const buttonType = (root: Queryable, selector: string): string =>
+  (root.querySelector(selector) as QueryNode).type;
+
+const textOf = (root: Queryable, selector: string): string | undefined =>
+  (root.querySelector(selector) as QueryNode | null)?.textContent;
+
+const storedCart = (h: Harness): unknown => {
+  const raw = h.window.sessionStorage.getItem(
+    `tickets:external-order:v1:${ORIGIN}`,
+  );
+  return raw === null ? null : JSON.parse(raw);
+};
+
+/** Mount the widget with a single enhanceable "open" listing in the page. */
+const mountOpenListing = (h: Harness, debug = false): void => {
+  setBody(h, addLink("open"));
+  h.run(makeCatalog([listing({ id: 1, slug: "open" })], debug));
+};
+
+/** Mount, add one "open" ticket, and open the cart dialog. */
+const openCartWithOne = (h: Harness): QueryNode => {
+  mountOpenListing(h);
+  clickAnchor(h, "open");
+  return openCart(h);
+};
+
+const stepperButtons = (dialog: Queryable): QueryNode[] =>
+  Array.from(dialog.querySelectorAll(".stepper button")) as QueryNode[];
+
+/** Install a stubbed `sessionStorage` and return the array its `setItem` records
+ * (`failSet` makes every write throw after recording). */
+const stubStorage = (
+  h: Harness,
+  handlers: {
+    getItem: () => string | null;
+    removeItem?: () => void;
+    failSet?: boolean;
+  },
+): unknown[] => {
+  const setCalls: unknown[] = [];
+  h.setGlobal("sessionStorage", {
+    getItem: handlers.getItem,
+    removeItem: handlers.removeItem ?? (() => {}),
+    setItem: (key: string, value: string) => {
+      setCalls.push([key, value]);
+      if (handlers.failSet) throw new Error("write failed");
+    },
+  });
+  return setCalls;
+};
+
+// happy-dom's `Window` starts internal async tasks/timers (its task manager and
+// MutationObserver delivery) that no public teardown — `abort()`, `close()`,
+// `waitUntilComplete()` — fully clears, so Deno's op/resource sanitizers flag
+// them as leaks under the coverage runner. They are confined to the emulated
+// DOM and torn down in `afterEach`; disable the sanitizers for this suite only.
+describe("order widget", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = harness();
+  });
+
+  afterEach(async () => {
+    h.restore();
+    await h.cleanup();
+  });
+
+  test("mounts a shadow-root host and enhances only catalog links", () => {
+    setBody(
+      h,
+      addLink("open") +
+        `<a data-add-listing="https://evil.test/ticket/open">x</a>` +
+        `<a data-add-listing="not a url">y</a>` +
+        `<a data-add-listing="${ORIGIN}/ticket/missing">z</a>`,
+    );
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], true));
+
+    expect(hostEl(h)).not.toBeNull();
+    const anchors = h.document.querySelectorAll("a");
+    expect(anchors[0]!.getAttribute("data-chobble-enhanced")).toBe("1");
+    expect(anchors[1]!.getAttribute("data-chobble-enhanced")).toBeNull();
+    expect(anchors[2]!.getAttribute("data-chobble-enhanced")).toBeNull();
+    expect(anchors[3]!.getAttribute("data-chobble-enhanced")).toBeNull();
+  });
+
+  test("logs init, enhancement, and skips when debug is on", () => {
+    setBody(h, `${addLink("open")}<a data-add-listing="bad">y</a>`);
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], true));
+
+    expect(h.logs[0]).toEqual([
+      "[chobble-order]",
+      "init",
+      { listings: 1, origin: ORIGIN },
+    ]);
+    expect(logHas(h, "enhanced")).toBe(true);
+    expect(logHas(h, "skipped un-enhanceable link")).toBe(true);
+  });
+
+  test("stays silent when debug is off", () => {
+    mountOpenListing(h);
+    clickAnchor(h, "open");
+
+    expect(h.logs).toHaveLength(0);
+  });
+
+  test("adding a listing reveals the cart button with a live count", () => {
+    mountOpenListing(h, true);
+
+    // Scoped styles are mounted into the shadow root.
+    expect(shadow(h).querySelector("style")).not.toBeNull();
+    expect(buttonType(shadow(h), ".cart-button")).toBe("button");
+    expect(cartButton(h).hidden).toBe(true);
+    const prevented = clickAnchor(h, "open");
+
+    expect(prevented).toBe(true);
+    expect(cartButton(h).hidden).toBe(false);
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("1");
+    expect(cartButton(h).getAttribute("aria-label")).toBe(
+      "View ticket cart, 1 item",
+    );
+    expect(h.animateCalls).toHaveLength(1);
+    expect(logHas(h, "add")).toBe(true);
+  });
+
+  test("renders accessible cart chrome with typed buttons", () => {
+    setBody(h, addLink("open"));
+    h.run(
+      makeCatalog([listing({ id: 1, name: "Open Day", slug: "open" })], false),
+    );
+    clickAnchor(h, "open");
+    const dialog = openCart(h);
+
+    expect(textOf(dialog, "h2")).toBe("Your tickets");
+    expect(textOf(dialog, ".row .name")).toBe("Open Day");
+
+    expect(buttonType(dialog, ".continue")).toBe("button");
+    expect(buttonType(dialog, ".close")).toBe("button");
+    const steppers = stepperButtons(dialog);
+    expect(steppers.map((b) => b.type)).toEqual(["button", "button", "button"]);
+    expect(steppers[0]!.getAttribute("aria-label")).toBe("Decrease quantity");
+    expect(steppers[1]!.getAttribute("aria-label")).toBe("Increase quantity");
+  });
+
+  test("data-add-quantity adds the requested count, pluralising the label", () => {
+    setBody(h, addLink("open", "3"));
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+    clickAnchor(h, "open");
+
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("3");
+    expect(cartButton(h).getAttribute("aria-label")).toBe(
+      "View ticket cart, 3 items",
+    );
+  });
+
+  test("an invalid data-add-quantity falls back to one", () => {
+    setBody(h, addLink("open", "0") + addLink("dup", "2.5"));
+    h.run(
+      makeCatalog(
+        [listing({ id: 1, slug: "open" }), listing({ id: 2, slug: "dup" })],
+        false,
+      ),
+    );
+    clickAnchor(h, "open");
+    clickAnchor(h, "dup");
+
+    expect(shadow(h).querySelector(".count")!.textContent).toBe("2");
+  });
+
+  test("clicking the same listing twice increments the existing line", () => {
+    setBody(h, addLink("open"));
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+    clickAnchor(h, "open");
+    clickAnchor(h, "open");
+
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("2");
+  });
+
+  test("persists the cart to sessionStorage under an origin-scoped key", () => {
+    mountOpenListing(h);
+    clickAnchor(h, "open");
+
+    expect(storedCart(h)).toEqual([{ quantity: 1, slug: "open" }]);
+  });
+
+  test("reloads a stored cart and shows fixed and variable subtotals", () => {
+    h.window.sessionStorage.setItem(
+      `tickets:external-order:v1:${ORIGIN}`,
+      JSON.stringify([
+        { quantity: 2, slug: "fixed" },
+        { quantity: 1, slug: "pwyw" },
+      ]),
+    );
+    h.run(
+      makeCatalog(
+        [
+          listing({ id: 1, slug: "fixed", unit_price: 1500 }),
+          listing({ can_pay_more: true, id: 2, slug: "pwyw", unit_price: 500 }),
+        ],
+        false,
+      ),
+    );
+    // Nothing was dropped, so no notice is rendered at construction. (Checked
+    // before opening: a re-render would clear a stale notice and hide the bug.)
+    expect(shadow(h).querySelector(".notice")).toBeNull();
+    const dialog = openCart(h);
+
+    // formatMoney strips trailing zeros for whole amounts (stripIfInteger).
+    expect(
+      (dialog.querySelector(".subtotal") as { textContent: string })
+        .textContent,
+    ).toBe("Subtotal from £30");
+    const prices = Array.from(
+      dialog.querySelectorAll(".price"),
+      (el) => (el as { textContent: string }).textContent,
+    );
+    expect(prices).toEqual(["£30", "Price set at checkout"]);
+    expect(
+      (dialog.querySelector(".caveat") as { textContent: string }).textContent,
+    ).toContain("confirmed at checkout");
+  });
+
+  test("a fixed-only cart shows a plain subtotal", () => {
+    setBody(h, addLink("open"));
+    h.run(
+      makeCatalog([listing({ id: 1, slug: "open", unit_price: 250 })], false),
+    );
+    clickAnchor(h, "open");
+    const dialog = openCart(h);
+
+    expect(
+      (dialog.querySelector(".subtotal") as { textContent: string })
+        .textContent,
+    ).toBe("Subtotal £2.50");
+  });
+
+  test("the stepper raises, lowers, and removes a line", () => {
+    const dialog = openCartWithOne(h);
+
+    // Order: decrease, increase, remove.
+    stepperButtons(dialog)[1]!.click(); // increase -> 2
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("2");
+    // setQuantity persists the new quantity to storage.
+    expect(storedCart(h)).toEqual([{ quantity: 2, slug: "open" }]);
+    stepperButtons(dialog)[0]!.click(); // decrease -> 1
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("1");
+  });
+
+  test("the remove button clears the line entirely", () => {
+    mountOpenListing(h);
+    clickAnchor(h, "open");
+    clickAnchor(h, "open");
+    const dialog = openCart(h);
+
+    stepperButtons(dialog)[2]!.click(); // the "Remove" button -> onChange(0)
+
+    expect(cartButton(h).hidden).toBe(true);
+    expect(storedCart(h)).toEqual([]);
+  });
+
+  test("decreasing to zero removes the line and empties the cart", () => {
+    const dialog = openCartWithOne(h);
+    clickIn(dialog, ".stepper button"); // decrease 1 -> 0 removes
+
+    expect(cartButton(h).hidden).toBe(true);
+    const paras = Array.from(
+      dialog.querySelectorAll("p"),
+      (el) => (el as { textContent: string }).textContent,
+    );
+    expect(paras).toContain("Your cart is empty.");
+    expect(dialog.querySelector(".subtotal")).toBeNull();
+  });
+
+  test("Continue navigates to the canonical ticket URL with quantities", () => {
+    setBody(h, addLink("a") + addLink("b"));
+    h.run(
+      makeCatalog(
+        [listing({ id: 11, slug: "a" }), listing({ id: 22, slug: "b" })],
+        true,
+      ),
+    );
+    clickAnchor(h, "a");
+    clickAnchor(h, "b");
+    clickAnchor(h, "b");
+    const dialog = openCart(h);
+    clickIn(dialog, ".continue");
+
+    expect(h.navigations).toEqual([`${ORIGIN}/ticket/a+b?q_11=1&q_22=2`]);
+    expect(logHas(h, "continue ->")).toBe(true);
+  });
+
+  test("Continue with an empty cart does not navigate", () => {
+    setBody(h, "");
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+    // Open via the cart button is impossible when hidden; render directly by
+    // adding then removing leaves the empty branch with no Continue button.
+    const empty = openCart(h);
+    expect(empty.querySelector(".continue")).toBeNull();
+    expect(h.navigations).toEqual([]);
+  });
+
+  test("the close button and the dialog close event return focus", () => {
+    const dialog = openCartWithOne(h);
+    expect(dialog.open).toBe(true);
+
+    clickIn(dialog, ".close");
+    expect(dialog.open).toBe(false);
+
+    dialog.dispatchEvent(new h.window.Event("close"));
+    expect(h.focusCalls.length).toBeGreaterThan(0);
+  });
+
+  test("drops stored items no longer in the catalog and notes it once", () => {
+    h.window.sessionStorage.setItem(
+      `tickets:external-order:v1:${ORIGIN}`,
+      JSON.stringify([
+        { quantity: 1, slug: "gone" },
+        { quantity: 2, slug: "open" },
+      ]),
+    );
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], true));
+
+    expect(logHas(h, "reconcile dropped unavailable cart items")).toBe(true);
+    // The drop notice is rendered at construction (a subsequent re-render clears
+    // it), so read it straight from the cart body rather than after re-opening.
+    expect(
+      (shadow(h).querySelector(".notice") as { textContent: string })
+        .textContent,
+    ).toBe("Some items are no longer available and were removed.");
+    // The reconciled cart is re-saved without the dropped slug.
+    expect(storedCart(h)).toEqual([{ quantity: 2, slug: "open" }]);
+    // The notice is shown once: re-opening the cart re-renders without it.
+    const dialog = openCart(h);
+    expect(dialog.querySelector(".notice")).toBeNull();
+  });
+
+  test("merges duplicate stored lines for the same slug", () => {
+    h.window.sessionStorage.setItem(
+      `tickets:external-order:v1:${ORIGIN}`,
+      JSON.stringify([
+        { quantity: 1, slug: "open" },
+        { quantity: 2, slug: "open" },
+      ]),
+    );
+    h.run(makeCatalog([listing({ id: 7, slug: "open" })], false));
+
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("3");
+    const dialog = openCart(h);
+    clickIn(dialog, ".continue");
+    expect(h.navigations).toEqual([`${ORIGIN}/ticket/open?q_7=3`]);
+  });
+
+  test("keeps only well-formed stored cart lines", () => {
+    h.window.sessionStorage.setItem(
+      `tickets:external-order:v1:${ORIGIN}`,
+      JSON.stringify([
+        null,
+        { quantity: 1, slug: "open" },
+        { slug: "open" },
+        { quantity: -1, slug: "open" },
+        { quantity: 2.5, slug: "open" },
+        { quantity: 1 },
+      ]),
+    );
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("1");
+  });
+
+  test("ignores a non-array stored value", () => {
+    h.window.sessionStorage.setItem(
+      `tickets:external-order:v1:${ORIGIN}`,
+      JSON.stringify({ quantity: 1, slug: "open" }),
+    );
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+
+    expect(hostEl(h)).not.toBeNull();
+    expect(shadow(h).querySelector(".cart-button")).not.toBeNull();
+    expect(cartButton(h).hidden).toBe(true);
+  });
+
+  test("discards a corrupt stored cart but keeps using storage", () => {
+    const key = `tickets:external-order:v1:${ORIGIN}`;
+    h.window.sessionStorage.setItem(key, "{not json");
+    const removeSpy = spy(h.window.sessionStorage, "removeItem");
+    mountOpenListing(h, true);
+
+    expect(logHas(h, "discarding corrupt stored cart")).toBe(true);
+    // The corrupt entry is actively removed before storage is reused.
+    expect(removeSpy.calls.map((c) => c.args[0])).toContain(key);
+    // The corrupt value is dropped; the reconciled empty cart is re-saved over
+    // it, proving storage is still in use (not memory-only).
+    expect(JSON.parse(h.window.sessionStorage.getItem(key)!)).toEqual([]);
+
+    clickAnchor(h, "open");
+    expect(JSON.parse(h.window.sessionStorage.getItem(key)!)).toEqual([
+      { quantity: 1, slug: "open" },
+    ]);
+  });
+
+  test("falls back to memory-only when storage reads throw", () => {
+    const setCalls = stubStorage(h, {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    mountOpenListing(h, true);
+
+    expect(logHas(h, "sessionStorage unavailable; cart is memory-only")).toBe(
+      true,
+    );
+    // memoryOnly suppresses every write; the cart still works in memory.
+    clickAnchor(h, "open");
+    expect(setCalls).toEqual([]);
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("1");
+  });
+
+  test("goes memory-only when a corrupt cart cannot be cleared", () => {
+    const setCalls = stubStorage(h, {
+      getItem: () => "{not json",
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    mountOpenListing(h);
+
+    clickAnchor(h, "open");
+    expect(setCalls).toEqual([]);
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("1");
+  });
+
+  test("stops retrying writes once a save fails", () => {
+    const setCalls = stubStorage(h, { failSet: true, getItem: () => null });
+    mountOpenListing(h);
+    // The constructor's save attempt flips to memory-only; later adds must not
+    // retry the failing write.
+    const afterInit = setCalls.length;
+    clickAnchor(h, "open");
+
+    expect(setCalls.length).toBe(afterInit);
+    expect(cartButton(h).querySelector(".count")!.textContent).toBe("1");
+  });
+
+  test("a second init for the same origin is a no-op", () => {
+    setBody(h, addLink("open"));
+    const catalog = makeCatalog([listing({ id: 1, slug: "open" })], true);
+    h.run(catalog);
+    h.run(catalog);
+
+    expect(h.document.querySelectorAll("[data-chobble-order]")).toHaveLength(1);
+    expect(logHas(h, "already initialised for")).toBe(true);
+  });
+
+  test("runs init immediately when the document is already parsed", () => {
+    h.setReadyState("complete");
+    setBody(h, addLink("open"));
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+
+    expect(hostEl(h)).not.toBeNull();
+  });
+
+  test("defers init to DOMContentLoaded while the document is loading", () => {
+    h.setReadyState("loading");
+    setBody(h, addLink("open"));
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+
+    expect(hostEl(h)).toBeNull();
+    h.document.dispatchEvent(new h.window.Event("DOMContentLoaded"));
+    expect(hostEl(h)).not.toBeNull();
+  });
+
+  test("enhances direct and nested links added after load", async () => {
+    setBody(h, "<section></section>");
+    h.run(makeCatalog([listing({ id: 1, slug: "late" })], false));
+
+    h.document.body.insertAdjacentHTML("beforeend", addLink("late"));
+    h.document
+      .querySelector("section")!
+      .insertAdjacentHTML("beforeend", addLink("late"));
+    await h.flush();
+
+    const enhanced = Array.from(
+      h.document.querySelectorAll("a[data-chobble-enhanced]"),
+    );
+    expect(enhanced).toHaveLength(2);
+  });
+
+  test("observes deep subtree insertions, not just body's children", async () => {
+    setBody(h, "<div><p></p></div>");
+    h.run(makeCatalog([listing({ id: 1, slug: "deep" })], false));
+
+    // Mutate only a deeply nested node — no direct child of <body> changes — so
+    // the observer must be watching the subtree, not just body's children.
+    h.document
+      .querySelector("p")!
+      .insertAdjacentHTML("beforeend", addLink("deep"));
+    await h.flush();
+
+    expect(h.document.querySelector("a[data-chobble-enhanced]")).not.toBeNull();
+  });
+
+  test("re-resolves at click time and ignores a now-foreign link", () => {
+    setBody(h, addLink("open"));
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], false));
+    const anchor = h.document.querySelector("a")!;
+    anchor.setAttribute("data-add-listing", `${ORIGIN}/ticket/unknown`);
+
+    const prevented = clickAnchor(h, "unknown");
+    expect(prevented).toBe(false);
+    expect(cartButton(h).hidden).toBe(true);
+  });
+
+  test("keeps module-only syntax via the exported marker", () => {
+    setBody(h, "");
+    h.run(makeCatalog([], false));
+    const marker = (globalThis as Record<string, unknown>)[MODULE_MARKER] as
+      | (() => boolean)
+      | undefined;
+    expect(marker?.()).toBe(true);
+  });
+});

--- a/test/shared/external-order.test.ts
+++ b/test/shared/external-order.test.ts
@@ -9,6 +9,7 @@ import { testListing } from "#test-utils/factories.ts";
 
 const base = {
   currency: "GBP",
+  debug: false,
   decimalPlaces: 2,
   generatedAt: "2026-06-28T20:00:00Z",
   origin: "https://tickets.test",
@@ -56,8 +57,23 @@ describe("external-order", () => {
       ).toBeNull();
     });
 
+    test("wildcard requires a dot boundary, not just the suffix text", () => {
+      // `bbexample.com` ends with `example.com` but not with the `.example.com`
+      // the wildcard demands — the host-length check alone would wrongly allow
+      // it, so the boundary `&&` must hold.
+      expect(
+        resolveAllowOrigin("https://bbexample.com", ["*.example.com"]),
+      ).toBeNull();
+    });
+
     test("rejects a missing origin against a non-empty list", () => {
       expect(resolveAllowOrigin(null, ["example.com"])).toBeNull();
+    });
+
+    test("rejects an empty-string origin against a non-empty list", () => {
+      // An empty `Origin` header is falsy but still a string; it must be denied
+      // (null), not echoed back as the allowed origin.
+      expect(resolveAllowOrigin("", ["example.com"])).toBeNull();
     });
 
     test("rejects a malformed origin", () => {
@@ -87,6 +103,12 @@ describe("external-order", () => {
       expect(catalog.currency).toBe("GBP");
       expect(catalog.decimalPlaces).toBe(2);
       expect(catalog.generatedAt).toBe("2026-06-28T20:00:00Z");
+      expect(catalog.debug).toBe(false);
+    });
+
+    test("carries the debug flag through to the catalog", () => {
+      const catalog = buildCatalog({ ...base, debug: true, listings: [] });
+      expect(catalog.debug).toBe(true);
     });
 
     test("flags variablePrice for daily, customisable-days, and PWYW", () => {


### PR DESCRIPTION
## What & why

The dynamically-served `/order.js` external-order widget is fetched on **every** embedding page load, so this PR (a) adds an opt-in debug mode for integrators and (b) tightens the per-request code path around it.

> Note: there is no `quote.js` in the repo — the only dynamically-created JS file is `/order.js` (built from `src/ui/client/order.ts`, with a per-request `CATALOG` prepended by `src/features/public/order-js.ts`). That's the file this PR targets, confirmed with the requester.

## Debug logging

- `GET /order.js?debug=true` bakes a `debug` flag into the embedded `CATALOG`, and the widget emits verbose `console.debug` output — init summary, which `data-add-listing` links were enhanced/skipped, cart adds, Continue navigation, and the storage fallbacks. This is what an integrator sees in their own browser console when debugging an embed.
- **Off by default** — a production embed stays silent. A non-`true` value (e.g. `?debug=1`) leaves it off.

## Efficiency around the dynamic route

- **Memoize the widget body** with `once()` — read from disk once per process instead of `Deno.readTextFileSync` on every request. (The edge build already inlines it as a constant; this only helps the Deno dev/Deploy path.)
- **Pre-encode the constant stub bodies** (feature-disabled / disallowed-origin) once at module load instead of re-encoding the same bytes per request — these are the common case for a site that hasn't finished setup.
- **Parse the request URL once** for both the catalog origin and the debug flag.

## Testing

- New behavioural suite `test/lib/order-widget.test.ts` runs the **real built bundle** in a happy-dom DOM, prepending `CATALOG` exactly as the server does. This brings the previously-untested widget to a **100% mutation kill** (133 mutants killed; 40 genuinely-equivalent operator swaps — `=`→`+=` on fresh-element `.textContent`/`.className`, boolean truthiness coercions, and `??`→`||` where the operand is never falsy-non-null — recorded in `scripts/mutation/equivalent-mutants.txt`).
- Added coverage for the new `debug` flag (route + `buildCatalog`) and the body-read memoization.
- Closed two pre-existing mutation gaps in `external-order.ts` that came into scope with the change: the wildcard-host dot boundary, and rejecting an empty-string `Origin`.
- happy-dom's `Window` starts internal async tasks/timers that no public teardown clears, so the op/resource sanitizers are scoped off for that one suite (DOM is torn down in `afterEach`).

`deno task precommit` passes — lint, typecheck, jscpd (0%), build:edge, full test suite + 100% coverage, and the mutation gate (149/149 killed, 40 suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKeTJxq6YwUrjFB4CoFJq)_