### PR TITLE
Entity pages: left-align tabs, section-panel grouping, prose chunks

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -2928,6 +2928,9 @@ label:hover .embed-toggle-badge,
 .entity-tabs {
   border-bottom: 1px solid var(--color-bg-secondary);
   margin-block: var(--space-m);
+  /* The base `nav` rule centres its row; the tab strip reads left-to-right
+     like the page content beneath it, so pin it to the start. */
+  justify-content: flex-start;
 
   ul {
     display: flex;

--- a/src/ui/templates/admin/attendee-page.tsx
+++ b/src/ui/templates/admin/attendee-page.tsx
@@ -125,33 +125,35 @@ const ContactRecordSection = ({
   const { hashParam, record } = channel;
   return (
     <section>
-      <h4>{label}</h4>
-      <ul>
-        <li>
-          <strong>{t("attendee_form.online_bookings")}:</strong>{" "}
-          {record.publicBookingCount}
-        </li>
-        <li>
-          <strong>{t("attendee_form.admin_bookings")}:</strong>{" "}
-          {record.adminBookingCount}
-        </li>
-        <li>
-          <strong>{t("attendee_form.total_messages")}:</strong>{" "}
-          {record.contactCount}
-        </li>
-        {record.lastContact && (
+      <div class="prose">
+        <h4>{label}</h4>
+        <ul>
           <li>
-            <strong>{t("attendee_form.last_contacted")}:</strong>{" "}
-            {formatDatetimeShort(record.lastContact)}
+            <strong>{t("attendee_form.online_bookings")}:</strong>{" "}
+            {record.publicBookingCount}
           </li>
-        )}
-        {record.lastSubject && (
           <li>
-            <strong>{t("attendee_form.last_subject")}:</strong>{" "}
-            {record.lastSubject}
+            <strong>{t("attendee_form.admin_bookings")}:</strong>{" "}
+            {record.adminBookingCount}
           </li>
-        )}
-      </ul>
+          <li>
+            <strong>{t("attendee_form.total_messages")}:</strong>{" "}
+            {record.contactCount}
+          </li>
+          {record.lastContact && (
+            <li>
+              <strong>{t("attendee_form.last_contacted")}:</strong>{" "}
+              {formatDatetimeShort(record.lastContact)}
+            </li>
+          )}
+          {record.lastSubject && (
+            <li>
+              <strong>{t("attendee_form.last_subject")}:</strong>{" "}
+              {record.lastSubject}
+            </li>
+          )}
+        </ul>
+      </div>
       {record.adminNotes && (
         <div class="contact-notes">
           <Raw html={renderMarkdown(record.adminNotes)} />
@@ -179,22 +181,24 @@ export const ContactHistory = ({
   const hasEmail = Boolean(attendee.email);
   return (
     <article>
-      <h3>{t("attendee_form.contact_history")}</h3>
-      {contactRecords.email ? (
+      {/* Heading and any "no X on file" lines are one prose chunk; the record
+          panels (their own sections) follow. */}
+      <div class="prose">
+        <h3>{t("attendee_form.contact_history")}</h3>
+        {!contactRecords.email && <p>{t("attendee_form.no_email_on_file")}</p>}
+        {!contactRecords.phone && <p>{t("attendee_form.no_phone_on_file")}</p>}
+      </div>
+      {contactRecords.email && (
         <ContactRecordSection
           channel={contactRecords.email}
           label={t("attendee_form.stats_for", { value: attendee.email })}
         />
-      ) : (
-        <p>{t("attendee_form.no_email_on_file")}</p>
       )}
-      {contactRecords.phone ? (
+      {contactRecords.phone && (
         <ContactRecordSection
           channel={contactRecords.phone}
           label={t("attendee_form.stats_for", { value: attendee.phone })}
         />
-      ) : (
-        <p>{t("attendee_form.no_phone_on_file")}</p>
       )}
       {isOwner && (
         <p>

--- a/src/ui/templates/admin/entity-pages.tsx
+++ b/src/ui/templates/admin/entity-pages.tsx
@@ -11,6 +11,7 @@
  * Layout backstop above the page content.
  */
 
+import { compact } from "#fp";
 import { t } from "#i18n";
 import type { ActivityLogEntry } from "#shared/db/activityLog.ts";
 import type { TabLink } from "#shared/entity-pages/core.ts";
@@ -220,7 +221,11 @@ export interface EntityPageView {
 }
 
 /** The whole entity page: title → banner → tab strip → active tab's
- * sections, in order. */
+ * sections, in order. The panel is a `<section>` (flex column with the
+ * standard gap) and each rendered section sits in its own `.table-controls`
+ * group, so a heading and its table/actions stay bound together with even
+ * spacing. Sections that render nothing are dropped rather than left as empty
+ * groups. */
 export const entityPageView = (view: EntityPageView): string =>
   String(
     <Layout title={view.title}>
@@ -230,6 +235,10 @@ export const entityPageView = (view: EntityPageView): string =>
       </div>
       {view.banner}
       <TabStrip tabs={view.tabs} />
-      <div class="entity-tab-panel">{view.sections.map(renderSection)}</div>
+      <section class="entity-tab-panel">
+        {compact(view.sections.map(renderSection)).map((section) => (
+          <div class="table-controls">{section}</div>
+        ))}
+      </section>
     </Layout>,
   );

--- a/test/templates/admin/entity-pages.test.ts
+++ b/test/templates/admin/entity-pages.test.ts
@@ -205,4 +205,29 @@ describe("entityPageView", () => {
     expect(html).not.toContain("tablist");
     expect(html).not.toContain('role="tab"');
   });
+
+  test("panel is a <section>; each section sits in its own .table-controls group", () => {
+    const html = entityPageView(view);
+    expect(html).toContain('<section class="entity-tab-panel">');
+    // The one rendered section is wrapped in exactly one grouping div.
+    expect(html).toContain('<div class="table-controls">');
+    expect((html.match(/class="table-controls"/g) ?? []).length).toBe(1);
+  });
+
+  test("a section that renders nothing is dropped, not left as an empty group", () => {
+    const html = entityPageView({
+      ...view,
+      sections: [
+        // An actions section with no actions renders null…
+        { danger: [], kind: "actions" as const, plain: [], titleKey: "x" },
+        // …and a real summary follows it.
+        {
+          kind: "summary" as const,
+          rows: [{ labelKey: "common.name", value: "Jane" }],
+        },
+      ],
+    });
+    // Only the summary yields a group — the null section leaves no empty one.
+    expect((html.match(/class="table-controls"/g) ?? []).length).toBe(1);
+  });
 });


### PR DESCRIPTION
## What & why

Structural/visual polish on the tabbed **edit-X** framework (`edit-pages.md`, landed in #1500), so the entity page's chrome lines up with the rest of the admin and its prose is grouped the way the standalone pages already do it.

## Changes

- **Tabs left-aligned.** `.entity-tabs` is a `<nav>`, so it inherited `justify-content: center` from the base `nav` rule and floated centred above the left-aligned page content. Pinned to `flex-start` (the mobile breakpoint already did this; now it's consistent).
- **Panel is a `<section>` with grouped sections.** The tab panel was a bare `<div>`; it's now a `<section>` (already flex-column with the standard gap) and each rendered section sits in its own `.table-controls` group, so a heading stays bound to its table/actions with even spacing. Sections that render nothing are dropped rather than left as empty groups.
- **Prose wrapped by chunk, not by element.** In the attendee Overview content, `ContactHistory`'s heading and its "no X on file" notes share one `<div class="prose">`, and each contact record's `<h4>` + stats `<ul>` share one — mirroring the standalone contact-history page. Functional bits (tables, record panels, action buttons, the markdown note block) stay outside prose.

## Tests

- `entity-pages.test.ts` gains coverage for the `<section class="entity-tab-panel">` shell, the per-section `.table-controls` grouping, and the null-section drop path.
- Full suite green (12,586 passing) except the two pre-existing environment-bound stripe-mock download tests; lint, typecheck, and jscpd (0 clones) clean. SCSS compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEm3JJi3n7VAcPz71HkRoc)_