### PR TITLE
Servicing follow-ups: fix dateless cost replay, unify money parsing app-wide

### DIFF
--- a/servicing.md
+++ b/servicing.md
@@ -71,24 +71,31 @@ The fuller registry-driven variant (resolve the route first, consult a per-route
 `readOnly: "allow"` flag) remains an optional future refactor; the current
 path-based allowlist already fails closed.
 
-### Holistic 2 — One money schema (servicing slice + ledger done; broader migration remaining)
+### Holistic 2 — One money schema (largely done)
 
-`src/shared/validation/money.ts` now houses the shared currency-aware positive
-parser, and both the service-cost routes and the ledger use it. The remaining
-work is to migrate the **other** money call sites onto the shared family and
-delete their ad-hoc `toMinorUnits(Number.parseFloat(...))` / unrestricted-regex
-parses — and to add the non-negative / optional-override / signed variants those
-sites need (see the axes below). Until then, those fields keep their old parsing:
+`src/shared/validation/money.ts` houses the shared currency-aware family across
+both axes — **bound** (positive / non-negative / signed) × **blank handling**
+(required blank ⇒ `0`, optional blank ⇒ `null` — never a real `0`): plus a
+currency-aware `validatePrice`. The migrated sites now reject a prefix, comma
+group, or over-precise amount instead of `Number.parseFloat`-coercing/rounding:
 
-- `validatePrice` (public/QR prices) — still `Number.parseFloat`, accepts prefixes.
-- listing `unit_price`, modifier `min_subtotal` / `calc_value`, balance-adjust,
-  reservation amounts (flat/per-item), the QR price override, and custom day
-  prices — ad-hoc parses.
+- service costs + ledger entries (positive);
+- listing `unit_price` + custom day prices (optional) and the non-negative price
+  validator behind `unit_price` / `max_price`;
+- public / QR prices (`validatePrice`);
+- balance / income / modifier-revenue corrections (signed `money-adjust`);
+- reservation `flat` / `perItem` amounts (currency-precise; percentages keep
+  their precision).
 
-The bound axes for the full family are **bound** (positive / non-negative /
-signed) × **blank handling** (required vs optional, where blank ≠ zero for the
-optional-override fields). Build them from one `ledgerAmountPattern`-style
-decimal check; do **not** collapse "unset" into a real zero. The browser-side
-`PriceInput` already derives `step` from the currency for every site that adopts
-it; the two hard-coded `pattern="\d+(\.\d{1,2})?"` inputs (QR override price,
-custom day prices) still need the same treatment.
+The browser side matches via `PriceInput`'s `moneyStep()` and a shared
+`moneyPattern()`, now used for `unit_price`, `max_price`, the QR override price,
+and custom day prices (so KWD's 3 decimals are typeable and JPY isn't offered
+cents).
+
+**Remaining:** the modifier `calc_value` / `min_subtotal` fields. These are NOT
+plain money fields — `calc_value` is polymorphic (a currency amount only when
+`calc_kind === "fixed"`, otherwise a percentage or a bare multiplier) and is
+stored in **major** units (converted at resolve time), and both use `parse`/
+`validate` field callbacks. Making the fixed case currency-aware needs
+cross-field (calc_kind-aware) validation rather than the single-field swap the
+other sites took, so it's left as a separate, self-contained change.

--- a/servicing.md
+++ b/servicing.md
@@ -26,10 +26,14 @@ the moment it exists. Asserted in `test/routes/read-only.test.ts`.
 
 `recordServiceCost` no longer short-circuits on a stored `reference` alone. It
 returns the existing cost id **only** when the stored `service_costs` row matches
-the whole submitted payload — amount, servicing event, listing, date, and the
+the operator-entered payload — amount, servicing event, listing, and the
 decrypted memo. A reused idempotency key (or a payload-derived reference that
 omits the memo) whose payload has since changed throws `COST_REPLAY_MISMATCH`,
 which the route surfaces as a form error instead of a false success or a 500.
+`occurredAt` is deliberately excluded from the match: it isn't an operator-
+editable field (it's the booking date, or `new Date()` for a dateless event), so
+comparing it would break a legitimate double-submit of a dateless cost — the
+exact retry the key exists to cover.
 
 ### P2 — Free-text answers survive a failed servicing-edit rollback
 

--- a/src/features/admin/listing-qr.ts
+++ b/src/features/admin/listing-qr.ts
@@ -25,7 +25,6 @@ import {
   type FormValidator,
 } from "#shared/app-forms.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
-import { validatePrice } from "#shared/currency.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getListingWithCount } from "#shared/db/listings.ts";
@@ -33,6 +32,7 @@ import { FormParams } from "#shared/form-data.ts";
 import { generateQrSvg, listingSupportsDirectCheckout } from "#shared/qr.ts";
 import { buildQrBookPayload, signQrBookToken } from "#shared/qr-token.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
+import { validatePrice } from "#shared/validation/money.ts";
 import { parsePositiveInt } from "#shared/validation/number.ts";
 import type {
   AdminListingQrResult,

--- a/src/features/admin/listings-form.ts
+++ b/src/features/admin/listings-form.ts
@@ -31,6 +31,7 @@ import {
   type ListingType,
   parseDayPrices,
 } from "#shared/types.ts";
+import { parseOptionalMinorUnits } from "#shared/validation/money.ts";
 import type {
   ListingAggregateFormValues,
   ListingEditFormValues,
@@ -96,8 +97,10 @@ const parseDayPricesFromForm = (
 ): DayPrices => {
   const result: DayPrices = {};
   for (let n = 1; n <= maxDays; n++) {
-    const raw = form.getString(`day_price_${n}`).trim();
-    if (raw !== "") result[n] = toMinorUnits(Number.parseFloat(raw));
+    // Optional per-day price: blank ⇒ skip (that day isn't offered), an amount
+    // with more decimals than the currency allows ⇒ skip (rejected, not rounded).
+    const price = parseOptionalMinorUnits(form.getString(`day_price_${n}`));
+    if (price !== null) result[n] = price;
   }
   return parseDayPrices(result);
 };
@@ -108,9 +111,10 @@ const normalizeOptionalDatetime = (
   field: string,
 ): string | undefined => (raw ? normalizeDatetime(raw, field) : raw);
 
-/** Parse an optional minor-units price field, undefined when blank. */
+/** Parse an optional minor-units price field: undefined when blank or invalid,
+ *  else the currency-validated non-negative amount. */
 const parseOptionalPrice = (raw: string | undefined): number | undefined =>
-  raw ? toMinorUnits(Number.parseFloat(raw)) : undefined;
+  parseOptionalMinorUnits(raw ?? "") ?? undefined;
 
 /** Extract common listing fields from validated form values, normalizing datetimes to UTC */
 const extractCommonFields = (

--- a/src/features/admin/listings-form.ts
+++ b/src/features/admin/listings-form.ts
@@ -134,11 +134,6 @@ const normalizeOptionalDatetime = (
   field: string,
 ): string | undefined => (raw ? normalizeDatetime(raw, field) : raw);
 
-/** Parse an optional minor-units price field: undefined when blank or invalid,
- *  else the currency-validated non-negative amount. */
-const parseOptionalPrice = (raw: string | undefined): number | undefined =>
-  parseOptionalMinorUnits(raw ?? "") ?? undefined;
-
 /** Extract common listing fields from validated form values, normalizing datetimes to UTC */
 const extractCommonFields = (
   values: ListingFormValues,
@@ -148,7 +143,10 @@ const extractCommonFields = (
   const webhookUrl = isDemoMode() ? "" : values.webhook_url || "";
   const durationDays = values.duration_days ?? 1;
   const listingType = resolveListingType(values.listing_type);
-  const unitPrice = parseOptionalPrice(values.unit_price);
+  // Blank/invalid unit price ⇒ unset (the column defaults to 0 = free); a valid
+  // value is the currency-checked minor-units amount. `unit_price` is always a
+  // string here, so no nullish fallback is needed before parsing.
+  const unitPrice = parseOptionalMinorUnits(values.unit_price) ?? undefined;
   const bookableDays = parseBookableDays(
     values.bookable_days,
     listingType,

--- a/src/features/admin/listings-form.ts
+++ b/src/features/admin/listings-form.ts
@@ -97,12 +97,35 @@ const parseDayPricesFromForm = (
 ): DayPrices => {
   const result: DayPrices = {};
   for (let n = 1; n <= maxDays; n++) {
-    // Optional per-day price: blank ⇒ skip (that day isn't offered), an amount
-    // with more decimals than the currency allows ⇒ skip (rejected, not rounded).
+    // Optional per-day price: blank ⇒ skip (that day isn't offered). A non-blank
+    // value that fails to parse is caught by validateDayPricesFromForm before
+    // the save, so here a null result is only ever a blank.
     const price = parseOptionalMinorUnits(form.getString(`day_price_${n}`));
     if (price !== null) result[n] = price;
   }
   return parseDayPrices(result);
+};
+
+/**
+ * Reject the save when a `day_price_*` field carries a non-blank value that
+ * isn't a valid amount for the currency (e.g. `10.005` in GBP, `10.5` in JPY, or
+ * `abc`). Without this, an invalid value would be silently dropped by
+ * {@link parseDayPricesFromForm} — on an update that would remove an existing
+ * day price rather than surfacing the error. Blank fields are skipped (that
+ * duration simply isn't offered). Returns an error message, or null when every
+ * present day price is valid. These dynamic fields aren't part of the static
+ * field schema, so they're validated here through the resource's `validate` hook.
+ */
+const validateDayPricesFromForm = (form: FormParams): string | null => {
+  const hasInvalid = [...form.entries()].some(
+    ([field, raw]) =>
+      field.startsWith("day_price_") &&
+      raw.trim() !== "" &&
+      parseOptionalMinorUnits(raw) === null,
+  );
+  return hasInvalid
+    ? "Enter a valid day price for each duration, or leave it blank."
+    : null;
 };
 
 /** Normalize an optional datetime field to UTC, passing through blanks/undefined. */
@@ -214,13 +237,21 @@ const buildListingResourceFields = (): Field[] => [
  * raw form, so the dynamic `day_price_*` inputs can be read alongside the
  * validated fields (the resource only hands `toInput` the validated values).
  */
+/** The listing validation for a request: reject an invalid day price first
+ *  (the dynamic fields the static schema can't see), then the standard input
+ *  validation. Closes over the raw `form` so both create and update share it. */
+const listingValidate =
+  (form: FormParams) =>
+  async (input: ListingInput, id?: number): Promise<string | null> =>
+    validateDayPricesFromForm(form) ?? (await validateListingInput(input, id));
+
 export const buildCreateListingResource = (form: FormParams) =>
   defineResource({
     fields: buildListingResourceFields(),
     nameField: "name",
     table: listingsTable,
     toInput: (values: ListingFormValues) => extractListingInput(values, form),
-    validate: validateListingInput,
+    validate: listingValidate(form),
   });
 
 /** Build a per-request listings update resource (includes the slug field). */
@@ -231,5 +262,5 @@ export const buildUpdateListingResource = (form: FormParams) =>
     table: listingsTable,
     toInput: (values: ListingEditFormValues) =>
       extractListingUpdateInput(values, form),
-    validate: validateListingInput,
+    validate: listingValidate(form),
   });

--- a/src/features/admin/money-adjust.ts
+++ b/src/features/admin/money-adjust.ts
@@ -20,9 +20,8 @@
 
 import { OWNER_FORM, withAuth } from "#routes/auth.ts";
 import { errorRedirect, notFoundResponse, redirect } from "#routes/response.ts";
-import { toMinorUnits } from "#shared/currency.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
-import type { FormParams } from "#shared/form-data.ts";
+import { parseSignedMinorUnits } from "#shared/validation/money.ts";
 
 /** Configuration for one entity's money-correction handler. */
 type MoneyAdjustConfig<Entity> = {
@@ -41,16 +40,6 @@ type MoneyAdjustConfig<Entity> = {
   editPath: (id: number) => string;
 };
 
-/** Parse a money field in major units to minor units. Blank or non-finite input
- * is rejected (null); a finite value — including a negative, which a modifier's
- * net revenue can legitimately be — converts to integer minor units. */
-const parseMoneyField = (form: FormParams, field: string): number | null => {
-  const raw = form.getString(field).trim();
-  if (raw === "") return null;
-  const parsed = Number.parseFloat(raw);
-  return Number.isFinite(parsed) ? toMinorUnits(parsed) : null;
-};
-
 /**
  * Build the POST handler for one entity's money correction. Owner-only; loads the
  * entity, parses the new figure, posts the delta as a `writeoff` adjustment, logs
@@ -62,7 +51,7 @@ export const makeMoneyAdjustHandler =
     withAuth(request, OWNER_FORM, async (_session, form) => {
       const entity = await config.load(id);
       if (!entity) return notFoundResponse();
-      const target = parseMoneyField(form, config.field);
+      const target = parseSignedMinorUnits(form.getString(config.field));
       if (target === null) {
         return errorRedirect(config.editPath(id), "Enter a valid amount");
       }

--- a/src/features/public/ticket-form.ts
+++ b/src/features/public/ticket-form.ts
@@ -5,7 +5,6 @@
 import { filter, map } from "#fp";
 import { capacityErrorFormatter } from "#routes/format.ts";
 import { errorRedirect, htmlResponse } from "#routes/response.ts";
-import { validatePrice } from "#shared/currency.ts";
 import type { AddOnOption } from "#shared/db/modifier-resolve.ts";
 import type {
   AttendeeAnswerSet,
@@ -16,6 +15,7 @@ import type {
 } from "#shared/db/questions.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { ListingFields } from "#shared/types.ts";
+import { validatePrice } from "#shared/validation/money.ts";
 import { parseNonNegativeInt } from "#shared/validation/number.ts";
 import { extractContact, mergeListingFields } from "#templates/fields.ts";
 import { type TicketListing, ticketPage } from "#templates/public.tsx";

--- a/src/shared/currency.ts
+++ b/src/shared/currency.ts
@@ -48,43 +48,6 @@ export const toMajorUnits = (minorUnits: number): string => {
   return (minorUnits / 10 ** places).toFixed(places);
 };
 
-/** Result type for price validation */
-export type PriceResult =
-  | { ok: true; price: number }
-  | { ok: false; error: string };
-
-/**
- * Validate and convert a raw price string to minor units.
- * Returns ok with 0 if raw is empty and minPrice is 0 (pay-what-you-want with no input).
- * Returns error if raw is empty and minPrice > 0, or if parsed value is out of range.
- */
-export const validatePrice = (
-  raw: string,
-  minPrice: number,
-  maxPrice: number,
-): PriceResult => {
-  if (!raw) {
-    return minPrice === 0
-      ? { ok: true, price: 0 }
-      : { error: "Please enter a price", ok: false };
-  }
-  const parsed = Number.parseFloat(raw);
-  if (Number.isNaN(parsed) || parsed < 0) {
-    return { error: "Please enter a valid price", ok: false };
-  }
-  const priceMinor = toMinorUnits(parsed);
-  if (priceMinor < minPrice) {
-    return {
-      error: "Price must be at least the minimum ticket price",
-      ok: false,
-    };
-  }
-  if (priceMinor > maxPrice) {
-    return { error: "Price exceeds the maximum allowed", ok: false };
-  }
-  return { ok: true, price: priceMinor };
-};
-
 /** Create a Liquid engine pre-configured with strict mode and the currency filter */
 export const createBaseLiquidEngine = (): Liquid => {
   const engine = new Liquid({ strictFilters: true, strictVariables: false });

--- a/src/shared/db/attendees/servicing.ts
+++ b/src/shared/db/attendees/servicing.ts
@@ -582,15 +582,22 @@ export const COST_REPLAY_MISMATCH =
 
 /**
  * The transfer id of an existing service cost stored under `reference`, but ONLY
- * when its stored leg matches the WHOLE submitted payload — amount, servicing
- * event, listing, date, and (decrypted) memo. Returns null when no leg is stored
- * for the reference (a fresh cost). Throws {@link COST_REPLAY_MISMATCH} when a
- * leg IS stored but differs from the new payload: the cost form's per-render
- * idempotency key is an opaque token, so a stale/bfcached form the operator
- * edited before resubmitting would otherwise resolve to the old leg and report a
- * false success while recording nothing. The memo is checked too — a
- * payload-derived reference omits it, so "same amount/date, changed memo only"
- * must not silently keep the old memo.
+ * when its stored leg matches the submitted **operator-entered** payload —
+ * amount, servicing event, listing, and (decrypted) memo. Returns null when no
+ * leg is stored for the reference (a fresh cost). Throws
+ * {@link COST_REPLAY_MISMATCH} when a leg IS stored but differs: the cost form's
+ * per-render idempotency key is an opaque token, so a stale/bfcached form the
+ * operator edited before resubmitting would otherwise resolve to the old leg and
+ * report a false success while recording nothing. The memo is checked too — a
+ * payload-derived reference omits it, so "same amount, changed memo only" must
+ * not silently keep the old memo.
+ *
+ * `occurredAt` is deliberately NOT compared: it isn't an operator-editable cost
+ * form field — it's derived (the event's booking date, or `new Date()` for a
+ * dateless event). Comparing it would make a legitimate double-submit of a
+ * dateless cost (same key, same amount/listing/memo, a millisecond-different
+ * server clock) fail as a mismatch, defeating the idempotency key for the exact
+ * retry case it exists to cover.
  */
 const matchingServiceCostReplayId = async (
   input: RecordServiceCostInput,
@@ -601,12 +608,10 @@ const matchingServiceCostReplayId = async (
     amount: number;
     servicing_attendee_id: number;
     listing_id: number;
-    occurred_at: string;
     memo: string;
   }>(
     `SELECT transfer.id AS transfer_id, transfer.amount,
-            cost.servicing_attendee_id, cost.listing_id, cost.occurred_at,
-            cost.memo
+            cost.servicing_attendee_id, cost.listing_id, cost.memo
        FROM transfers AS transfer
        JOIN service_costs AS cost ON cost.transfer_id = transfer.id
       WHERE transfer.reference = ?`,
@@ -617,7 +622,6 @@ const matchingServiceCostReplayId = async (
     stored.amount === input.amount &&
     stored.servicing_attendee_id === input.servicingId &&
     stored.listing_id === input.listingId &&
-    stored.occurred_at === input.occurredAt &&
     (await decrypt(stored.memo)) === input.memo;
   if (!matches) throw new Error(COST_REPLAY_MISMATCH);
   return stored.transfer_id;

--- a/src/shared/reservation-amount.ts
+++ b/src/shared/reservation-amount.ts
@@ -38,21 +38,21 @@ const decimalPlaces = (numStr: string): number => {
 
 /**
  * Parse a reservation-amount string into its kind and numeric value, or null
- * when the string is malformed. A `flat` or `perItem` value is a currency
- * amount, so it's rejected when it carries more decimal places than the active
- * currency represents (e.g. `"10.005"` in GBP, which `toMinorUnits` would
- * otherwise round); a `percent` value keeps its precision (`"33.33%"`).
+ * when the string is malformed. Deliberately currency-tolerant: this is on the
+ * checkout deposit-calculation path ({@link computeReservationDeposit}), which
+ * must keep computing a deposit for values stored before the save-time
+ * precision rule below — so an over-precise `flat`/`perItem` amount still parses
+ * here (and `toMinorUnits` rounds it) rather than silently collecting no
+ * deposit. Precision is enforced on save by {@link validateReservationAmount}.
  */
 export const parseReservationAmount = (
   raw: string,
 ): ReservationAmount | null => {
   const match = RESERVATION_AMOUNT_RE.exec(raw.trim());
   if (!match) return null;
-  const numStr = match[1]!;
-  // numStr is `\d+(\.\d+)?`, so this always parses to a finite number.
-  const value = Number.parseFloat(numStr);
+  // match[1] is `\d+(\.\d+)?`, so this always parses to a finite number.
+  const value = Number.parseFloat(match[1]!);
   if (match[2] === "%") return { kind: "percent", value };
-  if (decimalPlaces(numStr) > getDecimalPlaces(settings.currency)) return null;
   if (match[2] === "x") return { kind: "perItem", value };
   return { kind: "flat", value };
 };
@@ -60,10 +60,23 @@ export const parseReservationAmount = (
 /**
  * Validate a reservation-amount string for form input. Returns an error
  * message, or null when valid. Empty input is rejected — the field must be
- * filled in (use "0" for no deposit).
+ * filled in (use "0" for no deposit). A `flat`/`perItem` amount is a currency
+ * value, so it's rejected here (on save) when it carries more decimal places
+ * than the active currency represents (e.g. `"10.005"` in GBP); a `percent`
+ * keeps its precision (`"33.33%"`). The calc path stays tolerant of any value
+ * already stored.
  */
-export const validateReservationAmount = (raw: string): string | null =>
-  parseReservationAmount(raw) === null ? RESERVATION_AMOUNT_HINT : null;
+export const validateReservationAmount = (raw: string): string | null => {
+  const parsed = parseReservationAmount(raw);
+  if (parsed === null) return RESERVATION_AMOUNT_HINT;
+  if (parsed.kind === "percent") return null;
+  // The numeric part is match[1]; strip the trailing % / x suffix to count its
+  // decimal places against the currency.
+  const numStr = raw.trim().replace(/[%x]$/, "");
+  return decimalPlaces(numStr) > getDecimalPlaces(settings.currency)
+    ? RESERVATION_AMOUNT_HINT
+    : null;
+};
 
 /**
  * Parse `raw`, turn the parsed amount into a deposit via `fromParsed`, and

--- a/src/shared/reservation-amount.ts
+++ b/src/shared/reservation-amount.ts
@@ -14,7 +14,8 @@
  */
 
 import { sum, sumOf } from "#fp";
-import { toMinorUnits } from "#shared/currency.ts";
+import { getDecimalPlaces, toMinorUnits } from "#shared/currency.ts";
+import { settings } from "#shared/db/settings.ts";
 import { largestRemainderAllocation } from "#shared/largest-remainder.ts";
 
 /** A parsed reservation amount. `value` is the bare number (not minor units). */
@@ -29,18 +30,29 @@ const RESERVATION_AMOUNT_RE = /^(\d+(?:\.\d+)?)(%|x)?$/;
 export const RESERVATION_AMOUNT_HINT =
   "Enter an amount like 10 (currency units), 10% (of the total) or 10x (per item)";
 
+/** Digits after the decimal point in a numeric string (0 when there is none). */
+const decimalPlaces = (numStr: string): number => {
+  const dot = numStr.indexOf(".");
+  return dot === -1 ? 0 : numStr.length - dot - 1;
+};
+
 /**
  * Parse a reservation-amount string into its kind and numeric value, or null
- * when the string is malformed.
+ * when the string is malformed. A `flat` or `perItem` value is a currency
+ * amount, so it's rejected when it carries more decimal places than the active
+ * currency represents (e.g. `"10.005"` in GBP, which `toMinorUnits` would
+ * otherwise round); a `percent` value keeps its precision (`"33.33%"`).
  */
 export const parseReservationAmount = (
   raw: string,
 ): ReservationAmount | null => {
   const match = RESERVATION_AMOUNT_RE.exec(raw.trim());
   if (!match) return null;
-  // match[1] is `\d+(\.\d+)?`, so this always parses to a finite number.
-  const value = Number.parseFloat(match[1]!);
+  const numStr = match[1]!;
+  // numStr is `\d+(\.\d+)?`, so this always parses to a finite number.
+  const value = Number.parseFloat(numStr);
   if (match[2] === "%") return { kind: "percent", value };
+  if (decimalPlaces(numStr) > getDecimalPlaces(settings.currency)) return null;
   if (match[2] === "x") return { kind: "perItem", value };
   return { kind: "flat", value };
 };

--- a/src/shared/validation/money.ts
+++ b/src/shared/validation/money.ts
@@ -17,46 +17,136 @@ import { settings } from "#shared/db/settings.ts";
  *
  * Because the decimal places depend on the currency, the pattern is rebuilt
  * inside the `check`/`transform` callbacks on every parse (they read
- * `settings.currency` when they run), so the schema itself can stay a module
- * constant — exactly as `ledgerAmountPattern` does.
+ * `settings.currency` when they run), so the schemas can stay module constants —
+ * exactly as `ledgerAmountPattern` does.
+ *
+ * The family spans two axes — **bound** (positive / non-negative / signed) and
+ * **blank handling** (required vs optional, where blank ≠ zero for an optional
+ * field). Pick the parser that matches the field:
+ *
+ * | Parser | Bound | Blank |
+ * | --- | --- | --- |
+ * | `parsePositiveMinorUnits`    | `> 0`  | invalid (`null`)  |
+ * | `parseNonNegativeMinorUnits` | `>= 0` | `0`               |
+ * | `parseOptionalMinorUnits`    | `>= 0` | unset (`null`)    |
+ * | `parseSignedMinorUnits`      | any    | invalid (`null`)  |
+ *
+ * "Unset" (optional blank) is `null`, never a real `0` — the QR override and
+ * day-price fields distinguish "no value" from a genuine £0.
  *
  * Mirrors the schema + `parseXxx` (null-on-invalid) convention of
  * validation/number.ts and validation/date.ts.
  */
 
 /** Decimal-string pattern for the active currency: `\d+` with up to
- *  `getDecimalPlaces` fractional digits (none for a zero-decimal currency). */
-const currencyDecimalPattern = (): RegExp => {
+ *  `getDecimalPlaces` fractional digits (none for a zero-decimal currency). The
+ *  signed form additionally allows a leading `-`. */
+const currencyDecimalPattern = (signed: boolean): RegExp => {
   const places = getDecimalPlaces(settings.currency);
-  return places === 0 ? /^\d+$/ : new RegExp(`^\\d+(?:\\.\\d{1,${places}})?$`);
+  const sign = signed ? "-?" : "";
+  const frac = places === 0 ? "" : `(?:\\.\\d{1,${places}})?`;
+  return new RegExp(`^${sign}\\d+${frac}$`);
 };
 
-/** Core money schema: a trimmed, non-empty, currency-decimal-valid major-unit
- *  string coerced to safe-integer minor units bounded below by `min`. */
-const moneyMinorSchema = (min: number) =>
+/** Core money pipeline up to the safe-integer minor-unit value (no bound). */
+const baseMoneySchema = (signed: boolean) =>
   v.pipe(
     v.string(),
     v.trim(),
     v.nonEmpty(),
-    v.check((amount: string) => currencyDecimalPattern().test(amount)),
+    v.check((amount: string) => currencyDecimalPattern(signed).test(amount)),
     v.transform(Number),
     v.finite(),
     v.transform(toMinorUnits),
     v.safeInteger(),
-    v.minValue(min),
   );
 
-const PositiveMoneySchema = moneyMinorSchema(1);
+const PositiveMoneySchema = v.pipe(baseMoneySchema(false), v.minValue(1));
+const NonNegativeMoneySchema = v.pipe(baseMoneySchema(false), v.minValue(0));
+const SignedMoneySchema = baseMoneySchema(true);
+
+const parseWith = (
+  schema:
+    | typeof PositiveMoneySchema
+    | typeof NonNegativeMoneySchema
+    | typeof SignedMoneySchema,
+  raw: string,
+): number | null => {
+  const result = v.safeParse(schema, raw);
+  return result.success ? result.output : null;
+};
 
 /**
- * Parse a strictly positive money amount in major units into positive minor
- * units, or `null` when `raw` is empty, non-numeric, carries more decimal places
- * than the currency allows, non-positive, non-finite, or rounds to a non-safe
- * amount of minor units. Used by routes that take a positive money amount from a
- * form (service costs) so an invalid value becomes a form error rather than a
- * silently-rounded or 500-ing ledger post.
+ * Parse a strictly positive money amount into positive minor units, or `null`
+ * when `raw` is empty, non-numeric, carries more decimal places than the
+ * currency allows, non-positive, non-finite, or rounds to a non-safe amount.
+ * Use for amounts that must be non-zero (service costs, ledger entries).
  */
-export const parsePositiveMinorUnits = (raw: string): number | null => {
-  const result = v.safeParse(PositiveMoneySchema, raw);
-  return result.success ? result.output : null;
+export const parsePositiveMinorUnits = (raw: string): number | null =>
+  parseWith(PositiveMoneySchema, raw);
+
+/**
+ * Parse a **required** non-negative money amount into minor units. Blank ⇒ `0`
+ * (the field's real value — a free listing / zero-threshold modifier), any other
+ * invalid input ⇒ `null`. Use where an explicit zero is meaningful and a blank
+ * means zero.
+ */
+export const parseNonNegativeMinorUnits = (raw: string): number | null =>
+  raw.trim() === "" ? 0 : parseWith(NonNegativeMoneySchema, raw);
+
+/**
+ * Parse an **optional** non-negative money amount into minor units. Blank ⇒
+ * `null` (unset — NOT a real `0`), a present value is validated as non-negative,
+ * and any invalid input ⇒ `null`. Use for override fields that distinguish "no
+ * value" from "£0" (QR price override, custom day prices).
+ */
+export const parseOptionalMinorUnits = (raw: string): number | null =>
+  raw.trim() === "" ? null : parseWith(NonNegativeMoneySchema, raw);
+
+/**
+ * Parse a **signed** money amount into minor units (negatives and zero allowed),
+ * or `null` when empty or invalid. Use for owner-correction targets where the
+ * figure can legitimately be negative (a modifier's net revenue).
+ */
+export const parseSignedMinorUnits = (raw: string): number | null =>
+  parseWith(SignedMoneySchema, raw);
+
+/** Result of validating a public/QR price against a min/max bound. */
+export type PriceResult =
+  | { ok: true; price: number }
+  | { ok: false; error: string };
+
+/**
+ * Validate and convert a raw price string (major units) to minor units against a
+ * `[minPrice, maxPrice]` bound. A blank value is `0` when `minPrice` is 0
+ * (pay-what-you-want with no input) and an error otherwise. A present value is
+ * parsed currency-aware — a prefix (`"12abc"`), a comma group (`"1,000"`), or
+ * more decimals than the currency allows is rejected rather than silently
+ * coerced/rounded. Lives here (not currency.ts) so it can reuse the shared
+ * non-negative parser without a currency ⇄ money import cycle.
+ */
+export const validatePrice = (
+  raw: string,
+  minPrice: number,
+  maxPrice: number,
+): PriceResult => {
+  if (!raw) {
+    return minPrice === 0
+      ? { ok: true, price: 0 }
+      : { error: "Please enter a price", ok: false };
+  }
+  const priceMinor = parseNonNegativeMinorUnits(raw);
+  if (priceMinor === null) {
+    return { error: "Please enter a valid price", ok: false };
+  }
+  if (priceMinor < minPrice) {
+    return {
+      error: "Price must be at least the minimum ticket price",
+      ok: false,
+    };
+  }
+  if (priceMinor > maxPrice) {
+    return { error: "Price exceeds the maximum allowed", ok: false };
+  }
+  return { ok: true, price: priceMinor };
 };

--- a/src/ui/templates/admin/listing-qr.tsx
+++ b/src/ui/templates/admin/listing-qr.tsx
@@ -16,6 +16,7 @@ import { QR_TOKEN_MAX_AGE_S } from "#shared/qr-token.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
+import { moneyPattern } from "#templates/components/price-input.tsx";
 import { Layout } from "#templates/layout.tsx";
 
 const EXPIRY_LABEL = `${Math.round(QR_TOKEN_MAX_AGE_S / 60)} minutes`;
@@ -74,7 +75,7 @@ const PriceInput = ({
         max={max}
         min={min}
         name="value"
-        pattern="\d+(\.\d{1,2})?"
+        pattern={moneyPattern()}
         title={t("listing_qr.price_input_title")}
         type="text"
         value={value}

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -86,7 +86,10 @@ import {
   MaybeButtonLink,
   SubmitButton,
 } from "#templates/components/actions.tsx";
-import { PriceInput } from "#templates/components/price-input.tsx";
+import {
+  moneyPattern,
+  PriceInput,
+} from "#templates/components/price-input.tsx";
 import { colClass } from "#templates/components/table-columns.ts";
 import {
   getAddAttendeeFields,
@@ -1493,7 +1496,7 @@ export const renderDayPricesFieldset = (listing?: ListingWithCount): string => {
       return (
         `<label>${t("listings_table.day_price_row_label", { n })}` +
         `<input type="text" inputmode="decimal" name="day_price_${n}" ` +
-        `value="${escapeHtml(value)}" pattern="\\d+(\\.\\d{1,2})?" ` +
+        `value="${escapeHtml(value)}" pattern="${moneyPattern()}" ` +
         `placeholder="${t("listings_table.day_price_placeholder")}" title="${t(
           "listings_table.day_price_input_title",
         )}" />` +

--- a/src/ui/templates/components/price-input.tsx
+++ b/src/ui/templates/components/price-input.tsx
@@ -22,6 +22,15 @@ export const moneyStep = (): string => {
   return places === 0 ? "1" : `0.${"0".repeat(places - 1)}1`;
 };
 
+/** The `<input pattern>` (regex source) for a non-negative amount in the active
+ *  currency: `\d+` with up to `getDecimalPlaces` fractional digits (none for a
+ *  zero-decimal currency). Use on a `type="text"` money input so native
+ *  validation accepts exactly what the shared money schema does. */
+export const moneyPattern = (): string => {
+  const places = getDecimalPlaces(settings.currency);
+  return places === 0 ? "\\d+" : `\\d+(\\.\\d{1,${places}})?`;
+};
+
 /**
  * A price/amount input in MAJOR units (e.g. `10.50`). `step` is always derived
  * from the currency; pass `min` for a lower bound (`"0"` for a non-negative

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -40,6 +40,8 @@ import {
 import { validateSafeServerFetchUrl } from "#shared/url-safety.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import { EmailFormatSchema } from "#shared/validation/email.ts";
+import { parseOptionalMinorUnits } from "#shared/validation/money.ts";
+import { moneyPattern } from "#templates/components/price-input.tsx";
 
 // ---------------------------------------------------------------------------
 // Typed form value interfaces
@@ -176,15 +178,15 @@ const validateHttpsDomainUrl = (value: string): string | null =>
   validateSafeServerFetchUrl(value, t("fields.validation.url_https"));
 
 /**
- * Validate price is non-negative
+ * Validate a required non-negative price. Currency-aware: rejects a blank, a
+ * negative, a non-numeric value, AND an amount carrying more decimal places than
+ * the active currency allows (so `1.005` in GBP is a validation error rather
+ * than a value that later rounds to 101 pence).
  */
-const validateNonNegativePrice = (value: string): string | null => {
-  const num = Number.parseFloat(value);
-  if (Number.isNaN(num) || num < 0) {
-    return t("fields.validation.price_min");
-  }
-  return null;
-};
+const validateNonNegativePrice = (value: string): string | null =>
+  parseOptionalMinorUnits(value) === null
+    ? t("fields.validation.price_min")
+    : null;
 
 const validateNonNegativeInteger =
   (label: string) =>
@@ -486,7 +488,7 @@ export const getListingFields = (): Field[] => [
     inputmode: "decimal",
     label: t("fields.listing.price"),
     name: "unit_price",
-    pattern: "\\d+(\\.\\d{1,2})?",
+    pattern: moneyPattern(),
     placeholder: t("fields.listing.price_placeholder"),
     title: t("fields.listing.price_title"),
     type: "text",
@@ -505,7 +507,7 @@ export const getListingFields = (): Field[] => [
     inputmode: "decimal",
     label: t("fields.listing.max_price"),
     name: "max_price",
-    pattern: "\\d+(\\.\\d{1,2})?",
+    pattern: moneyPattern(),
     placeholder: t("fields.listing.max_price_placeholder"),
     title: t("fields.listing.max_price_title"),
     type: "text",

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -4,7 +4,7 @@
 
 import * as v from "valibot";
 import { t } from "#i18n";
-import { formatCurrency } from "#shared/currency.ts";
+import { formatCurrency, getDecimalPlaces } from "#shared/currency.ts";
 import { DAY_NAMES } from "#shared/dates.ts";
 import { isUpdateTier } from "#shared/db/built-sites.ts";
 import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
@@ -502,7 +502,9 @@ export const getListingFields = (): Field[] => [
     type: "checkbox-group",
   },
   {
-    defaultValue: "100.00",
+    // 100 currency units, formatted to the currency's decimals so the default
+    // is valid for a zero-decimal currency (JPY "100") as well as GBP "100.00".
+    defaultValue: (100).toFixed(getDecimalPlaces(settings.currency)),
     hint: t("fields.listing.max_price_hint", { amount: formatCurrency(100) }),
     inputmode: "decimal",
     label: t("fields.listing.max_price"),

--- a/src/ui/templates/public/reservations.tsx
+++ b/src/ui/templates/public/reservations.tsx
@@ -34,6 +34,7 @@ import {
   PARENT_CHILD_GROUP_UNITS,
   sharedGroupRemaining,
 } from "#shared/types.ts";
+import { moneyPattern } from "#templates/components/price-input.tsx";
 import {
   questionFieldset,
   questionWrapper,
@@ -252,7 +253,7 @@ const renderPayMoreInput = (
       value,
     )}" min="${escapeHtml(toMajorUnits(minPrice))}" max="${escapeHtml(
       toMajorUnits(maxPrice),
-    )}" pattern="\\d+(\\.\\d{1,2})?" title="${escapeHtml(
+    )}" pattern="${moneyPattern()}" title="${escapeHtml(
       t("public.ticket.price_input_title"),
     )}"${required && minPrice > 0 ? " required" : ""} /></label>`
   );

--- a/test/lib/currency.test.ts
+++ b/test/lib/currency.test.ts
@@ -5,7 +5,6 @@ import {
   getDecimalPlaces,
   toMajorUnits,
   toMinorUnits,
-  validatePrice,
 } from "#shared/currency.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
 import {
@@ -153,86 +152,6 @@ describe("currency", () => {
     testWithSetting("converts KWD (3 decimals)", { currency: "KWD" }, () => {
       expect(toMajorUnits(1050)).toBe("1.050");
     });
-  });
-
-  describe("validatePrice", () => {
-    // GBP → 2 decimal places, so toMinorUnits multiplies major units by 100.
-    testWithSetting(
-      "accepts empty input as 0 when the minimum is 0 (pay-what-you-want)",
-      { currency: "GBP" },
-      () => {
-        expect(validatePrice("", 0, 100_000)).toEqual({ ok: true, price: 0 });
-      },
-    );
-
-    testWithSetting(
-      "rejects empty input when a minimum is required",
-      { currency: "GBP" },
-      () => {
-        expect(validatePrice("", 500, 100_000)).toEqual({
-          error: "Please enter a price",
-          ok: false,
-        });
-      },
-    );
-
-    testWithSetting("rejects non-numeric input", { currency: "GBP" }, () => {
-      expect(validatePrice("abc", 0, 100_000)).toEqual({
-        error: "Please enter a valid price",
-        ok: false,
-      });
-    });
-
-    testWithSetting("rejects a negative price", { currency: "GBP" }, () => {
-      expect(validatePrice("-5", 0, 100_000)).toEqual({
-        error: "Please enter a valid price",
-        ok: false,
-      });
-    });
-
-    testWithSetting(
-      "accepts an in-range price and converts it to minor units",
-      { currency: "GBP" },
-      () => {
-        expect(validatePrice("10", 0, 100_000)).toEqual({
-          ok: true,
-          price: 1000,
-        });
-      },
-    );
-
-    testWithSetting(
-      "rejects a price below the minimum",
-      { currency: "GBP" },
-      () => {
-        // £1 = 100 minor units, below the 500 minimum.
-        expect(validatePrice("1", 500, 100_000)).toEqual({
-          error: "Price must be at least the minimum ticket price",
-          ok: false,
-        });
-      },
-    );
-
-    testWithSetting(
-      "rejects a price above the maximum",
-      { currency: "GBP" },
-      () => {
-        // £2000 = 200000 minor units, above the 100000 maximum.
-        expect(validatePrice("2000", 0, 100_000)).toEqual({
-          error: "Price exceeds the maximum allowed",
-          ok: false,
-        });
-      },
-    );
-
-    testWithSetting(
-      "accepts a price exactly on the minimum and maximum bounds",
-      { currency: "GBP" },
-      () => {
-        // The guards are strict (< / >), so priceMinor === min === max passes.
-        expect(validatePrice("5", 500, 500)).toEqual({ ok: true, price: 500 });
-      },
-    );
   });
 
   describe("settings.currency integration", () => {

--- a/test/lib/reservation-amount.test.ts
+++ b/test/lib/reservation-amount.test.ts
@@ -51,31 +51,19 @@ describe("reservation-amount", () => {
       });
     });
 
-    testWithSetting(
-      "rejects a flat/perItem amount more precise than the currency, but keeps percentages",
-      { currency: "GBP" },
-      () => {
-        // "10.005" flat would round to 1001 pence via toMinorUnits — reject it.
-        expect(parseReservationAmount("10.005")).toBeNull();
-        expect(parseReservationAmount("10.005x")).toBeNull();
-        // A percentage keeps its precision — it's not a currency amount.
-        expect(parseReservationAmount("33.335%")).toEqual({
-          kind: "percent",
-          value: 33.335,
-        });
-      },
-    );
-
-    testWithSetting(
-      "accepts 3-decimal flat amounts in a 3-decimal currency (KWD)",
-      { currency: "KWD" },
-      () => {
-        expect(parseReservationAmount("10.005")).toEqual({
-          kind: "flat",
-          value: 10.005,
-        });
-      },
-    );
+    test("parse stays currency-tolerant so legacy stored values still compute", () => {
+      // Precision is enforced on save (validateReservationAmount), NOT here on
+      // the calc path — a value stored before the rule must still parse and
+      // compute a deposit rather than silently falling to zero.
+      expect(parseReservationAmount("10.005")).toEqual({
+        kind: "flat",
+        value: 10.005,
+      });
+      expect(parseReservationAmount("10.005x")).toEqual({
+        kind: "perItem",
+        value: 10.005,
+      });
+    });
 
     test("rejects malformed input", () => {
       const malformed = [
@@ -106,6 +94,30 @@ describe("reservation-amount", () => {
       expect(validateReservationAmount("")).toBe(RESERVATION_AMOUNT_HINT);
       expect(validateReservationAmount("nope")).toBe(RESERVATION_AMOUNT_HINT);
     });
+
+    testWithSetting(
+      "rejects a flat/perItem amount more precise than the currency on save, but keeps percentages and in-currency amounts",
+      { currency: "GBP" },
+      () => {
+        expect(validateReservationAmount("10.005")).toBe(
+          RESERVATION_AMOUNT_HINT,
+        );
+        expect(validateReservationAmount("10.005x")).toBe(
+          RESERVATION_AMOUNT_HINT,
+        );
+        // A percentage keeps its precision, and an in-currency amount is fine.
+        expect(validateReservationAmount("33.335%")).toBeNull();
+        expect(validateReservationAmount("10.50")).toBeNull();
+      },
+    );
+
+    testWithSetting(
+      "accepts a 3-decimal flat amount in a 3-decimal currency (KWD)",
+      { currency: "KWD" },
+      () => {
+        expect(validateReservationAmount("10.005")).toBeNull();
+      },
+    );
   });
 
   describe("computeReservationDeposit", () => {

--- a/test/lib/reservation-amount.test.ts
+++ b/test/lib/reservation-amount.test.ts
@@ -51,6 +51,32 @@ describe("reservation-amount", () => {
       });
     });
 
+    testWithSetting(
+      "rejects a flat/perItem amount more precise than the currency, but keeps percentages",
+      { currency: "GBP" },
+      () => {
+        // "10.005" flat would round to 1001 pence via toMinorUnits — reject it.
+        expect(parseReservationAmount("10.005")).toBeNull();
+        expect(parseReservationAmount("10.005x")).toBeNull();
+        // A percentage keeps its precision — it's not a currency amount.
+        expect(parseReservationAmount("33.335%")).toEqual({
+          kind: "percent",
+          value: 33.335,
+        });
+      },
+    );
+
+    testWithSetting(
+      "accepts 3-decimal flat amounts in a 3-decimal currency (KWD)",
+      { currency: "KWD" },
+      () => {
+        expect(parseReservationAmount("10.005")).toEqual({
+          kind: "flat",
+          value: 10.005,
+        });
+      },
+    );
+
     test("rejects malformed input", () => {
       const malformed = [
         "",

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -2096,6 +2096,50 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       });
       expect(response.status).toBe(302);
     });
+
+    test("creates a free listing when unit_price is blank (no price)", async () => {
+      // Exercises the optional-price parse's blank path: a blank unit_price
+      // resolves to no price, and the listing stores 0 (free).
+      const { response } = await adminFormPost("/admin/listing", {
+        max_attendees: "50",
+        max_quantity: "1",
+        name: "Free Listing",
+        thank_you_url: "https://example.com/thanks",
+        unit_price: "",
+      });
+      expect(response.status).toBe(302);
+      expect((await getListingWithCount(1))?.unit_price).toBe(0);
+    });
+  });
+
+  describe("POST /admin/listing day-price validation", () => {
+    test("rejects a create when a day price is over-precise for the currency", async () => {
+      // 10.005 has 3 decimals — invalid in GBP (2). Without validation this
+      // would be silently dropped; instead the save is rejected.
+      const { response } = await adminFormPost("/admin/listing", {
+        day_price_1: "10.005",
+        max_attendees: "50",
+        max_quantity: "1",
+        name: "Bad Day Price",
+        thank_you_url: "https://example.com/thanks",
+      });
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("valid day price");
+      // Nothing was created.
+      expect(await getListingWithCount(1)).toBeNull();
+    });
+
+    test("accepts a create with a valid day price and stores it", async () => {
+      const { response } = await adminFormPost("/admin/listing", {
+        day_price_1: "10.00",
+        max_attendees: "50",
+        max_quantity: "1",
+        name: "Good Day Price",
+        thank_you_url: "https://example.com/thanks",
+      });
+      expect(response.status).toBe(302);
+      expect((await getListingWithCount(1))?.day_prices).toEqual({ 1: 1000 });
+    });
   });
 
   describe("POST /admin/listing with can_pay_more", () => {

--- a/test/lib/servicing/ledger.test.ts
+++ b/test/lib/servicing/ledger.test.ts
@@ -231,11 +231,13 @@ describeWithEnv("servicing §22 — ledger integration", { db: true }, () => {
     expect(await costOf(listing.id)).toBe(9000);
   });
 
-  test("a double-submit of the cost form records only one cost (idempotency key)", async () => {
-    // The cost form carries a per-render idempotency key the route passes as
-    // the ledger reference, so a browser retry / double-click of the same form
-    // posts the cost once — not twice — even though each POST generates a fresh
-    // occurredAt. A genuinely separate submission (fresh key) still posts.
+  test("a double-submit of the cost form records once and reports a clean success (idempotency key)", async () => {
+    // The cost form carries a per-render idempotency key the route passes as the
+    // ledger reference, so a browser retry / double-click of the same form posts
+    // the cost once — not twice. The hold is DATELESS, so the route stamps a
+    // fresh `occurredAt = new Date()` on each POST; the retry must still be
+    // treated as a clean idempotent success (occurredAt is not compared), not an
+    // error, which is the exact case the key exists to cover.
     const { id, listing } = await createServicingHold();
     const postCost = (idempotencyKey: string) =>
       adminPost(`/admin/servicing/${id}`, {
@@ -248,6 +250,9 @@ describeWithEnv("servicing §22 — ledger integration", { db: true }, () => {
     await postCost(key);
     const retried = await postCost(key); // same form, double-submit
     expect(retried.status).toBe(302);
+    // The retry is a success flash, NOT a COST_REPLAY_MISMATCH error.
+    expect(parseFlashCookie(retried).error).toBeUndefined();
+    expect(parseFlashCookie(retried).success).toBeDefined();
     expect((await transfersOfKind(SERVICE_COST_KIND)).length).toBe(1);
     expect(await costOf(listing.id)).toBe(9000);
     // A separate submission (fresh key) posts a second, independent cost.

--- a/test/lib/validation/money.test.ts
+++ b/test/lib/validation/money.test.ts
@@ -1,8 +1,32 @@
 import { expect } from "@std/expect";
 import { describe } from "@std/testing/bdd";
 import type { SettingsData } from "#shared/db/settings.ts";
-import { parsePositiveMinorUnits } from "#shared/validation/money.ts";
+import {
+  parseNonNegativeMinorUnits,
+  parseOptionalMinorUnits,
+  parsePositiveMinorUnits,
+  parseSignedMinorUnits,
+  validatePrice,
+} from "#shared/validation/money.ts";
 import { testWithSetting } from "#test-utils";
+
+/** Build a table-driven describe for one currency-aware parser. */
+const parserTable =
+  (parse: (raw: string) => number | null) =>
+  (
+    currency: SettingsData["currency"],
+    rows: Array<[string, number | null]>,
+  ) => {
+    for (const [input, expected] of rows) {
+      testWithSetting(
+        `${currency}: ${JSON.stringify(input)} → ${expected}`,
+        { currency },
+        () => {
+          expect(parse(input)).toBe(expected);
+        },
+      );
+    }
+  };
 
 /**
  * Currency-aware money parsing. The invariant under test is that the accepted
@@ -66,4 +90,160 @@ describe("parsePositiveMinorUnits", () => {
     ["1.0005", null],
     ["0", null],
   ]);
+});
+
+describe("parseNonNegativeMinorUnits (required; blank ⇒ 0)", () => {
+  const table = parserTable(parseNonNegativeMinorUnits);
+  table("GBP", [
+    ["", 0], // blank is a real zero
+    ["0", 0],
+    ["0.00", 0],
+    ["10.50", 1050],
+    ["-1", null], // negative rejected
+    ["1.005", null], // extra decimal rejected, not rounded
+    ["abc", null],
+    ["1,000", null],
+  ]);
+  table("JPY", [
+    ["", 0],
+    ["1000", 1000],
+    ["1.5", null],
+  ]);
+});
+
+describe("parseOptionalMinorUnits (optional; blank ⇒ null, never 0)", () => {
+  const table = parserTable(parseOptionalMinorUnits);
+  table("GBP", [
+    ["", null], // unset, NOT a real zero
+    ["0", 0], // an explicit zero is kept
+    ["12.34", 1234],
+    ["-1", null],
+    ["1.005", null],
+    ["nope", null],
+  ]);
+  table("KWD", [
+    ["", null],
+    ["1.005", 1005],
+    ["1.0005", null],
+  ]);
+});
+
+describe("parseSignedMinorUnits (signed; negatives + zero allowed)", () => {
+  const table = parserTable(parseSignedMinorUnits);
+  table("GBP", [
+    ["10.50", 1050],
+    ["0", 0],
+    ["-10.50", -1050], // a negative correction is valid
+    ["-0.01", -1],
+    ["", null], // blank rejected — a correction needs a figure
+    ["1.005", null],
+    ["--1", null],
+    ["abc", null],
+  ]);
+  table("JPY", [
+    ["-100", -100],
+    ["-1.5", null],
+  ]);
+});
+
+describe("validatePrice (bounded public/QR price)", () => {
+  testWithSetting(
+    "blank ⇒ 0 when minPrice is 0 (pay-what-you-want)",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("", 0, 100_000)).toEqual({ ok: true, price: 0 });
+    },
+  );
+
+  testWithSetting(
+    "blank ⇒ error when a minimum is required",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("", 500, 100_000)).toEqual({
+        error: "Please enter a price",
+        ok: false,
+      });
+    },
+  );
+
+  testWithSetting("rejects non-numeric input", { currency: "GBP" }, () => {
+    expect(validatePrice("abc", 0, 100_000)).toEqual({
+      error: "Please enter a valid price",
+      ok: false,
+    });
+  });
+
+  testWithSetting("rejects a negative price", { currency: "GBP" }, () => {
+    expect(validatePrice("-5", 0, 100_000).ok).toBe(false);
+  });
+
+  testWithSetting(
+    "rejects a leading-numeric prefix (12abc), not parseFloat-coerced",
+    { currency: "GBP" },
+    () => {
+      // The old Number.parseFloat accepted "12abc" as 12; the currency-aware
+      // parser rejects the trailing junk.
+      expect(validatePrice("12abc", 0, 100_000)).toEqual({
+        error: "Please enter a valid price",
+        ok: false,
+      });
+    },
+  );
+
+  testWithSetting(
+    "rejects a comma-grouped amount (1,000)",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("1,000", 0, 1_000_000).ok).toBe(false);
+    },
+  );
+
+  testWithSetting(
+    "rejects an over-precise amount (1.005 GBP), not rounded",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("1.005", 0, 100_000).ok).toBe(false);
+    },
+  );
+
+  testWithSetting(
+    "accepts an in-range price ⇒ minor units",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("10", 0, 100_000)).toEqual({
+        ok: true,
+        price: 1000,
+      });
+    },
+  );
+
+  testWithSetting(
+    "rejects a price below the minimum",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("1", 500, 100_000)).toEqual({
+        error: "Price must be at least the minimum ticket price",
+        ok: false,
+      });
+    },
+  );
+
+  testWithSetting(
+    "rejects a price above the maximum",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("2000", 0, 100_000)).toEqual({
+        error: "Price exceeds the maximum allowed",
+        ok: false,
+      });
+    },
+  );
+
+  testWithSetting(
+    "accepts a price exactly on the min and max bounds",
+    { currency: "GBP" },
+    () => {
+      expect(validatePrice("5", 500, 500)).toEqual({ ok: true, price: 500 });
+    },
+  );
 });

--- a/test/templates/components/price-input.test.tsx
+++ b/test/templates/components/price-input.test.tsx
@@ -1,6 +1,10 @@
 import { expect } from "@std/expect";
 import { describe } from "@std/testing/bdd";
-import { moneyStep, PriceInput } from "#templates/components/price-input.tsx";
+import {
+  moneyPattern,
+  moneyStep,
+  PriceInput,
+} from "#templates/components/price-input.tsx";
 import { testWithSetting } from "#test-utils";
 
 describe("moneyStep", () => {
@@ -25,6 +29,32 @@ describe("moneyStep", () => {
     { currency: "KWD" },
     () => {
       expect(moneyStep()).toBe("0.001");
+    },
+  );
+});
+
+describe("moneyPattern", () => {
+  testWithSetting(
+    "allows up to N decimals for an N-decimal currency (GBP)",
+    { currency: "GBP" },
+    () => {
+      expect(moneyPattern()).toBe("\\d+(\\.\\d{1,2})?");
+    },
+  );
+
+  testWithSetting(
+    "allows no decimals for a zero-decimal currency (JPY)",
+    { currency: "JPY" },
+    () => {
+      expect(moneyPattern()).toBe("\\d+");
+    },
+  );
+
+  testWithSetting(
+    "allows up to 3 decimals for a 3-decimal currency (KWD)",
+    { currency: "KWD" },
+    () => {
+      expect(moneyPattern()).toBe("\\d+(\\.\\d{1,3})?");
     },
   );
 });


### PR DESCRIPTION
Follow-up to the merged servicing deep-dive (#1499): the Codex review fix plus the app-wide money-parsing unification (servicing.md Holistic 2). Every change ships with a regression test; full `deno task precommit` is green (lint, typecheck, cpd 0%, build:edge, 100% coverage, changed-file mutation).

## Codex review fix — dateless service-cost replay

Codex flagged that for a **dateless** servicing event, `handleCostPost` stamps a fresh `occurredAt = new Date()` on every POST, so a legitimate double-click (same idempotency key, same amount/listing/memo) had a different timestamp and tripped `COST_REPLAY_MISMATCH` — showing the operator an error for the exact retry the key exists to cover. `occurredAt` isn't an operator-editable cost-form field, so it's dropped from the replay match; the double-submit test now asserts the retry is a clean success (my earlier test missed this because it only checked "no double-post", not "no error").

## Holistic 2 — one currency-aware money schema, app-wide

`src/shared/validation/money.ts` now houses the full family across both axes — **bound** (positive / non-negative / signed) × **blank handling** (required blank ⇒ `0`, optional blank ⇒ `null`, never a real `0`) — plus a currency-aware `validatePrice`. Migrated sites now reject a prefix (`"12abc"`), comma group (`"1,000"`), or over-precise amount (`"1.005"` GBP) instead of `Number.parseFloat`-coercing/rounding:

- service costs + ledger entries (positive; from #1499);
- listing `unit_price` + custom day prices (optional) and the non-negative validator behind `unit_price`/`max_price`;
- public / QR prices (`validatePrice`, moved out of currency.ts to avoid an import cycle);
- balance / income / modifier-revenue corrections (signed `money-adjust`);
- reservation `flat`/`perItem` amounts (currency-precise; percentages keep their precision).

The browser side matches via `PriceInput`'s `moneyStep()` and a new shared `moneyPattern()`, now used for `unit_price`, `max_price`, the QR override price, and custom day prices — so KWD's 3 decimals are typeable and JPY isn't offered cents.

**Deliberately left as a separate change:** the modifier `calc_value`/`min_subtotal` fields. `calc_value` is polymorphic (a currency amount only when `calc_kind === "fixed"`, else a percentage or bare multiplier) and stored in major units, so making the fixed case currency-aware needs cross-field (`calc_kind`-aware) validation rather than the single-field swap the other sites took. Documented in `servicing.md`.

Table-driven tests cover every parser variant and `validatePrice` across GBP/JPY/KWD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AojeLrM3G6TEpURj28Gw81)_