### PR TITLE
i18n: throw on a missing translation key instead of rendering it raw

### DIFF
--- a/src/locales/en/listing-defaults.json
+++ b/src/locales/en/listing-defaults.json
@@ -22,6 +22,8 @@
   "listing_defaults.field.webhook_url.hint": "A URL that receives a POST when a booking is made.",
   "listing_defaults.field.thank_you_url.label": "Thank you URL",
   "listing_defaults.field.thank_you_url.hint": "Where buyers are redirected after a successful purchase.",
+  "listing_defaults.field.hidden.label": "Hidden",
+  "listing_defaults.field.hidden.hint": "Whether new listings are hidden from public listing pages.",
   "listing_defaults.use_defaults_toggle": "Use defaults",
   "listing_defaults.use_defaults_hint": "Inherit the fields you've set defaults for. Turn this off to edit them on this listing."
 }

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -141,12 +141,23 @@ const getFormat = (locale: string, key: string): IntlMessageFormat | null => {
   return fmt;
 };
 
-/** Translate a key with optional ICU MessageFormat parameters */
+/**
+ * Translate a key with optional ICU MessageFormat parameters.
+ *
+ * A key absent from both the active locale and the `en` fallback is a
+ * programming error — a typo or, more often, a dynamically built key
+ * (`listing_defaults.field.${field}.label`) whose translation was never added,
+ * which the static forward coverage scan can't catch. Rather than silently
+ * render the raw key (an ugly string that ships to production unnoticed), throw
+ * so a page render — in tests or in the browser — fails loudly and the missing
+ * translation is fixed at its source.
+ */
 export const t = (key: string, values?: Record<string, unknown>): string => {
   const locale = getLocale();
   const fmt = getFormat(locale, key);
-  // Missing translation falls back to the key itself.
-  if (!fmt) return key;
+  if (!fmt) {
+    throw new Error(`Missing translation for key "${key}" (locale "${locale}")`);
+  }
   return String(fmt.format(values));
 };
 

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -156,7 +156,9 @@ export const t = (key: string, values?: Record<string, unknown>): string => {
   const locale = getLocale();
   const fmt = getFormat(locale, key);
   if (!fmt) {
-    throw new Error(`Missing translation for key "${key}" (locale "${locale}")`);
+    throw new Error(
+      `Missing translation for key "${key}" (locale "${locale}")`,
+    );
   }
   return String(fmt.format(values));
 };

--- a/test/lib/i18n.test.ts
+++ b/test/lib/i18n.test.ts
@@ -17,9 +17,12 @@ describe("i18n", () => {
       expect(t("common.yes")).toBe("Yes");
     });
 
-    test("returns key for unknown key", () => {
-      expect(t("unknown.key.that.does.not.exist")).toBe(
-        "unknown.key.that.does.not.exist",
+    test("throws for an unknown key", () => {
+      // A missing translation is a programming error (typically a dynamically
+      // built key whose value was never added), so t() fails loudly rather than
+      // silently rendering the raw key to users.
+      expect(() => t("unknown.key.that.does.not.exist")).toThrow(
+        'Missing translation for key "unknown.key.that.does.not.exist"',
       );
     });
 
@@ -163,12 +166,12 @@ describe("i18n", () => {
       });
     });
 
-    test("never rewrites the fallback key of a missing translation", () => {
-      // A missing key is returned verbatim; "key" must not become "code"
-      // even though the substring matches.
+    test("a missing translation throws rather than being rebranded", () => {
+      // Replacements rewrite copy, never keys — a missing key throws outright,
+      // so "key" is never reachable to be turned into "code".
       withReplacements("key|code", () => {
-        expect(t("unknown.key.that.does.not.exist")).toBe(
-          "unknown.key.that.does.not.exist",
+        expect(() => t("unknown.key.that.does.not.exist")).toThrow(
+          'Missing translation for key "unknown.key.that.does.not.exist"',
         );
       });
     });

--- a/test/shared/listing-defaults.test.ts
+++ b/test/shared/listing-defaults.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import en from "#locales/en/index.ts";
 import {
   hasAnyListingDefault,
   LISTING_DEFAULT_FIELDS,
@@ -14,7 +15,6 @@ import {
   serializeListingDefaults,
   setListingDefaultFields,
 } from "#shared/listing-defaults.ts";
-import en from "#locales/en/index.ts";
 import { testListing } from "#test-utils";
 
 const messages = en as Record<string, string>;

--- a/test/shared/listing-defaults.test.ts
+++ b/test/shared/listing-defaults.test.ts
@@ -14,7 +14,10 @@ import {
   serializeListingDefaults,
   setListingDefaultFields,
 } from "#shared/listing-defaults.ts";
+import en from "#locales/en/index.ts";
 import { testListing } from "#test-utils";
+
+const messages = en as Record<string, string>;
 
 const fullDefaults: ListingDefaults = {
   bookableDays: ["Monday", "Wednesday"],
@@ -232,5 +235,18 @@ describe("shared > listing-defaults > LISTING_DEFAULT_FIELDS", () => {
     const fields = LISTING_DEFAULT_FIELDS.map((f) => f.field);
     expect(new Set(keys).size).toBe(keys.length);
     expect(new Set(fields).size).toBe(fields.length);
+  });
+
+  test("every field has a label and hint translation", () => {
+    // The label/hint keys are built dynamically, so the static forward i18n
+    // coverage scan can't verify them — adding a field without translations
+    // (as `hidden` once was) would otherwise ship a raw key to the page. With
+    // t() now throwing on a missing key, this guards the whole set at its source.
+    const missing = LISTING_DEFAULT_FIELDS.flatMap((f) =>
+      [listingDefaultLabelKey(f), listingDefaultHintKey(f)].filter(
+        (key) => !(key in messages),
+      ),
+    );
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## What & why

On `/admin/listing-defaults`, the `hidden` field rendered its raw i18n keys — `listing_defaults.field.hidden.label` and `.hint` — because the `hidden` field was added to `LISTING_DEFAULT_FIELDS` without its translations, and `t()` silently fell back to returning the key itself when a translation was absent.

The static forward i18n-coverage scan can only verify literal `t("key")` calls. Dynamically built keys like `` t(`listing_defaults.field.${field.field}.label`) `` slip straight through it, so the missing copy shipped unnoticed.

This makes a missing key a **loud failure** rather than a silent one, matching the codebase's "let it throw, loudly" stance for invariant violations. Because the admin pages are rendered end-to-end in the test suite, a missing dynamic key now fails a test at its source instead of drawing an ugly dot-key in production.

## Changes

- **`src/shared/i18n.ts`** — `t()` now throws `Missing translation for key "…"` when a key is absent from both the active locale and the `en` fallback, instead of returning the key.
- **`src/locales/en/listing-defaults.json`** — add the missing `listing_defaults.field.hidden.label` / `.hint` copy that triggered this.
- **`test/shared/listing-defaults.test.ts`** — regression test asserting every `LISTING_DEFAULT_FIELDS` entry has a label and hint translation (guards the dynamic keys the forward scan can't reach; fails on the old code, passes now).
- **`test/lib/i18n.test.ts`** — update the two unit tests that asserted the old key-fallback to expect the throw.

## Verification

- New and updated i18n / listing-defaults tests pass.
- The i18n-coverage forward + backward scans still pass.
- Ran the page-rendering test files that exercise dynamic `t()` keys (guide, site-pages, ledger, entity pages, listings, order gallery, dashboard, privacy, listing-defaults) — no missing-translation errors surfaced, confirming every reachable dynamic key resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGXTf6DF28wJ5GKhACWuWv)_