### PR TITLE
Add a listing_prices table synced with the listing price columns

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -188,3 +188,7 @@ src/ui/client/order.ts:433:48  ?? → ||   # link.dataset.addListing: string|und
 src/ui/client/order.ts:443:59  ?? → ||   # link.dataset.addListing: string|undefined; the only falsy-non-null value "" equals the "" fallback
 src/shared/site-pages/core.ts:120:50  ?? → ||    # descendantsOf: forest.itemsByPage.get() → SitePageItem[]|undefined — an array is always truthy
 src/shared/site-pages/core.ts:301:43  ?? → ||    # levelOf: forest.itemsByPage.get() → SitePageItem[]|undefined — an array is always truthy
+
+# listing_prices sync (listing-prices.ts): `?? → ||` where the operand's only
+# falsy-non-null value equals the fallback.
+src/shared/db/listing-prices.ts:70:19  ?? → ||    # sourceRowStatements row.unit_price: number|null; the only falsy-non-null value is 0 and 0 ?? 0 === 0 || 0

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -191,4 +191,4 @@ src/shared/site-pages/core.ts:301:43  ?? → ||    # levelOf: forest.itemsByPage
 
 # listing_prices sync (listing-prices.ts): `?? → ||` where the operand's only
 # falsy-non-null value equals the fallback.
-src/shared/db/listing-prices.ts:70:19  ?? → ||    # sourceRowStatements row.unit_price: number|null; the only falsy-non-null value is 0 and 0 ?? 0 === 0 || 0
+src/shared/db/listing-prices.ts:76:19  ?? → ||    # sourceRowStatements row.unit_price: number|null; the only falsy-non-null value is 0 and 0 ?? 0 === 0 || 0

--- a/src/features/admin/api.ts
+++ b/src/features/admin/api.ts
@@ -14,6 +14,7 @@ import { jsonResponse } from "#routes/response.ts";
 import type { RouteHandlerFn } from "#routes/router.ts";
 import type { TxScope } from "#shared/db/client.ts";
 import { setChildIdsTx } from "#shared/db/listing-parents.ts";
+import { syncListingPrices } from "#shared/db/listing-prices.ts";
 import {
   computeSlugIndex,
   getAllListings,
@@ -452,6 +453,10 @@ const listingApiRoutes = defineCrudApi<
   ListingWithCount,
   PreparedChildEdges
 >({
+  // Keep listing_prices in step on the transactional API write path, which uses
+  // insertStatement/updateStatement and so bypasses the listingsTable wrapper
+  // that syncs the form/direct write paths.
+  afterWrite: syncListingPrices,
   extraRoutes: {
     "DELETE /api/admin/listings/:listingId": handleDeleteListing,
     "POST /api/admin/listings/:listingId/deactivate": (

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -1,0 +1,95 @@
+/**
+ * The `listing_prices` table: generalised per-listing pricing, one row per
+ * (listing, pricing *dimension*, key within it). A `price_type` names the
+ * dimension and `price_id` the key:
+ *  - `("base", "")`        — the listing's single fixed price (mirrors
+ *                            `listings.unit_price`).
+ *  - `("day_count", "<n>")`— the price for an n-day booking (mirrors an entry of
+ *                            `listings.day_prices`).
+ *  - reserved for later: `("group", "<groupId>")` (package/group overrides),
+ *    `("start_day", "friday")` (weekday pricing) — the shape admits them with no
+ *    schema change; nothing writes them yet.
+ *
+ * Today the `base`/`day_count` rows are backfilled from, and kept in step with,
+ * `listings.unit_price`/`day_prices`, which stay as the source-of-truth mirror
+ * columns every display/API/charge caller still reads. This module owns writing
+ * those rows; the read/resolve API lands with its first consumer.
+ */
+
+import { execute, executeBatch } from "#shared/db/client.ts";
+import { type DayPrices, parseDayPrices } from "#shared/types.ts";
+
+export const PRICE_TYPE_BASE = "base";
+export const PRICE_TYPE_DAY_COUNT = "day_count";
+
+/** The delete-then-insert statements that make a listing's `base`/`day_count`
+ * rows exactly match `unitPrice` + `dayPrices`. Only these two managed
+ * dimensions are touched — any reserved (`group`/…) rows are left untouched. A
+ * day-count entry is normalised through {@link parseDayPrices} so the rows carry
+ * exactly what a reader would accept. */
+export const listingPriceStatements = (
+  listingId: number,
+  unitPrice: number,
+  dayPrices: DayPrices,
+): Array<{ sql: string; args: (number | string)[] }> => {
+  const statements: Array<{ sql: string; args: (number | string)[] }> = [
+    {
+      args: [listingId, PRICE_TYPE_BASE, PRICE_TYPE_DAY_COUNT],
+      sql: "DELETE FROM listing_prices WHERE listing_id = ? AND price_type IN (?, ?)",
+    },
+    {
+      args: [listingId, PRICE_TYPE_BASE, "", unitPrice],
+      sql: "INSERT INTO listing_prices (listing_id, price_type, price_id, unit_price) VALUES (?, ?, ?, ?)",
+    },
+  ];
+  for (const [days, price] of Object.entries(parseDayPrices(dayPrices))) {
+    statements.push({
+      args: [listingId, PRICE_TYPE_DAY_COUNT, days, price],
+      sql: "INSERT INTO listing_prices (listing_id, price_type, price_id, unit_price) VALUES (?, ?, ?, ?)",
+    });
+  }
+  return statements;
+};
+
+/** A `listings` row projected to just the columns the managed price rows mirror.
+ * `day_prices` is the stored JSON text; `unit_price` may be NULL (read as 0). */
+export type ListingPriceSourceRow = {
+  id: number;
+  unit_price: number | null;
+  day_prices: string;
+};
+
+/** The managed statements that sync one raw `listings` row's `base`/`day_count`
+ * rows — the {@link listingPriceStatements} call shared by the backfill and the
+ * per-listing {@link syncListingPrices}, so both normalise the stored JSON the
+ * same way. A NULL `unit_price` reads as 0 and blank/absent `day_prices` as an
+ * empty map. */
+export const sourceRowStatements = (row: ListingPriceSourceRow) =>
+  listingPriceStatements(
+    row.id,
+    row.unit_price ?? 0,
+    parseDayPrices(JSON.parse(row.day_prices || "{}")),
+  );
+
+/** Populate `listing_prices` from every listing's current `unit_price`/
+ * `day_prices` — the migration backfill. Idempotent: each listing's managed
+ * rows are deleted and reinserted, so re-running converges. */
+export const backfillListingPrices = async (): Promise<void> => {
+  const rows = await execute("SELECT id, unit_price, day_prices FROM listings");
+  const statements = (rows.rows as unknown as ListingPriceSourceRow[]).flatMap(
+    sourceRowStatements,
+  );
+  if (statements.length > 0) await executeBatch(statements);
+};
+
+/** Re-sync one listing's managed price rows from its current `listings` columns.
+ * Called after every listing insert/update so the table never drifts from the
+ * `unit_price`/`day_prices` mirrors. A missing listing is a no-op. */
+export const syncListingPrices = async (listingId: number): Promise<void> => {
+  const rows = await execute(
+    "SELECT id, unit_price, day_prices FROM listings WHERE id = ?",
+    [listingId],
+  );
+  const row = (rows.rows as unknown as ListingPriceSourceRow[])[0];
+  if (row) await executeBatch(sourceRowStatements(row));
+};

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -16,7 +16,13 @@
  * those rows; the read/resolve API lands with its first consumer.
  */
 
-import { execute, executeBatch } from "#shared/db/client.ts";
+import {
+  execute,
+  executeBatch,
+  inPlaceholders,
+  queryBatchPrimary,
+  queryIdColumn,
+} from "#shared/db/client.ts";
 import { type DayPrices, parseDayPrices } from "#shared/types.ts";
 
 export const PRICE_TYPE_BASE = "base";
@@ -71,25 +77,73 @@ export const sourceRowStatements = (row: ListingPriceSourceRow) =>
     parseDayPrices(JSON.parse(row.day_prices || "{}")),
   );
 
+/** Listings read per backfill SELECT, and the ceiling on statements per write
+ * batch — both bounded so a large site's backfill never materialises the whole
+ * table into one libsql batch, which can exceed the edge migrator's payload
+ * limits. A single listing contributes at most one delete plus one row per
+ * offered day count, so a page stays comfortably within bounds. */
+const BACKFILL_LISTING_PAGE = 200;
+const BACKFILL_STATEMENT_PAGE = 500;
+
+/** Read the price-source columns for a set of listing ids. */
+const readSourceRows = async (
+  ids: readonly number[],
+): Promise<ListingPriceSourceRow[]> => {
+  const rows = await execute(
+    `SELECT id, unit_price, day_prices FROM listings
+      WHERE id IN (${inPlaceholders(ids)})`,
+    [...ids],
+  );
+  return rows.rows as unknown as ListingPriceSourceRow[];
+};
+
+/** Execute the statements in bounded batches so no single write batch grows past
+ * {@link BACKFILL_STATEMENT_PAGE}. Each listing's own delete+inserts may straddle
+ * a page boundary; the backfill is idempotent, so a re-run still converges. */
+const executePaged = async (
+  statements: Array<{ sql: string; args: (number | string)[] }>,
+): Promise<void> => {
+  for (let i = 0; i < statements.length; i += BACKFILL_STATEMENT_PAGE) {
+    await executeBatch(statements.slice(i, i + BACKFILL_STATEMENT_PAGE));
+  }
+};
+
 /** Populate `listing_prices` from every listing's current `unit_price`/
  * `day_prices` — the migration backfill. Idempotent: each listing's managed
- * rows are deleted and reinserted, so re-running converges. */
+ * rows are deleted and reinserted, so re-running converges. Paged by listing id
+ * (read) and by statement count (write) to stay within edge payload limits on
+ * large sites. */
 export const backfillListingPrices = async (): Promise<void> => {
-  const rows = await execute("SELECT id, unit_price, day_prices FROM listings");
-  const statements = (rows.rows as unknown as ListingPriceSourceRow[]).flatMap(
-    sourceRowStatements,
-  );
-  if (statements.length > 0) await executeBatch(statements);
+  const ids = await queryIdColumn("SELECT id FROM listings ORDER BY id");
+  for (let i = 0; i < ids.length; i += BACKFILL_LISTING_PAGE) {
+    const rows = await readSourceRows(ids.slice(i, i + BACKFILL_LISTING_PAGE));
+    await executePaged(rows.flatMap(sourceRowStatements));
+  }
+};
+
+/** Re-sync the managed price rows for a set of listings from their current
+ * `listings` columns — the seed flow's bulk equivalent of
+ * {@link syncListingPrices}, paged the same way as the backfill. */
+export const syncListingPricesForIds = async (
+  ids: readonly number[],
+): Promise<void> => {
+  if (ids.length === 0) return;
+  const rows = await readSourceRows(ids);
+  await executePaged(rows.flatMap(sourceRowStatements));
 };
 
 /** Re-sync one listing's managed price rows from its current `listings` columns.
  * Called after every listing insert/update so the table never drifts from the
- * `unit_price`/`day_prices` mirrors. A missing listing is a no-op. */
+ * `unit_price`/`day_prices` mirrors. The source row is read on the primary
+ * (write-mode batch) so it reflects the just-committed write rather than a
+ * lagging replica. A missing listing is a no-op. */
 export const syncListingPrices = async (listingId: number): Promise<void> => {
-  const rows = await execute(
-    "SELECT id, unit_price, day_prices FROM listings WHERE id = ?",
-    [listingId],
-  );
-  const row = (rows.rows as unknown as ListingPriceSourceRow[])[0];
+  const [result] = await queryBatchPrimary([
+    {
+      args: [listingId],
+      sql: "SELECT id, unit_price, day_prices FROM listings WHERE id = ?",
+    },
+  ]);
+  const row = (result?.rows as unknown as ListingPriceSourceRow[])[0];
   if (row) await executeBatch(sourceRowStatements(row));
 };

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -42,6 +42,7 @@ import {
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
 } from "#shared/db/common-schema.ts";
+import { syncListingPrices } from "#shared/db/listing-prices.ts";
 import {
   LISTING_AGGREGATE_WRITE_COLUMNS,
   TICKET_COUNTS_PREDICATE,
@@ -469,8 +470,30 @@ const listingsEntity = cachedEntityTable<
 );
 const listingsCache = listingsEntity.cache;
 
-/** Listings table with CRUD operations — writes auto-invalidate the cache */
-export const listingsTable = listingsEntity.table;
+/**
+ * Listings table with CRUD operations — writes auto-invalidate the cache and,
+ * on top of the raw table, re-sync the listing's `listing_prices` rows so the
+ * generalised price table never drifts from the `unit_price`/`day_prices` mirror
+ * columns. Both write paths run the sync from the row's id after a successful
+ * write; `update` skips it when the row is missing (returns null). The sync
+ * reads the canonical columns straight from the row rather than trusting the
+ * returned input shape, so a partial update that never mentions the price fields
+ * still reconciles against the current stored values.
+ */
+const rawTable = listingsEntity.table;
+export const listingsTable: typeof rawTable = {
+  ...rawTable,
+  insert: async (input) => {
+    const row = await rawTable.insert(input);
+    await syncListingPrices(row.id);
+    return row;
+  },
+  update: async (id, input) => {
+    const row = await rawTable.update(id, input);
+    if (row) await syncListingPrices(row.id);
+    return row;
+  },
+};
 
 /**
  * Get a single listing by ID (from cache; fetches just this listing on a miss).

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -550,6 +550,12 @@ export const deleteListing = async (listingId: number): Promise<void> => {
       sql: "DELETE FROM listing_parents WHERE parent_listing_id = ? OR child_listing_id = ?",
     },
     { args: [listingId], sql: "DELETE FROM activity_log WHERE listing_id = ?" },
+    // The generalised price rows have no cascading FK, so drop them with the
+    // listing rather than leaving orphaned base/day_count rows behind.
+    {
+      args: [listingId],
+      sql: "DELETE FROM listing_prices WHERE listing_id = ?",
+    },
     { args: [listingId], sql: "DELETE FROM listings WHERE id = ?" },
   ]);
 };

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -83,8 +83,8 @@ import listingAttendeeLedgerEventGroupIndexMigration from "./migrations/2026-06-
 import attendeesKindNotNullMigration from "./migrations/2026-06-26_attendees_kind_not_null.ts";
 import serviceCostsMigration from "./migrations/2026-06-27_service_costs.ts";
 import listingUseDefaultsMigration from "./migrations/2026-06-28_listing_use_defaults.ts";
-import sitePagesMigration from "./migrations/2026-07-01_site_pages.ts";
 import listingPricesMigration from "./migrations/2026-07-01_listing_prices.ts";
+import sitePagesMigration from "./migrations/2026-07-01_site_pages.ts";
 import { repairLegacyRenames } from "./migrations/rename-utils.ts";
 import {
   LATEST_UPDATE,

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -84,6 +84,7 @@ import attendeesKindNotNullMigration from "./migrations/2026-06-26_attendees_kin
 import serviceCostsMigration from "./migrations/2026-06-27_service_costs.ts";
 import listingUseDefaultsMigration from "./migrations/2026-06-28_listing_use_defaults.ts";
 import sitePagesMigration from "./migrations/2026-07-01_site_pages.ts";
+import listingPricesMigration from "./migrations/2026-07-01_listing_prices.ts";
 import { repairLegacyRenames } from "./migrations/rename-utils.ts";
 import {
   LATEST_UPDATE,
@@ -269,6 +270,8 @@ export const MIGRATIONS: Migration[] = [
   listingUseDefaultsMigration,
   // Two new tables for user-created content pages; appended last (additive).
   sitePagesMigration,
+  // New listing_prices table + backfill from unit_price/day_prices; appended last.
+  listingPricesMigration,
 ].map((build) => build(migrationContext));
 
 export const MIGRATION_IDS: string[] = MIGRATIONS.map(

--- a/src/shared/db/migrations/2026-07-01_listing_prices.ts
+++ b/src/shared/db/migrations/2026-07-01_listing_prices.ts
@@ -1,0 +1,21 @@
+import { backfillListingPrices } from "#shared/db/listing-prices.ts";
+import { schemaMigration } from "./define.ts";
+
+/**
+ * Introduce `listing_prices` — generalised per-listing pricing keyed by a
+ * dimension (`price_type`/`price_id`), see the table's schema comment. This
+ * migration creates the table and backfills the two dimensions that exist today
+ * from every listing's `unit_price` (a `("base","")` row) and `day_prices`
+ * (`("day_count","<n>")` rows). Those columns stay as read mirrors; the reserved
+ * `group`/`start_day` dimensions get no rows here. The backfill deletes and
+ * reinserts each listing's managed rows, so it is idempotent on re-run.
+ */
+export default schemaMigration(
+  "2026-07-01_listing_prices",
+  "Add listing_prices and backfill base + day-count rows from listings.unit_price/day_prices.",
+  {
+    indexes: ["idx_listing_prices_key", "idx_listing_prices_listing"],
+    newTables: ["listing_prices"],
+  },
+  backfillListingPrices,
+);

--- a/src/shared/db/migrations/schema.ts
+++ b/src/shared/db/migrations/schema.ts
@@ -34,7 +34,7 @@ export type Trigger = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "Add site_pages and site_page_items tables backing user-created content pages.";
+  "Add a listing_prices table (generalised per-listing pricing dimensions), backfilled from listings.unit_price and day_prices.";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 
@@ -122,6 +122,37 @@ export const SCHEMA: [name: string, table: Table][] = [
           columns: ["slug_index"],
           name: "idx_listings_slug_index",
           unique: true,
+        },
+      ],
+    },
+  ],
+
+  [
+    // Generalised per-listing pricing, keyed by a pricing *dimension*: a
+    // `price_type` (e.g. "base", "day_count", and — reserved for later —
+    // "group"/"start_day") and a `price_id` selecting within it ("" for base,
+    // the day count "2", a group id, a weekday). One row per (listing,
+    // dimension, key) so future dimensions (weekday pricing, package overrides)
+    // slot in with no schema change. Today it is backfilled from and kept in
+    // sync with `listings.unit_price` ("base","") and `listings.day_prices`
+    // ("day_count","<n>"); those columns remain as read mirrors for now.
+    "listing_prices",
+    {
+      columns: [
+        ["listing_id", "INTEGER NOT NULL"],
+        ["price_type", "TEXT NOT NULL"],
+        ["price_id", "TEXT NOT NULL DEFAULT ''"],
+        ["unit_price", "INTEGER NOT NULL"],
+      ],
+      indexes: [
+        {
+          columns: ["listing_id", "price_type", "price_id"],
+          name: "idx_listing_prices_key",
+          unique: true,
+        },
+        {
+          columns: ["listing_id"],
+          name: "idx_listing_prices_listing",
         },
       ],
     },

--- a/src/shared/rest/crud-api.ts
+++ b/src/shared/rest/crud-api.ts
@@ -140,6 +140,12 @@ export interface CrudApiConfig<
    * atomicity). `Prepared` is the value its `validate` carries forward to its
    * `persist`, inferred per resource. See {@link CrudSideEffect}. */
   sideEffect?: CrudSideEffect<Input, FullRow, Prepared>;
+  /** Run after a create/update has committed and the row has been re-read, keyed
+   * on the row id. Unlike `sideEffect` (which runs inside the write transaction),
+   * this fires post-commit — for reconciling a derived table that the form paths
+   * keep in sync elsewhere but the transactional `insertStatement`/
+   * `updateStatement` path would otherwise bypass. */
+  afterWrite?: (id: number) => Promise<void>;
   /** Extra route entries to merge in (can also override generated routes) */
   extraRoutes?: Record<string, RouteHandlerFn>;
   /** Fetch all rows (from cache) — may return a richer row type than the table (e.g. joined counts) */
@@ -262,6 +268,7 @@ export const defineCrudApi = <
     action: string,
     status: number,
   ): Promise<Response> => {
+    if (config.afterWrite) await config.afterWrite(fullRow.id);
     await logAction(action, fullRow);
     return jsonResponse({ [responseKey]: toResponse(fullRow) }, status);
   };

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -11,6 +11,7 @@ import {
   encryptAttendeeFields,
 } from "#shared/db/attendees.ts";
 import { executeBatch, insert, queryAll, rawSql } from "#shared/db/client.ts";
+import { syncListingPricesForIds } from "#shared/db/listing-prices.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   DEMO_ADDRESSES,
@@ -216,6 +217,10 @@ export const createSeeds = async (
     [listingCount],
   );
   const listingIds = map((r: { id: number }) => r.id)(rows).reverse();
+
+  // The seed inserts listings via raw batch statements (not listingsTable), so
+  // populate their listing_prices rows the same way an admin write would.
+  await syncListingPricesForIds(listingIds);
 
   // Prepare all attendee inserts in parallel, in chunks to avoid memory pressure
   const CHUNK_SIZE = 50;

--- a/test/admin-api-listings.test.ts
+++ b/test/admin-api-listings.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { bodyToCreateInput, bodyToUpdateInput } from "#routes/admin/api.ts";
+import { queryAll } from "#shared/db/client.ts";
 import {
   getListingWithCount,
   invalidateListingsCache,
@@ -206,6 +207,34 @@ describeWithEnv("Admin API - Listings", { db: true }, () => {
           expect(body.listing.day_prices).toEqual({ 1: 1000, 2: 1800 });
         },
       );
+    });
+
+    test("syncs listing_prices on the transactional API create path", async () => {
+      // The API create goes through the crud-api sideEffect (child-edge) path,
+      // which uses insertStatement and so bypasses the listingsTable wrapper;
+      // the afterWrite hook must still reconcile listing_prices.
+      const response = await apiRequest("/api/admin/listings", {
+        body: {
+          customisable_days: true,
+          day_prices: { 1: 1000, 2: 1800 },
+          duration_days: 2,
+          max_attendees: 20,
+          name: "API Priced",
+          unit_price: 900,
+        },
+        method: "POST",
+      });
+      const { listing } = await response.json();
+      const rows = await queryAll(
+        `SELECT price_type, price_id, unit_price FROM listing_prices
+          WHERE listing_id = ? ORDER BY price_type, price_id`,
+        [listing.id],
+      );
+      expect(rows).toEqual([
+        { price_id: "", price_type: "base", unit_price: 900 },
+        { price_id: "1", price_type: "day_count", unit_price: 1000 },
+        { price_id: "2", price_type: "day_count", unit_price: 1800 },
+      ]);
     });
 
     test("returns 400 when name is missing", async () => {

--- a/test/lib/db/listing-prices.test.ts
+++ b/test/lib/db/listing-prices.test.ts
@@ -6,8 +6,9 @@ import {
   listingPriceStatements,
   sourceRowStatements,
   syncListingPrices,
+  syncListingPricesForIds,
 } from "#shared/db/listing-prices.ts";
-import { listingsTable } from "#shared/db/listings.ts";
+import { deleteListing, listingsTable } from "#shared/db/listings.ts";
 import {
   createTestListing,
   describeWithEnv,
@@ -144,6 +145,33 @@ describeWithEnv("listing_prices persistence", { db: true }, () => {
     ]);
     // Remove the 2-day price and re-sync: only the managed rows change.
     expect(await resyncedPriceIds(listing.id, { 1: 500 })).toEqual(["", "1"]);
+  });
+
+  test("deleting a listing removes its price rows", async () => {
+    const listing = await createTestListing({ unitPrice: 640 });
+    expect((await priceRows(listing.id)).length).toBe(1);
+    await deleteListing(listing.id);
+    expect(await priceRows(listing.id)).toEqual([]);
+  });
+
+  test("syncListingPricesForIds rebuilds rows for the given listings only", async () => {
+    const a = await createTestListing({ unitPrice: 300 });
+    const b = await createTestListing({ unitPrice: 700 });
+    await seedDayPrices(b.id, { 2: 1300 });
+    await queryAll("DELETE FROM listing_prices");
+    await syncListingPricesForIds([a.id, b.id]);
+    expect(await priceRows(a.id)).toEqual([
+      { price_id: "", price_type: "base", unit_price: 300 },
+    ]);
+    expect(await priceRows(b.id)).toEqual([
+      { price_id: "", price_type: "base", unit_price: 700 },
+      { price_id: "2", price_type: "day_count", unit_price: 1300 },
+    ]);
+  });
+
+  test("syncListingPricesForIds is a no-op for an empty id list", async () => {
+    await syncListingPricesForIds([]);
+    expect(await priceRows(987656)).toEqual([]);
   });
 
   test("syncListingPrices is a no-op for a listing that does not exist", async () => {

--- a/test/lib/db/listing-prices.test.ts
+++ b/test/lib/db/listing-prices.test.ts
@@ -1,0 +1,160 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { queryAll } from "#shared/db/client.ts";
+import {
+  backfillListingPrices,
+  listingPriceStatements,
+  sourceRowStatements,
+  syncListingPrices,
+} from "#shared/db/listing-prices.ts";
+import { listingsTable } from "#shared/db/listings.ts";
+import {
+  createTestListing,
+  describeWithEnv,
+  updateTestListing,
+} from "#test-utils";
+
+describe("listingPriceStatements", () => {
+  test("emits a scoped delete, a base insert, then one insert per day count", () => {
+    const stmts = listingPriceStatements(5, 750, { 1: 750, 2: 1200 });
+    expect(stmts.map((s) => s.args)).toEqual([
+      [5, "base", "day_count"],
+      [5, "base", "", 750],
+      [5, "day_count", "1", 750],
+      [5, "day_count", "2", 1200],
+    ]);
+    // The first statement scopes its delete to the two managed dimensions; the
+    // rest are inserts, so reserved (group/…) rows are never disturbed.
+    const sqls = stmts.map((s) => s.sql);
+    expect(sqls[0]).toContain(
+      "DELETE FROM listing_prices WHERE listing_id = ? AND price_type IN (?, ?)",
+    );
+    expect(
+      sqls
+        .slice(1)
+        .every((sql) => sql.startsWith("INSERT INTO listing_prices")),
+    ).toBe(true);
+  });
+
+  test("emits only the delete + base row when there are no day prices", () => {
+    expect(listingPriceStatements(9, 0, {}).map((s) => s.args)).toEqual([
+      [9, "base", "day_count"],
+      [9, "base", "", 0],
+    ]);
+  });
+});
+
+describe("sourceRowStatements", () => {
+  test("projects a raw listings row, reading NULL price + day prices", () => {
+    const stmts = sourceRowStatements({
+      day_prices: '{"2":900}',
+      id: 3,
+      unit_price: 250,
+    });
+    expect(stmts.map((s) => s.args)).toEqual([
+      [3, "base", "day_count"],
+      [3, "base", "", 250],
+      [3, "day_count", "2", 900],
+    ]);
+  });
+
+  test("reads a NULL price as 0 and a blank day_prices as no day rows", () => {
+    expect(
+      sourceRowStatements({ day_prices: "", id: 4, unit_price: null }).map(
+        (s) => s.args,
+      ),
+    ).toEqual([
+      [4, "base", "day_count"],
+      [4, "base", "", 0],
+    ]);
+  });
+});
+
+/** The managed rows for a listing, ordered for stable assertions. */
+const priceRows = (
+  listingId: number,
+): Promise<{ price_type: string; price_id: string; unit_price: number }[]> =>
+  queryAll(
+    `SELECT price_type, price_id, unit_price FROM listing_prices
+      WHERE listing_id = ? ORDER BY price_type, price_id`,
+    [listingId],
+  );
+
+/** Write a listing's `day_prices` column directly (bypassing the day-price form
+ * plumbing), so tests can exercise the day_count branch on demand. */
+const seedDayPrices = (
+  listingId: number,
+  dayPrices: Record<number, number>,
+): Promise<unknown> =>
+  queryAll("UPDATE listings SET day_prices = ? WHERE id = ?", [
+    JSON.stringify(dayPrices),
+    listingId,
+  ]);
+
+/** Seed a listing's day prices, re-sync, and return the resulting price_ids. */
+const resyncedPriceIds = async (
+  listingId: number,
+  dayPrices: Record<number, number>,
+): Promise<string[]> => {
+  await seedDayPrices(listingId, dayPrices);
+  await syncListingPrices(listingId);
+  return (await priceRows(listingId)).map((r) => r.price_id);
+};
+
+describeWithEnv("listing_prices persistence", { db: true }, () => {
+  test("admin create and edit keep the base price row in sync", async () => {
+    // The real admin form paths go through listingsTable.insert/update, which
+    // re-sync listing_prices — so a listing's base row tracks its price without
+    // anyone touching listing_prices directly.
+    const listing = await createTestListing({ unitPrice: 750 });
+    expect(await priceRows(listing.id)).toEqual([
+      { price_id: "", price_type: "base", unit_price: 750 },
+    ]);
+    await updateTestListing(listing.id, { unitPrice: 900 });
+    expect(await priceRows(listing.id)).toEqual([
+      { price_id: "", price_type: "base", unit_price: 900 },
+    ]);
+  });
+
+  test("backfill populates base + day-count rows from the listings columns", async () => {
+    const standard = await createTestListing({ unitPrice: 750 });
+    const dated = await createTestListing({ unitPrice: 400 });
+    // Seed a day-prices map directly on the row so the backfill's day_count
+    // branch is exercised independently of the admin day-price form plumbing.
+    await seedDayPrices(dated.id, { 1: 400, 3: 1000 });
+    // Clear the dual-write's rows, then rebuild everything from listings.
+    await queryAll("DELETE FROM listing_prices");
+    await backfillListingPrices();
+    expect(await priceRows(standard.id)).toEqual([
+      { price_id: "", price_type: "base", unit_price: 750 },
+    ]);
+    expect(await priceRows(dated.id)).toEqual([
+      { price_id: "", price_type: "base", unit_price: 400 },
+      { price_id: "1", price_type: "day_count", unit_price: 400 },
+      { price_id: "3", price_type: "day_count", unit_price: 1000 },
+    ]);
+  });
+
+  test("re-syncing drops a day count that is no longer offered", async () => {
+    const listing = await createTestListing({ unitPrice: 500 });
+    expect(await resyncedPriceIds(listing.id, { 1: 500, 2: 800 })).toEqual([
+      "",
+      "1",
+      "2",
+    ]);
+    // Remove the 2-day price and re-sync: only the managed rows change.
+    expect(await resyncedPriceIds(listing.id, { 1: 500 })).toEqual(["", "1"]);
+  });
+
+  test("syncListingPrices is a no-op for a listing that does not exist", async () => {
+    await syncListingPrices(987654);
+    expect(await priceRows(987654)).toEqual([]);
+  });
+
+  test("updating a missing listing writes no price rows", async () => {
+    // The table wrapper only re-syncs when the update returns a row; a missing
+    // id yields null and must not touch listing_prices.
+    expect(await listingsTable.update(987655, { unitPrice: 500 })).toBeNull();
+    expect(await priceRows(987655)).toEqual([]);
+  });
+});

--- a/test/lib/db/migration-schema-guard.test.ts
+++ b/test/lib/db/migration-schema-guard.test.ts
@@ -66,7 +66,7 @@ describe("db > migrations > schema change guard", () => {
         "2026-07-01_site_pages",
         "2026-07-01_listing_prices",
       ],
-      schemaHash: "mu35o2",
+      schemaHash: "mw6yc4",
     });
   });
 });

--- a/test/lib/db/migration-schema-guard.test.ts
+++ b/test/lib/db/migration-schema-guard.test.ts
@@ -64,8 +64,9 @@ describe("db > migrations > schema change guard", () => {
         "2026-06-27_service_costs",
         "2026-06-28_listing_use_defaults",
         "2026-07-01_site_pages",
+        "2026-07-01_listing_prices",
       ],
-      schemaHash: "1ig89xd",
+      schemaHash: "mu35o2",
     });
   });
 });


### PR DESCRIPTION
## What

Introduces `listing_prices`, a generalised per-listing pricing table, as a foundation for later pricing work (package/group overrides, weekday pricing) without changing any current behaviour.

Each row is one `(listing, pricing dimension, key)`:

- `("base", "")` — mirrors `listings.unit_price`
- `("day_count", "<n>")` — mirrors an entry of `listings.day_prices`
- reserved for later: `("group", "<groupId>")`, `("start_day", "friday")` — the shape admits them with **no schema change**; nothing writes them yet.

## Why

Today pricing lives in `listings.unit_price` (a scalar) and `listings.day_prices` (a JSON blob). A proper table keyed by pricing dimension lets us add per-package and per-weekday prices later as ordinary rows rather than growing more columns/blobs. This PR lands the table and keeps it in lock-step with the existing columns; a follow-up wires the read side into pricing.

## How

- **Schema + migration** — new `listing_prices` table (unique index on `listing_id, price_type, price_id`) added to `SCHEMA`, with a migration that creates it and backfills the two dimensions that exist today from every listing's current `unit_price`/`day_prices`.
- **Source of truth unchanged** — `unit_price`/`day_prices` remain the columns every display/API/charge caller reads. This PR only adds the mirror table, so behaviour is identical.
- **Kept in sync on every write:**
  - the `listingsTable` insert/update wrapper re-syncs a listing's managed rows after each write — covering the admin edit form, bulk actions, uploads and lifecycle paths;
  - a new `afterWrite` post-commit hook on `defineCrudApi` covers the transactional JSON-API path, which writes via `insertStatement`/`updateStatement` and would otherwise bypass the wrapper.
- The sync is delete-then-reinsert of only the `base`/`day_count` rows, so reserved dimensions are never disturbed and re-running converges.

## Tests

- Pure tests for the statement builders (`listingPriceStatements`, `sourceRowStatements`) covering base-only, multi-day, NULL price, and blank `day_prices`.
- DB tests: admin create/edit keep the base row in sync, backfill rebuilds base + day-count rows from the columns, re-sync drops a dropped day count, and no-op paths (missing listing / missing-id update) write nothing.
- API test proving the transactional create path syncs `listing_prices` via the `afterWrite` hook.
- Migration schema-guard snapshot updated (new migration id + schema hash).

Full suite green with 100% line/branch coverage; 100% mutation on the new module (`equivalent-mutants.txt` records the one provably-equivalent `?? → ||`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZAky434H6h2jzEudEqcPU)_