### PR TITLE
Make modifier fixed calc_value and min_subtotal currency-aware

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -137,7 +137,7 @@ fixed-depth code. Purely a simplification — no behaviour change expected.
 
 ---
 
-## Servicing — modifier money fields
+## Servicing — read-only guard (optional variant)
 
 *Origin: `servicing.md` (+ its review docs `review.md`, `tests.md`).*
 
@@ -146,22 +146,18 @@ listing capacity without being customers) shipped and was hardened across PRs
 #1395, #1499, #1501: all P0/P1/P2 review defects fixed, a unified currency-aware
 money schema introduced at `src/shared/validation/money.ts`
 (`parsePositiveMinorUnits` / `validatePrice`), and the read-only default-deny
-guard added (path-based allowlist, fails closed).
+guard added (path-based allowlist, fails closed). The last money site — the
+modifier `calc_value` / `min_subtotal` fields — was then made currency-aware:
+`min_subtotal` through the shared `parseOptionalMinorUnits`, and the polymorphic
+fixed `calc_value` through a `calc_kind`-aware `exceedsCurrencyPrecision` guard
+in `validateModifier` (so a percentage or multiplier keeps its precision).
 
-**Remaining:**
+**Remaining (optional):**
 
-- **Make modifier `calc_value` / `min_subtotal` currency-aware.** These two
-  fields in `src/ui/templates/fields.ts` (~lines 924 and 970) still parse via
-  `Number.parseFloat` instead of the shared money schema. They were left out of
-  the app-wide money-parsing unification on purpose: `calc_value` is
-  **polymorphic** (its meaning depends on `calc_kind`) and is stored in **major**
-  units, not minor, so making the fixed/amount case currency-aware needs
-  cross-field, `calc_kind`-aware validation rather than a drop-in swap. Do it as
-  a self-contained change with its own tests.
-- **Registry-driven read-only default-deny (optional).** The current path-based
-  allowlist already fails closed. The fuller variant — resolve the route first,
-  then consult a per-route `readOnly: "allow"` flag — is an optional future
-  refactor, not a fix.
+- **Registry-driven read-only default-deny.** The current path-based allowlist
+  already fails closed. The fuller variant — resolve the route first, then
+  consult a per-route `readOnly: "allow"` flag — is an optional future refactor,
+  not a fix.
 
 ---
 

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -70,6 +70,7 @@ import {
 } from "#shared/price-modifier.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
 import type { Modifier } from "#shared/types.ts";
+import { exceedsCurrencyPrecision } from "#shared/validation/money.ts";
 import {
   type AnswerLinks,
   adminModifierDeletePage,
@@ -218,6 +219,21 @@ const childAddOnInputError = async (
   });
 };
 
+/** The value error for a modifier: the kind-aware magnitude/sign rules
+ * ({@link validateCalcValue}), plus a currency-precision guard for a fixed
+ * amount — it's a currency value (converted major→minor when the modifier
+ * resolves), so an over-precise amount is rejected rather than letting
+ * `toMinorUnits` silently round it at apply time. A percentage or multiplier is
+ * not a currency amount, so it keeps its precision. Null when the value is
+ * valid. */
+const modifierValueError = (kind: CalcKind, value: number): string | null => {
+  const valueError = validateCalcValue(kind, value);
+  if (valueError) return valueError;
+  return kind === "fixed" && exceedsCurrencyPrecision(value)
+    ? "Amount has more decimal places than your currency allows"
+    : null;
+};
+
 /** Validate a modifier's kind, direction, trigger, scope, and value (the select
  * options can be bypassed by a crafted POST, so re-check membership here), then
  * — when the parents feature is on — block an opt-in add-on whose would-be scope
@@ -254,7 +270,7 @@ const validateModifier = (
   if (isOptionalAddOn && requiresPreviousBookings) {
     return Promise.resolve("Optional add-ons cannot require previous bookings");
   }
-  const valueError = validateCalcValue(input.calcKind, input.calcValue);
+  const valueError = modifierValueError(input.calcKind, input.calcValue);
   if (valueError) return Promise.resolve(valueError);
   return childAddOnInputError(input, id);
 };

--- a/src/shared/validation/money.ts
+++ b/src/shared/validation/money.ts
@@ -111,6 +111,18 @@ export const parseOptionalMinorUnits = (raw: string): number | null =>
 export const parseSignedMinorUnits = (raw: string): number | null =>
   parseWith(SignedMoneySchema, raw);
 
+/**
+ * True when a numeric amount in MAJOR units carries more decimal places than the
+ * active currency can represent — the value {@link toMinorUnits} would silently
+ * round. The string parsers above reject over-precise input up front; use this
+ * at a call site that only holds the already-parsed number (e.g. a modifier's
+ * fixed `calc_value`, checked after `Number.parseFloat` alongside its kind).
+ * `value` must be finite (round it through the currency's decimal places and
+ * compare): `10.005` in GBP is over-precise, `10.01` is not.
+ */
+export const exceedsCurrencyPrecision = (value: number): boolean =>
+  Number(value.toFixed(getDecimalPlaces(settings.currency))) !== value;
+
 /** Result of validating a public/QR price against a min/max bound. */
 export type PriceResult =
   | { ok: true; price: number }

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -964,17 +964,17 @@ export const modifierFields: Field[] = [
     inputmode: "decimal",
     label: "Minimum order (optional)",
     name: "min_subtotal",
-    // Optional: blank means no minimum (0). A provided value must be a
-    // non-negative number; `validateSingleField` only runs `validate` when the
-    // field is non-empty, and `parse` maps blank to 0.
+    // Optional: blank means no minimum (0). `parse` maps blank to 0;
+    // `validateSingleField` only runs `validate` on a non-empty value.
     parse: (value: string) => (value ? Number.parseFloat(value) : 0),
     type: "text",
-    validate: (value: string) => {
-      const n = Number.parseFloat(value);
-      return Number.isFinite(n) && n >= 0
-        ? null
-        : "Minimum order must be a positive number";
-    },
+    // A present value is a currency amount, so reject a negative, a non-number,
+    // or one with more decimals than the currency allows (which `toMinorUnits`
+    // would otherwise round at save) rather than silently coercing it.
+    validate: (value: string) =>
+      parseOptionalMinorUnits(value) === null
+        ? "Minimum order must be a valid amount for your currency"
+        : null,
   },
   {
     hint: "Only apply to a returning customer with at least this many previous bookings. 0 (or blank) applies to everyone; 1 means seen at least once before.",

--- a/test/lib/server-modifiers.test.ts
+++ b/test/lib/server-modifiers.test.ts
@@ -138,6 +138,30 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
       expect(modifier.direction).toBe("charge");
     });
 
+    test("accepts a fixed amount at the currency's precision", async () => {
+      await adminFormPost(
+        "/admin/modifiers",
+        createData({ calc_kind: "fixed", calc_value: "5.50" }),
+      );
+      expect((await lastModifier()).calc_value).toBe(5.5);
+    });
+
+    test("rejects a fixed amount with too many decimals for the currency", async () => {
+      // A fixed amount is a currency value (major units, converted at resolve).
+      // 10.005 has 3 decimals — invalid in GBP (2) — so it's rejected rather
+      // than silently rounded when the modifier is applied. A percentage or
+      // multiplier keeps its precision, so this only guards the fixed kind.
+      const { response } = await adminFormPost(
+        "/admin/modifiers",
+        createData({ calc_kind: "fixed", calc_value: "10.005" }),
+      );
+      await expectFlashRedirect(
+        "/admin/modifiers/new",
+        "Amount has more decimal places than your currency allows",
+        false,
+      )(response);
+    });
+
     test("stores the minimum order in minor units", async () => {
       await adminFormPost(
         "/admin/modifiers",
@@ -158,7 +182,21 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
       );
       await expectFlashRedirect(
         "/admin/modifiers/new",
-        "Minimum order must be a positive number",
+        "Minimum order must be a valid amount for your currency",
+        false,
+      )(response);
+    });
+
+    test("rejects a minimum order with too many decimals for the currency", async () => {
+      // 10.005 has 3 decimals — invalid in GBP (2). Without validation this
+      // would be rounded by toMinorUnits at save; instead it's rejected.
+      const { response } = await adminFormPost(
+        "/admin/modifiers",
+        createData({ min_subtotal: "10.005" }),
+      );
+      await expectFlashRedirect(
+        "/admin/modifiers/new",
+        "Minimum order must be a valid amount for your currency",
         false,
       )(response);
     });

--- a/test/lib/validation/money.test.ts
+++ b/test/lib/validation/money.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe } from "@std/testing/bdd";
 import type { SettingsData } from "#shared/db/settings.ts";
 import {
+  exceedsCurrencyPrecision,
   parseNonNegativeMinorUnits,
   parseOptionalMinorUnits,
   parsePositiveMinorUnits,
@@ -246,4 +247,42 @@ describe("validatePrice (bounded public/QR price)", () => {
       expect(validatePrice("5", 500, 500)).toEqual({ ok: true, price: 500 });
     },
   );
+});
+
+describe("exceedsCurrencyPrecision (already-parsed major-unit amount)", () => {
+  const table = (
+    currency: SettingsData["currency"],
+    rows: Array<[number, boolean]>,
+  ) => {
+    for (const [value, expected] of rows) {
+      testWithSetting(
+        `${currency}: ${value} → ${expected}`,
+        { currency },
+        () => {
+          expect(exceedsCurrencyPrecision(value)).toBe(expected);
+        },
+      );
+    }
+  };
+
+  // GBP allows 2 decimals: 3+ is over-precise, an integer or ≤2 dp is not.
+  table("GBP", [
+    [10, false],
+    [10.1, false],
+    [10.01, false],
+    [10.005, true],
+    [10.999, true],
+  ]);
+
+  // JPY has no minor unit, so any fraction is over-precise.
+  table("JPY", [
+    [10, false],
+    [10.5, true],
+  ]);
+
+  // KWD allows 3 decimals.
+  table("KWD", [
+    [1.005, false],
+    [1.0005, true],
+  ]);
 });


### PR DESCRIPTION
## What & why

The modifier fields were the last money site not yet on the shared currency-aware validation family (the "modifier money fields" follow-up in `TODO.md`). A modifier's **fixed** `calc_value` and its `min_subtotal` are currency amounts entered in major units, but both accepted any decimal precision — an over-precise value (e.g. `10.005` in GBP, `10.5` in JPY) was silently **rounded** rather than rejected:

- `min_subtotal` is rounded by `toMinorUnits` at save;
- a fixed `calc_value` is rounded by `toMinorUnits` when the modifier resolves for a checkout (`signedValue` in `modifier-resolve.ts`).

They couldn't ride the single-field swap the other money fields took, because `calc_value` is polymorphic: it's a currency amount only when `calc_kind === "fixed"`, otherwise a percentage or a bare multiplier (which legitimately keep their precision). So the fixed rule needs calc-kind-aware validation.

## Changes

- **`shared/validation/money.ts`** — new `exceedsCurrencyPrecision(value)`: true when an already-parsed major-units amount carries more decimal places than the active currency can represent. For call sites that only hold the parsed number.
- **`features/admin/modifiers.ts`** — extracted `modifierValueError(kind, value)`: the existing kind-aware magnitude/sign rules (`validateCalcValue`), then for the **fixed** kind only an `exceedsCurrencyPrecision` guard. Percentages and multipliers keep their precision. (Extracted to keep `validateModifier` under the complexity limit.)
- **`ui/templates/fields.ts`** — `min_subtotal`'s field `validate` now rejects a negative, a non-number, a comma group, or an over-precise amount via the string-based `parseOptionalMinorUnits`, mirroring `validateNonNegativePrice`, instead of a permissive `Number.parseFloat`. Blank still means "no minimum" (0).
- **`TODO.md`** — strikes the now-completed "modifier `calc_value` / `min_subtotal`" item, leaving only the optional read-only registry variant. (Rebased onto main after #1505 retired `servicing.md` into `TODO.md`.)

## Tests

- `test/lib/validation/money.test.ts` — `exceedsCurrencyPrecision` across GBP (2dp), JPY (0dp), KWD (3dp), both accept and reject cases.
- `test/lib/server-modifiers.test.ts` — route-level: reject an over-precise fixed `calc_value` and an over-precise `min_subtotal`, accept at-precision values, plus the updated negative-`min_subtotal` message.

## Verification

- Full suite: **12643 passed**; the only failures are the two pre-existing `stripe-mock.test.ts` binary-download tests, which need outbound GitHub-releases access this sandbox blocks (they pass in CI). CI was green on the pre-rebase commit; the rebase only picked up #1505 (docs-only).
- `lint`, `typecheck`, `cpd` (0 clones), `build:edge` all green.
- Coverage of every new line and branch verified directly from the lcov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)