### PR TITLE
Harden payment sandbox e2e: reject live keys, honest Stripe scope, assert paid amount

### DIFF
--- a/e2e-payments/README.md
+++ b/e2e-payments/README.md
@@ -88,7 +88,8 @@ A target with missing secrets **skips** (exits 0) rather than failing.
 Other knobs (all optional): `DENO_BIN`, `CLOUDFLARED_BIN`,
 `CHROMIUM_EXECUTABLE` (unset in CI so Playwright uses its own build),
 `HEADLESS`, `SETUP_COUNTRY` (site currency; defaults per provider — GB/GBP for
-Stripe & SumUp, US/USD for Square), `E2E_UNIT_PRICE` (minor units, default 100),
+Stripe & SumUp, US/USD for Square), `E2E_UNIT_PRICE` (minor units, default 137
+— a non-round amount so the ledger shows decimals),
 `E2E_TUNNEL` (`1`/`0` to force), and the `E2E_*_TIMEOUT_MS` values in
 `src/config.ts`. Screenshots and server logs land in `artifacts/` on failure.
 

--- a/e2e-payments/README.md
+++ b/e2e-payments/README.md
@@ -32,19 +32,23 @@ For a target (`stripe` | `square` | `sumup` | `free`):
    - books, is redirected to the provider's hosted checkout, and pays with the
      provider's sandbox test card;
    - lands back on the app return URL and asserts the booking shows as paid
-     (customer success page **and** the booker appears on the admin listing).
+     (customer success page, the booker on the admin listing, **and** the
+     captured amount in the listing's income ledger).
 
 ### What is (and isn't) exercised per provider
 
 Confirmation is asserted via the **browser return URL** for every provider (the
 success handler validates the session with the provider's API and records the
-booking). Webhook coverage differs:
+booking as paid — the harness then asserts the captured amount shows in the
+listing's income ledger, not merely that an attendee row exists). No provider
+leg *asserts* webhook delivery; webhook involvement differs only in what setup
+each requires:
 
-| Provider | Return-URL confirmation | Webhook exercised? |
+| Provider | Confirmation asserted | Webhook involvement |
 | --- | --- | --- |
-| Stripe | ✅ | ✅ — endpoint registered for the tunnel and a signed webhook is received. |
-| SumUp | ✅ | Best-effort — SumUp needs no signature, so a delivered webhook is processed; not separately asserted. |
-| Square | ✅ | ❌ — Square requires a manually-signed subscription against a fixed URL, which can't be provisioned for an ephemeral tunnel. Return path only. |
+| Stripe | Return URL + captured amount | Endpoint **registration** is exercised (required to save the key); delivery is **not** asserted — the return handler records the payment, and a webhook may arrive before teardown but nothing waits on it. |
+| SumUp | Return URL + captured amount | Needs no signature; a delivered webhook would be processed, but delivery is not asserted. |
+| Square | Return URL + captured amount | None — Square requires a manually-signed subscription against a fixed URL, which can't be provisioned for an ephemeral tunnel. |
 
 For Stripe, each run leaves a webhook endpoint pointing at that run's tunnel;
 the harness deletes all `*.trycloudflare.com` webhook endpoints on teardown

--- a/e2e-payments/src/config.ts
+++ b/e2e-payments/src/config.ts
@@ -51,8 +51,13 @@ export const config = {
   /** ISO country picked in setup — determines the site currency. */
   setupCountry: env("SETUP_COUNTRY") ?? "GB",
 
-  /** Ticket price in minor units (e.g. 100 = £1.00 / $1.00). */
-  unitPrice: num("E2E_UNIT_PRICE", 100),
+  /**
+   * Ticket price in minor units (e.g. 137 = £1.37 / $1.37). Deliberately a
+   * non-round amount: the admin income ledger formats via `stripIfInteger`, so
+   * a whole price like 100 would render "£1" (no decimals) — a non-round price
+   * keeps its decimals, making the paid-amount assertion specific.
+   */
+  unitPrice: num("E2E_UNIT_PRICE", 137),
 
   /** Timeouts (ms). Hosted checkout pages can be slow, so keep these generous. */
   serverBootTimeoutMs: num("E2E_SERVER_BOOT_TIMEOUT_MS", 60_000),

--- a/e2e-payments/src/config.ts
+++ b/e2e-payments/src/config.ts
@@ -73,11 +73,13 @@ export const needsTunnel = (target: Target): boolean => {
     return config.forceTunnel === "1" || config.forceTunnel === "true";
   }
   // Stripe registers its webhook endpoint against a public HTTPS URL at config
-  // time (and then receives a signed webhook), so it cannot be set up without a
-  // tunnel. Square/SumUp confirm via the browser return URL, which providers
-  // expect to be a public HTTPS URL — hence the tunnel for them too. Note the
-  // tunnel does NOT mean every leg exercises webhooks: Square's webhook needs a
-  // manually-signed subscription and is not tested here; SumUp needs no
+  // time, so it cannot be set up without a tunnel. Square/SumUp confirm via the
+  // browser return URL, which providers expect to be a public HTTPS URL — hence
+  // the tunnel for them too. Note the tunnel does NOT mean any leg *asserts*
+  // webhook delivery: confirmation is asserted via the return URL for every
+  // provider (Stripe additionally exercises webhook registration, but delivery
+  // is not asserted). Square's webhook needs a manually-signed subscription and
+  // is not tested here; SumUp needs no
   // signature. See the providers' notes and the README.
   return target !== "free";
 };
@@ -88,7 +90,17 @@ export const providerSecrets = (
 ): Record<string, string> | null => {
   if (provider === "stripe") {
     const key = env("STRIPE_SECRET_KEY");
-    return key ? { secretKey: key } : null;
+    if (!key) return null;
+    // Fail closed on a live key: this "sandbox" harness registers webhook
+    // endpoints and creates checkout sessions, which must never touch a live
+    // Stripe account. Test keys are sk_test_… (or restricted rk_test_…).
+    if (!/^(sk|rk)_test_/.test(key)) {
+      throw new Error(
+        "STRIPE_SECRET_KEY is not a test-mode key (expected sk_test_ or rk_test_). " +
+          "Refusing to run the sandbox harness against a live Stripe key.",
+      );
+    }
+    return { secretKey: key };
   }
   if (provider === "square") {
     const token = env("SQUARE_ACCESS_TOKEN");

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -161,7 +161,7 @@ export const assertPaidBookingConfirmed = async (
   }
   log(`  ✔ customer saw the success page (${page.url()})`);
 
-  // 2. Cross-check in admin: the booker appears on the listing with a payment.
+  // 2. Cross-check in admin: the booker appears on the listing…
   await session.goto("/admin/");
   await login(session);
   await session.clickLink(LISTING_NAME);
@@ -172,5 +172,27 @@ export const assertPaidBookingConfirmed = async (
       `paid booker ${BOOKER_EMAIL} not visible on the admin listing page`,
     );
   }
-  log(`  ✔ admin listing shows the paid booker (${BOOKER_EMAIL})`);
+
+  // …and, crucially, that the payment was actually captured. The listing's
+  // income ledger projects from the payment ledger, so a regression that
+  // creates the attendee but drops the payment (price_paid = 0) leaves the
+  // recognised income at zero. Assert the captured amount shows up rather than
+  // just that a row exists. The amount is in major units (e.g. "1.00"), which
+  // appears regardless of the currency symbol (£1.00 / $1.00 / €1.00).
+  const expectedAmount = (config.unitPrice / 100).toFixed(2);
+  const ledger = session.page.locator("#income-ledger");
+  const paidRegion = (await ledger.count())
+    ? await ledger.innerText()
+    : adminBody;
+  if (!paidRegion.includes(expectedAmount)) {
+    await session.screenshot("paid-admin-no-income");
+    throw new Error(
+      `payment not reflected in the listing's income (expected amount ${expectedAmount}). ` +
+        `Attendee row exists but the paid amount is missing — likely a lost payment ledger. ` +
+        `Income region:\n${paidRegion.slice(0, 600)}`,
+    );
+  }
+  log(
+    `  ✔ admin listing shows the paid booker (${BOOKER_EMAIL}) and captured amount (${expectedAmount})`,
+  );
 };

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -177,22 +177,32 @@ export const assertPaidBookingConfirmed = async (
   // income ledger projects from the payment ledger, so a regression that
   // creates the attendee but drops the payment (price_paid = 0) leaves the
   // recognised income at zero. Assert the captured amount shows up rather than
-  // just that a row exists. The amount is in major units (e.g. "1.00"), which
-  // appears regardless of the currency symbol (£1.00 / $1.00 / €1.00).
-  const expectedAmount = (config.unitPrice / 100).toFixed(2);
+  // just that a row exists.
+  //
+  // Match the app's rendering: formatCurrency uses `trailingZeroDisplay:
+  // "stripIfInteger"`, so a whole amount renders "£1" (no decimals) while a
+  // non-round amount keeps them ("£1.37"). We assume a 2-decimal sandbox
+  // currency (GBP/USD/EUR, per SETUP_COUNTRY); the digits match regardless of
+  // the symbol. Accept both the decimal and the stripped-whole forms so an
+  // E2E_UNIT_PRICE override to a whole amount still matches.
+  const withDecimals = (config.unitPrice / 100).toFixed(2); // "1.37" / "2.00"
+  const strippedWhole = withDecimals.replace(/\.00$/, ""); //  "1.37" / "2"
   const ledger = session.page.locator("#income-ledger");
   const paidRegion = (await ledger.count())
     ? await ledger.innerText()
     : adminBody;
-  if (!paidRegion.includes(expectedAmount)) {
+  if (
+    !paidRegion.includes(withDecimals) &&
+    !paidRegion.includes(strippedWhole)
+  ) {
     await session.screenshot("paid-admin-no-income");
     throw new Error(
-      `payment not reflected in the listing's income (expected amount ${expectedAmount}). ` +
+      `payment not reflected in the listing's income (expected ${withDecimals}). ` +
         `Attendee row exists but the paid amount is missing — likely a lost payment ledger. ` +
         `Income region:\n${paidRegion.slice(0, 600)}`,
     );
   }
   log(
-    `  ✔ admin listing shows the paid booker (${BOOKER_EMAIL}) and captured amount (${expectedAmount})`,
+    `  ✔ admin listing shows the paid booker (${BOOKER_EMAIL}) and captured amount (${withDecimals})`,
   );
 };


### PR DESCRIPTION
Follow-up to the merged `e2e-payments` harness (#1489), addressing three Codex P2 suggestions that landed around merge time and so weren't included there.

## Changes

1. **Reject live Stripe keys** (`e2e-payments/src/config.ts`) — *safety.* If `STRIPE_SECRET_KEY` were set to an `sk_live_…` key, the scheduled "sandbox" job would register webhook endpoints and create checkout sessions in the **live** Stripe account before the test card failed. `providerSecrets` now fails closed unless the key is test-mode (`sk_test_`/`rk_test_`), throwing before anything boots. Verified: a fake `sk_live_` key exits 1 with a clear message; an absent key still skips (exit 0).

2. **Assert the payment was captured** (`e2e-payments/src/flow.ts`) — the paid-booking check previously only confirmed an attendee row with the booker's email existed. A regression that created the attendee but dropped the payment (`price_paid = 0`) would still pass. It now also asserts the captured amount appears in the listing's income ledger (`#income-ledger`), which projects from the payment ledger. The major-unit amount (e.g. `1.00`) matches regardless of currency symbol.

3. **Stop overclaiming Stripe webhook coverage** (README + `config.ts`) — the return-path handler records the payment, so the run never actually waits on or verifies a webhook. Docs now state plainly that **no leg asserts webhook delivery**; Stripe only exercises webhook *registration*. Updated the coverage table and the `needsTunnel` note.

## Validation

- Harness `tsc` clean; the `free` end-to-end self-test still passes against a real server + browser.
- Live-key guard and missing-key skip both verified locally.
- The provider hosted-checkout legs still require live sandbox credentials to exercise (unchanged from the original PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q434qqSbAPGUBRoxRYF8FF)_