### PR TITLE
Tighten payment sandbox e2e: Stripe key guard, income-ledger assertion, currency scope

### DIFF
--- a/e2e-payments/README.md
+++ b/e2e-payments/README.md
@@ -88,8 +88,10 @@ A target with missing secrets **skips** (exits 0) rather than failing.
 Other knobs (all optional): `DENO_BIN`, `CLOUDFLARED_BIN`,
 `CHROMIUM_EXECUTABLE` (unset in CI so Playwright uses its own build),
 `HEADLESS`, `SETUP_COUNTRY` (site currency; defaults per provider — GB/GBP for
-Stripe & SumUp, US/USD for Square), `E2E_UNIT_PRICE` (minor units, default 137
-— a non-round amount so the ledger shows decimals),
+Stripe & SumUp, US/USD for Square; must be a 2-decimal currency such as
+GBP/USD/EUR — zero-decimal currencies like JPY are unsupported),
+`E2E_UNIT_PRICE` (minor units, default 137 — a non-round amount so the ledger
+shows decimals),
 `E2E_TUNNEL` (`1`/`0` to force), and the `E2E_*_TIMEOUT_MS` values in
 `src/config.ts`. Screenshots and server logs land in `artifacts/` on failure.
 

--- a/e2e-payments/src/config.ts
+++ b/e2e-payments/src/config.ts
@@ -48,7 +48,12 @@ export const config = {
   /** Admin credentials created by the setup wizard. Password must be 8+ chars. */
   adminUsername: env("ADMIN_USERNAME") ?? "admin",
   adminPassword: env("ADMIN_PASSWORD") ?? "password",
-  /** ISO country picked in setup — determines the site currency. */
+  /**
+   * ISO country picked in setup — determines the site currency. Must map to a
+   * 2-decimal currency (GBP/USD/EUR, as the provider defaults do): the price
+   * entry and paid-amount assertion assume minor units are hundredths, so a
+   * zero-decimal currency (e.g. JPY via JP) is unsupported.
+   */
   setupCountry: env("SETUP_COUNTRY") ?? "GB",
 
   /**
@@ -96,13 +101,16 @@ export const providerSecrets = (
   if (provider === "stripe") {
     const key = env("STRIPE_SECRET_KEY");
     if (!key) return null;
-    // Fail closed on a live key: this "sandbox" harness registers webhook
-    // endpoints and creates checkout sessions, which must never touch a live
-    // Stripe account. Test keys are sk_test_… (or restricted rk_test_…).
-    if (!/^(sk|rk)_test_/.test(key)) {
+    // Fail closed unless this is a Stripe test-mode secret key. The harness
+    // registers webhook endpoints and creates checkout sessions, which must
+    // never touch a live account. Match the app exactly: detectStripeKeyMode
+    // (src/shared/stripe.ts) only recognises sk_test_/sk_live_, so accepting a
+    // restricted rk_test_ key here would just fail confusingly at the settings
+    // form. Require sk_test_.
+    if (!key.startsWith("sk_test_")) {
       throw new Error(
-        "STRIPE_SECRET_KEY is not a test-mode key (expected sk_test_ or rk_test_). " +
-          "Refusing to run the sandbox harness against a live Stripe key.",
+        "STRIPE_SECRET_KEY is not a Stripe test-mode secret key (expected sk_test_). " +
+          "Refusing to run the sandbox harness against a live or unrecognised key.",
       );
     }
     return { secretKey: key };

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -173,33 +173,40 @@ export const assertPaidBookingConfirmed = async (
     );
   }
 
-  // …and, crucially, that the payment was actually captured. The listing's
-  // income ledger projects from the payment ledger, so a regression that
-  // creates the attendee but drops the payment (price_paid = 0) leaves the
-  // recognised income at zero. Assert the captured amount shows up rather than
-  // just that a row exists.
-  //
+  // …and, crucially, that the payment was actually captured. Assert against the
+  // listing's INCOME LEDGER specifically — it projects from the payment ledger,
+  // so a regression that creates the attendee but drops the payment
+  // (price_paid = 0) records no income and the ledger section does not render.
+  // Do NOT fall back to scanning the whole page: the listing detail also shows
+  // the configured ticket price, which would give a false pass with no payment.
+  const ledger = session.page.locator("#income-ledger");
+  if ((await ledger.count()) === 0) {
+    await session.screenshot("paid-admin-no-income-ledger");
+    throw new Error(
+      "the listing's income ledger (#income-ledger) did not render — no recognised " +
+        "income was recorded for the paid booking (lost/failed payment?)",
+    );
+  }
+  const paidRegion = await ledger.innerText();
+
   // Match the app's rendering: formatCurrency uses `trailingZeroDisplay:
   // "stripIfInteger"`, so a whole amount renders "£1" (no decimals) while a
-  // non-round amount keeps them ("£1.37"). We assume a 2-decimal sandbox
-  // currency (GBP/USD/EUR, per SETUP_COUNTRY); the digits match regardless of
-  // the symbol. Accept both the decimal and the stripped-whole forms so an
+  // non-round amount keeps them ("£1.37"). This assumes a 2-decimal currency —
+  // the provider defaults (GBP/USD/EUR via SETUP_COUNTRY) are all 2-decimal;
+  // zero-decimal currencies (e.g. JPY) are unsupported, as the price entry
+  // itself would need currency-aware decimals. The digits match regardless of
+  // the symbol; accept both the decimal and stripped-whole forms so an
   // E2E_UNIT_PRICE override to a whole amount still matches.
   const withDecimals = (config.unitPrice / 100).toFixed(2); // "1.37" / "2.00"
   const strippedWhole = withDecimals.replace(/\.00$/, ""); //  "1.37" / "2"
-  const ledger = session.page.locator("#income-ledger");
-  const paidRegion = (await ledger.count())
-    ? await ledger.innerText()
-    : adminBody;
   if (
     !paidRegion.includes(withDecimals) &&
     !paidRegion.includes(strippedWhole)
   ) {
     await session.screenshot("paid-admin-no-income");
     throw new Error(
-      `payment not reflected in the listing's income (expected ${withDecimals}). ` +
-        `Attendee row exists but the paid amount is missing — likely a lost payment ledger. ` +
-        `Income region:\n${paidRegion.slice(0, 600)}`,
+      `captured payment not reflected in the listing's income ledger (expected ${withDecimals}). ` +
+        `Income ledger:\n${paidRegion.slice(0, 600)}`,
     );
   }
   log(


### PR DESCRIPTION
Follow-up to #1491, addressing three Codex P2 findings from its final review that couldn't land before the merge queue merged it. All three are follow-ons to that PR's own changes.

## Changes

1. **Align the Stripe key guard with the app** (`e2e-payments/src/config.ts`) — #1491's guard advertised `rk_test_` restricted keys as acceptable, but the app's `detectStripeKeyMode` (`src/shared/stripe.ts`) only recognises `sk_test_`/`sk_live_`. So a restricted key passed the early guard and then failed confusingly at the settings form. The guard now requires `sk_test_`, matching the app, and fails closed with a clear message otherwise.

2. **Require the income ledger; drop the whole-page fallback** (`e2e-payments/src/flow.ts`) — the paid-amount check previously fell back to scanning the entire admin listing page when `#income-ledger` was absent. That page also renders the configured ticket price, so the expected amount could match even when no payment was recorded (false pass). It now requires `#income-ledger` to render and asserts the captured amount within it — a missing ledger fails, which is the correct signal since the ledger projects from the payment ledger.

3. **Document the 2-decimal-currency scope** (`config.ts` + README) — the price entry and amount assertion assume minor units are hundredths, so a zero-decimal currency (e.g. JPY via `SETUP_COUNTRY=JP`) would fail a genuine payment. Documented that `SETUP_COUNTRY` must map to a 2-decimal currency (GBP/USD/EUR — the provider defaults already satisfy this).

## Validation

- Harness `tsc` clean; the `free` end-to-end self-test still passes against a real server + browser.
- Verified the `rk_test_` guard now fails closed (exit 1, clear message) while an absent key still skips (exit 0).
- Scope unchanged otherwise: the provider hosted-checkout legs still require live sandbox credentials to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q434qqSbAPGUBRoxRYF8FF)_