### PR TITLE
Always serve /custom.css as a stylesheet, never an HTML system page

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -13,6 +13,10 @@ import {
   isEmbeddablePath,
   isValidContentType,
 } from "#routes/middleware.ts";
+import {
+  emptyCustomCssResponse,
+  isCssResponse,
+} from "#routes/public/custom-css.ts";
 import { bufferRequestBody } from "#routes/request-body.ts";
 import {
   databaseBusyResponse,
@@ -949,6 +953,8 @@ const handleRoutingError = (
   return temporaryErrorResponse();
 };
 
+const CUSTOM_CSS_PATH = "/custom.css";
+
 /**
  * The core request pipeline that runs inside all async context wrappers.
  * Performs parsing, early redirects, content-type validation, routing,
@@ -963,6 +969,22 @@ const processRequest = async (
   detectIframeMode(request.url);
   clearSavedFormData();
 
+  // The public layout links /custom.css on every page, including the system
+  // pages the pipeline answers before the dynamic CSS route runs (setup /
+  // site-not-activated, migration-in-progress, transient error). Serving those
+  // HTML fallbacks for this asset trips the browser's strict MIME check, so any
+  // non-CSS response for /custom.css is coerced to an empty stylesheet. On a
+  // healthy site the route already returns text/css, making this a no-op.
+  const finish = (response: Response): Response =>
+    logAndReturn(
+      path === CUSTOM_CSS_PATH && !isCssResponse(response)
+        ? emptyCustomCssResponse()
+        : response,
+      method,
+      path,
+      getElapsed,
+    );
+
   let response!: Response;
   try {
     // Buffer the POST body up front, before the DB init / settings load awaits
@@ -974,11 +996,8 @@ const processRequest = async (
 
     const staticResponse = await routeStatic(bufferedRequest, path, method);
     if (staticResponse) {
-      return logAndReturn(
+      return finish(
         await applySecurityHeaders(staticResponse, isEmbeddablePath(path)),
-        method,
-        path,
-        getElapsed,
       );
     }
 
@@ -990,41 +1009,28 @@ const processRequest = async (
 
     const notActivated = await initializeDatabaseForPath(path);
     if (notActivated) {
-      return logAndReturn(notActivated, method, path, getElapsed);
+      return finish(notActivated);
     }
 
     const trackingRedirect = trackingParamRedirect(url, method);
     if (trackingRedirect) {
-      return logAndReturn(trackingRedirect, method, path, getElapsed);
+      return finish(trackingRedirect);
     }
 
     await prepareRequestEnvironment(bufferedRequest, path, method);
 
     if (!isValidContentType(bufferedRequest, path)) {
-      return logAndReturn(
-        contentTypeRejectionResponse(),
-        method,
-        path,
-        getElapsed,
-      );
+      return finish(contentTypeRejectionResponse());
     }
 
-    response = logAndReturn(
+    response = finish(
       await routeAndFinalize(bufferedRequest, path, method, server),
-      method,
-      path,
-      getElapsed,
     );
     // Dev/test safety net: prove this route declared every setting it read.
     // No-op in production (audit scope is never entered).
     assertSettingsReadsDeclared(`${method} ${path}`);
   } catch (error) {
-    response = logAndReturn(
-      handleRoutingError(error, method, path),
-      method,
-      path,
-      getElapsed,
-    );
+    response = finish(handleRoutingError(error, method, path));
   } finally {
     await flushPendingWork();
   }

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -955,6 +955,10 @@ const handleRoutingError = (
 
 const CUSTOM_CSS_PATH = "/custom.css";
 
+/** True for a 3xx redirect response (bodyless — never a stray stylesheet). */
+const isRedirectResponse = (response: Response): boolean =>
+  response.status >= 300 && response.status < 400;
+
 /**
  * The core request pipeline that runs inside all async context wrappers.
  * Performs parsing, early redirects, content-type validation, routing,
@@ -972,12 +976,18 @@ const processRequest = async (
   // The public layout links /custom.css on every page, including the system
   // pages the pipeline answers before the dynamic CSS route runs (setup /
   // site-not-activated, migration-in-progress, transient error). Serving those
-  // HTML fallbacks for this asset trips the browser's strict MIME check, so any
-  // non-CSS response for /custom.css is coerced to an empty stylesheet. On a
+  // HTML fallbacks for this asset trips the browser's strict MIME check, so an
+  // HTML response for /custom.css is coerced to an empty stylesheet. On a
   // healthy site the route already returns text/css, making this a no-op.
+  // Redirects (3xx) pass through untouched — a bodyless redirect isn't a stray
+  // stylesheet, and coercing one would swallow the tracking-param cleanup that
+  // rewrites e.g. /custom.css?utm_source=x to the clean URL before the CSS is
+  // served.
   const finish = (response: Response): Response =>
     logAndReturn(
-      path === CUSTOM_CSS_PATH && !isCssResponse(response)
+      path === CUSTOM_CSS_PATH &&
+        !isRedirectResponse(response) &&
+        !isCssResponse(response)
         ? emptyCustomCssResponse()
         : response,
       method,

--- a/src/features/public/custom-css.ts
+++ b/src/features/public/custom-css.ts
@@ -18,7 +18,7 @@
 import { encodeBody } from "#routes/response.ts";
 import { settings } from "#shared/db/settings.ts";
 
-const CSS_CONTENT_TYPE = "text/css; charset=utf-8";
+export const CSS_CONTENT_TYPE = "text/css; charset=utf-8";
 
 /** Handle `GET /custom.css`. */
 export const handleCustomCss = (): Response =>
@@ -27,6 +27,27 @@ export const handleCustomCss = (): Response =>
   new Response(encodeBody(settings.customCss), {
     headers: {
       "cache-control": "public, max-age=31536000, immutable",
+      "content-type": CSS_CONTENT_TYPE,
+    },
+  });
+
+/** True when a response is already a stylesheet (content-type is `text/css`). */
+export const isCssResponse = (response: Response): boolean =>
+  (response.headers.get("content-type") ?? "").includes("text/css");
+
+/**
+ * Empty, uncached stylesheet served for `/custom.css` when the request pipeline
+ * would otherwise answer with an HTML system page (site-not-activated,
+ * migration-in-progress, transient error). The public layout links
+ * `/custom.css` on *every* page — including those system pages — so returning
+ * HTML there trips the browser's strict MIME check. This keeps the asset a
+ * stylesheet in every state; it is deliberately `no-store` so it can never be
+ * cached in place of the operator's real CSS once the site is healthy.
+ */
+export const emptyCustomCssResponse = (): Response =>
+  new Response(encodeBody(""), {
+    headers: {
+      "cache-control": "no-store",
       "content-type": CSS_CONTENT_TYPE,
     },
   });

--- a/test/lib/custom-css.test.ts
+++ b/test/lib/custom-css.test.ts
@@ -63,4 +63,14 @@ describeWithEnv("custom.css handler", { db: true, triggers: true }, () => {
     const res = await handleRequest(mockRequest("/custom.css/extra"));
     expect(res.status).toBe(404);
   });
+
+  test("preserves the tracking-param redirect instead of coercing to empty CSS", async () => {
+    // The CSS coercion must not swallow the 301 that strips tracking params;
+    // the clean URL is where the real stylesheet is then served.
+    const res = await handleRequest(
+      mockRequest("/custom.css?v=1&utm_source=x"),
+    );
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("/custom.css?v=1");
+  });
 });

--- a/test/lib/custom-css.test.ts
+++ b/test/lib/custom-css.test.ts
@@ -1,11 +1,44 @@
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
+import {
+  emptyCustomCssResponse,
+  isCssResponse,
+} from "#routes/public/custom-css.ts";
 import { settings } from "#shared/db/settings.ts";
 import { describeWithEnv, mockRequest } from "#test-utils";
 
 const customCss = (): Promise<Response> =>
   handleRequest(mockRequest("/custom.css"));
+
+describe("custom.css asset helpers", () => {
+  test("isCssResponse is true for a text/css response", () => {
+    const res = new Response("", {
+      headers: { "content-type": "text/css; charset=utf-8" },
+    });
+    expect(isCssResponse(res)).toBe(true);
+  });
+
+  test("isCssResponse is false for an HTML response", () => {
+    const res = new Response("<h1>nope</h1>", {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+    expect(isCssResponse(res)).toBe(false);
+  });
+
+  test("isCssResponse is false when no content-type header is present", () => {
+    const res = new Response("", { headers: {} });
+    res.headers.delete("content-type");
+    expect(isCssResponse(res)).toBe(false);
+  });
+
+  test("emptyCustomCssResponse is an empty, uncached stylesheet", async () => {
+    const res = emptyCustomCssResponse();
+    expect(res.headers.get("content-type")).toContain("text/css");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.text()).toBe("");
+  });
+});
 
 describeWithEnv("custom.css handler", { db: true, triggers: true }, () => {
   test("serves an empty text/css body by default", async () => {

--- a/test/lib/server-setup.test.ts
+++ b/test/lib/server-setup.test.ts
@@ -146,6 +146,17 @@ describeWithEnv("server (setup)", { db: true }, () => {
         expect(await settingsTableExists()).toBe(false);
       });
 
+      test("custom.css is served as a stylesheet, not the HTML system page", async () => {
+        // The layout links /custom.css on the not-activated page itself, so the
+        // asset must stay text/css even before setup — an HTML fallback trips
+        // the browser's strict MIME check.
+        const response = await handleRequest(mockRequest("/custom.css"));
+
+        expect(response.headers.get("content-type")).toContain("text/css");
+        expect(response.headers.get("content-type")).not.toContain("text/html");
+        expect(await response.text()).toBe("");
+      });
+
       test("health and static assets work when settings DB cannot be read", async () => {
         const { stub } = await import("@std/testing/mock");
         const executeStub = stub(getDb(), "execute", () =>


### PR DESCRIPTION
## Problem

The browser refused to apply the operator stylesheet:

```
Refused to apply style from '.../custom.css?v=0' because its MIME type
('text/html') is not a supported stylesheet MIME type, and strict MIME
checking is enabled.
```

`/style.css` is served by `routeStatic` **before** the DB/setup gates, but `/custom.css` runs through the main app request pipeline, which requires setup to be complete and the database initialised. On a not-yet-activated site (the `?v=0` in the report), during a migration, or on a transient error, that pipeline answers `/custom.css` with an HTML page (`siteNotActivatedResponse`, `migrationInProgressResponse`, `temporaryErrorResponse`). Because the public layout links `/custom.css` on **every** page — including those system pages themselves — the browser trips strict MIME checking and refuses the stylesheet.

## Fix

Funnel every response in `processRequest` through a small `finish` helper that coerces any non-CSS response for the `/custom.css` path into an empty, uncached (`no-store`) stylesheet. This keeps the asset `text/css` in every application state, while a healthy site still serves the operator's real CSS unchanged (the coercion is a no-op there). The `no-store` guard ensures the degraded empty body is never cached in place of the real CSS once the site comes up.

## Changes

- `src/features/public/custom-css.ts` — export `CSS_CONTENT_TYPE`, add `isCssResponse` (predicate) and `emptyCustomCssResponse` (empty, `no-store` fallback stylesheet).
- `src/features/index.ts` — route every `processRequest` response through a `finish` closure that coerces non-CSS responses for `/custom.css`.
- `test/lib/server-setup.test.ts` — regression test: `/custom.css` stays `text/css` when setup is incomplete (fails before the fix, passes after).
- `test/lib/custom-css.test.ts` — direct unit tests for `isCssResponse` (both branches) and `emptyCustomCssResponse`.

## Verification

`deno task precommit` passes (lint, typecheck, cpd, build:edge, test:coverage at 100%). Confirmed the new regression test fails without the fix (returns HTML 503) and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEdGQz7R7JFi5Uhum8mik)_