### PR TITLE
Document the ten qualities every new system should have, with exemplars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,258 @@ The `.tool-versions` file is kept in sync for asdf-compatible tooling.
 - **Answer every PR review thread you address**: When a pull request review leaves comments — from an automated reviewer (e.g. Codex) or a human — reply to **each** thread directly with a concise, proper note: how it was resolved (the mechanism + the regression test that locks it), or why it is not actionable/incorrect. Do this even when the commit message already explains the change — an open thread reads as unaddressed, so close the loop on the thread itself. This is a deliberate exception to general GitHub-comment frugality: resolution replies on review threads are expected, not noise. Keep each reply tight (a few sentences), and reference the fixing commit.
 - **Final check**: Run `deno task precommit` (via `mise exec -- deno task precommit` when using the pinned toolchain) before finishing any job with code or documentation changes. It is the only check that mirrors CI exactly — it typechecks the **test** files too, so `deno check <src>` plus `test:files` is not a substitute (a test-only type error will pass locally and still break CI).
 
+## Designing New Systems
+
+When planning a new feature, design it to have every quality below. Each one
+names reference implementations in this codebase — read the exemplar before
+designing, and copy its shape rather than inventing a new one. These are the
+systems we want more of.
+
+### Schema-tized
+
+Model the thing as data first — a typed schema plus a few functions folded
+over it — and derive everything else (types, validation, rendering, routes)
+from that one declaration. The philosophy is in the Preferences ("Schema over
+organic structure", "Shared interfaces over branch-per-case"); these are the
+mechanisms to copy:
+
+- **A valibot schema as the single source of truth for a value type.**
+  Declare once; derive the TS type, the runtime guard, and the options list:
+
+  ```typescript
+  export const ContactFieldSchema = v.picklist(["email", "phone", "address", "special_instructions"]);
+  export type ContactField = v.InferOutput<typeof ContactFieldSchema>;
+  export const CONTACT_FIELDS = ContactFieldSchema.options;
+  export const isContactField = (s: string): s is ContactField =>
+    v.is(ContactFieldSchema, s);
+  ```
+
+  See `src/shared/types.ts` (six of these) and `src/shared/price-modifier.ts`
+  (a whole family). For structured values, compose `v.object` schemas into a
+  discriminated union with `v.variant("kind", […])` and a single `v.is` guard
+  — `src/shared/bulk-email-targets.ts` is the reference.
+- **Declarative tables.** `defineTable`/`defineIdTable`
+  (`src/shared/db/table.ts`, `src/shared/db/define-id-table.ts`): a `columns`
+  config built from the `col.*` builders (`col.boolean`, `col.encrypted`,
+  `col.generated`, …) drives serialization, encryption, and the derived
+  `Input` type. Never hand-write row mapping.
+- **Config-driven CRUD.** `defineCrudApi` (`src/shared/rest/crud-api.ts`)
+  turns one config object into the five standard admin API routes;
+  `defineResource`/`defineNamedResource` (`src/shared/rest/resource.ts`) turn
+  `{table, fields, toInput, validate}` into typed operations that the
+  handlers in `src/shared/rest/handlers.ts` wire to HTTP.
+- **Schema-driven forms.** `defineForm` + a `Field[]` (`src/shared/forms.tsx`):
+  one field list drives the HTML rendering, the parsing/validation, and the
+  `FormValuesFor<>` value types; `createFormRoute`/`createAuthedFormRoute`
+  (`src/shared/app-forms.ts`) wire that same schema to both the GET (render)
+  and POST (validate) handlers.
+- **A data table plus one fold.** `LISTING_DEFAULT_FIELDS` +
+  `resolveListingDefaults` (`src/shared/listing-defaults.ts`); the admin
+  guide's `GuideSection[]` + `renderGuideSections`.
+
+If your plan contains a hand-rolled dispatcher, an ad-hoc form, bespoke CRUD
+routes, or hand-written row (de)serialization, stop: there is a `define*`
+factory for that already. Use it — or extend it for every caller.
+
+### Pure, functional
+
+Write the core of a feature as pure data-in/data-out functions and keep IO
+(DB reads, settings, fetches) in a thin shell around it. Pure modules are
+trivially unit-testable, which is what keeps 100% coverage and a 100%
+mutation kill rate cheap to sustain.
+
+- `src/shared/largest-remainder.ts` — a complete allocation algorithm with
+  zero imports; the hardest logic in the money paths and the easiest to test.
+- `src/shared/listing-defaults.ts` — the header states "This module is
+  pure": callers fetch, it computes.
+- `src/shared/ledger/project.ts` — pure projections over a slice of
+  transfers; every derived total reuses the single `allBalances` fold, so no
+  two totals can disagree.
+- `src/shared/phone.ts`, `src/shared/countries.ts` — pure normalization, and
+  a pure data table with total accessors.
+
+Prefer the curried utilities from `#fp` over imperative loops (see
+[FP Imports](#fp-imports)). When a module needs both computation and
+configuration, split it the way `src/shared/dates.ts` does: the pure
+functions take the timezone as an argument, and thin wrappers inject
+`settings.timezone` — the pure core stays testable without a database.
+
+### Modularised
+
+One concept per file; one layer per directory. `REPO_STRUCTURE.md` defines
+where things go (`src/features/*` routes, `src/shared/*` domain logic,
+`src/ui/*` presentation). Within `shared/`, the shapes to copy:
+
+- `src/shared/rest/` — `resource.ts` (the resource abstraction),
+  `handlers.ts` (HTTP wiring), `crud-api.ts` (the JSON API): each file is
+  one layer, named for its job.
+- `src/shared/ledger/` — `types.ts`, `project.ts`, `account.ts`,
+  `reconcile.ts`: a domain split into files you can navigate blind.
+- `src/shared/db/attendees/` — `queries.ts`, `pii.ts`, `capacity.ts`,
+  `stats.ts`, `delete.ts`: a big table's concerns separated instead of one
+  1,500-line module.
+
+A new system should arrive as a small directory of single-purpose files, not
+one grab-bag module — and not as fragments scattered through unrelated
+existing files.
+
+### Well-named files
+
+The filename states the concept; the concept fills the file.
+`largest-remainder.ts`, `phone.ts`, `slug.ts`, `define-id-table.ts`,
+`request-cache.ts`, `keyed-cache.ts` — you can guess each file's exports
+from its name and vice versa. Function names carry contracts the same way:
+the `Raw` suffix on `getAttendeesRaw`/`getAttendeeRaw` means "PII still
+encrypted — decrypt before display", and `getUserDisplayFields` names the
+exact narrow column set it selects. If you can't name the file in a couple
+of words, it is probably two concepts — split it.
+
+### Valibot and standard libraries
+
+Validation is valibot; collections are `@std/collections` (via `#fp`);
+paths, media types, and cookies are `@std/path`, `@std/media-types`, and
+`@std/http/cookie`; date/timezone math is `Temporal` (temporal-polyfill);
+formatting is `Intl`. Valibot patterns to copy:
+
+- **Branded scalar** — `src/shared/validation/email.ts`:
+  `v.pipe(v.string(), v.trim(), v.toLowerCase(), v.email(), v.brand("ValidEmail"))`.
+  A `ValidEmail` can only be produced by validation, so downstream code
+  needs no re-checks.
+- **Coercing schema factory** — `src/shared/validation/number.ts`:
+  `createIntSchema(minimum)` validates digits *before* `v.transform(Number)`
+  (closing the `parseInt("5abc")` hole); `PositiveIntSchema` and friends are
+  its specializations.
+- **Boundary validation** — `src/features/api/sms-webhook.ts`: `v.safeParse`
+  an envelope `v.object` immediately after `JSON.parse`, 400 on failure.
+  Validate at the boundary; pass typed values inward.
+- **Deliberate non-use is fine when the platform is better** —
+  `src/shared/validation/timestamp.ts` delegates instant validation to
+  `Temporal.Instant.from` (valibot's `isoTimestamp` accepts overflow days)
+  and documents why.
+
+### Don't reinvent the wheel
+
+Before writing an algorithm, formatter, or parser, check `deno.json` — the
+answer is usually already a dependency. When the project's calling
+convention differs from a library's, write a thin adapter; don't
+re-implement:
+
+- `src/fp.ts` — `unique`, `uniqueBy`, `mapNotNullish`, `sumOf`, `chunk` are
+  one-line curried adapters over `@std/collections`.
+- `src/shared/db/table.ts` — `toCamelCase`/`toSnakeCase` delegate to
+  valibot's case actions rather than bespoke regexes.
+- `src/shared/timezone.ts` — all DST/offset math is `Temporal`;
+  `src/shared/currency.ts` gets currency symbols and decimal places from
+  `Intl.NumberFormat` instead of a hand-maintained table;
+  `src/shared/slug.ts` validates with `v.slug()`.
+
+When you genuinely must hand-roll, document the reason at the definition the
+way `#fp`'s `groupBy` does (it exists because `@std/collections` lacks the
+ordering guarantee its callers rely on).
+
+### Curried helpers
+
+Currying is the house style for both de-duplication (see
+[Code Duplication](#code-duplication)) and API design: the factory takes the
+configuration, the returned function takes the data.
+
+- `makeOutcome(succeeded)` → `export const ok = makeOutcome(true)` /
+  `fail = makeOutcome(false)` (`src/shared/response.ts`).
+- `roleIn(levels)` → `isStaffRole`, `isDeliveryRole` (`src/shared/types.ts`)
+  — predicate factories instead of near-identical functions.
+- `balanceOf(account)` → `(transfers) => number` and friends
+  (`src/shared/ledger/project.ts`) — curried projections that compose.
+- At larger scale the same shape becomes the config-driven factories:
+  `defineTable`, `defineCrudApi`, `defineForm`, and `cachedClientFactory`
+  (`src/shared/payment-helpers.ts`).
+
+### Built for cold starts
+
+Most production requests land on a freshly booted edge isolate with a
+~500ms startup budget and a limited subrequest budget
+(`scripts/profile-cold-boot.ts` measures both). The rules, with their
+reference implementations:
+
+- **Nothing heavy at module load.** Entry points only register the handler
+  (`src/edge.ts`); app boot runs `once()` on the *first request*
+  (`src/serve-app.ts`). Module-load work is fine only when pure and cheap
+  (e.g. `defineTable` building its schemas once).
+- **Lazy singletons via `once`/`lazyRef` from `#fp`.** The DB client
+  (`getDb` in `src/shared/db/client.ts`), the dynamically imported Stripe
+  SDK (`src/shared/stripe.ts`), the Liquid email engine, crypto key material
+  — all first-use, never import-time.
+- **Request-scoped memoization, not global state.** `requestCache`
+  (`src/shared/request-cache.ts`) shares one fetch among all callers within
+  a request; `createRequestScoped` (`src/shared/request-scoped.ts`) keeps
+  two concurrent requests on one isolate from clobbering each other.
+  Isolate-lived caches are best-effort and bounded
+  (`src/shared/db/keyed-cache.ts`; the settings version-stamp cache in
+  `src/shared/db/settings.ts`) — never authoritative for security
+  decisions, and invalidated automatically by the write-sniffing db client
+  (`src/shared/cache-registry.ts`).
+- **Compile once, render many.** ICU message templates (including the
+  `I18N_REPLACEMENTS` rebranding pass) compile once and cache
+  (`src/shared/i18n.ts`), so rendering is a plain format call.
+- **Respect the subrequest budget.** Fixed-cost designs like
+  `src/shared/limits.ts` (one SELECT plus one batch regardless of batch
+  size), `UPDATE … RETURNING` instead of update-then-select
+  (`src/shared/db/table.ts`), and `queryBatch` for multi-read round-trips.
+
+A new feature that adds a top-level `await`, an import-time SDK load, or a
+per-request whole-table read is a cold-start regression even if it works.
+
+### Efficient SQL
+
+The rules live in [Database Queries](#database-queries) (narrow column
+lists, bounded reads, batches vs interactive transactions). Beyond those,
+copy these shapes:
+
+- **Enforce invariants in the mutating statement itself.**
+  `src/shared/db/capacity.ts` embeds the capacity check in the same
+  INSERT/UPDATE that books the attendee — no read-modify-write race, no
+  second round-trip.
+- **Trigger-maintained aggregates instead of scans.**
+  `listings.booked_quantity`/`tickets_count` are maintained by triggers on
+  `listing_attendees`
+  (`src/shared/db/migrations/2026-06-16_listing_aggregates.ts`), so listing
+  reads never sum attendee rows.
+- **One-round-trip patterns.** `UPDATE … RETURNING *` in
+  `src/shared/db/table.ts`; `queryBatch`/`executeBatchWithResults` in
+  `src/shared/db/client.ts`; keyset pagination for unbounded reads
+  (`src/shared/db/backup.ts` with `BACKUP_PAGE_SIZE`).
+
+### Decrypt only what you need
+
+Encrypted data stays encrypted until the moment of display, and lookups
+never require decryption:
+
+- **Blind HMAC indexes for lookups.** Alongside each searchable encrypted
+  value sits a deterministic `hmacHash` index column: `username_index`
+  (`src/shared/db/users.ts`), `ticket_token_index`
+  (`src/shared/crypto/hashing.ts`, `src/shared/db/attendees/queries.ts`),
+  `phone_index` for inbound SMS (`src/shared/db/attendee-phone-index.ts`),
+  `code_index` on modifiers. Query `WHERE …_index = ?`; never
+  scan-and-decrypt. (The one sanctioned scan-decrypt — invite codes in
+  `users.ts` — is documented and bounded by a tiny keyspace.)
+- **One blob, one decrypt, decrypt late.** All attendee PII lives in a
+  single `pii_blob` (`src/shared/db/attendees/pii.ts`); list queries select
+  it without decrypting (`getAttendeesRaw` and friends in
+  `src/shared/db/attendees/queries.ts`), and `decryptAttendees` runs only at
+  render time. `decryptPiiBlob`'s `paidListing` flag even gates which fields
+  come out of the blob, and `getAttendeeNamesByIds` decrypts just the name.
+- **Skip encrypted columns entirely when you can.** `getUserAuthFieldsById`
+  (`SELECT id, admin_level`) and `getAttendeeKindsByIds` (`SELECT id, kind`)
+  answer their questions without touching a ciphertext — the same
+  discipline as "Select only needed columns", applied to
+  plaintext-in-memory.
+- **Declarative encryption at the column layer.**
+  `col.encrypted`/`col.encryptedText` in `src/shared/db/table.ts` decrypt
+  lazily, per present column; a new encrypted column is declared, not
+  hand-wired.
+- **Keys are request-scoped and short-lived.** The session private key is
+  fail-closed per request (`src/shared/session-private-key.ts`) and decrypt
+  caches are TTL-bounded to seconds (`src/shared/crypto/keys.ts`).
+
 ## FP Imports
 
 ```typescript


### PR DESCRIPTION
## Summary

Adds a **"Designing New Systems"** section to `AGENTS.md` (between Preferences and FP Imports) so future agents planning features have a concrete checklist of the qualities a new system should have — each backed by reference implementations already in the codebase, found by sweeping `src/` for the best exemplars of each.

The ten subsections:

- **Schema-tized** — valibot picklist → `InferOutput` type + `v.is` guard + `.options` array (`types.ts`, `price-modifier.ts`, `bulk-email-targets.ts`); `defineTable`/`defineIdTable`, `defineCrudApi`/`defineResource`, `defineForm`; data-table-plus-fold (`listing-defaults.ts`, admin guide).
- **Pure, functional** — `largest-remainder.ts`, `ledger/project.ts`, `phone.ts`, `countries.ts`; the `dates.ts` pattern of pure functions taking `timezone` as an argument with thin `settings.timezone` wrappers.
- **Modularised** — one concept per file, one layer per directory: `shared/rest/`, `shared/ledger/`, `shared/db/attendees/`.
- **Well-named files** — filename states the concept; names carry contracts (`getAttendeesRaw` = still encrypted).
- **Valibot and standard libraries** — branded scalars (`validation/email.ts`), coercing schema factories (`validation/number.ts`), boundary `safeParse` (`sms-webhook.ts`), documented non-use (`validation/timestamp.ts` → `Temporal`).
- **Don't reinvent the wheel** — `#fp`'s one-line adapters over `@std/collections`, valibot case actions for casing, `Temporal`/`Intl` for tz and currency; document the reason when hand-rolling (like `#fp`'s `groupBy`).
- **Curried helpers** — `makeOutcome` → `ok`/`fail`, `roleIn` → `isStaffRole`, ledger projections, and the `define*` factories as the same shape at larger scale.
- **Built for cold starts** — nothing heavy at module load, `once`/`lazyRef` singletons, request-scoped memoization vs bounded isolate caches, compile-once i18n, fixed subrequest budgets.
- **Efficient SQL** — capacity enforced inside the mutating statement (`capacity.ts`), trigger-maintained aggregates, `UPDATE … RETURNING`, batches, keyset pagination; cross-references the existing Database Queries section.
- **Decrypt only what you need** — blind HMAC index columns for lookups, single `pii_blob` decrypted late (and partially, via `paidListing`), narrow selects that never touch ciphertext, declarative `col.encrypted`, short-lived request-scoped keys.

Docs-only change: 252 added lines in `AGENTS.md`, no code touched.

## Verification

- `deno task precommit` — lint, typecheck, cpd, and edge build all pass; full test suite run in progress at time of writing (docs-only diff, no code paths affected) — will confirm green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ta1F1PzGzRGQsaLKUjZWk

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ta1F1PzGzRGQsaLKUjZWk)_