### PR TITLE
Add a suite-level storage backend option to describeWithEnv

### DIFF
--- a/test/lib/attachment-route.test.ts
+++ b/test/lib/attachment-route.test.ts
@@ -13,6 +13,7 @@ import {
   describeWithEnv,
   installUrlHandler,
   mockRequest,
+  TEST_STORAGE_ZONE,
   withFetchMock,
   withStorageDisabled,
 } from "#test-utils";
@@ -98,7 +99,7 @@ describeWithEnv(
       data: Uint8Array,
       fn: () => Promise<void>,
     ): Promise<void> =>
-      runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, () =>
+      runWithStorageConfig(TEST_STORAGE_ZONE, () =>
         withFetchMock(async (originalFetch) => {
           const encrypted = await encryptBytes(data);
           installUrlHandler(originalFetch, (url) => {
@@ -137,7 +138,7 @@ describeWithEnv(
 
     /** Shorthand for running a test body with storage enabled */
     const withStorage = <T>(fn: () => T): T =>
-      runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, fn);
+      runWithStorageConfig(TEST_STORAGE_ZONE, fn);
 
     test("returns 403 when query params are missing", async () => {
       await withStorage(async () => {

--- a/test/lib/describe-with-env-storage.test.ts
+++ b/test/lib/describe-with-env-storage.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "@std/expect";
+import { afterAll, describe, test } from "@std/testing/bdd";
+import { getStorageBackend, isStorageEnabled } from "#shared/storage.ts";
+import {
+  describeWithEnv,
+  getTestStoragePath,
+  withStorageDisabled,
+} from "#test-utils";
+
+const dirExists = (path: string): boolean => {
+  try {
+    return Deno.statSync(path).isDirectory;
+  } catch {
+    return false;
+  }
+};
+
+describe("describeWithEnv storage option", () => {
+  describeWithEnv("cdn backend", { storage: "cdn" }, () => {
+    test("resolves the Bunny CDN backend for every test", () => {
+      expect(getStorageBackend()).toBe("bunny");
+      expect(isStorageEnabled()).toBe(true);
+      // No temp dir is allocated for the CDN backend.
+      expect(getTestStoragePath()).toBeNull();
+    });
+  });
+
+  describe("local backend", () => {
+    // Captured in the first test, asserted removed in the second — proving the
+    // per-test temp dir is created before and torn down after each test.
+    let firstDir: string | null = null;
+
+    describeWithEnv("local storage lifecycle", { storage: "local" }, () => {
+      test("allocates a real temp dir and selects the local backend", () => {
+        const dir = getTestStoragePath();
+        expect(dir).not.toBeNull();
+        expect(dirExists(dir!)).toBe(true);
+        expect(getStorageBackend()).toBe("local");
+        expect(isStorageEnabled()).toBe(true);
+        firstDir = dir;
+      });
+
+      test("a per-test withStorageDisabled scope overrides the suite default", () => {
+        // The previous test's dir was cleaned up in its afterEach.
+        expect(firstDir).not.toBeNull();
+        expect(dirExists(firstDir!)).toBe(false);
+        // This test still has its own live dir…
+        expect(getStorageBackend()).toBe("local");
+        // …but an explicit scope wins over the suite's env default.
+        withStorageDisabled(() => {
+          expect(getStorageBackend()).toBe("none");
+        });
+      });
+    });
+
+    afterAll(() => {
+      // After the whole suite, the last test's dir is gone too.
+      expect(getTestStoragePath()).toBeNull();
+    });
+  });
+
+  describeWithEnv("no storage option", {}, () => {
+    test("leaves storage disabled by default", () => {
+      expect(getStorageBackend()).toBe("none");
+      expect(getTestStoragePath()).toBeNull();
+    });
+  });
+});

--- a/test/lib/describe-with-env-storage.test.ts
+++ b/test/lib/describe-with-env-storage.test.ts
@@ -26,9 +26,10 @@ describe("describeWithEnv storage option", () => {
   });
 
   describe("local backend", () => {
-    // Captured in the first test, asserted removed in the second — proving the
-    // per-test temp dir is created before and torn down after each test.
-    let firstDir: string | null = null;
+    // Each test records the live dir it observed; the afterAll then proves that
+    // dir was torn down. This holds no matter which subset of tests runs (e.g.
+    // under `test:files --filter`), so the cases stay independent.
+    let observedDir: string | null = null;
 
     describeWithEnv("local storage lifecycle", { storage: "local" }, () => {
       test("allocates a real temp dir and selects the local backend", () => {
@@ -37,27 +38,47 @@ describe("describeWithEnv storage option", () => {
         expect(dirExists(dir!)).toBe(true);
         expect(getStorageBackend()).toBe("local");
         expect(isStorageEnabled()).toBe(true);
-        firstDir = dir;
+        observedDir = dir;
       });
 
       test("a per-test withStorageDisabled scope overrides the suite default", () => {
-        // The previous test's dir was cleaned up in its afterEach.
-        expect(firstDir).not.toBeNull();
-        expect(dirExists(firstDir!)).toBe(false);
-        // This test still has its own live dir…
+        // This test has its own live dir…
+        const dir = getTestStoragePath();
+        expect(dir).not.toBeNull();
+        expect(dirExists(dir!)).toBe(true);
         expect(getStorageBackend()).toBe("local");
         // …but an explicit scope wins over the suite's env default.
         withStorageDisabled(() => {
           expect(getStorageBackend()).toBe("none");
         });
+        observedDir = dir;
       });
     });
 
     afterAll(() => {
-      // After the whole suite, the last test's dir is gone too.
+      // After the suite, the last-observed dir is removed and the path cleared —
+      // proving each test's dir is torn down in its afterEach.
+      expect(observedDir).not.toBeNull();
+      expect(dirExists(observedDir!)).toBe(false);
       expect(getTestStoragePath()).toBeNull();
     });
   });
+
+  // Regression: getStorageBackend() checks the Bunny creds before the local
+  // path, so a `storage: "local"` suite must clear any conflicting zone env —
+  // otherwise ambient credentials would resolve it to "bunny", not "local".
+  describeWithEnv(
+    "local backend clears conflicting zone credentials",
+    {
+      env: { STORAGE_ZONE_KEY: "leak", STORAGE_ZONE_NAME: "leak" },
+      storage: "local",
+    },
+    () => {
+      test("selects local even when zone credentials are present in the env", () => {
+        expect(getStorageBackend()).toBe("local");
+      });
+    },
+  );
 
   describeWithEnv("no storage option", {}, () => {
     test("leaves storage disabled by default", () => {

--- a/test/lib/server-backup.test.ts
+++ b/test/lib/server-backup.test.ts
@@ -18,10 +18,13 @@ import {
   expectHtmlResponse,
   getTestSession,
   testRequiresAuth,
-  withLocalStorageEnabled,
+  withStorageDisabled,
 } from "#test-utils";
 
-describeWithEnv("server (admin backup)", { db: true }, () => {
+// The whole suite runs with a per-test local storage backend so the backup
+// create/restore/download paths have a real filesystem to read and write; the
+// one test that asserts the disabled state opts out with `withStorageDisabled`.
+describeWithEnv("server (admin backup)", { db: true, storage: "local" }, () => {
   describe("GET /admin/backup", () => {
     testRequiresAuth("/admin/backup");
 
@@ -50,23 +53,23 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
     });
 
     test("shows storage not configured when disabled", async () => {
-      const response = await adminGet("/admin/backup");
-      const html = await response.text();
-      expect(html).toContain("Storage is not configured");
+      await withStorageDisabled(async () => {
+        const response = await adminGet("/admin/backup");
+        const html = await response.text();
+        expect(html).toContain("Storage is not configured");
+      });
     });
 
     test("cleans up stale restore-pending files on page load", async () => {
-      await withLocalStorageEnabled(async () => {
-        await uploadRaw(new Uint8Array(1), "restore-pending-stale.zip");
+      await uploadRaw(new Uint8Array(1), "restore-pending-stale.zip");
 
-        await adminGet("/admin/backup");
+      await adminGet("/admin/backup");
 
-        // Give the fire-and-forget cleanup a moment to complete
-        await new Promise((r) => setTimeout(r, 50));
+      // Give the fire-and-forget cleanup a moment to complete
+      await new Promise((r) => setTimeout(r, 50));
 
-        const data = await downloadRaw("restore-pending-stale.zip");
-        expect(data).toBeNull();
-      });
+      const data = await downloadRaw("restore-pending-stale.zip");
+      expect(data).toBeNull();
     });
   });
 
@@ -77,36 +80,30 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
     });
 
     test("creates backup and redirects with success", async () => {
-      await withLocalStorageEnabled(async () => {
-        await createTestListing({ name: "Backup Test" });
-        const { response } = await adminFormPost("/admin/backup/create");
-        await expectFlashRedirect(
-          "/admin/backup",
-          "Database backup created",
-        )(response);
-      });
+      await createTestListing({ name: "Backup Test" });
+      const { response } = await adminFormPost("/admin/backup/create");
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Database backup created",
+      )(response);
     });
 
     test("lists only valid backup files on backup page", async () => {
-      await withLocalStorageEnabled(async () => {
-        // A non-backup file sharing the folder must not appear in the list.
-        await uploadRaw(new Uint8Array(0), `${backupDir()}backup-stale.tmp`);
-        await adminFormPost("/admin/backup/create");
-        const response = await adminGet("/admin/backup");
-        const html = await response.text();
-        expect(html).not.toContain("backup-stale.tmp");
-        expect(html).toContain(".zip");
-      });
+      // A non-backup file sharing the folder must not appear in the list.
+      await uploadRaw(new Uint8Array(0), `${backupDir()}backup-stale.tmp`);
+      await adminFormPost("/admin/backup/create");
+      const response = await adminGet("/admin/backup");
+      const html = await response.text();
+      expect(html).not.toContain("backup-stale.tmp");
+      expect(html).toContain(".zip");
     });
 
     test("shows the retention summary once a backup exists", async () => {
-      await withLocalStorageEnabled(async () => {
-        await adminFormPost("/admin/backup/create");
-        const response = await adminGet("/admin/backup");
-        const html = await response.text();
-        expect(html).toContain("There is 1 backup");
-        expect(html).toContain("Up to 30 are kept");
-      });
+      await adminFormPost("/admin/backup/create");
+      const response = await adminGet("/admin/backup");
+      const html = await response.text();
+      expect(html).toContain("There is 1 backup");
+      expect(html).toContain("Up to 30 are kept");
     });
   });
 
@@ -121,13 +118,11 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
     });
 
     test("returns 404 for missing file", async () => {
-      await withLocalStorageEnabled(async () => {
-        // Validly formatted leaf, but no such backup exists in this DB's folder.
-        const response = await adminGet(
-          "/admin/backup/download/backup-2024-01-15T12-30-00-000Z.zip",
-        );
-        expect(response.status).toBe(404);
-      });
+      // Validly formatted leaf, but no such backup exists in this DB's folder.
+      const response = await adminGet(
+        "/admin/backup/download/backup-2024-01-15T12-30-00-000Z.zip",
+      );
+      expect(response.status).toBe(404);
     });
 
     test("returns 400 for filename with path traversal", async () => {
@@ -138,22 +133,20 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
     });
 
     test("downloads existing backup as zip", async () => {
-      await withLocalStorageEnabled(async () => {
-        await adminFormPost("/admin/backup/create");
-        const listResp = await adminGet("/admin/backup");
-        const html = await listResp.text();
-        const linkMatch = html.match(
-          /\/admin\/backup\/download\/(backup-[^"]+\.zip)/,
-        );
-        expect(linkMatch).toBeTruthy();
-        const response = await adminGet(
-          `/admin/backup/download/${linkMatch![1]}`,
-        );
-        expect(response.status).toBe(200);
-        expect(response.headers.get("content-type")).toBe("application/zip");
-        // The response body must be the actual zip bytes, not an empty slice.
-        expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
-      });
+      await adminFormPost("/admin/backup/create");
+      const listResp = await adminGet("/admin/backup");
+      const html = await listResp.text();
+      const linkMatch = html.match(
+        /\/admin\/backup\/download\/(backup-[^"]+\.zip)/,
+      );
+      expect(linkMatch).toBeTruthy();
+      const response = await adminGet(
+        `/admin/backup/download/${linkMatch![1]}`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/zip");
+      // The response body must be the actual zip bytes, not an empty slice.
+      expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
     });
   });
 
@@ -185,75 +178,65 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
     };
 
     test("shows confirm page after uploading valid zip", async () => {
-      await withLocalStorageEnabled(async () => {
-        const zipData = await createBackupZip();
-        const { cookie, csrfToken } = await getTestSession();
-        const response = await postRestore(cookie, csrfToken, {
-          backup_file: new File([zipData.buffer as ArrayBuffer], "backup.zip"),
-        });
-        expect(response.status).toBe(200);
-        const html = await response.text();
-        expect(html).toContain("Confirm Database Restore");
-        // The statement count must be a real number, not NaN.
-        expect(html).not.toContain("NaN");
-        // A backup whose schema matches must NOT show the mismatch warning.
-        expect(html).not.toContain("Schema mismatch");
-        // The uploaded zip must be stored so the confirm step can read it back.
-        const tempName = html.match(
-          /value="(restore-pending-[^"]+\.zip)"/,
-        )?.[1];
-        expect(tempName).toBeDefined();
-        expect(await downloadRaw(tempName!)).not.toBeNull();
+      const zipData = await createBackupZip();
+      const { cookie, csrfToken } = await getTestSession();
+      const response = await postRestore(cookie, csrfToken, {
+        backup_file: new File([zipData.buffer as ArrayBuffer], "backup.zip"),
       });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Confirm Database Restore");
+      // The statement count must be a real number, not NaN.
+      expect(html).not.toContain("NaN");
+      // A backup whose schema matches must NOT show the mismatch warning.
+      expect(html).not.toContain("Schema mismatch");
+      // The uploaded zip must be stored so the confirm step can read it back.
+      const tempName = html.match(/value="(restore-pending-[^"]+\.zip)"/)?.[1];
+      expect(tempName).toBeDefined();
+      expect(await downloadRaw(tempName!)).not.toBeNull();
     });
 
     test("shows schema mismatch warning for different schema", async () => {
-      await withLocalStorageEnabled(async () => {
-        const encoder = new TextEncoder();
-        const fakeZip = zipSync({
-          "manifest.json": encoder.encode(
-            JSON.stringify({
-              latestUpdate: "",
-              schemaHash: "wrong",
-              tables: {},
-              timestamp: "",
-            }),
-          ),
-          "settings.sql": new Uint8Array(0),
-        });
-        const { cookie, csrfToken } = await getTestSession();
-        const response = await postRestore(cookie, csrfToken, {
-          backup_file: new File([fakeZip.buffer as ArrayBuffer], "backup.zip"),
-        });
-        const html = await response.text();
-        expect(html).toContain("Schema mismatch");
+      const encoder = new TextEncoder();
+      const fakeZip = zipSync({
+        "manifest.json": encoder.encode(
+          JSON.stringify({
+            latestUpdate: "",
+            schemaHash: "wrong",
+            tables: {},
+            timestamp: "",
+          }),
+        ),
+        "settings.sql": new Uint8Array(0),
       });
+      const { cookie, csrfToken } = await getTestSession();
+      const response = await postRestore(cookie, csrfToken, {
+        backup_file: new File([fakeZip.buffer as ArrayBuffer], "backup.zip"),
+      });
+      const html = await response.text();
+      expect(html).toContain("Schema mismatch");
     });
 
     test("rejects missing file field", async () => {
-      await withLocalStorageEnabled(async () => {
-        const { cookie, csrfToken } = await getTestSession();
-        const response = await postRestore(cookie, csrfToken);
-        await expectFlashRedirect(
-          "/admin/backup",
-          "Please select a backup file",
-          false,
-        )(response);
-      });
+      const { cookie, csrfToken } = await getTestSession();
+      const response = await postRestore(cookie, csrfToken);
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Please select a backup file",
+        false,
+      )(response);
     });
 
     test("rejects invalid zip file", async () => {
-      await withLocalStorageEnabled(async () => {
-        const { cookie, csrfToken } = await getTestSession();
-        const response = await postRestore(cookie, csrfToken, {
-          backup_file: new File([new ArrayBuffer(100)], "bad.zip"),
-        });
-        await expectFlashRedirect(
-          "/admin/backup",
-          expect.stringContaining("Invalid backup file"),
-          false,
-        )(response);
+      const { cookie, csrfToken } = await getTestSession();
+      const response = await postRestore(cookie, csrfToken, {
+        backup_file: new File([new ArrayBuffer(100)], "bad.zip"),
       });
+      await expectFlashRedirect(
+        "/admin/backup",
+        expect.stringContaining("Invalid backup file"),
+        false,
+      )(response);
     });
   });
 
@@ -311,41 +294,96 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
     });
 
     test("rejects missing backup file", async () => {
-      await withLocalStorageEnabled(async () => {
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-gone.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Backup file expired or not found. Please upload again.",
+        false,
+      )(response);
+    });
+
+    test("successfully restores from backup", async () => {
+      const listing = await createTestListing({ name: "Restore Me" });
+      const zipData = await createBackupZip();
+      // Delete the listing after capturing it in the backup so we can
+      // verify the restore actually writes data back to the DB.
+      const { deleteListing, getAllListings } = await import(
+        "#shared/db/listings.ts"
+      );
+      await deleteListing(listing.id);
+      expect((await getAllListings()).find((e) => e.id === listing.id)).toBe(
+        undefined,
+      );
+
+      await uploadRaw(zipData, "restore-pending-test.zip");
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-test.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      await expectFlashRedirect(
+        "/admin/login",
+        "Database restored from backup",
+      )(response);
+
+      const restored = (await getAllListings()).find(
+        (e) => e.id === listing.id,
+      );
+      expect(restored).toBeDefined();
+      expect(restored!.name).toBe("Restore Me");
+    });
+
+    test("surfaces the full recorded commit so the operator can redeploy the code", async () => {
+      // The running build records its commit into settings; the dump carries
+      // it, so the restore tells the operator which commit to redeploy. The
+      // FULL SHA is shown because the restore-deploy workflow requires one.
+      const fullSha = "0123456789abcdef0123456789abcdef01234567";
+      setBuildCommitForTest(fullSha);
+      try {
+        await getTestSession(); // ensure session row is in DB before backup
+        await recordScriptVersion();
+        const zipData = await createBackupZip();
+        await uploadRaw(zipData, "restore-pending-commit.zip");
+
         const { response } = await adminFormPost(
           "/admin/backup/restore/confirm",
           {
-            backup_filename: "restore-pending-gone.zip",
+            backup_filename: "restore-pending-commit.zip",
             confirm_identifier: RESTORE_CONFIRM_PHRASE,
           },
         );
         await expectFlashRedirect(
-          "/admin/backup",
-          "Backup file expired or not found. Please upload again.",
-          false,
+          "/admin/login",
+          `Database restored from backup. It was running commit ${fullSha} — run the restore-deploy workflow with that commit to restore the code to this point in time.`,
         )(response);
-      });
+      } finally {
+        setBuildCommitForTest(null);
+      }
     });
 
-    test("successfully restores from backup", async () => {
-      await withLocalStorageEnabled(async () => {
-        const listing = await createTestListing({ name: "Restore Me" });
+    test("omits the redeploy hint when the restored commit is not a full SHA", async () => {
+      // An uploaded/old backup may hold a non-SHA commit value; it must not be
+      // echoed into the flash (it's unusable by restore-deploy and could be
+      // oversized), so the message falls back to the plain confirmation.
+      setBuildCommitForTest("not-a-real-sha");
+      try {
+        await getTestSession(); // ensure session row is in DB before backup
+        await recordScriptVersion();
         const zipData = await createBackupZip();
-        // Delete the listing after capturing it in the backup so we can
-        // verify the restore actually writes data back to the DB.
-        const { deleteListing, getAllListings } = await import(
-          "#shared/db/listings.ts"
-        );
-        await deleteListing(listing.id);
-        expect((await getAllListings()).find((e) => e.id === listing.id)).toBe(
-          undefined,
-        );
+        await uploadRaw(zipData, "restore-pending-badsha.zip");
 
-        await uploadRaw(zipData, "restore-pending-test.zip");
         const { response } = await adminFormPost(
           "/admin/backup/restore/confirm",
           {
-            backup_filename: "restore-pending-test.zip",
+            backup_filename: "restore-pending-badsha.zip",
             confirm_identifier: RESTORE_CONFIRM_PHRASE,
           },
         );
@@ -353,226 +391,147 @@ describeWithEnv("server (admin backup)", { db: true }, () => {
           "/admin/login",
           "Database restored from backup",
         )(response);
-
-        const restored = (await getAllListings()).find(
-          (e) => e.id === listing.id,
-        );
-        expect(restored).toBeDefined();
-        expect(restored!.name).toBe("Restore Me");
-      });
-    });
-
-    test("surfaces the full recorded commit so the operator can redeploy the code", async () => {
-      await withLocalStorageEnabled(async () => {
-        // The running build records its commit into settings; the dump carries
-        // it, so the restore tells the operator which commit to redeploy. The
-        // FULL SHA is shown because the restore-deploy workflow requires one.
-        const fullSha = "0123456789abcdef0123456789abcdef01234567";
-        setBuildCommitForTest(fullSha);
-        try {
-          await getTestSession(); // ensure session row is in DB before backup
-          await recordScriptVersion();
-          const zipData = await createBackupZip();
-          await uploadRaw(zipData, "restore-pending-commit.zip");
-
-          const { response } = await adminFormPost(
-            "/admin/backup/restore/confirm",
-            {
-              backup_filename: "restore-pending-commit.zip",
-              confirm_identifier: RESTORE_CONFIRM_PHRASE,
-            },
-          );
-          await expectFlashRedirect(
-            "/admin/login",
-            `Database restored from backup. It was running commit ${fullSha} — run the restore-deploy workflow with that commit to restore the code to this point in time.`,
-          )(response);
-        } finally {
-          setBuildCommitForTest(null);
-        }
-      });
-    });
-
-    test("omits the redeploy hint when the restored commit is not a full SHA", async () => {
-      await withLocalStorageEnabled(async () => {
-        // An uploaded/old backup may hold a non-SHA commit value; it must not be
-        // echoed into the flash (it's unusable by restore-deploy and could be
-        // oversized), so the message falls back to the plain confirmation.
-        setBuildCommitForTest("not-a-real-sha");
-        try {
-          await getTestSession(); // ensure session row is in DB before backup
-          await recordScriptVersion();
-          const zipData = await createBackupZip();
-          await uploadRaw(zipData, "restore-pending-badsha.zip");
-
-          const { response } = await adminFormPost(
-            "/admin/backup/restore/confirm",
-            {
-              backup_filename: "restore-pending-badsha.zip",
-              confirm_identifier: RESTORE_CONFIRM_PHRASE,
-            },
-          );
-          await expectFlashRedirect(
-            "/admin/login",
-            "Database restored from backup",
-          )(response);
-        } finally {
-          setBuildCommitForTest(null);
-        }
-      });
+      } finally {
+        setBuildCommitForTest(null);
+      }
     });
 
     test("rejects filename with traversal despite valid prefix and suffix", async () => {
-      await withLocalStorageEnabled(async () => {
-        // Place a decoy at the traversal target — if traversal were allowed,
-        // the restore would attempt to read it. The validation layer must
-        // reject before any filesystem access.
-        await uploadRaw(new Uint8Array(1), "etc-passwd-decoy.zip");
-        const { response } = await adminFormPost(
-          "/admin/backup/restore/confirm",
-          {
-            backup_filename: "restore-pending-x/../../etc-passwd-decoy.zip",
-            confirm_identifier: RESTORE_CONFIRM_PHRASE,
-          },
-        );
-        await expectFlashRedirect(
-          "/admin/backup",
-          "Invalid backup reference",
-          false,
-        )(response);
-      });
+      // Place a decoy at the traversal target — if traversal were allowed,
+      // the restore would attempt to read it. The validation layer must
+      // reject before any filesystem access.
+      await uploadRaw(new Uint8Array(1), "etc-passwd-decoy.zip");
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-x/../../etc-passwd-decoy.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      await expectFlashRedirect(
+        "/admin/backup",
+        "Invalid backup reference",
+        false,
+      )(response);
     });
 
     test("routes pre-reset restore failure to backup page", async () => {
-      await withLocalStorageEnabled(async () => {
-        // Upload raw non-zip bytes — restoreFromZip throws from unzipSync
-        // before any DB reset, so the session is intact and onError redirects
-        // back to /admin/backup.
-        await uploadRaw(
-          new Uint8Array([0, 1, 2, 3]),
-          "restore-pending-badzip.zip",
-        );
-        const { response } = await adminFormPost(
-          "/admin/backup/restore/confirm",
-          {
-            backup_filename: "restore-pending-badzip.zip",
-            confirm_identifier: RESTORE_CONFIRM_PHRASE,
-          },
-        );
-        await expectFlashRedirect(
-          "/admin/backup",
-          expect.any(String),
-          false,
-        )(response);
-      });
+      // Upload raw non-zip bytes — restoreFromZip throws from unzipSync
+      // before any DB reset, so the session is intact and onError redirects
+      // back to /admin/backup.
+      await uploadRaw(
+        new Uint8Array([0, 1, 2, 3]),
+        "restore-pending-badzip.zip",
+      );
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-badzip.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      await expectFlashRedirect(
+        "/admin/backup",
+        expect.any(String),
+        false,
+      )(response);
     });
 
     test("routes post-reset restore failure to setup page", async () => {
-      await withLocalStorageEnabled(async () => {
-        // A valid zip whose SQL is invalid reaches restoreFromSql, which runs
-        // resetDatabase() before executeBatch fails — sessions and settings are
-        // wiped, so onError must send to /setup/ (not /admin/login or /admin/backup).
-        const badSqlZip = zipSync({
-          "settings.sql": new TextEncoder().encode("INVALID SQL SYNTAX;"),
-        });
-        await uploadRaw(badSqlZip, "restore-pending-badsql.zip");
-        const { response } = await adminFormPost(
-          "/admin/backup/restore/confirm",
-          {
-            backup_filename: "restore-pending-badsql.zip",
-            confirm_identifier: RESTORE_CONFIRM_PHRASE,
-          },
-        );
-        await expectFlashRedirect(
-          "/setup/",
-          expect.any(String),
-          false,
-        )(response);
+      // A valid zip whose SQL is invalid reaches restoreFromSql, which runs
+      // resetDatabase() before executeBatch fails — sessions and settings are
+      // wiped, so onError must send to /setup/ (not /admin/login or /admin/backup).
+      const badSqlZip = zipSync({
+        "settings.sql": new TextEncoder().encode("INVALID SQL SYNTAX;"),
       });
+      await uploadRaw(badSqlZip, "restore-pending-badsql.zip");
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-badsql.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      await expectFlashRedirect("/setup/", expect.any(String), false)(response);
     });
 
     test("cleans up temp file even on restore failure", async () => {
-      await withLocalStorageEnabled(async () => {
-        // Upload an invalid zip (valid zip format but contains bad SQL)
-        const badZip = zipSync({
-          "settings.sql": new TextEncoder().encode("INVALID SQL SYNTAX;"),
-        });
-        await uploadRaw(badZip, "restore-pending-fail.zip");
-
-        // Attempt restore — should fail but still clean up the temp file
-        try {
-          await adminFormPost("/admin/backup/restore/confirm", {
-            backup_filename: "restore-pending-fail.zip",
-            confirm_identifier: RESTORE_CONFIRM_PHRASE,
-          });
-        } catch {
-          // Restore failure is expected
-        }
-
-        // Temp file should be cleaned up regardless
-        const data = await downloadRaw("restore-pending-fail.zip");
-        expect(data).toBeNull();
+      // Upload an invalid zip (valid zip format but contains bad SQL)
+      const badZip = zipSync({
+        "settings.sql": new TextEncoder().encode("INVALID SQL SYNTAX;"),
       });
+      await uploadRaw(badZip, "restore-pending-fail.zip");
+
+      // Attempt restore — should fail but still clean up the temp file
+      try {
+        await adminFormPost("/admin/backup/restore/confirm", {
+          backup_filename: "restore-pending-fail.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        });
+      } catch {
+        // Restore failure is expected
+      }
+
+      // Temp file should be cleaned up regardless
+      const data = await downloadRaw("restore-pending-fail.zip");
+      expect(data).toBeNull();
     });
 
     test("restore clears all entity caches including holidays", async () => {
-      await withLocalStorageEnabled(async () => {
-        const { getAllHolidays } = await import("#shared/db/holidays.ts");
+      const { getAllHolidays } = await import("#shared/db/holidays.ts");
 
-        // Snapshot before creating any holidays — backup has no holidays
-        const zipData = await createBackupZip();
-        await uploadRaw(zipData, "restore-pending-caches.zip");
+      // Snapshot before creating any holidays — backup has no holidays
+      const zipData = await createBackupZip();
+      await uploadRaw(zipData, "restore-pending-caches.zip");
 
-        // Create a holiday after the backup so it exists in the cache but
-        // will be absent from the restored DB
-        await createTestHoliday({ name: "Cache Test Holiday" });
-        const before = await getAllHolidays();
-        expect(before.some((h) => h.name === "Cache Test Holiday")).toBe(true);
+      // Create a holiday after the backup so it exists in the cache but
+      // will be absent from the restored DB
+      await createTestHoliday({ name: "Cache Test Holiday" });
+      const before = await getAllHolidays();
+      expect(before.some((h) => h.name === "Cache Test Holiday")).toBe(true);
 
-        // Restore from the pre-holiday snapshot
-        const { response } = await adminFormPost(
-          "/admin/backup/restore/confirm",
-          {
-            backup_filename: "restore-pending-caches.zip",
-            confirm_identifier: RESTORE_CONFIRM_PHRASE,
-          },
-        );
-        expect(response.status).toBe(302);
+      // Restore from the pre-holiday snapshot
+      const { response } = await adminFormPost(
+        "/admin/backup/restore/confirm",
+        {
+          backup_filename: "restore-pending-caches.zip",
+          confirm_identifier: RESTORE_CONFIRM_PHRASE,
+        },
+      );
+      expect(response.status).toBe(302);
 
-        // The holidays cache must be cleared: the holiday is gone from the DB
-        // and must not be served from a stale cache entry
-        const after = await getAllHolidays();
-        expect(after.some((h) => h.name === "Cache Test Holiday")).toBe(false);
-      });
+      // The holidays cache must be cleared: the holiday is gone from the DB
+      // and must not be served from a stale cache entry
+      const after = await getAllHolidays();
+      expect(after.some((h) => h.name === "Cache Test Holiday")).toBe(false);
     });
 
     test("restore clears session cache so pre-restore sessions are re-validated", async () => {
-      await withLocalStorageEnabled(async () => {
-        // Snapshot before the manager session is created
-        const zipData = await createBackupZip();
-        await uploadRaw(zipData, "restore-pending-sessions.zip");
+      // Snapshot before the manager session is created
+      const zipData = await createBackupZip();
+      await uploadRaw(zipData, "restore-pending-sessions.zip");
 
-        // Create a manager session after the backup — it will not be in the
-        // restored DB, so it must also be evicted from the session cache
-        const managerCookie = await createTestManagerSession(
-          "cache-test-mgr",
-          "cache-test-manager",
-        );
+      // Create a manager session after the backup — it will not be in the
+      // restored DB, so it must also be evicted from the session cache
+      const managerCookie = await createTestManagerSession(
+        "cache-test-mgr",
+        "cache-test-manager",
+      );
 
-        // Restore from the pre-manager snapshot
-        await adminFormPost("/admin/backup/restore/confirm", {
-          backup_filename: "restore-pending-sessions.zip",
-          confirm_identifier: RESTORE_CONFIRM_PHRASE,
-        });
-
-        // After restore the manager token is absent from the DB and the
-        // session cache has been cleared, so using it must fail auth.
-        // /admin/backup returns 403 for authenticated managers and 302 for
-        // unauthenticated requests; a 302 here proves the session was rejected.
-        const response = await awaitTestRequest("/admin/backup", {
-          cookie: managerCookie,
-        });
-        expect(response.status).toBe(302); // redirected to login (not 403)
+      // Restore from the pre-manager snapshot
+      await adminFormPost("/admin/backup/restore/confirm", {
+        backup_filename: "restore-pending-sessions.zip",
+        confirm_identifier: RESTORE_CONFIRM_PHRASE,
       });
+
+      // After restore the manager token is absent from the DB and the
+      // session cache has been cleared, so using it must fail auth.
+      // /admin/backup returns 403 for authenticated managers and 302 for
+      // unauthenticated requests; a 302 here proves the session was rejected.
+      const response = await awaitTestRequest("/admin/backup", {
+        cookie: managerCookie,
+      });
+      expect(response.status).toBe(302); // redirected to login (not 403)
     });
   });
 });

--- a/test/lib/server-demo-reset.test.ts
+++ b/test/lib/server-demo-reset.test.ts
@@ -22,6 +22,7 @@ import {
   invalidateTestDbCache,
   mockFormRequest,
   mockRequest,
+  TEST_STORAGE_ZONE,
   testCookie,
   testCsrfToken,
   withFetchMock,
@@ -174,35 +175,33 @@ describeWithEnv("server (demo reset)", { db: true }, () => {
         imageUrl: "reset-image.jpg",
       });
 
-      await runWithStorageConfig(
-        { zoneKey: "testkey", zoneName: "testzone" },
-        () =>
-          withFetchMock(async (originalFetch) => {
-            const deletedUrls: string[] = [];
-            installUrlHandler(originalFetch, (url) => {
-              if (url.includes("storage.bunnycdn.com")) {
-                deletedUrls.push(url);
-                return Promise.resolve(
-                  new Response(JSON.stringify({ HttpCode: 200 }), {
-                    status: 200,
-                  }),
-                );
-              }
-              return null;
-            });
+      await runWithStorageConfig(TEST_STORAGE_ZONE, () =>
+        withFetchMock(async (originalFetch) => {
+          const deletedUrls: string[] = [];
+          installUrlHandler(originalFetch, (url) => {
+            if (url.includes("storage.bunnycdn.com")) {
+              deletedUrls.push(url);
+              return Promise.resolve(
+                new Response(JSON.stringify({ HttpCode: 200 }), {
+                  status: 200,
+                }),
+              );
+            }
+            return null;
+          });
 
-            const response = await submitDemoResetForm({
-              confirm_phrase: RESET_DATABASE_PHRASE,
-            });
+          const response = await submitDemoResetForm({
+            confirm_phrase: RESET_DATABASE_PHRASE,
+          });
 
-            expectRedirectWithFlash("/setup/", "Database reset")(response);
-            expect(deletedUrls.some((u) => u.includes("reset-image.jpg"))).toBe(
-              true,
-            );
-            expect(
-              deletedUrls.some((u) => u.includes("reset-attachment.pdf")),
-            ).toBe(true);
-          }),
+          expectRedirectWithFlash("/setup/", "Database reset")(response);
+          expect(deletedUrls.some((u) => u.includes("reset-image.jpg"))).toBe(
+            true,
+          );
+          expect(
+            deletedUrls.some((u) => u.includes("reset-attachment.pdf")),
+          ).toBe(true);
+        }),
       );
 
       invalidateTestDbCache();

--- a/test/lib/server-images.test.ts
+++ b/test/lib/server-images.test.ts
@@ -24,6 +24,7 @@ import {
   mockRequest,
   PDF_BYTES,
   setupListingAndLogin,
+  TEST_STORAGE_ZONE,
   testCookie,
   testCsrfToken,
   updateTestListing,
@@ -757,21 +758,19 @@ describeWithEnv(
       test("reports error when attachment upload fails", async () => {
         const { listing, cookie, csrfToken } = await setupListingAndLogin();
 
-        await runWithStorageConfig(
-          { zoneKey: "testkey", zoneName: "testzone" },
-          () =>
-            withFetchMock(async (originalFetch) => {
-              installUrlHandler(originalFetch, () =>
-                Promise.reject(new Error("CDN unreachable")),
-              );
+        await runWithStorageConfig(TEST_STORAGE_ZONE, () =>
+          withFetchMock(async (originalFetch) => {
+            installUrlHandler(originalFetch, () =>
+              Promise.reject(new Error("CDN unreachable")),
+            );
 
-              const response = await submitEditGuidePdf(
-                listing.id,
-                cookie,
-                csrfToken,
-              );
-              expectImageErrorRedirect(response, "upload failed");
-            }),
+            const response = await submitEditGuidePdf(
+              listing.id,
+              cookie,
+              csrfToken,
+            );
+            expectImageErrorRedirect(response, "upload failed");
+          }),
         );
       });
     });

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -53,6 +53,7 @@ import {
   setTestEnv,
   setupListingAndLogin,
   submitTicketForm,
+  TEST_STORAGE_ZONE,
   testCookie,
   testCsrfToken,
   testRequiresAuth,
@@ -3566,36 +3567,30 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
         attachmentUrl: "uuid-guide.pdf",
       });
 
-      await runWithStorageConfig(
-        { zoneKey: "testkey", zoneName: "testzone" },
-        async () => {
-          const response = await awaitTestRequest(
-            `/admin/listing/${listing.id}/edit`,
-            { cookie },
-          );
-          const html = await response.text();
-          expect(html).toContain("attachment-info");
-          expect(html).toContain("Listing Guide.pdf");
-          expect(html).toContain("Remove Attachment");
-        },
-      );
+      await runWithStorageConfig(TEST_STORAGE_ZONE, async () => {
+        const response = await awaitTestRequest(
+          `/admin/listing/${listing.id}/edit`,
+          { cookie },
+        );
+        const html = await response.text();
+        expect(html).toContain("attachment-info");
+        expect(html).toContain("Listing Guide.pdf");
+        expect(html).toContain("Remove Attachment");
+      });
     });
 
     test("admin listing edit page does not show attachment info when empty", async () => {
       const { listing, cookie } = await setupListingAndLogin();
 
-      await runWithStorageConfig(
-        { zoneKey: "testkey", zoneName: "testzone" },
-        async () => {
-          const response = await awaitTestRequest(
-            `/admin/listing/${listing.id}/edit`,
-            { cookie },
-          );
-          const html = await response.text();
-          expect(html).not.toContain("attachment-info");
-          expect(html).not.toContain("Remove Attachment");
-        },
-      );
+      await runWithStorageConfig(TEST_STORAGE_ZONE, async () => {
+        const response = await awaitTestRequest(
+          `/admin/listing/${listing.id}/edit`,
+          { cookie },
+        );
+        const html = await response.text();
+        expect(html).not.toContain("attachment-info");
+        expect(html).not.toContain("Remove Attachment");
+      });
     });
   });
 

--- a/test/routes/backup.test.ts
+++ b/test/routes/backup.test.ts
@@ -12,6 +12,7 @@ import {
   describeWithEnv,
   installUrlHandler,
   mockRequest,
+  TEST_STORAGE_ZONE,
   testCookie,
   withFetchMock,
   withLocalStorageEnabled,
@@ -56,26 +57,24 @@ describeWithEnv("backup routes", { db: true }, () => {
     test("loads backup page when stale cleanup listing fails", async () => {
       const cookie = await testCookie();
 
-      await runWithStorageConfig(
-        { zoneKey: "testkey", zoneName: "testzone" },
-        () =>
-          withFetchMock(async (originalFetch) => {
-            let calls = 0;
-            installUrlHandler(originalFetch, (url) => {
-              if (!url.includes("storage.bunnycdn.com")) return null;
-              calls += 1;
-              return calls === 1
-                ? Promise.reject(new Error("list failed"))
-                : Promise.resolve(Response.json([]));
-            });
+      await runWithStorageConfig(TEST_STORAGE_ZONE, () =>
+        withFetchMock(async (originalFetch) => {
+          let calls = 0;
+          installUrlHandler(originalFetch, (url) => {
+            if (!url.includes("storage.bunnycdn.com")) return null;
+            calls += 1;
+            return calls === 1
+              ? Promise.reject(new Error("list failed"))
+              : Promise.resolve(Response.json([]));
+          });
 
-            const response = await handleRequest(
-              mockRequest("/admin/backup", { headers: { cookie } }),
-            );
+          const response = await handleRequest(
+            mockRequest("/admin/backup", { headers: { cookie } }),
+          );
 
-            expect(response.status).toBe(200);
-            expect(await response.text()).toContain("Backup");
-          }),
+          expect(response.status).toBe(200);
+          expect(await response.text()).toContain("Backup");
+        }),
       );
     });
   });

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -20,6 +20,7 @@ import {
   describeWithEnv,
   hasSelectedOption,
   setupTestEncryptionKey,
+  TEST_STORAGE_ZONE,
   testAttendee,
   testGroup,
   testListingWithCount,
@@ -1851,16 +1852,13 @@ describeWithEnv(
       });
 
       test("shows current image and remove button when image is set", () => {
-        runWithStorageConfig(
-          { zoneKey: "testkey", zoneName: "testzone" },
-          () => {
-            const listing = testListingWithCount({ image_url: "current.jpg" });
-            const html = adminListingEditPage(listing, [], TEST_SESSION);
-            expect(html).toContain("/image/current.jpg");
-            expect(html).toContain("Remove Image");
-            expect(html).toContain("/image/delete");
-          },
-        );
+        runWithStorageConfig(TEST_STORAGE_ZONE, () => {
+          const listing = testListingWithCount({ image_url: "current.jpg" });
+          const html = adminListingEditPage(listing, [], TEST_SESSION);
+          expect(html).toContain("/image/current.jpg");
+          expect(html).toContain("Remove Image");
+          expect(html).toContain("/image/delete");
+        });
       });
 
       test("does not show image field when storage is not enabled", () => {
@@ -1873,30 +1871,24 @@ describeWithEnv(
       });
 
       test("shows full-width image preview when listing has image", () => {
-        runWithStorageConfig(
-          { zoneKey: "testkey", zoneName: "testzone" },
-          () => {
-            const listing = testListingWithCount({ image_url: "preview.jpg" });
-            const html = adminListingEditPage(listing, [], TEST_SESSION);
-            expect(html).toContain("listing-image-full");
-            expect(html).toContain("/image/preview.jpg");
-          },
-        );
+        runWithStorageConfig(TEST_STORAGE_ZONE, () => {
+          const listing = testListingWithCount({ image_url: "preview.jpg" });
+          const html = adminListingEditPage(listing, [], TEST_SESSION);
+          expect(html).toContain("listing-image-full");
+          expect(html).toContain("/image/preview.jpg");
+        });
       });
     });
 
     describe("adminDuplicateListingPage image section", () => {
       test("shows image upload field when storage enabled", () => {
-        runWithStorageConfig(
-          { zoneKey: "testkey", zoneName: "testzone" },
-          () => {
-            const listing = testListingWithCount({ image_url: "" });
-            const html = adminDuplicateListingPage(listing, [], TEST_SESSION);
-            expect(html).toContain('type="file"');
-            expect(html).toContain('name="image"');
-            expect(html).toContain("multipart/form-data");
-          },
-        );
+        runWithStorageConfig(TEST_STORAGE_ZONE, () => {
+          const listing = testListingWithCount({ image_url: "" });
+          const html = adminDuplicateListingPage(listing, [], TEST_SESSION);
+          expect(html).toContain('type="file"');
+          expect(html).toContain('name="image"');
+          expect(html).toContain("multipart/form-data");
+        });
       });
 
       test("does not show image field when storage is not enabled", () => {
@@ -1911,15 +1903,12 @@ describeWithEnv(
 
     describe("adminListingNewPage image section", () => {
       test("shows image upload field on create form when storage enabled", () => {
-        runWithStorageConfig(
-          { zoneKey: "testkey", zoneName: "testzone" },
-          () => {
-            const html = adminListingNewPage([], TEST_SESSION);
-            expect(html).toContain('type="file"');
-            expect(html).toContain('name="image"');
-            expect(html).toContain("multipart/form-data");
-          },
-        );
+        runWithStorageConfig(TEST_STORAGE_ZONE, () => {
+          const html = adminListingNewPage([], TEST_SESSION);
+          expect(html).toContain('type="file"');
+          expect(html).toContain('name="image"');
+          expect(html).toContain("multipart/form-data");
+        });
       });
 
       test("does not show image field on create form when storage is not enabled", () => {

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -47,6 +47,7 @@ import {
   setTestStoragePath,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
+  TEST_STORAGE_ZONE,
 } from "#test-utils/internal.ts";
 
 type SchemaEntry = (typeof SCHEMA)[number];
@@ -348,8 +349,8 @@ const setupStorageEnv = async (
     // Clear any ambient local path so the Bunny backend resolves deterministically.
     return {
       LOCAL_STORAGE_PATH: undefined,
-      STORAGE_ZONE_KEY: "testkey",
-      STORAGE_ZONE_NAME: "testzone",
+      STORAGE_ZONE_KEY: TEST_STORAGE_ZONE.zoneKey,
+      STORAGE_ZONE_NAME: TEST_STORAGE_ZONE.zoneName,
     };
   }
   if (storage === "local") {

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -345,12 +345,23 @@ const setupStorageEnv = async (
   storage: DescribeEnvOptions["storage"],
 ): Promise<Record<string, string | undefined>> => {
   if (storage === "cdn") {
-    return { STORAGE_ZONE_KEY: "testkey", STORAGE_ZONE_NAME: "testzone" };
+    // Clear any ambient local path so the Bunny backend resolves deterministically.
+    return {
+      LOCAL_STORAGE_PATH: undefined,
+      STORAGE_ZONE_KEY: "testkey",
+      STORAGE_ZONE_NAME: "testzone",
+    };
   }
   if (storage === "local") {
     const dir = await Deno.makeTempDir();
     setTestStoragePath(dir);
-    return { LOCAL_STORAGE_PATH: dir };
+    // Clear any ambient Bunny creds — getStorageBackend() checks those before
+    // the local path, so leaving them set would resolve to "bunny", not "local".
+    return {
+      LOCAL_STORAGE_PATH: dir,
+      STORAGE_ZONE_KEY: undefined,
+      STORAGE_ZONE_NAME: undefined,
+    };
   }
   return {};
 };

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -36,6 +36,7 @@ import {
   type DescribeEnvOptions,
   getCachedSetupSettings,
   getCachedSetupUsers,
+  getTestStoragePath,
   type RawListingRange,
   resetTestSession,
   resetTestSlugCounter,
@@ -43,6 +44,7 @@ import {
   setCachedSetupSettings,
   setCachedSetupUsers,
   setTestSession,
+  setTestStoragePath,
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
 } from "#test-utils/internal.ts";
@@ -333,6 +335,34 @@ export const invalidateTestDbCache = (): void => {
   setCachedAdminSession(null);
 };
 
+/**
+ * Env additions that establish the requested `storage` backend for a test.
+ * `"local"` also allocates a fresh temp dir and records it for `getTestStoragePath`.
+ * Storage config is read env-first with an AsyncLocalStorage override, so a
+ * per-test `runWithStorageConfig` scope still overrides this suite default.
+ */
+const setupStorageEnv = async (
+  storage: DescribeEnvOptions["storage"],
+): Promise<Record<string, string | undefined>> => {
+  if (storage === "cdn") {
+    return { STORAGE_ZONE_KEY: "testkey", STORAGE_ZONE_NAME: "testzone" };
+  }
+  if (storage === "local") {
+    const dir = await Deno.makeTempDir();
+    setTestStoragePath(dir);
+    return { LOCAL_STORAGE_PATH: dir };
+  }
+  return {};
+};
+
+/** Remove the `storage: "local"` temp dir and clear the recorded path. */
+const teardownStorageEnv = async (): Promise<void> => {
+  const dir = getTestStoragePath();
+  if (!dir) return;
+  setTestStoragePath(null);
+  await Deno.remove(dir, { recursive: true });
+};
+
 export const describeWithEnv = (
   name: string,
   options: DescribeEnvOptions,
@@ -349,11 +379,17 @@ export const describeWithEnv = (
         settings.googleWallet.setHostConfigForTest(null);
         await createTestDbWithSetup("GB", options.triggers ?? false);
       }
-      if (options.env) restoreEnv = setTestEnv(options.env);
+      const env = {
+        ...options.env,
+        ...(await setupStorageEnv(options.storage)),
+      };
+      if (Object.keys(env).length > 0) restoreEnv = setTestEnv(env);
     });
-    afterEach(() => {
+    afterEach(async () => {
       if (options.db) resetDb();
       if (restoreEnv) restoreEnv();
+      restoreEnv = undefined;
+      await teardownStorageEnv();
     });
     fn();
   });

--- a/test/test-utils/internal.ts
+++ b/test/test-utils/internal.ts
@@ -8,6 +8,14 @@ export const TEST_ADMIN_PASSWORD = "testpassword123";
 export const TEST_ENCRYPTION_KEY =
   "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
 
+// The standard Bunny CDN test zone. Single source of truth shared by the
+// storage-mock helpers (as a runWithStorageConfig object) and describeWithEnv's
+// `storage: "cdn"` option (as STORAGE_ZONE_KEY/NAME env vars).
+export const TEST_STORAGE_ZONE = {
+  zoneKey: "testkey",
+  zoneName: "testzone",
+} as const;
+
 type AdminSessionRow = {
   token: string;
   csrf_token: string;

--- a/test/test-utils/internal.ts
+++ b/test/test-utils/internal.ts
@@ -56,7 +56,24 @@ export interface DescribeEnvOptions {
   encryptionKey?: boolean;
   env?: Record<string, string | undefined>;
   triggers?: boolean;
+  /**
+   * Establish an image-storage backend for every test in the suite, instead of
+   * wrapping each body in `withStorageEnabled` / `withLocalStorageEnabled`:
+   * - `"cdn"`: the standard Bunny test zone (`isStorageEnabled()` ⇒ true).
+   * - `"local"`: a fresh temp dir per test (path via `getTestStoragePath()`),
+   *   created before the test and removed after.
+   * An individual test can still override with a per-body `runWithStorageConfig`
+   * scope (e.g. `withStorageDisabled`), which wins over the suite's env default.
+   */
+  storage?: "cdn" | "local";
 }
+
+// The temp dir backing `storage: "local"`; set per test in describeWithEnv's
+// beforeEach and cleared/removed in afterEach. Tests that write through the
+// local backend read the active dir from here.
+export const [getTestStoragePath, setTestStoragePath] = lazyRef<string | null>(
+  () => null,
+);
 
 export interface TestRequestOptions {
   cookie?: string;

--- a/test/test-utils/mocks.ts
+++ b/test/test-utils/mocks.ts
@@ -7,7 +7,10 @@ import { getSessionCookieName } from "#shared/cookies.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
 import { runWithStorageConfig } from "#shared/storage.ts";
 import { setTestEnv } from "#test-utils/env.ts";
-import type { TestRequestOptions } from "#test-utils/internal.ts";
+import {
+  TEST_STORAGE_ZONE,
+  type TestRequestOptions,
+} from "#test-utils/internal.ts";
 
 export const mockRequestWithHost = (
   path: string,
@@ -276,21 +279,36 @@ export const expectFetchSilent = async (
   }
 };
 
+/** Core of the storage-mock helpers: run `body` with a fetch mock whose URL
+ *  `handler` intercepts requests (non-matching URLs fall through to the real
+ *  fetch). When `withConfig` is true (default) the body also runs under the
+ *  standard Bunny test zone, so `isStorageEnabled()` is true and uploads target
+ *  the CDN; pass `false` to exercise the fetch mock with storage unconfigured. */
+const withStorageFetchMock = (
+  handler: (url: string, init?: RequestInit) => Promise<Response> | null,
+  body: () => Promise<void>,
+  withConfig = true,
+): Promise<void> => {
+  const run = (): Promise<void> =>
+    withFetchMock(async (originalFetch) => {
+      installUrlHandler(originalFetch, handler);
+      await body();
+    });
+  return withConfig ? runWithStorageConfig(TEST_STORAGE_ZONE, run) : run();
+};
+
 /** Run `body` under the standard test zone config with a fetch mock that
  * answers every Bunny storage URL via `respond` (other URLs fall through). */
 export const withBunnyStorageStub = (
   respond: (url: string, init?: RequestInit) => Promise<Response> | Response,
   body: () => Promise<void>,
 ): Promise<void> =>
-  runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, () =>
-    withFetchMock(async (originalFetch) => {
-      installUrlHandler(originalFetch, (url, init) =>
-        url.includes("storage.bunnycdn.com")
-          ? Promise.resolve(respond(url, init))
-          : null,
-      );
-      await body();
-    }),
+  withStorageFetchMock(
+    (url, init) =>
+      url.includes("storage.bunnycdn.com")
+        ? Promise.resolve(respond(url, init))
+        : null,
+    body,
   );
 
 /** Run `body` with a fetch mock that records and 200s every Bunny
@@ -304,25 +322,22 @@ export const withBunnyDeleteCapture = (
     extraHandler?: (url: string) => Promise<Response> | null;
   } = {},
 ): Promise<void> => {
-  const run = (): Promise<void> =>
-    withFetchMock(async (originalFetch) => {
-      const deletedUrls: string[] = [];
-      installUrlHandler(originalFetch, (url) => {
-        const extra = opts.extraHandler?.(url);
-        if (extra) return extra;
-        if (url.includes("storage.bunnycdn.com")) {
-          deletedUrls.push(url);
-          return Promise.resolve(
-            new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
-          );
-        }
-        return null;
-      });
-      await body(deletedUrls);
-    });
-  return opts.withConfig === false
-    ? run()
-    : runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, run);
+  const deletedUrls: string[] = [];
+  return withStorageFetchMock(
+    (url) => {
+      const extra = opts.extraHandler?.(url);
+      if (extra) return extra;
+      if (url.includes("storage.bunnycdn.com")) {
+        deletedUrls.push(url);
+        return Promise.resolve(
+          new Response(JSON.stringify({ HttpCode: 200 }), { status: 200 }),
+        );
+      }
+      return null;
+    },
+    () => body(deletedUrls),
+    opts.withConfig !== false,
+  );
 };
 
 export const testRequest = (
@@ -379,32 +394,27 @@ export const cdnOkResponse = (): Response =>
 
 export const withStorageMock = (
   fn: (fetchCalls: string[]) => Promise<void>,
-): Promise<void> =>
-  runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, () =>
-    withFetchMock(async (originalFetch) => {
-      const fetchCalls: string[] = [];
-      installUrlHandler(originalFetch, (url) => {
-        fetchCalls.push(url);
-        if (url.includes("storage.bunnycdn.com") || url.includes("b-cdn.net")) {
-          return Promise.resolve(cdnOkResponse());
-        }
-        return null;
-      });
-      await fn(fetchCalls);
-    }),
+): Promise<void> => {
+  const fetchCalls: string[] = [];
+  return withStorageFetchMock(
+    (url) => {
+      fetchCalls.push(url);
+      if (url.includes("storage.bunnycdn.com") || url.includes("b-cdn.net")) {
+        return Promise.resolve(cdnOkResponse());
+      }
+      return null;
+    },
+    () => fn(fetchCalls),
   );
+};
 
 const withCdnFetch = (
   handle: (url: string) => Promise<Response> | null,
   fn: () => Promise<void>,
 ): Promise<void> =>
-  runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, () =>
-    withFetchMock(async (originalFetch) => {
-      installUrlHandler(originalFetch, (url) =>
-        url.includes("storage.bunnycdn.com") ? handle(url) : null,
-      );
-      await fn();
-    }),
+  withStorageFetchMock(
+    (url) => (url.includes("storage.bunnycdn.com") ? handle(url) : null),
+    fn,
   );
 
 export const withCdnProxy = (
@@ -421,7 +431,7 @@ export const withStorageDisabled = <T>(fn: () => T): T =>
   runWithStorageConfig({ localPath: "", zoneKey: "", zoneName: "" }, fn);
 
 export const withStorageEnabled = <T>(fn: () => T): T =>
-  runWithStorageConfig({ zoneKey: "testkey", zoneName: "testzone" }, fn);
+  runWithStorageConfig(TEST_STORAGE_ZONE, fn);
 
 export const withLocalStorageEnabled = async <T>(
   fn: (dir: string) => Promise<T>,


### PR DESCRIPTION
## What

Adds a `storage` option to `describeWithEnv` so a whole test suite can declare its image-storage backend once, instead of wrapping every test body in `withStorageEnabled` / `withLocalStorageEnabled`:

```ts
describeWithEnv("server (admin backup)", { db: true, storage: "local" }, () => { ... })
```

- **`"cdn"`** — the standard Bunny test zone for every test (`isStorageEnabled()` ⇒ true).
- **`"local"`** — a fresh temp dir per test, created before the test and removed after; its path is exposed via `getTestStoragePath()` for tests that read/write files through the local backend.

## Why

This started as "collapse the request-scope wrapper pyramid into a middleware fold" (already merged for `index.ts` in #1487). Auditing the rest of the tree, the *only* homogeneous 3+ wrapper pyramid was the one #1487 already folded — everything else is 2-layer, data-dependent auth→entity pipelines the fold rule explicitly excludes.

The genuinely repetitive wrapping lives in **tests**: the same per-test storage scope repeated across a suite. That's repetition, not a nestable pyramid, so the right lever is hoisting the scope into the suite harness rather than a `reduceRight` fold.

## How

The storage backend is resolved env-first (with an AsyncLocalStorage override), and `describeWithEnv` already establishes per-test env — so the option is implemented entirely in the test harness with **no production-code change**. Because the per-test ALS scope still wins over the suite's env default, an individual test can opt out with `withStorageDisabled(...)`; the mechanism is additive, not a lock-in.

## Changes

- `test/test-utils/internal.ts` — `storage?: "cdn" | "local"` on `DescribeEnvOptions`; `getTestStoragePath` / `setTestStoragePath` (a resettable `lazyRef`).
- `test/test-utils/db.ts` — `describeWithEnv` sets up the backend in `beforeEach` (temp dir for `"local"`, zone env for `"cdn"`) and tears the temp dir down in `afterEach`.
- `test/lib/server-backup.test.ts` — first adopter: 20 `withLocalStorageEnabled` wrappers collapse to one suite option; the lone "storage not configured" test opts back out via `withStorageDisabled`.
- `test/lib/describe-with-env-storage.test.ts` — new: covers both backends, the temp-dir lifecycle (created then cleaned up between tests), and the per-test override.

## Verification

- `deno task test:files test/lib/server-backup.test.ts` — 40 passed (behavior-preserving migration).
- `deno task test:files test/lib/describe-with-env-storage.test.ts` — 9 passed.
- `deno task precommit` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01281Ud3brm4GYgx69BvQErT

---
_Generated by [Claude Code](https://claude.ai/code/session_01281Ud3brm4GYgx69BvQErT)_