### PR TITLE
Fix flaky tests at the source (no parallelism changes)

### DIFF
--- a/src/shared/accounting/adjustments.ts
+++ b/src/shared/accounting/adjustments.ts
@@ -28,10 +28,14 @@ import { nowIso } from "#shared/now.ts";
  * `delta` (in "credit-the-account" terms), or `null` for a zero delta (which
  * posts nothing). Shared by the own-transaction and in-transaction posters so
  * the leg's direction, amount, and reference derivation live in exactly one
- * place. Each save is its own business event — a fresh `nowIso()` is mixed into
- * the `eventGroup`/`reference` — so editing a figure up, down, then back up
- * posts three distinct adjustments rather than colliding on an earlier event's
- * references.
+ * place. Each save is its own business event — both the `delta` and a fresh
+ * `nowIso()` are mixed into the `eventGroup`/`reference` — so editing a figure
+ * up, down, then back up posts three distinct adjustments rather than colliding
+ * on an earlier event's references. The `delta` is part of the key because
+ * `nowIso()` is only millisecond-resolution: two opposite corrections of the
+ * same figure (a raise then a lower) posted within the same millisecond would
+ * otherwise share `[...keyParts, occurredAt]` and the second would be dropped by
+ * the `INSERT OR IGNORE`; including the (signed) delta keeps them distinct.
  */
 const writeoffAdjustmentLeg = async (
   account: AccountRef,
@@ -40,7 +44,7 @@ const writeoffAdjustmentLeg = async (
 ): Promise<TransferInput | null> => {
   if (delta === 0) return null;
   const occurredAt = nowIso();
-  const parts: RefPart[] = [...keyParts, occurredAt];
+  const parts: RefPart[] = [...keyParts, delta, occurredAt];
   return {
     amount: Math.abs(delta),
     // Crediting the account sources from writeoff (the figure rises);

--- a/test/lib/accounting/adjustments.test.ts
+++ b/test/lib/accounting/adjustments.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import { revenueAccount, WRITEOFF } from "#shared/accounting/accounts.ts";
 import { writeoffAdjustmentInserts } from "#shared/accounting/adjustments.ts";
 import { accountBalance, allTransfers } from "#shared/accounting/queries.ts";
@@ -61,6 +62,22 @@ describe("db > accounting > postWriteoffAdjustment", () => {
     expect(all.length).toBe(2);
     // The two corrections net the account back to zero.
     expect(await accountBalance(revenue)).toBe(0);
+  });
+
+  test("two opposite corrections in the same millisecond both post", async () => {
+    // Freeze the clock so both posts share one millisecond `occurredAt`. Because
+    // the signed delta is part of the reference, the raise and the lower hash
+    // differently and both land — without it they would collide on
+    // `[...keyParts, occurredAt]` and INSERT OR IGNORE would drop the second.
+    const time = new FakeTime(new Date("2026-06-21T00:00:00.000Z"));
+    try {
+      await postWriteoffAdjustment(revenue, 1000, ["income-adjust", 7]);
+      await postWriteoffAdjustment(revenue, -1000, ["income-adjust", 7]);
+      expect((await allTransfers()).length).toBe(2);
+      expect(await accountBalance(revenue)).toBe(0);
+    } finally {
+      time.restore();
+    }
   });
 
   test("the writeoff account mirrors the opposite of the adjusted figure", async () => {


### PR DESCRIPTION
## Why

The full test suite is intermittently red: across repeated CI reruns of an unchanged commit, a *different* single test fails each time (≈1 failure in 12,400+). This PR fixes the underlying nondeterminism at the source, **without** disabling `--parallel` or otherwise masking the problem.

## Fix #1 — ledger adjustment same-millisecond collision

`test/lib/accounting/adjustments.test.ts` → "repeated edits of the same figure each post a distinct event" was flaky.

**Root cause:** a writeoff adjustment's idempotency reference was `[...keyParts, occurredAt]`, where `occurredAt = nowIso()` is only millisecond-resolution and the **delta was not part of the key**. Two opposite corrections of the same figure (a raise `+1000` then a lower `−1000`) posted within the same millisecond produced identical `eventGroup`/`legReference` digests, so the second leg was silently dropped by `INSERT OR IGNORE` — yielding 1 transfer instead of 2 whenever the two posts happened to land in the same millisecond.

**Fix:** include the signed `delta` in the reference parts (`src/shared/accounting/adjustments.ts`). Opposite/different corrections now stay distinct regardless of clock resolution; `occurredAt` is kept so that same-`delta` edits across time also remain distinct (e.g. up, down, up). References are opaque HMAC digests, so this is an internal change with no migration impact and no effect on balances.

**Regression test:** a new deterministic test freezes the clock with `FakeTime` and posts a raise then a lower in a single instant, asserting both legs land — it fails without the fix and passes with it.

## Notes

- No change to `--parallel` or the test runner.
- This is the first of potentially several flaky-source fixes; further intermittent tests (e.g. some `public.test.ts` render cases and a `routes/api.test.ts` availability case) are still under investigation and, if they turn out to need code changes, will be added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZAky434H6h2jzEudEqcPU)_