### PR TITLE
Request-scope iframe/CSRF/saved-form state to fix concurrent-request leakage

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -102,6 +102,15 @@ src/shared/largest-remainder.ts:20:40  ?? → ||   # tieBreaker?: function|undef
 src/shared/crypto/utils.ts:18:23  ?? → ||   # bufA[i]: number|undefined, 0 ?? 0 === 0 || 0
 src/shared/crypto/utils.ts:18:40  ?? → ||   # bufB[i]: number|undefined, 0 ?? 0 === 0 || 0
 
+# request-scoped ambient fallback: store.getStore() is T|undefined where T is
+# always a truthy container object (never a falsy-non-null value), so
+# `?? fallback` and `|| fallback` always agree.
+src/shared/request-scoped.ts:41:36  ?? → ||   # getStore(): T|undefined — a container object is always truthy
+
+# savedFormValue: form?.getString(name) is string|undefined; the only falsy
+# non-null string is "" which equals the "" fallback, so ?? and || agree.
+src/shared/forms.tsx:599:49  ?? → ||   # getString(): string|undefined, "" ?? "" === "" || ""
+
 # test-utils/csrf: regex `match` results are either null/undefined or truthy
 # values; the quantity capture is `\d+`, so it can never be an empty string.
 test/test-utils/csrf.ts:13:46  ?? → ||   # input tag match: RegExpMatchArray|null; a non-null array is truthy

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -39,6 +39,7 @@ import {
   clearSessionCookie,
   parseFlashValue,
 } from "#shared/cookies.ts";
+import { runWithCsrfContext } from "#shared/csrf.ts";
 import { maybeBackfillActivityLog } from "#shared/db/activity-log-backfill.ts";
 import { DatabaseBusyError } from "#shared/db/client.ts";
 import {
@@ -70,8 +71,12 @@ import {
 } from "#shared/flash-context.ts";
 import { FormParams } from "#shared/form-data.ts";
 import { takeForm } from "#shared/form-stash.ts";
-import { clearSavedFormData, setSavedFormData } from "#shared/forms.tsx";
-import { detectIframeMode } from "#shared/iframe.ts";
+import {
+  clearSavedFormData,
+  runWithSavedFormContext,
+  setSavedFormData,
+} from "#shared/forms.tsx";
+import { detectIframeMode, runWithIframeContext } from "#shared/iframe.ts";
 import {
   createRequestTimer,
   ErrorCode,
@@ -1035,19 +1040,27 @@ export const handleRequest = async (
 ): Promise<Response> => {
   const locale = parseAcceptLanguage(request.headers.get("accept-language"));
 
-  return runWithLocale(locale, () =>
-    runWithClientIp(getClientIp(request, server), () =>
-      runWithRequestId(() =>
-        runWithRequestCache(() =>
-          runWithQueryLogContext(() =>
-            runWithFlashContext(() =>
-              runWithSessionContext(() =>
-                runWithSettingsAudit(() => processRequest(request, server)),
-              ),
-            ),
-          ),
-        ),
-      ),
-    ),
-  );
+  // Each request runs inside a stack of AsyncLocalStorage scopes so per-request
+  // state (locale, client IP, caches, flash, iframe mode, CSRF token, saved
+  // form data, …) stays isolated across concurrent requests sharing one edge
+  // isolate. Composed as a fold rather than hand-nested callbacks so the stack
+  // stays flat and adding a scope is a one-line change.
+  const scopes: ((fn: () => Promise<Response>) => Promise<Response>)[] = [
+    (fn) => runWithLocale(locale, fn),
+    (fn) => runWithClientIp(getClientIp(request, server), fn),
+    runWithRequestId,
+    runWithRequestCache,
+    runWithQueryLogContext,
+    runWithFlashContext,
+    runWithSessionContext,
+    runWithIframeContext,
+    runWithCsrfContext,
+    runWithSavedFormContext,
+    runWithSettingsAudit,
+  ];
+
+  return scopes.reduceRight<() => Promise<Response>>(
+    (next, scope) => () => scope(next),
+    () => processRequest(request, server),
+  )();
 };

--- a/src/shared/csrf.ts
+++ b/src/shared/csrf.ts
@@ -15,12 +15,18 @@ import {
   generateSecureToken,
 } from "#shared/crypto/utils.ts";
 import { nowMs } from "#shared/now.ts";
+import { createRequestScoped } from "#shared/request-scoped.ts";
 
 const SIGNED_PREFIX = "s1.";
 const DEFAULT_MAX_AGE_S = 3600; // 1 hour
 
 /** Most recently generated CSRF token, readable synchronously by CsrfForm */
-const _tokenStore = { value: "" };
+const tokenScope = createRequestScoped<{ value: string }>(() => ({
+  value: "",
+}));
+
+/** Run a function within a CSRF-token scope (one container per request) */
+export const runWithCsrfContext = <T>(fn: () => T): T => tokenScope.run(fn);
 
 /** Default message for invalid/expired CSRF form submissions (request-scoped). */
 export const csrfInvalidFormMessage = (): string => t("error.csrf_invalid");
@@ -35,12 +41,13 @@ export const signCsrfToken = async (): Promise<string> => {
   const nonce = generateSecureToken();
   const message = buildMessage(timestamp, nonce);
   const hmac = base64ToBase64Url(await hmacHash(message));
-  _tokenStore.value = `${message}.${hmac}`;
-  return _tokenStore.value;
+  const token = `${message}.${hmac}`;
+  tokenScope.current().value = token;
+  return token;
 };
 
 /** Get the most recently generated CSRF token (for synchronous JSX rendering) */
-export const getCurrentCsrfToken = (): string => _tokenStore.value;
+export const getCurrentCsrfToken = (): string => tokenScope.current().value;
 
 /** Check whether a token uses the signed format */
 export const isSignedCsrfToken = (token: string): boolean =>

--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -14,6 +14,7 @@ import {
 import type { FormParams } from "#shared/form-data.ts";
 import { appendIframeParam } from "#shared/iframe.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
+import { createRequestScoped } from "#shared/request-scoped.ts";
 import { Icon } from "#templates/components/actions.tsx";
 
 const escapeHtml = (str: string): string =>
@@ -562,16 +563,22 @@ const SENSITIVE_FIELD_TYPES: ReadonlySet<FieldType> = new Set([
  * without any changes to individual form handlers or templates.
  * Only non-sensitive field types (not password/file) are restored.
  */
-const _savedFormData: { form: FormParams | null } = { form: null };
+const savedFormScope = createRequestScoped<{ form: FormParams | null }>(() => ({
+  form: null,
+}));
+
+/** Run a function within a saved-form-data scope (one container per request) */
+export const runWithSavedFormContext = <T,>(fn: () => T): T =>
+  savedFormScope.run(fn);
 
 /** Save form data for restoration after CSRF failure */
 export const setSavedFormData = (form: FormParams): void => {
-  _savedFormData.form = form;
+  savedFormScope.current().form = form;
 };
 
 /** Clear saved form data (called on successful CSRF validation) */
 export const clearSavedFormData = (): void => {
-  _savedFormData.form = null;
+  savedFormScope.current().form = null;
 };
 
 /**
@@ -579,7 +586,8 @@ export const clearSavedFormData = (): void => {
  * Used by `redirect()` to stash a failed submission for re-filling after the
  * follow-up GET.
  */
-export const getSavedFormData = (): FormParams | null => _savedFormData.form;
+export const getSavedFormData = (): FormParams | null =>
+  savedFormScope.current().form;
 
 /**
  * Read a raw saved form value by name, or "" when nothing was restored. Lets the
@@ -588,26 +596,27 @@ export const getSavedFormData = (): FormParams | null => _savedFormData.form;
  * after a failed booking redirect, alongside renderFields for the normal inputs.
  */
 export const savedFormValue = (name: string): string =>
-  _savedFormData.form?.getString(name) ?? "";
+  savedFormScope.current().form?.getString(name) ?? "";
 
 /** Get a saved value for a field, or empty string if not available */
 const getSavedValue = (field: Field): string => {
-  if (!_savedFormData.form || SENSITIVE_FIELD_TYPES.has(field.type)) return "";
+  const form = savedFormScope.current().form;
+  if (!form || SENSITIVE_FIELD_TYPES.has(field.type)) return "";
   if (field.type === "checkbox-group") {
-    return _savedFormData.form
+    return form
       .getAll(field.name)
       .map((v) => v.trim())
       .filter((v) => v)
       .join(",");
   }
   if (field.type === "datetime") {
-    const date = _savedFormData.form.getString(`${field.name}_date`);
-    const time = _savedFormData.form.getString(`${field.name}_time`);
+    const date = form.getString(`${field.name}_date`);
+    const time = form.getString(`${field.name}_time`);
     if (date && time) return `${date}T${time}`;
     if (date) return `${date}T00:00`;
     return "";
   }
-  return _savedFormData.form.getString(field.name);
+  return form.getString(field.name);
 };
 
 /**

--- a/src/shared/iframe.ts
+++ b/src/shared/iframe.ts
@@ -4,26 +4,34 @@
  * <iframe> or the embed script. It affects response strategy (popup vs redirect
  * for Stripe checkout) and template rendering (hide header, include resizer).
  *
- * The iframe mode is stored per-request (like the CSRF token store) and read
+ * The iframe mode is request-scoped (see request-scoped.ts) and read
  * synchronously by CsrfForm, redirectResponse, checkoutResponse, and templates.
  */
 
+import { createRequestScoped } from "#shared/request-scoped.ts";
+
 /** Per-request iframe mode, readable synchronously by consumers */
-const _iframeStore = { value: false };
+const iframeScope = createRequestScoped<{ value: boolean }>(() => ({
+  value: false,
+}));
+
+/** Run a function within an iframe-mode scope (one container per request) */
+export const runWithIframeContext = <T>(fn: () => T): T => iframeScope.run(fn);
 
 /** Detect iframe mode from a request URL and store it for the current request */
 export const detectIframeMode = (url: string): void => {
   if (!URL.canParse(url)) throw new TypeError("Invalid iframe detection URL");
 
-  _iframeStore.value = new URL(url).searchParams.get("iframe") === "true";
+  iframeScope.current().value =
+    new URL(url).searchParams.get("iframe") === "true";
 };
 
 /** Get the current request's iframe mode */
-export const getIframeMode = (): boolean => _iframeStore.value;
+export const getIframeMode = (): boolean => iframeScope.current().value;
 
 /** Append iframe=true query param to a URL when in iframe mode */
 export const appendIframeParam = (url: string): string => {
-  if (!_iframeStore.value) return url;
+  if (!getIframeMode()) return url;
   if (!URL.canParse(url, "http://localhost")) {
     throw new TypeError("Invalid iframe redirect URL");
   }

--- a/src/shared/request-scoped.ts
+++ b/src/shared/request-scoped.ts
@@ -1,0 +1,44 @@
+/**
+ * Request-scoped mutable state with an ambient fallback.
+ *
+ * A handful of render-time values (iframe mode, the current CSRF token, the
+ * saved-form-data stash) are set at the request boundary and read synchronously
+ * by deep JSX components, so they can't be threaded through as arguments. They
+ * used to live in plain module-global objects, which race under concurrency: a
+ * single edge isolate serving two requests at once has one global, so request
+ * B's write clobbers request A's value while A is parked on an `await`.
+ *
+ * `createRequestScoped` fixes that by backing each value with an
+ * `AsyncLocalStorage` container. Inside a `run()` scope (established once per
+ * request in the `runWith*` chain) each request gets its own container, so
+ * concurrent requests never see each other's state. Outside any scope — unit
+ * tests that render a component directly, or any non-request rendering — reads
+ * and writes fall back to a single ambient container, preserving the simple
+ * synchronous set-then-read behaviour those callers have always relied on.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** A request-scoped container plus the helpers its owning module builds on. */
+export type RequestScoped<T extends object> = {
+  /** Run `fn` with a fresh per-request container bound to the async scope. */
+  run: <R>(fn: () => R) => R;
+  /** The active request's container, or the ambient fallback outside a scope. */
+  current: () => T;
+};
+
+/**
+ * Build a request-scoped container. `initial` is called to mint a fresh
+ * container for each scope (and once for the ambient fallback), so callers must
+ * return a new object each time rather than sharing one instance.
+ */
+export const createRequestScoped = <T extends object>(
+  initial: () => T,
+): RequestScoped<T> => {
+  const store = new AsyncLocalStorage<T>();
+  const fallback = initial();
+  return {
+    current: () => store.getStore() ?? fallback,
+    run: (fn) => store.run(initial(), fn),
+  };
+};

--- a/test/lib/csrf.test.ts
+++ b/test/lib/csrf.test.ts
@@ -1,8 +1,12 @@
 import { expect } from "@std/expect";
 import { beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+import { hmacHash } from "#shared/crypto/hashing.ts";
+import { base64ToBase64Url } from "#shared/crypto/utils.ts";
 import {
+  getCurrentCsrfToken,
   isSignedCsrfToken,
+  runWithCsrfContext,
   signCsrfToken,
   verifySignedCsrfToken,
 } from "#shared/csrf.ts";
@@ -140,7 +144,58 @@ describe("verifySignedCsrfToken", () => {
     expect(await verifySignedCsrfToken("s1..nonce.hmac")).toBe(false);
   });
 
+  test("rejects a correctly-signed token whose nonce is empty", async () => {
+    // An attacker crafts a token with a valid HMAC but an empty nonce slot.
+    // The signature itself verifies, so only the explicit empty-part guard
+    // rejects it — a weaker guard would accept the malformed token.
+    const timestamp = Math.floor(Date.now() / 1000);
+    const message = `s1.${timestamp}.`; // buildMessage(timestamp, "") — empty nonce
+    const hmac = base64ToBase64Url(await hmacHash(message));
+    const token = `s1.${timestamp}..${hmac}`;
+    expect(await verifySignedCsrfToken(token)).toBe(false);
+  });
+
   test("rejects a token with non-numeric timestamp", async () => {
     expect(await verifySignedCsrfToken("s1.notanumber.nonce.hmac")).toBe(false);
+  });
+});
+
+describe("getCurrentCsrfToken (request-scoped)", () => {
+  beforeEach(() => {
+    setupTestEncryptionKey();
+  });
+
+  test("returns the token signed in the current scope", async () => {
+    const { signed, current } = await runWithCsrfContext(async () => {
+      const signed = await signCsrfToken();
+      return { current: getCurrentCsrfToken(), signed };
+    });
+    expect(current).toBe(signed);
+    expect(isSignedCsrfToken(current)).toBe(true);
+  });
+
+  test("re-signing within a scope replaces the rendered token", async () => {
+    const { first, second, rendered } = await runWithCsrfContext(async () => {
+      const first = await signCsrfToken();
+      const second = await signCsrfToken();
+      return { first, rendered: getCurrentCsrfToken(), second };
+    });
+    expect(second).not.toBe(first);
+    expect(rendered).toBe(second); // replaced outright, not appended to `first`
+  });
+
+  test("concurrent request scopes each render their own token", async () => {
+    const request = () =>
+      runWithCsrfContext(async () => {
+        const signed = await signCsrfToken();
+        await new Promise((r) => setTimeout(r, 20)); // render happens later
+        return { rendered: getCurrentCsrfToken(), signed };
+      });
+    const [a, b] = await Promise.all([request(), request()]);
+    // Each scope's rendered token matches the one it signed — no cross-request
+    // bleed from a shared global.
+    expect(a.rendered).toBe(a.signed);
+    expect(b.rendered).toBe(b.signed);
+    expect(a.rendered).not.toBe(b.rendered);
   });
 });

--- a/test/lib/forms/saved-data.test.ts
+++ b/test/lib/forms/saved-data.test.ts
@@ -7,6 +7,7 @@ import {
   type Field,
   getSavedFormData,
   renderFields,
+  runWithSavedFormContext,
   setSavedFormData,
 } from "#shared/forms.tsx";
 
@@ -194,5 +195,28 @@ describe("saved form data", () => {
     setSavedFormData(new FormParams("name=Alice"));
     clearSavedFormData();
     expect(getSavedFormData()).toBeNull();
+  });
+
+  test("saved data set inside a scope stays within that scope", () => {
+    const scopedForm = new FormParams("name=Scoped");
+    const inside = runWithSavedFormContext(() => {
+      setSavedFormData(scopedForm);
+      return getSavedFormData();
+    });
+    expect(inside).toBe(scopedForm);
+    expect(getSavedFormData()).toBeNull(); // ambient container untouched
+  });
+
+  test("concurrent request scopes do not leak saved form data", async () => {
+    const request = (name: string) =>
+      runWithSavedFormContext(async () => {
+        const form = new FormParams(`name=${name}`);
+        setSavedFormData(form);
+        await new Promise((r) => setTimeout(r, 20));
+        return getSavedFormData()?.getString("name");
+      });
+    const [a, b] = await Promise.all([request("Alice"), request("Bob")]);
+    expect(a).toBe("Alice");
+    expect(b).toBe("Bob");
   });
 });

--- a/test/lib/iframe.test.ts
+++ b/test/lib/iframe.test.ts
@@ -4,6 +4,7 @@ import {
   appendIframeParam,
   detectIframeMode,
   getIframeMode,
+  runWithIframeContext,
 } from "#shared/iframe.ts";
 
 describe("iframe", () => {
@@ -88,6 +89,44 @@ describe("iframe", () => {
     test("rejects invalid redirect URLs before appending iframe params", () => {
       detectIframeMode("https://example.com/?iframe=true");
       expect(() => appendIframeParam("http://[::1")).toThrow(TypeError);
+    });
+  });
+
+  describe("request-scoped isolation", () => {
+    test("a fresh iframe scope defaults to non-iframe mode", () => {
+      // No detectIframeMode call — the scope's initial container must be
+      // non-iframe, so an embed flag never leaks in as the default.
+      expect(runWithIframeContext(() => getIframeMode())).toBe(false);
+    });
+
+    test("iframe mode set inside a scope stays within that scope", () => {
+      const inside = runWithIframeContext(() => {
+        detectIframeMode("https://example.com/?iframe=true");
+        return getIframeMode();
+      });
+      expect(inside).toBe(true);
+      // The per-request container is gone once the scope ends; the ambient
+      // fallback (reset by afterEach) is unaffected by the scoped write.
+      expect(getIframeMode()).toBe(false);
+    });
+
+    test("concurrent request scopes do not leak iframe mode", async () => {
+      const embedded = () =>
+        runWithIframeContext(async () => {
+          detectIframeMode("https://example.com/?iframe=true");
+          await new Promise((r) => setTimeout(r, 20));
+          return getIframeMode(); // still an iframe request
+        });
+      const normal = () =>
+        runWithIframeContext(async () => {
+          await new Promise((r) => setTimeout(r, 5));
+          detectIframeMode("https://example.com/"); // would clobber a global
+          await new Promise((r) => setTimeout(r, 20));
+          return getIframeMode();
+        });
+      const [a, b] = await Promise.all([embedded(), normal()]);
+      expect(a).toBe(true);
+      expect(b).toBe(false);
     });
   });
 });

--- a/test/lib/request-scoped.test.ts
+++ b/test/lib/request-scoped.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { createRequestScoped } from "#shared/request-scoped.ts";
+
+describe("createRequestScoped", () => {
+  test("outside a scope, current() returns a stable ambient container", () => {
+    const scoped = createRequestScoped<{ value: number }>(() => ({ value: 0 }));
+    scoped.current().value = 7;
+    // Same ambient container across calls, so mutations persist (the plain
+    // synchronous set-then-read behaviour unit tests rely on).
+    expect(scoped.current().value).toBe(7);
+  });
+
+  test("run() binds a fresh container isolated from the ambient one", () => {
+    const scoped = createRequestScoped<{ value: number }>(() => ({ value: 0 }));
+    scoped.current().value = 1; // ambient
+    const seenInside = scoped.run(() => {
+      scoped.current().value = 2; // scoped container, not the ambient one
+      return scoped.current().value;
+    });
+    expect(seenInside).toBe(2);
+    expect(scoped.current().value).toBe(1); // ambient untouched by the scope
+  });
+
+  test("each run() gets its own container (no reuse between scopes)", () => {
+    const scoped = createRequestScoped<{ value: number }>(() => ({ value: 0 }));
+    const first = scoped.run(() => {
+      scoped.current().value = 42;
+      return scoped.current().value;
+    });
+    const second = scoped.run(() => scoped.current().value); // fresh container
+    expect(first).toBe(42);
+    expect(second).toBe(0);
+  });
+
+  test("concurrent interleaved scopes do not leak state into each other", async () => {
+    const scoped = createRequestScoped<{ value: string }>(() => ({
+      value: "",
+    }));
+
+    const scopeA = () =>
+      scoped.run(async () => {
+        scoped.current().value = "A";
+        await new Promise((r) => setTimeout(r, 20));
+        return scoped.current().value; // must still be "A"
+      });
+    const scopeB = () =>
+      scoped.run(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        scoped.current().value = "B"; // would clobber a shared global
+        await new Promise((r) => setTimeout(r, 20));
+        return scoped.current().value;
+      });
+
+    const [a, b] = await Promise.all([scopeA(), scopeB()]);
+    expect(a).toBe("A");
+    expect(b).toBe("B");
+  });
+});


### PR DESCRIPTION
## Diagnosis (the original report)

`public.test.ts` "hides header and description in iframe mode" was reported as flaky "because of leakage under high concurrency." I chased that first, and the specific unit test **cannot** flake that way:

- `renderTicket` sets `detectIframeMode(…?iframe=true)` and then calls `ticketPage` on the very next synchronous line; `ticketPage` reads `getIframeMode()` synchronously and returns a plain `string`. There is no `await` between the set and the read, so nothing can mutate the store in between.
- Deno gives every test file its own module-graph instance (verified empirically: under `--parallel`, files sharing a worker still see only their own writes to a module singleton). So the store cannot leak across files either.

But the instinct pointed at a **real** bug. `detectIframeMode` writes a process-global `_iframeStore`, and in `processRequest` that write happens *before* a long chain of `await`s (body buffer → DB init → settings → routing → render). In one edge isolate serving concurrent requests, request B's `detectIframeMode` clobbers request A's flag while A is parked on an `await`; when A resumes and renders, it reads B's value. Reproduced with the real functions (A expected `true`, read back `false`). The same plain-global pattern backs the CSRF token (`_tokenStore`) and the saved-form-data stash (`_savedFormData`).

## The fix

Back each of the three values with an `AsyncLocalStorage` container via a new shared `createRequestScoped` helper, matching the existing `runWith*` request-context pattern (client IP, request id, flash, session, …):

- Inside the scope established in the `handleRequest` chain, each request gets its own container — concurrent requests can't see each other's iframe mode, CSRF token, or saved form input.
- Outside any scope (non-request rendering, unit tests), reads/writes fall back to a single ambient container, preserving the previous synchronous set-then-read behaviour, so no existing call site or test had to change.
- The `handleRequest` scope stack is folded (array + `reduceRight`) instead of hand-nested callbacks, so adding a scope is a one-line change and cognitive complexity stays in bounds.

### Impact of the bug (now fixed)
- Embedded (iframe) page loads could render the header/description that iframe mode hides, and pick the wrong Stripe checkout strategy (popup vs. 302 redirect).
- A CSRF token or another visitor's restored form input could bleed across concurrent requests.

## Tests
- New `createRequestScoped` helper test: ambient fallback, per-scope isolation, fresh container per `run()`, and interleaved-scopes-don't-leak.
- Per-store concurrency regression tests (iframe / CSRF / saved-form): two interleaved request scopes must not see each other's state. These fail against the old plain-global implementation.
- Hardened CSRF tests along the way: a fresh iframe scope defaults to non-iframe; re-signing within a scope replaces (not appends) the rendered token; a correctly-signed token with an empty nonce is still rejected.

## Verification
- `lint:ci`, `typecheck`, `cpd` (0% duplication), `build:edge`, and `test:coverage` all green — **12305 tests pass, 100% line + branch coverage**.
- Targeted `deno task mutation` on the changed logic: `request-scoped.ts`, `iframe.ts` (7/7), `csrf.ts` (20/20) all clean; the only survivors on changed lines are equivalent `?? → ||` cases (recorded in `equivalent-mutants.txt`). Note: the local precommit mutation gate whole-file-mutates the large touched files (`forms.tsx`, `index.ts`) against only the changed test subset, so it reports pre-existing survivors from code those tests don't cover — the documented gate limitation; the full suite kills them, and CI does not run mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mq9iP4PTP9UrkFxngCU9FR)_