### PR TITLE
Standardize FakeTime clock restoration on `using` in tests

### DIFF
--- a/test/admin-built-sites-actions.test.ts
+++ b/test/admin-built-sites-actions.test.ts
@@ -50,21 +50,17 @@ const expectBumpClamps = async (
   months: string,
   expectedMonths: number,
 ): Promise<void> => {
-  const fakeTime = new FakeTime(NOW_MS);
-  try {
-    const site = await createTestBuiltSite({
-      hostingId: scriptId,
-      name: siteName,
-    });
-    const { response } = await siteAction(site, "bump-deadline", { months });
-    expect(response.status).toBe(302);
-    const updated = await findSite(site.id);
-    expect(updated.readOnlyFrom).toBe(
-      addMonthsIso(new Date(NOW_MS).toISOString(), expectedMonths),
-    );
-  } finally {
-    fakeTime.restore();
-  }
+  using _fakeTime = new FakeTime(NOW_MS);
+  const site = await createTestBuiltSite({
+    hostingId: scriptId,
+    name: siteName,
+  });
+  const { response } = await siteAction(site, "bump-deadline", { months });
+  expect(response.status).toBe(302);
+  const updated = await findSite(site.id);
+  expect(updated.readOnlyFrom).toBe(
+    addMonthsIso(new Date(NOW_MS).toISOString(), expectedMonths),
+  );
 };
 
 describeWithEnv("admin built-sites actions", { db: true }, () => {
@@ -176,69 +172,57 @@ describeWithEnv("admin built-sites actions", { db: true }, () => {
 
   describe("POST /admin/built-sites/:id/bump-deadline", () => {
     test("bumps from current deadline on future-dated site", async () => {
-      const fakeTime = new FakeTime(NOW_MS);
-      try {
-        const site = await createTestBuiltSite({
-          hostingId: "6010",
-          name: "Bump Future",
-        });
-        await updateBuiltSiteRenewalState(site.id, {
-          readOnlyFrom: new Date(NOW_MS + 10 * 86400000).toISOString(),
-        });
+      using _fakeTime = new FakeTime(NOW_MS);
+      const site = await createTestBuiltSite({
+        hostingId: "6010",
+        name: "Bump Future",
+      });
+      await updateBuiltSiteRenewalState(site.id, {
+        readOnlyFrom: new Date(NOW_MS + 10 * 86400000).toISOString(),
+      });
 
-        await adminFormPost(`/admin/built-sites/${site.id}/bump-deadline`, {
-          months: "3",
-        });
+      await adminFormPost(`/admin/built-sites/${site.id}/bump-deadline`, {
+        months: "3",
+      });
 
-        const updated = await findSite(site.id);
-        const expectedBase = new Date(NOW_MS + 10 * 86400000).toISOString();
-        expect(updated.readOnlyFrom).toBe(addMonthsIso(expectedBase, 3));
-      } finally {
-        fakeTime.restore();
-      }
+      const updated = await findSite(site.id);
+      const expectedBase = new Date(NOW_MS + 10 * 86400000).toISOString();
+      expect(updated.readOnlyFrom).toBe(addMonthsIso(expectedBase, 3));
     });
 
     test("bumps from now on expired site", async () => {
-      const fakeTime = new FakeTime(NOW_MS);
-      try {
-        const site = await createTestBuiltSite({
-          hostingId: "6011",
-          name: "Bump Expired",
-        });
-        await updateBuiltSiteRenewalState(site.id, {
-          readOnlyFrom: new Date(NOW_MS - 30 * 86400000).toISOString(),
-        });
+      using _fakeTime = new FakeTime(NOW_MS);
+      const site = await createTestBuiltSite({
+        hostingId: "6011",
+        name: "Bump Expired",
+      });
+      await updateBuiltSiteRenewalState(site.id, {
+        readOnlyFrom: new Date(NOW_MS - 30 * 86400000).toISOString(),
+      });
 
-        await adminFormPost(`/admin/built-sites/${site.id}/bump-deadline`, {
-          months: "6",
-        });
+      await adminFormPost(`/admin/built-sites/${site.id}/bump-deadline`, {
+        months: "6",
+      });
 
-        const updated = await findSite(site.id);
-        const expected = addMonthsIso(new Date(NOW_MS).toISOString(), 6);
-        expect(updated.readOnlyFrom).toBe(expected);
-      } finally {
-        fakeTime.restore();
-      }
+      const updated = await findSite(site.id);
+      const expected = addMonthsIso(new Date(NOW_MS).toISOString(), 6);
+      expect(updated.readOnlyFrom).toBe(expected);
     });
 
     test("bumps from now on deadline-less site", async () => {
-      const fakeTime = new FakeTime(NOW_MS);
-      try {
-        const site = await createTestBuiltSite({
-          hostingId: "6012",
-          name: "Bump No Deadline",
-        });
+      using _fakeTime = new FakeTime(NOW_MS);
+      const site = await createTestBuiltSite({
+        hostingId: "6012",
+        name: "Bump No Deadline",
+      });
 
-        await adminFormPost(`/admin/built-sites/${site.id}/bump-deadline`, {
-          months: "2",
-        });
+      await adminFormPost(`/admin/built-sites/${site.id}/bump-deadline`, {
+        months: "2",
+      });
 
-        const updated = await findSite(site.id);
-        const expected = addMonthsIso(new Date(NOW_MS).toISOString(), 2);
-        expect(updated.readOnlyFrom).toBe(expected);
-      } finally {
-        fakeTime.restore();
-      }
+      const updated = await findSite(site.id);
+      const expected = addMonthsIso(new Date(NOW_MS).toISOString(), 2);
+      expect(updated.readOnlyFrom).toBe(expected);
     });
 
     test("works without a renewal token (no RENEWAL_URL push)", async () => {

--- a/test/lib/csrf.test.ts
+++ b/test/lib/csrf.test.ts
@@ -107,20 +107,12 @@ describe("verifySignedCsrfToken", () => {
     // of "now"; FakeTime cannot move backwards, so verify under a separate
     // present-time clock. The gap (decades) far exceeds the 60s skew window.
     const signedInFuture = await (async () => {
-      const future = new FakeTime(4_000_000_000_000);
-      try {
-        return await signCsrfToken();
-      } finally {
-        future.restore();
-      }
+      using _future = new FakeTime(4_000_000_000_000);
+      return await signCsrfToken();
     })();
 
-    const present = new FakeTime(1_700_000_000_000);
-    try {
-      expect(await verifySignedCsrfToken(signedInFuture)).toBe(false);
-    } finally {
-      present.restore();
-    }
+    using _present = new FakeTime(1_700_000_000_000);
+    expect(await verifySignedCsrfToken(signedInFuture)).toBe(false);
   });
 
   test("rejects a plain (unsigned) token", async () => {

--- a/test/lib/db/prune.test.ts
+++ b/test/lib/db/prune.test.ts
@@ -687,23 +687,19 @@ describeWithEnv("db > prune", { db: true }, () => {
 
   test("a task becomes due exactly PRUNE_INTERVAL_MS after its last run", async () => {
     const start = 1_700_000_000_000;
-    const time = new FakeTime(start);
-    try {
-      await setAllLastPruned(String(start));
-      const old = new Date(
-        start - PRUNE_PAYMENTS_RETENTION_MS - 60_000,
-      ).toISOString();
-      await insertFinalizedPayment("sess_interval", old);
+    using time = new FakeTime(start);
+    await setAllLastPruned(String(start));
+    const old = new Date(
+      start - PRUNE_PAYMENTS_RETENTION_MS - 60_000,
+    ).toISOString();
+    await insertFinalizedPayment("sess_interval", old);
 
-      time.tick(PRUNE_INTERVAL_MS - 1);
-      await maybeRunPrunes();
-      expect(await paymentExists("sess_interval")).toBe(true);
+    time.tick(PRUNE_INTERVAL_MS - 1);
+    await maybeRunPrunes();
+    expect(await paymentExists("sess_interval")).toBe(true);
 
-      time.tick(1);
-      await maybeRunPrunes();
-      expect(await paymentExists("sess_interval")).toBe(false);
-    } finally {
-      time.restore();
-    }
+    time.tick(1);
+    await maybeRunPrunes();
+    expect(await paymentExists("sess_interval")).toBe(false);
   });
 });

--- a/test/lib/db/sessions.test.ts
+++ b/test/lib/db/sessions.test.ts
@@ -100,22 +100,18 @@ describeWithEnv("db > sessions", { db: true }, () => {
 
   test("getSession expires cached entry after TTL", async () => {
     const startTime = Date.now();
-    const time = new FakeTime(startTime);
+    using time = new FakeTime(startTime);
 
-    try {
-      await createSession("ttl-test", "csrf-ttl", startTime + 60000, null, 1);
-      const firstCall = await getSession("ttl-test");
-      expect(firstCall).not.toBeNull();
+    await createSession("ttl-test", "csrf-ttl", startTime + 60000, null, 1);
+    const firstCall = await getSession("ttl-test");
+    expect(firstCall).not.toBeNull();
 
-      // Advance time past the 10-second TTL
-      time.now = startTime + 11000;
+    // Advance time past the 10-second TTL
+    time.now = startTime + 11000;
 
-      const afterTtl = await getSession("ttl-test");
-      expect(afterTtl).not.toBeNull();
-      expect(afterTtl?.csrf_token).toBe("csrf-ttl");
-    } finally {
-      time.restore();
-    }
+    const afterTtl = await getSession("ttl-test");
+    expect(afterTtl).not.toBeNull();
+    expect(afterTtl?.csrf_token).toBe("csrf-ttl");
   });
 
   // The following tests observe the cache's *effect* by mutating the DB row
@@ -147,19 +143,15 @@ describeWithEnv("db > sessions", { db: true }, () => {
 
   test("getSession re-queries the DB once the cache TTL expires", async () => {
     const start = Date.now();
-    const time = new FakeTime(start);
-    try {
-      await createSession("ttl-requery", "csrf-old", start + 60000, null, 1);
-      // Within TTL: cached (stale) value is served even after the DB changes.
-      await execute("UPDATE sessions SET csrf_token = 'csrf-new'");
-      expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-old");
+    using time = new FakeTime(start);
+    await createSession("ttl-requery", "csrf-old", start + 60000, null, 1);
+    // Within TTL: cached (stale) value is served even after the DB changes.
+    await execute("UPDATE sessions SET csrf_token = 'csrf-new'");
+    expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-old");
 
-      // Past the 10s TTL: the cache entry expires and the DB is re-read.
-      time.now = start + 11000;
-      expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-new");
-    } finally {
-      time.restore();
-    }
+    // Past the 10s TTL: the cache entry expires and the DB is re-read.
+    time.now = start + 11000;
+    expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-new");
   });
 
   test("repeated reads of a missing session stay null (cached null is safe)", async () => {

--- a/test/lib/db/token-attempts.test.ts
+++ b/test/lib/db/token-attempts.test.ts
@@ -50,35 +50,27 @@ describeWithEnv("db > token-attempts", { db: true }, () => {
 
     test("resets expired lockout and returns false", async () => {
       const ip = "10.0.0.3";
-      const time = new FakeTime(1_800_000_000_000);
-      try {
-        await recordTokenFailure(ip, makeTokens("tok-b", MAX_TOKEN_404S));
-        expect(await isTokenRateLimited(ip)).toBe(true);
+      using time = new FakeTime(1_800_000_000_000);
+      await recordTokenFailure(ip, makeTokens("tok-b", MAX_TOKEN_404S));
+      expect(await isTokenRateLimited(ip)).toBe(true);
 
-        time.tick(TOKEN_LOCKOUT_MS + 1);
-        expect(await isTokenRateLimited(ip)).toBe(false);
-      } finally {
-        time.restore();
-      }
+      time.tick(TOKEN_LOCKOUT_MS + 1);
+      expect(await isTokenRateLimited(ip)).toBe(false);
     });
 
     test("deletes the stored row when an expired lockout is checked", async () => {
       const ip = "10.0.0.11";
-      const time = new FakeTime(1_800_000_000_000);
-      try {
-        await recordTokenFailure(ip, makeTokens("exp", MAX_TOKEN_404S));
-        // While locked, the row persists.
-        expect(await rawRow(ip)).not.toBeNull();
+      using time = new FakeTime(1_800_000_000_000);
+      await recordTokenFailure(ip, makeTokens("exp", MAX_TOKEN_404S));
+      // While locked, the row persists.
+      expect(await rawRow(ip)).not.toBeNull();
 
-        time.tick(TOKEN_LOCKOUT_MS + 1);
-        expect(await isTokenRateLimited(ip)).toBe(false);
+      time.tick(TOKEN_LOCKOUT_MS + 1);
+      expect(await isTokenRateLimited(ip)).toBe(false);
 
-        // Checking an expired lockout must clear the row so the next attempt
-        // starts fresh (and no fingerprint is left behind).
-        expect(await rawRow(ip)).toBeNull();
-      } finally {
-        time.restore();
-      }
+      // Checking an expired lockout must clear the row so the next attempt
+      // starts fresh (and no fingerprint is left behind).
+      expect(await rawRow(ip)).toBeNull();
     });
   });
 
@@ -114,20 +106,16 @@ describeWithEnv("db > token-attempts", { db: true }, () => {
 
     test("ignores attempts older than TOKEN_WINDOW_MS", async () => {
       const ip = "10.0.0.7";
-      const time = new FakeTime(1_800_000_000_000);
-      try {
-        for (let i = 0; i < MAX_TOKEN_404S - 1; i++) {
-          await recordTokenFailure(ip, [`old-${i}`]);
-        }
-
-        time.tick(TOKEN_WINDOW_MS + 1);
-
-        const locked = await recordTokenFailure(ip, ["fresh"]);
-        expect(locked).toBe(false);
-        expect(await isTokenRateLimited(ip)).toBe(false);
-      } finally {
-        time.restore();
+      using time = new FakeTime(1_800_000_000_000);
+      for (let i = 0; i < MAX_TOKEN_404S - 1; i++) {
+        await recordTokenFailure(ip, [`old-${i}`]);
       }
+
+      time.tick(TOKEN_WINDOW_MS + 1);
+
+      const locked = await recordTokenFailure(ip, ["fresh"]);
+      expect(locked).toBe(false);
+      expect(await isTokenRateLimited(ip)).toBe(false);
     });
 
     test("empty token list is a no-op", async () => {

--- a/test/lib/form-stash.test.ts
+++ b/test/lib/form-stash.test.ts
@@ -31,14 +31,10 @@ const withTimedStash =
   (data: string) =>
   (elapsedMs: number) =>
   <T>(body: (token: string) => T): T => {
-    const time = new FakeTime();
-    try {
-      const token = stashRequired(data);
-      time.tick(elapsedMs);
-      return body(token);
-    } finally {
-      time.restore();
-    }
+    using time = new FakeTime();
+    const token = stashRequired(data);
+    time.tick(elapsedMs);
+    return body(token);
   };
 
 const stashIndexedBodies =

--- a/test/lib/qr-token.test.ts
+++ b/test/lib/qr-token.test.ts
@@ -151,34 +151,26 @@ describe("qr-token", () => {
     });
 
     test("rejects an expired token", async () => {
-      const time = new FakeTime(1_700_000_000_000);
-      try {
-        const token = await signQrBookToken(
-          "listing",
-          buildQrBookPayload({ name: "Ada", value: 100 }),
-        );
-        // Advance past the max-age window
-        time.tick((QR_TOKEN_MAX_AGE_S + 10) * 1000);
-        expect(await verifyQrBookToken("listing", token)).toBe(null);
-      } finally {
-        time.restore();
-      }
+      using time = new FakeTime(1_700_000_000_000);
+      const token = await signQrBookToken(
+        "listing",
+        buildQrBookPayload({ name: "Ada", value: 100 }),
+      );
+      // Advance past the max-age window
+      time.tick((QR_TOKEN_MAX_AGE_S + 10) * 1000);
+      expect(await verifyQrBookToken("listing", token)).toBe(null);
     });
 
     test("accepts a token still within its validity window", async () => {
-      const time = new FakeTime(1_700_000_000_000);
-      try {
-        const token = await signQrBookToken(
-          "listing",
-          buildQrBookPayload({ name: "Ada", value: 100 }),
-        );
-        // Advance by just under the max-age window
-        time.tick((QR_TOKEN_MAX_AGE_S - 10) * 1000);
-        const result = await verifyQrBookToken("listing", token);
-        expect(result?.n).toBe("Ada");
-      } finally {
-        time.restore();
-      }
+      using time = new FakeTime(1_700_000_000_000);
+      const token = await signQrBookToken(
+        "listing",
+        buildQrBookPayload({ name: "Ada", value: 100 }),
+      );
+      // Advance by just under the max-age window
+      time.tick((QR_TOKEN_MAX_AGE_S - 10) * 1000);
+      const result = await verifyQrBookToken("listing", token);
+      expect(result?.n).toBe("Ada");
     });
 
     test("rejects a token with an unreasonably far-future expiry", async () => {

--- a/test/lib/renewals.test.ts
+++ b/test/lib/renewals.test.ts
@@ -67,7 +67,7 @@ const withFakeTimeAndStub = async (
   fn: (secretStub: SecretStub) => Promise<void>,
   stubResult: StubResult = { ok: true as const },
 ): Promise<void> => {
-  const fakeTime = new FakeTime(nowMs);
+  using _fakeTime = new FakeTime(nowMs);
   const secretStub = stub(bunnyCdnApi, "setEdgeScriptSecret", () =>
     Promise.resolve(stubResult),
   );
@@ -75,7 +75,6 @@ const withFakeTimeAndStub = async (
     await fn(secretStub);
   } finally {
     secretStub.restore();
-    fakeTime.restore();
   }
 };
 

--- a/test/lib/retry.test.ts
+++ b/test/lib/retry.test.ts
@@ -71,30 +71,26 @@ describe("retryWithBackoff", () => {
   });
 
   test("waits for the backoff delay before the next attempt", async () => {
-    const time = new FakeTime();
-    try {
-      let attempts = 0;
-      const promise = retryWithBackoff(
-        () => {
-          attempts++;
-          return attempts < 2
-            ? Promise.reject(new Error("transient"))
-            : Promise.resolve("ok");
-        },
-        [1000],
-        () => {},
-      );
-      // Flush microtasks: the first attempt has failed and is now parked on the
-      // 1000ms backoff, so the retry must not have run yet.
-      await time.tickAsync(0);
-      expect(attempts).toBe(1);
-      // Only once the backoff elapses does the next attempt fire.
-      await time.tickAsync(1000);
-      expect(await promise).toBe("ok");
-      expect(attempts).toBe(2);
-    } finally {
-      time.restore();
-    }
+    using time = new FakeTime();
+    let attempts = 0;
+    const promise = retryWithBackoff(
+      () => {
+        attempts++;
+        return attempts < 2
+          ? Promise.reject(new Error("transient"))
+          : Promise.resolve("ok");
+      },
+      [1000],
+      () => {},
+    );
+    // Flush microtasks: the first attempt has failed and is now parked on the
+    // 1000ms backoff, so the retry must not have run yet.
+    await time.tickAsync(0);
+    expect(attempts).toBe(1);
+    // Only once the backoff elapses does the next attempt fire.
+    await time.tickAsync(1000);
+    expect(await promise).toBe("ok");
+    expect(attempts).toBe(2);
   });
 
   test("lets onError swap in a different error on the final attempt", async () => {

--- a/test/lib/server-qr-book.test.ts
+++ b/test/lib/server-qr-book.test.ts
@@ -171,20 +171,14 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
         maxAttendees: 10,
         unitPrice: 500,
       });
-      const time = new FakeTime(1_700_000_000_000);
-      try {
-        const token = await signQrBookToken(
-          listing.slug,
-          buildQrBookPayload({ name: "Ada", value: 500 }),
-        );
-        time.tick((QR_TOKEN_MAX_AGE_S + 30) * 1000);
-        const response = await awaitTestRequest(
-          qrBookPath(listing.slug, token),
-        );
-        expect(response.status).toBe(400);
-      } finally {
-        time.restore();
-      }
+      using time = new FakeTime(1_700_000_000_000);
+      const token = await signQrBookToken(
+        listing.slug,
+        buildQrBookPayload({ name: "Ada", value: 500 }),
+      );
+      time.tick((QR_TOKEN_MAX_AGE_S + 30) * 1000);
+      const response = await awaitTestRequest(qrBookPath(listing.slug, token));
+      expect(response.status).toBe(400);
     });
 
     test("deactivated listing is treated like unknown (404)", async () => {

--- a/test/lib/server-scanner.test.ts
+++ b/test/lib/server-scanner.test.ts
@@ -502,28 +502,24 @@ describeWithEnv("QR Scanner", { db: true }, () => {
         "Aged",
         "aged@test.com",
       );
-      const time = new FakeTime();
-      try {
-        const agedToken = await signCsrfToken();
-        // Jump halfway into the scanner window — comfortably past the 1-hour
-        // default that every other endpoint enforces.
-        time.tick(Math.floor(SCANNER_CSRF_MAX_AGE_S / 2) * 1000);
+      using time = new FakeTime();
+      const agedToken = await signCsrfToken();
+      // Jump halfway into the scanner window — comfortably past the 1-hour
+      // default that every other endpoint enforces.
+      time.tick(Math.floor(SCANNER_CSRF_MAX_AGE_S / 2) * 1000);
 
-        // The standard CSRF window would already reject this token...
-        expect(await verifySignedCsrfToken(agedToken)).toBe(false);
+      // The standard CSRF window would already reject this token...
+      expect(await verifySignedCsrfToken(agedToken)).toBe(false);
 
-        // ...but the scanner endpoint still accepts it.
-        const result = await scanAndGetJson(
-          listing.id,
-          { token },
-          session.cookie,
-          agedToken,
-        );
-        expect(result.status).toBe("checked_in");
-        expect(result.name).toBe("Aged");
-      } finally {
-        time.restore();
-      }
+      // ...but the scanner endpoint still accepts it.
+      const result = await scanAndGetJson(
+        listing.id,
+        { token },
+        session.cookie,
+        agedToken,
+      );
+      expect(result.status).toBe("checked_in");
+      expect(result.name).toBe("Aged");
     });
 
     test("returns 400 for missing token in body", async () => {

--- a/test/lib/timezone.test.ts
+++ b/test/lib/timezone.test.ts
@@ -41,12 +41,8 @@ describe("timezone", () => {
       // Temporal.Now bypasses FakeTime; todayInTz must derive "today" from
       // Date.now() so date-dependent code stays deterministic in frozen-time
       // tests (booking windows, holiday cutoffs, calendar/delivery pages).
-      const time = new FakeTime(new Date("2030-01-15T12:00:00Z"));
-      try {
-        expect(todayInTz("Europe/London")).toBe("2030-01-15");
-      } finally {
-        time.restore();
-      }
+      using _time = new FakeTime(new Date("2030-01-15T12:00:00Z"));
+      expect(todayInTz("Europe/London")).toBe("2030-01-15");
     });
   });
 

--- a/test/lib/uptime.test.ts
+++ b/test/lib/uptime.test.ts
@@ -5,13 +5,9 @@ import { getUptimeSeconds } from "#shared/uptime.ts";
 
 describe("getUptimeSeconds", () => {
   test("grows by the wall-clock seconds elapsed since the instance started", () => {
-    const time = new FakeTime();
-    try {
-      const before = getUptimeSeconds();
-      time.tick(3000);
-      expect(getUptimeSeconds() - before).toBeCloseTo(3);
-    } finally {
-      time.restore();
-    }
+    using time = new FakeTime();
+    const before = getUptimeSeconds();
+    time.tick(3000);
+    expect(getUptimeSeconds() - before).toBeCloseTo(3);
   });
 });


### PR DESCRIPTION
## What

Sweeps the test suite to replace `FakeTime` + `try { ... } finally { time.restore() }` blocks with Deno's `using` declaration.

## Why

`FakeTime` swaps out the process-wide `Date`/timers, so the real clock **must** be restored on every exit path — including when an `expect(...)` assertion throws — or a single test failure leaks a frozen clock into every subsequent test in that process. The `try/finally` idiom achieves this with boilerplate; `using time = new FakeTime(...)` gives the identical leak-proof guarantee natively (via `Symbol.dispose`) with none of it. This standardizes on the pattern already present in `csrf.test.ts`/`domain.test.ts` and applied to the accounting tests in #1485, rather than introducing a bespoke helper for the same job.

## Changes

- Converted **21 blocks across 13 files** from `try/finally` to `using` (net **−83 lines**).
- Bindings not referenced in the test body are underscore-prefixed (`_time`, `_fakeTime`, …) to satisfy the linter.
- **Left as-is** (not convertible to `using`):
  - `attachment-url.test.ts`, `webhook-example.test.ts` — clock is lifecycle-managed via `beforeEach/afterEach`, which `using` cannot span.
  - `bunny-cdn/domain.test.ts`, `csrf.test.ts:96` — already use `using`.
  - `try/finally` blocks that restore stubs/mocks rather than a clock.
- **Special case** — `renewals.test.ts` `withFakeTimeAndStub`: only the clock moved to `using`; the `try/finally` restoring the secret stub stays, and disposal order (stub then clock) is preserved.

## Verification

- `deno task precommit` passes (exit 0) — typecheck (incl. test files), lint, full test suite.
- Subagent-run per-file checks before integration: `deno check` + Biome clean + `deno test` on all 13 files (`17 passed, 331 steps, 0 failed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9GuEVoPdupf95e7QY187a)_